### PR TITLE
[LTS] CircleCI: Deprecate `gpu.medium` class

### DIFF
--- a/.circleci/cimodel/data/binary_build_definitions.py
+++ b/.circleci/cimodel/data/binary_build_definitions.py
@@ -100,7 +100,7 @@ class Conf(object):
                 if self.os == "windows":
                     job_def["executor"] = "windows-with-nvidia-gpu"
                 else:
-                    job_def["resource_class"] = "gpu.medium"
+                    job_def["resource_class"] = "gpu.nvidia.small"
 
         os_name = miniutils.override(self.os, {"macos": "mac"})
         job_name = "_".join([self.get_name_prefix(), os_name, phase])

--- a/.circleci/cimodel/data/pytorch_build_definitions.py
+++ b/.circleci/cimodel/data/pytorch_build_definitions.py
@@ -182,7 +182,7 @@ def gen_dependent_configs(xenial_parent_config):
         (["multigpu"], "large"),
         (["nogpu", "NO_AVX2"], None),
         (["nogpu", "NO_AVX"], None),
-        (["slow"], "medium"),
+        (["slow"], "nvidia.small"),
     ]
 
     configs = []
@@ -340,7 +340,7 @@ def instantiate_configs():
 
         gpu_resource = None
         if cuda_version and cuda_version != "10":
