### PR TITLE
codegen/templates: disable clang-format check

### DIFF
--- a/aten/src/ATen/templates/DispatchKeyNativeFunctions.h
+++ b/aten/src/ATen/templates/DispatchKeyNativeFunctions.h
@@ -1,4 +1,10 @@
 #pragma once
+
+// an external backend might generate file within its code tree
+// and check all the source files within the tree with clang-format.
+// so, disable it since the backend might have a different config.
+// clang-format off
+
 // ${generated_comment}
 
 #include <ATen/Tensor.h>

--- a/aten/src/ATen/templates/RegisterDispatchKey.cpp
+++ b/aten/src/ATen/templates/RegisterDispatchKey.cpp
@@ -5,6 +5,11 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
+// an external backend might generate file within its code tree
+// and check all the source files within the tree with clang-format.
+// so, disable it since the backend might have a different config.
+// clang-format off
+
 // NOTE: This condition is true for all PyTorch internal libraries, it
 //       just excludes external projects such as torch_xla which
 //       re-use some of the PyTorch codegen machinery.


### PR DESCRIPTION
It is possible that external backends check the generated code
by clang-format with different configs, and so just disable the
check.