### PR TITLE
[XNNPACK] Expose available() to xnnpack namespace

### DIFF
--- a/aten/src/ATen/native/xnnpack/Activation.cpp
+++ b/aten/src/ATen/native/xnnpack/Activation.cpp
@@ -10,7 +10,7 @@ namespace xnnpack {
 
 bool use_hardswish(
   const Tensor& input) {
-  return xnnpack::internal::available() &&
+  return xnnpack::available() &&
           (1 <= input.ndimension()) &&
           (input.device().is_cpu()) &&
           (kFloat == input.scalar_type()) &&

--- a/aten/src/ATen/native/xnnpack/AveragePooling.cpp
+++ b/aten/src/ATen/native/xnnpack/AveragePooling.cpp
@@ -10,7 +10,7 @@ namespace xnnpack {
 
 bool use_global_average_pool(
   const Tensor& input) {
-  return xnnpack::internal::available() &&
+  return xnnpack::available() &&
           (1 <= input.ndimension()) &&
           (input.device().is_cpu()) &&
           (kFloat == input.scalar_type()) &&

--- a/aten/src/ATen/native/xnnpack/ChannelShuffle.cpp
+++ b/aten/src/ATen/native/xnnpack/ChannelShuffle.cpp
@@ -17,7 +17,7 @@ bool use_channel_shuffle(
   //   and all dimensions must be positive.
   // * The number of groups must be larger than 1 and
   //   the number of channels must be divisible by the number of groups.
-  return xnnpack::internal::available() &&
+  return xnnpack::available() &&
       // Input
       (4 == input.dim()) &&
       (input.device().is_cpu()) &&

--- a/aten/src/ATen/native/xnnpack/Common.h
+++ b/aten/src/ATen/native/xnnpack/Common.h
@@ -67,6 +67,9 @@ struct ContextConv2D final {
   static constexpr float kMax = std::numeric_limits<float>::infinity();
 };
 
+
+bool available();
+
 namespace internal {
 
 struct Layout final {
@@ -121,9 +124,6 @@ struct Layout final {
     static constexpr size_t width = 1u;
   };
 };
-
-bool available();
-
 } // namespace internal
 } // namespace xnnpack
 } // namespace native

--- a/aten/src/ATen/native/xnnpack/Convolution.cpp
+++ b/aten/src/ATen/native/xnnpack/Convolution.cpp
@@ -36,7 +36,7 @@ bool available(
     const float output_min,
     const float output_max) {
          // XNNPACK
-  return xnnpack::internal::available() &&
+  return xnnpack::available() &&
          // Weight
          (4 == weight.ndimension()) &&
          (weight.size(Layout::Filter::height) > 0) &&

--- a/aten/src/ATen/native/xnnpack/Init.cpp
+++ b/aten/src/ATen/native/xnnpack/Init.cpp
@@ -49,13 +49,13 @@ bool C10_UNUSED deinitialize() {
 }
 
 } // namespace
+} // namespace internal
 
 bool available() {
   // Add extra conditions here that should disable mobile CPU impl at runtime in its totality.
   return internal::initialize();
 }
 
-} // namespace internal
 } // namespace xnnpack
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/xnnpack/Linear.cpp
+++ b/aten/src/ATen/native/xnnpack/Linear.cpp
@@ -21,7 +21,7 @@ bool available(
     const float output_min,
     const float output_max) {
          // XNNPACK
-  return xnnpack::internal::available() &&
+  return xnnpack::available() &&
           // Weight
           (2 == weight.ndimension()) &&
           (weight.device().is_cpu()) &&

--- a/aten/src/ATen/native/xnnpack/MaxPooling.cpp
+++ b/aten/src/ATen/native/xnnpack/MaxPooling.cpp
@@ -88,7 +88,7 @@ bool use_max_pool2d(
   const bool output_size_eq = (pt_outputHeight == xnnpack_outputHeight) &&
     (pt_outputWidth == xnnpack_outputWidth);
 
-  return xnnpack::internal::available() &&
+  return xnnpack::available() &&
       // Input
       (4 == input.dim()) &&
       (input.device().is_cpu()) &&


### PR DESCRIPTION
Summary: Linter doesn't like a call to xnnpack::internal::available() from outside the namespace

Differential Revision: D33641389

