### PR TITLE
[LTS] CherryPick: Fix failing test due to a bug in NumPy when using OpenBLAS

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1081,7 +1081,12 @@ class TestLinalg(TestCase):
         a = torch.eye(3, dtype=dtype, device=device)
         a[-1, -1] = 0  # make 'a' singular
         for p in norm_types:
-            run_test_case(a, p)
+            try:
+                run_test_case(a, p)
+            except np.linalg.LinAlgError:
+                # Numpy may fail to converge for some BLAS backends (although this is very rare)
+                # See the discussion in https://github.com/pytorch/pytorch/issues/67675
+                pass
 
         # test for 0x0 matrices. NumPy doesn't work for such input, we return 0
         input_sizes = [(0, 0), (2, 5, 0, 0)]


### PR DESCRIPTION
This PR cherrypicks the commit 43874d79e72c041c9bcf09cfcea6cccc94f44ce7 from the master branch that fixesfailing test due to a bug in NumPy when using OpenBLAS.