### PR TITLE
[torch] set workspace size for cublas lt interface 1M

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -688,7 +688,9 @@ void gemm_and_bias(
   CuBlasLtMatrixLayout Cdesc(abcType, m, n, result_ld);
 
   CuBlasLtMatmulPreference preference;
-  size_t workspaceSize = 0;
+  // See https://github.com/pytorch/pytorch/issues/73328 for reasoning behind
+  // setting this to 1M.
+  size_t workspaceSize = 1024 * 1024;
   TORCH_CUDABLAS_CHECK(cublasLtMatmulPreferenceSetAttribute(
       preference.descriptor(),
       CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,


### PR DESCRIPTION
Summary:
Per discussion in https://github.com/pytorch/pytorch/issues/73328#issuecomment-1050422698
Workspace size is needed to get good cublas lt performance

Test Plan:
In PyTorch benchmark
python run.py nvidia_deeprecommender -d cuda -t train

Differential Revision: D34480690

