### PR TITLE
[1.11] Add missing entry for sampled_addmm in sparse.rst

### DIFF
--- a/docs/source/sparse.rst
+++ b/docs/source/sparse.rst
@@ -590,6 +590,7 @@ Torch functions specific to sparse Tensors
     sparse_csr_tensor
     sparse.sum
     sparse.addmm
+    sparse.sampled_addmm
     sparse.mm
     sspaddmm
     hspmm

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -98,7 +98,9 @@ Performs a matrix multiplication of the dense matrices :attr:`mat1` and :attr:`m
 specified by the sparsity pattern of :attr:`input`. The matrix :attr:`input` is added to the final result.
 
 Mathematically this performs the following operation:
+
 .. math::
+
     \text{out} = \alpha\ (\text{mat1} \mathbin{@} \text{mat2})*\text{spy}(\text{input}) + \beta\ \text{input}
 
 where :math:`\text{spy}(\text{input})` is the sparsity pattern matrix of :attr:`input`, :attr:`alpha`


### PR DESCRIPTION
Cherry-picking critical documentation change.

Pull Request: https://github.com/pytorch/pytorch/pull/72312