### PR TITLE
Do not set the `logtostderr` GLOG flag just to be on the safe side

### DIFF
--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -224,9 +224,6 @@ void initGoogleLogging(char const* name) {
 } // namespace
 
 void initLogging() {
-  // Unlike caffe2 torch always writes to stderr.
-  FLAGS_logtostderr = 1;
-
   detail::setLogLevelFlagFromEnv();
 
   UpdateLoggingLevelsFromFlags();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73360

Some (internal) PyTorch users use GLOG for their own logging purposes as well. Since the default setting is already to write to `stderr` anyways, let's be a good citizen and don't interfere with the logging settings of the main application.

Differential Revision: [D34452040](https://our.internmc.facebook.com/intern/diff/D34452040/)