### PR TITLE
[PyTorch] RFC: existing MHA: can't we fuse the attn_mask addition easily?

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4988,9 +4988,11 @@ def _scaled_dot_product_attention(
     B, Nt, E = q.shape
     q = q / math.sqrt(E)
     # (B, Nt, E) x (B, E, Ns) -> (B, Nt, Ns)
-    attn = torch.bmm(q, k.transpose(-2, -1))
     if attn_mask is not None:
-        attn += attn_mask
+        attn = torch.baddbmm(attn_mask, q, k.transpose(-2, -1))
+    else:
+        attn = torch.bmm(q, k.transpose(-2, -1))
+
     attn = softmax(attn, dim=-1)
     if dropout_p > 0.0:
         attn = dropout(attn, p=dropout_p)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #72691

Saw a report that this elementwise add is causing overhead. IIUC this is easy to fuse?

Differential Revision: [D34160547](https://our.internmc.facebook.com/intern/diff/D34160547/)