### PR TITLE
Add documentation for c10d log levels

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -787,3 +787,24 @@ With the ``NCCL`` backend, such an application would likely result in a hang whi
 In addition, `TORCH_DISTRIBUTED_DEBUG=DETAIL` can be used in conjunction with `TORCH_SHOW_CPP_STACKTRACES=1` to log the entire callstack when a collective desynchronization is detected. These
 collective desynchronization checks will work for all applications that use ``c10d`` collective calls backed by process groups created with the
 :func:`torch.distributed.init_process_group` and :func:`torch.distributed.new_group` APIs.
+
+Logging
+-------
+
+In addition to explicit debugging support via :func:`torch.distributed.monitored_barrier` and ``TORCH_DISTRIBUTED_DEBUG``, the underlying C++ library of ``torch.distributed`` also outputs log
+messages at various levels. These messages can be helpful to understand the execution state of a distributed training job and to troubleshoot problems such as network connection failures. The
+following matrix shows how the log level can be adjusted via the combination of ``TORCH_CPP_LOG_LEVEL`` and ``TORCH_DISTRIBUTED_DEBUG`` environment variables.
+
++-------------------------+-----------------------------+------------------------+
+| ``TORCH_CPP_LOG_LEVEL`` | ``TORCH_DISTRIBUTED_DEBUG`` |   Effective Log Level  |
++=========================+=============================+========================+
+| ``ERROR``               | ignored                     | Error                  |
++-------------------------+-----------------------------+------------------------+
+| ``WARNING``             | ignored                     | Warning                |
++-------------------------+-----------------------------+------------------------+
+| ``INFO``                | ignored                     | Info                   |
++-------------------------+-----------------------------+------------------------+
+| ``INFO``                | ``INFO``                    | Debug                  |
++-------------------------+-----------------------------+------------------------+
+| ``INFO``                | ``DETAIL``                  | Trace (a.k.a. All)     |
++-------------------------+-----------------------------+------------------------+


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73361

This PR adds the documentation for the newly introduced `TORCH_CPP_LOG_LEVEL` and how it can be used along with `TORCH_DISTRIBUTED_DEBUG` to adjust the log level of c10d.

Differential Revision: [D34452352](https://our.internmc.facebook.com/intern/diff/D34452352/)