### PR TITLE
[PyTorch] MHA: remove TODO about transposing second arg to linear()

### DIFF
--- a/aten/src/ATen/native/attention.cpp
+++ b/aten/src/ATen/native/attention.cpp
@@ -190,7 +190,6 @@ Tensor transform_0213(const Tensor& a) {
 
 Tensor gemm_nt_bias(const Tensor& a, const Tensor& b, const Tensor& c) {
   auto a_ = a.view({a.size(0) * a.size(1), a.size(2)});
-  // TODO: should be b.transpose(1, 0)?
   auto r_ = at::native::linear(a_, b, c);
   return r_.view({a.size(0), a.size(1), r_.size(1)});
 }

--- a/aten/src/ATen/native/cuda/attention.cu
+++ b/aten/src/ATen/native/cuda/attention.cu
@@ -203,7 +203,6 @@ Tensor transform_0213(const Tensor& a) {
 
 Tensor gemm_nt_bias(const Tensor& a, const Tensor& b, const Tensor& c) {
   auto a_ = a.view({a.size(0) * a.size(1), a.size(2)});
-  // TODO: should be b.transpose(1, 0)?
   auto r_ = at::native::linear(a_, b, c);
   return r_.view({a.size(0), a.size(1), r_.size(1)});
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72229

linear() transposes its second argument internally.

Differential Revision: [D33962112](https://our.internmc.facebook.com/intern/diff/D33962112/)