### PR TITLE
Eliminate unused parameters in PyTorch

### DIFF
--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -69,6 +69,7 @@ struct strided_tensor_iter_fixed {
   strided_tensor_iter_fixed(strided_tensor_iter_fixed&&) = default;
   strided_tensor_iter_fixed(Tensor& tensor, bool sort_strides = false)
       : data_(tensor.data_ptr<T>()) {
+    (void)sort_strides; // Suppress unused variable warning
     std::memset(counter_, 0, sizeof(int64_t) * N);
     if (tensor.dim() > 0) {
       std::memcpy(
@@ -152,7 +153,7 @@ inline int64_t _max_dim_tensors(ArrayRef<Tensor> tensors) {
   return dim;
 }
 
-inline void iterate(int64_t size){};
+inline void iterate(int64_t /*size*/){};
 
 template <typename Arg, typename... Args>
 inline void iterate(int64_t size, Arg& iter, Args&... iter_tail) {
@@ -199,7 +200,7 @@ inline void iterate_overflow(Arg& iter, Args&... iter_tail) {
   iterate_overflow(iter_tail...);
 }
 
-inline void forward(int64_t offset){};
+inline void forward(int64_t /*offset*/){};
 
 template <typename Arg, typename... Args>
 inline void forward(int64_t offset, Arg& iter, Args&... iter_tail) {

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -20,8 +20,8 @@ namespace at {
  * included in this file when code-gen is ready.
  */
 inline constexpr bool should_include_kernel_dtype(
-  const char *kernel_tag_str,
-  at::ScalarType scalar_type
+  const char* /*kernel_tag_str*/,
+  at::ScalarType /*scalar_type*/
 ) {
   return true;
 }

--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -19,7 +19,7 @@ namespace at {
 
 template <typename T,
           typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
-inline C10_HOST_DEVICE bool _isnan(T val) {
+inline C10_HOST_DEVICE bool _isnan(T /*val*/) {
   return false;
 }
 
@@ -63,7 +63,7 @@ inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
 
 template <typename T,
           typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
-inline C10_HOST_DEVICE bool _isinf(T val) {
+inline C10_HOST_DEVICE bool _isinf(T /*val*/) {
   return false;
 }
 

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -217,7 +217,7 @@ static inline Tensor applySelect(
     int64_t dim,
     int64_t index,
     int64_t real_dim,
-    const at::Device& self_device,
+    const at::Device& /*self_device*/,
     const IntArrayRef& self_sizes) {
   TORCH_CHECK_INDEX(
     !(index == 0 && dim == 0 && self_sizes.size() == 0),
@@ -272,7 +272,7 @@ static inline void recordTensorIndex(const Tensor& tensor, std::vector<Tensor>& 
   (*dim_ptr)++;
 };
 
-static inline c10::List<c10::optional<Tensor>> typeConvertIndices(const Tensor& self, std::vector<Tensor>&& indices) {
+static inline c10::List<c10::optional<Tensor>> typeConvertIndices(const Tensor& /*self*/, std::vector<Tensor>&& indices) {
   c10::List<c10::optional<Tensor>> converted_inds;
   converted_inds.reserve(indices.size());
   for (const auto &i: indices){

--- a/aten/src/ATen/core/DistributionsHelper.h
+++ b/aten/src/ATen/core/DistributionsHelper.h
@@ -158,7 +158,7 @@ template <typename RNG, typename ret_type,                                      
             !has_member_next_##TYPE##_normal_sample<RNG>::value ||                                  \
             !has_member_set_next_##TYPE##_normal_sample<RNG>::value                                 \
           ), int> = 0>                                                                              \
-C10_HOST_DEVICE inline bool maybe_get_next_##TYPE##_normal_sample(RNG* generator, ret_type* ret) {  \
+C10_HOST_DEVICE inline bool maybe_get_next_##TYPE##_normal_sample(RNG* /*generator*/, ret_type* /*ret*/) {  \
   return false;                                                                                     \
 }                                                                                                   \
                                                                                                     \
@@ -174,7 +174,7 @@ template <typename RNG, typename ret_type,                                      
           typename std::enable_if_t<(                                                               \
             !has_member_set_next_##TYPE##_normal_sample<RNG>::value                                 \
           ), int> = 0>                                                                              \
-C10_HOST_DEVICE inline void maybe_set_next_##TYPE##_normal_sample(RNG* generator, ret_type cache) { \
+C10_HOST_DEVICE inline void maybe_set_next_##TYPE##_normal_sample(RNG* /*generator*/, ret_type /*cache*/) { \
 }
 
 DISTRIBUTION_HELPER_GENERATE_NEXT_NORMAL_METHODS(double);

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -866,7 +866,7 @@ struct MaybeOwnedTraits<at::TensorBase> {
     return &borrow;
   }
 
-  static bool debugBorrowIsValid(const borrow_type& borrow) {
+  static bool debugBorrowIsValid(const borrow_type& /*borrow*/) {
     return true;
   }
 };

--- a/aten/src/ATen/core/boxing/KernelFunction_impl.h
+++ b/aten/src/ATen/core/boxing/KernelFunction_impl.h
@@ -157,6 +157,7 @@ inline KernelFunction KernelFunction::makeFromUnboxedFunction(FuncPtr func_ptr) 
     static_assert(FuncPtr::func_ptr() != nullptr, "Kernel function cannot be nullptr");
 
 #if !defined(C10_MOBILE)
+    (void)func_ptr; // Suppress unused variable warning
     return makeFromUnboxedFunctor<AllowLegacyTypes, typename impl::WrapFunctionIntoFunctor<FuncPtr>::type>(
         guts::make_unique_base<OperatorKernel, typename impl::WrapFunctionIntoFunctor<FuncPtr>::type>()
     );

--- a/aten/src/ATen/core/class_type.h
+++ b/aten/src/ATen/core/class_type.h
@@ -391,6 +391,7 @@ struct TORCH_API ClassType : public NamedType {
       std::vector<std::string> unresolved_class_attributes = {});
 
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
+    (void)printer; // Suppress unused variable warning
     const auto& n = name().value();
     return n.qualifiedName();
   }

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -74,7 +74,7 @@ namespace detail {
         }
       }
     }
-    void operator()(at::ArrayRef<c10::optional<at::Tensor>> xs) {
+    void operator()(at::ArrayRef<c10::optional<at::Tensor>>) {
       // Just checking that the handling of Tensor?[] didn't change.
       TORCH_INTERNAL_ASSERT(false);
     }
@@ -89,7 +89,7 @@ namespace detail {
       }
     }
     template <typename T>
-    void operator()(const T& x) {
+    void operator()(const T&) {
       // do nothing
     }
   };

--- a/aten/src/ATen/core/enum_type.h
+++ b/aten/src/ATen/core/enum_type.h
@@ -87,6 +87,7 @@ struct TORCH_API EnumType : public NamedType {
 
   std::string annotation_str_impl(
       TypePrinter printer = nullptr) const override {
+    (void)printer; // Suppress unused variable warning
     const auto& n = name().value();
     return n.qualifiedName();
   }

--- a/aten/src/ATen/core/function.h
+++ b/aten/src/ATen/core/function.h
@@ -48,8 +48,9 @@ struct TORCH_API Function {
   virtual void run(Stack& stack) = 0;
 
   virtual c10::intrusive_ptr<c10::ivalue::Future> runAsync(
-      Stack& stack,
+      Stack& /*stack*/,
       TaskLauncher taskLauncher = at::launch) {
+    (void)taskLauncher; // Suppress unused variable warning
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(false);
     return {};
   }

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1235,7 +1235,7 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
 
   // We need devices to be sorted in order to use ensureIsSubsetOfDevices.
   static std::vector<c10::Device> sortAndDeduplicateDevices(
-      const c10::impl::VirtualGuardImpl& impl,
+      const c10::impl::VirtualGuardImpl& /*impl*/,
       std::vector<c10::Device> devices) {
     std::sort(
       devices.begin(), devices.end(),
@@ -2192,7 +2192,7 @@ IValue from_(c10::intrusive_ptr<T> x, std::false_type) {
   return IValue(std::move(x));
 }
 template <typename T>
-IValue from_(T&& x, std::false_type) {
+IValue from_(T&& /*x*/, std::false_type) {
   static_assert(
       guts::false_t<T>::value,
       "You are calling from with a type that it doesn't support, and isn't a potential custom class (ie: is an intrusive_ptr)");

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -466,7 +466,7 @@ inline bool isComplete(const Stride& s) {
 }
 
 template<typename T>
-inline bool isComplete(const T& t) {
+inline bool isComplete(const T& /*t*/) {
   return true;
 }
 }
@@ -1173,6 +1173,7 @@ struct TORCH_API NumberType : public Type {
   NumberType(TypeKind kind = TypeKind::NumberType) : Type(kind) {}
 
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
+    (void)printer; // Suppress unused variable warning
     return "number"; // technically not a valid python type, but
                      // we need to use it when parsing back in annotations
                      // for implicit conversions
@@ -1200,6 +1201,7 @@ struct TORCH_API FloatType : public NumberType {
  private:
   FloatType() : NumberType(TypeKind::FloatType) {}
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
+    (void)printer; // Suppress unused variable warning
     return "float";
   }
 };
@@ -1225,6 +1227,7 @@ struct TORCH_API ComplexType : public NumberType {
  private:
   ComplexType() : NumberType(TypeKind::ComplexType) {}
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
+    (void)printer; // Suppress unused variable warning
     return "complex";
   }
 };
@@ -1250,6 +1253,7 @@ struct TORCH_API IntType : public NumberType {
  private:
   IntType() : NumberType(TypeKind::IntType) {}
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
+    (void)printer; // Suppress unused variable warning
     return "int";
   }
 };
@@ -1284,6 +1288,7 @@ struct TORCH_API StringType : public Type {
     return annotation_str();
   }
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
+    (void)printer; // Suppress unused variable warning
     return "str";
   }
   static const TypeKind Kind = TypeKind::StringType;
@@ -1304,6 +1309,7 @@ struct TORCH_API StorageType : public Type {
     return annotation_str();
   }
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
+    (void)printer; // Suppress unused variable warning
     return "Storage";
   }
   static const TypeKind Kind = TypeKind::StorageType;
@@ -1339,6 +1345,7 @@ struct TORCH_API FunctionType : public NamedType {
  private:
   FunctionType(torch::jit::Function* function);
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
+    (void)printer; // Suppress unused variable warning
     const auto& n = name().value();
     return n.qualifiedName();
   }
@@ -1922,6 +1929,7 @@ struct TORCH_API InterfaceType : public NamedType {
       std::ostream* why_not);
 
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
+    (void)printer; // Suppress unused variable warning
     return name()->qualifiedName();
   }
 

--- a/aten/src/ATen/core/jit_type_base.h
+++ b/aten/src/ATen/core/jit_type_base.h
@@ -140,7 +140,7 @@ struct TORCH_API Type {
   protected:
   Type(TypeKind kind) : kind_(kind) {}
 
-  virtual std::string annotation_str_impl(TypePrinter printer) const {
+  virtual std::string annotation_str_impl(TypePrinter /*printer*/) const {
     return str();
   }
   // a == b
@@ -567,7 +567,7 @@ struct TORCH_API Type {
   // per-type constructor, you only need to override this if the
   // containedTypes() is not empty
   virtual TypePtr createWithContained(
-      std::vector<TypePtr> contained_types) const {
+      std::vector<TypePtr> /*contained_types*/) const {
     AT_ERROR(
         "type with contained types did not overload createWithContained: ",
         str());

--- a/aten/src/ATen/core/op_registration/op_allowlist.h
+++ b/aten/src/ATen/core/op_registration/op_allowlist.h
@@ -185,7 +185,7 @@ constexpr bool op_allowlist_contains_name_in_schema(string_view allowlist, strin
 // and should be registered.  When we turn this on, the list of valid
 // mobile dispatch keys is hard coded (but you need to make sure
 // that you have the correct set of dispatch keys for this).
-constexpr bool dispatch_key_allowlist_check(DispatchKey k) {
+constexpr bool dispatch_key_allowlist_check(DispatchKey /*k*/) {
 #ifdef C10_MOBILE
   return true;
   // Disabled for now: to be enabled later!

--- a/aten/src/ATen/core/stack.h
+++ b/aten/src/ATen/core/stack.h
@@ -188,7 +188,7 @@ struct TuplePacker {
 
 template <typename... Args>
 struct TuplePacker<0, Args...> {
-  static void execute(Stack& stack, std::tuple<Args...>&& t){};
+  static void execute(Stack& /*stack*/, std::tuple<Args...>&& /*t*/){};
 };
 
 template <typename... Args>

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_double.h
@@ -214,7 +214,7 @@ public:
     return _mm256_sub_pd(pi_2, asin());
   }
   Vectorized<c10::complex<double>> atan() const;
-  Vectorized<c10::complex<double>> atan2(const Vectorized<c10::complex<double>> &b) const {
+  Vectorized<c10::complex<double>> atan2(const Vectorized<c10::complex<double>>&) const {
     AT_ERROR("not supported for complex numbers");
   }
   Vectorized<c10::complex<double>> erf() const {
@@ -255,20 +255,20 @@ public:
   Vectorized<c10::complex<double>> floor() const {
     return _mm256_floor_pd(values);
   }
-  Vectorized<c10::complex<double>> hypot(const Vectorized<c10::complex<double>> &b) const {
+  Vectorized<c10::complex<double>> hypot(const Vectorized<c10::complex<double>> &) const {
     AT_ERROR("not supported for complex numbers");
   }
-  Vectorized<c10::complex<double>> igamma(const Vectorized<c10::complex<double>> &x) const {
+  Vectorized<c10::complex<double>> igamma(const Vectorized<c10::complex<double>> &) const {
     AT_ERROR("not supported for complex numbers");
   }
-  Vectorized<c10::complex<double>> igammac(const Vectorized<c10::complex<double>> &x) const {
+  Vectorized<c10::complex<double>> igammac(const Vectorized<c10::complex<double>> &) const {
     AT_ERROR("not supported for complex numbers");
   }
   Vectorized<c10::complex<double>> neg() const {
     auto zero = _mm256_setzero_pd();
     return _mm256_sub_pd(zero, values);
   }
-  Vectorized<c10::complex<double>> nextafter(const Vectorized<c10::complex<double>> &b) const {
+  Vectorized<c10::complex<double>> nextafter(const Vectorized<c10::complex<double>> &) const {
     AT_ERROR("not supported for complex numbers");
   }
   Vectorized<c10::complex<double>> round() const {
@@ -309,31 +309,31 @@ public:
   Vectorized<c10::complex<double>> operator!=(const Vectorized<c10::complex<double>>& other) const {
     return _mm256_cmp_pd(values, other.values, _CMP_NEQ_UQ);
   }
-  Vectorized<c10::complex<double>> operator<(const Vectorized<c10::complex<double>>& other) const {
+  Vectorized<c10::complex<double>> operator<(const Vectorized<c10::complex<double>>&) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<double>> operator<=(const Vectorized<c10::complex<double>>& other) const {
+  Vectorized<c10::complex<double>> operator<=(const Vectorized<c10::complex<double>>&) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<double>> operator>(const Vectorized<c10::complex<double>>& other) const {
+  Vectorized<c10::complex<double>> operator>(const Vectorized<c10::complex<double>>&) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<double>> operator>=(const Vectorized<c10::complex<double>>& other) const {
+  Vectorized<c10::complex<double>> operator>=(const Vectorized<c10::complex<double>>&) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
 
   Vectorized<c10::complex<double>> eq(const Vectorized<c10::complex<double>>& other) const;
   Vectorized<c10::complex<double>> ne(const Vectorized<c10::complex<double>>& other) const;
-  Vectorized<c10::complex<double>> lt(const Vectorized<c10::complex<double>>& other) const {
+  Vectorized<c10::complex<double>> lt(const Vectorized<c10::complex<double>>&) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<double>> le(const Vectorized<c10::complex<double>>& other) const {
+  Vectorized<c10::complex<double>> le(const Vectorized<c10::complex<double>>&) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<double>> gt(const Vectorized<c10::complex<double>>& other) const {
+  Vectorized<c10::complex<double>> gt(const Vectorized<c10::complex<double>>&) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<double>> ge(const Vectorized<c10::complex<double>>& other) const {
+  Vectorized<c10::complex<double>> ge(const Vectorized<c10::complex<double>>&) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
 };

--- a/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_complex_float.h
@@ -248,7 +248,7 @@ public:
     return map(std::acos);
   }
   Vectorized<c10::complex<float>> atan() const;
-  Vectorized<c10::complex<float>> atan2(const Vectorized<c10::complex<float>> &b) const {
+  Vectorized<c10::complex<float>> atan2(const Vectorized<c10::complex<float>>& /*b*/) const {
     AT_ERROR("not supported for complex numbers");
   }
   Vectorized<c10::complex<float>> erf() const {
@@ -289,20 +289,20 @@ public:
   Vectorized<c10::complex<float>> floor() const {
     return _mm256_floor_ps(values);
   }
-  Vectorized<c10::complex<float>> hypot(const Vectorized<c10::complex<float>> &b) const {
+  Vectorized<c10::complex<float>> hypot(const Vectorized<c10::complex<float>>& /*b*/) const {
     AT_ERROR("not supported for complex numbers");
   }
-  Vectorized<c10::complex<float>> igamma(const Vectorized<c10::complex<float>> &x) const {
+  Vectorized<c10::complex<float>> igamma(const Vectorized<c10::complex<float>>& /*x*/) const {
     AT_ERROR("not supported for complex numbers");
   }
-  Vectorized<c10::complex<float>> igammac(const Vectorized<c10::complex<float>> &x) const {
+  Vectorized<c10::complex<float>> igammac(const Vectorized<c10::complex<float>>& /*x*/) const {
     AT_ERROR("not supported for complex numbers");
   }
   Vectorized<c10::complex<float>> neg() const {
     auto zero = _mm256_setzero_ps();
     return _mm256_sub_ps(zero, values);
   }
-  Vectorized<c10::complex<float>> nextafter(const Vectorized<c10::complex<float>> &b) const {
+  Vectorized<c10::complex<float>> nextafter(const Vectorized<c10::complex<float>>& /*b*/) const {
     AT_ERROR("not supported for complex numbers");
   }
   Vectorized<c10::complex<float>> round() const {
@@ -343,31 +343,31 @@ public:
   Vectorized<c10::complex<float>> operator!=(const Vectorized<c10::complex<float>>& other) const {
     return _mm256_cmp_ps(values, other.values, _CMP_NEQ_UQ);
   }
-  Vectorized<c10::complex<float>> operator<(const Vectorized<c10::complex<float>>& other) const {
+  Vectorized<c10::complex<float>> operator<(const Vectorized<c10::complex<float>>& /*other*/) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<float>> operator<=(const Vectorized<c10::complex<float>>& other) const {
+  Vectorized<c10::complex<float>> operator<=(const Vectorized<c10::complex<float>>& /*other*/) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<float>> operator>(const Vectorized<c10::complex<float>>& other) const {
+  Vectorized<c10::complex<float>> operator>(const Vectorized<c10::complex<float>>& /*other*/) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<float>> operator>=(const Vectorized<c10::complex<float>>& other) const {
+  Vectorized<c10::complex<float>> operator>=(const Vectorized<c10::complex<float>>& /*other*/) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
 
   Vectorized<c10::complex<float>> eq(const Vectorized<c10::complex<float>>& other) const;
   Vectorized<c10::complex<float>> ne(const Vectorized<c10::complex<float>>& other) const;
-  Vectorized<c10::complex<float>> lt(const Vectorized<c10::complex<float>>& other) const {
+  Vectorized<c10::complex<float>> lt(const Vectorized<c10::complex<float>>& /*other*/) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<float>> le(const Vectorized<c10::complex<float>>& other) const {
+  Vectorized<c10::complex<float>> le(const Vectorized<c10::complex<float>>& /*other*/) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<float>> gt(const Vectorized<c10::complex<float>>& other) const {
+  Vectorized<c10::complex<float>> gt(const Vectorized<c10::complex<float>>& /*other*/) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
-  Vectorized<c10::complex<float>> ge(const Vectorized<c10::complex<float>>& other) const {
+  Vectorized<c10::complex<float>> ge(const Vectorized<c10::complex<float>>& /*other*/) const {
     TORCH_CHECK(false, "not supported for complex numbers");
   }
 };

--- a/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_qint.h
@@ -65,10 +65,10 @@ __m256i pack_saturate_and_clamp(
 
 template <>
 inline __m256i pack_saturate_and_clamp<int32_t>(
-    __m256i first,
-    __m256i second,
-    int32_t min_val,
-    int32_t max_val) {
+    __m256i /*first*/,
+    __m256i /*second*/,
+    int32_t /*min_val*/,
+    int32_t /*max_val*/) {
   // This function is for linkage only, will not be used
   AT_ERROR("pack_saturate_and_clamp<int32_t> is not supported");
 }
@@ -259,7 +259,7 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
 
     float_vec_return_type dequantize(
         Vectorized<float> scale,
-        Vectorized<float> zero_point,
+        Vectorized<float> /*zero_point*/,
         Vectorized<float> scale_zp_premul) const {
       __m256 float_vals = _mm256_cvtepi32_ps(vals);
       return {vec::fmadd(scale, Vectorized<float>(float_vals), scale_zp_premul)};
@@ -269,7 +269,7 @@ struct Vectorized<c10::qint32> : public Vectorizedqi {
         const float_vec_return_type& rhs,
         float scale,
         int32_t zero_point,
-        float inverse_scale) {
+        float /*inverse_scale*/) {
       Vectorized<c10::qint32> retval;
       auto rhs_data = (__m256)rhs[0];
       at::native::quantize_vec<c10::qint32, /*precision=*/32>(
@@ -442,7 +442,7 @@ struct Vectorized<c10::qint8> : public Vectorizedqi {
  public:
   float_vec_return_type dequantize(
       Vectorized<float> scale,
-      Vectorized<float> zero_point,
+      Vectorized<float> /*zero_point*/,
       Vectorized<float> scale_neg_zp_premul) const {
     __m128i int_val0 = _mm_set1_epi64x(_mm256_extract_epi64(vals, 0));
     __m128i int_val1 = _mm_set1_epi64x(_mm256_extract_epi64(vals, 1));
@@ -467,7 +467,7 @@ struct Vectorized<c10::qint8> : public Vectorizedqi {
 
   static Vectorized<c10::qint8> quantize(
       const float_vec_return_type& rhs,
-      float scale,
+      float /*scale*/,
       int32_t zero_point,
       float inverse_scale) {
     auto* rhs_data = (float*)rhs.data();
@@ -605,7 +605,7 @@ struct Vectorized<c10::quint8> : public Vectorizedqi {
  public:
   float_vec_return_type dequantize(
       Vectorized<float> scale,
-      Vectorized<float> zero_point,
+      Vectorized<float> /*zero_point*/,
       Vectorized<float> scale_zp_premul) const {
     __m128i int_val0 = _mm_set1_epi64x(_mm256_extract_epi64(vals, 0));
     __m128i int_val1 = _mm_set1_epi64x(_mm256_extract_epi64(vals, 1));
@@ -630,7 +630,7 @@ struct Vectorized<c10::quint8> : public Vectorizedqi {
 
   static Vectorized<c10::quint8> quantize(
       const float_vec_return_type& rhs,
-      float scale,
+      float /*scale*/,
       int32_t zero_point,
       float inverse_scale) {
     auto* rhs_data = (float*)rhs.data();
@@ -763,7 +763,7 @@ struct VectorizedQuantizedConverter {
   float_vec_return_type dequantize(
       Vectorized<float> scale,
       Vectorized<float> zero_point,
-      Vectorized<float> scale_zp_premul) const {
+      Vectorized<float> /*scale_zp_premul*/) const {
     float_vec_return_type rv;
     for (const auto i : c10::irange(float_num_vecs())) {
       float tmp_vals[8];
@@ -820,7 +820,7 @@ struct Vectorized<c10::qint32> : public VectorizedQuantizedConverter<
       const float_vec_return_type& rhs,
       float scale,
       int32_t zero_point,
-      float inverse_scale) {
+      float /*inverse_scale*/) {
     std::array<value_type, size()> qvals;
     std::array<float, float_num_vecs() * 8> float_vals;
 
@@ -952,7 +952,7 @@ struct Vectorized<c10::qint8> : public VectorizedQuantizedConverter<
       const float_vec_return_type& rhs,
       float scale,
       int32_t zero_point,
-      float inverse_scale) {
+      float /*inverse_scale*/) {
     std::array<value_type, size()> qvals;
     std::array<float, float_num_vecs() * 8> float_vals;
 
@@ -1072,7 +1072,7 @@ struct Vectorized<c10::quint8> : public VectorizedQuantizedConverter<
       const float_vec_return_type& rhs,
       float scale,
       int32_t zero_point,
-      float inverse_scale) {
+      float /*inverse_scale*/) {
     std::array<value_type, size()> qvals;
     std::array<float, float_num_vecs() * 8> float_vals;
 

--- a/aten/src/ATen/cudnn/Handle.cpp
+++ b/aten/src/ATen/cudnn/Handle.cpp
@@ -9,7 +9,7 @@ void createCuDNNHandle(cudnnHandle_t *handle) {
   AT_CUDNN_CHECK(cudnnCreate(handle));
 }
 
-void destroyCuDNNHandle(cudnnHandle_t handle) {
+void destroyCuDNNHandle(cudnnHandle_t /*handle*/) {
 // this is because of something dumb in the ordering of
 // destruction. Sometimes atexit, the cuda context (or something)
 // would already be destroyed by the time this gets destroyed. It


### PR DESCRIPTION
Summary: Unused parameters cause compiler warnings which distract from real issues. Let's remove unused parameters!

Test Plan: Sandcastle

Reviewed By: ngimel

Differential Revision: D34567733

