### PR TITLE
fused int8 static

### DIFF
--- a/caffe2/operators/quantized/int8_fc_op.cc
+++ b/caffe2/operators/quantized/int8_fc_op.cc
@@ -10,7 +10,7 @@ REGISTER_CPU_OPERATOR(Int8FC, int8::Int8FCOp);
 
 using namespace std::placeholders;
 OPERATOR_SCHEMA(Int8FC)
-    .NumInputs(3, 4)
+    .NumInputs(3, 5)
     .NumOutputs(1, 4)
     // NOLINTNEXTLINE(modernize-avoid-bind)
     .TensorInferenceFunction(std::bind(FCShapeInference, _1, _2, false))
@@ -50,6 +50,11 @@ will throw errors.
         "Qparam",
         "Optional Qparam blob that contains quant param computed on activation histogram data"
         "Will overwrite Y_scale and Y_zero_point argument if specified")
+    .Input(
+        4,
+        "in_Qparam",
+        "Optional Qparam blob that contains quant param computed on activation histogram data"
+        "Will overwrite X_scale and X_zero_point argument if specified")
     .Output(0, "Y", "2D output tensor");
 
 } // namespace caffe2

--- a/caffe2/quantization/server/dnnlowp_test_utils.py
+++ b/caffe2/quantization/server/dnnlowp_test_utils.py
@@ -385,6 +385,8 @@ def run_conv_or_fc(
     outputs,
     scale=None,
     zero_point=None,
+    x_scale=None,
+    x_zero_point=None,
 ):
     if order:
         # Conv
@@ -407,6 +409,11 @@ def run_conv_or_fc(
             dnnlowp_pybind11.CreateInt8QuantParamsBlob(
                 "quant_param", float(scale), int(zero_point)
             )
+    if x_scale is not None and x_zero_point is not None:
+        with workspace.WorkspaceGuard(test_case.ws):
+            dnnlowp_pybind11.CreateInt8QuantParamsBlob(
+                "X_quant_param", float(x_scale), int(x_zero_point)
+            )
 
     if init_net:
         test_case.ws.run(init_net)
@@ -426,6 +433,10 @@ def run_conv_or_fc(
         if scale is not None and zero_point is not None:
             dnnlowp_pybind11.CreateInt8QuantParamsBlob(
                 "quant_param", float(scale), int(zero_point)
+            )
+        if x_scale is not None and x_zero_point is not None:
+            dnnlowp_pybind11.CreateInt8QuantParamsBlob(
+                "X_quant_param", float(x_scale), int(x_zero_point)
             )
 
         if init_net:

--- a/caffe2/quantization/server/fully_connected_dnnlowp_op.h
+++ b/caffe2/quantization/server/fully_connected_dnnlowp_op.h
@@ -17,10 +17,12 @@ class FullyConnectedDNNLowPOp
   USE_DNNLOWP_OPERATOR_BASE_FUNCTIONS(T, FullyConnectedOp<CPUContext>);
 
  protected:
-  bool GetQuantizationParameters_();
+  bool GetQuantizationParameters_(float X_scale_=-1.0, int X_zero_point_=0);
 
   std::size_t axis_{1};
   std::size_t axis_w_{1};
+  float X_scale_{-1.0};
+  int X_zero_point_{0};
   vector<std::int64_t> Y_shape_cache_;
 
   std::vector<dnnlowp::RequantizationParams> requantization_params_;


### PR DESCRIPTION
Summary:
Added a fused Int8FC path using PackAWithQuantRowOffset like the INT8 dynamic path. There are two ways to enable it
(1) set an positive "X_scale" value in the arg list of Int8FC op
(2) send both "Qparam" (for output requantization, could be dummy values) and "in_Qparam" (for fused input quantization)

Differential Revision: D34034681

