### PR TITLE
[vulkan] some optimizations to encoder block op

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/mclaren_encoder_block.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mclaren_encoder_block.glsl
@@ -9,18 +9,13 @@ layout(std430) buffer;
 layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D   uOutput;
 layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput1;
 layout(set = 0, binding = 2)         uniform PRECISION                    sampler3D uInput2;
-layout(set = 0, binding = 3)         uniform PRECISION                    sampler3D uKernel1;
-layout(set = 0, binding = 4)         uniform PRECISION                    sampler3D uBias1;
-layout(set = 0, binding = 5)         uniform PRECISION                    sampler3D uKernel2;
-layout(set = 0, binding = 6)         uniform PRECISION                    sampler3D uBias2;
-layout(set = 0, binding = 7)         uniform PRECISION restrict           Block {
+layout(set = 0, binding = 3)         uniform PRECISION                    sampler3D uKernel;
+layout(set = 0, binding = 4)         uniform PRECISION                    sampler3D uBias;
+layout(set = 0, binding = 5)         uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
   ivec2 ikernel;
   ivec2 stride;
-  ivec2 padding;
-  ivec2 dilate;
-  vec2 clamp;
 } uBlock;
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -29,40 +24,47 @@ void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
-    const ivec2 ipos = pos.xy * uBlock.stride - uBlock.padding;
+    const int start_x = pos.x * uBlock.stride.x;
+    const int end_x = min(start_x + uBlock.kernel.x, uBlock.kernel.z);
+    ivec2 kstart = ivec2(0.0, 2 * pos.z * uBlock.ikernel.y);
 
-    const ivec2 start = max(ivec2(0), ipos);
-    const ivec2 end = min(ipos + uBlock.kernel.xy, uBlock.kernel.zw);
-    ivec2 kstart = (start - ipos) / uBlock.dilate;
-
-    kstart.x *= 4;
-    kstart.y += pos.z * uBlock.ikernel.y;
-
-    vec4 sum1 = texelFetch(uBias1, ivec3(pos.z, 0, 0), 0);
-    vec4 sum2 = texelFetch(uBias2, ivec3(pos.z, 0, 0), 0);
+    vec4 sum1 = texelFetch(uBias, ivec3(pos.z, 0, 0), 0);
+    vec4 sum2 = texelFetch(uBias, ivec3(pos.z, 1, 0), 0);
 
     for (int z4 = 0; z4 < uBlock.size.w/4; ++z4, kstart.x += uBlock.ikernel.x*4) {
-      for (int y = start.y, ky = kstart.y; y < end.y; y += uBlock.dilate.y, ++ky) {
-        for (int x = start.x, kx = kstart.x; x < end.x; x += uBlock.dilate.x, kx += 4) {
-          vec4 In = (y == 0) ? texelFetch(uInput1, ivec3(x, 0, z4), 0)
-                             : texelFetch(uInput2, ivec3(x, 0, z4), 0);
-          const ivec4 kxs = kx + ivec4(0, 1, 2, 3);
+      int ky = kstart.y;
+      for (int x = start_x, kx = kstart.x; x < end_x; ++x, kx += 4) {
+        vec4 In = texelFetch(uInput1, ivec3(x, 0, z4), 0);
+        const ivec4 kxs = kx + ivec4(0, 1, 2, 3);
 
-          sum1 = fma(In.xxxx, texelFetch(uKernel1, ivec3(kxs.x, ky, 0), 0), sum1);
-          sum1 = fma(In.yyyy, texelFetch(uKernel1, ivec3(kxs.y, ky, 0), 0), sum1);
-          sum1 = fma(In.zzzz, texelFetch(uKernel1, ivec3(kxs.z, ky, 0), 0), sum1);
-          sum1 = fma(In.wwww, texelFetch(uKernel1, ivec3(kxs.w, ky, 0), 0), sum1);
+        sum1 = fma(In.xxxx, texelFetch(uKernel, ivec3(kxs.x, ky, 0), 0), sum1);
+        sum1 = fma(In.yyyy, texelFetch(uKernel, ivec3(kxs.y, ky, 0), 0), sum1);
+        sum1 = fma(In.zzzz, texelFetch(uKernel, ivec3(kxs.z, ky, 0), 0), sum1);
+        sum1 = fma(In.wwww, texelFetch(uKernel, ivec3(kxs.w, ky, 0), 0), sum1);
 
-          sum2 = fma(In.xxxx, texelFetch(uKernel2, ivec3(kxs.x, ky, 0), 0), sum2);
-          sum2 = fma(In.yyyy, texelFetch(uKernel2, ivec3(kxs.y, ky, 0), 0), sum2);
-          sum2 = fma(In.zzzz, texelFetch(uKernel2, ivec3(kxs.z, ky, 0), 0), sum2);
-          sum2 = fma(In.wwww, texelFetch(uKernel2, ivec3(kxs.w, ky, 0), 0), sum2);
-        }
+        sum2 = fma(In.xxxx, texelFetch(uKernel, ivec3(kxs.x, ky+1, 0), 0), sum2);
+        sum2 = fma(In.yyyy, texelFetch(uKernel, ivec3(kxs.y, ky+1, 0), 0), sum2);
+        sum2 = fma(In.zzzz, texelFetch(uKernel, ivec3(kxs.z, ky+1, 0), 0), sum2);
+        sum2 = fma(In.wwww, texelFetch(uKernel, ivec3(kxs.w, ky+1, 0), 0), sum2);
+      }
+      ky += 2;
+      for (int x = start_x, kx = kstart.x; x < end_x; ++x, kx += 4) {
+        vec4 In = texelFetch(uInput2, ivec3(x, 0, z4), 0);
+        const ivec4 kxs = kx + ivec4(0, 1, 2, 3);
+
+        sum1 = fma(In.xxxx, texelFetch(uKernel, ivec3(kxs.x, ky, 0), 0), sum1);
+        sum1 = fma(In.yyyy, texelFetch(uKernel, ivec3(kxs.y, ky, 0), 0), sum1);
+        sum1 = fma(In.zzzz, texelFetch(uKernel, ivec3(kxs.z, ky, 0), 0), sum1);
+        sum1 = fma(In.wwww, texelFetch(uKernel, ivec3(kxs.w, ky, 0), 0), sum1);
+
+        sum2 = fma(In.xxxx, texelFetch(uKernel, ivec3(kxs.x, ky+1, 0), 0), sum2);
+        sum2 = fma(In.yyyy, texelFetch(uKernel, ivec3(kxs.y, ky+1, 0), 0), sum2);
+        sum2 = fma(In.zzzz, texelFetch(uKernel, ivec3(kxs.z, ky+1, 0), 0), sum2);
+        sum2 = fma(In.wwww, texelFetch(uKernel, ivec3(kxs.w, ky+1, 0), 0), sum2);
       }
     }
 
     vec4 outtex = sum1 * (1/(1+exp(-1*sum2)));
-    //vec4 outtex = sum1 * sum2;
 
     imageStore(uOutput, pos, outtex);
   }

