### PR TITLE
Pin builder repo for GHA builds to release/1.11

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -72,7 +72,7 @@ jobs:
     steps:
       !{{ common.setup_ec2_linux() }}
       !{{ common.checkout(deep_clone=False, directory="pytorch") }}
-      !{{ common.checkout(deep_clone=False, directory="builder", repository="pytorch/builder") }}
+      !{{ common.checkout(deep_clone=False, directory="builder", repository="pytorch/builder", branch="release/1.11") }}
 {%- if config["gpu_arch_type"] == 'cuda' and config["gpu_arch_version"].startswith('11') %}
       - name: Set BUILD_SPLIT_CUDA
         run: |

--- a/.github/templates/windows_binary_build_workflow.yml.j2
+++ b/.github/templates/windows_binary_build_workflow.yml.j2
@@ -93,6 +93,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -137,6 +138,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |

--- a/.github/workflows/generated-linux-binary-conda.yml
+++ b/.github/workflows/generated-linux-binary-conda.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -501,6 +502,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -898,6 +900,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -1298,6 +1301,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -1698,6 +1702,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2097,6 +2102,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2487,6 +2493,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2884,6 +2891,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -3284,6 +3292,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -3684,6 +3693,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4083,6 +4093,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4473,6 +4484,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4870,6 +4882,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -5270,6 +5283,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -5670,6 +5684,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6069,6 +6084,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6459,6 +6475,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6856,6 +6873,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -7256,6 +7274,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -7656,6 +7675,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
@@ -112,6 +112,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -504,6 +505,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -896,6 +898,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -1288,6 +1291,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -1681,6 +1685,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2081,6 +2086,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2481,6 +2487,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2881,6 +2888,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -3281,6 +3289,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -3684,6 +3693,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4087,6 +4097,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4490,6 +4501,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4893,6 +4905,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -5296,6 +5309,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -5699,6 +5713,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6102,6 +6117,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6505,6 +6521,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6908,6 +6925,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -7311,6 +7329,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -7714,6 +7733,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
@@ -112,6 +112,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -504,6 +505,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -896,6 +898,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -1288,6 +1291,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -1681,6 +1685,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2081,6 +2086,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2481,6 +2487,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2881,6 +2888,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -3281,6 +3289,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -3684,6 +3693,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4087,6 +4097,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4490,6 +4501,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4893,6 +4905,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -5296,6 +5309,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -5699,6 +5713,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6102,6 +6117,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6505,6 +6521,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6908,6 +6925,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -7311,6 +7329,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -7714,6 +7733,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |

--- a/.github/workflows/generated-linux-binary-manywheel.yml
+++ b/.github/workflows/generated-linux-binary-manywheel.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -501,6 +502,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -898,6 +900,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -1298,6 +1301,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -1698,6 +1702,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2098,6 +2103,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2490,6 +2496,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -2881,6 +2888,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -3271,6 +3279,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -3668,6 +3677,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4068,6 +4078,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4468,6 +4479,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -4868,6 +4880,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -5260,6 +5273,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -5651,6 +5665,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6041,6 +6056,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6438,6 +6454,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -6838,6 +6855,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -7238,6 +7256,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -7638,6 +7657,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -8030,6 +8050,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -8421,6 +8442,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -8811,6 +8833,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -9208,6 +9231,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -9608,6 +9632,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -10008,6 +10033,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -10408,6 +10434,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |
@@ -10800,6 +10827,7 @@ jobs:
         with:
           submodules: recursive
           repository: pytorch/builder
+          ref: release/1.11
           path: builder
       - name: Clean pytorch/builder checkout
         run: |

--- a/.github/workflows/generated-windows-binary-libtorch-cxx11-abi.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-cxx11-abi.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -178,6 +179,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -373,6 +375,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -462,6 +465,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -657,6 +661,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -746,6 +751,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -941,6 +947,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1030,6 +1037,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1226,6 +1234,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1316,6 +1325,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1513,6 +1523,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1603,6 +1614,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1800,6 +1812,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1890,6 +1903,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2087,6 +2101,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2177,6 +2192,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2374,6 +2390,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2464,6 +2481,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2661,6 +2679,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2751,6 +2770,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2948,6 +2968,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3038,6 +3059,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3235,6 +3257,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3325,6 +3348,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3522,6 +3546,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3612,6 +3637,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3809,6 +3835,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3899,6 +3926,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -4096,6 +4124,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -4186,6 +4215,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -4383,6 +4413,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -4473,6 +4504,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |

--- a/.github/workflows/generated-windows-binary-libtorch-pre-cxx11.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-pre-cxx11.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -178,6 +179,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -373,6 +375,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -462,6 +465,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -657,6 +661,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -746,6 +751,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -941,6 +947,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1030,6 +1037,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1226,6 +1234,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1316,6 +1325,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1513,6 +1523,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1603,6 +1614,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1800,6 +1812,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1890,6 +1903,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2087,6 +2101,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2177,6 +2192,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2374,6 +2390,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2464,6 +2481,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2661,6 +2679,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2751,6 +2770,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2948,6 +2968,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3038,6 +3059,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3235,6 +3257,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3325,6 +3348,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3522,6 +3546,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3612,6 +3637,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3809,6 +3835,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3899,6 +3926,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -4096,6 +4124,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -4186,6 +4215,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -4383,6 +4413,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -4473,6 +4504,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |

--- a/.github/workflows/generated-windows-binary-wheel.yml
+++ b/.github/workflows/generated-windows-binary-wheel.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -170,6 +171,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -358,6 +360,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -444,6 +447,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -633,6 +637,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -719,6 +724,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -908,6 +914,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -994,6 +1001,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1182,6 +1190,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1267,6 +1276,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1455,6 +1465,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1541,6 +1552,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1730,6 +1742,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -1816,6 +1829,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2005,6 +2019,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2091,6 +2106,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2279,6 +2295,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2364,6 +2381,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2552,6 +2570,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2638,6 +2657,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2827,6 +2847,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -2913,6 +2934,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3102,6 +3124,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3188,6 +3211,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3376,6 +3400,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3461,6 +3486,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3649,6 +3675,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3735,6 +3762,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -3924,6 +3952,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -4010,6 +4039,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -4199,6 +4229,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |
@@ -4285,6 +4316,7 @@ jobs:
         with:
           repository: pytorch/builder
           path: ${{ env.BUILDER_ROOT }}
+          ref: release/1.11
       - name: Populate binary env
         shell: bash
         run: |


### PR DESCRIPTION
Fix for builder repo not pinned in release branch
