### PR TITLE
Don't print so much in Display and Upload Test Stats

### DIFF
--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -44,13 +44,11 @@ concurrency:
 {%- endmacro -%}
 
 {%- macro upload_test_statistics(build_environment, when="always()", pytorch_directory="", needs_credentials=False) -%}
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
 {%- if pytorch_directory %}
         working-directory: !{{ pytorch_directory }}
 {%- endif %}
         if: !{{ when }}
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -2223,10 +2223,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -467,10 +467,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -719,10 +717,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -967,10 +963,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -1215,10 +1209,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -1467,10 +1459,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -1719,10 +1709,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -1971,10 +1959,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -464,10 +464,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -712,10 +710,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -960,10 +960,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -896,10 +896,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -448,10 +448,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -672,10 +670,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -464,10 +464,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -301,10 +301,8 @@ jobs:
           if-no-files-found: warn
           path:
             test-jsons-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -467,10 +467,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -719,10 +717,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -971,10 +971,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -464,10 +464,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -712,10 +710,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -960,10 +960,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -464,10 +464,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -712,10 +712,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -1703,10 +1703,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -463,10 +463,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -711,10 +709,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -959,10 +955,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -1207,10 +1201,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -1455,10 +1447,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -463,10 +463,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -711,10 +709,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -959,10 +959,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -180,10 +180,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -294,10 +294,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -462,10 +462,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -710,10 +710,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -969,10 +969,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -465,10 +465,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -717,10 +715,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -467,10 +467,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -719,10 +719,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -970,10 +970,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -466,10 +466,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -718,10 +716,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -582,10 +582,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -266,10 +266,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -424,10 +422,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -258,10 +258,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -416,10 +414,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -574,10 +570,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -732,10 +732,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
+++ b/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
@@ -430,10 +430,8 @@ jobs:
           if-no-files-found: error
           path:
             test-reports-*.zip
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -551,10 +551,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -251,10 +251,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -401,10 +399,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -260,10 +260,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -418,10 +416,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -576,10 +572,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -734,10 +734,8 @@ jobs:
       - name: Parse ref
         id: parse-ref
         run: .github/scripts/parse_ref.py
-      - name: Display and upload test statistics (Click Me)
+      - name: Upload test statistics
         if: always()
-        # temporary hack: set CIRCLE_* vars, until we update
-        # tools/stats/print_test_stats.py to natively support GitHub Actions
         env:
           AWS_DEFAULT_REGION: us-east-1
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -1092,16 +1092,10 @@ if __name__ == '__main__':
     except Exception as e:
         print(f"ERROR ENCOUNTERED WHEN UPLOADING TO SCRIBE: {e}")
 
-    # longest_tests can contain duplicates as the same tests can be spawned from different files
-    longest_tests: List[TestCase] = []
     total_time = 0.0
     for filename, test_filename in reports_by_file.items():
         for suite_name, test_suite in test_filename.test_suites.items():
             total_time += test_suite.total_time
-            if test_suite.total_time >= args.class_print_threshold:
-                test_suite.print_report(args.longest_of_class)
-                longest_tests.extend(test_suite.test_cases.values())
-    longest_tests = sorted(longest_tests, key=lambda x: x.time)[-args.longest_of_run:]
 
     obj = assemble_s3_object(reports_by_file, total_seconds=total_time)
 
@@ -1110,14 +1104,6 @@ if __name__ == '__main__':
             send_report_to_s3(obj)
         except Exception as e:
             print(f"ERROR ENCOUNTERED WHEN UPLOADING TO S3: {e}")
-
-    print(f"Total runtime is {datetime.timedelta(seconds=total_time)}")
-    print(
-        f"{len(longest_tests)} longest tests of entire run"
-        f" (ignoring suites totaling less than {args.class_print_threshold} seconds):"
-    )
-    for test_case in reversed(longest_tests):
-        print(f"    {test_case.class_name}.{test_case.name}  time: {test_case.time:.2f} seconds")
 
     if args.compare_with_s3:
         head_json = obj

--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -637,23 +637,6 @@ class TestSuite:
         self.test_cases[name].unexpected_success |= test_case.unexpected_success
         self.test_cases[name].expected_failure |= test_case.expected_failure
 
-    def print_report(self, num_longest: int = 3) -> None:
-        sorted_tests = sorted(self.test_cases.values(), key=lambda x: x.time)
-        test_count = len(sorted_tests)
-        print(f"class {self.name}:")
-        print(
-            f"    tests: {test_count} failed: {self.failed_count} skipped: {self.skipped_count} "
-            f"errored: {self.errored_count} unexpected_success: {self.unexpected_success_count} "
-            f"expected_failure: {self.expected_failure_count}")
-        print(f"    run_time: {self.total_time:.2f} seconds")
-        print(f"    avg_time: {self.total_time/test_count:.2f} seconds")
-        if test_count >= 2:
-            print(f"    median_time: {statistics.median(x.time for x in sorted_tests):.2f} seconds")
-        sorted_tests = sorted_tests[-num_longest:]
-        print(f"    {len(sorted_tests)} longest tests:")
-        for test in reversed(sorted_tests):
-            print(f"        {test.name} time: {test.time:.2f} seconds")
-        print("")
 
 DuplicatedDict = Dict[str, Dict[str, List[TestCase]]]
 


### PR DESCRIPTION
Following some discussion, it seems that the value of these logs do not outweigh the confusion it sometimes brings when people look at the logs to debug test failures. 