### PR TITLE
add fx2trt diagnostics (and a framework)

### DIFF
--- a/test/fx2trt/trt_lower/test_diagnostics.py
+++ b/test/fx2trt/trt_lower/test_diagnostics.py
@@ -1,0 +1,184 @@
+# Owner(s): ["oncall: aiacc"]
+from typing import Union
+from unittest import TestCase
+import functools
+import glob
+import os
+import shutil
+import tempfile
+import torch.fx.experimental.fx2trt.diagnostics as diag
+
+
+def reset_diag(fn):
+    @functools.wraps(fn)
+    def reset(*a, **kw):
+        try:
+            tok1 = diag._CURRENT_COLLECTOR.set(None)
+            tok2 = diag._CURRENT_WRITER.set(None)
+            tok3 = diag._SUBSEQUENT_COLLECT_SUPPRESSED_BY.set(None)
+            return fn(*a, **kw)
+        finally:
+            diag._CURRENT_COLLECTOR.reset(tok1)
+            diag._CURRENT_WRITER.reset(tok2)
+            diag._SUBSEQUENT_COLLECT_SUPPRESSED_BY.reset(tok3)
+    return reset
+
+
+class Fx2trtDiagnosticsTest(TestCase):
+    @reset_diag
+    def test_diagnostics(self):
+        collector = diag.ZipDiagnosticsCollector(
+            writer=diag.get_current_writer()
+        )
+
+        diag.set_current_collector(collector)
+
+        try:
+            with diag.collect_when_fail():
+                diag.write("aaa", "hello")
+                diag.write("bbb", lambda: "world")
+                diag.write("ccc", b"123")
+                diag.write("ddd", lambda: b"456")
+
+                def boom() -> str:
+                    raise AssertionError("Error generating diagnostics.")
+                diag.write("eee", boom)
+
+                diag.write("zzz", "done")
+                raise _UserDefinedError("Error while lowering")
+        except _UserDefinedError:
+            pass
+
+        zip_fn = collector._last_zip_path_for_test
+        assert os.path.exists(zip_fn)
+        with tempfile.TemporaryDirectory() as tempdir:
+            print(f"Unpacking into {tempdir}")
+            shutil.unpack_archive(zip_fn, tempdir)
+            _check_file(tempdir, "aaa", "hello")
+            _check_file(tempdir, "bbb", "world")
+            _check_file(tempdir, "ccc", b"123")
+            _check_file(tempdir, "ddd", b"456")
+            _check_file(tempdir, "zzz", "done")
+            # file eee should still exist to contain err msg
+            _check_file(tempdir, "eee", "")
+
+    @reset_diag
+    def test_condition_func_name(self):
+        collector = diag.ZipDiagnosticsCollector(
+            writer=diag.get_current_writer()
+        )
+        diag.set_current_collector(collector)
+
+        with diag.collect_when(
+            diag.CollectionConditions.when_called_by_function(self.test_condition_func_name.__name__)
+        ):
+            diag.write("aaa", "hello")
+
+        zip_fn = collector._last_zip_path_for_test
+        assert os.path.exists(zip_fn)
+        with tempfile.TemporaryDirectory() as tempdir:
+            print(f"Unpacking into {tempdir}")
+            shutil.unpack_archive(zip_fn, tempdir)
+            _check_file(tempdir, "aaa", "hello")
+
+    @reset_diag
+    def test_write_without_collect(self):
+        collector = diag.ZipDiagnosticsCollector(
+            writer=diag.get_current_writer()
+        )
+        diag.set_current_collector(collector)
+        diag.write("aaa", "hello")
+        root_dir = diag.get_current_writer().root_dir()
+        res = glob.glob(f"{root_dir}/*")
+        assert not res  # root dir should be empty
+
+    def test_conditions(self):
+
+        _test_cond(
+            diag.CollectionConditions.when_called_by_function(self.test_conditions.__name__),
+            should_collect=True,
+        )
+
+        _test_cond(
+            diag.CollectionConditions.when_called_by_function("moo_baa_la_la_la"),
+            should_collect=False,
+        )
+
+        _test_cond(
+            diag.CollectionConditions.any(
+                diag.CollectionConditions.never(),
+                diag.CollectionConditions.always(),
+            ),
+            True,
+        )
+
+        _test_cond(
+            diag.CollectionConditions.all(
+                diag.CollectionConditions.never(),
+                diag.CollectionConditions.always(),
+            ),
+            False,
+        )
+
+        # nested
+        _test_cond(
+            diag.CollectionConditions.any(
+                diag.CollectionConditions.never(),
+                diag.CollectionConditions.any(
+                    diag.CollectionConditions.always(),
+                ),
+            ),
+            True,
+        )
+
+
+@reset_diag
+def _test_cond(
+    cond: diag.CollectionCondition,
+    should_collect: bool,
+) -> None:
+    collector = diag.ZipDiagnosticsCollector(
+        writer=diag.get_current_writer()
+    )
+    diag.set_current_collector(collector)
+
+    with diag.collect_when(cond):
+        diag.write("aaa", "hello")
+
+    zip_fn = collector._last_zip_path_for_test
+    if should_collect:
+        assert os.path.exists(zip_fn)
+        with tempfile.TemporaryDirectory() as tempdir:
+            print(f"Unpacking into {tempdir}")
+            shutil.unpack_archive(zip_fn, tempdir)
+            _check_file(tempdir, "aaa", "hello")
+    else:
+        assert not zip_fn, "the collection should not have triggered"
+
+
+def _check_file(dir: str, fn: str, content: Union[str, bytes]):
+    fp = os.path.join(dir, fn)
+    res = glob.glob(f"{fp}*")
+    assert len(res) == 1
+    fp = res[0]
+    if not os.path.exists(fp):
+        raise _CheckFileDoesNotExist(f"{fp} must exist")
+    if not content:
+        # don't check content then
+        return
+    if isinstance(content, bytes):
+        with open(fp, "rb") as f:
+            content_actual = f.read()
+            assert content == content_actual
+    else:
+        content: str
+        with open(fp, "r", encoding="utf-8") as f:
+            content_actual = f.read()
+            assert content == content_actual
+
+
+class _UserDefinedError(Exception):
+    pass
+
+class _CheckFileDoesNotExist(AssertionError):
+    pass

