### PR TITLE
[ONNX] Add infra for quantized model export and support quantized mobilenet v3 (#72215)

### DIFF
--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -774,8 +774,10 @@ static void eraseTupleConstruct(Block* block) {
       for (auto* input: output_node->inputs()) {
         block->insertOutput(index + (input_index++), input);
       }
+      index += input_index;
+    } else {
+      index++;
     }
-    index++;
   }
 }
 

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -10,7 +10,7 @@ import torch.onnx.utils
 import torch.onnx.symbolic_helper as sym_help
 from torch.onnx.symbolic_helper import parse_args, _unimplemented
 import torch.onnx.symbolic_opset9
-from torch.onnx.symbolic_opset9 import linear
+from torch.onnx.symbolic_opset9 import linear, conv2d, add, mul, hardswish, relu
 
 from sys import maxsize
 
@@ -322,39 +322,75 @@ def isfinite(g, input):
     return __not_(g, __or_(g, inf_node, nan_node))
 
 
-# https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter#quantized-model-export
+def quantize_per_tensor(g, input, scale, zero_point, dtype):
+    dtype = sym_help._get_const(dtype, "i", "dtype")
+    zero_point = g.op("Cast", zero_point, to_i=sym_help.scalar_type_to_onnx[dtype])
+    scale = g.op("Cast", scale, to_i=torch.onnx.TensorProtoDataType.FLOAT)
+    return sym_help.quantize_helper(g, input, scale, zero_point)
+
+
+def dequantize(g, input):
+    return sym_help.dequantize_helper(g, input)[0]
+
+
 class Quantized:
+    """
+    https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter#quantized-model-export
+
+    Support starts from opset 10 because `DequantizeLinear` and `QuantizeLinear` were introduced in opset version 10.
+    """
     domain = "quantized"
 
-    # DequantizeLinear was added in opset version 10.
     @staticmethod
-    def linear(g, input_original, weight, weight_scale, weight_zero_point, bias, op_scale, op_zero_point):
-        input_value, input_scale, input_zero_point = sym_help._unpack_tuple(input_original)
-        # From https://pytorch.org/docs/master/generated/torch.nn.quantized.functional.linear.html
-        # input (Tensor) – Quantized input of type torch.quint8
-        input_type_dq = torch.onnx.TensorProtoDataType.UINT8
-        input_value = g.op("Cast", input_value, to_i=input_type_dq)
-        input_scale = g.op("Cast", input_scale, to_i=torch.onnx.TensorProtoDataType.FLOAT)
-        input_zero_point = g.op("Cast", input_zero_point, to_i=input_type_dq)
-        input = g.op("DequantizeLinear", input_value, input_scale, input_zero_point)
-        # weight (Tensor) – Quantized weight of type torch.qint8
-        weight_type_dq = torch.onnx.TensorProtoDataType.INT8
-        weight = g.op("Cast", weight, to_i=weight_type_dq)
-        weight_scale = g.op("Cast", weight_scale, to_i=torch.onnx.TensorProtoDataType.FLOAT)
-        weight_zero_point = g.op("Cast", weight_zero_point, to_i=weight_type_dq)
-        weight = g.op("DequantizeLinear", weight, weight_scale, weight_zero_point)
-        # bias (Tensor) – None or fp32 bias of type torch.float
-        bias = g.op("Cast", bias, to_i=torch.onnx.TensorProtoDataType.FLOAT)
+    def linear(g, q_input, q_weight, bias, op_scale, op_zero_point):
+        input, _, _ = sym_help.dequantize_helper(g, q_input)
+        weight, _, _ = sym_help.dequantize_helper(g, q_weight)
+
         output = linear(g, input, weight, bias)
 
-        if op_scale is None:
-            op_scale = input_scale
-        elif op_scale.type().scalarType() != "Float":
-            op_scale = g.op("Cast", op_scale, to_i=sym_help.cast_pytorch_to_onnx["Float"])
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)
 
