### PR TITLE
[Demo] Don't always unmutate transpose

### DIFF
--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -2849,7 +2849,7 @@ graph(%x.1 : Tensor):
       &*graph,
       vmap);
   RemoveTensorMutation(graph, [](Node*) { return true; });
-  testing::FileCheck().check_not("aten::transpose_")->run(*graph);
+  testing::FileCheck().check("aten::transpose_")->run(*graph);
 }
 
 TEST(TestMutation, Basic) {

--- a/torch/csrc/jit/passes/remove_mutation.cpp
+++ b/torch/csrc/jit/passes/remove_mutation.cpp
@@ -252,7 +252,7 @@ bool MutationRemover::RemoveTensorMutation(Block* block) {
     // their functional equivalents if the input tensor to them has more than
     // one use.
     auto kind_of_node = node->kind();
-    if (kind_of_node == aten::permute || kind_of_node == aten::transpose) {
+    if (kind_of_node == aten::permute_ || kind_of_node == aten::transpose_) {
       if (mutated_value->uses().size() != 1) {
         continue;
       }

--- a/torch/csrc/jit/passes/remove_mutation.cpp
+++ b/torch/csrc/jit/passes/remove_mutation.cpp
@@ -249,10 +249,9 @@ bool MutationRemover::RemoveTensorMutation(Block* block) {
 
     Value* mutated_value = node->inputs().at(0);
     // If tranpose is inplace, then it should not be converted to its
-    // functional equivalents if the input tensor to them has more than
+    // functional equivalent if the input tensor to it has more than
     // one use.
-    auto kind_of_node = node->kind();
-    if (kind_of_node == Symbol::fromQualString(aten::permute_)) {
+    if (node->kind() == Symbol::fromQualString(aten::transpose_)) {
       if (mutated_value->uses().size() != 1) {
         continue;
       }

--- a/torch/csrc/jit/passes/remove_mutation.cpp
+++ b/torch/csrc/jit/passes/remove_mutation.cpp
@@ -251,7 +251,7 @@ bool MutationRemover::RemoveTensorMutation(Block* block) {
     // If tranpose is inplace, then it should not be converted to its
     // functional equivalent if the input tensor to it has more than
     // one use.
-    if (node->kind() == Symbol::fromQualString(aten::transpose_)) {
+    if (node->kind() == Symbol::fromQualString("aten::transpose_")) {
       if (mutated_value->uses().size() != 1) {
         continue;
       }

--- a/torch/csrc/jit/passes/remove_mutation.cpp
+++ b/torch/csrc/jit/passes/remove_mutation.cpp
@@ -248,11 +248,11 @@ bool MutationRemover::RemoveTensorMutation(Block* block) {
     }
 
     Value* mutated_value = node->inputs().at(0);
-    // If permute or tranpose are inplace, then they should not be converted to
-    // their functional equivalents if the input tensor to them has more than
+    // If tranpose is inplace, then it should not be converted to its
+    // functional equivalents if the input tensor to them has more than
     // one use.
     auto kind_of_node = node->kind();
-    if (kind_of_node == aten::permute_ || kind_of_node == aten::transpose_) {
+    if (kind_of_node == Symbol::fromQualString(aten::permute_)) {
       if (mutated_value->uses().size() != 1) {
         continue;
       }


### PR DESCRIPTION
Demo to show that we shouldn't always replace inplace ops such as `transpose_`  by its functional equivalent in `RemoveTensorMutation` if its input is used by some other op as well.

Let's consider this graph -

```
graph(%x.1 : Tensor):
  %2 : int = prim::Constant[value=0]()
  %9 : int = prim::Constant[value=1]()
  %x.3 : Tensor = aten::add(%x.1, %2, %2)
  %7 : Tensor = aten::transpose_(%x.3, %2, %9)
  %y.1 : Tensor = aten::add(%x.3, %9, %2)
  return (%y.1))
```

`RemoveTensorMutation` shouldn't replace `transpose_` with `transpose` in the current code, but it does.
In this demo, `transpose_` wouldn't be replaced by `transpose`.