### PR TITLE
[LTS] Pin pytorch/manylinux images for python 3.6 manywheel build/test jobs

### DIFF
--- a/.circleci/cimodel/data/binary_build_definitions.py
+++ b/.circleci/cimodel/data/binary_build_definitions.py
@@ -42,7 +42,17 @@ class Conf(object):
             "rocm:" + self.gpu_version.strip("rocm") if self.gpu_version.startswith("rocm") else self.gpu_version)
         docker_distro_suffix = alt_docker_suffix if self.pydistro != "conda" else (
             "cuda" if alt_docker_suffix.startswith("cuda") else "rocm")
-        return miniutils.quote("pytorch/" + docker_distro_prefix + "-" + docker_distro_suffix)
+
+        docker_digest_map = {
+            "binary_linux_manywheel_3_6m_cu111_devtoolset7_nightly_build" : "@sha256:3a9c1537a6ae97a36ea29c6bad6e9bbd3dbd18e4f34fbce30f176bcbb10c12d8",
+            "binary_linux_manywheel_3_6m_cu102_devtoolset7_nightly_build" : "@sha256:2277f8c324c3928cc0baa574591a32cbec1f32979d40f8c15b41584171819169",
+            "binary_linux_manywheel_3_6m_cu101_devtoolset7_nightly_build" : "@sha256:0e8df61551e084c9fe26ac1c9c009136ea4376c62ea55884e1c96bb74415353f",
+            "binary_linux_manywheel_3_6m_cpu_devtoolset7_nightly_build" : "@sha256:2277f8c324c3928cc0baa574591a32cbec1f32979d40f8c15b41584171819169"
+        }
+        build_name = self.gen_build_name("build", nightly=True)
+        docker_digest = docker_digest_map.get(build_name, "")
+
+        return miniutils.quote("pytorch/" + docker_distro_prefix + "-" + docker_distro_suffix + docker_digest)
 
     def get_name_prefix(self):
         return "smoke" if self.smoke else "binary"

--- a/.circleci/cimodel/data/binary_build_definitions.py
+++ b/.circleci/cimodel/data/binary_build_definitions.py
@@ -44,10 +44,14 @@ class Conf(object):
             "cuda" if alt_docker_suffix.startswith("cuda") else "rocm")
 
         docker_digest_map = {
-            "binary_linux_manywheel_3_6m_cu111_devtoolset7_nightly_build" : "@sha256:3a9c1537a6ae97a36ea29c6bad6e9bbd3dbd18e4f34fbce30f176bcbb10c12d8",
-            "binary_linux_manywheel_3_6m_cu102_devtoolset7_nightly_build" : "@sha256:2277f8c324c3928cc0baa574591a32cbec1f32979d40f8c15b41584171819169",
-            "binary_linux_manywheel_3_6m_cu101_devtoolset7_nightly_build" : "@sha256:0e8df61551e084c9fe26ac1c9c009136ea4376c62ea55884e1c96bb74415353f",
-            "binary_linux_manywheel_3_6m_cpu_devtoolset7_nightly_build" : "@sha256:2277f8c324c3928cc0baa574591a32cbec1f32979d40f8c15b41584171819169"
+            "binary_linux_manywheel_3_6m_cu111_devtoolset7_nightly_build" : 
+                "@sha256:3a9c1537a6ae97a36ea29c6bad6e9bbd3dbd18e4f34fbce30f176bcbb10c12d8",
+            "binary_linux_manywheel_3_6m_cu102_devtoolset7_nightly_build" : 
+                "@sha256:2277f8c324c3928cc0baa574591a32cbec1f32979d40f8c15b41584171819169",
+            "binary_linux_manywheel_3_6m_cu101_devtoolset7_nightly_build" : 
+                "@sha256:0e8df61551e084c9fe26ac1c9c009136ea4376c62ea55884e1c96bb74415353f",
+            "binary_linux_manywheel_3_6m_cpu_devtoolset7_nightly_build" : 
+                "@sha256:2277f8c324c3928cc0baa574591a32cbec1f32979d40f8c15b41584171819169"
         }
         build_name = self.gen_build_name("build", nightly=True)
         docker_digest = docker_digest_map.get(build_name, "")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2014,7 +2014,7 @@ workflows:
             tags:
               only:
                 - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
+          docker_image: "pytorch/manylinux-cuda102@sha256:2277f8c324c3928cc0baa574591a32cbec1f32979d40f8c15b41584171819169"
       - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cpu_devtoolset7_nightly_build
           build_environment: "manywheel 3.7m cpu devtoolset7"
