### PR TITLE
only pass --std=c++14 to C++ compilation actions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-build --copt=--std=c++14
+build --cxxopt=--std=c++14
 build --copt=-I.
 # Bazel does not support including its cc_library targets as system
 # headers. We work around this for generated code


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73654
* #73653
* #73652
* #73651
* #73650
* #73649
* #73648
* **#73647**

Clang is a bit more persnickety than GCC for this flag.