### PR TITLE
[Static Runtime] Fix a broken test & Add an out variant wrapper for `mse_loss`

### DIFF
--- a/benchmarks/static_runtime/test_generated_ops.cc
+++ b/benchmarks/static_runtime/test_generated_ops.cc
@@ -3557,12 +3557,47 @@ TEST(StaticRuntime, autogen__convert_indices_from_csr_to_coo) {
       /*use_equalnan=*/false,
       /*check_resize=*/true);
 
-  auto crow_indices1 = torch::tensor({0, 1}, torch::kInt32);
-  auto col_indices1 = torch::tensor({0, 1, 0, 2, 1, 2}, torch::kInt32);
+  auto crow_indices1 = torch::tensor({0}, torch::kInt32);
+  auto col_indices1 =
+      torch::tensor({0, 1, 0, 2, 1, 2, 0, 1, 0, 2, 1, 2}, torch::kInt32);
   auto out_int321 = false;
   auto transpose1 = false;
   std::vector<IValue> args2{
       crow_indices1, col_indices1, out_int321, transpose1};
+  testStaticRuntime(
+      script,
+      args,
+      args2,
+      /*use_allclose=*/false,
+      /*use_equalnan=*/false,
+      /*check_resize=*/true);
+}
+
+TEST(StaticRuntime, autogen_mse_loss) {
+  const std::string script = R"IR(
+    graph(%self: Tensor, %target: Tensor, %reduction: int):
+        %bias: None = prim::Constant()
+        %ret = aten::mse_loss(%self, %target, %reduction)
+        %cloned = aten::clone(%ret, %bias)
+        return (%cloned)
+  )IR";
+
+  auto self0 = at::rand({6, 6, 6});
+  auto target0 = at::rand({6, 6, 6});
+  auto reduction0 = 1;
+  std::vector<IValue> args{self0, target0, reduction0};
+  testStaticRuntime(
+      script,
+      args,
+      {},
+      /*use_allclose=*/false,
+      /*use_equalnan=*/false,
+      /*check_resize=*/true);
+
+  auto self1 = at::rand({22, 22, 22});
+  auto target1 = at::rand({22, 22, 22});
+  auto reduction1 = 1;
+  std::vector<IValue> args2{self1, target1, reduction1};
   testStaticRuntime(
       script,
       args,

--- a/tools/codegen/static_runtime/config.py
+++ b/tools/codegen/static_runtime/config.py
@@ -162,8 +162,8 @@ def override_test_values(arg_map: Dict[str, str], op_name: str, index: int) -> N
             arg_map["col_indices"] = "torch::tensor({0, 1, 0}, torch::kInt32)"
             arg_map["out_int32"] = "false"
         else:
-            arg_map["crow_indices"] = "torch::tensor({0, 1}, torch::kInt32)"
-            arg_map["col_indices"] = "torch::tensor({0, 1, 0, 2, 1, 2}, torch::kInt32)"
+            arg_map["crow_indices"] = "torch::tensor({0}, torch::kInt32)"
+            arg_map["col_indices"] = "torch::tensor({0, 1, 0, 2, 1, 2, 0, 1, 0, 2, 1, 2}, torch::kInt32)"
             arg_map["out_int32"] = "false"
         return
     if op_name == "_convert_indices_from_coo_to_csr":

--- a/torch/csrc/jit/runtime/static/generated_ops.cpp
+++ b/torch/csrc/jit/runtime/static/generated_ops.cpp
@@ -2157,6 +2157,26 @@ REGISTER_OPERATOR_FUNCTOR(
       return nullptr;
     });
 