@@ -2058,7 +2058,7 @@ workflows:
             tags:
               only:
                 - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101@sha256:0e8df61551e084c9fe26ac1c9c009136ea4376c62ea55884e1c96bb74415353f"
       - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cu101_devtoolset7_nightly_build
           build_environment: "manywheel 3.7m cu101 devtoolset7"
@@ -2102,7 +2102,7 @@ workflows:
             tags:
               only:
                 - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda102"
+          docker_image: "pytorch/manylinux-cuda102@sha256:2277f8c324c3928cc0baa574591a32cbec1f32979d40f8c15b41584171819169"
       - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cu102_devtoolset7_nightly_build
           build_environment: "manywheel 3.7m cu102 devtoolset7"
@@ -2146,7 +2146,7 @@ workflows:
             tags:
               only:
                 - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          docker_image: "pytorch/manylinux-cuda111"
+          docker_image: "pytorch/manylinux-cuda111@sha256:3a9c1537a6ae97a36ea29c6bad6e9bbd3dbd18e4f34fbce30f176bcbb10c12d8"
       - binary_linux_build:
           name: binary_linux_manywheel_3_7m_cu111_devtoolset7_nightly_build
           build_environment: "manywheel 3.7m cu111 devtoolset7"
@@ -3350,7 +3350,7 @@ workflows:
                 - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           requires:
             - binary_linux_manywheel_3_6m_cpu_devtoolset7_nightly_build
-          docker_image: "pytorch/manylinux-cuda102"
+          docker_image: "pytorch/manylinux-cuda102@sha256:2277f8c324c3928cc0baa574591a32cbec1f32979d40f8c15b41584171819169"
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_cpu_devtoolset7_nightly_test
           build_environment: "manywheel 3.7m cpu devtoolset7"
@@ -3402,7 +3402,7 @@ workflows:
                 - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           requires:
             - binary_linux_manywheel_3_6m_cu101_devtoolset7_nightly_build
-          docker_image: "pytorch/manylinux-cuda101"
+          docker_image: "pytorch/manylinux-cuda101@sha256:0e8df61551e084c9fe26ac1c9c009136ea4376c62ea55884e1c96bb74415353f"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.nvidia.small
       - binary_linux_test:
@@ -3462,7 +3462,7 @@ workflows:
                 - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           requires:
             - binary_linux_manywheel_3_6m_cu102_devtoolset7_nightly_build
-          docker_image: "pytorch/manylinux-cuda102"
+          docker_image: "pytorch/manylinux-cuda102@sha256:2277f8c324c3928cc0baa574591a32cbec1f32979d40f8c15b41584171819169"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.nvidia.small
       - binary_linux_test:
@@ -3522,7 +3522,7 @@ workflows:
                 - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
           requires:
             - binary_linux_manywheel_3_6m_cu111_devtoolset7_nightly_build
-          docker_image: "pytorch/manylinux-cuda111"
+          docker_image: "pytorch/manylinux-cuda111@sha256:3a9c1537a6ae97a36ea29c6bad6e9bbd3dbd18e4f34fbce30f176bcbb10c12d8"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.nvidia.small
       - binary_linux_test:


### PR DESCRIPTION
The pytorch/manylinux images for manywheel jobs for python 3.6 (on cpu and cuda) are pinned since the latest images do not have python 3.6.

**Original job failure:** [binary_linux_manywheel_3_6m_cu111_devtoolset7_nightly_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/450126/workflows/fa817c17-87e4-4cc6-af98-c0c5d4907c6e/jobs/16975517), [binary_linux_manywheel_3_6m_cu102_devtoolset7_nightly_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/450126/workflows/fa817c17-87e4-4cc6-af98-c0c5d4907c6e/jobs/16975449), [binary_linux_manywheel_3_6m_cpu_devtoolset7_nightly_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/450126/workflows/fa817c17-87e4-4cc6-af98-c0c5d4907c6e/jobs/16975510)

**Current job success:** [binary_linux_manywheel_3_6m_cu111_devtoolset7_nightly_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/450572/workflows/6b9b2765-7ecf-4b06-b004-989e96bf5eea/jobs/16978300), [binary_linux_manywheel_3_6m_cu102_devtoolset7_nightly_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/450572/workflows/6b9b2765-7ecf-4b06-b004-989e96bf5eea/jobs/16978280), [binary_linux_manywheel_3_6m_cpu_devtoolset7_nightly_build](https://app.circleci.com/pipelines/github/pytorch/pytorch/450572/workflows/6b9b2765-7ecf-4b06-b004-989e96bf5eea/jobs/16978315)