### PR TITLE
[vulkan] speed benchmark torch to handle non-single tensor outputs

### DIFF
--- a/binaries/speed_benchmark_torch.cc
+++ b/binaries/speed_benchmark_torch.cc
@@ -187,28 +187,38 @@ class vkRunner final : public Runner<T> {
       if (input.isTensor()) {
         inputs_.emplace_back(input.toTensor().vulkan());
       }
-      else if (input.isList()) {
-        const c10::List<c10::IValue> input_as_list = input.toList();
+      else if (input.isTensorList()) {
+        const c10::List<at::Tensor> input_as_list = input.toTensorList();
         c10::List<at::Tensor> input_vk_list;
         input_vk_list.reserve(input_as_list.size());
         for (int i=0; i < input_as_list.size(); ++i) {
-          const c10::IValue element = input_as_list.get(i);
-          if (element.isTensor()) {
-            input_vk_list.emplace_back(element.toTensor().vulkan());
-          }
-          else {
-            CAFFE_THROW("Input of type c10::List must only contain Tensors!");
-          }
+          const at::Tensor element = input_as_list.get(i);
+          input_vk_list.emplace_back(element.vulkan());
         }
         inputs_.emplace_back(c10::IValue(input_vk_list));
       }
       else {
-        CAFFE_THROW("Inputs must only contain IValues of type c10::Tensor or c10::List!");
+        CAFFE_THROW("Inputs must only contain IValues of type c10::Tensor or c10::TensorList!");
       }
     }
 
     // Run, and download the output tensor to system memory.
-    return module.forward(inputs_).toTensor().cpu();
+    c10::IValue output = module.forward(inputs_);
+    if (output.isTensor()) {
+      return output.toTensor().cpu();
+    }
+    else if (output.isTensorList()) {
+      return output.toTensorList().get(0).cpu();
+    }
+    else if (output.isList()) {
+      return output.toList().get(0).toTensor().cpu();
+    }
+    else if (output.isTuple()) {
+      return output.toTuple()->elements()[0].toTensor().cpu();
+    }
+    else {
+      CAFFE_THROW("Outputs must only be either c10::Tensor or c10::TensorList!");
+    };
   }
 
  private:
@@ -240,6 +250,7 @@ int main(int argc, char** argv) {
   torch::jit::GraphOptimizerEnabledGuard no_optimizer_guard(false);
   auto module = torch::jit::load(FLAGS_model);
 #endif
+  module.dump(true, false, false);
 
   if (FLAGS_use_bundled_input >= 0) {
     auto get_method = module.find_method("get_all_bundled_inputs");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #72386 remove GatedConv2dModule rewrites
* #72385 Simplify Op Context and Fix Gated Conv Transpose 2D block
* #72384 Rename to GatedConv2dBlock
* #72383 [vulkan] Add decoder conv block
* #72382 [vulkan] some optimizations to encoder block op
* #72381 [vulkan] Mclaren consolidated ops
* **#72380 [vulkan] speed benchmark torch to handle non-single tensor outputs**

