### PR TITLE
[quant][fx] Move MatchAllNode from match_utils.py to utils.py under quantization

### DIFF
--- a/torch/ao/quantization/fx/match_utils.py
+++ b/torch/ao/quantization/fx/match_utils.py
@@ -13,6 +13,9 @@ from .quantization_patterns import (
 from ..qconfig import (
     QConfigAny,
 )
+from ..utils import (
+    MatchAllNode
+)
 from .graph_module import (
     is_observed_standalone_module,
 )
@@ -21,12 +24,6 @@ from typing import Any, Dict, List, Callable, Optional, Tuple, Set
 
 MatchResult = Tuple[Node, List[Node], Optional[Pattern], QuantizeHandler,
                     QConfigAny]
-
-# TODO: maybe rename this to MatchInputNode
-class MatchAllNode:
-    """ A node pattern that matches all nodes
-    """
-    pass
 
 # Note: The order of patterns is important! match function will take whatever is matched first, so we'll
 # need to put the fusion patterns before single patterns. For example, add_relu should be registered come before relu.

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -12,6 +12,13 @@ from typing import Tuple, Any, Union, Callable
 # TODO: not sure if typing supports recursive data types
 Pattern = Union[Callable, Tuple[Callable, Callable], Tuple[Callable, Tuple[Callable, Callable]], Any]
 
+# TODO: maybe rename this to MatchInputNode
+class MatchAllNode:
+    """ A node pattern that matches all nodes, used in defining
+    fusion patterns in FX Graph Mode Quantization
+    """
+    pass
+
 module_type_list = {
     torch.nn.ReLU,
     torch.nn.ReLU6,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73345
* #72735
* __->__ #73344

Summary:
not user facing as of now, since we haven't advertised the backend_config_dict api,
we need this in fuser_method_mapping.py, this is to avoid circular dependency

Test Plan:
python test/test_quantization.py TestQuantizeFx

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D34441778](https://our.internmc.facebook.com/intern/diff/D34441778)