### PR TITLE
[vulkan] Add decoder conv block

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/mclaren_decoder_block.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mclaren_decoder_block.glsl
@@ -1,0 +1,71 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput1;
+layout(set = 0, binding = 2)         uniform PRECISION                    sampler3D uInput2;
+layout(set = 0, binding = 3)         uniform PRECISION                    sampler3D uKernel;
+layout(set = 0, binding = 4)         uniform PRECISION                    sampler3D uBias;
+layout(set = 0, binding = 5)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  ivec4 kernel;
+  ivec2 ikernel;
+  ivec2 stride;
+  ivec2 padding;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  const ivec2 isize = ivec2(uBlock.kernel.zw);
+  const vec2 ksize = vec2(uBlock.kernel.xy);
+  const vec2 stride = vec2(uBlock.stride);
+  const vec2 padding = vec2(uBlock.padding);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    ivec2 ipos = pos.xy + uBlock.padding;
+    vec2 ipos_f = vec2(ipos);
+
+    const ivec2 start = max(ivec2(0), ivec2(ceil((ipos_f - ksize + 1)/stride)));
+    const ivec2 end = min(isize, ivec2(floor(ipos_f/stride))+1);
+    ivec2 kstart = start;
+
+    vec4 sum1 = texelFetch(uBias, ivec3(pos.z, 0, 0), 0);
+    vec4 sum2 = texelFetch(uBias, ivec3(pos.z, 1, 0), 0);
+
+    int ky_start = uBlock.kernel.y - 1 - (ipos.y - uBlock.stride.y*start.y) + pos.z * uBlock.ikernel.y;
+    int kx_start = (uBlock.kernel.x - 1 - (ipos.x - uBlock.stride.x*start.x)) * uBlock.size.w;
+    int kx_stride = uBlock.size.w * (uBlock.stride.x - 1);
+    for (int y = start.y, ky = ky_start; y < end.y; ++y, ky += uBlock.stride.y) {
+      int kx = kx_start;
+      for (int x = start.x, kx = kx_start; x < end.x; ++x, kx += kx_stride) {
+        for (int z4 = 0; z4 < uBlock.size.w/4; ++z4, kx += 4) {
+          const vec4 In = (y == 0) ? texelFetch(uInput1, ivec3(x, 0, z4), 0)
+                                   : texelFetch(uInput2, ivec3(x, 0, z4), 0);
+          const ivec4 kxs = kx + ivec4(0, 1, 2, 3);
+
+          sum1 = fma(In.xxxx, texelFetch(uKernel, ivec3(kxs.x, 2*ky, 0), 0), sum1);
+          sum1 = fma(In.yyyy, texelFetch(uKernel, ivec3(kxs.y, 2*ky, 0), 0), sum1);
+          sum1 = fma(In.zzzz, texelFetch(uKernel, ivec3(kxs.z, 2*ky, 0), 0), sum1);
+          sum1 = fma(In.wwww, texelFetch(uKernel, ivec3(kxs.w, 2*ky, 0), 0), sum1);
+
+          sum2 = fma(In.xxxx, texelFetch(uKernel, ivec3(kxs.x, 2*ky + 1, 0), 0), sum2);
+          sum2 = fma(In.yyyy, texelFetch(uKernel, ivec3(kxs.y, 2*ky + 1, 0), 0), sum2);
+          sum2 = fma(In.zzzz, texelFetch(uKernel, ivec3(kxs.z, 2*ky + 1, 0), 0), sum2);
+          sum2 = fma(In.wwww, texelFetch(uKernel, ivec3(kxs.w, 2*ky + 1, 0), 0), sum2);
+        }
+      }
+    }
+
+    vec4 outtex = sum1 * (1/(1+exp(-1*sum2)));
+
+    imageStore(uOutput, pos, outtex);
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/mclaren_encoder_block.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mclaren_encoder_block.glsl
@@ -16,6 +16,7 @@ layout(set = 0, binding = 5)         uniform PRECISION restrict           Block 
   ivec4 kernel;
   ivec2 ikernel;
   ivec2 stride;
+  ivec2 padding;
 } uBlock;
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;

