### PR TITLE
[fx][acc_tracer] fix defaulted placeholder normalization

### DIFF
--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -5,6 +5,7 @@ from .proxy import Proxy
 from ._symbolic_trace import Tracer
 from ._compatibility import compatibility
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+import inspect
 
 @compatibility(is_backward_compatible=True)
 class Interpreter:
@@ -407,7 +408,8 @@ class Transformer(Interpreter):
             kwargs (Dict): Dict of keyword arguments for this invocation
         """
         assert isinstance(target, str)
-        return Proxy(self.new_graph.placeholder(target), self.tracer)
+        default_value = next(iter(args)) if args else inspect.Signature.empty
+        return Proxy(self.new_graph.placeholder(target, default_value=default_value), self.tracer)
 
     @compatibility(is_backward_compatible=True)
     def get_attr(self, target : 'Target', args : Tuple[Argument, ...], kwargs : Dict[str, Any]) -> Proxy:


### PR DESCRIPTION
Summary: Placeholder defaults are stored in `node.args`, during normalization we had dropped these. This diff passes the default args through the normalization transformation.

Test Plan:
Added tests to cover cases with optional inputs, test covers
* nothing passed to optional input
* `None` passed to optional input
* a tensor passed to optional input

Differential Revision: D34463493

