### PR TITLE
Support nested templates in generated code via helper

### DIFF
--- a/aten/src/ATen/templates/DispatchKeyNativeFunctions.h
+++ b/aten/src/ATen/templates/DispatchKeyNativeFunctions.h
@@ -3,11 +3,11 @@
 
 #include <ATen/Tensor.h>
 
-namespace ${cpp_namespace} {
+${namespace_prologue}
 
 struct ${class_name} {
 
 ${dispatch_declarations}
 
 };
-}  // namespace ${cpp_namespace}
+${namespace_epilogue}

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -71,6 +71,33 @@ T = TypeVar('T')
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
+class NamespaceHelper():
+    """ A helper for constructing the namespace open and close strings for a nested set of namespaces.
+
+        e.g. for namespace_str torch::lazy,
+
+        prologue:
+        namespace torch {
+        namespace lazy {
+
+        epilogue:
+        } // namespace lazy
+        } // namespace torch
+    """
+    def __init__(self, namespace_str: str):
+        # cpp_namespace can be a colon joined string such as torch::lazy
+        cpp_namespaces = namespace_str.split("::")
+        self.prologue_ = "\n".join([f"namespace {n} {{" for n in cpp_namespaces])
+        self.epilogue_ = "\n".join([f"}} // namespace {n}" for n in reversed(cpp_namespaces)])
+
+    @property
+    def prologue(self) -> str:
+        return self.prologue_
+
+    @property
+    def epilogue(self) -> str:
+        return self.epilogue_
+
 # A custom loader for YAML to let us also keep track of line numbers
 # of each entry in the YAML file
 class LineLoader(YamlLoader):

--- a/tools/codegen/gen_backend_stubs.py
+++ b/tools/codegen/gen_backend_stubs.py
@@ -5,7 +5,7 @@ import yaml
 import re
 from collections import namedtuple, Counter, defaultdict
 from typing import List, Dict, Union, Sequence, Optional
-from tools.codegen.gen import get_grouped_native_functions, parse_native_yaml
+from tools.codegen.gen import get_grouped_native_functions, parse_native_yaml, NamespaceHelper
 from tools.codegen.model import (BackendIndex, BackendMetadata, DispatchKey,
                                  NativeFunction, NativeFunctionsGroup, OperatorName)
 from tools.codegen.selective_build.selector import SelectiveBuilder
@@ -223,10 +223,12 @@ def gen_dispatchkey_nativefunc_headers(
         dest.compute_native_function_declaration(f, backend_indices[autograd_dispatch_key]),
         grouped_native_functions))))
 
+    ns_helper = NamespaceHelper(cpp_namespace)
     fm.write_with_template(f'{backend_dispatch_key}NativeFunctions.h', 'DispatchKeyNativeFunctions.h', lambda: {
         'generated_comment': generated_comment,
-        'cpp_namespace': cpp_namespace,
+        'namespace_prologue': ns_helper.prologue,
         'class_name': class_name,
+        'namespace_epilogue': ns_helper.epilogue,
         'dispatch_declarations': backend_declarations + autograd_declarations,
     })
 


### PR DESCRIPTION
Summary:
- makes DispatchKeyNativeFunctions template/generator handle multi-level
  namespace (e.g. torch::lazy)
- moves helper for constructing prologue/epilogue into 'common' module

Test Plan: run CI (and verified locally in lazy tensor codegen patch)

Differential Revision: D34400821

