### PR TITLE
[ONNX] Improve Expand shape inference (#69264)

### DIFF
--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -114,5 +114,14 @@ class TestONNXShapeInference(unittest.TestCase):
         slice = g.op("Slice", input, start_input, end, axis, step)
         self.run_test(g, slice.node(), expect_tensor(None, shape=(None, None)))
 
+    def test_expand(self):
+        g = self.create_empty_graph()
+        input = g.addInput()
+        constant = self.insert_tensor_constant(g, torch.ones(2, 4))
+        input.setType(constant.type().with_sizes([None, None]))
+        shape = g.op("Shape", input)
+        expand = g.op("Expand", constant, shape)
+        self.run_test(g, expand.node(), expect_tensor("Float", shape=(None, None)))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #72990
* #72989
* #72988
* #72987
* #72986
* __->__ #72985

Extend shape inference support for `Expand`, when value of argument `shape` is unknown. Infer the rank of the output of `Expand`, and set shape to dynamic, if shape of argument `shape` is known.

Without this, shape inference aborts, and falls back to the static shape provided by tracer, which is incorrect in many cases.

Co-authored-by: BowenBao <bowbao@microsoft.com>