### PR TITLE
[PT-D][BE] Fix DDP no_sync() test logic

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4376,7 +4376,7 @@ class DistributedTest:
                     rank * local_batch_size : (rank + 1) * local_batch_size
                 ]
 
-                if iteration % num_iters == 0:
+                if iteration % 2 == 0:
                     # accumulate grads locally
                     with ddp_model.no_sync():
                         step_model(ddp_model, ddp_input, ddp_target)
@@ -4387,7 +4387,7 @@ class DistributedTest:
                 for i, j in zip(model.parameters(), ddp_model.parameters()):
                     if not i.requires_grad:
                         continue
-                    if iteration % num_iters == 0:
+                    if iteration % 2 == 0:
                         self.assertNotEqual(i.grad, j.grad)
                     else:
                         self.assertEqual(i.grad, j.grad)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#72348 [PT-D][BE] Fix DDP no_sync() test logic**

**Overview**
#43307 changed `_test_accumulate_gradients_no_sync()` to add a `num_iters` argument. However, I think the change misconstrued the test logic slightly.

https://github.com/pytorch/pytorch/blob/8551989bff33db47f8a5571b69c1afa6d8ef87eb/torch/testing/_internal/distributed/distributed_test.py#L4369-L4397

- `iteration % num_iters == 0` evaluates to `True` only for `iteration == 0` since `iteration` comes from `for iteration in range(num_iters)`.
- IIUC, the intention is to alternate between accumulating gradients (using `no_sync()`) and synchronizing gradients normally. In the existing implementation, any iterations following the second one are non-productive since gradients are in sync, meaning it reduces to testing normal DDP.
- This PR changes the check back to `iteration % 2 == 0` to restore the alternating behavior from before #43307.

**Test Plan**
I ran
```
BACKEND=nccl WORLD_SIZE=4 python -m pytest test/distributed/test_distributed_spawn.py -k test_accumulate_gradients
```
which tests:
- `test_accumulate_gradients_no_sync`
- `test_accumulate_gradients_no_sync_grad_is_view`
- `test_accumulate_gradients_no_sync_allreduce_hook`
- `test_accumulate_gradients_no_sync_allreduce_with_then_hook`

Differential Revision: [D34011559](https://our.internmc.facebook.com/intern/diff/D34011559)