### PR TITLE
[DistributedInference] Relax the assertion for uniqueness of blob name across external inputs and outputs

### DIFF
--- a/caffe2/opt/distributed.cc
+++ b/caffe2/opt/distributed.cc
@@ -16,7 +16,10 @@ void setDeviceOption(NNGraph::NodeRef n, caffe2::DeviceOption& d) {
 void addBlobDeviceOptions(
     std::map<std::string, caffe2::DeviceOption> blobMap,
     NNModule* nn) {
-  // Names we've seen in the NNModule
+  // Names we've seen in the NNModule. Uniqueness within inputs or outputs is ensured
+  // but same blob can exist across inputs and outputs
+  std::unordered_set<std::string> seen_inputs;
+  std::unordered_set<std::string> seen_outputs;
   std::unordered_set<std::string> seen;
 
   auto declareNodes = nn::filter<Declare>(*nn);
@@ -30,9 +33,9 @@ void addBlobDeviceOptions(
     }
 
     CAFFE_ENFORCE(
-        !seen.count(input->getName()),
-        "Ambiguous name->deviceOption map.  Please do this manually.");
-
+        !seen_inputs.count(input->getName()),
+        "Ambiguous name->deviceOption map.  Please do this manually. Affected blob: " + input->getName());
+    seen_inputs.insert(input->getName());
     seen.insert(input->getName());
     setDeviceOption(declareNode, blobMap[input->getName()]);
   }
@@ -48,9 +51,10 @@ void addBlobDeviceOptions(
     }
 
     CAFFE_ENFORCE(
-        !seen.count(output->getName()),
-        "Ambiguous name->deviceOption map.  Please do this manually.");
+        !seen_outputs.count(output->getName()),
+        "Ambiguous name->deviceOption map.  Please do this manually. Affected blob: " + output->getName());
 
+    seen_outputs.insert(output->getName());
     seen.insert(output->getName());
     setDeviceOption(exportNode, blobMap[output->getName()]);
   }


### PR DESCRIPTION
Summary: Having same blob name present in external inputs and external outputs is a valid case, so relaxing the validation for that.

Differential Revision: D34062055

