### PR TITLE
[Vulkan] Implement GRU operator

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Gru.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Gru.cpp
@@ -1,0 +1,101 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+//
+// input_vk: input tensor of shape (L, N, H_in) when batch_first=False
+//                                 (N, L, H_in) when batch_first=True containing the features of the input sequence
+// hx_vk: initial hidden state for each element in the batch. tensor of shape (D * num_layers, N, H_out)
+// output: tensor of shape (N, L, D * H_out)) when batch_first=True
+// h_n: tensor of shape (D * num_layers, N, H_out)
+//
+//  where
+//    L = sequence length
+//    N = batch size
+//    D = 2 if bidirectional=True otherwise 1
+//    H_in = input_size (# of expected features in the input x)
+//    H_out = hidden_size (# of features in the hidden state h)
+//
+std::tuple<Tensor, Tensor> gru_input(
+  const Tensor & input_vk,  // input sequence (vulkan)
+  const Tensor & hx_vk,     // initial hidden state (vulkan)
+  TensorList params_cpu,    // weights/biases (cpu)
+  bool has_biases,
+  int64_t num_layers,
+  double dropout,
+  bool train,
+  bool bidirectional,
+  bool batch_first) {
+  TORCH_CHECK(params_cpu.size() == 4 * num_layers, "Vulkan gru expects 'params_cpu' size to be 4 * 'num_layers'.");
+  TORCH_INTERNAL_ASSERT(input_vk.sizes().size() == 3, "Vulkan gru expects 'input_vk' dims to be 3.");
+  TORCH_INTERNAL_ASSERT(hx_vk.sizes().size() == 3, "Vulkan gru expects 'hx_vk' dims to be 3.");
+  TORCH_INTERNAL_ASSERT(has_biases, "Vulkan gru expects 'has_biases' to be true.");
+  TORCH_INTERNAL_ASSERT(!train, "Vulkan gru expects 'train' to be false.");
+  TORCH_INTERNAL_ASSERT(!bidirectional, "Vulkan gru expects 'bidirectional' to be false.");
+  TORCH_INTERNAL_ASSERT(batch_first, "Vulkan gru expects 'batch_first' to be true.");
+  TORCH_INTERNAL_ASSERT(dropout < std::numeric_limits<double>::epsilon()*1000, "Vulkan gru expects 'dropout' to be 0.0.");
+
+  const auto h_in = input_vk.size(2);
+  std::vector<at::Tensor> h_n_list;  // hidden output
+
+  // reshape to 2D due to Vulkan at::mm op accepts only 2D
+  auto x = input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
+
+  for (int64_t i = 0; i < num_layers; ++i) {
+    // extract each hidden state and squeeze into 2D dim
+    auto h = at::slice(hx_vk, 0, i, i + 1, 1);
+    h = h.reshape({h.size(0) * h.size(1), h.size(2)});
+
+    const auto& w_ih = params_cpu[i * 4];
+    const auto& w_hh = params_cpu[i * 4 + 1];
+    const auto& b_ih = params_cpu[i * 4 + 2];
+    const auto& b_hh = params_cpu[i * 4 + 3];
+
+    const auto&  w_i_rzn = w_ih.split(h_in);
+    const auto&  w_h_rzn = w_hh.split(h_in);
+    const auto&  b_i_rzn = b_ih.split(h_in);
+    const auto&  b_h_rzn = b_hh.split(h_in);
+
+    const auto&  w_ir = w_i_rzn[0];
+    const auto&  w_iz = w_i_rzn[1];
+    const auto&  w_in = w_i_rzn[2];
+    const auto&  w_hr = w_h_rzn[0];
+    const auto&  w_hz = w_h_rzn[1];
+    const auto&  w_hn = w_h_rzn[2];
+    const auto&  b_ir = b_i_rzn[0];
+    const auto&  b_iz = b_i_rzn[1];
+    const auto&  b_in = b_i_rzn[2];
+    const auto&  b_hr = b_h_rzn[0];
+    const auto&  b_hz = b_h_rzn[1];
+    const auto&  b_hn = b_h_rzn[2];
+
+    const auto&  r = at::sigmoid(at::addmm(b_ir, x, w_ir.t()) + at::addmm(b_hr, h, w_hr.t()));
+    const auto&  z = at::sigmoid(at::addmm(b_iz, x, w_iz.t()) + at::addmm(b_hz, h, w_hz.t()));
+    const auto&  n = at::tanh(at::addmm(b_in, x, w_in.t()) + r * (at::addmm(b_hn, h, w_hn.t())));
+    h = (z * (-1) + 1) * n + z * h;
+    x = h;  // next input
+    h_n_list.emplace_back(h.reshape({1, 1, h.size(0), h.size(1)}));  // 2D to 4D for cat op
+  }
+
+  auto h_n = at::cat(h_n_list, 1);
+  h_n = h_n.reshape({h_n.size(0) * h_n.size(1), h_n.size(2), h_n.size(3)});
+  return std::tuple<Tensor, Tensor>(x, h_n);
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::gru.input"), TORCH_FN(gru_input));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -2805,6 +2805,163 @@ TEST(VulkanAPITest, mobilenetv2) {
   ASSERT_TRUE(check);
 }
 
