### PR TITLE
remove GatedConv2dModule rewrites

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/tanh.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/tanh.glsl
@@ -18,6 +18,10 @@ void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
-    imageStore(uOutput, pos, tanh(texelFetch(uInput, pos, 0)));
+    const vec4 intex = texelFetch(uInput, pos, 0);
+    imageStore(
+        uOutput,
+        pos,
+        tanh(clamp(intex, -15.0, 15.0)));
   }
 }

--- a/aten/src/ATen/native/vulkan/ops/GatedConv2dModule.h
+++ b/aten/src/ATen/native/vulkan/ops/GatedConv2dModule.h
@@ -39,10 +39,9 @@ class GatedConv2dModuleOpContext final : public torch::jit::CustomClassHolder {
 
   Tensor run(const Tensor& padding, const Tensor& prev_out) const;
   Tensor run_transpose(
-      const Tensor& prev_out, const Tensor& encoder_out, const Tensor& padding) const;
+      const Tensor& prev_out, const Tensor& prev_enc_out, const Tensor& encoder_out, const Tensor& padding) const;
   State unpack() const;
 
- private:
   GatedConv2dModuleOpContext(
       const Tensor& weight_a,
       const c10::optional<Tensor>& bias_a,
@@ -55,7 +54,6 @@ class GatedConv2dModuleOpContext final : public torch::jit::CustomClassHolder {
       int64_t groups,
       bool transposed);
 
- private:
   struct {
     vTensor v_weight;
     vTensor v_bias;
@@ -86,10 +84,23 @@ Tensor gated_conv2d_module_run(
     const Tensor& prev_out,
     const c10::intrusive_ptr<GatedConv2dModuleOpContext>& context);
 
+Tensor gated_conv2d_module_run_cpu(
+    const Tensor& padding,
+    const Tensor& prev_out,
+    const c10::intrusive_ptr<GatedConv2dModuleOpContext>& context);
+
 Tensor gated_conv_transpose2d_module_run(
+    const Tensor& padding,
+    const Tensor& prev_enc_out,
     const Tensor& prev_out,
     const Tensor& encoder_out,
+    const c10::intrusive_ptr<GatedConv2dModuleOpContext>& context);
+
+Tensor gated_conv_transpose2d_module_run_cpu(
     const Tensor& padding,
+    const Tensor& prev_enc_out,
+    const Tensor& prev_out,
+    const Tensor& encoder_out,
     const c10::intrusive_ptr<GatedConv2dModuleOpContext>& context);
 
 c10::intrusive_ptr<GatedConv2dModuleOpContext> gated_conv2d_module_prepack(

--- a/aten/src/ATen/native/vulkan/ops/Register.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Register.cpp
@@ -118,7 +118,7 @@ TORCH_LIBRARY(vulkan_prepack, m) {
       "vulkan_prepack::gated_conv2d_module_run(Tensor X_padding, Tensor X_prev_out, "
       "__torch__.torch.classes.vulkan.GatedConv2dModuleOpContext prepacked) -> Tensor Y"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "vulkan_prepack::gated_conv_transpose2d_module_run(Tensor X_padding, Tensor X_prev_out, Tensor X_encoder_out, "
+      "vulkan_prepack::gated_conv_transpose2d_module_run(Tensor X_padding, Tensor X_prev_enc_out, Tensor X_prev_out, Tensor X_encoder_out, "
       "__torch__.torch.classes.vulkan.GatedConv2dModuleOpContext prepacked) -> Tensor Y"));
 }
 
@@ -127,6 +127,8 @@ TORCH_LIBRARY_IMPL(vulkan_prepack, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::conv2d_transpose_clamp_prepack"), TORCH_FN(conv2d_transpose_clamp_prepack));
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::linear_prepack"), TORCH_FN(linear_prepack));
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::gated_conv2d_module_prepack"), TORCH_FN(gated_conv2d_module_prepack));
+  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::gated_conv2d_module_run"), TORCH_FN(gated_conv2d_module_run_cpu));
+  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::gated_conv_transpose2d_module_run"), TORCH_FN(gated_conv_transpose2d_module_run_cpu));
 }
 
 TORCH_LIBRARY_IMPL(vulkan_prepack, Vulkan, m) {

--- a/torch/csrc/jit/passes/vulkan_rewrite.cpp
+++ b/torch/csrc/jit/passes/vulkan_rewrite.cpp
@@ -45,93 +45,6 @@ void insertPrePackedLinearOp(std::shared_ptr<Graph>& graph) {
   linear_rewriter.runOnGraph(graph);
 }
 
-void insertPrePackedGatedConv2dModuleOp(std::shared_ptr<Graph>& graph) {
-  graph_rewrite_helper::replaceConvolutionWithAtenConv(graph);
-
-  std::string conv_2d_pattern = R"(
-    graph(%dim:int,
-          %input1, %weight1, %bias1, %stride1:int[], %padding1:int[], %dilation1:int[], %groups1:int,
-          %input2, %weight2, %bias2, %stride2:int[], %padding2:int[], %dilation2:int[], %groups2:int):
-        %list : Tensor[] = prim::ListConstruct(%input1, %input2)
-        %input = aten::cat(%list, %dim)
-        %r1 = aten::conv2d(%input, %weight1, %bias1, %stride1, %padding1, %dilation1, %groups1)
-        %r2 = aten::conv2d(%input, %weight2, %bias2, %stride2, %padding2, %dilation2, %groups2)
-        %r3 = aten::sigmoid(%r2)
-        %r = aten::mul(%r1, %r3)
-        return (%r) )";
-
-  std::string prepacked_ops_conv2d_pattern = R"(
-    graph(%dim:int, %input1, %weight1, %bias1, %stride1:int[], %padding1:int[], %dilation1:int[], %groups1:int,
-          %input2, %weight2, %bias2, %stride2:int[], %padding2:int[], %dilation2:int[], %groups2:int):
-        %transposed : bool = prim::Constant[value=0]()
-        %output_padding : int[] = prim::Constant[value=[0, 0]]()
-        %packed = vulkan_prepack::gated_conv2d_module_prepack(
-          %weight1, %bias1, %stride1, %padding1, %output_padding, %dilation1, %groups1,
-          %weight2, %bias2, %stride2, %padding2, %output_padding, %dilation2, %groups2,
-          %transposed)
-        %r = vulkan_prepack::gated_conv2d_module_run(%input1, %input2, %packed)
-        return (%r) )";
-
-  SubgraphRewriter rewriter;
-  rewriter.RegisterRewritePattern(
-      conv_2d_pattern, prepacked_ops_conv2d_pattern);
-  rewriter.runOnGraph(graph);
-
-  std::string conv_2d_transpose_pattern = R"(
-    graph(%channel_dim:int, %height_dim:int, %prev_output, %encoder_output, %left_padding,
-          %weight1, %bias1, %weight2, %bias2, %stride:int[], %padding:int[], %dilation:int[], %output_padding:int[], %groups:int):
-        %bottom_row_list : Tensor[] = prim::ListConstruct(%prev_output, %encoder_output)
-        %bottom_row = aten::cat(%bottom_row_list, %channel_dim)
-        %top_row_list : Tensor[] = prim::ListConstruct(%left_padding, %bottom_row)
-        %input = aten::cat(%top_row_list, %height_dim)
-        %r1 = aten::conv_transpose2d(%input, %weight1, %bias1, %stride, %padding, %output_padding, %groups, %dilation)
-        %r2 = aten::conv_transpose2d(%input, %weight2, %bias2, %stride, %padding, %output_padding, %groups, %dilation)
-        %r3 = aten::sigmoid(%r2)
-        %r = aten::mul(%r1, %r3)
-        return (%r) )";
-
-  std::string conv_2d_transpose_pattern_2 = R"(
-    graph(%channel_dim:int, %height_dim:int, %prev_output:Tensor, %encoder_output:Tensor, %left_padding:Tensor,
-          %weight1, %bias1, %weight2, %bias2,
-          %stride:int[], %padding:int[], %dilation:int[], %output_padding:int[], %groups:int):
-        %bottom_row_list : Tensor[] = prim::ListConstruct(%prev_output, %encoder_output)
-        %bottom_row : Tensor = aten::cat(%bottom_row_list, %channel_dim)
-        %input_list : Tensor[] = prim::ListConstruct(%left_padding, %bottom_row)
-        %input : Tensor = aten::cat(%input_list, %height_dim)
-        %r1 = aten::conv_transpose2d(%input, %weight1, %bias1, %stride, %padding, %output_padding, %groups, %dilation)
-        %r2 = aten::conv_transpose2d(%input, %weight2, %bias2, %stride, %padding, %output_padding, %groups, %dilation)
-        %r3 = aten::sigmoid(%r2)
-        %r = aten::mul(%r1, %r3)
-        return (%r) )";
-
-  std::string prepacked_ops_conv2d_transpose_pattern = R"(
-    graph(%channel_dim:int, %height_dim:int, %prev_output:Tensor, %encoder_output:Tensor, %left_padding:Tensor,
-          %weight1, %bias1, %weight2, %bias2, %stride:int[], %padding:int[], %dilation:int[], %output_padding:int[], %groups:int):
-        %transposed : bool = prim::Constant[value=1]()
-        %packed = vulkan_prepack::gated_conv2d_module_prepack(
-          %weight1, %bias1, %stride, %padding, %output_padding, %dilation, %groups,
-          %weight2, %bias2, %stride, %padding, %output_padding, %dilation, %groups,
-          %transposed)
-        %r = vulkan_prepack::gated_conv_transpose2d_module_run(%prev_output, %encoder_output, %left_padding, %packed)
-        return (%r) )";
-
-  std::string prepacked_ops_conv2d_transpose_pattern_2 = R"(
-    graph(%channel_dim:int, %height_dim:int, %prev_output, %encoder_output, %left_padding, %weight1, %bias1, %weight2, %bias2,
-          %stride:int[], %padding:int[], %dilation:int[], %output_padding:int[], %groups:int):
-        %transposed : bool = prim::Constant[value=1]()
-        %packed = vulkan_prepack::gated_conv2d_module_prepack(
-          %weight1, %bias1, %stride, %padding, %output_padding, %dilation, %groups,
-          %weight2, %bias2, %stride, %padding, %output_padding, %dilation, %groups,
-          %transposed)
-        %r = vulkan_prepack::gated_conv_transpose2d_module_run(%left_padding, %prev_output, %encoder_output, %packed)
-        return (%r) )";
-
-  SubgraphRewriter transpose_rewriter;
-  transpose_rewriter.RegisterRewritePattern(
-      conv_2d_transpose_pattern_2, prepacked_ops_conv2d_transpose_pattern_2);
-  transpose_rewriter.runOnGraph(graph);
-}
-
 void insertPrePackedConv2dOp(std::shared_ptr<Graph>& graph) {
   graph_rewrite_helper::replaceConvolutionWithAtenConv(graph);
 
@@ -262,8 +175,7 @@ void fuseReluWithPackedOps(std::shared_ptr<Graph>& graph) {
 
 void vulkanInsertPrePackedOps(std::shared_ptr<Graph>& graph) {
   insertPrePackedLinearOp(graph);
-  insertPrePackedGatedConv2dModuleOp(graph);
-  //insertPrePackedConv2dOp(graph);
+  insertPrePackedConv2dOp(graph);
 }
 
 void vulkanInsertPrePackedOps(script::Module& module) {
@@ -315,15 +227,12 @@ script::Module vulkanOptimizeForMobile(
     const script::Module& m,
     const std::vector<std::string>& preserved_methods) {
   auto cloned_module = m.clone();
-  cloned_module.dump(true, false, false);
   cloned_module.eval();
   cloned_module = FoldConvBatchNorm(cloned_module);
   cloned_module = freeze_module(cloned_module, preserved_methods);
   vulkanInsertPrePackedOps(cloned_module);
   vulkanFusePrePackedConvWithClamp(cloned_module);
   vulkanFoldPrePackingOps(cloned_module);
-
-  //cloned_module.dump(true, false, false);
 
   removeDropout(cloned_module);
   vulkanRemoveMutation(cloned_module);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#72386 remove GatedConv2dModule rewrites**
* #72385 Simplify Op Context and Fix Gated Conv Transpose 2D block
* #72384 Rename to GatedConv2dBlock
* #72383 [vulkan] Add decoder conv block
* #72382 [vulkan] some optimizations to encoder block op
* #72381 [vulkan] Mclaren consolidated ops
* #72380 [vulkan] speed benchmark torch to handle non-single tensor outputs

