### PR TITLE
Fix SequentialLR initialization

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -20,7 +20,8 @@ from torch.optim.lr_scheduler import LambdaLR, MultiplicativeLR, SequentialLR, S
     _LRScheduler, CyclicLR, CosineAnnealingWarmRestarts, OneCycleLR, ChainedScheduler, \
     EPOCH_DEPRECATION_WARNING
 from torch.optim.swa_utils import AveragedModel, SWALR, update_bn
-from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_UBSAN, load_tests
+from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_UBSAN, load_tests, \
+    parametrize, instantiate_parametrized_tests
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests
@@ -2018,6 +2019,7 @@ class TestLRScheduler(TestCase):
         scheduler = MultiplicativeLR(self.opt, lr_lambda=[lambda x1: 0.9, lambda x2: 0.8])
         self._test(scheduler, targets, epochs)
 
+    @parametrize("T_mult", [1, 2, 4])
     def test_CosineAnnealingWarmRestarts_lr1(self):
         iters = 100
         eta_min = 1e-10
@@ -2648,6 +2650,7 @@ class TestSWAUtils(TestCase):
         # check that momentum is preserved
         self.assertEqual(dnn.bn.momentum, 0.3)
 
+instantiate_parametrized_tests(TestLRScheduler)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1471,6 +1471,21 @@ class TestLRScheduler(TestCase):
         scheduler = SequentialLR(self.opt, schedulers=schedulers, milestones=milestones)
         self._test(scheduler, targets, epochs)
 
+    def test_sequentiallr4(self):
+        optimizer = torch.optim.SGD([torch.tensor(0.5)], lr=0.1)
+        prev_lr = optimizer.param_groups[0]["lr"]
+
+        schedulers = [
+            torch.optim.lr_scheduler.ConstantLR(optimizer, factor=1),
+            torch.optim.lr_scheduler.ConstantLR(optimizer, factor=0.1)
+        ]
+        scheduler = torch.optim.lr_scheduler.SequentialLR(optimizer, schedulers, milestones=[10])
+
+        new_lr = optimizer.param_groups[0]["lr"]
+
+        # Ensure that multiple schedulers does not affect the initial learning rate
+        self.assertEqual(prev_lr, new_lr)
+
     def test_get_last_lr_sequentiallr(self):
         epochs = 12
         milestones = [3, 6]

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2020,23 +2020,21 @@ class TestLRScheduler(TestCase):
         self._test(scheduler, targets, epochs)
 
     @parametrize("T_mult", [1, 2, 4])
-    def test_CosineAnnealingWarmRestarts_lr1(self):
+    def test_CosineAnnealingWarmRestarts_lr1(self, T_mult):
         iters = 100
         eta_min = 1e-10
-        T_mults = [1, 2, 4]
-        for T_mult in T_mults:
-            T_i = 10
-            T_cur = 0
-            targets = [[0.05], [0.5]]
-            scheduler = CosineAnnealingWarmRestarts(self.opt, T_0=T_i, T_mult=T_mult, eta_min=eta_min)
-            for _ in range(1, iters, 1):
-                T_cur += 1
-                if T_cur >= T_i:
-                    T_cur = T_cur - T_i
-                    T_i = int(T_mult) * T_i
-                targets[0] += [eta_min + (0.05 - eta_min) * (1 + math.cos(math.pi * T_cur / T_i)) / 2]
-                targets[1] += [eta_min + (0.5 - eta_min) * (1 + math.cos(math.pi * T_cur / T_i)) / 2]
-            self._test(scheduler, targets, iters)
+        T_i = 10
+        T_cur = 0
+        targets = [[0.05], [0.5]]
+        scheduler = CosineAnnealingWarmRestarts(self.opt, T_0=T_i, T_mult=T_mult, eta_min=eta_min)
+        for _ in range(1, iters, 1):
+            T_cur += 1
+            if T_cur >= T_i:
+                T_cur = T_cur - T_i
+                T_i = int(T_mult) * T_i
+            targets[0] += [eta_min + (0.05 - eta_min) * (1 + math.cos(math.pi * T_cur / T_i)) / 2]
+            targets[1] += [eta_min + (0.5 - eta_min) * (1 + math.cos(math.pi * T_cur / T_i)) / 2]
+        self._test(scheduler, targets, iters)
 
     def test_CosineAnnealingWarmRestarts_lr2(self):
         iters = 30

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -74,7 +74,12 @@ class _LRScheduler(object):
         self._step_count = 0
         self.verbose = verbose
 
+        self.reset_optimizer_lr()
         self.step()