--- a/aten/src/ATen/native/vulkan/ops/McLarenEncoderBlock.cpp
+++ b/aten/src/ATen/native/vulkan/ops/McLarenEncoderBlock.cpp
@@ -85,6 +85,80 @@ vTensor pack_combined_weights(const Tensor& weight_1, const Tensor& weight_2) {
   return v_weight;
 }
 
+vTensor pack_combined_weights_reverse(const Tensor& weight_arg_1, const Tensor& weight_arg_2) {
+  api::Context* const context = api::context();
+  api::Command::Buffer& command_buffer = context->command().pool.stream();
+
+  /* Source */
+  const Tensor weight_1 = at::permute(weight_arg_1, {1, 0, 2, 3}).contiguous();
+  const IntArrayRef src_filter = weight_1.sizes();
+  const float* const src_weight_1_ptr = weight_1.data_ptr<float>();
+  const Tensor weight_2 = at::permute(weight_arg_2, {1, 0, 2, 3}).contiguous();
+  const float* const src_weight_2_ptr = weight_2.data_ptr<float>();
+
+  const int64_t src_kw_sz = src_filter[Layout::Filter::width];
+  const int64_t src_kh_sz = src_filter[Layout::Filter::height];
+  const int64_t src_kernel_sz = src_kw_sz * src_kh_sz;
+  const int64_t src_block_sz = src_kernel_sz * src_filter[Layout::Filter::input];
+
+  const int64_t num_stacks = div_up(src_filter[Layout::Filter::output], INT64_C(4));
+  const int64_t stack_depth = api::utils::align_up(src_filter[Layout::Filter::input], INT64_C(4));
+
+  /* Destination */
+  const int64_t dst_kw_sz = src_kw_sz * stack_depth;
+  const int64_t dst_kh_sz = 2 * src_kh_sz * num_stacks;
+  const int64_t dst_kernel_sz = dst_kw_sz * dst_kh_sz;
+
+  vTensor v_weight{
+      context,
+      {
+          4,
+          dst_kh_sz,
+          dst_kw_sz,
+      },
+      weight_1.options(),
+  };
+
+  using Future = vTensor::Future<float, vTensor::Access::Write>;
+  Future v_weight_future = v_weight.host<float, vTensor::Access::Write>(command_buffer);
+  Future::Payload v_weight_payload = v_weight_future.wait();
+
+  float* const dst_weight_ptr = v_weight_payload.get();
+  memset(dst_weight_ptr, 0, v_weight.nbytes());
+
+  for (int64_t src_oc = 0; src_oc < src_filter[Layout::Filter::output]; ++src_oc) {
+    /* Source */
+    const float* const src_weight_1_oc_ptr = src_weight_1_ptr + src_oc * src_block_sz;
+    const float* const src_weight_2_oc_ptr = src_weight_2_ptr + src_oc * src_block_sz;
+
+    /* Destination */
+    const int64_t dst_oh = src_oc / 4;
+    const int64_t dst_c = src_oc % 4;
+
+    float* const dst_weight_c_ptr = dst_weight_ptr + dst_c * dst_kernel_sz;
+
+    for (int64_t src_ic = 0; src_ic < src_filter[Layout::Filter::input]; ++src_ic) {
+      for (int64_t src_ih = 0; src_ih < src_kh_sz; ++src_ih) {
+        const int64_t dst_h = src_kh_sz - 1 - src_ih;
+        for (int64_t src_iw = 0; src_iw < src_kw_sz; ++src_iw) {
+          const int64_t dst_w = src_kw_sz - 1 - src_iw;
+          const int64_t dst_w_offset = dst_w * stack_depth;
+          memcpy(
+              dst_weight_c_ptr + (2*(dst_oh * src_kh_sz + dst_h)) * dst_kw_sz + src_ic + dst_w_offset,
+              src_weight_1_oc_ptr + src_ic * src_kernel_sz + src_ih * src_kw_sz + src_iw,
+              sizeof(float));
+          memcpy(
+              dst_weight_c_ptr + (2*(dst_oh * src_kh_sz + dst_h)+1) * dst_kw_sz + src_ic + dst_w_offset,
+              src_weight_2_oc_ptr + src_ic * src_kernel_sz + src_ih * src_kw_sz + src_iw,
+              sizeof(float));
+        }
+      }
+    }
+  }
+
+  return v_weight;
+}
+
 vTensor pack_combined_biases(const c10::optional<Tensor>& bias_1,
                              const c10::optional<Tensor>& bias_2) {
   api::Context* const context = api::context();
@@ -135,25 +209,44 @@ vTensor pack_combined_biases(const c10::optional<Tensor>& bias_1,
   return v_bias;
 }
 
+static inline std::vector<int64_t> get_conv_transpose_output_size(
+    IntArrayRef input_size, IntArrayRef weight_size,
+    IntArrayRef padding, IntArrayRef output_padding,
+    IntArrayRef stride, IntArrayRef dilation = IntArrayRef()) {
+  auto dim = input_size.size();
+  std::vector<int64_t> output_size(dim);
+  output_size[0] = input_size[input_batch_size_dim];
+  output_size[1] = weight_size[weight_input_channels_dim];
+  for (size_t d = 2; d < dim; ++d) {
+    output_size[d] = stride[d - 2] * (input_size[d] - 1) + weight_size[d] - 2 * padding[d - 2] + output_padding[d - 2];
+  }
+  return output_size;
+}
 
 McLarenEncoderBlockOpContext::McLarenEncoderBlockOpContext(
       const Tensor& weight_1,
       const c10::optional<Tensor>& bias_1,
       IntArrayRef stride_1,
       IntArrayRef padding_1,
+      IntArrayRef output_padding_1,
       IntArrayRef dilation_1,
-      int64_t groups_1,
+      const int64_t groups_1,
       const Tensor& weight_2,
       const c10::optional<Tensor>& bias_2,
       IntArrayRef stride_2,
       IntArrayRef padding_2,
+      IntArrayRef output_padding_2,
       IntArrayRef dilation_2,
-      int64_t groups_2)
+      const int64_t groups_2,
+      const bool transposed)
   : packed_{
-      pack_combined_weights(weight_1, weight_2),
+      transposed ? pack_combined_weights_reverse(weight_1, weight_2) : pack_combined_weights(weight_1, weight_2),
       pack_combined_biases(bias_1, bias_2),
       pack_conv2d_filter(weight_1, expand_param_if_needed(dilation_1, "dilation", 2)),
       pack_conv2d_params(expand_param_if_needed(stride_1, "stride", 2)),
+      pack_conv2d_params(expand_param_if_needed(padding_1, "padding", 2)),
+      pack_conv2d_params(expand_param_if_needed(output_padding_1, "output_padding", 2)),
+      pack_conv2d_params(expand_param_if_needed(dilation_1, "dilation", 2)),
     },
     unpacked_{
       weight_1,
@@ -161,6 +254,7 @@ McLarenEncoderBlockOpContext::McLarenEncoderBlockOpContext(
       weight_1.sizes().vec(),
       stride_1.vec(),
       padding_1.vec(),
+      output_padding_1.vec(),
       dilation_1.vec(),
       groups_1,
       weight_2,
@@ -168,8 +262,10 @@ McLarenEncoderBlockOpContext::McLarenEncoderBlockOpContext(
       weight_2.sizes().vec(),
       stride_2.vec(),
       padding_2.vec(),
+      output_padding_2.vec(),
       dilation_2.vec(),
       groups_2,
+      transposed,
     } {
 }
 
@@ -178,126 +274,35 @@ McLarenEncoderBlockOpContext McLarenEncoderBlockOpContext::create(
       const c10::optional<Tensor>& bias_1,
       IntArrayRef stride_1,
       IntArrayRef padding_1,
+      IntArrayRef output_padding_1,
       IntArrayRef dilation_1,
-      int64_t groups_1,
+      const int64_t groups_1,
       const Tensor& weight_2,
       const c10::optional<Tensor>& bias_2,
       IntArrayRef stride_2,
       IntArrayRef padding_2,
+      IntArrayRef output_padding_2,
       IntArrayRef dilation_2,
-      int64_t groups_2) {
+      const int64_t groups_2,
+      const bool transposed) {
   // Pass in the originals
   return McLarenEncoderBlockOpContext{
     weight_1,
     bias_1,
     stride_1,
     padding_1,
+    output_padding_1,
     dilation_1,
     groups_1,
     weight_2,
     bias_2,
     stride_2,
     padding_2,
+    output_padding_2,
     dilation_2,
     groups_2,
+    transposed
   };
-}
-
-void McLarenEncoderBlockOpContext::conv2d_sliding_window(
-    vTensor& v_output,
-    const vTensor& v_input,
-    const vTensor& v_weight,
-    const vTensor& v_bias,
-    std::array<int64_t, 4> filter,
-    std::vector<int64_t> orig_filter,
-    std::array<int64_t, 2> stride,
-    std::array<int64_t, 2> padding,
-    std::array<int64_t, 2> dilation) const {
-  api::Context* const context = api::context();
-  api::Command::Pool& command_pool = context->command().pool;
-  api::Command::Buffer& command_buffer = command_pool.stream();
-  {
-    const struct Block final {
-      uvec3 extents;
-      int32_t ic4;
-      ivec4 kernel;
-      ivec2 ikernel;
-      ivec2 stride;
-      ivec2 padding;
-      ivec2 dilate;
-      vec2 clamp;
-      ivec4 src_filter;
-    } block {
-      v_output.extents(),
-      safe_downcast<int32_t>(filter[Layout::Filter::input]),
-      {
-        safe_downcast<int32_t>(filter[Layout::Filter::width]),
-        safe_downcast<int32_t>(filter[Layout::Filter::height]),
-        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::width]),
-        safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::height]),
-      },
-      {
-        safe_downcast<int32_t>(orig_filter[Layout::Filter::width]),
-        safe_downcast<int32_t>(orig_filter[Layout::Filter::height]),
-      },
-      {
-        safe_downcast<int32_t>(stride[Layout::Parameter::width]),
-        safe_downcast<int32_t>(stride[Layout::Parameter::height]),
-      },
-      {
-        safe_downcast<int32_t>(padding[Layout::Parameter::width]),
-        safe_downcast<int32_t>(padding[Layout::Parameter::height]),
-      },
-      {
-        safe_downcast<int32_t>(dilation[Layout::Parameter::width]),
-        safe_downcast<int32_t>(dilation[Layout::Parameter::height]),
-      },
-      {
-        -std::numeric_limits<float>::infinity(),
-        std::numeric_limits<float>::infinity()
-      },
-    };
-
-    uvec3 global_size = v_output.extents();
-
-    context->dispatch(
-        command_buffer,
-        {
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-        },
-        VK_KERNEL(conv2d),
-        global_size,
-        adaptive_work_group_size(global_size),
-        // Write-only access bypasses synchronization but inserts appropriate
-        // barriers if necessary.
-        v_output.image(
-            command_buffer,
-            vTensor::Stage::Compute,
-            vTensor::Access::Write),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_input.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_weight.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        v_bias.image(
-            command_buffer,
-            vTensor::Stage::Compute),
-        // Object lifetime is managed by the resource pool.
-        // It is OK not to keep track of the handle.
-        context->resource().pool.uniform(block).object);
-  }
-  command_pool.submit(context->gpu().queue, command_buffer);
 }
 
 Tensor McLarenEncoderBlockOpContext::run(const Tensor& input_arg_1, const Tensor& input_arg_2) const {
@@ -311,15 +316,22 @@ Tensor McLarenEncoderBlockOpContext::run(const Tensor& input_arg_1, const Tensor
   std::vector<int64_t> input_1_size = input_1.sizes().vec();
   std::vector<int64_t> input_2_size = input_2.sizes().vec();
   TORCH_CHECK(input_1_size.size() == 4, "McLarenEncoderBlock: first input tensor must have exactly 4 dims")
-  TORCH_CHECK(input_1_size.size() == 4, "McLarenEncoderBlock: second input tensor must have exactly 4 dims")
-  TORCH_CHECK(input_1_size[2] == 1, "McLarenEncoderBlock: first input tensor must have height of exactly 1")
-  TORCH_CHECK(input_2_size[2] == 1, "McLarenEncoderBlock: second input tensor must have height of exactly 1")
+  TORCH_CHECK(input_2_size.size() == 4, "McLarenEncoderBlock: second input tensor must have exactly 4 dims")
+  //TORCH_CHECK(input_1_size[2] == 1, "McLarenEncoderBlock: first input tensor must have height of exactly 1")
+  //TORCH_CHECK(input_2_size[2] == 1, "McLarenEncoderBlock: second input tensor must have height of exactly 1")
   std::vector<int64_t> conv_input_size(input_1_size);
   conv_input_size[2] = 2;
-  std::vector<int64_t> output_size = conv_output_size(
+  std::vector<int64_t> output_size = !unpacked_.transposed ? conv_output_size(
     conv_input_size,
     unpacked_.filter_1,
     /*padding=*/{0,0},
+    packed_.stride,
+    /*dilation=*/{1,1}
+  ) : get_conv_transpose_output_size(
+    conv_input_size,
+    unpacked_.filter_1,
+    packed_.padding,
+    packed_.output_padding,
     packed_.stride,
     /*dilation=*/{1,1}
   );
@@ -339,6 +351,7 @@ Tensor McLarenEncoderBlockOpContext::run(const Tensor& input_arg_1, const Tensor
       ivec4 kernel;
       ivec2 ikernel;
       ivec2 stride;
+      ivec2 padding;
     } block {
       v_output.extents(),
       safe_downcast<int32_t>(packed_.filter[Layout::Filter::input]),
@@ -356,6 +369,10 @@ Tensor McLarenEncoderBlockOpContext::run(const Tensor& input_arg_1, const Tensor
         safe_downcast<int32_t>(packed_.stride[Layout::Parameter::width]),
         safe_downcast<int32_t>(packed_.stride[Layout::Parameter::height]),
       },
+      {
+        safe_downcast<int32_t>(packed_.padding[Layout::Parameter::width]),
+        safe_downcast<int32_t>(packed_.padding[Layout::Parameter::height]),
+      },
     };
 
     uvec3 global_size = v_output.extents();
@@ -370,7 +387,7 @@ Tensor McLarenEncoderBlockOpContext::run(const Tensor& input_arg_1, const Tensor
           VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
           VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
         },
-        VK_KERNEL(mclaren_encoder_block),
+        unpacked_.transposed ? VK_KERNEL(mclaren_decoder_block) : VK_KERNEL(mclaren_encoder_block),
         global_size,
         adaptive_work_group_size(global_size),
         v_output.image(
@@ -394,6 +411,7 @@ Tensor McLarenEncoderBlockOpContext::run(const Tensor& input_arg_1, const Tensor
   command_pool.submit(context->gpu().queue, command_buffer);
 
   return convert(v_output);
+  //return convert(packed_.v_weight);
 }
 
 McLarenEncoderBlockOpContext::State McLarenEncoderBlockOpContext::unpack() const {
@@ -402,14 +420,17 @@ McLarenEncoderBlockOpContext::State McLarenEncoderBlockOpContext::unpack() const
     unpacked_.bias_1,
     unpacked_.stride_1,
     unpacked_.padding_1,
+    unpacked_.output_padding_1,
     unpacked_.dilation_1,
     unpacked_.groups_1,
     unpacked_.weight_2,
     unpacked_.bias_2,
     unpacked_.stride_2,
     unpacked_.padding_2,
+    unpacked_.output_padding_2,
     unpacked_.dilation_2,
     unpacked_.groups_2,
+    unpacked_.transposed
   };
 }
 
@@ -418,28 +439,34 @@ c10::intrusive_ptr<McLarenEncoderBlockOpContext> mclaren_encoder_block_prepack(
     c10::optional<Tensor>&& bias_1,
     std::vector<int64_t>&& stride_1,
     std::vector<int64_t>&& padding_1,
+    std::vector<int64_t>&& output_padding_1,
     std::vector<int64_t>&& dilation_1,
     const int64_t groups_1,
     Tensor&& weight_2,
     c10::optional<Tensor>&& bias_2,
     std::vector<int64_t>&& stride_2,
     std::vector<int64_t>&& padding_2,
+    std::vector<int64_t>&& output_padding_2,
     std::vector<int64_t>&& dilation_2,
-    const int64_t groups_2) {
+    const int64_t groups_2,
+    const bool transposed) {
   return c10::make_intrusive<McLarenEncoderBlockOpContext>(
       McLarenEncoderBlockOpContext::create(
           std::move(weight_1),
           std::move(bias_1),
           std::move(stride_1),
           std::move(padding_1),
+          std::move(output_padding_1),
           std::move(dilation_1),
           groups_1,
           std::move(weight_2),
           std::move(bias_2),
           std::move(stride_2),
           std::move(padding_2),
+          std::move(output_padding_2),
           std::move(dilation_2),
-          groups_2));
+          groups_2,
+          transposed));
 }
 
 Tensor mclaren_encoder_block_run(

--- a/aten/src/ATen/native/vulkan/ops/McLarenEncoderBlock.h
+++ b/aten/src/ATen/native/vulkan/ops/McLarenEncoderBlock.h
@@ -18,18 +18,22 @@ class McLarenEncoderBlockOpContext final : public torch::jit::CustomClassHolder 
       const c10::optional<Tensor>& bias_1,
       IntArrayRef stride_1,
       IntArrayRef padding_1,
+      IntArrayRef output_padding_1,
       IntArrayRef dilation_1,
-      int64_t groups_1,
+      const int64_t groups_1,
       const Tensor& weight_2,
       const c10::optional<Tensor>& bias_2,
       IntArrayRef stride_2,
       IntArrayRef padding_2,
+      IntArrayRef output_padding_2,
       IntArrayRef dilation_2,
-      int64_t groups_2);
+      const int64_t groups_2,
+      const bool transposed);
 
   using State = std::tuple<
       Tensor,
       c10::optional<Tensor>,
