### PR TITLE
[ONNX] Add infra for quantized model export and support quantized mobilenet v3

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -10396,6 +10396,11 @@ class TestONNXRuntime(unittest.TestCase):
     @skipIfUnsupportedMinOpsetVersion(10)
     def test_quantized_conv2d(self):
         model = torch.nn.quantized.Conv2d(16, 33, 3, stride=2)
+        # Manually initialize model weight and bias to random numbers.
+        # By default all zeros.
+        q_weight = torch.quantize_per_tensor(torch.randn(33, 16, 3, 3), 0.2, 0, torch.qint8)
+        bias = torch.randn(33)
+        model.set_weight_bias(q_weight, bias)
         input = torch.randn(3, 16, 32, 32)
         q_input = torch.quantize_per_tensor(input, 0.2, 128, torch.quint8)
         self.run_test(torch.jit.trace(model, q_input), (q_input,))
@@ -10410,6 +10415,11 @@ class TestONNXRuntime(unittest.TestCase):
     @skipIfUnsupportedMinOpsetVersion(10)
     def test_quantized_conv2d_relu(self):
         model = torch.nn.intrinsic.quantized.ConvReLU2d(16, 33, 3, stride=2)
+        # Manually initialize model weight and bias to random numbers.
+        # By default all zeros.
+        q_weight = torch.quantize_per_tensor(torch.randn(33, 16, 3, 3), 0.2, 0, torch.qint8)
+        bias = torch.randn(33)
+        model.set_weight_bias(q_weight, bias)
         input = torch.randn(3, 16, 32, 32)
         q_input = torch.quantize_per_tensor(input, 0.2, 128, torch.quint8)
         self.run_test(torch.jit.trace(model, q_input), (q_input,))

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -99,7 +99,7 @@ def convert_to_onnx(model, input=None, opset_version=9, do_constant_folding=True
     # suppress ort warnings.
     # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
     so.log_severity_level = 3
-    ort_sess = onnxruntime.InferenceSession(f.getvalue(), so)
+    ort_sess = onnxruntime.InferenceSession(f.getvalue(), so, providers=["CPUExecutionProvider"])
     return ort_sess
 
 
@@ -373,7 +373,7 @@ class TestONNXRuntime(unittest.TestCase):
                 # suppress ort warnings.
                 # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
                 ort_sess_opt.log_severity_level = 3
-                ort_sess = onnxruntime.InferenceSession(model_file_name, sess_options=ort_sess_opt)
+                ort_sess = onnxruntime.InferenceSession(model_file_name, sess_options=ort_sess_opt, providers=["CPUExecutionProvider"])
                 input_copy = copy.deepcopy(input)
                 ort_outs = run_ort(ort_sess, input_copy)
                 ort_compare_with_pytorch(ort_outs, output, rtol, atol)
@@ -729,6 +729,44 @@ class TestONNXRuntime(unittest.TestCase):
                       input_names=["input_images"], output_names=["outputs"],
                       dynamic_axes={"input_images": {0: "batch_size"}, "output": {0: "batch_size"}},
                       rtol=1e-3, atol=1e-5)
+
+    @disableScriptTest()
+    def test_mobilenet_v3(self):
+        model = torchvision.models.quantization.mobilenet_v3_large(pretrained=False)
+        dummy_input = torch.randn(1, 3, 224, 224, requires_grad=True)
+        self.run_test(model, (dummy_input,))
+
+    @unittest.skip("Fixed in PyTorch master. RuntimeError: Error(s) in loading state_dict for QuantizableMobileNetV3")
+    @disableScriptTest()
+    def test_mobilenet_v3_quant(self):
+        model = torchvision.models.quantization.mobilenet_v3_large(pretrained=True, quantize=True)
+        from PIL import Image
+        from torchvision import transforms
+        data_dir = os.path.join(os.path.dirname(__file__), "assets")
+        path = os.path.join(data_dir, "grace_hopper_517x606.jpg")
+        input_image = Image.open(path)
+        preprocess = transforms.Compose([
+            transforms.Resize(256),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ])
+        input_tensor = preprocess(input_image).unsqueeze(0)
+
+        # Due to precision error from quantization, check only that the top prediction matches.
+        class TopPredictor(torch.nn.Module):
+            def __init__(self, mobilenet):
+                super().__init__()
+                self.mobilenet = mobilenet
+
+            def forward(self, x):
+                x = self.mobilenet(x)
+                probs = torch.nn.functional.softmax(x[0], dim=0)
+                topk_prob, topk_catid = torch.topk(probs, 1)
+                return topk_catid
+
+        model = torch.jit.trace(TopPredictor(model), input_tensor)
+        self.run_test(model, (input_tensor, ))
 
     @disableScriptTest()
     def test_word_language_model_RNN_TANH(self):
@@ -10335,14 +10373,94 @@ class TestONNXRuntime(unittest.TestCase):
     @skipIfUnsupportedMinOpsetVersion(10)
     def test_quantized_linear(self):
         model = torch.nn.quantized.Linear(1, 2)
