### PR TITLE
[RELAND] [cuDNN] Add a new optimized cuDNN RNN algorithm for small RNN hidden_size

### DIFF
--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -757,8 +757,6 @@ namespace {
                                             const TensorDescriptorListParams& tensors,
                                             bool forward) {
 #if CUDNN_VERSION >= 8201 // 8.2.1
-    if (tensors.is_input_packed()) return false;
-
     cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
     if (prop->major < 6) return false;
 
@@ -790,17 +788,23 @@ namespace {
       return CUDNN_RNN_ALGO_STANDARD;
     }
 
+    // Persistent algos typically don't work for packed inputs with sequence lengths that vary
+    // across batch elements, and will return CUDNN_STATUS_NOT_SUPPORTED if attempted. See
+    // https://docs.nvidia.com/deeplearning/cudnn/developer-guide/index.html#features-of-rnn-functions
+    if (!tensors.is_input_packed()) {
+      auto cudnnDataType = getCudnnDataType(input);
 #if CUDNN_VERSION >= 8201 // 8.2.1
-    if (use_rnn_persist_small_h(rnn, tensors, forward)) {
-      return CUDNN_RNN_ALGO_PERSIST_STATIC_SMALL_H;
-    }
+      if (cudnnDataType != CUDNN_DATA_DOUBLE) {
+        if (use_rnn_persist_small_h(rnn, tensors, forward)) {
+          return CUDNN_RNN_ALGO_PERSIST_STATIC_SMALL_H;
+        }
+      }
 #endif
-
-    if (getCudnnDataType(input) == CUDNN_DATA_HALF &&
-        !tensors.is_input_packed()) {
-      if (use_persist_common_heuristics(rnn, tensors) &&
-          use_persist_device_heuristics(rnn, tensors)) {
-        return CUDNN_RNN_ALGO_PERSIST_STATIC;
+      if (cudnnDataType == CUDNN_DATA_HALF) {
+        if (use_persist_common_heuristics(rnn, tensors) &&
+            use_persist_device_heuristics(rnn, tensors)) {
+          return CUDNN_RNN_ALGO_PERSIST_STATIC;
+        }
       }
     }
 

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -757,6 +757,8 @@ namespace {
                                             const TensorDescriptorListParams& tensors,
                                             bool forward) {
 #if CUDNN_VERSION >= 8201 // 8.2.1
+    if (tensors.is_input_packed()) return false;
+
     cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
     if (prop->major < 6) return false;
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/62143 was reverted (https://github.com/pytorch/pytorch/pull/72089) because, when running native tests internally with cudnn and GPUs such that `CUDNN_RNN_ALGO_PERSIST_STATIC_SMALL_H` was used, we hit some `CUDNN_STATUS_NOT_SUPPORTED` errors.

Based on https://docs.nvidia.com/deeplearning/cudnn/developer-guide/index.html#features-of-rnn-functions and experiments, I strongly suspect the errors were because `CUDNN_RNN_ALGO_PERSIST_STATIC_SMALL_H` doesn't support variable sequence lengths in the batch.

This PR restores https://github.com/pytorch/pytorch/pull/62143 and adds a bailout condition if the input is a packed batch that might have different sequence lengths per element.

Question for review: Do we also need to add a bailout condition if the input is double precision?