### PR TITLE
Cleanup C10::Scalar stringification

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -12,6 +12,28 @@ namespace c10 {
 std::ostream& operator<<(std::ostream & out, Backend b) {
   return out << toString(b);
 }
+
+std::ostream& operator<<(std::ostream & out, Scalar s) {
+  if (s.isFloatingPoint()) {
+    return out << s.toDouble();
+  }
+  if (s.isComplex()) {
+    return out << s.toComplexDouble();
+  }
+  if (s.isBoolean()) {
+    return out << (s.toBool() ? "true" : "false");
+  }
+  if (s.isIntegral(false)) {
+    return out << s.toLong();
+  }
+  throw std::logic_error("Unknown type in Scalar");
+}
+
+std::string toString(Scalar s) {
+  std::stringstream out;
+  out << s;
+  return out.str();
+}
 }
 namespace at {
 

--- a/aten/src/ATen/core/Formatting.h
+++ b/aten/src/ATen/core/Formatting.h
@@ -1,12 +1,15 @@
 #pragma once
 
+#include <ostream>
+#include <string>
+
 #include <c10/core/Scalar.h>
 #include <ATen/core/Tensor.h>
-#include <ostream>
-
 
 namespace c10 {
 TORCH_API std::ostream& operator<<(std::ostream& out, Backend b);
+TORCH_API std::ostream& operator<<(std::ostream & out, Scalar s);
+TORCH_API std::string toString(Scalar s);
 }
 namespace at {
 
@@ -19,21 +22,4 @@ static inline std::ostream& operator<<(std::ostream & out, const Tensor & t) {
   return print(out,t,80);
 }
 TORCH_API void print(const Tensor & t, int64_t linesize=80);
-
-static inline std::ostream& operator<<(std::ostream & out, Scalar s) {
-  if (s.isFloatingPoint()) {
-    return out << s.toDouble();
-  }
-  if (s.isComplex()) {
-    return out << s.toComplexDouble();
-  }
-  if (s.isBoolean()) {
-    return out << (s.toBool() ? "true" : "false");
-  }
-  if (s.isIntegral(false)) {
-    return out << s.toLong();
-  }
-  throw std::logic_error("Unknown type in Scalar");
-}
-
 }


### PR DESCRIPTION
Summary: Because `operator<<` for Scalar is in `namespace at`, overload resolution fails very outside of `at`. By moving to `c10`, `namespace c10` will be included in the candidates due to the Scalar arg. I also didn't a good reason for the definition to be inline, and we're missing a `toString` overload so I added one.

Test Plan: Template deduction during compile should be sufficient.

Differential Revision: D34483818

