### PR TITLE
[quant] Add support for multiple inputs in fusion pattern

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -525,7 +525,14 @@ class TestFuseFx(QuantizationTestCase):
             self.assertFalse(hasattr(m, "bn"))
             self.assertFalse(hasattr(m, "relu"))
 
-    def test_root_node_getter(self):
+    def test_fusion_pattern_with_multiple_inputs(self):
+        """ This test tests two keys in backend_config_dict: root_node_getter and
+        extra_inputs_getter,
+        root_node_getter is used to identify a "root" module in the node pattern,
+        the node that we'll keep after fusion.
+        extra_inputs_getter will return a list of node that needs to be added to the
+        fused node as extra inputs.
+        """
         class M(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -556,10 +563,20 @@ class TestFuseFx(QuantizationTestCase):
             bn, conv = bn_pattern
             return conv
 
+        def conv_bn_res_relu_extra_inputs_getter(pattern):
+            """ get inputs pattern for extra inputs, inputs for root node
+            are assumed to be copied over from root node to the fused node
+            """
+            relu, add_pattern = pattern
+            _, bn_pattern, extra_input = add_pattern
+            bn, conv = bn_pattern
+            return [extra_input]
+
         conv_bn_res_relu_config = {
             "pattern": (nn.ReLU, (torch.add, (nn.BatchNorm2d, nn.Conv2d), MatchAllNode)),
             "fuser_method": fuse_conv_bn_relu,
             "root_node_getter": conv_bn_res_relu_root_node_getter,
+            "extra_inputs_getter": conv_bn_res_relu_extra_inputs_getter
         }
 
         backend_config_dict = {
@@ -570,6 +587,12 @@ class TestFuseFx(QuantizationTestCase):
         # check bn and relu are gone since we replaced the whole pattern to conv
         self.assertFalse(hasattr(m, "bn"))
         self.assertFalse(hasattr(m, "relu"))
+
+        # check conv module has two inputs
+        named_modules = dict(m.named_modules())
+        for node in m.graph.nodes:
+            if node.op == "call_module" and type(named_modules[node.target]) == torch.nn.Conv2d:
+                self.assertTrue(len(node.args) == 2), "Expecting the fused op to have two arguments"
 
 @skipIfNoFBGEMM
 class TestQuantizeFx(QuantizationTestCase):

--- a/torch/ao/quantization/fx/backend_config/utils.py
+++ b/torch/ao/quantization/fx/backend_config/utils.py
@@ -101,3 +101,22 @@ def get_fusion_pattern_to_root_node_getter(
             root_node_getter_mapping[pattern] = root_node_getter
 
     return root_node_getter_mapping
+
+def get_fusion_pattern_to_extra_inputs_getter(
+        backend_config_dict: Dict[str, Any]) -> Dict[Pattern, Callable]:
+    """ Get a map from fusion pattern to a function that returns extra input nodes
+    from the fusion pattern, in the order required by the root node. This is optional,
+    if not specified, we will not copy over any extra inputs for the root node.
+    Example:
+    # given a pattern, return the input node that need to be copied to the root node
+    def extra_inputs_getter(pattern) -> List[Any]:
+        ...
+    """
+    extra_inputs_getter_mapping: Dict[Pattern, Callable] = dict()
+    for config in backend_config_dict.get("configs", []):
+        if "extra_inputs_getter" in config:
+            pattern = config["pattern"]
+            extra_inputs_getter = config["extra_inputs_getter"]
+            extra_inputs_getter_mapping[pattern] = extra_inputs_getter
+
+    return extra_inputs_getter_mapping

--- a/torch/ao/quantization/fx/backend_config/utils.py
+++ b/torch/ao/quantization/fx/backend_config/utils.py
@@ -108,9 +108,14 @@ def get_fusion_pattern_to_extra_inputs_getter(
     from the fusion pattern, in the order required by the root node. This is optional,
     if not specified, we will not copy over any extra inputs for the root node.
     Example:
-    # given a pattern, return the input node that need to be copied to the root node
+    # Let's say we have the pattern (torch.add, MatchAllNode, (torch.nn.BatchNorm2d, torch.nn.Conv2d))
+    # and root node is torch.nn.Conv2d, and the node in MatchAllNode would be an extra
+    # argument to the fused module, we can unpack the pattern and return the node at
+    # MatchAllNode here
+    # we can implement extra_inputs_getter as follows:
     def extra_inputs_getter(pattern) -> List[Any]:
-        ...
+        add, extra_input, conv_pattern = pattern
+        return [extra_input]
     """
     extra_inputs_getter_mapping: Dict[Pattern, Callable] = dict()
     for config in backend_config_dict.get("configs", []):

--- a/torch/ao/quantization/fx/fusion_patterns.py
+++ b/torch/ao/quantization/fx/fusion_patterns.py
@@ -27,6 +27,7 @@ class FuseHandler(ABC):
              named_modules: Dict[str, torch.nn.Module],
              fused_graph: Graph,
              root_node: Node,
+             extra_inputs: List[Any],
              matched_node_pattern: NodePattern,
              fuse_custom_config_dict: Dict[str, Any],
              fuser_method_mapping: Optional[Dict[Pattern, Union[torch.nn.Sequential, Callable]]],
@@ -69,6 +70,7 @@ class DefaultFuseHandler(FuseHandler):
              named_modules: Dict[str, torch.nn.Module],
              fused_graph: Graph,
              root_node: Node,
+             extra_inputs: List[Any],
              matched_node_pattern: NodePattern,
              fuse_custom_config_dict: Dict[str, Any],
              fuser_method_mapping: Optional[Dict[Pattern, Union[torch.nn.Sequential, Callable]]],
@@ -119,6 +121,12 @@ class DefaultFuseHandler(FuseHandler):
         # TODO: change the signature for fuser_method to take matched module patterns
         # as input
         fused_module = fuser_method(is_qat, *matched_modules)
-        # TODO: maybe add a pass to cleanup bn modules?
         setattr(named_modules[module_parent_name], module_name, fused_module)
-        return fused_graph.node_copy(root_node, load_arg)
+        extra_args = []
+        for input in extra_inputs:
+            extra_args.append(load_arg(input))
+        node = fused_graph.node_copy(root_node, load_arg)
+        args = list(node.args)
+        args.extend(extra_args)
+        node.args = args
+        return node

--- a/torch/ao/quantization/fx/fusion_patterns.py
+++ b/torch/ao/quantization/fx/fusion_patterns.py
@@ -128,5 +128,5 @@ class DefaultFuseHandler(FuseHandler):
         node = fused_graph.node_copy(root_node, load_arg)
         args = list(node.args)
         args.extend(extra_args)
-        node.args = args
+        node.args = tuple(args)
         return node


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73572

Summary:
Previously we can't specify how to get extra inputs for fused ops in backend_config_dict,
for example, for patterns like:
(torch.add, (nn.BatchNorm2d, nn.Conv2d), MatchAllNode)

where nn.Conv2d is the root node, the extra MatchAllNode (the input for original torch.add) would be lost
This PR added a "extra_inputs_getter" key in the backend_config_dict, which allows user to provide a function,
that can return a list of extra input node for the fused op given the matched node pattern. In this case,
we need a function that returns the node that matches with `MatchAllNode`, it would be something like the following:

```
def extra_inputs_getter(pattern):
    add, conv_bn, extra_input = pattern
    return [extra_input]
```

Test Plan:
python test/test_quantization.py TestFuseFx.test_fusion_pattern_with_multiple_inputs

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D34553210](https://our.internmc.facebook.com/intern/diff/D34553210)