### PR TITLE
Use default value on empty llvm_code_path

### DIFF
--- a/binaries/aot_model_compiler.cc
+++ b/binaries/aot_model_compiler.cc
@@ -97,6 +97,10 @@ int main(int argc, char** argv) {
       split(';', FLAGS_input_dims).size() ==
           split(';', FLAGS_input_types).size(),
       "Number of input_dims and input_types should be the same");
+  if (FLAGS_output_llvm.empty()) {
+    FLAGS_output_llvm =
+        FLAGS_model.substr(0, FLAGS_model.find('.')) + ".compiled.ll";
+  }
 
   std::string output_model_name = FLAGS_output_model;
   if (output_model_name.empty()) {


### PR DESCRIPTION
Summary:
Bug: FLAGS_output_llvm option was introduced recently to specify LLVM assembly code file. Without previously default value, now the llvm code is not being saved to a file if asmfile input is not specified and is resulting in making the compiled output unusable.

Fix: Use default value if output_llvm/asmfile input is not specified.

Test Plan: Verified that output is saved to deafult .ll file path

Reviewed By: IvanKobzarev

Differential Revision: D34189107

