### PR TITLE
[Caffe2] Use more irange()s in loops.

### DIFF
--- a/aten/src/ATen/core/DeprecatedTypePropertiesRegistry.cpp
+++ b/aten/src/ATen/core/DeprecatedTypePropertiesRegistry.cpp
@@ -1,6 +1,7 @@
 #include <ATen/core/DeprecatedTypePropertiesRegistry.h>
 
 #include <ATen/core/DeprecatedTypeProperties.h>
+#include <c10/util/irange.h>
 
 namespace at {
 
@@ -9,8 +10,8 @@ void DeprecatedTypePropertiesDeleter::operator()(DeprecatedTypeProperties * ptr)
 }
 
 DeprecatedTypePropertiesRegistry::DeprecatedTypePropertiesRegistry() {
-  for (int b = 0; b < static_cast<int>(Backend::NumOptions); ++b) {
-    for (int s = 0; s < static_cast<int>(ScalarType::NumOptions); ++s) {
+  for (const auto b : c10::irange(static_cast<int>(Backend::NumOptions))) {
+    for (const auto s : c10::irange(static_cast<int>(ScalarType::NumOptions))) {
       registry[b][s] = std::make_unique<DeprecatedTypeProperties>(
               static_cast<Backend>(b),
               static_cast<ScalarType>(s));

--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -173,7 +173,7 @@ static void __printMatrix(std::ostream& stream, const Tensor& self, int64_t line
     for (const auto l : c10::irange(self.size(0))) {
       Tensor row = self.select(0,l);
       double *row_ptr = row.data_ptr<double>();
-      for(int64_t c = firstColumn; c < lastColumn+1; c++) {
+      for (const auto c : c10::irange(firstColumn, lastColumn+1)) {
         stream << std::setw(sz) << row_ptr[c]/scale;
         if(c == lastColumn) {
           stream << std::endl;
@@ -226,7 +226,7 @@ void __printTensor(std::ostream& stream, Tensor& self, int64_t linesize)
     }
     stream << "(";
     Tensor tensor = self;
-    for(int64_t i=0; i < self.ndimension()-2; i++) {
+    for (const auto i : c10::irange(self.ndimension()-2)) {
       tensor = tensor.select(0, counter[i]);
       stream << counter[i]+1 << ",";
     }

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp
@@ -1,4 +1,5 @@
 #include <ATen/core/dispatch/DispatchKeyExtractor.h>
+#include <c10/util/irange.h>
 
 #include <sstream>
 
@@ -14,7 +15,7 @@ void DispatchKeyExtractor::setOperatorHasFallthroughForKey(DispatchKey k, bool h
 
 std::string DispatchKeyExtractor::dumpState() const {
   std::ostringstream oss;
-  for (size_t i=0; i < c10::utils::bitset::NUM_BITS(); ++i) {
+  for (const auto i : c10::irange(c10::utils::bitset::NUM_BITS())) {
     if (dispatch_arg_indices_reverse_.get(i)) {
       oss << "1";
     } else {

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -344,7 +344,7 @@ struct FunctionSchema {
   }
 
   c10::optional<int> argumentIndexWithName(c10::string_view name) const {
-    for(size_t i = 0; i < arguments().size(); ++i) {
+    for (const auto i : c10::irange(arguments().size())) {
       if(name == arguments()[i].name())
         return i;
     }

--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -5,6 +5,8 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
+
 #if defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
 #include <sleef.h>
 #endif
@@ -764,7 +766,7 @@ inline void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>& ou
 #else // defined(CPU_CAPABILITY_AVX2) && !defined(_MSC_VER)
 inline void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>& out) {
   __at_align__ float values[Vectorized<float>::size()];
-  for (int k = 0; k < Vectorized<float>::size(); ++k) {
+  for (const auto k : c10::irange(Vectorized<float>::size())) {
     values[k] = data[k];
   }
   out = Vectorized<float>::loadu(values);

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -88,7 +88,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < 2*size(); ++i) {
+    for (const auto i : c10::irange(2*size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -123,7 +123,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < 2*size(); ++i) {
+    for (const auto i : c10::irange(2*size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -902,7 +902,7 @@ Vectorized<c10::qint32> inline operator*(
     const Vectorized<c10::qint32>& a,
     const Vectorized<c10::qint32>& b) {
   Vectorized<c10::qint32> retval;
-  for (size_t i = 0; i < std::decay_t<decltype(a)>::size(); ++i) {
+  for (const auto i : c10::irange(std::decay_t<decltype(a)>::size())) {
     retval.vals[i] = a.vals[i] * b.vals[i];
   }
   return retval;
@@ -913,7 +913,7 @@ Vectorized<c10::qint32> inline operator+(
     const Vectorized<c10::qint32>& a,
     const Vectorized<c10::qint32>& b) {
   Vectorized<c10::qint32> retval;
-  for (size_t i = 0; i < std::decay_t<decltype(a)>::size(); ++i) {
+  for (const auto i : c10::irange(std::decay_t<decltype(a)>::size())) {
     retval.vals[i] = a.vals[i] + b.vals[i];
   }
   return retval;

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_bfloat16_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_bfloat16_vsx.h
@@ -3,6 +3,8 @@
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec256/vsx/vsx_helpers.h>
 #include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
+
 namespace at {
 namespace vec {
 // See Note [CPU_CAPABILITY namespace]
@@ -34,7 +36,7 @@ inline Vectorized<BFloat16> convert_float_bfloat16(
 
 inline void load_fp32_from_bf16(const c10::BFloat16* data, Vectorized<float>& out) {
   __at_align__ float values[Vectorized<float>::size()];
-  for (int k = 0; k < Vectorized<float>::size(); ++k) {
+  for (const auto k : c10::irange(Vectorized<float>::size())) {
     values[k] = data[k];
   }
   out = Vectorized<float>::loadu(values);

--- a/aten/src/ATen/cpu/vec/vec256/vsx/vec256_double_vsx.h
+++ b/aten/src/ATen/cpu/vec/vec256/vsx/vec256_double_vsx.h
@@ -3,6 +3,8 @@
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
 #include <ATen/cpu/vec/vec256/vsx/vsx_helpers.h>
+#include <c10/util/irange.h>
+
 #include <sleef.h>
 
 namespace at {
@@ -190,10 +192,10 @@ class Vectorized<double> {
   double& operator[](int idx) = delete;
   Vectorized<double> map(double (*const f)(double)) const {
     Vectorized<double> ret;
-    for (int i = 0; i < size()/2; i++) {
+    for (const auto i : c10::irange(size()/2)) {
         ret._vec0[i] = f(_vec0[i]);
     }
-    for (int i = 0; i < size()/2; i++) {
+    for (const auto i : c10::irange(size()/2)) {
         ret._vec1[i] = f(_vec1[i]);
     }
     return ret;
@@ -202,10 +204,10 @@ class Vectorized<double> {
   Vectorized<double> mapbi(double (*const f)(double, double), const Vectorized<double>& other)
       const {
     Vectorized<double> ret;
-    for (int i = 0; i < size()/2; i++) {
+    for (const auto i : c10::irange(size()/2)) {
         ret._vec0[i] = f(_vec0[i], other._vec0[i]);
     }
-    for (int i = 0; i < size()/2; i++) {
+    for (const auto i : c10::irange(size()/2)) {
         ret._vec1[i] = f(_vec1[i], other._vec1[i]);
     }
     return ret;

--- a/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
@@ -5,6 +5,8 @@
 
 #include <ATen/cpu/vec/intrinsics.h>
 #include <ATen/cpu/vec/vec_base.h>
+#include <c10/util/irange.h>
+
 #if defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
 #include <sleef.h>
 #endif
@@ -865,7 +867,7 @@ inline void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>& ou
 #else // defined(CPU_CAPABILITY_AVX512) && !defined(_MSC_VER)
 inline void load_fp32_from_bf16(const c10::BFloat16 *data, Vectorized<float>& out) {
   __at_align__ float values[Vectorized<float>::size()];
-  for (int k = 0; k < Vectorized<float>::size(); ++k) {
+  for (const auto k : c10::irange(Vectorized<float>::size())) {
     values[k] = data[k];
   }
   out = Vectorized<float>::loadu(values);

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_double.h
@@ -127,7 +127,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < 2*size(); ++i) {
+    for (const auto i : c10::irange(2*size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(

--- a/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_complex_float.h
@@ -632,7 +632,7 @@ public:
     // Ensure uninitialized memory does not change the output value See https://github.com/pytorch/pytorch/issues/32502
     // for more details. We do not initialize arrays to zero using "={0}" because gcc would compile it to two
     // instructions while a loop would be compiled to one instruction.
-    for (auto i = 0; i < 2*size(); ++i) {
+    for (const auto i : c10::irange(2*size())) {
       tmp_values[i] = 0.0;
     }
     std::memcpy(

--- a/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_qint.h
@@ -909,7 +909,7 @@ Vectorized<c10::qint32> inline operator*(
     const Vectorized<c10::qint32>& a,
     const Vectorized<c10::qint32>& b) {
   Vectorized<c10::qint32> retval;
-  for (size_t i = 0; i < std::decay_t<decltype(a)>::size(); ++i) {
+  for (const auto i : c10::irange(std::decay_t<decltype(a)>::size())) {
     retval.vals[i] = a.vals[i] * b.vals[i];
   }
   return retval;
@@ -920,7 +920,7 @@ Vectorized<c10::qint32> inline operator+(
     const Vectorized<c10::qint32>& a,
     const Vectorized<c10::qint32>& b) {
   Vectorized<c10::qint32> retval;
-  for (size_t i = 0; i < std::decay_t<decltype(a)>::size(); ++i) {
+  for (const auto i : c10::irange(std::decay_t<decltype(a)>::size())) {
     retval.vals[i] = a.vals[i] + b.vals[i];
   }
   return retval;

--- a/aten/src/ATen/cuda/PeerToPeerAccess.cpp
+++ b/aten/src/ATen/cuda/PeerToPeerAccess.cpp
@@ -1,6 +1,7 @@
 #include <ATen/cuda/PeerToPeerAccess.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <vector>
 #include <algorithm>
@@ -23,7 +24,7 @@ void init_p2p_access_cache(int64_t num_devices) {
   p2pAccessEnabled_.resize(num_devices * num_devices, -1);
   num_devices_ = num_devices;
 
-  for (int64_t i = 0; i < num_devices; ++i) {
+  for (const auto i : c10::irange(num_devices)) {
     p2pAccessEnabled_[i * num_devices + i] = 1;
   }
 }

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -15,6 +15,7 @@
 #include <ATen/native/cuda/CuFFTPlanCache.h>
 #include <c10/util/Exception.h>
 #include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/util/irange.h>
 
 #if AT_CUDNN_ENABLED()
 #include <ATen/cudnn/cudnn-wrapper.h>
@@ -208,7 +209,7 @@ c10::optional<int64_t> getDeviceIndexWithPrimaryContext() {
       return current_device_index;
     }
   }
-  for (int64_t device_index = 0; device_index < at::cuda::device_count(); device_index++) {
+  for (const auto device_index : c10::irange(at::cuda::device_count())) {
     if (device_index == current_device_index) continue;
     if (hasPrimaryContext(device_index)) {
       return device_index;

--- a/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebraKernel.cpp
@@ -256,7 +256,7 @@ void apply_linalg_eig(Tensor& values, Tensor& vectors, Tensor& input, Tensor& in
   Tensor work = at::empty({lwork}, input.dtype());
   auto work_data = work.data_ptr<scalar_t>();
 
-  for (auto i = decltype(batch_size){0}; i < batch_size; i++) {
+  for (const auto i : c10::irange(decltype(batch_size){0}, batch_size)) {
     scalar_t* input_working_ptr = &input_data[i * input_matrix_stride];
     scalar_t* values_working_ptr = &values_data[i * values_stride];
     scalar_t* rvectors_working_ptr = compute_eigenvectors ? &rvectors_data[i * input_matrix_stride] : nullptr;

--- a/aten/src/ATen/native/CPUBlas.cpp
+++ b/aten/src/ATen/native/CPUBlas.cpp
@@ -4,6 +4,7 @@
 
 #include <c10/util/SmallBuffer.h>
 #include <c10/util/C++17.h>
+#include <c10/util/irange.h>
 
 #include <climits>
 
@@ -331,7 +332,7 @@ void gemm_batched_generic(
     const scalar_t **b, int64_t ldb,
     scalar_t beta,
     scalar_t **c, int64_t ldc) {
-  for (int64_t batch = 0; batch < batch_size; ++batch) {
+  for (const auto batch : c10::irange(batch_size)) {
     gemm(transa, transb, m, n, k, alpha, a[batch], lda, b[batch], ldb, beta, c[batch], ldc);
   }
 }
@@ -376,7 +377,7 @@ void gemm_batched_with_stride_generic(
     const scalar_t *b, int64_t ldb, int64_t batch_stride_b,
     scalar_t beta,
     scalar_t *c, int64_t ldc, int64_t batch_stride_c) {
-  for (int64_t batch = 0; batch < batch_size; ++batch) {
+  for (const auto batch : c10::irange(batch_size)) {
     const auto a_batch = a + batch_stride_a * batch;
     const auto b_batch = b + batch_stride_b * batch;
     const auto c_batch = c + batch_stride_c * batch;
@@ -405,7 +406,7 @@ void gemm_batched_with_stride(
           c10::SmallBuffer<const scalar_t*, 16> b_ptrs(batch_size);
           c10::SmallBuffer<scalar_t*, 16> c_ptrs(batch_size);
 
-          for (int64_t batch = 0; batch < batch_size; ++batch) {
+          for (const auto batch : c10::irange(batch_size)) {
             a_ptrs[batch] = a + batch_stride_a * batch;
             b_ptrs[batch] = b + batch_stride_b * batch;
             c_ptrs[batch] = c + batch_stride_c * batch;

--- a/aten/src/ATen/native/ConvolutionMM2d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM2d.cpp
@@ -122,7 +122,7 @@ static inline void slow_conv2d_shape_check(
 
   // Allow for empty batch size and channel size but not other dimensions
   TORCH_CHECK(ndim == 4, "Expected 4D input tensor, but got: ", input.sizes());
-  for (int64_t dim = 2; dim < ndim; ++dim) {
+  for (const auto dim : c10::irange(2, ndim)) {
     TORCH_CHECK(input.size(dim) != 0,
                 "Expected non-zero size for input dimension ", dim,
                 ", but got input shape: ", input.sizes(), ". Only the batch and channel dimensions support size 0.");
@@ -444,7 +444,7 @@ static void slow_conv2d_backward_weight_out_cpu_template(
     auto grad_weight_2d_a = grad_weight_2d.accessor<scalar_t, 2>();
     auto finput_a = finput.accessor<scalar_t, 3>();
 
-    for (int64_t t = 0; t < batch_size; t++) {
+    for (const auto t : c10::irange(batch_size)) {
       auto grad_output_t = grad_output_a[t];
       auto finput_t = finput_a[t];
 

--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -136,7 +136,7 @@ void fbgemm_spmdm_report_error_(
     int64_t N,
     const index_t* offsets,
     const index_t* indices) {
-  for (int m = 0; m < output_size; ++m) {
+  for (const auto m : c10::irange(output_size)) {
     for (index_t i = offsets[m]; i < offsets[m + 1]; ++i) {
       TORCH_CHECK(i < index_size);
       index_t idx = indices[i];
@@ -927,7 +927,7 @@ static Tensor _embedding_bag_dense_backward_cpu_max(
   auto nonempty_max_indices = max_indices.index_select(0, bag_size.nonzero().view(-1));
   auto nonempty_grad = grad.index_select(0, bag_size.nonzero().view(-1));
 
-  for (int64_t dim = 0; dim < grad.sizes()[1]; dim++) {
+  for (const auto dim : c10::irange(grad.sizes()[1])) {
     index_grad_weight.select(1, dim).index_add_(
       0, nonempty_max_indices.select(1, dim), nonempty_grad.select(1, dim));
   }


### PR DESCRIPTION
Summary:
Using an explicitly typed loop variable risks type mismatches with the loop
bound; using an const auto variable and c10::irange eliminates this
possibility. This change modifies loops in files under
fbsource/fbcode/caffe2/aten from the format
`for(TYPE var=x0;var<x_max;x++)` to `for(const auto var: irange(xmax))`

This was achieved by running r-barnes's loop upgrader script (D28874212)
modified for the appropriate directory.

Test Plan: arc sanity

Differential Revision: D33952436

