### PR TITLE
skip HPU tensor in TensorIterator

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -1494,7 +1494,8 @@ void TensorIteratorBase::build(TensorIteratorConfig& config) {
   // Extend the condition to ORT tesnors as ORT tensors also don't have storage.
   if (common_device_.type() == DeviceType::XLA  ||
       common_device_.type() == DeviceType::Lazy ||
-      common_device_.type() == DeviceType::ORT) return;
+      common_device_.type() == DeviceType::ORT  ||
+      common_device_.type() == DeviceType::HPU) return;
 
   for (auto& op : operands_) {
     TORCH_INTERNAL_ASSERT(op.tensor_base().defined());


### PR DESCRIPTION
HPU tensors are lazy tensors which doesn't have storage.
So add this conditon for HPU.

Signed-off-by: Gune <gsingh@habana.ai>
Signed-off-by: Jeeja <jeejakp@habana.ai>

Fixes #ISSUE_NUMBER
