### PR TITLE
[LTS] CherryPick: Skip broken svd tests

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1246,6 +1246,9 @@ class TestLinalg(TestCase):
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     def test_norm_extreme_values(self, device):
+        if torch.device(device).type == 'cpu':
+            self.skipTest("Test broken on cpu (see gh-71645)")
+
         vector_ords = [0, 1, 2, 3, inf, -1, -2, -3, -inf]
         matrix_ords = ['fro', 'nuc', 1, 2, inf, -1, -2, -inf]
         vectors = []

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1246,11 +1246,10 @@ class TestLinalg(TestCase):
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     def test_norm_extreme_values(self, device):
-        if torch.device(device).type == 'cpu':
-            self.skipTest("Test broken on cpu (see gh-71645)")
-
         vector_ords = [0, 1, 2, 3, inf, -1, -2, -3, -inf]
-        matrix_ords = ['fro', 'nuc', 1, 2, inf, -1, -2, -inf]
+        # matrix_ords 'nuc', 2, -2 are skipped currently
+        # See issue https://github.com/pytorch/pytorch/issues/71911
+        matrix_ords = ['fro', 1, inf, -1, -inf]
         vectors = []
         matrices = []
         for pair in itertools.product([inf, -inf, 0.0, nan, 1.0], repeat=2):
@@ -1281,8 +1280,8 @@ class TestLinalg(TestCase):
             x_n = x.cpu().numpy()
             for ord in matrix_ords:
                 msg = f'ord={ord}, matrix={matrix}'
-                result = torch.linalg.norm(x, ord=ord)
                 result_n = np.linalg.norm(x_n, ord=ord)
+                result = torch.linalg.norm(x, ord=ord)
 
                 if is_broken_matrix_norm_case(ord, x):
                     continue


### PR DESCRIPTION
This PR uses commits 4e031419aac33332888de2e48ca4819d3083acea and 29c81bbff543f0098989d698c4b884ee0568a2ea from the master branch to skip some broken svd tests.

As seen in issue https://github.com/pytorch/pytorch/issues/71911, `test_norm_extreme_values` (when `ord='nuc' or 2 or -2`) is broken so these matrix_ords  are skipped.
