### PR TITLE
Squeeze p2: hook up Squeeze to LazyView

### DIFF
--- a/torch/csrc/lazy/core/lazy_view.cpp
+++ b/torch/csrc/lazy/core/lazy_view.cpp
@@ -11,6 +11,7 @@
 #include <torch/csrc/lazy/core/view_ops/permute.h>
 #include <torch/csrc/lazy/core/view_ops/resize.h>
 #include <torch/csrc/lazy/core/view_ops/select.h>
+#include <torch/csrc/lazy/core/view_ops/squeeze.h>
 #include <torch/csrc/lazy/core/view_ops/select_view_update.h>
 #include <torch/csrc/lazy/core/view_ops/view.h>
 
@@ -43,6 +44,8 @@ Value ApplyViewInfo(Value ir_value, const ViewInfo& view_info) {
       return MakeNode<View>(ir_value, view_info.shape.sizes().vec());
     case ViewInfo::Type::kResize:
       return MakeNode<Resize>(ir_value, view_info.shape.sizes().vec());
+    case ViewInfo::Type::kSqueeze:
+      return MakeNode<torch::lazy::Squeeze>(ir_value, view_info.squeeze_index);
     case ViewInfo::Type::kAsStrided:
       return MakeNode<AsStrided>(
           ir_value,
@@ -98,6 +101,10 @@ Value ApplyUpdate(Value ir_value, const Alias::UpdateData& update_data) {
       case ViewInfo::Type::kResize:
         result = MakeNode<Resize>(result, view_info.source_shape.sizes().vec());
         break;
+      case ViewInfo::Type::kSqueeze:
+        // TODO: in the next PR, replace this w/ MakeNode<Unsqueeze>
+        result = MakeNode<View>(result, view_info.source_shape.sizes().vec());
+        break;
       case ViewInfo::Type::kAsStrided:
         result = MakeNode<AsStridedViewUpdate>(
             tmp_values[i - 1],
@@ -129,6 +136,15 @@ ViewInfo::ViewInfo(Type view_type, Shape shape, Shape source_shape)
       shape(std::move(shape)),
       indices(source_shape.dim(), 0),
       source_shape(std::move(source_shape)) {}
+
+ViewInfo::ViewInfo(Type view_type, Shape shape, Shape source_shape, int64_t sqi)
+    : view_type(view_type),
+      shape(std::move(shape)),
+      source_shape(std::move(source_shape)),
+      squeeze_index(sqi)
+{
+  TORCH_CHECK(view_type == Type::kSqueeze);
+}
 
 ViewInfo::ViewInfo(
     Type view_type,

--- a/torch/csrc/lazy/core/lazy_view.h
+++ b/torch/csrc/lazy/core/lazy_view.h
@@ -52,10 +52,12 @@ struct TORCH_API ViewInfo {
     kSelect,
     kAsStrided,
     kDiagonal,
+    kSqueeze,
   };
 
   ViewInfo() = default;
   ViewInfo(Type view_type, Shape shape, Shape source_shape);
+  ViewInfo(Type view_type, Shape shape, Shape source_shape, int64_t sqi);
   ViewInfo(
       Type view_type,
       Shape source_shape,
@@ -92,6 +94,8 @@ struct TORCH_API ViewInfo {
   c10::optional<AsStridedInfo> as_strided;
   // Information used for diagonal views.
   c10::optional<DiagonalInfo> diagonal;
+  // Squeeze/Unsqueeze Index
+  int64_t squeeze_index;
 };
 
 // When a "view" (capture by reference) is taken on a node, an Alias object is

--- a/torch/csrc/lazy/core/lazy_view.h
+++ b/torch/csrc/lazy/core/lazy_view.h
@@ -53,6 +53,7 @@ struct TORCH_API ViewInfo {
     kAsStrided,
     kDiagonal,
     kSqueeze,
+    kUnsqueeze,
   };
 
   ViewInfo() = default;


### PR DESCRIPTION
This PR hooks up Squeeze op to LazyView.
The end goal to reduce the instances where we need to rely on explicit shapes.
In the final PR we will make `aten_ops` to use the right ViewInfo and update the lowering in ts_lowering.