### PR TITLE
batch_norm_jvp: improve error message when running_{mean,var} have forward grad defined

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -22,6 +22,7 @@ import torch
 torch.set_default_dtype(torch.double)
 
 from torch._six import inf, nan
+import torch.autograd.forward_ad as fwAD
 import torch.backends.cudnn as cudnn
 import torch.nn as nn
 import torch.nn.functional as F
@@ -9575,6 +9576,31 @@ class TestNN(NNTestCase):
         for size in wrong_sizes:
             with self.assertRaises(RuntimeError):
                 F.batch_norm(input, running_mean, running_var, bias=Parameter(torch.rand(size)))
+
+    def test_batchnorm_raises_error_if_running_var_or_running_mean_have_forward_grad(self):
+        args = (
+            torch.randn(3, 2, 5),  # input
+            torch.randn(2),  # running_mean
+            torch.randn(2),  # running_var
+        )
+        kwargs = {'training': False, 'momentum': -1.2}
+        fn = partial(F.batch_norm, **kwargs)
+
+        for dual_indices in ((0,), (1,), (1, 2), (0, 1), (0, 1, 2),):
+            print(dual_indices)
+            tangents = tuple(torch.rand_like(x) for x in args)
+
+            with fwAD.dual_level():
+                duals = [fwAD.make_dual(primal, tangent) if i in dual_indices else primal
+                        for i, (primal, tangent) in enumerate(zip(args, tangents))]
+                print(duals)
+                msg = "batch_norm is not differentiable wrt running_mean and running_var"
+                # 0 needs to have forward grad because otherwise we won't even run batch_norm_jvp
+                if (1 in dual_indices or 2 in dual_indices) and 0 in dual_indices:
+                    with self.assertRaisesRegex(RuntimeError, msg):
+                        fn(*duals)
+                else:
+                    fn(*duals)
 
     def test_batchnorm_buffer_update_when_stats_are_not_tracked(self):
         input_size = (32, 4)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9591,7 +9591,7 @@ class TestNN(NNTestCase):
 
             with fwAD.dual_level():
                 duals = [fwAD.make_dual(primal, tangent) if i in dual_indices else primal
-                        for i, (primal, tangent) in enumerate(zip(args, tangents))]
+                         for i, (primal, tangent) in enumerate(zip(args, tangents))]
                 msg = "batch_norm is not differentiable wrt running_mean and running_var"
                 # 0 needs to have forward grad because otherwise we won't even run batch_norm_jvp
                 if (1 in dual_indices or 2 in dual_indices) and 0 in dual_indices:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9587,13 +9587,11 @@ class TestNN(NNTestCase):
         fn = partial(F.batch_norm, **kwargs)
 
         for dual_indices in ((0,), (1,), (1, 2), (0, 1), (0, 1, 2),):
-            print(dual_indices)
             tangents = tuple(torch.rand_like(x) for x in args)
 
             with fwAD.dual_level():
                 duals = [fwAD.make_dual(primal, tangent) if i in dual_indices else primal
                         for i, (primal, tangent) in enumerate(zip(args, tangents))]
-                print(duals)
                 msg = "batch_norm is not differentiable wrt running_mean and running_var"
                 # 0 needs to have forward grad because otherwise we won't even run batch_norm_jvp
                 if (1 in dual_indices or 2 in dual_indices) and 0 in dual_indices:

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -4842,8 +4842,8 @@ Tensor batch_norm_jvp(
         running_mean.has_value() && running_var.has_value(),
         "Expect running_mean and running_var to have value when train=false");
     TORCH_CHECK(
-        !running_mean.value()._fw_grad(/*level=*/0).defined() && !running_mean.value()._fw_grad(/*level=*/0).defined(),
-        "batch_norm_jvp expects running_mean and running_var to not have forward grad defined");
+        !running_mean.value()._fw_grad(/*level=*/0).defined() && !running_var.value()._fw_grad(/*level=*/0).defined(),
+        "batch_norm is not differentiable wrt running_mean and running_var, they cannot have forward grad defined");
     mean_p = running_mean.value().view(view_size);
     invstd_p = (1 / at::sqrt(running_var.value() + at::Scalar(eps))).view(view_size);
     result_t = input_t * invstd_p;

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -4841,6 +4841,9 @@ Tensor batch_norm_jvp(
     TORCH_INTERNAL_ASSERT(
         running_mean.has_value() && running_var.has_value(),
         "Expect running_mean and running_var to have value when train=false");
+    TORCH_CHECK(
+        !running_mean.value()._fw_grad(/*level=*/0).defined() && !running_mean.value()._fw_grad(/*level=*/0).defined(),
+        "batch_norm_jvp expects running_mean and running_var to not have forward grad defined");
     mean_p = running_mean.value().view(view_size);
     invstd_p = (1 / at::sqrt(running_var.value() + at::Scalar(eps))).view(view_size);
     result_t = input_t * invstd_p;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73655
* #72811
* #72677

Fixes: https://github.com/pytorch/pytorch/issues/73541

Differential Revision: [D34586758](https://our.internmc.facebook.com/intern/diff/D34586758)