### PR TITLE
[Quant][Eager][improvement] Added 4 bit support for eager mode quantization flow (reland PR 69806)

### DIFF
--- a/test/quantization/eager/test_quantize_eager_ptq.py
+++ b/test/quantization/eager/test_quantize_eager_ptq.py
@@ -18,6 +18,7 @@ from torch.ao.quantization import (
     per_channel_dynamic_qconfig,
     float16_dynamic_qconfig,
     float_qparams_weight_only_qconfig,
+    float_qparams_weight_only_qconfig_4bit,
     PerChannelMinMaxObserver,
     default_dynamic_quant_observer,
     QConfig,
@@ -568,26 +569,28 @@ class TestQuantizeEagerPTQStatic(QuantizationTestCase):
         r""" Test the post-training quantization flow, serialization and scripting
         of embedding modules
         """
-        model = EmbeddingModule().eval()
-        indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
-        weights = torch.randn(10, 12, dtype=torch.float32)
-        model.qconfig = float_qparams_weight_only_qconfig
-        prepare(model, inplace=True)
-        convert(model, inplace=True)
-        self.assertTrue('QuantizedEmbedding' in str(model))
-        self.assertEqual(type(model.emb), torch.nn.quantized.Embedding)
-        self.checkScriptable(model, [[indices]], check_save_load=True)
 
-        idx = torch.LongTensor([1, 2, 4, 5, 4, 3, 2, 9])
-        offsets = torch.LongTensor([0, 4])
-        x = torch.randn(2, 4)
-        model = EmbeddingWithStaticLinear().eval()
-        prepare(model, inplace=True)
-        convert(model, inplace=True)
-        self.assertTrue('QuantizedEmbedding' in str(model))
-        self.assertTrue('QuantizedLinear' in str(model))
-        self.checkQuantizedLinear(model.fc)
-        model(idx, offsets, x)
+        for qconfig in [float_qparams_weight_only_qconfig, float_qparams_weight_only_qconfig_4bit]:
+            model = EmbeddingModule().eval()
+            indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
+            weights = torch.randn(10, 12, dtype=torch.float32)
+            model.qconfig = qconfig
+            prepare(model, inplace=True)
+            convert(model, inplace=True)
+            self.assertTrue('QuantizedEmbedding' in str(model))
+            self.assertEqual(type(model.emb), torch.nn.quantized.Embedding)
+            self.checkScriptable(model, [[indices]], check_save_load=True)
+
+            idx = torch.LongTensor([1, 2, 4, 5, 4, 3, 2, 9])
+            offsets = torch.LongTensor([0, 4])
+            x = torch.randn(2, 4)
+            model = EmbeddingWithStaticLinear().eval()
+            prepare(model, inplace=True)
+            convert(model, inplace=True)
+            self.assertTrue('QuantizedEmbedding' in str(model))
+            self.assertTrue('QuantizedLinear' in str(model))
+            self.checkQuantizedLinear(model.fc)
+            model(idx, offsets, x)
 
     @skipIfNoFBGEMM
     def test_dequant_stub(self):

--- a/torch/nn/quantized/modules/embedding_ops.py
+++ b/torch/nn/quantized/modules/embedding_ops.py
@@ -158,13 +158,12 @@ class Embedding(torch.nn.Module):
                 weight_observer = float_qparams_weight_only_qconfig.weight()
 
         dtype = weight_observer.dtype
-
         is_float_qparams_qconfig = weight_observer.qscheme == torch.per_channel_affine_float_qparams
         assert is_float_qparams_qconfig, \
             'Embedding quantization is only supported with float_qparams_weight_only_qconfig.'
 
-        assert dtype == torch.quint8, \
-            f'The only supported weight dtype for nnq.Embedding is torch.quint8, got {dtype}'
+        assert dtype == torch.quint8 or dtype == torch.quint4x2, \
+            f'The only supported dtype for nnq.Embedding is torch.quint8 and torch.quint4x2, got {dtype}'
 
         # Run the observer to calculate qparams.
         weight_observer(mod.weight)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #72278
* __->__ #72277
* #72276

Summary:
Minor modifications were made to support 4 bit embedding quantized module in eager mode quantization flow and to allow for testing of the changes

Test Plan:
In pytorch main dir, execute
```
python test_quantization.py TestPostTrainingStatic.test_quantized_embedding
```

Differential Revision: [D33994545](https://our.internmc.facebook.com/intern/diff/D33994545)