-        input = torch.rand(1, 1)
-        input_tensor = torch.quantize_per_tensor(input, 1, 0, torch.quint8)
+        w = torch.tensor([[2.], [4.]])
+        q_w = torch.quantize_per_tensor(w, 1, 0, torch.qint8)
+        b = torch.tensor([0., 0.])
+        model.set_weight_bias(q_w, b)
+
+        input = torch.tensor([[10.5]])
+        input_tensor = torch.quantize_per_tensor(input, 0.5, 5, torch.quint8)
         # Currently, we need convert the model to ScriptModule before export.
         # The reason is that PackedParams contains int (not tensor).
         # Then it fails when the exporter calls _trace_and_get_graph_from_model().
         # TODO: https://msdata.visualstudio.com/Vienna/_workitems/edit/1547858
         self.run_test(torch.jit.trace(model, input_tensor), (input_tensor,))
         self.run_test(torch.jit.script(model), (input_tensor,))
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantized_conv2d(self):
+        model = torch.nn.quantized.Conv2d(16, 33, 3, stride=2)
+        input = torch.randn(3, 16, 32, 32)
+        q_input = torch.quantize_per_tensor(input, 0.2, 0, torch.quint8)
+        self.run_test(torch.jit.trace(model, q_input), (q_input,))
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantized_adaptive_avg_pool2d(self):
+        model = torch.nn.AdaptiveAvgPool2d((5, 7))
+        input = torch.randn(4, 3, 10, 14)
+        q_input = torch.quantize_per_tensor(input, 0.2, 0, torch.quint8)
+        self.run_test(torch.jit.trace(model, q_input), (q_input,))
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantized_conv2d_relu(self):
+        model = torch.nn.intrinsic.quantized.ConvReLU2d(16, 33, 3, stride=2)
+        input = torch.randn(3, 16, 32, 32)
+        q_input = torch.quantize_per_tensor(input, 1, 0, torch.quint8)
+        self.run_test(torch.jit.trace(model, q_input), (q_input,))
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantized_hardswish(self):
+        model = torch.nn.quantized.Hardswish(1, 0)
+        input = torch.randn(2, 6)
+        q_input = torch.quantize_per_tensor(input, 0.26, 1, torch.quint8)
+        self.run_test(torch.jit.trace(model, q_input), (q_input,))
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantized_hardsigmoid(self):
+        model = torch.nn.Hardsigmoid()
+        input = torch.randn(2, 6)
+        q_input = torch.quantize_per_tensor(input, 0.26, 1, torch.quint8)
+        self.run_test(torch.jit.trace(model, q_input), (q_input,))
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantized_flatten(self):
+        class FlattenModel(torch.nn.Module):
+            def forward(self, input):
+                return torch.flatten(input)
+
+        x = torch.quantize_per_tensor(torch.randn(1, 2, 3, 4), 1, 0, torch.quint8)
+        self.run_test(torch.jit.trace(FlattenModel(), x), x)
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantized_arithmetic(self):
+        class ArithmeticModel(torch.nn.Module):
+            def forward(self, x, y):
+                o = torch.nn.quantized.QFunctional().add(x, y)
+                o = torch.nn.quantized.QFunctional().mul(o, x)
+                return o
+
+        x = torch.quantize_per_tensor(torch.randn(3, 4), 0.2, 128, torch.quint8)
+        y = torch.quantize_per_tensor(torch.randn(3, 4), 0.2, 128, torch.quint8)
+        self.run_test(torch.jit.trace(ArithmeticModel(), (x, y)), (x, y))
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_quantize_per_tensor(self):
+        class Module(torch.nn.Module):
+            def forward(self, x):
+                return (torch.quantize_per_tensor(x, 0.2, 0, torch.qint8),
+                        torch.quantize_per_tensor(x, 0.2, 128, torch.quint8))
+
+        x = torch.randn(4, 6)
+        self.run_test(torch.jit.trace(Module(), x), x)
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    def test_dequantize(self):
+        class Module(torch.nn.Module):
+            def forward(self, x):
+                return torch.dequantize(x)
+
+        x = torch.quantize_per_tensor(torch.randn(3, 4), 0.2, 0, torch.qint8)
+        self.run_test(torch.jit.trace(Module(), x), x)
 
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -373,7 +373,9 @@ class TestONNXRuntime(unittest.TestCase):
                 # suppress ort warnings.
                 # 0:Verbose, 1:Info, 2:Warning. 3:Error, 4:Fatal. Default is 2.
                 ort_sess_opt.log_severity_level = 3
-                ort_sess = onnxruntime.InferenceSession(model_file_name, sess_options=ort_sess_opt, providers=["CPUExecutionProvider"])
+                ort_sess = onnxruntime.InferenceSession(model_file_name,
+                                                        sess_options=ort_sess_opt,
+                                                        providers=["CPUExecutionProvider"])
                 input_copy = copy.deepcopy(input)
                 ort_outs = run_ort(ort_sess, input_copy)
                 ort_compare_with_pytorch(ort_outs, output, rtol, atol)

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -873,39 +873,6 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         self.assertEqual(next(iter).kind(), "onnx::Constant")
         self.assertEqual(next(iter).kind(), "aten::cosine_similarity")
 
-    def test_quantized_fallthrough(self):
-        # Test Quantized op
-        class QModule(torch.nn.Module):
-            def __init__(self):
-                super(QModule, self).__init__()
-                self.quant1 = torch.ao.quantization.QuantStub()
-                self.dequant = torch.ao.quantization.DeQuantStub()
-
-            def forward(self, x):
-                res = self.quant1(x)
-                return self.dequant(res)
-
-        model = QModule()
-        torch.backends.quantized.engine = "qnnpack"
-        pt_inputs = (torch.randn(1, 2, 3, 4))
-        model.qconfig = torch.ao.quantization.default_qconfig
-        q_model = torch.ao.quantization.prepare(model, inplace=False)
-        q_model = torch.ao.quantization.convert(q_model, inplace=False)
-
-        q_model.eval()
-
-        graph, _, __ = self._model_to_graph(q_model, pt_inputs,
-                                            operator_export_type=OperatorExportTypes.ONNX_FALLTHROUGH,
-                                            input_names=["pt_inputs"],
-                                            dynamic_axes={"pt_inputs": [0, 1, 2, 3]})
-
-        iter = graph.nodes()
-        self.assertEqual(next(iter).kind(), "onnx::Constant")
-        self.assertEqual(next(iter).kind(), "onnx::Constant")
-        self.assertEqual(next(iter).kind(), "onnx::Constant")
-        self.assertEqual(next(iter).kind(), "aten::quantize_per_tensor")
-        self.assertEqual(next(iter).kind(), "aten::dequantize")
-
     # prim::ListConstruct is exported as onnx::SequenceConstruct for opset >= 11
     @skipIfUnsupportedMaxOpsetVersion(10)
     def test_prim_fallthrough(self):

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -774,9 +774,10 @@ static void eraseTupleConstruct(Block* block) {
       for (auto* input: output_node->inputs()) {
         block->insertOutput(index + (input_index++), input);
       }
-      index += 2;
+      index += input_index;
+    } else {
+      index++;
     }
-    index++;
   }
 }
 

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -774,6 +774,7 @@ static void eraseTupleConstruct(Block* block) {
       for (auto* input: output_node->inputs()) {
         block->insertOutput(index + (input_index++), input);
       }
+      index += 2;
     }
     index++;
   }

