### PR TITLE
[BE][GHA] Use `timeout_after` for win templates

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -401,6 +401,8 @@ WINDOWS_WORKFLOWS = [
         test_runner_type=WINDOWS_CUDA_TEST_RUNNER,
         num_test_shards=2,
         enable_force_on_cpu_test=True,
+        # TODO: Revert back to default value after https://github.com/pytorch/pytorch/issues/73489 is closed
+        timeout_after=270,
         ciflow_config=CIFlowConfig(
             run_on_canary=True,
             labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_CUDA, LABEL_CIFLOW_WIN}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -189,8 +189,8 @@ jobs:
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
-        # Time out the test phase after 3.5 hours
-        timeout-minutes: 270
+        # Time out the test phase after !{{ timeout_after }} minutes
+        timeout-minutes: !{{ timeout_after }}
         run: |
             .jenkins/pytorch/win-test.sh
       !{{ common.upload_downloaded_files(name='windows', config=test_job.config, shard=test_job.shard, num_shards=test_job.num_shards, runner=test_job.runner) }}

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -200,8 +200,8 @@ jobs:
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
-        # Time out the test phase after 3.5 hours
-        timeout-minutes: 270
+        # Time out the test phase after 240 minutes
+        timeout-minutes: 240
         run: |
             .jenkins/pytorch/win-test.sh
       - name: Zip JSONs for upload
@@ -357,8 +357,8 @@ jobs:
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
-        # Time out the test phase after 3.5 hours
-        timeout-minutes: 270
+        # Time out the test phase after 240 minutes
+        timeout-minutes: 240
         run: |
             .jenkins/pytorch/win-test.sh
       - name: Zip JSONs for upload
@@ -514,8 +514,8 @@ jobs:
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
-        # Time out the test phase after 3.5 hours
-        timeout-minutes: 270
+        # Time out the test phase after 240 minutes
+        timeout-minutes: 240
         run: |
             .jenkins/pytorch/win-test.sh
       - name: Zip JSONs for upload

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -194,8 +194,8 @@ jobs:
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
-        # Time out the test phase after 3.5 hours
-        timeout-minutes: 270
+        # Time out the test phase after 240 minutes
+        timeout-minutes: 240
         run: |
             .jenkins/pytorch/win-test.sh
       - name: Zip JSONs for upload
@@ -343,8 +343,8 @@ jobs:
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
-        # Time out the test phase after 3.5 hours
-        timeout-minutes: 270
+        # Time out the test phase after 240 minutes
+        timeout-minutes: 240
         run: |
             .jenkins/pytorch/win-test.sh
       - name: Zip JSONs for upload

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -203,7 +203,7 @@ jobs:
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
-        # Time out the test phase after 3.5 hours
+        # Time out the test phase after 270 minutes
         timeout-minutes: 270
         run: |
             .jenkins/pytorch/win-test.sh
@@ -360,7 +360,7 @@ jobs:
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
-        # Time out the test phase after 3.5 hours
+        # Time out the test phase after 270 minutes
         timeout-minutes: 270
         run: |
             .jenkins/pytorch/win-test.sh
@@ -517,7 +517,7 @@ jobs:
         shell: bash
         env:
           PYTORCH_FINAL_PACKAGE_DIR: /c/${{ github.run_id }}/build-results/
-        # Time out the test phase after 3.5 hours
+        # Time out the test phase after 270 minutes
         timeout-minutes: 270
         run: |
             .jenkins/pytorch/win-test.sh


### PR DESCRIPTION
Rather than hardcode the value to 240 min, use `timeout_after` argument
to specify different limits depending on config