### PR TITLE
Disable special scalar handling for the TS backend

### DIFF
--- a/torch/csrc/lazy/core/config.cpp
+++ b/torch/csrc/lazy/core/config.cpp
@@ -8,6 +8,11 @@ C10_DEFINE_bool(
     "Enable parameter aliasing support");
 
 C10_DEFINE_bool(
+    torch_lazy_handle_special_scalars,
+    false,
+    "Handle special scalars 0 and 1 diffrently");
+
+C10_DEFINE_bool(
     torch_lazy_use_thread_pool,
     false,
     "Use thread pool to schedule backend execution");

--- a/torch/csrc/lazy/core/config.h
+++ b/torch/csrc/lazy/core/config.h
@@ -2,6 +2,7 @@
 #include <c10/util/Flags.h>
 
 C10_DECLARE_bool(torch_lazy_ir_debug);
+C10_DECLARE_bool(torch_lazy_handle_special_scalars);
 C10_DECLARE_bool(torch_lazy_param_aliasing);
 C10_DECLARE_bool(torch_lazy_use_thread_pool);
 

--- a/torch/csrc/lazy/core/tensor_util.cpp
+++ b/torch/csrc/lazy/core/tensor_util.cpp
@@ -6,6 +6,7 @@
 #include <c10/util/irange.h>
 #include <torch/csrc/lazy/backend/backend_device.h>
 #include <torch/csrc/lazy/backend/backend_interface.h>
+#include <torch/csrc/lazy/core/config.h>
 #include <torch/csrc/lazy/core/helpers.h>
 
 #include <algorithm>
@@ -57,10 +58,7 @@ std::vector<BackendDataPtr> CreateTensorsData(
 }
 
 bool IsSpecialScalar(const at::Scalar& value) {
-  static bool no_scalars = false;
-  // TODO: need to clean up all the env options
-  // lazy_tensors::sys_util::GetEnvBool("NO_SPECIAL_SCALARS", false);
-  if (!no_scalars && (value.isIntegral(false) || value.isFloatingPoint())) {
+  if (FLAGS_torch_lazy_handle_special_scalars && (value.isIntegral(false) || value.isFloatingPoint())) {
     double scalar_value = value.toDouble();
     return scalar_value == 0.0 || std::fabs(scalar_value) == 1.0;
   }


### PR DESCRIPTION
This gives a 4% performance boost to resnet50.

RUN_TORCHBENCH: ALL
TORCHBENCH_BRANCH: wconstab/ltc-noopt