+TEST(VulkanAPITest, gru_mclareninputs_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const int H_in = 384;  // input_size
+  const int H_out = 384; // hidden_size
+  const int num_layers = 2;
+  const double gru_dropout = .0;
+  const bool has_biases = true;
+  const bool train = false;
+  const bool bidirectional = false;
+  const bool batch_first = true;
+  const auto in_cpu = at::rand({1, 1, H_in}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto h0_cpu = at::rand({num_layers, 1, H_out}, at::device(at::kCPU).dtype(at::kFloat));
+
+  c10::List<at::Tensor> weight_ih_l; // shape (3 * hidden_size, input_size)
+  c10::List<at::Tensor> weight_hh_l; // shape (3 * hidden_size, hidden_size)
+  c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
+  c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
+  for (int i = 0; i < num_layers; ++i) {
+    weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    weight_hh_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_ih_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_hh_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+  }
+
+  // put this guard here to run inference inststead of training
+  // to avoid the following error:
+  //     C++ exception with description "0INTERNAL ASSERT FAILED at "xplat/caffe2/aten/src/ATen/core/boxing/KernelFunction.cpp":31, please report a bug to PyTorch. aten::gru.input has kernels registered to both CompositeImplicitAutograd and a backend mapped to AutogradOther. This makes the backend kernel unreachable; the dispatcher will always prefer the CompositeImplicitAutograd lowering (see Note [Ambiguity in AutogradOther kernel]). If you want to override CompositeImplicitAutograd, please open an issue to request a dedicated Autograd dispatch key for the backend.
+  //     If you only want to run inference instead of training, add `c10::InferenceMode mode;` before model.forward(). Note this guard is only available in C++ but not Python at present.
+  c10::InferenceMode mode;
+
+  // Act
+  const auto out_cpu = at::gru(in_cpu, h0_cpu,
+      { weight_ih_l[0], weight_hh_l[0], bias_ih_l[0], bias_hh_l[0], weight_ih_l[1], weight_hh_l[1], bias_ih_l[1], bias_hh_l[1] },
+      has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+
+  // weights/biases should be always on CPU.
+  const auto out_vulkan = at::gru(in_cpu.vulkan(), h0_cpu.vulkan(), { weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+      weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) },
+      has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+
+  auto cpu_output = std::get<0>(out_cpu);
+  auto cpu_hidden = std::get<1>(out_cpu);
+  auto vulkan_output = std::get<0>(out_vulkan);
+  auto vulkan_hidden = std::get<1>(out_vulkan);
+
+  // Assert
+  const auto check_output = almostEqual(cpu_output, vulkan_output.cpu());
+  if (!check_output) {
+    showRtol(cpu_output, vulkan_output.cpu());
+  }
+  ASSERT_TRUE(check_output);
+
+  const auto check_hidden = almostEqual(cpu_hidden, vulkan_hidden.cpu());
+  if (!check_hidden) {
+    showRtol(cpu_hidden, vulkan_hidden.cpu());
+  }
+  ASSERT_TRUE(check_hidden);
+}
+
+TEST(VulkanAPITest, gru_invalidinputs_exceptions) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const int H_in = 384;  // input_size
+  const int H_out = 384; // hidden_size
+  const int num_layers = 2;
+  const double gru_dropout = .0;
+  const bool has_biases = true;
+  const bool train = false;
+  const bool bidirectional = false;
+  const bool batch_first = true;
+  const auto in_cpu = at::rand({1, 1, H_in}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto h0_cpu = at::rand({num_layers, 1, H_out}, at::device(at::kCPU).dtype(at::kFloat));
+
+  c10::List<at::Tensor> weight_ih_l; // shape (3 * hidden_size, input_size)
+  c10::List<at::Tensor> weight_hh_l; // shape (3 * hidden_size, hidden_size)
+  c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
+  c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
+  for (int i = 0; i < num_layers; ++i) {
+    weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    weight_hh_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_ih_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_hh_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+  }
+
+  // put this guard here to run inference inststead of training
+  // to avoid the following error:
+  //     C++ exception with description "0INTERNAL ASSERT FAILED at "xplat/caffe2/aten/src/ATen/core/boxing/KernelFunction.cpp":31, please report a bug to PyTorch. aten::gru.input has kernels registered to both CompositeImplicitAutograd and a backend mapped to AutogradOther. This makes the backend kernel unreachable; the dispatcher will always prefer the CompositeImplicitAutograd lowering (see Note [Ambiguity in AutogradOther kernel]). If you want to override CompositeImplicitAutograd, please open an issue to request a dedicated Autograd dispatch key for the backend.
+  //     If you only want to run inference instead of training, add `c10::InferenceMode mode;` before model.forward(). Note this guard is only available in C++ but not Python at present.
+  c10::InferenceMode mode;
+
+  // Act: incorrect # of weights/biases
+  EXPECT_THROW({
+    at::gru(in_cpu.vulkan(), h0_cpu.vulkan(), { weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+      weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1) },
+      has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+  }, ::c10::Error);
+
+  // Act: non-3D input tensor
+  EXPECT_THROW({
+    const auto in_cpu_2d = at::rand({1, H_in}, at::device(at::kCPU).dtype(at::kFloat));
+    at::gru(in_cpu_2d.vulkan(), h0_cpu.vulkan(), { weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+      weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) },
+      has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+  }, ::c10::Error);
+
+  // Act: non-3D hidden tensor
+  EXPECT_THROW({
+    const auto h0_cpu_2d = at::rand({num_layers, H_out}, at::device(at::kCPU).dtype(at::kFloat));
+    at::gru(in_cpu.vulkan(), h0_cpu_2d.vulkan(), { weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+      weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) },
+      has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+  }, ::c10::Error);
+
+  // Act: has_biases should be true
+  EXPECT_THROW({
+    at::gru(in_cpu.vulkan(), h0_cpu.vulkan(), { weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+      weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) },
+      false, num_layers, gru_dropout, train, bidirectional, batch_first);
+  }, ::c10::Error);
+
+  // Act: train should be false
+  EXPECT_THROW({
+    at::gru(in_cpu.vulkan(), h0_cpu.vulkan(), { weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+      weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) },
+      has_biases, num_layers, gru_dropout, true, bidirectional, batch_first);
+  }, ::c10::Error);
+
+  // Act: bidirectional should be false
+  EXPECT_THROW({
+    at::gru(in_cpu.vulkan(), h0_cpu.vulkan(), { weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+      weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) },
+      has_biases, num_layers, gru_dropout, train, true, batch_first);
+  }, ::c10::Error);
+
+  // Act: batch_first should be true
+  EXPECT_THROW({
+    at::gru(in_cpu.vulkan(), h0_cpu.vulkan(), { weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+      weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) },
+      has_biases, num_layers, gru_dropout, train, bidirectional, false);
+  }, ::c10::Error);
+
+  // Act: dropout should be 0.0
+  EXPECT_THROW({
+    at::gru(in_cpu.vulkan(), h0_cpu.vulkan(), { weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+      weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) },
+      has_biases, num_layers, 1.0, train, bidirectional, batch_first);
+  }, ::c10::Error);
+}
 } // namespace
 
 #endif /* USE_VULKAN_API */


