### PR TITLE
(torch/elastic) skip logging structured error info if error_file is not set

### DIFF
--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -14,7 +14,7 @@ from torch.distributed.elastic.multiprocessing.errors import (
     ProcessFailure,
     record,
 )
-from torch.distributed.elastic.multiprocessing.errors.error_handler import _write_error
+from torch.distributed.elastic.multiprocessing.errors.error_handler import ErrorHandler
 
 
 class SentinelError(Exception):
@@ -36,7 +36,8 @@ def good_fn():
 @record
 def raise_child_failure_error_fn(name, child_error_file=""):
     if child_error_file:
-        _write_error(SentinelError("foobar"), child_error_file)
+        with mock.patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": child_error_file}):
+            ErrorHandler().record_exception(SentinelError("foobar"))
     pf = ProcessFailure(local_rank=0, pid=997, exitcode=1, error_file=child_error_file)
     raise ChildFailedError(name, {0: pf})
 
@@ -64,7 +65,10 @@ class ApiTest(unittest.TestCase):
             )
 
     def failure_with_error_file(self, exception):
-        _write_error(exception, self.test_error_file)
+        with mock.patch.dict(
+            os.environ, {"TORCHELASTIC_ERROR_FILE": self.test_error_file}
+        ):
+            ErrorHandler().record_exception(exception)
         return ProcessFailure(
             local_rank=0, pid=997, exitcode=1, error_file=self.test_error_file
         )

--- a/test/distributed/elastic/multiprocessing/errors/error_handler_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/error_handler_test.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from torch.distributed.elastic.multiprocessing.errors.error_handler import ErrorHandler, _write_error
+from torch.distributed.elastic.multiprocessing.errors.error_handler import ErrorHandler
 from torch.distributed.elastic.multiprocessing.errors.handlers import get_error_handler
 
 
@@ -78,15 +78,15 @@ class ErrorHandlerTest(unittest.TestCase):
 
     def test_dump_error_file(self):
         src_error_file = os.path.join(self.test_dir, "src_error.json")
-        _write_error(RuntimeError("foobar"), src_error_file)
+        eh = ErrorHandler()
+        with patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": src_error_file}):
+            eh.record_exception(RuntimeError("foobar"))
 
         with patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": self.test_error_file}):
-            eh = ErrorHandler()
             eh.dump_error_file(src_error_file)
             self.assertTrue(filecmp.cmp(src_error_file, self.test_error_file))
 
         with patch.dict(os.environ, {}):
-            eh = ErrorHandler()
             eh.dump_error_file(src_error_file)
             # just validate that dump_error_file works when
             # my error file is not set
@@ -95,10 +95,13 @@ class ErrorHandlerTest(unittest.TestCase):
     def test_dump_error_file_overwrite_existing(self):
         dst_error_file = os.path.join(self.test_dir, "dst_error.json")
         src_error_file = os.path.join(self.test_dir, "src_error.json")
-        _write_error(RuntimeError("foo"), dst_error_file)
-        _write_error(RuntimeError("bar"), src_error_file)
+        eh = ErrorHandler()
+        with patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": dst_error_file}):
+            eh.record_exception(RuntimeError("foo"))
+
+        with patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": src_error_file}):
+            eh.record_exception(RuntimeError("bar"))
 
         with patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": dst_error_file}):
-            eh = ErrorHandler()
             eh.dump_error_file(src_error_file)
             self.assertTrue(filecmp.cmp(src_error_file, dst_error_file))

--- a/torch/distributed/elastic/multiprocessing/errors/error_handler.py
+++ b/torch/distributed/elastic/multiprocessing/errors/error_handler.py
@@ -18,24 +18,6 @@ from typing import Optional
 log = logging.getLogger(__name__)
 
 
-def _write_error(e: BaseException, error_file: Optional[str]):
-    data = {
-        "message": {
-            "message": f"{type(e).__name__}: {e}",
-            "extraInfo": {
-                "py_callstack": traceback.format_exc(),
-                "timestamp": str(int(time.time())),
-            },
-        }
-    }
-
-    if error_file:
-        with open(error_file, "w") as fp:
-            json.dump(data, fp)
-    else:
-        log.error(json.dumps(data, indent=2))
-
-
 class ErrorHandler:
     """
     Writes the provided exception object along with some other metadata about
@@ -83,7 +65,20 @@ class ErrorHandler:
         JSON format. If the error file cannot be determined, then logs the content
         that would have been written to the error file.
         """
-        _write_error(e, self._get_error_file_path())
+
+        file = self._get_error_file_path()
+        if file:
+            data = {
+                "message": {
+                    "message": f"{type(e).__name__}: {e}",
+                    "extraInfo": {
+                        "py_callstack": traceback.format_exc(),
+                        "timestamp": str(int(time.time())),
+                    },
+                }
+            }
+            with open(file, "w") as fp:
+                json.dump(data, fp)
 
     def dump_error_file(self, rootcause_error_file: str, error_code: int = 0):
         """


### PR DESCRIPTION
Summary:
resolves https://github.com/pytorch/pytorch/issues/73465

This `log.error` is not necessary (and its also not human-friendly formatted) because we end up re-raising the same exception after recording the exception into an error_file (if present). Eventually python should handle this error the way it handles any other errors and will write the trace info into the console. This additional logging produces duplicate error console prints, which affects all users whose schedulers do not set `TORCHELASTIC_ERROR_FILE` env var when calling `torch.distributed.run`.

Test Plan:
Induce an error on the agent process by `kill -15 $AGENT_PID`
```
python -m torch.distributed.run \
   --nproc_per_node 2 \
   --nnodes 1:1 \
   --rdzv_backend c10d \
  --rdzv_endpoint localhost:29500 \
  --monitor_interval 3 test.py
```

Produces

{F704936697}

In contrast to the duplicated error before:

{F704936729}

Differential Revision: D34501852

