### PR TITLE
Print ref on win

### DIFF
--- a/.github/scripts/parse_ref.py
+++ b/.github/scripts/parse_ref.py
@@ -6,7 +6,6 @@ import re
 
 def main() -> None:
     ref = os.environ['GITHUB_REF']
-    print(f"ref is: {ref}")
     m = re.match(r'^refs/(\w+)/(.*)$', ref)
     if m:
         category, stripped = m.groups()
@@ -19,5 +18,4 @@ def main() -> None:
 
 
 if __name__ == '__main__':
-    print("HELLO I AM PRINTING. PRINTING WORKS.")
     main()

--- a/.github/scripts/parse_ref.py
+++ b/.github/scripts/parse_ref.py
@@ -6,6 +6,7 @@ import re
 
 def main() -> None:
     ref = os.environ['GITHUB_REF']
+    print(f"ref is: {ref}")
     m = re.match(r'^refs/(\w+)/(.*)$', ref)
     if m:
         category, stripped = m.groups()

--- a/.github/scripts/parse_ref.py
+++ b/.github/scripts/parse_ref.py
@@ -19,4 +19,5 @@ def main() -> None:
 
 
 if __name__ == '__main__':
+    print("HELLO I AM PRINTING. PRINTING WORKS.")
     main()

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -40,12 +40,11 @@ concurrency:
 
 {%- macro parse_ref(pytorch_directory="") -%}
       - name: Parse ref
-        shell: bash
 {%- if pytorch_directory %}
         working-directory: !{{ pytorch_directory }}
 {%- endif %}
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
 {%- endmacro -%}
 
 {%- macro upload_test_statistics(build_environment, when="always()", pytorch_directory="", needs_credentials=False) -%}

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -44,7 +44,7 @@ concurrency:
         working-directory: !{{ pytorch_directory }}
 {%- endif %}
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
 {%- endmacro -%}
 
 {%- macro upload_test_statistics(build_environment, when="always()", pytorch_directory="", needs_credentials=False) -%}

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -44,7 +44,7 @@ concurrency:
         working-directory: !{{ pytorch_directory }}
 {%- endif %}
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
 {%- endmacro -%}
 
 {%- macro upload_test_statistics(build_environment, when="always()", pytorch_directory="", needs_credentials=False) -%}

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -44,7 +44,7 @@ concurrency:
         working-directory: !{{ pytorch_directory }}
 {%- endif %}
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
 {%- endmacro -%}
 
 {%- macro upload_test_statistics(build_environment, when="always()", pytorch_directory="", needs_credentials=False) -%}

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -40,6 +40,7 @@ concurrency:
 
 {%- macro parse_ref(pytorch_directory="") -%}
       - name: Parse ref
+        shell: bash
 {%- if pytorch_directory %}
         working-directory: !{{ pytorch_directory }}
 {%- endif %}

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -44,7 +44,7 @@ concurrency:
         working-directory: !{{ pytorch_directory }}
 {%- endif %}
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
 {%- endmacro -%}
 
 {%- macro upload_test_statistics(build_environment, when="always()", pytorch_directory="", needs_credentials=False) -%}

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -45,7 +45,7 @@ concurrency:
         working-directory: !{{ pytorch_directory }}
 {%- endif %}
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
 {%- endmacro -%}
 
 {%- macro upload_test_statistics(build_environment, when="always()", pytorch_directory="", needs_credentials=False) -%}

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -40,11 +40,12 @@ concurrency:
 
 {%- macro parse_ref(pytorch_directory="") -%}
       - name: Parse ref
+        shell: python
 {%- if pytorch_directory %}
         working-directory: !{{ pytorch_directory }}
 {%- endif %}
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
 {%- endmacro -%}
 
 {%- macro upload_test_statistics(build_environment, when="always()", pytorch_directory="", needs_credentials=False) -%}

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -40,12 +40,12 @@ concurrency:
 
 {%- macro parse_ref(pytorch_directory="") -%}
       - name: Parse ref
-        shell: python
+        shell: bash
 {%- if pytorch_directory %}
         working-directory: !{{ pytorch_directory }}
 {%- endif %}
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
 {%- endmacro -%}
 
 {%- macro upload_test_statistics(build_environment, when="always()", pytorch_directory="", needs_credentials=False) -%}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -104,6 +104,10 @@ jobs:
         run: |
           .circleci/scripts/windows_cudnn_install.sh
 {%- endif %}
