### PR TITLE
[Quant] Qlinear Add qint8 support backed by xnnpack

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -706,7 +706,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_impl_xnnp(
     }
 
     // copy from the original weight and take care of dtype change if necessary
-    at::native::xnnp_utils::q8_conv_weight_copy_and_add_offset<scalar_t>(
+    at::native::xnnp_utils::q8_copy_int8_weight_and_add_offset<scalar_t>(
         weight_contig, weight_tensor);
     const at::Tensor xnnp_weight =
         at::native::xnnp_utils::convert_conv_weights_to_channel_last_tensor<

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -4,6 +4,7 @@
 #include <ATen/native/quantized/cpu/fbgemm_utils.h>
 #include <ATen/native/quantized/cpu/packed_params.h>
 #include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <ATen/native/quantized/cpu/xnnpack_utils.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 #include <torch/custom_class.h>
 #include <torch/library.h>
@@ -270,6 +271,161 @@ at::Tensor& PackedLinearWeight::apply_relu_out(
 #endif // USE_FBGEMM
 
 #ifdef USE_PYTORCH_QNNPACK
+
+#ifdef USE_XNNPACK
+// TODO: add per_channel support in the future when xnnp supports it
+template <typename scalar_t, bool kReluFused>
+at::Tensor PackedLinearWeightsQnnp::apply_impl_xnnp(
+    const at::Tensor& input,
+    double output_scale,
+    int64_t output_zero_point) {
+  using underlying_t = typename scalar_t::underlying;
+
+  std::lock_guard<std::mutex> lock(qnnp_mutex_);
+
+  const std::string func_name = kReluFused ? "quantized::linear_relu (xnnpack)"
+                                           : "quantized::linear (xnnpack)";
+  TORCH_CHECK(
+      input.dim() >= 2, func_name, ": Input tensor rank should be >= 2.");
+  TORCH_CHECK(
+      !per_channel(),
+      func_name,
+      ": xnnpack does not currently have per_channel support.");
+
+  const auto input_contig = input.contiguous();
+  const auto input_scale = input_contig.q_scale();
+
+  const size_t rows_w = bias_.size(0);
+  const size_t cols_w = input_contig.size(input_contig.dim() - 1);
+
+  auto status = xnn_status_invalid_state;
+
+  // Create an operator iff not already created
+  if (!xnnp_linear_op ||
+      (!this->input_scale.has_value() ||
+       this->input_scale.value() != input_scale)) {
+    // Update the input scale so we may cache the op
+    this->input_scale = input_scale;
+
+    xnn_operator_t xnnp_op = nullptr;
+
+    const float* weight_scales_data = w_scales.data_ptr<float>();
+
+    // prepare weights
+    underlying_t w_zp = static_cast<underlying_t>(
+        orig_weight.q_zero_point() +
+        (std::is_same<underlying_t, uint8_t>::value ? 128 : 0));
+
+   at::Tensor xnnp_weight = at::_empty_affine_quantized(
+        orig_weight.sizes(),
+        c10::CppTypeToScalarType<scalar_t>::value,
+        weight_scales_data[0],
+        w_zp);
+
+    // copy from the original weight and take care of dtype change if necessary
+    at::native::xnnp_utils::q8_copy_int8_weight_and_add_offset<scalar_t>(
+        orig_weight, xnnp_weight);
+
+    // Original bias was float, so we requantize it here.
+    at::Tensor qbias = at::native::quantize_per_tensor(
+          bias_, orig_weight.q_scale() * input_scale, 0, c10::kQInt32);
+
+    // output limits
+   auto output_min = kReluFused
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+        ? activationLimits<underlying_t>(output_scale, output_zero_point, Activation::RELU).first
+        : std::numeric_limits<underlying_t>::min();
+    auto output_max = kReluFused
+        // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
+        ? activationLimits<underlying_t>(output_scale, output_zero_point, Activation::RELU).second
+        : std::numeric_limits<underlying_t>::max();
+
+    // Create an operator
+    status = at::native::xnnp_utils::xnnp_create_fully_connected_nc(
+        cols_w, /* input_channels */
+        rows_w, /* output_channels */
+        cols_w, /* input_stride */
+        rows_w, /* output_stride */
+        input_contig.q_zero_point(),
+        input_contig.q_scale(),
+        w_zp,
+        weight_scales_data[0],
+        reinterpret_cast<const underlying_t*>(
+            xnnp_weight.template data_ptr<scalar_t>()),
+        reinterpret_cast<int32_t*>(qbias.data_ptr<c10::qint32>()),
+        output_zero_point,
+        output_scale,
+        output_min,
+        output_max,
+        0, /* flags */
+        &xnnp_op);
+    xnnp_linear_op = xnnpack_operator(xnnp_op);
+
+    TORCH_CHECK(
+        status == xnn_status_success,
+        func_name,
+        ": xnn create operator failed(",
+        status,
+        ")");
+  }
+
+  /*
+   * Allocate output Tensor and a buffer for XNNPACK to use
+   * The resulting matrix here is 2-D, let's view it with the original
+   * left hand dimensions of the input. Here are two examples:
+   * 1. If the input tensor is {M, K}, the output tensor is {M, N}.
+   * 2. If the input tensor is {b, M, K}, the output tensor is {b, M, N}.
+   */
+  std::vector<int64_t> out_sizes = input.sizes().vec();
+  out_sizes.back() = static_cast<int64_t>(rows_w);
+  at::Tensor output = at::native::empty_affine_quantized(
+      out_sizes,
+      c10::CppTypeToScalarType<scalar_t>::value,
+      c10::nullopt /* layout */,
+      c10::kCPU,
+      c10::nullopt /* pin_memory */,
+      output_scale,
+      output_zero_point,
+      input.suggest_memory_format());
+
+  // calculate batch_size
+  size_t rows_input = 1;
+  for (const auto i : c10::irange(input_contig.dim() - 1)) {
+    rows_input *= input_contig.size(i);
+  }
+
+  // Setup the operator
+  status = at::native::xnnp_utils::xnnp_setup_fully_connected_nc(
+      xnnp_linear_op.get(),
+      rows_input, /* batch_size */
+      reinterpret_cast<const underlying_t*>(
+          input_contig.template data_ptr<scalar_t>()),
+      reinterpret_cast<underlying_t*>(output.template data_ptr<scalar_t>()),
+      caffe2::pthreadpool_());
+
+  TORCH_CHECK(
+      status == xnn_status_success,
+      func_name,
+      ": xnn setup operator failed(",
+      status,
+      ")");
+
+  // Run the opeator
+  status = xnn_run_operator(
+      xnnp_linear_op.get(), // Linear op
+      caffe2::pthreadpool_() // threadpool
+  );
+  TORCH_CHECK(
+      status == xnn_status_success,
+      func_name,
+      ": xnn run operator failed(",
+      status,
+      ")");
+
+  return output;
+}
+#endif // USE_XNNPACK
+
 template <bool ReluFused>
 at::Tensor PackedLinearWeightsQnnp::apply_impl(
     at::Tensor input,
@@ -414,10 +570,35 @@ at::Tensor PackedLinearWeightsQnnp::apply_impl(
   return output;
 }
 
+#ifdef USE_XNNPACK
+bool can_use_xnnp(c10::ScalarType dtype, bool per_channel) {
+  if(!at::native::xnnpack::available()) {
+    return false;
+  }
+
+  bool supported_dtypes = dtype == c10::kQInt8;
+  bool invalid_config = per_channel; /* xnnp does not currently support
+                                        per-channel fully connected op */
+  if (supported_dtypes && invalid_config) {
+    /* don't want this to fall through to QNNPACK */
+    TORCH_CHECK(
+        false,
+        "quantized::linear (xnnpack): Unsupported config for dtype KQInt8");
+  }
+  return supported_dtypes && !invalid_config;
+}
+#endif // USE_XNNPACK
+
 at::Tensor PackedLinearWeightsQnnp::apply(
     at::Tensor input,
     double output_scale,
     int64_t output_zero_point) {
+#ifdef USE_XNNPACK
+  if (can_use_xnnp(input.scalar_type(), per_channel())) {
+    return apply_impl_xnnp<c10::qint8, false>(
+        input, output_scale, output_zero_point);
+  } /* fall through for unsupported types, configs, or shapes */
+#endif // USE_XNNPACK
   return apply_impl<false>(std::move(input), output_scale, output_zero_point);
 }
 
@@ -425,6 +606,12 @@ at::Tensor PackedLinearWeightsQnnp::apply_relu(
     at::Tensor input,
     double output_scale,
     int64_t output_zero_point) {
+#ifdef USE_XNNPACK
+  if (can_use_xnnp(input.scalar_type(), per_channel())) {
+    return apply_impl_xnnp<c10::qint8, true>(
+        input, output_scale, output_zero_point);
+  } /* fall through for unsupported types, configs, or shapes */
+#endif // USE_XNNPACK
   return apply_impl<true>(std::move(input), output_scale, output_zero_point);
 }
 

--- a/aten/src/ATen/native/quantized/cpu/xnnpack_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/xnnpack_utils.cpp
@@ -1,6 +1,10 @@
-#include <ATen/ATen.h>
-
 #ifdef USE_XNNPACK
+
+#include <ATen/ATen.h>
+#include <ATen/quantized/Quantizer.h>
+#include <ATen/native/quantized/cpu/xnnpack_utils.h>
+#include <c10/util/irange.h>
+
 namespace at {
 namespace native {
 namespace xnnp_utils {
@@ -25,8 +29,57 @@ std::vector<size_t> get_mem_format_aware_shape(const at::Tensor& in) {
   }
   return ret;
 }
+
+template <typename PT>
+void q8_conv_weight_copy_and_add_offset(const at::Tensor& in, at::Tensor& out) {
+  using T = typename PT::underlying;
+
+  static constexpr auto offset = std::is_same<T, uint8_t>::value ? 128 : 0;
+
+  const int8_t* in_ptr =
+      reinterpret_cast<const int8_t*>(in.data_ptr<c10::qint8>());
+  T* out_ptr = reinterpret_cast<T*>(out.data_ptr<PT>());
+
+  for (const auto i : c10::irange(in.numel())) {
+    out_ptr[i] = static_cast<T>(static_cast<int32_t>(in_ptr[i]) + offset);
+  }
+}
+
+template void q8_conv_weight_copy_and_add_offset<c10::quint8>(
+    const at::Tensor& in,
+    at::Tensor& out);
+template void q8_conv_weight_copy_and_add_offset<c10::qint8>(
+    const at::Tensor& in,
+    at::Tensor& out);
+
+/*
+ * Stolen from fbgemm_utils::ConvertConvWeightsToChannelLastTensor to avoid
+ * dependence on USE_FBGEMM. Reorder weights to the format xnnpack expects.
+ * TODO: add a 3d variant.
+ */
+template <>
+Tensor convert_conv_weights_to_channel_last_tensor<2>(
+    const at::Tensor& src,
+    int groups,
+    bool transpose) {
+  return transpose ?
+                   // 2D conv transpose weight transform
+                   // IC OC/G KH KW -> G OC/G KH KW IC/G
+      [&]() {
+        auto ic_g_oc_g_hw_tensors = src.chunk(groups);
+        for (auto& tensor : ic_g_oc_g_hw_tensors) {
+          tensor = tensor.unsqueeze(0);
+        }
+        auto fused_tensor = at::cat(ic_g_oc_g_hw_tensors);
+        set_quantizer_(fused_tensor, src.quantizer());
+        return fused_tensor.permute({0, 2, 3, 4, 1})
+            .contiguous(c10::MemoryFormat::Contiguous);
+      }()
+                   // 2d conv weight transform
+                   : src.contiguous(c10::MemoryFormat::ChannelsLast);
+}
 } // namespace xnnp_utils
 } // namespace native
 } // namespace at
 
-#endif  // USE_XNNPACK
+#endif // USE_XNNPACK

--- a/aten/src/ATen/native/quantized/cpu/xnnpack_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/xnnpack_utils.cpp
@@ -31,11 +31,15 @@ std::vector<size_t> get_mem_format_aware_shape(const at::Tensor& in) {
 }
 
 template <typename PT>
-void q8_conv_weight_copy_and_add_offset(const at::Tensor& in, at::Tensor& out) {
+void q8_copy_int8_weight_and_add_offset(const at::Tensor& in, at::Tensor& out) {
   using T = typename PT::underlying;
-
   static constexpr auto offset = std::is_same<T, uint8_t>::value ? 128 : 0;
-
+  TORCH_CHECK(
+      in.scalar_type() == c10::kQInt8,
+      "q8_copy_int8_weight_and_add_offset: Expected input weight data type ",
+      toString(c10::kQInt8),
+      " but got ",
+      toString(in.scalar_type()))
   const int8_t* in_ptr =
       reinterpret_cast<const int8_t*>(in.data_ptr<c10::qint8>());
   T* out_ptr = reinterpret_cast<T*>(out.data_ptr<PT>());
@@ -45,10 +49,10 @@ void q8_conv_weight_copy_and_add_offset(const at::Tensor& in, at::Tensor& out) {
   }
 }
 
-template void q8_conv_weight_copy_and_add_offset<c10::quint8>(
+template void q8_copy_int8_weight_and_add_offset<c10::quint8>(
     const at::Tensor& in,
     at::Tensor& out);
-template void q8_conv_weight_copy_and_add_offset<c10::qint8>(
+template void q8_copy_int8_weight_and_add_offset<c10::qint8>(
     const at::Tensor& in,
     at::Tensor& out);
 

--- a/aten/src/ATen/native/quantized/cpu/xnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/xnnpack_utils.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #ifdef USE_XNNPACK
+#include <cstdint>
+
+#include <ATen/ATen.h>
 #include <ATen/native/xnnpack/Common.h>
 
 using xnnpack_operator = at::native::xnnpack::Operator;
@@ -9,8 +12,206 @@ namespace at {
 namespace native {
 namespace xnnp_utils {
 
+/*
+ * Return shape in the same order as the memory format
+ * e.g. channels_last will return NHWC instead of NCHW
+ */
 std::vector<size_t> get_mem_format_aware_shape(const at::Tensor& in);
 
+/*
+ * Input is always int8_t, output can be [int8_t, uint8_t].
+ * input  + offset = output
+ * int8_t + 128    = uint8_t
+ * int8_t + 0      = int8_t
+ */
+template <typename PT>
+void q8_conv_weight_copy_and_add_offset(const at::Tensor& in, at::Tensor& out);
+
+template <int kSpatialDim>
+Tensor convert_conv_weights_to_channel_last_tensor(
+    const at::Tensor& src,
+    int groups,
+    bool transpose);
+
+/*
+ * A series of create wrapper functions to call xnn_create_[de]conv* functions.
+ */
+C10_ALWAYS_INLINE
+enum xnn_status xnnp_create_convolution2d_nhwc(
+    uint32_t pad_top,
+    uint32_t pad_right,
+    uint32_t pad_bottom,
+    uint32_t pad_left,
+    uint32_t kernel_h,
+    uint32_t kernel_w,
+    uint32_t stride_h,
+    uint32_t stride_w,
+    uint32_t dilation_h,
+    uint32_t dilation_w,
+    uint32_t groups,
+    size_t group_input_channels,
+    size_t group_output_channels,
+    size_t ip_chan_stride,
+    size_t op_chan_stride,
+    int8_t izp,
+    float ip_scale,
+    int8_t kzp,
+    const float* k_scales,
+    const int8_t* kernel,
+    const int32_t* bias,
+    int8_t ozp,
+    float op_scale,
+    int8_t op_min,
+    int8_t op_max,
+    uint32_t flags,
+    xnn_operator_t* op,
+    bool per_channel,
+    bool transpose) {
+  /* Symmetric quantization forces kzp = 0 */
+  TORCH_CHECK(!kzp, "XNNPACK Q[SC]8 conv kernels expects kernel zero point to be zero."
+                    "But got: ", kzp);
+
+  if (transpose) {
+    TORCH_CHECK(!per_channel, "XNNPACK Q[SC]8 does not have a per channel deconvolution!");
+    return xnn_create_deconvolution2d_nhwc_qs8(
+        pad_top,        /* uint32_t output_padding_top          */
+        pad_right,      /* uint32_t output_padding_right        */
+        pad_bottom,     /* uint32_t output_padding_bottom       */
+        pad_left,       /* uint32_t output_padding_left         */
+        kernel_h,       /* uint32_t kernel_height               */
+        kernel_w,       /* uint32_t kernel_width                */
+        stride_h,       /* uint32_t stride_height               */
+        stride_w,       /* uint32_t stride_width                */
+        dilation_h,     /* uint32_t dilation_height             */
+        dilation_w,     /* uint32_t dilation_width              */
+        groups,         /* uint32_t groups                      */
+        group_input_channels,  /* size_t group_input_channels   */
+        group_output_channels, /* size_t group_output_channels  */
+        ip_chan_stride, /* size_t input_pixel_stride            */
+        op_chan_stride, /* size_t output_pixel_stride           */
+        izp,            /* int8_t input_zero_point              */
+        ip_scale,       /* float input_scale                    */
+        k_scales[0],    /* float kernel_scale                   */
+        kernel,         /* const int8_t* kernel                 */
+        bias,           /* const int32_t* bias                  */
+        ozp,            /* int8_t output_zero_point             */
+        op_scale,       /* float output_scale                   */
+        op_min,         /* int8_t output_min                    */
+        op_max,         /* int8_t output_max                    */
+        flags,          /* uint32_t flags                       */
+        op);            /* xnn_operator_t* deconvolution_op_out */
+
+  }
+
+  if (!per_channel) {
+    return xnn_create_convolution2d_nhwc_qs8(
+        pad_top,        /* uint32_t input_padding_top         */
+        pad_right,      /* uint32_t input_padding_right       */
+        pad_bottom,     /* uint32_t input_padding_bottom      */
+        pad_left,       /* uint32_t input_padding_left        */
+        kernel_h,       /* uint32_t kernel_height             */
+        kernel_w,       /* uint32_t kernel_width              */
+        stride_h,       /* uint32_t subsampling_height        */
+        stride_w,       /* uint32_t subsampling_width         */
+        dilation_h,     /* uint32_t dilation_height           */
+        dilation_w,     /* uint32_t dilation_width            */
+        groups,         /* uint32_t groups                    */
+        group_input_channels,  /* size_t group_input_channels */
+        group_output_channels, /* size_t group_output_channels*/
+        ip_chan_stride, /* size_t input_channel_stride        */
+        op_chan_stride, /* size_t output_channel_stride       */
+        izp,            /* int8_t input_zero_point            */
+        ip_scale,       /* float input_scale                  */
+        k_scales[0],    /* float kernel_scale                 */
+        kernel,         /* const int8_t* kernel               */
+        bias,           /* const int32_t* bias                */
+        ozp,            /* int8_t output_zero_point           */
+        op_scale,       /* float output_scale                 */
+        op_min,         /* int8_t output_min                  */
+        op_max,         /* int8_t output_max                  */
+        flags,          /* uint32_t flags                     */
+        op);            /* xnn_operator_t* convolution_op_out */
+  } else { /* per_channel */
+    return xnn_create_convolution2d_nhwc_qc8(
+        pad_top,        /* uint32_t input_padding_top         */
+        pad_right,      /* uint32_t input_padding_right       */
+        pad_bottom,     /* uint32_t input_padding_bottom      */
+        pad_left,       /* uint32_t input_padding_left        */
+        kernel_h,       /* uint32_t kernel_height             */
+        kernel_w,       /* uint32_t kernel_width              */
+        stride_h,       /* uint32_t subsampling_height        */
+        stride_w,       /* uint32_t subsampling_width         */
+        dilation_h,     /* uint32_t dilation_height           */
+        dilation_w,     /* uint32_t dilation_width            */
+        groups,         /* uint32_t groups                    */
+        group_input_channels,  /* size_t group_input_channels */
+        group_output_channels, /* size_t group_output_channels*/
+        ip_chan_stride, /* size_t input_channel_stride        */
+        op_chan_stride, /* size_t output_channel_stride       */
+        izp,            /* int8_t input_zero_point            */
+        ip_scale,       /* float input_scale                  */
+        k_scales,       /* const float* kernel_scale          */
+        kernel,         /* const int8_t* kernel               */
+        bias,           /* const int32_t* bias                */
+        ozp,            /* int8_t output_zero_point           */
+        op_scale,       /* float output_scale                 */
+        op_min,         /* int8_t output_min                  */
+        op_max,         /* int8_t output_max                  */
+        flags,          /* uint32_t flags                     */
+        op);            /* xnn_operator_t* convolution_op_out */
+  }
+}
+
+/*
+ * A series of setup wrapper functions to call xnn_setup_[de]conv* functions.
+ */
+C10_ALWAYS_INLINE
+enum xnn_status xnnp_setup_convolution2d_nhwc(
+    xnn_operator_t op,
+    size_t batch,
+    size_t in_h,
+    size_t in_w,
+    const int8_t* inp,
+    int8_t* outp,
+    pthreadpool_t pt_pool,
+    bool per_channel = false,
+    bool transpose = false,
+    uint32_t adj_h = 0,
+    uint32_t adj_w = 0) {
+  if(transpose) {
+    TORCH_CHECK(!per_channel, "XNNPACK Q[SC]8 does not have a per channel deconvolution!");
+    return xnn_setup_deconvolution2d_nhwc_qs8(
+        op,       /* xnn_operator_t deconvolution_op */
+        batch,    /* size_t batch_size               */
+        in_h,     /* size_t input_height             */
+        in_w,     /* size_t input_width              */
+        adj_h,    /* uint32_t adjustment_height      */
+        adj_w,    /* uint32_t adjustment_width       */
+        inp,      /* const int8_t* input             */
+        outp,     /* int8_t* output                  */
+        pt_pool); /* pthreadpool_t threadpool        */
+  }
+
+  if (!per_channel) {
+    return xnn_setup_convolution2d_nhwc_qs8(
+        op,       /* xnn_operator_t convolution_op */
+        batch,    /* size_t batch_size             */
+        in_h,     /* size_t input_height           */
+        in_w,     /* size_t input_width            */
+        inp,      /* const int8_t* input           */
+        outp,     /* int8_t* output                */
+        pt_pool); /* pthreadpool_t threadpool      */
+  } else { /* per_channel */
+    return xnn_setup_convolution2d_nhwc_qc8(
+        op,       /* xnn_operator_t convolution_op */
+        batch,    /* size_t batch_size             */
+        in_h,     /* size_t input_height           */
+        in_w,     /* size_t input_width            */
+        inp,      /* const int8_t* input           */
+        outp,     /* int8_t* output                */
+        pt_pool); /* pthreadpool_t threadpool      */
+  }
+}
 } // namespace xnnp_utils
 } // namespace native
 } // namespace at

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -72,7 +72,7 @@ def avoid_vpmaddubsw_overflow_linear(
 
 
 # Reference quantized Linear operator
-def qlinear_ref(X_q, X_scale, X_zp, W_q, W_scale, W_zp, b_q, Y_scale, Y_zp):
+def qlinear_ref(X_q, X_scale, X_zp, W_q, W_scale, W_zp, b_q, Y_scale, Y_zp, dtype=np.uint8):
     X_q = np.reshape(X_q, (-1, X_q.shape[X_q.ndim - 1]))
     row_offsets_ref = X_q.sum(axis=1).astype(np.int32).reshape((-1, 1))
     col_offsets_ref = W_q.sum(axis=1).astype(np.int32).reshape((1, -1))
@@ -86,7 +86,7 @@ def qlinear_ref(X_q, X_scale, X_zp, W_q, W_scale, W_zp, b_q, Y_scale, Y_zp):
     )
     if b_q is not None:
         Prod_XqWq_ref += b_q
-    Y_q_ref = _quantize(Prod_XqWq_ref, Y_scale / (X_scale * W_scale), Y_zp)
+    Y_q_ref = _quantize(Prod_XqWq_ref, Y_scale / (X_scale * W_scale), Y_zp, dtype=dtype)
     return Y_q_ref
 
 """Computes the output shape given pooling parameters."""
@@ -3261,6 +3261,7 @@ class TestQuantizedLinear(TestCase):
     def test_qlinear(self, batch_size, input_channels, output_channels, use_bias,
                      use_relu, use_multi_dim_input, use_channelwise):
         decimal_val = 4
+        dtypes = [torch.quint8]
         if torch.backends.quantized.engine == 'qnnpack':
             # QNNPACK supports uint8 in the kernels. In the op we shift the int8
             # weight values to uint8 to be on par with fbgemm. However, this causes
@@ -3268,107 +3269,126 @@ class TestQuantizedLinear(TestCase):
             # off by one results.
             decimal_val = 0
 
-        qlinear_prepack = torch.ops.quantized.linear_prepack
-        if use_relu:
-            qlinear = torch.ops.quantized.linear_relu
-        else:
-            qlinear = torch.ops.quantized.linear
-        if use_multi_dim_input:
-            batch_size *= 3  # Test the multi-dim input tensor
-        X_scale = 1.5
-        X_zp = 5
-        X_value_min = 0
-        X_value_max = 225
-        X_q0 = np.round(
-            np.random.rand(batch_size, input_channels) *
-            (X_value_max - X_value_min)
-            + X_value_min
-        ).astype(np.uint8)
-        W_scales = np.random.rand(output_channels)
-        W_zps = np.round(np.random.rand(output_channels) * 100 - 50).astype(np.int)
-        W_value_min = -128
-        W_value_max = 127
-        W_q0 = np.round(
-            np.random.rand(output_channels, input_channels)
-            * (W_value_max - W_value_min)
-            + W_value_min
-        ).astype(np.int8)
-        b_value_min = -10
-        b_value_max = 10
-        b_q0 = np.round(
-            np.random.rand(output_channels) *
-            (b_value_max - b_value_min) + b_value_min
-        ).astype(np.int32) if use_bias else None
-        avoid_vpmaddubsw_overflow_linear(
-            batch_size,
-            input_channels,
-            output_channels,
-            X_q0,
-            X_value_min,
-            X_value_max,
-            W_q0,
-            W_value_min,
-            W_value_max,
-        )
-        X = torch.from_numpy(_dequantize(
-            X_q0, X_scale, X_zp)).to(dtype=torch.float)
-        X_q = torch.quantize_per_tensor(
-            X, scale=X_scale, zero_point=X_zp, dtype=torch.quint8)
-        if use_channelwise:
-            W = torch.from_numpy(_dequantize(W_q0, W_scales.reshape(
-                (-1, 1)), W_zps.reshape((-1, 1)))).to(dtype=torch.float)
-            W_q = torch.quantize_per_channel(W, scales=torch.from_numpy(W_scales),
-                                             zero_points=torch.from_numpy(W_zps), axis=0, dtype=torch.qint8)
-            b = torch.from_numpy(_dequantize(
-                b_q0, X_scale * W_scales, 0)).to(dtype=torch.float) if use_bias else None
-            b_q = torch.quantize_per_channel(b, scales=torch.from_numpy(X_scale * W_scales),
-                                             zero_points=torch.zeros(output_channels, dtype=torch.long),
-                                             axis=0, dtype=torch.qint32) if use_bias else None
-        else:
-            W = torch.from_numpy(_dequantize(
-                W_q0, W_scales[0], W_zps[0])).to(dtype=torch.float)
-            W_q = torch.quantize_per_tensor(W, scale=W_scales[0], zero_point=(
-                W_zps[0].astype(int).item()), dtype=torch.qint8)
-            b = torch.from_numpy(_dequantize(
-                b_q0, X_scale * (W_scales[0].item()), 0)).to(dtype=torch.float) if use_bias else None
-            b_q = torch.quantize_per_tensor(
-                b, scale=X_scale * (W_scales[0].item()), zero_point=0, dtype=torch.qint32) if use_bias else None
-        # Compare X_scale * W_scale * input_channels * X_value_max * W_value_max with
-        # Y_scale * 255 (max for uint8).
-        Y_scale = 125.1234
-        Y_zp = 5
-        # Weight prepacking operator for quantized Linear
-        float_bias = b if use_bias else None
-        W_prepack = qlinear_prepack(W_q, float_bias)
-        if use_multi_dim_input:
-            X_q = X_q.view(3, int(batch_size / 3), input_channels)
-        # Quantized Linear operator with prepacked weight
-        Y_q = qlinear(X_q, W_prepack, Y_scale, Y_zp)
-        if not use_channelwise:
-            # Test the per-tensor quantization only
-            # Reference quantized Linear operator
-            Y_q_ref = qlinear_ref(X_q0, X_scale, X_zp, W_q0,
-                                  W_scales[0], W_zps[0], b_q0, Y_scale, Y_zp)
+            # only qnnpack qengine supports qint8 when xnnpack is available
+            if torch.backends.xnnpack.enabled:
+                dtypes.append(torch.qint8)
+
+        for dtype in dtypes:
+            # No support for channelwise in xnnpack (int8)
+            if dtype == torch.qint8 and use_channelwise:
+                return
+
+            nptype = np_dtype[dtype]
+            qlinear_prepack = torch.ops.quantized.linear_prepack
             if use_relu:
-                Y_q_ref[Y_q_ref < Y_zp] = Y_zp
+                qlinear = torch.ops.quantized.linear_relu
+            else:
+                qlinear = torch.ops.quantized.linear
             if use_multi_dim_input:
-                Y_q_ref = np.reshape(
-                    Y_q_ref, (3, int(batch_size / 3), output_channels))
+                batch_size *= 3  # Test the multi-dim input tensor
+            X_scale = 1.5
+            X_zp = 5
+            X_value_min = -128 if dtype == torch.qint8 else 0
+            X_value_max = 127 if dtype == torch.qint8 else 255
+            X_q0 = np.round(
+                np.random.rand(batch_size, input_channels) *
+                (X_value_max - X_value_min)
+                + X_value_min
+            ).astype(nptype)
+
+            W_scales = np.random.rand(output_channels)
+            # xnnpack forces W_zp to 0 when using symmetric quantization
+            if dtype == torch.qint8:
+                W_zps = np.zeros(output_channels).astype(np.int)
+            else:
+                W_zps = np.round(np.random.rand(output_channels) * 100 - 50).astype(np.int)
+            # when using symmetric quantization
+            # special restriction for xnnpack fully connected op weight
+            # [-127, 127] instead of [-128, 127]
+            W_value_min = -127 if dtype == torch.qint8 else -128
+            W_value_max = 127
+            W_q0 = np.round(
+                np.random.rand(output_channels, input_channels)
+                * (W_value_max - W_value_min)
+                + W_value_min
+            ).astype(np.int8)  # weight is always int8_t
+            b_value_min = -10
+            b_value_max = 10
+            b_q0 = np.round(
+                np.random.rand(output_channels) *
+                (b_value_max - b_value_min) + b_value_min
+            ).astype(np.int32) if use_bias else None
+            if torch.backends.quantized.engine == 'fbgemm':
+                avoid_vpmaddubsw_overflow_linear(
+                    batch_size,
+                    input_channels,
+                    output_channels,
+                    X_q0,
+                    X_value_min,
+                    X_value_max,
+                    W_q0,
+                    W_value_min,
+                    W_value_max,
+                )
+            X = torch.from_numpy(_dequantize(
+                X_q0, X_scale, X_zp)).to(dtype=torch.float)
+            X_q = torch.quantize_per_tensor(
+                X, scale=X_scale, zero_point=X_zp, dtype=dtype)
+            if use_channelwise:
+                W = torch.from_numpy(_dequantize(W_q0, W_scales.reshape(
+                    (-1, 1)), W_zps.reshape((-1, 1)))).to(dtype=torch.float)
+                W_q = torch.quantize_per_channel(W, scales=torch.from_numpy(W_scales),
+                                                 zero_points=torch.from_numpy(W_zps), axis=0, dtype=torch.qint8)
+                b = torch.from_numpy(_dequantize(
+                    b_q0, X_scale * W_scales, 0)).to(dtype=torch.float) if use_bias else None
+                b_q = torch.quantize_per_channel(b, scales=torch.from_numpy(X_scale * W_scales),
+                                                 zero_points=torch.zeros(output_channels, dtype=torch.long),
+                                                 axis=0, dtype=torch.qint32) if use_bias else None
+            else:
+                W = torch.from_numpy(_dequantize(
+                    W_q0, W_scales[0], W_zps[0])).to(dtype=torch.float)
+                W_q = torch.quantize_per_tensor(W, scale=W_scales[0], zero_point=(
+                    W_zps[0].astype(int).item()), dtype=torch.qint8)
+                b = torch.from_numpy(_dequantize(
+                    b_q0, X_scale * (W_scales[0].item()), 0)).to(dtype=torch.float) if use_bias else None
+                b_q = torch.quantize_per_tensor(
+                    b, scale=X_scale * (W_scales[0].item()), zero_point=0, dtype=torch.qint32) if use_bias else None
+            # Compare X_scale * W_scale * input_channels * X_value_max * W_value_max with
+            # Y_scale * 255 (max for uint8).
+            Y_scale = 125.1234
+            Y_zp = 5
+            # Weight prepacking operator for quantized Linear
+            float_bias = b if use_bias else None
+            W_prepack = qlinear_prepack(W_q, float_bias)
+            if use_multi_dim_input:
+                X_q = X_q.view(3, int(batch_size / 3), input_channels)
+            # Quantized Linear operator with prepacked weight
+            Y_q = qlinear(X_q, W_prepack, Y_scale, Y_zp)
+            if not use_channelwise:
+                # Test the per-tensor quantization only
+                # Reference quantized Linear operator
+                Y_q_ref = qlinear_ref(X_q0, X_scale, X_zp, W_q0,
+                                      W_scales[0], W_zps[0], b_q0, Y_scale, Y_zp, dtype=nptype)
+                if use_relu:
+                    Y_q_ref[Y_q_ref < Y_zp] = Y_zp
+                if use_multi_dim_input:
+                    Y_q_ref = np.reshape(
+                        Y_q_ref, (3, int(batch_size / 3), output_channels))
+                # Assert equal
+                np.testing.assert_array_almost_equal(Y_q_ref, Y_q.int_repr().numpy(), decimal=decimal_val)
+            # Test both per-tensor and per-channel quantization
+            # Reference quantized result from PyTorch Linear operator
+            W_fp32 = W_q.dequantize().to(dtype=torch.float)
+            X_fp32 = X_q.dequantize().to(dtype=torch.float)
+            b_fp32 = b_q.dequantize().to(dtype=torch.float) if use_bias else None
+            Y_fp32_ref = F.linear(X_fp32, W_fp32, b_fp32)
+            if use_relu:
+                Y_fp32_ref[Y_fp32_ref < 0.0] = 0.0
+            Y_q_ref2 = torch.quantize_per_tensor(
+                Y_fp32_ref, Y_scale, Y_zp, dtype)
             # Assert equal
-            np.testing.assert_array_almost_equal(Y_q_ref, Y_q.int_repr().numpy(), decimal=decimal_val)
-        # Test both per-tensor and per-channel quantization
-        # Reference quantized result from PyTorch Linear operator
-        W_fp32 = W_q.dequantize().to(dtype=torch.float)
-        X_fp32 = X_q.dequantize().to(dtype=torch.float)
-        b_fp32 = b_q.dequantize().to(dtype=torch.float) if use_bias else None
-        Y_fp32_ref = F.linear(X_fp32, W_fp32, b_fp32)
-        if use_relu:
-            Y_fp32_ref[Y_fp32_ref < 0.0] = 0.0
-        Y_q_ref2 = torch.quantize_per_tensor(
-            Y_fp32_ref, Y_scale, Y_zp, torch.quint8)
-        # Assert equal
-        np.testing.assert_array_almost_equal(
-            Y_q_ref2.int_repr().numpy(), Y_q.int_repr().numpy(), decimal=decimal_val)
+            np.testing.assert_array_almost_equal(
+                Y_q_ref2.int_repr().numpy(), Y_q.int_repr().numpy(), decimal=decimal_val)
 
     """Tests the correctness of the quantized::linear_unpack op."""
     @given(W=hu.tensor(shapes=hu.array_shapes(2, 2,),


### PR DESCRIPTION
Summary: If built w/ USE_XNNPACK, for qint8 dtype, qlinear is performed using xnnpack. For quint8 input dtype, use QNNPACK.

Differential Revision: D34022360