+      std::vector<int64_t>,
       std::vector<int64_t>,
       std::vector<int64_t>,
       std::vector<int64_t>,
@@ -39,7 +43,9 @@ class McLarenEncoderBlockOpContext final : public torch::jit::CustomClassHolder 
       std::vector<int64_t>,
       std::vector<int64_t>,
       std::vector<int64_t>,
-      int64_t>;
+      std::vector<int64_t>,
+      int64_t,
+      bool>;
 
   Tensor run(const Tensor& input_arg_1, const Tensor& input_arg_2) const;
   State unpack() const;
@@ -50,25 +56,17 @@ class McLarenEncoderBlockOpContext final : public torch::jit::CustomClassHolder 
       const c10::optional<Tensor>& bias_1,
       IntArrayRef stride_1,
       IntArrayRef padding_1,
+      IntArrayRef output_padding_1,
       IntArrayRef dilation_1,
       int64_t groups_1,
       const Tensor& weight_2,
       const c10::optional<Tensor>& bias_2,
       IntArrayRef stride_2,
       IntArrayRef padding_2,
+      IntArrayRef output_padding_2,
       IntArrayRef dilation_2,
-      int64_t groups_2);
-
-  void conv2d_sliding_window(
-      vTensor& v_output,
-      const vTensor& v_input,
-      const vTensor& v_weight,
-      const vTensor& v_bias,
-      std::array<int64_t, 4> filter,
-      std::vector<int64_t> orig_filter,
-      std::array<int64_t, 2> stride,
-      std::array<int64_t, 2> padding,
-      std::array<int64_t, 2> dilation) const;
+      int64_t groups_2,
+      bool transposed);
 
  private:
   struct {
@@ -76,6 +74,9 @@ class McLarenEncoderBlockOpContext final : public torch::jit::CustomClassHolder 
     vTensor v_bias;
     std::array<int64_t, 4> filter;
     std::array<int64_t, 2> stride;
+    std::array<int64_t, 2> padding;
+    std::array<int64_t, 2> output_padding;
+    std::array<int64_t, 2> dilation;
   } packed_;
 
   struct {
@@ -84,6 +85,7 @@ class McLarenEncoderBlockOpContext final : public torch::jit::CustomClassHolder 
     std::vector<int64_t> filter_1;
     std::vector<int64_t> stride_1;
     std::vector<int64_t> padding_1;
+    std::vector<int64_t> output_padding_1;
     std::vector<int64_t> dilation_1;
     int64_t groups_1;
     Tensor weight_2;
@@ -91,8 +93,10 @@ class McLarenEncoderBlockOpContext final : public torch::jit::CustomClassHolder 
     std::vector<int64_t> filter_2;
     std::vector<int64_t> stride_2;
     std::vector<int64_t> padding_2;
+    std::vector<int64_t> output_padding_2;
     std::vector<int64_t> dilation_2;
     int64_t groups_2;
+    bool transposed;
   } unpacked_;
 };
 
