### PR TITLE
[Vulkan] Optimize GRU operator with pre-packing

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Gru.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Gru.cpp
@@ -1,5 +1,5 @@
-#include <ATen/native/vulkan/ops/Common.h>
-#include <torch/library.h>
+#include <ATen/native/vulkan/ops/Gru.h>
+#include <vector>
 
 namespace at {
 namespace native {
@@ -95,6 +95,151 @@ TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
 #endif /* USE_VULKAN_API */
 
 } // namespace
+
+std::vector<LinearOpContext> pack_linear_op_contexts(
+    const std::vector<Tensor>& params_cpu,
+    int64_t num_layers) {
+  TORCH_CHECK(params_cpu.size() == 4 * num_layers, "Vulkan gru expects 'params_cpu' size to be 4 * 'num_layers'.");
+  std::vector<LinearOpContext> linear_op_contexts;
+  for (int64_t i = 0; i < num_layers; ++i) {
+    const auto& w_ih = params_cpu.at(i * 4);
+    const auto& w_hh = params_cpu.at(i * 4 + 1);
+    const auto& b_ih = params_cpu.at(i * 4 + 2);
+    const auto& b_hh = params_cpu.at(i * 4 + 3);
+    const auto& h_in = w_ih.size(0) / 3;
+
+    const auto&  w_i_rzn = w_ih.split(h_in);
+    const auto&  w_h_rzn = w_hh.split(h_in);
+    const auto&  b_i_rzn = b_ih.split(h_in);
+    const auto&  b_h_rzn = b_hh.split(h_in);
+
+    const auto&  w_ir = w_i_rzn[0];
+    const auto&  w_iz = w_i_rzn[1];
+    const auto&  w_in = w_i_rzn[2];
+    const auto&  w_hr = w_h_rzn[0];
+    const auto&  w_hz = w_h_rzn[1];
+    const auto&  w_hn = w_h_rzn[2];
+    const auto&  b_ir = b_i_rzn[0];
+    const auto&  b_iz = b_i_rzn[1];
+    const auto&  b_in = b_i_rzn[2];
+    const auto&  b_hr = b_h_rzn[0];
+    const auto&  b_hz = b_h_rzn[1];
+    const auto&  b_hn = b_h_rzn[2];
+
+    linear_op_contexts.emplace_back(LinearOpContext::create(w_ir.t(), b_ir));
+    linear_op_contexts.emplace_back(LinearOpContext::create(w_hr.t(), b_hr));
+    linear_op_contexts.emplace_back(LinearOpContext::create(w_iz.t(), b_iz));
+    linear_op_contexts.emplace_back(LinearOpContext::create(w_hz.t(), b_hz));
+    linear_op_contexts.emplace_back(LinearOpContext::create(w_in.t(), b_in));
+    linear_op_contexts.emplace_back(LinearOpContext::create(w_hn.t(), b_hn));
+  }
+  return linear_op_contexts;
+}
+
+GruOpContext::GruOpContext(
+    const std::vector<Tensor>& params_cpu,
+    bool has_biases,
+    int64_t num_layers,
+    double dropout,
+    bool train,
+    bool bidirectional,
+    bool batch_first)
+  : packed_{pack_linear_op_contexts(params_cpu, num_layers), has_biases, num_layers, dropout, train, bidirectional, batch_first},
+    unpacked_{params_cpu, has_biases, num_layers, dropout, train, bidirectional, batch_first} {
+  TORCH_INTERNAL_ASSERT(packed_.has_biases, "Vulkan gru expects 'has_biases' to be true.");
+  TORCH_INTERNAL_ASSERT(!packed_.train, "Vulkan gru expects 'train' to be false.");
+  TORCH_INTERNAL_ASSERT(!packed_.bidirectional, "Vulkan gru expects 'bidirectional' to be false.");
+  TORCH_INTERNAL_ASSERT(packed_.batch_first, "Vulkan gru expects 'batch_first' to be true.");
+  TORCH_INTERNAL_ASSERT(packed_.dropout < std::numeric_limits<double>::epsilon()*1000, "Vulkan gru expects 'dropout' to be 0.0.");
+}
+
+GruOpContext GruOpContext::create(
+    const std::vector<Tensor>& params_cpu, // weights/biases (cpu)
+    bool has_biases,
+    int64_t num_layers,
+    double dropout,
+    bool train,
+    bool bidirectional,
+    bool batch_first) {
+  return GruOpContext{
+      params_cpu,
+      has_biases,
+      num_layers,
+      dropout,
+      train,
+      bidirectional,
+      batch_first
+    };
+}
+
+std::tuple<Tensor, Tensor> GruOpContext::run(
+    const Tensor & input_vk,      // input sequence (vulkan)
+    const Tensor & hx_vk) const { // initial hidden state (vulkan)
+  TORCH_INTERNAL_ASSERT(input_vk.sizes().size() == 3, "Vulkan gru expects 'input_vk' dims to be 3.");
+  TORCH_INTERNAL_ASSERT(hx_vk.sizes().size() == 3, "Vulkan gru expects 'hx_vk' dims to be 3.");
+
+  const int64_t linear_op_contexts_per_layer = 6;   // (b_ir, w_ir), (b_hr, w_hr), (b_iz, w_iz), (b_hz, w_hz), (b_in, w_in), (b_hn, w_hn)
+  std::vector<at::Tensor> h_n_list;  // hidden output
+
+  // reshape to 2D due to Vulkan at::mm op accepts only 2D
+  auto x = input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
+
+  for (int64_t i = 0; i < packed_.num_layers; ++i) {
+    // extract each hidden state and squeeze into 2D dim
+    auto h = at::slice(hx_vk, 0, i, i + 1, 1);
+    h = h.reshape({h.size(0) * h.size(1), h.size(2)});
+
+    const auto&  cxt_ir = packed_.linear_op_contexts[i * linear_op_contexts_per_layer + 0];
+    const auto&  cxt_hr = packed_.linear_op_contexts[i * linear_op_contexts_per_layer + 1];
+    const auto&  cxt_iz = packed_.linear_op_contexts[i * linear_op_contexts_per_layer + 2];
+    const auto&  cxt_hz = packed_.linear_op_contexts[i * linear_op_contexts_per_layer + 3];
+    const auto&  cxt_in = packed_.linear_op_contexts[i * linear_op_contexts_per_layer + 4];
+    const auto&  cxt_hn = packed_.linear_op_contexts[i * linear_op_contexts_per_layer + 5];
+
+    const auto&  r = at::sigmoid(cxt_ir.run(x, 1.0f, 1.0f) + cxt_hr.run(h, 1.0f, 1.0f));
+    const auto&  z = at::sigmoid(cxt_iz.run(x, 1.0f, 1.0f) + cxt_hz.run(h, 1.0f, 1.0f));
+    const auto&  n = at::tanh(cxt_in.run(x, 1.0f, 1.0f) + r * (cxt_hn.run(h, 1.0f, 1.0f)));
+    h = (z * (-1) + 1) * n + z * h;
+    x = h;  // next input
+    h_n_list.emplace_back(h.reshape({1, 1, h.size(0), h.size(1)}));  // 2D to 4D for cat op
+  }
+
+  auto h_n = at::cat(h_n_list, 1);
+  h_n = h_n.reshape({h_n.size(0) * h_n.size(1), h_n.size(2), h_n.size(3)});
+  return std::tuple<Tensor, Tensor>(x, h_n);
+}
+
+GruOpContext::State GruOpContext::unpack() const {
+  return GruOpContext::State{
+    unpacked_.params_cpu,
+    unpacked_.has_biases,
+    unpacked_.num_layers,
+    unpacked_.dropout,
+    unpacked_.train,
+    unpacked_.bidirectional,
+    unpacked_.batch_first,
+  };
+}
+
+c10::intrusive_ptr<GruOpContext> gru_prepack(
+    std::vector<Tensor>&& params_cpu,
+    bool has_biases,
+    int64_t num_layers,
+    double dropout,
+    bool train,
+    bool bidirectional,
+    bool batch_first) {
+  return c10::make_intrusive<GruOpContext>(GruOpContext::create(
+      params_cpu, has_biases, num_layers, dropout, train, bidirectional, batch_first));
+}
+
+std::tuple<Tensor, Tensor> gru_run(
+    const Tensor& input_vk,
+    const Tensor& hx_vk,
+    const c10::intrusive_ptr<GruOpContext>& context) {
+  return context->run(input_vk, hx_vk);
+}
+
 } // namespace ops
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/native/vulkan/ops/Gru.h
+++ b/aten/src/ATen/native/vulkan/ops/Gru.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Mm.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+
+class GruOpContext final : public torch::jit::CustomClassHolder {
+ public:
+  static GruOpContext create(
+      const std::vector<Tensor>& params_cpu, // weights/biases (cpu)
+      bool has_biases,
+      int64_t num_layers,
+      double dropout,
+      bool train,
+      bool bidirectional,
+      bool batch_first);
+
+  using State = std::tuple<std::vector<Tensor>, bool, int64_t, double, bool, bool, bool>;
+
+  std::tuple<Tensor, Tensor> run(
+      const Tensor& input_vk,
+      const Tensor & hx_vk) const;
+  State unpack() const;
+
+ private:
+  GruOpContext(
+      const std::vector<Tensor>& params_cpu, // weights/biases (cpu)
+      bool has_biases,
+      int64_t num_layers,
+      double dropout,
+      bool train,
+      bool bidirectional,
+      bool batch_first);
+
+ private:
+  struct {
+    std::vector<LinearOpContext> linear_op_contexts;  // {{ op context for b_ir, w_ir, op context for b_hr, w_hr,
+                                                      //    op context for b_iz, w_iz, op context for b_hz, w_hz,
+                                                      //    op context for b_in, w_in, op context for b_hn, w_hn,}, ...}
+    bool has_biases{};
+    int64_t num_layers{};
+    double dropout{};
+    bool train{};
+    bool bidirectional{};
+    bool batch_first{};
+  } packed_;
+
+  struct {
+    std::vector<Tensor> params_cpu;      // weights/biases (cpu)
+    bool has_biases{};
+    int64_t num_layers{};
+    double dropout{};
+    bool train{};
+    bool bidirectional{};
+    bool batch_first{};
+  } unpacked_;
+};
+
+c10::intrusive_ptr<GruOpContext> gru_prepack(
+    std::vector<Tensor>&& params_cpu,   // weights/biases (cpu)
+    bool has_biases,
+    int64_t num_layers,
+    double dropout,
+    bool train,
+    bool bidirectional,
+    bool batch_first);
+
+std::tuple<Tensor, Tensor> gru_run(
+    const Tensor& input_vk,
+    const Tensor & hx_vk,
+    const c10::intrusive_ptr<GruOpContext>& context);
+
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 #include <ATen/ATen.h>
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/native/vulkan/ops/Gru.h>
 #include <c10/util/irange.h>
 
 // TODO: These functions should move to a common place.
