### PR TITLE
Fixed docstring typo for nn.Module.get_submodule

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -404,7 +404,7 @@ class Module:
         For example, let's say you have an ``nn.Module`` ``A`` that
         looks like this:
 
-        .. code-block::text
+        .. code-block:: text
 
             A(
                 (net_b): Module(


### PR DESCRIPTION
Description:
- Fixed docstring typo for nn.Module.get_submodule

otherwise output is invisible: https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.get_submodule
