### PR TITLE
use cross-platform sed command in cmake_configure_file

### DIFF
--- a/c10/macros/cmake_configure_file.bzl
+++ b/c10/macros/cmake_configure_file.bzl
@@ -13,7 +13,7 @@ def _cmake_configure_file_impl(ctx):
         )
 
     # Replace any that remain with /* #undef FOO */.
-    command.append("| sed --regexp-extended 's@#cmakedefine (\\w+)@/* #undef \\1 */@'")
+    command.append("| sed -r 's@#cmakedefine ([A-Z0-9_]+)@/* #undef \\1 */@'")
     command.append("> $2")
 
     ctx.actions.run_shell(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73597
* #73596
* #73595
* #73594
* #73593
* #73592
* #73591
* #73590
* **#73589**

Long-form flags do not work and neither does the \w character class.

Differential Revision: [D34558345](https://our.internmc.facebook.com/intern/diff/D34558345)