### PR TITLE
Fix addcmul/addcdiv/addmm opinfos to not pass float scalar when an integer dtype is requested.

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2077,8 +2077,11 @@ def sample_inputs_mm(op_info, device, dtype, requires_grad, **kwargs):
 
 
 def sample_inputs_addmm(op_info, device, dtype, requires_grad, **kwargs):
-    alpha_val = kwargs.get('alpha', 2 + 3j if dtype.is_complex else 0.6)
-    beta_val = kwargs.get('beta', 1 + 2j if dtype.is_complex else 0.2)
+    alpha_val = kwargs.get('alpha', 2 + 3j if dtype.is_complex else 2.6)
+    beta_val = kwargs.get('beta', 1 + 2j if dtype.is_complex else 3.2)
+    if not dtype.is_floating_point:
+        alpha_val = int(alpha_val)
+        beta_val = int(beta_val)
     tests_list = [
         ((2, 3), (2, 2), (2, 3), False)
     ]

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2218,7 +2218,7 @@ def sample_inputs_addcmul_addcdiv(op_info, device, dtype, requires_grad, **kwarg
         sample_inputs.append(SampleInput(
             args[0],
             args=args[1:],
-            kwargs=dict(value=3.14), broadcasts_input=broadcasts_input))
+            kwargs=dict(value=3.14 if dtype.is_floating_point else 3), broadcasts_input=broadcasts_input))
 
     return tuple(sample_inputs)
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2077,11 +2077,20 @@ def sample_inputs_mm(op_info, device, dtype, requires_grad, **kwargs):
 
 
 def sample_inputs_addmm(op_info, device, dtype, requires_grad, **kwargs):
-    alpha_val = kwargs.get('alpha', 2 + 3j if dtype.is_complex else 2.6)
-    beta_val = kwargs.get('beta', 1 + 2j if dtype.is_complex else 3.2)
-    if not dtype.is_floating_point:
-        alpha_val = int(alpha_val)
-        beta_val = int(beta_val)
+    if dtype.is_complex:
+        alpha_val = 2 + 3j
+        beta_val = 1 + 2j
+    elif dtype.is_floating_point:
+        alpha_val = 2.6
+        beta_val = 3.2
+    elif not dtype.is_floating_point:
+        alpha_val = 2
+        beta_val = 3
+    if 'alpha' in kwargs:
+        alpha_val = kwargs['alpha']
+    if 'beta' in kwargs:
+        beta_val = kwargs['beta']
+
     tests_list = [
         ((2, 3), (2, 2), (2, 3), False)
     ]


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/72915