### PR TITLE
[test] Disable TestXNNPACK on ROCM machines

### DIFF
--- a/test/test_xnnpack_integration.py
+++ b/test/test_xnnpack_integration.py
@@ -14,12 +14,13 @@ from hypothesis import strategies as st
 import io
 import itertools
 
-from torch.testing._internal.common_utils import TEST_WITH_TSAN
+from torch.testing._internal.common_utils import (TEST_WITH_TSAN, TEST_WITH_ROCM)
 
 @unittest.skipUnless(torch.backends.xnnpack.enabled,
                      " XNNPACK must be enabled for these tests."
                      " Please build with USE_XNNPACK=1.")
 @unittest.skipIf(TEST_WITH_TSAN, "TSAN fails with XNNPACK. Does not seem to have a good reason for failures.")
+@unittest.skipIf(TEST_WITH_ROCM, "HACK, not sure why these fail on ROCM.")
 class TestXNNPACKOps(TestCase):
     @given(batch_size=st.integers(0, 3),
            data_shape=hu.array_shapes(1, 3, 2, 64),
@@ -181,6 +182,7 @@ class TestXNNPACKOps(TestCase):
                      " XNNPACK must be enabled for these tests."
                      " Please build with USE_XNNPACK=1.")
 @unittest.skipIf(TEST_WITH_TSAN, "TSAN fails with XNNPACK. Does not seem to have a good reason for failures.")
+@unittest.skipIf(TEST_WITH_ROCM, "HACK, not sure why these fail on ROCM.")
 class TestXNNPACKSerDes(TestCase):
     @given(batch_size=st.integers(0, 3),
            data_shape=hu.array_shapes(1, 3, 2, 64),
@@ -572,6 +574,7 @@ class TestXNNPACKSerDes(TestCase):
                      " XNNPACK must be enabled for these tests."
                      " Please build with USE_XNNPACK=1.")
 @unittest.skipIf(TEST_WITH_TSAN, "TSAN fails with XNNPACK. Does not seem to have a good reason for failures.")
+@unittest.skipIf(TEST_WITH_ROCM, "HACK, not sure why these fail on ROCM.")
 class TestXNNPACKRewritePass(TestCase):
     @staticmethod
     def validate_transformed_module(
@@ -933,6 +936,7 @@ class TestXNNPACKRewritePass(TestCase):
                      " XNNPACK must be enabled for these tests."
                      " Please build with USE_XNNPACK=1.")
 @unittest.skipIf(TEST_WITH_TSAN, "TSAN is not fork-safe since we're forking in a multi-threaded environment")
+@unittest.skipIf(TEST_WITH_ROCM, "HACK, not sure why these fail on ROCM.")
 class TestXNNPACKConv1dTransformPass(TestCase):
     @staticmethod
     def validate_transform_conv1d_to_conv2d(


### PR DESCRIPTION
Summary: This is a temp fix, and needs further investigation.

Test Plan: CI

Differential Revision: D34501632

