### PR TITLE
Fix type annotation for `torch.backends.cudnn.allow_tf32`

### DIFF
--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -133,3 +133,4 @@ sys.modules[__name__] = CudnnModule(sys.modules[__name__], __name__)
 enabled: bool
 deterministic: bool
 benchmark: bool
+allow_tf32: bool


### PR DESCRIPTION
Fixes #72753
