### PR TITLE
Documenting cuda 11.5 windows issue

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -913,16 +913,20 @@ def CUDAExtension(name, sources, *args, **kwargs):
     Note that while it's possible to include all supported archs, the more archs get included the
     slower the building process will be, as it will build a separate kernel image for each arch.
 
-    Note: Don't use torch/extension.h In CUDA 11.5 under windows in your C++ code:
-    Use aten instead for torch interface in all cuda 11.5 code under windows. It has been failing with errors, due to a bug in nvcc.
-    Example:
+    Note that CUDA-11.5 nvcc will hit internal compiler error while parsing torch/extension.h on Windows.
+    To workaround the issue, move python binding logic to pure C++ file.
+
+    Example use:
         >>> #include <ATen/ATen.h>
         >>> at::Tensor SigmoidAlphaBlendForwardCuda(....)
+
     Instead of:
         >>> #include <torch/extension.h>
         >>> torch::Tensor SigmoidAlphaBlendForwardCuda(...)
+
     Currently open issue for nvcc bug: https://github.com/pytorch/pytorch/issues/69460
-    Complete Workaround code example: https://github.com/facebookresearch/pytorch3d/commit/cb170ac024a949f1f9614ffe6af1c38d972f7d48
+    Complete workaround code example: https://github.com/facebookresearch/pytorch3d/commit/cb170ac024a949f1f9614ffe6af1c38d972f7d48
+
     '''
     library_dirs = kwargs.get('library_dirs', [])
     library_dirs += library_paths(cuda=True)

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -913,6 +913,16 @@ def CUDAExtension(name, sources, *args, **kwargs):
     Note that while it's possible to include all supported archs, the more archs get included the
     slower the building process will be, as it will build a separate kernel image for each arch.
 
+    Note: Don't use torch/extension.h In CUDA 11.5 under windows in your C++ code:
+    Use aten instead for torch interface in all cuda 11.5 code under windows. It has been failing with errors, due to a bug in nvcc.
+    Example:
+        >>> #include <ATen/ATen.h>
+        >>> at::Tensor SigmoidAlphaBlendForwardCuda(....)
+    Instead of:
+        >>> #include <torch/extension.h>
+        >>> torch::Tensor SigmoidAlphaBlendForwardCuda(...)
+    Currently open issue for nvcc bug: https://github.com/pytorch/pytorch/issues/69460
+    Complete Workaround code example: https://github.com/facebookresearch/pytorch3d/commit/cb170ac024a949f1f9614ffe6af1c38d972f7d48
     '''
     library_dirs = kwargs.get('library_dirs', [])
     library_dirs += library_paths(cuda=True)


### PR DESCRIPTION
Adding documentation about compiling extension with CUDA 11.5 and Windows

Example of failure: https://github.com/pytorch/pytorch/runs/4408796098?check_suite_focus=true

 Note: Don't use torch/extension.h In CUDA 11.5 under windows in your C++ code:
    Use aten instead of torch interface in all cuda 11.5 code under windows. It has been failing with errors, due to a bug in nvcc.
    Example use:
        >>> #include <ATen/ATen.h>
        >>> at::Tensor SigmoidAlphaBlendForwardCuda(....)
    Instead of:
        >>> #include <torch/extension.h>
        >>> torch::Tensor SigmoidAlphaBlendForwardCuda(...)
    Currently open issue for nvcc bug: https://github.com/pytorch/pytorch/issues/69460
    Complete Workaround code example: https://github.com/facebookresearch/pytorch3d/commit/cb170ac024a949f1f9614ffe6af1c38d972f7d48
