### PR TITLE
fix shape cache hash for dynamic shape

### DIFF
--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -598,7 +598,7 @@ if __name__ == "__main__" :
                         help="Run the tracing portion only, with noop backend, useful for running under a profiler.")
     parser.add_argument("--run_in_subprocess", "-s", type=str,
                         help="which model run in subprocess. This will ignore filter and exclude")
-    parser.add_argument("--allclose_atol", type=float, default=1e-8, 
+    parser.add_argument("--allclose_atol", type=float, default=1e-8,
                         help="Absolute tolerance to check lazy result again the correct result")
     args = parser.parse_args()
     results = []

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -384,7 +384,7 @@ at::Tensor & LazyNativeFunctions::normal_(at::Tensor & self, double mean, double
     // Unconditionally fall back.
     // implementing normal_ via lazy tensor caused differences in results compared to eager.
     return at::native::call_fallback_fn<&ltc_eager_fallback, ATEN_OP(normal_)>::call(self, mean, std, generator);
-    
+
     // if (force_eager_fallback(c10::Symbol::fromQualString("aten::normal_"))) {
     //   return at::native::call_fallback_fn<&ltc_eager_fallback, ATEN_OP(normal_)>::call(self, mean, std, generator);
     // }

--- a/test/cpp/lazy/test_ir.cpp
+++ b/test/cpp/lazy/test_ir.cpp
@@ -12,7 +12,7 @@ namespace lazy {
 class TestLeafNode : public Node {
  public:
   explicit TestLeafNode(size_t param)
-      : Node(OpKind(), /* num_outputs */ 1, /* hash_seed */ Hash(param)),
+      : Node(OpKind(), /* num_outputs */ 1, [&](bool /*unused*/) { return Hash(param); }),
         param_(param) {}
   ~TestLeafNode() override = default;
 

--- a/test/cpp/lazy/test_ir_util.cpp
+++ b/test/cpp/lazy/test_ir_util.cpp
@@ -12,7 +12,7 @@ namespace lazy {
 class IrUtilNode : public Node {
  public:
   explicit IrUtilNode()
-      : Node(OpKind(), /* num_outputs */ 1, /* hash_seed */ Hash(0)) {}
+      : Node(OpKind(), /* num_outputs */ 1, [&](bool /* unused */) { return Hash(0); }) {}
   ~IrUtilNode() override = default;
 
   void AddOperand(Value v) {

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -1,6 +1,8 @@
 #include <torch/csrc/lazy/core/ir.h>
 #include <torch/csrc/lazy/core/ir_metadata.h>
 
+C10_DEFINE_bool(ltc_enable_dynamic_shapes, false, "Whether dynamic shape is enabled");
+
 namespace torch {
 namespace lazy {
 
@@ -23,6 +25,14 @@ hash_t Value::hash() const {
   return HashCombine(node->hash(), Hash(index));
 }
 
+hash_t Value::hash_with_sizes() const {
+  return HashCombine(node->hash_with_sizes(), Hash(index));
+}
+
+hash_t Value::hash_without_sizes() const {
+  return HashCombine(node->hash_without_sizes(), Hash(index));
+}
+
 OpKind OpKind::Get(const std::string& name) {
   return OpKind(c10::Symbol::fromQualString(name));
 }
@@ -31,18 +41,20 @@ hash_t OpKind::hash() const {
   return StringHash(op.toQualString());
 }
 
-Node::Node(OpKind op, size_t num_outputs, hash_t node_hash, hash_t dag_hash)
+Node::Node(OpKind op, size_t num_outputs, hash_t node_hash, std::function<hash_t(bool)> dag_hash_fn)
     : op_(op),
       num_outputs_(num_outputs),
       node_hash_(node_hash),
-      dag_hash_(dag_hash),
+      dag_hash_without_sizes_(dag_hash_fn(false)),
+      dag_hash_with_sizes_(dag_hash_fn(true)),
       metadata_(GetMetaDataIfDebugging()) {}
 
-Node::Node(OpKind op, size_t num_outputs, hash_t node_hash)
+Node::Node(OpKind op, size_t num_outputs, std::function<hash_t(bool)> node_hash_fn)
     : op_(op),
       num_outputs_(num_outputs),
-      node_hash_(node_hash),
-      dag_hash_(node_hash),
+      node_hash_(node_hash_fn(!enableDynamicShape())),
+      dag_hash_without_sizes_(node_hash_fn(false)),
+      dag_hash_with_sizes_(node_hash_fn(true)),
       metadata_(GetMetaDataIfDebugging()) {}
 
 Node::~Node() = default;

--- a/torch/csrc/lazy/core/ir.h
+++ b/torch/csrc/lazy/core/ir.h
@@ -15,6 +15,9 @@
 #include <c10/util/ArrayRef.h>
 #include <torch/csrc/lazy/core/hash.h>
 #include <torch/csrc/lazy/core/ir_metadata.h>
+#include <c10/util/Flags.h>
+
+C10_DECLARE_bool(ltc_enable_dynamic_shapes);
 
 namespace torch {
 namespace lazy {
@@ -69,6 +72,8 @@ struct TORCH_API Value {
   /* implicit */ Value(const NodePtr& node, size_t index = 0) : node(node), index(index) {}
 
   hash_t hash() const;
+  hash_t hash_with_sizes() const;
+  hash_t hash_without_sizes() const;
 
   operator bool() const {
     return node != nullptr;
@@ -122,7 +127,6 @@ inline std::ostream& operator<<(std::ostream& stream, const OpKind& op) {
 
 using OpList = c10::ArrayRef<Value>;
 
-
 // A node in the graph. Nodes for operations which requires extra data to be
 // stored for lowering, should inherit from this class and add operation
 // specific member there. For example, a constant might create a new
@@ -131,13 +135,21 @@ using OpList = c10::ArrayRef<Value>;
 // client data handle in it.
 class TORCH_API Node {
  public:
+  static bool enableDynamicShape() {
+    static bool enabled = std::getenv("LTC_ENABLE_DYNAMIC_SHAPES") != nullptr;
+    return enabled || FLAGS_ltc_enable_dynamic_shapes;
+  }
+
   // Creates a new node with the given op name. The op is a unique identifier
   // for the operation. The num_outputs tells how many outputs a given operation
   // generates.
-  Node(OpKind op, size_t num_outputs, hash_t node_hash, hash_t dag_hash);
+  //
+  // None leaf node's node_hash does not contains shape information always.
+  // So we pass in the hash value rather than a function.
+  Node(OpKind op, size_t num_outputs, hash_t node_hash, std::function<hash_t(bool)> dag_hash_fn);
 
   // Contructor used to create leaf nodes.
-  Node(OpKind op, size_t num_outputs, hash_t node_hash);
+  Node(OpKind op, size_t num_outputs, std::function<hash_t(bool)> node_hash_fn);
 
   virtual ~Node();
 
@@ -158,7 +170,15 @@ class TORCH_API Node {
   }
 
   hash_t hash() const {
-    return dag_hash_;
+    return enableDynamicShape() ? dag_hash_without_sizes_ : dag_hash_with_sizes_;
+  }
+
+  hash_t hash_without_sizes() const {
+    return dag_hash_without_sizes_;
+  }
+
+  hash_t hash_with_sizes() const {
+    return dag_hash_with_sizes_;
   }
 
   const MetaData& metadata() const {
@@ -185,7 +205,8 @@ class TORCH_API Node {
   // The hash value of this node.
   hash_t node_hash_;
   // The hash value of the graph rooted at this node.
-  hash_t dag_hash_;
+  hash_t dag_hash_without_sizes_;
+  hash_t dag_hash_with_sizes_;
   // The IR specific metadata attached to the IR node.
   MetaData metadata_;
   // The IR framework user can attach a user defined metadata object deriving

--- a/torch/csrc/lazy/core/ir.h
+++ b/torch/csrc/lazy/core/ir.h
@@ -204,7 +204,15 @@ class TORCH_API Node {
 
   // The hash value of this node.
   hash_t node_hash_;
-  // The hash value of the graph rooted at this node.
+  // dag_hash represents the hash value of the graph rooted at this node. There are 2 variants, one
+  // with sizes info and one without. We need 2 such hashes to support dynamic
+  // shape. Here are the logic to pick the hash in the 2 major scenarios that a hash is needed:
+  // - shape cache: in this case, we always use the dag hash with size info. This way, looking up the
+  //   shape for one node does not get the shape for another node with the same rank but different sizes
+  // - lookup the compiled graph by a hash: in this case, we will use the dag hash
+  //   WITHOUT size info if dynamic shape is enabled and use the dag hash WITH size info otherwise.
+  // The different requirement for the hash in these 2 scenarios forces us to maintain 2
+  // different hashes.
   hash_t dag_hash_without_sizes_;
   hash_t dag_hash_with_sizes_;
   // The IR specific metadata attached to the IR node.

--- a/torch/csrc/lazy/core/shape.cpp
+++ b/torch/csrc/lazy/core/shape.cpp
@@ -28,8 +28,12 @@ size_t Shape::numel() const {
   return elts;
 }
 
-hash_t Shape::hash() const {
-  return HashCombine(Hash(scalar_type_), DataHash(sizes_.data(), sizes_.size() * sizeof(int64_t)));
+hash_t Shape::hash(bool bakeInSizes) const {
+  if (bakeInSizes) {
+    return HashCombine(Hash(scalar_type_), DataHash(sizes_.data(), sizes_.size() * sizeof(int64_t)));
+  } else {
+    return HashCombine(Hash(scalar_type_), Hash(sizes_.size()));
+  }
 }
 
 }  // namespace lazy

--- a/torch/csrc/lazy/core/shape.h
+++ b/torch/csrc/lazy/core/shape.h
@@ -25,7 +25,7 @@ class TORCH_API Shape {
   int64_t size(int64_t dim) const { return sizes_.at(dim); }
   void set_size(int64_t dim, int64_t size) { sizes_.at(dim) = size; }
   size_t numel() const;
-  hash_t hash() const;
+  hash_t hash(bool bakeInSizes) const;
 
   bool operator==(const Shape& other) const;
 

--- a/torch/csrc/lazy/ts_backend/ts_node.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_node.cpp
@@ -28,14 +28,15 @@ void TsNodeSetShapeDeferred(
   throw std::runtime_error("Expected TsNode but could not dynamic cast");
 }
 
-hash_t OperandHashes(const OpList& operands, const hash_t& seed) {
+hash_t OperandHashes(const OpList& operands, const hash_t& seed, bool bakeInSizes) {
   hash_t hash = seed;
   for (auto& operand : operands) {
     if (!operand) {
       hash = HashCombine(hash, static_cast<uint64_t>(kNullOpt));
       continue;
     }
-    hash = HashCombine(hash, operand.hash());
+    auto operand_hash = bakeInSizes ? operand.hash_with_sizes() : operand.hash_without_sizes();
+    hash = HashCombine(hash, operand_hash);
   }
   return hash;
 }
@@ -48,7 +49,7 @@ TsNode::TsNode(OpKind op, OpList operands, std::vector<Shape>&& shapes,
            // initialization to a separate function?
            /* node_hash */ HashCombine(op.hash(), hash_seed),
            /* dag_hash */
-           OperandHashes(operands, HashCombine(op.hash(), hash_seed))),
+           [&](bool bakeInSizes) { return OperandHashes(operands, HashCombine(op.hash(), hash_seed), bakeInSizes); }),
       shapes_(shapes) {
   for (auto& operand : operands) {
     // Ideally, optional operands should be filtered by the leaf node classes,
@@ -80,7 +81,7 @@ void TsNode::SetShapeDeferred(
 }
 
 TsNode::TsNode(OpKind op, Shape shape, size_t num_outputs, hash_t hash_seed)
-    : Node(op, num_outputs, GetOpHash(op, shape, hash_seed))
+    : Node(op, num_outputs, [&](bool bakeInSizes) -> hash_t { return GetOpHash(op, shape, hash_seed, bakeInSizes); })
 {
   shapes_.push_back(std::move(shape));
 }
@@ -98,10 +99,11 @@ ShapeCache* GetShapeCache() {
 
 Shape TsNode::GetOpShape(
     const std::function<Shape()>& shape_fn) const {
+  auto hash = hash_with_sizes();
   ShapeCache* shape_cache = GetShapeCache();
-  auto shape = shape_cache->Get(hash());
+  auto shape = shape_cache->Get(hash);
   if (shape == nullptr) {
-    shape = shape_cache->Add(hash(),
+    shape = shape_cache->Add(hash,
                              std::make_shared<Shape>(shape_fn()));
   }
   return *shape;
@@ -120,8 +122,8 @@ std::string TsNode::ToString() const {
   return ss.str();
 }
 
-hash_t TsNode::GetOpHash(OpKind op, const Shape& shape, hash_t hash_seed) {
-  hash_t h = HashCombine(op.hash(), shape.hash());
+hash_t TsNode::GetOpHash(OpKind op, const Shape& shape, hash_t hash_seed, bool bakeInSizes) {
+  hash_t h = HashCombine(op.hash(), shape.hash(bakeInSizes));
   return HashCombine(h, hash_seed);
 }
 

--- a/torch/csrc/lazy/ts_backend/ts_node.h
+++ b/torch/csrc/lazy/ts_backend/ts_node.h
@@ -55,7 +55,7 @@ class TORCH_API TsNode : public lazy::Node {
 
   std::string ToString() const override;
 
-  static hash_t GetOpHash(OpKind op, const Shape& shape, hash_t hash_seed);
+  static hash_t GetOpHash(OpKind op, const Shape& shape, hash_t hash_seed, bool bakeInSizes);
 
   const std::vector<Output>& operands() const override {
     return operands_as_outputs_;


### PR DESCRIPTION
When dynamic shape is enabled, the dag hash for a node will no longer contain information about tensor sizes. Using such a dag hash to lookup the shape cache will result in issues: Looking up the shape for one node may get the shape for another node with the same rank but different sizes. This is some real issue we encounter when running a Bert model.

The fix is to create 2 dag hashes, one with size info and another without. Here are the logic to pick the hash in the 2 major scenarios that a hash is needed:
- shape cache: in this case, we always use the dag hash with size info
- lookup the compiled graph by a hash: in this case, we will use the dag hash WITHOUT size info if dynamic shape is enabled and use the dag hash WITH size info otherwise.

