### PR TITLE
dbr quant: store auto_quant_state on the top level model

### DIFF
--- a/torch/ao/quantization/_dbr/auto_trace_rewriter.py
+++ b/torch/ao/quantization/_dbr/auto_trace_rewriter.py
@@ -8,7 +8,10 @@ import torch
 import torch.fx
 from .mappings import conv_ops
 from .quantization_state import AutoQuantizationState
-from .utils import get_packable_arg_idxs
+from .utils import (
+    get_packable_arg_idxs,
+    AutoQuantizationStateModuleDict,
+)
 
 class AllModuleTracer(torch.fx.Tracer):
     """
@@ -207,7 +210,7 @@ class AllModuleTracer(torch.fx.Tracer):
     # class.
     # TODO(future): remove the hack
     def call_module(self, m: torch.nn.Module, forward: Callable[..., Any], args : Tuple[Any, ...], kwargs : Dict[str, Any]) -> Any:
-        if isinstance(m, AutoQuantizationState):
+        if isinstance(m, AutoQuantizationStateModuleDict):
             return args[0]
         return super().call_module(m, forward, args, kwargs)
 

--- a/torch/ao/quantization/_quantize_dbr.py
+++ b/torch/ao/quantization/_quantize_dbr.py
@@ -82,6 +82,8 @@ def prepare(model, qconfig_dict, example_inputs, inplace=False, allow_list=None,
         for v in parents_to_delete_auto_quant_state:
             del v._auto_quant_state
 
+        del model._fqn_to_auto_quant_state_map
+
         # the model hierarchy might have changed during fusion, so we
         # have to delete the cached module hook types
         for k, v in model.named_modules():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#72934 dbr quant: store auto_quant_state on the top level model**

Summary:

Before this PR, DBR quantization had a limitation on handling user
code which iterates over all module children. For example, imagine
a forward function such as

```
def forward(self, x):
    for module in self:
        x = module(x)
    return x
```

Before this PR, this code would break with DBR quantization, because
we attach `AutoQuantizationState` objects to each child, and those
objects live in the child's module hierarchy and will appear in
these kinds of iterations, changing the meaning of the user program.

This PR reduces the scope of this problem to just the top level module.
Instead of attaching `AutoQuantizationState` objects to each child,
we register them in a map on the parent. Here is a before and after:

```
// toy model
model
 |--> child1

// toy model with AutoQuantizationState objects, before this PR
model
 |--> child1
 |  |--> _auto_quant_state
 |--> _auto_quant_state

// toy model with AutoQuantizationState objects, after this PR
model
 |--> child1
 |--> _fqn_to_auto_quant_state_map
    |--> ( ) --> _auto_quant_state // of `model`
    |--> (child1) --> _auto_quant_state // of `model.child1`
```

Note: `child1._auto_quant_state` works as before for convenience,
but the `child1` object now stores a soft link to its `_auto_quant_state`
instead of properly registering it in its module hierarchy. This is
somewhat hacky. If we need to improve this in the future, we could
remove this soft link and refactor the code to call the FQN map
instead.

Note: if the top level module iterates over its children, things will
still be broken. This is less likely, and we will recommend that the
user work around this by wrapping their model, or checking for the
`AutoQuantizationStateModuleDict` type in their iteration loop.

The impact of this change should be an improvement of coverage
of user models. In fact, we expect this to drive our coverage of
torchbenchmark models from 89% to 100%.

Test plan:

```
// previously disabled test cases with user code iterating
// over module children are now enabled, with wrappers
python test/test_quantization.py -k test_module_calls_items
python test/test_quantization.py -k test_vovnet_sequential
```

Differential Revision: [D34281074](https://our.internmc.facebook.com/intern/diff/D34281074)