### PR TITLE
Added missing antialias argument to functional.pyi.in

### DIFF
--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -305,7 +305,8 @@ def upsample(input: Any, size: Optional[Any] = ..., scale_factor: Optional[Any] 
 
 
 def interpolate(input: Any, size: Optional[Any] = ..., scale_factor: Optional[Any] = ..., mode: str = ...,
-                align_corners: Optional[Any] = ..., recompute_scale_factor: Optional[Any] = ...): ...
+                align_corners: Optional[Any] = ..., recompute_scale_factor: Optional[Any] = ...,
+                antialias: bool = ...): ...
 
 
 def upsample_nearest(input: Any, size: Optional[Any] = ..., scale_factor: Optional[Any] = ...): ...


### PR DESCRIPTION

Description:
- Added missing antialias argument to functional.pyi.in
- mypy is happy if checking `interpolate` method with antialias argument

Related torchvision issue: https://github.com/pytorch/vision/pull/5329