### PR TITLE
[Static Runtime] [Code Cleanup] Use `SROperator` for operators' function type

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -232,6 +232,8 @@ class ProcessedFunction;
 class ProcessedNode;
 class StaticRuntime;
 
+using SROperator = std::function<void(ProcessedNode*)>;
+
 // A `BlockInfo` instance stores all of the shared state that each
 // `BlockRunner` will need to access. Most of this information is
 // read-only and shared between threads.
@@ -765,7 +767,7 @@ class TORCH_API ProcessedFunction {
   }
 
  private:
-  std::function<void(ProcessedNode*)> f_;
+  SROperator f_;
   Kind kind_{ProcessedFunction::Kind::kOutVariant};
   bool check_memory_overlap_{false};
   size_t num_outputs_{0};

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -39,7 +39,7 @@ bool nativeOpIsRegistered(const c10::Symbol& op_name) {
   return SRNativeOperatorRegistry()->Has(name);
 }
 
-std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
+SROperator getNativeOperation(Node* n) {
   auto op_name = n->kind().toQualString();
   if (SRNativeOperatorRegistry()->Has(op_name)) {
     return SRNativeOperatorRegistry()->Create(op_name)->Generate(n);

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -429,7 +429,7 @@ bool disableUnsafeMathOp(const char* op_name) {
   return fast_ops.count(op_name) > 0;
 }
 
-std::function<void(ProcessedNode*)> getOutOfPlaceOperation(Node* n) {
+SROperator getOutOfPlaceOperation(Node* n) {
   auto op_name = n->kind().toQualString();
   if (SROperatorRegistry()->Has(op_name) && !disableUnsafeMathOp(op_name)) {
     return SROperatorRegistry()->Create(op_name)->Generate(n);

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -23,11 +23,10 @@ at::Tensor& to_copy_out(
 namespace torch {
 namespace jit {
 
-using SROperator = std::function<void(ProcessedNode*)>;
 using SROpFunctor = SROperator (*)(Node* n);
 struct SROperatorFunctor {
   virtual SROperator Generate(Node*) {
-    std::function<void(ProcessedNode*)> out;
+    SROperator out;
     return out;
   }
   virtual ~SROperatorFunctor() = default;
@@ -154,8 +153,8 @@ bool isOptimizableContainerType(
     Node* n,
     const FastMap<Node*, bool>& node_has_out_variant);
 
-std::function<void(ProcessedNode*)> getOutOfPlaceOperation(Node* n);
-std::function<void(ProcessedNode*)> getNativeOperation(Node* n);
+SROperator getOutOfPlaceOperation(Node* n);
+SROperator getNativeOperation(Node* n);
 
 bool hasVarArgs(Node* n);
 


### PR DESCRIPTION
Summary: This change uses `SROperator` for operators' function type

Test Plan: N/A

Reviewed By: mikeiovine

Differential Revision: D34483246

