### PR TITLE
.github: Switch binary builds to use linux.2xlarge

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -47,7 +47,7 @@ jobs:
 {%- for config in build_configs %}
   !{{ config["build_name"] }}-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: !{{ common.timeout_minutes }}
     !{{ upload.binary_env(config) }}
     steps:
@@ -108,7 +108,7 @@ jobs:
 {%- if config["gpu_arch_type"] == "cuda" %}
     runs-on: linux.4xlarge.nvidia.gpu
 {%- else %}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
 {%- endif %}
     timeout-minutes: !{{ common.timeout_minutes }}
     !{{ upload.binary_env(config) }}

--- a/.github/workflows/generated-linux-binary-conda.yml
+++ b/.github/workflows/generated-linux-binary-conda.yml
@@ -42,7 +42,7 @@ concurrency:
 jobs:
   conda-py3_7-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -189,7 +189,7 @@ jobs:
   conda-py3_7-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: conda-py3_7-cpu-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -446,7 +446,7 @@ jobs:
           docker system prune -af
   conda-py3_7-cuda10_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -858,7 +858,7 @@ jobs:
           docker system prune -af
   conda-py3_7-cuda11_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -1273,7 +1273,7 @@ jobs:
           docker system prune -af
   conda-py3_7-cuda11_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -1688,7 +1688,7 @@ jobs:
           docker system prune -af
   conda-py3_7-cuda11_5-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -2103,7 +2103,7 @@ jobs:
           docker system prune -af
   conda-py3_8-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -2250,7 +2250,7 @@ jobs:
   conda-py3_8-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: conda-py3_8-cpu-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -2507,7 +2507,7 @@ jobs:
           docker system prune -af
   conda-py3_8-cuda10_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -2919,7 +2919,7 @@ jobs:
           docker system prune -af
   conda-py3_8-cuda11_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -3334,7 +3334,7 @@ jobs:
           docker system prune -af
   conda-py3_8-cuda11_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -3749,7 +3749,7 @@ jobs:
           docker system prune -af
   conda-py3_8-cuda11_5-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -4164,7 +4164,7 @@ jobs:
           docker system prune -af
   conda-py3_9-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -4311,7 +4311,7 @@ jobs:
   conda-py3_9-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: conda-py3_9-cpu-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -4568,7 +4568,7 @@ jobs:
           docker system prune -af
   conda-py3_9-cuda10_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -4980,7 +4980,7 @@ jobs:
           docker system prune -af
   conda-py3_9-cuda11_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -5395,7 +5395,7 @@ jobs:
           docker system prune -af
   conda-py3_9-cuda11_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -5810,7 +5810,7 @@ jobs:
           docker system prune -af
   conda-py3_9-cuda11_5-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -6225,7 +6225,7 @@ jobs:
           docker system prune -af
   conda-py3_10-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -6372,7 +6372,7 @@ jobs:
   conda-py3_10-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: conda-py3_10-cpu-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -6629,7 +6629,7 @@ jobs:
           docker system prune -af
   conda-py3_10-cuda10_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -7041,7 +7041,7 @@ jobs:
           docker system prune -af
   conda-py3_10-cuda11_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -7456,7 +7456,7 @@ jobs:
           docker system prune -af
   conda-py3_10-cuda11_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda
