### PR TITLE
[codemod][type-comments] Convert type comments in examples.py

### DIFF
--- a/torch/csrc/deploy/example/examples.py
+++ b/torch/csrc/deploy/example/examples.py
@@ -146,8 +146,7 @@ class MultiReturn(torch.nn.Module):
     def __init__(self):
         super(MultiReturn, self).__init__()
 
-    def forward(self, t):
-        # type: (Tuple[Tensor, Tensor]) -> Tuple[Tuple[Tensor, Tensor], Tuple[Tensor, Tensor]]
+    def forward(self, t: Tuple[Tensor, Tensor]) -> Tuple[Tuple[Tensor, Tensor], Tuple[Tensor, Tensor]]:
         a, b = t
         result = ((a.masked_fill_(b, 0.1), b), (torch.ones_like(a), b))
         return result


### PR DESCRIPTION
Summary:
I'm wrapping up the conversion of type comments to type annotations
in caffe2. The last remaining "bulk" codemod has test failures that
are hard for me to understand, so I'm going to submit PRs for each
module individually which makes it easier to see what's causing
problems.

All the codemods were produced via LibCST and then manually cleaned up.

Test Plan: Wait for github CI

Differential Revision: D34344276

