### PR TITLE
Fix tagged build detection for binary builds (#72628)

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -5,7 +5,7 @@ export TZ=UTC
 tagged_version() {
   # Grabs version from either the env variable CIRCLE_TAG
   # or the pytorch git described version
-  if [[ "$OSTYPE" == "msys" ]]; then
+  if [[ "$OSTYPE" == "msys" &&  -z "${IS_GHA:-}" ]]; then
     GIT_DIR="${workdir}/p/.git"
   else
     GIT_DIR="${workdir}/pytorch/.git"
@@ -13,6 +13,9 @@ tagged_version() {
   GIT_DESCRIBE="git --git-dir ${GIT_DIR} describe --tags --match v[0-9]*.[0-9]*.[0-9]*"
   if [[ -n "${CIRCLE_TAG:-}" ]]; then
     echo "${CIRCLE_TAG}"
+  elif [[ ! -d "${GIT_DIR}" ]]; then
+    echo "Abort, abort! Git dir ${GIT_DIR} does not exists!"
+    kill $$
   elif ${GIT_DESCRIBE} --exact >/dev/null; then
     ${GIT_DESCRIBE}
   else
@@ -58,7 +61,12 @@ if [[ -z ${IS_GHA:-} ]]; then
   fi
 else
   envfile=${BINARY_ENV_FILE:-/tmp/env}
-  workdir="/pytorch"
+  if [[ -n "${PYTORCH_ROOT}"  ]]; then
+    workdir=$(dirname "${PYTORCH_ROOT}")
+  else
+    # docker executor (binary builds)
+    workdir="/"
+  fi
 fi
 
 if [[ "$PACKAGE_TYPE" == 'libtorch' ]]; then


### PR DESCRIPTION
Summary:
Should fix the following [error](https://github.com/pytorch/pytorch/runs/5058514346#step:13:88):
```
+ git --git-dir /pytorch/pytorch/.git describe --tags --match 'v[0-9]*.[0-9]*.[0-9]*' --exact
fatal: not a git repository: '/pytorch/pytorch/.git'
```
By setting `workdir` correctly for GHA linux and Windows builds

Also, abort `tagged_version` if GIT_DIR does not exist (as this script should only be executed in context of git folder.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/72628

Reviewed By: atalman

Differential Revision: D34120721

Pulled By: malfet

fbshipit-source-id: 035e93e243e601f9c24659cd247f9c029210fba5
(cherry picked from commit 3a6c97b6ddb185d706494f64423a761fee8fce09)
(cherry picked from commit b6df02bbbb5b786b198938ffb5d90fa5251df3eb)