@@ -7871,7 +7871,7 @@ jobs:
           docker system prune -af
   conda-py3_10-cuda11_5-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: conda

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi.yml
@@ -42,7 +42,7 @@ concurrency:
 jobs:
   libtorch-cpu-shared-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -190,7 +190,7 @@ jobs:
   libtorch-cpu-shared-with-deps-cxx11-abi-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-cpu-shared-with-deps-cxx11-abi-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -449,7 +449,7 @@ jobs:
           docker system prune -af
   libtorch-cpu-shared-without-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -597,7 +597,7 @@ jobs:
   libtorch-cpu-shared-without-deps-cxx11-abi-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-cpu-shared-without-deps-cxx11-abi-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -856,7 +856,7 @@ jobs:
           docker system prune -af
   libtorch-cpu-static-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -1004,7 +1004,7 @@ jobs:
   libtorch-cpu-static-with-deps-cxx11-abi-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-cpu-static-with-deps-cxx11-abi-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -1263,7 +1263,7 @@ jobs:
           docker system prune -af
   libtorch-cpu-static-without-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -1411,7 +1411,7 @@ jobs:
   libtorch-cpu-static-without-deps-cxx11-abi-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-cpu-static-without-deps-cxx11-abi-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -1670,7 +1670,7 @@ jobs:
           docker system prune -af
   libtorch-cuda10_2-shared-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -2085,7 +2085,7 @@ jobs:
           docker system prune -af
   libtorch-cuda10_2-shared-without-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -2500,7 +2500,7 @@ jobs:
           docker system prune -af
   libtorch-cuda10_2-static-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -2915,7 +2915,7 @@ jobs:
           docker system prune -af
   libtorch-cuda10_2-static-without-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -3330,7 +3330,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_1-shared-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -3748,7 +3748,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_1-shared-without-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -4166,7 +4166,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_1-static-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -4584,7 +4584,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_1-static-without-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -5002,7 +5002,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_3-shared-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -5420,7 +5420,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_3-shared-without-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -5838,7 +5838,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_3-static-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -6256,7 +6256,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_3-static-without-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -6674,7 +6674,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_5-shared-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -7092,7 +7092,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_5-shared-without-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -7510,7 +7510,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_5-static-with-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -7928,7 +7928,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_5-static-without-deps-cxx11-abi-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11.yml
@@ -42,7 +42,7 @@ concurrency:
 jobs:
   libtorch-cpu-shared-with-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -190,7 +190,7 @@ jobs:
   libtorch-cpu-shared-with-deps-pre-cxx11-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-cpu-shared-with-deps-pre-cxx11-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -449,7 +449,7 @@ jobs:
           docker system prune -af
   libtorch-cpu-shared-without-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -597,7 +597,7 @@ jobs:
   libtorch-cpu-shared-without-deps-pre-cxx11-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-cpu-shared-without-deps-pre-cxx11-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -856,7 +856,7 @@ jobs:
           docker system prune -af
   libtorch-cpu-static-with-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -1004,7 +1004,7 @@ jobs:
   libtorch-cpu-static-with-deps-pre-cxx11-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-cpu-static-with-deps-pre-cxx11-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -1263,7 +1263,7 @@ jobs:
           docker system prune -af
   libtorch-cpu-static-without-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -1411,7 +1411,7 @@ jobs:
   libtorch-cpu-static-without-deps-pre-cxx11-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: libtorch-cpu-static-without-deps-pre-cxx11-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -1670,7 +1670,7 @@ jobs:
           docker system prune -af
   libtorch-cuda10_2-shared-with-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -2085,7 +2085,7 @@ jobs:
           docker system prune -af
   libtorch-cuda10_2-shared-without-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -2500,7 +2500,7 @@ jobs:
           docker system prune -af
   libtorch-cuda10_2-static-with-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -2915,7 +2915,7 @@ jobs:
           docker system prune -af
   libtorch-cuda10_2-static-without-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -3330,7 +3330,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_1-shared-with-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -3748,7 +3748,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_1-shared-without-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -4166,7 +4166,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_1-static-with-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -4584,7 +4584,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_1-static-without-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -5002,7 +5002,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_3-shared-with-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -5420,7 +5420,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_3-shared-without-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -5838,7 +5838,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_3-static-with-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -6256,7 +6256,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_3-static-without-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -6674,7 +6674,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_5-shared-with-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -7092,7 +7092,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_5-shared-without-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -7510,7 +7510,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_5-static-with-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch
@@ -7928,7 +7928,7 @@ jobs:
           docker system prune -af
   libtorch-cuda11_5-static-without-deps-pre-cxx11-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: libtorch

