### PR TITLE
[JIT] add pass to cast inputs of specified ops to float

### DIFF
--- a/torch/csrc/jit/passes/autocast.h
+++ b/torch/csrc/jit/passes/autocast.h
@@ -7,6 +7,9 @@ namespace torch {
 namespace jit {
 
 TORCH_API void Autocast(const std::shared_ptr<Graph>& graph);
+TORCH_API void CastOpsToFloat(
+    std::shared_ptr<Graph>& graph,
+    const std::vector<Symbol>& ops);
 
 TORCH_API bool setAutocastMode(bool value);
 TORCH_API bool autocastEnabled();

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -283,6 +283,19 @@ void initJITBindings(PyObject* module) {
       .def("_jit_pass_onnx_set_dynamic_input_shape", ONNXSetDynamicInputShape)
       .def("_jit_pass_autocast", Autocast)
       .def("_jit_set_autocast_mode", &setAutocastMode)
+      .def(
+          "_jit_pass_cast_ops_to_float",
+          [](std::shared_ptr<Graph>& g, std::vector<std::string>& op_names) {
+            std::vector<Symbol> op_symbols;
+            std::transform(
+                op_names.begin(),
+                op_names.end(),
+                std::back_inserter(op_symbols),
+                [](const std::string& name) {
+                  return Symbol::fromQualString(name);
+                });
+            CastOpsToFloat(g, op_symbols);
+          })
       .def("_jit_pass_onnx_lint", ONNXLintGraph)
       .def("_jit_pass_onnx_function_extraction", onnx::ONNXFunctionExtraction)
       .def("_jit_pass_fuse", FuseGraph)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72641

This pass will allow for casting the inputs to specific ops to float. One application of this is with autocasting: there can be custom ops, or unsupported ops, that might not support fp16.

Differential Revision: [D34113007](https://our.internmc.facebook.com/intern/diff/D34113007/)