### PR TITLE
[libkineto] Re-enable user-annotations on GPU timeline

### DIFF
--- a/benchmarks/fastrnns/bench.py
+++ b/benchmarks/fastrnns/bench.py
@@ -6,6 +6,7 @@ import sys
 import json
 import copy
 import time
+from torch.autograd.profiler import record_function
 
 from .fuser import set_fuser
 from .runner import get_nn_runners
@@ -73,7 +74,8 @@ def trainbench(name, rnn_creator, nloops=100, warmup=10,
         gc.collect()
 
         fwd_start_event.record()
-        forward_output = modeldef.forward(*modeldef.inputs)
+        with record_function("## forward ##"):
+            forward_output = modeldef.forward(*modeldef.inputs)
         fwd_end_event.record()
 
         # XXX: Use if need to print something

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -62,14 +62,18 @@ TraceWrapper::TraceWrapper(const int64_t start_time, const std::string& name)
 
 void TraceWrapper::addCPUActivity(
     const std::string& name,
+    const uint8_t scope,
     const DeviceAndResource device_and_resource,
     const uint64_t correlation_id,
     const int64_t start_time,
     const int64_t end_time) {
 #ifdef USE_KINETO
   TORCH_CHECK((bool)(*this), "Cannot add event to non-existent trace.");
+  auto type = ((at::RecordScope)scope == at::RecordScope::USER_SCOPE)
+    ? libkineto::ActivityType::USER_ANNOTATION
+    : libkineto::ActivityType::CPU_OP;
   cpu_trace_->activities.emplace_back(libkineto::GenericTraceActivity(
-    cpu_trace_->span, libkineto::ActivityType::CPU_OP, name));
+    cpu_trace_->span, type, name));
   auto& act = cpu_trace_->activities.back();
   act.device = device_and_resource.device;
   act.resource = device_and_resource.resource;
@@ -194,9 +198,21 @@ void pushCorrelationId(uint64_t correlation_id) {
 #endif // USE_KINETO
 }
 
+void pushUserCorrelationId(uint64_t correlation_id) {
+#ifdef USE_KINETO
+  libkineto::api().activityProfiler().pushUserCorrelationId(correlation_id);
+#endif // USE_KINETO
+}
+
 void popCorrelationId() {
 #ifdef USE_KINETO
   libkineto::api().activityProfiler().popCorrelationId();
+#endif // USE_KINETO
+}
+
+void popUserCorrelationId() {
+#ifdef USE_KINETO
+  libkineto::api().activityProfiler().popUserCorrelationId();
 #endif // USE_KINETO
 }
 

--- a/torch/csrc/profiler/kineto_shim.h
+++ b/torch/csrc/profiler/kineto_shim.h
@@ -68,6 +68,7 @@ struct TraceWrapper {
   // addMemoryUsageActivity.
   void addCPUActivity(
       const std::string& name,
+      const uint8_t scope,
       const DeviceAndResource device_and_resource,
       const uint64_t correlation_id,
       const int64_t start_time,
@@ -118,7 +119,9 @@ void prepareTrace(const bool cpuOnly, const ActivitySet& activities);
 void startTrace();
 ActivityTraceWrapper stopTrace();
 void pushCorrelationId(uint64_t correlation_id);
+void pushUserCorrelationId(uint64_t correlation_id);
 void popCorrelationId();
+void popUserCorrelationId();
 void recordThreadInfo();
 
 } // namespace kineto


### PR DESCRIPTION
Summary:
Re-submitting Re-enable user-annotations on GPU timeline diff from Gisle.

User annotations was previously pushed down to the GPU timelines but was disabled during a refactoring some time back.
This patch re-enables it internally at FB, and also enables it for the PyTorch profiler.

Test Plan: Added unit test.

Reviewed By: briancoutinho

Differential Revision: D32313588

Pulled By: aaronenyeshi

