### PR TITLE
Simplify Op Context and Fix Gated Conv Transpose 2D block

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/gated_conv2d_module.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/gated_conv2d_module.glsl
@@ -7,8 +7,8 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput1;
-layout(set = 0, binding = 2)         uniform PRECISION                    sampler3D uInput2;
+layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uPadding;
+layout(set = 0, binding = 2)         uniform PRECISION                    sampler3D uPrevOut;
 layout(set = 0, binding = 3)         uniform PRECISION                    sampler3D uKernel;
 layout(set = 0, binding = 4)         uniform PRECISION                    sampler3D uBias;
 layout(set = 0, binding = 5)         uniform PRECISION restrict           Block {
@@ -35,7 +35,7 @@ void main() {
     for (int z4 = 0; z4 < uBlock.size.w/4; ++z4, kstart.x += uBlock.ikernel.x*4) {
       int ky = kstart.y;
       for (int x = start_x, kx = kstart.x; x < end_x; ++x, kx += 4) {
-        vec4 In = texelFetch(uInput1, ivec3(x, 0, z4), 0);
+        vec4 In = texelFetch(uPadding, ivec3(x, 0, z4), 0);
         const ivec4 kxs = kx + ivec4(0, 1, 2, 3);
 
         sum1 = fma(In.xxxx, texelFetch(uKernel, ivec3(kxs.x, ky, 0), 0), sum1);
@@ -50,7 +50,7 @@ void main() {
       }
       ky += 2;
       for (int x = start_x, kx = kstart.x; x < end_x; ++x, kx += 4) {
-        vec4 In = texelFetch(uInput2, ivec3(x, 0, z4), 0);
+        vec4 In = texelFetch(uPrevOut, ivec3(x, 0, z4), 0);
         const ivec4 kxs = kx + ivec4(0, 1, 2, 3);
 
         sum1 = fma(In.xxxx, texelFetch(uKernel, ivec3(kxs.x, ky, 0), 0), sum1);

--- a/aten/src/ATen/native/vulkan/ops/GatedConv2dModule.h
+++ b/aten/src/ATen/native/vulkan/ops/GatedConv2dModule.h
@@ -14,30 +14,20 @@ namespace ops {
 class GatedConv2dModuleOpContext final : public torch::jit::CustomClassHolder {
  public:
   static GatedConv2dModuleOpContext create(
-      const Tensor& weight_1,
-      const c10::optional<Tensor>& bias_1,
-      IntArrayRef stride_1,
-      IntArrayRef padding_1,
-      IntArrayRef output_padding_1,
-      IntArrayRef dilation_1,
-      const int64_t groups_1,
-      const Tensor& weight_2,
-      const c10::optional<Tensor>& bias_2,
-      IntArrayRef stride_2,
-      IntArrayRef padding_2,
-      IntArrayRef output_padding_2,
-      IntArrayRef dilation_2,
-      const int64_t groups_2,
+      const Tensor& weight_a,
+      const c10::optional<Tensor>& bias_a,
+      const Tensor& weight_b,
+      const c10::optional<Tensor>& bias_b,
+      IntArrayRef stride,
+      IntArrayRef padding,
+      IntArrayRef output_padding,
+      IntArrayRef dilation,
+      const int64_t groups,
       const bool transposed);
 
   using State = std::tuple<
       Tensor,
       c10::optional<Tensor>,
-      std::vector<int64_t>,
-      std::vector<int64_t>,
-      std::vector<int64_t>,
-      std::vector<int64_t>,
-      int64_t,
       Tensor,
       c10::optional<Tensor>,
       std::vector<int64_t>,
@@ -47,25 +37,22 @@ class GatedConv2dModuleOpContext final : public torch::jit::CustomClassHolder {
       int64_t,
       bool>;
 
-  Tensor run(const Tensor& input_arg_1, const Tensor& input_arg_2) const;
+  Tensor run(const Tensor& padding, const Tensor& prev_out) const;
+  Tensor run_transpose(
+      const Tensor& prev_out, const Tensor& encoder_out, const Tensor& padding) const;
   State unpack() const;
 
  private:
   GatedConv2dModuleOpContext(
-      const Tensor& weight_1,
-      const c10::optional<Tensor>& bias_1,
-      IntArrayRef stride_1,
-      IntArrayRef padding_1,
-      IntArrayRef output_padding_1,
-      IntArrayRef dilation_1,
-      int64_t groups_1,
-      const Tensor& weight_2,
-      const c10::optional<Tensor>& bias_2,
-      IntArrayRef stride_2,
-      IntArrayRef padding_2,
-      IntArrayRef output_padding_2,
-      IntArrayRef dilation_2,
-      int64_t groups_2,
+      const Tensor& weight_a,
+      const c10::optional<Tensor>& bias_a,
+      const Tensor& weight_b,
+      const c10::optional<Tensor>& bias_b,
+      IntArrayRef stride,
+      IntArrayRef padding,
+      IntArrayRef output_padding,
+      IntArrayRef dilation,
+      int64_t groups,
       bool transposed);
 
  private:
@@ -80,46 +67,41 @@ class GatedConv2dModuleOpContext final : public torch::jit::CustomClassHolder {
   } packed_;
 
   struct {
-    Tensor weight_1;
-    c10::optional<Tensor> bias_1;
-    std::vector<int64_t> filter_1;
-    std::vector<int64_t> stride_1;
-    std::vector<int64_t> padding_1;
-    std::vector<int64_t> output_padding_1;
-    std::vector<int64_t> dilation_1;
-    int64_t groups_1;
-    Tensor weight_2;
-    c10::optional<Tensor> bias_2;
-    std::vector<int64_t> filter_2;
-    std::vector<int64_t> stride_2;
-    std::vector<int64_t> padding_2;
-    std::vector<int64_t> output_padding_2;
-    std::vector<int64_t> dilation_2;
-    int64_t groups_2;
+    Tensor weight_a;
+    c10::optional<Tensor> bias_a;
+    Tensor weight_b;
+    c10::optional<Tensor> bias_b;
+    std::vector<int64_t> filter;
+    std::vector<int64_t> stride;
+    std::vector<int64_t> padding;
+    std::vector<int64_t> output_padding;
+    std::vector<int64_t> dilation;
+    int64_t groups;
     bool transposed;
   } unpacked_;
 };
 
 Tensor gated_conv2d_module_run(
-    const Tensor& input_1,
-    const Tensor& input_2,
+    const Tensor& padding,
+    const Tensor& prev_out,
+    const c10::intrusive_ptr<GatedConv2dModuleOpContext>& context);
+
+Tensor gated_conv_transpose2d_module_run(
+    const Tensor& prev_out,
+    const Tensor& encoder_out,
+    const Tensor& padding,
     const c10::intrusive_ptr<GatedConv2dModuleOpContext>& context);
 
 c10::intrusive_ptr<GatedConv2dModuleOpContext> gated_conv2d_module_prepack(
-    Tensor&& weight_1,
-    c10::optional<Tensor>&& bias_1,
-    std::vector<int64_t>&& stride_1,
-    std::vector<int64_t>&& padding_1,
-    std::vector<int64_t>&& output_padding_1,
-    std::vector<int64_t>&& dilation_1,
-    const int64_t groups_1,
-    Tensor&& weight_2,
-    c10::optional<Tensor>&& bias_2,
-    std::vector<int64_t>&& stride_2,
-    std::vector<int64_t>&& padding_2,
-    std::vector<int64_t>&& output_padding_2,
-    std::vector<int64_t>&& dilation_2,
-    const int64_t groups_2,
+    Tensor&& weight_a,
+    c10::optional<Tensor>&& bias_a,
+    Tensor&& weight_b,
+    c10::optional<Tensor>&& bias_b,
+    std::vector<int64_t>&& stride,
+    std::vector<int64_t>&& padding,
+    std::vector<int64_t>&& output_padding,
+    std::vector<int64_t>&& dilation,
+    const int64_t groups,
     const bool transposed);
 
 } // namespace ops

--- a/aten/src/ATen/native/vulkan/ops/Register.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Register.cpp
@@ -51,12 +51,7 @@ TORCH_LIBRARY(vulkan, m) {
                 std::move(std::get<6>(state)),
                 std::move(std::get<7>(state)),
                 std::move(std::get<8>(state)),
-                std::move(std::get<9>(state)),
-                std::move(std::get<10>(state)),
-                std::move(std::get<11>(state)),
-                std::move(std::get<12>(state)),
-                std::move(std::get<13>(state)),
-                std::move(std::get<14>(state)));
+                std::move(std::get<9>(state)));
           });
   m.class_<TransposeConv2dOpContext>("TransposeConv2dOpContext")
       .def_pickle(
@@ -115,13 +110,16 @@ TORCH_LIBRARY(vulkan_prepack, m) {
       "__torch__.torch.classes.vulkan.LinearOpContext BW_prepack) -> Tensor Y"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "vulkan_prepack::gated_conv2d_module_prepack("
-      "Tensor W_1, Tensor? B_1, int[2] stride_1, int[2] padding_1, int[2] output_padding_1, int[2] dilation_1, int groups_1, "
-      "Tensor W_2, Tensor? B_2, int[2] stride_2, int[2] padding_2, int[2] output_padding_2, int[2] dilation_2, int groups_2, "
+      "Tensor W_a, Tensor? B_a, Tensor W_b, Tensor? B_b,"
+      "int[2] stride, int[2] padding, int[2] output_padding, int[2] dilation, int groups, "
       "bool transposed) "
       "-> __torch__.torch.classes.vulkan.GatedConv2dModuleOpContext"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "vulkan_prepack::gated_conv2d_module_run(Tensor X_1, Tensor X_2, "
-      "__torch__.torch.classes.vulkan.GatedConv2dModuleOpContext W_prepack) -> Tensor Y"));
+      "vulkan_prepack::gated_conv2d_module_run(Tensor X_padding, Tensor X_prev_out, "
+      "__torch__.torch.classes.vulkan.GatedConv2dModuleOpContext prepacked) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "vulkan_prepack::gated_conv_transpose2d_module_run(Tensor X_padding, Tensor X_prev_out, Tensor X_encoder_out, "
+      "__torch__.torch.classes.vulkan.GatedConv2dModuleOpContext prepacked) -> Tensor Y"));
 }
 
 TORCH_LIBRARY_IMPL(vulkan_prepack, CPU, m) {
@@ -136,6 +134,7 @@ TORCH_LIBRARY_IMPL(vulkan_prepack, Vulkan, m) {
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::conv2d_transpose_clamp_run"), TORCH_FN(conv2d_transpose_clamp_run));
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::linear_run"), TORCH_FN(linear_run));
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::gated_conv2d_module_run"), TORCH_FN(gated_conv2d_module_run));
+  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::gated_conv_transpose2d_module_run"), TORCH_FN(gated_conv_transpose2d_module_run));
 }
 
 Tensor convolution(

--- a/torch/csrc/jit/passes/vulkan_rewrite.cpp
+++ b/torch/csrc/jit/passes/vulkan_rewrite.cpp
@@ -78,32 +78,57 @@ void insertPrePackedGatedConv2dModuleOp(std::shared_ptr<Graph>& graph) {
   rewriter.runOnGraph(graph);
 
   std::string conv_2d_transpose_pattern = R"(
-    graph(%dim:int,
-          %input1, %weight1, %bias1, %stride1:int[], %padding1:int[], %dilation1:int[], %output_padding1:int[], %groups1:int,
-          %input2, %weight2, %bias2, %stride2:int[], %padding2:int[], %dilation2:int[], %output_padding2:int[], %groups2:int):
-        %list : Tensor[] = prim::ListConstruct(%input1, %input2)
-        %input = aten::cat(%list, %dim)
-        %r1 = aten::conv_transpose2d(%input, %weight1, %bias1, %stride1, %padding1, %output_padding1, %groups1, %dilation1)
-        %r2 = aten::conv_transpose2d(%input, %weight2, %bias2, %stride2, %padding2, %output_padding2, %groups2, %dilation2)
+    graph(%channel_dim:int, %height_dim:int, %prev_output, %encoder_output, %left_padding,
+          %weight1, %bias1, %weight2, %bias2, %stride:int[], %padding:int[], %dilation:int[], %output_padding:int[], %groups:int):
+        %bottom_row_list : Tensor[] = prim::ListConstruct(%prev_output, %encoder_output)
+        %bottom_row = aten::cat(%bottom_row_list, %channel_dim)
+        %top_row_list : Tensor[] = prim::ListConstruct(%left_padding, %bottom_row)
+        %input = aten::cat(%top_row_list, %height_dim)
+        %r1 = aten::conv_transpose2d(%input, %weight1, %bias1, %stride, %padding, %output_padding, %groups, %dilation)
+        %r2 = aten::conv_transpose2d(%input, %weight2, %bias2, %stride, %padding, %output_padding, %groups, %dilation)
+        %r3 = aten::sigmoid(%r2)
+        %r = aten::mul(%r1, %r3)
+        return (%r) )";
+
+  std::string conv_2d_transpose_pattern_2 = R"(
+    graph(%channel_dim:int, %height_dim:int, %prev_output:Tensor, %encoder_output:Tensor, %left_padding:Tensor,
+          %weight1, %bias1, %weight2, %bias2,
+          %stride:int[], %padding:int[], %dilation:int[], %output_padding:int[], %groups:int):
+        %bottom_row_list : Tensor[] = prim::ListConstruct(%prev_output, %encoder_output)
+        %bottom_row : Tensor = aten::cat(%bottom_row_list, %channel_dim)
+        %input_list : Tensor[] = prim::ListConstruct(%left_padding, %bottom_row)
+        %input : Tensor = aten::cat(%input_list, %height_dim)
+        %r1 = aten::conv_transpose2d(%input, %weight1, %bias1, %stride, %padding, %output_padding, %groups, %dilation)
+        %r2 = aten::conv_transpose2d(%input, %weight2, %bias2, %stride, %padding, %output_padding, %groups, %dilation)
         %r3 = aten::sigmoid(%r2)
         %r = aten::mul(%r1, %r3)
         return (%r) )";
 
   std::string prepacked_ops_conv2d_transpose_pattern = R"(
-    graph(%dim:int,
-          %input1, %weight1, %bias1, %stride1:int[], %padding1:int[], %dilation1:int[], %output_padding1:int[], %groups1:int,
-          %input2, %weight2, %bias2, %stride2:int[], %padding2:int[], %dilation2:int[], %output_padding2:int[], %groups2:int):
+    graph(%channel_dim:int, %height_dim:int, %prev_output:Tensor, %encoder_output:Tensor, %left_padding:Tensor,
+          %weight1, %bias1, %weight2, %bias2, %stride:int[], %padding:int[], %dilation:int[], %output_padding:int[], %groups:int):
         %transposed : bool = prim::Constant[value=1]()
         %packed = vulkan_prepack::gated_conv2d_module_prepack(
-          %weight1, %bias1, %stride1, %padding1, %output_padding1, %dilation1, %groups1,
-          %weight2, %bias2, %stride2, %padding2, %output_padding2, %dilation2, %groups2,
+          %weight1, %bias1, %stride, %padding, %output_padding, %dilation, %groups,
+          %weight2, %bias2, %stride, %padding, %output_padding, %dilation, %groups,
           %transposed)
-        %r = vulkan_prepack::gated_conv2d_module_run(%input1, %input2, %packed)
+        %r = vulkan_prepack::gated_conv_transpose2d_module_run(%prev_output, %encoder_output, %left_padding, %packed)
+        return (%r) )";
+
+  std::string prepacked_ops_conv2d_transpose_pattern_2 = R"(
+    graph(%channel_dim:int, %height_dim:int, %prev_output, %encoder_output, %left_padding, %weight1, %bias1, %weight2, %bias2,
+          %stride:int[], %padding:int[], %dilation:int[], %output_padding:int[], %groups:int):
+        %transposed : bool = prim::Constant[value=1]()
+        %packed = vulkan_prepack::gated_conv2d_module_prepack(
+          %weight1, %bias1, %stride, %padding, %output_padding, %dilation, %groups,
+          %weight2, %bias2, %stride, %padding, %output_padding, %dilation, %groups,
+          %transposed)
+        %r = vulkan_prepack::gated_conv_transpose2d_module_run(%left_padding, %prev_output, %encoder_output, %packed)
         return (%r) )";
 
   SubgraphRewriter transpose_rewriter;
   transpose_rewriter.RegisterRewritePattern(
-      conv_2d_transpose_pattern, prepacked_ops_conv2d_transpose_pattern);
+      conv_2d_transpose_pattern_2, prepacked_ops_conv2d_transpose_pattern_2);
   transpose_rewriter.runOnGraph(graph);
 }
 
