### PR TITLE
[ao][fx]refactor memoryless from user facing APIs

### DIFF
--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -400,7 +400,7 @@ class TestObserver(QuantizationTestCase):
             x = obs(x)
 
     def _test_memoryless(self, obs_class):
-        obs = obs_class(memoryless=True)
+        obs = obs_class(dtype=torch.float32, compute_dtype=obs_class().dtype)
         x = torch.randn((3, 3))
         obs(x)
         params = obs.calculate_qparams()

--- a/torch/ao/quantization/fake_quantize.py
+++ b/torch/ao/quantization/fake_quantize.py
@@ -338,7 +338,7 @@ Default fake_quant for weights.
 """
 
 default_dynamic_fake_quant = FakeQuantize.with_args(observer=MinMaxObserver, quant_min=0, quant_max=255,
-                                                    dtype=torch.quint8, memoryless=True)
+                                                    dtype=torch.float32, compute_dtype=torch.quint8)
 """
 Default dynamic fake_quant for activations.
 """
@@ -358,11 +358,11 @@ Default fake_quant for per-channel weights.
 """
 default_embedding_fake_quant = FakeQuantize.with_args(observer=PerChannelMinMaxObserver,
                                                       qscheme=torch.per_channel_affine_float_qparams,
-                                                      dtype=torch.quint8,
+                                                      dtype=torch.float32,
                                                       quant_min=0,
                                                       quant_max=255,
                                                       ch_axis=0,
-                                                      memoryless=True)
+                                                      compute_dtype=torch.quint8)
 """
 Default fake_quant for embeddings.
 """
@@ -370,8 +370,8 @@ Default fake_quant for embeddings.
 default_embedding_fake_quant_4bit = FakeQuantize.with_args(observer=PerChannelMinMaxObserver,
                                                            qscheme=torch.per_channel_affine_float_qparams,
                                                            ch_axis=0,
-                                                           dtype=torch.quint4x2,
-                                                           memoryless=True)
+                                                           dtype=torch.float32,
+                                                           compute_dtype=torch.quint4x2)
 
 default_histogram_fake_quant = FakeQuantize.with_args(observer=HistogramObserver,
                                                       quant_min=0,

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -497,7 +497,7 @@ class MinMaxObserver(_MinMaxObserver):
 
 
 
-class MovingAverageMinMaxObserver(_MinMaxObserver):
+class MovingAverageMinMaxObserver(MinMaxObserver):
     r"""Observer module for computing the quantization parameters based on the
     moving average of the min and max values.
 
@@ -791,7 +791,7 @@ class PerChannelMinMaxObserver(_PerChannelMinMaxObserver):
             factory_kwargs=factory_kwargs,
         )
 
-class MovingAveragePerChannelMinMaxObserver(_PerChannelMinMaxObserver):
+class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
     r"""Observer module for computing the quantization parameters based on the
     running per channel min and max values.
 

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -481,7 +481,10 @@ class MinMaxObserver(_MinMaxObserver):
         compute_dtype=None,
     ):
         # memoryless should not be a user facing argument, infer it from compute dtype and dtype
-        memoryless = compute_dtype in (torch.quint8, torch.qint8) and dtype == torch.float32
+        memoryless = compute_dtype in (torch.qint8,
+                                       torch.quint8,
+                                       torch.quint4x2,
+                                       torch.qint32,) and dtype == torch.float32
         super(MinMaxObserver, self).__init__(
             dtype=dtype if compute_dtype is None else compute_dtype,
             qscheme=qscheme,
@@ -761,6 +764,7 @@ class PerChannelMinMaxObserver(_PerChannelMinMaxObserver):
     .. note:: If the running minimum equals to the running maximum, the scales
               and zero_points are set to 1.0 and 0.
     """
+
     def __init__(
         self,
         ch_axis=0,
@@ -772,8 +776,12 @@ class PerChannelMinMaxObserver(_PerChannelMinMaxObserver):
         compute_dtype=None,
         factory_kwargs=None,
     ) -> None:
-        memoryless = compute_dtype in (torch.quint8, torch.qint8) and dtype==torch.float32
+        memoryless = compute_dtype in (torch.qint8,
+                                       torch.quint8,
+                                       torch.quint4x2,
+                                       torch.qint32,) and dtype == torch.float32
         super(PerChannelMinMaxObserver, self).__init__(
+            ch_axis=ch_axis,
             dtype=dtype if compute_dtype is None else compute_dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -335,7 +335,7 @@ class _ObserverBase(ObserverBase):
 class _MinMaxObserver(_ObserverBase):
     min_val: torch.Tensor
     max_val: torch.Tensor
-    
+
     def __init__(
         self,
         dtype=torch.quint8,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73560

Summary: removed memoryless from user facing APIs and replaced with logic through the use of compute_dtype.
if compute_dtype isn't specified there are no changes to how this works, if compute_dtype is specified
then its used as the observer dtype (rather than the dtype which is treated as the activation_dtype).
Finally if compute_dtype is a quantized dtype and dtype=float (which is the designation for dynamic quantization we
came up with) then a memoryless observer is created.

Test Plan: python test/test_quantization.py

Differential Revision: [D34546005](https://our.internmc.facebook.com/intern/diff/D34546005)