### PR TITLE
Fix `asarray` docs + add test case.

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4071,6 +4071,8 @@ class TestAsArray(TestCase):
             [0.0, True, False, 42],
             # With Complex
             [0.0, True, False, 42, 5j],
+            # With Range
+            range(5),
         ]
 
         for e in examples:

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1031,9 +1031,6 @@ returned tensor will, by default, infer its datatype from the scalar values, be 
 CPU device, and not share its memory.
 
 .. seealso::
-    :func:`torch.as_tensor` creates a tensor that always shares memory if the input is a
-           tensor or a NumPy array, copying otherwise.
-
     :func:`torch.tensor` creates a tensor that always copies the data from the input object.
 
     :func:`torch.from_numpy` creates a tensor that always shares memory from NumPy arrays.


### PR DESCRIPTION
Follow up: #71757

- Added a range object as a test case example
- Remove `torch.as_tensor` entry from the `see also` section


