### PR TITLE
Back out "[DDP][BE] Fix clang-tidy"

### DIFF
--- a/torch/csrc/distributed/c10d/logger.cpp
+++ b/torch/csrc/distributed/c10d/logger.cpp
@@ -125,11 +125,11 @@ std::vector<std::vector<size_t>> Logger::get_per_bucket_variable_indices() {
   return per_bucket_variable_indices;
 }
 
-std::vector<int64_t> Logger::get_bucket_sizes() {
-  std::vector<int64_t> bucket_sizes;
+std::vector<int> Logger::get_bucket_sizes() {
+  std::vector<int> bucket_sizes;
   for (const auto& bucket : reducer_->buckets_) {
     const auto& variables = bucket.variables;
-    int64_t bucket_size = 0;
+    int bucket_size = 0;
     for (const auto& v : variables) {
       bucket_size += v.numel() * v.element_size();
     }

--- a/torch/csrc/distributed/c10d/logger.hpp
+++ b/torch/csrc/distributed/c10d/logger.hpp
@@ -41,7 +41,7 @@ class TORCH_API Logger {
   // Set parameters stats.
   void set_parameter_stats();
   // Get size of each bucket (Bytes).
-  std::vector<int64_t> get_bucket_sizes();
+  std::vector<int> get_bucket_sizes();
   // Get bucket size limits specified during DDP construction.
   std::vector<int> get_bucket_size_limits();
   // Get variable indices for each bucket.

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -1906,7 +1906,7 @@ namespace {
 // composite key of a tensor's type identifier and its device.
 struct BucketKey {
   BucketKey(c10::ScalarType type, c10::Device device)
-      : type(type), device(device) {}
+      : type(std::move(type)), device(std::move(device)) {}
 
   const c10::ScalarType type;
   const c10::Device device;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73524
* #73523
* __->__ #73522
* #73521

Original commit changeset: 41bcb2b9f617

Original Phabricator Diff: D34422578

Differential Revision: [D34527890](https://our.internmc.facebook.com/intern/diff/D34527890/)