--- a/torch/fx/experimental/fx2trt/diagnostics.py
+++ b/torch/fx/experimental/fx2trt/diagnostics.py
@@ -1,0 +1,268 @@
+from contextvars import ContextVar
+import time
+import traceback
+from dataclasses import dataclass
+import inspect
+import contextlib
+import logging
+import os
+import os.path
+import typing as t
+import shutil
+import tempfile
+
+
+TWrite = t.Union[str, bytes]
+WriteObj = t.Union[TWrite, t.Callable[[], TWrite]]
+
+_CURRENT_WRITER: ContextVar["DiagnosticsWriter"] = ContextVar("_CURRENT_WRITER")
+_CURRENT_COLLECTOR: ContextVar["DiagnosticsCollector"] = ContextVar("_CURRENT_COLLECTOR")
+# Allows a collector to indicate subsequent collections should be suppressed to
+# avoid duplicate collections.
+_SUBSEQUENT_COLLECT_SUPPRESSED_BY: ContextVar[object] = ContextVar("_SUBSEQUENT_COLLECT_SUPPRESSED_BY")
+# Indicates current execution context is within a context manager by
+# `collect_when`. Only when it's set do we actually write diagnostics.
+_IS_IN_COLLECT_CONTEXT: ContextVar[bool] = ContextVar("_IS_IN_COLLECT_CONTEXT")
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class CollectionConditionContext:
+    exception: t.Optional[Exception]
+
+CollectionCondition = t.Callable[[CollectionConditionContext], bool]
+
+
+def collect_when(condition: "CollectionCondition", supress_subsequent_collect: bool = True):
+    """See `DiagnosticsCollector.collect_when`"""
+    return get_current_collector().collect_when(condition, supress_subsequent_collect)
+
+
+def collect():
+    return collect_when(CollectionConditions.always())
+
+
+def collect_when_fail():
+    return collect_when(CollectionConditions.when_fail())
+
+
+def write(file_name: str, text: WriteObj):
+    return get_current_writer().write(file_name, text)
+
+
+def get_current_writer() -> "DiagnosticsWriter":
+    """Get the writer for current execution context.
+
+    Lazily instantiates and registers one if not already done.
+    """
+    current_writer = _CURRENT_WRITER.get(None)
+    if not current_writer:
+        current_writer = DiagnosticsWriter()
+        _CURRENT_WRITER.set(current_writer)
+    return current_writer
+
+
+def get_current_collector() -> "DiagnosticsCollector":
+    current_collector = _CURRENT_COLLECTOR.get(None)
+    if not current_collector:
+        current_collector = DiagnosticsCollector()
+        _CURRENT_COLLECTOR.set(current_collector)
+    return current_collector
+
+
+def set_current_collector(collector: "DiagnosticsCollector"):
+    _CURRENT_COLLECTOR.set(collector)
+
+
+class DiagnosticsWriter:
+
+    # the root dir in which the diagnostics will be written
+    _root_dir: str
+
+    def __init__(self):
+        self._root_dir = tempfile.mkdtemp(prefix="fx2trt.")
+        _LOGGER.info(f"Initializing DiagnosticsWriter with root_dir: {self._root_dir}")
+
+    def write(self, file_name: str, data: WriteObj):
+        """
+        TODO: Can be disabled by regex on file_name
+        """
+        # Only write if we are inside a collect_when() context.
+        if not _IS_IN_COLLECT_CONTEXT.get(False):
+            return
+
+        try:
+            res, err = _res_or_err(data)
+            if err:
+                to_write = err.encode("utf-8")
+            else:
+                if isinstance(res, str):
+                    to_write = res.encode("utf-8")
+                elif isinstance(res, bytes):
+                    to_write = res
+                else:
+                    raise TypeError(f"Unknown data type: {type(res)}")
+            self._write(file_name, to_write)
+        except Exception as e:
+            # Log the error and swallow the exception, as this should not
+            # propagated into business logic
+            _LOGGER.warning(f"Error writing diagnostics: {e}")
+
+    def root_dir(self) -> str:
+        return self._root_dir
+
+    def _write(self, file_name: str, to_write: bytes):
+        # ms granularity - no naming collash, otherwise file will be
+        # overwritten.
+        ts = int(time.time() * 1000)
+        file_name = f"{file_name}.{ts}"
+        fn = os.path.join(self.root_dir(), file_name)
+        with open(fn, "wb") as f:
+            f.write(to_write)
+
+
+class CollectionConditions:
+    @classmethod
+    def any(cls, *conditions: "CollectionCondition") -> "CollectionCondition":
+        return lambda ctx: any(
+            cond(ctx) for cond in conditions
+        )
+
+    @classmethod
+    def all(cls, *conditions: "CollectionCondition") -> "CollectionCondition":
+        return lambda ctx: all(
+            cond(ctx) for cond in conditions
+        )
+
+    @classmethod
+    def always(cls) -> "CollectionCondition":
+        """Always collect"""
+        return lambda ctx: True
+
+    @classmethod
+    def never(cls) -> "CollectionCondition":
+        """Never collect"""
+        return lambda ctx: False
+
+    @classmethod
+    def when_fail(cls) -> "CollectionCondition":
+        """Collect when failed"""
+        ctx: CollectionConditionContext
+        return lambda ctx: ctx.exception is not None
+
+    @classmethod
+    def when_called_by_function(cls, func_name: str) -> "CollectionCondition":
+        def _when_called_by_function(ctx: CollectionConditionContext) -> bool:
+            frames = inspect.stack()
+            for frame in frames:
+                if frame[3] == func_name:
+                    return True
+            return False
+        return _when_called_by_function
+
+
+class DiagnosticsCollector:
+    @contextlib.contextmanager
+    def collect_when(self, condition: "CollectionCondition", supress_subsequent_collect: bool = True):
+        """
+        Context manager to collect diagnostics when the enclosed code completes
+        and *any* of the given condition is met.
+
+        Args:
+            condition:
+                the condition only when met should the collection be done
+            supress_subsequent_collect:
+                When true, suppress any collections registered by this function
+                call. This is to ensure duplicate collections registered across
+                the callstack by different components. In this case, only the
+                outermost component will collect.
+
+                When false, always collect (subject to given condition) regardless
+                of earlier collection registration's suppression.
+
+        Returns:
+            a context manager that handles the collection when its enclosed
+            code finished run.
+        """
+        this_collection_handle = object()
+        suppressed_by = _SUBSEQUENT_COLLECT_SUPPRESSED_BY.get(None)
+        reset_suppressed_by = False
+        if supress_subsequent_collect:
+            if suppressed_by and suppressed_by != this_collection_handle:
+                # Disable this collection since it's suppressed by a previously
+                # installed collection
+                condition = CollectionConditions.never()
+            else:
+                suppressed_by = this_collection_handle
+                _SUBSEQUENT_COLLECT_SUPPRESSED_BY.set(suppressed_by)
+                # don't forget to reset it in `finanlly`
+                reset_suppressed_by = True
+
+        is_in_collect_context_tok = _IS_IN_COLLECT_CONTEXT.set(True)
+        exception: t.Optional[Exception] = None
+        try:
+            yield
+        except Exception as e:
+            exception = e
+            raise
+        finally:
+            if reset_suppressed_by:
+                _SUBSEQUENT_COLLECT_SUPPRESSED_BY.set(None)
+            if self._test_condition(condition, CollectionConditionContext(exception)):
+                try:
+                    self.collect()
+                except Exception as e:
+                    _LOGGER.warning(
+                        f"Error while collecting diagnostics (THIS EXCEPTION IS HANDLED):\n"
+                        f"{e}\n"
+                        f"{traceback.format_exc()}"
+                    )
+            _IS_IN_COLLECT_CONTEXT.reset(is_in_collect_context_tok)
+
+    def collect(self) -> str:
+        """Collect the diagnostics. Overridable in sub-classes."""
+        return ""
+
+    @classmethod
+    def _test_condition(
+        cls,
+        cond: CollectionCondition,
+        ctx: CollectionConditionContext
+    ) -> bool:
+        try:
+            return cond(ctx)
+        except Exception as e:
+            _LOGGER.warning(f"Error while testing condition: {e}")
+            return False
+
+
+class ZipDiagnosticsCollector(DiagnosticsCollector):
+    _write: DiagnosticsWriter
+    _last_zip_path_for_test: str = ""  # for test purpose only
+
+    def __init__(self, writer: DiagnosticsWriter):
+        self._write = writer
+
+    def collect(self) -> str:
+        _, fp = tempfile.mkstemp()
+        try:
+            zip_path = shutil.make_archive(fp, "zip", self._write.root_dir())
+            self._last_zip_path_for_test = zip_path
+            return zip_path
+        finally:
+            os.remove(fp)
+
+
+def _res_or_err(data: WriteObj) -> t.Tuple[TWrite, str]:
+    if isinstance(data, (str, bytes)):
+        return data, ""
+    if not callable(data):
+        raise TypeError(
+            f"data must be a callable that returns actual data to"
+            f"write, but got {type(data)}"
+        )
+    try:
+        return data(), ""
+    except Exception as e:
+        _LOGGER.warning(f"Error getting data to write: {e}")
+        return "", str(e)

