### PR TITLE
change stale processing order to ascending

### DIFF
--- a/.github/workflows/stale_pull_requests.yml
+++ b/.github/workflows/stale_pull_requests.yml
@@ -36,4 +36,3 @@ jobs:
           days-before-stale: 150
           days-before-close: 180
           ascending: true
-

--- a/.github/workflows/stale_pull_requests.yml
+++ b/.github/workflows/stale_pull_requests.yml
@@ -19,6 +19,7 @@ jobs:
           exempt-pr-labels: "no-stale,open source,high priority"
           days-before-stale: 60
           days-before-close: 90
+          ascending: true
   stale-open-source:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     runs-on: ubuntu-18.04
@@ -34,3 +35,5 @@ jobs:
           only-labels: "open source"
           days-before-stale: 150
           days-before-close: 180
+          ascending: true
+


### PR DESCRIPTION
Right now this workflow doesn't really do anything because it runs through it's rate limit before getting to stale PRs. Switch to ascending to process the oldest items first, which hopefully will get us through more of the backlog.