### PR TITLE
[Static Runtime] Add a script to auto-generate out variant dispatchers

### DIFF
--- a/tools/codegen/static_runtime/config.py
+++ b/tools/codegen/static_runtime/config.py
@@ -1,0 +1,138 @@
+from tools.codegen.model import NativeFunctionsGroup
+
+from typing import Dict
+
+
+def func_name_base_str(g: NativeFunctionsGroup) -> str:
+    return str(g.functional.func.name.name.base)
+
+is_hand_written_ops_ = frozenset(("add", "addmm", "all", "any", "argmin", "bmm", "clamp",
+                                  "cumsum", "div", "fmod", "leaky_relu", "log", "mul", "pow",
+                                  "remainder", "sigmoid", "sign", "sub", "tanh"))
+
+def is_hand_written(g: NativeFunctionsGroup) -> bool:
+    name_base = func_name_base_str(g)
+    return name_base in is_hand_written_ops_
+
+def override_test_values(arg_map: Dict[str, str], op_name: str, index: int) -> None:
+    assert index == 0 or index == 1
+    if op_name == "addmv":
+        if index == 0:
+            arg_map["self"] = "at::rand({2})"
+            arg_map["mat"] = "at::rand({2, 2})"
+            arg_map["vec"] = "at::rand({2})"
+        else:
+            arg_map["self"] = "at::rand({35})"
+            arg_map["mat"] = "at::rand({35, 35})"
+            arg_map["vec"] = "at::rand({35})"
+        return
+    if op_name == "acosh":
+        if index == 0:
+            arg_map["self"] = "at::rand({2, 2, 2}) + at::ones({2, 2, 2})"
+        else:
+            arg_map["self"] = "at::rand({5, 5, 5}) + at::ones({5, 5, 5})"
+        return
+    if op_name == "index_add":
+        if index == 0:
+            arg_map["self"] = "at::rand({2})"
+            arg_map["dim"] = "0"
+            arg_map["index"] = "at::randint(0, 1, {2}, at::kInt)"
+            arg_map["source"] = "at::rand({2})"
+            arg_map["alpha"] = "2"
+        else:
+            arg_map["self"] = "at::rand({16})"
+            arg_map["dim"] = "0"
+            arg_map["index"] = "at::randint(0, 10, {16}, at::kInt)"
+            arg_map["source"] = "at::rand({16})"
+            arg_map["alpha"] = "2"
+        return
+    if op_name == "adaptive_max_pool2d_backward":
+        if index == 0:
+            arg_map["grad_output"] = "at::randint(-3, 2, {2,2,2})"
+            arg_map["self"] = "at::randint(-3, 2, {2,2,2})"
+            arg_map["indices"] = "at::randint(0, 1, {2,2,2}, at::kLong)"
+        else:
+            arg_map["grad_output"] = "at::randint(-3, 3, {3,3,3})"
+            arg_map["self"] = "at::randint(-3, 2, {3,3,3})"
+            arg_map["indices"] = "at::randint(0, 1, {3,3,3}, at::kLong)"
+        return
+    if op_name == "adaptive_max_pool3d_backward":
+        if index == 0:
+            arg_map["grad_output"] = "at::randint(-3, 2, {2,2,2,2})"
+            arg_map["self"] = "at::randint(-3, 2, {2,2,2,2})"
+            arg_map["indices"] = "at::randint(0, 1, {2,2,2,2}, at::kLong)"
+        else:
+            arg_map["grad_output"] = "at::randint(-3, 3, {3,3,3,3})"
+            arg_map["self"] = "at::randint(-3, 2, {3,3,3,3})"
+            arg_map["indices"] = "at::randint(0, 1, {3,3,3,3}, at::kLong)"
+        return
+    if op_name == "gather":
+        if index == 0:
+            arg_map["self"] = "at::randint(1, 100, {2,2,2}, at::kInt)"
+            arg_map["dim"] = "1"
+            arg_map["index"] = "at::randint(0, 1, {2,2,2}, torch::kInt64)"
+            arg_map["sparse_grad"] = "false"
+        else:
+            arg_map["self"] = "at::randint(1, 100, {5,5,5}, at::kInt)"
+            arg_map["dim"] = "1"
+            arg_map["index"] = "at::randint(0, 4, {5,5,5}, torch::kInt64)"
+            arg_map["sparse_grad"] = "false"
+        return
+    if op_name == "nll_loss_backward":
+        if index == 0:
+            arg_map["grad_output"] = "at::rand({})"
+            arg_map["self"] = "at::rand({6})"
+            arg_map["target"] = "at::randint(0, 5, {6}, torch::kInt64)"
+            arg_map["weight"] = "at::rand({6})"
+            arg_map["reduction"] = "1"
+            arg_map["ignore_index"] = "1"
+            arg_map["total_weight"] = "at::rand({})"
+        else:
+            arg_map["grad_output"] = "at::rand({})"
+            arg_map["self"] = "at::rand({36})"
+            arg_map["target"] = "at::randint(0, 11, {36}, torch::kInt64)"
+            arg_map["weight"] = "at::rand({36})"
+            arg_map["reduction"] = "1"
+            arg_map["ignore_index"] = "1"
+            arg_map["total_weight"] = "at::rand({})"
+        return
+    if op_name in ["scatter", "scatter_add", "_scatter_reduce"]:
+        if index == 0:
+            arg_map["self"] = "at::randint(1, 100, {2,2,2}, torch::kInt64)"
+            arg_map["index"] = "at::randint(0, 1, {2,2,2}, torch::kInt64)"
+            arg_map["src"] = "at::randint(1, 100, {2,2,2}, torch::kInt64)"
+        else:
+            arg_map["self"] = "at::randint(1, 100, {5,5,5}, torch::kInt64)"
+            arg_map["index"] = "at::randint(0, 1, {5,5,5}, torch::kInt64)"
+            arg_map["src"] = "at::randint(1, 100, {5,5,5}, torch::kInt64)"
+        if "reduce" in arg_map:
+            arg_map["reduce"] = "\"sum\"" if op_name == "_scatter_reduce" else "\"add\""
+        return
+    if op_name == "special_zeta":
+        if index == 0:
+            arg_map["self"] = "at::rand({2,2,2}, at::kDouble) + at::ones({2,2,2})"
+            arg_map["other"] = "at::rand({2,2,2}, at::kDouble) + at::ones({2,2,2})"
+        else:
+            arg_map["self"] = "at::rand({5,5,5}, at::kDouble) + at::ones({5,5,5})"
+            arg_map["other"] = "at::rand({5,5,5}, at::kDouble) + at::ones({5,5,5})"
+        return
+    if op_name == "_convert_indices_from_csr_to_coo":
+        if index == 0:
+            arg_map["crow_indices"] = "torch::tensor({1}, torch::kInt32)"
+            arg_map["col_indices"] = "torch::tensor({0, 1, 0}, torch::kInt32)"
+            arg_map["out_int32"] = "false"
+        else:
+            arg_map["crow_indices"] = "torch::tensor({0, 1}, torch::kInt32)"
+            arg_map["col_indices"] = "torch::tensor({0, 1, 0, 2, 1, 2}, torch::kInt32)"
+            arg_map["out_int32"] = "false"
+        return
+    if op_name == "_convert_indices_from_coo_to_csr":
+        if index == 0:
+            arg_map["self"] = "at::randint(0, 3, {2}, at::kInt)"
+            arg_map["size"] = "10"
+            arg_map["out_int32"] = "false"
+        else:
+            arg_map["self"] = "at::randint(0, 3, {12}, at::kInt)"
+            arg_map["size"] = "24"
+            arg_map["out_int32"] = "false"
+        return

