### PR TITLE
Convert type comments to annotations in torch/nn

### DIFF
--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -544,8 +544,7 @@ class GRU(RNNBase):
     def _get_name(self):
         return 'DynamicQuantizedGRU'
 
-    def check_forward_args(self, input, hidden, batch_sizes):
-        # type: (Tensor, Tensor, Optional[Tensor])->None
+    def check_forward_args(self, input: Tensor, hidden: Tensor, batch_sizes: Optional[Tensor]) -> None:
         self.check_input(input, batch_sizes)
         expected_hidden_size = self.get_expected_hidden_size(input, batch_sizes)
 

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -153,8 +153,12 @@ class PackedSequence(PackedSequence_):
 
 # TorchScript doesn't support constructors on named tuples, so we use this helper
 # method to construct PackedSequence
-def _packed_sequence_init_args(data, batch_sizes=None, sorted_indices=None, unsorted_indices=None):
-    # type: (Tensor, Optional[Tensor], Optional[Tensor], Optional[Tensor]) -> Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]  # noqa: B950
+def _packed_sequence_init_args(
+    data: Tensor,
+    batch_sizes: Optional[Tensor] = None,
+    sorted_indices: Optional[Tensor] = None,
+    unsorted_indices: Optional[Tensor] = None,
+) -> Tuple[Tensor, Tensor, Optional[Tensor], Optional[Tensor]]:
     # NB: if unsorted_indices is provided, it should be the inverse permutation
     # to sorted_indices. Don't assert it here because the PackedSequence ctor
     # should only be used internally.
@@ -180,15 +184,18 @@ def _packed_sequence_init_args(data, batch_sizes=None, sorted_indices=None, unso
         return data[0], data[1], sorted_indices, unsorted_indices
 
 
-def _packed_sequence_init(data, batch_sizes=None, sorted_indices=None, unsorted_indices=None):
-    # type: (Tensor, Optional[Tensor], Optional[Tensor], Optional[Tensor]) -> PackedSequence
+def _packed_sequence_init(
+    data: Tensor,
+    batch_sizes: Optional[Tensor] = None,
+    sorted_indices: Optional[Tensor] = None,
+    unsorted_indices: Optional[Tensor] = None,
+) -> PackedSequence:
     data, batch_sizes, sorted_indices, unsorted_indices = _packed_sequence_init_args(
         data, batch_sizes, sorted_indices, unsorted_indices)
     return PackedSequence(data, batch_sizes, sorted_indices, unsorted_indices)
 
 
-def invert_permutation(permutation):
-    # type: (Optional[Tensor]) -> Optional[Tensor]
+def invert_permutation(permutation: Optional[Tensor]) -> Optional[Tensor]:
     if permutation is None:
         return None
     output = torch.empty_like(permutation, memory_format=torch.legacy_contiguous_format)
@@ -197,8 +204,12 @@ def invert_permutation(permutation):
     return output
 
 
-def pack_padded_sequence(input, lengths, batch_first=False, enforce_sorted=True):
-    # type: (Tensor, Tensor, bool, bool) -> PackedSequence
+def pack_padded_sequence(
+    input: Tensor,
+    lengths: Tensor,
+    batch_first: bool = False,
+    enforce_sorted: bool = True,
+) -> PackedSequence:
     r"""Packs a Tensor containing padded sequences of variable length.
 
     :attr:`input` can be of size ``T x B x *`` where `T` is the length of the
@@ -250,8 +261,12 @@ def pack_padded_sequence(input, lengths, batch_first=False, enforce_sorted=True)
     return _packed_sequence_init(data, batch_sizes, sorted_indices, None)
 
 
-def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0, total_length=None):
-    # type: (PackedSequence, bool, float, Optional[int]) -> Tuple[Tensor, Tensor]
+def pad_packed_sequence(
+    sequence: PackedSequence,
+    batch_first: bool = False,
+    padding_value: float = 0.0,
+    total_length: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
     r"""Pads a packed batch of variable length sequences.
 
     It is an inverse operation to :func:`pack_padded_sequence`.
@@ -320,8 +335,11 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0, total_le
     return padded_output, lengths
 
 
-def pad_sequence(sequences, batch_first=False, padding_value=0.0):
-    # type: (Union[List[Tensor], Tensor], bool, float) -> Tensor
+def pad_sequence(
+    sequences: Union[Tensor, List[Tensor]],
+    batch_first: bool = False,
+    padding_value: float = 0.0,
+) -> Tensor:
     r"""Pad a list of variable length Tensors with ``padding_value``
 
     ``pad_sequence`` stacks a list of Tensors along a new dimension,
@@ -378,8 +396,11 @@ def pad_sequence(sequences, batch_first=False, padding_value=0.0):
     return torch._C._nn.pad_sequence(sequences, batch_first, padding_value)
 
 
-def unpad_sequence(padded_sequences, lengths, batch_first=False):
-    # type: (Tensor, Tensor, bool) -> List[Tensor]
+def unpad_sequence(
+    padded_sequences: Tensor,
+    lengths: Tensor,
+    batch_first: bool = False,
+) -> List[Tensor]:
     r"""Unpad padded Tensor into a list of variable length Tensors
 
     ``unpad_sequence`` unstacks padded Tensor into a list of variable length Tensors.
@@ -425,8 +446,7 @@ def unpad_sequence(padded_sequences, lengths, batch_first=False):
     return unpadded_sequences
 
 
-def pack_sequence(sequences, enforce_sorted=True):
-    # type: (List[Tensor], bool) -> PackedSequence
+def pack_sequence(sequences: List[Tensor], enforce_sorted: bool = True) -> PackedSequence:
     r"""Packs a list of variable length Tensors
 
     Consecutive call of the next functions: ``pad_sequence``, ``pack_padded_sequence``.
@@ -462,8 +482,7 @@ def pack_sequence(sequences, enforce_sorted=True):
     return pack_padded_sequence(pad_sequence(sequences), lengths, enforce_sorted=enforce_sorted)
 
 
-def unpack_sequence(packed_sequences):
-    # type: (PackedSequence) -> List[Tensor]
+def unpack_sequence(packed_sequences: PackedSequence) -> List[Tensor]:
     r"""Unpacks PackedSequence into a list of variable length Tensors
 
     ``packed_sequences`` should be a PackedSequence object.


### PR DESCRIPTION
Summary:
This commit was produced by running
```
python -m libcst.tool codemod --no-format --jobs=1 convert_type_comments.ConvertTypeComments caffe2/torch/nn/ --no-quote-annotations
```
and then manually fixing unreadable lines by breaking up very
long function defintiion (unfortuantely
it's very difficult to fully automate tranforms of code that
isn't autoformatted).

Test Plan:
Wait for CI. This should be safe, the types all appear to be valid - but it's
always good to let the jit tests run, in some cases we find typing errors that
crash tests.

release notes:

Converts type comments to annotations.

topics:

Refactor

Differential Revision: D34147388

