### PR TITLE
[LTS] CircleCI: Resize resources to avoid timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -954,6 +954,7 @@ jobs:
     <<: *binary_mac_params
     macos:
       xcode: "12.0"
+      resource_class: "large"
     steps:
     # See Note [Workspace for CircleCI scripts] in job-specs-setup.yml
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,12 @@ executors:
       resource_class: windows.xlarge
       image: windows-server-2019-vs2019:stable
       shell: bash.exe
+  
+  windows-2xlarge-cpu-with-nvidia-cuda:
+    machine:
+      resource_class: windows.2xlarge
+      image: windows-server-2019-vs2019:stable
+      shell: bash.exe
 
   windows-medium-cpu-with-nvidia-cuda:
     machine:
@@ -1082,7 +1088,7 @@ jobs:
         default: ""
       executor:
         type: string
-        default: "windows-xlarge-cpu-with-nvidia-cuda"
+        default: "windows-2xlarge-cpu-with-nvidia-cuda"
     executor: <<parameters.executor>>
     steps:
     # See Note [Workspace for CircleCI scripts] in job-specs-setup.yml

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -31,6 +31,12 @@ executors:
       resource_class: windows.xlarge
       image: windows-server-2019-vs2019:stable
       shell: bash.exe
+  
+  windows-2xlarge-cpu-with-nvidia-cuda:
+    machine:
+      resource_class: windows.2xlarge
+      image: windows-server-2019-vs2019:stable
+      shell: bash.exe
 
   windows-medium-cpu-with-nvidia-cuda:
     machine:

--- a/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
@@ -161,6 +161,7 @@
     <<: *binary_mac_params
     macos:
       xcode: "12.0"
+      resource_class: "large"
     steps:
     # See Note [Workspace for CircleCI scripts] in job-specs-setup.yml
     - checkout

--- a/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/binary-job-specs.yml
@@ -289,7 +289,7 @@
         default: ""
       executor:
         type: string
-        default: "windows-xlarge-cpu-with-nvidia-cuda"
+        default: "windows-2xlarge-cpu-with-nvidia-cuda"
     executor: <<parameters.executor>>
     steps:
     # See Note [Workspace for CircleCI scripts] in job-specs-setup.yml


### PR DESCRIPTION
This PR resizes resources used for some jobs to avoid timeout on CircleCI. 

The context deadline for CircleCI has changed from 5 hours to 5 hours and some jobs are also running slower leading to timeouts. So we increase the resource size for the following jobs:

- **binary_windows_build:** `xlarge` -> `2xlarge`
- **binary_macos_build:** `medium` -> `large`
