### PR TITLE
Use "large" macos for binary builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -847,6 +847,7 @@ jobs:
     <<: *binary_mac_params
     macos:
       xcode: "12.0"
+      resource_class: "large"
     steps:
     # See Note [Workspace for CircleCI scripts] in job-specs-setup.yml
     - checkout

--- a/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
@@ -161,6 +161,7 @@
     <<: *binary_mac_params
     macos:
       xcode: "12.0"
+      resource_class: "large"
     steps:
     # See Note [Workspace for CircleCI scripts] in job-specs-setup.yml
     - checkout


### PR DESCRIPTION
Hopefully it will fix the timeout

