### PR TITLE
Fix typo in error message (THCGenerateByteType.h)

### DIFF
--- a/torch/csrc/THCGenerateByteType.h
+++ b/torch/csrc/THCGenerateByteType.h
@@ -1,5 +1,5 @@
 #ifndef THC_GENERIC_FILE
-#error "You must define THC_GENERIC_FILE before including THGenerateByteType.h"
+#error "You must define THC_GENERIC_FILE before including THCGenerateByteType.h"
 #endif
 
 #define scalar_t uint8_t


### PR DESCRIPTION
`THCGenerateByteType.h` was accidentally named as `THGenerateByteType.h` (missing a `C`) in an error message. And this is problematic because there is also a file named `THGenerateByteType.h`. This PR fixes this typo.

Fixes https://github.com/pytorch/pytorch/issues/69444
