### PR TITLE
modify the check condition of Conv-> Add/Sub/Mul/Div folding

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1760,7 +1760,7 @@ class TestFrozenOptimizations(JitTestCase):
 
             # add with different dtype
             test_conv_fusion(use_bias, nn.Conv2d, False, pytorch_op, False,
-                             add_tensor=torch.rand(1).to(torch.int), expect_success=False)
+                             add_tensor=torch.tensor([2]).to(torch.int), expect_success=True)
 
     @unittest.skipIf(not TEST_CUDA, "Optimization currently only run for GPU")
     def test_linear_concat(self):

--- a/torch/csrc/jit/passes/frozen_conv_folding.cpp
+++ b/torch/csrc/jit/passes/frozen_conv_folding.cpp
@@ -173,7 +173,6 @@ bool checkConvAndBroadcastingOpPreConditions(Node* conv, Node* op) {
     return false;
   }
 
-  auto conv_w = constant_as<Tensor>(conv->namedInput("weight")).value();
   Tensor weight_tensor =
       constant_as<Tensor>(conv->namedInput("weight")).value();
 
@@ -188,12 +187,11 @@ bool checkConvAndBroadcastingOpPreConditions(Node* conv, Node* op) {
     if (!opDoesNotBroadCastWithConv(op_tensor, weight_tensor)) {
       return false;
     }
-    if (!op_tensor.is_floating_point()) {
-      return false;
-    }
-    if (c10::promoteTypes(
+
+    if (!op_tensor.is_floating_point() &&
+        c10::promoteTypes(
             op_tensor.scalar_type(), weight_tensor.scalar_type()) !=
-        weight_tensor.scalar_type()) {
+            weight_tensor.scalar_type()) {
       return false;
     }
   }
@@ -235,9 +233,9 @@ void FoldFrozenConvAddOrSub(Block* b) {
 
     if (supportedAddOrSub(n) && supportedConvNode(n->inputs().at(0)->node())) {
       auto conv = n->inputs().at(0)->node();
-      auto add_or_div = n;
+      auto add_or_sub = n;
 
-      if (!checkConvAndBroadcastingOpPreConditions(conv, add_or_div)) {
+      if (!checkConvAndBroadcastingOpPreConditions(conv, add_or_sub)) {
         continue;
       }
 
@@ -245,35 +243,35 @@ void FoldFrozenConvAddOrSub(Block* b) {
           constant_as<Tensor>(conv->namedInput("weight")).value();
 
       Tensor add_or_sub_tensor = resizeConstantScalarOrTensorToShape(
-          add_or_div->inputs().at(1),
+          add_or_sub->inputs().at(1),
           {weight_tensor.size(0)},
           weight_tensor.options());
       Tensor bias;
       if (conv->namedInput("bias")->type() == NoneType::get()) {
-        bias = at::zeros_like(add_or_sub_tensor);
+        bias = at::zeros_like(add_or_sub_tensor, weight_tensor.dtype());
       } else {
         bias = constant_as<Tensor>(conv->namedInput("bias")).value();
       }
 
       WithInsertPoint guard(conv);
 
-      add_or_div->replaceInputWith(
+      add_or_sub->replaceInputWith(
           conv->output(), b->owningGraph()->insertConstant(bias));
-      add_or_div->replaceInput(
+      add_or_sub->replaceInput(
           1, b->owningGraph()->insertConstant(add_or_sub_tensor));
 
-      auto stack_out = runNodeIfInputsAreConstant(add_or_div);
+      auto stack_out = runNodeIfInputsAreConstant(add_or_sub);
       TORCH_INTERNAL_ASSERT(stack_out && stack_out->size() == 1);
-      Tensor fuse_bias = (*stack_out)[0].toTensor();
+      Tensor fuse_bias = (*stack_out)[0].toTensor().to(bias.dtype());
 
       auto fused_conv_b = b->owningGraph()->insertConstant(fuse_bias);
       auto conv_b_value = conv->namedInput("bias");
 
       fused_conv_b->setDebugName(
           conv_b_value->debugName() + "_fused_" +
-          add_or_div->kind().toUnqualString());
+          add_or_sub->kind().toUnqualString());
       conv->replaceInputWith(conv_b_value, fused_conv_b);
-      add_or_div->output()->replaceAllUsesWith(conv->output());
+      add_or_sub->output()->replaceAllUsesWith(conv->output());
       // DCE run after cleans up nodes
     }
   }
@@ -331,7 +329,7 @@ void FoldFrozenConvMulOrDiv(Block* b) {
 
       auto stack_out = runNodeIfInputsAreConstant(mul_or_div);
       TORCH_INTERNAL_ASSERT(stack_out && stack_out->size() == 1);
-      Tensor fuse_weight = (*stack_out)[0].toTensor();
+      Tensor fuse_weight = (*stack_out)[0].toTensor().to(weight_tensor.dtype());
 
       auto fused_conv_weight = b->owningGraph()->insertConstant(fuse_weight);
       auto conv_weight_value = conv->namedInput("weight");
@@ -355,7 +353,7 @@ void FoldFrozenConvMulOrDiv(Block* b) {
 
         auto stack_out = runNodeIfInputsAreConstant(mul_or_div);
         TORCH_INTERNAL_ASSERT(stack_out && stack_out->size() == 1);
-        Tensor fuse_bias = (*stack_out)[0].toTensor();
+        Tensor fuse_bias = (*stack_out)[0].toTensor().to(bias.dtype());
 
         auto fused_conv_bias = b->owningGraph()->insertConstant(fuse_bias);
         auto conv_b_value = conv->namedInput("bias");


### PR DESCRIPTION
Relax the check condition of Conv-> Add/Sub/Mul/Div folding to accept that the input tensor of Add/Sub/Mul/Div is floating type or the promoteTypes of the input tensor of Add/Sub/Mul/Div is equal to the type of conv weight.

Relaxing this condition is mainly to deal with a common situation in models:
the conv output add/sub/mul/div an integer tensor or integer scalar tensor.