### PR TITLE
Fix `sequence_ops_test`

### DIFF
--- a/caffe2/python/operator_test/sequence_ops_test.py
+++ b/caffe2/python/operator_test/sequence_ops_test.py
@@ -385,7 +385,7 @@ class TestSequenceOps(serial.SerializedTestCase):
             ["shrunk_data"])
 
         def op_ref(data, indices):
-            unique_indices = np.unique(indices)
+            unique_indices = np.unique(indices) if len(indices)>0 else np.array([],dtype=np.int64)
             sorted_indices = np.sort(unique_indices)
             shrunk_data = np.delete(data, sorted_indices, axis=0)
             return (shrunk_data,)


### PR DESCRIPTION
Fuzzing gone bad again: `np.unique([])` returns array or float64, but `np.delete` expects array of int

Fixes recent regressions in ONNX tests in OSS CI, see https://github.com/pytorch/pytorch/runs/5188636426?check_suite_focus=true for example