@@ -106,14 +110,17 @@ c10::intrusive_ptr<McLarenEncoderBlockOpContext> mclaren_encoder_block_prepack(
     c10::optional<Tensor>&& bias_1,
     std::vector<int64_t>&& stride_1,
     std::vector<int64_t>&& padding_1,
+    std::vector<int64_t>&& output_padding_1,
     std::vector<int64_t>&& dilation_1,
     const int64_t groups_1,
     Tensor&& weight_2,
     c10::optional<Tensor>&& bias_2,
     std::vector<int64_t>&& stride_2,
     std::vector<int64_t>&& padding_2,
+    std::vector<int64_t>&& output_padding_2,
     std::vector<int64_t>&& dilation_2,
-    const int64_t groups_2);
+    const int64_t groups_2,
+    const bool transposed);
 
 } // namespace ops
 } // namespace vulkan

--- a/aten/src/ATen/native/vulkan/ops/Register.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Register.cpp
@@ -53,7 +53,10 @@ TORCH_LIBRARY(vulkan, m) {
                 std::move(std::get<8>(state)),
                 std::move(std::get<9>(state)),
                 std::move(std::get<10>(state)),
-                std::move(std::get<11>(state)));
+                std::move(std::get<11>(state)),
+                std::move(std::get<12>(state)),
+                std::move(std::get<13>(state)),
+                std::move(std::get<14>(state)));
           });
   m.class_<TransposeConv2dOpContext>("TransposeConv2dOpContext")
       .def_pickle(
@@ -90,8 +93,9 @@ TORCH_LIBRARY(vulkan, m) {
 TORCH_LIBRARY(mclaren_prepack, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "mclaren_prepack::mclaren_encoder_block_prepack("
-      "Tensor W_1, Tensor? B_1, int[2] stride_1, int[2] padding_1, int[2] dilation_1, int groups_1, "
-      "Tensor W_2, Tensor? B_2, int[2] stride_2, int[2] padding_2, int[2] dilation_2, int groups_2) "
+      "Tensor W_1, Tensor? B_1, int[2] stride_1, int[2] padding_1, int[2] output_padding_1, int[2] dilation_1, int groups_1, "
+      "Tensor W_2, Tensor? B_2, int[2] stride_2, int[2] padding_2, int[2] output_padding_2, int[2] dilation_2, int groups_2, "
+      "bool transposed) "
       "-> __torch__.torch.classes.vulkan.McLarenEncoderBlockOpContext"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "mclaren_prepack::mclaren_encoder_block_run(Tensor X_1, Tensor X_2, "
@@ -174,37 +178,6 @@ Tensor convolution(
       output_padding,
       groups
   ).run(input);
-}
-
-Tensor mclaren_encoder_block(
-    const Tensor& input_1,
-    const Tensor& input_2,
-    const Tensor& weight_1,
-    const c10::optional<Tensor>& bias_1,
-    const IntArrayRef stride_1,
-    const IntArrayRef padding_1,
-    const IntArrayRef dilation_1,
-    const int64_t groups_1,
-    const Tensor& weight_2,
-    const c10::optional<Tensor>& bias_2,
-    const IntArrayRef stride_2,
-    const IntArrayRef padding_2,
-    const IntArrayRef dilation_2,
-    const int64_t groups_2) {
-  return McLarenEncoderBlockOpContext::create(
-      weight_1,
-      bias_1,
-      stride_1,
-      padding_1,
-      dilation_1,
-      groups_1,
-      weight_2,
-      bias_2,
-      stride_2,
-      padding_2,
-      dilation_2,
-      groups_2
-  ).run(input_1, input_2);
 }
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #72386 remove GatedConv2dModule rewrites
* #72385 Simplify Op Context and Fix Gated Conv Transpose 2D block
* #72384 Rename to GatedConv2dBlock
* **#72383 [vulkan] Add decoder conv block**
* #72382 [vulkan] some optimizations to encoder block op
* #72381 [vulkan] Mclaren consolidated ops
* #72380 [vulkan] speed benchmark torch to handle non-single tensor outputs

