### PR TITLE
Catch overflows in calculating storage byte size

### DIFF
--- a/aten/src/ATen/EmptyTensor.cpp
+++ b/aten/src/ATen/EmptyTensor.cpp
@@ -36,7 +36,7 @@ size_t computeStorageNbytesContiguous(
   // Ignore overflow checks on mobile
 #ifndef C10_MOBILE
   uint64_t size = 1;
-  bool overflowed = c10::safe_multiplies_u64(sizes.begin(), sizes.end(), &size);
+  bool overflowed = c10::safe_multiplies_u64(sizes, &size);
   overflowed |= c10::add_overflows(size, storage_offset, &size);
   overflowed |= c10::mul_overflows(size, itemsize_bytes, &size);
   overflowed |= size > storage_max();
@@ -44,7 +44,7 @@ size_t computeStorageNbytesContiguous(
               "Storage size calculation overflowed with sizes=", sizes);
   return static_cast<size_t>(size);
 #else
-  const auto numel = c10::multiply_integers(sizes.begin(), sizes.end());
+  const auto numel = c10::multiply_integers(sizes);
   return itemsize_bytes * (storage_offset + numel);
 #endif
 }

--- a/aten/src/ATen/EmptyTensor.cpp
+++ b/aten/src/ATen/EmptyTensor.cpp
@@ -36,10 +36,7 @@ size_t computeStorageNbytesContiguous(
   // Ignore overflow checks on mobile
 #ifndef C10_MOBILE
   uint64_t size = 1;
-  bool overflowed = false;
-  for (const auto s : sizes) {
-    overflowed |= c10::mul_overflows(size, s, &size);
-  }
+  bool overflowed = c10::safe_multiplies_u64(sizes.begin(), sizes.end(), &size);
   overflowed |= c10::add_overflows(size, storage_offset, &size);
   overflowed |= c10::mul_overflows(size, itemsize_bytes, &size);
   overflowed |= size > storage_max();

--- a/aten/src/ATen/EmptyTensor.h
+++ b/aten/src/ATen/EmptyTensor.h
@@ -10,8 +10,11 @@ inline void check_size_nonnegative(IntArrayRef size) {
   }
 }
 
