### PR TITLE
Skip optimizer overlap tests that have issues with NCCL async error handling

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4064,8 +4064,8 @@ class DistributedTest:
                     dist.barrier()
 
         @sandcastle_skip_if(
-            BACKEND not in DistTestCases.backend_feature["ddp"],
-            f"The {BACKEND} backend does not support DistributedDataParallel"
+            BACKEND == "nccl",
+            "Issues with async error handling, see https://github.com/pytorch/pytorch/issues/73259"
         )
         @skip_if_lt_x_gpu(2)
         @skip_if_rocm
@@ -4092,8 +4092,8 @@ class DistributedTest:
             )
 
         @sandcastle_skip_if(
-            BACKEND not in DistTestCases.backend_feature["ddp"],
-            f"The {BACKEND} backend does not support DistributedDataParallel"
+            BACKEND == "nccl",
+            "Issues with async error handling, see https://github.com/pytorch/pytorch/issues/73259"
         )
         @skip_if_lt_x_gpu(2)
         @skip_if_rocm
@@ -4113,8 +4113,8 @@ class DistributedTest:
             )
 
         @sandcastle_skip_if(
-            BACKEND not in DistTestCases.backend_feature["ddp"],
-            f"The {BACKEND} backend does not support DistributedDataParallel"
+            BACKEND == "nccl",
+            "Issues with async error handling, see https://github.com/pytorch/pytorch/issues/73259"
         )
         @skip_if_lt_x_gpu(2)
         @skip_if_rocm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73295
* __->__ #73261

Skip these tests which sometimes have issues on unrelated PRs such as
https://github.com/pytorch/pytorch/runs/5291461671?check_suite_focus=true. See
https://github.com/pytorch/pytorch/issues/73259 for additional detail 

Differential Revision: [D34404857](https://our.internmc.facebook.com/intern/diff/D34404857/)