### PR TITLE
[vulkan] Clamp tanh activation op input to preserve numerical stability

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/tanh.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/tanh.glsl
@@ -18,6 +18,10 @@ void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
-    imageStore(uOutput, pos, tanh(texelFetch(uInput, pos, 0)));
+    const vec4 intex = texelFetch(uInput, pos, 0);
+    imageStore(
+        uOutput,
+        pos,
+        tanh(clamp(intex, -15.0, 15.0)));
   }
 }

--- a/aten/src/ATen/native/vulkan/glsl/tanh_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/tanh_.glsl
@@ -17,6 +17,10 @@ void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
-    imageStore(uOutput, pos, tanh(imageLoad(uOutput, pos)));
+    const vec4 intex = imageLoad(uOutput, pos);
+    imageStore(
+        uOutput,
+        pos,
+        tanh(clamp(intex, -15.0, 15.0)));
   }
 }

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -1551,7 +1551,7 @@ TEST(VulkanAPITest, tanh) {
     return;
   }
 
-  const auto in_cpu = at::rand({17, 197, 302, 5}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu = at::rand({17, 197, 302, 5}, at::device(at::kCPU).dtype(at::kFloat)) * 30;
   const auto in_vulkan = in_cpu.vulkan();
 
   const auto out_cpu = at::tanh(in_cpu);
@@ -1570,7 +1570,7 @@ TEST(VulkanAPITest, tanh_) {
     return;
   }
 
-  auto cpu = at::rand({17, 197, 302, 5}, at::device(at::kCPU).dtype(at::kFloat));
+  auto cpu = at::rand({17, 197, 302, 5}, at::device(at::kCPU).dtype(at::kFloat)) * 30;
   auto vulkan = cpu.vulkan();
 
   at::tanh_(cpu);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73110 [vulkan] Add fused GatedConv2D ops for speech models
* #73109 [vulkan] Allow benchmark binary to handle non-single tensor inputs/outputs for Vulkan models
* #73108 [vulkan] Re-route arithmetic ops to scalar versions when second arg is zero-dim
* **#73107 [vulkan] Clamp tanh activation op input to preserve numerical stability**

It was observed that for large inputs (magnitude >= 30), the `tanh` shader would produce numerically unstable outputs when running with MoltenVK. The solution is to clamp the input with the range [-15, 15] before applying the `tanh` function.

Differential Revision: [D34354838](https://our.internmc.facebook.com/intern/diff/D34354838)