### PR TITLE
fft: Fix invalid shape error for complex-to-real transforms

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -446,6 +446,7 @@ ShapeAndDims canonicalize_fft_c2r_shape_and_dim_args(
   auto desc = canonicalize_fft_shape_and_dim_args(self, s, dims);
   TORCH_CHECK(desc.shape.size() > 0, fname, " must transform at least one axis");
 
+  // Expected output size of the hermitian-symmetric dimension
   last_dim_size = [&] {
     // Fixup default shape handling in the last dimension,
     if (!s.has_value() || (s->back() == -1)) {
@@ -454,9 +455,10 @@ ShapeAndDims canonicalize_fft_c2r_shape_and_dim_args(
     }
     return desc.shape.back();
   }();
-  auto ld = last_dim_size / 2 + 1;
-  desc.shape.back() = ld;
-  TORCH_CHECK(ld >= 1, "Invalid number of data points (", last_dim_size, ") specified");
+  TORCH_CHECK(last_dim_size >= 1, "Invalid number of data points (", last_dim_size, ") specified");
+
+  // Expected input size of the complex-hermitian data
+  desc.shape.back() = last_dim_size / 2 + 1;
   return desc;
 }
 

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -297,6 +297,16 @@ class TestFFT(TestCase):
             op(t)
 
     @onlyNativeDeviceTypes
+    def test_empty_ifft(self, device):
+        t = torch.empty(2, 1, device=device, dtype=torch.complex64)
+        match = r"Invalid number of data points \([-\d]*\) specified"
+
+        for f in [torch.fft.irfft, torch.fft.irfft2, torch.fft.irfftn,
+                  torch.fft.hfft, torch.fft.hfft2, torch.fft.hfftn]:
+            with self.assertRaisesRegex(RuntimeError, match):
+                f(t)
+
+    @onlyNativeDeviceTypes
     def test_fft_invalid_dtypes(self, device):
         t = torch.randn(64, device=device, dtype=torch.complex128)
 


### PR DESCRIPTION
Fixes #72910

`last_dim_size` is the expected output size for the
Hermitian-compressed dimension and must be > 0. The confusingly named
`ld` represents the input's last dim size which is calculated as
`last_dim_size / 2 + 1` so could never be 0.
