### PR TITLE
[Quant][core][devs] Changed empty_quantized call for quantized tensor to resize_output

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -751,11 +751,7 @@ void index_select_out_cuda_impl(
     newSize[dim] = numIndices;
   }
 
-  if (self.is_quantized()){
-      out = at::empty_quantized(newSize, out);
-  } else {
-    at::native::resize_output(out, newSize);
-  }
+  at::native::resize_output(out, newSize);
 
   ptrdiff_t outTotalSize = out.numel();
   if (outTotalSize == 0) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72524

Summary: This PR is part of a series of PRs addressing https://github.com/pytorch/pytorch/issues/54150,
related to using dispatcher for calls to quantized backends as opposed to if/else conditionals. This particular PR removes the call to empty_quantized for quantized tensors and substitutes
it for resize_output, which works for quantized tensors, based on current understanding.

Differential Revision: [D34080604](https://our.internmc.facebook.com/intern/diff/D34080604)