### PR TITLE
[GH1] Enable cross-repo merges

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -127,7 +127,10 @@ class GitRepo:
         return self._run_git("symbolic-ref", "--short", "HEAD").strip()
 
     def checkout(self, branch: str) -> None:
-        self._run_git('checkout', branch)
+        self._run_git("checkout", branch)
+
+    def fetch(self, ref: str, branch: str) -> None:
+        self._run_git("fetch", self.remote, f"{ref}:{branch}")
 
     def show_ref(self, name: str) -> str:
         refs = self._run_git('show-ref', '-s', name).strip().split('\n')

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -303,7 +303,9 @@ class GitHubPR:
         if not self.is_ghstack_pr():
             msg = self.get_title() + "\n\n" + self.get_body()
             msg += f"\nPull Request resolved: {self.get_pr_url()}\n"
-            repo._run_git("merge", "--squash", f"{repo.remote}/{self.head_ref()}")
+            pr_branch_name = f"__pull-request-{self.pr_num}__init__"
+            repo.fetch(f"pull/{self.pr_num}/head", pr_branch_name)
+            repo._run_git("merge", "--squash", pr_branch_name)
             repo._run_git("commit", f"--author=\"{self.get_author()}\"", "-m", msg)
         else:
             self.merge_ghstack_into(repo)
@@ -422,8 +424,8 @@ def main() -> None:
         gh_post_comment(org, project, args.pr_num, f"Can't merge closed PR #{args.pr_num}", dry_run=args.dry_run)
         return
 
-    if pr.is_cross_repo():
-        gh_post_comment(org, project, args.pr_num, "Cross-repo merges are not supported at the moment", dry_run=args.dry_run)
+    if pr.is_cross_repo() and pr.is_ghstack_pr():
+        gh_post_comment(org, project, args.pr_num, "Cross-repo ghstack merges are not supported", dry_run=args.dry_run)
         return
 
     try:


### PR DESCRIPTION
GHStack based PRs still can not be cross-repo, but for regular ones
checkout `pull/{pr_no}/head`

