### PR TITLE
Add BatchNormalization to ONNX Scalar type analysis pass to support fp16

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5124,6 +5124,13 @@ class TestONNXRuntime(unittest.TestCase):
                           input_names=["x"],
                           dynamic_axes={"x": {0: "batch_size", 1: "dims"}})
 
+    def test_batchnorm1d_type_promotion(self):
+        num_features = 5
+        fp16 = torch.rand(300, num_features).half()
+        model = torch.nn.BatchNorm1d(num_features)
+        with torch.autocast(device_type='cpu'):
+            self.run_test(model, (fp16))
+
     def test_concat(self):
         class ConcatModel(torch.nn.Module):
             def forward(self, x, y, z):

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -51,6 +51,7 @@ static const std::unordered_set<NodeKind> standardOps = {
     onnx::Pow,
     onnx::Mod,
     onnx::Concat,
+    onnx::BatchNormalization,
 };
 
 // For these operators, all inputs share the same scalar type.


### PR DESCRIPTION
Fixes #72494
