### PR TITLE
Add num_head param to native multihead attention to evade dim_per_head always 64 bug

### DIFF
--- a/aten/src/ATen/native/cuda/attention.cu
+++ b/aten/src/ATen/native/cuda/attention.cu
@@ -48,6 +48,7 @@ __global__ void transform_bias_rescale_qkv_kernel(
 
   auto D = NH * DH;
   constexpr int VEC = 4;
+  const scalar_t sqrt_dim_per_head = std::sqrt(static_cast<scalar_t>(DH));
   using LoadT = memory::aligned_vector<scalar_t, VEC>;
 
   // FIXME: assert ((D % VEC) == 0)
@@ -83,7 +84,7 @@ __global__ void transform_bias_rescale_qkv_kernel(
       qkv_q[ii] = static_cast<scalar_t>(
           (static_cast<accscalar_t>(qkv_q[ii]) +
            static_cast<accscalar_t>(qkv_bias_q[ii])) /
-          static_cast<accscalar_t>(8));
+          static_cast<accscalar_t>(sqrt_dim_per_head));
       qkv_k[ii] = static_cast<scalar_t>(
           (static_cast<accscalar_t>(qkv_k[ii]) +
            static_cast<accscalar_t>(qkv_bias_k[ii])));
@@ -103,13 +104,14 @@ __global__ void transform_bias_rescale_qkv_kernel(
 // compute q = (q + q_bias) / sqrt(dim_per_head), k = k + k_bias, v = v + v_bias
 std::tuple<Tensor, Tensor, Tensor> transform_bias_rescale_qkv(
     const Tensor& qkv,
-    const Tensor& qkv_bias) {
+    const Tensor& qkv_bias,
+    const int64_t num_head) {
   auto B = qkv.size(0);
   auto T = qkv.size(1);
   auto _3D = qkv.size(2);
   auto D = _3D / 3;
-  auto dim_per_head = 64;
-  auto num_head = D / dim_per_head;
+  TORCH_CHECK(D % num_head == 0);
+  const auto dim_per_head = D / num_head;
   auto q_k_v = at::empty({3, B, num_head, T, dim_per_head}, qkv.options());
   AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half,
@@ -215,6 +217,7 @@ Tensor multi_head_self_attention_cuda(
     const Tensor& qkv_bias,
     const Tensor& proj_weight,
     const Tensor& proj_bias,
+    const int64_t num_head,
     const c10::optional<Tensor>& mask) {
   // query shape: [B, T, D]
   // qkv_weight shape: [3 * D, D]
@@ -223,7 +226,7 @@ Tensor multi_head_self_attention_cuda(
   auto qkv = gemm_nt(query, qkv_weight);
 
   // shape: 3 x [B, num_head, T, dim_per_head]
-  auto q_k_v = transform_bias_rescale_qkv(qkv, qkv_bias);
+  auto q_k_v = transform_bias_rescale_qkv(qkv, qkv_bias, num_head);
   auto q = std::get<0>(q_k_v);
   auto k = std::get<1>(q_k_v);
   auto v = std::get<2>(q_k_v);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2543,7 +2543,7 @@
     CUDA: layer_norm_cuda
     CompositeImplicitAutograd: math_native_layer_norm
 
-- func: _native_multi_head_self_attention(Tensor query, Tensor qkv_weight, Tensor qkv_bias, Tensor proj_weight, Tensor proj_bias, Tensor? mask=None) -> Tensor
+- func: _native_multi_head_self_attention(Tensor query, Tensor qkv_weight, Tensor qkv_bias, Tensor proj_weight, Tensor proj_bias, int num_head, Tensor? mask=None) -> Tensor
   dispatch:
     CPU: multi_head_self_attention_cpu
     CUDA: multi_head_self_attention_cuda


### PR DESCRIPTION
Summary: Current MHA does not have num_head as param, add it

Test Plan: In the following diff

Reviewed By: swolchok

Differential Revision: D33972168

