### PR TITLE
Fix ConvTranspose2D dilation type annotaion

### DIFF
--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -897,7 +897,7 @@ class ConvTranspose2d(_ConvTransposeNd):
         output_padding: _size_2_t = 0,
         groups: int = 1,
         bias: bool = True,
-        dilation: int = 1,
+        dilation: _size_2_t = 1,
         padding_mode: str = 'zeros',
         device=None,
         dtype=None


### PR DESCRIPTION
ConvTranspose2D dilation parameters allows a 2-tuple as specified in the documentation.