### PR TITLE
Fix tensor.__deepcopy__ for lazy device

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -92,7 +92,7 @@ class Tensor(torch._C._TensorBase):
             # does accurate alias tracking; however, the code below
             # doesn't work because of
             # https://github.com/pytorch/pytorch/issues/47442
-            if self.is_sparse or self.device.type in ['xla', 'mlc', 'ort', 'meta', 'hpu']:
+            if self.is_sparse or self.device.type in ['lazy', 'xla', 'mlc', 'ort', 'meta', 'hpu']:
                 new_tensor = self.clone()
             else:
                 new_storage = self.storage().__deepcopy__(memo)


### PR DESCRIPTION
A small bug that misses `lazy` in tensor.__deepcopy__, which results in segmentation when deepcopy a lazy model.