### PR TITLE
stop sccache server after building (#72794)

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -157,4 +157,5 @@ python setup.py install --cmake && sccache --show-stats && (
 
 sccache --show-stats > stats.txt
 python -m tools.stats.upload_sccache_stats stats.txt
+sccache --stop-server
 rm stats.txt


### PR DESCRIPTION
Summary:
This is to avoid the directory , where the sccache is installed, couldn't be deleted.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/72794

Reviewed By: H-Huang

Differential Revision: D34222877

Pulled By: janeyx99

fbshipit-source-id: 2765d6f49b375d15598586ed83ae4c5e667e7226
(cherry picked from commit 551e21ca582c80d88a466b7bfe4eda9dee0c9a5f)

