### PR TITLE
[LTS] Skip TestSerialization.test_lstm if avx512_vnni supported 

### DIFF
--- a/test/quantization/test_backward_compatibility.py
+++ b/test/quantization/test_backward_compatibility.py
@@ -2,7 +2,7 @@
 
 import sys
 import os
-
+import unittest
 # torch
 import torch
 import torch.nn as nn
@@ -11,7 +11,7 @@ import torch.nn.quantized.dynamic as nnqd
 import torch.nn.intrinsic.quantized as nniq
 
 # Testing utils
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import TestCase, IS_AVX512_VNNI_SUPPORTED
 from torch.testing._internal.common_quantized import override_qengines, qengine_is_fbgemm
 
 def remove_prefix(text, prefix):
@@ -216,6 +216,7 @@ class TestSerialization(TestCase):
             # TODO: graph mode quantized conv3d module
 
     @override_qengines
+    @unittest.skipIf(IS_AVX512_VNNI_SUPPORTED, "This test fails on machines with AVX512_VNNI support. Ref: GH Issue 59098")
     def test_lstm(self):
         class LSTMModule(torch.nn.Module):
             def __init__(self):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -299,6 +299,15 @@ IS_WINDOWS = sys.platform == "win32"
 IS_MACOS = sys.platform == "darwin"
 IS_PPC = platform.machine() == "ppc64le"
 
+def is_avx512_vnni_supported():
+    if sys.platform != 'linux':
+        return False
+    with open("/proc/cpuinfo", encoding="ascii") as f:
+        lines = f.read()
+    return "vnni" in lines
+
+IS_AVX512_VNNI_SUPPORTED = is_avx512_vnni_supported()
+
 if IS_WINDOWS:
     @contextmanager
     def TemporaryFileName(*args, **kwargs):


### PR DESCRIPTION
This PR skips `TestSerialization.test_lstm` if the cpu supports the `avx512_vnni` instruction set. From issue it is known that `test_lstm` in `quantization.test_backward_compatibility.TestSerialization` fails on devices that support the `avx512_vnni` instruction set. 

The changes are made combining the skipping logic from commits 9e53c823b8ce7c04a310bde621197001753a63af and 3282386aa40c90ba68cae892dd2f3896610b14ce from the master branch.

