### PR TITLE
Fix torchbench CI issue.

### DIFF
--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -37,7 +37,7 @@ jobs:
           . "${HOME}"/anaconda3/etc/profile.d/conda.sh
           conda activate pr-ci
           conda install -y numpy requests ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions \
-                           future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm
+                           future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
           # install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
       - name: Setup TorchBench branch
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: pytorch/benchmark
           path: benchmark
-          lfs: true
+          lfs: false
           ref: ${{ env.TORCHBENCH_BRANCH }}
       - name: Run TorchBench
         run: |


### PR DESCRIPTION
The TorchBench OnDemand CI is currently broken because:
1) it requires a new package `psutil` to be pre-installed because the improved subprocess worker component requires that
2) `git lfs` needs to update forcefully, and the checkout action doesn't support that

This PR adds the new `psutil` dependency, and use `install.py`, not the checkout action, to fix the CI.

RUN_TORCHBENCH: nvidia_deeprecommender