### PR TITLE
[Static Runtime] Avoid adjusting output indices at runtime for ProcessedNode::run()

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1445,7 +1445,7 @@ TEST(StaticRuntime, LeakyReLU) {
 }
 
 static ProcessedNodeInputs createProcessedNodeInputs(
-    c10::ArrayRef<uint16_t> inputs) {
+    c10::ArrayRef<int16_t> inputs) {
   ProcessedNodeInputs result(inputs.size());
   for (const auto idx : c10::irange(inputs.size())) {
     result[idx] = inputs[idx];
@@ -1455,14 +1455,14 @@ static ProcessedNodeInputs createProcessedNodeInputs(
 
 static void checkProcessedNodeInputs(
     const ProcessedNodeInputs& io,
-    c10::ArrayRef<uint16_t> inputs) {
+    c10::ArrayRef<int16_t> inputs) {
   ASSERT_EQ(inputs.size(), io.size());
   for (const auto idx : c10::irange(inputs.size())) {
     EXPECT_EQ(inputs[idx], io[idx]);
   }
 }
 
-static void testProcessedNodeInputsRoundTrip(c10::ArrayRef<uint16_t> inputs) {
+static void testProcessedNodeInputsRoundTrip(c10::ArrayRef<int16_t> inputs) {
   auto io = createProcessedNodeInputs(inputs);
   checkProcessedNodeInputs(io, inputs);
 
@@ -1473,12 +1473,12 @@ static void testProcessedNodeInputsRoundTrip(c10::ArrayRef<uint16_t> inputs) {
 }
 
 TEST(ProcessedNodeInputs, Basic) {
-  std::vector<std::vector<uint16_t>> testCases = {
+  std::vector<std::vector<int16_t>> testCases = {
       {}, // empty
-      {0xABCD, 0x5a5a}, // inline
-      {0x11, 0x22, 0x33, 0x44, 0x55}, // max inline size
-      {0x11, 0x22, 0x33, 0x44, 0x55, 0x66}, // minimum outline size
-      std::vector<uint16_t>(100, 0x5a), // large outline size
+      {-0x11, 0x5a5a}, // inline
+      {0x11, -0x22, 0x33, -0x44, 0x55}, // max inline size
+      {0x11, 0x22, -0x33, -0x44, 0x55, 0x66}, // minimum outline size
+      std::vector<int16_t>(100, 0x5a), // large outline size
   };
 
   for (const auto& values : testCases) {

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -681,11 +681,10 @@ size_t StaticModule::prepareStaticNodeInfos(
     ProcessedFunction* fn = &functions_[node_idx];
 
     // create a new ProcessedNode
-    const auto node_output_idx = node->outputs().empty()
-        // The index is unused if there are no outputs, so just create a
-        // placeholder value.
-        ? std::numeric_limits<uint16_t>::max()
-        : value_to_index.at(node->output(0));
+    c10::optional<uint16_t> node_output_idx;
+    if (!node->outputs().empty()) {
+      node_output_idx = value_to_index.at(node->output(0));
+    }
     nodes.emplace_back(node, fn, std::move(input_indices), node_output_idx);
 
     node_has_out_variant.emplace(node, nodes.back().has_out_variant());
@@ -1822,7 +1821,7 @@ StaticNodeInfo::StaticNodeInfo(
     Node* node,
     ProcessedFunction* fn,
     ProcessedNodeInputs inputs,
-    uint16_t outputs_offset)
+    c10::optional<uint16_t> outputs_offset)
     : node_(node),
       fn_(fn),
       inputs_(std::move(inputs)),


### PR DESCRIPTION
Summary:
Currently, `ProcessedNode::Output` computes the output offset by adding `outputs_offset` to the given index of an output *at runtime* as follows:

```
  // Output is readwrite
  IValue& Output(uint32_t i) {
    DCHECK(i < num_outputs());
    return values_[outputs_offset_ + i];
  }
```

This change avoids this unnecessary runtime computation by adjusting `values_` pointer at the creation of `ProcessedNode`. A bonus of doing this is that we can now remove `ProcessedNode::outputs_offset_`. This removal doesn't compact the size of `ProcessedNode` with this change (still 48 bytes), but paves a road for further compaction.

Test Plan: Existing tests

Reviewed By: mikeiovine

Differential Revision: D34024340

