### PR TITLE
Support CSR to COO conversion in to_sparse(2).

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5481,11 +5481,13 @@
   variants: method
   dispatch:
     CPU, CUDA: dense_to_sparse
+    SparseCsrCPU, SparseCsrCUDA: sparse_csr_to_sparse
 
 - func: to_sparse(Tensor self) -> Tensor
   variants: method
   dispatch:
     CPU, CUDA: dense_to_sparse
+    SparseCsrCPU, SparseCsrCUDA: sparse_csr_to_sparse
 
 - func: to_mkldnn(Tensor self, ScalarType? dtype=None) -> Tensor
   variants: method

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -22,6 +22,7 @@
 #include <ATen/ops/_coalesce.h>
 #include <ATen/ops/_coalesce_native.h>
 #include <ATen/ops/_coalesced_native.h>
+#include <ATen/ops/_convert_indices_from_csr_to_coo.h>
 #include <ATen/ops/_dimI_native.h>
 #include <ATen/ops/_dimV_native.h>
 #include <ATen/ops/_indices_native.h>
@@ -541,6 +542,29 @@ SparseTensor dense_to_sparse(const Tensor& self, int64_t sparse_dim) {
 
   Tensor sparse = at::sparse_coo_tensor(indices, values, sizes, sparse_options);
   return sparse._coalesced_(true);
+}
+
+SparseTensor sparse_csr_to_sparse(const Tensor& self, int64_t sparse_dim) {
+  TORCH_INTERNAL_ASSERT(self.is_sparse_csr());
+  TORCH_CHECK(sparse_dim > 0, "sparse_dim must be >0");
+  TORCH_CHECK(sparse_dim <= 2,
+              "sparse_dim must be less than or equal to 2");
+  if (sparse_dim == 2) {
+    auto sizes = self.sizes();
+    Tensor crow_indices = self.crow_indices();
+    Tensor col_indices = self.col_indices();
+    Tensor values = self.values();
+    Tensor indices = at::_convert_indices_from_csr_to_coo(crow_indices, col_indices, false, false);
+    return at::native::_sparse_coo_tensor_unsafe(indices, values, sizes)._coalesced_(true);
+  } else {
+    TORCH_CHECK(false, "sparse dim 1 is not supported by sparse_csr_to_dense");
+    // TODO: implement coo.to_sparse(sparse_dim) and then use
+    // return self.to_sparse().to_sparse(sparse_dim);
+  }
+}
+
+SparseTensor sparse_csr_to_sparse(const Tensor& self) {
+  return sparse_csr_to_sparse(self, 2);
 }
 
 // NB: Dropped the resizeNd variants

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -1296,6 +1296,7 @@ class TestSparseCSR(TestCase):
         with self.assertRaisesRegex(RuntimeError, r"Expected mat2 to have strided layout"):
             torch.sparse.sampled_addmm(a_sparse, a, a_sparse)
 
+    @skipMeta
     @dtypes(*get_all_dtypes())
     def test_coo_csr_conversion(self, device, dtype):
         for m, n in itertools.product([5, 2, 0], [5, 2, 0]):
@@ -1305,6 +1306,17 @@ class TestSparseCSR(TestCase):
             csr_sparse = coo_sparse.to_sparse_csr()
 
             self.assertEqual(csr_sparse.to_dense(), dense)
+
+    @skipMeta
+    @dtypes(*get_all_dtypes())
+    def test_csr_coo_conversion(self, device, dtype):
+        for m, n in itertools.product([5, 2, 0], [5, 2, 0]):
+            size = (m, n)
+            dense = make_tensor(size, dtype=dtype, device=device)
+            csr_sparse = dense.to_sparse_csr()
+            coo_sparse = csr_sparse.to_sparse()
+
+            self.assertEqual(coo_sparse.to_dense(), dense)
 
     @ops(_sparse_csr_ops)
     def test_sparse_csr_consistency(self, device, dtype, op):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14313,6 +14313,7 @@ op_db: List[OpInfo] = [
            backward_dtypes=floating_types(),
            backward_dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
            supports_out=False,
+           supports_sparse_csr=True,
            check_batched_grad=False,
            check_batched_gradgrad=False,
            skips=(
@@ -14325,6 +14326,8 @@ op_db: List[OpInfo] = [
                DecorateInfo(unittest.skip("Skipped!"), 'TestJit', 'test_variant_consistency_jit'),
                # Allowed exception: sparse tensors don't have strides
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_composite_compliance'),
+               # TODO: implement csr.to_sparse(sample_dim) where sampled_dim is 1.
+               DecorateInfo(unittest.skip("csr.to_sparse(1) not implemented. Skipped!"), 'TestSparseCSR', 'test_sparse_csr_consistency'),
            )
            ),
     OpInfo('logcumsumexp',


### PR DESCRIPTION
Former https://github.com/pytorch/pytorch/pull/73471 that was reverted due to lack of `to_sparse(sparse_dim)` support.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #72633
* #71239
* __->__ #73642

Differential Revision: [D34580353](https://our.internmc.facebook.com/intern/diff/D34580353)