### PR TITLE
[pkg] improve error message for module detection on saving pass

### DIFF
--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -607,7 +607,8 @@ class PackageExporter:
                             f"Object '{field}' from module {module} was mocked out during packaging "
                             f"but is being used in resource - {resource} in package {package}. "
                             "If this error is happening during 'save_pickle', please ensure that your "
-                            "pickled object doesn't contain any mocked objects."
+                            "pickled object doesn't contain any mocked objects. Try interning or externing"
+                            f"{module} if {field} is supposed to be in the package."
                         )
                     else:
                         return


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73106

The original error message didn't have next steps, and someone got confused. This error message should make debugging a bit easier.

Differential Revision: [D34559499](https://our.internmc.facebook.com/intern/diff/D34559499)