### PR TITLE
stop sccache server after building

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -157,4 +157,5 @@ python setup.py install --cmake && sccache --show-stats && (
 
 sccache --show-stats > stats.txt
 python -m tools.stats.upload_sccache_stats stats.txt
+sccache --stop-server
 rm stats.txt


### PR DESCRIPTION
This is to avoid the directory , where the sccache is installed, couldn't be deleted.
