### PR TITLE
Show friendly error message when forgetting `init` in `torch.cuda`

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1562,7 +1562,9 @@ static inline void assertValidDevice(int device) {
   const auto device_num = caching_allocator.device_allocator.size();
   TORCH_CHECK(
       0 <= device && device < static_cast<int64_t>(device_num),
-      "Invalid device argument.");
+      "Invalid device argument ",
+      device,
+      ": did you call init?");
 }
 
 DeviceStats getDeviceStats(int device) {


### PR DESCRIPTION
# Problem
The error message `RuntimeError: Invalid device argument` is not friendly when users just forget calling `torch.cuda.init()`.
This error message is shown for example by calling  `torch.cuda.reset_accumulated_memory_stats`, or other methods which internally calls [assertValidDevice](https://github.com/pytorch/pytorch/blob/6297aa114f8278f5cf5e661cba9bcf5c83f2ac1e/c10/cuda/CUDACachingAllocator.cpp#L1561-L1566).

# Reproduce
```python
$ python
Python 3.8.6 (default, Apr  1 2021, 08:23:31) 
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import torch.cuda
>>> torch.cuda.reset_accumulated_memory_stats(0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/site-packages/torch/cuda/memory.py", line 219, in reset_accumulated_memory_stats
    return torch._C._cuda_resetAccumulatedMemoryStats(device)
RuntimeError: Invalid device argument.
>>> torch.cuda.current_device()
0
```

# This PR
Shows better error message like `RuntimeError: Invalid device argument 0: did you call init?`. I cited the error message from https://github.com/pytorch/pytorch/blob/6297aa114f8278f5cf5e661cba9bcf5c83f2ac1e/c10/cuda/CUDACachingAllocator.cpp#L1392-L1396.