### PR TITLE
[PyTorch] Make NestedTensor::dim() work

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -29,6 +29,13 @@ NestedTensorImpl::NestedTensorImpl(
   remove_autograd_key();
   key_set_ =
       key_set_ - c10::DispatchKeySet({c10::DispatchKey::ADInplaceOrView});
+  refresh_dim();
+}
+
+void NestedTensorImpl::refresh_dim() {
+  const auto my_dim = nested_size_tensor_.dim() ? nested_size_tensor_.sizes()[1] + 1 : 1;
+  sizes_and_strides_.resize(my_dim);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(dim() == my_dim);
 }
 
 } // namespace native

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -14,12 +14,6 @@ struct NestedTensorImpl : public c10::TensorImpl {
   explicit NestedTensorImpl(at::Tensor buffer, at::Tensor nested_size_tensor);
 
 #ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
-  int64_t dim() const override {
-    TORCH_CHECK(
-        false, "dim is disabled. These methods are not virtual in fbcode.");
-  }
-#endif
-#ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
   int64_t numel() const override {
     TORCH_CHECK(
         false, "numel is disabled. These methods are not virtual in fbcode.");
@@ -32,6 +26,9 @@ struct NestedTensorImpl : public c10::TensorImpl {
         "is_contiguous is disabled. These methods are not virtual in fbcode.");
   }
 #endif
+  // TODO: don't expose private implementation details like this; in
+  // particular, resizing this tensor will mess up our dim() and
+  // callers cannot fix it.
   const Tensor& get_nested_size_tensor() {
     return nested_size_tensor_;
   }
@@ -57,6 +54,10 @@ struct NestedTensorImpl : public c10::TensorImpl {
   }
 
  private:
+  // Must be called after any changes to our dim() to sync the state
+  // to TensorImpl.
+  void refresh_dim();
+
   at::Tensor buffer_;
   const at::Tensor nested_size_tensor_;
 };

--- a/torch/nested/_nestedtensor.py
+++ b/torch/nested/_nestedtensor.py
@@ -62,10 +62,7 @@ class NestedTensor:
         """
         The dimension of ```self``` NestedTensor.
         """
-        tensors = self.unbind()
-        if len(tensors) == 0:
-            return 1
-        return int(tensors[0].dim() + 1)
+        return self._impl.dim()
 
     def numel(self):
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73679

We can update the TensorImpl state used to track dim() just fine.

I'm not sure if this is sustainable; do we *want* callers to be able to muck with nested_size_tensor_ directly?

Differential Revision: [D34570523](https://our.internmc.facebook.com/intern/diff/D34570523/)