### PR TITLE
Add a default implementation of __torch_dispatch__

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -681,6 +681,7 @@ def _vmapmode_decrement_nesting() -> _int: ...  # THPModule_vmapmode_decrement_n
 def _log_api_usage_once(str) -> None: ...  # LogAPIUsageOnceFromPython
 def _demangle(str) -> str: ...  # c10::demangle
 def _disabled_torch_function_impl(func: Callable, types: Iterable[Type], args: Tuple, kwargs: Dict) -> Any: ...  # THPModule_disable_torch_function
+def _disabled_torch_dispatch_impl(func: Callable, types: Iterable[Type], args: Tuple, kwargs: Dict) -> Any: ...  # THPModule_disable_dispatch_function
 def _get_linalg_preferred_backend() -> torch._C._LinalgBackend: ...
 def _set_linalg_preferred_backend(arg: torch._C._LinalgBackend): ...
 class _LinalgBackend:

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1181,6 +1181,8 @@ class Tensor(torch._C._TensorBase):
             else:
                 return _convert(ret, cls)
 
+    __torch_dispatch__ = _C._disabled_torch_dispatch_impl
+
     def __dlpack__(self, stream=None):
         """
         Creates a DLpack `capsule https://data-apis.org/array-api/latest/design_topics/data_interchange.html#data-interchange`_

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -711,6 +711,7 @@ static PyMethodDef TorchMethods[] = {
   {"_unset_default_mobile_cpu_allocator", THPModule_unsetDefaultMobileCPUAllocator, METH_NOARGS, nullptr},
   {"_is_torch_function_enabled", THPModule_isEnabledTorchFunction, METH_NOARGS, nullptr},
   {"_disabled_torch_function_impl", THPModule_disable_torch_function, METH_VARARGS, nullptr},
+  {"_disabled_torch_dispatch_impl", THPModule_disable_torch_dispatch, METH_VARARGS, nullptr},
   {"_has_torch_function", THPModule_has_torch_function, METH_O, nullptr},
   {"_has_torch_function_unary", THPModule_has_torch_function_unary, METH_O, nullptr},
   {"_has_torch_function_variadic", MAYBE_WRAP_FASTCALL(THPModule_has_torch_function_variadic), MAYBE_METH_FASTCALL, nullptr},
@@ -1067,6 +1068,8 @@ Call this whenever a new thread is created in order to propagate values from
   ASSERT_TRUE(set_module_attr("DisableTorchFunction", (PyObject*)THPModule_DisableTorchFunctionType(), /* incref= */ false));
   torch::set_disabled_torch_function_impl(PyObject_GetAttrString(module, "_disabled_torch_function_impl"));
   ASSERT_TRUE(torch::disabled_torch_function_impl() != nullptr);
+  torch::set_disabled_torch_dispatch_impl(PyObject_GetAttrString(module, "_disabled_torch_dispatch_impl"));
+  ASSERT_TRUE(torch::disabled_torch_dispatch_impl() != nullptr);
   return module;
   END_HANDLE_TH_ERRORS
 }

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/python_headers.h>
 
+#include <torch/csrc/utils/disable_torch_function.h>
 #include <c10/core/DeviceType.h>
 #include <c10/core/InferenceMode.h>
 #include <torch/csrc/Exceptions.h>
@@ -25,13 +26,6 @@
 
 #include <set>
 #include <unordered_set>
-
-struct DisableTorchDispatch {
-  DisableTorchDispatch() : guard_(c10::DispatchKey::Python),
-                           guard_tls_snapshot_(c10::DispatchKey::PythonTLSSnapshot) {}
-  c10::impl::ExcludeDispatchKeyGuard guard_;
-  c10::impl::ExcludeDispatchKeyGuard guard_tls_snapshot_;
-};
 
 PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject *unused) {
   using namespace torch::autograd::profiler;
@@ -319,7 +313,8 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject *unused) {
   py::class_<c10::InferenceMode>(_C_m, "_InferenceMode")
       .def(py::init<bool>());
 
-  py::class_<DisableTorchDispatch>(_C_m, "_DisableTorchDispatch")
+  // TODO: line up this binding with DisableTorchFunction
+  py::class_<torch::DisableTorchDispatch>(_C_m, "_DisableTorchDispatch")
       .def(py::init<>());
 
   py::class_<torch::autograd::SavedVariable>(m, "SavedTensor")

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -151,12 +151,12 @@ static const char* VOLATILE_WARNING =
 
 static bool check_has_torch_dispatch(PyObject *obj) {
   PyTypeObject *tp = Py_TYPE(obj);
-  auto* attr = PyObject_FastGetAttrString(obj, "__torch_dispatch__").ptr();
+  py::object attr = PyObject_FastGetAttrString(obj, "__torch_dispatch__");
   return (
     !THPVariable_CheckTypeExact(tp) &&
     // TODO: test if Python key is disabled
-    attr != nullptr &&
-    attr != torch::disabled_torch_dispatch_impl()
+    attr.ptr() != nullptr &&
+    attr.ptr() != torch::disabled_torch_dispatch_impl()
   );
 }
 
@@ -419,8 +419,8 @@ static PyObject* THPVariable_make_wrapper_subclass(PyObject*, PyObject* args, Py
   // TODO: This check is not complete; because the user can disable torch
   // dispatch and then go again, triggering segfault.  TBH I'm thinking I want
   // to delete this function entirely
-  auto* attr = PyObject_FastGetAttrString(cls, "__torch_dispatch__").ptr();
-  TORCH_CHECK_TYPE(attr != nullptr && attr != torch::disabled_torch_dispatch_impl()
+  py::object attr = PyObject_FastGetAttrString(cls, "__torch_dispatch__");
+  TORCH_CHECK_TYPE(attr.ptr() != nullptr && attr.ptr() != torch::disabled_torch_dispatch_impl()
 ,
     ((PyTypeObject*)cls)->tp_name, " must define __torch_dispatch__");
 

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -151,10 +151,12 @@ static const char* VOLATILE_WARNING =
 
 static bool check_has_torch_dispatch(PyObject *obj) {
   PyTypeObject *tp = Py_TYPE(obj);
+  auto* attr = PyObject_FastGetAttrString(obj, "__torch_dispatch__").ptr();
   return (
     !THPVariable_CheckTypeExact(tp) &&
     // TODO: test if Python key is disabled
-    PyObject_FastGetAttrString(obj, "__torch_dispatch__").ptr() != nullptr
+    attr != nullptr &&
+    attr != torch::disabled_torch_dispatch_impl()
   );
 }
 
@@ -414,7 +416,12 @@ static PyObject* THPVariable_make_wrapper_subclass(PyObject*, PyObject* args, Py
   // to continue on to the underlying CPU/CUDA kernel advertised by the dispatch
   // key, which will immediately segfault because the data pointer is null.  By
   // forcing users to define __torch_dispatch__ we ensure this does not happen
-  TORCH_CHECK_TYPE(PyObject_FastGetAttrString(cls, "__torch_dispatch__").ptr() != nullptr,
+  // TODO: This check is not complete; because the user can disable torch
+  // dispatch and then go again, triggering segfault.  TBH I'm thinking I want
+  // to delete this function entirely
+  auto* attr = PyObject_FastGetAttrString(cls, "__torch_dispatch__").ptr();
+  TORCH_CHECK_TYPE(attr != nullptr && attr != torch::disabled_torch_dispatch_impl()
+,
     ((PyTypeObject*)cls)->tp_name, " must define __torch_dispatch__");
 
   const auto options = TensorOptions()

--- a/torch/csrc/utils/disable_torch_function.cpp
+++ b/torch/csrc/utils/disable_torch_function.cpp
@@ -6,6 +6,7 @@
 namespace torch {
   static thread_local bool enable_torch_function = true;
   PyObject* disabled_torch_function = nullptr;
+  PyObject* disabled_torch_dispatch = nullptr;
 
   bool torch_function_enabled() {
       return enable_torch_function;
@@ -17,6 +18,14 @@ namespace torch {
 
   void set_disabled_torch_function_impl(PyObject* value) {
     disabled_torch_function = value;
+  }
+
+  PyObject* disabled_torch_dispatch_impl() {
+    return disabled_torch_dispatch;
+  }
+
+  void set_disabled_torch_dispatch_impl(PyObject* value) {
+    disabled_torch_dispatch = value;
   }
 }
 
@@ -124,6 +133,43 @@ PyObject* THPModule_disable_torch_function(PyObject *self, PyObject *a) {
   PyObject *result = PyObject_Call(func, py_args.ptr(), kwargs);
   torch::enable_torch_function = old_value;
   return result;
+  END_HANDLE_TH_ERRORS
+}
+
+PyObject* THPModule_disable_torch_dispatch(PyObject *self, PyObject *a) {
+  HANDLE_TH_ERRORS
+  PyObject *func=nullptr, *types=nullptr, *args=nullptr, *kwargs=nullptr;
+  if (!PyArg_ParseTuple(a, "OO|OO", &func, &types, &args, &kwargs)) {
+    return nullptr;
+  }
+  py::tuple py_args;
+  if (args == nullptr) {
+    py_args = py::make_tuple();
+  }
+  else {
+    py_args = py::reinterpret_borrow<py::tuple>(args);
+  }
+
+  // This implementation is not completely correct.  The moral
+  // meaning of this function is that we should do a redispatch
+  // "after" PythonKey, aka a redispatch() call.  But we don't have a
+  // dispatcher call here; we have an opaque Python object.
+  //
+  // What we have here is a close approximation: instead of redispatch(), we
+  // just exclude Python and all the keys before it, so that we will go
+  // to the next key after Python.  The difference, however, is we are
+  // now PERMANENTLY after Python.  We don't think there are any legitimate
+  // cases where we want to go for another round on the entire dispatcher key
+  // set, but if there are, then we will have to do something else here.
+  c10::impl::ExcludeDispatchKeyGuard guard_(
+      // TODO: add constructor for this specifically
+      c10::DispatchKeySet(c10::DispatchKeySet::FULL) -
+      c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::Python)
+      // NB: off by one hazard here, but it works out: python key is not
+      // included in AFTER, so it is included in the negation (and that's
+      // correct: we want to exclude Python key and everything BEFORE it.)
+  );
+  return PyObject_Call(func, py_args.ptr(), kwargs);
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/utils/disable_torch_function.h
+++ b/torch/csrc/utils/disable_torch_function.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <torch/csrc/python_headers.h>
+#include <c10/core/DispatchKey.h>
+#include <c10/core/impl/LocalDispatchKeySet.h>
 
 namespace torch {
   // Sometimes we don't want infinite recursion for subclasses,
@@ -8,13 +10,23 @@ namespace torch {
   // This is an internal utility, not exposed to users.
   bool torch_function_enabled();
   PyObject* disabled_torch_function_impl();
+  PyObject* disabled_torch_dispatch_impl();
   void set_disabled_torch_function_impl(PyObject* value);
+  void set_disabled_torch_dispatch_impl(PyObject* value);
   bool check_has_torch_function(PyObject* obj);
+
+  struct DisableTorchDispatch {
+    DisableTorchDispatch() : guard_(c10::DispatchKey::Python),
+                             guard_tls_snapshot_(c10::DispatchKey::PythonTLSSnapshot) {}
+    c10::impl::ExcludeDispatchKeyGuard guard_;
+    c10::impl::ExcludeDispatchKeyGuard guard_tls_snapshot_;
+  };
 }
 
 PyObject* THPModule_isEnabledTorchFunction(PyObject* self, PyObject *unused);
 PyObject* THPModule_DisableTorchFunctionType();
 PyObject* THPModule_disable_torch_function(PyObject *self, PyObject *args);
+PyObject* THPModule_disable_torch_dispatch(PyObject *self, PyObject *args);
 PyObject* THPModule_has_torch_function(PyObject*, PyObject *arg);
 PyObject* THPModule_has_torch_function_unary(PyObject*, PyObject *obj);
 PyObject* THPModule_has_torch_function_variadic(PyObject*, PyObject *const *args, Py_ssize_t nargs);

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -218,6 +218,7 @@ def get_ignored_functions() -> Set[Callable]:
         Tensor.__delattr__,
         Tensor.__setattr__,
         Tensor.__torch_function__,
+        Tensor.__torch_dispatch__,
         Tensor.__new__,
         Tensor.__class__,
         Tensor.__subclasshook__,

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -21,9 +21,9 @@ from typing import Iterator
 # - Better name (see https://github.com/pytorch/pytorch/pull/63496#discussion_r694091694)
 @contextlib.contextmanager
 def enable_python_mode(cls) -> Iterator[None]:
-    if not hasattr(cls, '__torch_dispatch__'):
+    if cls.__torch_dispatch__ is torch.Tensor.__torch_dispatch__:
         raise ValueError('The class passed to enable_python_mode '
-                         'must have a __torch_dispatch__ classmethod')
+                         'must have a non-default __torch_dispatch__ classmethod')
     if not isinstance(cls, type) or not issubclass(cls, (torch.Tensor,)):
         raise ValueError('The argument passed to enable_python_mode '
                          'must be the type of a Tensor subclass')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73727
* __->__ #73684

I was working on an explanation of how to call into the "super"
implementation of some given ATen operation inside of __torch_dispatch__
(https://github.com/albanD/subclass_zoo/blob/main/trivial_tensors.py)
and I kept thinking to myself "Why doesn't just calling super() on
__torch_dispatch__ work"?  Well, after this patch, it does!  The idea
is if you don't actually unwrap the input tensors, you can call
super().__torch_dispatch__ to get at the original behavior.

Internally, this is implemented by disabling PythonKey and then
redispatching.  This implementation of disabled_torch_dispatch is
not /quite/ right, and some reasons why are commented in the code.
There is then some extra work I have to do to make sure we recognize
disabled_torch_dispatch as the "default" implementation (so we don't
start slapping PythonKey on all tensors, including base Tensors),
which is modeled the same way as how disabled_torch_function is done.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D34590357](https://our.internmc.facebook.com/intern/diff/D34590357)