-        if op_zero_point is None:
-            op_zero_point = input_zero_point
-        elif op_zero_point.type().scalarType() != "Byte":
-            op_zero_point = g.op("Cast", op_zero_point, to_i=sym_help.cast_pytorch_to_onnx["Byte"])
-        output = g.op("QuantizeLinear", output, op_scale, op_zero_point)
-        return g.op("prim::TupleConstruct", output, op_scale, op_zero_point)
+    @staticmethod
+    def add(g, x, y, op_scale, op_zero_point):
+        x, _, _ = sym_help.dequantize_helper(g, x)
+        y, _, _ = sym_help.dequantize_helper(g, y)
+
+        output = add(g, x, y)
+
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)
+
+    @staticmethod
+    def mul(g, x, y, op_scale, op_zero_point):
+        x, _, _ = sym_help.dequantize_helper(g, x)
+        y, _, _ = sym_help.dequantize_helper(g, y)
+
+        output = mul(g, x, y)
+
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)
+
+    @staticmethod
+    def hardswish(g, x, op_scale, op_zero_point):
+        x, _, _ = sym_help.dequantize_helper(g, x)
+
+        output = hardswish(g, x)
+
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)
+
+    @staticmethod
+    def conv2d_relu(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
+        input, _, _ = sym_help.dequantize_helper(g, q_input)
+        weight, _, _ = sym_help.dequantize_helper(g, q_weight)
+
+        output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
+        output = relu(g, output)
+
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)
+
+    @staticmethod
+    def conv2d(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
+        input, _, _ = sym_help.dequantize_helper(g, q_input)
+        weight, _, _ = sym_help.dequantize_helper(g, q_weight)
+
+        output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
+
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -7,7 +7,7 @@ import torch
 import torch.onnx.symbolic_helper as sym_help
 import warnings
 
-from torch.onnx.symbolic_helper import parse_args, _unimplemented, _is_tensor_list, ScalarType
+from torch.onnx.symbolic_helper import parse_args, _unimplemented, _is_tensor_list, ScalarType, quantized_args
 from torch.onnx.symbolic_opset9 import expand, unused, mul
 from torch.onnx.symbolic_opset9 import linalg_vector_norm as lvn
 from torch.nn.modules.utils import _single, _pair, _triple
@@ -791,7 +791,7 @@ def narrow(g, input, dim, start, length):
     end = g.op("Add", start, length)
     return _slice_helper(g, input, axes=dim, starts=start, ends=end, dynamic_slice=True)
 
-
+@quantized_args(True, False, False)
 @parse_args("v", "i", "i")
 def flatten(g, input, start_dim, end_dim):
     dim = sym_help._get_tensor_rank(input)

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -52,3 +52,18 @@ def batch_norm(g, input, weight, bias, running_mean, running_var, training, mome
         new_running_mean.setType(running_mean.type())
         new_running_var.setType(running_var.type())
         return res
+
+
+class Quantized:
+    """
+    https://github.com/pytorch/pytorch/wiki/PyTorch-ONNX-exporter#quantized-model-export
+    """
+    domain = "quantized"
+
+    @staticmethod
+    def hardswish(g, x, op_scale, op_zero_point):
+        x, _, _ = sym_help.dequantize_helper(g, x)
+
+        output = hardswish(g, x)
+
+        return sym_help.quantize_helper(g, output, op_scale, op_zero_point)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -13,7 +13,7 @@ from functools import partial
 from functools import wraps
 
 import torch.onnx.symbolic_helper as sym_help
-from torch.onnx.symbolic_helper import parse_args, _parse_arg, _unimplemented, ScalarType
+from torch.onnx.symbolic_helper import parse_args, _parse_arg, _unimplemented, ScalarType, quantized_args
 
 from typing import Optional
 from sys import maxsize as maxsize
@@ -949,6 +949,7 @@ avg_pool3d = _avg_pool("avg_pool3d", _triple)
 
 
 def _adaptive_pool(name, type, tuple_fn, fn=None):
+    @quantized_args(True, False)
     def symbolic_fn(g, input, output_size):
         # _adaptive_pool is supported for cases where output_size is 1 for all dimensions,
         # by executing a GlobalPool.
@@ -1957,6 +1958,8 @@ def hardswish(g, self):
     return g.op("Mul", self, hs)
 
 
+# Fixed scale and zero_point, discovered from aten/src/ATen/native/quantized/cpu/qhardsigmoid.cpp
+@quantized_args(True, scale=1.0 / 256.0, zero_point=0)
 @parse_args("v")
 def hardsigmoid(g, self):
     # Set alpha_f to 1 / 6 to make op equivalent to PyTorch's definition of Hardsigmoid.
@@ -2521,6 +2524,7 @@ def erf(g, input):
     return g.op("Erf", input)
 
 
+@quantized_args(True, False, False)
 @parse_args("v", "i", "i")
 def flatten(g, input, start_dim, end_dim):
     dim = sym_help._get_tensor_rank(input)

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -131,14 +131,14 @@ class UnsupportedOperatorError(RuntimeError):
     def __init__(self, domain, opname, version):
         supported_version = get_op_supported_version(opname, domain, version)
         if domain in ["", "aten", "prim", "quantized"]:
-            msg = "Exporting the operator " + opname + " to ONNX opset version " + str(version) + " is not supported. "
+            msg = f"Exporting the operator {domain}::{opname} to ONNX opset version {version} is not supported. "
             if supported_version is not None:
-                msg += "Support for this operator was added in version " + str(supported_version) + \
-                       ", try exporting with this version."
+                msg += (f"Support for this operator was added in version {supported_version}, "
+                        "try exporting with this version.")
             else:
                 msg += "Please feel free to request support or submit a pull request on PyTorch GitHub."
         else:
-            msg = ("ONNX export failed on an operator with unrecognized namespace {}::{}. "
+            msg = (f"ONNX export failed on an operator with unrecognized namespace {domain}::{opname}. "
                    "If you are trying to export a custom operator, make sure you registered "
-                   "it with the right domain and version.".format(domain, opname))
+                   "it with the right domain and version.")
         super().__init__(msg)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

* Add infrastructure and helper functions to enable future work for other quantized operators and models.
* Add export for quantized operators needed by torchvision mobilenet v3 large.
    * ATen namespace: hardsigmoid, flatten, adaptive_avg_pool, quantize_per_tensor, dequantize.
    * Quantized namespace: conv2d, conv2d_relu, hardswish, add, mul.
* Numerous bug fixes, in unpack_quantized_weight.cpp, symbolic functions, and unit test.

Co-authored-by: BowenBao <bowbao@microsoft.com>