### PR TITLE
[LT] Fix a bug in lazy_model.mark_step()

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/core/lazy_model.py
+++ b/lazy_tensor_core/lazy_tensor_core/core/lazy_model.py
@@ -723,7 +723,7 @@ def mark_step(device: torch.device = lazy_tensor_core._LAZYC._ltc_get_default_de
     if xu.getenv_as('LTC_EMIT_STEPLOG', bool, False):
         print('lazy_tensor_core.core.lazy_model::mark_step', file=sys.stderr, flush=True)
     lazy_tensor_core._LAZYC._ltc_step_marker(
-        device, [],
+        str(device), [],
         wait=xu.getenv_as('LTC_SYNC_WAIT', bool, False))
     # Only emit metrics from the first local device index, to avoid emitting the
     # same values from different threads.


### PR DESCRIPTION
Summary:
lazy_tensor_core._LAZYC._ltc_step_marker accepts a device string instead
of torch.device. Fix that by wrapping torch.device with str().

Test Plan:
Manual test...
