### PR TITLE
[PTE] Reduce unnecessary ref count bumps in callstack debug

### DIFF
--- a/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
+++ b/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
@@ -133,7 +133,7 @@ InlinedCallStackPtr InlinedCallStackDeserializer::deserialize(
     return it->second;
   }
 
-  const auto& tup_elems = std::move(iv.toTupleRef()).elements();
+  const auto& tup_elems = tup->elements();
   TORCH_INTERNAL_ASSERT(tup_elems.size() == 4);
   // {IValue(module_instance_info), source_range_tag, IValue(InlinedCallStack),
   // function name}
@@ -182,7 +182,7 @@ c10::optional<ModuleInstanceInfo> InlinedCallStackDeserializer::
   if (it != cached_module_instance_info_.end()) {
     return it->second;
   }
-  const auto& tup_elems = std::move(iv.toTupleRef()).elements();
+  const auto& tup_elems = iv.toTupleRef().elements();
   TORCH_CHECK(tup_elems.size() == 2);
   std::string type_name = tup_elems[0].toString()->string();
   std::string instance_name = tup_elems[1].toString()->string();
@@ -222,9 +222,9 @@ ska::flat_hash_map<int64_t, DebugInfoTuple> CallStackDebugInfoUnpickler::
       {},
       c10::parseType);
   ska::flat_hash_map<int64_t, DebugInfoTuple> callstack_ptrs;
-  auto ivalues = std::move(ival.toTupleRef()).elements();
+  const auto& ivalues = ival.toTupleRef().elements();
   for (auto& val : ivalues) {
-    const auto& tup_elems = std::move(val.toTupleRef()).elements();
+    const auto& tup_elems = val.toTupleRef().elements();
     TORCH_CHECK(
         tup_elems.size() == 4,
         "Pickled map must have four elements: "

--- a/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
+++ b/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
@@ -133,7 +133,7 @@ InlinedCallStackPtr InlinedCallStackDeserializer::deserialize(
     return it->second;
   }
 
-  const auto& tup_elems = tup->elements();
+  const auto& tup_elems = std::move(iv.toTupleRef()).elements();
   TORCH_INTERNAL_ASSERT(tup_elems.size() == 4);
   // {IValue(module_instance_info), source_range_tag, IValue(InlinedCallStack),
   // function name}
@@ -182,7 +182,7 @@ c10::optional<ModuleInstanceInfo> InlinedCallStackDeserializer::
   if (it != cached_module_instance_info_.end()) {
     return it->second;
   }
-  const auto& tup_elems = iv.toTupleRef().elements();
+  const auto& tup_elems = std::move(iv.toTupleRef()).elements();
   TORCH_CHECK(tup_elems.size() == 2);
   std::string type_name = tup_elems[0].toString()->string();
   std::string instance_name = tup_elems[1].toString()->string();
@@ -222,9 +222,9 @@ ska::flat_hash_map<int64_t, DebugInfoTuple> CallStackDebugInfoUnpickler::
       {},
       c10::parseType);
   ska::flat_hash_map<int64_t, DebugInfoTuple> callstack_ptrs;
-  auto ivalues = std::move(*std::move(ival).toTuple()).elements();
+  auto ivalues = std::move(std::move(ival).toTupleRef()).elements();
   for (auto& val : ivalues) {
-    const auto& tup_elems = val.toTupleRef().elements();
+    const auto& tup_elems = std::move(val.toTupleRef()).elements();
     TORCH_CHECK(
         tup_elems.size() == 4,
         "Pickled map must have four elements: "

--- a/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
+++ b/torch/csrc/jit/serialization/callstack_debug_info_serialization.cpp
@@ -222,7 +222,7 @@ ska::flat_hash_map<int64_t, DebugInfoTuple> CallStackDebugInfoUnpickler::
       {},
       c10::parseType);
   ska::flat_hash_map<int64_t, DebugInfoTuple> callstack_ptrs;
-  auto ivalues = std::move(std::move(ival).toTupleRef()).elements();
+  auto ivalues = std::move(ival.toTupleRef()).elements();
   for (auto& val : ivalues) {
     const auto& tup_elems = std::move(val.toTupleRef()).elements();
     TORCH_CHECK(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72547

toTuple() returns a  new intrusive pointer that bumps its underlying ref count. Whereas, toTupeRef returns a reference. We can save an unnecessary ref count bump.


Differential Revision: [D34082609](https://our.internmc.facebook.com/intern/diff/D34082609/)