### PR TITLE
Fix cusparse sync issue in bsrsv2 and bsrsm2

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
+++ b/aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp
@@ -195,7 +195,8 @@ void block_sparse_triangular_solve_vec(
             &buffer_size);
 
         auto& allocator = *c10::cuda::CUDACachingAllocator::get();
-        auto work_data = allocator.allocate(buffer_size);
+        auto work_data_analysis = allocator.allocate(buffer_size);
+        auto work_data_solve = allocator.allocate(buffer_size);
 
         at::cuda::sparse::bsrsv2_analysis(
             handle,
@@ -209,8 +210,8 @@ void block_sparse_triangular_solve_vec(
             col_indices_data_ptr,
             block_size,
             info.descriptor(),
-            CUSPARSE_SOLVE_POLICY_NO_LEVEL,
-            work_data.get());
+            CUSPARSE_SOLVE_POLICY_USE_LEVEL,
+            work_data_analysis.get());
 
         at::cuda::sparse::bsrsv2_solve(
             handle,
@@ -227,8 +228,8 @@ void block_sparse_triangular_solve_vec(
             info.descriptor(),
             B_->data_ptr<scalar_t>(),
             X_->data_ptr<scalar_t>(),
-            CUSPARSE_SOLVE_POLICY_NO_LEVEL,
-            work_data.get());
+            CUSPARSE_SOLVE_POLICY_USE_LEVEL,
+            work_data_solve.get());
       });
   if (!X.is_same(*X_)) {
     X.copy_(*X_);
@@ -319,7 +320,8 @@ void block_sparse_triangular_solve_mat(
             &buffer_size);
 
         auto& allocator = *c10::cuda::CUDACachingAllocator::get();
-        auto work_data = allocator.allocate(buffer_size);
+        auto work_data_analysis = allocator.allocate(buffer_size);
+        auto work_data_solve = allocator.allocate(buffer_size);
 
         at::cuda::sparse::bsrsm2_analysis(
             handle,
@@ -335,8 +337,8 @@ void block_sparse_triangular_solve_mat(
             col_indices_data_ptr,
             block_size,
             info.descriptor(),
-            CUSPARSE_SOLVE_POLICY_NO_LEVEL,
-            work_data.get());
+            CUSPARSE_SOLVE_POLICY_USE_LEVEL,
+            work_data_analysis.get());
 
         at::cuda::sparse::bsrsm2_solve(
             handle,
@@ -357,8 +359,8 @@ void block_sparse_triangular_solve_mat(
             ldb,
             X_->data_ptr<scalar_t>(),
             ldx,
-            CUSPARSE_SOLVE_POLICY_NO_LEVEL,
-            work_data.get());
+            CUSPARSE_SOLVE_POLICY_USE_LEVEL,
+            work_data_solve.get());
       });
   if (!X.is_same(*X_)) {
     X.copy_(*X_);


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/71297

This PR does

- change `CUSPARSE_SOLVE_POLICY_NO_LEVEL` to `CUSPARSE_SOLVE_POLICY_USE_LEVEL`
- allocate extra buffers for `bsrs{v,m}2_analysis` and `bsrs{v,m}2_solve`, i.e., do not share buffer between the two consecutive function calls

Reason for changes:

`CUSPARSE_SOLVE_POLICY_USE_LEVEL` gives better stability

Applying `export PYTORCH_NO_CUDA_MEMORY_CACHING=1` can resolve the issue. Also, adding a `cudaDeviceSynchronize()` between `bsrsv2_analysis` and `bsrsv2_solve` can resolve the issue as well. There may be something weird between the cuda caching allocator and cusparse routines. Using separately allocated buffers for the two function calls solve the issue.
