### PR TITLE
Add naive native FFN in aten

### DIFF
--- a/aten/src/ATen/native/Transformer.cpp
+++ b/aten/src/ATen/native/Transformer.cpp
@@ -1,0 +1,21 @@
+#include <ATen/ATen.h>
+#include <ATen/AccumulateType.h>
+#include <ATen/Dispatch.h>
+#include <ATen/NativeFunctions.h>
+
+namespace at {
+
+namespace native {
+
+Tensor ffn_cpu(const Tensor& input, const Tensor& w1, const Tensor& b1, const Tensor& w2, const Tensor& b2, bool use_gelu, bool add_norm){
+  TORCH_CHECK(add_norm == false, "TODO add_norm to be supported in FFN");
+  TORCH_CHECK(use_gelu == false, "TODO gelu to be supported in FFN");
+  Tensor res = at::baddbmm(b1, input, w1);
+  if (!use_gelu) {
+    res = at::relu(res);
+  }
+  res = at::baddbmm(b2, res, w2);
+  return res;
+}
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/cuda/Transformer.cu
+++ b/aten/src/ATen/native/cuda/Transformer.cu
@@ -1,0 +1,21 @@
+#include <ATen/ATen.h>
+#include <ATen/AccumulateType.h>
+#include <ATen/Dispatch.h>
+#include <ATen/NativeFunctions.h>
+
+namespace at {
+
+namespace native {
+
+Tensor ffn_cuda(const Tensor& input, const Tensor& w1, const Tensor& b1, const Tensor& w2, const Tensor& b2, bool use_gelu, bool add_norm){
+  TORCH_CHECK(add_norm == false, "TODO add_norm to be supported in FFN");
+  TORCH_CHECK(use_gelu == false, "TODO gelu to be supported in FFN");
+  Tensor res = at::baddbmm(b1, input, w1);
+  if (!use_gelu) {
+    res = at::relu(res);
+  }
+  res = at::baddbmm(b2, res, w2);
+  return res;
+}
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5892,6 +5892,12 @@
     CUDA: masked_softmax_cuda
     CPU: masked_softmax_cpu
 
+# Native FFN feed forward network used for Transformer
+- func: _ffn(Tensor input, Tensor weight1, Tensor bias1, Tensor weight2, Tensor bias2, bool use_gelu=False, bool add_norm=False) -> Tensor
+  dispatch:
+    CUDA: ffn_cuda
+    CPU: ffn_cpu
+
 - func: view(Tensor(a) self, int[] size) -> Tensor(a)
   variants: method
   device_check: NoCheck

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -17506,6 +17506,29 @@ class TestNNDeviceType(NNTestCase):
         self._test_EmbeddingBag(device, 'sum', True, wdtype=torch.bfloat16, dtype=dtypes[0], odtype=dtypes[1], test_backward=True)
         self._test_EmbeddingBag(device, 'mean', True, wdtype=torch.bfloat16, dtype=dtypes[0], odtype=dtypes[1], test_backward=True)
 
+    # TODO current baddbmm does not support fp16
+    # But we would like it to be supported in native FFN
+    @dtypes(torch.float, torch.double)
+    def test_ffn(self, device, dtype):
+        B = 10
+        N = 12
+        M = 14
+        K = 16
+        L = 18
+        # B * N * M
+        x = torch.randn(B, N, M, dtype=dtype, device=device)
+        # B * M * K
+        w1 = torch.randn(B, M, K, dtype=dtype, device=device)
+        # B * K * L
+        w2 = torch.randn(B, K, L, dtype=dtype, device=device)
+        # N * K
+        b1 = torch.randn(N, K, dtype=dtype, device=device)
+        # N * L
+        b2 = torch.randn(N, L, dtype=dtype, device=device)
+
+        res = torch.baddbmm(b2, torch.relu(torch.baddbmm(b1, x, w1)), w2)
+        res_pt = torch._ffn(x, w1, b1, w2, b2)
+        self.assertEqual(res_pt, res)
 
     @onlyCUDA
     @dtypes(torch.half, torch.float, torch.double)

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -1264,6 +1264,7 @@ aten_native_source_non_codegen_list = [
     "aten/src/ATen/native/TensorShape.cpp",
     "aten/src/ATen/native/TensorTransformations.cpp",
     "aten/src/ATen/native/TestOps.cpp",
+    "aten/src/ATen/native/Transformer.cpp",
     "aten/src/ATen/native/TriangularOps.cpp",
     "aten/src/ATen/native/TypeProperties.cpp",
     "aten/src/ATen/native/UnaryOps.cpp",


### PR DESCRIPTION
Summary:
This is an alias of feed forward network in transformer. We would like to use this API in the prototype of the new transformer encoder. Notice this diff might not bring any perf improvement since it is just a combination of aten ops, but we can improve its kernels later.

fp16 is not supported in this version, due to the poor support of Half type in current aten::baddbmm. We should improve this in our future implemented fast FFN kernel.

Test Plan: buck build mode/opt -c fbcode.enable_gpu_sections=true caffe2/test:nn && buck-out/gen/caffe2/test/nn\#binary.par -r test_ffn

Differential Revision: D33800859

