### PR TITLE
[CP-1.11] Remove forcing CUDNN_STATIC when CAFFE2_STATIC_LINK_CUDA

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -102,11 +102,7 @@ if(CUDA_FOUND)
 endif()
 
 # Find cuDNN.
-if(CAFFE2_STATIC_LINK_CUDA AND NOT USE_STATIC_CUDNN)
-  message(WARNING "cuDNN will be linked statically because CAFFE2_STATIC_LINK_CUDA is ON. "
-    "Set USE_STATIC_CUDNN to ON to suppress this warning.")
-endif()
-if(CAFFE2_STATIC_LINK_CUDA OR USE_STATIC_CUDNN)
+if(USE_STATIC_CUDNN)
   set(CUDNN_STATIC ON CACHE BOOL "")
 else()
   set(CUDNN_STATIC OFF CACHE BOOL "")


### PR DESCRIPTION
Remove forcing CUDNN_STATIC when CAFFE2_STATIC_LINK_CUDA is set
Since we are transitioning to using dynamic loading for multiple pytorch dependecies  and CUDNN is the first step in this transition,  hence we want to remove forcing CUDNN to statically load, and instead load it dynamically.

Tested using following workflow:
https://github.com/pytorch/pytorch/actions/runs/1790666862

Cherry-pick  https://github.com/pytorch/pytorch/pull/72290 into `release/1.11`
