### PR TITLE
Improve numerical stability of `torch.distributions.constraints.positive_semidefinite`

### DIFF
--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -498,7 +498,7 @@ class _PositiveSemidefinite(_Symmetric):
         sym_check = super().check(value)
         if not sym_check.all():
             return sym_check
-        return torch.linalg.eigvalsh(value).ge(0).all(-1)
+        return torch.linalg.eigvalsh(value).ge(-torch.finfo(value.dtype).eps).all(-1)
 
 
 class _PositiveDefinite(_Symmetric):


### PR DESCRIPTION
It is observered that `torch.linalg.eigvalsh` used in `torch.distributions.constraints.positive_semidefinite` produce numerical errors sometimes.
Example:
```
>>> a = tensor([[[0.4294, 1.1281, 0.8743],
         [1.1281, 2.9678, 2.2876],
         [0.8743, 2.2876, 1.7998]]])
>>> torch.linalg.eigvalsh(a)
tensor([[-1.2535e-07,  2.2937e-02,  5.1741e+00]])
```
Note) This PR does not solve all the numerical issues. Positive-semidefinite matrices (i.e matrix generated by multipling the matrix with its transpose) occasionally yield negative values with magnitude larger than torch.finfo(<torch.dtype>).eps.

cc @neerajprad 