### PR TITLE
array_api: Add an offset to `torch.eye`

### DIFF
--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -31,25 +31,39 @@
 namespace at {
 namespace native {
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ eye ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Tensor& eye_out_cuda(int64_t n, Tensor& result) {
-  // the default value of `m` equals to `n`
-  return at::native::eye_out_cuda(n, n, result);
+  // the default value of `k` equals to 0
+  return at::native::eye_out_cuda(n, n, 0, result);
 }
 
 Tensor& eye_out_cuda(int64_t n, int64_t m, Tensor& result) {
+  // the default value of `k` equals to 0
+  return at::native::eye_out_cuda(n, m, 0, result);
+}
+
+Tensor& eye_out_cuda_nk(int64_t n, c10::optional<int64_t> k, Tensor& result) {
+  // the default value of `m` equals to `n`
+  int64_t k_v{k.has_value() ? k.value() : 0};
+  return at::native::eye_out_cuda(n, n, k_v, result);
+}
+
+Tensor& eye_out_cuda(int64_t n, int64_t m, int64_t k, Tensor& result) {
   TORCH_CHECK(n >= 0, "n must be greater or equal to 0, got ", n);
   TORCH_CHECK(m >= 0, "m must be greater or equal to 0, got ", m);
+  TORCH_CHECK((k > -n && k < m) || (k == 0),
+              "k out of range, should be between (-",
+              n, ", ", m, "), or 0 but got ", k);
 
   result.resize_({n, m});
   result.zero_();
+  result.diagonal(k).fill_(1);
 
-  int64_t sz = std::min<int64_t>(n, m);
-  int64_t stride = result.stride(0) + result.stride(1);
-
-  Tensor diag = result.as_strided({sz}, {stride});
-  diag.fill_(1);
   return result;
 }
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ empty ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tensor empty_cuda(IntArrayRef size, c10::optional<ScalarType> dtype_opt, c10::optional<Layout> layout_opt, c10::optional<Device> device_opt, c10::optional<bool> pin_memory_opt, c10::optional<c10::MemoryFormat> memory_format_opt) {
   return at::detail::empty_cuda(size, dtype_opt, layout_opt, device_opt, pin_memory_opt, memory_format_opt);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2312,6 +2312,10 @@
   dispatch:
     CompositeExplicitAutograd: eye
 
+- func: eye.nk(int n, *, int? k, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+
+- func: eye.nmk(int n, int m, int k, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+
 - func: eye.out(int n, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU, Meta: eye_out_cpu
@@ -2323,6 +2327,16 @@
     CPU, Meta: eye_out_cpu
     CUDA: eye_out_cuda
     MPS: eye_out_mps
+
+- func: eye.nk_out(int n, *, int? k, Tensor(a!) out) -> Tensor(a!)
+  dispatch:
+    CPU: eye_out_cpu_nk
+    CUDA: eye_out_cuda_nk
+
+- func: eye.nmk_out(int n, int m, int k, *, Tensor(a!) out) -> Tensor(a!)
+  dispatch:
+    CPU: eye_out_cpu
+    CUDA: eye_out_cuda
 
 - func: flatten.using_ints(Tensor(a) self, int start_dim=0, int end_dim=-1) -> Tensor(a)
   variants: function, method

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2314,8 +2314,12 @@
 
 # These are basically overloads for NumPy compatibility
 - func: eye.nk(int n, *, int? k, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+  dispatch:
+    CompositeExplicitAutograd: eye
 
 - func: eye.nmk(int n, int m, int k, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+  dispatch:
+    CompositeExplicitAutograd: eye
 
 - func: eye.out(int n, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2312,6 +2312,7 @@
   dispatch:
     CompositeExplicitAutograd: eye
 
+# These are basically overloads for NumPy compatibility
 - func: eye.nk(int n, *, int? k, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
 - func: eye.nmk(int n, int m, int k, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5955,9 +5955,11 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
             def forward(self, x):
                 return (
                     torch.eye(x.size()[1], 3),
+                    torch.eye(x.size()[1], 3, 1),
                     torch.eye(4, 4, dtype=torch.long),
                     torch.eye(x.size()[1], 2, dtype=torch.long),
                     torch.eye(x.shape[0]),
+                    torch.eye(3, 3, -2),
                     torch.eye(x.shape[0], dtype=torch.float64),
                 )
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4215,6 +4215,7 @@ Args:
            to a lower diagonal, with the default being 0, the main diagonal
 
 Keyword arguments:
+    {k}
     {out}
     {dtype}
     {layout}

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4204,13 +4204,15 @@ Alias for :func:`torch.special.expm1`.
 add_docstr(
     torch.eye,
     r"""
-eye(n, m=None, *, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) -> Tensor
+eye(n, m=None, *, k=0, out=None, dtype=None, layout=torch.strided, device=None, requires_grad=False) -> Tensor
 
 Returns a 2-D tensor with ones on the diagonal and zeros elsewhere.
 
 Args:
     n (int): the number of rows
     m (int, optional): the number of columns with default being :attr:`n`
+    k (int, optional): the diagonal offset, a positive value refers to an upper diagonal, and a negative value
+           to a lower diagonal, with the default being 0, the main diagonal
 
 Keyword arguments:
     {out}
@@ -4220,7 +4222,7 @@ Keyword arguments:
     {requires_grad}
 
 Returns:
-    Tensor: A 2-D tensor with ones on the diagonal and zeros elsewhere
+    Tensor: A 2-D tensor with ones on the :attr:`k`-th diagonal and zeros elsewhere
 
 Example::
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -3088,6 +3088,18 @@ def eye(g, *args):
         )
         tensor = zeros(g, shape, dtype, layout, device)
         return g.op("EyeLike", tensor)
+    elif len(args) == 7:
+        # aten::eye(n, m, k, dtype, layout, device, pin_memory)
+        n, m, k, dtype, layout, device, pin_memory = args
+        shape = g.op(
+            "Concat",
+            symbolic_helper._unsqueeze_helper(g, n, [0]),
+            symbolic_helper._unsqueeze_helper(g, m, [0]),
+            axis_i=0,
+        )
+        tensor = zeros(g, shape, dtype, layout, device)
+        k_val = symbolic_helper._parse_arg(k, "i")
+        return g.op("EyeLike", tensor, k_i=k_val)
     else:
         raise NotImplementedError("Unknown aten::eye signature")
 


### PR DESCRIPTION
Fixes #70910.
To-do status:
- [x] CPU implementation
- [x] Use a keyword argument for compatibility with `np.eye(4, k=-1)` 
- [x] Add tests
- [x] CUDA implementation
- ~[ ] Benchmark (?)~
- ~[ ] Cleanup history (?)~
- [x] Solicit reviews [Deferred]
   - [x] Internal
   - [x] External