--- a/tools/codegen/static_runtime/gen_static_runtime_ops.py
+++ b/tools/codegen/static_runtime/gen_static_runtime_ops.py
@@ -1,0 +1,148 @@
+from tools.codegen import gen
+from tools.codegen.context import native_function_manager
+from tools.codegen.model import NativeFunctionsGroup
+from tools.codegen.static_runtime import gen_structured
+
+import argparse
+import itertools
+import os
+from typing import Sequence
+
+# Given a list of `grouped_native_functions` sorted by their op names, return a list of
+# lists each of which groups ops that share the base name. For example, `mean` and
+# `mean.dim` are grouped together by this function.
+def group_functions_by_op_name(grouped_native_functions:
+                               Sequence[NativeFunctionsGroup]) -> Sequence[Sequence[NativeFunctionsGroup]]:
+    if not grouped_native_functions:
+        return []
+    groups = []
+    current_op_name = None
+    current_group = None
+
+    def is_supported(g: NativeFunctionsGroup) -> bool:
+        with native_function_manager(g):
+            return gen_structured.is_supported(g)
+
+    eligible_ops = (g for g in grouped_native_functions if is_supported(g))
+    groups = [list(group) for k, group in (itertools.groupby(eligible_ops, key=lambda g: g.functional.func.name.name.base))]
+    return groups
+
+def clang_format(cpp_file_path: str) -> None:
+    import subprocess
+    subprocess.run(["clang-format", "-i", cpp_file_path])
+
+def write_cpp(cpp_ops: Sequence[str], file_path: str) -> None:
+    code = "\n".join(cpp_ops)
+    generated = f"""// @lint-ignore-every CLANGTIDY HOWTOEVEN
+#include <torch/csrc/jit/runtime/static/ops.h>
+
+#include <ATen/CPUFunctions.h>
+#include <ATen/InferSize.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/Parallel.h>
+#include <ATen/ScalarOps.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/cpu/vec/functional.h>
+#include <ATen/cpu/vec/vec.h>
+#include <ATen/native/EmbeddingBag.h>
+#include <ATen/native/Fill.h>
+#include <ATen/native/IndexingUtils.h>
+#include <ATen/native/Resize.h>
+#include <ATen/native/SharedReduceOps.h>
+#include <ATen/native/TensorAdvancedIndexing.h>
+#include <ATen/native/cpu/SerialStackImpl.h>
+#include <ATen/native/layer_norm.h>
+#include <ATen/native/quantized/cpu/fbgemm_utils.h>
+#include <ATen/native/quantized/cpu/qembeddingbag.h>
+#include <ATen/native/quantized/cpu/qembeddingbag_prepack.h>
+#include <ATen/quantized/QTensorImpl.h>
+#include <ATen/quantized/Quantizer.h>
+#include <c10/core/ScalarType.h>
+#include <c10/core/WrapDimMinimal.h>
+#include <c10/util/irange.h>
+#include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/runtime/static/impl.h>
+#include <torch/csrc/jit/runtime/static/te_wrapper.h>
+#include <torch/csrc/jit/runtime/vararg_functions.h>
+#include <torch/csrc/jit/tensorexpr/ir.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
+#include <torch/csrc/jit/tensorexpr/loopnest.h>
+
+namespace torch {{
+namespace jit {{
+
+{code}
+
+}} // namespace jit
+}} // namespace torch
+"""
+    with open(file_path, "w") as f:
+        f.write(generated)
+    clang_format(file_path)
+
+
+def write_test_cpp(cpp_ops: Sequence[str], file_path: str) -> None:
+    code = "\n".join(cpp_ops)
+    generated = f"""// @lint-ignore-every CLANGTIDY HOWTOEVEN
+#include <gtest/gtest.h>
+#include <torch/csrc/jit/runtime/static/impl.h>
+#include <torch/torch.h>
+
+#include "test_utils.h"
+
+using namespace caffe2;
+using namespace torch;
+using namespace torch::jit;
+using namespace torch::jit::test;
+using c10::IValue;
+
+{code}
+
+"""
+    with open(file_path, "w") as f:
+        f.write(generated)
+    clang_format(file_path)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Generate ATen source files')
+    parser.add_argument(
+        '-s',
+        '--source-path',
+        help='path to source directory for ATen',
+        default='aten/src/ATen')
+    parser.add_argument(
+        '-p',
+        '--generated-ops-cpp-path',
+        help='path to directory to generate op dispatcher .cpp file',
+        default='torch/csrc/jit/runtime/static/generated_ops.cpp')
+    parser.add_argument(
+        '-t',
+        '--generated-ops-test-cpp-path',
+        help='path to directory to generate op dispatcher .cpp file',
+        default='benchmarks/static_runtime/test_generated_ops.cc')
+    options = parser.parse_args()
+    native_yaml_path = os.path.join(options.source_path, 'native/native_functions.yaml')
+    parsed_yaml = gen.parse_native_yaml(native_yaml_path)
+    native_functions, backend_indices = parsed_yaml.native_functions, parsed_yaml.backend_indices
+    grouped_native_functions = gen.get_grouped_native_functions(native_functions)
+    structured_native_functions = [g for g in grouped_native_functions
+                                   if isinstance(g, NativeFunctionsGroup)]
+    supported_function_groups = group_functions_by_op_name(structured_native_functions)
+
+    gen_out_variant_dispatcher = gen_structured.GenOutVariantDispatcher()
+    result = [gen_out_variant_dispatcher(groups) for groups in supported_function_groups]
+
+    gen_out_variant_dispatcher_test_case = gen_structured.GenOutVariantDispatcherTestCase()
+    test_result = [gen_out_variant_dispatcher_test_case(groups) for groups in supported_function_groups]
+
+    write_cpp(result, options.generated_ops_cpp_path)
+    write_test_cpp(test_result, options.generated_ops_test_cpp_path)
+
+    print("total grouped native ops: %d" % len(grouped_native_functions))
+    print("structured grouped native ops: %d" % len(structured_native_functions))
+    supported_grouped_functions = sum([len(groups) for groups in supported_function_groups])
+    print("generated grouped native ops: %d" % supported_grouped_functions)
+
+if __name__ == '__main__':
+    main()

