### PR TITLE
[PyTorchEdge] Add getFileFormat() so we can differentiate Zip/Pickle from Flatbuffer

### DIFF
--- a/test/cpp/jit/CMakeLists.txt
+++ b/test/cpp/jit/CMakeLists.txt
@@ -90,6 +90,7 @@ set(JIT_TEST_SRCS
   ${JIT_TEST_ROOT}/test_script_profile.cpp
   ${JIT_TEST_ROOT}/test_shape_analysis.cpp
   ${JIT_TEST_ROOT}/test_jit_logging_levels.cpp
+  ${JIT_TEST_ROOT}/test_file_format.cpp
   ${JIT_TEST_ROOT}/test_flatbuffer.cpp
 )
 

--- a/test/cpp/jit/test_file_format.cpp
+++ b/test/cpp/jit/test_file_format.cpp
@@ -1,0 +1,124 @@
+#include <torch/csrc/jit/mobile/file_format.h>
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+// Tests go in torch::jit
+namespace torch {
+namespace jit {
+
+TEST(FileFormatTest, IdentifiesFlatbufferStream) {
+  // Create data whose initial bytes look like a Flatbuffer stream.
+  std::stringstream data;
+  data << "abcd" // First four bytes don't matter.
+       << "PTMF" // Magic string.
+       << "efgh"; // Trailing bytes don't matter.
+
+  // The data should be identified as Flatbuffer.
+  EXPECT_EQ(getFileFormat(data), FileFormat::FlatbufferFileFormat);
+}
+
+TEST(FileFormatTest, IdentifiesZipStream) {
+  // Create data whose initial bytes look like a ZIP stream.
+  std::stringstream data;
+  data << "PK\x03\x04" // Magic string.
+       << "abcd" // Trailing bytes don't matter.
+       << "efgh";
+
+  // The data should be identified as ZIP.
+  EXPECT_EQ(getFileFormat(data), FileFormat::ZipFileFormat);
+}
+
+TEST(FileFormatTest, FlatbufferTakesPrecedence) {
+  // Since the Flatbuffer and ZIP magic bytes are at different offsets,
+  // the same data could be identified as both. Demonstrate that Flatbuffer
+  // takes precedence. (See details in file_format.h)
+  std::stringstream data;
+  data << "PK\x03\x04" // ZIP magic string.
+       << "PTMF" // Flatbuffer magic string.
+       << "abcd"; // Trailing bytes don't matter.
+
+  // The data should be identified as Flatbuffer.
+  EXPECT_EQ(getFileFormat(data), FileFormat::FlatbufferFileFormat);
+}
+
+TEST(FileFormatTest, HandlesUnknownStream) {
+  // Create data that doesn't look like any known format.
+  std::stringstream data;
+  data << "abcd"
+       << "efgh"
+       << "ijkl";
+
+  // The data should be classified as unknown.
+  EXPECT_EQ(getFileFormat(data), FileFormat::UnknownFileFormat);
+}
+
+TEST(FileFormatTest, ShortStreamIsUnknown) {
+  // Create data with fewer than kFileFormatHeaderSize (8) bytes.
+  std::stringstream data;
+  data << "ABCD";
+
+  // The data should be classified as unknown.
+  EXPECT_EQ(getFileFormat(data), FileFormat::UnknownFileFormat);
+}
+
+TEST(FileFormatTest, EmptyStreamIsUnknown) {
+  // Create an empty stream.
+  std::stringstream data;
+
+  // The data should be classified as unknown.
+  EXPECT_EQ(getFileFormat(data), FileFormat::UnknownFileFormat);
+}
+
+TEST(FileFormatTest, BadStreamIsUnknown) {
+  // Create a stream with valid Flatbuffer data.
+  std::stringstream data;
+  data << "abcd"
+       << "PTMF" // Flatbuffer magic string.
+       << "efgh";
+
+  // Demonstrate that the data would normally be identified as Flatbuffer.
+  EXPECT_EQ(getFileFormat(data), FileFormat::FlatbufferFileFormat);
+
+  // Mark the stream as bad, and demonstrate that it is in an error state.
+  data.setstate(std::stringstream::badbit);
+  // Demonstrate that the stream is in an error state.
+  EXPECT_FALSE(data.good());
+
+  // The data should now be classified as unknown.
+  EXPECT_EQ(getFileFormat(data), FileFormat::UnknownFileFormat);
+}
+
+TEST(FileFormatTest, StreamOffsetIsObservedAndRestored) {
+  // Create data with a Flatbuffer header at a non-zero offset into the stream.
+  std::stringstream data;
+  // Add initial padding.
+  data << "PADDING";
+  size_t offset = data.str().size();
+  // Add a valid Flatbuffer header.
+  data << "abcd"
+       << "PTMF" // Flatbuffer magic string.
+       << "efgh";
+  // Seek just after the padding.
+  data.seekg(static_cast<std::stringstream::off_type>(offset), data.beg);
+  // Demonstrate that the stream points to the beginning of the Flatbuffer data,
+  // not to the padding.
+  EXPECT_EQ(data.peek(), 'a');
+
+  // The data should be identified as Flatbuffer.
+  EXPECT_EQ(getFileFormat(data), FileFormat::FlatbufferFileFormat);
+
+  // The stream position should be where it was before identification.
+  EXPECT_EQ(offset, data.tellg());
+}
+
+TEST(FileFormatTest, HandlesMissingFile) {
+  // A missing file should be classified as unknown.
+  EXPECT_EQ(
+      getFileFormat("NON_EXISTENT_FILE_4965c363-44a7-443c-983a-8895eead0277"),
+      FileFormat::UnknownFileFormat);
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/mobile/file_format.h
+++ b/torch/csrc/jit/mobile/file_format.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstring>
+#include <fstream>
+#include <istream>
+
+/**
+ * @file
+ *
+ * Helpers for identifying file formats when reading serialized data.
+ *
+ * Note that these functions are declared inline because they will typically
+ * only be called from one or two locations per binary.
+ */
+
+namespace torch {
+namespace jit {
+
+/**
+ * The format of a file or data stream.
+ */
+enum class FileFormat {
+  UnknownFileFormat = 0,
+  FlatbufferFileFormat,
+  ZipFileFormat,
+};
+
+namespace internal {
+
+/// The size of the buffer to pass to #getFileFormat(), in bytes.
+constexpr size_t kFileFormatHeaderSize = 8;
+
+/**
+ * Returns the likely file format based on the magic header bytes in @p header,
+ * which should contain the first bytes of a file or data stream.
+ */
+// NOLINTNEXTLINE(facebook-hte-NamespaceScopedStaticDeclaration)
+static inline FileFormat getFileFormat(
+    const std::array<char, kFileFormatHeaderSize>& header) {
+  // The size of magic strings to look for in the buffer.
+  static constexpr size_t kMagicSize = 4;
+
+  // Bytes 4..7 of a Flatbuffer-encoded file produced by
+  // `flatbuffer_serializer.h`. (The first four bytes contain an offset to the
+  // actual Flatbuffer data.)
+  static constexpr std::array<char, kMagicSize> kFlatbufferMagicString = {
+      'P', 'T', 'M', 'F'};
+  static constexpr size_t kFlatbufferMagicOffset = 4;
+
+  // The first four bytes of a ZIP file.
+  static constexpr std::array<char, kMagicSize> kZipMagicString = {
+      'P', 'K', '\x03', '\x04'};
+
+  // Note that we check for Flatbuffer magic first. Since the first four bytes
+  // of flatbuffer data contain an offset to the root struct, it's theoretically
+  // possible to construct a file whose offset looks like the ZIP magic. On the
+  // other hand, bytes 4-7 of ZIP files are constrained to a small set of values
+  // that do not typically cross into the printable ASCII range, so a ZIP file
+  // should never have a header that looks like a Flatbuffer file.
+  if (std::memcmp(
+          header.data() + kFlatbufferMagicOffset,
+          kFlatbufferMagicString.data(),
+          kMagicSize) == 0) {
+    // Magic header for a binary file containing a Flatbuffer-serialized mobile
+    // Module.
+    return FileFormat::FlatbufferFileFormat;
+  } else if (
+      std::memcmp(header.data(), kZipMagicString.data(), kMagicSize) == 0) {
+    // Magic header for a zip file, which we use to store pickled sub-files.
+    return FileFormat::ZipFileFormat;
+  }
+  return FileFormat::UnknownFileFormat;
+}
+
+} // namespace internal
+
+/**
+ * Returns the likely file format based on the magic header bytes of @p data.
+ * If the stream position changes while inspecting the data, this function will
+ * restore the stream position to its original offset before returning.
+ */
+// NOLINTNEXTLINE(facebook-hte-NamespaceScopedStaticDeclaration)
+static inline FileFormat getFileFormat(std::istream& data) {
+  FileFormat format = FileFormat::UnknownFileFormat;
+  std::streampos orig_pos = data.tellg();
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+  std::array<char, internal::kFileFormatHeaderSize> header;
+  data.read(header.data(), header.size());
+  if (data.good()) {
+    format = internal::getFileFormat(header);
+  }
+  data.seekg(orig_pos, data.beg);
+  return format;
+}
+
+/**
+ * Returns the likely file format based on the magic header bytes of the file
+ * named @p filename.
+ */
+// NOLINTNEXTLINE(facebook-hte-NamespaceScopedStaticDeclaration)
+static inline FileFormat getFileFormat(const std::string& filename) {
+  std::ifstream data(filename, std::ifstream::binary);
+  return getFileFormat(data);
+}
+
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73707

Add a helper function to detect the file format from the first bytes of a data file or stream. This will be necessary during the migration from Pickle-serialized modules to Flatbuffer-serialized modules.

Differential Revision: [D34527859](https://our.internmc.facebook.com/intern/diff/D34527859/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D34527859/)!