### PR TITLE
[codemod][type-comments] Convert type comments in api.py

### DIFF
--- a/torch/distributed/elastic/metrics/api.py
+++ b/torch/distributed/elastic/metrics/api.py
@@ -60,7 +60,7 @@ class MetricStream:
 
 
 _metrics_map = {}
-_default_metrics_handler = NullMetricHandler()  # type: MetricHandler
+_default_metrics_handler: MetricHandler = NullMetricHandler()
 
 
 # pyre-fixme[9]: group has type `str`; used as `None`.


### PR DESCRIPTION
Summary:
I'm wrapping up the conversion of type comments to type annotations
in caffe2. The last remaining "bulk" codemod has test failures that
are hard for me to understand, so I'm going to submit PRs for each
module individually which makes it easier to see what's causing
problems.

All the codemods were produced via LibCST and then manually cleaned up.

Test Plan: Wait for github CI

Differential Revision: D34344289

