### PR TITLE
[Static Runtime] Introduce StaticNodeInfo to store ProcessedNode's data independent from runtime instances

### DIFF
--- a/benchmarks/static_runtime/test_static_module.cc
+++ b/benchmarks/static_runtime/test_static_module.cc
@@ -889,8 +889,9 @@ TEST(
       sigmoid_node,
       /*enable_out_variant=*/true,
       /*check_memory_overlap=*/false);
-  ProcessedNode pnode(sigmoid_node, &fn, createProcessedNodeInputs({0}), 1);
-  pnode.set_values(values.data());
+  StaticNodeInfo static_node_info(
+      sigmoid_node, &fn, createProcessedNodeInputs({0}), 1);
+  ProcessedNode pnode(static_node_info, values.data());
   EXPECT_TRUE(pnode.verify_no_memory_overlap(/* force_check*/ true));
 
   pnode.Output(0) = values[0];
@@ -908,8 +909,9 @@ TEST(ProcessedNode, VerifyNoMemoryOverlapWithImmutableInputsWithInplaceOps) {
       sigmoid_node,
       /*enable_out_variant=*/true,
       /*check_memory_overlap=*/false);
-  ProcessedNode pnode(sigmoid_node, &fn, createProcessedNodeInputs({0}), 1);
-  pnode.set_values(values.data());
+  StaticNodeInfo static_node_info(
+      sigmoid_node, &fn, createProcessedNodeInputs({0}), 1);
+  ProcessedNode pnode(static_node_info, values.data());
 
   ASSERT_EQ(&pnode.Output(0), &values[1]);
   EXPECT_TRUE(pnode.verify_no_memory_overlap());
@@ -935,9 +937,10 @@ TEST(ProcessedNode, VerifyNoMemoryOverlapWithOverlappingOutputs) {
         list_unpack_node,
         /*enable_out_variant=*/true,
         /*check_memory_overlap */ false);
