### PR TITLE
Introduce an environment variable to change c10 log level (#71746)

### DIFF
--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -145,8 +145,13 @@ bool LogAPIUsageFakeReturn(const std::string& event) try {
   // static destructor race
   return true;
 }
-} // namespace detail
 
+namespace {
+
+void setLogLevelFlagFromEnv();
+
+} // namespace
+} // namespace detail
 } // namespace c10
 
 #if defined(C10_USE_GFLAGS) && defined(C10_USE_GLOG)
@@ -198,15 +203,15 @@ bool IsGoogleLoggingInitialized();
 } // namespace google
 
 namespace c10 {
-bool InitCaffeLogging(int* argc, char** argv) {
-  if (*argc == 0)
-    return true;
+namespace {
+
+void initGoogleLogging(char const* name) {
 #if !defined(_MSC_VER)
   // This trick can only be used on UNIX platforms
   if (!::google::glog_internal_namespace_::IsGoogleLoggingInitialized())
 #endif
   {
-    ::google::InitGoogleLogging(argv[0]);
+    ::google::InitGoogleLogging(name);
 #if !defined(_MSC_VER)
     // This is never defined on Windows
 #if !defined(__XROS__)
@@ -214,7 +219,25 @@ bool InitCaffeLogging(int* argc, char** argv) {
 #endif
 #endif
   }
+}
+
+} // namespace
+
+void initLogging() {
+  detail::setLogLevelFlagFromEnv();
+
   UpdateLoggingLevelsFromFlags();
+}
+
+bool InitCaffeLogging(int* argc, char** argv) {
+  if (*argc == 0) {
+    return true;
+  }
+
+  initGoogleLogging(argv[0]);
+
+  UpdateLoggingLevelsFromFlags();
+
   return true;
 }
 
@@ -254,6 +277,11 @@ C10_DEFINE_int(
     "The minimum log level that caffe2 will output.");
 
 namespace c10 {
+
+void initLogging() {
+  detail::setLogLevelFlagFromEnv();
+}
+
 bool InitCaffeLogging(int* argc, char** argv) {
   // When doing InitCaffeLogging, we will assume that caffe's flag parser has
   // already finished.
@@ -356,3 +384,51 @@ MessageLogger::~MessageLogger() {
 } // namespace c10
 
 #endif // !C10_USE_GLOG
+
+namespace c10 {
+namespace detail {
+namespace {
+
+void setLogLevelFlagFromEnv() {
+  const char* level_str = std::getenv("TORCH_CPP_LOG_LEVEL");
+
+  // Not set, fallback to the default level (i.e. WARNING).
+  std::string level{level_str != nullptr ? level_str : ""};
+  if (level.empty()) {
+    return;
+  }
+
+  std::transform(level.begin(), level.end(), level.begin(),
+    [](unsigned char c) {
+      return toupper(c);
+    });
+
+  if (level == "0" || level == "INFO") {
+    FLAGS_caffe2_log_level = 0;
+
+    return;
+  }
+  if (level == "1" || level == "WARNING") {
+    FLAGS_caffe2_log_level = 1;
+
+    return;
+  }
+  if (level == "2" || level == "ERROR") {
+    FLAGS_caffe2_log_level = 2;
+
+    return;
+  }
+  if (level == "3" || level == "FATAL") {
+    FLAGS_caffe2_log_level = 3;
+
+    return;
+  }
+
+  std::cerr << "`TORCH_CPP_LOG_LEVEL` environment variable cannot be parsed. Valid values are "
+               "`INFO`, `WARNING`, `ERROR`, and `FATAL` or their numerical equivalents `0`, `1`, "
+               "`2`, and `3`." << std::endl;
+}
+
+} // namespace
+} // namespace detail
+} // namespace c10

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -305,6 +305,9 @@ namespace detail {
 C10_API bool LogAPIUsageFakeReturn(const std::string& context);
 } // namespace detail
 
+// Initializes the c10 logger.
+C10_API void initLogging();
+
 } // namespace c10
 
 #endif // C10_UTIL_LOGGING_H_

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -780,6 +780,9 @@ TORCH_API PyObject* initModule();
 // separate decl and defn for msvc error C2491
 PyObject* initModule() {
   HANDLE_TH_ERRORS
+
+  c10::initLogging();
+
   at::internal::lazy_init_num_threads();
 
   C10_LOG_API_USAGE_ONCE("torch.python.import");


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/71746

This PR contains the following improvements:

- It exposes a new environment variable `TORCH_CPP_LOG_LEVEL` that enables users to set the log level of c10 logging facility (supports both GLOG and c10 loggers). Valid values are `INFO`, `WARNING`, `ERROR`, and `FATAL` or their numerical equivalents `0`, `1`, `2`, and `3`.
- It implements an `initLogging()` function and calls it as part of `torch._C` module import to ensure that the underlying logging facility is correctly initialized in Python.

With these changes a user can dynamically set the log level of c10 as in the following example:

```
$ TORCH_CPP_LOG_LEVEL=INFO python my_torch_script.py
```
ghstack-source-id: 149822703

Test Plan: Run existing tests.

Reviewed By: malfet

Differential Revision: D33756252

fbshipit-source-id: 7fd078c03a598595d992de0b474a23cec91838af
(cherry picked from commit 01d6ec6207faedf259ed1368730e9e197cb3e1c6)

Fixes regressions reported by HuggingFace and ByteDance regarding inability to troubleshoot network related problems.