### PR TITLE
(WIP) Allow requires_grad=False for forward AD gradcheck

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -596,6 +596,8 @@ class OpInfo(object):
                  gradcheck_fast_mode=None,  # Whether to use the fast implmentation for gradcheck/gradgradcheck.
                                             # When set to None, defers to the default value provided by the wrapper
                                             # function around gradcheck (testing._internal.common_utils.gradcheck)
+                 diff_input_indices=None,  # TODO
+                 diff_output_indices=None,  # TODO
 
                  # the following metadata relates to JIT support and is tested for correctness in test_ops.py
                  aten_name=None,  # name of the corresponding aten:: operator
@@ -755,6 +757,8 @@ class OpInfo(object):
         self.check_batched_gradgrad = check_batched_gradgrad
         self.check_batched_forward_grad = check_batched_forward_grad
         self.check_inplace_batched_forward_grad = check_inplace_batched_forward_grad
+        self.diff_input_indices = diff_input_indices
+        self.diff_output_indices = diff_output_indices
 
         # Autograd flags that depend on both forward AD and backward AD
         if supports_inplace_autograd is None:
@@ -11627,6 +11631,8 @@ op_db: List[OpInfo] = [
            supports_out=False,
            supports_forward_ad=True,
            sample_inputs_func=sample_inputs_batch_norm,
+           diff_input_indices=(0, "weight", "bias"),
+           diff_output_indices=(0,),
            skips=(
                DecorateInfo(unittest.skip("We don't want to differentiate wrt running mean / std"),
                             "TestCommon", "test_floating_inputs_are_differentiable"),)
@@ -11639,6 +11645,8 @@ op_db: List[OpInfo] = [
            dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
            supports_out=False,
            supports_forward_ad=True,
+           diff_input_indices=(0, "weight", "bias"),
+           diff_output_indices=(0,),
            decorators=[onlyCUDA, disablecuDNN],
            skips=(
                DecorateInfo(unittest.skip("We don't want to differentiate wrt running mean / std"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72271
* #72166
* #72165

Notes in case this gets picked up later:
- adds differentiable inputs/outputs indices parameter to OpInfos and gradcheck
  - gradcheck only accepts positional arguments, but sample inputs can have kwargs, so we need to transform those
- we have two wrapper functions, `fn_fw` and `fn_rev`, the only difference being that `fn_rev` filters out inputs/outputs that don't require grad
- check non differentiable inputs (only applies to reverse-mode) needs to use `fn_fw` because it needs to check that the outputs that don't have requires_grad=True have numerical Jacobian of zero
- we cannot remove the checks for get_numerical_jacobian because it is considered external API, unfortunately. They are redundant, but don't cause any harm.
- we cannot remove iter_tensors because it is still used in common_nn
- add some more asserts to make sure there is no silent size mismatch, including zip -> _safe_zip 
- example op, batch norm. There doesn't seem like any others where differentiability could not be inferred from dtype, or no error was produced

Differential Revision: [D33991621](https://our.internmc.facebook.com/intern/diff/D33991621)