--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
@@ -130,22 +130,28 @@ Node* CreateQuantizedBiasCaffe2(
 }
 
 std::vector<Node*> CreateQuantizedWeights(
-    std::vector<float> data,
+    int8_t* data,
     std::shared_ptr<Graph>& graph,
-    std::vector<int64_t> shapes,
+    const std::vector<int64_t>& shapes,
+    const std::vector<int64_t>& strides,
     float scale,
     int64_t zero_point) {
   Node* const_node_1 = graph->create(prim::Constant);
-  auto const_value = at::from_blob(data.data(), c10::IntArrayRef(shapes), at::kFloat).to(at::kCPU);
-  auto options = c10::TensorOptions().dtype(at::kFloat).device(at::kCPU);
-  at::Tensor const_value_copy = at::empty(c10::IntArrayRef(shapes), options);
-  const_value.copy_(const_value);
+  auto const_value =
+      at::from_blob(
+          data, c10::IntArrayRef(shapes), c10::IntArrayRef(strides), at::kChar)
+          .to(at::kCPU);
+  auto options = c10::TensorOptions().dtype(at::kChar).device(at::kCPU);
+  at::Tensor const_value_copy = at::empty_strided(
+      c10::IntArrayRef(shapes), c10::IntArrayRef(strides), options);
+  const_value_copy.copy_(const_value);
   const_node_1->t_(Symbol::attr("value"), const_value_copy);
 
   Node* const_node_2 = graph->create(prim::Constant);
   std::vector<float> scale_v{scale};
   std::vector<int64_t> scale_shapes{1};
   auto const_shape = at::from_blob(scale_v.data(), c10::IntArrayRef(scale_shapes), at::kFloat).to(at::kCPU);
+  options = c10::TensorOptions().dtype(at::kFloat).device(at::kCPU);
   at::Tensor const_shape_copy = at::empty(c10::IntArrayRef(scale_shapes), options);
   const_shape_copy.copy_(const_shape);
   const_node_2->t_(Symbol::attr("value"), const_shape_copy);
@@ -154,6 +160,7 @@ std::vector<Node*> CreateQuantizedWeights(
   std::vector<int64_t> zero_point_v{zero_point};
   std::vector<int64_t> zero_shapes{1};
   auto const_zero = at::from_blob(zero_point_v.data(), c10::IntArrayRef(zero_shapes), at::kInt).to(at::kCPU);
+  options = c10::TensorOptions().dtype(at::kInt).device(at::kCPU);
   at::Tensor const_zero_copy = at::empty(c10::IntArrayRef(zero_shapes), options);
   const_zero_copy.copy_(const_zero);
   const_node_3->t_(Symbol::attr("value"), const_zero_copy);
@@ -391,9 +398,10 @@ void unpackQuantizedWeightsHelper(
       std::tie(unpacked_weight, bias) = op.call(packed_weight);
     }
 
-    // Permute weights
     std::vector<int64_t> wt_sizes = unpacked_weight.sizes().vec();
-    if (unpacked_weight.ndimension() == 4) {
+    std::vector<int64_t> wt_strides = unpacked_weight.strides().vec();
+    if (unpacked_weight.ndimension() == 4 && caffe2) {
+      // Permute weights
       unpacked_weight.permute({0, 2, 3, 1});
       wt_sizes = {
           unpacked_weight.size(0),
@@ -423,21 +431,21 @@ void unpackQuantizedWeightsHelper(
       c2_weight->insertBefore(qlinear_node);
       qlinear_node->insertInput(1, c2_weight->output());
     } else {
-      std::vector<float> unpacked_weight_values;
-      unpacked_weight_values.reserve(unpacked_weight.numel());
-      auto unpacked_weight_data = reinterpret_cast<int8_t*>(unpacked_weight.data_ptr<c10::qint8>());
-      for (const auto i : c10::irange(unpacked_weight.numel())) {
-        unpacked_weight_values.push_back(static_cast<float>(unpacked_weight_data[i]));
-      }
-      std::vector<Node*> c2_weight = CreateQuantizedWeights(
-          unpacked_weight_values, graph, wt_sizes, static_cast<float>(unpacked_weight.q_scale()), weight_zp);
+      std::vector<Node*> unpacked_wt = CreateQuantizedWeights(
+          inp_data,
+          graph,
+          wt_sizes,
+          wt_strides,
+          static_cast<float>(unpacked_weight.q_scale()),
+          weight_zp - 128);
       graph->setInsertPoint(qlinear_node);
-      c2_weight[0]->insertBefore(qlinear_node);
-      qlinear_node->insertInput(1, c2_weight[0]->output());
-      c2_weight[1]->insertBefore(qlinear_node);
-      qlinear_node->insertInput(2, c2_weight[1]->output());
-      c2_weight[2]->insertBefore(qlinear_node);
-      qlinear_node->insertInput(3, c2_weight[2]->output());
+      Node* quant_node = graph->create(prim::TupleConstruct);
+      for (auto* n : unpacked_wt) {
+        n->insertBefore(qlinear_node);
+        quant_node->addInput(n->output());
+      }
+      quant_node->insertBefore(qlinear_node);
+      qlinear_node->insertInput(1, quant_node->output());
     }
 
     // Add bias
@@ -491,10 +499,8 @@ void unpackQuantizedWeightsHelper(
           original_bias.sizes().vec());
       bias->insertBefore(qlinear_node);
       // For quantized_linear inputs, the order is input, weight, bias, ....
-      // We unpack weight into 3 values. then it is
-      // input, weight_value, weight_scale, weight_zero_point, bias, ...
-      // Therefore bias is at location 4.
-      qlinear_node->insertInput(4, bias->output());
+      // Therefore bias is at location 2.
+      qlinear_node->insertInput(2, bias->output());
     }
 
     // add conv arguments: stride, padding, dilation, groups
@@ -504,6 +510,8 @@ void unpackQuantizedWeightsHelper(
       conv_ints_args.push_back(stride);
       conv_ints_args.push_back(padding);
       conv_ints_args.push_back(dilation);
+      // For quantized_conv inputs, the order is input, weight, bias, stride,
+      // padding, dilation, groups
       const size_t arg_offset = 3;
       for (const auto i : c10::irange(conv_ints_args.size())) {
         Node* ints_node =
@@ -591,32 +599,35 @@ void UnpackQuantizedWeights(
       "quantized::linear_unpack",
       QuantizedParamsType::LINEAR,
       caffe2);
-  if (caffe2) {
-    unpackQuantizedWeightsHelper(
-        graph,
-        paramsDict,
-        qconv2d,
-        "quantized::conv2d_unpack",
-        QuantizedParamsType::CONV);
-    unpackQuantizedWeightsHelper(
-        graph,
-        paramsDict,
-        qconv2d_relu,
-        "quantized::conv2d_unpack",
-        QuantizedParamsType::CONV);
-    unpackQuantizedWeightsHelper(
-        graph,
-        paramsDict,
-        qconv3d,
-        "quantized::conv3d_unpack",
-        QuantizedParamsType::CONV);
-    unpackQuantizedWeightsHelper(
-        graph,
-        paramsDict,
-        qconv3d_relu,
-        "quantized::conv3d_unpack",
-        QuantizedParamsType::CONV);
-  } else {
+  unpackQuantizedWeightsHelper(
+      graph,
+      paramsDict,
+      qconv2d,
+      "quantized::conv2d_unpack",
+      QuantizedParamsType::CONV,
+      caffe2);
+  unpackQuantizedWeightsHelper(
+      graph,
+      paramsDict,
+      qconv2d_relu,
+      "quantized::conv2d_unpack",
+      QuantizedParamsType::CONV,
+      caffe2);
+  unpackQuantizedWeightsHelper(
+      graph,
+      paramsDict,
+      qconv3d,
+      "quantized::conv3d_unpack",
+      QuantizedParamsType::CONV,
+      caffe2);
+  unpackQuantizedWeightsHelper(
+      graph,
+      paramsDict,
+      qconv3d_relu,
+      "quantized::conv3d_unpack",
+      QuantizedParamsType::CONV,
+      caffe2);
+  if (!caffe2) {
     UnpackQuantizedTensorInputs(graph);
   }
   GRAPH_DUMP("After UnpackQuantizedWeights: ", graph);

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -239,7 +239,8 @@ def quantized_args(*arg_q_descriptors, op_scale=None, op_zero_point=None):
 
             # some args may be optional, so the length may be smaller
             assert len(arg_q_descriptors) >= len(args)
-            get_desc_args = lambda : zip(arg_q_descriptors[:len(args)], args)
+            def get_desc_args():
+                return zip(arg_q_descriptors[:len(args)], args)
             # Run regular symbolic function if none of the argument is QTensor.
             if not any([(desc and arg.node().kind() == "prim::TupleConstruct") for desc, arg in get_desc_args()]):
                 return fn(g, *args, **kwargs)

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -194,6 +194,36 @@ def parse_args(*arg_descriptors):
     return decorator
 
 def quantized_args(*arg_q_descriptors, op_scale=None, op_zero_point=None):
+    """A decorator which extends support for quantized version of the base operator.
+    Quantization is detected by examining the arguments that are annotated by
+    `arg_q_descriptors`.
+    If quantization is detected, the base operator symbolic function will be wrapped with
+    argument dequantization and output quantization.
+    Otherwise, only base symbolic function will be invoked.
+
+    For example:
+    @quantized_args(True, False)
+    def foo(g, x, y):
+        return x + y
+
+    is equivalent to
+
+    def q_foo(g, x, y):
+        if is_quantized_tensor(x):
+            x = dequantize(x)
+            out = foo(g, x, y)
+            return quantize(out)
+        else:
+            return foo(g, x, y)
+
+    Args:
+        arg_q_descriptors: list of bool, where each element represents if the
+          argument is QTensor for quantized version of this operator.
+        op_scale: float default None, quantized output scale. If None, derive from
+          the first quantized input scale.
+        op_zero_point: int default None, quantized output zero point. If None,
+          derive from the first quantized input zero point.
+    """
     def decorator(fn):
         fn._op_scale = op_scale
         fn._op_zero_point = op_zero_point

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -341,10 +341,10 @@ class Quantized:
     @staticmethod
     def linear(g, q_input, q_weight, bias, op_scale, op_zero_point):
         # From https://pytorch.org/docs/master/generated/torch.nn.quantized.functional.linear.html
-        input, input_scale, input_zero_point = sym_help._dequantize_helper(g, q_input)
+        input, _, _ = sym_help._dequantize_helper(g, q_input)
         # weight (Tensor) – Quantized weight of type torch.qint8
         weight_type_dq = torch.onnx.TensorProtoDataType.INT8
-        weight, weight_scale, weight_zero_point = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
+        weight, _, _ = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
 
         output = linear(g, input, weight, bias)
 
@@ -352,8 +352,8 @@ class Quantized:
 
     @staticmethod
     def add(g, x, y, op_scale, op_zero_point):
-        x, x_s, x_zp = sym_help._dequantize_helper(g, x)
-        y, y_s, y_zp = sym_help._dequantize_helper(g, y)
+        x, _, _ = sym_help._dequantize_helper(g, x)
+        y, _, _ = sym_help._dequantize_helper(g, y)
 
         output = add(g, x, y)
 
@@ -361,8 +361,8 @@ class Quantized:
 
     @staticmethod
     def mul(g, x, y, op_scale, op_zero_point):
-        x, x_s, x_zp = sym_help._dequantize_helper(g, x)
-        y, y_s, y_zp = sym_help._dequantize_helper(g, y)
+        x, _, _ = sym_help._dequantize_helper(g, x)
+        y, _, _ = sym_help._dequantize_helper(g, y)
 
         output = mul(g, x, y)
 
@@ -370,7 +370,7 @@ class Quantized:
 
     @staticmethod
     def hardswish(g, x, op_scale, op_zero_point):
-        x, x_s, x_zp = sym_help._dequantize_helper(g, x)
+        x, _, _ = sym_help._dequantize_helper(g, x)
 
         output = hardswish(g, x)
 
@@ -378,10 +378,10 @@ class Quantized:
 
     @staticmethod
     def conv2d_relu(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
-        input, input_scale, input_zero_point = sym_help._dequantize_helper(g, q_input)
+        input, _, _ = sym_help._dequantize_helper(g, q_input)
         # weight (Tensor) – Quantized weight of type torch.qint8
         weight_type_dq = torch.onnx.TensorProtoDataType.INT8
-        weight, weight_scale, weight_zero_point = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
+        weight, _, _ = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
 
         output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
         output = relu(g, output)
@@ -391,9 +391,9 @@ class Quantized:
     @staticmethod
     def conv2d(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
         # From https://pytorch.org/docs/master/generated/torch.nn.quantized.Conv2d.html#torch.nn.quantized.Conv2d
-        input, input_scale, input_zero_point = sym_help._dequantize_helper(g, q_input)
+        input, _, _ = sym_help._dequantize_helper(g, q_input)
         weight_type_dq = torch.onnx.TensorProtoDataType.INT8
-        weight, weight_scale, weight_zero_point = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
+        weight, _, _ = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
 
         output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
 

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -326,11 +326,11 @@ def quantize_per_tensor(g, input, scale, zero_point, dtype):
     dtype = sym_help._get_const(dtype, "i", "dtype")
     zero_point = g.op("Cast", zero_point, to_i=sym_help.scalar_type_to_onnx[dtype])
     scale = g.op("Cast", scale, to_i=torch.onnx.TensorProtoDataType.FLOAT)
-    return sym_help._quantize_helper(g, input, scale, zero_point)
+    return sym_help.quantize_helper(g, input, scale, zero_point)
 
 
 def dequantize(g, input):
-    return sym_help._dequantize_helper(g, input)[0]
+    return sym_help.dequantize_helper(g, input)[0]
 
 
 # https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter#quantized-model-export
@@ -341,60 +341,60 @@ class Quantized:
     @staticmethod
     def linear(g, q_input, q_weight, bias, op_scale, op_zero_point):
         # From https://pytorch.org/docs/master/generated/torch.nn.quantized.functional.linear.html
-        input, _, _ = sym_help._dequantize_helper(g, q_input)
+        input, _, _ = sym_help.dequantize_helper(g, q_input)
         # weight (Tensor) – Quantized weight of type torch.qint8
         weight_type_dq = torch.onnx.TensorProtoDataType.INT8
-        weight, _, _ = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
+        weight, _, _ = sym_help.dequantize_helper(g, q_weight, weight_type_dq)
 
         output = linear(g, input, weight, bias)
 
-        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)
 
     @staticmethod
     def add(g, x, y, op_scale, op_zero_point):
-        x, _, _ = sym_help._dequantize_helper(g, x)
-        y, _, _ = sym_help._dequantize_helper(g, y)
+        x, _, _ = sym_help.dequantize_helper(g, x)
+        y, _, _ = sym_help.dequantize_helper(g, y)
 
         output = add(g, x, y)
 
-        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)
 
     @staticmethod
     def mul(g, x, y, op_scale, op_zero_point):
-        x, _, _ = sym_help._dequantize_helper(g, x)
-        y, _, _ = sym_help._dequantize_helper(g, y)
+        x, _, _ = sym_help.dequantize_helper(g, x)
+        y, _, _ = sym_help.dequantize_helper(g, y)
 
         output = mul(g, x, y)
 
-        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)
 
     @staticmethod
     def hardswish(g, x, op_scale, op_zero_point):
-        x, _, _ = sym_help._dequantize_helper(g, x)
+        x, _, _ = sym_help.dequantize_helper(g, x)
 
         output = hardswish(g, x)
 
-        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)
 
     @staticmethod
     def conv2d_relu(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
-        input, _, _ = sym_help._dequantize_helper(g, q_input)
+        input, _, _ = sym_help.dequantize_helper(g, q_input)
         # weight (Tensor) – Quantized weight of type torch.qint8
         weight_type_dq = torch.onnx.TensorProtoDataType.INT8
-        weight, _, _ = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
+        weight, _, _ = sym_help.dequantize_helper(g, q_weight, weight_type_dq)
 
         output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
         output = relu(g, output)
 
-        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)
 
     @staticmethod
     def conv2d(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
         # From https://pytorch.org/docs/master/generated/torch.nn.quantized.Conv2d.html#torch.nn.quantized.Conv2d
-        input, _, _ = sym_help._dequantize_helper(g, q_input)
+        input, _, _ = sym_help.dequantize_helper(g, q_input)
         weight_type_dq = torch.onnx.TensorProtoDataType.INT8
-        weight, _, _ = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
+        weight, _, _ = sym_help.dequantize_helper(g, q_weight, weight_type_dq)
 
         output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
 
-        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -336,10 +336,11 @@ def dequantize(g, input):
 class Quantized:
     """
     https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter#quantized-model-export
+
+    Support starts from opset 10 because `DequantizeLinear` and `QuantizeLinear` were introduced in opset version 10.
     """
     domain = "quantized"
 
-    # DequantizeLinear was added in opset version 10.
     @staticmethod
     def linear(g, q_input, q_weight, bias, op_scale, op_zero_point):
         input, _, _ = sym_help.dequantize_helper(g, q_input)

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -333,18 +333,17 @@ def dequantize(g, input):
     return sym_help.dequantize_helper(g, input)[0]
 
 
-# https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter#quantized-model-export
 class Quantized:
+    """
+    https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter#quantized-model-export
+    """
     domain = "quantized"
 
     # DequantizeLinear was added in opset version 10.
     @staticmethod
     def linear(g, q_input, q_weight, bias, op_scale, op_zero_point):
-        # From https://pytorch.org/docs/master/generated/torch.nn.quantized.functional.linear.html
         input, _, _ = sym_help.dequantize_helper(g, q_input)
-        # weight (Tensor) – Quantized weight of type torch.qint8
-        weight_type_dq = torch.onnx.TensorProtoDataType.INT8
-        weight, _, _ = sym_help.dequantize_helper(g, q_weight, weight_type_dq)
+        weight, _, _ = sym_help.dequantize_helper(g, q_weight)
 
         output = linear(g, input, weight, bias)
 
@@ -379,9 +378,7 @@ class Quantized:
     @staticmethod
     def conv2d_relu(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
         input, _, _ = sym_help.dequantize_helper(g, q_input)
-        # weight (Tensor) – Quantized weight of type torch.qint8
-        weight_type_dq = torch.onnx.TensorProtoDataType.INT8
-        weight, _, _ = sym_help.dequantize_helper(g, q_weight, weight_type_dq)
+        weight, _, _ = sym_help.dequantize_helper(g, q_weight)
 
         output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
         output = relu(g, output)
@@ -390,10 +387,8 @@ class Quantized:
 
     @staticmethod
     def conv2d(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
-        # From https://pytorch.org/docs/master/generated/torch.nn.quantized.Conv2d.html#torch.nn.quantized.Conv2d
         input, _, _ = sym_help.dequantize_helper(g, q_input)
-        weight_type_dq = torch.onnx.TensorProtoDataType.INT8
-        weight, _, _ = sym_help.dequantize_helper(g, q_weight, weight_type_dq)
+        weight, _, _ = sym_help.dequantize_helper(g, q_weight)
 
         output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
 

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -8,9 +8,9 @@ import torch.onnx
 import torch.onnx.utils
 
 import torch.onnx.symbolic_helper as sym_help
-from torch.onnx.symbolic_helper import parse_args, _unimplemented
+from torch.onnx.symbolic_helper import parse_args, _unimplemented, ScalarType, _dequantize_helper, _quantize_helper
 import torch.onnx.symbolic_opset9
-from torch.onnx.symbolic_opset9 import linear
+from torch.onnx.symbolic_opset9 import linear, conv2d, add, mul, hardswish, relu
 
 from sys import maxsize
 
@@ -322,39 +322,79 @@ def isfinite(g, input):
     return __not_(g, __or_(g, inf_node, nan_node))
 
 
+def quantize_per_tensor(g, input, scale, zero_point, dtype):
+    dtype = sym_help._get_const(dtype, "i", "dtype")
+    zero_point = g.op("Cast", zero_point, to_i=sym_help.scalar_type_to_onnx[dtype])
+    scale = g.op("Cast", scale, to_i=torch.onnx.TensorProtoDataType.FLOAT)
+    return sym_help._quantize_helper(g, input, scale, zero_point)
+
+
+def dequantize(g, input):
+    return sym_help._dequantize_helper(g, input)[0]
+
+
 # https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter#quantized-model-export
 class Quantized:
     domain = "quantized"
 
     # DequantizeLinear was added in opset version 10.
     @staticmethod
-    def linear(g, input_original, weight, weight_scale, weight_zero_point, bias, op_scale, op_zero_point):
-        input_value, input_scale, input_zero_point = sym_help._unpack_tuple(input_original)
+    def linear(g, q_input, q_weight, bias, op_scale, op_zero_point):
         # From https://pytorch.org/docs/master/generated/torch.nn.quantized.functional.linear.html
-        # input (Tensor) – Quantized input of type torch.quint8
-        input_type_dq = torch.onnx.TensorProtoDataType.UINT8
-        input_value = g.op("Cast", input_value, to_i=input_type_dq)
-        input_scale = g.op("Cast", input_scale, to_i=torch.onnx.TensorProtoDataType.FLOAT)
-        input_zero_point = g.op("Cast", input_zero_point, to_i=input_type_dq)
-        input = g.op("DequantizeLinear", input_value, input_scale, input_zero_point)
+        input, input_scale, input_zero_point = sym_help._dequantize_helper(g, q_input)
         # weight (Tensor) – Quantized weight of type torch.qint8
         weight_type_dq = torch.onnx.TensorProtoDataType.INT8
-        weight = g.op("Cast", weight, to_i=weight_type_dq)
-        weight_scale = g.op("Cast", weight_scale, to_i=torch.onnx.TensorProtoDataType.FLOAT)
-        weight_zero_point = g.op("Cast", weight_zero_point, to_i=weight_type_dq)
-        weight = g.op("DequantizeLinear", weight, weight_scale, weight_zero_point)
-        # bias (Tensor) – None or fp32 bias of type torch.float
-        bias = g.op("Cast", bias, to_i=torch.onnx.TensorProtoDataType.FLOAT)
+        weight, weight_scale, weight_zero_point = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
+
         output = linear(g, input, weight, bias)
 
-        if op_scale is None:
-            op_scale = input_scale
-        elif op_scale.type().scalarType() != "Float":
-            op_scale = g.op("Cast", op_scale, to_i=sym_help.cast_pytorch_to_onnx["Float"])
+        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
 
-        if op_zero_point is None:
-            op_zero_point = input_zero_point
-        elif op_zero_point.type().scalarType() != "Byte":
-            op_zero_point = g.op("Cast", op_zero_point, to_i=sym_help.cast_pytorch_to_onnx["Byte"])
-        output = g.op("QuantizeLinear", output, op_scale, op_zero_point)
-        return g.op("prim::TupleConstruct", output, op_scale, op_zero_point)
+    @staticmethod
+    def add(g, x, y, op_scale, op_zero_point):
+        x, x_s, x_zp = sym_help._dequantize_helper(g, x)
+        y, y_s, y_zp = sym_help._dequantize_helper(g, y)
+
+        output = add(g, x, y)
+
+        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
+
+    @staticmethod
+    def mul(g, x, y, op_scale, op_zero_point):
+        x, x_s, x_zp = sym_help._dequantize_helper(g, x)
+        y, y_s, y_zp = sym_help._dequantize_helper(g, y)
+
+        output = mul(g, x, y)
+
+        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
+
+    @staticmethod
+    def hardswish(g, x, op_scale, op_zero_point):
+        x, x_s, x_zp = sym_help._dequantize_helper(g, x)
+
+        output = hardswish(g, x)
+
+        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
+
+    @staticmethod
+    def conv2d_relu(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
+        input, input_scale, input_zero_point = sym_help._dequantize_helper(g, q_input)
+        # weight (Tensor) – Quantized weight of type torch.qint8
+        weight_type_dq = torch.onnx.TensorProtoDataType.INT8
+        weight, weight_scale, weight_zero_point = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
+
+        output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
+        output = relu(g, output)
+
+        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
+
+    @staticmethod
+    def conv2d(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
+        # From https://pytorch.org/docs/master/generated/torch.nn.quantized.Conv2d.html#torch.nn.quantized.Conv2d
+        input, input_scale, input_zero_point = sym_help._dequantize_helper(g, q_input)
+        weight_type_dq = torch.onnx.TensorProtoDataType.INT8
+        weight, weight_scale, weight_zero_point = sym_help._dequantize_helper(g, q_weight, weight_type_dq)
+
+        output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
+
+        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -8,7 +8,7 @@ import torch.onnx
 import torch.onnx.utils
 
 import torch.onnx.symbolic_helper as sym_help
-from torch.onnx.symbolic_helper import parse_args, _unimplemented, ScalarType, _dequantize_helper, _quantize_helper
+from torch.onnx.symbolic_helper import parse_args, _unimplemented
 import torch.onnx.symbolic_opset9
 from torch.onnx.symbolic_opset9 import linear, conv2d, add, mul, hardswish, relu
 

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -791,7 +791,8 @@ def narrow(g, input, dim, start, length):
     end = g.op("Add", start, length)
     return _slice_helper(g, input, axes=dim, starts=start, ends=end, dynamic_slice=True)
 
-
+from torch.onnx.symbolic_helper import quantized_args
+@quantized_args(True, False, False)
 @parse_args("v", "i", "i")
 def flatten(g, input, start_dim, end_dim):
     dim = sym_help._get_tensor_rank(input)

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -7,7 +7,7 @@ import torch
 import torch.onnx.symbolic_helper as sym_help
 import warnings
 
-from torch.onnx.symbolic_helper import parse_args, _unimplemented, _is_tensor_list, ScalarType
+from torch.onnx.symbolic_helper import parse_args, _unimplemented, _is_tensor_list, ScalarType, quantized_args
 from torch.onnx.symbolic_opset9 import expand, unused, mul
 from torch.onnx.symbolic_opset9 import linalg_vector_norm as lvn
 from torch.nn.modules.utils import _single, _pair, _triple
@@ -791,7 +791,6 @@ def narrow(g, input, dim, start, length):
     end = g.op("Add", start, length)
     return _slice_helper(g, input, axes=dim, starts=start, ends=end, dynamic_slice=True)
 
-from torch.onnx.symbolic_helper import quantized_args
 @quantized_args(True, False, False)
 @parse_args("v", "i", "i")
 def flatten(g, input, start_dim, end_dim):

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -60,7 +60,7 @@ class Quantized:
 
     @staticmethod
     def hardswish(g, x, op_scale, op_zero_point):
-        x, x_s, x_zp = sym_help._dequantize_helper(g, x)
+        x, _, _ = sym_help._dequantize_helper(g, x)
 
         output = hardswish(g, x)
 

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -54,8 +54,10 @@ def batch_norm(g, input, weight, bias, running_mean, running_var, training, mome
         return res
 
 
-# https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter#quantized-model-export
 class Quantized:
+    """
+    https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter#quantized-model-export
+    """
     domain = "quantized"
 
     @staticmethod

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -52,3 +52,16 @@ def batch_norm(g, input, weight, bias, running_mean, running_var, training, mome
         new_running_mean.setType(running_mean.type())
         new_running_var.setType(running_var.type())
         return res
+
+
+# https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter#quantized-model-export
+class Quantized:
+    domain = "quantized"
+
+    @staticmethod
+    def hardswish(g, x, op_scale, op_zero_point):
+        x, x_s, x_zp = sym_help._dequantize_helper(g, x)
+
+        output = hardswish(g, x)
+
+        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -60,8 +60,8 @@ class Quantized:
 
     @staticmethod
     def hardswish(g, x, op_scale, op_zero_point):
-        x, _, _ = sym_help._dequantize_helper(g, x)
+        x, _, _ = sym_help.dequantize_helper(g, x)
 
         output = hardswish(g, x)
 
-        return sym_help._quantize_helper(g, output, op_scale, op_zero_point)
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1939,7 +1939,7 @@ def hardswish(g, self):
 
 
 # Fixed scale and zero_point, discovered from aten/src/ATen/native/quantized/cpu/qhardsigmoid.cpp
-@quantized_args(True, op_scale=1.0/256.0, op_zero_point=0)
+@quantized_args(True, op_scale=1.0 / 256.0, op_zero_point=0)
 @parse_args("v")
 def hardsigmoid(g, self):
     # Set alpha_f to 1 / 6 to make op equivalent to PyTorch's definition of Hardsigmoid.

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -12,7 +12,7 @@ from functools import partial
 from functools import wraps
 
 import torch.onnx.symbolic_helper as sym_help
-from torch.onnx.symbolic_helper import parse_args, _parse_arg, _unimplemented, ScalarType
+from torch.onnx.symbolic_helper import parse_args, _parse_arg, _unimplemented, ScalarType, quantized_args
 
 from typing import Optional
 from sys import maxsize as maxsize
@@ -920,7 +920,23 @@ def _avg_pool(name, tuple_fn):
                       strides_i=tuple_fn(stride),
                       pads_i=padding)
         return output
-    return symbolic_fn
+
+    sym_fn = symbolic_fn
+
+    def quant_wrapper(g, *args):
+        input = args[0]
+        if input.node().kind() == "prim::TupleConstruct":
+            # input_value, input_scale, input_zero_point = sym_help._unpack_tuple(input)
+            # input = sym_help._dequantize_helper(g, input_value, input_scale, input_zero_point)
+            input, input_scale, input_zero_point = sym_help._dequantize_helper(g, input)
+
+            output = sym_fn(g, input, *args[1:])
+
+            return sym_help._quantize_helper(g, output, input_scale, input_zero_point)
+        else:
+            return sym_fn
+
+    return quant_wrapper
 
 
 avg_pool1d = _avg_pool("avg_pool1d", _single)
@@ -971,7 +987,23 @@ def _adaptive_pool(name, type, tuple_fn, fn=None):
                       kernel_shape_i=tuple_fn(k),
                       strides_i=tuple_fn(k))
         return output
-    return symbolic_fn
+
+    sym_fn = symbolic_fn
+
+    def quant_wrapper(g, *args):
+        input = args[0]
+        if input.node().kind() == "prim::TupleConstruct":
+            # input_value, input_scale, input_zero_point = sym_help._unpack_tuple(input)
+            # input = sym_help._dequantize_helper(g, input_value, input_scale, input_zero_point)
+            input, input_scale, input_zero_point = sym_help._dequantize_helper(g, input)
+
+            output = sym_fn(g, input, *args[1:])
+
+            return sym_help._quantize_helper(g, output, input_scale, input_zero_point)
+        else:
+            return sym_fn(g, *args)
+
+    return quant_wrapper
 
 
 adaptive_avg_pool1d = _adaptive_pool("adaptive_avg_pool1d", "AveragePool", _single)
@@ -1937,6 +1969,8 @@ def hardswish(g, self):
     return g.op("Mul", self, hs)
 
 
+# Fixed scale and zero_point, discovered from aten/src/ATen/native/quantized/cpu/qhardsigmoid.cpp
+@quantized_args(True, op_scale=1.0/256.0, op_zero_point=0)
 @parse_args("v")
 def hardsigmoid(g, self):
     # Set alpha_f to 1 / 6 to make op equivalent to PyTorch's definition of Hardsigmoid.
@@ -2501,6 +2535,7 @@ def erf(g, input):
     return g.op("Erf", input)
 
 
+@quantized_args(True, False, False)
 @parse_args("v", "i", "i")
 def flatten(g, input, start_dim, end_dim):
     dim = sym_help._get_tensor_rank(input)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1939,7 +1939,7 @@ def hardswish(g, self):
 
 
 # Fixed scale and zero_point, discovered from aten/src/ATen/native/quantized/cpu/qhardsigmoid.cpp
-@quantized_args(True, op_scale=1.0 / 256.0, op_zero_point=0)
+@quantized_args(True, scale=1.0 / 256.0, zero_point=0)
 @parse_args("v")
 def hardsigmoid(g, self):
     # Set alpha_f to 1 / 6 to make op equivalent to PyTorch's definition of Hardsigmoid.

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -920,23 +920,7 @@ def _avg_pool(name, tuple_fn):
                       strides_i=tuple_fn(stride),
                       pads_i=padding)
         return output
-
-    sym_fn = symbolic_fn
-
-    def quant_wrapper(g, *args):
-        input = args[0]
-        if input.node().kind() == "prim::TupleConstruct":
-            # input_value, input_scale, input_zero_point = sym_help._unpack_tuple(input)
-            # input = sym_help._dequantize_helper(g, input_value, input_scale, input_zero_point)
-            input, input_scale, input_zero_point = sym_help._dequantize_helper(g, input)
-
-            output = sym_fn(g, input, *args[1:])
-
-            return sym_help._quantize_helper(g, output, input_scale, input_zero_point)
-        else:
-            return sym_fn
-
-    return quant_wrapper
+    return symbolic_fn
 
 
 avg_pool1d = _avg_pool("avg_pool1d", _single)
@@ -945,6 +929,7 @@ avg_pool3d = _avg_pool("avg_pool3d", _triple)
 
 
 def _adaptive_pool(name, type, tuple_fn, fn=None):
+    @quantized_args(True, False)
     def symbolic_fn(g, input, output_size):
         # _adaptive_pool is supported for cases where output_size is 1 for all dimensions,
         # by executing a GlobalPool.
@@ -987,23 +972,7 @@ def _adaptive_pool(name, type, tuple_fn, fn=None):
                       kernel_shape_i=tuple_fn(k),
                       strides_i=tuple_fn(k))
         return output
-
-    sym_fn = symbolic_fn
-
-    def quant_wrapper(g, *args):
-        input = args[0]
-        if input.node().kind() == "prim::TupleConstruct":
-            # input_value, input_scale, input_zero_point = sym_help._unpack_tuple(input)
-            # input = sym_help._dequantize_helper(g, input_value, input_scale, input_zero_point)
-            input, input_scale, input_zero_point = sym_help._dequantize_helper(g, input)
-
-            output = sym_fn(g, input, *args[1:])
-
-            return sym_help._quantize_helper(g, output, input_scale, input_zero_point)
-        else:
-            return sym_fn(g, *args)
-
-    return quant_wrapper
+    return symbolic_fn
 
 
 adaptive_avg_pool1d = _adaptive_pool("adaptive_avg_pool1d", "AveragePool", _single)

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -131,15 +131,14 @@ class UnsupportedOperatorError(RuntimeError):
     def __init__(self, domain, opname, version):
         supported_version = get_op_supported_version(opname, domain, version)
         if domain in ["", "aten", "prim", "quantized"]:
-            msg = ("Exporting the operator {}::{} to ONNX opset version {} is not supported. "
-                   .format(domain, opname, version))
+            msg = f"Exporting the operator {domain}::{opname} to ONNX opset version {version} is not supported. "
             if supported_version is not None:
-                msg += ("Support for this operator was added in version {}, "
-                        "try exporting with this version.".format(supported_version))
+                msg += (f"Support for this operator was added in version {supported_version}, "
+                         "try exporting with this version.")
             else:
                 msg += "Please feel free to request support or submit a pull request on PyTorch GitHub."
         else:
-            msg = ("ONNX export failed on an operator with unrecognized namespace {}::{}. "
-                   "If you are trying to export a custom operator, make sure you registered "
-                   "it with the right domain and version.".format(domain, opname))
+            msg = (f"ONNX export failed on an operator with unrecognized namespace {domain}::{opname}. "
+                    "If you are trying to export a custom operator, make sure you registered "
+                    "it with the right domain and version.")
         super().__init__(msg)

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -134,11 +134,11 @@ class UnsupportedOperatorError(RuntimeError):
             msg = f"Exporting the operator {domain}::{opname} to ONNX opset version {version} is not supported. "
             if supported_version is not None:
                 msg += (f"Support for this operator was added in version {supported_version}, "
-                         "try exporting with this version.")
+                        "try exporting with this version.")
             else:
                 msg += "Please feel free to request support or submit a pull request on PyTorch GitHub."
         else:
             msg = (f"ONNX export failed on an operator with unrecognized namespace {domain}::{opname}. "
-                    "If you are trying to export a custom operator, make sure you registered "
-                    "it with the right domain and version.")
+                   "If you are trying to export a custom operator, make sure you registered "
+                   "it with the right domain and version.")
         super().__init__(msg)

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -131,7 +131,8 @@ class UnsupportedOperatorError(RuntimeError):
     def __init__(self, domain, opname, version):
         supported_version = get_op_supported_version(opname, domain, version)
         if domain in ["", "aten", "prim", "quantized"]:
-            msg = "Exporting the operator " + opname + " to ONNX opset version " + str(version) + " is not supported. "
+            msg = "Exporting the operator " + domain + "::" + opname + " to ONNX opset version " + \
+                  str(version) + " is not supported. "
             if supported_version is not None:
                 msg += "Support for this operator was added in version " + str(supported_version) + \
                        ", try exporting with this version."

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -131,11 +131,11 @@ class UnsupportedOperatorError(RuntimeError):
     def __init__(self, domain, opname, version):
         supported_version = get_op_supported_version(opname, domain, version)
         if domain in ["", "aten", "prim", "quantized"]:
-            msg = "Exporting the operator " + domain + "::" + opname + " to ONNX opset version " + \
-                  str(version) + " is not supported. "
+            msg = ("Exporting the operator {}::{} to ONNX opset version {} is not supported. "
+                   .format(domain, opname, version))
             if supported_version is not None:
-                msg += "Support for this operator was added in version " + str(supported_version) + \
-                       ", try exporting with this version."
+                msg += ("Support for this operator was added in version {}, "
+                        "try exporting with this version.".format(supported_version))
             else:
                 msg += "Please feel free to request support or submit a pull request on PyTorch GitHub."
         else:

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -104,21 +104,6 @@ def exporter_context(model, mode):
         yield (mode_ctx, apex_ctx)
 
 
-def _quantize_wrapper(symbolic_func):
-    from symbolic_helper import _dequantize_helper, _quantize_helper
-    def wrapper(g, *args, **kwargs):
-        is_quantized_arg = len(args) > 0 and args[0].node().kind() == "prim::TupleConstruct"
-
-        if is_quantized_arg:
-            x, x_scale, x_zero_point = _dequantize_helper(g, args[0])
-            output = symbolic_func(g, x, *args[1:], **kwargs)
-            return _quantize_helper(g, output, x_scale, x_zero_point)
-        else:
-            return symbolic_func(g, *args, **kwargs)
-
-    return wrapper
-
-
 def export(model, args, f, export_params=True, verbose=False, training=None,
            input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
            opset_version=None, do_constant_folding=True, dynamic_axes=None,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -104,6 +104,21 @@ def exporter_context(model, mode):
         yield (mode_ctx, apex_ctx)
 
 
+def _quantize_wrapper(symbolic_func):
+    from symbolic_helper import _dequantize_helper, _quantize_helper
+    def wrapper(g, *args, **kwargs):
+        is_quantized_arg = len(args) > 0 and args[0].node().kind() == "prim::TupleConstruct"
+
+        if is_quantized_arg:
+            x, x_scale, x_zero_point = _dequantize_helper(g, args[0])
+            output = symbolic_func(g, x, *args[1:], **kwargs)
+            return _quantize_helper(g, output, x_scale, x_zero_point)
+        else:
+            return symbolic_func(g, *args, **kwargs)
+
+    return wrapper
+
+
 def export(model, args, f, export_params=True, verbose=False, training=None,
            input_names=None, output_names=None, operator_export_type=OperatorExportTypes.ONNX,
            opset_version=None, do_constant_folding=True, dynamic_axes=None,


### PR DESCRIPTION
* Add infrastructure and helper functions to enable future work for other quantized operators and models.
* Add export for quantized operators needed by torchvision mobilenet v3 large.
    * ATen namespace: hardsigmoid, flatten, adaptive_avg_pool, quantize_per_tensor, dequantize.
    * Quantized namespace: conv2d, conv2d_relu, hardswish, add, mul.
* Numerous bug fixes, in unpack_quantized_weight.cpp, symbolic functions, and unit test. 