### PR TITLE
[quant][debug] using torch.ops.quantized.{op}.op instead of torch.ops.quantized.{op}

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -170,13 +170,14 @@ class _OpNamespace(types.ModuleType):
         # with qualified_op_name
         torch.jit._builtins._register_builtin(op, qualified_op_name)
         op.__module__ = self.__module__ + "." + namespace_name
-        # opoverloadpacket = OpOverloadPacket(qualified_op_name, op_name, op)
-        # opoverloadpacket.__module__ = self.__module__ + "." + namespace_name
+        opoverloadpacket = OpOverloadPacket(qualified_op_name, op_name, op)
+        opoverloadpacket.__module__ = self.__module__ + "." + namespace_name
         # cache the opoverloadpacket to ensure that each op corresponds to
         # a unique OpOverloadPacket object
-        # setattr(self, op_name, opoverloadpacket)
-        setattr(self, op_name, op)
-        return op
+        setattr(self, op_name, opoverloadpacket)
+        # setattr(self, op_name, op)
+        # return op
+        return opoverloadpacket
 
 class _Ops(types.ModuleType):
     __file__ = '_ops.py'

--- a/torch/ao/quantization/fx/quantization_patterns.py
+++ b/torch/ao/quantization/fx/quantization_patterns.py
@@ -337,16 +337,16 @@ class BinaryOpQuantizeHandler(QuantizeHandler):
             (self.num_tensor_args == len(self.binary_op_node.args))
 
         qbin_op_mapping: Dict[Union[Callable, str], Callable] = {
-            operator.add: torch.ops.quantized.add,
-            torch.add: torch.ops.quantized.add,
-            operator.mul: torch.ops.quantized.mul,
-            torch.mul: torch.ops.quantized.mul,
+            operator.add: torch.ops.quantized.add.op,
+            torch.add: torch.ops.quantized.add.op,
+            operator.mul: torch.ops.quantized.mul.op,
+            torch.mul: torch.ops.quantized.mul.op,
         }
         qbin_relu_op_mapping: Dict[Union[Callable, str], Callable] = {
-            operator.add: torch.ops.quantized.add_relu,
-            torch.add: torch.ops.quantized.add_relu,
-            operator.mul: torch.ops.quantized.mul_relu,
-            torch.mul: torch.ops.quantized.mul_relu,
+            operator.add: torch.ops.quantized.add_relu.op,
+            torch.add: torch.ops.quantized.add_relu.op,
+            operator.mul: torch.ops.quantized.mul_relu.op,
+            torch.mul: torch.ops.quantized.mul_relu.op,
         }
         # corresponding quantized op
         self.quantized_binary_op: Optional[Callable] = None
@@ -1092,7 +1092,7 @@ class LinearReLUQuantizeHandler(QuantizeHandler):
                         'call_function', prepack_op, prepack_args, {})
                 # construct linear input
                 if activation_int8_quantized:
-                    qlinear_op = torch.ops.quantized.linear_relu if self.relu_node else torch.ops.quantized.linear
+                    qlinear_op = torch.ops.quantized.linear_relu.op if self.relu_node else torch.ops.quantized.linear.op
                     linear_input = load_arg(quantized=torch.quint8)(self.linear_node.args[0])
                     activation_post_process = \
                         self._maybe_get_last_node_only_observer(modules)
@@ -1118,14 +1118,14 @@ class LinearReLUQuantizeHandler(QuantizeHandler):
                     # choose linear dynamic or linear dynamic fp16 op based on weight dtype
                     if weight_dtype == torch.qint8:
                         if self.relu_node:
-                            qlinear_op = torch.ops.quantized.linear_relu_dynamic
+                            qlinear_op = torch.ops.quantized.linear_relu_dynamic.op
                         else:
-                            qlinear_op = torch.ops.quantized.linear_dynamic
+                            qlinear_op = torch.ops.quantized.linear_dynamic.op
                     else:
                         if self.relu_node:
-                            qlinear_op = torch.ops.quantized.linear_relu_dynamic_fp16
+                            qlinear_op = torch.ops.quantized.linear_relu_dynamic_fp16.op
                         else:
-                            qlinear_op = torch.ops.quantized.linear_dynamic_fp16
+                            qlinear_op = torch.ops.quantized.linear_dynamic_fp16.op
 
                     linear_input = load_arg(quantized=torch.float)(self.linear_node.args[0])
                     qlinear_args = (linear_input, packed_weight)  # type: ignore[assignment]

--- a/torch/ao/quantization/quantization_mappings.py
+++ b/torch/ao/quantization/quantization_mappings.py
@@ -132,12 +132,12 @@ _INCLUDE_QCONFIG_PROPAGATE_LIST : Set[Callable] = {
 # Default mapping from floating point function or torch ops to quantized ops
 # TODO: merge with default static mapping
 DEFAULT_FLOAT_TO_QUANTIZED_OPERATOR_MAPPINGS : Dict[Union[Callable, str], Callable] = {
-    F.elu: torch.ops.quantized.elu,
-    F.hardswish: torch.ops.quantized.hardswish,
-    F.instance_norm: torch.ops.quantized.instance_norm,
-    F.layer_norm: torch.ops.quantized.layer_norm,
-    F.leaky_relu: torch.ops.quantized.leaky_relu,
-    F.dropout: torch.ops.quantized.dropout,
+    F.elu: torch.ops.quantized.elu.op,
+    F.hardswish: torch.ops.quantized.hardswish.op,
+    F.instance_norm: torch.ops.quantized.instance_norm.op,
+    F.layer_norm: torch.ops.quantized.layer_norm.op,
+    F.leaky_relu: torch.ops.quantized.leaky_relu.op,
+    F.dropout: torch.ops.quantized.dropout.op,
 }
 
 # mapping from module to output activation post process class


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72370

Summary:
Testing the overload op change

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D34017672](https://our.internmc.facebook.com/intern/diff/D34017672)