### PR TITLE
Add run_android_tests workflow

### DIFF
--- a/.github/workflows/run_android_tests.yml
+++ b/.github/workflows/run_android_tests.yml
@@ -2,16 +2,16 @@ name: android-tests
 
 on:
   push:
+    tags:
+      # Trigger on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - 'ciflow/trunk/*'
+      - 'ciflow/android/*'
     branches:
       - master
       - main
       - release/*
-    tags:
-      # NOTE: Binary build pipelines should only get triggered on release candidate builds
-      # Release candidate tags look like: v1.11.0-rc1
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-    - 'ciflow/trunk/*'
-    - 'ciflow/android/*'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/run_android_tests.yml
+++ b/.github/workflows/run_android_tests.yml
@@ -15,6 +15,10 @@ on:
       - release/*
   workflow_dispatch:
 
+concurrency:
+  group: run-android-tests-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash -e -l {0}

--- a/.github/workflows/run_android_tests.yml
+++ b/.github/workflows/run_android_tests.yml
@@ -1,6 +1,7 @@
 name: android-tests
 
 on:
+  pull_request:
   push:
     tags:
       # Trigger on release candidate builds

--- a/.github/workflows/run_android_tests.yml
+++ b/.github/workflows/run_android_tests.yml
@@ -1,0 +1,60 @@
+name: android-tests
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - release/*
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash -e -l {0}
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    env:
+      JOB_BASE_NAME: ubuntu-latest-android-tests
+    steps:
+      - name: Setup miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: 3.8
+          activate-environment: build
+
+      - name: Install dependencies
+        run: |
+          conda install -y \
+            cffi \
+            cmake \
+            mkl \
+            mkl-include \
+            ninja \
+            numpy \
+            pyyaml \
+            requests \
+            setuptools \
+            typing_extensions
+
+      - name: Checkout PyTorch
+        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Build PyTorch Android
+        run: |
+          export ANDROID_NDK="${ANDROID_SDK_ROOT}/ndk-bundle"
+          echo "CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname "$(which conda)")/../"}" >> "${GITHUB_ENV}"
+          ./scripts/build_pytorch_android.sh x86
+
+      - name: Run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 25
+          script: ./android/run_tests.sh

--- a/.github/workflows/run_android_tests.yml
+++ b/.github/workflows/run_android_tests.yml
@@ -25,7 +25,7 @@ defaults:
 
 jobs:
 
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     env:
       JOB_BASE_NAME: ubuntu-latest-android-tests

--- a/.github/workflows/run_android_tests.yml
+++ b/.github/workflows/run_android_tests.yml
@@ -1,7 +1,6 @@
 name: android-tests
 
 on:
-  pull_request:
   push:
     tags:
       # Trigger on release candidate builds

--- a/.github/workflows/run_android_tests.yml
+++ b/.github/workflows/run_android_tests.yml
@@ -6,6 +6,12 @@ on:
       - master
       - main
       - release/*
+    tags:
+      # NOTE: Binary build pipelines should only get triggered on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+    - 'ciflow/trunk/*'
+    - 'ciflow/android/*'
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
Android emulator tests workflow on Linux Github hosted runners, for now triggers on master/main/release push.

Example successful run: https://github.com/pytorch/pytorch/runs/5488927387
