### PR TITLE
Fix `sequence_ops_test` (#72844)

### DIFF
--- a/caffe2/python/operator_test/sequence_ops_test.py
+++ b/caffe2/python/operator_test/sequence_ops_test.py
@@ -385,7 +385,7 @@ class TestSequenceOps(serial.SerializedTestCase):
             ["shrunk_data"])
 
         def op_ref(data, indices):
-            unique_indices = np.unique(indices)
+            unique_indices = np.unique(indices) if len(indices)>0 else np.array([],dtype=np.int64)
             sorted_indices = np.sort(unique_indices)
             shrunk_data = np.delete(data, sorted_indices, axis=0)
             return (shrunk_data,)


### PR DESCRIPTION
Summary:
Fuzzing gone bad again: `np.unique([])` returns array or float64, but `np.delete` expects array of int

Fixes recent regressions in ONNX tests in OSS CI, see https://github.com/pytorch/pytorch/runs/5188636426?check_suite_focus=true for example

Pull Request resolved: https://github.com/pytorch/pytorch/pull/72844

Reviewed By: gmagogsfm

Differential Revision: D34235295

Pulled By: malfet

fbshipit-source-id: 37ad39ac04f81ac519a5d4e4e8a86901944973bd
(cherry picked from commit 683c767e72dad70a12297545a1b9345c89add3c4)
(cherry picked from commit 511ec7f366dd4a54fb150cc1b8f90614d835f77d)

Fixes #ISSUE_NUMBER