--- a/tools/codegen/static_runtime/gen_structured.py
+++ b/tools/codegen/static_runtime/gen_structured.py
@@ -1,0 +1,310 @@
+import tools.codegen.api.cpp as cpp
+from tools.codegen.context import native_function_manager
+from tools.codegen.model import (Argument, BaseTy, FunctionSchema, OptionalType,
+                                 SelfArgument,
+                                 BaseType, NativeFunctionsGroup, TensorOptionsArguments, Type)
+from tools.codegen.static_runtime import config
+
+import math
+from typing import List, Optional, Sequence, Tuple, Union
+
+
+def has_alias(arguments: Sequence[Union[Argument, SelfArgument, TensorOptionsArguments]]) -> bool:
+    for arg in arguments:
+        annotation = getattr(arg, "annotation", None)
+        if not annotation:
+            continue
+        alias_set = getattr(annotation, "alias_set", ())
+        if alias_set:
+            return True
+    return False
+
+def is_supported(g: NativeFunctionsGroup) -> bool:
+    if not g.structured:
+        return False
+    if config.is_hand_written(g):
+        return False
+    if has_alias(g.out.func.arguments.non_out):
+        # This op may create an alias of inputs.
+        return False
+    if len(g.out.func.arguments.out) > 1:
+        # More than 1 output values.
+        return False
+    if "at::Tensor &" != cpp.returns_type(g.out.func.returns).cpp_type():
+        # Returns a non-Tensor value.
+        return False
+    for arg in g.out.func.schema_order_arguments():
+        maybe_method = ivalue_type_conversion_method(arg.type)
+        if not maybe_method:
+            # Type converting is unsupported yet.
+            return False
+    return True
+
+def ivalue_type_conversion_method(arg_type: Union[BaseType, OptionalType, Type]) -> Optional[Tuple[bool, str]]:
+    """
+    Return the method call expression of `c10::ivalue' to convert its contained value to
+    the expected value of `arg_type` type. For example, for `arg_type` == BaseTy.Tensor,
+    this function returns ".toTensor()", so that it can be appended to the ivalue's
+    variable name to get the value of the expected type.
+    """
+    type_conversion_methods = {
+        BaseTy.Tensor: ((True, "toTensor()"), (False, "toOptional<at::Tensor>()")),
+        BaseTy.int: ((False, "toInt()"), (False, "toOptional<int64_t>()")),
+        BaseTy.bool: ((False, "toBool()"), (False, "toOptional<bool>()")),
+        BaseTy.Scalar: ((False, "toScalar()"), (False, "toOptional<at::Scalar>()")),
+        BaseTy.ScalarType: ((False, "toScalarType()"), (False, "toOptional<at::ScalarType>()")),
+        BaseTy.str: ((False, "toStringView()"), (False, "toOptional<c10::string_view>()"))}
+
+    base_ty_object = None
+    if isinstance(arg_type, BaseType):
+        base_ty_object = arg_type.name
+    elif isinstance(arg_type, OptionalType):
+        assert isinstance(arg_type.elem, BaseType)
+        base_ty_object = arg_type.elem.name
+    else:
+        return None
+
+    if base_ty_object not in type_conversion_methods:
+        return None
+    methods = type_conversion_methods[base_ty_object]
+    if isinstance(arg_type, BaseType):
+        return methods[0]
+    return methods[1]
+
+should_use_int_tensor_ops_ = frozenset(("bitwise_not", "bitwise_and", "bitwise_or", "bitwise_xor", "gcd",
+                                        "lcm", "scatter", "gather", "_convert_indices_from_coo_to_csr",
+                                        "_convert_indices_from_csr_to_coo"))
+
+def should_use_int_tensor(op_name: str) -> bool:
+    return op_name in should_use_int_tensor_ops_
+
+test_tensor_dim_ops_1_ = frozenset(("addmv", "index_add", "_convert_indices_from_coo_to_csr",
+                                    "_convert_indices_from_csr_to_coo", "nll_loss_backward"))
+test_tensor_dim_ops_2_ = frozenset(("addmm", "mm"))
+
+def test_tensor_dim(op_name: str) -> int:
+    if op_name in test_tensor_dim_ops_1_:
+        return 1
+    if op_name in test_tensor_dim_ops_2_:
+        return 2
+    return 3
+
+def test_value_expression(arg_type: Union[BaseType, OptionalType, Type], index: int, op_name: str) -> str:
+    num_tensors = 16 if index == 0 else 64
+    num_dim = test_tensor_dim(op_name)
+    size_per_dim = math.ceil(num_tensors / float(num_dim))
+    size_per_dim += size_per_dim % 2
+    tensor_size_ex = "{%s}" % (",".join([f"{size_per_dim}"] * num_dim))
+    if should_use_int_tensor(op_name):
+        tensor_expression = f"at::randint(1, 100, {tensor_size_ex}, at::kInt)"
+    else:
+        tensor_expression = f"at::rand({tensor_size_ex})"
+
+    value_expressions = {
+        BaseTy.Tensor: tensor_expression,
+        BaseTy.int: "1",
+        BaseTy.bool: "false",
+        BaseTy.Scalar: "2",
+        BaseTy.ScalarType: "at::ScalarType::Float",
+        BaseTy.str: "\"floor\""}
+
+    base_ty_object = None
+    if isinstance(arg_type, BaseType):
+        base_ty_object = arg_type.name
+    else:
+        assert isinstance(arg_type, OptionalType) and isinstance(arg_type.elem, BaseType)
+        base_ty_object = arg_type.elem.name
+    assert base_ty_object in value_expressions, "not expected type"
+    value_expression = value_expressions[base_ty_object]
+    return value_expression
+
+def generate_test_value_definitions(g: NativeFunctionsGroup, index: int) -> str:
+    schema = g.functional.func
+    assert not schema.is_out_fn()
+    schema_name = schema.name.name.base
+    arg_map = {}
+    for arg in schema.schema_order_arguments():
+        test_value_exp = test_value_expression(arg.type, index, schema_name)
+        arg_map[arg.name] = test_value_exp
+    config.override_test_values(arg_map, schema_name, index)
+    arg_populations = []
+    for arg_name, arg_value in arg_map.items():
+        arg_populations.append(f'auto {arg_name}{index} = {arg_value}')
+    return ";\n    ".join(arg_populations) + ";"
+
+def generate_test_value_names(g: NativeFunctionsGroup, index: int) -> str:
+    schema = g.functional.func
+    assert not schema.is_out_fn()
+    return ",".join(f"{arg.name}{index}" for arg in schema.schema_order_arguments())
+
+generate_test_ir_arguments_base_ty_to_type_str_ = {
+    BaseTy.Tensor: 'Tensor', BaseTy.int: 'int', BaseTy.float: 'float',
+    BaseTy.str: 'str', BaseTy.Scalar: 'int', BaseTy.ScalarType: 'int',
+    BaseTy.bool: 'bool'}
+
+def generate_test_ir_arguments(g: NativeFunctionsGroup) -> List[Tuple[str, Optional[str]]]:
+    def ir_argument(arg: Argument) -> Tuple[str, Optional[str]]:
+        t = arg.type
+        add_optional = False
+        if isinstance(t, OptionalType):
+            t = t.elem
+            add_optional = True
+        assert isinstance(t, BaseType)
+        type_str = None
+        if t.name in generate_test_ir_arguments_base_ty_to_type_str_:
+            type_str = generate_test_ir_arguments_base_ty_to_type_str_[t.name]
+        if type_str and add_optional:
+            type_str = f'{type_str}?'
+        return ("%" + arg.name, type_str)
+
+    schema = g.functional.func
+    assert not schema.is_out_fn()
+    return [ir_argument(arg) for arg in schema.schema_order_arguments()]
+
+def generate_arg_extraction(g: NativeFunctionsGroup) -> str:
+    schema = g.functional.func
+    assert not schema.is_out_fn()
+    arg_populations = []
+    for i, arg in enumerate(schema.schema_order_arguments()):
+        maybe_method = ivalue_type_conversion_method(arg.type)
+        assert maybe_method
+        is_reference, type_conversion_method = maybe_method
+        reference = "&" if is_reference else ""
+        arg_populations.append(f'const auto{reference} {arg.name} = p_node->Input({i}).{type_conversion_method}')
+    return ";\n    ".join(arg_populations) + ";"
+
+def generate_non_out_variant_call(g: NativeFunctionsGroup) -> str:
+    schema = g.functional.func
+    assert not schema.is_out_fn()
+    arg_names = (arg.name for arg in schema.schema_order_arguments())
+    return f'at::cpu::{cpp.name(schema)}({",".join(arg_names)})'
+
+def generate_out_variant_call(g: NativeFunctionsGroup) -> str:
+    schema = g.out.func
+    assert schema.is_out_fn()
+    arg_names = [out_arg.name for out_arg in schema.arguments.out]
+    for arg in schema.arguments.non_out:
+        if isinstance(arg, SelfArgument):
+            arg_names.append(arg.argument.name)
+        else:
+            assert isinstance(arg, Argument)
+            arg_names.append(arg.name)
+    cpp_func_name = cpp.name(schema)
+    cpp_arg_names = ",".join(arg_names)
+    return f'at::cpu::{cpp_func_name}({cpp_arg_names})'
+
+
+def should_check_resize(schema: FunctionSchema) -> bool:
+    schema_str = str(schema)
+    type_variant_op_name = schema_str[: schema_str.find("(")]
+    return type_variant_op_name not in ("isin.Scalar_Tensor", "index_add")
+
+
+def op_name_from_group(g: NativeFunctionsGroup) -> str:
+    return g.functional.func.name.name.base
+
+
+class GenOutVariantDispatcher:
+    def __call__(self, groups: Sequence[NativeFunctionsGroup]) -> str:
+        if not groups:
+            return ""
+        generated_type_variants = []
+        for g in groups:
+            with native_function_manager(g):
+                assert is_supported(g)
+                assert isinstance(g, NativeFunctionsGroup)
+                generated_type_variant = self.gen_structured(g)
+                generated_type_variants.append(generated_type_variant)
+        op_name = op_name_from_group(groups[0])
+        body = "\n".join(generated_type_variants)
+        generated = f"""
+REGISTER_OPERATOR_FUNCTOR(
+    aten::{op_name},
+    aten_{op_name},
+    [](Node* n) -> SROperator {{
+      {body}
+      LogAndDumpSchema(n);
+      return nullptr;
+    }});
+"""
+        return generated
+
+    def gen_structured(self, g: NativeFunctionsGroup) -> str:
+        functional = g.functional
+        schema = str(functional.func)
+        op_name = op_name_from_group(g)
+        populated_argument = generate_arg_extraction(g)
+        functional_variant_call = generate_non_out_variant_call(g)
+        assert len(g.out.func.arguments.out) == 1
+        out_variable_name = str(g.out.func.arguments.out[0].name)
+        out_variant_call = generate_out_variant_call(g)
+        generated = f"""
+      if (n->matches(torch::schema("aten::{schema}"))) {{
+        return [](ProcessedNode* p_node) {{
+          {populated_argument}
+          if (p_node->Output(0).isNone()) {{
+            p_node->Output(0) = {functional_variant_call};
+            return;
+          }}
+          auto& {out_variable_name} = p_node->Output(0).toTensor();
+          fastResizeToZero({out_variable_name});
+          {out_variant_call};
+        }};
+      }}"""
+        return generated
+
+
+class GenOutVariantDispatcherTestCase:
+    def __call__(self, groups: Sequence[NativeFunctionsGroup]) -> str:
+        if not groups:
+            return ""
+        generated_type_variants = []
+        for g in groups:
+            with native_function_manager(g):
+                assert is_supported(g)
+                assert isinstance(g, NativeFunctionsGroup)
+                generated_type_variant = self.gen_structured_test_case(g)
+                generated_type_variants.append(generated_type_variant)
+        return "\n".join(generated_type_variants)
+
+    def gen_structured_test_case(self, g: NativeFunctionsGroup) -> str:
+        functional = g.functional
+        schema = str(functional.func)
+        assert schema.find("(") > 0
+        type_variant_op_name = schema[: schema.find("(")].replace(".", "_")
+        op_name = op_name_from_group(g)
+        assert type_variant_op_name.startswith(op_name)
+
+        arg_types = generate_test_ir_arguments(g)
+        arg_declarations = ", ".join((arg_name if arg_type is None
+                                      else f"{arg_name}: {arg_type}"
+                                      for arg_name, arg_type in arg_types))
+        arg_names = ", ".join((arg_name for arg_name, _ in arg_types))
+        assert (len(functional.func.returns) == 1 and isinstance(functional.func.returns[0].type, BaseType) and
+                functional.func.returns[0].type.name is BaseTy.Tensor)
+        test_value_definitions = generate_test_value_definitions(g, 0)
+        test_value_names = generate_test_value_names(g, 0)
+        test_value_definitions2 = generate_test_value_definitions(g, 1)
+        test_value_names2 = generate_test_value_names(g, 1)
+        check_resize = "true" if should_check_resize(functional.func) else "false"
+        generated = f"""
+TEST(StaticRuntime, autogen_{type_variant_op_name}) {{
+  const std::string script = R"IR(
+    graph({arg_declarations}):
+        %bias: None = prim::Constant()
+        %ret = aten::{op_name}({arg_names})
+        %cloned = aten::clone(%ret, %bias)
+        return (%cloned)
+  )IR";
+
+  {test_value_definitions}
+  std::vector<IValue> args{{{test_value_names}}};
+  testStaticRuntime(script, args, {{}}, /*use_allclose=*/false, /*use_equalnan=*/false, /*check_resize=*/{check_resize});
+
+  {test_value_definitions2}
+  std::vector<IValue> args2{{{test_value_names2}}};
+  testStaticRuntime(script, args, args2, /*use_allclose=*/false, /*use_equalnan=*/false, /*check_resize=*/{check_resize});
+
+}}
+"""
+        return generated


