### PR TITLE
[nnc] Make our exceptions c10::Errors, get C++ stacktraces

### DIFF
--- a/torch/csrc/jit/tensorexpr/exceptions.h
+++ b/torch/csrc/jit/tensorexpr/exceptions.h
@@ -26,61 +26,75 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
-class unsupported_dtype : public std::runtime_error {
+TORCH_API std::string buildErrorMessage(const std::string& s);
+
+class compilation_error : public c10::Error {
  public:
-  explicit unsupported_dtype() : std::runtime_error("UNSUPPORTED DTYPE") {}
+  explicit compilation_error(const std::string& err)
+      : c10::Error(
+            {
+                __func__,
+                __FILE__,
+                static_cast<uint32_t>(__LINE__),
+            },
+            buildErrorMessage(err)) {}
+};
+
+class unsupported_dtype : public compilation_error {
+ public:
+  explicit unsupported_dtype() : compilation_error("UNSUPPORTED DTYPE") {}
   explicit unsupported_dtype(const std::string& err)
-      : std::runtime_error("UNSUPPORTED DTYPE: " + err) {}
+      : compilation_error("UNSUPPORTED DTYPE: " + err) {}
 };
 
-class out_of_range_index : public std::runtime_error {
+class out_of_range_index : public compilation_error {
  public:
-  explicit out_of_range_index() : std::runtime_error("OUT OF RANGE INDEX") {}
+  explicit out_of_range_index() : compilation_error("OUT OF RANGE INDEX") {}
   explicit out_of_range_index(const std::string& err)
-      : std::runtime_error("OUT OF RANGE INDEX: " + err) {}
+      : compilation_error("OUT OF RANGE INDEX: " + err) {}
 };
 
-class unimplemented_lowering : public std::runtime_error {
+class unimplemented_lowering : public compilation_error {
  public:
   explicit unimplemented_lowering()
-      : std::runtime_error("UNIMPLEMENTED LOWERING") {}
+      : compilation_error("UNIMPLEMENTED LOWERING") {}
   explicit unimplemented_lowering(ExprPtr expr)
-      : std::runtime_error("UNIMPLEMENTED LOWERING: " + std::to_string(expr)) {}
+      : compilation_error("UNIMPLEMENTED LOWERING: " + std::to_string(expr)) {}
   explicit unimplemented_lowering(StmtPtr stmt)
-      : std::runtime_error("UNIMPLEMENTED LOWERING: " + std::to_string(stmt)) {}
+      : compilation_error("UNIMPLEMENTED LOWERING: " + std::to_string(stmt)) {}
 };
 
-class malformed_input : public std::runtime_error {
+class malformed_input : public compilation_error {
  public:
-  explicit malformed_input() : std::runtime_error("MALFORMED INPUT") {}
+  explicit malformed_input() : compilation_error("MALFORMED INPUT") {}
   explicit malformed_input(const std::string& err)
-      : std::runtime_error("MALFORMED INPUT: " + err) {}
+      : compilation_error("MALFORMED INPUT: " + err) {}
   explicit malformed_input(ExprPtr expr)
-      : std::runtime_error("MALFORMED INPUT: " + std::to_string(expr)) {}
+      : compilation_error("MALFORMED INPUT: " + std::to_string(expr)) {}
   explicit malformed_input(const std::string& err, ExprPtr expr)
-      : std::runtime_error(
+      : compilation_error(
             "MALFORMED INPUT: " + err + " - " + std::to_string(expr)) {}
   explicit malformed_input(StmtPtr stmt)
-      : std::runtime_error("MALFORMED INPUT: " + std::to_string(stmt)) {}
+      : compilation_error("MALFORMED INPUT: " + std::to_string(stmt)) {}
   explicit malformed_input(const std::string& err, StmtPtr stmt)
-      : std::runtime_error(
+      : compilation_error(
             "MALFORMED INPUT: " + err + " - " + std::to_string(stmt)) {}
 };
 
-class malformed_ir : public std::runtime_error {
+class malformed_ir : public compilation_error {
  public:
-  explicit malformed_ir() : std::runtime_error("MALFORMED IR") {}
+  explicit malformed_ir() : compilation_error("MALFORMED IR") {}
   explicit malformed_ir(const std::string& err)
-      : std::runtime_error("MALFORMED IR: " + err) {}
+      : compilation_error("MALFORMED IR: " + err) {}
   explicit malformed_ir(ExprPtr expr)
-      : std::runtime_error("MALFORMED IR: " + std::to_string(expr)) {}
+      : compilation_error("MALFORMED IR: " + std::to_string(expr)) {}
   explicit malformed_ir(const std::string& err, ExprPtr expr)
-      : std::runtime_error(
+      : compilation_error(
             "MALFORMED IR: " + err + " - " + std::to_string(expr)) {}
   explicit malformed_ir(StmtPtr stmt)
-      : std::runtime_error("MALFORMED IR: " + std::to_string(stmt)) {}
+      : compilation_error("MALFORMED IR: " + std::to_string(stmt)) {}
   explicit malformed_ir(const std::string& err, StmtPtr stmt)
-      : std::runtime_error(
+      : compilation_error(
             "MALFORMED IR: " + err + " - " + std::to_string(stmt)) {}
 };
 


### PR DESCRIPTION
This was landed as https://github.com/pytorch/pytorch/pull/64332 but got reverted due to bad compilation performance, which in turn was due to a bug in vectorizer that has already been fixed.

This reverts commit bcc7e82371082a284ad9ee423cad192bb024e1a1.


