### PR TITLE
[LT] Allow lazy_model.mark_step to specify a device

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/core/lazy_model.py
+++ b/lazy_tensor_core/lazy_tensor_core/core/lazy_model.py
@@ -719,11 +719,11 @@ def _run_step_closures():
     return devctx
 
 
-def mark_step():
+def mark_step(device: torch.device = lazy_tensor_core._LAZYC._ltc_get_default_device()):
     if xu.getenv_as('LTC_EMIT_STEPLOG', bool, False):
         print('lazy_tensor_core.core.lazy_model::mark_step', file=sys.stderr, flush=True)
     lazy_tensor_core._LAZYC._ltc_step_marker(
-        lazy_tensor_core._LAZYC._ltc_get_default_device(), [],
+        device, [],
         wait=xu.getenv_as('LTC_SYNC_WAIT', bool, False))
     # Only emit metrics from the first local device index, to avoid emitting the
     # same values from different threads.


### PR DESCRIPTION
Summary:
Currently this API only synchronizes tensors in the default device. This
is bad in distributed environment given there will be multiple devices.

This PR adds a paramter to the API such that caller can specify which device
to synchronize the tensors. Please refer to the attached cuda1.py for detailed
examples. This aligns with how DDP works as rank (device index) is often
passed from torch.multiprocessing and then models will need to move to
that rank first before training/inference.

Another alternative is to add an API for users to setup the default device,
which seems too verbose.

Test Plan:
Run the attached cuda1.py and observe logs suggesting that tensors are
synchronized on device Unknown1 (We should fix the log to show CUDA1).
