### PR TITLE
[easy][PT] Using toTupleRef insted of toTuple

### DIFF
--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -102,8 +102,8 @@ void addFormattedArg(
 } // namespace
 
 void tupleUnpack(Stack& stack) {
-  auto tuple = pop(stack).toTuple();
-  stack.insert(stack.end(), tuple->elements().begin(), tuple->elements().end());
+  const auto& tuple = pop(stack).toTupleRef();
+  stack.insert(stack.end(), tuple.elements().begin(), tuple.elements().end());
 }
 
 void format(Stack& stack, size_t num_inputs) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Differential Revision: [D34254456](https://our.internmc.facebook.com/intern/diff/D34254456/)