### PR TITLE
[torch.package] add test case for repackaging parent module (#72299)

### DIFF
--- a/test/package/package_d/imports_directly.py
+++ b/test/package/package_d/imports_directly.py
@@ -1,0 +1,11 @@
+import torch
+
+from .subpackage_0.subsubpackage_0 import important_string
+
+
+class ImportsDirectlyFromSubSubPackage(torch.nn.Module):
+
+    key = important_string
+
+    def forward(self, inp):
+        return torch.sum(inp)

--- a/test/package/package_d/imports_indirectly.py
+++ b/test/package/package_d/imports_indirectly.py
@@ -1,0 +1,11 @@
+import torch
+
+from .subpackage_0 import important_string
+
+
+class ImportsIndirectlyFromSubPackage(torch.nn.Module):
+
+    key = important_string
+
+    def forward(self, inp):
+        return torch.sum(inp)

--- a/test/package/package_d/subpackage_0/__init__.py
+++ b/test/package/package_d/subpackage_0/__init__.py
@@ -1,0 +1,1 @@
+from .subsubpackage_0 import important_string

--- a/test/package/package_d/subpackage_0/subsubpackage_0/__init__.py
+++ b/test/package/package_d/subpackage_0/subsubpackage_0/__init__.py
@@ -1,0 +1,1 @@
+important_string = "subsubpackage_0"

--- a/test/package/test_repackage.py
+++ b/test/package/test_repackage.py
@@ -1,0 +1,50 @@
+# Owner(s): ["oncall: package/deploy"]
+
+from io import BytesIO
+
+from torch.package import (
+    PackageExporter,
+    PackageImporter,
+    sys_importer,
+)
+from torch.testing._internal.common_utils import run_tests
+
+try:
+    from .common import PackageTestCase
+except ImportError:
+    # Support the case where we run this file directly.
+    from common import PackageTestCase
+
+
+class TestRepackage(PackageTestCase):
+    """Tests for repackaging."""
+
+    def test_repackage_import_indirectly_via_parent_module(self):
+        from package_d.imports_directly import ImportsDirectlyFromSubSubPackage
+        from package_d.imports_indirectly import ImportsIndirectlyFromSubPackage
+
+        model_a = ImportsDirectlyFromSubSubPackage()
+        buffer = BytesIO()
+        with PackageExporter(buffer) as pe:
+            pe.intern("**")
+            pe.save_pickle("default", "model.py", model_a)
+
+        buffer.seek(0)
+        pi = PackageImporter(buffer)
+        loaded_model = pi.load_pickle("default", "model.py")
+
+        model_b = ImportsIndirectlyFromSubPackage()
+        buffer = BytesIO()
+        with PackageExporter(
+            buffer,
+            importer=(
+                pi,
+                sys_importer,
+            ),
+        ) as pe:
+            pe.intern("**")
+            pe.save_pickle("default", "model_b.py", model_b)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/pytorch/pull/72299

Test Plan:
Before https://github.com/pytorch/pytorch/pull/71520:
```
Summary
  Pass: 106
  Fail: 1
    ✗ caffe2/test:package - test_repackage_import_indirectly_via_parent_module (package.package_d.test_repackage.TestRepackage)
  Skip: 22
  ...
  ListingSuccess: 1
```

After https://github.com/pytorch/pytorch/pull/71520:

```
BUILD SUCCEEDED
    ✓ ListingSuccess: caffe2/test:package : 129 tests discovered (28.595)
    ✓ Pass: caffe2/test:package - test_repackage_import_indirectly_via_parent_module (package.package_d.test_repackage.TestRepackage) (18.635)
Summary
  Pass: 1
  ListingSuccess: 1
```

Differential Revision: D34015540