--- a/torch/fx/experimental/fx2trt/fx2trt.py
+++ b/torch/fx/experimental/fx2trt/fx2trt.py
@@ -11,6 +11,7 @@ from torch.fx.passes.shape_prop import TensorMetadata
 from .converter_registry import CONVERTERS
 from .input_tensor_spec import InputTensorSpec
 from .utils import torch_dtype_to_trt, get_dynamic_dims
+import torch.fx.experimental.fx2trt.diagnostics as diagnostics
 
 
 class TRTInterpreterResult(NamedTuple):
@@ -150,6 +151,11 @@ class TRTInterpreter(torch.fx.Interpreter):
         timing_cache=None,
         profiling_verbosity=None,
     ) -> TRTInterpreterResult:
+        diagnostics.write(
+            "trt_interpreter.graph.input",
+            lambda: str(self.module.graph),
+        )
+
         # For float outputs, we set their dtype to fp16 only if fp16_mode=True and
         # force_fp32_output=False.
         self.output_fp16 = not force_fp32_output and fp16_mode

--- a/torch/fx/experimental/fx2trt/lower.py
+++ b/torch/fx/experimental/fx2trt/lower.py
@@ -9,6 +9,7 @@ import torch.fx.experimental.fx_acc.acc_tracer as acc_tracer
 import torch.nn as nn
 from torch.fx.experimental.const_fold import split_const_subgraphs
 from torch.fx.passes.splitter_base import SplitResult
