### PR TITLE
Allow ingesters of gen_backend_stubs codegen to customize "class name"

### DIFF
--- a/tools/codegen/gen_backend_stubs.py
+++ b/tools/codegen/gen_backend_stubs.py
@@ -19,7 +19,7 @@ from tools.codegen.api.types import DispatcherSignature
 # Parses the external backend's yaml, and adds a new BackendIndex for the backend's dispatch key.
 # Returns a Tuple of (backend_key, autograd_key, cpp_namespace, updated BackendIndex mapping)
 ParsedExternalYaml = namedtuple('ParsedExternalYaml', [
-    'backend_key', 'autograd_key', 'cpp_namespace', 'backend_indices'])
+    'backend_key', 'autograd_key', 'class_name', 'cpp_namespace', 'backend_indices'])
 def parse_backend_yaml(
         backend_yaml_path: str,
         grouped_native_functions: Sequence[Union[NativeFunction, NativeFunctionsGroup]],
@@ -35,10 +35,12 @@ def parse_backend_yaml(
         yaml_values = yaml.load(f, Loader=YamlLoader)
     assert isinstance(yaml_values, dict)
 
-    valid_keys = ['backend', 'cpp_namespace', 'extra_headers', 'supported', 'autograd', 'full_codegen']
+    valid_keys = ['backend', 'class_name', 'cpp_namespace', 'extra_headers', 'supported', 'autograd', 'full_codegen']
 
     backend = yaml_values.pop('backend', None)
     assert backend is not None, 'You must provide a value for "backend"'
+
+    class_name = yaml_values.pop('class_name', None)
 
     cpp_namespace = yaml_values.pop('cpp_namespace', None)
     assert cpp_namespace is not None, 'You must provide a value for "cpp_namespace"'
@@ -133,13 +135,14 @@ the behavior of autograd for some operators on your backend. However "Autograd{b
 autograd key. They cannot be mix and matched. If this is something you need, feel free to create an issue! \
 {forward_kernels[0].kernel} is listed under "supported", but {backward_kernels[0].kernel} is listed under "autograd".'
 
-    return ParsedExternalYaml(backend_key, autograd_key, cpp_namespace, backend_indices)
+    return ParsedExternalYaml(backend_key, autograd_key, class_name, cpp_namespace, backend_indices)
 
 def error_on_missing_kernels(
         native_functions: Sequence[NativeFunction],
         backend_indices: Dict[DispatchKey, BackendIndex],
         backend_key: DispatchKey,
         autograd_key: Optional[DispatchKey],
+        class_name: str,
         kernel_defn_file_path: str,
         full_codegen: Optional[List[OperatorName]] = None,
 ) -> None:
@@ -151,9 +154,6 @@ def error_on_missing_kernels(
 
     if full_codegen is None:
         full_codegen = []
-
-    class_name: Optional[str] = backend_indices[backend_key].native_function_class_name()
-    assert class_name is not None
 
     expected_backend_op_names: List[OperatorName] = \
         list(backend_indices[backend_key].index.keys()) + \
@@ -236,6 +236,7 @@ def gen_dispatchkey_nativefunc_headers(
 def gen_dispatcher_registrations(
         fm: FileManager,
         output_dir: str,
+        class_name: str,
         cpp_namespace: str,
         backend_indices: Dict[DispatchKey, BackendIndex],
         grouped_native_functions: Sequence[Union[NativeFunction, NativeFunctionsGroup]],
@@ -253,6 +254,7 @@ def gen_dispatcher_registrations(
     else:
         external_backend_headers_str = "\n".join(f'#include "{h}"' for h in headers)
 
+    assert class_name is not None
     backend_index = backend_indices[dispatch_key]
     fm.write_with_template(f'Register{dispatch_key}.cpp', 'RegisterDispatchKey.cpp', lambda: {
         'extra_cuda_headers': '',
@@ -270,7 +272,7 @@ def gen_dispatcher_registrations(
                 selector,
                 rocm=False,
                 cpp_namespace=cpp_namespace,
-                class_method_name=f'{backend_dispatch_key}NativeFunctions'),
+                class_method_name=f'{class_name}'),
             grouped_native_functions
         )),
         'dispatch_registrations': list(concatMap(
@@ -280,7 +282,7 @@ def gen_dispatcher_registrations(
                 selector,
                 rocm=False,
                 cpp_namespace=cpp_namespace,
-                class_method_name=f'{dispatch_key}NativeFunctions'),
+                class_method_name=f'{class_name}'),
             grouped_native_functions
         )),
     })
@@ -304,6 +306,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
     backend_key = parsed_backend_yaml.backend_key
     autograd_key = parsed_backend_yaml.autograd_key
     cpp_namespace = parsed_backend_yaml.cpp_namespace
+    class_name = parsed_backend_yaml.class_name
     backend_indices = parsed_backend_yaml.backend_indices
 
     selector = SelectiveBuilder.get_nop_selector()
@@ -313,17 +316,24 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
         # This could be useful if a backend wants to quickly set up a noop yaml file but doesn't have any kernels ready yet.
         return
 
-    class_name = backend_indices[backend_key].native_function_class_name()
+    if class_name is None:
+        # class_name is an optional argument to backend yaml file.
+        # if specified it allows an external backend to override
+        # the name of the class that all generated kernel definitions live under.
+        # if not specified, its value is given as native_function_class_name.
+        class_name = backend_indices[backend_key].native_function_class_name()
+    assert class_name is not None
 
     if impl_path is not None:
-        error_on_missing_kernels(native_functions, backend_indices, backend_key, autograd_key, impl_path)
+        error_on_missing_kernels(native_functions, backend_indices, backend_key, autograd_key, class_name, impl_path)
 
 
     gen_dispatchkey_nativefunc_headers(fm, class_name, cpp_namespace, backend_indices,
                                        grouped_native_functions, backend_key, autograd_key)
 
     for dispatch_key in [backend_key] if autograd_key is None else [backend_key, autograd_key]:
-        gen_dispatcher_registrations(fm, output_dir, cpp_namespace, backend_indices, grouped_native_functions,
-                                     backend_key, dispatch_key, selector)
+        gen_dispatcher_registrations(fm, output_dir, class_name, cpp_namespace, backend_indices,
+                                     grouped_native_functions, backend_key, dispatch_key, selector)
+
 if __name__ == '__main__':
     main()

--- a/tools/codegen/gen_backend_stubs.py
+++ b/tools/codegen/gen_backend_stubs.py
@@ -319,11 +319,11 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
         error_on_missing_kernels(native_functions, backend_indices, backend_key, autograd_key, impl_path)
 
 
-        gen_dispatchkey_nativefunc_headers(fm, class_name, cpp_namespace, backend_indices,
-                                           grouped_native_functions, backend_key, autograd_key)
+    gen_dispatchkey_nativefunc_headers(fm, class_name, cpp_namespace, backend_indices,
+                                       grouped_native_functions, backend_key, autograd_key)
 
-        for dispatch_key in [backend_key] if autograd_key is None else [backend_key, autograd_key]:
-            gen_dispatcher_registrations(fm, output_dir, cpp_namespace, backend_indices, grouped_native_functions,
-                                         backend_key, dispatch_key, selector)
+    for dispatch_key in [backend_key] if autograd_key is None else [backend_key, autograd_key]:
+        gen_dispatcher_registrations(fm, output_dir, cpp_namespace, backend_indices, grouped_native_functions,
+                                     backend_key, dispatch_key, selector)
 if __name__ == '__main__':
     main()

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -193,7 +193,7 @@ def run_gen_lazy_tensor(aten_path: str, source_yaml: str, output_dir: str,
 
     if impl_path is not None:
         error_on_missing_kernels(native_functions, backend_indices, backend_key,
-                                 autograd_key, impl_path, full_codegen)
+                                 autograd_key, class_name, impl_path, full_codegen)
 
 
     """ Validate Shape Inference Definitions
@@ -228,7 +228,7 @@ def run_gen_lazy_tensor(aten_path: str, source_yaml: str, output_dir: str,
 
     # Generate Dispatcher registrations which hook up the nativefunctions
     for dispatch_key in [backend_key] if autograd_key is None else [backend_key, autograd_key]:
-        gen_dispatcher_registrations(fm, output_dir, cpp_namespace, backend_indices, grouped_native_functions,
+        gen_dispatcher_registrations(fm, output_dir, class_name, cpp_namespace, backend_indices, grouped_native_functions,
                                      backend_key, dispatch_key, selector,
                                      build_in_tree=build_in_tree,
                                      per_operator_headers=per_operator_headers)

--- a/tools/test/test_gen_backend_stubs.py
+++ b/tools/test/test_gen_backend_stubs.py
@@ -208,7 +208,7 @@ supported:
 - abs
 invalid_key: invalid_val'''
         output_error = self.get_errors_from_gen_backend_stubs(yaml_str)
-        self.assertExpectedInline(output_error, ''' contains unexpected keys: invalid_key. Only the following keys are supported: backend, cpp_namespace, extra_headers, supported, autograd, full_codegen''')  # noqa: B950
+        self.assertExpectedInline(output_error, ''' contains unexpected keys: invalid_key. Only the following keys are supported: backend, class_name, cpp_namespace, extra_headers, supported, autograd, full_codegen''')  # noqa: B950
 
     # if use_out_as_primary is provided, it must be a bool
     def test_use_out_as_primary_non_bool(self) -> None:


### PR DESCRIPTION
When a backend (and its corresponding dispatch key) like `XPU` or `Lazy` runs the external codegen pipeline, all of its kernels get generated as methods inside of a `{DispatchKey}NativeFunctions` class. This PR allows the backend to customize the generated name if they wish to.