### PR TITLE
[LTS] Skip large tensor tests that cause OOM kill on CircleCI

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -23,7 +23,7 @@ from torch.testing._internal.common_utils import (
     do_test_dtypes, IS_SANDCASTLE, IS_FBCODE, IS_REMOTE_GPU, load_tests, slowTest,
     skipCUDAMemoryLeakCheckIf, BytesIOContext,
     skipIfRocm, skipIfNoSciPy, TemporaryFileName, TemporaryDirectoryName,
-    wrapDeterministicFlagAPITest, DeterministicGuard, make_tensor)
+    wrapDeterministicFlagAPITest, DeterministicGuard, make_tensor, IN_CI)
 from multiprocessing.reduction import ForkingPickler
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
@@ -4242,6 +4242,7 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(expected, actual.cpu().float())
 
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "sandcastle OOM with current tpx gpu/re configuration")
+    @unittest.skipIf(IN_CI, "OOM with current configuration (gpu.nvidia.small)")
     @onlyCUDA
     @dtypesIfCUDA(torch.half)  # only small dtype not to get oom
     def test_large_cumsum(self, device, dtype):
@@ -4252,6 +4253,7 @@ class TestTorchDeviceType(TestCase):
         x[2::3] = 1
         self._test_large_cum_fn_helper(x, lambda x: torch.cumsum(x, 0))
 
+    @unittest.skipIf(IN_CI, "OOM with current configuration (gpu.nvidia.small)")
     @onlyCUDA
     @dtypesIfCUDA(torch.half)  # only small dtype not to get oom
     def test_large_cumprod(self, device, dtype):
@@ -5015,6 +5017,7 @@ class TestTorchDeviceType(TestCase):
                 for trans in [False, True]:
                     self._pdist_single(shape, device, p, torch.float64, trans, grad_check=True)
 
+    @unittest.skipIf(IN_CI, "OOM with current configuration (gpu.nvidia.small)")
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "sandcastle OOM with current tpx gpu/re configuration")
     @skipIfRocm
     def test_pdist_norm_large(self, device):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -62,6 +62,7 @@ if sys.platform == 'win32':
 IS_SANDCASTLE = os.getenv('SANDCASTLE') == '1' or os.getenv('TW_JOB_USER') == 'sandcastle'
 IS_FBCODE = os.getenv('PYTORCH_TEST_FBCODE') == '1'
 IS_REMOTE_GPU = os.getenv('PYTORCH_TEST_REMOTE_GPU') == '1'
+IN_CI = os.getenv('IN_CI') == '1'
 
 class ProfilingMode(Enum):
     LEGACY = 1


### PR DESCRIPTION
This PR resolves the out of memory problem on the `gpu.nvidia.small` or `gpu.nvidia.medium` resources for tests with large tensors by skipping them.

On these resources tests such as `TestTorchDeviceTypeCUDA.test_large_cumprod_cuda_float16` and `TestTorchDeviceTypeCUDA.test_pdist_norm_large_cuda` that have tensors of `size > 1 billion` fail due to OOM. 
