### PR TITLE
static_cast value to microsecond type

### DIFF
--- a/torch/csrc/distributed/c10d/TCPStore.cpp
+++ b/torch/csrc/distributed/c10d/TCPStore.cpp
@@ -893,7 +893,9 @@ void TCPClient::setTimeout(std::chrono::milliseconds value) {
       static_cast<long>((value.count() % 1000) * 1000)};
 #else
   struct timeval timeoutTV = {
-      .tv_sec = value.count() / 1000, .tv_usec = (value.count() % 1000) * 1000};
+      .tv_sec = value.count() / 1000,
+      .tv_usec = static_cast<suseconds_t>((value.count() % 1000) * 1000),
+  };
 #endif
   SYSCHECK_ERR_RETURN_NEG1(::setsockopt(
       socket_.handle(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73654
* #73653
* #73652
* #73651
* #73650
* #73649
* **#73648**
* #73647

In some platforms, this might be a distinct type from 64-bit signed
integral, and the compiler might warn about implicit coercion.