@@ -238,7 +263,7 @@ void fuseReluWithPackedOps(std::shared_ptr<Graph>& graph) {
 void vulkanInsertPrePackedOps(std::shared_ptr<Graph>& graph) {
   insertPrePackedLinearOp(graph);
   insertPrePackedGatedConv2dModuleOp(graph);
-  insertPrePackedConv2dOp(graph);
+  //insertPrePackedConv2dOp(graph);
 }
 
 void vulkanInsertPrePackedOps(script::Module& module) {
@@ -290,16 +315,15 @@ script::Module vulkanOptimizeForMobile(
     const script::Module& m,
     const std::vector<std::string>& preserved_methods) {
   auto cloned_module = m.clone();
+  cloned_module.dump(true, false, false);
   cloned_module.eval();
   cloned_module = FoldConvBatchNorm(cloned_module);
   cloned_module = freeze_module(cloned_module, preserved_methods);
-  cloned_module.dump(true, false, false);
   vulkanInsertPrePackedOps(cloned_module);
-  //cloned_module.dump(true, false, false);
   vulkanFusePrePackedConvWithClamp(cloned_module);
   vulkanFoldPrePackingOps(cloned_module);
 
-  cloned_module.dump(true, false, false);
+  //cloned_module.dump(true, false, false);
 
   removeDropout(cloned_module);
   vulkanRemoveMutation(cloned_module);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #72386 remove GatedConv2dModule rewrites
* **#72385 Simplify Op Context and Fix Gated Conv Transpose 2D block**
* #72384 Rename to GatedConv2dBlock
* #72383 [vulkan] Add decoder conv block
* #72382 [vulkan] some optimizations to encoder block op
* #72381 [vulkan] Mclaren consolidated ops
* #72380 [vulkan] speed benchmark torch to handle non-single tensor outputs

