### PR TITLE
[torchrec] remove __getstate__ from PyTorch base optimizer (#16)

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -53,13 +53,6 @@ class Optimizer(object):
         for param_group in param_groups:
             self.add_param_group(param_group)
 
-    def __getstate__(self):
-        return {
-            'defaults': self.defaults,
-            'state': self.state,
-            'param_groups': self.param_groups,
-        }
-
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._hook_for_profile()  # To support multiprocessing pickle/unpickle.


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/torchrec/pull/16

`__getstate__` functions are used by pickle and the base class (PyTorch optimizer) overrides this function https://github.com/pytorch/pytorch/blob/6f29313e38881edeb8e877ed40626f56cb00c34a/torch/optim/optimizer.py#L56.

Torchrec optimizer classes has different attributes from the base class which is causing AttributeNotFound error during pickling.

This diff remove the `__getstate__` from the base class as it returns all the class members which is the default behavior and not need to override.

Test Plan:
PyTorch CI and torchrec unit test

buck test torchrec/optim/tests:test_keyed -- test_pickle

Differential Revision: D34147809

