### PR TITLE
[ROCM] Navi21 Enablement 2: Depthwise kernels

### DIFF
--- a/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv2d.cu
@@ -442,7 +442,7 @@ void conv_depthwise2d_backward_out(
 int getGradParamsNumThreads(int batchSize) {
   //warp per item in a batch, up to a maximum
   constexpr int MAX_BLOCK_SIZE = 256;
-  return std::min(batchSize * C10_WARP_SIZE, MAX_BLOCK_SIZE);
+  return std::min(batchSize * at::cuda::warp_size(), MAX_BLOCK_SIZE);
 }
 
 void conv_depthwise2d_grad_weight_out(
@@ -498,8 +498,9 @@ void conv_depthwise2d_grad_weight_out(
     const auto input_a = input.packed_accessor32<scalar_t, 4>();
     const auto grad_weight_a = grad_weight.packed_accessor32<scalar_t, 4>();
     using acc_t = at::acc_type<scalar_t, true>;
-    TORCH_INTERNAL_ASSERT(block.x % C10_WARP_SIZE == 0);
-    int smem = (block.x  / C10_WARP_SIZE) * sizeof(acc_t);
+    int warp_size = at::cuda::warp_size();
+    TORCH_INTERNAL_ASSERT(block.x % warp_size == 0);
+    int smem = (block.x  / warp_size) * sizeof(acc_t);
     conv_depthwise2d_grad_weight_kernel<<<grid, block, smem, stream>>>(
         grad_output_a, input_a, grad_weight_a, batchSize, inputChannels, outputChannels, depthwiseMultiplier,
         width, height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);

--- a/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
+++ b/aten/src/ATen/native/cuda/DepthwiseConv3d.cu
@@ -596,9 +596,10 @@ std::tuple<Tensor&, Tensor&, Tensor&> _depthwise_3d_backward_cuda_out(
             TORCH_CHECK(padding[i] * 2 + input.size(i + 2) <= int_max,
                         "Padded input tensor is too large.");
           }
-          TORCH_CHECK(grad_output_.size(0) * grad_output_.size(2) < int_max - block / C10_WARP_SIZE &&
-                      grad_output_.size(3) <= int_max - C10_WARP_SIZE &&
-                      grad_output_.size(4) <= int_max - C10_WARP_SIZE,
+          int64_t warp_size = at::cuda::warp_size();
+          TORCH_CHECK(grad_output_.size(0) * grad_output_.size(2) < int_max - block / warp_size &&
+                      grad_output_.size(3) <= int_max - warp_size &&
+                      grad_output_.size(4) <= int_max - warp_size,
                       "Output size is too large.");
 
           DWCONV3D_BACKWARD_WEIGHT_DISPATCH_SPECIALIZATION(1, 1)


### PR DESCRIPTION
This PR is a follow up to https://github.com/pytorch/pytorch/pull/69942.

We are adding support to Navi21 GPUs which have a warpsize of 32. We cannot rely on a constant so we have to dynamically look up the warpsize when launching the kernel on the host side. Inside device functions this is not needed and the compiler can correctly detect the correct warpsize to replace the C10_WARP_SIZE constant.