### PR TITLE
[ATen][rocm] fix type issue

### DIFF
--- a/aten/src/ATen/native/miopen/RNN_miopen.cpp
+++ b/aten/src/ATen/native/miopen/RNN_miopen.cpp
@@ -352,7 +352,7 @@ std::pair<std::vector<Tensor>, size_t> get_parameters(miopenHandle_t handle, con
             param_size /= elem_size;
 
             if(linear_id == 0 || linear_id == num_linear_layers / 2) {
-                const auto size = { static_cast<int64_t>(param_size * num_linear_layers / 2), 1L};
+                std::initializer_list<int64_t> size = { static_cast<int64_t>(param_size * num_linear_layers / 2), 1L};
                 Tensor param = at::empty({0}, weight_buf.options()).set_(weight_buf.storage(), offset, size);
                 params.emplace_back(std::move(param));
                 layer_params_count++;
@@ -386,7 +386,7 @@ std::pair<std::vector<Tensor>, size_t> get_parameters(miopenHandle_t handle, con
                 bias_size /= elem_size;
 
                 if(linear_id == 0 || linear_id == num_linear_layers / 2) {
-                    const auto size = { static_cast<int64_t>(bias_size * num_linear_layers / 2), 1L};
+                    std::initializer_list<int64_t> size = { static_cast<int64_t>(bias_size * num_linear_layers / 2), 1L};
                     Tensor param = at::empty({0}, weight_buf.options()).set_(weight_buf.storage(), offset, size);
                     params.emplace_back(std::move(param));
                     layer_params_count++;


### PR DESCRIPTION
Summary:
Fixes a nightly build failure at AMD.

Originally,
```c
std::initializer_list<int64_t> size = { param_size * num_linear_layers / 2, 1};
```
but https://github.com/pytorch/pytorch/pull/71925 changed as follows.
```c
const auto size = { static_cast<int64_t>(bias_size * num_linear_layers / 2), 1L};
```

This caused a problem as follows (with a certain compiler):
```
/pytorch/aten/src/ATen/native/miopen/RNN_miopen.cpp:356:108: error: no matching function for call to 'at::Tensor::set_(const c10::Storage&, size_t&, const std::initializer_list<const long int>&)'
```

This patch reverts the type of `size`.
```c
std::initializer_list<int64_t> size = { static_cast<int64_t>(bias_size * num_linear_layers / 2), 1L};
```
This issue happens with GCC <= 9.1, but not with Clang and GCC >= 9.2. See this: https://godbolt.org/z/sbErY7her

(Note: please let me explcitly cast the first variable (`bias_size * num_linear_layers / 2`) to avoid signed/unsigned type conversion warning. It should not cause any issue.)

Test Plan: CI

Differential Revision: D34153890