+REGISTER_OPERATOR_FUNCTOR(aten::mse_loss, aten_mse_loss, [](Node* n) -> SROperator {
+  if (n->matches(torch::schema(
+          "aten::mse_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor"))) {
+    return [](ProcessedNode* p_node) {
+      const auto& self = p_node->Input(0).toTensor();
+      const auto& target = p_node->Input(1).toTensor();
+      const auto reduction = p_node->Input(2).toInt();
+      if (p_node->Output(0).isNone()) {
+        p_node->Output(0) = at::cpu::mse_loss(self, target, reduction);
+        return;
+      }
+      auto& out = p_node->Output(0).toTensor();
+      fastResizeToZero(out);
+      at::cpu::mse_loss_out(out, self, target, reduction);
+    };
+  }
+  LogAndDumpSchema(n);
+  return nullptr;
+});
+
 REGISTER_OPERATOR_FUNCTOR(
     aten::nll_loss_backward,
     aten_nll_loss_backward,


### PR DESCRIPTION
Summary:
T113070663 identified a test breakage in `StaticRuntime.autogen__convert_indices_from_csr_to_coo` using `mode/opt`. This change fixes it by using a correct test value.

By generating the out variants for Static Runtime, this change also includes an out variant wrapper for `mse_loss`.

**Generating out variants for Static Runtime**
```
[djang@devbig024.ftw2 ~/fbsource/fbcode/caffe2]  buck run //caffe2/torch/fb/jit:gen_static_runtime_ops
Invalidating internal cached state: Buck configuration options changed between invocations. This may cause slower builds.
  Changed value //fbcode.sanitizer='address-undefined-dev' (was 'thread')
  ... and 13 more. See logs for all changes
Parsing buck files: finished in 0.8 sec
Downloaded 14/25 artifacts, 159.45 Kbytes, 30.0% cache miss (for updated rules)
Building: finished in 1.6 sec (100%) 52/52 jobs, 35/52 updated
  Total time: 2.5 sec
BUILD SUCCEEDED
total grouped native ops: 1501
structured grouped native ops: 540
generated grouped native ops: 137
```

Test Plan:
Ran the broken test in `mode/opt` and confirmed that it passes now.

```
[djang@devbig024.ftw2 ~/fbsource/fbcode/caffe2] buck test mode/opt //caffe2/benchmarks/static_runtime:static_runtime_cpptest -- --exact 'caffe2/benchmarks/static_runtime:static_runtime_cpptest - StaticRuntime.autogen__convert_indices_from_csr_to_coo' --run-disabled
Invalidating internal cached state: Buck configuration options changed between invocations. This may cause slower builds.
  Changed value //project.buck_out='buck-out/opt' (was 'buck-out/dev')
  ... and 307 more. See logs for all changes
DEBUG: /data/users/djang/fbsource/tools/build_defs/fbcode_macros/build_defs/lib/cpp_common.bzl:287:14: Using disallowed linker flag 'arvr/third-party/toolchains/platform009/build/mesa/lib/libGL.so' in library rule 'fbsource//third-party/toolchains:opengl'
DEBUG: /data/users/djang/fbsource/tools/build_defs/fbcode_macros/build_defs/lib/cpp_common.bzl:287:14: Using disallowed linker flag 'arvr/third-party/freeglut/3.0.0/libs/x64-linux/libglut.a' in library rule 'fbsource//third-party/toolchains:GLUT'
I0301 08:28:08.884272 2239319 configeratorc.cpp:70] Attempting to get config buck/detectors/bypass_dirty_builds, timeout=10000

I0301 08:30:14.751745 2261718 configeratorc.cpp:70] Attempting to get config buck/detectors/bypass_dirty_builds, timeout=10000

Parsing buck files: finished in 10.1 sec
Creating action graph: finished in 6.1 sec
[RE] Metadata: Session ID=[https://fburl.com/b/reSessionID-fa0ba93b-33a1-4e6f-88f8-9f508d2c27c3]
[RE] Waiting on 0 remote actions. Completed 247 actions remotely, action cache hit rate: 0.00%.
Downloaded 13000/17457 artifacts, 463.99 Mbytes, 2.6% cache miss (for updated rules)
Building: finished in 04:16.6 min (100%) 28628/28628 jobs, 28628/28628 updated
  Total time: 04:32.9 min
More details at https://www.internalfb.com/intern/buck/build/c774ff43-5311-49ce-a677-30e3f6afdad1
BUILD SUCCEEDED
Tpx test run coordinator for Facebook. See https://fburl.com/tpx for details.
Running with tpx session id: 16d9b24c-4a63-4671-84b5-690fac0ee086
Trace available for this run at /tmp/tpx-20220301-083049.472831-16d9b24c-4a63-4671-84b5-690fac0ee086/trace.log
RemoteExecution session id: reSessionID-16d9b24c-4a63-4671-84b5-690fac0ee086-tpx
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/4503599719295685
    ✓ ListingSuccess: caffe2/benchmarks/static_runtime:static_runtime_cpptest : 285 tests discovered (0.425)
    ✓ Pass: caffe2/benchmarks/static_runtime:static_runtime_cpptest - StaticRuntime.autogen__convert_indices_from_csr_to_coo (0.105)
Summary
  Pass: 1
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/4503599719295685
```

Differential Revision: D34552645

