### PR TITLE
Print correct NCCL version

### DIFF
--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -36,9 +36,11 @@ std::string getNcclVersion() {
     if (status != ncclSuccess || version < 100) {
       versionString = "Unknown NCCL version";
     } else {
-      auto ncclMajor = version / 1000;
-      auto ncclMinor = (version % 1000) / 100;
-      auto ncclPatch = version % (ncclMajor * 1000 + ncclMinor * 100);
+      // NCCL version encoding changed after v2.8.0
+      auto ncclMajorFactor = version <= 2800 ? 1000 : 10000;
+      auto ncclMajor = version / ncclMajorFactor;
+      auto ncclMinor = (version % ncclMajorFactor) / 100;
+      auto ncclPatch = version % (ncclMajor * ncclMajorFactor + ncclMinor * 100);
       versionString = std::to_string(ncclMajor) + "." +
           std::to_string(ncclMinor) + "." + std::to_string(ncclPatch);
     }


### PR DESCRIPTION
NCCL version encoding changed after v2.8.0 to allow for double-digit minor version numbers.  Update the decoding logic to handle this.

The corresponding code in NCCL is: 
```
#define NCCL_VERSION(X,Y,Z) (((X) <= 2 && (Y) <= 8) ? (X) * 1000 + (Y) * 100 + (Z) : (X) * 10000 + (Y) * 100 + (Z))
```
so versions until 2800 inclusive need to be decoded using the old logic.