+TORCH_API size_t computeStorageNbytesContiguous(
+    IntArrayRef sizes, size_t itemsize, size_t storage_offset=0);
 TORCH_API size_t computeStorageNbytes(
-    IntArrayRef sizes, IntArrayRef strides, size_t itemsize);
+    IntArrayRef sizes, IntArrayRef strides,
+    size_t itemsize, size_t storage_offset=0);
 
 TORCH_API TensorBase empty_generic(
     IntArrayRef size,

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -158,6 +158,12 @@ inline void setStrided(
     IntArrayRef stride,
     int64_t storage_offset) {
   TORCH_CHECK(size.size() == stride.size(), "mismatch in length of strides and shape");
+  for (auto val : stride) {
+    TORCH_CHECK(val >= 0,
+                "as_strided: Negative strides are not supported at the moment, "
+                "got strides: ", stride);
+  }
+
   auto* self_ = self.unsafeGetTensorImpl();
   checkInBoundsForStorage(
       size, stride, storage_offset, self_->dtype(), self_->storage());
@@ -169,11 +175,6 @@ inline void setStrided(
   /* size and stride */
   if (self_->sizes() == size && self_->strides() == stride) {
     return;
-  }
-  for (auto val : stride) {
-    TORCH_CHECK(val >= 0,
-                "as_strided: Negative strides are not supported at the moment, "
-                "got strides: ", stride);
   }
   self_->set_sizes_and_strides(size, stride);
 }

--- a/aten/src/ATen/native/cuda/Resize.h
+++ b/aten/src/ATen/native/cuda/Resize.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <ATen/EmptyTensor.h>
 #include <ATen/native/ResizeCommon.h>
 
 #include <c10/cuda/CUDAGuard.h>
@@ -9,19 +10,15 @@ namespace at { namespace native {
 
 TORCH_CUDA_CPP_API void resize_bytes_cuda(StorageImpl* storage, size_t size_bytes);
 
-static inline void maybe_resize_storage_cuda(TensorImpl* self, uint64_t new_size) {
+static inline void maybe_resize_storage_cuda(TensorImpl* self, size_t new_size_bytes) {
   // It does not make sense to try to resize a storage
   // to hold 0 elements, and this can break
   // if storage_offset is positive but
   // new_size is 0, so just bail in that case
   // (same comment is in Resize.h)
-  if (new_size == 0) {
+  if (self->numel() == 0) {
     return;
   }
-  auto new_size_bytes_i = (new_size + self->storage_offset()) * self->dtype().itemsize();
-  TORCH_CHECK(!overflows<size_t>(new_size_bytes_i), "Requested storage size (",
-              new_size_bytes_i, ") cannot be represented as a size_t");
-  const auto new_size_bytes = static_cast<size_t>(new_size_bytes_i);
 
   const Storage &storage = self->unsafe_storage();
   TORCH_CHECK(storage, "Tensor: invalid null storage");
@@ -45,14 +42,17 @@ inline TensorImpl* resize_impl_cuda_(
     guard.set_index(self->storage().device().index());
   }
 
-  int64_t storage_size = 1;
+  const auto itemsize = self->dtype().itemsize();
+  const auto storage_offset = self->storage_offset();
+  size_t storage_size = 1;
   if (stride) {
     self->set_sizes_and_strides(size, *stride);
-    // NB: storage size can be different from numel.
-    storage_size = storage_size_for(size, *stride);
+    storage_size = at::detail::computeStorageNbytes(
+        size, *stride, itemsize, storage_offset);
   } else {
     self->set_sizes_contiguous(size);
-    storage_size = self->numel();
+    storage_size = at::detail::computeStorageNbytesContiguous(
+        size, itemsize, storage_offset);
   }
   maybe_resize_storage_cuda(self, storage_size);
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2301,11 +2301,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * using a sparse layout has multiple dimensions with large sizes.
    */
   int64_t safe_compute_numel() const {
+    const auto size = sizes();
     uint64_t n = 1;
-    bool overflows = false;
-    for (auto s : sizes()) {
-      overflows |= c10::mul_overflows(n, s, &n);
-    }
+    bool overflows = c10::safe_multiplies_u64(size.begin(), size.end(), &n);
     constexpr auto numel_max = std::min(
         static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
         static_cast<uint64_t>(std::numeric_limits<size_t>::max()));

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2290,8 +2290,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     // Use overflow checks if supported by the compiler
     return safe_compute_numel();
 #else
-    auto size = sizes();
-    return c10::multiply_integers(size.begin(), size.end());
+    return c10::multiply_integers(sizes());
 #endif
   }
 
@@ -2301,9 +2300,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * using a sparse layout has multiple dimensions with large sizes.
    */
   int64_t safe_compute_numel() const {
-    const auto size = sizes();
     uint64_t n = 1;
-    bool overflows = c10::safe_multiplies_u64(size.begin(), size.end(), &n);
+    bool overflows = c10::safe_multiplies_u64(sizes(), &n);
     constexpr auto numel_max = std::min(
         static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
         static_cast<uint64_t>(std::numeric_limits<size_t>::max()));

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2286,7 +2286,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * Compute the number of elements based on the sizes of a tensor.
    */
   int64_t compute_numel() const {
-#if C10_HAS_BUILTIN_OVERFLOW()
+#if C10_HAS_BUILTIN_OVERFLOW() && !defined(C10_MOBILE)
     // Use overflow checks if supported by the compiler
     return safe_compute_numel();
 #else

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -10,9 +10,9 @@
 #ifdef __GNUC__
 #define C10_HAS_BUILTIN_OVERFLOW() (1)
 #elif defined(__has_builtin)
-#define C10_HAS_BUILTIN_OVERFLOW() (            \
-      __has_builtin(__builtin_mul_overflow) &&  \
-      __has_builtin(__builtin_add_overflow))
+#define C10_HAS_BUILTIN_OVERFLOW()          \
+  (__has_builtin(__builtin_mul_overflow) && \
+   __has_builtin(__builtin_add_overflow))
 #else
 #define C10_HAS_BUILTIN_OVERFLOW() (0)
 #endif
@@ -21,11 +21,9 @@
 #include <intrin.h>
 #endif
 
-
-
 namespace c10 {
 
-C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t *out) {
+C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t* out) {
 #if C10_HAS_BUILTIN_OVERFLOW()
   return __builtin_add_overflow(a, b, out);
 #elif defined(_MSC_VER)
@@ -40,7 +38,7 @@ C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t *out) {
 #endif
 }
 
-C10_ALWAYS_INLINE bool mul_overflows(uint64_t a, uint64_t b, uint64_t *out) {
+C10_ALWAYS_INLINE bool mul_overflows(uint64_t a, uint64_t b, uint64_t* out) {
 #if C10_HAS_BUILTIN_OVERFLOW()
   return __builtin_mul_overflow(a, b, out);
 #elif defined(_MSC_VER)
@@ -48,12 +46,9 @@ C10_ALWAYS_INLINE bool mul_overflows(uint64_t a, uint64_t b, uint64_t *out) {
 
   // Avoid division by using bsr to test if:
   // log2(a) + log2(b) >= 64
-  unsigned long i1, i2;
+  unsigned long i1 = 0, i2 = 0;
   return (
-      _BitScanForward64(&i1, a) &
-      _BitScanForward64(&i2, b) &
-      (i1 + i2 >= 64)
-    );
+      _BitScanForward64(&i1, a) & _BitScanForward64(&i2, b) & (i1 + i2 >= 64));
 #else
   auto result = a * b;
   *out = result;

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -1,0 +1,64 @@
+#pragma once
+#include <c10/macros/Macros.h>
+#include <c10/util/ArrayRef.h>
+
+#include <iterator>
+#include <numeric>
+#include <type_traits>
+
+// GCC has __builtin_mul_overflow from before it supported __has_builtin
+#ifdef __GNUC__
+#define C10_HAS_BUILTIN_OVERFLOW() (1)
+#elif defined(__has_builtin)
+#define C10_HAS_BUILTIN_OVERFLOW() (            \
+      __has_builtin(__builtin_mul_overflow) &&  \
+      __has_builtin(__builtin_add_overflow))
+#else
+#define C10_HAS_BUILTIN_OVERFLOW() (0)
+#endif
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
+
+
+namespace c10 {
+
+C10_ALWAYS_INLINE bool add_overflows(uint64_t a, uint64_t b, uint64_t *out) {
+#if C10_HAS_BUILTIN_OVERFLOW()
+  return __builtin_add_overflow(a, b, out);
+#elif defined(_MSC_VER)
+  unsigned long long tmp;
+  auto carry = _addcarry_u64(0, a, b, &tmp);
+  *out = tmp;
+  return carry;
+#else
+  auto result = a + b;
+  *out = result;
+  return result < (a | b);
+#endif
+}
+
+C10_ALWAYS_INLINE bool mul_overflows(uint64_t a, uint64_t b, uint64_t *out) {
+#if C10_HAS_BUILTIN_OVERFLOW()
+  return __builtin_mul_overflow(a, b, out);
+#elif defined(_MSC_VER)
+  *out = a * b;
+
+  // Avoid division by using bsr to test if:
+  // log2(a) + log2(b) >= 64
+  unsigned long i1, i2;
+  return (
+      _BitScanForward64(&i1, a) &
+      _BitScanForward64(&i2, b) &
+      (i1 + i2 >= 64)
+    );
+#else
+  auto result = a * b;
+  *out = result;
+  return (a != 0) && (result / a != b);
+#endif
+}
+
+} // namespace c10

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2677,11 +2677,11 @@ class TestTensorCreation(TestCase):
     @onlyNativeDeviceTypes
     def test_empty_overflow(self, device):
         with self.assertRaisesRegex(RuntimeError, 'Storage size calculation overflowed'):
-            torch.empty([2, 4, 536870912, 536870912], dtype=torch.float64)
+            torch.empty([2, 4, 2**29, 2**29], dtype=torch.float64)
         with self.assertRaisesRegex(RuntimeError, 'Storage size calculation overflowed'):
-            torch.empty([8, 8, 536870912, 536870912], dtype=torch.float64)
+            torch.empty([8, 8, 2**29, 2**29], dtype=torch.float64)
         with self.assertRaisesRegex(RuntimeError, 'Storage size calculation overflowed'):
-            torch.empty_strided([8, 8], [8 * 536870912**2, 1], dtype=torch.float64)
+            torch.empty_strided([8, 8], [2**61, 1], dtype=torch.float64)
 
     def test_eye(self, device):
         for dtype in get_all_dtypes():

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2674,6 +2674,15 @@ class TestTensorCreation(TestCase):
             y = torch.empty(tuple(size_ones_instead_of_zeros), device=device)
             self.assertEqual(x.stride(), y.stride())
 
+    @onlyNativeDeviceTypes
+    def test_empty_overflow(self, device):
+        with self.assertRaisesRegex(RuntimeError, 'Storage size calculation overflowed'):
+            torch.empty([2, 4, 536870912, 536870912], dtype=torch.float64)
+        with self.assertRaisesRegex(RuntimeError, 'Storage size calculation overflowed'):
+            torch.empty([8, 8, 536870912, 536870912], dtype=torch.float64)
+        with self.assertRaisesRegex(RuntimeError, 'Storage size calculation overflowed'):
+            torch.empty_strided([8, 8], [8 * 536870912**2, 1], dtype=torch.float64)
+
     def test_eye(self, device):
         for dtype in get_all_dtypes():
             if dtype == torch.bfloat16:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7419,6 +7419,10 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertEqual(b.nelement(), 3 * 100 * 100)
         self.assertEqual(b.numel(), 3 * 100 * 100)
 
+    def test_empty_overflow(self):
+        with self.assertRaisesRegex(RuntimeError, "storage size calculation overflows"):
+            torch.zeros([2, 4, 536870912, 536870912], dtype=torch.float64)
+
     # Verifies that (deep)copies of dtypes are the same objects
     def test_copy_dtypes(self):
         for dtype in get_all_dtypes(include_complex32=True):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7419,10 +7419,6 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertEqual(b.nelement(), 3 * 100 * 100)
         self.assertEqual(b.numel(), 3 * 100 * 100)
 
-    def test_empty_overflow(self):
-        with self.assertRaisesRegex(RuntimeError, "storage size calculation overflows"):
-            torch.zeros([2, 4, 536870912, 536870912], dtype=torch.float64)
-
     # Verifies that (deep)copies of dtypes are the same objects
     def test_copy_dtypes(self):
         for dtype in get_all_dtypes(include_complex32=True):

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1800,9 +1800,9 @@ class TestOldViewOps(TestCase):
     def test_resize_overflow(self, device):
         x = torch.empty((), dtype=torch.float64)
         with self.assertRaisesRegex(RuntimeError, 'Storage size calculation overflowed'):
-            x.resize_([2, 4, 536870912, 536870912])
+            x.resize_([2, 4, 2**29, 2**29])
         with self.assertRaisesRegex(RuntimeError, 'overflow'):
-            x.resize_([8, 8, 536870912, 536870912])
+            x.resize_([8, 8, 2**29, 2**29])
 
     def test_view_all_dtypes_and_devices(self, device):
         for dt in get_all_dtypes():

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1796,6 +1796,14 @@ class TestOldViewOps(TestCase):
             x.resize_as_(y)
             self.assertEqual(y.shape, x.shape)
 
+    @onlyNativeDeviceTypes
+    def test_resize_overflow(self, device):
+        x = torch.empty((), dtype=torch.float64)
+        with self.assertRaisesRegex(RuntimeError, 'Storage size calculation overflowed'):
+            x.resize_([2, 4, 536870912, 536870912])
+        with self.assertRaisesRegex(RuntimeError, 'overflow'):
+            x.resize_([8, 8, 536870912, 536870912])
+
     def test_view_all_dtypes_and_devices(self, device):
         for dt in get_all_dtypes():
             x = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=dt, device=device)


### PR DESCRIPTION
Fixes #73184

In the issue the output tensor's shape is `[2, 4, 536870912, 536870912]` which results in a `numel()` slightly below the point of overflow. When the storage is created it does `numel() * 8` which overflows and a much smaller storage is allocated than required.
