### PR TITLE
Enable adding docstrings to OpOverloadPacket objects, add docstring for quantized add

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -821,11 +821,6 @@ from torch import profiler as profiler
 
 _C._init_names(list(torch._storage_classes))
 
-# attach docstrings to torch and tensor functions
-from . import _torch_docs, _tensor_docs, _storage_docs
-del _torch_docs, _tensor_docs, _storage_docs
-
-
 def compiled_with_cxx11_abi():
     r"""Returns whether PyTorch was built with _GLIBCXX_USE_CXX11_ABI=1"""
     return _C._GLIBCXX_USE_CXX11_ABI
@@ -834,6 +829,10 @@ def compiled_with_cxx11_abi():
 # Import the ops "namespace"
 from torch._ops import ops
 from torch._classes import classes
+
+# attach docstrings to torch, tensor, storage, quantization functions
+from . import _torch_docs, _tensor_docs, _storage_docs, _quantization_docs
+del _torch_docs, _tensor_docs, _storage_docs, _quantization_docs
 
 # quantization depends on torch.fx
 # Import quantization

--- a/torch/_quantization_docs.py
+++ b/torch/_quantization_docs.py
@@ -1,0 +1,15 @@
+"""Adds docstrings to functions in the torch.ops.quantized namespace"""
+
+import torch._C
+from torch._C import _add_docstr as add_docstr
+
+# TODO(future PR): extend this docblock and make it render in the html docs
+add_docstr(torch.ops.quantized.add,
+           """
+torch.ops.quantized.add(Tensor qa, Tensor qb, float scale, int zero_point) -> Tensor qc
+
+This is the quantized version of `torch.add`.
+""")
+
+# TODO(future PR): document the other developer facing functions from
+# torch.ops.quantized

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -269,6 +269,17 @@ PyObject *THPModule_addDocStr(PyObject *_unused, PyObject *args)
           "Type '%s' already has a docstring", t->tp_name);
     }
     t->tp_doc = doc_str;
+  } else if (strcmp(Py_TYPE(obj)->tp_name, "OpOverloadPacket") == 0) {
+    const auto current_doc_str = PyObject_GetAttrString(obj, "__doc__");
+    if (current_doc_str != Py_None) {
+      const auto qual_op_name_obj = PyObject_GetAttrString(
+        obj, "qualified_op_name");
+      const auto qual_op_name_str = THPUtils_unpackString(
+        qual_op_name_obj);
+      return PyErr_Format(PyExc_RuntimeError,
+          "function '%s' already has a docstring", qual_op_name_str.c_str());
+    }
+    PyModule_SetDocString(obj, doc_str);
   } else {
     return PyErr_Format(PyExc_TypeError,
         "don't know how to add docstring to type '%s'", Py_TYPE(obj)->tp_name);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#73437 Enable adding docstrings to OpOverloadPacket objects, add docstring for quantized add**

Summary:

For quantization, we'd like to add some developer docs on the functions exposed
in the `torch.ops.quantized` namespace (they live in
`aten/src/ATen/native/quantized/library.cpp`).

This PR makes the `torch._C._add_docstr` function work with objects
of type `OpOverloadPacket`, which then enables us to set docstrings
on these functions in a similar way to how it is done in other places
in PyTorch. It also adds the first docstring to test the pipes.

Keeping this PR small since this should be the only place we need to touch
the C bindings, future PRs will extend the doc coverage as well as
add the html pages to render these docstrings.

Test plan:

```
import torch
// prints correct docstring
print(torch.ops.quantized.add.__doc__)

// fails with good error message, since docstring is already defined
from torch._C import _add_docstr as add_docstr
add_docstr(torch.ops.quantized.add, "foobar")
```

Differential Revision: [D34480452](https://our.internmc.facebook.com/intern/diff/D34480452)