### PR TITLE
Remove legacy tensor constructors for complex dtypes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -129,8 +129,6 @@ coverage_ignore_functions = [
 
 coverage_ignore_classes = [
     # torch.cuda
-    "ComplexDoubleTensor",
-    "ComplexFloatTensor",
     "BFloat16Storage",
     "BFloat16Tensor",
     "BoolStorage",

--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -84,16 +84,14 @@ at::TensorOptions options_from_string(const std::string& str) {
 std::vector<std::pair<Backend, ScalarType>> all_declared_types() {
   std::vector<std::pair<Backend, ScalarType>> ret;
 
-  // Can't easily iterate over enum classes.
+  // NOTE: Do not add more types here. This list controls the creation
+  // of legacy tensor types e.g. torch.cuda.FloatTensor which are
+  // maintained for backwards-compatibility only.
   std::vector<Backend> backends = { Backend::CPU, Backend::CUDA, Backend::SparseCPU, Backend::SparseCUDA };
-  // Try to keep in sync with ScalarType.  Note how this doesn't use
-  // AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS as ScalarType does because
-  // this list is used for initializing empty tensors, and that doesn't work
-  // with qint.
   std::vector<ScalarType> scalar_types = {
-    #define DEFINE_ENUM(_1, n) ScalarType::n,
-      AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_ENUM)
-  };
+    ScalarType::Byte, ScalarType::Char, ScalarType::Double, ScalarType::Float,
+    ScalarType::Int, ScalarType::Long, ScalarType::Short, ScalarType::Half,
+    ScalarType::Bool, ScalarType::BFloat16};
 
   for (auto& backend : backends) {
     for (auto& scalar_type : scalar_types) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #73370
* #73369

PR #72405 added four new types to the public python API:
`torch.ComplexFloatTensor`, `torch.ComplexDoubleTensor`,
`torch.cuda.ComplexFloatTensor` and `torch.cuda.ComplexDoubleTensor`.

I believe this was unintentional and a clarifying comment as to the
purpose of `all_declared_types` is needed to avoid this in future.