### PR TITLE
[DOC] Add link to "double backward" from "extending pytorch" page

### DIFF
--- a/docs/source/notes/autograd.rst
+++ b/docs/source/notes/autograd.rst
@@ -354,7 +354,7 @@ parallel backwards that share part/whole of the GraphTask.
 
 Custom Python ``autograd.function`` is automatically thread safe because of GIL.
 For built-in C++ Autograd Nodes (e.g. AccumulateGrad, CopySlices) and custom
-``autograd::Function``s, the Autograd Engine uses thread mutex locking to ensure
+``autograd::Function``\s, the Autograd Engine uses thread mutex locking to ensure
 thread safety on autograd Nodes that might have state write/read.
 
 No thread safety on C++ hooks

--- a/docs/source/notes/autograd.rst
+++ b/docs/source/notes/autograd.rst
@@ -353,8 +353,8 @@ potential parallelism, it's important that we ensure thread safety on CPU with
 parallel backwards that share part/whole of the GraphTask.
 
 Custom Python ``autograd.function`` is automatically thread safe because of GIL.
-for built-in C++ Autograd Nodes(e.g. AccumulateGrad, CopySlices) and custom
-``autograd::Function``, the Autograd Engine uses thread mutex locking to protect
+For built-in C++ Autograd Nodes (e.g. AccumulateGrad, CopySlices) and custom
+``autograd::Function``s, the Autograd Engine uses thread mutex locking to ensure
 thread safety on autograd Nodes that might have state write/read.
 
 No thread safety on C++ hooks

--- a/docs/source/notes/autograd.rst
+++ b/docs/source/notes/autograd.rst
@@ -352,7 +352,7 @@ Since Autograd allows the caller thread to drive its backward execution for
 potential parallelism, it's important that we ensure thread safety on CPU with
 parallel backwards that share part/whole of the GraphTask.
 
-Custom Python ``autograd.function`` is automatically thread safe because of GIL.
+Custom Python ``autograd.Function`` is automatically thread safe because of GIL.
 For built-in C++ Autograd Nodes (e.g. AccumulateGrad, CopySlices) and custom
 ``autograd::Function``\s, the Autograd Engine uses thread mutex locking to ensure
 thread safety on autograd Nodes that might have state write/read.

--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -54,7 +54,8 @@ Take the following steps:
 1. Subclass :class:`~Function` and implement the :meth:`~Function.forward` and
 :meth:`~Function.backward` methods.
 2. Call the proper methods on the `ctx` argument.
-3. Declare whether your function supports double backward.
+3. Declare whether your function supports
+`double backward <https://pytorch.org/tutorials/intermediate/custom_function_double_backward_tutorial.html>`_.
 4. Validate whether your gradients are correct using gradcheck.
 
 **Step 1:** After subclassing :class:`Function`, you'll need to define 2 methods:


### PR DESCRIPTION
It is probably the most user friendly to link to that (lesser known?) feature.