### PR TITLE
Deprecate torch.jit.quantized

### DIFF
--- a/aten/src/ATen/native/QuantizedLinear.cpp
+++ b/aten/src/ATen/native/QuantizedLinear.cpp
@@ -53,6 +53,9 @@ Tensor fbgemm_linear_int8_weight_fp32_activation(
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(fbgemm::fbgemmSupportedCPU(), "Your CPU doesn't support FBGEMM.");
 
+  TORCH_WARN_ONCE("fbgemm_linear_int8_weight_fp32_activation is deprecated "
+                  "and will be removed in a future PyTorch release.")
+
   const Tensor input_contig = input.contiguous();
   const float* input_ptr = input_contig.data_ptr<float>();
 
@@ -179,11 +182,6 @@ Tensor fbgemm_linear_int8_weight(
     const Scalar& weight_scale,
     const Scalar& weight_zero_point,
     const Tensor& bias) {
-  // Replace after https://github.com/pytorch/pytorch/issues/24354 is fixed
-  // TORCH_WARN(
-  //     "fbgemm_linear_int8_weight will be deprecated soon."
-  //     "Please use fbgemm_linear_int8_weight_fp32_activation instead.");
-
   return at::native::fbgemm_linear_int8_weight_fp32_activation(
       input,
       weight,
@@ -219,6 +217,9 @@ void CalcColOffsetsTranspose(
 
 std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
     const Tensor& weight) {
+  TORCH_WARN_ONCE("fbgemm_linear_quantize_weight is deprecated "
+                  "and will be removed in a future PyTorch release.")
+
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -284,6 +285,9 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
 }
 
 Tensor fbgemm_pack_quantized_matrix(const Tensor& weight) {
+  TORCH_WARN_ONCE("fbgemm_pack_quantized_matrix is deprecated "
+                  "and will be removed in a future PyTorch release.")
+
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -366,6 +370,9 @@ void HandleWeightsSaturation(int64_t N, float* weight) {
 } // namespace
 
 Tensor fbgemm_pack_gemm_matrix_fp16(const Tensor& weight) {
+  TORCH_WARN_ONCE("fbgemm_pack_gemm_matrix_fp16 is deprecated "
+                  "and will be removed in a future PyTorch release.")
+
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -398,6 +405,9 @@ Tensor fbgemm_linear_fp16_weight_fp32_activation(
     const Tensor& input,
     const Tensor& packed_weight,
     const Tensor& bias) {
+  TORCH_WARN_ONCE("fbgemm_linear_fp16_weight_fp32_activation is deprecated "
+                  "and will be removed in a future PyTorch release.")
+
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -443,10 +453,6 @@ Tensor fbgemm_linear_fp16_weight(
     const Tensor& input,
     const Tensor& packed_weight,
     const Tensor& bias) {
-  // Replace after https://github.com/pytorch/pytorch/issues/24354 is fixed
-  // TORCH_WARN(
-  //     "fbgemm_linear_fp16_weight will be deprecated soon."
-  //     "Please use fbgemm_linear_fp16_weight_fp32_activation instead.");
   return at::native::fbgemm_linear_fp16_weight_fp32_activation(
       input, packed_weight, bias);
 }
@@ -461,6 +467,9 @@ Tensor fbgemm_linear_int8_weight_fp32_activation(
     const Scalar& /*weight_scale*/,
     const Scalar& /*weight_zero_point*/,
     const Tensor& /*bias*/) {
+  TORCH_WARN_ONCE("fbgemm_linear_int8_weight_fp32_activation is deprecated "
+                  "and will be removed in a future PyTorch release.")
+
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -476,10 +485,8 @@ Tensor fbgemm_linear_int8_weight(
     const Scalar& /*weight_scale*/,
     const Scalar& /*weight_zero_point*/,
     const Tensor& /*bias*/) {
-  // Replace after https://github.com/pytorch/pytorch/issues/24354 is fixed
-  // TORCH_WARN(
-  //     "fbgemm_linear_int8_weight will be deprecated soon."
-  //     "Please use fbgemm_linear_int8_weight_fp32_activation instead.");
+  TORCH_WARN_ONCE("fbgemm_linear_int8_weight is deprecated "
+                  "and will be removed in a future PyTorch release.")
 
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
@@ -490,6 +497,9 @@ Tensor fbgemm_linear_int8_weight(
 
 std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
     const Tensor& /*weight*/) {
+  TORCH_WARN_ONCE("fbgemm_linear_quantize_weight is deprecated "
+                  "and will be removed in a future PyTorch release.")
+
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -498,6 +508,9 @@ std::tuple<Tensor, Tensor, double, int64_t> fbgemm_linear_quantize_weight(
 }
 
 Tensor fbgemm_pack_quantized_matrix(const Tensor& /*input*/) {
+  TORCH_WARN_ONCE("fbgemm_pack_quantized_matrix is deprecated "
+                  "and will be removed in a future PyTorch release.")
+
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -509,10 +522,8 @@ Tensor fbgemm_pack_quantized_matrix(
     const Tensor& /*input*/,
     int64_t /*K*/,
     int64_t /*N*/) {
-  // Replace after https://github.com/pytorch/pytorch/issues/24354 is fixed
-  // TORCH_WARN(
-  //     "fbgemm_pack_quantized_matrix(weight, K, N) will be deprecated soon."
-  //     "Please use fbgemm_pack_quantized_matrix(weight) instead.");
+  TORCH_WARN_ONCE("fbgemm_pack_quantized_matrix is deprecated "
+                  "and will be removed in a future PyTorch release.")
 
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
@@ -522,6 +533,9 @@ Tensor fbgemm_pack_quantized_matrix(
 }
 
 Tensor fbgemm_pack_gemm_matrix_fp16(const Tensor& weight) {
+  TORCH_WARN_ONCE("fbgemm_pack_gemm_matrix_fp16 is deprecated "
+                  "and will be removed in a future PyTorch release.")
+
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -533,6 +547,9 @@ Tensor fbgemm_linear_fp16_weight_fp32_activation(
     const Tensor& input,
     const Tensor& packed_weight,
     const Tensor& bias) {
+  TORCH_WARN_ONCE("fbgemm_linear_fp16_weight_fp32_activation is deprecated "
+                  "and will be removed in a future PyTorch release.")
+
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
@@ -544,20 +561,14 @@ Tensor fbgemm_linear_fp16_weight(
     const Tensor& input,
     const Tensor& packed_weight,
     const Tensor& bias) {
-  // Replace after https://github.com/pytorch/pytorch/issues/24354 is fixed
-  // TORCH_WARN(
-  //     "fbgemm_linear_fp16_weight will be deprecated soon."
-  //     "Please use fbgemm_linear_fp16_weight_fp32_activation instead.");
+  TORCH_WARN_ONCE("fbgemm_linear_fp16_weight is deprecated "
+                  "and will be removed in a future PyTorch release.")
 
   // We make a strong guarantee that models using these operators will have the
   // same numerics across different machines. Therefore, we do not provide a
   // fallback path and rather fail loudly if we cannot run FBGEMM.
   TORCH_CHECK(
       false, "This PyTorch installation was not built with FBGEMM operators");
-}
-
-bool fbgemm_is_cpu_supported() {
-  return false;
 }
 
 #endif // USE_FBGEMM

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -12,6 +12,10 @@ class QuantizedLinear(torch.jit.ScriptModule):
 
     def __init__(self, other):
         super(QuantizedLinear, self).__init__()
+        warnings.warn(
+            "torch.jit.QuantizedLinear is deprecated and will be removed in an upcoming "
+            "PyTorch release. Please use the torch.nn.quantized.dynamic.Linear instead.")
+
         self.in_features = other.in_features
         self.out_features = other.out_features
         # Quantize weight and discard the original
@@ -53,6 +57,9 @@ class QuantizedLinearFP16(torch.jit.ScriptModule):
 
     def __init__(self, other):
         super(QuantizedLinearFP16, self).__init__()
+        warnings.warn(
+            "torch.jit.QuantizedLinearFP16 is deprecated and will be removed in an upcoming "
+            "PyTorch release. Please use the torch.nn.quantized.dynamic.Linear instead.")
         self.in_features = other.in_features
         self.out_features = other.out_features
         self.original_weight = other.weight
@@ -90,6 +97,10 @@ class QuantizedRNNCellBase(torch.jit.ScriptModule):
 
     def __init__(self, other):
         super(QuantizedRNNCellBase, self).__init__()
+        warnings.warn(
+            "torch.jit.QuantizedRNNCellBase is deprecated and will be removed in an upcoming "
+            "PyTorch release. Please use the torch.nn.quantized.dynamic.RNNCell instead.")
+
         self.input_size = other.input_size
         self.hidden_size = other.hidden_size
         self.bias = other.bias
@@ -164,6 +175,9 @@ class QuantizedRNNCell(QuantizedRNNCellBase):
 
     def __init__(self, other):
         super(QuantizedRNNCell, self).__init__(other)
+        warnings.warn(
+            "torch.jit.QuantizedRNNCell is deprecated and will be removed in an upcoming "
+            "PyTorch release. Please use the torch.nn.quantized.dynamic.RNNCell instead.")
         self.nonlinearity = other.nonlinearity
 
     @torch.jit.script_method
@@ -196,6 +210,9 @@ class QuantizedRNNCell(QuantizedRNNCellBase):
 class QuantizedLSTMCell(QuantizedRNNCellBase):
     def __init__(self, other):
         super(QuantizedLSTMCell, self).__init__(other)
+        warnings.warn(
+            "torch.jit.QuantizedLSTMCell is deprecated and will be removed in an upcoming "
+            "PyTorch release. Please use the torch.nn.quantized.dynamic.LSTMCell instead.")
 
     @torch.jit.script_method
     def forward(self, input: Tensor, hx: Optional[Tuple[Tensor, Tensor]] = None) -> Tuple[Tensor, Tensor]:
@@ -216,6 +233,9 @@ class QuantizedLSTMCell(QuantizedRNNCellBase):
 class QuantizedGRUCell(QuantizedRNNCellBase):
     def __init__(self, other):
         super(QuantizedGRUCell, self).__init__(other)
+        warnings.warn(
+            "torch.jit.QuantizedGRUCell is deprecated and will be removed in an upcoming "
+            "PyTorch release. Please use the torch.nn.quantized.dynamic.GRUCell instead.")
 
     @torch.jit.script_method
     def forward(self, input: Tensor, hx: Optional[Tensor] = None) -> Tensor:
@@ -241,6 +261,9 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
 
     def __init__(self, other, dtype=torch.int8):
         super(QuantizedRNNBase, self).__init__()
+        warnings.warn(
+            "torch.jit.QuantizedRNNBase is deprecated and will be removed in an upcoming "
+            "PyTorch release. Please use the torch.nn.quantized.dynamic instead.")
         self.mode = other.mode
         self.input_size = other.input_size
         self.hidden_size = other.hidden_size
@@ -343,6 +366,9 @@ class QuantizedLSTM(QuantizedRNNBase):
 
     def __init__(self, other, dtype):
         super(QuantizedLSTM, self).__init__(other, dtype)
+        warnings.warn(
+            "torch.jit.QuantizedLSTM is deprecated and will be removed in an upcoming "
+            "PyTorch release. Please use the torch.nn.quantized.dynamic.LSTM instead.")
 
     @torch.jit.script_method
     def forward_impl(self, input: Tensor, hx: Optional[Tuple[Tensor, Tensor]], batch_sizes: Optional[Tensor],
@@ -417,6 +443,13 @@ class QuantizedLSTM(QuantizedRNNBase):
 
 class QuantizedGRU(QuantizedRNNBase):
     __overloads__ = {'forward': ['forward_packed', 'forward_tensor']}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            "torch.jit.QuantizedGRU is deprecated and will be removed in an upcoming "
+            "PyTorch release. Please use the torch.nn.quantized.dynamic.GRU instead.")
+
 
     @torch.jit.script_method
     def forward_impl(self, input: Tensor, hx: Optional[Tensor], batch_sizes: Optional[Tensor], max_batch_size: int,


### PR DESCRIPTION
Ref #72263 for cpp_custom_type_hack removal

This module depends on the deprecated `at::cpp_custom_type_hack` in
such a way that updating it would require a full deprecation cycle and
BC break. However, this entire module seems to be legacy. I can't find
it in any of the documentation and the `quantize_***_modules`
functions have already been deprecated for 2 years according to the
git-blame.

So, it makes more sense to deprecate the whole module and clean it up
along with `cpp_custom_type_hack`.
