### PR TITLE
Make __new__ on tensor subclasses match _make_subclass

### DIFF
--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -68,7 +68,7 @@ static PyObject* Tensor_new(PyTypeObject *type, PyObject *args, PyObject *kwargs
   if (tensor_type.is_cuda && !torch::utils::cuda_enabled()) {
     throw unavailable_type(tensor_type);
   }
-  return THPVariable_Wrap(torch::utils::legacy_tensor_ctor(tensor_type.get_dispatch_key(), tensor_type.get_scalar_type(), args, kwargs));
+  return THPVariable_Wrap(torch::utils::legacy_tensor_ctor(type, tensor_type.get_dispatch_key(), tensor_type.get_scalar_type(), args, kwargs));
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/utils/tensor_new.h
+++ b/torch/csrc/utils/tensor_new.h
@@ -6,7 +6,11 @@
 
 namespace torch { namespace utils {
 
-at::Tensor legacy_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyObject* args, PyObject* kwargs);
+// NB: this is not 100% legacy; the single Tensor constructor is undeprecated
+// for subclasses when passed a single Tensor (in which case _make_subclass is
+// called)
+at::Tensor legacy_tensor_ctor(PyTypeObject *type, c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyObject* args, PyObject* kwargs);
+at::Tensor make_subclass(const at::Tensor& other);
 at::Tensor legacy_tensor_new(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyObject* args, PyObject* kwargs);
 at::Tensor indexing_tensor_from_data(
     c10::TensorOptions options,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73727
* #73684

Previously, calling SubclassTensor(tensor) would give you a
SubclassTensor where the underlying at::Tensor was computed by an
alias() call.  In particular, a grad_fn would be created in this
situation.  This is usually not what people want, as the alias grad_fn
is oblivious to the subclass's semantics (and just as likely to be wrong)
and it means that you cannot use the constructor to directly create a
leaf SubclassTensor that requires_grad=True.

This PR changes the meaning of this call so that SubclassTensor(tensor)
is equivalent to torch.Tensor._make_subclass(SubclassTensor, tensor);
that is to say, the underlying at::Tensor is created by a detach() call
(deleting grad_fn), and furthermore the requires_grad defaults to False
(but you can set it explicitly afterwards).  I keep exactly the old
behavior if you call a normal Tensor, which could be somewhat confusing
as it doesn't match exactly.

I'm not sure if this is completely correct. Here are some other ways
we could skin the cat:

- detach(), but propagate requires_grad-ness.  This lets an idiom like
  TensorSubclass(torch.empty(2, requires_grad=True)) do the intuitive
  thing.
- detach(), ignore input requires_grad and also accept a requires_grad
  kwarg for setting requires_grad directly.  This means you would write
  TensorSubclass(torch.empty(2), requires_grad=True) to create a leaf
  node.
- Same as above, but assert that requires_grad=False or that we are
  in a no_grad mode.  This would remind users that if they want a
  non-leaf tensor subclass, they are obligated to think about the
  autograd semantics for this boundary.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D34615319](https://our.internmc.facebook.com/intern/diff/D34615319)