### PR TITLE
[quant][fix][performance] Remove model.recompile to speedup convert

### DIFF
--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -92,7 +92,6 @@ def _lower_weighted_ref_module(model: QuantizedGraphModule) -> QuantizedGraphMod
             model.graph.erase_node(q_node)
             model.graph.erase_node(scale_node)
             model.graph.erase_node(zero_point_node)
-        model.recompile()
     return model
 
 def special_pattern_replacement(model: QuantizedGraphModule) -> QuantizedGraphModule:
@@ -129,8 +128,6 @@ def special_pattern_replacement(model: QuantizedGraphModule) -> QuantizedGraphMo
                     model.graph.erase_node(scale_node)
                     model.graph.erase_node(zero_point_node)
 
-
-    model.recompile()
     return model
 
 def _lower_to_native_backend(model: QuantizedGraphModule) -> QuantizedGraphModule:
@@ -140,7 +137,8 @@ def _lower_to_native_backend(model: QuantizedGraphModule) -> QuantizedGraphModul
     """
     model = _lower_weighted_ref_module(model)
     for pattern, replacement in get_fbgemm_patterns_and_replacements():
-        subgraph_rewriter_FORKED_DO_NOT_USE.replace_pattern(model, pattern, replacement)
+        subgraph_rewriter_FORKED_DO_NOT_USE.replace_pattern(model, pattern, replacement, recompile=False)
     special_pattern_replacement(model)
     model.graph.lint()
+    model.recompile()
     return model

--- a/torch/ao/quantization/fx/convert.py
+++ b/torch/ao/quantization/fx/convert.py
@@ -144,66 +144,53 @@ def fold_weight(
     quantized = QuantizedGraphModule(quantized_root, folded_graph, quantized_root.preserved_attr_names)
     return quantized
 
-def remove_quant_dequant_pairs(quantized: QuantizedGraphModule) -> QuantizedGraphModule:
-    quantized_root = quantized
-    for node in quantized.graph.nodes:
+def remove_quant_dequant_pairs(quantized_graph: Graph):
+    for node in quantized_graph.nodes:
         if node.op == "call_function" and node.target in [torch.quantize_per_tensor, torch.quantize_per_channel]:
             users = list(node.users)
             user = users[0] if users else None
             if len(users) == 1 and user.op == "call_method" and user.target == "dequantize":
                 user.replace_all_uses_with(node.args[0])
-                quantized.graph.erase_node(user)
+                quantized_graph.erase_node(user)
                 orig_args = list(node.args)
-                quantized.graph.erase_node(node)
+                quantized_graph.erase_node(node)
                 for arg in orig_args:
                     if isinstance(arg, Node) and len(list(arg.users)) == 0:
-                        quantized.graph.erase_node(arg)
+                        quantized_graph.erase_node(arg)
 
-    quantized = QuantizedGraphModule(quantized_root, quantized.graph, quantized_root.preserved_attr_names)
-    return quantized
-
-def duplicate_dequantize_node(quantized: QuantizedGraphModule) -> QuantizedGraphModule:
+def duplicate_dequantize_node(quantized_graph: Graph):
     """
     If a dequantize node has multiple uses, duplicate it and create one dequantize node for each use.
     This is to enable the pattern matching to map from individual quant - dequant - ref_module to
     final quantized module.
     """
-    quantized_root = quantized
-    for node in quantized.graph.nodes:
+    for node in quantized_graph.nodes:
         if (node.op == "call_method" and node.target == "dequantize" or
            (node.op == "call_function" and node.target == torch.dequantize)):
             users = list(node.users)
             if len(users) > 1:
                 for user in users:
-                    with quantized.graph.inserting_before(node):
-                        new_node = quantized.graph.create_node("call_method", "dequantize", node.args, {})
+                    with quantized_graph.inserting_before(node):
+                        new_node = quantized_graph.create_node("call_method", "dequantize", node.args, {})
                     user.replace_input_with(node, new_node)
-                quantized.graph.erase_node(node)
+                quantized_graph.erase_node(node)
 
-    quantized = QuantizedGraphModule(quantized_root, quantized.graph, quantized_root.preserved_attr_names)
-    return quantized
-
-def remove_extra_dequantize(quantized: QuantizedGraphModule) -> QuantizedGraphModule:
+def remove_extra_dequantize(quantized_graph: Graph):
     """
     Removes duplicate dequant nodes in the graph, for an operator that has multiple dequant nodes as a user,
     replace them with a single dequant node that can be shared across all the uses.
     """
-    quantized_root = quantized
-    for node in quantized.graph.nodes:
+    for node in quantized_graph.nodes:
         users = list(node.users)
         dequant_users = [user for user in node.users if user.op == "call_method" and user.target == "dequantize" or
                          (user.op == "call_function" and user.target == torch.dequantize)]
 
         if len(dequant_users) > 1:
-            with quantized.graph.inserting_after(node):
-                unique_dq = quantized.graph.create_node("call_method", "dequantize", users[0].args, {})
+            with quantized_graph.inserting_after(node):
+                unique_dq = quantized_graph.create_node("call_method", "dequantize", users[0].args, {})
             for dequant in dequant_users:
                 dequant.replace_all_uses_with(unique_dq)
-                quantized.graph.erase_node(dequant)
-
-    quantized = QuantizedGraphModule(quantized_root, quantized.graph, quantized_root.preserved_attr_names)
-    return quantized
-
+                quantized_graph.erase_node(dequant)
 
 def restore_state(
         observed: torch.nn.Module
@@ -644,9 +631,10 @@ def convert(model: GraphModule, is_reference: bool = False,
     preserved_attributes = set(convert_custom_config_dict.get("preserved_attributes", []))
     model = QuantizedGraphModule(model, act_post_process_removed_graph, preserved_attributes)
     if not is_reference:
-        model = duplicate_dequantize_node(model)
+        duplicate_dequantize_node(model.graph)
         model = fold_weight(model, node_name_to_scope)
         model = lower_to_fbgemm(model)
-        model = remove_quant_dequant_pairs(model)
-        model = remove_extra_dequantize(model)
+        remove_quant_dequant_pairs(model.graph)
+        remove_extra_dequantize(model.graph)
+        model.recompile()
     return model

--- a/torch/ao/quantization/fx/subgraph_rewriter_FORKED_DO_NOT_USE.py
+++ b/torch/ao/quantization/fx/subgraph_rewriter_FORKED_DO_NOT_USE.py
@@ -132,7 +132,7 @@ def _replace_submodules(gm: GraphModule, replacement: torch.nn.Module) -> None:
     gm.graph.lint()
 
 @compatibility(is_backward_compatible=True)
-def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -> List[Match]:
+def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable, recompile: bool=True) -> List[Match]:
     """
     Matches all possible non-overlapping sets of operators and their
     data dependencies (``pattern``) in the Graph of a GraphModule
