### PR TITLE
Add custom operator set to TE fuser

### DIFF
--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -2284,11 +2284,19 @@ TypePtr NamedValue::type() const {
 const Symbol ProfileOp::Kind = ::c10::prim::profile;
 const Symbol ProfileIValueOp::Kind = ::c10::prim::profile_ivalue;
 
+TORCH_API void AddOperatorSet(struct OperatorSet& op, const char *sig) {
+  op.AddOperator(sig);
+}
+
 OperatorSet::OperatorSet(std::initializer_list<const char*> sig_literals) {
   for (const char* sig : sig_literals) {
-    auto op = getOperatorForLiteral(sig);
-    ops[Symbol::fromQualString(op->schema().name())].push_back(op);
+    AddOperator(sig);
   }
+}
+
+void OperatorSet::AddOperator(const char* sig_literal) {
+  auto op = getOperatorForLiteral(sig_literal);
+  ops[Symbol::fromQualString(op->schema().name())].push_back(op);
 }
 
 std::vector<std::shared_ptr<Operator>> OperatorSet::getOps() const {

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -1627,11 +1627,14 @@ TORCH_API std::vector<Node*> findAllNodes(
 struct OperatorSet {
   OperatorSet(std::initializer_list<const char*> sig_literals);
   std::vector<std::shared_ptr<Operator>> getOps() const;
+  void AddOperator(const char* sig_literal);
 
  private:
   friend struct Node;
   std::unordered_map<Symbol, std::vector<std::shared_ptr<Operator>>> ops;
 };
+
+TORCH_API void AddOperatorSet(struct OperatorSet& op, const char *sig);
 
 template <typename T>
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -69,6 +69,11 @@ Value* broadcastSizes(at::ArrayRef<Value*> sizes, AliasDb* db) {
 
 namespace tensorexpr {
 
+OperatorSet& getCustomOperatorSet() {
+  static OperatorSet _g_customer_operator_set{};
+  return _g_customer_operator_set;
+}
+
 static const OperatorSet& supported_non_eltwise_set() {
   // clang-format off
   static const OperatorSet supported_non_eltwise_set{
@@ -101,6 +106,7 @@ bool isSupported(Node* node) {
   if (get_tensorexpr_elementwise_set().contains(node) ||
       node->isMemberOf(supported_non_eltwise_set()) ||
       node->isMemberOf(supported_misc_set) ||
+      node->isMemberOf(getCustomOperatorSet()) ||
       (texpr_reductions_enabled && node->isMemberOf(supported_reduction_set))) {
     // We only insert guards on Tensor types, so we rely on the output
     // of a node being uniquely determined by its input types.

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -60,6 +60,7 @@ TORCH_API Value* broadcastSizes(at::ArrayRef<Value*> sizes, AliasDb* db);
 
 namespace tensorexpr {
 TORCH_API bool isSupported(Node* node);
+TORCH_API OperatorSet& getCustomOperatorSet();
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
## Motivation
PyTorch supports the extension programming model. The developer could extend PyTorch features and provide extra performance by the PyTorch extension mechanism. The [Intel® Extension for PyTorch*](https://github.com/intel/intel-extension-for-pytorch/tree/release/1.10) is a typical PyTorch extension case that is initiated by the Intel PyTorch framework team. It extends PyTorch with optimizations for extra performance boost on Intel hardware. Most of the optimizations will be included in stock PyTorch releases eventually, and the intention of the extension is to deliver up-to-date features and optimizations for PyTorch on Intel hardware. 

The extension implements more fusion patterns by leveraging oneDNN fusion capability. 