### PR TITLE
[NNC] Use index for stride mapping in kernel.cpp

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -2100,6 +2100,14 @@ class TestTEFuser(JitTestCase):
             return F.hardsigmoid(x) * 1.01
         self._test_fwd_bwd(eager)
 
+    def test_cat_graph_opt(self):
+        def foo(x, y, z):
+            return torch.log(torch.cat([x, y, z]))
+
+        self.checkScript(foo, (torch.rand([5, 5]), torch.rand([2, 5]), torch.rand([1, 5])))
+        # TODO: not sure why not updated graph isn't reflected in last_optimized_graph
+        self.assertLastGraphAllFused()
+
     def test_dynamic_cat(self):
         with inline_fusion_groups():
             @torch.jit.script

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -271,6 +271,8 @@ class TORCH_API TensorExprKernel {
   std::vector<ExprHandle> getInputStrides(
       const torch::jit::Value* input,
       const std::vector<ExprHandle>& inputTensorDims);
+  std::vector<torch::jit::StrideInput>& getSymbolicInputStrideDesc(
+      const torch::jit::Value* value);
 
   int64_t nInputs_ = 0;
   int64_t nOutputs_ = 0;
@@ -319,10 +321,9 @@ class TORCH_API TensorExprKernel {
   // map from <input index, tensor dimension> to stride as arg VarHandle
   std::unordered_map<std::pair<size_t, size_t>, VarHandle, SmallSizeTPairHash>
       strideArgToVar_;
-  std::unordered_map<
-      const torch::jit::Value*,
-      std::vector<torch::jit::StrideInput>>
-      symbolic_strides_;
+  std::unordered_map<size_t, std::vector<torch::jit::StrideInput>>
+      sym_stride_inputs_;
+  std::unordered_map<size_t, torch::jit::StrideInput> sym_stride_outputs_;
 };
 
 TORCH_API int& getTECudaPointwiseLoopLevels();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72266

Within the kernel, we may manipulate `Value *` in `OptimizeCat`, which would invalidate the input `Value *` -> Stride mapping.

Fix for https://github.com/pytorch/pytorch/issues/72173

Differential Revision: [D33986306](https://our.internmc.facebook.com/intern/diff/D33986306)