+import torch.fx.experimental.fx2trt.diagnostics as diagnostics
 
 from .fx2trt import (
     TRTInterpreter,
@@ -333,10 +334,9 @@ class Lowerer:
         # TesnorRT doesn't like duplicate outputs. Run this pass to eliminate such case.
         remove_duplicate_output_args(split_result.split_module, split_result.submodule_inputs.keys())
 
-
         for submod_name, submod_inputs in split_result.submodule_inputs.items():
             submod = getattr(split_result.split_module, submod_name)
-
+            diagnostics.write(f"lower.split.{submod_name}.module.graph", lambda: str(submod.graph))
             if self.trt_module_observer:
                 self.trt_module_observer(submod_name, submod, submod_inputs)  # type: ignore[arg-type]
 


### PR DESCRIPTION
Summary:
This change:
1. Collects various diagnostics along the code path of fx2trt (currently, lowering module graph/code, trt interpreter input module graph, each trt split module graphs)
2. Uploads them when an error happens
3. Provided a framework for easily collecting more diagnostics

The diagnostics framework has following features:
1. easy to use (see example)
2. safe to use - diagnostics itself should never throw exceptions into business logic, this includes errors when generate, writing, or uploading diagnostics
3. concurrency-safe, i.e., diagnostics collected on different execution contexts (threads, asyncio tasks/coroutines) are isolated from each other.

Example:

```
import torch.fx.experimental.diagnostics as diag

with diag.collect_when_fail():
    ...
    # in places where you want to dump diagnostics:
    diag.write("module.graph", str(module.graph))
    diag.write("some_bytes", pickle.dumps(module.some_param))
    # also supports retrieving data from a lambda. If it throws, it'll not impact
    # business logic:
    diag.write("some_data_2", lambda: this_might_throw())
    ...

    some_code_that_throws()  # this will trigger diagnostics to be uploaded
    ...
```

Note:
* `write()` will dump some diagnostics to tmp file
* `collect_when_fail()` will collect and zip all the dumped diagnostic files and uploads them.
* I already put `collect_when_fail()` in appropriate place, so we don't need to call it again. All we need to add will just be `write(...)`

Differential Revision: D33991890

