### PR TITLE
Jit save/load meta tensors

### DIFF
--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -340,6 +340,10 @@ class TORCH_API Tensor: public TensorBase {
     return to(options().device(DeviceType::Metal), /*non_blocking*/ false, /*copy*/ false);
   }
 
+  Tensor meta() const {
+    return to(options().device(DeviceType::Meta), /*non_blocking*/ false, /*copy*/ false);
+  }
+
   // ~~~~~ Autograd API ~~~~~
 
   /// \fn bool is_leaf() const;

--- a/c10/core/Device.h
+++ b/c10/core/Device.h
@@ -101,6 +101,11 @@ struct C10_API Device final {
     return type_ == DeviceType::HPU;
   }
 
+  /// Return true if the device is of META type.
+  bool is_meta() const noexcept {
+    return type_ == DeviceType::Meta;
+  }
+
   /// Return true if the device is of CPU type.
   bool is_cpu() const noexcept {
     return type_ == DeviceType::CPU;

--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -484,3 +484,47 @@ class TestSaveLoad(JitTestCase):
             loaded_name, loaded_buffer = loaded_b
             self.assertEqual(m_name, loaded_name)
             self.assertEqual(m_buffer, loaded_buffer)
+
+    def test_save_load_meta_tensors(self):
+        """
+        Check that parameters, buffers, and submodules are the same after loading
+        for a module with parameters and buffers that are meta tensors
+        """
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super(Foo, self).__init__()
+                self.foo = torch.nn.Linear(2, 3, device="meta")
+                self.bar = torch.nn.Linear(3, 4)
+                self.register_buffer("buffer", torch.randn(4, device="meta"))
+
+            def forward(self, x):
+                x = self.foo(x)
+                x = self.bar(x)
+                return x
+
+        m = Foo()
+        m_loaded = self.getExportImportCopy(torch.jit.script(m))
+        # Check submodules.
+        self.assertEqual(len(list(m.named_modules())), len(list(m_loaded.named_modules())))
+        self.assertEqual(set(name for name, _ in m.named_modules()), set(name for name, _ in m_loaded.named_modules()))
+        # Check parameters.
+        m_params = dict(m.named_parameters())
+        m_loaded_params = dict(m_loaded.named_parameters())
+        self.assertEqual(len(m_params), len(m_loaded_params))
+        self.assertEqual(m_params, m_loaded_params)
+        # Check buffers.
+        m_buffers = dict(m.named_buffers())
+        m_loaded_buffers = dict(m_loaded.named_buffers())
+        self.assertEqual(len(m_buffers), len(m_loaded_buffers))
+        self.assertEqual(m_buffers, m_loaded_buffers)
+        # Check params and buffers that are/are not meta tensors
+        self.assertTrue(m_params['foo.weight'].is_meta)
+        self.assertTrue(m_loaded_params['foo.weight'].is_meta)
+        self.assertTrue(m_params['foo.bias'].is_meta)
+        self.assertTrue(m_loaded_params['foo.bias'].is_meta)
+        self.assertFalse(m_params['bar.weight'].is_meta)
+        self.assertFalse(m_loaded_params['bar.weight'].is_meta)
+        self.assertFalse(m_params['bar.bias'].is_meta)
+        self.assertFalse(m_loaded_params['bar.bias'].is_meta)
+        self.assertTrue(m_buffers['buffer'].is_meta)
+        self.assertTrue(m_loaded_buffers['buffer'].is_meta)

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -508,8 +508,12 @@ void ScriptModuleSerializer::writeArchive(
   TORCH_INTERNAL_ASSERT(tensor_names.size() == data_pickle.tensorData().size());
 
   for (const auto& td : data_pickle.tensorData()) {
-    WriteableTensorData writable_td = getWriteableTensorData(td);
     std::string tensor_name = tensor_names[i++];
+    if (td.is_meta()) {
+      writer_.writeRecord(tensor_dir + tensor_name, nullptr, 0);
+      continue;
+    }
+    WriteableTensorData writable_td = getWriteableTensorData(td);
     if (use_storage_context && serialized_tensors.count(tensor_name)) {
       // storage has been serialzed already, skip
       continue;

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -500,7 +500,7 @@ PickleOpCode Unpickler::readInstruction() {
         tensor = at::empty({0}, options).set_(storage);
       }
 
-      if (device.is_cuda() || device.is_xpu()) {
+      if (device.is_cuda() || device.is_xpu() || device.is_meta()) {
         tensor = tensor.to(device, tensor.scalar_type());
       } else if (device.type() != DeviceType::CPU) {
         AT_ERROR(


### PR DESCRIPTION
Summary: Add support for torch.jit.save and load for meta tensors to use in meta tensor based xl weights.

Test Plan:
```
buck test //caffe2/test:jit && -- -r .*save_load_meta_tensors.*
```

Differential Revision: D34479511

