### PR TITLE
[BE] Fix pybind deprecation warnings

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1795,7 +1795,7 @@ void concrete_dispatch_fn(
 
   if (num_returns == 0) {
     // Check that we got a None return from Python. Anything else is an error.
-    TORCH_CHECK(out == py::none(), "Expected __torch_dispatch__ for ", op.operator_name(),
+    TORCH_CHECK(out.is(py::none()), "Expected __torch_dispatch__ for ", op.operator_name(),
                 " to return None but it returned something else instead.");
   } else if (num_returns == 1) {
     torch::jit::push(stack, torch::jit::toIValue(out.ptr(), op.schema().returns()[0].type()));

--- a/torch/csrc/jit/python/python_list.cpp
+++ b/torch/csrc/jit/python/python_list.cpp
@@ -251,7 +251,7 @@ void initScriptListBindings(PyObject* module) {
             try {
               for (py::handle obj : iter) {
                 iter_list.append(toIValue(
-                    py::object(obj, /*is_borrowed*/ true),
+                    py::reinterpret_borrow<py::object>(obj),
                     self->type()->getElementType()));
               }
             } catch (const py::cast_error& e) {


### PR DESCRIPTION
Fixes:
```
../torch/csrc/autograd/python_variable.cpp:1798:33: warning: ‘bool pybind11::handle::operator==(const pybind11::handle&) const’ is deprecated: Use obj1.is(obj2) instead [-Wdeprecated-declarations]
     TORCH_CHECK(out == py::none(), "Expected __torch_dispatch__ for ", op.operator_name(),
```
and
```
../torch/csrc/jit/python/python_list.cpp:254:57: warning: ‘pybind11::object::object(pybind11::handle, bool)’ is deprecated: Use reinterpret_borrow<object>() or reinterpret_steal<object>() [-Wdeprecated-declarations]
                     py::object(obj, /*is_borrowed*/ true),
```
