### PR TITLE
[ONNX] Export bias requantize steps to ONNX

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -740,6 +740,7 @@ class TestONNXRuntime(unittest.TestCase):
         dummy_input = torch.randn(1, 3, 224, 224)
         self.run_test(model, (dummy_input,))
 
+    @skipIfUnsupportedMinOpsetVersion(10)
     @disableScriptTest()
     def test_mobilenet_v3_quant(self):
         model = torchvision.models.quantization.mobilenet_v3_large(pretrained=True, quantize=True)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -740,6 +740,7 @@ class TestONNXRuntime(unittest.TestCase):
         dummy_input = torch.randn(1, 3, 224, 224)
         self.run_test(model, (dummy_input,))
 
+    @unittest.skip("Unstable loading pretrained quantized mobilenet v3: https://github.com/pytorch/vision/issues/5303")
     @skipIfUnsupportedMinOpsetVersion(10)
     @disableScriptTest()
     def test_mobilenet_v3_quant(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -740,7 +740,6 @@ class TestONNXRuntime(unittest.TestCase):
         dummy_input = torch.randn(1, 3, 224, 224)
         self.run_test(model, (dummy_input,))
 
-    @unittest.skip("Fixed in PyTorch master. RuntimeError: Error(s) in loading state_dict for QuantizableMobileNetV3")
     @disableScriptTest()
     def test_mobilenet_v3_quant(self):
         model = torchvision.models.quantization.mobilenet_v3_large(pretrained=True, quantize=True)
@@ -10515,6 +10514,9 @@ class TestONNXRuntime(unittest.TestCase):
     @skipIfUnsupportedMinOpsetVersion(10)
     def test_quantized_linear(self):
         model = torch.nn.quantized.Linear(4, 8)
+        # Set non-zero bias.
+        bias = torch.arange(8).to(torch.float)
+        model.set_weight_bias(model.weight(), bias)
         input = torch.randn(4, 4)
         input_tensor = torch.quantize_per_tensor(input, 0.5, 128, torch.quint8)
         # Currently, we need convert the model to ScriptModule before export.
@@ -10529,11 +10531,11 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.quantized.Conv2d(16, 33, 3, stride=2)
         # Manually initialize model weight and bias to random numbers.
         # By default all zeros.
-        q_weight = torch.quantize_per_tensor(torch.randn(33, 16, 3, 3), 0.2, 0, torch.qint8)
-        bias = torch.randn(33)
+        q_weight = torch.quantize_per_tensor(torch.randn(33, 16, 3, 3), 0.5, 0, torch.qint8)
+        bias = torch.arange(33).to(torch.float) - 16
         model.set_weight_bias(q_weight, bias)
         input = torch.randn(3, 16, 32, 32)
-        q_input = torch.quantize_per_tensor(input, 0.2, 128, torch.quint8)
+        q_input = torch.quantize_per_tensor(input, 0.5, 128, torch.quint8)
         self.run_test(torch.jit.trace(model, q_input), (q_input,))
 
     @skipIfUnsupportedMinOpsetVersion(10)
@@ -10548,11 +10550,11 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.intrinsic.quantized.ConvReLU2d(16, 33, 3, stride=2)
         # Manually initialize model weight and bias to random numbers.
         # By default all zeros.
-        q_weight = torch.quantize_per_tensor(torch.randn(33, 16, 3, 3), 0.2, 0, torch.qint8)
-        bias = torch.randn(33)
+        q_weight = torch.quantize_per_tensor(torch.randn(33, 16, 3, 3), 0.5, 0, torch.qint8)
+        bias = torch.arange(33).to(torch.float) - 16
         model.set_weight_bias(q_weight, bias)
         input = torch.randn(3, 16, 32, 32)
-        q_input = torch.quantize_per_tensor(input, 0.2, 128, torch.quint8)
+        q_input = torch.quantize_per_tensor(input, 0.5, 128, torch.quint8)
         self.run_test(torch.jit.trace(model, q_input), (q_input,))
 
     @skipIfUnsupportedMinOpsetVersion(10)

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -939,9 +939,9 @@ def quantize_helper(g, tensor, scale, zero_point):
     output = g.op("QuantizeLinear", tensor, scale, zero_point)
     return g.op("prim::TupleConstruct", output, scale, zero_point)
 
-# NOTE: Original `bias`` is float in PyTorch. Quantization is applied in kernel.
+# NOTE: Original `bias` is float in PyTorch. Quantization is applied in kernel.
 #       To mimic behavior in ONNX, perform the `bias` quantization step here.
-#       Then append the dequantization step to ready `bias` for unquantized opeartors.
+#       Then append the dequantization step to ready `bias` for unquantized operators.
 def requantize_bias_helper(g, bias, input_scale, weight_scale):
     bias_scale = g.op("Mul", weight_scale, input_scale)
     bias_zero_point = g.op("Constant", value_t=torch.tensor([0], dtype=torch.int))

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -939,9 +939,10 @@ def quantize_helper(g, tensor, scale, zero_point):
     output = g.op("QuantizeLinear", tensor, scale, zero_point)
     return g.op("prim::TupleConstruct", output, scale, zero_point)
 
-# NOTE: Original `bias` is float in PyTorch. Quantization is applied in kernel.
-#       To mimic behavior in ONNX, perform the `bias` quantization step here.
 def requantize_bias_helper(g, bias, input_scale, weight_scale):
+    # In PyTorch, bias is float and is quantized implicitly inside the quantized ATen op kernel.
+    # In ONNX we need to make the quantization explicit because operators expect all of their inputs to be quantized.
+    # Since int32 is not supported by ONNX operator `QuantizeLinear`, quantization is exported using regular operators.
     bias_scale = g.op("Mul", weight_scale, input_scale)
     bias_zero_point = g.op("Constant", value_t=torch.tensor([0], dtype=torch.int))
     q_bias = g.op("Cast",

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -941,14 +941,13 @@ def quantize_helper(g, tensor, scale, zero_point):
 
 # NOTE: Original `bias` is float in PyTorch. Quantization is applied in kernel.
 #       To mimic behavior in ONNX, perform the `bias` quantization step here.
-#       Then append the dequantization step to ready `bias` for unquantized operators.
 def requantize_bias_helper(g, bias, input_scale, weight_scale):
     bias_scale = g.op("Mul", weight_scale, input_scale)
     bias_zero_point = g.op("Constant", value_t=torch.tensor([0], dtype=torch.int))
     q_bias = g.op("Cast",
                   g.op("Div", bias, bias_scale),
                   to_i=torch.onnx.TensorProtoDataType.INT32)
-    return g.op("DequantizeLinear", q_bias, bias_scale, bias_zero_point)
+    return g.op("prim::TupleConstruct", q_bias, bias_scale, bias_zero_point)
 
 # ---------------------------------------------------------------------
 # ONNX operator version

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -377,8 +377,9 @@ class Quantized:
 
     @staticmethod
     def linear(g, q_input, q_weight, bias, op_scale, op_zero_point):
-        input, _, _ = sym_help.dequantize_helper(g, q_input)
-        weight, _, _ = sym_help.dequantize_helper(g, q_weight)
+        input, input_scale, _ = sym_help.dequantize_helper(g, q_input)
+        weight, weight_scale, _ = sym_help.dequantize_helper(g, q_weight)
+        bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
 
         output = linear(g, input, weight, bias)
 
@@ -412,8 +413,9 @@ class Quantized:
 
     @staticmethod
     def conv2d_relu(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
-        input, _, _ = sym_help.dequantize_helper(g, q_input)
-        weight, _, _ = sym_help.dequantize_helper(g, q_weight)
+        input, input_scale, _ = sym_help.dequantize_helper(g, q_input)
+        weight, weight_scale, _ = sym_help.dequantize_helper(g, q_weight)
+        bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
 
         output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
         output = relu(g, output)
@@ -422,8 +424,9 @@ class Quantized:
 
     @staticmethod
     def conv2d(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
-        input, _, _ = sym_help.dequantize_helper(g, q_input)
-        weight, _, _ = sym_help.dequantize_helper(g, q_weight)
+        input, input_scale, _ = sym_help.dequantize_helper(g, q_input)
+        weight, weight_scale, _ = sym_help.dequantize_helper(g, q_weight)
+        bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
 
         output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
 

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -379,7 +379,9 @@ class Quantized:
     def linear(g, q_input, q_weight, bias, op_scale, op_zero_point):
         input, input_scale, _ = sym_help.dequantize_helper(g, q_input)
         weight, weight_scale, _ = sym_help.dequantize_helper(g, q_weight)
-        bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
+        # Preserve bias quantization step in ONNX graph
+        q_bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
+        bias, _, _ = sym_help.dequantize_helper(g, q_bias)
 
         output = linear(g, input, weight, bias)
 
@@ -415,7 +417,9 @@ class Quantized:
     def conv2d_relu(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
         input, input_scale, _ = sym_help.dequantize_helper(g, q_input)
         weight, weight_scale, _ = sym_help.dequantize_helper(g, q_weight)
-        bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
+        # Preserve bias quantization step in ONNX graph
+        q_bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
+        bias, _, _ = sym_help.dequantize_helper(g, q_bias)
 
         output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
         output = relu(g, output)
@@ -426,7 +430,9 @@ class Quantized:
     def conv2d(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
         input, input_scale, _ = sym_help.dequantize_helper(g, q_input)
         weight, weight_scale, _ = sym_help.dequantize_helper(g, q_weight)
-        bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
+        # Preserve bias quantization step in ONNX graph
+        q_bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
+        bias, _, _ = sym_help.dequantize_helper(g, q_bias)
 
         output = conv2d(g, input, weight, bias, stride, padding, dilation, groups)
 

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -379,7 +379,6 @@ class Quantized:
     def linear(g, q_input, q_weight, bias, op_scale, op_zero_point):
         input, input_scale, _ = sym_help.dequantize_helper(g, q_input)
         weight, weight_scale, _ = sym_help.dequantize_helper(g, q_weight)
-        # Preserve bias quantization step in ONNX graph
         q_bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
         bias, _, _ = sym_help.dequantize_helper(g, q_bias)
 
@@ -417,7 +416,6 @@ class Quantized:
     def conv2d_relu(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
         input, input_scale, _ = sym_help.dequantize_helper(g, q_input)
         weight, weight_scale, _ = sym_help.dequantize_helper(g, q_weight)
-        # Preserve bias quantization step in ONNX graph
         q_bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
         bias, _, _ = sym_help.dequantize_helper(g, q_bias)
 
@@ -430,7 +428,6 @@ class Quantized:
     def conv2d(g, q_input, q_weight, bias, stride, padding, dilation, groups, op_scale, op_zero_point):
         input, input_scale, _ = sym_help.dequantize_helper(g, q_input)
         weight, weight_scale, _ = sym_help.dequantize_helper(g, q_weight)
-        # Preserve bias quantization step in ONNX graph
         q_bias = sym_help.requantize_bias_helper(g, bias, input_scale, weight_scale)
         bias, _, _ = sym_help.dequantize_helper(g, q_bias)
 


### PR DESCRIPTION
Original `bias` is float in PyTorch. Quantization is applied in kernel.
To mimic behavior in ONNX, export the `bias` quantization step,
then append the dequantization step to ready `bias` for unquantized operators.