### PR TITLE
qlinear: Remove legacy cpp_custom_type_hack support

### DIFF
--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_prepack.cpp
@@ -2,7 +2,6 @@
 #include <c10/util/irange.h>
 #include <torch/custom_class.h>
 
-#include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>

--- a/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/ao_sparse/quantized/cpu/qlinear_unpack.cpp
@@ -1,7 +1,6 @@
 #include <ATen/ATen.h>
 #include <torch/custom_class.h>
 
-#include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/ao_sparse/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/ao_sparse/quantized/cpu/packed_params.h>
 #include <ATen/native/ao_sparse/quantized/cpu/qnnpack_utils.h>

--- a/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_prepack.cpp
@@ -1,5 +1,4 @@
 #include <ATen/ATen.h>
-#include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/packed_params.h>
@@ -352,81 +351,18 @@ class QLinearPackWeightFp16 final {
 class QLinearPackWeightInt8Legacy final {
  public:
   static Tensor run(at::Tensor weight, c10::optional<Tensor> bias) {
-    auto& ctx = at::globalContext();
-    auto options = weight.options();
-
-#ifdef USE_FBGEMM
-    if (ctx.qEngine() == at::QEngine::FBGEMM) {
-      auto prepacked =
-          PackedLinearWeight::prepack(std::move(weight), std::move(bias));
-      auto wrapped =
-          std::make_unique<c10::intrusive_ptr<LinearPackedParamsBase>>(
-              std::move(prepacked));
-      return cpp_custom_type_hack::create(std::move(wrapped), options);
-    }
-#endif // USE_FBGEMM
-#ifdef USE_PYTORCH_QNNPACK
-    if (ctx.qEngine() == at::QEngine::QNNPACK) {
-      auto prepacked =
-          PackedLinearWeightsQnnp::prepack(std::move(weight), std::move(bias));
-      auto wrapped =
-          std::make_unique<c10::intrusive_ptr<LinearPackedParamsBase>>(
-              std::move(prepacked));
-      return cpp_custom_type_hack::create(std::move(wrapped), options);
-    }
-#endif // USE_PYTORCH_QNNPACK
-#if AT_MKLDNN_ENABLED()
-    if (ctx.qEngine() == at::QEngine::ONEDNN) {
-      auto prepacked =
-          PackedLinearWeightsOnednn::prepack(std::move(weight), std::move(bias));
-      auto wrapped =
-          std::make_unique<c10::intrusive_ptr<LinearPackedParamsBase>>(
-              std::move(prepacked));
-      return cpp_custom_type_hack::create(std::move(wrapped), options);
-    }
-#endif // #if AT_MKLDNN_ENABLED()
-    TORCH_CHECK(
-        false,
-        "Didn't find engine for operation quantized::linear_prepack ",
-        toString(ctx.qEngine()));
+    TORCH_CHECK(false,
+        "This model uses an outdated version of quantized.linear_prepack. "
+        "Please re-export your model using the newer definitions in torch.jit.quantized");
   }
 };
 
 class QLinearPackWeightFp16Legacy final {
  public:
   static Tensor run(at::Tensor weight, c10::optional<Tensor> bias) {
-    auto& ctx = at::globalContext();
-#ifdef USE_FBGEMM
-    auto options = weight.options();
-    if (ctx.qEngine() == at::QEngine::FBGEMM) {
-      auto prepacked =
-          PackedLinearWeightFp16::prepack(std::move(weight), std::move(bias));
-      auto wrapped =
-          std::make_unique<c10::intrusive_ptr<LinearPackedParamsBase>>(
-              std::move(prepacked));
-      return cpp_custom_type_hack::create(std::move(wrapped), options);
-    }
-#endif // USE_FBGEMM
-#ifdef USE_PYTORCH_QNNPACK
-    if (ctx.qEngine() == at::QEngine::QNNPACK) {
-      TORCH_CHECK(
-          false,
-          "quantized::linear_prepack_fp16 is currently "
-          "not supported by QNNPACK");
-    }
-#endif // USE_PYTORCH_QNNPACK
-#if AT_MKLDNN_ENABLED()
-    if (ctx.qEngine() == at::QEngine::ONEDNN) {
-      TORCH_CHECK(
-          false,
-          "quantized::linear_prepack_fp16 is currently "
-          "not supported by ONEDNN");
-    }
-#endif // #if AT_MKLDNN_ENABLED()
-    TORCH_CHECK(
-        false,
-        "Didn't find engine for operation quantized::linear_prepack_fp16 ",
-        toString(ctx.qEngine()));
+    TORCH_CHECK(false,
+        "This model uses an outdated version of quantized.linear_prepack_fp16. "
+        "Please re-export your model using the newer definitions in torch.jit.quantized");
   }
 };
 

--- a/aten/src/ATen/native/quantized/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/quantized/qlinear_unpack.cpp
@@ -7,7 +7,6 @@ The implementations for the unpack functions can be found in /cpu/qlinear_unpack
 and /cudnn/linear_unpack_impl.cpp, for cudnn.
 */
 #include <ATen/ATen.h>
-#include <ATen/cpp_custom_type_hack.h>
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/packed_params.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
@@ -45,13 +44,10 @@ class QLinearUnpackWeightInt8Legacy final {
  public:
   static std::tuple<at::Tensor, c10::optional<Tensor>> run(
       const at::Tensor& packed_weight) {
-    TORCH_WARN_ONCE(
-        "quantized.linear_unpack(Tensor) is deprecated! Please "
+    TORCH_CHECK(false,
+        "quantized.linear_unpack(Tensor) is unsupported! Please "
         "upgrade your model to use the newer quantized.linear_"
         "unpack(LinearPackedParamsBase) overload");
-    return cpp_custom_type_hack::cast<
-               c10::intrusive_ptr<LinearPackedParamsBase>>(packed_weight)
-        ->unpack();
   }
 };
 
@@ -59,20 +55,10 @@ class QLinearUnpackWeightFp16Legacy final {
  public:
   static std::tuple<at::Tensor, c10::optional<Tensor>> run(
       const at::Tensor& packed_weight) {
-    TORCH_WARN_ONCE(
-        "quantized.linear_unpack(Tensor) is deprecated! Please "
+    TORCH_CHECK(false,
+        "quantized.linear_unpack(Tensor) is unsupported! Please "
         "upgrade your model to use the newer quantized.linear_"
         "unpack(LinearPackedParamsBase) overload");
-    auto& ctx = at::globalContext();
-
-    TORCH_CHECK(
-        ctx.qEngine() != at::QEngine::QNNPACK,
-        "quantized::linear_unpack_fp16 is currently "
-        "not supported by QNNPACK");
-
-    return cpp_custom_type_hack::cast<
-               c10::intrusive_ptr<LinearPackedParamsBase>>(packed_weight)
-        ->unpack();
   }
 };
 


### PR DESCRIPTION
Ref #72263 for cpp_custom_type_hack removal

`qlinear_prepack` and `qlinear_unpack` were updated to use torchbind
and the `cpp_custom_type_hack` overloads marked with a deprecation
warning in #38101 which was in the PyTorch 1.6 release. So, we are
safe to break BC here. 

The deprecation warning only appears in unpack, but you can't use one 
without the other I think that's still okay.

## BC-breaking note
### TorchScript models exported prior to PyTorch 1.6 using quantized linear operators will no longer work
TorchScipt models created with PyTorch 1.5 or earlier and using the operators `quantized::linear_prepack`, `quantized::linear_prepack_fp16`, `quantized::linear_unpack`, or `quantized::linear_unpack_fp16` will no longer work and need to be re-exported.