### PR TITLE
Ensure all modules in the dict are instance instead of class

### DIFF
--- a/test/jit/fixtures_srcs/generate_models.py
+++ b/test/jit/fixtures_srcs/generate_models.py
@@ -171,7 +171,7 @@ def generate_models(model_directory_path: Path):
                 f"The module {torch_module_name} "
                 f"is not a torch.nn.module instance. "
                 f"Please ensure it's a subclass of torch.nn.module in fixtures_src.py"
-                f"and it's registered as a instance in ALL_MODULES in generated_models.py")
+                f"and it's registered as an instance in ALL_MODULES in generated_models.py")
 
 
         # The corresponding model name is: test_versioned_div_tensor_example_v4

--- a/test/jit/fixtures_srcs/generate_models.py
+++ b/test/jit/fixtures_srcs/generate_models.py
@@ -163,9 +163,16 @@ likely this script is running with the commit to make the change.
 def generate_models(model_directory_path: Path):
     all_models = get_all_models(model_directory_path)
     for a_module, expect_operator in ALL_MODULES.items():
-        print(a_module, expect_operator)
         # For example: TestVersionedDivTensorExampleV7
         torch_module_name = type(a_module).__name__
+
+        if not isinstance(a_module, torch.nn.Module):
+            logger.error(
+                f"The module {torch_module_name} "
+                f"is not a torch.nn.module instance. "
+                f"Please ensure it's a subclass of torch.nn.module in fixtures_src.py"
+                f"and it's registered as a instance in ALL_MODULES in generated_models.py")
+
 
         # The corresponding model name is: test_versioned_div_tensor_example_v4
         model_name = ''.join([

--- a/test/jit/fixtures_srcs/test_upgrader_models_generation.py
+++ b/test/jit/fixtures_srcs/test_upgrader_models_generation.py
@@ -5,13 +5,6 @@ from test.jit.fixtures_srcs.generate_models import ALL_MODULES
 from torch.testing._internal.common_utils import TestCase, run_tests
 
 
-if __name__ == "__main__":
-    raise RuntimeError(
-        "This test file is not meant to be run directly, use:\n\n"
-        "\tpython test/test_jit.py TESTNAME\n\n"
-        "instead."
-    )
-
 class TestUpgraderModelGeneration(TestCase):
     def test_all_modules(self):
         for a_module, expect_operator in ALL_MODULES.items():

--- a/test/jit/fixtures_srcs/test_upgrader_models_generation.py
+++ b/test/jit/fixtures_srcs/test_upgrader_models_generation.py
@@ -1,0 +1,18 @@
+# Owner(s): ["oncall: mobile"]
+
+import torch
+from test.jit.fixtures_srcs.fixtures_src import generate_models
+from unittest import TestCase
+
+
+if __name__ == "__main__":
+    raise RuntimeError(
+        "This test file is not meant to be run directly, use:\n\n"
+        "\tpython test/test_jit.py TESTNAME\n\n"
+        "instead."
+    )
+
+class TestTyping(TestCase):
+    def test_all_modules(self):
+        for a_module, expect_operator in generate_models.ALL_MODULES.items():
+            self.assertEqual(isinstance(a_module, torch.nn.Module))

--- a/test/jit/fixtures_srcs/test_upgrader_models_generation.py
+++ b/test/jit/fixtures_srcs/test_upgrader_models_generation.py
@@ -1,8 +1,8 @@
 # Owner(s): ["oncall: mobile"]
 
 import torch
-from test.jit.fixtures_srcs.fixtures_src import generate_models
-from unittest import TestCase
+from test.jit.fixtures_srcs.generate_models import ALL_MODULES
+from torch.testing._internal.common_utils import TestCase, run_tests
 
 
 if __name__ == "__main__":
@@ -12,7 +12,16 @@ if __name__ == "__main__":
         "instead."
     )
 
-class TestTyping(TestCase):
+class TestUpgraderModelGeneration(TestCase):
     def test_all_modules(self):
-        for a_module, expect_operator in generate_models.ALL_MODULES.items():
-            self.assertEqual(isinstance(a_module, torch.nn.Module))
+        for a_module, expect_operator in ALL_MODULES.items():
+            module_name = type(a_module).__name__
+            self.assertTrue(
+                isinstance(a_module, torch.nn.Module),
+                f"The module {module_name} "
+                f"is not a torch.nn.module instance. "
+                f"Please ensure it's a subclass of torch.nn.module in fixtures_src.py"
+                f"and it's registered as an instance in ALL_MODULES in generated_models.py")
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #72470
* __->__ #72615

1. Add unit test to ensure the key in `ALL_MODULES` is an instance
2. In `generate_models.py`, add a check to ensure the key is an instance of `torch.nn.Module`.



Differential Revision: [D34116938](https://our.internmc.facebook.com/intern/diff/D34116938/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D34116938/)!

Differential Revision: [D34116938](https://our.internmc.facebook.com/intern/diff/D34116938)