### PR DESCRIPTION
Summary:
Implemented GRU operator in the Vulkan GPU backend:
* This is an initial implementation to support an internal model.
* Internal name for GRU is `aten::gru.input`
* There should be 2 weights and 2 biases per layer. See [GRU >> Variables](https://pytorch.org/docs/stable/generated/torch.nn.GRU.html) section
* For num_layers=1 the weights should contain [weight_ih, weight_hh, bias_ih, bias_hh] (4 elements)
* Need to reshape input and hidden state to 2D since Vulkan `mm` and `addmm` ops accept only 2D dim
* By design, all weights and biases should be on the CPU where input sequence and hidden state should be on the Vulkan GPU.
* Input arguments and return values:
    * `input_vk`: input tensor of shape (L, N, H_in) when batch_first=False or (N, L, H_in) when batch_first=True containing the features of the input sequence
    * `hx_vk`: initial hidden state for each element in the batch. tensor of shape (D * num_layers, N, H_out)
    * `output`: tensor of shape (N, L, D * H_out)) when batch_first=True
    * `h_n`: tensor of shape (D * num_layers, N, H_out)
    * where
        * L = sequence length
        * N = batch size
        * D = 2 if bidirectional=True otherwise 1
        * H_in = input_size (# of expected features in the input x)
        * H_out = hidden_size (# of features in the hidden state h)
* This initial implementation has some limitations:
    * Tensor dim should be 3 for input sequence and hidden state.
    * has_biases=True
    * train=False
    * bidirectional=False
    * batch_first=True
    * dropout=0.0
    * D=1 since bidirectional=False
    * N=1 (batch size)
    * L=1 (sequence length)
* GRU high-level python code:
```
import torch
from torch import nn
import numpy as np
import math

H_in = 10
H_out = 10
num_layers = 2
D = 1

gru = nn.GRU(H_in, H_out, num_layers)
input = torch.randn(1, 1, H_in)
h0 = torch.randn(D * num_layers, 1, H_out)
output, h_n = gru(input, h0)

print(output)
print(h_n)

print(gru._all_weights)

# the same result can be calculated directly
x = input
output = x
h_n = []
for i in range(num_layers):
    h = h0[i]
    W_ih, W_hh, b_ih, b_hh = gru._flat_weights[i * 4 : (i + 1) * 4]
    W_ir, W_iz, W_in = W_ih.split(H_in)
    W_hr, W_hz, W_hn = W_hh.split(H_in)
    b_ir, b_iz, b_in = b_ih.split(H_in)
    b_hr, b_hz, b_hn = b_hh.split(H_in)

    r = torch.sigmoid(x @ W_ir.T + b_ir + h @ W_hr.T + b_hr)
    z = torch.sigmoid(x @ W_iz.T + b_iz + h @ W_hz.T + b_hz)
    n = torch.tanh(x @ W_in.T + b_in + r * (h @ W_hn.T + b_hn))
    h = (1 - z) * n + z * h
    x = h
    output = x
    h_n.append(h[0])

print(output)
print(h_n)
```
* References
    * PyTorch Docs > torch.nn > [GRU](https://pytorch.org/docs/stable/generated/torch.nn.GRU.html)
    * Dive into Deep Learning > [9.1. Gated Recurrent Units (GRU)](https://d2l.ai/chapter_recurrent-modern/gru.html)
    * [Gated Recurrent Unit (GRU) With PyTorch](https://blog.floydhub.com/gru-with-pytorch/)
    * [From GRU to Transformer](https://ogunlao.github.io/blog/2020/06/12/from_gru_to_transformer.html)

Test Plan:
Build & test on Android:
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
```
Test result on Android (Google Pixel 5):
```
[ RUN      ] VulkanAPITest.gru_mclareninputs_success
[       OK ] VulkanAPITest.gru_mclareninputs_success (59 ms)
[ RUN      ] VulkanAPITest.gru_invalidinputs_exceptions
[       OK ] VulkanAPITest.gru_invalidinputs_exceptions (17 ms)
```

Differential Revision: D33995221