+      - uses: actions/setup-python@v2
+        name: Setup Python3
+        with:
+          python-version: '3.x'
       !{{ common.parse_ref() }}
       - name: Build
         shell: bash

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -104,10 +104,6 @@ jobs:
         run: |
           .circleci/scripts/windows_cudnn_install.sh
 {%- endif %}
-      - uses: actions/setup-python@v2
-        name: Setup Python3
-        with:
-          python-version: '3.x'
       !{{ common.parse_ref() }}
       - name: Build
         shell: bash

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
@@ -158,9 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
@@ -158,8 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
@@ -158,6 +158,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
@@ -158,9 +158,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-docker-builds.yml
+++ b/.github/workflows/generated-docker-builds.yml
@@ -144,8 +144,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()

--- a/.github/workflows/generated-docker-builds.yml
+++ b/.github/workflows/generated-docker-builds.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()

--- a/.github/workflows/generated-docker-builds.yml
+++ b/.github/workflows/generated-docker-builds.yml
@@ -144,6 +144,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Hold runner for 2 hours or until ssh sessions have drained

--- a/.github/workflows/generated-docker-builds.yml
+++ b/.github/workflows/generated-docker-builds.yml
@@ -145,7 +145,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()

--- a/.github/workflows/generated-docker-builds.yml
+++ b/.github/workflows/generated-docker-builds.yml
@@ -144,9 +144,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()

--- a/.github/workflows/generated-docker-builds.yml
+++ b/.github/workflows/generated-docker-builds.yml
@@ -144,9 +144,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()

--- a/.github/workflows/generated-docker-builds.yml
+++ b/.github/workflows/generated-docker-builds.yml
@@ -145,7 +145,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()

--- a/.github/workflows/generated-docker-builds.yml
+++ b/.github/workflows/generated-docker-builds.yml
@@ -145,7 +145,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()

