### PR TITLE
[PTE] Adding `prim::to_list` to be emitted

### DIFF
--- a/torch/csrc/jit/runtime/interpreter/code_impl.h
+++ b/torch/csrc/jit/runtime/interpreter/code_impl.h
@@ -755,6 +755,9 @@ struct CodeImpl {
       case prim::NumToTensor:
         emitOperatorOrInstruction(node, NUM_TO_TENSOR);
         break;
+      case prim::tolist:
+        emitOperatorOrInstruction(node, TO_LIST);
+        break;
     }
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72238

Adding missed operator to be emitted either as operator (version 7 and below) and as an instruction (version 8 and above)

Differential Revision: [D33970756](https://our.internmc.facebook.com/intern/diff/D33970756/)