### PR TITLE
Convert type comments to annotations in caffe2/torch/util

### DIFF
--- a/torch/utils/benchmark/utils/common.py
+++ b/torch/utils/benchmark/utils/common.py
@@ -227,17 +227,17 @@ class Measurement:
         return "\n".join(l for l in repr_str.splitlines(keepends=False) if skip_line not in l)
 
     @staticmethod
-    def merge(measurements):  # type: (Iterable[Measurement]) -> List[Measurement]
+    def merge(measurements: Iterable["Measurement"]) -> List["Measurement"]:
         """Convenience method for merging replicates.
 
         Merge will extrapolate times to `number_per_run=1` and will not
         transfer any metadata. (Since it might differ between replicates)
         """
-        grouped_measurements: DefaultDict[TaskSpec, List[Measurement]] = collections.defaultdict(list)
+        grouped_measurements: DefaultDict[TaskSpec, List["Measurement"]] = collections.defaultdict(list)
         for m in measurements:
             grouped_measurements[m.task_spec].append(m)
 
-        def merge_group(task_spec: TaskSpec, group: List[Measurement]) -> Measurement:
+        def merge_group(task_spec: TaskSpec, group: List["Measurement"]) -> "Measurement":
             times: List[float] = []
             for m in group:
                 # Different measurements could have different `number_per_run`,

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -58,7 +58,7 @@ class FunctionCounts(object):
     def __len__(self) -> int:
         return len(self._data)
 
-    def __getitem__(self, item: Any) -> "Union[FunctionCount, FunctionCounts]":
+    def __getitem__(self, item: Any) -> Union[FunctionCount, "FunctionCounts"]:
         data: Union[FunctionCount, Tuple[FunctionCount, ...]] = self._data[item]
         return (
             FunctionCounts(cast(Tuple[FunctionCount, ...], data), self.inclusive, truncate_rows=False)
@@ -90,13 +90,13 @@ class FunctionCounts(object):
 
     def __add__(
         self,
-        other,  # type: FunctionCounts
+        other: "FunctionCounts",
     ) -> "FunctionCounts":
         return self._merge(other, lambda c: c)
 
     def __sub__(
         self,
-        other,  # type: FunctionCounts
+        other: "FunctionCounts",
     ) -> "FunctionCounts":
         return self._merge(other, lambda c: -c)
 
@@ -137,7 +137,7 @@ class FunctionCounts(object):
 
     def _merge(
         self,
-        second,   # type: FunctionCounts
+        second: "FunctionCounts",
         merge_fn: Callable[[int], int]
     ) -> "FunctionCounts":
         assert self.inclusive == second.inclusive, "Cannot merge inclusive and exclusive counts."
@@ -217,7 +217,7 @@ class CallgrindStats(object):
     # FIXME: Once 3.7 is the minimum version, type annotate `other` per PEP 563
     def delta(
         self,
-        other,  # type: CallgrindStats
+        other: "CallgrindStats",
         inclusive: bool = False,
     ) -> FunctionCounts:
         """Diff two sets of counts.

--- a/torch/utils/tensorboard/_proto_graph.py
+++ b/torch/utils/tensorboard/_proto_graph.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from tensorboard.compat.proto.node_def_pb2 import NodeDef
 from tensorboard.compat.proto.attr_value_pb2 import AttrValue
 from tensorboard.compat.proto.tensor_shape_pb2 import TensorShapeProto
@@ -29,7 +30,7 @@ def node_proto(name,
                op='UnSpecified',
                input=None,
                dtype=None,
-               shape=None,  # type: tuple
+               shape: Optional[tuple] = None,
                outputsize=None,
                attributes=''
                ):


### PR DESCRIPTION
Summary:
Created by running
```
python -m libcst.tool codemod --no-format --jobs=1 convert_type_comments.ConvertTypeComments ~/fbsource/fbcode/caffe2/torch/utils/ --no-quote-annotations
```
and then manually cleaning up unreadable function headers (which is needed due to lack of autoformatting).

Test Plan:
Wait for CI - usually type annotations are safe to land, but the jit
compiler sometimes can choke if there's a problem.

release notes:
Converting type comments to type annotations

topics:
Refactor

Differential Revision: D34148011

