### PR TITLE
Add TORCH_CUDA_CU_API to CUDABlas functions (take 2)

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -107,13 +107,13 @@ inline void trsm(CUDABLAS_TRSM_ARGTYPES(Dtype)) {
 }
 
 template <>
-void trsm<float>(CUDABLAS_TRSM_ARGTYPES(float));
+TORCH_CUDA_CU_API void trsm<float>(CUDABLAS_TRSM_ARGTYPES(float));
 template <>
-void trsm<double>(CUDABLAS_TRSM_ARGTYPES(double));
+TORCH_CUDA_CU_API void trsm<double>(CUDABLAS_TRSM_ARGTYPES(double));
 template <>
-void trsm<c10::complex<float>>(CUDABLAS_TRSM_ARGTYPES(c10::complex<float>));
+TORCH_CUDA_CU_API void trsm<c10::complex<float>>(CUDABLAS_TRSM_ARGTYPES(c10::complex<float>));
 template <>
-void trsm<c10::complex<double>>(CUDABLAS_TRSM_ARGTYPES(c10::complex<double>));
+TORCH_CUDA_CU_API void trsm<c10::complex<double>>(CUDABLAS_TRSM_ARGTYPES(c10::complex<double>));
 
 #define CUDABLAS_TRSM_BATCHED_ARGTYPES(Dtype)                          \
   cublasHandle_t handle, cublasSideMode_t side, cublasFillMode_t uplo, \
@@ -130,13 +130,13 @@ inline void trsmBatched(CUDABLAS_TRSM_BATCHED_ARGTYPES(Dtype)) {
 }
 
 template <>
-void trsmBatched<float>(CUDABLAS_TRSM_BATCHED_ARGTYPES(float));
+TORCH_CUDA_CU_API void trsmBatched<float>(CUDABLAS_TRSM_BATCHED_ARGTYPES(float));
 template <>
-void trsmBatched<double>(CUDABLAS_TRSM_BATCHED_ARGTYPES(double));
+TORCH_CUDA_CU_API void trsmBatched<double>(CUDABLAS_TRSM_BATCHED_ARGTYPES(double));
 template <>
-void trsmBatched<c10::complex<float>>(CUDABLAS_TRSM_BATCHED_ARGTYPES(c10::complex<float>));
+TORCH_CUDA_CU_API void trsmBatched<c10::complex<float>>(CUDABLAS_TRSM_BATCHED_ARGTYPES(c10::complex<float>));
 template <>
-void trsmBatched<c10::complex<double>>(CUDABLAS_TRSM_BATCHED_ARGTYPES(c10::complex<double>));
+TORCH_CUDA_CU_API void trsmBatched<c10::complex<double>>(CUDABLAS_TRSM_BATCHED_ARGTYPES(c10::complex<double>));
 
 /* LEVEL 2 BLAS FUNCTIONS */
 
@@ -214,13 +214,13 @@ void getrsBatched(CUDABLAS_GETRS_ARGTYPES(Dtype)) {
     typeid(Dtype).name());
 }
 template<>
-void getrsBatched<float>(CUDABLAS_GETRS_ARGTYPES(float));
+TORCH_CUDA_CU_API void getrsBatched<float>(CUDABLAS_GETRS_ARGTYPES(float));
 template<>
-void getrsBatched<double>(CUDABLAS_GETRS_ARGTYPES(double));
+TORCH_CUDA_CU_API void getrsBatched<double>(CUDABLAS_GETRS_ARGTYPES(double));
 template<>
-void getrsBatched<c10::complex<float>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<float>));
+TORCH_CUDA_CU_API void getrsBatched<c10::complex<float>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<float>));
 template<>
-void getrsBatched<c10::complex<double>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<double>));
+TORCH_CUDA_CU_API void getrsBatched<c10::complex<double>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<double>));
 
 #define CUDABLAS_GEQRF_BATCHED_ARGTYPES(Dtype)                   \
   cublasHandle_t handle, int m, int n, Dtype **A_array, int lda, \
