### PR TITLE
Fix inline variable errors with const

### DIFF
--- a/aten/src/ATen/core/qualified_name.h
+++ b/aten/src/ATen/core/qualified_name.h
@@ -106,7 +106,7 @@ struct QualifiedName {
   }
 
  private:
-  static constexpr char delimiter_ = '.';
+  static const char delimiter_ = '.';
 
   // Helper for cacheAccessors() below.
   template<typename T>

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -420,11 +420,6 @@ __host__ __device__
 #define IS_NOT_GCC5_CONSTEXPR 1
 #endif
 
-#if defined(__CUDA_ARCH__)
-#if defined(_MSC_VER) && defined(__CUDACC__)
-#define CONSTEXPR_EXCEPT_WIN_CUDA const
-#define C10_HOST_CONSTEXPR_EXCEPT_WIN_CUDA __host__
-
 // Note [static constexpr char* members for windows NVCC]
 // The Windows NVCC compiler doesn't handle static constexpr class members,
 // although it's fixed in a later version.
@@ -450,36 +445,43 @@ __host__ __device__
 //
 // This gives us a small perf hit for any code that wants to access these field
 // members, but right now it isn't used in any perf-critical code paths.
-#define STATIC_CONSTEXPR_STR_INL_EXCEPT_WIN_CUDA(field, val) \
-  static const char* field;
-#define STATIC_CONST_STR_OUT_OF_LINE_FOR_WIN_CUDA(cls, field, val) \
-  const char* cls::field = val;
-#else
-#define CONSTEXPR_EXCEPT_WIN_CUDA constexpr
-#define C10_HOST_CONSTEXPR_EXCEPT_WIN_CUDA __host__
 
-#define STATIC_CONSTEXPR_STR_INL_EXCEPT_WIN_CUDA(field, val) \
-  static constexpr const char* field = val;
-#define STATIC_CONST_STR_OUT_OF_LINE_FOR_WIN_CUDA(cls, field, val)
-#endif
-#else
-#if defined(_MSC_VER) && defined(__CUDACC__)
-#define CONSTEXPR_EXCEPT_WIN_CUDA const
-#define C10_HOST_CONSTEXPR_EXCEPT_WIN_CUDA
+// clang-format off
+#if defined(__CUDA_ARCH__)
+  #if defined(__CUDACC__)
+    #define CONSTEXPR_EXCEPT_WIN_CUDA const
+    #define C10_HOST_CONSTEXPR_EXCEPT_WIN_CUDA __host__
+    #define STATIC_CONSTEXPR_STR_INL_EXCEPT_WIN_CUDA(field, val) \
+      static const char* field;
+    #define STATIC_CONST_STR_OUT_OF_LINE_FOR_WIN_CUDA(cls, field, val) \
+      const char* cls::field = val;
+  #else
+    #define CONSTEXPR_EXCEPT_WIN_CUDA constexpr
+    #define C10_HOST_CONSTEXPR_EXCEPT_WIN_CUDA __host__
 
-#define STATIC_CONSTEXPR_STR_INL_EXCEPT_WIN_CUDA(field, val) \
-  static const char* field;
-#define STATIC_CONST_STR_OUT_OF_LINE_FOR_WIN_CUDA(cls, field, val) \
-  const char* cls::field = val;
+    #define STATIC_CONSTEXPR_STR_INL_EXCEPT_WIN_CUDA(field, val) \
+      static constexpr const char* field = val;
+    #define STATIC_CONST_STR_OUT_OF_LINE_FOR_WIN_CUDA(cls, field, val)
+  #endif
 #else
-#define CONSTEXPR_EXCEPT_WIN_CUDA constexpr
-#define C10_HOST_CONSTEXPR_EXCEPT_WIN_CUDA constexpr
+  #if defined(__CUDACC__)
+    #define CONSTEXPR_EXCEPT_WIN_CUDA const
+    #define C10_HOST_CONSTEXPR_EXCEPT_WIN_CUDA
 
