### PR TITLE
[DataPipe] Extend FileLister to support load multiple directories

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -291,6 +291,14 @@ class TestIterableDataPipeBasic(TestCase):
             self.assertTrue((pathname in self.temp_files) or (pathname in self.temp_sub_files))
         self.assertEqual(count, len(self.temp_files) + len(self.temp_sub_files))
 
+        temp_files = self.temp_files
+        datapipe = dp.iter.FileLister([temp_dir, *temp_files])
+        count = 0
+        for pathname in datapipe:
+            count += 1
+            self.assertTrue(pathname in self.temp_files)
+        self.assertEqual(count, 2 * len(self.temp_files))
+
     def test_listdirfilesdeterministic_iterable_datapipe(self):
         temp_dir = self.temp_dir.name
 

--- a/torch/utils/data/datapipes/iter/__init__.py
+++ b/torch/utils/data/datapipes/iter/__init__.py
@@ -1,3 +1,6 @@
+from torch.utils.data.datapipes.iter.utils import (
+    IterableWrapperIterDataPipe as IterableWrapper,
+)
 from torch.utils.data.datapipes.iter.callable import (
     CollatorIterDataPipe as Collator,
     MapperIterDataPipe as Mapper,
@@ -34,9 +37,6 @@ from torch.utils.data.datapipes.iter.selecting import (
 )
 from torch.utils.data.datapipes.iter.streamreader import (
     StreamReaderIterDataPipe as StreamReader,
-)
-from torch.utils.data.datapipes.iter.utils import (
-    IterableWrapperIterDataPipe as IterableWrapper,
 )
 
 __all__ = ['Batcher',

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -53,18 +53,26 @@ def get_file_pathnames_from_root(
         warnings.warn(err.filename + " : " + err.strerror)
         raise err
 
-    for path, dirs, files in os.walk(root, onerror=onerror):
+    if os.path.isfile(root):
+        path = root
         if abspath:
             path = os.path.abspath(path)
-        if not non_deterministic:
-            files.sort()
-        for f in files:
-            if match_masks(f, masks):
-                yield os.path.join(path, f)
-        if not recursive:
-            break
-        if not non_deterministic:
-            dirs.sort()
+        fname = os.path.basename(path)
+        if match_masks(fname, masks):
+            yield path
+    else:
+        for path, dirs, files in os.walk(root, onerror=onerror):
+            if abspath:
+                path = os.path.abspath(path)
+            if not non_deterministic:
+                files.sort()
+            for f in files:
+                if match_masks(f, masks):
+                    yield os.path.join(path, f)
+            if not recursive:
+                break
+            if not non_deterministic:
+                dirs.sort()
 
 
 def get_file_binaries_from_pathnames(pathnames: Iterable, mode: str):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#72260 [DataPipe] Extend FileLister to support load multiple directories**

Change `FileLister` to support single directory, multiple directories and files. This is needed for TorchAudio revamping especially for `OnDiskCacheHolder`

Differential Revision: [D33979744](https://our.internmc.facebook.com/intern/diff/D33979744)