### PR TITLE
[ONNX] Mergerule: add onnx pass registration file

### DIFF
--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -9,7 +9,8 @@
        "docs/source/onnx.rst",
        "torch/csrc/jit/serialization/export.*",
        "torch/csrc/jit/serialization/onnx.*",
-       "torch/_C/__init__.pyi.in"
+       "torch/_C/__init__.pyi.in",
+       "torch/csrc/onnx/**"
       ],
     "approved_by": ["BowenBao", "garymm"],
     "mandatory_app_id": 12274


### PR DESCRIPTION
Forgot about this one in #72297. This folder contains files that registers ONNX bindings.