--- a/aten/src/ATen/native/vulkan/ops/McLarenEncoderBlock.h
+++ b/aten/src/ATen/native/vulkan/ops/McLarenEncoderBlock.h
@@ -72,20 +72,10 @@ class McLarenEncoderBlockOpContext final : public torch::jit::CustomClassHolder 
 
  private:
   struct {
-    vTensor v_weight_1;
-    vTensor v_bias_1;
-    std::array<int64_t, 4> filter_1;
-    std::array<int64_t, 2> stride_1;
-    std::array<int64_t, 2> padding_1;
-    std::array<int64_t, 2> dilation_1;
-    int32_t groups_1;
-    vTensor v_weight_2;
-    vTensor v_bias_2;
-    std::array<int64_t, 4> filter_2;
-    std::array<int64_t, 2> stride_2;
-    std::array<int64_t, 2> padding_2;
-    std::array<int64_t, 2> dilation_2;
-    int32_t groups_2;
+    vTensor v_weight;
+    vTensor v_bias;
+    std::array<int64_t, 4> filter;
+    std::array<int64_t, 2> stride;
   } packed_;
 
   struct {

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -176,10 +176,10 @@ TEST(VulkanAPITest, mclaren_encoder_block) {
   const auto input_2_cpu = at::randn({1,4,1,161}, at::device(at::kCPU).dtype(at::kFloat))*5;
 
   const auto weights_1_cpu = at::randn({32,4,2,3}, at::device(at::kCPU).dtype(at::kFloat))*2;
-  const auto bias_1_cpu = at::randn({32}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto bias_1_cpu = at::randn({32}, at::device(at::kCPU).dtype(at::kFloat))*2;
 
   const auto weights_2_cpu = at::randn({32,4,2,3}, at::device(at::kCPU).dtype(at::kFloat))*2;
-  const auto bias_2_cpu = at::randn({32}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto bias_2_cpu = at::randn({32}, at::device(at::kCPU).dtype(at::kFloat))*2;
 
   const auto input_cpu = at::cat({input_1_cpu, input_2_cpu}, 2);
   const auto output_1_cpu = at::conv2d(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #72386 remove GatedConv2dModule rewrites
* #72385 Simplify Op Context and Fix Gated Conv Transpose 2D block
* #72384 Rename to GatedConv2dBlock
* #72383 [vulkan] Add decoder conv block
* **#72382 [vulkan] some optimizations to encoder block op**
* #72381 [vulkan] Mclaren consolidated ops
* #72380 [vulkan] speed benchmark torch to handle non-single tensor outputs

