### PR TITLE
[FSDP] Add always_wrap policy

### DIFF
--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -266,7 +266,7 @@ class TestAutoWrap(TestCase):
         self.assertEqual(layer.rank, 0)
         self.assertEqual(layer.world_size, 2)
 
-    @skip_if_lt_x_gpu(2)
+    @unittest.skipIf(not torch.cuda.is_available(), "Test Requires CUDA")
     def test_always_wrap(self):
         """
         Test to ensure that if `always_wrap_policy` is

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -4,7 +4,7 @@ from enum import Enum, auto
 import functools
 import os
 import tempfile
-import unittest 
+import unittest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -266,7 +266,6 @@ class TestAutoWrap(TestCase):
         self.assertEqual(layer.rank, 0)
         self.assertEqual(layer.world_size, 2)
 
-    
     @skip_if_lt_x_gpu(2)
     def test_always_wrap(self):
         """

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -69,6 +69,15 @@ class TestFSDPWrap(FSDPTest):
             return sequential
 
         @staticmethod
+        def verify_model_all_wrapped(cls, model):
+            cls.assertTrue(isinstance(model, FSDP))
+            cls.assertTrue(isinstance(model.module[0], FSDP))
+            cls.assertTrue(isinstance(model.module[1], FSDP))
+            cls.assertTrue(isinstance(model.module[2], FSDP))
+            cls.assertTrue(isinstance(model.module[2].module[0], FSDP))
+            cls.assertTrue(isinstance(model.module[2].module[1], FSDP))
+
+        @staticmethod
         def verify_model(cls, model):
             cls.assertTrue(isinstance(model, FSDP))
             cls.assertTrue(isinstance(model.module[0], nn.Linear))
@@ -264,9 +273,8 @@ class TestAutoWrap(TestCase):
         passed into FSDP, all submodules are wrapped.
         """
         seq = TestFSDPWrap.NestedSequentialModel.get_model(cuda=True)
-        model = FSDP(sequential, process_group=self.process_group, fsdp_auto_wrap_policy=always_wrap_policy)
-        for mod in model.modules():
-            self.assertTrue(isinstance(mod, FSDP))
+        model = FSDP(seq, process_group=self.process_group, fsdp_auto_wrap_policy=always_wrap_policy)
+        TestFSDPWrap.NestedSequentialModel.verify_model_all_wrapped(self, model)
 
     def test_auto_wrap_api(self):
         """

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -15,6 +15,7 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import (
     BackwardPrefetch,
 )
 from torch.distributed.fsdp.wrap import (
+    always_wrap_policy,
     default_auto_wrap_policy,
     enable_wrap,
     wrap,
@@ -256,6 +257,16 @@ class TestAutoWrap(TestCase):
         self.assertTrue(layer.process_group is new_process_group)
         self.assertEqual(layer.rank, 0)
         self.assertEqual(layer.world_size, 2)
+
+    def test_always_wrap(self):
+        """
+        Test to ensure that if `always_wrap_policy` is
+        passed into FSDP, all submodules are wrapped.
+        """
+        seq = TestFSDPWrap.NestedSequentialModel.get_model(cuda=True)
+        model = FSDP(sequential, process_group=self.process_group, fsdp_auto_wrap_policy=always_wrap_policy)
+        for mod in model.modules():
+            self.assertTrue(isinstance(mod, FSDP))
 
     def test_auto_wrap_api(self):
         """

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -4,8 +4,7 @@ from enum import Enum, auto
 import functools
 import os
 import tempfile
-import unittest
-
+import unittest 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -267,6 +266,8 @@ class TestAutoWrap(TestCase):
         self.assertEqual(layer.rank, 0)
         self.assertEqual(layer.world_size, 2)
 
+    
+    @skip_if_lt_x_gpu(2)
     def test_always_wrap(self):
         """
         Test to ensure that if `always_wrap_policy` is

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -9,6 +9,14 @@ from typing import Any, Callable, Dict, Generator, Optional, Set, Tuple, Type, c
 import torch.nn as nn
 
 
+def always_wrap_policy(*args, **kwargs) -> bool:
+    """
+    A simple wrapper policy that always returns ``True``,
+    i.e. when passed as the `auto_wrap_policy` into FSDP,
+    this will result in all submodules being wrapped.
+    """
+    return True
+
 def default_auto_wrap_policy(
     module: nn.Module,
     recurse: bool,

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -13,7 +13,8 @@ def always_wrap_policy(*args, **kwargs) -> bool:
     """
     A simple wrapper policy that always returns ``True``,
     i.e. when passed as the `auto_wrap_policy` into FSDP,
-    this will result in all submodules being wrapped.
+    this will result in all submodules being wrapped as 
+    distinct FSDP instances.
     """
     return True
 

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -13,7 +13,7 @@ def always_wrap_policy(*args, **kwargs) -> bool:
     """
     A simple wrapper policy that always returns ``True``,
     i.e. when passed as the `auto_wrap_policy` into FSDP,
-    this will result in all submodules being wrapped as 
+    this will result in all submodules being wrapped as
     distinct FSDP instances.
     """
     return True


### PR DESCRIPTION
Add a smaller helper policy that always returns True to automatically always wrap all FSDP submodules. This is the first and simplest step of providing a set of policies that allow users to seamlessly experiment with different FSDP config. 

More Context: https://github.com/pytorch/pytorch/issues/68789