### PR TITLE
Fixing few bugs in torch flatbuffer

### DIFF
--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -170,8 +170,16 @@ mobile::Module FlatbufferLoader::parseModule(
       all_ivalues_[i] = parseIValue(ival);
     }
   }
-
   IValue& module_ivalue = getIValue(module->state_obj());
+
+  // register functions
+  for (const auto& f : all_functions_) {
+    uint32_t class_index =
+        ivalues->Get(f.first)->val_as_Function()->class_type();
+    ClassTypePtr class_type = all_types_[class_index];
+    class_type->addMethod(f.second);
+  }
+
   return mobile::Module(module_ivalue.toObject(), mcu_);
 }
 
@@ -368,14 +376,14 @@ IValue parseIntList(
   return parseListNative<int64_t>(list);
 }
 
-IValue parseBoolList(
+IValue parseDoubleList(
     FlatbufferLoader&,
     const mobile::serialization::IValue& ivalue) {
   const auto& list = ivalue.val_as_DoubleList();
   return parseListNative<double>(list);
 }
 
-IValue parseDoubleList(
+IValue parseBoolList(
     FlatbufferLoader&,
     const mobile::serialization::IValue& ivalue) {
   const auto& list = ivalue.val_as_BoolList();

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -236,6 +236,7 @@ flatbuffers::Offset<mobile::serialization::Function> FlatbufferSerializer::
   };
 
   flatbuffers::Offset<mobile::serialization::Schema> schema_offset = 0;
+  uint32_t class_index = 0;
   if (func.hasSchema()) {
     const auto& schema = func.getSchema();
     TORCH_CHECK(
@@ -249,13 +250,12 @@ flatbuffers::Offset<mobile::serialization::Function> FlatbufferSerializer::
         "A variable number of return values is not supported in mobile modules.");
     schema_offset =
         CreateFBSchema(fbb, schema.arguments(), schema.returns(), type_printer);
+    auto classtype = schema.arguments()[0].type()->cast<ClassType>();
+    class_index = storeClassTypeAndGetIndex(fbb, classtype);
   }
 
   auto debug_info_offset =
       CreateDebugInfo(fbb, fbb.CreateVector(code.debug_handles_));
-
-  // auto classtype = schema.arguments()[0].type()->cast<ClassType>();
-  // uint32_t class_type = storeClassTypeAndGetIndex(fbb, classtype);
 
   auto function_offset = CreateFunctionDirect(
       fbb,
@@ -267,7 +267,7 @@ flatbuffers::Offset<mobile::serialization::Function> FlatbufferSerializer::
       register_size,
       schema_offset,
       debug_info_offset,
-      0);
+      class_index);
   return function_offset;
 }
 


### PR DESCRIPTION
Summary:
1. Interface call'd methods need to be registered to class. Previously all interface calls are inlined so  there was no such problem.
2. parseDoubleList and parseBoolList got reversed when refactoring.

Test Plan:
1. Get ASR's test model at
```
mkdir ~/asr1 && cd ~/asr1
fbpkg fetch speech.tuna.milan.ondevice.en_us
```
2. Convert model:
```
cd ~/fbsource
buck run //xplat/caffe2/fb/lite_predictor:convert_model -- --model=$HOME/asr1/pytorchmodel.pt --output_name=$HOME/asr1/pytorchmodel.ff
```
3. Ran lite_predictor_flatbuffer
```
 buck run //xplat/caffe2/fb/lite_predictor:lite_predictor_flatbuffer -- --model=$HOME/asr1/pytorchmodel.ff --method_to_call=encode_src --method_to_generate_input=get_all_bundled_inputs_for_encode_src

```

See perf metric generated (means loading and inference succeeded).

Differential Revision: D33959746

