### PR TITLE
Add all 4 android ABIs to android build script by default

### DIFF
--- a/android/common.sh
+++ b/android/common.sh
@@ -29,6 +29,7 @@ check_gradle() {
 }
 
 parse_abis_list() {
+  # sync with https://github.com/pytorch/pytorch/blob/0ca0e02685a9d033ac4f04e2fa5c8ba6dbc5ae50/android/gradle.properties#L1
   ABIS_LIST="armeabi-v7a,arm64-v8a,x86,x86_64"
   CUSTOM_ABIS_LIST=false
   if [ $# -gt 0 ]; then

--- a/android/common.sh
+++ b/android/common.sh
@@ -29,7 +29,7 @@ check_gradle() {
 }
 
 parse_abis_list() {
-  ABIS_LIST="x86"
+  ABIS_LIST="armeabi-v7a,arm64-v8a,x86,x86_64"
   CUSTOM_ABIS_LIST=false
   if [ $# -gt 0 ]; then
     ABIS_LIST=$1


### PR DESCRIPTION
The android build script (./scripts/build_pytorch_android.sh) is broken if user didn't provide the abi list. 

./scripts/build_pytorch_android.sh ==> failed due to the so file for armv7 cannot be found
./scripts/build_pytorch_android.sh x86,x86_64 ==> works

This is because by default we will build 4 ABIs:
https://github.com/pytorch/pytorch/blob/0ca0e02685a9d033ac4f04e2fa5c8ba6dbc5ae50/android/gradle.properties#L1
but only one is provided in this script.

