### PR TITLE
[codemod][type-comments] Convert type comments in functional.py

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -927,8 +927,13 @@ def _unique_consecutive_impl(input: Tensor, return_inverse: bool = False,
     return output, inverse_indices, counts
 
 
-def _return_counts(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
+def _return_counts(
+    input: Tensor,
+    sorted: bool = True,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
 
     if has_torch_function_unary(input):
         return _unique_impl(input, sorted, return_inverse, return_counts, dim)
@@ -937,8 +942,13 @@ def _return_counts(input, sorted=True, return_inverse=False, return_counts=False
     return output, counts
 
 
-def _return_output(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, bool, Optional[int]) -> Tensor
+def _return_output(
+    input: Tensor,
+    sorted: bool = True,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tensor:
 
     if has_torch_function_unary(input):
         return _unique_impl(input, sorted, return_inverse, return_counts, dim)
@@ -947,8 +957,13 @@ def _return_output(input, sorted=True, return_inverse=False, return_counts=False
     return output
 
 
-def _return_inverse(input, sorted=True, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
+def _return_inverse(
+    input: Tensor,
+    sorted: bool = True,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
 
     if has_torch_function_unary(input):
         return _unique_impl(input, sorted, return_inverse, return_counts, dim)
@@ -989,8 +1004,12 @@ unique = boolean_dispatch(
 unique.__doc__ = _unique_impl.__doc__
 
 
-def _consecutive_return_counts(input, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
+def _consecutive_return_counts(
+    input: Tensor,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
 
     if has_torch_function_unary(input):
         return _unique_consecutive_impl(input, return_inverse, return_counts, dim)
@@ -999,8 +1018,12 @@ def _consecutive_return_counts(input, return_inverse=False, return_counts=False,
     return output, counts
 
 
-def _consecutive_return_output(input, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, Optional[int]) -> Tensor
+def _consecutive_return_output(
+    input: Tensor,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tensor:
 
     if has_torch_function_unary(input):
         return _unique_consecutive_impl(input, return_inverse, return_counts, dim)
@@ -1009,8 +1032,12 @@ def _consecutive_return_output(input, return_inverse=False, return_counts=False,
     return output
 
 
-def _consecutive_return_inverse(input, return_inverse=False, return_counts=False, dim=None):
-    # type: (Tensor, bool, bool, Optional[int]) -> Tuple[Tensor, Tensor]
+def _consecutive_return_inverse(
+    input: Tensor,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    dim: Optional[int] = None,
+) -> Tuple[Tensor, Tensor]:
 
     if has_torch_function_unary(input):
         return _unique_consecutive_impl(input, return_inverse, return_counts, dim)
@@ -1229,8 +1256,12 @@ def block_diag(*tensors):
     return torch._C._VariableFunctions.block_diag(tensors)  # type: ignore[attr-defined]
 
 
-def cdist(x1, x2, p=2., compute_mode='use_mm_for_euclid_dist_if_necessary'):
-    # type: (Tensor, Tensor, float, str) -> (Tensor)
+def cdist(
+    x1: Tensor,
+    x2: Tensor,
+    p: float = 2.,
+    compute_mode: str = 'use_mm_for_euclid_dist_if_necessary',
+) -> Tensor:
     r"""Computes batched the p-norm distance between each pair of the two collections of row vectors.
 
     Args:
@@ -1640,8 +1671,12 @@ def chain_matmul(*matrices, out=None):
         return _VF.chain_matmul(matrices, out=out)  # type: ignore[attr-defined]
 
 
-def _lu_impl(A, pivot=True, get_infos=False, out=None):
-    # type: (Tensor, bool, bool, Any) -> Tuple[Tensor, Tensor, Tensor]
+def _lu_impl(
+    A: Tensor,
+    pivot: bool = True,
+    get_infos: bool = False,
+    out: Any = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
     r"""Computes the LU factorization of a matrix or batches of matrices
     :attr:`A`. Returns a tuple containing the LU factorization and
     pivots of :attr:`A`.  Pivoting is done if :attr:`pivot` is set to
@@ -1732,8 +1767,12 @@ def _check_list_size(out_len: int, get_infos: bool, out: _ListOrSeq) -> None:
     if not isinstance(out, (tuple, list)):
         raise TypeError(f"argument 'out' must be tuple of Tensors, not {type(out).__name__}")
 
-def _lu_with_infos(A, pivot=True, get_infos=False, out=None):
-    # type: (Tensor, bool, bool, Optional[Tuple[Tensor, Tensor, Tensor]]) -> Tuple[Tensor, Tensor, Tensor]
+def _lu_with_infos(
+    A: Tensor,
+    pivot: bool = True,
+    get_infos: bool = False,
+    out: Optional[Tuple[Tensor, Tensor, Tensor]] = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
     if has_torch_function_unary(A):
         return handle_torch_function(
             lu, (A,), A, pivot=pivot, get_infos=get_infos, out=out)
@@ -1746,8 +1785,12 @@ def _lu_with_infos(A, pivot=True, get_infos=False, out=None):
     else:
         return result  # A_LU, pivots, infos
 
-def _lu_no_infos(A, pivot=True, get_infos=False, out=None):
-    # type: (Tensor, bool, bool, Optional[Tuple[Tensor, Tensor]]) -> Tuple[Tensor, Tensor]
+def _lu_no_infos(
+    A: Tensor,
+    pivot: bool = True,
+    get_infos: bool = False,
+    out: Optional[Tuple[Tensor, Tensor]] = None,
+) -> Tuple[Tensor, Tensor]:
     # need to check for torch_function here so that we exit if
     if has_torch_function_unary(A):
         return handle_torch_function(


### PR DESCRIPTION
Summary:
I'm wrapping up the conversion of type comments to type annotations
in caffe2. The last remaining "bulk" codemod has test failures that
are hard for me to understand, so I'm going to submit PRs for each
module individually which makes it easier to see what's causing
problems.

All the codemods were produced via LibCST and then manually cleaned up.

Test Plan: Wait for github CI

Differential Revision: D34344304

