### PR TITLE
[ONNX] Make graph name spec-compliant (#71961)

### DIFF
--- a/test/onnx/expect/TestOperators.test_acos.expect
+++ b/test/onnx/expect/TestOperators.test_acos.expect
@@ -8,7 +8,7 @@ graph {
     name: "Acos_0"
     op_type: "Acos"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Acos_0"
     type {

--- a/test/onnx/expect/TestOperators.test_add_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_broadcast.expect
@@ -9,7 +9,7 @@ graph {
     name: "Add_0"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_add_left_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_left_broadcast.expect
@@ -9,7 +9,7 @@ graph {
     name: "Add_0"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_add_size1_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_broadcast.expect
@@ -9,7 +9,7 @@ graph {
     name: "Add_0"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_add_size1_right_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_right_broadcast.expect
@@ -9,7 +9,7 @@ graph {
     name: "Add_0"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_add_size1_singleton_broadcast.expect
+++ b/test/onnx/expect/TestOperators.test_add_size1_singleton_broadcast.expect
@@ -9,7 +9,7 @@ graph {
     name: "Add_0"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_addconstant.expect
+++ b/test/onnx/expect/TestOperators.test_addconstant.expect
@@ -22,7 +22,7 @@ graph {
     name: "Add_1"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_addmm.expect
+++ b/test/onnx/expect/TestOperators.test_addmm.expect
@@ -38,7 +38,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Gemm_0"
     type {

--- a/test/onnx/expect/TestOperators.test_arange_dynamic.expect
+++ b/test/onnx/expect/TestOperators.test_arange_dynamic.expect
@@ -16,7 +16,7 @@ graph {
       type: TENSOR
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   output {
     name: "1"
     type {

--- a/test/onnx/expect/TestOperators.test_argmax.expect
+++ b/test/onnx/expect/TestOperators.test_argmax.expect
@@ -18,7 +18,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ArgMax_0"
     type {

--- a/test/onnx/expect/TestOperators.test_asin.expect
+++ b/test/onnx/expect/TestOperators.test_asin.expect
@@ -8,7 +8,7 @@ graph {
     name: "Asin_0"
     op_type: "Asin"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Asin_0"
     type {

--- a/test/onnx/expect/TestOperators.test_at_op.expect
+++ b/test/onnx/expect/TestOperators.test_at_op.expect
@@ -14,7 +14,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_atan.expect
+++ b/test/onnx/expect/TestOperators.test_atan.expect
@@ -8,7 +8,7 @@ graph {
     name: "Atan_0"
     op_type: "Atan"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Atan_0"
     type {

--- a/test/onnx/expect/TestOperators.test_aten_embedding_1.expect
+++ b/test/onnx/expect/TestOperators.test_aten_embedding_1.expect
@@ -16,7 +16,7 @@ graph {
       type: TENSOR
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   output {
     name: "3"
     type {

--- a/test/onnx/expect/TestOperators.test_aten_embedding_2.expect
+++ b/test/onnx/expect/TestOperators.test_aten_embedding_2.expect
@@ -95,7 +95,7 @@ graph {
       type: TENSOR
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 4
     dims: 8

--- a/test/onnx/expect/TestOperators.test_avg_pool2d.expect
+++ b/test/onnx/expect/TestOperators.test_avg_pool2d.expect
@@ -56,7 +56,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Pad_0"
     type {

--- a/test/onnx/expect/TestOperators.test_baddbmm.expect
+++ b/test/onnx/expect/TestOperators.test_baddbmm.expect
@@ -30,7 +30,7 @@ graph {
     name: "Add_3"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     data_type: 1
     name: "onnx::Mul_11"

--- a/test/onnx/expect/TestOperators.test_basic.expect
+++ b/test/onnx/expect/TestOperators.test_basic.expect
@@ -34,7 +34,7 @@ graph {
     name: "Neg_4"
     op_type: "Neg"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_batchnorm.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm.expect
@@ -22,7 +22,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 2
     data_type: 1

--- a/test/onnx/expect/TestOperators.test_batchnorm_1d.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_1d.expect
@@ -22,7 +22,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 2
     data_type: 1

--- a/test/onnx/expect/TestOperators.test_batchnorm_noaffine.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_noaffine.expect
@@ -50,7 +50,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 128
     data_type: 1

--- a/test/onnx/expect/TestOperators.test_batchnorm_onnx_irv4.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_onnx_irv4.expect
@@ -22,7 +22,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 2
     data_type: 1

--- a/test/onnx/expect/TestOperators.test_batchnorm_training.expect
+++ b/test/onnx/expect/TestOperators.test_batchnorm_training.expect
@@ -26,7 +26,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 2
     data_type: 1

--- a/test/onnx/expect/TestOperators.test_bitshift.expect
+++ b/test/onnx/expect/TestOperators.test_bitshift.expect
@@ -52,7 +52,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     data_type: 1
     name: "onnx::Pow_11"

--- a/test/onnx/expect/TestOperators.test_c2_op.expect
+++ b/test/onnx/expect/TestOperators.test_c2_op.expect
@@ -63,7 +63,7 @@ graph {
     }
     domain: "org.pytorch._caffe2"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "_caffe2::GenerateProposals_0"
     type {

--- a/test/onnx/expect/TestOperators.test_chunk.expect
+++ b/test/onnx/expect/TestOperators.test_chunk.expect
@@ -20,7 +20,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Split_0"
     type {

--- a/test/onnx/expect/TestOperators.test_clip.expect
+++ b/test/onnx/expect/TestOperators.test_clip.expect
@@ -18,7 +18,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Clip_0"
     type {

--- a/test/onnx/expect/TestOperators.test_clip_max.expect
+++ b/test/onnx/expect/TestOperators.test_clip_max.expect
@@ -13,7 +13,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Clip_0"
     type {

--- a/test/onnx/expect/TestOperators.test_clip_min.expect
+++ b/test/onnx/expect/TestOperators.test_clip_min.expect
@@ -13,7 +13,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Clip_0"
     type {

--- a/test/onnx/expect/TestOperators.test_concat2.expect
+++ b/test/onnx/expect/TestOperators.test_concat2.expect
@@ -14,7 +14,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Concat_0"
     type {

--- a/test/onnx/expect/TestOperators.test_conv.expect
+++ b/test/onnx/expect/TestOperators.test_conv.expect
@@ -40,7 +40,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 13
     dims: 16

--- a/test/onnx/expect/TestOperators.test_conv_onnx_irv4.expect
+++ b/test/onnx/expect/TestOperators.test_conv_onnx_irv4.expect
@@ -40,7 +40,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 13
     dims: 16

--- a/test/onnx/expect/TestOperators.test_conv_onnx_irv4_opset8.expect
+++ b/test/onnx/expect/TestOperators.test_conv_onnx_irv4_opset8.expect
@@ -40,7 +40,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 4
     dims: 2

--- a/test/onnx/expect/TestOperators.test_convtranspose.expect
+++ b/test/onnx/expect/TestOperators.test_convtranspose.expect
@@ -46,7 +46,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 3
     dims: 3

--- a/test/onnx/expect/TestOperators.test_cos.expect
+++ b/test/onnx/expect/TestOperators.test_cos.expect
@@ -8,7 +8,7 @@ graph {
     name: "Cos_0"
     op_type: "Cos"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Cos_0"
     type {

--- a/test/onnx/expect/TestOperators.test_cumsum.expect
+++ b/test/onnx/expect/TestOperators.test_cumsum.expect
@@ -22,7 +22,7 @@ graph {
     name: "CumSum_1"
     op_type: "CumSum"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::CumSum_0"
     type {

--- a/test/onnx/expect/TestOperators.test_det.expect
+++ b/test/onnx/expect/TestOperators.test_det.expect
@@ -8,7 +8,7 @@ graph {
     name: "Det_0"
     op_type: "Det"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Det_0"
     type {

--- a/test/onnx/expect/TestOperators.test_dict.expect
+++ b/test/onnx/expect/TestOperators.test_dict.expect
@@ -9,7 +9,7 @@ graph {
     name: "Add_0"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_dict_str.expect
+++ b/test/onnx/expect/TestOperators.test_dict_str.expect
@@ -22,7 +22,7 @@ graph {
     name: "Add_1"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_dim.expect
+++ b/test/onnx/expect/TestOperators.test_dim.expect
@@ -15,7 +15,7 @@ graph {
       type: TENSOR
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   output {
     name: "1"
     type {

--- a/test/onnx/expect/TestOperators.test_dropout.expect
+++ b/test/onnx/expect/TestOperators.test_dropout.expect
@@ -13,7 +13,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_dropout_default.expect
+++ b/test/onnx/expect/TestOperators.test_dropout_default.expect
@@ -25,7 +25,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_dropout_opset12.expect
+++ b/test/onnx/expect/TestOperators.test_dropout_opset12.expect
@@ -13,7 +13,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_dropout_training.expect
+++ b/test/onnx/expect/TestOperators.test_dropout_training.expect
@@ -25,7 +25,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_dropout_training_opset12.expect
+++ b/test/onnx/expect/TestOperators.test_dropout_training_opset12.expect
@@ -48,7 +48,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_add.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_add.expect
@@ -9,7 +9,7 @@ graph {
     name: "Add_0"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input_1"
     type {

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_add_inputs_same_symbolic_shape.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_add_inputs_same_symbolic_shape.expect
@@ -9,7 +9,7 @@ graph {
     name: "Add_0"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input_1"
     type {

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_matmul.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_matmul.expect
@@ -9,7 +9,7 @@ graph {
     name: "MatMul_0"
     op_type: "MatMul"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input_1"
     type {

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_reduce_mean.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_reduce_mean.expect
@@ -18,7 +18,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_dynamic_axes_unchange.expect
+++ b/test/onnx/expect/TestOperators.test_dynamic_axes_unchange.expect
@@ -37,7 +37,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_elu.expect
+++ b/test/onnx/expect/TestOperators.test_elu.expect
@@ -13,7 +13,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_embedding_bags.expect
+++ b/test/onnx/expect/TestOperators.test_embedding_bags.expect
@@ -37,7 +37,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 10
     dims: 8

--- a/test/onnx/expect/TestOperators.test_empty_like.expect
+++ b/test/onnx/expect/TestOperators.test_empty_like.expect
@@ -17,7 +17,7 @@ graph {
       type: TENSOR
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   output {
     name: "1"
     type {

--- a/test/onnx/expect/TestOperators.test_empty_like_opset7.expect
+++ b/test/onnx/expect/TestOperators.test_empty_like_opset7.expect
@@ -29,7 +29,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Shape_0"
     type {

--- a/test/onnx/expect/TestOperators.test_equal.expect
+++ b/test/onnx/expect/TestOperators.test_equal.expect
@@ -9,7 +9,7 @@ graph {
     name: "Equal_0"
     op_type: "Equal"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Equal_0"
     type {

--- a/test/onnx/expect/TestOperators.test_erf.expect
+++ b/test/onnx/expect/TestOperators.test_erf.expect
@@ -8,7 +8,7 @@ graph {
     name: "Erf_0"
     op_type: "Erf"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Erf_0"
     type {

--- a/test/onnx/expect/TestOperators.test_exp.expect
+++ b/test/onnx/expect/TestOperators.test_exp.expect
@@ -8,7 +8,7 @@ graph {
     name: "Exp_0"
     op_type: "Exp"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Exp_0"
     type {

--- a/test/onnx/expect/TestOperators.test_expand.expect
+++ b/test/onnx/expect/TestOperators.test_expand.expect
@@ -87,7 +87,7 @@ graph {
     name: "Expand_7"
     op_type: "Expand"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 1
     data_type: 7

--- a/test/onnx/expect/TestOperators.test_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_flatten.expect
@@ -62,7 +62,7 @@ graph {
     name: "Reshape_4"
     op_type: "Reshape"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Shape_0"
     type {

--- a/test/onnx/expect/TestOperators.test_flatten2D.expect
+++ b/test/onnx/expect/TestOperators.test_flatten2D.expect
@@ -13,7 +13,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Flatten_0"
     type {

--- a/test/onnx/expect/TestOperators.test_fmod.expect
+++ b/test/onnx/expect/TestOperators.test_fmod.expect
@@ -14,7 +14,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Mod_0"
     type {

--- a/test/onnx/expect/TestOperators.test_frobenius_norm.expect
+++ b/test/onnx/expect/TestOperators.test_frobenius_norm.expect
@@ -32,7 +32,7 @@ graph {
     name: "Sqrt_2"
     op_type: "Sqrt"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_full.expect
+++ b/test/onnx/expect/TestOperators.test_full.expect
@@ -17,7 +17,7 @@ graph {
       type: TENSOR
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   output {
     name: "1"
     type {

--- a/test/onnx/expect/TestOperators.test_full_like.expect
+++ b/test/onnx/expect/TestOperators.test_full_like.expect
@@ -17,7 +17,7 @@ graph {
       type: TENSOR
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   output {
     name: "1"
     type {

--- a/test/onnx/expect/TestOperators.test_gather.expect
+++ b/test/onnx/expect/TestOperators.test_gather.expect
@@ -106,7 +106,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Shape_0"
     type {

--- a/test/onnx/expect/TestOperators.test_gather_opset11.expect
+++ b/test/onnx/expect/TestOperators.test_gather_opset11.expect
@@ -14,7 +14,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::GatherElements_0"
     type {

--- a/test/onnx/expect/TestOperators.test_ge.expect
+++ b/test/onnx/expect/TestOperators.test_ge.expect
@@ -15,7 +15,7 @@ graph {
     name: "Not_1"
     op_type: "Not"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Less_0"
     type {

--- a/test/onnx/expect/TestOperators.test_gelu.expect
+++ b/test/onnx/expect/TestOperators.test_gelu.expect
@@ -75,7 +75,7 @@ graph {
     name: "Mul_7"
     op_type: "Mul"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Div_0"
     type {

--- a/test/onnx/expect/TestOperators.test_gt.expect
+++ b/test/onnx/expect/TestOperators.test_gt.expect
@@ -9,7 +9,7 @@ graph {
     name: "Greater_0"
     op_type: "Greater"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Greater_0"
     type {

--- a/test/onnx/expect/TestOperators.test_hardtanh.expect
+++ b/test/onnx/expect/TestOperators.test_hardtanh.expect
@@ -18,7 +18,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_implicit_expand.expect
+++ b/test/onnx/expect/TestOperators.test_implicit_expand.expect
@@ -22,7 +22,7 @@ graph {
     name: "Add_1"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_index.expect
+++ b/test/onnx/expect/TestOperators.test_index.expect
@@ -27,7 +27,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Gather_0"
     type {

--- a/test/onnx/expect/TestOperators.test_isnan.expect
+++ b/test/onnx/expect/TestOperators.test_isnan.expect
@@ -8,7 +8,7 @@ graph {
     name: "IsNaN_0"
     op_type: "IsNaN"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::IsNaN_0"
     type {

--- a/test/onnx/expect/TestOperators.test_layer_norm_aten.expect
+++ b/test/onnx/expect/TestOperators.test_layer_norm_aten.expect
@@ -30,7 +30,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 10
     dims: 10

--- a/test/onnx/expect/TestOperators.test_le.expect
+++ b/test/onnx/expect/TestOperators.test_le.expect
@@ -15,7 +15,7 @@ graph {
     name: "Not_1"
     op_type: "Not"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Greater_0"
     type {

--- a/test/onnx/expect/TestOperators.test_linear.expect
+++ b/test/onnx/expect/TestOperators.test_linear.expect
@@ -25,7 +25,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 5
     dims: 4

--- a/test/onnx/expect/TestOperators.test_log_sigmoid.expect
+++ b/test/onnx/expect/TestOperators.test_log_sigmoid.expect
@@ -14,7 +14,7 @@ graph {
     name: "Log_1"
     op_type: "Log"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Sigmoid_0"
     type {

--- a/test/onnx/expect/TestOperators.test_logsoftmax.expect
+++ b/test/onnx/expect/TestOperators.test_logsoftmax.expect
@@ -13,7 +13,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_lstm_none_sequence_lens.expect
+++ b/test/onnx/expect/TestOperators.test_lstm_none_sequence_lens.expect
@@ -18,7 +18,7 @@ graph {
       type: TENSOR
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   output {
     name: "7"
     type {

--- a/test/onnx/expect/TestOperators.test_lt.expect
+++ b/test/onnx/expect/TestOperators.test_lt.expect
@@ -9,7 +9,7 @@ graph {
     name: "Less_0"
     op_type: "Less"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Less_0"
     type {

--- a/test/onnx/expect/TestOperators.test_master_opset.expect
+++ b/test/onnx/expect/TestOperators.test_master_opset.expect
@@ -9,7 +9,7 @@ graph {
     name: "Add_0"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_max.expect
+++ b/test/onnx/expect/TestOperators.test_max.expect
@@ -9,7 +9,7 @@ graph {
     name: "Max_0"
     op_type: "Max"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Max_0"
     type {

--- a/test/onnx/expect/TestOperators.test_maxpool.expect
+++ b/test/onnx/expect/TestOperators.test_maxpool.expect
@@ -24,7 +24,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::MaxPool_0"
     type {

--- a/test/onnx/expect/TestOperators.test_maxpool_dilations.expect
+++ b/test/onnx/expect/TestOperators.test_maxpool_dilations.expect
@@ -34,7 +34,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::MaxPool_0"
     type {

--- a/test/onnx/expect/TestOperators.test_maxpool_indices.expect
+++ b/test/onnx/expect/TestOperators.test_maxpool_indices.expect
@@ -70,7 +70,7 @@ graph {
     name: "Sub_3"
     op_type: "Sub"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::MaxPool_0"
     type {

--- a/test/onnx/expect/TestOperators.test_mean.expect
+++ b/test/onnx/expect/TestOperators.test_mean.expect
@@ -13,7 +13,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceMean_0"
     type {

--- a/test/onnx/expect/TestOperators.test_mean_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_mean_dtype.expect
@@ -24,7 +24,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Cast_0"
     type {

--- a/test/onnx/expect/TestOperators.test_meshgrid.expect
+++ b/test/onnx/expect/TestOperators.test_meshgrid.expect
@@ -219,7 +219,7 @@ graph {
     name: "Expand_21"
     op_type: "Expand"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Reshape_0"
     type {

--- a/test/onnx/expect/TestOperators.test_min.expect
+++ b/test/onnx/expect/TestOperators.test_min.expect
@@ -9,7 +9,7 @@ graph {
     name: "Min_0"
     op_type: "Min"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Min_0"
     type {

--- a/test/onnx/expect/TestOperators.test_mm.expect
+++ b/test/onnx/expect/TestOperators.test_mm.expect
@@ -34,7 +34,7 @@ graph {
       type: FLOAT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Gemm_0"
     type {

--- a/test/onnx/expect/TestOperators.test_narrow.expect
+++ b/test/onnx/expect/TestOperators.test_narrow.expect
@@ -23,7 +23,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Slice_0"
     type {

--- a/test/onnx/expect/TestOperators.test_ne.expect
+++ b/test/onnx/expect/TestOperators.test_ne.expect
@@ -15,7 +15,7 @@ graph {
     name: "Not_1"
     op_type: "Not"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Equal_0"
     type {

--- a/test/onnx/expect/TestOperators.test_nonzero.expect
+++ b/test/onnx/expect/TestOperators.test_nonzero.expect
@@ -20,7 +20,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::NonZero_0"
     type {

--- a/test/onnx/expect/TestOperators.test_norm_p1.expect
+++ b/test/onnx/expect/TestOperators.test_norm_p1.expect
@@ -18,7 +18,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceL1_0"
     type {

--- a/test/onnx/expect/TestOperators.test_norm_p2.expect
+++ b/test/onnx/expect/TestOperators.test_norm_p2.expect
@@ -18,7 +18,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceL2_0"
     type {

--- a/test/onnx/expect/TestOperators.test_ones_like.expect
+++ b/test/onnx/expect/TestOperators.test_ones_like.expect
@@ -17,7 +17,7 @@ graph {
       type: TENSOR
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   output {
     name: "1"
     type {

--- a/test/onnx/expect/TestOperators.test_pad.expect
+++ b/test/onnx/expect/TestOperators.test_pad.expect
@@ -25,7 +25,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_params.expect
+++ b/test/onnx/expect/TestOperators.test_params.expect
@@ -34,7 +34,7 @@ graph {
     name: "Neg_4"
     op_type: "Neg"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 2
     dims: 2

--- a/test/onnx/expect/TestOperators.test_params_onnx_irv4.expect
+++ b/test/onnx/expect/TestOperators.test_params_onnx_irv4.expect
@@ -34,7 +34,7 @@ graph {
     name: "Neg_4"
     op_type: "Neg"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 2
     dims: 2

--- a/test/onnx/expect/TestOperators.test_permute2.expect
+++ b/test/onnx/expect/TestOperators.test_permute2.expect
@@ -18,7 +18,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Transpose_0"
     type {

--- a/test/onnx/expect/TestOperators.test_pixel_shuffle.expect
+++ b/test/onnx/expect/TestOperators.test_pixel_shuffle.expect
@@ -18,7 +18,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::DepthToSpace_0"
     type {

--- a/test/onnx/expect/TestOperators.test_pow.expect
+++ b/test/onnx/expect/TestOperators.test_pow.expect
@@ -9,7 +9,7 @@ graph {
     name: "Pow_0"
     op_type: "Pow"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Pow_0"
     type {

--- a/test/onnx/expect/TestOperators.test_prelu.expect
+++ b/test/onnx/expect/TestOperators.test_prelu.expect
@@ -9,7 +9,7 @@ graph {
     name: "PRelu_0"
     op_type: "PRelu"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 2
     dims: 1

--- a/test/onnx/expect/TestOperators.test_prod.expect
+++ b/test/onnx/expect/TestOperators.test_prod.expect
@@ -13,7 +13,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceProd_0"
     type {

--- a/test/onnx/expect/TestOperators.test_prod_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_prod_dtype.expect
@@ -24,7 +24,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Cast_0"
     type {

--- a/test/onnx/expect/TestOperators.test_rand.expect
+++ b/test/onnx/expect/TestOperators.test_rand.expect
@@ -22,7 +22,7 @@ graph {
     name: "Add_1"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_randn.expect
+++ b/test/onnx/expect/TestOperators.test_randn.expect
@@ -22,7 +22,7 @@ graph {
     name: "Add_1"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reduce_sum_negative_indices.expect
+++ b/test/onnx/expect/TestOperators.test_reduce_sum_negative_indices.expect
@@ -18,7 +18,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceSum_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reduced_mean.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_mean.expect
@@ -18,7 +18,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceMean_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reduced_mean_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_mean_dtype.expect
@@ -29,7 +29,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Cast_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reduced_mean_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_mean_keepdim.expect
@@ -19,7 +19,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceMean_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reduced_prod.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_prod.expect
@@ -18,7 +18,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceProd_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reduced_prod_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_prod_dtype.expect
@@ -29,7 +29,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Cast_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reduced_prod_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_prod_keepdim.expect
@@ -18,7 +18,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceProd_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reduced_sum.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum.expect
@@ -19,7 +19,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceSum_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reduced_sum_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum_dtype.expect
@@ -29,7 +29,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Cast_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reduced_sum_keepdim.expect
+++ b/test/onnx/expect/TestOperators.test_reduced_sum_keepdim.expect
@@ -18,7 +18,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceSum_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reducemax.expect
+++ b/test/onnx/expect/TestOperators.test_reducemax.expect
@@ -13,7 +13,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceMax_0"
     type {

--- a/test/onnx/expect/TestOperators.test_reducemin.expect
+++ b/test/onnx/expect/TestOperators.test_reducemin.expect
@@ -13,7 +13,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceMin_0"
     type {

--- a/test/onnx/expect/TestOperators.test_remainder.expect
+++ b/test/onnx/expect/TestOperators.test_remainder.expect
@@ -29,7 +29,7 @@ graph {
     name: "Sub_3"
     op_type: "Sub"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Div_0"
     type {

--- a/test/onnx/expect/TestOperators.test_repeat.expect
+++ b/test/onnx/expect/TestOperators.test_repeat.expect
@@ -45,7 +45,7 @@ graph {
     name: "Tile_3"
     op_type: "Tile"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 1
     data_type: 7

--- a/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
+++ b/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
@@ -45,7 +45,7 @@ graph {
     name: "Tile_3"
     op_type: "Tile"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 1
     data_type: 7

--- a/test/onnx/expect/TestOperators.test_round.expect
+++ b/test/onnx/expect/TestOperators.test_round.expect
@@ -8,7 +8,7 @@ graph {
     name: "Round_0"
     op_type: "Round"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Round_0"
     type {

--- a/test/onnx/expect/TestOperators.test_rrelu.expect
+++ b/test/onnx/expect/TestOperators.test_rrelu.expect
@@ -25,7 +25,7 @@ graph {
     name: "PRelu_1"
     op_type: "PRelu"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_rsqrt.expect
+++ b/test/onnx/expect/TestOperators.test_rsqrt.expect
@@ -28,7 +28,7 @@ graph {
     name: "Div_2"
     op_type: "Div"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Sqrt_0"
     type {

--- a/test/onnx/expect/TestOperators.test_rsub.expect
+++ b/test/onnx/expect/TestOperators.test_rsub.expect
@@ -22,7 +22,7 @@ graph {
     name: "Sub_1"
     op_type: "Sub"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Sub_0"
     type {

--- a/test/onnx/expect/TestOperators.test_scatter_add.expect
+++ b/test/onnx/expect/TestOperators.test_scatter_add.expect
@@ -37,7 +37,7 @@ graph {
     name: "Add_2"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_scatter_add_opset11.expect
+++ b/test/onnx/expect/TestOperators.test_scatter_add_opset11.expect
@@ -37,7 +37,7 @@ graph {
     name: "Add_2"
     op_type: "Add"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Add_0"
     type {

--- a/test/onnx/expect/TestOperators.test_selu.expect
+++ b/test/onnx/expect/TestOperators.test_selu.expect
@@ -8,7 +8,7 @@ graph {
     name: "Selu_0"
     op_type: "Selu"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_shape_value_map.expect
+++ b/test/onnx/expect/TestOperators.test_shape_value_map.expect
@@ -134,7 +134,7 @@ graph {
     name: "Reshape_11"
     op_type: "Reshape"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 1
     data_type: 7

--- a/test/onnx/expect/TestOperators.test_sign.expect
+++ b/test/onnx/expect/TestOperators.test_sign.expect
@@ -8,7 +8,7 @@ graph {
     name: "Sign_0"
     op_type: "Sign"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Sign_0"
     type {

--- a/test/onnx/expect/TestOperators.test_sin.expect
+++ b/test/onnx/expect/TestOperators.test_sin.expect
@@ -8,7 +8,7 @@ graph {
     name: "Sin_0"
     op_type: "Sin"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Sin_0"
     type {

--- a/test/onnx/expect/TestOperators.test_slice.expect
+++ b/test/onnx/expect/TestOperators.test_slice.expect
@@ -23,7 +23,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Slice_0"
     type {

--- a/test/onnx/expect/TestOperators.test_slice_dynamic.expect
+++ b/test/onnx/expect/TestOperators.test_slice_dynamic.expect
@@ -93,7 +93,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Slice_0"
     type {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy.expect
@@ -19,7 +19,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d.expect
@@ -19,7 +19,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d_none.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d_none.expect
@@ -19,7 +19,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_4d.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_4d.expect
@@ -19,7 +19,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_ignore_index.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_ignore_index.expect
@@ -19,7 +19,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_weights.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_weights.expect
@@ -20,7 +20,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 5
     data_type: 1

--- a/test/onnx/expect/TestOperators.test_split.expect
+++ b/test/onnx/expect/TestOperators.test_split.expect
@@ -22,7 +22,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "tensor"
     type {

--- a/test/onnx/expect/TestOperators.test_split_with_sizes.expect
+++ b/test/onnx/expect/TestOperators.test_split_with_sizes.expect
@@ -22,7 +22,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "tensor"
     type {

--- a/test/onnx/expect/TestOperators.test_sqrt.expect
+++ b/test/onnx/expect/TestOperators.test_sqrt.expect
@@ -8,7 +8,7 @@ graph {
     name: "Sqrt_0"
     op_type: "Sqrt"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Sqrt_0"
     type {

--- a/test/onnx/expect/TestOperators.test_std.expect
+++ b/test/onnx/expect/TestOperators.test_std.expect
@@ -144,7 +144,7 @@ graph {
     name: "Sqrt_13"
     op_type: "Sqrt"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceMean_0"
     type {

--- a/test/onnx/expect/TestOperators.test_sum.expect
+++ b/test/onnx/expect/TestOperators.test_sum.expect
@@ -13,7 +13,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::ReduceSum_0"
     type {

--- a/test/onnx/expect/TestOperators.test_sum_dtype.expect
+++ b/test/onnx/expect/TestOperators.test_sum_dtype.expect
@@ -24,7 +24,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Cast_0"
     type {

--- a/test/onnx/expect/TestOperators.test_tan.expect
+++ b/test/onnx/expect/TestOperators.test_tan.expect
@@ -8,7 +8,7 @@ graph {
     name: "Tan_0"
     op_type: "Tan"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Tan_0"
     type {

--- a/test/onnx/expect/TestOperators.test_topk.expect
+++ b/test/onnx/expect/TestOperators.test_topk.expect
@@ -36,7 +36,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::TopK_0"
     type {

--- a/test/onnx/expect/TestOperators.test_topk_smallest_unsorted.expect
+++ b/test/onnx/expect/TestOperators.test_topk_smallest_unsorted.expect
@@ -46,7 +46,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::TopK_0"
     type {

--- a/test/onnx/expect/TestOperators.test_transpose.expect
+++ b/test/onnx/expect/TestOperators.test_transpose.expect
@@ -8,7 +8,7 @@ graph {
     name: "Identity_0"
     op_type: "Identity"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Identity_0"
     type {

--- a/test/onnx/expect/TestOperators.test_type_as.expect
+++ b/test/onnx/expect/TestOperators.test_type_as.expect
@@ -8,7 +8,7 @@ graph {
     name: "Identity_0"
     op_type: "Identity"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Identity_0"
     type {

--- a/test/onnx/expect/TestOperators.test_unfold.expect
+++ b/test/onnx/expect/TestOperators.test_unfold.expect
@@ -78,7 +78,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Slice_0"
     type {

--- a/test/onnx/expect/TestOperators.test_unique.expect
+++ b/test/onnx/expect/TestOperators.test_unique.expect
@@ -21,7 +21,7 @@ graph {
       type: INT
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "input"
     type {

--- a/test/onnx/expect/TestOperators.test_unsqueeze.expect
+++ b/test/onnx/expect/TestOperators.test_unsqueeze.expect
@@ -13,7 +13,7 @@ graph {
       type: INTS
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Unsqueeze_0"
     type {

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_scale.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_scale.expect
@@ -14,7 +14,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 4
     data_type: 1

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
@@ -14,7 +14,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 4
     data_type: 1

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_size.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_size.expect
@@ -28,7 +28,7 @@ graph {
       type: STRING
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_view.expect
+++ b/test/onnx/expect/TestOperators.test_view.expect
@@ -23,7 +23,7 @@ graph {
     name: "Reshape_1"
     op_type: "Reshape"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   input {
     name: "onnx::Reshape_0"
     type {

--- a/test/onnx/expect/TestOperators.test_view_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_view_flatten.expect
@@ -9,7 +9,7 @@ graph {
     name: "Reshape_0"
     op_type: "Reshape"
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   initializer {
     dims: 2
     data_type: 7

--- a/test/onnx/expect/TestOperators.test_zeros_like.expect
+++ b/test/onnx/expect/TestOperators.test_zeros_like.expect
@@ -17,7 +17,7 @@ graph {
       type: TENSOR
     }
   }
-  name: "torch-jit-export"
+  name: "torch_jit"
   output {
     name: "1"
     type {

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -21,9 +21,9 @@
 #include <atomic>
 
 #include <onnx/checker.h>
-#include <onnx/shape_inference/implementation.h>
 #include <onnx/onnx_pb.h>
 #include <onnx/proto_utils.h>
+#include <onnx/shape_inference/implementation.h>
 
 #include <fstream>
 #include <memory>
@@ -650,7 +650,7 @@ void GraphEncoder::EncodeBlock(
     bool use_external_data_format,
     const std::string& onnx_file_path) {
   AT_ASSERT(graph_proto != nullptr);
-  std::string block_name = "torch-jit-export";
+  std::string block_name = "torch_jit";
   if (num_blocks_) {
     block_name += std::to_string(num_blocks_);
   }
@@ -1260,7 +1260,6 @@ void check_onnx_proto(const std::string& proto_string, bool full_check) {
   if (full_check) {
     onnx::shape_inference::InferShapes(model);
   }
-
 }
 
 } // namespace jit

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -61,7 +61,9 @@ export_onnx(
 TORCH_API std::string serialize_model_proto_to_string(
     const std::shared_ptr<::ONNX_NAMESPACE::ModelProto>& model_proto);
 
-TORCH_API void check_onnx_proto(const std::string& proto_string, bool full_check=false);
+TORCH_API void check_onnx_proto(
+    const std::string& proto_string,
+    bool full_check = false);
 
 // Serializer for both oldsyle and unified format TorchScript serialization
 class TORCH_API ScriptModuleSerializer {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73104
* #73103
* #73102
* #73101
* #73100
* __->__ #73099

[According to the ONNX spec](https://github.com/onnx/onnx/blob/main/docs/IR.md#names-within-a-graph),
all names must adhere to C90 identifier syntax rules, which means no
dashes.

Fixes: #30952