### PR TITLE
[TESTING ONLY] Use redispatch mechanism to redispatch for make_dual and fw_primal

### DIFF
--- a/aten/src/ATen/core/PythonFallbackKernel.cpp
+++ b/aten/src/ATen/core/PythonFallbackKernel.cpp
@@ -22,7 +22,9 @@ struct StashTLSStateGuard {
 
 void pythonFallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
   TORCH_INTERNAL_ASSERT(tls_on_entry.size() > 0);
-  c10::impl::ForceDispatchKeyGuard guard(tls_on_entry.top());
+  auto top_tls = tls_on_entry.top();
+  top_tls.excluded_ = c10::DispatchKeySet();
+  c10::impl::ForceDispatchKeyGuard guard(top_tls);
 
   // If Python Mode is active, use its PyInterpreter for dispatch
   const auto& maybe_python_mode_state = at::impl::PythonModeTLS::get_state();

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -333,7 +333,7 @@ namespace ADInplaceOrView {
   Tensor _fw_primal(c10::DispatchKeySet ks, const Tensor & self, int64_t level) {
     auto tmp = ([&]() {
       at::AutoDispatchBelowADInplaceOrView guard;
-      return at::alias(self);
+      return at::_ops::alias::redispatch(ks & c10::after_ADInplaceOrView_keyset, self);
     })();
     std::function<at::Tensor(const at::Tensor&)> func=nullptr;
     if (!self.unsafeGetTensorImpl()->support_as_strided()) {
@@ -352,7 +352,7 @@ namespace ADInplaceOrView {
   Tensor _make_dual(c10::DispatchKeySet ks, const Tensor & primal, const Tensor & tangent, int64_t level) {
     auto tmp = ([&]() {
       at::AutoDispatchBelowADInplaceOrView guard;
-      return at::alias(primal);
+      return at::_ops::alias::redispatch(ks & c10::after_ADInplaceOrView_keyset, primal);
     })();
     std::function<at::Tensor(const at::Tensor&)> func=nullptr;
     if (!primal.unsafeGetTensorImpl()->support_as_strided()) {

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -333,7 +333,7 @@ namespace ADInplaceOrView {
   Tensor _fw_primal(c10::DispatchKeySet ks, const Tensor & self, int64_t level) {
     auto tmp = ([&]() {
       at::AutoDispatchBelowADInplaceOrView guard;
-      return at::_ops::alias::redispatch(ks & c10::after_ADInplaceOrView_keyset, self);
+      return at::alias(self);
     })();
     std::function<at::Tensor(const at::Tensor&)> func=nullptr;
     if (!self.unsafeGetTensorImpl()->support_as_strided()) {
@@ -352,7 +352,7 @@ namespace ADInplaceOrView {
   Tensor _make_dual(c10::DispatchKeySet ks, const Tensor & primal, const Tensor & tangent, int64_t level) {
     auto tmp = ([&]() {
       at::AutoDispatchBelowADInplaceOrView guard;
-      return at::_ops::alias::redispatch(ks & c10::after_ADInplaceOrView_keyset, primal);
+      return at::alias(primal);
     })();
     std::function<at::Tensor(const at::Tensor&)> func=nullptr;
     if (!primal.unsafeGetTensorImpl()->support_as_strided()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73854
* #73853
* #73852
* __->__ #73705
* #73655

Fixes: https://github.com/pytorch/pytorch/issues/73557

TODO
- Not too sure why this works yet, presumably if we use the official redispatch mechanism instead of just at::blah, autograd/ADInplaceOrView kernels will be reenabled?
- LoggingTensor doesn't work for some reason still (it uses no_dispatch... but that shouldn't matter because we only have a single TensorWrapper anyway)