@@ -234,14 +234,14 @@ void geqrfBatched(CUDABLAS_GEQRF_BATCHED_ARGTYPES(Dtype)) {
       typeid(Dtype).name());
 }
 template <>
-void geqrfBatched<float>(CUDABLAS_GEQRF_BATCHED_ARGTYPES(float));
+TORCH_CUDA_CU_API void geqrfBatched<float>(CUDABLAS_GEQRF_BATCHED_ARGTYPES(float));
 template <>
-void geqrfBatched<double>(CUDABLAS_GEQRF_BATCHED_ARGTYPES(double));
+TORCH_CUDA_CU_API void geqrfBatched<double>(CUDABLAS_GEQRF_BATCHED_ARGTYPES(double));
 template <>
-void geqrfBatched<c10::complex<double>>(
+TORCH_CUDA_CU_API void geqrfBatched<c10::complex<double>>(
     CUDABLAS_GEQRF_BATCHED_ARGTYPES(c10::complex<double>));
 template <>
-void geqrfBatched<c10::complex<float>>(
+TORCH_CUDA_CU_API void geqrfBatched<c10::complex<float>>(
     CUDABLAS_GEQRF_BATCHED_ARGTYPES(c10::complex<float>));
 
 #define CUDABLAS_GETRF_ARGTYPES(Dtype)  \
@@ -252,13 +252,13 @@ void getrfBatched(CUDABLAS_GETRF_ARGTYPES(Dtype)) {
   TORCH_CHECK(false, "at::cuda::blas::getrfBatched: not implemented for ", typeid(Dtype).name());
 }
 template<>
-void getrfBatched<float>(CUDABLAS_GETRF_ARGTYPES(float));
+TORCH_CUDA_CU_API void getrfBatched<float>(CUDABLAS_GETRF_ARGTYPES(float));
 template<>
-void getrfBatched<double>(CUDABLAS_GETRF_ARGTYPES(double));
+TORCH_CUDA_CU_API void getrfBatched<double>(CUDABLAS_GETRF_ARGTYPES(double));
 template<>
-void getrfBatched<c10::complex<double>>(CUDABLAS_GETRF_ARGTYPES(c10::complex<double>));
+TORCH_CUDA_CU_API void getrfBatched<c10::complex<double>>(CUDABLAS_GETRF_ARGTYPES(c10::complex<double>));
 template<>
-void getrfBatched<c10::complex<float>>(CUDABLAS_GETRF_ARGTYPES(c10::complex<float>));
+TORCH_CUDA_CU_API void getrfBatched<c10::complex<float>>(CUDABLAS_GETRF_ARGTYPES(c10::complex<float>));
 
 #define CUDABLAS_GETRI_ARGTYPES(Dtype)  \
   int n, Dtype** dA_array, int ldda, int* ipiv_array, Dtype** dC_array, int lddc, int* info_array, int batchsize
@@ -268,13 +268,13 @@ void getriBatched(CUDABLAS_GETRI_ARGTYPES(Dtype)) {
   TORCH_CHECK(false, "at::cuda::blas::getriBatched: not implemented for ", typeid(Dtype).name());
 }
 template<>
-void getriBatched<float>(CUDABLAS_GETRI_ARGTYPES(float));
+TORCH_CUDA_CU_API void getriBatched<float>(CUDABLAS_GETRI_ARGTYPES(float));
 template<>
-void getriBatched<double>(CUDABLAS_GETRI_ARGTYPES(double));
+TORCH_CUDA_CU_API void getriBatched<double>(CUDABLAS_GETRI_ARGTYPES(double));
 template<>
-void getriBatched<c10::complex<double>>(CUDABLAS_GETRI_ARGTYPES(c10::complex<double>));
+TORCH_CUDA_CU_API void getriBatched<c10::complex<double>>(CUDABLAS_GETRI_ARGTYPES(c10::complex<double>));
 template<>
-void getriBatched<c10::complex<float>>(CUDABLAS_GETRI_ARGTYPES(c10::complex<float>));
+TORCH_CUDA_CU_API void getriBatched<c10::complex<float>>(CUDABLAS_GETRI_ARGTYPES(c10::complex<float>));
 
 #define CUDABLAS_GELS_BATCHED_ARGTYPES(Dtype)  \
   cublasHandle_t handle, cublasOperation_t trans, int m, int n, int nrhs, Dtype** dA_array, int ldda, Dtype** dC_array, int lddc, int* info, int *devInfoArray, int batchSize
@@ -285,13 +285,13 @@ void gelsBatched(CUDABLAS_GELS_BATCHED_ARGTYPES(Dtype)) {
 }
 
 template<>
-void gelsBatched<double>(CUDABLAS_GELS_BATCHED_ARGTYPES(double));
+TORCH_CUDA_CU_API void gelsBatched<double>(CUDABLAS_GELS_BATCHED_ARGTYPES(double));
 template<>
-void gelsBatched<float>(CUDABLAS_GELS_BATCHED_ARGTYPES(float));
+TORCH_CUDA_CU_API void gelsBatched<float>(CUDABLAS_GELS_BATCHED_ARGTYPES(float));
 template<>
-void gelsBatched<c10::complex<double>>(CUDABLAS_GELS_BATCHED_ARGTYPES(c10::complex<double>));
+TORCH_CUDA_CU_API void gelsBatched<c10::complex<double>>(CUDABLAS_GELS_BATCHED_ARGTYPES(c10::complex<double>));
 template<>
-void gelsBatched<c10::complex<float>>(CUDABLAS_GELS_BATCHED_ARGTYPES(c10::complex<float>));
+TORCH_CUDA_CU_API void gelsBatched<c10::complex<float>>(CUDABLAS_GELS_BATCHED_ARGTYPES(c10::complex<float>));
 
 #endif // CUDART_VERSION
 

--- a/aten/src/ATen/native/DispatchStub.h
+++ b/aten/src/ATen/native/DispatchStub.h
@@ -165,18 +165,18 @@ public:
     impl.hip_dispatch_ptr = reinterpret_cast<void*>(fn_ptr);
   }
 
-  static FnPtr DEFAULT;
+  static TORCH_API FnPtr DEFAULT;
 #ifdef HAVE_AVX512_CPU_DEFINITION
-  static FnPtr AVX512;
+  static TORCH_API FnPtr AVX512;
 #endif
 #ifdef HAVE_AVX2_CPU_DEFINITION
-  static FnPtr AVX2;
+  static TORCH_API FnPtr AVX2;
 #endif
 #ifdef HAVE_VSX_CPU_DEFINITION
-  static FnPtr VSX;
+  static TORCH_API FnPtr VSX;
 #endif
 #ifdef HAVE_ZVECTOR_CPU_DEFINITION
-  static FnPtr ZVECTOR;
+  static TORCH_API FnPtr ZVECTOR;
 #endif
 private:
   DispatchStubImpl impl;
@@ -215,7 +215,7 @@ struct RegisterHIPDispatch {
 #define DEFINE_DISPATCH(name) struct name name
 
 #define REGISTER_ARCH_DISPATCH(name, arch, fn) \
-  template <> name::FnPtr DispatchStub<name::FnPtr, struct name>::arch = fn;
+  template <> name::FnPtr TORCH_API DispatchStub<name::FnPtr, struct name>::arch = fn;
 
 #ifdef HAVE_AVX512_CPU_DEFINITION
 #define REGISTER_AVX512_DISPATCH(name, fn) REGISTER_ARCH_DISPATCH(name, AVX512, fn)


### PR DESCRIPTION
In order to make them accessible from other libraries
Also make `REGISTER_ARCH_DISPATCH` export dispatches as  TORCH_API, so that stubs could be called from libraries other than `torch_cpu`. To satisfy Windows builds, add the same `TORCH_API` to the static members declarations, although they are noops on Linux.

