### PR TITLE
Added prod op to FX2TRT

### DIFF
--- a/test/fx2trt/converters/acc_op/test_prod.py
+++ b/test/fx2trt/converters/acc_op/test_prod.py
@@ -1,0 +1,64 @@
+# Owner(s): ["oncall: aiacc"]
+
+import torch
+import torch.fx.experimental.fx_acc.acc_ops as acc_ops
+from torch.testing._internal.common_fx2trt import AccTestCase
+from parameterized import parameterized
+from torch.testing._internal.common_utils import run_tests
+
+# NOTE torch.prod will only accept one dim unlike other reduce ops which accept tuples
+
+class TestProdConverter(AccTestCase):
+    @parameterized.expand(
+        [
+            (f"{acc_ops.prod.__name__}_dim0_keepdim", 0, True, torch.prod, acc_ops.prod),
+            (f"{acc_ops.prod.__name__}_dim0_no_keepdim", 0, False, torch.prod, acc_ops.prod),
+            (f"{acc_ops.prod.__name__}_dim1_keepdim", 1, True, torch.prod, acc_ops.prod),
+            (f"{acc_ops.prod.__name__}_dim1_no_keepdim", 1, False, torch.prod, acc_ops.prod),
+            (f"{acc_ops.prod.__name__}_dim1_keepdim", 2, True, torch.prod, acc_ops.prod),
+            (f"{acc_ops.prod.__name__}_dim1_no_keepdim", 2, False, torch.prod, acc_ops.prod),
+        ]
+    )
+    def test_prod(self, test_name, dim, keepdim, op, expected_acc_op):
+        class Prod(torch.nn.Module):
+            def __init__(self, dim, keepdim):
+                super().__init__()
+                self.dim = dim
+                self.keepdim = keepdim
+
+            def forward(self, x):
+                return op(x, dim=self.dim, keepdim=self.keepdim)
+
+        inputs = [torch.randn(1, 2, 3, 4)]
+        self.run_test(
+            Prod(dim, keepdim),
+            inputs,
+            expected_ops={expected_acc_op},
+            test_implicit_batch_dim=(dim != 0),
+        )
+
+    @parameterized.expand(
+        [
+            (f"{acc_ops.prod.__name__}_no_dim_no_keepdim", torch.prod, acc_ops.prod)
+        ]
+    )
+    def test_prod_all_dims(
+        self,
+        test_name,
+        op,
+        expected_acc_op,
+    ):
+        class Prod(torch.nn.Module):
+            def forward(self, x):
+                return op(x)
+
+        inputs = [torch.randn(1, 2, 3, 4)]
+        self.run_test(
+            Prod(),
+            inputs,
+            expected_ops={expected_acc_op},
+            test_implicit_batch_dim=False,
+        )
+
+if __name__ == '__main__':
+    run_tests()

--- a/test/fx_acc/test_acc_tracer.py
+++ b/test/fx_acc/test_acc_tracer.py
@@ -66,7 +66,6 @@ class AccTracerTest(unittest.TestCase):
 
             def forward(self, a: torch.Tensor) -> torch.Tensor:
                 return self._torch_op(a, *self._args, **self._kwargs)
-
         m = TestModule(torch_op, args, kwargs)
         m.eval()
         a = torch.randn(*input_shape)
@@ -124,6 +123,10 @@ class AccTracerTest(unittest.TestCase):
     def test_sum(self):
         self._make_acc_op_function_test(acc_ops.sum, torch.sum)
         self._make_acc_op_function_test(acc_ops.sum, torch.sum, dim=(1,), keepdim=True)
+
+    def test_prod(self):
+        self._make_acc_op_function_test(acc_ops.prod, torch.prod)
+        self._make_acc_op_function_test(acc_ops.prod, torch.prod, dim=1, keepdim=True)
 
     def test_mean(self):
         self._make_acc_op_function_test(acc_ops.mean, torch.mean)
@@ -2045,6 +2048,7 @@ class AccTracerTest(unittest.TestCase):
                 acc_ops.unsqueeze,
                 acc_ops.sigmoid,
                 acc_ops.sum,
+                acc_ops.prod,
                 acc_ops.max_full_reduce,
                 acc_ops.max_dim_reduce,
                 acc_ops.maximum,

--- a/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
+++ b/torch/fx/experimental/fx2trt/converters/acc_ops_converters.py
@@ -895,6 +895,17 @@ def acc_ops_sum(
     return add_reduce_layer(network, target, args, kwargs, trt.ReduceOperation.SUM, name)
 
 
+@tensorrt_converter(acc_ops.prod)
+def acc_ops_prod(
+    network: TRTNetwork,
+    target: Target,
+    args: Tuple[Argument, ...],
+    kwargs: Dict[str, Argument],
+    name: str,
+) -> TRTTensor:
+    return add_reduce_layer(network, target, args, kwargs, trt.ReduceOperation.PROD, name)
+
+
 @tensorrt_converter(acc_ops.mean)
 def acc_ops_mean(
     network: TRTNetwork,

--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -862,6 +862,41 @@ def sum_mapper(node: torch.fx.Node, mod: torch.fx.GraphModule) -> torch.fx.Node:
 
 @register_acc_op_properties(AccOpProperty.unary)
 @register_acc_op
+def prod(*, input, dim=None, keepdim=False, dtype=None):
+    if dim is not None:
+        return torch.prod(input, dim=dim, keepdim=keepdim, dtype=dtype)
+    else:
+        return input.prod(dtype=dtype)
+
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_method", "prod"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+@register_custom_acc_mapper_fn(
+    op_and_target=("call_function", torch.prod),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("dim", "dim", this_arg_is_optional),
+        ("keepdim", "keepdim", this_arg_is_optional),
+        ("dtype", "dtype", this_arg_is_optional),
+    ],
+)
+def prod_mapper(node: torch.fx.Node, mod: torch.fx.GraphModule) -> torch.fx.Node:
+    func = prod
+    with node.graph.inserting_before(node):
+        kwargs = dict(node.kwargs)
+        new_node = node.graph.call_function(func, kwargs=kwargs)
+        new_node.meta = node.meta.copy()
+        return new_node
+
+
+@register_acc_op_properties(AccOpProperty.unary)
+@register_acc_op
 def mean(*, input, dim=None, keepdim=False, dtype=None):
     if dim is not None:
         return torch.mean(input, dim=dim, keepdim=keepdim, dtype=dtype)


### PR DESCRIPTION
Summary: This update adds the prod op to the fx2trt tool which is used to create a TensorRT engine for a PyTorch model.

Test Plan:
A new unit test was added to test that the op was added to the acc tracer.  This text can be run using the following command: buck test --debug //caffe2/test:test_fx_acc_tracer -- --exact 'caffe2/test:test_fx_acc_tracer - test_prod (fx_acc.test_acc_tracer.AccTracerTest)'

A new suite of unit tests were also added for the conversion to tensorRT and can be tested using the following command:  buck test mode/dev-nosan  //caffe2/test/fx2trt/converters:test_prod

Please note that unfortunately unlike other pytorch reduce ops such as sum, the pytorch prod function does not support reducing more than 1 dimension at a time (the dim arg cannot be a tuple, only a single int is acceptable for prod).  Therefore prod cannot utilize all of the reduce_op code.

https://pxl.cl/1Xpn8

https://pxl.cl/1Xpn9

Differential Revision: D33875336

