### PR TITLE
Avoid type qualifier specified more than once

### DIFF
--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -325,7 +325,7 @@ struct ApplyOp2<Op, scalar1, scalar2, IndexType, ADims, BDims, 0, Offset> {
 __device__ __forceinline__
 static void apply(detail::TensorInfo<scalar1, IndexType> &a,
                   detail::TensorInfo<scalar2, IndexType> &b,
-                  const Op &op, int n, IndexType linearIndex,
+                  const Op &op, int /*n*/, IndexType /*linearIndex*/,
                   Offset aOffset, Offset bOffset) {
   op(a.data[aOffset], b.data[bOffset]);
 }

--- a/caffe2/operators/max_pool_with_index.cu
+++ b/caffe2/operators/max_pool_with_index.cu
@@ -13,7 +13,7 @@ namespace {
 template <typename Dtype>
 __global__ void MaxPoolForward(
     const int nthreads,
-    const Dtype *const const bottom_data,
+    const Dtype *const bottom_data,
     const int channels,
     const int height,
     const int width,
@@ -25,7 +25,7 @@ __global__ void MaxPoolForward(
     const int stride_w,
     const int pad_h,
     const int pad_w,
-    Dtype *const const top_data,
+    Dtype *const top_data,
     int *const mask) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     const int pw = index % pooled_width;
@@ -58,8 +58,8 @@ __global__ void MaxPoolForward(
 template <typename Dtype>
 __global__ void MaxPoolBackward(
     const int nthreads,
-    const Dtype *const const top_diff,
-    const int *const const mask,
+    const Dtype *const top_diff,
+    const int *const mask,
     const int channels,
     const int height,
     const int width,
@@ -71,7 +71,7 @@ __global__ void MaxPoolBackward(
     const int stride_w,
     const int pad_h,
     const int pad_w,
-    Dtype *const const bottom_diff) {
+    Dtype *const bottom_diff) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     // find out the local index
     // find out the local offset

--- a/caffe2/operators/upsample_op.cu
+++ b/caffe2/operators/upsample_op.cu
@@ -28,8 +28,6 @@ __global__ void UpsampleBilinearKernel(
     const int input_width,
     const int output_height,
     const int output_width,
-    const float height_scale,
-    const float width_scale,
     const float* __restrict__ X,
     float* __restrict__ Y) {
 
@@ -98,9 +96,6 @@ __global__ void UpsampleBilinearGradientKernel(
     const int c = indexTemp % num_channels;
     indexTemp /= num_channels;
     const int n = indexTemp;
-
-    const int out_y = fminf(in_y / height_scale, output_height - 1);
-    const int out_x = fminf(in_x / width_scale, output_width - 1);
 
     const float rheight =
         output_height > 1 ? (output_height - 1.f) / (input_height - 1.f) : 0.f;
@@ -187,8 +182,6 @@ bool UpsampleBilinearOp<float, CUDAContext>::RunOnDevice() {
       input_width,
       output_height,
       output_width,
-      height_scale_,
-      width_scale_,
       X.data<float>(),
       Y->template mutable_data<float>());
   C10_CUDA_KERNEL_LAUNCH_CHECK();


### PR DESCRIPTION
Summary:
Fixes
```

caffe2/caffe2/operators/max_pool_with_index.cu(16): warning: type qualifier specified more than once

caffe2/caffe2/operators/max_pool_with_index.cu(28): warning: type qualifier specified more than once

caffe2/caffe2/operators/max_pool_with_index.cu(61): warning: type qualifier specified more than once

caffe2/caffe2/operators/max_pool_with_index.cu(62): warning: type qualifier specified more than once

caffe2/caffe2/operators/max_pool_with_index.cu(74): warning: type qualifier specified more than once
```

Test Plan: Sandcastle

Differential Revision: D34034382

