### PR TITLE
 Sync lazy_tensor_staging back to master

### DIFF
--- a/test/cpp/lazy/test_cache.cpp
+++ b/test/cpp/lazy/test_cache.cpp
@@ -11,7 +11,7 @@ namespace lazy {
 class CacheNode : public Node {
  public:
   explicit CacheNode(const std::string& str)
-      : Node(OpKind(), /* num_outputs */ 1, /* hash_seed */ Hash(str)),
+      : Node(OpKind(), /* num_outputs */ 1, /* hash_func */ [&](bool /*bakeInSizes*/) -> hash_t { return Hash(str); }),
         str_(str) {}
   ~CacheNode() override = default;
 

--- a/test/cpp/lazy/test_ir.cpp
+++ b/test/cpp/lazy/test_ir.cpp
@@ -12,7 +12,7 @@ namespace lazy {
 class TestLeafNode : public Node {
  public:
   explicit TestLeafNode(size_t param)
-      : Node(OpKind(), /* num_outputs */ 1, /* hash_seed */ Hash(param)),
+      : Node(OpKind(), /* num_outputs */ 1, /* hash_func */[&](bool /*bakeInSizes*/) -> hash_t { return Hash(param); }),
         param_(param) {}
   ~TestLeafNode() override = default;
 

--- a/test/cpp/lazy/test_ir_util.cpp
+++ b/test/cpp/lazy/test_ir_util.cpp
@@ -12,7 +12,7 @@ namespace lazy {
 class IrUtilNode : public Node {
  public:
   explicit IrUtilNode()
-      : Node(OpKind(), /* num_outputs */ 1, /* hash_seed */ Hash(0)) {}
+      : Node(OpKind(), /* num_outputs */ 1, /* hash_func */ [&](bool /*bakeInSizes*/) -> hash_t { return Hash(0); }) {}
   ~IrUtilNode() override = default;
 
   void AddOperand(Value v) {

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import List, Union
 from dataclasses import dataclass
 from tools.codegen.context import method_with_native_function
@@ -9,17 +10,23 @@ import tools.codegen.api.dispatcher as dispatcher
 from tools.codegen.api.lazy import LazyIrSchema, isValueType
 from tools.codegen.dest.lazy_ts_lowering import ts_lowering_body
 
-
-def node_ctor_arg_rvalue_string(arg: NamedCType) -> str:
+def node_ctor_arg_rvalue_string(arg: NamedCType, schema: LazyIrSchema) -> str:
     """
     Given a NamedCType from a lazy IR schema,
     generate a c++ string for materializing an rvalue of that arg for passing into
     a lazy Node constructor.
     """
+
     if isValueType(arg.type):
         if isinstance(arg.type, BaseCType):
+            if arg.name in schema.wrapped_scalar_names:
+                return f"torch::lazy::LazyGraphExecutor::Get()->GetIrValueForScalarFromCodegen({arg.name})"
             return f"lazy_{arg.name}.GetIrValue()"
         elif isinstance(arg.type, OptionalCType):
+            if arg.name in schema.wrapped_scalar_names:
+                return f"{arg.name} ? " \
+                    f"c10::make_optional(torch::lazy::LazyGraphExecutor::Get()->GetIrValueForScalarFromCodegen(*{arg.name})) : " \
+                    "c10::nullopt"
             return f"lazy_{arg.name} ? " \
                    f"c10::make_optional(lazy_{arg.name}.GetIrValue()) : " \
                    "c10::nullopt"
@@ -35,23 +42,54 @@ def node_ctor_arg_rvalue_string(arg: NamedCType) -> str:
         else:
             return f"{arg.name}"
 
-def node_ctor_inputs(func: LazyIrSchema) -> str:
+def node_ctor_inputs(schema: LazyIrSchema) -> str:
     """
     Produce a formatted string with the arguments as passed into the constructor of a node class.
     """
-    node_ctor_values = [node_ctor_arg_rvalue_string(arg) for arg in func.filtered_types()]
+    node_ctor_values = [node_ctor_arg_rvalue_string(arg, schema) for arg in schema.filtered_types()]
     return ",\n                              ".join(node_ctor_values)
 
+def gen_fallback_code(schema: LazyIrSchema, overload_name: str) -> str:
+    """
+    Generate code that falls back to eager conditioned on a predicate
+    """
+    fallback_args = ",\n                ".join([str(arg.name) for arg in schema.filtered_types()])
+    if len(overload_name):
+        aten_op_str = f"ATEN_OP2({schema.aten_name}, {overload_name})"
+    else:
+        aten_op_str = f"ATEN_OP({schema.aten_name})"
+    return f"""
+        if (force_eager_fallback({aten_symbol(schema)})) {{
+            return at::native::call_fallback_fn<&ltc_eager_fallback, {aten_op_str}>::call(
+                {fallback_args}
+            );
+        }}
+"""
+
+def aten_symbol(schema: LazyIrSchema) -> str:
+    missing_interned_strings = {
+        'sigmoid_backward',
+    }
+    if schema.aten_name in missing_interned_strings:
+        return f'c10::Symbol::fromQualString("aten::{schema.aten_name}")'
+    return f'at::aten::{schema.aten_name}'
 
 @dataclass(frozen=True)
-class LazyIR:
+class LazyIR(ABC):
     backend_index: BackendIndex
     node_base: str
+    lowering_function_type: str = ""
+    lowering_context_type: str = ""
+    lowering_return_type: str = ""
 
     @method_with_native_function
     def __call__(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> List[str]:
         func = f.functional.func if isinstance(f, NativeFunctionsGroup) else f.func
         return self.gen(f)
+
+    @abstractmethod
+    def lowering_body(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> str:
+        pass
 
     def gen(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> List[str]:
         # for now, we just want one IR class decl and soon after also the method defs
@@ -63,9 +101,9 @@ class LazyIR:
         scalar_types = schema.filtered_types(values=False, scalars=True)
 
         node_ctor_args = ", ".join([f"const {i.cpp_type()}& {i.name}" for i in all_types])
-        scalar_initializers = ",\n        ".join([f"{t.name}_({t.name})" for t in scalar_types])
+        scalar_initializers = ",\n        ".join([f"{t.name}({t.name})" for t in scalar_types])
         comma_if_scalar_initializers = ",\n" if len(scalar_initializers) else ""
-        scalar_decls = "\n  ".join([f"{t.cpp_type()} {t.name}_;" for t in scalar_types])
+        scalar_decls = "\n  ".join([f"{t.cpp_type()} {t.name};" for t in scalar_types])
         scalar_hashes = ", ".join([f"{f.name}" for f in scalar_types])
         base_ctor_value_args_list = []
         optional_values = []
@@ -83,21 +121,20 @@ class LazyIR:
         members_to_string = []
         for t in scalar_types:
             if isinstance(t.type, OptionalCType):
-                members_to_string.append(f"""if ({t.name}_.has_value()) {{
-    ss << ", {t.name}=" << {t.name}_.value();
+                members_to_string.append(f"""if ({t.name}.has_value()) {{
+    ss << ", {t.name}=" << {t.name}.value();
 }} else {{
     ss << ", {t.name}=null";
 }}""")
             else:
-                members_to_string.append(f'ss << ", {t.name}=" << {t.name}_;')
+                members_to_string.append(f'ss << ", {t.name}=" << {t.name};')
         members_to_string_str = "\n    ".join(members_to_string)
 
         return [f"""\
-// TODO(alanwaketan): Public members don't need to have _ suffix.
 class {schema.node_name} : public {self.node_base} {{
  public:
   {schema.node_name}({node_ctor_args}, std::vector<Shape>&& shapes)
-      : {self.node_base}(torch::lazy::OpKind(at::aten::{schema.aten_name}),
+      : {self.node_base}(torch::lazy::OpKind({aten_symbol(schema)}),
               {{{base_ctor_value_args}}}, std::move(shapes),
               /* num_outputs */ {len(func.returns)},
               torch::lazy::MHash({scalar_hashes})){comma_if_scalar_initializers}
@@ -109,14 +146,14 @@ class {schema.node_name} : public {self.node_base} {{
 
   std::string ToString() const override {{
     std::stringstream ss;
-    ss << TsNode::ToString();
+    ss << {self.node_base}::ToString();
     {members_to_string_str}
     return ss.str();
   }}
 
-  torch::lazy::TSOpVector Lower(std::shared_ptr<torch::jit::GraphFunction> function,
-                   torch::lazy::TSLoweringContext* loctx) const override {{
-    {ts_lowering_body(f)}
+  {self.lowering_return_type} Lower({self.lowering_function_type} function,
+                   {self.lowering_context_type} loctx) const override {{
+    {self.lowering_body(f)}
   }}
 
   {scalar_decls}
@@ -127,21 +164,34 @@ class {schema.node_name} : public {self.node_base} {{
 """, ]
 
 
-def lazy_tensor_decls(value_types: List[NamedCType], tensor_class: str) -> str:
+@dataclass(frozen=True)
+class TSLazyIR(LazyIR):
+    lowering_function_type: str = "std::shared_ptr<torch::jit::GraphFunction>"
+    lowering_context_type: str = "torch::lazy::TSLoweringContext*"
+    lowering_return_type: str = "torch::lazy::TSOpVector"
+
+    def lowering_body(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> str:
+        return ts_lowering_body(f)
+
+
+def lazy_tensor_decls(value_types: List[NamedCType], tensor_class: str, schema: LazyIrSchema) -> str:
     lazy_tensor_decls: List[str] = []
     for t in value_types:
+        if t.name in schema.wrapped_scalar_names:
+            # no lazy tensor wrapper for scalars that are promoted to IR values
+            continue
         if isinstance(t.type, BaseCType):
             lazy_tensor_decls.append(
                 f"{tensor_class} lazy_{t.name} = "
-                f"GetLtcTensorOrCreateForWrappedNumber({t.name}, *device);")
+                f"torch::lazy::GetLtcTensorOrCreateForWrappedNumber({t.name}, *common_device);")
         elif isinstance(t.type, OptionalCType):
             # TODO(alanwaketan): Maybe we want to apply GetLtcTensorOrCreateForWrappedNumber here, but hold it
             # until we encounter a real world example.
             lazy_tensor_decls.append(
-                f"    {tensor_class} lazy_{t.name} = TryGetLtcTensor({t.name}.value_or(at::Tensor()));")
+                f"    {tensor_class} lazy_{t.name} = torch::lazy::TryGetLtcTensor({t.name}.value_or(at::Tensor()));")
         else:
             raise AssertionError("TODO not sure if there are other valid types to handle here")
-    return "\n    ".join(lazy_tensor_decls)
+    return ("\n        ").join(lazy_tensor_decls)
 
 @dataclass(frozen=True)
 class GenLazyNativeFuncDefinition:
@@ -152,17 +202,22 @@ class GenLazyNativeFuncDefinition:
     @method_with_native_function
     def __call__(self, func: NativeFunction) -> List[str]:
         sig = kernel_signature(func, self.backend_index)
-
-        # Lazy IR stuff
+        metadata = self.backend_index.get_kernel(func)
+        assert metadata is not None
         schema = LazyIrSchema(func.func)
         all_types = schema.filtered_types()
         value_types = schema.filtered_types(values=True, scalars=False)
         scalar_types = schema.filtered_types(values=False, scalars=True)
         returns_length = len(schema.returns)
 
-        value_types_names = ", ".join([f"{t.name}" for t in value_types])
-        get_device_str = f"""auto device = bridge::GetBackendDevice({value_types_names});"""
-        lazy_tensor_decls_str = lazy_tensor_decls(value_types, self.tensor_class)
+        fallback_str = gen_fallback_code(schema, overload_name=func.func.name.overload_name)
+        value_types_names = [f"{t.name}" for t in value_types if t.name not in schema.wrapped_scalar_names]
+        assert len(value_types_names) > 0, "Code below assumes there is at least one tensor arg"
+        get_device_str = f"""auto common_device = torch::lazy::GetBackendDevice({', '.join(value_types_names)});
+        TORCH_INTERNAL_ASSERT(common_device);
+        """
+
+        lazy_tensor_decls_str = lazy_tensor_decls(value_types, self.tensor_class, schema)
         node_ctor_input_str = node_ctor_inputs(schema)
 
         # call the meta kernel if it exists, to compute output shape/dtype for our IR
@@ -174,37 +229,40 @@ class GenLazyNativeFuncDefinition:
                 shapes_str = ','.join([this_shape(i) for i in range(returns_length)])
                 meta_out = "std::vector<Shape> shapes{" + shapes_str + "};"
 
+            # TODO: INTEGRATION POINT HERE:
             meta_str = f"""auto out_meta = at::meta::{schema.aten_name}({', '.join(str(t.name) for t in all_types)});
         {meta_out}"""
         else:
-            shape_sig = ComputeShapeSignature(func)
+            shape_sig = ComputeShapeSignature(metadata.kernel, func)
             meta_str = f"""
         auto shapes = {shape_sig.shape_call};"""
+
         meta_str += f"""
         TORCH_INTERNAL_ASSERT(shapes.size() == {returns_length});"""
 
         node_str = f"""auto node = torch::lazy::MakeNode<ir::ops::{schema.node_name}>({node_ctor_input_str},
                                                                                       std::move(shapes));"""
+        first_tensor_name = value_types_names[0]
+        bridge_str = """auto result = torch::lazy::CreateAtenFromLtcTensor(
+                torch::lazy::LazyTensor::Create(std::move(node), *common_device));"""
 
-        assert len(value_types) > 0, f"Only supporting tensor ops so far, none found in {sig}"
-        first_tensor = value_types[0]
-        bridge_str = f"""auto result = CreateAtenFromLtcTensor(lazy_{first_tensor.name}.CreateFrom(node));"""
         if returns_length > 1:
             bridge_str = f"""std::vector<{self.tensor_class}> lazy_tensors;
         for (int i = 0; i < {returns_length}; i++) {{
-            lazy_tensors.push_back(lazy_{first_tensor.name}.CreateFrom(torch::lazy::Value(node, i)));
+            lazy_tensors.push_back(torch::lazy::LazyTensor::Create(torch::lazy::Value(node, i), *common_device));
         }}
-        auto result = TupleAtenFromLtcTensors<{returns_length}>(lazy_tensors);"""
-        if schema.name.name.inplace:
+        auto result = torch::lazy::TupleAtenFromLtcTensors<{returns_length}>(lazy_tensors);"""
+
+        if schema.name.name.inplace or func.func.is_out_fn():
             assert returns_length == 1, "We assumed there was no such case where an op is an in-place variant " \
                                         "and has tuple outputs."
-            bridge_str = f"""lazy_{first_tensor.name}.SetInPlaceIrValue(node);
-        auto& result = {first_tensor.name};"""
+            bridge_str = f"""lazy_{first_tensor_name}.SetInPlaceIrValue(node);
+        auto& result = {first_tensor_name};"""
 
 
         return [f"""\
-    // TODO(alanwaketan): Quite a lot inefficient copy-by-value there. Let's optimize it.
-    {sig.decl(name=f"{self.class_method_name}::{schema.aten_name}")} {{
+    {sig.decl(name=f"{self.class_method_name}::{metadata.kernel}")} {{
+        {fallback_str}
         TORCH_LAZY_FN_COUNTER("lazy::");
         {get_device_str}
         {lazy_tensor_decls_str}
@@ -219,17 +277,17 @@ class ComputeShapeSignature:
     """
     Here we use the base name as the suffix of the signature to avoid generating for in-place variants.
     """
-    @method_with_native_function
-    def __init__(self, f: NativeFunction):
+    def __init__(self, kernel_name: str, f: NativeFunction):
         self.__schema = LazyIrSchema(f.func)
         self.__dispatch_args = ', '.join([a.decl() for a in dispatcher.arguments(f.func)])
         self.__call_args = ", ".join([f"{t.name}" for t in self.__schema.filtered_types()])
+        self.__kernel_name = kernel_name
 
     def __decl_suffix(self) -> str:
-        return f"{self.__schema.base_name}({self.__dispatch_args})"
+        return f"{self.__kernel_name}({self.__dispatch_args})"
 
     def __call_suffix(self) -> str:
-        return f"{self.__schema.base_name}({self.__call_args})"
+        return f"{self.__kernel_name}({self.__call_args})"
 
     @property
     def shape_decl(self) -> str:
@@ -246,19 +304,20 @@ class GenLazyShapeInferenceDefinition:
     tensor_class: str
 
     @method_with_native_function
+    # def gen_lazy_shape_inference_decl(f: NativeFunction, backend_index: BackendIndex, tensor_class: str) -> List[str]:
     def __call__(self, f: NativeFunction) -> List[str]:
         sig = kernel_signature(f, self.backend_index)
-
-        # Lazy IR stuff
+        metadata = self.backend_index.get_kernel(f)
+        assert metadata is not None
         schema = LazyIrSchema(f.func)
         value_types = schema.filtered_types(values=True, scalars=False)
-        lazy_tensor_decls_str = lazy_tensor_decls(value_types, self.tensor_class)
+        lazy_tensor_decls_str = lazy_tensor_decls(value_types, self.tensor_class, schema)
         node_ctor_input_str = node_ctor_inputs(schema)
 
         # Only generate shape/dtype fn for non-structured kernels,
         # since we just use the meta function for structured kernels
         if not f.structured and f.structured_delegate is None:
-            shape_sig = ComputeShapeSignature(f)
+            shape_sig = ComputeShapeSignature(metadata.kernel, f)
             return ["\n".join([f"{shape_sig.shape_decl};"])]
         else:
             return []

--- a/torch/csrc/lazy/core/config.cpp
+++ b/torch/csrc/lazy/core/config.cpp
@@ -7,6 +7,11 @@ C10_DEFINE_bool(
     false,
     "Enable parameter aliasing support");
 
+C10_DEFINE_bool(
+    torch_lazy_use_thread_pool,
+    false,
+    "Use thread pool to schedule backend execution");
+
 C10_DEFINE_int(
     torch_lazy_compilation_cache_size,
     1024,

--- a/torch/csrc/lazy/core/config.h
+++ b/torch/csrc/lazy/core/config.h
@@ -3,6 +3,7 @@
 
 C10_DECLARE_bool(torch_lazy_ir_debug);
 C10_DECLARE_bool(torch_lazy_param_aliasing);
+C10_DECLARE_bool(torch_lazy_use_thread_pool);
 
 C10_DECLARE_int(torch_lazy_compilation_cache_size);
 C10_DECLARE_int(torch_lazy_device_data_cache_size);

--- a/torch/csrc/lazy/core/shape.cpp
+++ b/torch/csrc/lazy/core/shape.cpp
@@ -28,8 +28,12 @@ size_t Shape::numel() const {
   return elts;
 }
 
-hash_t Shape::hash() const {
-  return HashCombine(Hash(scalar_type_), DataHash(sizes_.data(), sizes_.size() * sizeof(int64_t)));
+hash_t Shape::hash(bool bakeInSizes) const {
+  if (bakeInSizes) {
+    return HashCombine(Hash(scalar_type_), DataHash(sizes_.data(), sizes_.size() * sizeof(int64_t)));
+  } else {
+    return HashCombine(Hash(scalar_type_), Hash(sizes_.size()));
+  }
 }
 
 }  // namespace lazy

--- a/torch/csrc/lazy/core/shape.h
+++ b/torch/csrc/lazy/core/shape.h
@@ -25,7 +25,7 @@ class TORCH_API Shape {
   int64_t size(int64_t dim) const { return sizes_.at(dim); }
   void set_size(int64_t dim, int64_t size) { sizes_.at(dim) = size; }
   size_t numel() const;
-  hash_t hash() const;
+  hash_t hash(bool bakeInSizes) const;
 
   bool operator==(const Shape& other) const;
 

--- a/torch/csrc/lazy/ts_backend/ts_node.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_node.cpp
@@ -28,14 +28,15 @@ void TsNodeSetShapeDeferred(
   throw std::runtime_error("Expected TsNode but could not dynamic cast");
 }
 
-hash_t OperandHashes(const OpList& operands, const hash_t& seed) {
+hash_t OperandHashes(const OpList& operands, const hash_t& seed, bool bakeInSizes) {
   hash_t hash = seed;
   for (auto& operand : operands) {
     if (!operand) {
       hash = HashCombine(hash, static_cast<uint64_t>(kNullOpt));
       continue;
     }
-    hash = HashCombine(hash, operand.hash());
+    auto operand_hash = bakeInSizes ? operand.hash_with_sizes() : operand.hash_without_sizes();
+    hash = HashCombine(hash, operand_hash);
   }
   return hash;
 }
@@ -48,7 +49,7 @@ TsNode::TsNode(OpKind op, OpList operands, std::vector<Shape>&& shapes,
            // initialization to a separate function?
            /* node_hash */ HashCombine(op.hash(), hash_seed),
            /* dag_hash */
-           OperandHashes(operands, HashCombine(op.hash(), hash_seed))),
+           [&](bool bakeInSizes) { return OperandHashes(operands, HashCombine(op.hash(), hash_seed), bakeInSizes); }),
       shapes_(shapes) {
   for (auto& operand : operands) {
     // Ideally, optional operands should be filtered by the leaf node classes,
@@ -80,7 +81,7 @@ void TsNode::SetShapeDeferred(
 }
 
 TsNode::TsNode(OpKind op, Shape shape, size_t num_outputs, hash_t hash_seed)
-    : Node(op, num_outputs, GetOpHash(op, shape, hash_seed))
+    : Node(op, num_outputs, [&](bool bakeInSizes) -> hash_t { return GetOpHash(op, shape, hash_seed, bakeInSizes); })
 {
   shapes_.push_back(std::move(shape));
 }
@@ -98,10 +99,11 @@ ShapeCache* GetShapeCache() {
 
 Shape TsNode::GetOpShape(
     const std::function<Shape()>& shape_fn) const {
+  auto hash = hash_with_sizes();
   ShapeCache* shape_cache = GetShapeCache();
-  auto shape = shape_cache->Get(hash());
+  auto shape = shape_cache->Get(hash);
   if (shape == nullptr) {
-    shape = shape_cache->Add(hash(),
+    shape = shape_cache->Add(hash,
                              std::make_shared<Shape>(shape_fn()));
   }
   return *shape;
@@ -120,8 +122,8 @@ std::string TsNode::ToString() const {
   return ss.str();
 }
 
-hash_t TsNode::GetOpHash(OpKind op, const Shape& shape, hash_t hash_seed) {
-  hash_t h = HashCombine(op.hash(), shape.hash());
+hash_t TsNode::GetOpHash(OpKind op, const Shape& shape, hash_t hash_seed, bool bakeInSizes) {
+  hash_t h = HashCombine(op.hash(), shape.hash(bakeInSizes));
   return HashCombine(h, hash_seed);
 }
 

--- a/torch/csrc/lazy/ts_backend/ts_node.h
+++ b/torch/csrc/lazy/ts_backend/ts_node.h
@@ -55,7 +55,7 @@ class TORCH_API TsNode : public lazy::Node {
 
   std::string ToString() const override;
 
-  static hash_t GetOpHash(OpKind op, const Shape& shape, hash_t hash_seed);
+  static hash_t GetOpHash(OpKind op, const Shape& shape, hash_t hash_seed, bool bakeInSizes);
 
   const std::vector<Output>& operands() const override {
     return operands_as_outputs_;


### PR DESCRIPTION
Pull Request resolved: https://github.com/pytorch/pytorch/pull/72875

This diff contains changes from several PRs landed to lazy_tensor_staging branch.
* generating 'fallback' overrides for each codegenned op, useful for debugging
* supports operators which are missing aten:: symbols for op names, instead using their string counterpart
* makes the IR class a base class instead of hardcoding the assumption of TS

It also resolves lint issues and in particular cleans up the following:
* {Type}s shouldn't be passed into isValueType, and using the catch-all base class of CType is nicer than specifying a list of types.

Fixes [#72852](https://www.internalfb.com/tasks?t=72852)