### PR TITLE
[_shard] use absolute imports for ShardMetadata instead

### DIFF
--- a/torch/distributed/_shard/sharded_tensor/metadata.py
+++ b/torch/distributed/_shard/sharded_tensor/metadata.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List
 
 import torch
-from ..metadata import ShardMetadata
+from torch.distributed._shard.metadata import ShardMetadata
 
 
 class MEM_FORMAT_ENCODING(Enum):

--- a/torch/distributed/_shard/sharded_tensor/reshard.py
+++ b/torch/distributed/_shard/sharded_tensor/reshard.py
@@ -15,7 +15,7 @@ from torch.distributed.nn.functional import (
     all_to_all,
     all_to_all_single,
 )
-from ..metadata import ShardMetadata
+from torch.distributed._shard.metadata import ShardMetadata
 
 from .shard import Shard
 

--- a/torch/distributed/_shard/sharded_tensor/shard.py
+++ b/torch/distributed/_shard/sharded_tensor/shard.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import List, cast
 
 import torch
-from ..metadata import ShardMetadata
+from torch.distributed._shard.metadata import ShardMetadata
 from torch.distributed.remote_device import _remote_device
 
 

--- a/torch/distributed/_shard/sharded_tensor/utils.py
+++ b/torch/distributed/_shard/sharded_tensor/utils.py
@@ -10,7 +10,7 @@ from torch.distributed._shard.sharding_spec._internals import (
     validate_non_overlapping_shards_metadata,
 )
 
-from ..metadata import ShardMetadata
+from torch.distributed._shard.metadata import ShardMetadata
 from .metadata import TensorProperties, ShardedTensorMetadata
 from .shard import Shard
 

--- a/torch/distributed/_shard/sharding_spec/__init__.py
+++ b/torch/distributed/_shard/sharding_spec/__init__.py
@@ -7,4 +7,4 @@ from .api import (
     _infer_sharding_spec_from_shards_metadata,
 )
 
-from ..metadata import ShardMetadata
+from torch.distributed._shard.metadata import ShardMetadata

--- a/torch/distributed/_shard/sharding_spec/_internals.py
+++ b/torch/distributed/_shard/sharding_spec/_internals.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ..metadata import ShardMetadata
+from torch.distributed._shard.metadata import ShardMetadata
 
 def _check_shard_metadata_pair_overlap(shard1: ShardMetadata, shard2: ShardMetadata):
     """

--- a/torch/distributed/_shard/sharding_spec/api.py
+++ b/torch/distributed/_shard/sharding_spec/api.py
@@ -11,7 +11,7 @@ from ._internals import (
     get_split_size,
     validate_non_overlapping_shards_metadata
 )
-from ..metadata import ShardMetadata
+from torch.distributed._shard.metadata import ShardMetadata
 
 from torch.distributed._shard.sharded_tensor.utils import (
     _parse_and_validate_remote_device


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73678

quick fix to use absolute imports instead of relative imports

Differential Revision: [D34587342](https://our.internmc.facebook.com/intern/diff/D34587342/)