### PR TITLE
use codegen for sub

### DIFF
--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -115,6 +115,7 @@ full_codegen:
   - std
   - std.dim
   - std.correction
+  - sub.Tensor
   - sum
   - sum.dim_IntList
   - tanh
@@ -167,8 +168,6 @@ supported:
   - transpose_
   - unsqueeze
   - unsqueeze_
-  - sub.Tensor
-  - sub.Scalar
   - view
   - alias
   - _unsafe_view


### PR DESCRIPTION
This disables support for sub.scalar, relying on pytorch dispatcher to wrap/route it to sub.Tensor.

It also lets us delete a few helper functions that were only lingering around because of sub.

RUN_TORCHBENCH: ALL
TORCHBENCH_BRANCH: wconstab/ltc-noopt