### PR TITLE
Move debug_util and python_util to torch/csrc/lazy

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -387,6 +387,7 @@ lazy_tensor_core_sources = [
     "torch/csrc/lazy/backend/backend_interface.cpp",
     "torch/csrc/lazy/backend/lowering_context.cpp",
     "torch/csrc/lazy/core/config.cpp",
+    "torch/csrc/lazy/core/debug_util.cpp",
     "torch/csrc/lazy/core/hash.cpp",
     "torch/csrc/lazy/core/helpers.cpp",
     "torch/csrc/lazy/core/ir.cpp",
@@ -424,6 +425,11 @@ lazy_tensor_core_sources = [
     "torch/csrc/lazy/ts_backend/ops/generic.cpp",
     "torch/csrc/lazy/ts_backend/ops/scalar.cpp",
     "torch/csrc/lazy/ts_backend/ts_node.cpp",
+]
+
+lazy_tensor_core_python_sources = [
+    "torch/csrc/lazy/python/init.cpp",
+    "torch/csrc/lazy/python/python_util.cpp",
 ]
 
 libtorch_core_sources = sorted(
@@ -885,7 +891,7 @@ libtorch_python_core_sources = [
     "torch/csrc/utils/tensor_numpy.cpp",
     "torch/csrc/utils/tensor_types.cpp",
     "torch/csrc/utils/disable_torch_function.cpp",
-]
+] + lazy_tensor_core_python_sources
 
 libtorch_python_distributed_core_sources = [
     "torch/csrc/distributed/c10d/init.cpp",

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -58,6 +58,7 @@
 #include <torch/csrc/utils/crash_handler.h>
 #include <torch/csrc/utils/python_arg_parser.h>
 #include <torch/csrc/utils/pycfunction_helpers.h>
+#include <torch/csrc/lazy/python/init.h>
 #include <torch/csrc/jit/python/python_tracer.h>
 #include <torch/csrc/jit/python/init.h>
 #include <torch/csrc/jit/python/python_ir.h>
@@ -845,6 +846,7 @@ PyObject* initModule() {
   torch::autograd::initSpecialFunctions(module);
   torch::autograd::init_legacy_variable(module);
   torch::python::init_bindings(module);
+  torch::lazy::initLazyBindings(module);
 #ifdef USE_CUDA
   torch::cuda::initModule(module);
 #endif

--- a/torch/csrc/lazy/core/debug_util.cpp
+++ b/torch/csrc/lazy/core/debug_util.cpp
@@ -1,0 +1,149 @@
+#include <torch/csrc/lazy/core/debug_util.h>
+
+#include <torch/csrc/lazy/backend/backend_device.h>
+#include <torch/csrc/lazy/core/helpers.h>
+#include <torch/csrc/lazy/core/ir.h>
+#include <torch/csrc/lazy/core/ir_dump_util.h>
+#include <torch/csrc/lazy/core/ir_util.h>
+#include <torch/csrc/lazy/core/unique.h>
+
+#include <fstream>
+#include <mutex>
+#include <sstream>
+#include <unordered_set>
+
+namespace torch {
+namespace lazy {
+namespace  {
+
+std::string GetEnvString(const char* name, const std::string& defval) {
+  const char* env = std::getenv(name);
+  return env != nullptr ? env : defval;
+}
+
+DebugUtil::GraphFormat DefaultGraphFormat() {
+  std::string fmt_str = GetEnvString("LTC_SAVE_TENSORS_FMT", "text");
+  if (fmt_str == "text") {
+    return DebugUtil::GraphFormat::kText;
+  } else if (fmt_str == "backend") {
+    return DebugUtil::GraphFormat::kBackend;
+  } else if (fmt_str == "dot") {
+    return DebugUtil::GraphFormat::kDot;
+  }
+  LOG(ERROR) << "Invalid save graph format: " << fmt_str;
+  return DebugUtil::GraphFormat::kText;
+}
+
+std::unordered_set<std::string>* LoadExperiments() {
+  std::unique_ptr<std::unordered_set<std::string>> xset =
+      std::make_unique<std::unordered_set<std::string>>();
+  std::string experiments = GetEnvString("LTC_EXPERIMENTAL", "");
+  std::vector<std::string> experiment_list =
+      torch::lazy::StrSplit(experiments, ':');
+  for (auto& name : experiment_list) {
+    xset->insert(name);
+  }
+  return xset.release();
+}
+
+}  // namespace
+
+std::vector<SourceLocation> NoPythonFrames(){
+  SourceLocation dummy_loc;
+  dummy_loc.file = "No Python Frames";
+  return {dummy_loc};
+}
+
+std::function<std::vector<SourceLocation>()>& GetPythonFramesFunction() {
+  static std::function<std::vector<SourceLocation>()> func_ = NoPythonFrames;
+  return func_;
+}
+
+DebugUtil::GraphFormat DebugUtil::GetDefaultGraphFormat() {
+  static GraphFormat format = DefaultGraphFormat();
+  return format;
+}
+
+std::string DebugUtil::GetTensorsGraphInfo(c10::ArrayRef<torch::lazy::LazyTensor> tensors,
+                                           const std::vector<size_t>* indices,
+                                           GraphFormat format) {
+  std::vector<torch::lazy::Node*> root_nodes;
+  std::vector<torch::lazy::Value> root_values;
+  std::vector<torch::lazy::hash_t> root_hashes;
+  torch::lazy::Unique<torch::lazy::BackendDevice> unique_device;
+  if (indices != nullptr) {
+    for (auto index : *indices) {
+      const torch::lazy::LazyTensor& tensor = tensors[index];
+      torch::lazy::Value ir_value = tensor.CurrentIrValue();
+      if (ir_value) {
+        root_nodes.push_back(ir_value.node.get());
+        root_hashes.push_back(ir_value.hash());
+        root_values.push_back(std::move(ir_value));
+        unique_device.set(tensor.GetDevice());
+      }
+    }
+  } else {
+    for (auto& tensor : tensors) {
+      torch::lazy::Value ir_value = tensor.CurrentIrValue();
+      if (ir_value) {
+        root_nodes.push_back(ir_value.node.get());
+        root_hashes.push_back(ir_value.hash());
+        root_values.push_back(std::move(ir_value));
+        unique_device.set(tensor.GetDevice());
+      }
+    }
+  }
+  std::stringstream ss;
+  // Call into a function pointer that may backed by python or empty depending on runtime
+  std::vector<SourceLocation> frames = GetPythonFramesFunction()();
+  ss << "Python Stacktrace:\n";
+  for (auto& location : frames) {
+    ss << "  " << location.function << " (" << location.file << ":"
+       << location.line << ")\n";
+  }
+  ss << "\nHashes: (";
+  for (size_t i = 0; i < root_hashes.size(); ++i) {
+    if (i > 0) {
+      ss << ", ";
+    }
+    ss << torch::lazy::HashToString(root_hashes[i]);
+  }
+  ss << ")\n";
+
+  std::string graph_str;
+  if (format == GraphFormat::kText) {
+    graph_str = torch::lazy::DumpUtil::ToText(root_nodes);
+  } else if (format == GraphFormat::kDot) {
+    graph_str = torch::lazy::DumpUtil::ToDot(root_nodes);
+  } else if (format == GraphFormat::kBackend) {
+    graph_str = torch::lazy::DumpUtil::ToBackend(
+        root_values,
+        unique_device ? *unique_device : torch::lazy::BackendDevice());
+  } else {
+    LOG(ERROR) << "Invalid graph format: " << format;
+  }
+  ss << "\n## BEGIN_GRAPH\n" << graph_str << "\n## END_GRAPH\n\n";
+  return ss.str();
+}
+
+void DebugUtil::SaveTensorsGraphInfo(const char* name,
+                                     c10::ArrayRef<torch::lazy::LazyTensor> tensors,
+                                     const std::vector<size_t>* indices,
+                                     GraphFormat format) {
+  static const std::string save_file = GetEnvString("LTC_SAVE_TENSORS_FILE", "");
+  if (!save_file.empty()) {
+    static std::mutex lock;
+    std::string info = GetTensorsGraphInfo(tensors, indices, format);
+    std::lock_guard<std::mutex> guard(lock);
+    std::ofstream graph_file(save_file, std::ios_base::app);
+    graph_file << "[" << name << "]\n" << info << "\n";
+  }
+}
+
+bool DebugUtil::ExperimentEnabled(const std::string& name) {
+  static const std::unordered_set<std::string>* xset = LoadExperiments();
+  return xset->find(name) != xset->end();
+}
+
+}  // namespace lazy
+}  // namespace torch

--- a/torch/csrc/lazy/core/debug_util.h
+++ b/torch/csrc/lazy/core/debug_util.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <torch/csrc/lazy/core/tensor.h>
+
+namespace torch {
+namespace lazy {
+
+TORCH_API std::function<std::vector<SourceLocation>()>& GetPythonFramesFunction();
+
+class TORCH_API DebugUtil {
+ public:
+  enum GraphFormat {
+    kText,
+    kDot,
+    kBackend,
+  };
+
+  static GraphFormat GetDefaultGraphFormat();
+
+  // Dumps the current Python frame and the IR Graph whose roots are the IR
+  // values held at the tensors. If indices is not nullptr, it selects the
+  // indices of the tensors whose graph will be emitted.
+  static std::string GetTensorsGraphInfo(
+      c10::ArrayRef<torch::lazy::LazyTensor> tensors, const std::vector<size_t>* indices,
+      GraphFormat format = GetDefaultGraphFormat());
+
+  // If the environment variable LTC_SAVE_TENSORS_FILE is set to the proper
+  // output path, an instance of the report returned by GetTensorsGraphInfo() is
+  // saved.
+  static void SaveTensorsGraphInfo(
+      const char* name, c10::ArrayRef<torch::lazy::LazyTensor> tensors,
+      const std::vector<size_t>* indices,
+      GraphFormat format = GetDefaultGraphFormat());
+
+  static bool ExperimentEnabled(const std::string& name);
+};
+
+
+}  // namespace lazy
+}  // namespace torch

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -10,8 +10,7 @@
 #include <torch/csrc/lazy/core/tensor_util.h>
 #include <torch/csrc/lazy/core/unique.h>
 
-// TODO: DebugUtil will be upstreamed after LazyTensor is in.
-// #include <">lazy_tensor_core/csrc/debug_util.h>
+#include <torch/csrc/lazy/core/debug_util.h>
 #include <torch/csrc/lazy/core/metrics.h>
 #include <torch/csrc/lazy/core/thread_pool.h>
 #include <torch/csrc/lazy/ts_backend/ops/arithmetic_ir_ops.h>
@@ -892,8 +891,8 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
   if (coll.indices.empty()) {
     return nullptr;
   }
-  // DebugUtil::SaveTensorsGraphInfo("ScheduleSyncTensorsGraph", *tensors,
-  //                                &coll.indices);
+  DebugUtil::SaveTensorsGraphInfo("ScheduleSyncTensorsGraph", *tensors,
+                                 &coll.indices);
 
   PostOrderData po_data = RunPostOrder(*tensors, coll.indices);
   coll.hash = HashCombine(coll.hash, Hash(po_data.parameter_sequence));

--- a/torch/csrc/lazy/python/README.md
+++ b/torch/csrc/lazy/python/README.md
@@ -1,0 +1,10 @@
+# Lazy Tensor Python Code
+
+Lazy Tensor Core is part of libtorch, which can not depend on python.
+
+Parts of lazy tensor core use python for 2 purposes
+A) py bindings let python programs call into lazy tensor c++ code
+B) lazy tensor core calls into python to use it (e.g. for grabbing stack traces)
+
+(A) is trivial since the python bindings only depend on libtorch;
+(B) requires making libtorch_python register a function with libtorch if loaded, and having a default (no-op) function otherwise.  Any functionality that strictly needs to depend on python should be part of the 'python' folder.

--- a/torch/csrc/lazy/python/init.cpp
+++ b/torch/csrc/lazy/python/init.cpp
@@ -1,0 +1,21 @@
+#include <torch/csrc/lazy/python/init.h>
+
+#include <torch/csrc/lazy/core/debug_util.h>
+#include <torch/csrc/lazy/python/python_util.h>
+
+namespace torch {
+namespace lazy {
+
+void initLazyBindings(PyObject* /* module */){
+#ifndef USE_DEPLOY
+  // When libtorch_python is loaded, we register the python frame getter
+  // otherwise, debug util simply omits python frames
+  // TODO(whc) can we make this work inside torch deploy interpreter?
+  // it doesn't work as-is, possibly becuase GetPythonFrames resolves to external
+  // cpython rather than embedded cpython
+  GetPythonFramesFunction() = GetPythonFrames;
+#endif
+}
+
+}  // namespace lazy
+}  // namespace torch

--- a/torch/csrc/lazy/python/init.h
+++ b/torch/csrc/lazy/python/init.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <c10/macros/Export.h>
+#include <pybind11/pybind11.h>
+
+namespace torch {
+namespace lazy {
+
+TORCH_API void initLazyBindings(PyObject* module);
+
+}  // namespace lazy
+}  // namespace torch

--- a/torch/csrc/lazy/python/python_util.cpp
+++ b/torch/csrc/lazy/python/python_util.cpp
@@ -1,0 +1,46 @@
+#include <torch/csrc/lazy/python/python_util.h>
+
+#include <Python.h>
+#include <frameobject.h>
+#include <pybind11/pybind11.h>
+#include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/lazy/core/debug_util.h>
+
+namespace torch {
+namespace lazy {
+
+c10::optional<SourceLocation> GetPythonFrameTop() {
+  if (!Py_IsInitialized()) {
+    return c10::nullopt;
+  }
+  pybind11::gil_scoped_acquire gil;
+  PyFrameObject* frame = PyEval_GetFrame();
+  if (frame == nullptr) {
+    return c10::nullopt;
+  }
+  SourceLocation loc;
+  loc.line = PyCode_Addr2Line(frame->f_code, frame->f_lasti);
+  loc.file = THPUtils_unpackString(frame->f_code->co_filename);
+  loc.function = THPUtils_unpackString(frame->f_code->co_name);
+  return loc;
+}
+
+std::vector<SourceLocation> GetPythonFrames() {
+  std::vector<SourceLocation> frames;
+  if (Py_IsInitialized()) {
+    pybind11::gil_scoped_acquire gil;
+    PyFrameObject* frame = PyEval_GetFrame();
+    while (frame != nullptr) {
+      SourceLocation loc;
+      loc.line = PyCode_Addr2Line(frame->f_code, frame->f_lasti);
+      loc.file = THPUtils_unpackString(frame->f_code->co_filename);
+      loc.function = THPUtils_unpackString(frame->f_code->co_name);
+      frames.push_back(std::move(loc));
+      frame = frame->f_back;
+    }
+  }
+  return frames;
+}
+
+}  // namespace lazy
+}  // namespace torch

--- a/torch/csrc/lazy/python/python_util.h
+++ b/torch/csrc/lazy/python/python_util.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <c10/macros/Export.h>
+#include <c10/util/Optional.h>
+#include <torch/csrc/lazy/core/ir_metadata.h>
+#include <vector>
+
+namespace torch {
+namespace lazy {
+
+c10::optional<SourceLocation> TORCH_API GetPythonFrameTop();
+
+std::vector<SourceLocation> TORCH_API GetPythonFrames();
+
+}  // namespace lazy
+}  // namespace torch


### PR DESCRIPTION
Summary:
since python isn't available from libtorch, most of lazy tensor
code can't depend on python.
separate python_util into libtorch_python library
make debug_util and IR dump work with or without python by providing
a default function for 'maybe getting python stacktrace' that returns
an empty stacktrace
use a registration mechanism on libtorch_python library load to update
the 'maybe' function to use the real python stacktrace getter

Test Plan:
OSS build tests:
- test_ptltc by itself works
- LTC_SAVE_TENSORS_FILE=log test_ptltc works, and log contains
empty stacktrces
- python examply.py by itself works
- LTC_SAVE_TENSORS_FILE=log test_ptltc works, and log contains
real stacktraces

fbcode build: rely on CI to run test/lazy

Differential Revision: D34115046