@@ -135,6 +137,31 @@ static void clone_test(const std::vector<int64_t>& size, c10::optional<at::Memor
   }
 
   ASSERT_TRUE(check);
+}
+
+template <class... Inputs>
+inline std::vector<c10::IValue> makeStack(Inputs&&... inputs) {
+  return {std::forward<Inputs>(inputs)...};
+}
+
+template <class... Args>
+inline std::vector<c10::IValue> callOpByHandle(
+    const c10::OperatorHandle& op,
+    Args... args) {
+  auto stack = makeStack(std::forward<Args>(args)...);
+  c10::Dispatcher::singleton().callBoxed(op, &stack);
+  return stack;
+}
+
+template <class... Args>
+inline std::vector<c10::IValue> callOpByName(
+    const char* func_name,
+    const char* overload_name,
+    Args... args) {
+  const c10::optional<c10::OperatorHandle> op_handle =
+      c10::Dispatcher::singleton().findSchema({func_name, overload_name});
+  assert(op_handle.has_value());
+  return callOpByHandle(op_handle.value(), std::forward<Args>(args)...);
 }
 
 } // namespace
@@ -2962,6 +2989,203 @@ TEST(VulkanAPITest, gru_invalidinputs_exceptions) {
       has_biases, num_layers, 1.0, train, bidirectional, batch_first);
   }, ::c10::Error);
 }
