### PR TITLE
[jiterator] stricter static_assert

### DIFF
--- a/aten/src/ATen/jit_macros.h
+++ b/aten/src/ATen/jit_macros.h
@@ -8,7 +8,6 @@
     #define AT_USE_JITERATOR() true
     #define jiterator_stringify(...) std::string(#__VA_ARGS__);
 #else
-    // TODO: update this to become a static assertion
     #define AT_USE_JITERATOR() false
-    #define jiterator_stringify(...) std::string("Jiterator is disabled");
+    #define jiterator_stringify(...) static_assert(false, "Jiterator is not supported on ROCm");
 #endif // USE_ROCM

--- a/aten/src/ATen/native/cuda/jit_utils.h
+++ b/aten/src/ATen/native/cuda/jit_utils.h
@@ -53,7 +53,7 @@ struct delayed_false : std::false_type {
 template <typename T>
 inline std::string typeName() {
   // we can't use static_assert(false) directly as the
-  // program will be not compile even if the template is not
+  // program will be not compiled even if the template is not
   // instantiated, so we use `delayed_false`
   // to make sure compiler doesn't eagerly raise
   // fail this assertion.
@@ -76,10 +76,6 @@ template <> inline std::string typeName<c10::complex<float>>(){
 }
 template <> inline std::string typeName<c10::complex<double>>(){
     return "std::complex<double>";
-}
-template <> inline std::string typeName<c10::complex<c10::Half>>(){
-    TORCH_INTERNAL_ASSERT(false, "torch.complex32 is not supported");
-    return "std::complex<at::Half>";
 }
 template <> inline std::string typeName<at::Half>(){
     return "at::Half";


### PR DESCRIPTION
* static_assert on `jiterator_stringify` usage in ROCm.
* static_assert for `complex<half>`
