### PR TITLE
Fix unused variable warning

### DIFF
--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -325,7 +325,7 @@ struct ApplyOp2<Op, scalar1, scalar2, IndexType, ADims, BDims, 0, Offset> {
 __device__ __forceinline__
 static void apply(detail::TensorInfo<scalar1, IndexType> &a,
                   detail::TensorInfo<scalar2, IndexType> &b,
-                  const Op &op, int n, IndexType linearIndex,
+                  const Op &op, int /*n*/, IndexType /*linearIndex*/,
                   Offset aOffset, Offset bOffset) {
   op(a.data[aOffset], b.data[bOffset]);
 }

--- a/caffe2/operators/upsample_op.cu
+++ b/caffe2/operators/upsample_op.cu
@@ -28,8 +28,6 @@ __global__ void UpsampleBilinearKernel(
     const int input_width,
     const int output_height,
     const int output_width,
-    const float height_scale,
-    const float width_scale,
     const float* __restrict__ X,
     float* __restrict__ Y) {
 
@@ -98,9 +96,6 @@ __global__ void UpsampleBilinearGradientKernel(
     const int c = indexTemp % num_channels;
     indexTemp /= num_channels;
     const int n = indexTemp;
-
-    const int out_y = fminf(in_y / height_scale, output_height - 1);
-    const int out_x = fminf(in_x / width_scale, output_width - 1);
 
     const float rheight =
         output_height > 1 ? (output_height - 1.f) / (input_height - 1.f) : 0.f;
@@ -187,8 +182,6 @@ bool UpsampleBilinearOp<float, CUDAContext>::RunOnDevice() {
       input_width,
       output_height,
       output_width,
-      height_scale_,
-      width_scale_,
       X.data<float>(),
       Y->template mutable_data<float>());
   C10_CUDA_KERNEL_LAUNCH_CHECK();


### PR DESCRIPTION
Summary:
Fixes:
```
caffe2/aten/src/ATen/cuda/CUDAApplyUtils.cuh(328): warning: parameter "n" was declared but never referenced
          detected during:
            instantiation of "void at::cuda::<unnamed>::ApplyOp2<Op, scalar1, scalar2, IndexType, ADims, BDims, remaining_steps, Offsets...>::apply(at::cuda::detail::TensorInfo<scalar1, IndexType> &, at::cuda::detail::TensorInfo<scalar2, IndexType> &, const Op &, int64_t, IndexType, Offsets..., Offsets...) [with Op=lambda [](double &, const double &)->void, scalar1=double, scalar2=double, IndexType=unsigned int, ADims=1, BDims=1, remaining_steps=1, Offsets=<>]"
(370): here
            instantiation of "void at::cuda::<unnamed>::kernelPointwiseApply2<Op,scalar1,scalar2,IndexType,ADims,BDims,step,max_threads_per_block,min_blocks_per_sm>(at::cuda::detail::TensorInfo<scalar1, IndexType>, at::cuda::detail::TensorInfo<scalar2, IndexType>, IndexType, Op) [with Op=lambda [](double &, const double &)->void, scalar1=double, scalar2=double, IndexType=unsigned int, ADims=1, BDims=1, step=1, max_threads_per_block=512, min_blocks_per_sm=2]"
(487): here
            instantiation of "__nv_bool at::cuda::CUDA_tensor_apply2<scalar1,scalar2,step,Op,max_threads_per_block,min_blocks_per_sm>(at::Tensor, at::Tensor, Op, at::cuda::TensorArgType, at::cuda::TensorArgType) [with scalar1=double, scalar2=double, step=1, Op=lambda [](double &, const double &)->void, max_threads_per_block=512, min_blocks_per_sm=2]"
(533): here
            instantiation of "__nv_bool at::cuda::CUDA_tensor_apply2<scalar1,scalar2,Op,max_threads_per_block,min_blocks_per_sm>(at::Tensor, at::Tensor, Op, at::cuda::TensorArgType, at::cuda::TensorArgType) [with scalar1=double, scalar2=double, Op=lambda [](double &, const double &)->void, max_threads_per_block=512, min_blocks_per_sm=2]"
caffe2/aten/src/ATen/native/cuda/Distributions.cu(60): here
            instantiation of "void <unnamed>::poisson_cuda_kernel<scalar_t>(at::Tensor &, const at::Tensor &, at::PhiloxCudaState) [with scalar_t=double]"
caffe2/aten/src/ATen/native/cuda/Distributions.cu(169): here

caffe2/aten/src/ATen/cuda/CUDAApplyUtils.cuh(328): warning: parameter "linearIndex" was declared but never referenced
          detected during:
            instantiation of "void at::cuda::<unnamed>::ApplyOp2<Op, scalar1, scalar2, IndexType, ADims, BDims, remaining_steps, Offsets...>::apply(at::cuda::detail::TensorInfo<scalar1, IndexType> &, at::cuda::detail::TensorInfo<scalar2, IndexType> &, const Op &, int64_t, IndexType, Offsets..., Offsets...) [with Op=lambda [](double &, const double &)->void, scalar1=double, scalar2=double, IndexType=unsigned int, ADims=1, BDims=1, remaining_steps=1, Offsets=<>]"
(370): here
            instantiation of "void at::cuda::<unnamed>::kernelPointwiseApply2<Op,scalar1,scalar2,IndexType,ADims,BDims,step,max_threads_per_block,min_blocks_per_sm>(at::cuda::detail::TensorInfo<scalar1, IndexType>, at::cuda::detail::TensorInfo<scalar2, IndexType>, IndexType, Op) [with Op=lambda [](double &, const double &)->void, scalar1=double, scalar2=double, IndexType=unsigned int, ADims=1, BDims=1, step=1, max_threads_per_block=512, min_blocks_per_sm=2]"
(487): here
            instantiation of "__nv_bool at::cuda::CUDA_tensor_apply2<scalar1,scalar2,step,Op,max_threads_per_block,min_blocks_per_sm>(at::Tensor, at::Tensor, Op, at::cuda::TensorArgType, at::cuda::TensorArgType) [with scalar1=double, scalar2=double, step=1, Op=lambda [](double &, const double &)->void, max_threads_per_block=512, min_blocks_per_sm=2]"
(533): here
            instantiation of "__nv_bool at::cuda::CUDA_tensor_apply2<scalar1,scalar2,Op,max_threads_per_block,min_blocks_per_sm>(at::Tensor, at::Tensor, Op, at::cuda::TensorArgType, at::cuda::TensorArgType) [with scalar1=double, scalar2=double, Op=lambda [](double &, const double &)->void, max_threads_per_block=512, min_blocks_per_sm=2]"
caffe2/aten/src/ATen/native/cuda/Distributions.cu(60): here
            instantiation of "void <unnamed>::poisson_cuda_kernel<scalar_t>(at::Tensor &, const at::Tensor &, at::PhiloxCudaState) [with scalar_t=double]"
caffe2/aten/src/ATen/native/cuda/Distributions.cu(169): here
caffe2/aten/src/ATen/cuda/CUDAApplyUtils.cuh(328): warning: parameter "linearIndex" was declared but never referenced
          detected during:
            instantiation of "void at::cuda::<unnamed>::ApplyOp2<Op, scalar1, scalar2, IndexType, ADims, BDims, remaining_steps, Offsets...>::apply(at::cuda::detail::TensorInfo<scalar1, IndexType> &, at::cuda::detail::TensorInfo<scalar2, IndexType> &, const Op &, int64_t, IndexType, Offsets..., Offsets...) [with Op=lambda [](double &, const double &)->void, scalar1=double, scalar2=double, IndexType=unsigned int, ADims=1, BDims=1, remaining_steps=1, Offsets=<>]"
(370): here
            instantiation of "void at::cuda::<unnamed>::kernelPointwiseApply2<Op,scalar1,scalar2,IndexType,ADims,BDims,step,max_threads_per_block,min_blocks_per_sm>(at::cuda::detail::TensorInfo<scalar1, IndexType>, at::cuda::detail::TensorInfo<scalar2, IndexType>, IndexType, Op) [with Op=lambda [](double &, const double &)->void, scalar1=double, scalar2=double, IndexType=unsigned int, ADims=1, BDims=1, step=1, max_threads_per_block=512, min_blocks_per_sm=2]"
(487): here
            instantiation of "__nv_bool at::cuda::CUDA_tensor_apply2<scalar1,scalar2,step,Op,max_threads_per_block,min_blocks_per_sm>(at::Tensor, at::Tensor, Op, at::cuda::TensorArgType, at::cuda::TensorArgType) [with scalar1=double, scalar2=double, step=1, Op=lambda [](double &, const double &)->void, max_threads_per_block=512, min_blocks_per_sm=2]"
(533): here
            instantiation of "__nv_bool at::cuda::CUDA_tensor_apply2<scalar1,scalar2,Op,max_threads_per_block,min_blocks_per_sm>(at::Tensor, at::Tensor, Op, at::cuda::TensorArgType, at::cuda::TensorArgType) [with scalar1=double, scalar2=double, Op=lambda [](double &, const double &)->void, max_threads_per_block=512, min_blocks_per_sm=2]"
caffe2/aten/src/ATen/native/cuda/Distributions.cu(60): here
            instantiation of "void <unnamed>::poisson_cuda_kernel<scalar_t>(at::Tensor &, const at::Tensor &, at::PhiloxCudaState) [with scalar_t=double]"
caffe2/aten/src/ATen/native/cuda/Distributions.cu(169): here

caffe2/aten/src/ATen/cuda/CUDAApplyUtils.cuh(328): warning: parameter "n" was declared but never referenced
          detected during:
            instantiation of "void at::cuda::<unnamed>::ApplyOp2<Op, scalar1, scalar2, IndexType, ADims, BDims, remaining_steps, Offsets...>::apply(at::cuda::detail::TensorInfo<scalar1, IndexType> &, at::cuda::detail::TensorInfo<scalar2, IndexType> &, const Op &, int64_t, IndexType, Offsets..., Offsets...) [with Op=lambda [](double &, const double &)->void, scalar1=double, scalar2=double, IndexType=unsigned int, ADims=1, BDims=1, remaining_steps=1, Offsets=<>]"
(370): here
            instantiation of "void at::cuda::<unnamed>::kernelPointwiseApply2<Op,scalar1,scalar2,IndexType,ADims,BDims,step,max_threads_per_block,min_blocks_per_sm>(at::cuda::detail::TensorInfo<scalar1, IndexType>, at::cuda::detail::TensorInfo<scalar2, IndexType>, IndexType, Op) [with Op=lambda [](double &, const double &)->void, scalar1=double, scalar2=double, IndexType=unsigned int, ADims=1, BDims=1, step=1, max_threads_per_block=512, min_blocks_per_sm=2]"
(487): here
            instantiation of "__nv_bool at::cuda::CUDA_tensor_apply2<scalar1,scalar2,step,Op,max_threads_per_block,min_blocks_per_sm>(at::Tensor, at::Tensor, Op, at::cuda::TensorArgType, at::cuda::TensorArgType) [with scalar1=double, scalar2=double, step=1, Op=lambda [](double &, const double &)->void, max_threads_per_block=512, min_blocks_per_sm=2]"
(533): here
            instantiation of "__nv_bool at::cuda::CUDA_tensor_apply2<scalar1,scalar2,Op,max_threads_per_block,min_blocks_per_sm>(at::Tensor, at::Tensor, Op, at::cuda::TensorArgType, at::cuda::TensorArgType) [with scalar1=double, scalar2=double, Op=lambda [](double &, const double &)->void, max_threads_per_block=512, min_blocks_per_sm=2]"
caffe2/aten/src/ATen/native/cuda/Distributions.cu(60): here
            instantiation of "void <unnamed>::poisson_cuda_kernel<scalar_t>(at::Tensor &, const at::Tensor &, at::PhiloxCudaState) [with scalar_t=double]"
caffe2/aten/src/ATen/native/cuda/Distributions.cu(169): here

caffe2/aten/src/ATen/cuda/CUDAApplyUtils.cuh(328): warning: parameter "linearIndex" was declared but never referenced
          detected during:
            instantiation of "void at::cuda::<unnamed>::ApplyOp2<Op, scalar1, scalar2, IndexType, ADims, BDims, remaining_steps, Offsets...>::apply(at::cuda::detail::TensorInfo<scalar1, IndexType> &, at::cuda::detail::TensorInfo<scalar2, IndexType> &, const Op &, int64_t, IndexType, Offsets..., Offsets...) [with Op=lambda [](double &, const double &)->void, scalar1=double, scalar2=double, IndexType=unsigned int, ADims=1, BDims=1, remaining_steps=1, Offsets=<>]"
(370): here
            instantiation of "void at::cuda::<unnamed>::kernelPointwiseApply2<Op,scalar1,scalar2,IndexType,ADims,BDims,step,max_threads_per_block,min_blocks_per_sm>(at::cuda::detail::TensorInfo<scalar1, IndexType>, at::cuda::detail::TensorInfo<scalar2, IndexType>, IndexType, Op) [with Op=lambda [](double &, const double &)->void, scalar1=double, scalar2=double, IndexType=unsigned int, ADims=1, BDims=1, step=1, max_threads_per_block=512, min_blocks_per_sm=2]"
(487): here
            instantiation of "__nv_bool at::cuda::CUDA_tensor_apply2<scalar1,scalar2,step,Op,max_threads_per_block,min_blocks_per_sm>(at::Tensor, at::Tensor, Op, at::cuda::TensorArgType, at::cuda::TensorArgType) [with scalar1=double, scalar2=double, step=1, Op=lambda [](double &, const double &)->void, max_threads_per_block=512, min_blocks_per_sm=2]"
(533): here
            instantiation of "__nv_bool at::cuda::CUDA_tensor_apply2<scalar1,scalar2,Op,max_threads_per_block,min_blocks_per_sm>(at::Tensor, at::Tensor, Op, at::cuda::TensorArgType, at::cuda::TensorArgType) [with scalar1=double, scalar2=double, Op=lambda [](double &, const double &)->void, max_threads_per_block=512, min_blocks_per_sm=2]"
caffe2/aten/src/ATen/native/cuda/Distributions.cu(60): here
            instantiation of "void <unnamed>::poisson_cuda_kernel<scalar_t>(at::Tensor &, const at::Tensor &, at::PhiloxCudaState) [with scalar_t=double]"
caffe2/aten/src/ATen/native/cuda/Distributions.cu(169): here
```

Test Plan: Sandcastle

Differential Revision: D34034374

