### PR TITLE
Fix doc build for release branches

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -11,8 +11,14 @@ on:
   pull_request:
 {%- endif %}
   push:
+{%- if enable_doc_jobs and is_scheduled %}
+    tags:
+      # NOTE: Binary build pipelines should only get triggered on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+{%- endif %}
 {%- for label in ciflow_config.labels | sort %}
-  {%- if loop.first %}
+  {%- if loop.first and not (enable_doc_jobs  and is_scheduled) %}
     tags:
   {%- endif %}
   {%- if label != "ciflow/default" %}
@@ -364,7 +370,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.build.outputs.docker_image }}
       DOCS_TYPE: ${{ matrix.docs_type }}
-      WITH_PUSH: ${{ github.event_name == 'schedule' }}
+      WITH_PUSH: ${{ github.event_name == 'schedule' || startsWith(github.event.ref, 'refs/tags/v') }}
     steps:
       !{{ common.setup_ec2_linux() }}
       !{{ common.checkout() }}
@@ -381,7 +387,7 @@ jobs:
           unzip -o artifacts.zip
 {%- if is_scheduled %}
       - name: Generate netrc (only for docs-push)
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' || startsWith(github.event.ref, 'refs/tags/v') }}
         env:
           GITHUB_PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
         run: |
@@ -394,9 +400,12 @@ jobs:
         run: |
           set -ex
           time docker pull "${DOCKER_IMAGE}" > /dev/null
-          echo "${GITHUB_REF}"
-          # TODO: Set it correctly when workflows are scheduled on tags
-          target="master"
+          # Convert refs/tags/v1.12.0rc3 into 1.12
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/v([0-9]+\.[0-9]+)\.* ]]; then
+            target="${BASH_REMATCH[1]}"
+          else
+            target="master"
+          fi
           # detached container should get cleaned up by teardown_ec2_linux
           container_name=$(docker run \
             -e BUILD_ENVIRONMENT \

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -6,6 +6,9 @@ name: linux-docs-push
 on:
   push:
     tags:
+      # NOTE: Binary build pipelines should only get triggered on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
       - 'ciflow/all/*'
       - 'ciflow/cpu/*'
       - 'ciflow/linux/*'
@@ -255,7 +258,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.build.outputs.docker_image }}
       DOCS_TYPE: ${{ matrix.docs_type }}
-      WITH_PUSH: ${{ github.event_name == 'schedule' }}
+      WITH_PUSH: ${{ github.event_name == 'schedule' || startsWith(github.event.ref, 'refs/tags/v') }}
     steps:
       - name: Display EC2 information
         shell: bash
@@ -324,7 +327,7 @@ jobs:
         run: |
           unzip -o artifacts.zip
       - name: Generate netrc (only for docs-push)
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' || startsWith(github.event.ref, 'refs/tags/v') }}
         env:
           GITHUB_PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
         run: |
@@ -336,9 +339,12 @@ jobs:
         run: |
           set -ex
           time docker pull "${DOCKER_IMAGE}" > /dev/null
-          echo "${GITHUB_REF}"
-          # TODO: Set it correctly when workflows are scheduled on tags
-          target="master"
+          # Convert refs/tags/v1.12.0rc3 into 1.12
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/v([0-9]+\.[0-9]+)\.* ]]; then
+            target="${BASH_REMATCH[1]}"
+          else
+            target="master"
+          fi
           # detached container should get cleaned up by teardown_ec2_linux
           container_name=$(docker run \
             -e BUILD_ENVIRONMENT \

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -258,7 +258,7 @@ jobs:
     env:
       DOCKER_IMAGE: ${{ needs.build.outputs.docker_image }}
       DOCS_TYPE: ${{ matrix.docs_type }}
-      WITH_PUSH: ${{ github.event_name == 'schedule' }}
+      WITH_PUSH: ${{ github.event_name == 'schedule' || startsWith(github.event.ref, 'refs/tags/v') }}
     steps:
       - name: Display EC2 information
         shell: bash
@@ -330,9 +330,12 @@ jobs:
         run: |
           set -ex
           time docker pull "${DOCKER_IMAGE}" > /dev/null
-          echo "${GITHUB_REF}"
-          # TODO: Set it correctly when workflows are scheduled on tags
-          target="master"
+          # Convert refs/tags/v1.12.0rc3 into 1.12
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/v([0-9]+\.[0-9]+)\.* ]]; then
+            target="${BASH_REMATCH[1]}"
+          else
+            target="master"
+          fi
           # detached container should get cleaned up by teardown_ec2_linux
           container_name=$(docker run \
             -e BUILD_ENVIRONMENT \


### PR DESCRIPTION
Add "v1.[0-9]+.[0-9]+-rc[0-9]+" wildcard to tag triggers
Add similar `startsWith(github.event.ref, "refs/tags/v1.")` for push
conditions

Fixes https://github.com/pytorch/pytorch/issues/72519