--- a/.github/workflows/generated-docker-builds.yml
+++ b/.github/workflows/generated-docker-builds.yml
@@ -145,7 +145,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Hold runner for 2 hours or until ssh sessions have drained
         # Always hold for active ssh sessions
         if: always()

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
@@ -159,6 +159,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
@@ -159,9 +159,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
@@ -159,9 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
@@ -159,8 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -159,6 +159,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -159,9 +159,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -159,9 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -159,8 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -352,7 +352,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -603,7 +603,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -850,7 +850,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1097,7 +1097,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1348,7 +1348,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1599,7 +1599,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1850,7 +1850,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -2101,7 +2101,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -159,8 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,8 +350,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -599,8 +601,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -845,8 +848,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1091,8 +1095,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1341,8 +1346,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1591,8 +1597,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1841,8 +1848,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -2091,8 +2099,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -159,9 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,9 +350,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -601,9 +601,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -848,9 +848,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1095,9 +1095,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1346,9 +1346,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1597,9 +1597,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1848,9 +1848,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -2099,9 +2099,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -846,7 +846,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1092,7 +1092,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1342,7 +1342,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1592,7 +1592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1842,7 +1842,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -2092,7 +2092,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -846,7 +846,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1092,7 +1092,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1342,7 +1342,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1592,7 +1592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1842,7 +1842,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -2092,7 +2092,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -159,6 +159,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -349,6 +350,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -599,6 +601,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -845,6 +848,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -1091,6 +1095,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -1341,6 +1346,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -1591,6 +1597,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -1841,6 +1848,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -2091,6 +2099,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -846,7 +846,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1092,7 +1092,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1342,7 +1342,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1592,7 +1592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1842,7 +1842,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -2092,7 +2092,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -846,7 +846,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1092,7 +1092,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1342,7 +1342,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1592,7 +1592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1842,7 +1842,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -2092,7 +2092,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -159,9 +159,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,9 +349,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -601,9 +599,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -848,9 +845,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1095,9 +1091,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1346,9 +1341,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1597,9 +1591,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1848,9 +1841,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -2099,9 +2091,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -160,8 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,8 +347,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,8 +594,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -838,8 +841,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,7 +349,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -596,7 +596,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -843,7 +843,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -160,6 +160,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -346,6 +347,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -592,6 +594,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -838,6 +841,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -160,9 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,9 +347,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -594,9 +594,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -841,9 +841,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -839,7 +839,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -160,9 +160,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,9 +346,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -594,9 +592,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -841,9 +838,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -839,7 +839,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -839,7 +839,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -839,7 +839,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -159,9 +159,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -342,9 +341,8 @@ jobs:
         run: |
           df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -565,9 +563,8 @@ jobs:
         run: |
           df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -788,9 +785,8 @@ jobs:
         run: |
           df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -159,8 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -341,8 +342,9 @@ jobs:
         run: |
           df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -563,8 +565,9 @@ jobs:
         run: |
           df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -785,8 +788,9 @@ jobs:
         run: |
           df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -159,6 +159,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -341,6 +342,7 @@ jobs:
         run: |
           df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -563,6 +565,7 @@ jobs:
         run: |
           df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -785,6 +788,7 @@ jobs:
         run: |
           df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -159,9 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -342,9 +342,9 @@ jobs:
         run: |
           df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -565,9 +565,9 @@ jobs:
         run: |
           df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -788,9 +788,9 @@ jobs:
         run: |
           df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -342,7 +342,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -564,7 +564,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -786,7 +786,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -342,7 +342,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -564,7 +564,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -786,7 +786,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -344,7 +344,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -567,7 +567,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -790,7 +790,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -342,7 +342,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -564,7 +564,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -786,7 +786,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -342,7 +342,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -564,7 +564,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -786,7 +786,7 @@ jobs:
           df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -160,9 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -160,6 +160,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -160,8 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -160,9 +160,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -160,9 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -160,6 +160,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -160,8 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -160,9 +160,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -160,6 +160,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -346,6 +347,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -160,8 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,8 +347,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -160,9 +160,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,9 +346,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -160,9 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,9 +347,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,7 +349,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -201,6 +201,7 @@ jobs:
           )
           docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && sudo chown -R jenkins /dev && .jenkins/pytorch/build.sh'
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -202,7 +202,7 @@ jobs:
           docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && sudo chown -R jenkins /dev && .jenkins/pytorch/build.sh'
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -202,7 +202,7 @@ jobs:
           docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && sudo chown -R jenkins /dev && .jenkins/pytorch/build.sh'
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -201,8 +201,9 @@ jobs:
           )
           docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && sudo chown -R jenkins /dev && .jenkins/pytorch/build.sh'
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -201,9 +201,9 @@ jobs:
           )
           docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && sudo chown -R jenkins /dev && .jenkins/pytorch/build.sh'
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -202,7 +202,7 @@ jobs:
           docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && sudo chown -R jenkins /dev && .jenkins/pytorch/build.sh'
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -202,7 +202,7 @@ jobs:
           docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && sudo chown -R jenkins /dev && .jenkins/pytorch/build.sh'
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -201,9 +201,8 @@ jobs:
           )
           docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && sudo chown -R jenkins /dev && .jenkins/pytorch/build.sh'
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
@@ -158,9 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
@@ -158,8 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
@@ -158,6 +158,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
@@ -158,9 +158,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -159,8 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,8 +350,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -599,8 +601,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -849,8 +852,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -159,9 +159,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,9 +349,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -601,9 +599,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -852,9 +849,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -850,7 +850,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -352,7 +352,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -603,7 +603,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -854,7 +854,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -850,7 +850,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -159,6 +159,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -349,6 +350,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -599,6 +601,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -849,6 +852,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -850,7 +850,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -159,9 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,9 +350,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -601,9 +601,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -852,9 +852,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -850,7 +850,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -159,6 +159,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -159,9 +159,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -159,9 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -159,8 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -159,6 +159,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -159,9 +159,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -159,9 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -159,8 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -160,8 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,8 +347,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,8 +594,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -838,8 +841,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,7 +349,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -596,7 +596,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -843,7 +843,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -160,6 +160,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -346,6 +347,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -592,6 +594,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -838,6 +841,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -160,9 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,9 +347,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -594,9 +594,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -841,9 +841,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -839,7 +839,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -160,9 +160,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,9 +346,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -594,9 +592,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -841,9 +838,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -839,7 +839,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -839,7 +839,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -839,7 +839,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,7 +349,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -596,7 +596,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -160,6 +160,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -346,6 +347,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -592,6 +594,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -160,8 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,8 +347,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,8 +594,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -160,9 +160,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,9 +346,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -594,9 +592,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -161,7 +161,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,7 +593,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -160,9 +160,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,9 +347,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -594,9 +594,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,7 +346,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,7 +592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -838,7 +838,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1084,7 +1084,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1330,7 +1330,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1576,7 +1576,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -159,6 +159,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -345,6 +346,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -591,6 +593,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -837,6 +840,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -1083,6 +1087,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -1329,6 +1334,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -1575,6 +1581,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,7 +346,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,7 +592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -838,7 +838,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1084,7 +1084,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1330,7 +1330,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1576,7 +1576,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -159,8 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -345,8 +346,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -591,8 +593,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -837,8 +840,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1083,8 +1087,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1329,8 +1334,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1575,8 +1581,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -159,9 +159,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,9 +345,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,9 +591,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -840,9 +837,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1087,9 +1083,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1334,9 +1329,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1581,9 +1575,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,7 +346,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,7 +592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -838,7 +838,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1084,7 +1084,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1330,7 +1330,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1576,7 +1576,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,7 +346,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,7 +592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -838,7 +838,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1084,7 +1084,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1330,7 +1330,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1576,7 +1576,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -348,7 +348,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -595,7 +595,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -842,7 +842,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1089,7 +1089,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1336,7 +1336,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1583,7 +1583,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -159,9 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,9 +346,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,9 +593,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -840,9 +840,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1087,9 +1087,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1334,9 +1334,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -1581,9 +1581,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
@@ -159,6 +159,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
@@ -159,9 +159,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
@@ -159,9 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
@@ -159,8 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -159,8 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -345,8 +346,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -591,8 +593,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -837,8 +840,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,7 +346,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,7 +592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -838,7 +838,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -159,6 +159,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -345,6 +346,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -591,6 +593,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -837,6 +840,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,7 +346,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,7 +592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -838,7 +838,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -159,9 +159,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,9 +345,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,9 +591,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -840,9 +837,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -348,7 +348,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -595,7 +595,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -842,7 +842,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,7 +346,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,7 +592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -838,7 +838,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -159,9 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,9 +346,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -593,9 +593,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -840,9 +840,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -346,7 +346,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,7 +592,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -838,7 +838,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -128,7 +128,7 @@ jobs:
           brew install libomp
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl
@@ -240,7 +240,7 @@ jobs:
           brew install libomp
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -127,8 +127,9 @@ jobs:
           # Install dependencies
           brew install libomp
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         run: |
           python3 -mpip install dist/*.whl
@@ -239,8 +240,9 @@ jobs:
           # Install dependencies
           brew install libomp
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         run: |
           python3 -mpip install dist/*.whl

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -127,9 +127,8 @@ jobs:
           # Install dependencies
           brew install libomp
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl
@@ -240,9 +239,8 @@ jobs:
           # Install dependencies
           brew install libomp
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -127,9 +127,9 @@ jobs:
           # Install dependencies
           brew install libomp
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl
@@ -240,9 +240,9 @@ jobs:
           # Install dependencies
           brew install libomp
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -128,7 +128,7 @@ jobs:
           brew install libomp
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl
@@ -240,7 +240,7 @@ jobs:
           brew install libomp
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl
@@ -242,7 +242,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -128,7 +128,7 @@ jobs:
           brew install libomp
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl
@@ -240,7 +240,7 @@ jobs:
           brew install libomp
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -127,6 +127,7 @@ jobs:
           # Install dependencies
           brew install libomp
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -239,6 +240,7 @@ jobs:
           # Install dependencies
           brew install libomp
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -128,7 +128,7 @@ jobs:
           brew install libomp
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl
@@ -240,7 +240,7 @@ jobs:
           brew install libomp
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         run: |
           python3 -mpip install dist/*.whl

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,7 +347,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -594,7 +594,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -345,7 +345,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -591,7 +591,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -158,9 +158,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -345,9 +344,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,9 +590,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -345,7 +345,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -591,7 +591,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -158,9 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -345,9 +345,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -592,9 +592,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -345,7 +345,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -591,7 +591,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -158,6 +158,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -344,6 +345,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -590,6 +592,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -345,7 +345,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -591,7 +591,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -158,8 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -344,8 +345,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -590,8 +592,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -158,9 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -158,8 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -158,6 +158,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build

--- a/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -158,9 +158,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
@@ -158,9 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
@@ -158,8 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
@@ -158,6 +158,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
@@ -158,9 +158,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-xenial-cuda11.1-py3.7-gcc7.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -157,6 +157,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -347,6 +348,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -597,6 +599,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -847,6 +850,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -158,7 +158,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -348,7 +348,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -598,7 +598,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -848,7 +848,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -601,7 +601,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -852,7 +852,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -157,8 +157,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -347,8 +348,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -597,8 +599,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -847,8 +850,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -157,9 +157,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -348,9 +348,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -599,9 +599,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -850,9 +850,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -158,7 +158,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -348,7 +348,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -598,7 +598,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -848,7 +848,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -158,7 +158,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -348,7 +348,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -598,7 +598,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -848,7 +848,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -158,7 +158,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -348,7 +348,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -598,7 +598,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -848,7 +848,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -157,9 +157,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -348,9 +347,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -599,9 +597,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -850,9 +847,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -159,8 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,8 +350,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -599,8 +601,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -159,6 +159,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -349,6 +350,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -599,6 +601,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -159,9 +159,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,9 +349,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -601,9 +599,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -352,7 +352,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -603,7 +603,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -160,7 +160,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,7 +350,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,7 +600,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -159,9 +159,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -350,9 +350,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -601,9 +601,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -158,6 +158,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -348,6 +349,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -598,6 +600,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test
@@ -848,6 +851,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -351,7 +351,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -602,7 +602,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -853,7 +853,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,7 +349,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -599,7 +599,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -849,7 +849,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,7 +349,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -599,7 +599,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -849,7 +849,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -158,9 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,9 +349,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,9 +600,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -851,9 +851,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -158,8 +158,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -348,8 +349,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -598,8 +600,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -848,8 +851,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,7 +349,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -599,7 +599,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -849,7 +849,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -159,7 +159,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,7 +349,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -599,7 +599,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -849,7 +849,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.1-py3.7-gcc7-debug.yml
@@ -158,9 +158,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -349,9 +348,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -600,9 +598,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -851,9 +848,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -93,9 +93,13 @@ jobs:
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
+      - uses: actions/setup-python@v2
+        name: Setup Python3
+        with:
+          python-version: '3.x'
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -265,7 +269,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -421,7 +425,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -93,13 +93,10 @@ jobs:
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
-      - uses: actions/setup-python@v2
-        name: Setup Python3
-        with:
-          python-version: '3.x'
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         shell: bash
         env:
@@ -268,8 +265,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Upload test statistics
         if: always()
         env:
@@ -424,8 +422,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -264,6 +265,7 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Upload test statistics
@@ -420,6 +422,7 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Upload test statistics

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -94,9 +94,8 @@ jobs:
         run: |
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -265,9 +264,8 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -422,9 +420,8 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -95,7 +95,7 @@ jobs:
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -265,7 +265,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -421,7 +421,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -271,7 +271,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -428,7 +428,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -95,7 +95,7 @@ jobs:
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -265,7 +265,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -421,7 +421,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -98,9 +98,9 @@ jobs:
         with:
           python-version: '3.x'
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -269,9 +269,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -426,9 +426,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -95,7 +95,7 @@ jobs:
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -265,7 +265,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -421,7 +421,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.1-py3.yml
@@ -93,6 +93,10 @@ jobs:
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
+      - uses: actions/setup-python@v2
+        name: Setup Python3
+        with:
+          python-version: '3.x'
       - name: Parse ref
         shell: python
         id: parse-ref

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -95,7 +95,7 @@ jobs:
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -257,7 +257,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -413,7 +413,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -569,7 +569,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -263,7 +263,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -420,7 +420,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -577,7 +577,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -95,7 +95,7 @@ jobs:
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -257,7 +257,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -413,7 +413,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -569,7 +569,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -93,9 +93,13 @@ jobs:
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
+      - uses: actions/setup-python@v2
+        name: Setup Python3
+        with:
+          python-version: '3.x'
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -257,7 +261,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -413,7 +417,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -569,7 +573,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -95,7 +95,7 @@ jobs:
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -257,7 +257,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -413,7 +413,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -569,7 +569,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -93,13 +93,10 @@ jobs:
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
-      - uses: actions/setup-python@v2
-        name: Setup Python3
-        with:
-          python-version: '3.x'
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         shell: bash
         env:
@@ -260,8 +257,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Upload test statistics
         if: always()
         env:
@@ -416,8 +414,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Upload test statistics
         if: always()
         env:
@@ -572,8 +571,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -256,6 +257,7 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Upload test statistics
@@ -412,6 +414,7 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Upload test statistics
@@ -568,6 +571,7 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Upload test statistics

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -98,9 +98,9 @@ jobs:
         with:
           python-version: '3.x'
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -261,9 +261,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -418,9 +418,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -575,9 +575,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -94,9 +94,8 @@ jobs:
         run: |
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -257,9 +256,8 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -414,9 +412,8 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -571,9 +568,8 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -93,6 +93,10 @@ jobs:
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
+      - uses: actions/setup-python@v2
+        name: Setup Python3
+        with:
+          python-version: '3.x'
       - name: Parse ref
         shell: python
         id: parse-ref

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build-arm-v7a
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
@@ -176,9 +176,8 @@ jobs:
         run: |
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build-arm-v7a
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
@@ -176,9 +176,9 @@ jobs:
         run: |
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build-arm-v7a
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
@@ -177,7 +177,7 @@ jobs:
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build-arm-v7a
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
@@ -176,6 +176,7 @@ jobs:
         run: |
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build-arm-v7a

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
@@ -177,7 +177,7 @@ jobs:
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build-arm-v7a
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
@@ -177,7 +177,7 @@ jobs:
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build-arm-v7a
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
@@ -177,7 +177,7 @@ jobs:
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build-arm-v7a
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
@@ -176,8 +176,9 @@ jobs:
         run: |
           env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build-arm-v7a
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -227,7 +227,7 @@ jobs:
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -227,7 +227,7 @@ jobs:
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -226,9 +226,8 @@ jobs:
           # Skip docker push as this job is purely for size analysis purpose.
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -226,8 +226,9 @@ jobs:
           # Skip docker push as this job is purely for size analysis purpose.
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -226,9 +226,9 @@ jobs:
           # Skip docker push as this job is purely for size analysis purpose.
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -227,7 +227,7 @@ jobs:
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -226,6 +226,7 @@ jobs:
           # Skip docker push as this job is purely for size analysis purpose.
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -227,7 +227,7 @@ jobs:
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -227,7 +227,7 @@ jobs:
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -227,7 +227,7 @@ jobs:
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -226,9 +226,8 @@ jobs:
           # Skip docker push as this job is purely for size analysis purpose.
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -226,8 +226,9 @@ jobs:
           # Skip docker push as this job is purely for size analysis purpose.
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -226,9 +226,9 @@ jobs:
           # Skip docker push as this job is purely for size analysis purpose.
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -227,7 +227,7 @@ jobs:
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -226,6 +226,7 @@ jobs:
           # Skip docker push as this job is purely for size analysis purpose.
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -227,7 +227,7 @@ jobs:
           # Result binaries are already in `/home/circleci/project/` as it's mounted instead of copied.
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
         # tools/stats/print_test_stats.py to natively support GitHub Actions

--- a/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
+++ b/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
@@ -125,7 +125,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -312,7 +312,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
+++ b/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
@@ -124,9 +124,8 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -312,9 +311,8 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
+++ b/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -314,7 +314,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
+++ b/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
@@ -125,7 +125,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -312,7 +312,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
+++ b/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
@@ -124,6 +124,7 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -311,6 +312,7 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Test

--- a/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
+++ b/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
@@ -125,7 +125,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -312,7 +312,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
+++ b/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
@@ -125,7 +125,7 @@ jobs:
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -312,7 +312,7 @@ jobs:
           sudo df -H
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
+++ b/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
@@ -124,9 +124,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -312,9 +312,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
+++ b/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
@@ -124,8 +124,9 @@ jobs:
           }
           retry docker pull "${DOCKER_IMAGE}"
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
@@ -311,8 +312,9 @@ jobs:
         run: |
           sudo df -H
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Test
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -87,9 +87,8 @@ jobs:
         run: |
           .\.circleci\scripts\vs_install.ps1
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -250,9 +249,8 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -399,9 +397,8 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -91,9 +91,9 @@ jobs:
         with:
           python-version: '3.x'
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -254,9 +254,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -403,9 +403,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -88,7 +88,7 @@ jobs:
           .\.circleci\scripts\vs_install.ps1
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -250,7 +250,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -398,7 +398,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -256,7 +256,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -405,7 +405,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -88,7 +88,7 @@ jobs:
           .\.circleci\scripts\vs_install.ps1
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -250,7 +250,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -398,7 +398,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -88,7 +88,7 @@ jobs:
           .\.circleci\scripts\vs_install.ps1
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -250,7 +250,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -398,7 +398,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -86,6 +86,10 @@ jobs:
         shell: powershell
         run: |
           .\.circleci\scripts\vs_install.ps1
+      - uses: actions/setup-python@v2
+        name: Setup Python3
+        with:
+          python-version: '3.x'
       - name: Parse ref
         shell: python
         id: parse-ref

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -87,6 +87,7 @@ jobs:
         run: |
           .\.circleci\scripts\vs_install.ps1
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -249,6 +250,7 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Upload test statistics
@@ -397,6 +399,7 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Upload test statistics

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -86,9 +86,13 @@ jobs:
         shell: powershell
         run: |
           .\.circleci\scripts\vs_install.ps1
+      - uses: actions/setup-python@v2
+        name: Setup Python3
+        with:
+          python-version: '3.x'
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -250,7 +254,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -398,7 +402,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -86,13 +86,10 @@ jobs:
         shell: powershell
         run: |
           .\.circleci\scripts\vs_install.ps1
-      - uses: actions/setup-python@v2
-        name: Setup Python3
-        with:
-          python-version: '3.x'
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         shell: bash
         env:
@@ -253,8 +250,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Upload test statistics
         if: always()
         env:
@@ -401,8 +399,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -97,7 +97,7 @@ jobs:
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -259,7 +259,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -415,7 +415,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -571,7 +571,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -97,7 +97,7 @@ jobs:
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -259,7 +259,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -415,7 +415,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -571,7 +571,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: echo $GITHUB_REF && .github/scripts/parse_ref.py
+        run: .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -96,6 +96,7 @@ jobs:
         run: |
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Build
@@ -258,6 +259,7 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Upload test statistics
@@ -414,6 +416,7 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Upload test statistics
@@ -570,6 +573,7 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: bash
         id: parse-ref
         run: .github/scripts/parse_ref.py
       - name: Upload test statistics

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -96,9 +96,8 @@ jobs:
         run: |
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -259,9 +258,8 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -416,9 +414,8 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -573,9 +570,8 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: bash
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -97,7 +97,7 @@ jobs:
           .circleci/scripts/windows_cudnn_install.sh
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -259,7 +259,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -415,7 +415,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -571,7 +571,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -100,9 +100,9 @@ jobs:
         with:
           python-version: '3.x'
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -263,9 +263,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -420,9 +420,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -577,9 +577,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
-        shell: python
+        shell: bash
         id: parse-ref
-        run: exec(open(".github/scripts/parse_ref.py").read())
+        run: python .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -95,9 +95,13 @@ jobs:
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
+      - uses: actions/setup-python@v2
+        name: Setup Python3
+        with:
+          python-version: '3.x'
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -259,7 +263,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -415,7 +419,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -571,7 +575,7 @@ jobs:
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
         id: parse-ref
-        run: .github/scripts/parse_ref.py
+        run: python3 .github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Build
         shell: bash
         env:
@@ -265,7 +265,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -422,7 +422,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:
@@ -579,7 +579,7 @@ jobs:
       - name: Parse ref
         shell: bash
         id: parse-ref
-        run: python .github/scripts/parse_ref.py
+        run: ./.github/scripts/parse_ref.py
       - name: Upload test statistics
         if: always()
         env:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -95,6 +95,10 @@ jobs:
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
+      - uses: actions/setup-python@v2
+        name: Setup Python3
+        with:
+          python-version: '3.x'
       - name: Parse ref
         shell: python
         id: parse-ref

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -95,13 +95,10 @@ jobs:
         shell: bash
         run: |
           .circleci/scripts/windows_cudnn_install.sh
-      - uses: actions/setup-python@v2
-        name: Setup Python3
-        with:
-          python-version: '3.x'
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Build
         shell: bash
         env:
@@ -262,8 +259,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Upload test statistics
         if: always()
         env:
@@ -418,8 +416,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Upload test statistics
         if: always()
         env:
@@ -574,8 +573,9 @@ jobs:
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
       - name: Parse ref
+        shell: python
         id: parse-ref
-        run: python3 .github/scripts/parse_ref.py
+        run: exec(open(".github/scripts/parse_ref.py").read())
       - name: Upload test statistics
         if: always()
         env:


### PR DESCRIPTION
Previously, the parse_ref.py script was not run at all with the default powershell in windows. Using bash + installing python on windows fixes the issue.