### PR TITLE
[codemod][type-comments] Convert type comments in workspace_test.py

### DIFF
--- a/caffe2/python/workspace_test.py
+++ b/caffe2/python/workspace_test.py
@@ -1,13 +1,16 @@
+import errno
 import os
 import shutil
 import tempfile
 import unittest
 from collections import namedtuple
+from typing import List
 
 import caffe2.python.hypothesis_test_util as htu
 import hypothesis.strategies as st
 import numpy as np
 import torch
+from torch import Tensor
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, test_util, workspace, model_helper, brew
 from hypothesis import given, settings
@@ -783,8 +786,7 @@ class MyModule(torch.jit.ScriptModule):
         return x + y + z
 
     @torch.jit.script_method
-    def multi_input_tensor_list(self, tensor_list):  # pyre-ignore: PT type annotations
-        # type: (List[Tensor]) -> Tensor
+    def multi_input_tensor_list(self, tensor_list: List[Tensor]) -> Tensor:
         return tensor_list[0] + tensor_list[1] + tensor_list[2]
 
     @torch.jit.script_method


### PR DESCRIPTION
Summary:
I'm wrapping up the conversion of type comments to type annotations
in caffe2. The last remaining "bulk" codemod has test failures that
are hard for me to understand, so I'm going to submit PRs for each
module individually which makes it easier to see what's causing
problems.

All the codemods were produced via LibCST and then manually cleaned up.

Test Plan: Wait for github CI

Differential Revision: D34344202