+
+    def reset_optimizer_lr(self):
+        for group in self.optimizer.param_groups:
+            group["lr"] = group["initial_lr"]
 
     def state_dict(self):
         """Returns the state of the scheduler as a :class:`dict`.
@@ -656,6 +661,7 @@ class SequentialLR(_LRScheduler):
         # decrement the last epoch, so that it remains the same after the step
         self.last_epoch -= 1
         # Call the step
+        self.reset_optimizer_lr()
         self.step()
 
     def step(self):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -86,7 +86,7 @@ class _LRScheduler(object):
     @contextmanager
     def _init_optimizer_lr(self):
         # Save the current learning rate values for all schedulers except the first
-        if self._scheduler_id > 1:
+        if self._scheduler_id > 0:
             for group in self.optimizer.param_groups:
                 group["prev_lr"] = group["lr"]
 
@@ -94,7 +94,7 @@ class _LRScheduler(object):
             yield
         finally:
             # Reset the learning rates to the previous value for all but the first scheduler
-            if self._scheduler_id > 1:
+            if self._scheduler_id > 0:
                 for group in self.optimizer.param_groups:
                     group["lr"] = group.pop("prev_lr")
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -635,7 +635,20 @@ class SequentialLR(_LRScheduler):
         self._milestones = milestones
         self.last_epoch = last_epoch + 1
         self.optimizer = optimizer
-        self._last_lr = schedulers[0].get_last_lr()
+        self._init_step()
+
+    def _init_step(self):
+        """Call step on the appropriate scheduler once more on initialization
+        in order to correctly set the current learning rate
+        """
+        # decrement the last epoch of the appropriate scheduler, so that it
+        # remains the same after the step
+        idx = bisect_right(self._milestones, self.last_epoch)
+        self._schedulers[idx].last_epoch -= 1
+        # decrement the last epoch, so that it remains the same after the step
+        self.last_epoch -= 1
+        # Call the step
+        self.step()
 
     def step(self):
         self.last_epoch += 1

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -658,33 +658,12 @@ class SequentialLR(_LRScheduler):
         self._milestones = milestones
         self.last_epoch = last_epoch + 1
         self.optimizer = optimizer
-        self._init_step()
-
-    def _get_scheduler(self):
-        """
-        Get the current scheduler and its index
-        """
-        idx = bisect_right(self._milestones, self.last_epoch)
-        return idx, self._schedulers[idx]
-
-    def _init_step(self):
-        """Call step on the appropriate scheduler once more on initialization
-        in order to correctly set the current learning rate
-        """
-        _, scheduler = self._get_scheduler()
-        # decrement the last epoch of the appropriate scheduler, so that it
-        # remains the same after the step
-        scheduler.last_epoch -= 1
-        scheduler._step_count -= 1
-        # decrement the last epoch, so that it remains the same after the step
-        self.last_epoch -= 1
-        # Call the step
-        with scheduler.init_optimizer_lr():
-            self.step()
+        self._last_lr = schedulers[0].get_last_lr()
 
     def step(self):
         self.last_epoch += 1
-        idx, scheduler = self._get_scheduler()
+        idx = bisect_right(self._milestones, self.last_epoch)
+        scheduler = self._schedulers[idx]
         if idx > 0 and self._milestones[idx - 1] == self.last_epoch:
             scheduler.step(0)
         else:

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -644,6 +644,10 @@ class SequentialLR(_LRScheduler):
         for group in self.optimizer.param_groups:
             group["lr"] = group["initial_lr"]
 
+        # "Undo" the step performed by other schedulers
+        for scheduler in self._schedulers:
+            scheduler.last_epoch -= 1
+
         # Perform the initial step for only the first scheduler
         self._schedulers[0]._initial_step()
 

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -680,7 +680,7 @@ class SequentialLR(_LRScheduler):
         # decrement the last epoch, so that it remains the same after the step
         self.last_epoch -= 1
         # Call the step
-        with self.init_optimizer_lr():
+        with scheduler.init_optimizer_lr():
             self.step()
 
     def step(self):

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -645,6 +645,7 @@ class SequentialLR(_LRScheduler):
         # remains the same after the step
         idx = bisect_right(self._milestones, self.last_epoch)
         self._schedulers[idx].last_epoch -= 1
+        self._schedulers[idx]._step_count -= 1
         # decrement the last epoch, so that it remains the same after the step
         self.last_epoch -= 1
         # Call the step

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -78,8 +78,7 @@ class _LRScheduler(object):
         # Increment LR registration count
         # Tracks the number of schedulers which this optimizer is registered to
         self._scheduler_id = getattr(self.optimizer, "_lr_registration_count", 0)
-        self._scheduler_id += 1
-        setattr(self.optimizer, "_lr_registration_count", self._scheduler_id)
+        self.optimizer._lr_registration_count = self._scheduler_id + 1
 
         with self.init_optimizer_lr():
             self.step()
@@ -661,7 +660,7 @@ class SequentialLR(_LRScheduler):
         self.optimizer = optimizer
         self._init_step()
 
-    def get_scheduler(self):
+    def _get_scheduler(self):
         """
         Get the current scheduler and its index
         """
@@ -672,7 +671,7 @@ class SequentialLR(_LRScheduler):
         """Call step on the appropriate scheduler once more on initialization
         in order to correctly set the current learning rate
         """
-        _, scheduler = self.get_scheduler()
+        _, scheduler = self._get_scheduler()
         # decrement the last epoch of the appropriate scheduler, so that it
         # remains the same after the step
         scheduler.last_epoch -= 1
@@ -685,7 +684,7 @@ class SequentialLR(_LRScheduler):
 
     def step(self):
         self.last_epoch += 1
-        idx, scheduler = self.get_scheduler()
+        idx, scheduler = self._get_scheduler()
         if idx > 0 and self._milestones[idx - 1] == self.last_epoch:
             scheduler.step(0)
         else:

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -80,11 +80,11 @@ class _LRScheduler(object):
         self._scheduler_id = getattr(self.optimizer, "_lr_registration_count", 0)
         self.optimizer._lr_registration_count = self._scheduler_id + 1
 
-        with self.init_optimizer_lr():
+        with self._init_optimizer_lr():
             self.step()
 
     @contextmanager
-    def init_optimizer_lr(self):
+    def _init_optimizer_lr(self):
         # Save the current learning rate values for all schedulers except the first
         if self._scheduler_id > 1:
             for group in self.optimizer.param_groups:

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -5,7 +5,6 @@ from functools import wraps
 import warnings
 import weakref
 from collections import Counter
-from contextlib import contextmanager
 from bisect import bisect_right
 
 from .optimizer import Optimizer
@@ -71,33 +70,15 @@ class _LRScheduler(object):
             return wrapper
 
         self.optimizer.step = with_counter(self.optimizer.step)
-        self.optimizer._step_count = 0
-        self._step_count = 0
         self.verbose = verbose
 
-        # Increment LR registration count
-        # Tracks the number of schedulers which this optimizer is registered to
-        self._scheduler_id = getattr(self.optimizer, "_lr_registration_count", 0)
-        self.optimizer._lr_registration_count = self._scheduler_id + 1
+        self._initial_step()
 
-        with self._init_optimizer_lr():
-            self.step()
-
-    @contextmanager
-    def _init_optimizer_lr(self):
-        # Save the current learning rate values for all schedulers except the first
-        if self._scheduler_id > 0:
-            for group in self.optimizer.param_groups:
-                group["prev_lr"] = group["lr"]
-
-        try:
-            yield
-        finally:
-            # Reset the learning rates to the previous value for all but the first scheduler
-            if self._scheduler_id > 0:
-                for group in self.optimizer.param_groups:
-                    group["lr"] = group.pop("prev_lr")
-
+    def _initial_step(self):
+        """Initialize step counts and performs a step"""
+        self.optimizer._step_count = 0
+        self._step_count = 0
+        self.step()
 
     def state_dict(self):
         """Returns the state of the scheduler as a :class:`dict`.
@@ -658,7 +639,16 @@ class SequentialLR(_LRScheduler):
         self._milestones = milestones
         self.last_epoch = last_epoch + 1
         self.optimizer = optimizer
+
+        # Reset learning rates back to initial values
+        for group in self.optimizer.param_groups:
+            group["lr"] = group["initial_lr"]
+
+        # Perform the initial step for only the first scheduler
+        self._schedulers[0]._initial_step()
+
         self._last_lr = schedulers[0].get_last_lr()
+
 
     def step(self):
         self.last_epoch += 1


### PR DESCRIPTION
What was happening is that when we have multiple learning rate schedulers, the order in which they are being initialized is not being taken into account. This is a problem if they were being initialized in sequential order (as one might intuitively do).

Each scheduler calls `step()` on initialization and sets the `lr` in its optimizer's `params_groups`. However, this means that step 0 will be using the `lr` that was set by the very last scheduler (in the case of initializing schedulers sequentially) instead of the first scheduler.

The fix in this PR, addresses the above bug by performing a call to the appropriate scheduler on initialization after decrementing the `last_epoch` values in order to keep them the same post-step. This will ensure that the correct scheduler is the one setting the `lr` values for the optimizer's `param_groups`