### PR TITLE
[Static Runtime] Fix a bug in aten::slice to honor optional arguments

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1645,6 +1645,13 @@ TEST(StaticRuntime, Slice) {
 
   testStaticRuntime(slice_script, args_a);
   testStaticRuntime(slice_script, args_a, args_b);
+
+  const auto slice_script2 = R"JIT(
+    def forward(self, a: Tensor, dim: int, step: int):
+      return a.slice(dim, None, None, step).clone()
+  )JIT";
+  std::vector<IValue> args_c{b, dim_b, step_b};
+  testStaticRuntime(slice_script2, args_c);
 }
 
 TEST(StaticRuntime, Narrow) {

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -299,8 +299,8 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(aten::slice, aten_slice, [](Node* n) -> SROpera
   return [](ProcessedNode* p_node) {
     const auto& in0_t = p_node->Input(0).toTensor();
     const auto in1_i = p_node->Input(1).toInt();
-    const auto in2_i = p_node->Input(2).toInt();
-    const auto in3_i = p_node->Input(3).toInt();
+    const auto in2_i = p_node->Input(2).toOptional<int64_t>();
+    const auto in3_i = p_node->Input(3).toOptional<int64_t>();
     const auto in4_i = p_node->Input(4).toInt();
     p_node->Output(0) = at::native::slice(in0_t, in1_i, in2_i, in3_i, in4_i);
   };


### PR DESCRIPTION
Summary: This bug was revealed from a failed attempt to run a feed/story model.

Test Plan:
- This fix was tested to successfully run the failed model: P479037453
- Added a unittest

Reviewed By: mikeiovine

Differential Revision: D34055801