+
+TEST(VulkanAPITest, gru_prepack_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const int H_in = 384;  // input_size
+  const int H_out = 384; // hidden_size
+  const int num_layers = 2;
+  const double gru_dropout = .0;
+  const bool has_biases = true;
+  const bool train = false;
+  const bool bidirectional = false;
+  const bool batch_first = true;
+  const auto in_cpu = at::rand({1, 1, H_in}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto h0_cpu = at::rand({num_layers, 1, H_out}, at::device(at::kCPU).dtype(at::kFloat));
+
+  c10::List<at::Tensor> weight_ih_l; // shape (3 * hidden_size, input_size)
+  c10::List<at::Tensor> weight_hh_l; // shape (3 * hidden_size, hidden_size)
+  c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
+  c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
+  for (int i = 0; i < num_layers; ++i) {
+    weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    weight_hh_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_ih_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_hh_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+  }
+
+  // put this guard here to run inference inststead of training
+  // to avoid the following error:
+  //     C++ exception with description "0INTERNAL ASSERT FAILED at "xplat/caffe2/aten/src/ATen/core/boxing/KernelFunction.cpp":31, please report a bug to PyTorch. aten::gru.input has kernels registered to both CompositeImplicitAutograd and a backend mapped to AutogradOther. This makes the backend kernel unreachable; the dispatcher will always prefer the CompositeImplicitAutograd lowering (see Note [Ambiguity in AutogradOther kernel]). If you want to override CompositeImplicitAutograd, please open an issue to request a dedicated Autograd dispatch key for the backend.
+  //     If you only want to run inference instead of training, add `c10::InferenceMode mode;` before model.forward(). Note this guard is only available in C++ but not Python at present.
+  c10::InferenceMode mode;
+
+  // Act
+  const auto out_cpu = at::gru(in_cpu, h0_cpu,
+      { weight_ih_l[0], weight_hh_l[0], bias_ih_l[0], bias_hh_l[0], weight_ih_l[1], weight_hh_l[1], bias_ih_l[1], bias_hh_l[1] },
+      has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+
+  auto prepack = callOpByName(
+      "vulkan_prepack::gru_prepack",
+      "",
+      std::vector<at::Tensor>({ weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+        weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) }),
+      has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+  auto out_vulkan = callOpByName(
+      "vulkan_prepack::gru_run",
+      "",
+      in_cpu.vulkan(), h0_cpu.vulkan(), prepack[0]);
+
+  auto cpu_output = std::get<0>(out_cpu);
+  auto cpu_hidden = std::get<1>(out_cpu);
+  auto vulkan_output = out_vulkan[0].toTensor();
+  auto vulkan_hidden = out_vulkan[1].toTensor();
+
+  // Assert
+  const auto check_output = almostEqual(cpu_output, vulkan_output.cpu());
+  if (!check_output) {
+    showRtol(cpu_output, vulkan_output.cpu());
+  }
+  ASSERT_TRUE(check_output);
+
+  const auto check_hidden = almostEqual(cpu_hidden, vulkan_hidden.cpu());
+  if (!check_hidden) {
+    showRtol(cpu_hidden, vulkan_hidden.cpu());
+  }
+  ASSERT_TRUE(check_hidden);
+}
+
+TEST(VulkanAPITest, gru_prepack_invalidinputs_exceptions) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const int H_in = 384;  // input_size
+  const int H_out = 384; // hidden_size
+  const int num_layers = 2;
+  const double gru_dropout = .0;
+  const bool has_biases = true;
+  const bool train = false;
+  const bool bidirectional = false;
+  const bool batch_first = true;
+  const auto in_cpu = at::rand({1, 1, H_in}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto h0_cpu = at::rand({num_layers, 1, H_out}, at::device(at::kCPU).dtype(at::kFloat));
+
+  c10::List<at::Tensor> weight_ih_l; // shape (3 * hidden_size, input_size)
+  c10::List<at::Tensor> weight_hh_l; // shape (3 * hidden_size, hidden_size)
+  c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
+  c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
+  for (int i = 0; i < num_layers; ++i) {
+    weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    weight_hh_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_ih_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_hh_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+  }
+
+  // put this guard here to run inference inststead of training
+  // to avoid the following error:
+  //     C++ exception with description "0INTERNAL ASSERT FAILED at "xplat/caffe2/aten/src/ATen/core/boxing/KernelFunction.cpp":31, please report a bug to PyTorch. aten::gru.input has kernels registered to both CompositeImplicitAutograd and a backend mapped to AutogradOther. This makes the backend kernel unreachable; the dispatcher will always prefer the CompositeImplicitAutograd lowering (see Note [Ambiguity in AutogradOther kernel]). If you want to override CompositeImplicitAutograd, please open an issue to request a dedicated Autograd dispatch key for the backend.
+  //     If you only want to run inference instead of training, add `c10::InferenceMode mode;` before model.forward(). Note this guard is only available in C++ but not Python at present.
+  c10::InferenceMode mode;
+
+  // Act: incorrect # of weights/biases
+  EXPECT_THROW({
+    auto prepack = callOpByName(
+        "vulkan_prepack::gru_prepack",
+        "",
+        std::vector<at::Tensor>({ weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+            weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1) }),
+        has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+  }, ::c10::Error);
+
+  // Act: non-3D input tensor
+  EXPECT_THROW({
+    const auto in_cpu_2d = at::rand({1, H_in}, at::device(at::kCPU).dtype(at::kFloat));
+    auto prepack = callOpByName(
+        "vulkan_prepack::gru_prepack",
+        "",
+        std::vector<at::Tensor>({ weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+            weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) }),
+        has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+    auto out_vulkan = callOpByName(
+        "vulkan_prepack::gru_run",
+        "",
+        in_cpu_2d.vulkan(), h0_cpu.vulkan(), prepack[0]);
+  }, ::c10::Error);
+
+  // Act: non-3D hidden tensor
+  EXPECT_THROW({
+    const auto h0_cpu_2d = at::rand({num_layers, H_out}, at::device(at::kCPU).dtype(at::kFloat));
+    auto prepack = callOpByName(
+        "vulkan_prepack::gru_prepack",
+        "",
+        std::vector<at::Tensor>({ weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+            weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) }),
+        has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+    auto out_vulkan = callOpByName(
+        "vulkan_prepack::gru_run",
+        "",
+        in_cpu.vulkan(), h0_cpu_2d.vulkan(), prepack[0]);
+  }, ::c10::Error);
+
+  // Act: has_biases should be true
+  EXPECT_THROW({
+    auto prepack = callOpByName(
+        "vulkan_prepack::gru_prepack",
+        "",
+        std::vector<at::Tensor>({ weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+           weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) }),
+        false, num_layers, gru_dropout, train, bidirectional, batch_first);
+  }, ::c10::Error);
+
+  // Act: train should be false
+  EXPECT_THROW({
+    auto prepack = callOpByName(
+        "vulkan_prepack::gru_prepack",
+        "",
+        std::vector<at::Tensor>({ weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+           weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) }),
+        has_biases, num_layers, gru_dropout, true, bidirectional, batch_first);
+  }, ::c10::Error);
+
+  // Act: bidirectional should be false
+  EXPECT_THROW({
+     auto prepack = callOpByName(
+        "vulkan_prepack::gru_prepack",
+        "",
+        std::vector<at::Tensor>({ weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+           weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) }),
+        has_biases, num_layers, gru_dropout, train, true, batch_first);
+ }, ::c10::Error);
+
+  // Act: batch_first should be true
+  EXPECT_THROW({
+    auto prepack = callOpByName(
+        "vulkan_prepack::gru_prepack",
+        "",
+        std::vector<at::Tensor>({ weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+           weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) }),
+        has_biases, num_layers, gru_dropout, train, bidirectional, false);
+  }, ::c10::Error);
+
+  // Act: dropout should be 0.0
+  EXPECT_THROW({
+    auto prepack = callOpByName(
+        "vulkan_prepack::gru_prepack",
+        "",
+        std::vector<at::Tensor>({ weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+           weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) }),
+        has_biases, num_layers, 1.0, train, bidirectional, batch_first);
+  }, ::c10::Error);
+}
+
 } // namespace
 
 #endif /* USE_VULKAN_API */


