### PR TITLE
[ROCm] Fix the argsort UT break

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15407,7 +15407,6 @@ op_db: List[OpInfo] = [
         "argsort",
         dtypes=all_types_and(torch.bool, torch.float16, torch.bfloat16),
         dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16),
-        dtypesIfROCM=all_types_and(torch.float16),
         sample_inputs_func=sample_inputs_argsort,
         supports_out=False,
         supports_autograd=False,


### PR DESCRIPTION
- PR#71226 caused the break.
- Solution needed to revert a line done in PR#67706

@jeffdaily @jithunnair-amd @KyleCZH 
