### PR TITLE
[quant][fx] Enable output_quantized_idxs to allow multiple indexs

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -2235,6 +2235,49 @@ class TestQuantizeFx(QuantizationTestCase):
         self._test_quantized_inputs_outputs(
             prepare_custom_config_dict, prepare_count_check, convert_count_check)
 
+
+    def _test_quantized_multiple_inputs_outputs(
+            self, prepare_custom_config_dict, prepare_count_check,
+            convert_count_check):
+        """
+        Test the option to have inputs and outputs of the graph quantized
+        """
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = torch.nn.Conv2d(1, 1, 1)
+                self.conv2 = torch.nn.Conv2d(1, 1, 1)
+
+            def forward(self, x):
+                c1 = self.conv1(x)
+                c2 = self.conv2(x)
+                return c1, c2
+
+        # quantized input, quantized output
+        m = M()
+        qconfig_dict = {'': torch.ao.quantization.default_qconfig}
+        m.eval()
+        mp = torch.ao.quantization.quantize_fx.prepare_fx(
+            m, qconfig_dict,
+            prepare_custom_config_dict=prepare_custom_config_dict)
+        self.checkGraphModuleNodes(mp, expected_node_occurrence=prepare_count_check)
+        mp(torch.randn(1, 1, 4, 4))
+        mq = torch.ao.quantization.quantize_fx.convert_fx(mp)
+        self.checkGraphModuleNodes(mq, expected_node_occurrence=convert_count_check)
+
+    def test_quantized_multiple_input_quantized_output(self):
+        prepare_custom_config_dict = {
+            'input_quantized_idxs': [0], 'output_quantized_idxs': [0, 1]}
+        prepare_count_check = {
+            ns.call_module(torch.ao.quantization.MinMaxObserver): 2,
+        }
+        convert_count_check = {
+            ns.call_function(torch.quantize_per_tensor): 0,
+            ns.call_method('dequantize'): 0,
+        }
+        self._test_quantized_multiple_inputs_outputs(
+            prepare_custom_config_dict, prepare_count_check, convert_count_check)
+
     @skipIfNoFBGEMM
     def test_convtranspose_per_channel_fails_early(self):
         r"""

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -2265,7 +2265,7 @@ class TestQuantizeFx(QuantizationTestCase):
         mq = torch.ao.quantization.quantize_fx.convert_fx(mp)
         self.checkGraphModuleNodes(mq, expected_node_occurrence=convert_count_check)
 
-    def test_quantized_multiple_input_quantized_output(self):
+    def test_quantized_input_quantized_multiple_output(self):
         prepare_custom_config_dict = {
             'input_quantized_idxs': [0], 'output_quantized_idxs': [0, 1]}
         prepare_count_check = {

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -700,8 +700,6 @@ def maybe_insert_observers_before_graph_output(
     # arbitrary data structures. There is always a single output, and
     # that output can have arbitrary nesting of values. List[int] is
     # not the right data type for this.
-    assert output_quantized_idxs == [0] or output_quantized_idxs == [], \
-        'unrecognized format of output_quantized_idxs'
 
     # Currently dequants are inserted in the convert step. So, we only
     # have to do anything if the output is hardcoded to be quantized

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -696,6 +696,11 @@ def maybe_insert_observers_before_graph_output(
     for those nodes.
     """
 
+    # TODO(future PR): update the output_quantized_idxs API to match
+    # arbitrary data structures. There is always a single output, and
+    # that output can have arbitrary nesting of values. List[int] is
+    # not the right data type for this.
+
     # Currently dequants are inserted in the convert step. So, we only
     # have to do anything if the output is hardcoded to be quantized
     if output_quantized_idxs == []:

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -696,11 +696,6 @@ def maybe_insert_observers_before_graph_output(
     for those nodes.
     """
 
-    # TODO(future PR): update the output_quantized_idxs API to match
-    # arbitrary data structures. There is always a single output, and
-    # that output can have arbitrary nesting of values. List[int] is
-    # not the right data type for this.
-
     # Currently dequants are inserted in the convert step. So, we only
     # have to do anything if the output is hardcoded to be quantized
     if output_quantized_idxs == []:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73264

Summary:
Enable output_quantized_idxs to allow multiple indexs

Test Plan:
python3 test/test_quantization.py TestQuantizeFx.test_quantized_multiple_input_quantized_output

Reviewers:

Subscribers:

Tasks:

Tags: