### PR TITLE
[LTS] CherryPick: Pin librosa

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -113,7 +113,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   as_jenkins pip install --progress-bar off pytest \
     scipy==1.1.0 \
     scikit-image \
-    librosa>=0.6.2 \
+    "librosa>=0.6.2,<0.9.0" \
     psutil \
     numba \
     llvmlite \

--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -122,7 +122,8 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     coverage \
     hypothesis==4.53.2 \
     mypy==0.770 \
-    tb-nightly
+    tb-nightly \
+    "numpy==1.18.5"
 
   # Update scikit-learn to a python-3.8 compatible version
   if [[ $(python -c "import sys; print(int(sys.version_info >= (3, 8)))") == "1" ]]; then

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -4,7 +4,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/macos-common.sh"
 
 conda install -y six
-pip install -q hypothesis "librosa>=0.6.2" "numba<=0.49.1" psutil "scipy==1.6.3"
+pip install -q hypothesis "librosa>=0.6.2,<0.9.0" "numba<=0.49.1" psutil "scipy==1.6.3"
 
 # TODO move this to docker
 pip install unittest-xml-reporting pytest

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -39,7 +39,7 @@ if %errorlevel% neq 0 ( exit /b %errorlevel% )
 popd
 
 :: The version is fixed to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
-pip install "ninja==1.10.0.post1" future "hypothesis==4.53.2" "librosa>=0.6.2" psutil pillow unittest-xml-reporting pytest coverage
+pip install "ninja==1.10.0.post1" future "hypothesis==4.53.2" "librosa>=0.6.2,<0.9.0" psutil pillow unittest-xml-reporting pytest coverage
 if %errorlevel% neq 0 ( exit /b %errorlevel% )
 
 set DISTUTILS_USE_SDK=1


### PR DESCRIPTION
This PR cherry-picks the commit a004f1356721eed4922f08341a592f312dd58424 from the master branch that pins librosa and resolves issue https://github.com/pytorch/pytorch/issues/72432.

`numpy=1.18.5` is added to the installation of other packages through pip in `.circleci/docker/common/install_conda.sh` to prevent it from getting replaced with a higher version. Otherwise, this leads to other test failures later.