### PR TITLE
[Quant] Qadd: Add qint8 support backed by xnnpack

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qadd.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qadd.cpp
@@ -7,9 +7,8 @@
 #include <ATen/native/quantized/cpu/quantized_ops.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <ATen/native/quantized/cpu/xnnpack_utils.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
-
-#include <algorithm>
 
 namespace at {
 namespace native {
@@ -217,18 +216,170 @@ Tensor qnnpack_add(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
 
   return qy;
 }
-#endif
+#endif // USE_PYTORCH_QNNPACK
+
+#ifdef USE_XNNPACK
+C10_ALWAYS_INLINE
+enum xnn_status xnnp_create_add_nd(
+    int8_t azp,
+    float ascale,
+    int8_t bzp,
+    float bscale,
+    int8_t czp,
+    float cscale,
+    int8_t output_min,
+    int8_t output_max,
+    uint32_t flags,
+    xnn_operator_t* op) {
+  return xnn_create_add_nd_qs8(
+      azp,        /* int8_t input1_zero_point   */
+      ascale,     /* float input1_scale         */
+      bzp,        /* int8_t input2_zero_point   */
+      bscale,     /* float input2_scale         */
+      czp,        /* int8_t output_zero_point   */
+      cscale,     /* float output_scale         */
+      output_min, /* int8_t output_min          */
+      output_max, /* int8_t output_max          */
+      flags,      /* uint32_t flags             */
+      op);        /* xnn_operator_t* add_op_out */
+}
+
+C10_ALWAYS_INLINE
+enum xnn_status xnnp_setup_add_nd(
+    xnn_operator_t op,
+    const std::vector<size_t>& a_shape,
+    const std::vector<size_t>& b_shape,
+    const int8_t* da,
+    const int8_t* db,
+    int8_t* dc,
+    pthreadpool_t pt_pool) {
+  return xnn_setup_add_nd_qs8(
+      op,             /* xnn_operator_t add_op      */
+      a_shape.size(), /* size_t num_input1_dims     */
+      a_shape.data(), /* const size_t* input1_shape */
+      b_shape.size(), /* size_t num_input2_dims     */
+      b_shape.data(), /* const size_t* input2_shape */
+      da,             /* const int8_t* input1       */
+      db,             /* const int8_t* input2       */
+      dc,             /* int8_t* output             */
+      pt_pool);       /* pthreadpool_t threadpool   */
+}
+
+template <typename scalar_t, bool ReLUFused = false>
+Tensor xnnp_add(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
+  using underlying_t = typename scalar_t::underlying;
+  const string func_name = "xnnp_add()";
+  TORCH_CHECK(qa.ndimension() > 0, func_name, ": Got empty input tensor.");
+  TORCH_CHECK(at::native::xnnpack::available(), func_name, ": XNNPACK is not available")
+
+  // using qa memory format for qb to allow xnnpack kernel to flatten all the
+  // dims
+  auto qa_mem_format = qa.suggest_memory_format();
+  Tensor qa_contig = qa.contiguous(qa_mem_format);
+  Tensor qb_contig = qb.contiguous(qa_mem_format);
+
+  const auto a_zero_point = qa_contig.q_zero_point();
+  const auto b_zero_point = qb_contig.q_zero_point();
+  const auto a_scale = qa_contig.q_scale();
+  const auto b_scale = qb_contig.q_scale();
+
+  Tensor qy = at::native::empty_affine_quantized(
+      at::infer_size_dimvector(qa_contig.sizes(), qb_contig.sizes()),
+      qa.scalar_type(),
+      c10::nullopt /* layout */,
+      kCPU,
+      c10::nullopt /* pin_memory */,
+      scale,
+      zero_point,
+      qa_mem_format);
+
+  if (qa_contig.size(0) == 0) {
+    return qy;
+  }
+
+  xnn_operator_t xnnp_op = nullptr;
+  xnnpack_operator xnnp_add_operator;
+
+  auto output_max = std::numeric_limits<underlying_t>::max();
+  auto output_min = std::numeric_limits<underlying_t>::min();
+  if (ReLUFused) {
+    /*
+     * FIXME: use acticationLimits<T>()
+     * With <T>, MSVC runs into "error C3862: indetifier activationLimits not found".
+     */
+    constexpr int64_t qmin = std::numeric_limits<underlying_t>::min();
+    constexpr int64_t qmax = std::numeric_limits<underlying_t>::max();
+    int64_t qvalue = static_cast<int64_t>(zero_point);
+    qvalue = std::max<int64_t>(qvalue, qmin);
+    output_min = static_cast<underlying_t>(std::min<int64_t>(qvalue, qmax));
+  }
+
+  // Create an operator
+  auto status = xnnp_create_add_nd(
+      a_zero_point,
+      a_scale,
+      b_zero_point,
+      b_scale,
+      static_cast<underlying_t>(zero_point),
+      static_cast<float>(scale),
+      output_min,
+      output_max,
+      0,
+      &xnnp_op);
+  xnnp_add_operator = xnnpack_operator(xnnp_op);
+  TORCH_CHECK(
+      status == xnn_status_success,
+      func_name, ": xnn create operator failed(", status,")!");
+
+  const auto qa_shape = xnnp_utils::get_mem_format_aware_shape(qa_contig);
+  const auto qb_shape = xnnp_utils::get_mem_format_aware_shape(qb_contig);
+
+  // Setup the operator
+  status = xnnp_setup_add_nd(
+      xnnp_add_operator.get(),
+      qa_shape,
+      qb_shape,
+      reinterpret_cast<const underlying_t*>(qa_contig.data_ptr<scalar_t>()),
+      reinterpret_cast<const underlying_t*>(qb_contig.data_ptr<scalar_t>()),
+      reinterpret_cast<underlying_t*>(qy.data_ptr<scalar_t>()),
+      caffe2::pthreadpool_());
+  TORCH_CHECK(
+      status == xnn_status_success,
+      func_name, ": xnn setup operator failed(", status,")!");
+
+  // Run the operator
+  status = xnn_run_operator(
+      xnnp_add_operator.get(), /* xnn_operator_t op */
+      caffe2::pthreadpool_()); /* pthreadpool_t threadpool */
+  TORCH_CHECK(
+      status == xnn_status_success,
+      func_name, ": xnn run operator failed(", status,")");
+  return qy;
+}
+#endif // USE_XNNPACK
 
 template <bool ReLUFused = false>
 Tensor qadd(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
   check_inputs(qa, qb);
+
+  if (at::globalContext().qEngine() == at::QEngine::QNNPACK) {
+    TORCH_CHECK(
+        qa.scalar_type() == qb.scalar_type(),
+        "Both inputs to qadd must have same type");
+
+#ifdef USE_XNNPACK
+    if (qa.scalar_type() == kQInt8) {
+          return xnnp_add<c10::qint8, ReLUFused>(qa, qb, scale, zero_point);
+    }
+#endif // USE_XNNPACK
+
 #ifdef USE_PYTORCH_QNNPACK
-  if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
-      qa.sizes() == qb.sizes() && /* qnnpack does not support boradcasting */
-      qa.scalar_type() == kQUInt8 && qb.scalar_type() == kQUInt8) {
+    if(qa.sizes() == qb.sizes() && /* qnnpack does not support boradcasting */
+      qa.scalar_type() == kQUInt8) {
     return qnnpack_add<ReLUFused>(qa, qb, scale, zero_point);
+    }
+#endif // USE_PYTORCH_QNNPACK
   }
-#endif
   auto qc = at::_empty_affine_quantized(
       qa.sizes(),
       at::device(kCPU)

--- a/aten/src/ATen/native/quantized/cpu/xnnpack_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/xnnpack_utils.cpp
@@ -1,0 +1,32 @@
+#include <ATen/ATen.h>
+
+#ifdef USE_XNNPACK
+namespace at {
+namespace native {
+namespace xnnp_utils {
+
+std::vector<size_t> get_mem_format_aware_shape(const at::Tensor& in) {
+  const auto mem_format = in.suggest_memory_format();
+  const auto& sizes = in.sizes();
+  std::vector<size_t> ret(sizes.begin(), sizes.end());
+  if (mem_format == c10::MemoryFormat::ChannelsLast) {
+    // NCHW -> NHWC
+    // 0123 -> 0231
+    ret[1] = sizes[2]; /* H */
+    ret[2] = sizes[3]; /* W */
+    ret[3] = sizes[1]; /* C */
+  } else if (mem_format == c10::MemoryFormat::ChannelsLast3d) {
+    // NCDHW -> NDHWC
+    // 01234 -> 02341
+    ret[1] = sizes[2]; /* D */
+    ret[2] = sizes[3]; /* H */
+    ret[3] = sizes[4]; /* W */
+    ret[4] = sizes[1]; /* C */
+  }
+  return ret;
+}
+} // namespace xnnp_utils
+} // namespace native
+} // namespace at
+
+#endif  // USE_XNNPACK

--- a/aten/src/ATen/native/quantized/cpu/xnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/xnnpack_utils.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#ifdef USE_XNNPACK
+#include <ATen/native/xnnpack/Common.h>
+
+using xnnpack_operator = at::native::xnnpack::Operator;
+
+namespace at {
+namespace native {
+namespace xnnp_utils {
+
+std::vector<size_t> get_mem_format_aware_shape(const at::Tensor& in);
+
+} // namespace xnnp_utils
+} // namespace native
+} // namespace at
+
+#endif // USE_XNNPACK

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -29,6 +29,7 @@ from torch.testing._internal.common_quantized import _quantize, _dequantize, _ca
 from torch.testing._internal.common_quantized import qengine_is_qnnpack
 from torch.ao.quantization import PerChannelMinMaxObserver
 from torch.testing._internal.common_cuda import TEST_CUDNN
+import torch.backends.xnnpack
 
 from typing import Optional
 
@@ -5089,7 +5090,7 @@ class TestQNNPackOps(TestCase):
     """Tests the correctness of the quantized::add (qnnpack) op."""
     @settings(suppress_health_check=(HealthCheck.filter_too_much,))
     @given(A=hu.tensor(shapes=hu.array_shapes(1, 5, 1, 5),
-                       qparams=hu.qparams(dtypes=torch.quint8)),
+                       qparams=hu.qparams(dtypes=[torch.quint8, torch.qint8])),
            zero_point=st.sampled_from([0, 2, 5, 15, 127]),
            scale_A=st.sampled_from([0.001, 0.057, 0.889, 12.3]),
            scale_B=st.sampled_from([0.008, 0.0821, 0.67, 7]),
@@ -5097,39 +5098,96 @@ class TestQNNPackOps(TestCase):
     def test_qnnpack_add(self, A, zero_point, scale_A, scale_B, scale_C):
         with override_quantized_engine('qnnpack'):
             A_temp = A
-            A, (scale_a, zero_point_A, torch_type) = A_temp
-            B, (scale_b, zero_point_B, torch_type) = A_temp
-            A = torch.from_numpy(A)
-            B = torch.from_numpy(B)
+            for channels_last in [True, False]:
+                if channels_last and len(A_temp[0].shape) != 4:
+                    continue
+                A, (scale_a, zero_point_A, torch_type) = A_temp
+                B, (scale_b, zero_point_B, torch_type) = A_temp
+                A = torch.from_numpy(A)
+                B = torch.from_numpy(B)
 
-            assume(scale_A // scale_C >= 2**-14)
-            assume(scale_A // scale_C < 2**8)
-            assume(scale_B // scale_C >= 2**-14)
-            assume(scale_B // scale_C < 2**8)
+                if torch_type == torch.qint8 and not torch.backends.xnnpack.enabled:
+                    continue
 
-            zero_point_C = 127
-            qA = torch.quantize_per_tensor(A, scale=scale_A, zero_point=zero_point,
-                                           dtype=torch.quint8)
-            qB = torch.quantize_per_tensor(B, scale=scale_B, zero_point=zero_point,
-                                           dtype=torch.quint8)
+                if channels_last:
+                    A = A.to(memory_format=torch.channels_last)
+                    B = B.to(memory_format=torch.channels_last)
+                assume(scale_A // scale_C >= 2**-14)
+                assume(scale_A // scale_C < 2**8)
+                assume(scale_B // scale_C >= 2**-14)
+                assume(scale_B // scale_C < 2**8)
 
-            # Add ground truth
-            C = (qA.dequantize() + qB.dequantize()).numpy()
+                zero_point_C = 127
+                np_dtype = np.uint8
 
-            qC = _quantize(C, scale_C, zero_point_C)
+                if torch_type == torch.qint8:
+                    zero_point_C = 0
+                    np_dtype = np.int8
 
-            qC_qnnp = torch.ops.quantized.add(qA, qB, scale_C, zero_point_C)
+                qA = torch.quantize_per_tensor(A, scale=scale_A, zero_point=zero_point,
+                                               dtype=torch_type)
+                qB = torch.quantize_per_tensor(B, scale=scale_B, zero_point=zero_point,
+                                               dtype=torch_type)
 
-            np.testing.assert_equal(qC, qC_qnnp.int_repr(),
-                                    "Quantized addition failed.")
+                # Add ground truth
+                C = (qA.dequantize() + qB.dequantize()).numpy()
 
-            Crelu = C.copy()
-            Crelu[C < 0] = 0
-            qCrelu = torch.quantize_per_tensor(torch.from_numpy(Crelu), scale_C,
-                                               zero_point_C, dtype=torch.quint8)
-            qCrelu_hat = torch.ops.quantized.add_relu(qA, qB, scale=scale_C, zero_point=zero_point_C)
-            np.testing.assert_equal(qCrelu.int_repr().numpy(), qCrelu_hat.int_repr(),
-                                    "Quantized addition with ReLU failed.")
+                qC = _quantize(C, scale_C, zero_point_C, dtype=np_dtype)
+
+                qC_qnnp = torch.ops.quantized.add(qA, qB, scale_C, zero_point_C)
+
+                np.testing.assert_equal(qC, qC_qnnp.int_repr(),
+                                        "Quantized addition failed.")
+
+                Crelu = C.copy()
+                Crelu[C < 0] = 0
+                qCrelu = torch.quantize_per_tensor(torch.from_numpy(Crelu), scale_C,
+                                                   zero_point_C, dtype=torch_type)
+                qCrelu_hat = torch.ops.quantized.add_relu(qA, qB, scale=scale_C, zero_point=zero_point_C)
+                np.testing.assert_equal(qCrelu.int_repr().numpy(), qCrelu_hat.int_repr(),
+                                        "Quantized addition with ReLU failed.")
+
+    """Tests that quantized add works with broadcasting """
+    def test_qnnpack_add_broadcast(self):
+        def _run_test(A, B):
+            qA = torch.quantize_per_tensor(A, 0.02, 0, dtype)
+            qB = torch.quantize_per_tensor(B, 0.04, 2, dtype)
+
+            output_scale = 0.01
+            output_zp = 1
+
+            # ground truth
+            C = qA.dequantize() + qB.dequantize()
+            qC = torch.quantize_per_tensor(C, output_scale, output_zp, dtype)
+
+            # quantized
+            qC_hat_1 = torch.ops.quantized.add(qA, qB, output_scale, output_zp)
+            qC_hat_2 = torch.ops.quantized.add(qB, qA, output_scale, output_zp)
+
+            self.assertTrue(torch.allclose(qC.dequantize(), qC_hat_1.dequantize()))
+            self.assertTrue(torch.allclose(qC.dequantize(), qC_hat_2.dequantize()))
+
+        with override_quantized_engine("qnnpack"):
+            for dtype in (torch.qint8, torch.quint8):
+                if dtype == torch.qint8 and not torch.backends.xnnpack.enabled:
+                    continue
+
+                for channels_last in [True, False]:
+                    # 4d
+                    A = torch.randn(1, 3, 4, 4)
+                    B = torch.randn(1, 1, 1, 1)
+                    if channels_last:
+                        A = A.to(memory_format=torch.channels_last)
+                        B = B.to(memory_format=torch.channels_last)
+                    _run_test(A, B)
+
+                    # 5d
+                    C = torch.randn(1, 3, 4, 4, 4)
+                    D = torch.randn(1, 1, 1, 1, 1)
+                    if channels_last:
+                        C = C.to(memory_format=torch.channels_last_3d)
+                        D = D.to(memory_format=torch.channels_last_3d)
+                    _run_test(C, D)
 
     """Tests the correctness of quantized::qnnpack_maxpool2d op."""
     @given(A=hu.tensor(shapes=hu.array_shapes(4, 4, 3, 5),

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -1195,6 +1195,7 @@ aten_native_source_non_codegen_list = [
     "aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp",
     "aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp",
     "aten/src/ATen/native/quantized/library.cpp",
+    "aten/src/ATen/native/quantized/cpu/xnnpack_utils.cpp",
     "aten/src/ATen/quantized/QTensorImpl.cpp",
     "aten/src/ATen/quantized/Quantizer.cpp",
     "aten/src/ATen/native/Activation.cpp",


### PR DESCRIPTION
Summary: If built w/ USE_XNNPACK, for qint8 dtype, qadd is performed using xnnpack.

Differential Revision: D34470378

