### PR TITLE
[LTS] Install dependencies explicitly before pytorch package for conda (pytorch repo)

### DIFF
--- a/.circleci/scripts/binary_macos_test.sh
+++ b/.circleci/scripts/binary_macos_test.sh
@@ -20,6 +20,24 @@ if [[ "$PACKAGE_TYPE" == libtorch ]]; then
   unzip "$pkg" -d /tmp
   cd /tmp/libtorch
 elif [[ "$PACKAGE_TYPE" == conda ]]; then
+  # install dependencies before installing package
+  NUMPY_PIN=">=1.19"
+  if [[ "$DESIRED_PYTHON" == "3.9" ]]; then
+    NUMPY_PIN=">=1.20"
+  fi
+
+  retry conda install -y "numpy${NUMPY_PIN}" dataclasses typing-extensions future pyyaml six
+
+  cuda_ver="$DESIRED_CUDA"
+
+  # install cpuonly or cudatoolkit explicitly
+  if [[ "$cuda_ver" == 'cpu' ]]; then
+    retry conda install -c pytorch -y cpuonly
+  else
+    toolkit_ver="${cuda_ver:2:2}.${cuda_ver:4}"
+    retry conda install -y -c nvidia -c pytorch -c conda-forge "cudatoolkit=${toolkit_ver}"
+  fi
+  
   conda install -y "$pkg"
 else
   pip install "$pkg" -v


### PR DESCRIPTION
This PR resolves the issue https://github.com/pytorch/pytorch/issues/71340 by installing the dependencies including `cpuonly` or `cudatoolkit` explicitly before installing the local pytorch package. There is a corresponding PR https://github.com/pytorch/builder/pull/956 on the lts branch of `pytorch/builder` that needs to be merged before this PR. 

This fix has been tested on this [circle CI workflow](https://app.circleci.com/pipelines/github/pytorch/pytorch?branch=pull%2F72369&filter=all). It can be seen on all the **windows** and **macos** conda builds/tests that the locally installed pytorch is not overwritten anymore. 