### PR TITLE
Convert type comments to annotations across caffe2

### DIFF
--- a/caffe2/python/workspace_test.py
+++ b/caffe2/python/workspace_test.py
@@ -1,13 +1,16 @@
+import errno
 import os
 import shutil
 import tempfile
 import unittest
 from collections import namedtuple
+from typing import List
 
 import caffe2.python.hypothesis_test_util as htu
 import hypothesis.strategies as st
 import numpy as np
 import torch
+from torch import Tensor
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, test_util, workspace, model_helper, brew
 from hypothesis import given, settings
@@ -783,8 +786,7 @@ class MyModule(torch.jit.ScriptModule):
         return x + y + z
 
     @torch.jit.script_method
-    def multi_input_tensor_list(self, tensor_list):  # pyre-ignore: PT type annotations
-        # type: (List[Tensor]) -> Tensor
+    def multi_input_tensor_list(self, tensor_list: List[Tensor]) -> Tensor:  # pyre-ignore: PT type annotations
         return tensor_list[0] + tensor_list[1] + tensor_list[2]
 
     @torch.jit.script_method

--- a/torch/_lobpcg.py
+++ b/torch/_lobpcg.py
@@ -652,17 +652,16 @@ class LOBPCG(object):
     """
 
     def __init__(self,
-                 A,        # type: Optional[Tensor]
-                 B,        # type: Optional[Tensor]
-                 X,        # type: Tensor
-                 iK,       # type: Optional[Tensor]
-                 iparams,  # type: Dict[str, int]
-                 fparams,  # type: Dict[str, float]
-                 bparams,  # type: Dict[str, bool]
-                 method,   # type: str
-                 tracker   # type: None
-                 ):
-        # type: (...) -> None
+                 A: Optional[Tensor],
+                 B: Optional[Tensor],
+                 X: Tensor,
+                 iK: Optional[Tensor],
+                 iparams: Dict[str, int],
+                 fparams: Dict[str, float],
+                 bparams: Dict[str, bool],
+                 method: str,
+                 tracker: None
+                 ) -> None:
 
         # constant parameters
         self.A = A
@@ -681,10 +680,10 @@ class LOBPCG(object):
         self.E = torch.zeros((n, ), dtype=X.dtype, device=X.device)
         self.R = torch.zeros((m, n), dtype=X.dtype, device=X.device)
         self.S = torch.zeros((m, 3 * n), dtype=X.dtype, device=X.device)
-        self.tvars = {}               # type: Dict[str, Tensor]
-        self.ivars = {'istep': 0}     # type: Dict[str, int]
-        self.fvars = {'_': 0.0}       # type: Dict[str, float]
-        self.bvars = {'_': False}     # type: Dict[str, bool]
+        self.tvars: Dict[str, Tensor] = {}
+        self.ivars: Dict[str, int] = {'istep': 0}
+        self.fvars: Dict[str, float] = {'_': 0.0}
+        self.bvars: Dict[str, bool] = {'_': False}
 
     def __str__(self):
         lines = ['LOPBCG:']
@@ -947,11 +946,10 @@ class LOBPCG(object):
         return Rinv * d_col
 
     def _get_svqb(self,
-                  U,     # Tensor
-                  drop,  # bool
-                  tau    # float
-                  ):
-        # type: (Tensor, bool, float) -> Tensor
+                  U: Tensor,     # Tensor
+                  drop: bool,  # bool
+                  tau: float    # float
+                  ) -> Tensor:
         """Return B-orthonormal U.
 
         .. note:: When `drop` is `False` then `svqb` is based on the

--- a/torch/csrc/deploy/example/examples.py
+++ b/torch/csrc/deploy/example/examples.py
@@ -146,8 +146,7 @@ class MultiReturn(torch.nn.Module):
     def __init__(self):
         super(MultiReturn, self).__init__()
 
-    def forward(self, t):
-        # type: (Tuple[Tensor, Tensor]) -> Tuple[Tuple[Tensor, Tensor], Tuple[Tensor, Tensor]]
+    def forward(self, t: Tuple[Tensor, Tensor]) -> Tuple[Tuple[Tensor, Tensor], Tuple[Tensor, Tensor]]:
         a, b = t
         result = ((a.masked_fill_(b, 0.1), b), (torch.ones_like(a), b))
         return result

--- a/torch/distributed/elastic/metrics/api.py
+++ b/torch/distributed/elastic/metrics/api.py
@@ -60,7 +60,7 @@ class MetricStream:
 
 
 _metrics_map = {}
