### PR TITLE
Disable cublasLt when batch is too large.

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -119,6 +119,12 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
          scalar_type == at::ScalarType::Half ||
          scalar_type == at::ScalarType::BFloat16) &&
         mat2_sizes[0] > 1 && mat2_sizes[1] > 1;
+
+    // https://docs.nvidia.com/cuda/cublas/index.html#cublasLt-general-description
+    // Batch size > 65535 does not work in most cases.
+    if (mat1_sizes[0] > 65535) {
+      useLtInterface = false;
+    }
 #endif
     if (!useLtInterface) {
       self_ = expand_size(self, {mat1_sizes[0], mat2_sizes[1]}, "addmm");


### PR DESCRIPTION
Summary: https://docs.nvidia.com/cuda/cublas/index.html#cublasLt-general-description

Differential Revision: D34531305

