### PR TITLE
Fix backwardcompat definitions after #72200

### DIFF
--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -109,6 +109,7 @@ ALLOW_LIST = [
     ("aten::nanquantile", datetime.date(2022, 9, 30)),
     ("aten::_convolution_double_backward", datetime.date(2022, 3, 31)),
     ("aten::_scatter_reduce", datetime.date(2022, 1, 31)),
+    ("aten::native_multi_head_self_attention", datetime.date(9999, 1, 1)),    
 ]
 
 ALLOW_LIST_COMPILED = [


### PR DESCRIPTION
Adds `aten::native_multi_head_self_attention` to allowlist
