### PR TITLE
[torch.package] add test case for repackaging parent module

### DIFF
--- a/test/package/package_d/imports_directly.py
+++ b/test/package/package_d/imports_directly.py
@@ -1,0 +1,11 @@
+import torch
+
+from .subpackage_0.subsubpackage_0 import important_string
+
+
+class ImportsDirectlyFromSubSubPackage(torch.nn.Module):
+
+    key = important_string
+
+    def forward(self, inp):
+        return torch.sum(inp)

--- a/test/package/package_d/imports_indirectly.py
+++ b/test/package/package_d/imports_indirectly.py
@@ -1,0 +1,11 @@
+import torch
+
+from .subpackage_0 import important_string
+
+
+class ImportsIndirectlyFromSubPackage(torch.nn.Module):
+
+    key = important_string
+
+    def forward(self, inp):
+        return torch.sum(inp)

--- a/test/package/package_d/subpackage_0/__init__.py
+++ b/test/package/package_d/subpackage_0/__init__.py
@@ -1,0 +1,1 @@
+from .subsubpackage_0 import important_string

--- a/test/package/package_d/subpackage_0/subsubpackage_0/__init__.py
+++ b/test/package/package_d/subpackage_0/subsubpackage_0/__init__.py
@@ -1,0 +1,1 @@
+important_string = "subsubpackage_0"

--- a/test/package/package_d/test_repackage.py
+++ b/test/package/package_d/test_repackage.py
@@ -1,0 +1,50 @@
+# Owner(s): ["oncall: package/deploy"]
+
+from io import BytesIO
+
+from torch.package import (
+    PackageExporter,
+    PackageImporter,
+    sys_importer,
+)
+from torch.testing._internal.common_utils import run_tests
+
+try:
+    from ..common import PackageTestCase
+except ImportError:
+    # Support the case where we run this file directly.
+    from common import PackageTestCase
+
+
+class TestRepackage(PackageTestCase):
+    """Tests for repackaging."""
+
+    def test_repackage_import_indirectly_via_parent_module(self):
+        from .imports_directly import ImportsDirectlyFromSubSubPackage
+        from .imports_indirectly import ImportsIndirectlyFromSubPackage
+
+        model_a = ImportsDirectlyFromSubSubPackage()
+        buffer = BytesIO()
+        with PackageExporter(buffer) as pe:
+            pe.intern("**")
+            pe.save_pickle("default", "model.py", model_a)
+
+        buffer.seek(0)
+        pi = PackageImporter(buffer)
+        loaded_model = pi.load_pickle("default", "model.py")
+
+        model_b = ImportsIndirectlyFromSubPackage()
+        buffer = BytesIO()
+        with PackageExporter(
+            buffer,
+            importer=(
+                pi,
+                sys_importer,
+            ),
+        ) as pe:
+            pe.intern("**")
+            pe.save_pickle("default", "model_b.py", model_b)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -406,14 +406,21 @@ class PackageImporter(Importer):
 
         return module
 
+    def _is_interned_package(self, module):
+        spec = getattr(module, '__spec__', None)
+        if spec is None:
+            return False
+        origin = getattr(spec, 'origin', None)
+        return origin == "<package_importer>" and not hasattr(module, "__path__")
+
     # note: copied from cpython's import code
     def _find_and_load(self, name):
         module = self.modules.get(name, _NEEDS_LOADING)
         if module is _NEEDS_LOADING:
             return self._do_find_and_load(name)
-
+        filename = getattr(module, '__file__', None)
         if module is None:
-            message = "import of {} halted; " "None in sys.modules".format(name)
+            message = f"import of {name} halted; " "None in sys.modules"
             raise ModuleNotFoundError(message, name=name)
 
         # To handle https://github.com/pytorch/pytorch/issues/57490, where std's
@@ -424,6 +431,10 @@ class PackageImporter(Importer):
         elif name == "typing":
             self.modules["typing.io"] = cast(Any, module).io
             self.modules["typing.re"] = cast(Any, module).re
+
+        if filename is None and self._is_interned_package(module):
+            message = f"import of {name} halted as its source was not interned"
+            raise ModuleNotFoundError(message, name=name)
 
         return module
 


### PR DESCRIPTION
Test Plan:
Before https://github.com/pytorch/pytorch/pull/71520:
```
Summary
  Pass: 106
  Fail: 1
    ✗ caffe2/test:package - test_repackage_import_indirectly_via_parent_module (package.package_d.test_repackage.TestRepackage)
  Skip: 22
  ...
  ListingSuccess: 1
```

After https://github.com/pytorch/pytorch/pull/71520:
currently failing, needs revision

Differential Revision: D33944270

