### PR TITLE
[LTS] Resolve OOM kill for large tensor tests

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4235,11 +4235,18 @@ class TestTorchDeviceType(TestCase):
             scalar = torch.tensor(2, device=device, dtype=dtype)
             torch.diff(scalar)
 
+    def _compare_large_tensors(self, expected, actual, num_splits):
+        length = expected.shape[0]
+        for i in range(num_splits):
+            start = (i * length) // num_splits
+            end = ((i + 1) * length) // num_splits
+            self.assertEqual(expected[start:end], actual[start:end])
+
     def _test_large_cum_fn_helper(self, x, fn):
         x_cpu = x.cpu().float()
         expected = fn(x_cpu)
         actual = fn(x).cpu().float()
-        self.assertEqual(expected, actual.cpu().float())
+        self._compare_large_tensors(expected, actual.cpu().float(), 3)
 
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "sandcastle OOM with current tpx gpu/re configuration")
     @onlyCUDA
@@ -5025,7 +5032,7 @@ class TestTorchDeviceType(TestCase):
             x = torch.randn(50000, 1, dtype=torch.float32)
             expected_cpu = torch.pdist(x, p=2)
             actual_gpu = torch.pdist(x.to(device), p=2)
-            self.assertEqual(expected_cpu, actual_gpu.cpu())
+            self._compare_large_tensors(expected_cpu, actual_gpu.cpu(), 3)
 
     @onlyOnCPUAndCUDA
     @dtypesIfCUDA(*set(torch.testing.get_all_math_dtypes('cuda')))


### PR DESCRIPTION
This PR resolves the out of memory problem on the `gpu.nvidia.small` or `gpu.nvidia.medium` resources for tests with large tensors. 

On these resources tests such as `TestTorchDeviceTypeCUDA.test_large_cumprod_cuda_float16` and `TestTorchDeviceTypeCUDA.test_pdist_norm_large_cuda` that have tensors of `size > 1 billion` fail during `torch.allclose` comparison due to OOM. 

We create a helper function that compares these large tensors by comparing parts of them iteratively.