### PR TITLE
Implement gamma cdf.

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2975,6 +2975,9 @@ class TestDistributions(DistributionsTestCase):
         # Tests if the differentiation of the CDF gives the PDF at a given value
         for Dist, params in EXAMPLES:
             for i, param in enumerate(params):
+                # We do not need grads wrt params here, e.g. shape of gamma distribution.
+                param = {key: value.detach() if isinstance(value, torch.Tensor) else value
+                         for key, value in param.items()}
                 dist = Dist(**param)
                 samples = dist.sample()
                 if not dist.support.is_discrete:

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -86,3 +86,9 @@ class Gamma(ExponentialFamily):
 
     def _log_normalizer(self, x, y):
         return torch.lgamma(x + 1) + (x + 1) * torch.log(-y.reciprocal())
+
+    def cdf(self, value):
+        value = torch.as_tensor(value, dtype=self.rate.dtype, device=self.rate.device)
+        if self._validate_args:
+            self._validate_sample(value)
+        return torch.special.gammainc(self.concentration, self.rate * value)

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -88,7 +88,6 @@ class Gamma(ExponentialFamily):
         return torch.lgamma(x + 1) + (x + 1) * torch.log(-y.reciprocal())
 
     def cdf(self, value):
-        value = torch.as_tensor(value, dtype=self.rate.dtype, device=self.rate.device)
         if self._validate_args:
             self._validate_sample(value)
         return torch.special.gammainc(self.concentration, self.rate * value)


### PR DESCRIPTION
Implements the cumulative distribution function for the gamma distribution. The tests needed a small adjustment to pass because gradients cannot be evaluated with respect to the first argument of the incomplete gamma function (and they're not needed for the test).