### PR TITLE
Use intrusive_ptr for LazyTensor

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.cpp
@@ -75,9 +75,10 @@ torch::lazy::Value GetIrValueOrDefault(const torch::lazy::LazyTensorPtr& input,
                                        const at::Scalar& default_value,
                                        const torch::lazy::Shape& default_shape,
                                        const torch::lazy::BackendDevice& device) {
-  return (input && *input) ? input->GetIrValue() :
-                             torch::lazy::LazyGraphExecutor::Get()->GetIrValueForExpandedScalar(
-                              default_value, default_shape, device);
+  return input ? input->GetIrValue()
+               : torch::lazy::LazyGraphExecutor::Get()->GetIrValueForExpandedScalar(default_value,
+                                                                                    default_shape,
+                                                                                    device);
 }
 
 torch::lazy::ViewInfo CreateAsStridedViewInfo(
@@ -227,8 +228,8 @@ std::tuple<torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr, torch::lazy::
         save_mean->GetIrValue(), save_invstd->GetIrValue(), training, eps,
         std::array<bool, 3>{output_mask[0], output_mask[1], output_mask[2]});
   } else {
-    CHECK(*running_mean);
-    CHECK(*running_var);
+    CHECK(running_mean);
+    CHECK(running_var);
     node = torch::lazy::MakeNode<ir::ops::TSNativeBatchNormBackward>(
         grad_out->GetIrValue(), input->GetIrValue(), weight_value,
         running_mean->GetIrValue(), running_var->GetIrValue(),

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_aten_ops.h
@@ -10,101 +10,102 @@ namespace lazy_tensor_aten_ops {
 //////////////////////////////////////////////////////////////////////////////
 // Takes a slice from the input as R1 at the specified offset and reshapes it
 // into the provided size.
-torch::lazy::LazyTensor as_strided(const torch::lazy::LazyTensor& input, std::vector<int64_t> size,
+torch::lazy::LazyTensorPtr as_strided(const torch::lazy::LazyTensorPtr& input, std::vector<int64_t> size,
                       std::vector<int64_t> stride,
                       c10::optional<int64_t> storage_offset);
 
 // In-place version of the method above.
-void as_strided_(torch::lazy::LazyTensor& input, std::vector<int64_t> size,
+void as_strided_(torch::lazy::LazyTensorPtr& input, std::vector<int64_t> size,
                  std::vector<int64_t> stride,
                  c10::optional<int64_t> storage_offset);
 
-torch::lazy::LazyTensor bernoulli(const torch::lazy::LazyTensor& input, double probability);
-torch::lazy::LazyTensor bernoulli(const torch::lazy::LazyTensor& input);
-void bernoulli_(torch::lazy::LazyTensor& input, double probability);
-void bernoulli_(torch::lazy::LazyTensor& input, const torch::lazy::LazyTensor& probability);
+torch::lazy::LazyTensorPtr bernoulli(const torch::lazy::LazyTensorPtr& input, double probability);
+torch::lazy::LazyTensorPtr bernoulli(const torch::lazy::LazyTensorPtr& input);
+void bernoulli_(torch::lazy::LazyTensorPtr& input, double probability);
+void bernoulli_(torch::lazy::LazyTensorPtr& input, const torch::lazy::LazyTensorPtr& probability);
 
-torch::lazy::LazyTensor expand(const torch::lazy::LazyTensor& input,
+torch::lazy::LazyTensorPtr expand(const torch::lazy::LazyTensorPtr& input,
                   std::vector<int64_t> size);
 
 // Fills the input with the given value.
-void fill_(torch::lazy::LazyTensor& input, const at::Scalar& value);
+void fill_(torch::lazy::LazyTensorPtr& input, const at::Scalar& value);
 
 // Returns a new tensor that is a narrowed view of the input in the given
 // dimension.
-torch::lazy::LazyTensor narrow(const torch::lazy::LazyTensor& input, int64_t dim, int64_t start,
+torch::lazy::LazyTensorPtr narrow(const torch::lazy::LazyTensorPtr& input, int64_t dim, int64_t start,
                   int64_t length);
 
-std::tuple<torch::lazy::LazyTensor, torch::lazy::LazyTensor, torch::lazy::LazyTensor> ts_native_batch_norm(
-    const torch::lazy::LazyTensor& input, const torch::lazy::LazyTensor& weight, const torch::lazy::LazyTensor& bias,
-    torch::lazy::LazyTensor& running_mean, torch::lazy::LazyTensor& running_var, bool training,
+std::tuple<torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr> ts_native_batch_norm(
+    const torch::lazy::LazyTensorPtr& input, const torch::lazy::LazyTensorPtr& weight, const torch::lazy::LazyTensorPtr& bias,
+    torch::lazy::LazyTensorPtr& running_mean, torch::lazy::LazyTensorPtr& running_var, bool training,
     double momentum, double eps);
 
-std::tuple<torch::lazy::LazyTensor, torch::lazy::LazyTensor, torch::lazy::LazyTensor> ts_native_batch_norm_backward(
-    const torch::lazy::LazyTensor& grad_out, const torch::lazy::LazyTensor& input,
-    const torch::lazy::LazyTensor& weight, const torch::lazy::LazyTensor& running_mean,
-    const torch::lazy::LazyTensor& running_var, const torch::lazy::LazyTensor& save_mean,
-    const torch::lazy::LazyTensor& save_invstd, bool training, double eps,
+std::tuple<torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr> ts_native_batch_norm_backward(
+    const torch::lazy::LazyTensorPtr& grad_out, const torch::lazy::LazyTensorPtr& input,
+    const torch::lazy::LazyTensorPtr& weight, const torch::lazy::LazyTensorPtr& running_mean,
+    const torch::lazy::LazyTensorPtr& running_var, const torch::lazy::LazyTensorPtr& save_mean,
+    const torch::lazy::LazyTensorPtr& save_invstd, bool training, double eps,
     c10::ArrayRef<bool> output_mask);
 
-std::pair<torch::lazy::LazyTensor, torch::lazy::LazyTensor> nms(const torch::lazy::LazyTensor& boxes,
-                                      const torch::lazy::LazyTensor& scores,
-                                      const torch::lazy::LazyTensor& score_threshold,
-                                      const torch::lazy::LazyTensor& iou_threshold,
+std::pair<torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr> nms(const torch::lazy::LazyTensorPtr& boxes,
+                                      const torch::lazy::LazyTensorPtr& scores,
+                                      const torch::lazy::LazyTensorPtr& score_threshold,
+                                      const torch::lazy::LazyTensorPtr& iou_threshold,
                                       int64_t output_size);
 
 // Permute the dimensions of this tensor according to the given permutation.
-torch::lazy::LazyTensor permute(const torch::lazy::LazyTensor& input, c10::ArrayRef<int64_t> dims);
+torch::lazy::LazyTensorPtr permute(const torch::lazy::LazyTensorPtr& input, c10::ArrayRef<int64_t> dims);
 
 // Repeats the input tensor along each dimension by the given number of
 // repeats.
-torch::lazy::LazyTensor repeat(const torch::lazy::LazyTensor& input, std::vector<int64_t> repeats);
+torch::lazy::LazyTensorPtr repeat(const torch::lazy::LazyTensorPtr& input, std::vector<int64_t> repeats);
 
-torch::lazy::LazyTensor rsub(const torch::lazy::LazyTensor& input, const at::Scalar& other,
+torch::lazy::LazyTensorPtr rsub(const torch::lazy::LazyTensorPtr& input, const at::Scalar& other,
                 const at::Scalar& alpha);
 
-void copy_(torch::lazy::LazyTensor& input, torch::lazy::LazyTensor& src);
+void copy_(torch::lazy::LazyTensorPtr& input, torch::lazy::LazyTensorPtr& src);
 
-torch::lazy::LazyTensor select(const torch::lazy::LazyTensor& input, int64_t dim, int64_t index);
+torch::lazy::LazyTensorPtr select(const torch::lazy::LazyTensorPtr& input, int64_t dim, int64_t index);
 
-torch::lazy::LazyTensor slice(const torch::lazy::LazyTensor& input, int64_t dim, int64_t start,
+torch::lazy::LazyTensorPtr slice(const torch::lazy::LazyTensorPtr& input, int64_t dim, int64_t start,
                  int64_t end, int64_t step);
 
 // Squeeze out all trivial (size 1) dimensions.
-torch::lazy::LazyTensor squeeze(const torch::lazy::LazyTensor& input);
+torch::lazy::LazyTensorPtr squeeze(const torch::lazy::LazyTensorPtr& input);
 
 // Squeeze out the specified dimension index, if trivial (size 1). Returns
 // unchanged input otherwise.
-torch::lazy::LazyTensor squeeze(const torch::lazy::LazyTensor& input, int64_t dim);
+torch::lazy::LazyTensorPtr squeeze(const torch::lazy::LazyTensorPtr& input, int64_t dim);
 
 // In-place versions of the methods above.
-void squeeze_(torch::lazy::LazyTensor& input);
-void squeeze_(torch::lazy::LazyTensor& input, int64_t dim);
+void squeeze_(torch::lazy::LazyTensorPtr& input);
+void squeeze_(torch::lazy::LazyTensorPtr& input, int64_t dim);
 
-torch::lazy::LazyTensor stack(c10::ArrayRef<torch::lazy::LazyTensor> tensors, int64_t dim);
+torch::lazy::LazyTensorPtr stack(c10::ArrayRef<torch::lazy::LazyTensorPtr> tensors, int64_t dim);
 
-torch::lazy::LazyTensor sub(const torch::lazy::LazyTensor& input, const torch::lazy::LazyTensor& other,
+torch::lazy::LazyTensorPtr sub(const torch::lazy::LazyTensorPtr& input, const torch::lazy::LazyTensorPtr& other,
                const at::Scalar& alpha);
-torch::lazy::LazyTensor sub(const torch::lazy::LazyTensor& input, const at::Scalar& other,
+torch::lazy::LazyTensorPtr sub(const torch::lazy::LazyTensorPtr& input, const at::Scalar& other,
                const at::Scalar& alpha);
 
-std::tuple<torch::lazy::LazyTensor, torch::lazy::LazyTensor, torch::lazy::LazyTensor> svd(const torch::lazy::LazyTensor& input,
-                                                   bool some, bool compute_uv);
+std::tuple<torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr> svd(
+    const torch::lazy::LazyTensorPtr& input,
+    bool some, bool compute_uv);
 
 // Swap given dimensions of the input.
-torch::lazy::LazyTensor transpose(const torch::lazy::LazyTensor& input, int64_t dim0, int64_t dim1);
+torch::lazy::LazyTensorPtr transpose(const torch::lazy::LazyTensorPtr& input, int64_t dim0, int64_t dim1);
 
 // In-place version of the method above.
-void transpose_(torch::lazy::LazyTensor& input, int64_t dim0, int64_t dim1);
+void transpose_(torch::lazy::LazyTensorPtr& input, int64_t dim0, int64_t dim1);
 
 // Insert a dimension of size one at the specified position.
-torch::lazy::LazyTensor unsqueeze(const torch::lazy::LazyTensor& input, int64_t dim);
+torch::lazy::LazyTensorPtr unsqueeze(const torch::lazy::LazyTensorPtr& input, int64_t dim);
 
 // In-place version of the method above.
-void unsqueeze_(torch::lazy::LazyTensor& input, int64_t dim);
+void unsqueeze_(torch::lazy::LazyTensorPtr& input, int64_t dim);
 
 // Like reshape, but it returns a view into the original tensor.
-torch::lazy::LazyTensor view(const torch::lazy::LazyTensor& input, c10::ArrayRef<int64_t> output_size);
+torch::lazy::LazyTensorPtr view(const torch::lazy::LazyTensorPtr& input, c10::ArrayRef<int64_t> output_size);
 
 }  // namespace lazy_tensor_aten_ops
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_distributed.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_distributed.cpp
@@ -8,66 +8,66 @@
 namespace torch_lazy_tensors {
 namespace lazy_tensor_distributed {
 
-std::pair<torch::lazy::LazyTensor, torch::lazy::Value> all_reduce(
-    const torch::lazy::LazyTensor& input, const torch::lazy::Value& token,
+std::pair<torch::lazy::LazyTensorPtr, torch::lazy::Value> all_reduce(
+    const torch::lazy::LazyTensorPtr& input, const torch::lazy::Value& token,
     AllReduceType reduce_type, double scale,
     std::vector<std::vector<int64_t>> groups) {
-  std::vector<torch::lazy::Value> input_values({input.GetIrValue()});
+  std::vector<torch::lazy::Value> input_values({input->GetIrValue()});
   torch::lazy::NodePtr node = torch::lazy::MakeNode<ir::ops::AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups));
-  return {torch::lazy::LazyTensor::Create(torch::lazy::Value(node, 0), input.GetDevice()), torch::lazy::Value(node, 1)};
+  return {torch::lazy::LazyTensor::Create(torch::lazy::Value(node, 0), input->GetDevice()), torch::lazy::Value(node, 1)};
 }
 
-torch::lazy::Value all_reduce_(torch::lazy::LazyTensor& input,
+torch::lazy::Value all_reduce_(torch::lazy::LazyTensorPtr& input,
                                const torch::lazy::Value& token,
                                AllReduceType reduce_type, double scale,
                                std::vector<std::vector<int64_t>> groups) {
-  std::vector<torch::lazy::Value> input_values({input.GetIrValue()});
+  std::vector<torch::lazy::Value> input_values({input->GetIrValue()});
   torch::lazy::NodePtr node = torch::lazy::MakeNode<ir::ops::AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups));
-  input.SetInPlaceIrValue(torch::lazy::Value(node, 0));
+  input->SetInPlaceIrValue(torch::lazy::Value(node, 0));
   return torch::lazy::Value(node, 1);
 }
 
-torch::lazy::Value all_reduce(std::vector<torch::lazy::LazyTensor>* inputs,
+torch::lazy::Value all_reduce(std::vector<torch::lazy::LazyTensorPtr>* inputs,
                               const torch::lazy::Value& token,
                               AllReduceType reduce_type, double scale,
                               std::vector<std::vector<int64_t>> groups) {
   std::vector<torch::lazy::Value> input_values;
   input_values.reserve(inputs->size());
   for (auto& input : *inputs) {
-    input_values.push_back(input.GetIrValue());
+    input_values.push_back(input->GetIrValue());
   }
   torch::lazy::NodePtr node = torch::lazy::MakeNode<ir::ops::AllReduce>(
       reduce_type, input_values, token, scale, std::move(groups));
   for (size_t i = 0; i < inputs->size(); ++i) {
-    (*inputs)[i].SetInPlaceIrValue(torch::lazy::Value(node, i));
+    (*inputs)[i]->SetInPlaceIrValue(torch::lazy::Value(node, i));
   }
   return torch::lazy::Value(node, inputs->size());
 }
 
-std::pair<torch::lazy::LazyTensor, torch::lazy::Value> all_to_all(
-    const torch::lazy::LazyTensor& input, const torch::lazy::Value& token,
+std::pair<torch::lazy::LazyTensorPtr, torch::lazy::Value> all_to_all(
+    const torch::lazy::LazyTensorPtr& input, const torch::lazy::Value& token,
     int64_t split_dimension, int64_t concat_dimension, int64_t split_count,
     std::vector<std::vector<int64_t>> groups) {
   torch::lazy::NodePtr node = torch::lazy::MakeNode<ir::ops::AllToAll>(
-      input.GetIrValue(), token, split_dimension, concat_dimension, split_count,
+      input->GetIrValue(), token, split_dimension, concat_dimension, split_count,
       std::move(groups));
-  return {torch::lazy::LazyTensor::Create(torch::lazy::Value(node, 0), input.GetDevice()), torch::lazy::Value(node, 1)};
+  return {torch::lazy::LazyTensor::Create(torch::lazy::Value(node, 0), input->GetDevice()), torch::lazy::Value(node, 1)};
 }
 
-torch::lazy::LazyTensor get_dimensions_size(const torch::lazy::LazyTensor& input,
+torch::lazy::LazyTensorPtr get_dimensions_size(const torch::lazy::LazyTensorPtr& input,
                                std::vector<int64_t> dimensions) {
   return torch::lazy::LazyTensor::Create(torch::lazy::MakeNode<ir::ops::GetDimensionsSize>(
-      input.GetIrValue(), std::move(dimensions)), input.GetDevice());
+      input->GetIrValue(), std::move(dimensions)), input->GetDevice());
 }
 
-std::pair<torch::lazy::LazyTensor, torch::lazy::Value> collective_permute(
-    const torch::lazy::LazyTensor& input, const torch::lazy::Value& token,
+std::pair<torch::lazy::LazyTensorPtr, torch::lazy::Value> collective_permute(
+    const torch::lazy::LazyTensorPtr& input, const torch::lazy::Value& token,
     std::vector<std::pair<int64_t, int64_t>> source_target_pairs) {
   torch::lazy::NodePtr node = torch::lazy::MakeNode<ir::ops::CollectivePermute>(
-      input.GetIrValue(), token, std::move(source_target_pairs));
-  return {torch::lazy::LazyTensor::Create(torch::lazy::Value(node, 0), input.GetDevice()), torch::lazy::Value(node, 1)};
+      input->GetIrValue(), token, std::move(source_target_pairs));
+  return {torch::lazy::LazyTensor::Create(torch::lazy::Value(node, 0), input->GetDevice()), torch::lazy::Value(node, 1)};
 }
 
 }  // namespace lazy_tensor_distributed

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_distributed.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_distributed.h
@@ -9,31 +9,31 @@ namespace lazy_tensor_distributed {
 //////////////////////////////////////////////////////////////////////////////
 // Distributed operators follows here, listed in alphabetical order.
 //////////////////////////////////////////////////////////////////////////////
-std::pair<torch::lazy::LazyTensor, torch::lazy::Value> all_reduce(
-    const torch::lazy::LazyTensor& input, const torch::lazy::Value& token,
+std::pair<torch::lazy::LazyTensorPtr, torch::lazy::Value> all_reduce(
+    const torch::lazy::LazyTensorPtr& input, const torch::lazy::Value& token,
     AllReduceType reduce_type, double scale,
     std::vector<std::vector<int64_t>> groups);
 
-torch::lazy::Value all_reduce_(torch::lazy::LazyTensor& input,
+torch::lazy::Value all_reduce_(torch::lazy::LazyTensorPtr& input,
                                const torch::lazy::Value& token,
                                AllReduceType reduce_type, double scale,
                                std::vector<std::vector<int64_t>> groups);
 
-torch::lazy::Value all_reduce(std::vector<torch::lazy::LazyTensor>* inputs,
+torch::lazy::Value all_reduce(std::vector<torch::lazy::LazyTensorPtr>* inputs,
                               const torch::lazy::Value& token,
                               AllReduceType reduce_type, double scale,
                               std::vector<std::vector<int64_t>> groups);
 
-std::pair<torch::lazy::LazyTensor, torch::lazy::Value> all_to_all(
-    const torch::lazy::LazyTensor& input, const torch::lazy::Value& token,
+std::pair<torch::lazy::LazyTensorPtr, torch::lazy::Value> all_to_all(
+    const torch::lazy::LazyTensorPtr& input, const torch::lazy::Value& token,
     int64_t split_dimension, int64_t concat_dimension, int64_t split_count,
     std::vector<std::vector<int64_t>> groups);
 
-std::pair<torch::lazy::LazyTensor, torch::lazy::Value> collective_permute(
-    const torch::lazy::LazyTensor& input, const torch::lazy::Value& token,
+std::pair<torch::lazy::LazyTensorPtr, torch::lazy::Value> collective_permute(
+    const torch::lazy::LazyTensorPtr& input, const torch::lazy::Value& token,
     std::vector<std::pair<int64_t, int64_t>> source_target_pairs);
 
-torch::lazy::LazyTensor get_dimensions_size(const torch::lazy::LazyTensor& input,
+torch::lazy::LazyTensorPtr get_dimensions_size(const torch::lazy::LazyTensorPtr& input,
                                std::vector<int64_t> dimensions);
 
 }  // namespace lazy_tensor_distributed

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.cpp
@@ -12,10 +12,10 @@
 namespace torch_lazy_tensors {
 namespace tensor_ops {
 
-torch::lazy::LazyTensor Select(const torch::lazy::LazyTensor& input, int64_t dim, int64_t index) {
-  auto shape = input.shape();
+torch::lazy::LazyTensorPtr Select(const torch::lazy::LazyTensorPtr& input, int64_t dim, int64_t index) {
+  auto shape = input->shape();
   dim = torch::lazy::GetCanonicalDimensionIndex(dim, shape.Get().dim());
-  torch::lazy::LazyTensor result = lazy_tensor_aten_ops::narrow(input, dim, index, 1);
+  torch::lazy::LazyTensorPtr result = lazy_tensor_aten_ops::narrow(input, dim, index, 1);
   auto new_dims = torch::lazy::DropDimensions(shape.Get().sizes(), {dim});
   return lazy_tensor_aten_ops::view(result, new_dims);
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_ops.h
@@ -9,7 +9,7 @@
 namespace torch_lazy_tensors {
 namespace tensor_ops {
 
-torch::lazy::LazyTensor Select(const torch::lazy::LazyTensor& input, int64_t dim, int64_t index);
+torch::lazy::LazyTensorPtr Select(const torch::lazy::LazyTensorPtr& input, int64_t dim, int64_t index);
 
 }  // namespace tensor_ops
 }  // namespace torch_lazy_tensors

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -37,7 +37,7 @@ std::pair<torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr> GetBinaryOpera
   torch::lazy::LazyTensorPtr self_tensor;
   torch::lazy::LazyTensorPtr other_tensor;
   auto self_xtensor = torch::lazy::TryGetLtcTensor(self);
-  if (!self_xtensor || self_xtensor->is_null()) {
+  if (!self_xtensor) {
     other_tensor = torch::lazy::TryGetLtcTensor(other);
     self_tensor = GetOrCreateLtcTensor(self, other_tensor->GetDevice());
   } else {
@@ -190,13 +190,13 @@ at::Tensor LazyNativeFunctions::_copy_from(const at::Tensor& self,
     // providing a new 'eager' value (self) for an existing lazy tensor (dst)
     static bool sync_update =
         lazy_tensors::sys_util::GetEnvBool("XLA_TENSOR_UPDATE_SYNC", true);
-    CHECK(dst_tensor && *dst_tensor);
+    CHECK(dst_tensor);
     dst_tensor->UpdateFromTensor(self, /*sync=*/sync_update);
   } else if (!dst_tensor) {
     // materializing a lazy tensor (self) and copying its value into eager tensor (dst)
     // detached=false lets us skip a copy in `ToTensor`, which should be safe
     // becuase we are only going to use the tensor for dst.copy_()
-    CHECK(self_tensor && *self_tensor);
+    CHECK(self_tensor);
     at::Tensor tensor = self_tensor->ToTensor(/*detached=*/false);
     at::Tensor typed_tensor =
         torch::lazy::CopyTensor(tensor, dst.scalar_type(), /*copy=*/false);
@@ -234,10 +234,10 @@ at::Tensor LazyNativeFunctions::_copy_from_and_resize(const at::Tensor& self,
   auto dst_tensor = torch::lazy::TryGetLtcTensor(dst);
   auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   if (!self_tensor) {
-    CHECK(dst_tensor && *dst_tensor);
+    CHECK(dst_tensor);
     dst_tensor->UpdateFromTensorOut(self);
   } else if (!dst_tensor) {
-    CHECK(self_tensor && *self_tensor);
+    CHECK(self_tensor);
     at::Tensor tensor = self_tensor->ToTensor(/*detached=*/true);
     at::Tensor typed_tensor =
         torch::lazy::CopyTensor(tensor, dst.scalar_type(), /*copy=*/false);

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -61,8 +61,8 @@ at::Tensor DoBinaryOp(const at::Tensor& self, const at::Tensor& other,
 template <typename B>
 at::Tensor DoBinaryOp(const at::Tensor& self, const at::Scalar& other,
                       const B& bin_op) {
-  torch::lazy::LazyTensor self_tensor = torch::lazy::GetLtcTensor(self);
-  torch::lazy::LazyTensor result = bin_op(self_tensor, other);
+  torch::lazy::LazyTensorPtr self_tensor = torch::lazy::GetLtcTensor(self);
+  torch::lazy::LazyTensor result = bin_op(*self_tensor, other);
   return torch::lazy::CreateAtenFromLtcTensor(result);
 }
 
@@ -244,7 +244,7 @@ at::Tensor LazyNativeFunctions::_copy_from_and_resize(const at::Tensor& self,
     // at this point we know dst is a lazy tensor
     auto* dest_impl =
         dynamic_cast<torch::lazy::LTCTensorImpl*>(dst.unsafeGetTensorImpl());
-    dest_impl->tensor().UpdateFromTensorOut(self_tensor);
+    dest_impl->tensor()->UpdateFromTensorOut(self_tensor);
     dest_impl->force_refresh_sizes();
   }
   return dst;

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_ltc_ts_type.cpp
@@ -32,29 +32,29 @@ void CheckSubOperandTypes(at::ScalarType type1, at::ScalarType type2) {
          "`logical_not()` operator instead.";
 }
 
-std::pair<torch::lazy::LazyTensor, torch::lazy::LazyTensor> GetBinaryOperands(const at::Tensor& self,
+std::pair<torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr> GetBinaryOperands(const at::Tensor& self,
                                                     const at::Tensor& other) {
-  torch::lazy::LazyTensor self_tensor;
-  torch::lazy::LazyTensor other_tensor;
+  torch::lazy::LazyTensorPtr self_tensor;
+  torch::lazy::LazyTensorPtr other_tensor;
   auto self_xtensor = torch::lazy::TryGetLtcTensor(self);
-  if (!self_xtensor) {
+  if (!self_xtensor || self_xtensor->is_null()) {
     other_tensor = torch::lazy::TryGetLtcTensor(other);
-    self_tensor = GetOrCreateLtcTensor(self, other_tensor.GetDevice());
+    self_tensor = GetOrCreateLtcTensor(self, other_tensor->GetDevice());
   } else {
     self_tensor = self_xtensor;
-    other_tensor = GetOrCreateLtcTensor(other, self_tensor.GetDevice());
+    other_tensor = GetOrCreateLtcTensor(other, self_tensor->GetDevice());
   }
-  return std::pair<torch::lazy::LazyTensor, torch::lazy::LazyTensor>(self_tensor, other_tensor);
+  return std::pair<torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr>(self_tensor, other_tensor);
 }
 
 template <typename B>
 at::Tensor DoBinaryOp(const at::Tensor& self, const at::Tensor& other,
                       const B& bin_op) {
   at::ScalarType dtype = at::result_type(self, other);
-  std::pair<torch::lazy::LazyTensor, torch::lazy::LazyTensor> operands =
+  std::pair<torch::lazy::LazyTensorPtr, torch::lazy::LazyTensorPtr> operands =
       GetBinaryOperands(torch::lazy::UnwrapNumber(self, dtype),
                         torch::lazy::UnwrapNumber(other, dtype));
-  torch::lazy::LazyTensor result = bin_op(operands.first, operands.second);
+  torch::lazy::LazyTensorPtr result = bin_op(operands.first, operands.second);
   return torch::lazy::CreateAtenFromLtcTensor(result);
 }
 
@@ -62,7 +62,7 @@ template <typename B>
 at::Tensor DoBinaryOp(const at::Tensor& self, const at::Scalar& other,
                       const B& bin_op) {
   torch::lazy::LazyTensorPtr self_tensor = torch::lazy::GetLtcTensor(self);
-  torch::lazy::LazyTensor result = bin_op(*self_tensor, other);
+  torch::lazy::LazyTensorPtr result = bin_op(self_tensor, other);
   return torch::lazy::CreateAtenFromLtcTensor(result);
 }
 
@@ -103,7 +103,7 @@ at::Tensor LazyNativeFunctions::as_strided(
     const at::Tensor& self, at::IntArrayRef size, at::IntArrayRef stride,
     c10::optional<int64_t> storage_offset) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  torch::lazy::LazyTensorPtr self_tensor = torch::lazy::TryGetLtcTensor(self);
   auto xsize = torch::lazy::ToI64Vector(size);
   auto xstride = torch::lazy::ToI64Vector(stride);
   if (!torch::lazy::AsStrided::StrideIsSupported(xstride)) {
@@ -119,7 +119,7 @@ const at::Tensor& LazyNativeFunctions::as_strided_(
     const at::Tensor& self, at::IntArrayRef size, at::IntArrayRef stride,
     c10::optional<int64_t> storage_offset) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   auto xsize = torch::lazy::ToI64Vector(size);
   auto xstride = torch::lazy::ToI64Vector(stride);
   if (!torch::lazy::AsStrided::StrideIsSupported(xstride)) {
@@ -140,7 +140,7 @@ at::Tensor LazyNativeFunctions::bernoulli(
                                         ATEN_OP(bernoulli)>::call(self,
                                                                   generator);
   }
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   return torch::lazy::CreateAtenFromLtcTensor(
       lazy_tensor_aten_ops::bernoulli(self_tensor));
 }
@@ -153,7 +153,7 @@ at::Tensor& LazyNativeFunctions::bernoulli_(
         &ltc_eager_fallback, ATEN_OP2(bernoulli_, float)>::call(self, p,
                                                                 generator);
   }
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   lazy_tensor_aten_ops::bernoulli_(self_tensor, p);
   return self;
 }
@@ -164,20 +164,20 @@ at::Tensor LazyNativeFunctions::cat(at::TensorList tensors, int64_t dim) {
   std::vector<torch::lazy::Value> values;
   values.reserve(lazy_tensors.size());
   for (auto& tensor : lazy_tensors) {
-    values.emplace_back(tensor.GetIrValue());
+    values.emplace_back(tensor->GetIrValue());
   }
 
   auto shapes = torch::lazy::compute_shape_cat(tensors, dim);
   auto node =
       torch::lazy::MakeNode<ir::ops::Cat>(values, dim, std::move(shapes));
   auto result = torch::lazy::CreateAtenFromLtcTensor(
-      torch::lazy::LazyTensor::Create(torch::lazy::Value(node, 0), lazy_tensors[0].GetDevice()));
+      torch::lazy::LazyTensor::Create(torch::lazy::Value(node, 0), lazy_tensors[0]->GetDevice()));
   return result;
 }
 
 at::Tensor LazyNativeFunctions::clone(const at::Tensor & self, c10::optional<at::MemoryFormat> memory_format) {
   auto self_lt = torch::lazy::TryGetLtcTensor(self);
-  return torch::lazy::CreateAtenFromLtcTensor(self_lt.Create(self_lt.GetIrValue(), self_lt.GetDevice()));
+  return torch::lazy::CreateAtenFromLtcTensor(self_lt->Create(self_lt->GetIrValue(), self_lt->GetDevice()));
 }
 
 at::Tensor LazyNativeFunctions::_copy_from(const at::Tensor& self,
@@ -190,24 +190,25 @@ at::Tensor LazyNativeFunctions::_copy_from(const at::Tensor& self,
     // providing a new 'eager' value (self) for an existing lazy tensor (dst)
     static bool sync_update =
         lazy_tensors::sys_util::GetEnvBool("XLA_TENSOR_UPDATE_SYNC", true);
-    CHECK(dst_tensor);
-    dst_tensor.UpdateFromTensor(self, /*sync=*/sync_update);
+    CHECK(dst_tensor && *dst_tensor);
+    dst_tensor->UpdateFromTensor(self, /*sync=*/sync_update);
   } else if (!dst_tensor) {
     // materializing a lazy tensor (self) and copying its value into eager tensor (dst)
     // detached=false lets us skip a copy in `ToTensor`, which should be safe
     // becuase we are only going to use the tensor for dst.copy_()
-    at::Tensor tensor = self_tensor.ToTensor(/*detached=*/false);
+    CHECK(self_tensor && *self_tensor);
+    at::Tensor tensor = self_tensor->ToTensor(/*detached=*/false);
     at::Tensor typed_tensor =
         torch::lazy::CopyTensor(tensor, dst.scalar_type(), /*copy=*/false);
     dst.resize_as_(typed_tensor).copy_(typed_tensor);
   } else {
     // Copying one lazy tensor to another
-    if (!dst_tensor.CurrentIrValue()) {
+    if (!dst_tensor->CurrentIrValue()) {
       // if dest is not backed by IR (e.g. result of some lazy operation),
       // then it should have at::Tensor data backing it instead
-      auto dst_tensor_data = dst_tensor.CurrentTensorData();
+      auto dst_tensor_data = dst_tensor->CurrentTensorData();
       CHECK(dst_tensor_data);
-      auto src_tensor_data = self_tensor.CurrentTensorData();
+      auto src_tensor_data = self_tensor->CurrentTensorData();
       if (src_tensor_data) {
         // both src/dst are simply backed by at::Tensor data, no IR- do a straightforward copy
         dst_tensor_data->copy_(*src_tensor_data);
@@ -216,7 +217,7 @@ at::Tensor LazyNativeFunctions::_copy_from(const at::Tensor& self,
         // since we use the src tensor only for making a copy, we don't need to detach it
         // note: it would be even more efficient if we could cause ToTensor to materialize the
         // value directly into dst's buffer (that would need to be detached though).
-        dst_tensor_data->copy_(self_tensor.ToTensor(/*detached=*/false));
+        dst_tensor_data->copy_(self_tensor->ToTensor(/*detached=*/false));
       }
     } else {
       lazy_tensor_aten_ops::copy_(dst_tensor, self_tensor);
@@ -233,10 +234,11 @@ at::Tensor LazyNativeFunctions::_copy_from_and_resize(const at::Tensor& self,
   auto dst_tensor = torch::lazy::TryGetLtcTensor(dst);
   auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   if (!self_tensor) {
-    CHECK(dst_tensor);
-    dst_tensor.UpdateFromTensorOut(self);
+    CHECK(dst_tensor && *dst_tensor);
+    dst_tensor->UpdateFromTensorOut(self);
   } else if (!dst_tensor) {
-    at::Tensor tensor = self_tensor.ToTensor(/*detached=*/true);
+    CHECK(self_tensor && *self_tensor);
+    at::Tensor tensor = self_tensor->ToTensor(/*detached=*/true);
     at::Tensor typed_tensor =
         torch::lazy::CopyTensor(tensor, dst.scalar_type(), /*copy=*/false);
     dst.resize_as_(typed_tensor).copy_(typed_tensor);
@@ -285,7 +287,7 @@ at::Tensor LazyNativeFunctions::expand(const at::Tensor& self,
 at::Tensor& LazyNativeFunctions::fill_(at::Tensor& self,
                                        const at::Scalar& value) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   lazy_tensor_aten_ops::fill_(self_tensor, value);
   return self;
 }
@@ -305,11 +307,11 @@ LazyNativeFunctions::native_batch_norm(
     const c10::optional<at::Tensor>& running_var, bool training,
     double momentum, double eps) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor input_tensor = torch::lazy::TryGetLtcTensor(input);
-  const torch::lazy::BackendDevice& device = input_tensor.GetDevice();
-  torch::lazy::LazyTensor running_mean_tensor =
+  auto input_tensor = torch::lazy::TryGetLtcTensor(input);
+  const torch::lazy::BackendDevice& device = input_tensor->GetDevice();
+  auto running_mean_tensor =
       GetOrCreateLtcTensor(running_mean, device);
-  torch::lazy::LazyTensor running_var_tensor =
+  auto running_var_tensor =
       GetOrCreateLtcTensor(running_var, device);
   auto outputs = lazy_tensor_aten_ops::ts_native_batch_norm(
       torch::lazy::TryGetLtcTensor(input), GetOrCreateLtcTensor(weight, device),
@@ -330,9 +332,9 @@ LazyNativeFunctions::native_batch_norm_backward(
     const c10::optional<at::Tensor>& save_invstd, bool train, double eps,
     std::array<bool, 3> output_mask) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor grad_out_tensor = torch::lazy::TryGetLtcTensor(grad_out);
-  const torch::lazy::BackendDevice& device = grad_out_tensor.GetDevice();
-  torch::lazy::LazyTensor null_tensor;
+  auto grad_out_tensor = torch::lazy::TryGetLtcTensor(grad_out);
+  const torch::lazy::BackendDevice& device = grad_out_tensor->GetDevice();
+  torch::lazy::LazyTensorPtr null_tensor;
   bool running_stats = running_mean && running_mean->defined();
   CHECK_EQ(running_var && running_var->defined(), running_stats);
   auto gradients = lazy_tensor_aten_ops::ts_native_batch_norm_backward(
@@ -408,7 +410,7 @@ at::Tensor & LazyNativeFunctions::normal_(at::Tensor & self, double mean, double
 at::Tensor LazyNativeFunctions::permute(const at::Tensor& self,
                                         at::IntArrayRef dims) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   return torch::lazy::CreateAtenFromLtcTensor(lazy_tensor_aten_ops::permute(
       self_tensor, torch::lazy::ToI64Vector(dims)));
 }
@@ -425,8 +427,8 @@ at::Tensor& LazyNativeFunctions::random_(
   }
 
   auto selfTensor = torch::lazy::TryGetLtcTensor(self);
-  selfTensor.SetInPlaceIrValue(torch::lazy::MakeNode<ir::ops::Random>(
-      selfTensor.GetIrValue(), from, to));
+  selfTensor->SetInPlaceIrValue(torch::lazy::MakeNode<ir::ops::Random>(
+      selfTensor->GetIrValue(), from, to));
   return self;
 }
 
@@ -441,8 +443,8 @@ at::Tensor& LazyNativeFunctions::random_(
   }
 
   auto selfTensor = torch::lazy::TryGetLtcTensor(self);
-  selfTensor.SetInPlaceIrValue(torch::lazy::MakeNode<ir::ops::Random>(
-      selfTensor.GetIrValue(), c10::nullopt, to));
+  selfTensor->SetInPlaceIrValue(torch::lazy::MakeNode<ir::ops::Random>(
+      selfTensor->GetIrValue(), c10::nullopt, to));
   return self;
 }
 
@@ -457,8 +459,8 @@ at::Tensor& LazyNativeFunctions::random_(
   }
 
   auto selfTensor = torch::lazy::TryGetLtcTensor(self);
-  selfTensor.SetInPlaceIrValue(torch::lazy::MakeNode<ir::ops::Random>(
-      selfTensor.GetIrValue(), c10::nullopt, c10::nullopt));
+  selfTensor->SetInPlaceIrValue(torch::lazy::MakeNode<ir::ops::Random>(
+      selfTensor->GetIrValue(), c10::nullopt, c10::nullopt));
   return self;
 }
 
@@ -507,14 +509,14 @@ at::Tensor LazyNativeFunctions::squeeze(const at::Tensor& self, int64_t dim) {
 
 at::Tensor& LazyNativeFunctions::squeeze_(at::Tensor& self) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   lazy_tensor_aten_ops::squeeze_(self_tensor);
   return self;
 }
 
 at::Tensor& LazyNativeFunctions::squeeze_(at::Tensor& self, int64_t dim) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   lazy_tensor_aten_ops::squeeze_(self_tensor, dim);
   return self;
 }
@@ -526,7 +528,7 @@ at::Tensor LazyNativeFunctions::sub(const at::Tensor& self,
   CheckSubOperandTypes(self.scalar_type(), other.scalar_type());
   at::native::alpha_check(at::result_type(self, other), alpha);
   return DoBinaryOp(self, other,
-                    [&](const torch::lazy::LazyTensor& xself, const torch::lazy::LazyTensor& xother) {
+                    [&](const torch::lazy::LazyTensorPtr& xself, const torch::lazy::LazyTensorPtr& xother) {
                       return lazy_tensor_aten_ops::sub(xself, xother, alpha);
                     });
 }
@@ -537,7 +539,7 @@ at::Tensor LazyNativeFunctions::sub(const at::Tensor& self,
   TORCH_LAZY_FN_COUNTER("lazy::");
   CheckSubOperandTypes(self.scalar_type(), other.type());
   return DoBinaryOp(self, other,
-                    [&](const torch::lazy::LazyTensor& xself, const at::Scalar& other) {
+                    [&](const torch::lazy::LazyTensorPtr& xself, const at::Scalar& other) {
                       return lazy_tensor_aten_ops::sub(xself, other, alpha);
                     });
 }
@@ -550,7 +552,7 @@ at::Tensor LazyNativeFunctions::t(const at::Tensor& self) {
 
 at::Tensor& LazyNativeFunctions::t_(at::Tensor& self) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   lazy_tensor_aten_ops::transpose_(self_tensor, 0, 1);
   return self;
 }
@@ -565,7 +567,7 @@ at::Tensor LazyNativeFunctions::transpose(const at::Tensor& self, int64_t dim0,
 at::Tensor& LazyNativeFunctions::transpose_(at::Tensor& self, int64_t dim0,
                                             int64_t dim1) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   lazy_tensor_aten_ops::transpose_(self_tensor, dim0, dim1);
   return self;
 }
@@ -578,7 +580,7 @@ at::Tensor LazyNativeFunctions::unsqueeze(const at::Tensor& self, int64_t dim) {
 
 at::Tensor& LazyNativeFunctions::unsqueeze_(at::Tensor& self, int64_t dim) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   lazy_tensor_aten_ops::unsqueeze_(self_tensor, dim);
   return self;
 }
@@ -586,7 +588,7 @@ at::Tensor& LazyNativeFunctions::unsqueeze_(at::Tensor& self, int64_t dim) {
 at::Tensor LazyNativeFunctions::view(const at::Tensor& self,
                                      at::IntArrayRef size) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   return torch::lazy::CreateAtenFromLtcTensor(
       lazy_tensor_aten_ops::view(self_tensor, torch::lazy::ToI64Vector(size)));
 }
@@ -594,7 +596,7 @@ at::Tensor LazyNativeFunctions::view(const at::Tensor& self,
 at::Tensor LazyNativeFunctions::_unsafe_view(const at::Tensor& self,
                                      at::IntArrayRef size) {
   TORCH_LAZY_FN_COUNTER("lazy::");
-  torch::lazy::LazyTensor self_tensor = torch::lazy::TryGetLtcTensor(self);
+  auto self_tensor = torch::lazy::TryGetLtcTensor(self);
   return torch::lazy::CreateAtenFromLtcTensor(
       lazy_tensor_aten_ops::view(self_tensor, torch::lazy::ToI64Vector(size)));
 }

--- a/lazy_tensor_core/test/cpp/cpp_test_util.cpp
+++ b/lazy_tensor_core/test/cpp/cpp_test_util.cpp
@@ -168,13 +168,13 @@ bool CloseValues(at::Tensor tensor1, at::Tensor tensor2, double rtol,
 }
 
 std::string GetTensorTextGraph(at::Tensor tensor) {
-  torch::lazy::LazyTensor xtensor = torch::lazy::TryGetLtcTensor(tensor);
-  return torch::lazy::DumpUtil::ToText({xtensor.GetIrValue().node.get()});
+  torch::lazy::LazyTensorPtr lazy_tensor = torch::lazy::TryGetLtcTensor(tensor);
+  return torch::lazy::DumpUtil::ToText({lazy_tensor->GetIrValue().node.get()});
 }
 
 std::string GetTensorDotGraph(at::Tensor tensor) {
-  torch::lazy::LazyTensor xtensor = torch::lazy::TryGetLtcTensor(tensor);
-  return torch::lazy::DumpUtil::ToDot({xtensor.GetIrValue().node.get()});
+  torch::lazy::LazyTensorPtr lazy_tensor = torch::lazy::TryGetLtcTensor(tensor);
+  return torch::lazy::DumpUtil::ToDot({lazy_tensor->GetIrValue().node.get()});
 }
 
 void TestBackward(

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -21,14 +21,14 @@ def node_ctor_arg_rvalue_string(arg: NamedCType, schema: LazyIrSchema) -> str:
         if isinstance(arg.type, BaseCType):
             if arg.name in schema.wrapped_scalar_names:
                 return f"torch::lazy::LazyGraphExecutor::Get()->GetIrValueForScalarFromCodegen({arg.name})"
-            return f"lazy_{arg.name}.GetIrValue()"
+            return f"lazy_{arg.name}->GetIrValue()"
         elif isinstance(arg.type, OptionalCType):
             if arg.name in schema.wrapped_scalar_names:
                 return f"{arg.name} ? " \
                     f"c10::make_optional(torch::lazy::LazyGraphExecutor::Get()->GetIrValueForScalarFromCodegen(*{arg.name})) : " \
                     "c10::nullopt"
             return f"lazy_{arg.name} ? " \
-                   f"c10::make_optional(lazy_{arg.name}.GetIrValue()) : " \
+                   f"c10::make_optional(lazy_{arg.name}->GetIrValue()) : " \
                    "c10::nullopt"
         else:
             raise AssertionError("TODO not sure if there are other valid types to handle here")
@@ -182,13 +182,13 @@ def lazy_tensor_decls(value_types: List[NamedCType], tensor_class: str, schema: 
             continue
         if isinstance(t.type, BaseCType):
             lazy_tensor_decls.append(
-                f"{tensor_class} lazy_{t.name} = "
+                f"{tensor_class}Ptr lazy_{t.name} = "
                 f"torch::lazy::GetLtcTensorOrCreateForWrappedNumber({t.name}, *common_device);")
         elif isinstance(t.type, OptionalCType):
             # TODO(alanwaketan): Maybe we want to apply GetLtcTensorOrCreateForWrappedNumber here, but hold it
             # until we encounter a real world example.
             lazy_tensor_decls.append(
-                f"    {tensor_class} lazy_{t.name} = torch::lazy::TryGetLtcTensor({t.name}.value_or(at::Tensor()));")
+                f"    {tensor_class}Ptr lazy_{t.name} = torch::lazy::TryGetLtcTensor({t.name}.value_or(at::Tensor()));")
         else:
             raise AssertionError("TODO not sure if there are other valid types to handle here")
     return ("\n        ").join(lazy_tensor_decls)
@@ -247,7 +247,7 @@ class GenLazyNativeFuncDefinition:
                 torch::lazy::LazyTensor::Create(std::move(node), *common_device));"""
 
         if returns_length > 1:
-            bridge_str = f"""std::vector<{self.tensor_class}> lazy_tensors;
+            bridge_str = f"""std::vector<{self.tensor_class}Ptr> lazy_tensors;
         for (int i = 0; i < {returns_length}; i++) {{
             lazy_tensors.push_back(torch::lazy::LazyTensor::Create(torch::lazy::Value(node, i), *common_device));
         }}
@@ -256,7 +256,7 @@ class GenLazyNativeFuncDefinition:
         if schema.name.name.inplace or func.func.is_out_fn():
             assert returns_length == 1, "We assumed there was no such case where an op is an in-place variant " \
                                         "and has tuple outputs."
-            bridge_str = f"""lazy_{first_tensor_name}.SetInPlaceIrValue(node);
+            bridge_str = f"""lazy_{first_tensor_name}->SetInPlaceIrValue(node);
         auto& result = {first_tensor_name};"""
 
 

--- a/torch/csrc/lazy/backend/backend_device.cpp
+++ b/torch/csrc/lazy/backend/backend_device.cpp
@@ -56,7 +56,9 @@ c10::Device backendDeviceToAtenDevice(const BackendDevice& device) {
 
 c10::optional<BackendDevice> GetBackendDevice(const at::Tensor& tensor) {
   if (auto lt = TryGetLtcTensor(tensor)) {
-    return lt.GetDevice();
+    if (*lt) {
+      return lt->GetDevice();
+    }
   }
   return c10::nullopt;
 }

--- a/torch/csrc/lazy/backend/backend_device.cpp
+++ b/torch/csrc/lazy/backend/backend_device.cpp
@@ -56,9 +56,7 @@ c10::Device backendDeviceToAtenDevice(const BackendDevice& device) {
 
 c10::optional<BackendDevice> GetBackendDevice(const at::Tensor& tensor) {
   if (auto lt = TryGetLtcTensor(tensor)) {
-    if (*lt) {
-      return lt->GetDevice();
-    }
+    return lt->GetDevice();
   }
   return c10::nullopt;
 }

--- a/torch/csrc/lazy/core/debug_util.cpp
+++ b/torch/csrc/lazy/core/debug_util.cpp
@@ -86,7 +86,7 @@ std::string GetFirstUserFrameInPython() {
   return empty;
 }
 
-std::string DebugUtil::GetTensorsGraphInfo(c10::ArrayRef<torch::lazy::LazyTensor> tensors,
+std::string DebugUtil::GetTensorsGraphInfo(c10::ArrayRef<torch::lazy::LazyTensorPtr> tensors,
                                            const std::vector<size_t>* indices,
                                            GraphFormat format) {
   std::vector<torch::lazy::Node*> root_nodes;
@@ -95,23 +95,23 @@ std::string DebugUtil::GetTensorsGraphInfo(c10::ArrayRef<torch::lazy::LazyTensor
   torch::lazy::Unique<torch::lazy::BackendDevice> unique_device;
   if (indices != nullptr) {
     for (auto index : *indices) {
-      const torch::lazy::LazyTensor& tensor = tensors[index];
-      torch::lazy::Value ir_value = tensor.CurrentIrValue();
+      const torch::lazy::LazyTensorPtr& tensor = tensors[index];
+      torch::lazy::Value ir_value = tensor->CurrentIrValue();
       if (ir_value) {
         root_nodes.push_back(ir_value.node.get());
         root_hashes.push_back(ir_value.hash());
         root_values.push_back(std::move(ir_value));
-        unique_device.set(tensor.GetDevice());
+        unique_device.set(tensor->GetDevice());
       }
     }
   } else {
     for (auto& tensor : tensors) {
-      torch::lazy::Value ir_value = tensor.CurrentIrValue();
+      torch::lazy::Value ir_value = tensor->CurrentIrValue();
       if (ir_value) {
         root_nodes.push_back(ir_value.node.get());
         root_hashes.push_back(ir_value.hash());
         root_values.push_back(std::move(ir_value));
-        unique_device.set(tensor.GetDevice());
+        unique_device.set(tensor->GetDevice());
       }
     }
   }
@@ -149,7 +149,7 @@ std::string DebugUtil::GetTensorsGraphInfo(c10::ArrayRef<torch::lazy::LazyTensor
 }
 
 void DebugUtil::SaveTensorsGraphInfo(const char* name,
-                                     c10::ArrayRef<torch::lazy::LazyTensor> tensors,
+                                     c10::ArrayRef<torch::lazy::LazyTensorPtr> tensors,
                                      const std::vector<size_t>* indices,
                                      GraphFormat format) {
   static const std::string save_file = GetEnvString("LTC_SAVE_TENSORS_FILE", "");

--- a/torch/csrc/lazy/core/debug_util.h
+++ b/torch/csrc/lazy/core/debug_util.h
@@ -27,14 +27,14 @@ class TORCH_API DebugUtil {
   // values held at the tensors. If indices is not nullptr, it selects the
   // indices of the tensors whose graph will be emitted.
   static std::string GetTensorsGraphInfo(
-      c10::ArrayRef<torch::lazy::LazyTensor> tensors, const std::vector<size_t>* indices,
+      c10::ArrayRef<torch::lazy::LazyTensorPtr> tensors, const std::vector<size_t>* indices,
       GraphFormat format = GetDefaultGraphFormat());
 
   // If the environment variable LTC_SAVE_TENSORS_FILE is set to the proper
   // output path, an instance of the report returned by GetTensorsGraphInfo() is
   // saved.
   static void SaveTensorsGraphInfo(
-      const char* name, c10::ArrayRef<torch::lazy::LazyTensor> tensors,
+      const char* name, c10::ArrayRef<torch::lazy::LazyTensorPtr> tensors,
       const std::vector<size_t>* indices,
       GraphFormat format = GetDefaultGraphFormat());
 

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -266,8 +266,8 @@ class DeviceContextArena {
     TORCH_LAZY_COUNTER("DestroyLtcTensor", 1);
   }
 
-  std::vector<LazyTensor> GetLiveTensors(const BackendDevice* device) {
-    std::vector<LazyTensor> tensors;
+  std::vector<LazyTensorPtr> GetLiveTensors(const BackendDevice* device) {
+    std::vector<LazyTensorPtr> tensors;
     auto fn = [&](DeviceContext* devctx) {
       std::lock_guard<std::mutex> lock(devctx->lock);
       for (auto& uid_wptr : devctx->tensors_data) {
@@ -386,9 +386,9 @@ bool ShouldSyncIrValue(const Value& ir_value) {
 
 // Return true if no tensor in the list has an underlying IR (leaf or
 // operation).
-bool TensorsHaveIR(const std::vector<LazyTensor>& tensors) {
+bool TensorsHaveIR(const std::vector<LazyTensorPtr>& tensors) {
   for (const auto& tensor : tensors) {
-    if (tensor.CurrentDataHandle() || tensor.CurrentIrValue()) {
+    if (tensor->CurrentDataHandle() || tensor->CurrentIrValue()) {
       return true;
     }
   }
@@ -439,7 +439,7 @@ BackendDataPtr LazyGraphExecutor::GetDeviceData(
   return DataCacheArena::Get()->GetDeviceData(value, scalar_type, device);
 }
 
-std::vector<LazyTensor> LazyGraphExecutor::GetLiveTensors(
+std::vector<LazyTensorPtr> LazyGraphExecutor::GetLiveTensors(
     const BackendDevice* device) {
   return DeviceContextArena::Get()->GetLiveTensors(device);
 }
@@ -455,7 +455,7 @@ void LazyGraphExecutor::SyncLiveTensorsGraph(
 }
 
 void LazyGraphExecutor::SyncTensorsGraph(
-    std::vector<LazyTensor>* tensors,
+    std::vector<LazyTensorPtr>* tensors,
     c10::ArrayRef<std::string> devices,
     bool wait,
     bool sync_ltc_data) {
@@ -496,7 +496,7 @@ void LazyGraphExecutor::WaitDeviceOps(c10::ArrayRef<BackendDevice> devices) {
 }
 
 std::vector<at::Tensor> LazyGraphExecutor::GetTensors(
-    std::vector<LazyTensor>* tensors) {
+    std::vector<LazyTensorPtr>* tensors) {
   VLOG(4) << "Trying to get the value of " << tensors->size() << " tensor(s)";
   return GetTensorsFused(tensors);
 }
@@ -506,10 +506,10 @@ size_t LazyGraphExecutor::IncTrimCounter() {
 }
 
 std::string LazyGraphExecutor::DumpBackendComputation(
-    const std::vector<LazyTensor>& tensors) {
+    const std::vector<LazyTensorPtr>& tensors) {
   std::vector<Value> ir_values;
   for (auto& tensor : tensors) {
-    Value ir_value = tensor.CurrentIrValue();
+    Value ir_value = tensor->CurrentIrValue();
     if (ir_value) {
       ir_values.push_back(std::move(ir_value));
     }
@@ -603,11 +603,11 @@ void LazyGraphExecutor::Async::Wait() {
 }
 
 LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     const SyncTensorsConfig& config) {
   Unique<BackendDevice> unique_device;
   for (const auto& tensor : tensors) {
-    unique_device.set(tensor.GetDevice());
+    unique_device.set(tensor->GetDevice());
   }
   SyncTensorCollection coll;
   if (!unique_device) {
@@ -635,9 +635,9 @@ LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
   }
   VLOG(4) << "Waiting on device barrier for device " << coll.device << " done!";
   for (const auto i : c10::irange(tensors.size())) {
-    if (tensor_ids.insert(tensors[i].GetUniqueId()).second &&
-        tensors[i].CurrentDataHandle() == nullptr) {
-      Value ir_value = tensors[i].CurrentIrValue();
+    if (tensor_ids.insert(tensors[i]->GetUniqueId()).second &&
+        tensors[i]->CurrentDataHandle() == nullptr) {
+      Value ir_value = tensors[i]->CurrentIrValue();
       if (ir_value) {
         if (ShouldSyncIrValue(ir_value)) {
           // Add only tensors which need to be synced.
@@ -647,10 +647,10 @@ LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
       } else if (config.force_ltc_data) {
         // The tensor only has at::Tensor data. We need to queue it for a
         // device upload.
-        c10::optional<at::Tensor> tensor_data = tensors[i].CurrentTensorData();
+        c10::optional<at::Tensor> tensor_data = tensors[i]->CurrentTensorData();
         TORCH_CHECK(tensor_data);
         at_tensors.push_back(*tensor_data);
-        devices.push_back(tensors[i].GetDevice());
+        devices.push_back(tensors[i]->GetDevice());
         at_tensor_index.push_back(i);
       }
     }
@@ -664,7 +664,7 @@ LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
       // present. Also, we uploaded the at::Tensor data to the device, but such
       // data is still valid so we leave it live on the lazy tensor (so that a
       // following ToTensor() does not need to fetch it from device).
-      tensors[at_tensor_index[i]].data()->handle = std::move(handles[i]);
+      tensors[at_tensor_index[i]]->data()->handle = std::move(handles[i]);
     }
   }
   VLOG(4) << "Tensors graph hash " << HashToString(coll.hash) << " on device "
@@ -673,24 +673,24 @@ LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
 }
 
 std::vector<Value> LazyGraphExecutor::CollectRoots(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     c10::ArrayRef<size_t> indices) {
   std::vector<Value> roots;
   roots.reserve(indices.size());
   for (auto index : indices) {
-    roots.push_back(tensors.at(index).CurrentIrValue());
+    roots.push_back(tensors.at(index)->CurrentIrValue());
   }
   return roots;
 }
 
 std::vector<BackendDataPtr> LazyGraphExecutor::FetchTensorData(
-    std::vector<LazyTensor>* tensors,
+    std::vector<LazyTensorPtr>* tensors,
     const SyncTensorsConfig& config,
     c10::ArrayRef<size_t> indices) {
   std::vector<BackendDataPtr> tensors_data;
   tensors_data.reserve(indices.size());
   for (auto index : indices) {
-    LazyTensor& tensor = (*tensors)[index];
+    LazyTensorPtr& tensor = (*tensors)[index];
     // If the config.force_ltc_data flag is true, the purpose of this tensor
     // sync operation is to truncate the IR graph and materialize device data in
     // place of IR graph, on selected tensors. But since operation will complete
@@ -700,12 +700,12 @@ std::vector<BackendDataPtr> LazyGraphExecutor::FetchTensorData(
     // into the async variable), any other operation trying to access the
     // tensor's device data will have to wait until the asynchronous operation
     // completes.
-    BackendDataPtr handle = tensor.CurrentDataHandle();
+    BackendDataPtr handle = tensor->CurrentDataHandle();
     if (handle == nullptr && config.force_ltc_data) {
-      const BackendDevice& tensor_device = tensor.GetDevice();
+      const BackendDevice& tensor_device = tensor->GetDevice();
       handle = getBackend()->CreateDataPlaceholder(
-          tensor_device, std::move(tensor.shape()));
-      tensor.SetDataHandle(handle, config.sync_ltc_data);
+          tensor_device, std::move(tensor->shape()));
+      tensor->SetDataHandle(handle, config.sync_ltc_data);
     }
     tensors_data.emplace_back(std::move(handle));
   }
@@ -713,12 +713,12 @@ std::vector<BackendDataPtr> LazyGraphExecutor::FetchTensorData(
 }
 
 LazyGraphExecutor::PostOrderData LazyGraphExecutor::RunPostOrder(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     c10::ArrayRef<size_t> indices) {
   std::vector<Node*> roots;
   roots.reserve(indices.size());
   for (auto index : indices) {
-    Value ir_value = tensors.at(index).CurrentIrValue();
+    Value ir_value = tensors.at(index)->CurrentIrValue();
     roots.push_back(ir_value.node.get());
   }
   PostOrderData po_data;
@@ -742,7 +742,7 @@ LazyGraphExecutor::PostOrderData LazyGraphExecutor::RunPostOrder(
 }
 
 std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::TryRunCachedSync(
-    std::vector<LazyTensor>* tensors,
+    std::vector<LazyTensorPtr>* tensors,
     SyncTensorCollection* coll,
     PostOrderData* po_data) {
   ComputationCache::TypePtr cached_computation =
@@ -761,7 +761,7 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::TryRunCachedSync(
 }
 
 LazyGraphExecutor::CompilationResult LazyGraphExecutor::Compile(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     c10::ArrayRef<std::string> devices,
     const SyncTensorCollection& coll,
     PostOrderData* po_data) {
@@ -771,7 +771,7 @@ LazyGraphExecutor::CompilationResult LazyGraphExecutor::Compile(
       po_data->post_order,
       std::move(po_data->emission_map));
   for (auto index : coll.indices) {
-    Value ir_value = tensors[index].CurrentIrValue();
+    Value ir_value = tensors[index]->CurrentIrValue();
     lowering_ctx->AddResult(ir_value);
   }
   if (FLAGS_torch_lazy_param_aliasing && coll.config.sync_ltc_data) {
@@ -848,13 +848,13 @@ typedef SSIZE_T ssize_t;
 #endif
 
 void LazyGraphExecutor::BuildInputOutputAliases(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     c10::ArrayRef<size_t> indices,
     LoweringContext* lowering_ctx) {
   std::unordered_map<int64_t, size_t> output_tensor_id_map;
   for (const auto i : c10::irange(indices.size())) {
     size_t tensor_index = indices[i];
-    int64_t tensor_id = tensors[tensor_index].GetUniqueId();
+    int64_t tensor_id = tensors[tensor_index]->GetUniqueId();
     output_tensor_id_map[tensor_id] = i;
   }
   const std::vector<BackendDataPtr>& parameters_data =
@@ -886,7 +886,7 @@ void LazyGraphExecutor::BuildInputOutputAliases(
 
 std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
     SyncTensorsGraphInternal(
-        std::vector<LazyTensor>* tensors,
+        std::vector<LazyTensorPtr>* tensors,
         c10::ArrayRef<std::string> devices,
         const SyncTensorsConfig& config) {
   SyncTensorCollection coll = CollectSyncTensors(*tensors, config);
@@ -988,7 +988,7 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
 
 std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
     ScheduleSyncTensorsGraph(
-        std::vector<LazyTensor>* tensors,
+        std::vector<LazyTensorPtr>* tensors,
         SyncTensorCollection* coll,
         std::vector<BackendDataPtr> parameters_data,
         ComputationCache::TypePtr cached_computation) {
@@ -1001,7 +1001,7 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
 }
 
 std::vector<at::Tensor> LazyGraphExecutor::GetTensorsFused(
-    std::vector<LazyTensor>* tensors) {
+    std::vector<LazyTensorPtr>* tensors) {
   SyncTensorsConfig config;
   config.force_ltc_data = false;
   auto async = SyncTensorsGraphInternal(tensors, {}, config);
@@ -1027,7 +1027,7 @@ std::vector<at::Tensor> LazyGraphExecutor::GetTensorsFused(
 // 'PopulateTensor' method on backend, which can either attach an existing
 // tensor buffer to the wrapper, or copy data?
 std::vector<at::Tensor> LazyGraphExecutor::FetchTensors(
-    std::vector<LazyTensor>* tensors,
+    std::vector<LazyTensorPtr>* tensors,
     c10::ArrayRef<BackendDataPtr> tensors_data,
     const std::vector<size_t>* indices) {
   std::vector<at::Tensor> results;
@@ -1038,17 +1038,17 @@ std::vector<at::Tensor> LazyGraphExecutor::FetchTensors(
     if (indices != nullptr && sync_index < indices->size() &&
         i == (*indices)[sync_index]) {
       results.push_back(getBackend()->MakeTensorFromComputationData(
-          tensors_data[literals_index], (*tensors)[i].dtype()));
+          tensors_data[literals_index], (*tensors)[i]->dtype()));
       ++literals_index;
       ++sync_index;
     } else {
-      c10::optional<at::Tensor> tensor_data = (*tensors)[i].CurrentTensorData();
+      c10::optional<at::Tensor> tensor_data = (*tensors)[i]->CurrentTensorData();
       if (tensor_data) {
         results.push_back(*tensor_data);
       } else {
         TORCH_CHECK(literals_index < tensors_data.size());
         results.push_back(getBackend()->MakeTensorFromComputationData(
-            tensors_data[literals_index], (*tensors)[i].dtype()));
+            tensors_data[literals_index], (*tensors)[i]->dtype()));
         ++literals_index;
       }
     }
@@ -1057,14 +1057,14 @@ std::vector<at::Tensor> LazyGraphExecutor::FetchTensors(
 }
 
 std::vector<BackendDataPtr> LazyGraphExecutor::GatherTensorsData(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     c10::ArrayRef<size_t> indices,
     c10::ArrayRef<BackendDataPtr> tensors_data) {
   std::vector<BackendDataPtr> result_tensors_data;
   std::unordered_map<int64_t, size_t> uid_index_map;
   size_t indices_index = 0;
   for (const auto i : c10::irange(tensors.size())) {
-    int64_t tensor_id = tensors[i].GetUniqueId();
+    int64_t tensor_id = tensors[i]->GetUniqueId();
     auto it = uid_index_map.find(tensor_id);
     if (it != uid_index_map.end()) {
       // Current tensor is a duplicate of a previously processed tensor that had
@@ -1077,8 +1077,8 @@ std::vector<BackendDataPtr> LazyGraphExecutor::GatherTensorsData(
       uid_index_map.emplace(tensor_id, result_tensors_data.size());
       result_tensors_data.push_back(tensors_data[indices_index]);
       ++indices_index;
-    } else if (!tensors[i].CurrentTensorData()) {
-      BackendDataPtr handle = tensors[i].CurrentDataHandle();
+    } else if (!tensors[i]->CurrentTensorData()) {
+      BackendDataPtr handle = tensors[i]->CurrentDataHandle();
       TORCH_CHECK(handle != nullptr);
       result_tensors_data.push_back(std::move(handle));
     }

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -46,7 +46,7 @@ class TORCH_API LazyGraphExecutor {
   // for the given device. If device is nullptr, the live tensors for all
   // devices will be returned. Returned tensors are sorted by device as primary
   // key, and by unique ID as secondary key.
-  std::vector<LazyTensor> GetLiveTensors(const BackendDevice* device);
+  std::vector<LazyTensorPtr> GetLiveTensors(const BackendDevice* device);
 
   // Makes sure that any outstanding IR operation accumulated over live tensors,
   // gets turned into device data. If wait is true, the sync operation will be
@@ -62,7 +62,7 @@ class TORCH_API LazyGraphExecutor {
   // will be run synchronously. The devices argument, if not empty, tells the
   // devices which should be partecipating into the replicated computation.
   void SyncTensorsGraph(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       c10::ArrayRef<std::string> devices,
       bool wait,
       bool sync_ltc_data);
@@ -77,13 +77,13 @@ class TORCH_API LazyGraphExecutor {
 
   // Retrieves the PyTorch CPU tensors behind the lazy tensors IR operations.
   // All the tensors must be on the same device.
-  std::vector<at::Tensor> GetTensors(std::vector<LazyTensor>* tensors);
+  std::vector<at::Tensor> GetTensors(std::vector<LazyTensorPtr>* tensors);
 
   size_t IncTrimCounter();
 
   // Dumps the backend specific text of the computation accumulated in the graph
   // which is attached the tensors.
-  std::string DumpBackendComputation(const std::vector<LazyTensor>& tensors);
+  std::string DumpBackendComputation(const std::vector<LazyTensorPtr>& tensors);
 
   Value GetDeviceDataIrValue(
       const at::Scalar& value,
@@ -176,28 +176,28 @@ class TORCH_API LazyGraphExecutor {
   };
 
   SyncTensorCollection CollectSyncTensors(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       const SyncTensorsConfig& config);
 
   std::vector<Value> CollectRoots(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<size_t> indices);
 
   std::vector<BackendDataPtr> FetchTensorData(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       const SyncTensorsConfig& config,
       c10::ArrayRef<size_t> indices);
 
   PostOrderData RunPostOrder(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<size_t> indices);
   std::shared_ptr<Async> TryRunCachedSync(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       SyncTensorCollection* coll,
       PostOrderData* po_data);
 
   CompilationResult Compile(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<std::string> devices,
       const SyncTensorCollection& coll,
       PostOrderData* po_data);
@@ -207,12 +207,12 @@ class TORCH_API LazyGraphExecutor {
   ComputationCache::TypePtr LookupCachedCompile(const hash_t& hash);
 
   void BuildInputOutputAliases(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<size_t> indices,
       LoweringContext* lowering_ctx);
 
   std::shared_ptr<Async> SyncTensorsGraphInternal(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       c10::ArrayRef<std::string> devices,
       const SyncTensorsConfig& config);
 
@@ -226,22 +226,22 @@ class TORCH_API LazyGraphExecutor {
       ComputationCache::TypePtr cached_computation);
 
   std::shared_ptr<Async> ScheduleSyncTensorsGraph(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       SyncTensorCollection* coll,
       std::vector<BackendDataPtr> parameters_data,
       ComputationCache::TypePtr cached_computation);
 
-  std::vector<at::Tensor> GetTensorsFused(std::vector<LazyTensor>* tensors);
+  std::vector<at::Tensor> GetTensorsFused(std::vector<LazyTensorPtr>* tensors);
 
   std::vector<at::Tensor> FetchTensors(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       c10::ArrayRef<BackendDataPtr> tensors_data,
       const std::vector<size_t>* indices);
 
   // Gathers the device data for all the input tensors, after an
   // asynchronous operation.
   std::vector<BackendDataPtr> GatherTensorsData(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<size_t> indices,
       c10::ArrayRef<BackendDataPtr> tensors_data);
 

--- a/torch/csrc/lazy/core/tensor.cpp
+++ b/torch/csrc/lazy/core/tensor.cpp
@@ -18,10 +18,10 @@ namespace {
 LazyTensorPtr GetOrCreateLtcTensor(const at::Tensor& tensor,
                                 const BackendDevice& device) {
   if (!tensor.defined()) {
-    return c10::make_intrusive<LazyTensor>();
+    return torch::lazy::LazyTensorPtr();
   }
   auto lazy_tensor = TryGetLtcTensor(tensor);
-  return !lazy_tensor->is_null() ? lazy_tensor : LazyTensor::Create(tensor, device);
+  return (lazy_tensor && *lazy_tensor) ? lazy_tensor : LazyTensor::Create(tensor, device);
 }
 }  // namespace
 
@@ -33,13 +33,13 @@ LazyTensorPtr LazyTensor::Create(
     const at::Tensor& tensor,
     const BackendDevice& device) {
   TORCH_CHECK(tensor.device().type() != at::kLazy);
-  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(tensor, device);
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(std::move(LazyTensor(tensor, device)));
   LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
   return lazy_tensor;
 }
 
 LazyTensorPtr LazyTensor::Create(Value ir_value, const BackendDevice& device) {
-  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(std::move(ir_value), device);
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(std::move(LazyTensor(std::move(ir_value), device)));
   LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
   return lazy_tensor;
 }
@@ -47,19 +47,19 @@ LazyTensorPtr LazyTensor::Create(Value ir_value, const BackendDevice& device) {
 LazyTensorPtr LazyTensor::Create(
     std::shared_ptr<LazyView> view,
     const BackendDevice& device) {
-  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(std::move(view), device);
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(std::move(LazyTensor(std::move(view), device)));
   LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
   return lazy_tensor;
 }
 
 LazyTensorPtr LazyTensor::Create(BackendDataPtr handle) {
-  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(std::move(handle));
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(std::move(LazyTensor(std::move(handle))));
   LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
   return lazy_tensor;
 }
 
 LazyTensorPtr LazyTensor::Create(std::shared_ptr<Data> data) {
-  return c10::make_intrusive<LazyTensor>(std::move(data));
+  return c10::make_intrusive<LazyTensor>(std::move(LazyTensor(std::move(data))));
 }
 
 LazyTensor::LazyTensor(const at::Tensor& tensor, const BackendDevice& device)
@@ -412,12 +412,12 @@ void LazyTensor::UpdateFromTensorOut(at::Tensor tensor) {
   UpdateFromTensor(std::move(tensor), /*sync=*/false);
 }
 
-void LazyTensor::UpdateFromTensorOut(const LazyTensor& tensor) {
+void LazyTensor::UpdateFromTensorOut(const LazyTensorPtr& tensor) {
   if (data()->view != nullptr &&
-      shape().Get().numel() != tensor.shape().Get().numel()) {
+      shape().Get().numel() != tensor->shape().Get().numel()) {
     data()->view = nullptr;
   }
-  SetIrValue(tensor.GetIrValue());
+  SetIrValue(tensor->GetIrValue());
 }
 
 Value LazyTensor::CreateTensorNode(BackendDataPtr data, bool read_only) const {
@@ -445,7 +445,7 @@ void LazyTensor::ApplyPendingGraph() {
   // This method is called to ensure that the tensor data is available on
   // device, so that a call to CurrentDataHandle() returns a valid pointer.
   if (CurrentDataHandle() == nullptr) {
-    std::vector<LazyTensor> tensors({*this});
+    std::vector<LazyTensorPtr> tensors({c10::make_intrusive<LazyTensor>(std::move(LazyTensor(*this)))});
     LazyGraphExecutor::Get()->SyncTensorsGraph(
         &tensors,
         {},
@@ -462,15 +462,16 @@ int64_t LazyTensor::GetNextTensorId() {
 LazyTensorPtr TryGetLtcTensor(const at::Tensor& tensor) {
   auto* impl = dynamic_cast<LTCTensorImpl*>(tensor.unsafeGetTensorImpl());
   if (impl == nullptr) {
-    return c10::make_intrusive<LazyTensor>();
+    // return c10::make_intrusive<LazyTensor>();
+    return LazyTensorPtr();
   }
   return impl->tensor();
 }
 
 LazyTensorPtr GetLtcTensor(const at::Tensor& tensor) {
   auto lazy_tensor = TryGetLtcTensor(tensor);
-  CHECK(lazy_tensor) << "Input tensor is not a lazy tensor: " << tensor.toString();
-  return c10::make_intrusive<LazyTensor>(std::move(lazy_tensor));
+  CHECK(lazy_tensor && *lazy_tensor) << "Input tensor is not a lazy tensor: " << tensor.toString();
+  return lazy_tensor;
 }
 
 std::vector<LazyTensorPtr> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors) {
@@ -496,9 +497,9 @@ LazyTensorPtr GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, con
              : GetLtcTensor(tensor);
 }
 
-at::Tensor CreateAtenFromLtcTensor(const LazyTensor& ltc_tensor) {
-  return ltc_tensor.is_null() ? at::Tensor()
-                              : at::Tensor(c10::make_intrusive<LTCTensorImpl>(ltc_tensor));
+at::Tensor CreateAtenFromLtcTensor(const LazyTensorPtr& ltc_tensor) {
+  return ltc_tensor->is_null() ? at::Tensor()
+                               : at::Tensor(c10::make_intrusive<LTCTensorImpl>(ltc_tensor));
 }
 
 at::Tensor CreateAtenFromLtcTensor(LazyTensor&& ltc_tensor) {

--- a/torch/csrc/lazy/core/tensor.cpp
+++ b/torch/csrc/lazy/core/tensor.cpp
@@ -21,7 +21,7 @@ LazyTensorPtr GetOrCreateLtcTensor(const at::Tensor& tensor,
     return torch::lazy::LazyTensorPtr();
   }
   auto lazy_tensor = TryGetLtcTensor(tensor);
-  return (lazy_tensor && *lazy_tensor) ? lazy_tensor : LazyTensor::Create(tensor, device);
+  return lazy_tensor ? lazy_tensor : LazyTensor::Create(tensor, device);
 }
 }  // namespace
 
@@ -470,7 +470,7 @@ LazyTensorPtr TryGetLtcTensor(const at::Tensor& tensor) {
 
 LazyTensorPtr GetLtcTensor(const at::Tensor& tensor) {
   auto lazy_tensor = TryGetLtcTensor(tensor);
-  CHECK(lazy_tensor && *lazy_tensor) << "Input tensor is not a lazy tensor: " << tensor.toString();
+  CHECK(lazy_tensor) << "Input tensor is not a lazy tensor: " << tensor.toString();
   return lazy_tensor;
 }
 
@@ -498,13 +498,12 @@ LazyTensorPtr GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, con
 }
 
 at::Tensor CreateAtenFromLtcTensor(const LazyTensorPtr& ltc_tensor) {
-  return ltc_tensor->is_null() ? at::Tensor()
-                               : at::Tensor(c10::make_intrusive<LTCTensorImpl>(ltc_tensor));
+  return ltc_tensor ? at::Tensor(c10::make_intrusive<LTCTensorImpl>(ltc_tensor))
+                    : at::Tensor();
 }
 
 at::Tensor CreateAtenFromLtcTensor(LazyTensor&& ltc_tensor) {
-  return ltc_tensor.is_null() ? at::Tensor()
-                              : at::Tensor(c10::make_intrusive<LTCTensorImpl>(std::move(ltc_tensor)));
+  return at::Tensor(c10::make_intrusive<LTCTensorImpl>(std::move(ltc_tensor)));
 }
 
 } // namespace lazy

--- a/torch/csrc/lazy/core/tensor.cpp
+++ b/torch/csrc/lazy/core/tensor.cpp
@@ -33,13 +33,13 @@ LazyTensorPtr LazyTensor::Create(
     const at::Tensor& tensor,
     const BackendDevice& device) {
   TORCH_CHECK(tensor.device().type() != at::kLazy);
-  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(std::move(LazyTensor(tensor, device)));
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(LazyTensor(tensor, device));
   LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
   return lazy_tensor;
 }
 
 LazyTensorPtr LazyTensor::Create(Value ir_value, const BackendDevice& device) {
-  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(std::move(LazyTensor(std::move(ir_value), device)));
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(LazyTensor(std::move(ir_value), device));
   LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
   return lazy_tensor;
 }
@@ -47,19 +47,19 @@ LazyTensorPtr LazyTensor::Create(Value ir_value, const BackendDevice& device) {
 LazyTensorPtr LazyTensor::Create(
     std::shared_ptr<LazyView> view,
     const BackendDevice& device) {
-  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(std::move(LazyTensor(std::move(view), device)));
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(LazyTensor(std::move(view), device));
   LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
   return lazy_tensor;
 }
 
 LazyTensorPtr LazyTensor::Create(BackendDataPtr handle) {
-  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(std::move(LazyTensor(std::move(handle))));
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(LazyTensor(std::move(handle)));
   LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
   return lazy_tensor;
 }
 
 LazyTensorPtr LazyTensor::Create(std::shared_ptr<Data> data) {
-  return c10::make_intrusive<LazyTensor>(std::move(LazyTensor(std::move(data))));
+  return c10::make_intrusive<LazyTensor>(LazyTensor(std::move(data)));
 }
 
 LazyTensor::LazyTensor(const at::Tensor& tensor, const BackendDevice& device)
@@ -445,7 +445,7 @@ void LazyTensor::ApplyPendingGraph() {
   // This method is called to ensure that the tensor data is available on
   // device, so that a call to CurrentDataHandle() returns a valid pointer.
   if (CurrentDataHandle() == nullptr) {
-    std::vector<LazyTensorPtr> tensors({c10::make_intrusive<LazyTensor>(std::move(LazyTensor(*this)))});
+    std::vector<LazyTensorPtr> tensors({c10::make_intrusive<LazyTensor>(LazyTensor(*this))});
     LazyGraphExecutor::Get()->SyncTensorsGraph(
         &tensors,
         {},

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/intrusive_ptr.h>
 #include <torch/csrc/lazy/backend/backend_device.h>
 #include <torch/csrc/lazy/backend/backend_interface.h>
 #include <torch/csrc/lazy/core/ir.h>
@@ -9,7 +10,10 @@
 namespace torch {
 namespace lazy {
 
-class TORCH_API LazyTensor {
+class LazyTensor;
+using LazyTensorPtr = c10::intrusive_ptr<LazyTensor>;
+
+class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
  public:
   // This is the core lazy tensor data structure where all the tensor data is
   // held. The lazy tensor is nothing more than a shared pointer to a Data
@@ -72,7 +76,7 @@ class TORCH_API LazyTensor {
 
   at::Tensor ToTensor(bool detached);
 
-  void ShallowCopyTo(LazyTensor* dest) const;
+  void ShallowCopyTo(LazyTensorPtr dest) const;
 
   // Assigns the tensor value to the lazy tensor.
   void SetTensor(at::Tensor tensor);
@@ -185,7 +189,7 @@ TORCH_API LazyTensor TryGetLtcTensor(const at::Tensor& tensor);
 
 // Extracts the LazyTensor out of an at::Tensor. Throws an exception
 // if the tensor is not a lazy tensor.
-TORCH_API LazyTensor GetLtcTensor(const at::Tensor& tensor);
+TORCH_API LazyTensorPtr GetLtcTensor(const at::Tensor& tensor);
 
 // Same as above, applied to a list of tensors.
 TORCH_API std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors);

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -47,12 +47,12 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
     size_t generation = 1;
   };
 
-  static LazyTensor Create(
+  static LazyTensorPtr Create(
       const at::Tensor& tensor,
       const BackendDevice& device);
-  static LazyTensor Create(Value ir_value, const BackendDevice& device);
-  static LazyTensor Create(BackendDataPtr handle);
-  static LazyTensor Create(std::shared_ptr<Data> data);
+  static LazyTensorPtr Create(Value ir_value, const BackendDevice& device);
+  static LazyTensorPtr Create(BackendDataPtr handle);
+  static LazyTensorPtr Create(std::shared_ptr<Data> data);
 
   // Creates an empty/null tensor.
   LazyTensor() = default;
@@ -125,10 +125,10 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
 
   c10::optional<at::Tensor> CurrentTensorData() const;
 
-  std::vector<LazyTensor> MakeOutputTensors(NodePtr node) const;
+  std::vector<LazyTensorPtr> MakeOutputTensors(NodePtr node) const;
 
-  LazyTensor CreateViewTensor(ViewInfo view_info) const;
-  LazyTensor CopyTensorToDevice(const BackendDevice& device);
+  LazyTensorPtr CreateViewTensor(ViewInfo view_info) const;
+  LazyTensorPtr CopyTensorToDevice(const BackendDevice& device);
 
   void ModifyCurrentView(ViewInfo view_info) const;
 
@@ -142,7 +142,7 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
   explicit LazyTensor(BackendDataPtr handle);
   explicit LazyTensor(std::shared_ptr<Data> data);
 
-  static LazyTensor Create(
+  static LazyTensorPtr Create(
       std::shared_ptr<LazyView> view,
       const BackendDevice& device);
 
@@ -185,21 +185,21 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
 // Section 1: at::Tensor => LazyTensor.
 // Extracts the LazyTensor out of an at::Tensor. Returns a null LazyTensor
 // if the tensor is not a lazy tensor.
-TORCH_API LazyTensor TryGetLtcTensor(const at::Tensor& tensor);
+TORCH_API LazyTensorPtr TryGetLtcTensor(const at::Tensor& tensor);
 
 // Extracts the LazyTensor out of an at::Tensor. Throws an exception
 // if the tensor is not a lazy tensor.
 TORCH_API LazyTensorPtr GetLtcTensor(const at::Tensor& tensor);
 
 // Same as above, applied to a list of tensors.
-TORCH_API std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors);
+TORCH_API std::vector<LazyTensorPtr> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors);
 
 // If tensor is a lazy tensor type, returns the LazyTensor embedded within it,
 // otherwise creates a new lazy tensor type with tensor as data.
-TORCH_API LazyTensor GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
+TORCH_API LazyTensorPtr GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
                                 const BackendDevice& device);
 
-TORCH_API LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const BackendDevice& device);
+TORCH_API LazyTensorPtr GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const BackendDevice& device);
 
 // Section 2: LazyTensor => at::Tensor.
 // Creates an ATen tensor from an LazyTensor.

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -68,8 +68,8 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
     return data()->generation;
   }
 
-  LazyTensor alias() const {
-    return LazyTensor(data_ptr());
+  LazyTensorPtr alias() const {
+    return c10::make_intrusive<LazyTensor>(data_ptr());
   }
 
   int64_t size(int64_t dim) const;
@@ -83,7 +83,7 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
 
   void UpdateFromTensor(at::Tensor tensor, bool sync);
   void UpdateFromTensorOut(at::Tensor tensor);
-  void UpdateFromTensorOut(const LazyTensor& tensor);
+  void UpdateFromTensorOut(const LazyTensorPtr& tensor);
 
   Data* data() const;
 
@@ -203,16 +203,16 @@ TORCH_API LazyTensorPtr GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& t
 
 // Section 2: LazyTensor => at::Tensor.
 // Creates an ATen tensor from an LazyTensor.
-TORCH_API at::Tensor CreateAtenFromLtcTensor(const LazyTensor& ltc_tensor);
+TORCH_API at::Tensor CreateAtenFromLtcTensor(const LazyTensorPtr& ltc_tensor);
 TORCH_API at::Tensor CreateAtenFromLtcTensor(LazyTensor&& ltc_tensor);
 
 template <size_t... Indices>
-auto TupleAtenFromLtcTensorsImpl(const std::vector<LazyTensor>& tensors, std::index_sequence<Indices...>) {
+auto TupleAtenFromLtcTensorsImpl(const std::vector<LazyTensorPtr>& tensors, std::index_sequence<Indices...>) {
     return std::make_tuple(CreateAtenFromLtcTensor(tensors[Indices])...);
 }
 
 template <size_t N>
-auto TupleAtenFromLtcTensors(const std::vector<LazyTensor>& tensors) {
+auto TupleAtenFromLtcTensors(const std::vector<LazyTensorPtr>& tensors) {
     return TupleAtenFromLtcTensorsImpl(tensors, std::make_index_sequence<N>{});
 }
 

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -69,7 +69,7 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
   }
 
   LazyTensorPtr alias() const {
-    return c10::make_intrusive<LazyTensor>(data_ptr());
+    return c10::make_intrusive<LazyTensor>(LazyTensor(data_ptr()));
   }
 
   int64_t size(int64_t dim) const;

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -54,15 +54,13 @@ class TORCH_API LazyTensor : public c10::intrusive_ptr_target {
   static LazyTensorPtr Create(BackendDataPtr handle);
   static LazyTensorPtr Create(std::shared_ptr<Data> data);
 
-  // Creates an empty/null tensor.
-  LazyTensor() = default;
-
-  bool is_null() const {
-    return data_ptr() == nullptr;
-  }
-  operator bool() const {
-    return !is_null();
-  }
+  // The default ctor previously created a null LazyTensor (one with no 'data' obj).
+  // Creating a null LazyTensor is no longer possible, since the same can be achieved by
+  // creating a null LazyTensorPtr and it is way too confusing to have to check both
+  // lazy_tensor_ptr && *lazy_tensor_ptr,
+  // so everywhere that used to rely on a LazyTensor obj with a null Data can now rely on
+  // a null LazyTensorPtr instead.
+  LazyTensor() = delete;
 
   size_t generation() const {
     return data()->generation;

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -65,6 +65,10 @@ C10_REGISTER_GUARD_IMPL(Lazy, LTCGuardImpl);
 
 }  // namespace
 
+// TODO(whc) when do we want to clone vs share?
+LTCTensorImpl::LTCTensorImpl(const LazyTensorPtr& tensor)
+    : LTCTensorImpl(LazyTensor(*tensor)) {}
+
 LTCTensorImpl::LTCTensorImpl(const LazyTensor& tensor)
     : LTCTensorImpl(LazyTensor(tensor)) {}
 
@@ -73,14 +77,14 @@ LTCTensorImpl::LTCTensorImpl(LazyTensor&& tensor)
                                           c10::DispatchKey::AutogradLazy},
                       c10::scalarTypeToTypeMeta(tensor.dtype()),
                       backendDeviceToAtenDevice(tensor.GetDevice())),
-      tensor_(std::move(tensor)) {
+      tensor_(c10::make_intrusive<LazyTensor>(std::move(tensor))) {
   // This is a temporary fix for a PyTorch core issue,
   // according to https://github.com/pytorch/xla/pull/2682.
   is_non_overlapping_and_dense_ = false;
 }
 
 void LTCTensorImpl::set_tensor(const LazyTensor& lazy_tensor) {
-  tensor_ = lazy_tensor;
+  tensor_ = c10::make_intrusive<LazyTensor>(lazy_tensor);
   generation_ = 0;
 }
 
@@ -117,7 +121,7 @@ void LTCTensorImpl::shallow_copy_from(
       /*dest_impl=*/this,
       /*version_counter=*/version_counter(),
       /*allow_tensor_metadata_change=*/allow_tensor_metadata_change());
-  ltc_impl->tensor_.ShallowCopyTo(&tensor_);
+  ltc_impl->tensor_->ShallowCopyTo(tensor_);
   generation_ = 0;
 }
 
@@ -134,11 +138,11 @@ int64_t LTCTensorImpl::stride(int64_t d) const {
 }
 
 void LTCTensorImpl::setup_size_properties() {
-  size_t generation = tensor_.generation();
+  size_t generation = tensor_->generation();
   if (generation != generation_) {
     // Fill up the basic dimension data members which the base class
     // implementation uses in its APIs.
-    auto shape = tensor_.shape();
+    auto shape = tensor_->shape();
     // We can't call refresh_numel() given we override sizes() too.
     numel_ = shape.Get().numel();
     sizes_and_strides_.set_sizes(shape.Get().sizes());
@@ -179,8 +183,8 @@ int64_t LTCTensorImpl::numel() const {
 }
 
 bool LTCTensorImpl::is_contiguous(c10::MemoryFormat _unused) const {
-  if (tensor_.CurrentTensorData()) {
-    return tensor_.CurrentTensorData()->is_contiguous();
+  if (tensor_->CurrentTensorData()) {
+    return tensor_->CurrentTensorData()->is_contiguous();
   }
   // Only check that the storage is already contiguous.
   CHECK(is_contiguous_) << "Non-contiguous storage for lazy tensor";

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -83,8 +83,8 @@ LTCTensorImpl::LTCTensorImpl(LazyTensor&& tensor)
   is_non_overlapping_and_dense_ = false;
 }
 
-void LTCTensorImpl::set_tensor(const LazyTensor& lazy_tensor) {
-  tensor_ = c10::make_intrusive<LazyTensor>(lazy_tensor);
+void LTCTensorImpl::set_tensor(const LazyTensorPtr& lazy_tensor) {
+  tensor_ = c10::make_intrusive<LazyTensor>(*lazy_tensor);
   generation_ = 0;
 }
 

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -19,7 +19,7 @@ class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
 
   LazyTensorPtr tensor() { return tensor_; }
 
-  void set_tensor(const LazyTensor& lazy_tensor);
+  void set_tensor(const LazyTensorPtr& lazy_tensor);
 
   void force_refresh_sizes() { generation_ = 0; }
 

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -13,10 +13,11 @@ namespace lazy {
 // Its scope is just to handle an LazyTensor.
 class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
  public:
+  explicit LTCTensorImpl(const LazyTensorPtr& tensor);
   explicit LTCTensorImpl(const LazyTensor& tensor);
   explicit LTCTensorImpl(LazyTensor&& tensor);
 
-  LazyTensor& tensor() { return tensor_; }
+  LazyTensorPtr tensor() { return tensor_; }
 
   void set_tensor(const LazyTensor& lazy_tensor);
 
@@ -50,7 +51,7 @@ class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
  private:
   void setup_size_properties();
 
-  LazyTensor tensor_;
+  LazyTensorPtr tensor_;
   size_t generation_ {0};
 };
 


### PR DESCRIPTION
Refactors the whole codebase to use LazyTensorPtr (defined as c10::intrusive_ptr<LazyTensor>) to enable XLA to use a derived class XlaLazyTensor and override functionality.

* this PR is just the first step, and we will need to add a factory class that XLA can override in their backend to actually hook up their derived tensor class.

RUN_TORCHBENCH: ALL
TORCHBENCH_BRANCH: wconstab/ltc