### PR TITLE
remove some spurious warnings fixing take 2

### DIFF
--- a/torch/csrc/autograd/utils/grad_layout_contract.h
+++ b/torch/csrc/autograd/utils/grad_layout_contract.h
@@ -13,9 +13,31 @@ namespace utils {
 inline bool obeys_layout_contract(const at::Tensor& grad, const at::Tensor& variable) {
   TORCH_INTERNAL_ASSERT(!grad.is_sparse());
   TORCH_INTERNAL_ASSERT(!variable.is_sparse());
-  return variable.is_non_overlapping_and_dense() ?
-         (grad.strides() == variable.strides()) :
-         grad.is_contiguous(at::MemoryFormat::Contiguous);
+  if (variable.is_non_overlapping_and_dense()) {
+    // Only look at stride for dimensions that are not of size 1.
+    const auto& grad_sizes = grad.sizes();
+    const auto& grad_strides = grad.strides();
+    const auto& variable_strides = variable.strides();
+    for (const auto idx : c10::irange(grad_sizes.size())) {
+      if (grad_sizes[idx] != 1) {
+        if (grad_strides[idx] != variable_strides[idx]) {
+          return false;
+        }
+      } else {
+        // This should not be needed but we don't check if a Tensor has views
+        // before stashing it. And 0-strided Tensors of size 1 are actually views
+        // for ops like cat.
+        // TODO: Actually detect views in the accumulateGrad function so that this
+        // Tensor is not considered at all.
+        if (grad_strides[idx] == 0) {
+          return false;
+        }
+      }
+    }
+    return true;
+  } else {
+    return grad.is_contiguous(at::MemoryFormat::Contiguous);
+  }
 }
 
 // Creates a clone of new_grad that obeys the contract with variable.


### PR DESCRIPTION
This adds an extra special case for size 1, stride 0 Tensors. These are considered contiguous by the backend but in practice come from view ops quite often.
Until we properly detect views in accumulategrad, this ensures we don't break more things.