### PR DESCRIPTION
**Summary:**
Optimized GRU operator by using pre-packing for weights and biases in the Vulkan GPU backend:
* The weights and biases are always on the CPU side by design.
* To reduce the overhead by retrieving the weight and bias tensors every time, it is the best way to store them by pre-packing.
    * A custom op context `GruOpContext` (derived from `torch::jit::CustomClassHolder`) is created to hold both packed and unpacked data. It corresponds to the unpacked_ struct which represents the data needed to construct the op context. This data will be pre-packed and be stored in the packed_ struct. The constructor of the `GruOpContext` loads the data into the unpacked_ and packed_ structs.
    * `at::native::vulkan::ops::gru_prepack` and `at::native::vulkan::ops::gru_run` methods use the op context. The `gru_prepack` takes in whatever data is needed to construct the op context and returns a pointer to a created context. The `gru_run` takes input tensors and a pointer to the op context that uses the data stored in the context to process the inputs.
    * Lastly, we need to register the op context class and ops in [Register.cpp](https://github.com/pytorch/pytorch/blob/11dc1581298c5bb2b322897c7b3999d1a3971720/aten/src/ATen/native/vulkan/ops/Register.cpp). And rewrite the subgraph function of GRU op in [vulkan_rewrite.cpp](https://github.com/pytorch/pytorch/blob/11dc1581298c5bb2b322897c7b3999d1a3971720/torch/csrc/jit/passes/vulkan_rewrite.cpp) so that `gru_prepack` and `gru_run` ops can be executed instead in the Vulkan GPU backend.
* To avoid `"Undefined symbols for architecture x86_64"` compiler error on the x86_64 platform, `c10::Dispatcher::callBoxed()` API is used to call `vulkan_prepack::gru_prepack` and `vulkan_prepack::gru_run` by name. Otherwise, the test methods can't resolve the symbols.
* Added new tests for the GRU pre-packing and run operations: `gru_prepack_success` and gru_prepack_invalidinputs_exceptions`
* To build your PyTorch OSS on your local machine:
```
python setup.py clean
git submodule update --init --recursive
USE_VULKAN=1 USE_VULKAN_FP16_INFERENCE=1 python3 setup.py install --cmake
python setup.py develop && python -c "import torch"
```
* To run and dump a model containing GRU operators in Python:
```
import torch
from torch.utils import mobile_optimizer
model = torch.jit.load("Mclaren_traced.pt")
vk_model = mobile_optimizer.optimize_for_mobile(model, backend="vulkan")
print(vk_model.graph)
```
* The following torch scripts are the updated version by GRU pre-packing:
```
%15 : Tensor[] = prim::ListConstruct(%weight_ih_l0.1, %weight_hh_l0.1, %bias_ih_l0.1, %bias_hh_l0.1, %weight_ih_l1.1, %weight_hh_l1.1, %bias_ih_l1.1, %bias_hh_l1.1)
%19 : __torch__.torch.classes.vulkan.GruOpContext = vulkan_prepack::gru_prepack(%15, %4, %5, %6, %3, %3, %4)
%20 : Tensor, %21 : Tensor = vulkan_prepack::gru_run(%input.1, %hx.1, %19)
%18 : (Tensor, Tensor) = prim::TupleConstruct(%21, %20)
return (%18)
```
* This implementation has some limitations:
    * Tensor dim should be 3 for input sequence and hidden state.
    * has_biases=True
    * train=False
    * bidirectional=False
    * batch_first=True
    * dropout=0.0
    * D=1 since bidirectional=False
    * N=1 (batch size)
    * L=1 (sequence length)

**Test Plan:**
Build & test on Android:
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
```
Build & test on MacOS (x86_64):
```
cd ~/fbsource
buck build //xplat/caffe2:pt_vulkan_api_test_binAppleMac
./buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAppleMac\#macosx-x86_64
```

Test result on Android (Google Pixel 5):
```
Running main() from gtest_main.cc
[==========] Running 4 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 4 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.gru_mclareninputs_success
[       OK ] VulkanAPITest.gru_mclareninputs_success (1037 ms)
[ RUN      ] VulkanAPITest.gru_invalidinputs_exceptions
[       OK ] VulkanAPITest.gru_invalidinputs_exceptions (16 ms)
[ RUN      ] VulkanAPITest.gru_prepack_success
[       OK ] VulkanAPITest.gru_prepack_success (45 ms)
[ RUN      ] VulkanAPITest.gru_prepack_invalidinputs_exceptions
[       OK ] VulkanAPITest.gru_prepack_invalidinputs_exceptions (16 ms)
[----------] 4 tests from VulkanAPITest (1114 ms total)
[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (1114 ms total)
[  PASSED  ] 4 tests.
```

Test result on MacOS (x86_64):
```
Running main() from gtest_main.cc
[==========] Running 4 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 4 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.gru_mclareninputs_success
[       OK ] VulkanAPITest.gru_mclareninputs_success (1012 ms)
[ RUN      ] VulkanAPITest.gru_invalidinputs_exceptions
[       OK ] VulkanAPITest.gru_invalidinputs_exceptions (40 ms)
[ RUN      ] VulkanAPITest.gru_prepack_success
[       OK ] VulkanAPITest.gru_prepack_success (99 ms)
[ RUN      ] VulkanAPITest.gru_prepack_invalidinputs_exceptions
[       OK ] VulkanAPITest.gru_prepack_invalidinputs_exceptions (39 ms)
[----------] 4 tests from VulkanAPITest (1190 ms total)
[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (1190 ms total)
[  PASSED  ] 4 tests.
```

Differential Revision: D34556940