### PR DESCRIPTION
Summary:
This change adds a script to auto-generate out variant dispatchers from `caffe2/aten/src/ATen/native/native_functions.yaml`.

This script lays down a basic infrastructure to generate

- a set of "out variant" ops (equivalent to hand-written ones in ops.cpp (https://www.internalfb.com/code/fbsource/[6e3f17579ebe]/fbcode/caffe2/torch/csrc/jit/runtime/static/ops.cpp))

- a set of unittests that exercise the auto-generated out variant dispatchers via Static Runtime (equivalent to op unittests in test_static_runtime.cpp at https://www.internalfb.com/code/fbsource/[6e3f17579ebe]/fbcode/caffe2/benchmarks/static_runtime/test_static_runtime.cc).

Note that this script only covers a small subset of ops specified in `caffe2/aten/src/ATen/native/native_functions.yaml`. Out of 1518 ops described in the yaml file, the code-generation logic implemented in this change only covers 133 of them. Here's the detailed statistics printed out by this script as an output from generating code:

```
total grouped native ops: 1518
structured grouped native ops: 538
generated grouped native ops: 133
```

This means that 1518 op groups are described in `native_functions.yaml`, and 538 of them are "structured" kernels (https://github.com/pytorch/rfcs/blob/rfc-0005/RFC-0005-structured-kernel-definitions.md) which guarantee that they have a well-defined out variant.

This change limits the scope of its coverage only to 133 of the 538 structured ops, with an intention to expand its scope to all the rest structures ops in the near future. `gen_structured.is_supported` function describes what ops are currently supported for generating out variant dispatchers.

**Unittest Generation**

A major source of complications in generating unittests for auto-generated out variant dispatchers is to generate input values that conform to ops's requirements. 11 ops out of the 133 auto-generated ones needed hand-picked input values to pass the tests. See `README` file for how to use hand-picked values.

**Initial Impact**

The number of the out variant dispatchers generated by this diff is 133, which increases the out variant coverage by 309% (current: 43, this diff: 133 + 43 = 176). This number is expected to increase a lot as we develop this script further to cover more ops.

**Future work**

I'm aiming at expanding the op coverage to include all 538 structured ops.

Test Plan: The following diff, D33373928, adds out variant dispatchers generated by this diff.

Differential Revision: D33373919

