### PR TITLE
[Caffe2] Use more irange()s in loops.

### DIFF
--- a/aten/src/ATen/core/DeprecatedTypePropertiesRegistry.cpp
+++ b/aten/src/ATen/core/DeprecatedTypePropertiesRegistry.cpp
@@ -1,6 +1,7 @@
 #include <ATen/core/DeprecatedTypePropertiesRegistry.h>
 
 #include <ATen/core/DeprecatedTypeProperties.h>
+#include <c10/util/irange.h>
 
 namespace at {
 
@@ -9,8 +10,8 @@ void DeprecatedTypePropertiesDeleter::operator()(DeprecatedTypeProperties * ptr)
 }
 
 DeprecatedTypePropertiesRegistry::DeprecatedTypePropertiesRegistry() {
-  for (int b = 0; b < static_cast<int>(Backend::NumOptions); ++b) {
-    for (int s = 0; s < static_cast<int>(ScalarType::NumOptions); ++s) {
+  for (const auto b : c10::irange(static_cast<int>(Backend::NumOptions))) {
+    for (const auto s : c10::irange(static_cast<int>(ScalarType::NumOptions))) {
       registry[b][s] = std::make_unique<DeprecatedTypeProperties>(
               static_cast<Backend>(b),
               static_cast<ScalarType>(s));

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -173,7 +173,7 @@ static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t line
     for (const auto l : c10::irange(self.size(0))) {
       Tensor row = self.select(0,l);
       double *row_ptr = row.data_ptr<double>();
-      for(int64_t c = firstColumn; c < lastColumn+1; c++) {
+      for (const auto c : c10::irange(firstColumn, lastColumn+1)) {
         stream << std::setw(sz) << row_ptr[c]/scale;
         if(c == lastColumn) {
           stream << std::endl;
@@ -226,7 +226,7 @@ void __printTensor(std::ostream& stream, Tensor& self, int64_t linesize)
     }
     stream << "(";
     Tensor tensor = self;
-    for(int64_t i=0; i < self.ndimension()-2; i++) {
+    for (const auto i : c10::irange(self.ndimension()-2)) {
       tensor = tensor.select(0, counter[i]);
       stream << counter[i]+1 << ",";
     }

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
@@ -1,4 +1,5 @@
 #include <ATen/core/dispatch/DispatchKeyExtractor.h>
+#include <c10/util/irange.h>
 
 #include <sstream>
 
@@ -14,7 +15,7 @@ void DispatchKeyExtractor::setOperatorHasFallthroughForKey(DispatchKey k, bool h
 
 std::string DispatchKeyExtractor::dumpState() const {
   std::ostringstream oss;
-  for (size_t i=0; i < c10::utils::bitset::NUM_BITS(); ++i) {
+  for (const auto i : c10::irange(c10::utils::bitset::NUM_BITS())) {
     if (dispatch_arg_indices_reverse_.get(i)) {
       oss << "1";
     } else {

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -344,7 +344,7 @@ struct FunctionSchema {
   }
 
   c10::optional<int> argumentIndexWithName(c10::string_view name) const {
-    for(size_t i = 0; i < arguments().size(); ++i) {
+    for (const auto i : c10::irange(arguments().size())) {
       if(name == arguments()[i].name())
         return i;
     }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -5,6 +5,8 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
+
 #if defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
 #include <sleef.h>
 #endif
@@ -764,7 +766,7 @@ inline void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>& ou
 #else // defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
 inline void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>& out) {
   __at_align__ float values[Vectorized<float>::size()];
-  for (int k = 0; k < Vectorized<float>::size(); ++k) {
+  for (const auto k : c10::irange(Vectorized<float>::size())) {
     values[k] = data[k];
   }
   out = Vectorized<float>::loadu(values);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -88,7 +88,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < 2*size(); ++i) {
+    for (const auto i : c10::irange(2*size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -123,7 +123,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < 2*size(); ++i) {
+    for (const auto i : c10::irange(2*size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -902,7 +902,7 @@ Vectorized<c10::qint32> inline operator*(
     const Vectorized<c10::qint32>& a,
     const Vectorized<c10::qint32>& b) {
   Vectorized<c10::qint32> retval;
-  for (size_t i = 0; i < std::decay_t<decltype(a)>::size(); ++i) {
+  for (const auto i : c10::irange(std::decay_t<decltype(a)>::size())) {
     retval.vals[i] = a.vals[i] * b.vals[i];
   }
   return retval;
@@ -913,7 +913,7 @@ Vectorized<c10::qint32> inline operator+(
     const Vectorized<c10::qint32>& a,
     const Vectorized<c10::qint32>& b) {
   Vectorized<c10::qint32> retval;
-  for (size_t i = 0; i < std::decay_t<decltype(a)>::size(); ++i) {
+  for (const auto i : c10::irange(std::decay_t<decltype(a)>::size())) {
     retval.vals[i] = a.vals[i] + b.vals[i];
   }
   return retval;

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_bfloat16_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_bfloat16_vsx.h
@@ -3,6 +3,8 @@
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec256/vsx/vsx_helpers.h>
 #include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
+
 namespace at {
 namespace vec {
 // See Note [CPU_CAPABILITY namespace]
@@ -34,7 +36,7 @@ inline Vectorized<BFloat16> convert_float_bfloat16(
 
 inline void load_fp32_from_bf16(const c10::BFloat16* data, Vectorized<float>& out) {
   __at_align__ float values[Vectorized<float>::size()];
-  for (int k = 0; k < Vectorized<float>::size(); ++k) {
+  for (const auto k : c10::irange(Vectorized<float>::size())) {
     values[k] = data[k];
   }
   out = Vectorized<float>::loadu(values);

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_double_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_double_vsx.h
@@ -3,6 +3,8 @@
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 #include <ATen/cpu/vec/vec256/vsx/vsx_helpers.h>
+#include <c10/util/irange.h>
+
 #include <sleef.h>
 
 namespace at {
@@ -190,10 +192,10 @@ class Vectorized<double> {
   double& operator[](int idx) = delete;
   Vectorized<double> map(double (*const f)(double)) const {
     Vectorized<double> ret;
-    for (int i = 0; i < size()/2; i++) {
+    for (const auto i : c10::irange(size()/2)) {
         ret._vec0[i] = f(_vec0[i]);
     }
-    for (int i = 0; i < size()/2; i++) {
+    for (const auto i : c10::irange(size()/2)) {
         ret._vec1[i] = f(_vec1[i]);
     }
     return ret;
@@ -202,10 +204,10 @@ class Vectorized<double> {
   Vectorized<double> mapbi(double (*const f)(double, double), const Vectorized<double>& other)
       const {
     Vectorized<double> ret;
-    for (int i = 0; i < size()/2; i++) {
+    for (const auto i : c10::irange(size()/2)) {
         ret._vec0[i] = f(_vec0[i], other._vec0[i]);
     }
-    for (int i = 0; i < size()/2; i++) {
+    for (const auto i : c10::irange(size()/2)) {
         ret._vec1[i] = f(_vec1[i], other._vec1[i]);
     }
     return ret;

--- a/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
@@ -5,6 +5,8 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
+
 #if defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
 #include <sleef.h>
 #endif
@@ -865,7 +867,7 @@ inline void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>& ou
 #else // defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
 inline void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>& out) {
   __at_align__ float values[Vectorized<float>::size()];
-  for (int k = 0; k < Vectorized<float>::size(); ++k) {
+  for (const auto k : c10::irange(Vectorized<float>::size())) {
     values[k] = data[k];
   }
   out = Vectorized<float>::loadu(values);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
@@ -127,7 +127,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < 2*size(); ++i) {
+    for (const auto i : c10::irange(2*size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
@@ -632,7 +632,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < 2*size(); ++i) {
+    for (const auto i : c10::irange(2*size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -909,7 +909,7 @@ Vectorized<c10::qint32> inline operator*(
     const Vectorized<c10::qint32>& a,
     const Vectorized<c10::qint32>& b) {
   Vectorized<c10::qint32> retval;
-  for (size_t i = 0; i < std::decay_t<decltype(a)>::size(); ++i) {
+  for (const auto i : c10::irange(std::decay_t<decltype(a)>::size())) {
     retval.vals[i] = a.vals[i] * b.vals[i];
   }
   return retval;
@@ -920,7 +920,7 @@ Vectorized<c10::qint32> inline operator+(
     const Vectorized<c10::qint32>& a,
     const Vectorized<c10::qint32>& b) {
   Vectorized<c10::qint32> retval;
-  for (size_t i = 0; i < std::decay_t<decltype(a)>::size(); ++i) {
+  for (const auto i : c10::irange(std::decay_t<decltype(a)>::size())) {
     retval.vals[i] = a.vals[i] + b.vals[i];
   }
   return retval;

--- a/aten/src/ATen/cuda/PeerToPeerAccess.cpp
+++ b/aten/src/ATen/cuda/PeerToPeerAccess.cpp
@@ -1,6 +1,7 @@
 #include <ATen/cuda/PeerToPeerAccess.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <vector>
 #include <algorithm>
@@ -23,7 +24,7 @@ void init_p2p_access_cache(int64_t num_devices) {
   p2pAccessEnabled_.resize(num_devices * num_devices, -1);
   num_devices_ = num_devices;
 
-  for (int64_t i = 0; i < num_devices; ++i) {
+  for (const auto i : c10::irange(num_devices)) {
     p2pAccessEnabled_[i * num_devices + i] = 1;
   }
 }

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -15,6 +15,7 @@
 #include <ATen/native/cuda/CuFFTPlanCache.h>
 #include <c10/util/Exception.h>
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/util/irange.h>
 
 #if AT_CUDNN_ENABLED()
 #include <ATen/cudnn/cudnn-wrapper.h>
@@ -208,7 +209,7 @@ c10::optional<int64_t> getDeviceIndexWithPrimaryContext() {
       return current_device_index;
     }
   }
-  for (int64_t device_index = 0; device_index < at::cuda::device_count(); device_index++) {
+  for (const auto device_index : c10::irange(at::cuda::device_count())) {
     if (device_index == current_device_index) continue;
     if (hasPrimaryContext(device_index)) {
       return device_index;

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -256,7 +256,7 @@ void apply_linalg_eig(Tensor& values, Tensor& vectors, Tensor& input, Tensor& in
   Tensor work = at::empty({lwork}, input.dtype());
   auto work_data = work.data_ptr<scalar_t>();
 
-  for (auto i = decltype(batch_size){0}; i < batch_size; i++) {
+  for (const auto i : c10::irange(decltype(batch_size){0}, batch_size)) {
     scalar_t* input_working_ptr = &input_data[i * input_matrix_stride];
     scalar_t* values_working_ptr = &values_data[i * values_stride];
     scalar_t* rvectors_working_ptr = compute_eigenvectors ? &rvectors_data[i * input_matrix_stride] : nullptr;

--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -4,6 +4,7 @@
 
 #include <c10/util/SmallBuffer.h>
 #include <c10/util/C++17.h>
+#include <c10/util/irange.h>
 
 #include <climits>
 
@@ -331,7 +332,7 @@ void gemm_batched_generic(
     const scalar_t **b, int64_t ldb,
     scalar_t beta,
     scalar_t **c, int64_t ldc) {
-  for (int64_t batch = 0; batch < batch_size; ++batch) {
+  for (const auto batch : c10::irange(batch_size)) {
     gemm(transa, transb, m, n, k, alpha, a[batch], lda, b[batch], ldb, beta, c[batch], ldc);
   }
 }
@@ -376,7 +377,7 @@ void gemm_batched_with_stride_generic(
     const scalar_t *b, int64_t ldb, int64_t batch_stride_b,
     scalar_t beta,
     scalar_t *c, int64_t ldc, int64_t batch_stride_c) {
-  for (int64_t batch = 0; batch < batch_size; ++batch) {
+  for (const auto batch : c10::irange(batch_size)) {
     const auto a_batch = a + batch_stride_a * batch;
     const auto b_batch = b + batch_stride_b * batch;
     const auto c_batch = c + batch_stride_c * batch;
@@ -405,7 +406,7 @@ void gemm_batched_with_stride(
           c10::SmallBuffer<const scalar_t*, 16> b_ptrs(batch_size);
           c10::SmallBuffer<scalar_t*, 16> c_ptrs(batch_size);
 
-          for (int64_t batch = 0; batch < batch_size; ++batch) {
+          for (const auto batch : c10::irange(batch_size)) {
             a_ptrs[batch] = a + batch_stride_a * batch;
             b_ptrs[batch] = b + batch_stride_b * batch;
             c_ptrs[batch] = c + batch_stride_c * batch;

--- a/aten/src/ATen/native/ConvolutionMM2d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM2d.cpp
@@ -122,7 +122,7 @@ static inline void slow_conv2d_shape_check(
 
   // Allow for empty batch size and channel size but not other dimensions
   TORCH_CHECK(ndim == 4, "Expected 4D input tensor, but got: ", input.sizes());
-  for (int64_t dim = 2; dim < ndim; ++dim) {
+  for (const auto dim : c10::irange(2, ndim)) {
     TORCH_CHECK(input.size(dim) != 0,
                 "Expected non-zero size for input dimension ", dim,
                 ", but got input shape: ", input.sizes(), ". Only the batch and channel dimensions support size 0.");
@@ -444,7 +444,7 @@ static void slow_conv2d_backward_weight_out_cpu_template(
     auto grad_weight_2d_a = grad_weight_2d.accessor<scalar_t, 2>();
     auto finput_a = finput.accessor<scalar_t, 3>();
 
-    for (int64_t t = 0; t < batch_size; t++) {
+    for (const auto t : c10::irange(batch_size)) {
       auto grad_output_t = grad_output_a[t];
       auto finput_t = finput_a[t];
 

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -136,7 +136,7 @@ void fbgemm_spmdm_report_error_(
     int64_t N,
     const index_t* offsets,
     const index_t* indices) {
-  for (int m = 0; m < output_size; ++m) {
+  for (const auto m : c10::irange(output_size)) {
     for (index_t i = offsets[m]; i < offsets[m + 1]; ++i) {
       TORCH_CHECK(i < index_size);
       index_t idx = indices[i];
@@ -927,7 +927,7 @@ static Tensor _embedding_bag_dense_backward_cpu_max(
   auto nonempty_max_indices = max_indices.index_select(0, bag_size.nonzero().view(-1));
   auto nonempty_grad = grad.index_select(0, bag_size.nonzero().view(-1));
 
-  for (int64_t dim = 0; dim < grad.sizes()[1]; dim++) {
+  for (const auto dim : c10::irange(grad.sizes()[1])) {
     index_grad_weight.select(1, dim).index_add_(
       0, nonempty_max_indices.select(1, dim), nonempty_grad.select(1, dim));
   }

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -428,11 +428,11 @@ Tensor _grid_sampler_2d_cpu_quantized(
   uint8_t* out_ptr = (uint8_t*)output.data_ptr<quint8>();
   float* grid_ptr = grid.data_ptr<float>();
   at::parallel_for(0, N, 0, [&](int64_t start, int64_t end) {
-    for (int64_t n = start; n < end; ++n) {
+    for (const auto n : c10::irange(start, end)) {
       float* grid_ptr_N = grid_ptr + n * grid_sN;
       uint8_t* inp_ptr_N = inp_ptr + n * inp_sN;
-      for (int64_t h = 0; h < out_H; ++h) {
-        for (int64_t w = 0; w < out_W; ++w) {
+      for (const auto h : c10::irange(out_H)) {
+        for (const auto w : c10::irange(out_W)) {
           // get the corresponding input x, y, z co-ordinates from grid
           float* grid_ptr_NHW = grid_ptr_N + h * grid_sH + w * grid_sW;
           float x = *grid_ptr_NHW;

--- a/aten/src/ATen/native/IndexingUtils.h
+++ b/aten/src/ATen/native/IndexingUtils.h
@@ -100,13 +100,13 @@ transposeToFront(Tensor self, TensorList indices) {
   std::vector<int64_t> dims;
   std::vector<Tensor> transposedIndices;
   dims.reserve(self.dim());
-  for (auto i = decltype(self.dim()){0}; i < self.dim(); i++) {
+  for (const auto i : c10::irange(decltype(self.dim()){0}, self.dim())) {
     if (indices[i].defined()) {
       dims.push_back(i);
       transposedIndices.emplace_back(indices[i]);
     }
   }
-  for (auto i = decltype(self.dim()){0}; i < self.dim(); i++) {
+  for (const auto i : c10::irange(decltype(self.dim()){0}, self.dim())) {
     if (!indices[i].defined()) {
       dims.push_back(i);
       transposedIndices.emplace_back();
@@ -122,19 +122,19 @@ transposeToFrontAndInvPerm(Tensor self, TensorList indices) {
   std::vector<Tensor> transposedIndices;
   dims.reserve(self.dim());
   invPerm.resize(self.dim());
-  for (auto i = decltype(self.dim()){0}; i < self.dim(); i++) {
+  for (const auto i : c10::irange(decltype(self.dim()){0}, self.dim())) {
     if (indices[i].defined()) {
       dims.push_back(i);
       transposedIndices.emplace_back(indices[i]);
     }
   }
-  for (auto i = decltype(self.dim()){0}; i < self.dim(); i++) {
+  for (const auto i : c10::irange(decltype(self.dim()){0}, self.dim())) {
     if (!indices[i].defined()) {
       dims.push_back(i);
       transposedIndices.emplace_back();
     }
   }
-  for (auto i = decltype(self.dim()){0}; i < self.dim(); i++) {
+  for (const auto i : c10::irange(decltype(self.dim()){0}, self.dim())) {
     invPerm[dims[i]] = i;
   }
   return std::make_tuple(self.permute(dims), std::move(transposedIndices), std::move(invPerm));

--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -345,8 +345,8 @@ static inline void singleCheckErrors(int64_t info, const c10::string_view name, 
  * this function checks if the computation over all these batches has been
  * successful (info = 0) or not, and report in case of the latter.
  */
-static inline void batchCheckErrors(const std::vector<int64_t>& infos, const c10::string_view name) {
-  for (size_t i = 0; i < infos.size(); i++) {
+static inline void batchCheckErrors(const std::vector<int64_t>& infos, const char* name) {
+  for (const auto i : c10::irange(infos.size())) {
     auto info = infos[i];
     singleCheckErrors(info, name, i);
   }
@@ -358,7 +358,7 @@ static inline void batchCheckErrors(const std::vector<int64_t>& infos, const c10
 static inline void batchCheckErrors(const Tensor& infos, const c10::string_view name) {
   auto infos_cpu = infos.to(at::kCPU);
   auto infos_data = infos_cpu.data_ptr<int>();
-  for (int64_t i = 0; i < infos.numel(); i++) {
+  for (const auto i : c10::irange(infos.numel())) {
     auto info = infos_data[i];
     singleCheckErrors(info, name, i);
   }

--- a/aten/src/ATen/native/LossCTC.cpp
+++ b/aten/src/ATen/native/LossCTC.cpp
@@ -118,7 +118,7 @@ std::tuple<Tensor, Tensor> ctc_loss_cpu_template(const Tensor& log_probs, const 
 
       // now the loop over the inputs
       for (const auto t : c10::irange(1, input_length)) {
-        for (int64_t s=0; s<2*target_length+1; s++) {
+        for (const auto s : c10::irange(2*target_length+1)) {
           auto current_target_prime = get_target_prime(targets_data, tg_batch_offset, tg_target_stride, s, BLANK);
           // this loop over s could be parallel/vectorized, too, but the required items are one index apart
           // alternatively, one might consider moving s to the outer loop to cache current_target_prime more (but then it needs to be descending)

--- a/aten/src/ATen/native/MaxUnpooling.cpp
+++ b/aten/src/ATen/native/MaxUnpooling.cpp
@@ -1,6 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/cpu/MaxUnpoolKernel.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -26,7 +27,7 @@ Tensor& max_unpooling2d_forward_out_cpu(
       "Expected shape of indices to be same as that of the input tensor (", self_.sizes(),
       ") but got indices tensor with shape: ", indices_.sizes());
 
-  for (int64_t i = 1; i < self_.ndimension(); ++i) {
+  for (const auto i : c10::irange(1, self_.ndimension())) {
     TORCH_CHECK(self_.size(i) > 0, "max_unpooling2d_forward_out_cpu(): ",
                 "Expected input to have non-zero size for non-batch dimensions, but got ",
                 self_.sizes(), " with dimension ", i , " being empty.");
@@ -93,7 +94,7 @@ static void max_unpooling3d_shape_check(
       "Expected shape of indices to be same as that of the input tensor (", input.sizes(),
       ") but got indices tensor with shape: ", indices.sizes());
 
-  for (int64_t i = 1; i < input.ndimension(); ++i) {
+  for (const auto i : c10::irange(1, input.ndimension())) {
     TORCH_CHECK(input.size(i) > 0, fn_name,
                 ": Expected input to have non-zero size for non-batch dimensions, but got ",
                 input.sizes(), " with dimension ", i , " being empty.");

--- a/aten/src/ATen/native/SegmentReduce.cpp
+++ b/aten/src/ATen/native/SegmentReduce.cpp
@@ -59,7 +59,7 @@ void _segment_reduce_cpu_kernel1(
             }
 
             // ===== step2: apply reduction
-            for (int64_t j = 0; j < lengths_data[i]; ++j) {
+            for (const auto j : c10::irange(lengths_data[i])) {
               int64_t starting_index =
                   ((lengths_cum_sum + j) * stride_count) + l;
               const auto data = values_data[starting_index];
@@ -153,7 +153,7 @@ void _segment_reduce_cpu_backward_kernel1(
             if (reduction == SegmentReductionType::MAX ||
                 reduction == SegmentReductionType::MIN) {
               int64_t counter = 0;
-              for (int64_t j = 0; j < lengths_data[i]; ++j) {
+              for (const auto j : c10::irange(lengths_data[i])) {
                 int64_t starting_index =
                     ((lengths_cum_sum + j) * stride_count) + l;
                 if (at::_isnan(values_data[starting_index]) ||
@@ -167,7 +167,7 @@ void _segment_reduce_cpu_backward_kernel1(
               if (counter < 2) {
                 continue;
               }
-              for (int64_t j = 0; j < lengths_data[i]; ++j) {
+              for (const auto j : c10::irange(lengths_data[i])) {
                 int64_t starting_index =
                     ((lengths_cum_sum + j) * stride_count) + l;
                 if (grad_input_data[starting_index] > 0) {
@@ -177,14 +177,14 @@ void _segment_reduce_cpu_backward_kernel1(
               }
             } else if (reduction == SegmentReductionType::MEAN) {
               auto grad_val = grad_data[output_index] / lengths_data[i];
-              for (int64_t j = 0; j < lengths_data[i]; ++j) {
+              for (const auto j : c10::irange(lengths_data[i])) {
                 int64_t starting_index =
                     ((lengths_cum_sum + j) * stride_count) + l;
                 grad_input_data[starting_index] = grad_val;
               }
             } else if (reduction == SegmentReductionType::SUM) {
               const auto& grad_val = grad_data[output_index];
-              for (int64_t j = 0; j < lengths_data[i]; ++j) {
+              for (const auto j : c10::irange(lengths_data[i])) {
                 int64_t starting_index =
                     ((lengths_cum_sum + j) * stride_count) + l;
                 grad_input_data[starting_index] = grad_val;

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -1296,7 +1296,7 @@ Tensor scatter_reduce_two_cpu(const Tensor& self,
 
   TORCH_CHECK(self.dim() == index.dim(),
       "Shape mismatch between `self` (got ", self.sizes(), ") and `index` (got ", index.sizes(), ")");
-  for (int64_t i = 0; i < self.dim(); i++) {
+  for (const auto i : c10::irange(self.dim())) {
     TORCH_CHECK(self.size(i) == index.size(i),
         "Shape mismatch between `self` (got ", self.sizes(), ") and `index` (got ", index.sizes(), ")");
   }
@@ -1333,18 +1333,17 @@ Tensor scatter_reduce_two_cpu(const Tensor& self,
 
 
     int64_t offset1 = 1, offset2 = 1;
-    for (int64_t d = 0; d < dim; d++)
-      offset1 *= self.size(d);
+    for (const auto d : c10::irange(dim))offset1 *= self.size(d);
     for (int64_t d = dim + 1; d < self.dim(); d++)
       offset2 *= self.size(d);
 
     scalar_t value;
     int64_t dim_index;
-    for (int64_t i = 0; i < offset1; i++) {
-      for (int64_t j = 0; j < self.size(dim); j++) {
-        for (int64_t k = 0; k < offset2; k++) {
-          value = self_data[i * self_cont.stride(dim) * self_cont.size(dim) + j * self_cont.stride(dim) + k];
-          dim_index = index_data[i * index_cont.stride(dim) * index_cont.size(dim) + j * index_cont.stride(dim) + k];
+    for (const auto i : c10::irange(offset1)) {
+      for (const auto j : c10::irange(self.size(dim))) {
+        for (const auto k : c10::irange(offset2)) {
+          value = self_data[i * self.stride(dim) * self.size(dim) + j * self.stride(dim) + k];
+          dim_index = index_data[i * index.stride(dim) * index.size(dim) + j * index.stride(dim) + k];
           TORCH_CHECK(dim_index >= 0 && dim_index < out.size(dim),
               "Expected `index` values to be in range ", 0, " to ", out.size(dim), " (got ", dim_index, ")");
           int64_t ind = i * out_cont.stride(dim) * out_cont.size(dim) + dim_index * out_cont.stride(dim) + k;

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1287,7 +1287,7 @@ Tensor index_select_sparse(const Tensor& self, int64_t dim, const Tensor& index)
     std::vector<int64_t> zindices;
     std::vector<int64_t> iindices;
     int64_t new_nnz = 0;
-    for (int64_t i = 0; i < new_sizes[dim]; i++) {
+    for (const auto i : c10::irange(new_sizes[dim])) {
       int64_t idx = cpu_index_ptr[i];
       if (idx < -size || idx >= size) {
         TORCH_CHECK_INDEX(false, "index_select(): index contains ", idx, " that is out of range for tensor of size ",
@@ -1296,7 +1296,7 @@ Tensor index_select_sparse(const Tensor& self, int64_t dim, const Tensor& index)
       if (idx < 0) {
         idx += size;
       }
-      for (int64_t j = 0; j < nnz; j++) {
+      for (const auto j : c10::irange(nnz)) {
         int64_t jdx = cpu_dim_indices_ptr[j];
         if (idx == jdx) {
           new_nnz++;

--- a/aten/src/ATen/native/TensorShape.h
+++ b/aten/src/ATen/native/TensorShape.h
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -10,7 +11,7 @@ inline void check_cat_shape_except_dim(const Tensor & first, const Tensor & seco
    int64_t second_dims = second.dim();
    TORCH_CHECK(first_dims == second_dims, "Tensors must have same number of dimensions: got ",
                first_dims, " and ", second_dims);
-   for (int64_t dim = 0; dim < first_dims; dim++) {
+   for (const auto dim : c10::irange(first_dims)) {
      if (dim == dimension) {
        continue;
      }

--- a/aten/src/ATen/native/UpSampleBilinear2d.cpp
+++ b/aten/src/ATen/native/UpSampleBilinear2d.cpp
@@ -76,7 +76,7 @@ TORCH_META_FUNC(_upsample_bilinear2d_aa_backward) (
       grad_output.dim() == 4,
       "Expected grad_output to be a tensor of dimension 4 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 4; ++i) {
+  for (const auto i : c10::irange(4)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",

--- a/aten/src/ATen/native/UpSampleNearest2d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest2d.cpp
@@ -72,7 +72,7 @@ TORCH_META_FUNC(_upsample_nearest_exact2d_backward) (
       grad_output.dim() == 4,
       "Expected grad_output to be a tensor of dimension 4 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 4; ++i) {
+  for (const auto i : c10::irange(4)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",

--- a/aten/src/ATen/native/UpSampleNearest3d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest3d.cpp
@@ -81,7 +81,7 @@ TORCH_META_FUNC(_upsample_nearest_exact3d_backward) (
       grad_output.dim() == 5,
       "Expected grad_output to be a tensor of dimension 5 but got: dimension ", grad_output.dim());
 
-  for (int i = 0; i < 5; ++i) {
+  for (const auto i : c10::irange(5)) {
     TORCH_CHECK(
         grad_output.size(i) == full_output_size[i],
         "Expected grad_output to have the same shape as output;",

--- a/aten/src/ATen/native/cpu/HistogramKernel.cpp
+++ b/aten/src/ATen/native/cpu/HistogramKernel.cpp
@@ -80,7 +80,7 @@ void histogramdd_cpu_contiguous(Tensor& hist, const TensorList& bin_edges,
 
     const int64_t D = input.size(1);
     TORCH_INTERNAL_ASSERT(int64_t(bin_edges.size()) == D);
-    for (int64_t dim = 0; dim < D; dim++) {
+    for (const auto dim : c10::irange(D)) {
         TORCH_INTERNAL_ASSERT(bin_edges[dim].is_contiguous());
         TORCH_INTERNAL_ASSERT(hist.size(dim) + 1 == bin_edges[dim].numel());
     }
@@ -103,7 +103,7 @@ void histogramdd_cpu_contiguous(Tensor& hist, const TensorList& bin_edges,
     std::vector<int64_t> num_bin_edges(D);
     std::vector<input_t> leftmost_edge(D), rightmost_edge(D);
 
-    for (int64_t dim = 0; dim < D; dim++) {
+    for (const auto dim : c10::irange(D)) {
         bin_seq[dim] = bin_edges[dim].data_ptr<input_t>();
         num_bin_edges[dim] = bin_edges[dim].numel();
         leftmost_edge[dim] = bin_seq[dim][0];
@@ -138,7 +138,7 @@ void histogramdd_cpu_contiguous(Tensor& hist, const TensorList& bin_edges,
             bool skip_elt = false;
             int64_t hist_index = 0;
 
-            for (int64_t dim = 0; dim < D; dim++) {
+            for (const auto dim : c10::irange(D)) {
                 const input_t elt = accessor_in[i][dim];
 
                 // Skips elements which fall outside the specified bins
@@ -215,7 +215,7 @@ void histogramdd_out_cpu_template(const Tensor& self, const c10::optional<Tensor
             : c10::optional<Tensor>();
 
     std::vector<Tensor> bin_edges_contig(bin_edges.size());
-    for (size_t dim = 0; dim < bin_edges_contig.size(); dim++) {
+    for (const auto dim : c10::irange(bin_edges_contig.size())) {
         bin_edges_contig[dim] = bin_edges[dim].contiguous();
     }
 
@@ -234,7 +234,7 @@ void histogramdd_out_cpu_template(const Tensor& self, const c10::optional<Tensor
          /* For each dimension, divides each bin's value
           * by the bin's length in that dimension.
           */
-        for (int64_t dim = 0; dim < N; dim++) {
+        for (const auto dim : c10::irange(N)) {
             const auto bin_lengths = bin_edges[dim].diff();
 
             // Used to reshape bin_lengths to align with the corresponding dimension of hist.

--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -53,7 +53,7 @@ static inline void vectorized_reduction(char** data, int64_t n, int64_t stride,
     scalar_t buffer[Vec::size()];
     acc[0] = vop(vop(acc[0], acc[1]), vop(acc[2], acc[3]));
     acc[0].store(buffer);
-    for (int j = 1; j < Vec::size(); j++) {
+    for (const auto j : c10::irange(1, Vec::size())) {
       buffer[0] = op(buffer[0], buffer[j]);
     }
     auto dst = (scalar_t*)out_ptr;

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -28,7 +28,7 @@ Vectorized<acc_t> load_reduce_vec(const scalar_t* data, F reduce, acc_t ident) {
   alignas(64) std::array<acc_t, vacc_t::size()> acc;
   acc.fill(ident);
   for (const auto k : c10::irange(vstride)) {
-    for (int i = 0; i < vacc_t::size(); ++i) {
+    for (const auto i : c10::irange(vacc_t::size())) {
       acc[i] = reduce(acc[i], values[i * vstride + k]);
     }
   }
@@ -139,7 +139,7 @@ struct OuterSumCastLoadPolicy {
     val.store(values);
 
     alignas(64) acc_t acc[vacc_t::size()];
-    for (int i = 0; i < vacc_t::size(); ++i) {
+    for (const auto i : c10::irange(vacc_t::size())) {
       acc[i] = values[i];
     }
 

--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -851,7 +851,7 @@ struct HelperInterpNearestExact : public HelperInterpNearest {
         // input_index = round(index_f32)
         // Same as Pillow and Scikit-Image/Scipy ndi.zoom
 
-        for (int64_t i=0; i<output_size; i++) {
+        for (const auto i : c10::irange(output_size)) {
           const scalar_t real_input_index = area_pixel_compute_source_index<scalar_t>(
               scale, i, /*align_corners=*/align_corners, /*cubic=*/false);
           input_index = static_cast<int64_t>(floorf(real_input_index + 0.5));

--- a/aten/src/ATen/native/cuda/Activation.cpp
+++ b/aten/src/ATen/native/cuda/Activation.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/native/Resize.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -145,7 +146,7 @@ std::tuple<Tensor, Tensor> prelu_backward_cuda(const Tensor& grad_out_, const Te
     std::vector<int64_t> reduce_dims;
     reduce_dims.push_back(0);
     if (dims > 2) {
-      for(int64_t i = 2; i < dims; i++) reduce_dims.push_back(i);
+      for (const auto i : c10::irange(2, dims)) reduce_dims.push_back(i);
     }
     weight_grad = weight_grad_collector.sum(reduce_dims);
   }

--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -82,7 +82,7 @@ void _fft_fill_with_conjugate_symmetry_slice(
     // Explicitly loop over a Hermitian mirrored dimension
     if (iter_index[0] > 0) {
       auto end = std::min(signal_half_sizes[0], iter_index[0] + numel_remaining);
-      for (int64_t i = iter_index[0]; i < end; ++i) {
+      for (const auto i : c10::irange(iter_index[0], end)) {
         out_ptr[(signal_half_sizes[0] - i) * out_strides[0]] = std::conj(in_ptr[i * in_strides[0]]);
       }
       numel_remaining -= (end - iter_index[0]);

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -149,7 +149,7 @@ void fbgemm_spmdm_report_error_(
     int64_t N,
     const OffsetType* offsets,
     const IndexType* indices) {
-  for (int m = 0; m < output_size; ++m) {
+  for (const auto m : c10::irange(output_size)) {
     for (OffsetType i = offsets[m]; i < offsets[m + 1]; ++i) {
       TORCH_CHECK(i < index_size);
       IndexType idx = indices[i];


### PR DESCRIPTION
Summary:
Using an explicitly typed loop variable risks type mismatches with the loop
bound; using an const auto variable and c10::irange eliminates this
possibility. This change modifies loops in files under
fbsource/fbcode/caffe2/aten from the format
`for(TYPE var=x0;var<x_max;x++)` to `for(const auto var: irange(xmax))`

This was achieved by running r-barnes's loop upgrader script (D28874212)
modified for the appropriate directory.

Test Plan: arc sanity

Differential Revision: D33952435

