### PR TITLE
[PyTorchEdge] Extend _save_for_mobile to support flatbuffer format

### DIFF
--- a/test/cpp/jit/test_flatbuffer.cpp
+++ b/test/cpp/jit/test_flatbuffer.cpp
@@ -166,6 +166,9 @@ TEST(FlatbufferTest, ExtraFiles) {
 
   ASSERT_EQ(loaded_extra_files["metadata.json"], "abc");
   ASSERT_EQ(loaded_extra_files["mobile_info.json"], "{\"key\": 23}");
+  std::stringstream ss;
+  module->_save_for_mobile(ss, {}, true, /*use_flatbuffer*/ true);
+  auto flatbuffer_module2 = load_mobile_module_from_stream(ss);
 }
 
 TEST(FlatbufferTest, Conv) {

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -608,6 +608,7 @@ libtorch_extra_sources = libtorch_core_jit_sources + [
     "torch/csrc/jit/serialization/export.cpp",
     "torch/csrc/jit/serialization/export_bytecode.cpp",
     "torch/csrc/jit/serialization/export_module.cpp",
+    "torch/csrc/jit/serialization/flatbuffer_serializer.cpp",
     "torch/csrc/jit/serialization/import_legacy.cpp",
     "torch/csrc/utils/byte_order.cpp",
     "torch/csrc/utils/out_types.cpp",

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -223,12 +223,14 @@ struct TORCH_API Module : public Object {
   void _save_for_mobile(
       std::ostream& out,
       const ExtraFilesMap& extra_files = ExtraFilesMap(),
-      bool save_mobile_debug_info = false) const;
+      bool save_mobile_debug_info = false,
+      bool use_flatbuffer = false) const;
 
   void _save_for_mobile(
       const std::string& filename,
       const ExtraFilesMap& extra_files = ExtraFilesMap(),
-      bool save_mobile_debug_info = false) const;
+      bool save_mobile_debug_info = false,
+      bool use_flatbuffer = false) const;
 
   Module copy() const;
 

--- a/torch/csrc/jit/api/module_save.cpp
+++ b/torch/csrc/jit/api/module_save.cpp
@@ -16,25 +16,29 @@ void Module::save(const std::string& filename, const ExtraFilesMap& extra_files)
 void Module::_save_for_mobile(
     std::ostream& out,
     const ExtraFilesMap& extra_files,
-    bool save_mobile_debug_info) const {
+    bool save_mobile_debug_info,
+    bool use_flatbuffer) const {
   ExportModule(
       *this,
       out,
       extra_files,
       true /* bytecode_format */,
-      save_mobile_debug_info);
+      save_mobile_debug_info,
+      use_flatbuffer);
 }
 
 void Module::_save_for_mobile(
     const std::string& filename,
     const ExtraFilesMap& extra_files,
-    bool save_mobile_debug_info) const {
+    bool save_mobile_debug_info,
+    bool use_flatbuffer) const {
   ExportModule(
       *this,
       filename,
       extra_files,
       true /* bytecode_format */,
-      save_mobile_debug_info);
+      save_mobile_debug_info,
+      use_flatbuffer);
 }
 
 } // namespace jit

--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -591,5 +591,20 @@ mobile::Module load_mobile_module_from_file(
   return parse_and_initialize_mobile_module(std::move(data), size, device);
 }
 
+mobile::Module load_mobile_module_from_stream(
+    std::istream& in,
+    c10::optional<c10::Device> device) {
+  // get size of the stream and reset to beg
+  in.seekg(0, std::ios::end);
+  const long size = in.tellg();
+  in.seekg(0, std::ios::beg);
+
+  // read stream
+  std::shared_ptr<char> data(static_cast<char*>(malloc(size)), free); // NOLINT
+  in.read(data.get(), size);
+
+  return parse_and_initialize_mobile_module(std::move(data), size, device);
+}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/mobile/flatbuffer_loader.h
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.h
@@ -52,6 +52,10 @@ TORCH_API mobile::Module load_mobile_module_from_file(
     const std::string& filename,
     c10::optional<at::Device> device = c10::nullopt);
 
+TORCH_API mobile::Module load_mobile_module_from_stream(
+    std::istream& in,
+    c10::optional<c10::Device> device = c10::nullopt);
+
 TORCH_API void parseExtraFiles(
     mobile::serialization::Module* module,
     ExtraFilesMap& extra_files);

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -3,6 +3,7 @@
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/serialization/flatbuffer_serializer.h>
 #include <torch/csrc/jit/serialization/pickler.h>
 #include <torch/csrc/jit/serialization/python_print.h>
 #include <torch/csrc/jit/serialization/storage_context.h>
@@ -156,21 +157,24 @@ TORCH_API void ExportModule(
     std::ostream& out,
     const ExtraFilesMap& metadata = ExtraFilesMap(),
     bool bytecode_format = false,
-    bool save_mobile_debug_info = false);
+    bool save_mobile_debug_info = false,
+    bool use_flatbuffer = false);
 
 TORCH_API void ExportModule(
     const Module& module,
     const std::string& filename,
     const ExtraFilesMap& metadata = ExtraFilesMap(),
     bool bytecode_format = false,
-    bool save_mobile_debug_info = false);
+    bool save_mobile_debug_info = false,
+    bool use_flatbuffer = false);
 
 TORCH_API void ExportModule(
     const Module& module,
     const std::function<size_t(const void*, size_t)>& writer_func,
     const ExtraFilesMap& metadata = ExtraFilesMap(),
     bool bytecode_format = false,
-    bool save_mobile_debug_info = false);
+    bool save_mobile_debug_info = false,
+    bool use_flatbuffer = false);
 
 // Write the bytes of a pickle archive and the tensors referenced inside that
 // archive

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -697,8 +697,7 @@ void save_mobile_module(
     const mobile::Module& module,
     const std::string& filename,
     const ExtraFilesMap& extra_files) {
-  FlatbufferSerializer fb_serializer;
-  auto buffer = fb_serializer.serializeModule(module, true, extra_files);
+  auto buffer = save_mobile_module_to_bytes(module, extra_files);
   std::fstream ofile(filename, std::ios::binary | std::ios::out);
   ofile.write(reinterpret_cast<char*>(buffer.data()), buffer.size());
   ofile.close();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73403

Add an additional argument (with default to pickle untill flatbuffer rollout) to provide option to switch between formats


Note: this is going to cause increase in the size of the libtorch or pytorch mobile build as flatbuffer and accompanying third party deps will be pulled in.

Differential Revision: [D34321403](https://our.internmc.facebook.com/intern/diff/D34321403/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D34321403/)!