### PR TITLE
[ONNX] Resolve attribute error in CI (#72350)

### DIFF
--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -13,13 +13,11 @@ def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7, opset_versions=None):
 
     for opset_version in opset_versions:
         self.opset_version = opset_version
+        self.onnx_shape_inference = True
         run_model_test(self, model, False,
                        input=inputs, rtol=rtol, atol=atol)
 
         if self.is_script_test_enabled and opset_version > 11:
-            TestModels.onnx_shape_inference = True
-
-            outputs = model(inputs)
             script_model = torch.jit.script(model)
             run_model_test(self, script_model, False,
                            input=inputs, rtol=rtol, atol=atol)


### PR DESCRIPTION
Summary:
Tests under `test/onnx/test_models_onnxruntime.py` complains `AttributeError: 'TestModels' object has no attribute 'onnx_shape_inference'`.

This failure in CI appears suddenly without any code changes to related files. It is likely due to different test case run order. The test code was badly written such that test class `TestModels_new_jit_API`, if called first, will assign `TestModels.onnx_shape_inference = True`, circumventing this problem. On the other hand, if `TestModels` is called first, `AttributeError` will be raised.

Fixes https://github.com/pytorch/pytorch/issues/72337

Pull Request resolved: https://github.com/pytorch/pytorch/pull/72350

Reviewed By: jbschlosser, seemethere, janeyx99

Differential Revision: D34010794

Pulled By: malfet

fbshipit-source-id: 816f7bee89ea0251bb5df8f482b68f8dc4823997
(cherry picked from commit b39b23bec5dfd3f2fd24a0d781757c20ff94b1db)

Fixes #ISSUE_NUMBER
