### PR TITLE
Add note in RPC docs about retries.

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -190,6 +190,14 @@ Example::
     :members:
     :inherited-members:
 
+.. note ::
+  The RPC framework does not automatically retry any 
+  :meth:`~torch.distributed.rpc.rpc_sync`, 
+  :meth:`~torch.distributed.rpc.rpc_async` and 
+  :meth:`~torch.distributed.rpc.remote` calls. The reason being that there is 
+  no way the RPC framework can determine whether an operation is idempotent or 
+  not and whether it is safe to retry. As a result, it is the application's 
+  responsibility to deal with failures and retry if necessary.
 
 .. _rref:
 

--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -191,13 +191,17 @@ Example::
     :inherited-members:
 
 .. note ::
-  The RPC framework does not automatically retry any 
-  :meth:`~torch.distributed.rpc.rpc_sync`, 
-  :meth:`~torch.distributed.rpc.rpc_async` and 
-  :meth:`~torch.distributed.rpc.remote` calls. The reason being that there is 
-  no way the RPC framework can determine whether an operation is idempotent or 
-  not and whether it is safe to retry. As a result, it is the application's 
-  responsibility to deal with failures and retry if necessary.
+  The RPC framework does not automatically retry any
+  :meth:`~torch.distributed.rpc.rpc_sync`,
+  :meth:`~torch.distributed.rpc.rpc_async` and
+  :meth:`~torch.distributed.rpc.remote` calls. The reason being that there is
+  no way the RPC framework can determine whether an operation is idempotent or
+  not and whether it is safe to retry. As a result, it is the application's
+  responsibility to deal with failures and retry if necessary. RPC communication
+  is based on TCP and as a result failures could happen due to network failures
+  or intermittent network connectivity issues. In such scenarios, the application
+  needs to retry appropriately with reasonable backoffs to ensure the network
+  isn't overwhelmed by aggressive retries.
 
 .. _rref:
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73601

Some users had questions about how the RPC framework deals with
failures and whether we retry. Adding a note about this to our docs to
elaborate on our current behavior and why we chose that approach.

![Screen Shot 2022-03-01 at 12 35 56 PM](https://user-images.githubusercontent.com/9958665/156244988-fecd80e2-71ab-4fac-9137-0d3c07578a50.png)

Differential Revision: [D34560199](https://our.internmc.facebook.com/intern/diff/D34560199/)