### PR TITLE
[caffe2] Allow LpNorm to accept empty tensor

### DIFF
--- a/caffe2/operators/lpnorm_op.cc
+++ b/caffe2/operators/lpnorm_op.cc
@@ -13,7 +13,6 @@ bool LpNormOp<float, CPUContext>::RunOnDevice() {
   auto* norm = Output(0, {1}, at::dtype<float>());
   const float* X_data = X.data<float>();
   const float size = average_ ? (float)X.numel() : 1.0f;
-  CAFFE_ENFORCE_GT(size, 0);
   if (p_ == 1) {
     *(norm->template mutable_data<float>()) =
         (ConstEigenVectorMap<float>(X_data, X.numel()).array()).abs().sum() /

--- a/caffe2/python/operator_test/lpnorm_op_test.py
+++ b/caffe2/python/operator_test/lpnorm_op_test.py
@@ -11,13 +11,7 @@ import hypothesis.strategies as st
 
 
 class LpnormTest(hu.HypothesisTestCase):
-    @given(inputs=hu.tensors(n=1,
-                             min_dim=1,
-                             max_dim=3,
-                             dtype=np.float32),
-           **hu.gcs)
-    @settings(deadline=10000)
-    def test_Lp_Norm(self, inputs, gc, dc):
+    def _test_Lp_Norm(self, inputs, gc, dc):
         X = inputs[0]
         # avoid kinks by moving away from 0
         X += 0.02 * np.sign(X)
@@ -73,6 +67,21 @@ class LpnormTest(hu.HypothesisTestCase):
             rtol=1e-4,
             atol=1e-4
         )
+
+    @given(inputs=hu.tensors(n=1,
+                             min_dim=1,
+                             max_dim=3,
+                             dtype=np.float32),
+           **hu.gcs)
+    @settings(deadline=10000)
+    def test_Lp_Norm(self, inputs, gc, dc):
+        self._test_Lp_Norm(inputs, gc, dc)
+
+    def test_Lp_Norm_empty(self):
+        self._test_Lp_Norm([np.array([], dtype=np.float32)], hu.cpu_do, [hu.cpu_do])
+        self.assertEqual(self.ws.blobs["l1_norm"].fetch()[0], 0.0)
+        self.assertEqual(self.ws.blobs["l2_norm"].fetch()[0], 0.0)
+        self.assertTrue(np.isnan(self.ws.blobs["l2_averaged_norm"].fetch()[0]))
 
     @given(x=hu.tensor(
         min_dim=1, max_dim=10, dtype=np.float32,


### PR DESCRIPTION
Summary:
Sometimes it might happen when model gets an empty input.

For consistency with numpy and torch we should just return 0 without averaging or NaN with averaging.

Test Plan: Modified unittest

Differential Revision: D33782786