-_default_metrics_handler = NullMetricHandler()  # type: MetricHandler
+_default_metrics_handler: MetricHandler = NullMetricHandler()
 
 
 # pyre-fixme[9]: group has type `str`; used as `None`.

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -927,8 +927,13 @@ def _unique_consecutive_impl(input: Tensor, return_inverse: bool = False,
     return output, inverse_indices, counts
 
 
-def _return_counts(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
+def _return_counts(
+    input: Tensor,
+    sorted: bool = True,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
 
     if has_torch_function_unary(input):
         return _unique_impl(input, sorted, return_inverse, return_counts, dim)
@@ -937,8 +942,13 @@ def _return_counts(input, sorted=True, return_inverse=False, return_counts=False
     return output, counts
 
 
-def _return_output(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, bool, Optional[int]) -> Tensor
+def _return_output(
+    input: Tensor,
+    sorted: bool = True,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tensor:
 
     if has_torch_function_unary(input):
         return _unique_impl(input, sorted, return_inverse, return_counts, dim)
@@ -947,8 +957,13 @@ def _return_output(input, sorted=True, return_inverse=False, return_counts=False
     return output
 
 
-def _return_inverse(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
+def _return_inverse(
+    input: Tensor,
+    sorted: bool = True,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
 
     if has_torch_function_unary(input):
         return _unique_impl(input, sorted, return_inverse, return_counts, dim)
@@ -989,8 +1004,12 @@ unique = boolean_dispatch(
 unique.__doc__ = _unique_impl.__doc__
 
 
-def _consecutive_return_counts(input, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
+def _consecutive_return_counts(
+    input: Tensor,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
 
     if has_torch_function_unary(input):
         return _unique_consecutive_impl(input, return_inverse, return_counts, dim)
@@ -999,8 +1018,12 @@ def _consecutive_return_counts(input, return_inverse=False, return_counts=False,
     return output, counts
 
 
-def _consecutive_return_output(input, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, Optional[int]) -> Tensor
+def _consecutive_return_output(
+    input: Tensor,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tensor:
 
     if has_torch_function_unary(input):
         return _unique_consecutive_impl(input, return_inverse, return_counts, dim)
@@ -1009,8 +1032,12 @@ def _consecutive_return_output(input, return_inverse=False, return_counts=False,
     return output
 
 
-def _consecutive_return_inverse(input, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
+def _consecutive_return_inverse(
+    input: Tensor,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
 
     if has_torch_function_unary(input):
         return _unique_consecutive_impl(input, return_inverse, return_counts, dim)
@@ -1229,8 +1256,12 @@ def block_diag(*tensors):
     return torch._C._VariableFunctions.block_diag(tensors)  # type: ignore[attr-defined]
 
 
-def cdist(x1, x2, p=2., compute_mode='use_mm_for_euclid_dist_if_necessary'):
-    # type: (Tensor, Tensor, float, str) -> (Tensor)
+def cdist(
+    x1: Tensor,
+    x2: Tensor,
+    p: float = 2.,
+    compute_mode: str = 'use_mm_for_euclid_dist_if_necessary',
+) -> Tensor:
     r"""Computes batched the p-norm distance between each pair of the two collections of row vectors.
 
     Args:
@@ -1640,8 +1671,12 @@ def chain_matmul(*matrices, out=None):
         return _VF.chain_matmul(matrices, out=out)  # type: ignore[attr-defined]
 
 
-def _lu_impl(A, pivot=True, get_infos=False, out=None):
-    # type: (Tensor, bool, bool, Any) -> Tuple[Tensor, Tensor, Tensor]
+def _lu_impl(
+    A: Tensor,
+    pivot: bool = True,
+    get_infos: bool = False,
+    out: Any = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
     r"""Computes the LU factorization of a matrix or batches of matrices
     :attr:`A`. Returns a tuple containing the LU factorization and
     pivots of :attr:`A`.  Pivoting is done if :attr:`pivot` is set to
@@ -1732,8 +1767,12 @@ def _check_list_size(out_len: int, get_infos: bool, out: _ListOrSeq) -> None:
     if not isinstance(out, (tuple, list)):
         raise TypeError(f"argument 'out' must be tuple of Tensors, not {type(out).__name__}")
 
-def _lu_with_infos(A, pivot=True, get_infos=False, out=None):
-    # type: (Tensor, bool, bool, Optional[Tuple[Tensor, Tensor, Tensor]]) -> Tuple[Tensor, Tensor, Tensor]
+def _lu_with_infos(
+    A: Tensor,
+    pivot: bool = True,
+    get_infos: bool = False,
+    out: Optional[Tuple[Tensor, Tensor, Tensor]] = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
     if has_torch_function_unary(A):
         return handle_torch_function(
             lu, (A,), A, pivot=pivot, get_infos=get_infos, out=out)
@@ -1746,8 +1785,12 @@ def _lu_with_infos(A, pivot=True, get_infos=False, out=None):
     else:
         return result  # A_LU, pivots, infos
 
-def _lu_no_infos(A, pivot=True, get_infos=False, out=None):
-    # type: (Tensor, bool, bool, Optional[Tuple[Tensor, Tensor]]) -> Tuple[Tensor, Tensor]
+def _lu_no_infos(
+    A: Tensor,
+    pivot: bool = True,
+    get_infos: bool = False,
+    out: Optional[Tuple[Tensor, Tensor]] = None,
+) -> Tuple[Tensor, Tensor]:
     # need to check for torch_function here so that we exit if
     if has_torch_function_unary(A):
         return handle_torch_function(


### PR DESCRIPTION
Summary:
This commit was generated by identifying remaining files
with type comments not covered by other commits, and codemodding
them via (e.g.)
```
python -m libcst.tool codemod --no-format --jobs=1 convert_type_comments.ConvertTypeComments ~/fbsource/fbcode/caffe2/caffe2/python/workspace_test.py --no-quote-annotations
```

I skipped autoformatting because black isn't enabled on pytorch,
but I did clean up some of the excessively long resulting function
definitions manually (following black style).

Test Plan:
Wait for CI - generally applying annotations is safe but we need
to be on the lookout for where it may affect the jit compiler.

Differential Revision: D34150232

