### PR TITLE
Don't use vector accessor methods to do pointer math; unblock platform010

### DIFF
--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -171,7 +171,8 @@ class MemoryPlanner {
     const auto start =
         reinterpret_cast<uintptr_t>(managed_tensor_storage_impls_.data());
     const auto end = reinterpret_cast<uintptr_t>(
-        &managed_tensor_storage_impls_[managed_tensor_storage_impls_.size()]);
+        managed_tensor_storage_impls_.data() +
+        managed_tensor_storage_impls_.size());
     return impl_p >= start && impl_p < end;
   }
 


### PR DESCRIPTION
Summary:
The code here previously used this creative pointer math
```
const auto end = reinterpret_cast<uintptr_t>(     &managed_tensor_storage_impls_.at(managed_tensor_storage_impls_.size()));
```
This has the form
```
const auto end = &A[N];
```
this works just fine if `A` is C-style array since `&A[N]` can get transformed to `(A+N)` where `A` is a simple pointer without ever dereferencing.

But this is C++ and `A` is a vector, so `A[N]` calls the accessor method, reaches into an illegal place in memory, and then we get the address of that. (Or so I deduce.)

We sidestep the issue by using `data()` to get the desired memory address directly.

Test Plan: Sandcastle

Differential Revision: D34468166

