### PR TITLE
[ao] bugfix for big tensors quantize to 0

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2938,7 +2938,7 @@ void quantize_tensor_per_tensor_affine_cpu(
     int64_t zero_point) {
   check_tensor_memory_format(rtensor, qtensor);
   const float* rdata = rtensor.data_ptr<float>();
-  int numel = rtensor.numel();
+  auto numel = rtensor.numel();
 #if defined(__ARM_NEON__) || defined(__aarch64__)
   AT_DISPATCH_QINT_TYPES(
       qtensor.scalar_type(), "quantize_tensor_per_tensor_affine_cpu", [&]() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72645

previously the test case would quantize the entire tensor to 0's when the number of tensor elements was greater than int32 max, this PR fixes that by changing the element indexer to use int64 rather than int32.

Differential Revision: [D33844167](https://our.internmc.facebook.com/intern/diff/D33844167/)