### PR TITLE
[tools_common] Don't remove underscores from call_module targets in get_acc_ops_name

### DIFF
--- a/torch/fx/passes/tools_common.py
+++ b/torch/fx/passes/tools_common.py
@@ -23,7 +23,7 @@ def get_acc_ops_name(k):
         return f"acc_ops.{k.__name__}"
     else:
         module = k.__module__
-        return f"{module if module else ''}.{k.__name__}".replace('_', '')
+        return f"{module if module else ''}.{k.__name__}"
 
 
 @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Test Plan: CI.

Reviewed By: wushirong

Differential Revision: D34148357

