### PR TITLE
Use intrusive_ptr for LazyTensor

### DIFF
--- a/torch/csrc/lazy/backend/backend_device.cpp
+++ b/torch/csrc/lazy/backend/backend_device.cpp
@@ -56,7 +56,7 @@ c10::Device backendDeviceToAtenDevice(const BackendDevice& device) {
 
 c10::optional<BackendDevice> GetBackendDevice(const at::Tensor& tensor) {
   if (auto lt = TryGetLtcTensor(tensor)) {
-    return lt.GetDevice();
+    return lt->GetDevice();
   }
   return c10::nullopt;
 }

--- a/torch/csrc/lazy/core/debug_util.cpp
+++ b/torch/csrc/lazy/core/debug_util.cpp
@@ -65,7 +65,7 @@ DebugUtil::GraphFormat DebugUtil::GetDefaultGraphFormat() {
   return format;
 }
 
-std::string DebugUtil::GetTensorsGraphInfo(c10::ArrayRef<torch::lazy::LazyTensor> tensors,
+std::string DebugUtil::GetTensorsGraphInfo(c10::ArrayRef<torch::lazy::LazyTensorPtr> tensors,
                                            const std::vector<size_t>* indices,
                                            GraphFormat format) {
   std::vector<torch::lazy::Node*> root_nodes;
@@ -74,23 +74,23 @@ std::string DebugUtil::GetTensorsGraphInfo(c10::ArrayRef<torch::lazy::LazyTensor
   torch::lazy::Unique<torch::lazy::BackendDevice> unique_device;
   if (indices != nullptr) {
     for (auto index : *indices) {
-      const torch::lazy::LazyTensor& tensor = tensors[index];
-      torch::lazy::Value ir_value = tensor.CurrentIrValue();
+      const torch::lazy::LazyTensorPtr& tensor = tensors[index];
+      torch::lazy::Value ir_value = tensor->CurrentIrValue();
       if (ir_value) {
         root_nodes.push_back(ir_value.node.get());
         root_hashes.push_back(ir_value.hash());
         root_values.push_back(std::move(ir_value));
-        unique_device.set(tensor.GetDevice());
+        unique_device.set(tensor->GetDevice());
       }
     }
   } else {
     for (auto& tensor : tensors) {
-      torch::lazy::Value ir_value = tensor.CurrentIrValue();
+      torch::lazy::Value ir_value = tensor->CurrentIrValue();
       if (ir_value) {
         root_nodes.push_back(ir_value.node.get());
         root_hashes.push_back(ir_value.hash());
         root_values.push_back(std::move(ir_value));
-        unique_device.set(tensor.GetDevice());
+        unique_device.set(tensor->GetDevice());
       }
     }
   }
@@ -128,7 +128,7 @@ std::string DebugUtil::GetTensorsGraphInfo(c10::ArrayRef<torch::lazy::LazyTensor
 }
 
 void DebugUtil::SaveTensorsGraphInfo(const char* name,
-                                     c10::ArrayRef<torch::lazy::LazyTensor> tensors,
+                                     c10::ArrayRef<torch::lazy::LazyTensorPtr> tensors,
                                      const std::vector<size_t>* indices,
                                      GraphFormat format) {
   static const std::string save_file = GetEnvString("LTC_SAVE_TENSORS_FILE", "");

--- a/torch/csrc/lazy/core/debug_util.h
+++ b/torch/csrc/lazy/core/debug_util.h
@@ -25,14 +25,14 @@ class TORCH_API DebugUtil {
   // values held at the tensors. If indices is not nullptr, it selects the
   // indices of the tensors whose graph will be emitted.
   static std::string GetTensorsGraphInfo(
-      c10::ArrayRef<torch::lazy::LazyTensor> tensors, const std::vector<size_t>* indices,
+      c10::ArrayRef<torch::lazy::LazyTensorPtr> tensors, const std::vector<size_t>* indices,
       GraphFormat format = GetDefaultGraphFormat());
 
   // If the environment variable LTC_SAVE_TENSORS_FILE is set to the proper
   // output path, an instance of the report returned by GetTensorsGraphInfo() is
   // saved.
   static void SaveTensorsGraphInfo(
-      const char* name, c10::ArrayRef<torch::lazy::LazyTensor> tensors,
+      const char* name, c10::ArrayRef<torch::lazy::LazyTensorPtr> tensors,
       const std::vector<size_t>* indices,
       GraphFormat format = GetDefaultGraphFormat());
 

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -264,8 +264,8 @@ class DeviceContextArena {
     TORCH_LAZY_COUNTER("DestroyLtcTensor", 1);
   }
 
-  std::vector<LazyTensor> GetLiveTensors(const BackendDevice* device) {
-    std::vector<LazyTensor> tensors;
+  std::vector<LazyTensorPtr> GetLiveTensors(const BackendDevice* device) {
+    std::vector<LazyTensorPtr> tensors;
     auto fn = [&](DeviceContext* devctx) {
       std::lock_guard<std::mutex> lock(devctx->lock);
       for (auto& uid_wptr : devctx->tensors_data) {
@@ -384,9 +384,9 @@ bool ShouldSyncIrValue(const Value& ir_value) {
 
 // Return true if no tensor in the list has an underlying IR (leaf or
 // operation).
-bool TensorsHaveIR(const std::vector<LazyTensor>& tensors) {
+bool TensorsHaveIR(const std::vector<LazyTensorPtr>& tensors) {
   for (const auto& tensor : tensors) {
-    if (tensor.CurrentDataHandle() || tensor.CurrentIrValue()) {
+    if (tensor->CurrentDataHandle() || tensor->CurrentIrValue()) {
       return true;
     }
   }
@@ -437,7 +437,7 @@ BackendDataPtr LazyGraphExecutor::GetDeviceData(
   return DataCacheArena::Get()->GetDeviceData(value, scalar_type, device);
 }
 
-std::vector<LazyTensor> LazyGraphExecutor::GetLiveTensors(
+std::vector<LazyTensorPtr> LazyGraphExecutor::GetLiveTensors(
     const BackendDevice* device) {
   return DeviceContextArena::Get()->GetLiveTensors(device);
 }
@@ -453,7 +453,7 @@ void LazyGraphExecutor::SyncLiveTensorsGraph(
 }
 
 void LazyGraphExecutor::SyncTensorsGraph(
-    std::vector<LazyTensor>* tensors,
+    std::vector<LazyTensorPtr>* tensors,
     c10::ArrayRef<std::string> devices,
     bool wait,
     bool sync_ltc_data) {
@@ -494,7 +494,7 @@ void LazyGraphExecutor::WaitDeviceOps(c10::ArrayRef<BackendDevice> devices) {
 }
 
 std::vector<at::Tensor> LazyGraphExecutor::GetTensors(
-    std::vector<LazyTensor>* tensors) {
+    std::vector<LazyTensorPtr>* tensors) {
   VLOG(4) << "Trying to get the value of " << tensors->size() << " tensor(s)";
   return GetTensorsFused(tensors);
 }
@@ -504,10 +504,10 @@ size_t LazyGraphExecutor::IncTrimCounter() {
 }
 
 std::string LazyGraphExecutor::DumpBackendComputation(
-    const std::vector<LazyTensor>& tensors) {
+    const std::vector<LazyTensorPtr>& tensors) {
   std::vector<Value> ir_values;
   for (auto& tensor : tensors) {
-    Value ir_value = tensor.CurrentIrValue();
+    Value ir_value = tensor->CurrentIrValue();
     if (ir_value) {
       ir_values.push_back(std::move(ir_value));
     }
@@ -601,11 +601,11 @@ void LazyGraphExecutor::Async::Wait() {
 }
 
 LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     const SyncTensorsConfig& config) {
   Unique<BackendDevice> unique_device;
   for (const auto& tensor : tensors) {
-    unique_device.set(tensor.GetDevice());
+    unique_device.set(tensor->GetDevice());
   }
   SyncTensorCollection coll;
   if (!unique_device) {
@@ -633,9 +633,9 @@ LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
   }
   VLOG(4) << "Waiting on device barrier for device " << coll.device << " done!";
   for (const auto i : c10::irange(tensors.size())) {
-    if (tensor_ids.insert(tensors[i].GetUniqueId()).second &&
-        tensors[i].CurrentDataHandle() == nullptr) {
-      Value ir_value = tensors[i].CurrentIrValue();
+    if (tensor_ids.insert(tensors[i]->GetUniqueId()).second &&
+        tensors[i]->CurrentDataHandle() == nullptr) {
+      Value ir_value = tensors[i]->CurrentIrValue();
       if (ir_value) {
         if (ShouldSyncIrValue(ir_value)) {
           // Add only tensors which need to be synced.
@@ -645,10 +645,10 @@ LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
       } else if (config.force_ltc_data) {
         // The tensor only has at::Tensor data. We need to queue it for a
         // device upload.
-        c10::optional<at::Tensor> tensor_data = tensors[i].CurrentTensorData();
+        c10::optional<at::Tensor> tensor_data = tensors[i]->CurrentTensorData();
         TORCH_CHECK(tensor_data);
         at_tensors.push_back(*tensor_data);
-        devices.push_back(tensors[i].GetDevice());
+        devices.push_back(tensors[i]->GetDevice());
         at_tensor_index.push_back(i);
       }
     }
@@ -662,7 +662,7 @@ LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
       // present. Also, we uploaded the at::Tensor data to the device, but such
       // data is still valid so we leave it live on the lazy tensor (so that a
       // following ToTensor() does not need to fetch it from device).
-      tensors[at_tensor_index[i]].data()->handle = std::move(handles[i]);
+      tensors[at_tensor_index[i]]->data()->handle = std::move(handles[i]);
     }
   }
   VLOG(4) << "Tensors graph hash " << HashToString(coll.hash) << " on device "
@@ -671,24 +671,24 @@ LazyGraphExecutor::SyncTensorCollection LazyGraphExecutor::CollectSyncTensors(
 }
 
 std::vector<Value> LazyGraphExecutor::CollectRoots(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     c10::ArrayRef<size_t> indices) {
   std::vector<Value> roots;
   roots.reserve(indices.size());
   for (auto index : indices) {
-    roots.push_back(tensors.at(index).CurrentIrValue());
+    roots.push_back(tensors.at(index)->CurrentIrValue());
   }
   return roots;
 }
 
 std::vector<BackendDataPtr> LazyGraphExecutor::FetchTensorData(
-    std::vector<LazyTensor>* tensors,
+    std::vector<LazyTensorPtr>* tensors,
     const SyncTensorsConfig& config,
     c10::ArrayRef<size_t> indices) {
   std::vector<BackendDataPtr> tensors_data;
   tensors_data.reserve(indices.size());
   for (auto index : indices) {
-    LazyTensor& tensor = (*tensors)[index];
+    LazyTensorPtr& tensor = (*tensors)[index];
     // If the config.force_ltc_data flag is true, the purpose of this tensor
     // sync operation is to truncate the IR graph and materialize device data in
     // place of IR graph, on selected tensors. But since operation will complete
@@ -698,12 +698,12 @@ std::vector<BackendDataPtr> LazyGraphExecutor::FetchTensorData(
     // into the async variable), any other operation trying to access the
     // tensor's device data will have to wait until the asynchronous operation
     // completes.
-    BackendDataPtr handle = tensor.CurrentDataHandle();
+    BackendDataPtr handle = tensor->CurrentDataHandle();
     if (handle == nullptr && config.force_ltc_data) {
-      const BackendDevice& tensor_device = tensor.GetDevice();
+      const BackendDevice& tensor_device = tensor->GetDevice();
       handle = getBackend()->CreateDataPlaceholder(
-          tensor_device, std::move(tensor.shape()));
-      tensor.SetDataHandle(handle, config.sync_ltc_data);
+          tensor_device, std::move(tensor->shape()));
+      tensor->SetDataHandle(handle, config.sync_ltc_data);
     }
     tensors_data.emplace_back(std::move(handle));
   }
@@ -711,12 +711,12 @@ std::vector<BackendDataPtr> LazyGraphExecutor::FetchTensorData(
 }
 
 LazyGraphExecutor::PostOrderData LazyGraphExecutor::RunPostOrder(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     c10::ArrayRef<size_t> indices) {
   std::vector<Node*> roots;
   roots.reserve(indices.size());
   for (auto index : indices) {
-    Value ir_value = tensors.at(index).CurrentIrValue();
+    Value ir_value = tensors.at(index)->CurrentIrValue();
     roots.push_back(ir_value.node.get());
   }
   PostOrderData po_data;
@@ -740,7 +740,7 @@ LazyGraphExecutor::PostOrderData LazyGraphExecutor::RunPostOrder(
 }
 
 std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::TryRunCachedSync(
-    std::vector<LazyTensor>* tensors,
+    std::vector<LazyTensorPtr>* tensors,
     SyncTensorCollection* coll,
     PostOrderData* po_data) {
   ComputationCache::TypePtr cached_computation =
@@ -759,7 +759,7 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::TryRunCachedSync(
 }
 
 LazyGraphExecutor::CompilationResult LazyGraphExecutor::Compile(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     c10::ArrayRef<std::string> devices,
     const SyncTensorCollection& coll,
     PostOrderData* po_data) {
@@ -769,7 +769,7 @@ LazyGraphExecutor::CompilationResult LazyGraphExecutor::Compile(
       po_data->post_order,
       std::move(po_data->emission_map));
   for (auto index : coll.indices) {
-    Value ir_value = tensors[index].CurrentIrValue();
+    Value ir_value = tensors[index]->CurrentIrValue();
     lowering_ctx->AddResult(ir_value);
   }
   if (FLAGS_torch_lazy_param_aliasing && coll.config.sync_ltc_data) {
@@ -846,13 +846,13 @@ typedef SSIZE_T ssize_t;
 #endif
 
 void LazyGraphExecutor::BuildInputOutputAliases(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     c10::ArrayRef<size_t> indices,
     LoweringContext* lowering_ctx) {
   std::unordered_map<int64_t, size_t> output_tensor_id_map;
   for (const auto i : c10::irange(indices.size())) {
     size_t tensor_index = indices[i];
-    int64_t tensor_id = tensors[tensor_index].GetUniqueId();
+    int64_t tensor_id = tensors[tensor_index]->GetUniqueId();
     output_tensor_id_map[tensor_id] = i;
   }
   const std::vector<BackendDataPtr>& parameters_data =
@@ -884,7 +884,7 @@ void LazyGraphExecutor::BuildInputOutputAliases(
 
 std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
     SyncTensorsGraphInternal(
-        std::vector<LazyTensor>* tensors,
+        std::vector<LazyTensorPtr>* tensors,
         c10::ArrayRef<std::string> devices,
         const SyncTensorsConfig& config) {
   SyncTensorCollection coll = CollectSyncTensors(*tensors, config);
@@ -986,7 +986,7 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
 
 std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
     ScheduleSyncTensorsGraph(
-        std::vector<LazyTensor>* tensors,
+        std::vector<LazyTensorPtr>* tensors,
         SyncTensorCollection* coll,
         std::vector<BackendDataPtr> parameters_data,
         ComputationCache::TypePtr cached_computation) {
@@ -999,7 +999,7 @@ std::shared_ptr<LazyGraphExecutor::Async> LazyGraphExecutor::
 }
 
 std::vector<at::Tensor> LazyGraphExecutor::GetTensorsFused(
-    std::vector<LazyTensor>* tensors) {
+    std::vector<LazyTensorPtr>* tensors) {
   SyncTensorsConfig config;
   config.force_ltc_data = false;
   auto async = SyncTensorsGraphInternal(tensors, {}, config);
@@ -1025,7 +1025,7 @@ std::vector<at::Tensor> LazyGraphExecutor::GetTensorsFused(
 // 'PopulateTensor' method on backend, which can either attach an existing
 // tensor buffer to the wrapper, or copy data?
 std::vector<at::Tensor> LazyGraphExecutor::FetchTensors(
-    std::vector<LazyTensor>* tensors,
+    std::vector<LazyTensorPtr>* tensors,
     c10::ArrayRef<BackendDataPtr> tensors_data,
     const std::vector<size_t>* indices) {
   std::vector<at::Tensor> results;
@@ -1036,17 +1036,17 @@ std::vector<at::Tensor> LazyGraphExecutor::FetchTensors(
     if (indices != nullptr && sync_index < indices->size() &&
         i == (*indices)[sync_index]) {
       results.push_back(getBackend()->MakeTensorFromComputationData(
-          tensors_data[literals_index], (*tensors)[i].dtype()));
+          tensors_data[literals_index], (*tensors)[i]->dtype()));
       ++literals_index;
       ++sync_index;
     } else {
-      c10::optional<at::Tensor> tensor_data = (*tensors)[i].CurrentTensorData();
+      c10::optional<at::Tensor> tensor_data = (*tensors)[i]->CurrentTensorData();
       if (tensor_data) {
         results.push_back(*tensor_data);
       } else {
         TORCH_CHECK(literals_index < tensors_data.size());
         results.push_back(getBackend()->MakeTensorFromComputationData(
-            tensors_data[literals_index], (*tensors)[i].dtype()));
+            tensors_data[literals_index], (*tensors)[i]->dtype()));
         ++literals_index;
       }
     }
@@ -1055,14 +1055,14 @@ std::vector<at::Tensor> LazyGraphExecutor::FetchTensors(
 }
 
 std::vector<BackendDataPtr> LazyGraphExecutor::GatherTensorsData(
-    const std::vector<LazyTensor>& tensors,
+    const std::vector<LazyTensorPtr>& tensors,
     c10::ArrayRef<size_t> indices,
     c10::ArrayRef<BackendDataPtr> tensors_data) {
   std::vector<BackendDataPtr> result_tensors_data;
   std::unordered_map<int64_t, size_t> uid_index_map;
   size_t indices_index = 0;
   for (const auto i : c10::irange(tensors.size())) {
-    int64_t tensor_id = tensors[i].GetUniqueId();
+    int64_t tensor_id = tensors[i]->GetUniqueId();
     auto it = uid_index_map.find(tensor_id);
     if (it != uid_index_map.end()) {
       // Current tensor is a duplicate of a previously processed tensor that had
@@ -1075,8 +1075,8 @@ std::vector<BackendDataPtr> LazyGraphExecutor::GatherTensorsData(
       uid_index_map.emplace(tensor_id, result_tensors_data.size());
       result_tensors_data.push_back(tensors_data[indices_index]);
       ++indices_index;
-    } else if (!tensors[i].CurrentTensorData()) {
-      BackendDataPtr handle = tensors[i].CurrentDataHandle();
+    } else if (!tensors[i]->CurrentTensorData()) {
+      BackendDataPtr handle = tensors[i]->CurrentDataHandle();
       TORCH_CHECK(handle != nullptr);
       result_tensors_data.push_back(std::move(handle));
     }

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -46,7 +46,7 @@ class TORCH_API LazyGraphExecutor {
   // for the given device. If device is nullptr, the live tensors for all
   // devices will be returned. Returned tensors are sorted by device as primary
   // key, and by unique ID as secondary key.
-  std::vector<LazyTensor> GetLiveTensors(const BackendDevice* device);
+  std::vector<LazyTensorPtr> GetLiveTensors(const BackendDevice* device);
 
   // Makes sure that any outstanding IR operation accumulated over live tensors,
   // gets turned into device data. If wait is true, the sync operation will be
@@ -62,7 +62,7 @@ class TORCH_API LazyGraphExecutor {
   // will be run synchronously. The devices argument, if not empty, tells the
   // devices which should be partecipating into the replicated computation.
   void SyncTensorsGraph(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       c10::ArrayRef<std::string> devices,
       bool wait,
       bool sync_ltc_data);
@@ -77,13 +77,13 @@ class TORCH_API LazyGraphExecutor {
 
   // Retrieves the PyTorch CPU tensors behind the lazy tensors IR operations.
   // All the tensors must be on the same device.
-  std::vector<at::Tensor> GetTensors(std::vector<LazyTensor>* tensors);
+  std::vector<at::Tensor> GetTensors(std::vector<LazyTensorPtr>* tensors);
 
   size_t IncTrimCounter();
 
   // Dumps the backend specific text of the computation accumulated in the graph
   // which is attached the tensors.
-  std::string DumpBackendComputation(const std::vector<LazyTensor>& tensors);
+  std::string DumpBackendComputation(const std::vector<LazyTensorPtr>& tensors);
 
   Value GetDeviceDataIrValue(
       const at::Scalar& value,
@@ -176,28 +176,28 @@ class TORCH_API LazyGraphExecutor {
   };
 
   SyncTensorCollection CollectSyncTensors(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       const SyncTensorsConfig& config);
 
   std::vector<Value> CollectRoots(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<size_t> indices);
 
   std::vector<BackendDataPtr> FetchTensorData(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       const SyncTensorsConfig& config,
       c10::ArrayRef<size_t> indices);
 
   PostOrderData RunPostOrder(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<size_t> indices);
   std::shared_ptr<Async> TryRunCachedSync(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       SyncTensorCollection* coll,
       PostOrderData* po_data);
 
   CompilationResult Compile(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<std::string> devices,
       const SyncTensorCollection& coll,
       PostOrderData* po_data);
@@ -207,12 +207,12 @@ class TORCH_API LazyGraphExecutor {
   ComputationCache::TypePtr LookupCachedCompile(const hash_t& hash);
 
   void BuildInputOutputAliases(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<size_t> indices,
       LoweringContext* lowering_ctx);
 
   std::shared_ptr<Async> SyncTensorsGraphInternal(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       c10::ArrayRef<std::string> devices,
       const SyncTensorsConfig& config);
 
@@ -226,22 +226,22 @@ class TORCH_API LazyGraphExecutor {
       ComputationCache::TypePtr cached_computation);
 
   std::shared_ptr<Async> ScheduleSyncTensorsGraph(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       SyncTensorCollection* coll,
       std::vector<BackendDataPtr> parameters_data,
       ComputationCache::TypePtr cached_computation);
 
-  std::vector<at::Tensor> GetTensorsFused(std::vector<LazyTensor>* tensors);
+  std::vector<at::Tensor> GetTensorsFused(std::vector<LazyTensorPtr>* tensors);
 
   std::vector<at::Tensor> FetchTensors(
-      std::vector<LazyTensor>* tensors,
+      std::vector<LazyTensorPtr>* tensors,
       c10::ArrayRef<BackendDataPtr> tensors_data,
       const std::vector<size_t>* indices);
 
   // Gathers the device data for all the input tensors, after an
   // asynchronous operation.
   std::vector<BackendDataPtr> GatherTensorsData(
-      const std::vector<LazyTensor>& tensors,
+      const std::vector<LazyTensorPtr>& tensors,
       c10::ArrayRef<size_t> indices,
       c10::ArrayRef<BackendDataPtr> tensors_data);
 

--- a/torch/csrc/lazy/core/tensor.cpp
+++ b/torch/csrc/lazy/core/tensor.cpp
@@ -15,10 +15,10 @@
 namespace torch {
 namespace lazy {
 namespace {
-LazyTensor GetOrCreateLtcTensor(const at::Tensor& tensor,
+LazyTensorPtr GetOrCreateLtcTensor(const at::Tensor& tensor,
                                 const BackendDevice& device) {
   if (!tensor.defined()) {
-    return LazyTensor();
+    return torch::lazy::LazyTensorPtr();
   }
   auto lazy_tensor = TryGetLtcTensor(tensor);
   return lazy_tensor ? lazy_tensor : LazyTensor::Create(tensor, device);
@@ -29,37 +29,37 @@ LazyTensor::Data::~Data() {
   LazyGraphExecutor::Get()->UnregisterTensor(this);
 }
 
-LazyTensor LazyTensor::Create(
+LazyTensorPtr LazyTensor::Create(
     const at::Tensor& tensor,
     const BackendDevice& device) {
   TORCH_CHECK(tensor.device().type() != at::kLazy);
-  LazyTensor xtensor(tensor, device);
-  LazyGraphExecutor::Get()->RegisterTensor(xtensor.data_ptr());
-  return xtensor;
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(LazyTensor(tensor, device));
+  LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
+  return lazy_tensor;
 }
 
-LazyTensor LazyTensor::Create(Value ir_value, const BackendDevice& device) {
-  LazyTensor xtensor(std::move(ir_value), device);
-  LazyGraphExecutor::Get()->RegisterTensor(xtensor.data_ptr());
-  return xtensor;
+LazyTensorPtr LazyTensor::Create(Value ir_value, const BackendDevice& device) {
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(LazyTensor(std::move(ir_value), device));
+  LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
+  return lazy_tensor;
 }
 
-LazyTensor LazyTensor::Create(
+LazyTensorPtr LazyTensor::Create(
     std::shared_ptr<LazyView> view,
     const BackendDevice& device) {
-  LazyTensor xtensor(std::move(view), device);
-  LazyGraphExecutor::Get()->RegisterTensor(xtensor.data_ptr());
-  return xtensor;
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(LazyTensor(std::move(view), device));
+  LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
+  return lazy_tensor;
 }
 
-LazyTensor LazyTensor::Create(BackendDataPtr handle) {
-  LazyTensor xtensor(std::move(handle));
-  LazyGraphExecutor::Get()->RegisterTensor(xtensor.data_ptr());
-  return xtensor;
+LazyTensorPtr LazyTensor::Create(BackendDataPtr handle) {
+  LazyTensorPtr lazy_tensor = c10::make_intrusive<LazyTensor>(LazyTensor(std::move(handle)));
+  LazyGraphExecutor::Get()->RegisterTensor(lazy_tensor->data_ptr());
+  return lazy_tensor;
 }
 
-LazyTensor LazyTensor::Create(std::shared_ptr<Data> data) {
-  return LazyTensor(std::move(data));
+LazyTensorPtr LazyTensor::Create(std::shared_ptr<Data> data) {
+  return c10::make_intrusive<LazyTensor>(LazyTensor(std::move(data)));
 }
 
 LazyTensor::LazyTensor(const at::Tensor& tensor, const BackendDevice& device)
@@ -344,7 +344,7 @@ std::shared_ptr<LazyView> LazyTensor::CreateView(ViewInfo view_info) const {
   return std::make_shared<LazyView>(view_info.shape, alias, view_info);
 }
 
-LazyTensor LazyTensor::CreateViewTensor(ViewInfo view_info) const {
+LazyTensorPtr LazyTensor::CreateViewTensor(ViewInfo view_info) const {
   return Create(CreateView(std::move(view_info)), GetDevice());
 }
 
@@ -379,7 +379,7 @@ at::Tensor LazyTensor::ToTensor(bool detached) {
   return tensor;
 }
 
-void LazyTensor::ShallowCopyTo(LazyTensor* dest) const {
+void LazyTensor::ShallowCopyTo(LazyTensorPtr dest) const {
   dest->SetIrValue(GetIrValue());
 }
 
@@ -412,12 +412,12 @@ void LazyTensor::UpdateFromTensorOut(at::Tensor tensor) {
   UpdateFromTensor(std::move(tensor), /*sync=*/false);
 }
 
-void LazyTensor::UpdateFromTensorOut(const LazyTensor& tensor) {
+void LazyTensor::UpdateFromTensorOut(const LazyTensorPtr& tensor) {
   if (data()->view != nullptr &&
-      shape().Get().numel() != tensor.shape().Get().numel()) {
+      shape().Get().numel() != tensor->shape().Get().numel()) {
     data()->view = nullptr;
   }
-  SetIrValue(tensor.GetIrValue());
+  SetIrValue(tensor->GetIrValue());
 }
 
 Value LazyTensor::CreateTensorNode(BackendDataPtr data, bool read_only) const {
@@ -426,8 +426,8 @@ Value LazyTensor::CreateTensorNode(BackendDataPtr data, bool read_only) const {
   return MakeNode<DeviceData>(std::move(data));
 }
 
-std::vector<LazyTensor> LazyTensor::MakeOutputTensors(NodePtr node) const {
-  std::vector<LazyTensor> tensors;
+std::vector<LazyTensorPtr> LazyTensor::MakeOutputTensors(NodePtr node) const {
+  std::vector<LazyTensorPtr> tensors;
   tensors.reserve(node->num_outputs());
   for (const auto i : c10::irange(node->num_outputs())) {
     tensors.push_back(Create(Value(node, i), GetDevice()));
@@ -435,7 +435,7 @@ std::vector<LazyTensor> LazyTensor::MakeOutputTensors(NodePtr node) const {
   return tensors;
 }
 
-LazyTensor LazyTensor::CopyTensorToDevice(const BackendDevice& device) {
+LazyTensorPtr LazyTensor::CopyTensorToDevice(const BackendDevice& device) {
   // TODO: This can be optimized.
   return Create(ToTensor(/*detached=*/true), device);
 }
@@ -445,7 +445,7 @@ void LazyTensor::ApplyPendingGraph() {
   // This method is called to ensure that the tensor data is available on
   // device, so that a call to CurrentDataHandle() returns a valid pointer.
   if (CurrentDataHandle() == nullptr) {
-    std::vector<LazyTensor> tensors({*this});
+    std::vector<LazyTensorPtr> tensors({c10::make_intrusive<LazyTensor>(LazyTensor(*this))});
     LazyGraphExecutor::Get()->SyncTensorsGraph(
         &tensors,
         {},
@@ -459,22 +459,23 @@ int64_t LazyTensor::GetNextTensorId() {
   return id_generator->fetch_add(1);
 }
 
-LazyTensor TryGetLtcTensor(const at::Tensor& tensor) {
+LazyTensorPtr TryGetLtcTensor(const at::Tensor& tensor) {
   auto* impl = dynamic_cast<LTCTensorImpl*>(tensor.unsafeGetTensorImpl());
   if (impl == nullptr) {
-    return LazyTensor();
+    // return c10::make_intrusive<LazyTensor>();
+    return LazyTensorPtr();
   }
   return impl->tensor();
 }
 
-LazyTensor GetLtcTensor(const at::Tensor& tensor) {
+LazyTensorPtr GetLtcTensor(const at::Tensor& tensor) {
   auto lazy_tensor = TryGetLtcTensor(tensor);
   CHECK(lazy_tensor) << "Input tensor is not a lazy tensor: " << tensor.toString();
   return lazy_tensor;
 }
 
-std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors) {
-  std::vector<LazyTensor> ltc_tensors;
+std::vector<LazyTensorPtr> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors) {
+  std::vector<LazyTensorPtr> ltc_tensors;
   ltc_tensors.reserve(tensors.size());
   for (const auto& tensor : tensors) {
     ltc_tensors.push_back(TryGetLtcTensor(tensor));
@@ -482,12 +483,12 @@ std::vector<LazyTensor> GetLtcTensors(c10::ArrayRef<at::Tensor> tensors) {
   return ltc_tensors;
 }
 
-LazyTensor GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
+LazyTensorPtr GetOrCreateLtcTensor(const c10::optional<at::Tensor>& tensor,
                                 const BackendDevice& device) {
   return GetOrCreateLtcTensor(tensor.value_or(at::Tensor()), device);
 }
 
-LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const BackendDevice& device) {
+LazyTensorPtr GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const BackendDevice& device) {
   // TODO: There are places in core where a scalar is wrapped but not marked as
   // wrapped.
   return (tensor.unsafeGetTensorImpl()->is_wrapped_number() ||
@@ -496,14 +497,13 @@ LazyTensor GetLtcTensorOrCreateForWrappedNumber(const at::Tensor& tensor, const 
              : GetLtcTensor(tensor);
 }
 
-at::Tensor CreateAtenFromLtcTensor(const LazyTensor& ltc_tensor) {
-  return ltc_tensor.is_null() ? at::Tensor()
-                              : at::Tensor(c10::make_intrusive<LTCTensorImpl>(ltc_tensor));
+at::Tensor CreateAtenFromLtcTensor(const LazyTensorPtr& ltc_tensor) {
+  return ltc_tensor ? at::Tensor(c10::make_intrusive<LTCTensorImpl>(ltc_tensor))
+                    : at::Tensor();
 }
 
 at::Tensor CreateAtenFromLtcTensor(LazyTensor&& ltc_tensor) {
-  return ltc_tensor.is_null() ? at::Tensor()
-                              : at::Tensor(c10::make_intrusive<LTCTensorImpl>(std::move(ltc_tensor)));
+  return at::Tensor(c10::make_intrusive<LTCTensorImpl>(std::move(ltc_tensor)));
 }
 
 } // namespace lazy

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -13,12 +13,13 @@ namespace lazy {
 // Its scope is just to handle an LazyTensor.
 class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
  public:
+  explicit LTCTensorImpl(const LazyTensorPtr& tensor);
   explicit LTCTensorImpl(const LazyTensor& tensor);
   explicit LTCTensorImpl(LazyTensor&& tensor);
 
-  LazyTensor& tensor() { return tensor_; }
+  LazyTensorPtr tensor() { return tensor_; }
 
-  void set_tensor(const LazyTensor& lazy_tensor);
+  void set_tensor(const LazyTensorPtr& lazy_tensor);
 
   void force_refresh_sizes() { generation_ = 0; }
 
@@ -50,7 +51,7 @@ class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
  private:
   void setup_size_properties();
 
-  LazyTensor tensor_;
+  LazyTensorPtr tensor_;
   size_t generation_ {0};
 };
 


### PR DESCRIPTION
Summary:
Refactors the whole codebase to use LazyTensorPtr (defined as c10::intrusive_ptr) to enable XLA to use a derived class XlaLazyTensor and override functionality.

this PR is just the first step, and we will need to add a factory class that XLA can override in their backend to actually hook up their derived tensor class.

Parallel PR on lazy_tensor_staging: #73429

Test Plan: tested via lazy_tensor_staging test_ptltc and torchbench and CI

Differential Revision: D34481918

