### PR TITLE
[static runtime] Fix aten::relu TE lowering to enable vectorization

### DIFF
--- a/torch/csrc/jit/runtime/static/te_wrapper.cpp
+++ b/torch/csrc/jit/runtime/static/te_wrapper.cpp
@@ -148,7 +148,7 @@ std::shared_ptr<TEWrapper> createRelu() {
   Tensor B = Compute("B", {N}, [&](const VarHandle& i) {
     auto zero = FloatImm::make(0.f);
     auto a = A.load(i);
-    return ifThenElse(a < zero, zero, a);
+    return CompareSelect::make(a, zero, zero, a, kLT);
   });
   wrap = wrapTECompute(wrap, B, {A, N});
   updateNNCCache(aten::relu, wrap);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73713

`IfThenElse` is not evaluated eagerly so could not be vectorized. Lowering `aten::relu` to `CompareSelect` instead which can be properly vectorized.

Differential Revision: [D34600058](https://our.internmc.facebook.com/intern/diff/D34600058)