-#define STATIC_CONSTEXPR_STR_INL_EXCEPT_WIN_CUDA(field, val) \
-  static constexpr const char* field = val;
-#define STATIC_CONST_STR_OUT_OF_LINE_FOR_WIN_CUDA(cls, field, val)
+    #define STATIC_CONSTEXPR_STR_INL_EXCEPT_WIN_CUDA(field, val) \
+      static const char* field;
+    #define STATIC_CONST_STR_OUT_OF_LINE_FOR_WIN_CUDA(cls, field, val) \
+      const char* cls::field = val;
+  #else
+    #define CONSTEXPR_EXCEPT_WIN_CUDA constexpr
+    #define C10_HOST_CONSTEXPR_EXCEPT_WIN_CUDA constexpr
+
+    #define STATIC_CONSTEXPR_STR_INL_EXCEPT_WIN_CUDA(field, val) \
+      static constexpr const char* field = val;
+    #define STATIC_CONST_STR_OUT_OF_LINE_FOR_WIN_CUDA(cls, field, val)
+  #endif
 #endif
-#endif
+// clang-format on
 
 #ifndef HAS_DEMANGLE
 #if defined(__ANDROID__) || defined(_WIN32) || defined(__EMSCRIPTEN__) || \

--- a/c10/util/BFloat16-inl.h
+++ b/c10/util/BFloat16-inl.h
@@ -255,31 +255,31 @@ namespace std {
 template <>
 class numeric_limits<c10::BFloat16> {
  public:
-  static constexpr bool is_signed = true;
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_integer = false;
-  static constexpr bool is_exact = false;
-  static constexpr bool has_infinity = true;
-  static constexpr bool has_quiet_NaN = true;
-  static constexpr bool has_signaling_NaN = true;
-  static constexpr auto has_denorm = numeric_limits<float>::has_denorm;
-  static constexpr auto has_denorm_loss =
-      numeric_limits<float>::has_denorm_loss;
-  static constexpr auto round_style = numeric_limits<float>::round_style;
-  static constexpr bool is_iec559 = false;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = 8;
-  static constexpr int digits10 = 2;
-  static constexpr int max_digits10 = 4;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = -125;
-  static constexpr int min_exponent10 = -37;
-  static constexpr int max_exponent = 128;
-  static constexpr int max_exponent10 = 38;
-  static constexpr auto traps = numeric_limits<float>::traps;
-  static constexpr auto tinyness_before =
-      numeric_limits<float>::tinyness_before;
+  static const bool is_signed = true;
+  static const bool is_specialized = true;
+  static const bool is_integer = false;
+  static const bool is_exact = false;
+  static const bool has_infinity = true;
+  static const bool has_quiet_NaN = true;
+  static const bool has_signaling_NaN = true;
+  static const std::float_denorm_style has_denorm =
+      numeric_limits<float>::has_denorm;
+  static const bool has_denorm_loss = numeric_limits<float>::has_denorm_loss;
+  static const std::float_round_style round_style =
+      numeric_limits<float>::round_style;
+  static const bool is_iec559 = false;
+  static const bool is_bounded = true;
+  static const bool is_modulo = false;
+  static const int digits = 8;
+  static const int digits10 = 2;
+  static const int max_digits10 = 4;
+  static const int radix = 2;
+  static const int min_exponent = -125;
+  static const int min_exponent10 = -37;
+  static const int max_exponent = 128;
+  static const int max_exponent10 = 38;
+  static const bool traps = numeric_limits<float>::traps;
+  static const bool tinyness_before = numeric_limits<float>::tinyness_before;
 
   static constexpr c10::BFloat16 min() {
     return c10::BFloat16(0x0080, c10::BFloat16::from_bits());

--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -252,31 +252,31 @@ namespace std {
 template <>
 class numeric_limits<c10::Half> {
  public:
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = true;
-  static constexpr bool is_integer = false;
-  static constexpr bool is_exact = false;
-  static constexpr bool has_infinity = true;
-  static constexpr bool has_quiet_NaN = true;
-  static constexpr bool has_signaling_NaN = true;
-  static constexpr auto has_denorm = numeric_limits<float>::has_denorm;
-  static constexpr auto has_denorm_loss =
-      numeric_limits<float>::has_denorm_loss;
-  static constexpr auto round_style = numeric_limits<float>::round_style;
-  static constexpr bool is_iec559 = true;
-  static constexpr bool is_bounded = true;
-  static constexpr bool is_modulo = false;
-  static constexpr int digits = 11;
-  static constexpr int digits10 = 3;
-  static constexpr int max_digits10 = 5;
-  static constexpr int radix = 2;
-  static constexpr int min_exponent = -13;
-  static constexpr int min_exponent10 = -4;
-  static constexpr int max_exponent = 16;
-  static constexpr int max_exponent10 = 4;
-  static constexpr auto traps = numeric_limits<float>::traps;
-  static constexpr auto tinyness_before =
-      numeric_limits<float>::tinyness_before;
+  static const bool is_specialized = true;
+  static const bool is_signed = true;
+  static const bool is_integer = false;
+  static const bool is_exact = false;
+  static const bool has_infinity = true;
+  static const bool has_quiet_NaN = true;
+  static const bool has_signaling_NaN = true;
+  static const std::float_denorm_style has_denorm =
+      numeric_limits<float>::has_denorm;
+  static const bool has_denorm_loss = numeric_limits<float>::has_denorm_loss;
+  static const std::float_round_style round_style =
+      numeric_limits<float>::round_style;
+  static const bool is_iec559 = true;
+  static const bool is_bounded = true;
+  static const bool is_modulo = false;
+  static const int digits = 11;
+  static const int digits10 = 3;
+  static const int max_digits10 = 5;
+  static const int radix = 2;
+  static const int min_exponent = -13;
+  static const int min_exponent10 = -4;
+  static const int max_exponent = 16;
+  static const int max_exponent10 = 4;
+  static const bool traps = numeric_limits<float>::traps;
+  static const bool tinyness_before = numeric_limits<float>::tinyness_before;
   static constexpr c10::Half min() {
     return c10::Half(0x0400, c10::Half::from_bits());
   }

--- a/c10/util/Metaprogramming.h
+++ b/c10/util/Metaprogramming.h
@@ -27,7 +27,7 @@ struct function_traits<Result(Args...)> {
   using func_type = Result(Args...);
   using return_type = Result;
   using parameter_types = typelist::typelist<Args...>;
-  static constexpr auto number_of_parameters = sizeof...(Args);
+  static const size_t number_of_parameters = sizeof...(Args);
 };
 
 /**

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -127,7 +127,7 @@ struct has_overloaded_addressof {
     return true;
   }
 
-  constexpr static bool value = has_overload<T>(true);
+  const static bool value = has_overload<T>(true);
 };
 
 template <typename T, TR2_OPTIONAL_REQUIRES(!has_overloaded_addressof<T>)>

--- a/c10/util/TypeCast.h
+++ b/c10/util/TypeCast.h
@@ -18,7 +18,7 @@ namespace c10 {
 
 template <typename dest_t, typename src_t>
 struct needs_real {
-  constexpr static bool value =
+  const static bool value =
       (is_complex<src_t>::value && !is_complex<dest_t>::value);
 };
 

--- a/c10/util/flat_hash_map.h
+++ b/c10/util/flat_hash_map.h
@@ -169,7 +169,7 @@ struct sherwood_v3_entry {
   }
 
   int8_t distance_from_desired = -1;
-  static constexpr int8_t special_end_value = 0;
+  static const int8_t special_end_value = 0;
   union {
     T value;
   };

--- a/c10/util/order_preserving_flat_hash_map.h
+++ b/c10/util/order_preserving_flat_hash_map.h
@@ -174,7 +174,7 @@ struct sherwood_v3_entry {
   sherwood_v3_entry<T>* prev = nullptr;
   sherwood_v3_entry<T>* next = nullptr;
   int8_t distance_from_desired = -1;
-  static constexpr int8_t special_end_value = 0;
+  static const int8_t special_end_value = 0;
   union {
     T value;
   };

--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -41,7 +41,7 @@ class basic_string_view final {
   using size_type = std::size_t;
   using difference_type = std::ptrdiff_t;
 
-  static constexpr size_type npos = size_type(-1);
+  static const size_type npos = std::numeric_limits<size_type>::max();
 
   constexpr basic_string_view() noexcept : begin_(nullptr), size_(0) {}
 


### PR DESCRIPTION
Summary:
Deals with inline variable errors for platform010 by using `const` instead of `constexpr`.

D33692616 looks at alternative strategies.

Test Plan:
```
reset && buck build --keep-going -c cxx.extra_cxxflags=-ferror-limit=300 -c fbcode.platform=platform010 glow/glow/...
```

Reviewed By: luciang, meyering

Differential Revision: D33988238