--- a/.github/workflows/generated-linux-binary-manywheel.yml
+++ b/.github/workflows/generated-linux-binary-manywheel.yml
@@ -42,7 +42,7 @@ concurrency:
 jobs:
   manywheel-py3_7-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -189,7 +189,7 @@ jobs:
   manywheel-py3_7-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_7-cpu-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -446,7 +446,7 @@ jobs:
           docker system prune -af
   manywheel-py3_7-cuda10_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -858,7 +858,7 @@ jobs:
           docker system prune -af
   manywheel-py3_7-cuda11_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -1273,7 +1273,7 @@ jobs:
           docker system prune -af
   manywheel-py3_7-cuda11_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -1688,7 +1688,7 @@ jobs:
           docker system prune -af
   manywheel-py3_7-cuda11_5-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -2103,7 +2103,7 @@ jobs:
           docker system prune -af
   manywheel-py3_7-rocm4_3_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -2251,7 +2251,7 @@ jobs:
   manywheel-py3_7-rocm4_3_1-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_7-rocm4_3_1-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -2510,7 +2510,7 @@ jobs:
           docker system prune -af
   manywheel-py3_7-rocm4_5_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -2658,7 +2658,7 @@ jobs:
   manywheel-py3_7-rocm4_5_2-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_7-rocm4_5_2-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -2917,7 +2917,7 @@ jobs:
           docker system prune -af
   manywheel-py3_8-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -3064,7 +3064,7 @@ jobs:
   manywheel-py3_8-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_8-cpu-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -3321,7 +3321,7 @@ jobs:
           docker system prune -af
   manywheel-py3_8-cuda10_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -3733,7 +3733,7 @@ jobs:
           docker system prune -af
   manywheel-py3_8-cuda11_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -4148,7 +4148,7 @@ jobs:
           docker system prune -af
   manywheel-py3_8-cuda11_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -4563,7 +4563,7 @@ jobs:
           docker system prune -af
   manywheel-py3_8-cuda11_5-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -4978,7 +4978,7 @@ jobs:
           docker system prune -af
   manywheel-py3_8-rocm4_3_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -5126,7 +5126,7 @@ jobs:
   manywheel-py3_8-rocm4_3_1-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_8-rocm4_3_1-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -5385,7 +5385,7 @@ jobs:
           docker system prune -af
   manywheel-py3_8-rocm4_5_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -5533,7 +5533,7 @@ jobs:
   manywheel-py3_8-rocm4_5_2-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_8-rocm4_5_2-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -5792,7 +5792,7 @@ jobs:
           docker system prune -af
   manywheel-py3_9-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -5939,7 +5939,7 @@ jobs:
   manywheel-py3_9-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_9-cpu-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -6196,7 +6196,7 @@ jobs:
           docker system prune -af
   manywheel-py3_9-cuda10_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -6608,7 +6608,7 @@ jobs:
           docker system prune -af
   manywheel-py3_9-cuda11_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -7023,7 +7023,7 @@ jobs:
           docker system prune -af
   manywheel-py3_9-cuda11_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -7438,7 +7438,7 @@ jobs:
           docker system prune -af
   manywheel-py3_9-cuda11_5-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -7853,7 +7853,7 @@ jobs:
           docker system prune -af
   manywheel-py3_9-rocm4_3_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -8001,7 +8001,7 @@ jobs:
   manywheel-py3_9-rocm4_3_1-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_9-rocm4_3_1-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -8260,7 +8260,7 @@ jobs:
           docker system prune -af
   manywheel-py3_9-rocm4_5_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -8408,7 +8408,7 @@ jobs:
   manywheel-py3_9-rocm4_5_2-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_9-rocm4_5_2-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -8667,7 +8667,7 @@ jobs:
           docker system prune -af
   manywheel-py3_10-cpu-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -8814,7 +8814,7 @@ jobs:
   manywheel-py3_10-cpu-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_10-cpu-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -9071,7 +9071,7 @@ jobs:
           docker system prune -af
   manywheel-py3_10-cuda10_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -9483,7 +9483,7 @@ jobs:
           docker system prune -af
   manywheel-py3_10-cuda11_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -9898,7 +9898,7 @@ jobs:
           docker system prune -af
   manywheel-py3_10-cuda11_3-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -10313,7 +10313,7 @@ jobs:
           docker system prune -af
   manywheel-py3_10-cuda11_5-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -10728,7 +10728,7 @@ jobs:
           docker system prune -af
   manywheel-py3_10-rocm4_3_1-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -10876,7 +10876,7 @@ jobs:
   manywheel-py3_10-rocm4_3_1-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_10-rocm4_3_1-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -11135,7 +11135,7 @@ jobs:
           docker system prune -af
   manywheel-py3_10-rocm4_5_2-build:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel
@@ -11283,7 +11283,7 @@ jobs:
   manywheel-py3_10-rocm4_5_2-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
     needs: manywheel-py3_10-rocm4_5_2-build
-    runs-on: linux.4xlarge
+    runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
       PACKAGE_TYPE: manywheel


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73260

Switches binary builds to use linux.2xlarge instead of linux.4xlarge.
The prior reason to using linux.4xlarge was because we were originally
hitting OOM issues. We were hitting those issues because we weren't
originally running binary_populate_env.sh but now that we are we can
safely return these to the more common machine type we use.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>