### PR TITLE
Fix unused variable warnings

### DIFF
--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -325,7 +325,7 @@ struct ApplyOp2<Op, scalar1, scalar2, IndexType, ADims, BDims, 0, Offset> {
 __device__ __forceinline__
 static void apply(detail::TensorInfo<scalar1, IndexType> &a,
                   detail::TensorInfo<scalar2, IndexType> &b,
-                  const Op &op, int n, IndexType linearIndex,
+                  const Op &op, int /*n*/, IndexType /*linearIndex*/,
                   Offset aOffset, Offset bOffset) {
   op(a.data[aOffset], b.data[bOffset]);
 }

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -87,7 +87,7 @@ struct SoftMaxBackwardEpilogue {
 // The 2d grid is used to parallelize inner dimension over y axis and outer over x.
 inline dim3 SpatialSoftMax_getGridSize(
     dim3 block, uint32_t max_active_blocks,
-    uint64_t outer_size, uint64_t dim_size, uint64_t inner_size) {
+    uint64_t outer_size, uint64_t inner_size) {
   // First, tile as many blocks as we can over the y axis
   uint32_t inner_blocks = (inner_size + block.y - 1) / block.y;
   if (inner_blocks > max_active_blocks)
@@ -102,7 +102,7 @@ inline dim3 SpatialSoftMax_getGridSize(
 const int max_threads = 1024;
 
 inline dim3 SpatialSoftMax_getBlockSize(
-  uint64_t outer_size, uint64_t dim_size, uint64_t inner_size) {
+  uint64_t dim_size, uint64_t inner_size) {
   uint32_t inner_threads = inner_size;
   inner_threads = std::min(inner_threads, static_cast<uint32_t>(max_threads));
   uint32_t dim_threads = 1;
@@ -120,7 +120,7 @@ void SpatialSoftMax_getLaunchSizes(
     Kernel k,
     uint64_t outer_size, uint64_t dim_size, uint64_t inner_size,
     dim3& grid, dim3& block, uint32_t& smem_size) {
-  block = SpatialSoftMax_getBlockSize(outer_size, dim_size, inner_size);
+  block = SpatialSoftMax_getBlockSize(dim_size, inner_size);
   uint32_t block_threads = block.x * block.y;
   smem_size = block.x == 1 ? 0 : block_threads * sizeof(accscalar_t);
   int max_active_blocks;
@@ -135,7 +135,7 @@ void SpatialSoftMax_getLaunchSizes(
                                                 k, block_threads, smem_size);
 #endif
   max_active_blocks *= at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-  grid = SpatialSoftMax_getGridSize(block, max_active_blocks, outer_size, dim_size, inner_size);
+  grid = SpatialSoftMax_getGridSize(block, max_active_blocks, outer_size, inner_size);
 }
 
 inline dim3 SoftMax_getBlockSize(int ILP, uint64_t dim_size) {

--- a/caffe2/operators/cross_entropy_op.cu
+++ b/caffe2/operators/cross_entropy_op.cu
@@ -188,7 +188,6 @@ __device__ float unjoined_sigmoid_xent_backward(float lgt, float tgt) {
 }
 
 __global__ void SigmoidCrossEntropyWithLogitsKernel(
-    const int outer_size,
     const int inner_size,
     const bool log_D_trick,
     const bool unjoined_lr_loss,
@@ -276,7 +275,6 @@ bool SigmoidCrossEntropyWithLogitsOp<float, CUDAContext>::RunOnDevice() {
       CAFFE_CUDA_NUM_THREADS,
       0,
       context_.cuda_stream()>>>(
-      outer_size,
       inner_size,
       log_D_trick_,
       unjoined_lr_loss_,
@@ -327,7 +325,6 @@ bool SigmoidCrossEntropyWithLogitsGradientOp<float, CUDAContext>::
 namespace {
 
 __global__ void WeightedSigmoidCrossEntropyWithLogitsKernel(
-    const int outer_size,
     const int inner_size,
     const float* logits_ptr,
     const float* targets_ptr,
@@ -396,7 +393,7 @@ bool WeightedSigmoidCrossEntropyWithLogitsOp<float, CUDAContext>::
       CAFFE_CUDA_NUM_THREADS,
       0,
       context_.cuda_stream()>>>(
-      outer_size, inner_size, logits_ptr, targets_ptr, weights_ptr, out_ptr);
+      inner_size, logits_ptr, targets_ptr, weights_ptr, out_ptr);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return true;

--- a/caffe2/operators/generate_proposals_op_util_nms.h
+++ b/caffe2/operators/generate_proposals_op_util_nms.h
@@ -344,7 +344,6 @@ int convex_hull_graham(
     Eigen::Vector2f* q,
     bool shift_to_zero = false) {
   CAFFE_ENFORCE(num_in >= 2);
-  std::vector<int> order;
 
   // Step 1:
   // Find point with minimum y

--- a/caffe2/operators/lp_pool_op.cu
+++ b/caffe2/operators/lp_pool_op.cu
@@ -189,7 +189,6 @@ __global__ void LpPoolBackwardNHWC(
     for (int ph = phstart; ph < phend; ++ph) {
       for (int pw = pwstart; pw < pwend; ++pw) {
         // figure out the pooling size
-        const int hstart = max(ph * stride_h - pad_t, 0);
         gradient += top_diff_slice[(ph * pooled_width + pw) * channels] *
             bottom_data[index] * pow(abs(bottom_data[index]), p - 2) /
             pow(top_data_slice[(ph * pooled_width + pw) * channels], p - 1);

--- a/caffe2/operators/max_pool_with_index.cu
+++ b/caffe2/operators/max_pool_with_index.cu
@@ -13,7 +13,7 @@ namespace {
 template <typename Dtype>
 __global__ void MaxPoolForward(
     const int nthreads,
-    const Dtype *const const bottom_data,
+    const Dtype *const bottom_data,
     const int channels,
     const int height,
     const int width,
@@ -25,7 +25,7 @@ __global__ void MaxPoolForward(
     const int stride_w,
     const int pad_h,
     const int pad_w,
-    Dtype *const const top_data,
+    Dtype *const top_data,
     int *const mask) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     const int pw = index % pooled_width;
@@ -58,8 +58,8 @@ __global__ void MaxPoolForward(
 template <typename Dtype>
 __global__ void MaxPoolBackward(
     const int nthreads,
-    const Dtype *const const top_diff,
-    const int *const const mask,
+    const Dtype *const top_diff,
+    const int *const mask,
     const int channels,
     const int height,
     const int width,
@@ -71,7 +71,7 @@ __global__ void MaxPoolBackward(
     const int stride_w,
     const int pad_h,
     const int pad_w,
-    Dtype *const const bottom_diff) {
+    Dtype *const bottom_diff) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     // find out the local index
     // find out the local offset

--- a/caffe2/operators/piecewise_linear_transform_op.cu
+++ b/caffe2/operators/piecewise_linear_transform_op.cu
@@ -12,7 +12,6 @@ namespace {
 __global__ void PieceWiseLinearTransformGeneralKernel(
     const int N,
     const int M,
-    const int num_grp,
     const int num_fnc_per_grp,
     const float* bounds,
     const float* slopes,
@@ -47,8 +46,6 @@ __global__ void PieceWiseLinearTransformGeneralKernel(
 namespace {
 __global__ void PieceWiseLinearTransformBinaryKernel1(
     const int N,
-    const int M,
-    const int num_grp,
     const int num_fnc_per_grp,
     const float* bounds,
     const float* slopes,
@@ -75,7 +72,6 @@ namespace {
 __global__ void PieceWiseLinearTransformBinaryKernel2(
     const int N,
     const int M,
-    const int num_grp,
     const int num_fnc_per_grp,
     const float* bounds,
     const float* slopes,
@@ -212,7 +208,6 @@ bool PiecewiseLinearTransformOp<float, CUDAContext>::TransformGeneral() {
       context_.cuda_stream()>>>(
       N,
       M,
-      num_group,
       num_func_per_group,
       bounds_device_.data<float>(),
       slopes_device_.data<float>(),
@@ -248,8 +243,6 @@ bool PiecewiseLinearTransformOp<float, CUDAContext>::TransformBinary() {
         0,
         context_.cuda_stream()>>>(
         N,
-        M,
-        num_group,
         num_func_per_group,
         bounds_device_.data<float>(),
         slopes_device_.data<float>(),
@@ -266,7 +259,6 @@ bool PiecewiseLinearTransformOp<float, CUDAContext>::TransformBinary() {
         context_.cuda_stream()>>>(
         N,
         M,
-        num_group,
         num_func_per_group,
         bounds_device_.data<float>(),
         slopes_device_.data<float>(),

--- a/caffe2/operators/roi_align_rotated_gradient_op.cu
+++ b/caffe2/operators/roi_align_rotated_gradient_op.cu
@@ -28,8 +28,7 @@ __device__ void bilinear_interpolate_gradient(
     int& x_low,
     int& x_high,
     int& y_low,
-    int& y_high,
-    const int index /* index for debug only*/) {
+    int& y_high) {
   // deal with cases that inverse elements are out of feature map boundary
   if (y < -1.0 || y > height || x < -1.0 || x > width) {
     // empty
@@ -75,7 +74,6 @@ template <typename T>
 __global__ void RoIAlignRotatedBackward(
     const int nthreads,
     const T* top_diff,
-    const int num_rois,
     const T spatial_scale,
     const int channels,
     const int height,
@@ -165,8 +163,7 @@ __global__ void RoIAlignRotatedBackward(
             x_low,
             x_high,
             y_low,
-            y_high,
-            index);
+            y_high);
 
         T g1 = top_diff_this_bin * w1 / count;
         T g2 = top_diff_this_bin * w2 / count;
@@ -213,7 +210,6 @@ C10_EXPORT bool RoIAlignRotatedGradientOp<float, CUDAContext>::RunOnDevice() {
            context_.cuda_stream()>>>(
             dY.numel(),
             dY.data<float>(),
-            R.dim32(0),
             spatial_scale_,
             X.dim32(1),
             X.dim32(2),

--- a/caffe2/operators/segment_reduction_op_gpu.cu
+++ b/caffe2/operators/segment_reduction_op_gpu.cu
@@ -91,9 +91,8 @@ __global__ void length_sum_gradient_kernel(
     const T* __restrict__ grad_in,
     T* __restrict__ grad_out,
     const int* __restrict__ prefix_sum_length_data,
-    int N,
-    int post,
-    int len_length) { //DESTROY
+    const int N,
+    const int post) { //DESTROY
   // len_length blocks
   int group = blockIdx.x;
 
@@ -316,7 +315,6 @@ __global__ void sparse_length_weighted_sum_kernel(
     T* __restrict__ out,
     const int* __restrict__ prefix_sum_length_data,
     const IndexType* __restrict__ indices,
-    int N,
     int post,
     int len_indices) {
   // len_length blocks
@@ -826,7 +824,6 @@ class CUDASparseLengthsWeightedSumOp : public Operator<CUDAContext> {
     const T* in_weights = weightsInput.template data<T>();
     auto* prefix_sum_length_data =
         inclusive_scan_length_buffer_.template data<int>();
-    int N = dataSize;
     int post = dataInput.size_from_dim(1);
 
     auto maxThreads =
@@ -843,7 +840,6 @@ class CUDASparseLengthsWeightedSumOp : public Operator<CUDAContext> {
               out_data,
               prefix_sum_length_data,
               indices,
-              N,
               post,
               dataToReduceSize);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -855,7 +851,6 @@ class CUDASparseLengthsWeightedSumOp : public Operator<CUDAContext> {
               out_data,
               prefix_sum_length_data,
               indices,
-              N,
               post,
               dataToReduceSize);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -1347,13 +1342,13 @@ class CUDASparseLengthsSumGradientWithIndicesOp : public Operator<CUDAContext> {
       length_sum_gradient_kernel<T, true, false>
           <<<len_length, block, 0, context_.cuda_stream()>>>(
 
-              in_data, out_data, prefix_sum_length_data, N, post, len_length);
+              in_data, out_data, prefix_sum_length_data, N, post);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       // calling cuda kernel with ExactBlock = false, Average = false
       length_sum_gradient_kernel<T, false, false>
           <<<len_length, maxThreads, 0, context_.cuda_stream()>>>(
-              in_data, out_data, prefix_sum_length_data, N, post, len_length);
+              in_data, out_data, prefix_sum_length_data, N, post);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 
@@ -1428,13 +1423,13 @@ class CUDASparseLengthsMeanGradientWithIndicesOp
       length_sum_gradient_kernel<T, true, true>
           <<<len_length, block, 0, context_.cuda_stream()>>>(
 
-              in_data, out_data, prefix_sum_length_data, N, post, len_length);
+              in_data, out_data, prefix_sum_length_data, N, post);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       // calling cuda kernel with ExactBlock = false, Average = true
       length_sum_gradient_kernel<T, false, true>
           <<<len_length, maxThreads, 0, context_.cuda_stream()>>>(
-              in_data, out_data, prefix_sum_length_data, N, post, len_length);
+              in_data, out_data, prefix_sum_length_data, N, post);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
 

--- a/caffe2/operators/upsample_op.cu
+++ b/caffe2/operators/upsample_op.cu
@@ -28,8 +28,6 @@ __global__ void UpsampleBilinearKernel(
     const int input_width,
     const int output_height,
     const int output_width,
-    const float height_scale,
-    const float width_scale,
     const float* __restrict__ X,
     float* __restrict__ Y) {
 
@@ -98,9 +96,6 @@ __global__ void UpsampleBilinearGradientKernel(
     const int c = indexTemp % num_channels;
     indexTemp /= num_channels;
     const int n = indexTemp;
-
-    const int out_y = fminf(in_y / height_scale, output_height - 1);
-    const int out_x = fminf(in_x / width_scale, output_width - 1);
 
     const float rheight =
         output_height > 1 ? (output_height - 1.f) / (input_height - 1.f) : 0.f;
@@ -187,8 +182,6 @@ bool UpsampleBilinearOp<float, CUDAContext>::RunOnDevice() {
       input_width,
       output_height,
       output_width,
-      height_scale_,
-      width_scale_,
       X.data<float>(),
       Y->template mutable_data<float>());
   C10_CUDA_KERNEL_LAUNCH_CHECK();

--- a/caffe2/operators/upsample_op.cu
+++ b/caffe2/operators/upsample_op.cu
@@ -83,8 +83,6 @@ __global__ void UpsampleBilinearGradientKernel(
     const int input_width,
     const int output_height,
     const int output_width,
-    const float height_scale,
-    const float width_scale,
     const float* dY,
     float* dX) {
   CUDA_1D_KERNEL_LOOP(index, input_size) {
@@ -227,8 +225,6 @@ bool UpsampleBilinearGradientOp<float, CUDAContext>::RunOnDevice() {
       input_width,
       output_height,
       output_width,
-      height_scale_,
-      width_scale_,
       dY.data<float>(),
       dX->template mutable_data<float>());
   C10_CUDA_KERNEL_LAUNCH_CHECK();


### PR DESCRIPTION
Summary:
Fixes
```
caffe2/caffe2/operators/cross_entropy_op.cu(330): warning: parameter "outer_size" was declared but never referenced

caffe2/caffe2/operators/cross_entropy_op.cu(191): warning: parameter "outer_size" was declared but never referenced
caffe2/caffe2/operators/generate_proposals_op_util_nms.h(347): warning: variable "order" was declared but never referenced
caffe2/caffe2/operators/segment_reduction_op_gpu.cu(319): warning: parameter "N" was declared but never referenced
          detected during:
            instantiation of "__nv_bool caffe2::CUDASparseLengthsWeightedSumOp<T, Context, SparseFused>::DoRunWithType<IndexType>() [with T=float, Context=caffe2::CUDAContext, SparseFused=true, IndexType=int32_t]"
caffe2/caffe2/core/operator.h(1304): here
            instantiation of "__nv_bool caffe2::DispatchHelper<caffe2::TensorTypes<FirstType, Types...>, ExtraArgs...>::call(Op *, caffe2::TypeMeta) [with FirstType=int32_t, Types=<int64_t>, ExtraArgs=<>, Op=caffe2::CUDASparseLengthsWeightedSumOp<float, caffe2::CUDAContext, true>]"
caffe2/caffe2/core/operator.h(1304): here
            instantiation of "__nv_bool caffe2::DispatchHelper<caffe2::TensorTypes<FirstType, Types...>, ExtraArgs...>::call(Op *, const caffe2::Tensor &) [with FirstType=int32_t, Types=<int64_t>, ExtraArgs=<>, Op=caffe2::CUDASparseLengthsWeightedSumOp<float, caffe2::CUDAContext, true>]"
(786): here
caffe2/caffe2/operators/segment_reduction_op_gpu.cu(96): warning: parameter "len_length" was declared but never referenced
          detected during:
            instantiation of "__nv_bool caffe2::CUDASparseLengthsSumGradientWithIndicesOp<T, Context>::RunOnDevice() [with T=float, Context=caffe2::CUDAContext]"
(1296): here
caffe2/caffe2/sgd/adagrad_fused_op_gpu.cu(1226): warning: variable "N" was declared but never referenced
          detected during:
            instantiation of "__nv_bool caffe2::DispatchHelper<caffe2::TensorTypes2<FirstType, Types...>, ExtraArgs...>::call(Op *, caffe2::TypeMeta) [with FirstType=float, Types=<c10::Half>, ExtraArgs=<int32_t>, Op=caffe2::CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientExactOp<float, int, false, caffe2::CUDAContext>]"
caffe2/caffe2/sgd/adagrad_fused_op_gpu.cu(259): warning: parameter "indices" was declared but never referenced
          detected during:
            instantiation of "__nv_bool caffe2::CUDARowWiseSparseAdagradFusedWithSparseLengthsSumGradientExactOp<T, TLengths, is_mean, Context>::DoRunWithType2<IndexType,TParam>() [with T=float, TLengths=int, is_mean=false, Context=caffe2::CUDAContext, IndexType=int32_t, TParam=float]"
caffe2/caffe2/core/operator.h(1308): here
caffe2/caffe2/operators/piecewise_linear_transform_op.cu(15): warning: parameter "num_grp" was declared but never referenced

caffe2/caffe2/operators/piecewise_linear_transform_op.cu(50): warning: parameter "M" was declared but never referenced

caffe2/caffe2/operators/piecewise_linear_transform_op.cu(51): warning: parameter "num_grp" was declared but never referenced

caffe2/caffe2/operators/piecewise_linear_transform_op.cu(78): warning: parameter "num_grp" was declared but never referenced
```

Test Plan: Sandcastle

Differential Revision: D34034404

