### PR TITLE
Small typing improvements

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from collections import OrderedDict, namedtuple
 import itertools
 import warnings

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -8,7 +8,6 @@ from ..parameter import Parameter
 import torch.utils.hooks as hooks
 
 from torch import Tensor, device, dtype
-import typing
 from typing import Union, Tuple, Any, Callable, Iterator, Set, Optional, overload, TypeVar, Mapping, Dict, List
 from ...utils.hooks import RemovableHandle
 
@@ -1286,10 +1285,8 @@ class Module:
     def state_dict(self, destination: T_destination, prefix: str = ..., keep_vars: bool = ...) -> T_destination:
         ...
 
-    # TODO: Remove string escape once Python-3.6 no longer supported
-    # See https://github.com/python/mypy/issues/6904#issuecomment-496207426
     @overload
-    def state_dict(self, prefix: str = ..., keep_vars: bool = ...) -> typing.OrderedDict[str, Tensor]:
+    def state_dict(self, prefix: str = ..., keep_vars: bool = ...) -> OrderedDict[str, Tensor]:
         ...
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):


### PR DESCRIPTION
Followup after https://github.com/pytorch/pytorch/pull/72211 - as https://github.com/python/mypy/issues/6904#issuecomment-496207426 in Python-3.7+ world OrderedDict from collections can be used directly for type annotations

