### PR TITLE
setup OpenMP compilation correctly for MacOS

### DIFF
--- a/third_party/mkl-dnn.BUILD
+++ b/third_party/mkl-dnn.BUILD
@@ -89,10 +89,15 @@ cc_library(
         "-D__STDC_CONSTANT_MACROS",
         "-D__STDC_LIMIT_MACROS",
         "-fno-strict-overflow",
-        "-fopenmp",
     ] + select({
         "@//tools/config:thread_sanitizer": ["-DDNNL_CPU_RUNTIME=0"],
         "//conditions:default": ["-DDNNL_CPU_RUNTIME=2"],
+    }) + select({
+        "@platforms//os:macos": [
+            "-Xpreprocessor",
+            "-openmp",
+        ],
+        "//conditions:default": ["-fopenmp"],
     }),
     includes = [
         "third_party/oneDNN/include/",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73654
* #73653
* #73652
* #73651
* **#73650**
* #73649
* #73648
* #73647

Here we are using MacOS as a proxy for the Clang compiler.