### PR TITLE
Use irange in PyTorch

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -406,7 +406,7 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
         py_event_indices_{
             { nullptr,
               std::string("null") }};
-    for (size_t i = 0; i < py_events.size(); i++) {
+    for (const auto i : c10::irange(py_events.size())) {
       py_event_indices_.insert({py_events[i].get(), std::to_string(i)});
     }
 

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -833,8 +833,7 @@ void gather(
 
   if (cur_rank == root)
   {
-    for (int r = 0; r < numranks; r++)
-    {
+    for (const auto r : c10::irange(numranks)) {
       if (r != root) {
         auto* recvbuff =  reinterpret_cast<char*>(outputs[r].data_ptr());
         NCCL_CHECK(ncclRecv(recvbuff, count, type, r, comm, stream));
@@ -874,8 +873,7 @@ void scatter(
   NCCL_CHECK(ncclGroupStart());
   if (cur_rank == root)
   {
-    for (int r = 0; r < numranks; r++)
-    {
+    for (const auto r : c10::irange(numranks)) {
       if (r != root) {
         size_t send_count = inputs[r].numel();
         auto send_type = to_nccl_data_type(inputs[r]);

--- a/torch/csrc/deploy/remove_dt_needed.cpp
+++ b/torch/csrc/deploy/remove_dt_needed.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <vector>
 
+#include <c10/util/irange.h>
 #include <fmt/format.h>
 
 #define ERROR(msg_fmt, ...) \
@@ -47,7 +48,7 @@ int main(int argc, const char** argv) {
   auto program_headers = (Elf64_Phdr*)(data + header->e_phoff);
   auto n_program_headers = header->e_phnum;
   Elf64_Dyn* dynamic = nullptr;
-  for (size_t i = 0; i < n_program_headers; ++i) {
+  for (const auto i : c10::irange(n_program_headers)) {
     const Elf64_Phdr* phdr = &program_headers[i];
     if (phdr->p_type == PT_DYNAMIC) {
       dynamic = reinterpret_cast<Elf64_Dyn*>(data + phdr->p_offset);

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -3,6 +3,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/lazy/core/tensor_util.h>
 
 namespace torch {
@@ -144,7 +145,7 @@ void LTCTensorImpl::setup_size_properties() {
     // We can't call empty_tensor_restride(c10::MemoryFormat::Contiguous) given we override sizes() too.
     std::vector<int64_t> updated_strides;
     updated_strides = ComputeArrayStrides(shape.Get().sizes());
-    for (int i = 0; i < updated_strides.size(); i++) {
+    for (const auto i : c10::irange(updated_strides.size())) {
       sizes_and_strides_.stride_at_unchecked(i) = updated_strides[i];
     }
     generation_ = generation;

--- a/torch/csrc/lazy/core/view_ops/squeeze.cpp
+++ b/torch/csrc/lazy/core/view_ops/squeeze.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/lazy/core/view_ops/squeeze.h>
 #include <torch/csrc/lazy/ts_backend/ts_lowering_context.h>
 
@@ -9,7 +10,7 @@ namespace lazy {
 std::vector<int64_t> BuildSqueezedDimensions(c10::ArrayRef<int64_t> dimensions,
                                              int64_t squeeze_dim) {
   std::vector<int64_t> output_dimensions;
-  for (int64_t i = 0; i < dimensions.size(); ++i) {
+  for (const auto i : c10::irange(dimensions.size())) {
     int64_t dim = dimensions[i];
     if (dim != 1 || (i != squeeze_dim && squeeze_dim >= 0)) {
       output_dimensions.push_back(dim);


### PR DESCRIPTION
Summary: Replacing increment iterator loops with ranged loops. It allows loops such as for(int i=0;i<10;i++) to be expressed as for(const auto i : c10::irange(10)). This auto-types the loops and adds const-safety to the iteration variable.

Differential Revision: D34136539