-    ProcessedNode list_unpack_pnode(
+    StaticNodeInfo list_unpack_static_node_info(
         list_unpack_node, &fn, createProcessedNodeInputs({0}), 1);
-    list_unpack_pnode.set_values(values.data());
+    ProcessedNode list_unpack_pnode(
+        list_unpack_static_node_info, values.data());
     ASSERT_EQ(list_unpack_pnode.outputs().size(), 2);
     EXPECT_TRUE(
         list_unpack_pnode.verify_no_memory_overlap(/* force_check*/ true));
@@ -949,9 +952,10 @@ TEST(ProcessedNode, VerifyNoMemoryOverlapWithOverlappingOutputs) {
         list_unpack_node,
         /*enable_out_variant=*/true,
         /*check_memory_overlap */ false);
-    ProcessedNode list_unpack_pnode(
+    StaticNodeInfo list_unpack_static_node_info(
         list_unpack_node, &fn, createProcessedNodeInputs({0}), 1);
-    list_unpack_pnode.set_values(values.data());
+    ProcessedNode list_unpack_pnode(
+        list_unpack_static_node_info, values.data());
     auto b = at::randn({2, 3});
     list_unpack_pnode.Output(0) = b;
     list_unpack_pnode.Output(1) = b;

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -228,6 +228,7 @@ struct TORCH_API StaticModuleOptions {
 /// @endcode
 ///
 class MemoryPlanner;
+class StaticNodeInfo;
 class ProcessedFunction;
 class ProcessedNode;
 class StaticRuntime;
@@ -250,10 +251,10 @@ class BlockInfo {
       : input_idx_(input_idx), block_(block) {}
 
   void set_nodes(
-      std::vector<ProcessedNode> nodes,
+      std::vector<StaticNodeInfo> nodes,
       const FastMap<Node*, bool>& node_has_out_variant);
 
-  const std::vector<ProcessedNode>& nodes() const {
+  const std::vector<StaticNodeInfo>& nodes() const {
     return nodes_;
   }
 
@@ -327,7 +328,7 @@ class BlockInfo {
   }
 
  private:
-  std::vector<ProcessedNode> nodes_;
+  std::vector<StaticNodeInfo> nodes_;
 
   ValueGroup value_group_;
 
@@ -464,7 +465,7 @@ class TORCH_API StaticModule {
 
   // Recurses on sub-blocks and populates the array of ProcessedNodes
   // Returns (number of nodes processed, number of blocks processed)
-  size_t prepareProcessedNodes(
+  size_t prepareStaticNodeInfos(
       Block* block,
       const FastMap<const Value*, uint32_t>& value_to_index,
       const AliasDb& alias_db,
@@ -485,8 +486,9 @@ class TORCH_API StaticModule {
   std::vector<IValue> constants_;
   // The functions to be called by corresponding ProcessedNode.
   std::vector<ProcessedFunction> functions_{};
-  // The nodes we need to run
-  std::vector<ProcessedNode> nodes_;
+  // A list of pre-processed nodes from which ProcessedNode are created per
+  // StaticRuntime instance.
+  std::vector<StaticNodeInfo> nodes_;
   // Indices of graph outputs in the single values array.
   std::vector<uint16_t> output_indices_;
 
@@ -774,55 +776,60 @@ class TORCH_API ProcessedFunction {
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-class TORCH_API ProcessedNode {
+class TORCH_API StaticNodeInfo {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-  ProcessedNode() = default;
-  // ProcessedNodes are created within StaticModule and then
-  // associated with a shared values array using set_values() when
-  // they are copied into a StaticRuntime. block_runners_ are also
-  // not initialized until StaticRuntime initialization; see
-  // BlockRunner's ctor.
-  ProcessedNode(
+  StaticNodeInfo(
       Node* n,
       ProcessedFunction* fn,
       ProcessedNodeInputs inputs,
       uint16_t outputs_offset);
 
-  ProcessedNode(const ProcessedNode& other)
+  Node* node() const {
+    return node_;
+  }
+
+  size_t num_outputs() const {
+    DCHECK(fn_ != nullptr);
+    return fn_->num_outputs();
+  }
+
+  bool has_out_variant() const {
+    return fn_->kind() == ProcessedFunction::Kind::kOutVariant;
+  }
+
+ private:
+  friend class ProcessedNode;
+
+  Node* node_;
+  const ProcessedFunction* fn_;
+  ProcessedNodeInputs inputs_;
+  uint16_t outputs_offset_;
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+class TORCH_API ProcessedNode {
+ public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+  ProcessedNode() = default;
+
+  ProcessedNode(const StaticNodeInfo& other, IValue* values)
       : node_(other.node_),
         fn_(other.fn_),
         inputs_(other.inputs_),
         outputs_offset_(other.outputs_offset_),
-        overlap_detected_(other.overlap_detected_),
-        values_(other.values_),
-        // It doesn't really make sense to copy block runners,
-        // each processed node needs its own. This is OK to do
-        // since ProcessedNodes are copied from StaticModule right before
-        // the block runners are set up.
+        values_(values),
         // TODO(T105178680): For this task, we should move
-        // block runners out of ProcessedNode. Then, we don't have to deal
-        // with this caveat.
+        // block runners out of ProcessedNode.
         block_runners_(nullptr) {}
-
-  ProcessedNode& operator=(const ProcessedNode& other) {
-    if (&other == this) {
-      return *this;
-    }
-    node_ = other.node_;
-    fn_ = other.fn_;
-    inputs_ = other.inputs_;
-    outputs_offset_ = other.outputs_offset_;
-    overlap_detected_ = other.overlap_detected_;
-    values_ = other.values_;
-    block_runners_ = nullptr;
-    return *this;
-  }
 
   // These should be noexcept, but some Android build is failing
   // saying the noexcept specification doesn't match the calculated
   // one. Maybe c10::variant is throwing it off?
   ProcessedNode(ProcessedNode&&) = default;
+
+  ProcessedNode(const ProcessedNode&) = delete;
+  ProcessedNode& operator=(const ProcessedNode& other) = delete;
   ProcessedNode& operator=(ProcessedNode&&) = default;
 
   void run();


### PR DESCRIPTION
Summary:
Currently `StaticNodeInfo` class assumes 2 distinct roles that are not too obvious:

1) "template" that contains metadata of an actual executable node by runtime. owned by `StaticModule`

2) fully instanced ones that are owned by `StaticRuntime`.

We currently merge these two usecases into one class, that can be error-prone in case illegal copying happens uncontrollably. Currently, we only copy objects of kind (1) into objects of kind (2) when a `StaticRuntime` instance is created.

To address ths issue, this change introduces `StaticNodeInfo`, a separate class, to distinguishes the aforementioned two usecases in the code more clearly. With this `StaticNodeInfo` is for (1) and `ProcessedNode` is now for (2).

Test Plan: Existing tests

Reviewed By: mikeiovine

Differential Revision: D33985600

