### PR TITLE
[fx2trt] update conv vanilla converter

### DIFF
--- a/test/fx2trt/converters/acc_op/test_convolution.py
+++ b/test/fx2trt/converters/acc_op/test_convolution.py
@@ -61,5 +61,57 @@ class TestConvolutionConverter(AccTestCase):
             TestModule(), input_specs, expected_ops={acc_ops.conv2d}
         )
 
+    @parameterized.expand(
+        [
+            ("default", 1),
+            param("no_bias", 1, bias=False),
+            ("tuple_parameters", 1, (1, 1, 1), (1, 1, 1)),
+            param("non_zero_padding", 1, padding=1),
+            param("dilation", 1, dilation=2),
+            param("groups", 1, groups=3),
+        ]
+    )
+    def test_conv3d(
+        self,
+        _,
+        kernel_size,
+        stride=1,
+        padding=0,
+        dilation=1,
+        groups=1,
+        bias=True,
+    ):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv3d(
+                    3, 6, kernel_size, stride, padding, dilation, groups, bias
+                )
+
+            def forward(self, x):
+                return self.conv(x)
+
+        inputs = [torch.randn(1, 3, 32, 32, 32)]
+        self.run_test(TestModule(), inputs, expected_ops={acc_ops.conv3d})
+
+    def test_conv3d_with_dynamic_shape(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv3d(3, 6, 1)
+
+            def forward(self, x):
+                return self.conv(x)
+        input_specs = [
+            InputTensorSpec(
+                shape=(-1, 3, -1, -1, -1),
+                dtype=torch.float32,
+                shape_ranges=[((1, 3, 1, 1, 1), (1, 3, 4, 4, 4), (8, 3, 32, 32, 32))],
+            ),
+        ]
+        self.run_test_with_dynamic_shape(
+            TestModule(), input_specs, expected_ops={acc_ops.conv3d}
+        )
+
 if __name__ == '__main__':
     run_tests()

--- a/test/fx2trt/converters/vanilla/test_convolution.py
+++ b/test/fx2trt/converters/vanilla/test_convolution.py
@@ -41,5 +41,38 @@ class TestConvolutionConverter(VanillaTestCase):
         inputs = [torch.randn(1, 3, 224, 224)]
         self.run_test(TestModule(), inputs, expected_ops={torch.nn.modules.conv.Conv2d})
 
+    @parameterized.expand(
+        [
+            ("default", 1),
+            param("no_bias", 1, bias=False),
+            ("tuple_parameters", 1, (1, 1, 1), (0, 0, 0)),
+            param("non_zero_padding", 1, padding=1),
+            param("dilation", 1, dilation=2),
+            param("groups", 1, groups=3),
+        ]
+    )
+    def test_conv3d(
+        self,
+        test_name,
+        kernel_size,
+        stride=1,
+        padding=0,
+        dilation=1,
+        groups=1,
+        bias=True,
+    ):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv3d(
+                    3, 6, kernel_size, stride, padding, dilation, groups, bias
+                )
+
+            def forward(self, x):
+                return self.conv(x)
+
+        inputs = [torch.randn(1, 3, 32, 32, 32)]
+        self.run_test(TestModule(), inputs, expected_ops={torch.nn.modules.conv.Conv3d})
+
 if __name__ == '__main__':
     run_tests()

--- a/test/fx_acc/test_acc_tracer.py
+++ b/test/fx_acc/test_acc_tracer.py
@@ -316,6 +316,49 @@ class AccTracerTest(unittest.TestCase):
 
         self.assertTrue(torch.equal(m(input), traced(input)))
 
+    def test_conv3d(self):
+        """
+        Test that a conv is traced as expected.
+        """
+
+        class TestModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv3d(8, 7, 3, stride=2)
+
+            def forward(self, a: torch.Tensor) -> torch.Tensor:
+                return self.conv(a)
+
+        m = TestModule()
+        input = torch.randn(3, 8, 8, 10, 10)
+        traced = acc_tracer.trace(m, [input])
+
+        ph = weight_attr = bias_attr = conv = None
+        for node in traced.graph.nodes:
+            if node.op == "placeholder":
+                self.assertEqual(str(node.target), "a")
+                ph = node
+            elif node.op == "get_attr" and node.target == "conv.weight":
+                weight_attr = node
+            elif node.op == "get_attr" and node.target == "conv.bias":
+                bias_attr = node
+            elif node.op == "call_function":
+                self.assertEqual(node.target, acc_ops.conv3d)
+                self.assertEqual(node.kwargs["input"], ph)
+                self.assertEqual(node.kwargs["weight"], weight_attr)
+                self.assertEqual(node.kwargs["bias"], bias_attr)
+                self.assertEqual(node.kwargs["stride"], (2, 2, 2))
+                self.assertEqual(node.kwargs["padding"], (0, 0, 0))
+                self.assertEqual(node.kwargs["dilation"], (1, 1, 1))
+                self.assertEqual(node.kwargs["groups"], 1)
+                conv = node
+            elif node.op == "output":
+                self.assertEqual(conv, node.args[0])
+            else:
+                self.fail(f"Unexpected node: {node.format_node()}")
+
+        self.assertTrue(torch.equal(m(input), traced(input)))
+
     def test_embedding_bag(self):
         """
         Test that an embedding_bag is traced as expected.
@@ -2065,6 +2108,7 @@ class AccTracerTest(unittest.TestCase):
                 acc_ops.size,
                 acc_ops.split,
                 acc_ops.conv2d,
+                acc_ops.conv3d,
                 acc_ops.batch_norm,
                 acc_ops.embedding_bag,
                 acc_ops.embedding_bag_byte_rowwise_offsets,

--- a/torch/fx/experimental/fx_acc/acc_ops.py
+++ b/torch/fx/experimental/fx_acc/acc_ops.py
@@ -1168,6 +1168,20 @@ def quantized_conv2d(
     )
 
 
+@register_acc_op_mapping(op_and_target=("call_function", torch.conv3d))
+@register_acc_op
+def conv3d(*, input, weight, bias, stride, padding, dilation, groups):
+    return nn.functional.conv3d(
+        input=input,
+        weight=weight,
+        bias=bias,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        groups=groups,
+    )
+
+
 @register_acc_op_mapping(op_and_target=("call_function", nn.functional.batch_norm))
 @register_acc_op
 def batch_norm(


### PR DESCRIPTION
Summary: Update conv converter to use convolution_nd interface, add a conv3d vanilla converter

Test Plan:
```
buck test mode/opt caffe2/test/fx2trt/converters:test_convolution_vanilla
```

Reviewed By: wushirong

Differential Revision: D34006397