@@ -435,7 +435,8 @@ def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable) -
 
     # Update the passed-in GraphModule to reflect the new state of
     # `original_graph`
-    gm.recompile()
+    if recompile:
+        gm.recompile()
 
     # If `replacement` was an nn.Module, we'll need to make sure that
     # all the submodules have been copied over correctly

--- a/torch/ao/quantization/fx/subgraph_rewriter_FORKED_DO_NOT_USE.py
+++ b/torch/ao/quantization/fx/subgraph_rewriter_FORKED_DO_NOT_USE.py
@@ -132,7 +132,7 @@ def _replace_submodules(gm: GraphModule, replacement: torch.nn.Module) -> None:
     gm.graph.lint()
 
 @compatibility(is_backward_compatible=True)
-def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable, recompile: bool=True) -> List[Match]:
+def replace_pattern(gm: GraphModule, pattern: Callable, replacement: Callable, recompile: bool = True) -> List[Match]:
     """
     Matches all possible non-overlapping sets of operators and their
     data dependencies (``pattern``) in the Graph of a GraphModule


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72241

Summary:
convert_fx runs slowly after a recent operator overload change, we suspect that it's because the recompile calls
removing some recompile calls to see if it fixes the problem

Test Plan:
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D33971264](https://our.internmc.facebook.com/intern/diff/D33971264)