-            gpu_resource = "medium"
+            gpu_resource = "nvidia.small"
 
         c = Conf(
             distro_name,

--- a/.circleci/cimodel/data/simple/binary_smoketest.py
+++ b/.circleci/cimodel/data/simple/binary_smoketest.py
@@ -164,7 +164,7 @@ WORKFLOW_DATA = [
         is_master_only=True,
         requires=["binary_linux_manywheel_3_7m_cu102_devtoolset7_build"],
         extra_props={
-            "resource_class": "gpu.medium",
+            "resource_class": "gpu.nvidia.small",
             "use_cuda_docker_runtime": miniutils.quote((str(1))),
         },
     ),

--- a/.circleci/cimodel/data/simple/ge_config_tests.py
+++ b/.circleci/cimodel/data/simple/ge_config_tests.py
@@ -37,7 +37,7 @@ class GeConfigTestJob:
 
     def gen_tree(self):
 
-        resource_class = "gpu.medium" if self.use_cuda_docker else "large"
+        resource_class = "gpu.nvidia.small" if self.use_cuda_docker else "large"
         docker_image = DOCKER_IMAGE_CUDA_10_2 if self.use_cuda_docker else DOCKER_IMAGE_BASIC
         full_name = "_".join(self.get_all_parts(False))
         build_env = self.build_env_override or "-".join(self.get_all_parts(True))

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3391,7 +3391,7 @@ workflows:
             - binary_linux_manywheel_3_6m_cu101_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_cu101_devtoolset7_nightly_test
           build_environment: "manywheel 3.7m cu101 devtoolset7"
@@ -3406,7 +3406,7 @@ workflows:
             - binary_linux_manywheel_3_7m_cu101_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_8m_cu101_devtoolset7_nightly_test
           build_environment: "manywheel 3.8m cu101 devtoolset7"
@@ -3421,7 +3421,7 @@ workflows:
             - binary_linux_manywheel_3_8m_cu101_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_9m_cu101_devtoolset7_nightly_test
           build_environment: "manywheel 3.9m cu101 devtoolset7"
@@ -3436,7 +3436,7 @@ workflows:
             - binary_linux_manywheel_3_9m_cu101_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_6m_cu102_devtoolset7_nightly_test
           build_environment: "manywheel 3.6m cu102 devtoolset7"
@@ -3451,7 +3451,7 @@ workflows:
             - binary_linux_manywheel_3_6m_cu102_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_cu102_devtoolset7_nightly_test
           build_environment: "manywheel 3.7m cu102 devtoolset7"
@@ -3466,7 +3466,7 @@ workflows:
             - binary_linux_manywheel_3_7m_cu102_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_8m_cu102_devtoolset7_nightly_test
           build_environment: "manywheel 3.8m cu102 devtoolset7"
@@ -3481,7 +3481,7 @@ workflows:
             - binary_linux_manywheel_3_8m_cu102_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_9m_cu102_devtoolset7_nightly_test
           build_environment: "manywheel 3.9m cu102 devtoolset7"
@@ -3496,7 +3496,7 @@ workflows:
             - binary_linux_manywheel_3_9m_cu102_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_6m_cu111_devtoolset7_nightly_test
           build_environment: "manywheel 3.6m cu111 devtoolset7"
@@ -3511,7 +3511,7 @@ workflows:
             - binary_linux_manywheel_3_6m_cu111_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_cu111_devtoolset7_nightly_test
           build_environment: "manywheel 3.7m cu111 devtoolset7"
@@ -3526,7 +3526,7 @@ workflows:
             - binary_linux_manywheel_3_7m_cu111_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_8m_cu111_devtoolset7_nightly_test
           build_environment: "manywheel 3.8m cu111 devtoolset7"
@@ -3541,7 +3541,7 @@ workflows:
             - binary_linux_manywheel_3_8m_cu111_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_9m_cu111_devtoolset7_nightly_test
           build_environment: "manywheel 3.9m cu111 devtoolset7"
@@ -3556,7 +3556,7 @@ workflows:
             - binary_linux_manywheel_3_9m_cu111_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_6m_rocm3_10_devtoolset7_nightly_test
           build_environment: "manywheel 3.6m rocm3.10 devtoolset7"
@@ -3571,7 +3571,7 @@ workflows:
             - binary_linux_manywheel_3_6m_rocm3_10_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-rocm:3.10"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_rocm3_10_devtoolset7_nightly_test
           build_environment: "manywheel 3.7m rocm3.10 devtoolset7"
@@ -3586,7 +3586,7 @@ workflows:
             - binary_linux_manywheel_3_7m_rocm3_10_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-rocm:3.10"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_8m_rocm3_10_devtoolset7_nightly_test
           build_environment: "manywheel 3.8m rocm3.10 devtoolset7"
@@ -3601,7 +3601,7 @@ workflows:
             - binary_linux_manywheel_3_8m_rocm3_10_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-rocm:3.10"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_9m_rocm3_10_devtoolset7_nightly_test
           build_environment: "manywheel 3.9m rocm3.10 devtoolset7"
@@ -3616,7 +3616,7 @@ workflows:
             - binary_linux_manywheel_3_9m_rocm3_10_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-rocm:3.10"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_6m_rocm4_0_1_devtoolset7_nightly_test
           build_environment: "manywheel 3.6m rocm4.0.1 devtoolset7"
@@ -3631,7 +3631,7 @@ workflows:
             - binary_linux_manywheel_3_6m_rocm4_0_1_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-rocm:4.0.1"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_7m_rocm4_0_1_devtoolset7_nightly_test
           build_environment: "manywheel 3.7m rocm4.0.1 devtoolset7"
@@ -3646,7 +3646,7 @@ workflows:
             - binary_linux_manywheel_3_7m_rocm4_0_1_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-rocm:4.0.1"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_8m_rocm4_0_1_devtoolset7_nightly_test
           build_environment: "manywheel 3.8m rocm4.0.1 devtoolset7"
@@ -3661,7 +3661,7 @@ workflows:
             - binary_linux_manywheel_3_8m_rocm4_0_1_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-rocm:4.0.1"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_manywheel_3_9m_rocm4_0_1_devtoolset7_nightly_test
           build_environment: "manywheel 3.9m rocm4.0.1 devtoolset7"
@@ -3676,7 +3676,7 @@ workflows:
             - binary_linux_manywheel_3_9m_rocm4_0_1_devtoolset7_nightly_build
           docker_image: "pytorch/manylinux-rocm:4.0.1"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_6_cpu_devtoolset7_nightly_test
           build_environment: "conda 3.6 cpu devtoolset7"
@@ -3743,7 +3743,7 @@ workflows:
             - binary_linux_conda_3_6_cu101_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_7_cu101_devtoolset7_nightly_test
           build_environment: "conda 3.7 cu101 devtoolset7"
@@ -3758,7 +3758,7 @@ workflows:
             - binary_linux_conda_3_7_cu101_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_8_cu101_devtoolset7_nightly_test
           build_environment: "conda 3.8 cu101 devtoolset7"
@@ -3773,7 +3773,7 @@ workflows:
             - binary_linux_conda_3_8_cu101_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_9_cu101_devtoolset7_nightly_test
           build_environment: "conda 3.9 cu101 devtoolset7"
@@ -3788,7 +3788,7 @@ workflows:
             - binary_linux_conda_3_9_cu101_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_6_cu102_devtoolset7_nightly_test
           build_environment: "conda 3.6 cu102 devtoolset7"
@@ -3803,7 +3803,7 @@ workflows:
             - binary_linux_conda_3_6_cu102_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_7_cu102_devtoolset7_nightly_test
           build_environment: "conda 3.7 cu102 devtoolset7"
@@ -3818,7 +3818,7 @@ workflows:
             - binary_linux_conda_3_7_cu102_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_8_cu102_devtoolset7_nightly_test
           build_environment: "conda 3.8 cu102 devtoolset7"
@@ -3833,7 +3833,7 @@ workflows:
             - binary_linux_conda_3_8_cu102_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_9_cu102_devtoolset7_nightly_test
           build_environment: "conda 3.9 cu102 devtoolset7"
@@ -3848,7 +3848,7 @@ workflows:
             - binary_linux_conda_3_9_cu102_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_6_cu111_devtoolset7_nightly_test
           build_environment: "conda 3.6 cu111 devtoolset7"
@@ -3863,7 +3863,7 @@ workflows:
             - binary_linux_conda_3_6_cu111_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_7_cu111_devtoolset7_nightly_test
           build_environment: "conda 3.7 cu111 devtoolset7"
@@ -3878,7 +3878,7 @@ workflows:
             - binary_linux_conda_3_7_cu111_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_8_cu111_devtoolset7_nightly_test
           build_environment: "conda 3.8 cu111 devtoolset7"
@@ -3893,7 +3893,7 @@ workflows:
             - binary_linux_conda_3_8_cu111_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_conda_3_9_cu111_devtoolset7_nightly_test
           build_environment: "conda 3.9 cu111 devtoolset7"
@@ -3908,7 +3908,7 @@ workflows:
             - binary_linux_conda_3_9_cu111_devtoolset7_nightly_build
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-with-deps_test
           build_environment: "libtorch 3.7m cpu devtoolset7"
@@ -3980,7 +3980,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-with-deps_build
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-without-deps_test
           build_environment: "libtorch 3.7m cu101 devtoolset7"
@@ -3996,7 +3996,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-without-deps_build
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-with-deps_test
           build_environment: "libtorch 3.7m cu101 devtoolset7"
@@ -4012,7 +4012,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-with-deps_build
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-without-deps_test
           build_environment: "libtorch 3.7m cu101 devtoolset7"
@@ -4028,7 +4028,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-without-deps_build
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu102_devtoolset7_nightly_shared-with-deps_test
           build_environment: "libtorch 3.7m cu102 devtoolset7"
@@ -4044,7 +4044,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu102_devtoolset7_nightly_shared-with-deps_build
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu102_devtoolset7_nightly_shared-without-deps_test
           build_environment: "libtorch 3.7m cu102 devtoolset7"
@@ -4060,7 +4060,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu102_devtoolset7_nightly_shared-without-deps_build
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu102_devtoolset7_nightly_static-with-deps_test
           build_environment: "libtorch 3.7m cu102 devtoolset7"
@@ -4076,7 +4076,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu102_devtoolset7_nightly_static-with-deps_build
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu102_devtoolset7_nightly_static-without-deps_test
           build_environment: "libtorch 3.7m cu102 devtoolset7"
@@ -4092,7 +4092,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu102_devtoolset7_nightly_static-without-deps_build
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu111_devtoolset7_nightly_shared-with-deps_test
           build_environment: "libtorch 3.7m cu111 devtoolset7"
@@ -4108,7 +4108,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu111_devtoolset7_nightly_shared-with-deps_build
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu111_devtoolset7_nightly_shared-without-deps_test
           build_environment: "libtorch 3.7m cu111 devtoolset7"
@@ -4124,7 +4124,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu111_devtoolset7_nightly_shared-without-deps_build
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu111_devtoolset7_nightly_static-with-deps_test
           build_environment: "libtorch 3.7m cu111 devtoolset7"
@@ -4140,7 +4140,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu111_devtoolset7_nightly_static-with-deps_build
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu111_devtoolset7_nightly_static-without-deps_test
           build_environment: "libtorch 3.7m cu111 devtoolset7"
@@ -4156,7 +4156,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu111_devtoolset7_nightly_static-without-deps_build
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
@@ -4228,7 +4228,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
@@ -4244,7 +4244,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
@@ -4260,7 +4260,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
@@ -4276,7 +4276,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           build_environment: "libtorch 3.7m cu102 gcc5.4_cxx11-abi"
@@ -4292,7 +4292,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           build_environment: "libtorch 3.7m cu102 gcc5.4_cxx11-abi"
@@ -4308,7 +4308,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           build_environment: "libtorch 3.7m cu102 gcc5.4_cxx11-abi"
@@ -4324,7 +4324,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           build_environment: "libtorch 3.7m cu102 gcc5.4_cxx11-abi"
@@ -4340,7 +4340,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_shared-with-deps_test
           build_environment: "libtorch 3.7m cu111 gcc5.4_cxx11-abi"
@@ -4356,7 +4356,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_shared-with-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_shared-without-deps_test
           build_environment: "libtorch 3.7m cu111 gcc5.4_cxx11-abi"
@@ -4372,7 +4372,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_shared-without-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_static-with-deps_test
           build_environment: "libtorch 3.7m cu111 gcc5.4_cxx11-abi"
@@ -4388,7 +4388,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_static-with-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_linux_test:
           name: binary_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_static-without-deps_test
           build_environment: "libtorch 3.7m cu111 gcc5.4_cxx11-abi"
@@ -4404,7 +4404,7 @@ workflows:
             - binary_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_static-without-deps_build
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - binary_windows_test:
           name: binary_windows_wheel_3_6_cpu_nightly_test
           build_environment: "wheel 3.6 cpu"
@@ -6945,7 +6945,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - pytorch_linux_build:
           name: pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc5_4_build
           requires:
@@ -6977,7 +6977,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7-test1"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test2
           requires:
@@ -6985,7 +6985,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7-test2"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - pytorch_linux_test:
           name: pytorch_linux_xenial_cuda10_2_cudnn7_py3_multigpu_test
           requires:
@@ -7039,7 +7039,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda10.2-cudnn7-py3-slow-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - pytorch_linux_build:
           name: pytorch_libtorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_build
           requires:
@@ -7077,7 +7077,7 @@ workflows:
           build_environment: "pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7-test"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - pytorch_linux_build:
           name: pytorch_libtorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_build
           requires:
@@ -7267,7 +7267,7 @@ workflows:
           name: pytorch_linux_xenial_cuda10_2_cudnn7_py3_jit_legacy_test
           requires:
             - pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_build
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
           use_cuda_docker_runtime: "1"
       - pytorch_linux_bazel_build:
           build_environment: pytorch-linux-xenial-py3.6-gcc7-bazel-build
@@ -7369,7 +7369,7 @@ workflows:
           name: binary_linux_manywheel_3_7m_cu102_devtoolset7_test
           requires:
             - binary_linux_manywheel_3_7m_cu102_devtoolset7_build
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
           use_cuda_docker_runtime: "1"
       - binary_linux_test:
           build_environment: libtorch 3.7m cpu devtoolset7
@@ -7687,7 +7687,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_7m_cu101_devtoolset7_nightly
           build_environment: "manywheel 3.7m cu101 devtoolset7"
@@ -7699,7 +7699,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_8m_cu101_devtoolset7_nightly
           build_environment: "manywheel 3.8m cu101 devtoolset7"
@@ -7711,7 +7711,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_9m_cu101_devtoolset7_nightly
           build_environment: "manywheel 3.9m cu101 devtoolset7"
@@ -7723,7 +7723,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_6m_cu102_devtoolset7_nightly
           build_environment: "manywheel 3.6m cu102 devtoolset7"
@@ -7735,7 +7735,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_7m_cu102_devtoolset7_nightly
           build_environment: "manywheel 3.7m cu102 devtoolset7"
@@ -7747,7 +7747,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_8m_cu102_devtoolset7_nightly
           build_environment: "manywheel 3.8m cu102 devtoolset7"
@@ -7759,7 +7759,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_9m_cu102_devtoolset7_nightly
           build_environment: "manywheel 3.9m cu102 devtoolset7"
@@ -7771,7 +7771,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_6m_cu111_devtoolset7_nightly
           build_environment: "manywheel 3.6m cu111 devtoolset7"
@@ -7783,7 +7783,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_7m_cu111_devtoolset7_nightly
           build_environment: "manywheel 3.7m cu111 devtoolset7"
@@ -7795,7 +7795,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_8m_cu111_devtoolset7_nightly
           build_environment: "manywheel 3.8m cu111 devtoolset7"
@@ -7807,7 +7807,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_9m_cu111_devtoolset7_nightly
           build_environment: "manywheel 3.9m cu111 devtoolset7"
@@ -7819,7 +7819,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_6m_rocm3_10_devtoolset7_nightly
           build_environment: "manywheel 3.6m rocm3.10 devtoolset7"
@@ -7831,7 +7831,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-rocm:3.10"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_7m_rocm3_10_devtoolset7_nightly
           build_environment: "manywheel 3.7m rocm3.10 devtoolset7"
@@ -7843,7 +7843,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-rocm:3.10"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_8m_rocm3_10_devtoolset7_nightly
           build_environment: "manywheel 3.8m rocm3.10 devtoolset7"
@@ -7855,7 +7855,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-rocm:3.10"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_9m_rocm3_10_devtoolset7_nightly
           build_environment: "manywheel 3.9m rocm3.10 devtoolset7"
@@ -7867,7 +7867,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-rocm:3.10"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_6m_rocm4_0_1_devtoolset7_nightly
           build_environment: "manywheel 3.6m rocm4.0.1 devtoolset7"
@@ -7879,7 +7879,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-rocm:4.0.1"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_7m_rocm4_0_1_devtoolset7_nightly
           build_environment: "manywheel 3.7m rocm4.0.1 devtoolset7"
@@ -7891,7 +7891,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-rocm:4.0.1"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_8m_rocm4_0_1_devtoolset7_nightly
           build_environment: "manywheel 3.8m rocm4.0.1 devtoolset7"
@@ -7903,7 +7903,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-rocm:4.0.1"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_manywheel_3_9m_rocm4_0_1_devtoolset7_nightly
           build_environment: "manywheel 3.9m rocm4.0.1 devtoolset7"
@@ -7915,7 +7915,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/manylinux-rocm:4.0.1"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_6_cpu_devtoolset7_nightly
           build_environment: "conda 3.6 cpu devtoolset7"
@@ -7967,7 +7967,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_7_cu101_devtoolset7_nightly
           build_environment: "conda 3.7 cu101 devtoolset7"
@@ -7979,7 +7979,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_8_cu101_devtoolset7_nightly
           build_environment: "conda 3.8 cu101 devtoolset7"
@@ -7991,7 +7991,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_9_cu101_devtoolset7_nightly
           build_environment: "conda 3.9 cu101 devtoolset7"
@@ -8003,7 +8003,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_6_cu102_devtoolset7_nightly
           build_environment: "conda 3.6 cu102 devtoolset7"
@@ -8015,7 +8015,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_7_cu102_devtoolset7_nightly
           build_environment: "conda 3.7 cu102 devtoolset7"
@@ -8027,7 +8027,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_8_cu102_devtoolset7_nightly
           build_environment: "conda 3.8 cu102 devtoolset7"
@@ -8039,7 +8039,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_9_cu102_devtoolset7_nightly
           build_environment: "conda 3.9 cu102 devtoolset7"
@@ -8051,7 +8051,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_6_cu111_devtoolset7_nightly
           build_environment: "conda 3.6 cu111 devtoolset7"
@@ -8063,7 +8063,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_7_cu111_devtoolset7_nightly
           build_environment: "conda 3.7 cu111 devtoolset7"
@@ -8075,7 +8075,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_8_cu111_devtoolset7_nightly
           build_environment: "conda 3.8 cu111 devtoolset7"
@@ -8087,7 +8087,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_conda_3_9_cu111_devtoolset7_nightly
           build_environment: "conda 3.9 cu111 devtoolset7"
@@ -8099,7 +8099,7 @@ workflows:
                 - postnightly
           docker_image: "pytorch/conda-cuda"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cpu_devtoolset7_nightly_shared-with-deps
           build_environment: "libtorch 3.7m cpu devtoolset7"
@@ -8156,7 +8156,7 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu101_devtoolset7_nightly_shared-without-deps
           build_environment: "libtorch 3.7m cu101 devtoolset7"
@@ -8169,7 +8169,7 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-with-deps
           build_environment: "libtorch 3.7m cu101 devtoolset7"
@@ -8182,7 +8182,7 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu101_devtoolset7_nightly_static-without-deps
           build_environment: "libtorch 3.7m cu101 devtoolset7"
@@ -8195,7 +8195,7 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda101"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu102_devtoolset7_nightly_shared-with-deps
           build_environment: "libtorch 3.7m cu102 devtoolset7"
@@ -8208,7 +8208,7 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu102_devtoolset7_nightly_shared-without-deps
           build_environment: "libtorch 3.7m cu102 devtoolset7"
@@ -8221,7 +8221,7 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu102_devtoolset7_nightly_static-with-deps
           build_environment: "libtorch 3.7m cu102 devtoolset7"
@@ -8234,7 +8234,7 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu102_devtoolset7_nightly_static-without-deps
           build_environment: "libtorch 3.7m cu102 devtoolset7"
@@ -8247,7 +8247,7 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda102"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu111_devtoolset7_nightly_shared-with-deps
           build_environment: "libtorch 3.7m cu111 devtoolset7"
@@ -8260,7 +8260,7 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu111_devtoolset7_nightly_shared-without-deps
           build_environment: "libtorch 3.7m cu111 devtoolset7"
@@ -8273,7 +8273,7 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu111_devtoolset7_nightly_static-with-deps
           build_environment: "libtorch 3.7m cu111 devtoolset7"
@@ -8286,7 +8286,7 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu111_devtoolset7_nightly_static-without-deps
           build_environment: "libtorch 3.7m cu111 devtoolset7"
@@ -8299,7 +8299,7 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/manylinux-cuda111"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cpu_gcc5_4_cxx11-abi_nightly_shared-with-deps
           build_environment: "libtorch 3.7m cpu gcc5.4_cxx11-abi"
@@ -8356,7 +8356,7 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_shared-without-deps
           build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
@@ -8369,7 +8369,7 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-with-deps
           build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
@@ -8382,7 +8382,7 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu101_gcc5_4_cxx11-abi_nightly_static-without-deps
           build_environment: "libtorch 3.7m cu101 gcc5.4_cxx11-abi"
@@ -8395,7 +8395,7 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-with-deps
           build_environment: "libtorch 3.7m cu102 gcc5.4_cxx11-abi"
@@ -8408,7 +8408,7 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_shared-without-deps
           build_environment: "libtorch 3.7m cu102 gcc5.4_cxx11-abi"
@@ -8421,7 +8421,7 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_static-with-deps
           build_environment: "libtorch 3.7m cu102 gcc5.4_cxx11-abi"
@@ -8434,7 +8434,7 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu102_gcc5_4_cxx11-abi_nightly_static-without-deps
           build_environment: "libtorch 3.7m cu102 gcc5.4_cxx11-abi"
@@ -8447,7 +8447,7 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_shared-with-deps
           build_environment: "libtorch 3.7m cu111 gcc5.4_cxx11-abi"
@@ -8460,7 +8460,7 @@ workflows:
           libtorch_variant: "shared-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_shared-without-deps
           build_environment: "libtorch 3.7m cu111 gcc5.4_cxx11-abi"
@@ -8473,7 +8473,7 @@ workflows:
           libtorch_variant: "shared-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_static-with-deps
           build_environment: "libtorch 3.7m cu111 gcc5.4_cxx11-abi"
@@ -8486,7 +8486,7 @@ workflows:
           libtorch_variant: "static-with-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_linux_test:
           name: smoke_linux_libtorch_3_7m_cu111_gcc5_4_cxx11-abi_nightly_static-without-deps
           build_environment: "libtorch 3.7m cu111 gcc5.4_cxx11-abi"
@@ -8499,7 +8499,7 @@ workflows:
           libtorch_variant: "static-without-deps"
           docker_image: "pytorch/pytorch-binary-docker-image-ubuntu16.04:latest"
           use_cuda_docker_runtime: "1"
-          resource_class: gpu.medium
+          resource_class: gpu.nvidia.small
       - smoke_mac_test:
           name: smoke_macos_wheel_3_6_cpu_nightly
           build_environment: "wheel 3.6 cpu"

--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -69,7 +69,7 @@ if [[ "${BUILD_ENVIRONMENT}" == *-build ]]; then
   add_to_env_file "MAX_JOBS=${MAX_JOBS}"
 
   if [ -n "${USE_CUDA_DOCKER_RUNTIME:-}" ]; then
-    add_to_env_file "TORCH_CUDA_ARCH_LIST=5.2"
+    add_to_env_file "TORCH_CUDA_ARCH_LIST=6.1"
   fi
 
   if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -169,7 +169,7 @@ if [ -z "$MAX_JOBS" ]; then
 fi
 
 # Target only our CI GPU machine's CUDA arch to speed up the build
-export TORCH_CUDA_ARCH_LIST="5.2"
+export TORCH_CUDA_ARCH_LIST="6.1"
 
 if [[ "$BUILD_ENVIRONMENT" == *ppc64le* ]]; then
   export TORCH_CUDA_ARCH_LIST="6.0"


### PR DESCRIPTION
This PR replaces the `gpu.medium` resource class which has been deprecated with `gpu.nvidia.small` as done in commit 3b1ef1fde8347564f17034a62582bcd91b2e5f59 on the master branch.

`TORCH_CUDA_ARCH_LIST` for CI GPU machine is set to 6.1 since `gpu.nvidia.small` resource class has `Tesla P4` gpu with compute capability `sm_61`.