### PR TITLE
Add transformation using cdf of distribution.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -174,6 +174,7 @@ coverage_ignore_classes = [
     "CatTransform",
     "ComposeTransform",
     "CorrCholeskyTransform",
+    "CumulativeDistributionTransform",
     "ExpTransform",
     "IndependentTransform",
     "PowerTransform",

--- a/test/distributions/test_transforms.py
+++ b/test/distributions/test_transforms.py
@@ -8,11 +8,12 @@ import torch
 from torch.autograd.functional import jacobian
 from torch.distributions import Dirichlet, Independent, Normal, TransformedDistribution, constraints
 from torch.distributions.transforms import (AbsTransform, AffineTransform, ComposeTransform,
-                                            CorrCholeskyTransform, ExpTransform, IndependentTransform,
-                                            LowerCholeskyTransform, PowerTransform, ReshapeTransform,
-                                            SigmoidTransform, TanhTransform, SoftmaxTransform,
-                                            StickBreakingTransform, identity_transform, Transform,
-                                            _InverseTransform)
+                                            CorrCholeskyTransform, CumulativeDistributionTransform,
+                                            ExpTransform, IndependentTransform,
+                                            LowerCholeskyTransform, PowerTransform,
+                                            ReshapeTransform, SigmoidTransform, TanhTransform,
+                                            SoftmaxTransform, StickBreakingTransform,
+                                            identity_transform, Transform, _InverseTransform)
 from torch.distributions.utils import tril_matrix_to_vec, vec_to_tril_matrix
 
 
@@ -67,6 +68,7 @@ def get_transforms(cache_size):
                             torch.randn(5),
                             cache_size=cache_size),
             1),
+        CumulativeDistributionTransform(Normal(0, 1)),
     ]
     transforms += [t.inv for t in transforms]
     return transforms

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -20,6 +20,7 @@ __all__ = [
     'CatTransform',
     'ComposeTransform',
     'CorrCholeskyTransform',
+    'CumulativeDistributionTransform',
     'ExpTransform',
     'IndependentTransform',
     'LowerCholeskyTransform',
@@ -1109,3 +1110,48 @@ class StackTransform(Transform):
     @constraints.dependent_property
     def codomain(self):
         return constraints.stack([t.codomain for t in self.transforms], self.dim)
+
+
+class CumulativeDistributionTransform(Transform):
+    """
+    Transform via the cumulative distribution function of a probability distribution.
+
+    Args:
+        distribution (Distribution): Distribution whose cumulative distribution function to use for
+            the transformation.
+
+    Example::
+
+        # Construct a Gaussian copula from a multivariate normal.
+        base_dist = MultivariateNormal(
+            loc=torch.zeros(2),
+            scale_tril=LKJCholesky(2).sample(),
+        )
+        transform = CumulativeDistributionTransform(Normal(0, 1))
+        copula = TransformedDistribution(base_dist, [transform])
+    """
+    bijective = True
+    codomain = constraints.unit_interval
+    sign = +1
+
+    def __init__(self, distribution, cache_size=0):
+        super(CumulativeDistributionTransform, self).__init__(cache_size=cache_size)
+        self.distribution = distribution
+
+    @property
+    def domain(self):
+        return self.distribution.support
+
+    def _call(self, x):
+        return self.distribution.cdf(x)
+
+    def _inverse(self, y):
+        return self.distribution.icdf(y)
+
+    def log_abs_det_jacobian(self, x, y):
+        return self.distribution.log_prob(x)
+
+    def with_cache(self, cache_size=1):
+        if self._cache_size == cache_size:
+            return self
+        return CumulativeDistributionTransform(self.distribution, cache_size=cache_size)


### PR DESCRIPTION
This PR adds a transform that uses the cumulative distribution function of a given probability distribution. 

For example, the following code constructs a simple Gaussian copula.

```python
# Construct a Gaussian copula from a multivariate normal.
base_dist = MultivariateNormal(
    loc=torch.zeros(2),
    scale_tril=LKJCholesky(2).sample(),
)
transform = CumulativeDistributionTransform(Normal(0, 1))
copula = TransformedDistribution(base_dist, [transform])
```

The following snippet creates a "wrapped" Gaussian copula for correlated positive variables with Weibull marginals.

```python
transforms = [
    CumulativeDistributionTransform(Normal(0, 1)),
    CumulativeDistributionTransform(Weibull(4, 2)).inv,
]
wrapped_copula = TransformedDistribution(base_dist, transforms)
```

cc @fritzo 