### PR TITLE
Fix alignment, make sure release labels are included

### DIFF
--- a/.github/scripts/process_commit.py
+++ b/.github/scripts/process_commit.py
@@ -68,7 +68,7 @@ def get_repo_labels() -> List[str]:
         page_labels = list(map(lambda x: str(x["name"]), response))
         if not page_labels:
             break
-            collected_labels += page_labels
+        collected_labels += page_labels
     return collected_labels
 
 def post_pytorch_comment(pr_number: int, merger: str) -> Any:


### PR DESCRIPTION
This issue was reported on this [PR](https://github.com/pytorch/pytorch/pull/73436#issuecomment-1057496607)  the bot commented on the PR even tho the labels where already added to pr correctly.  Issue found to one not idented properly line that collected repo labels in a set.

Tested locally by running the script against the commit, commit_hash = "2ab9702955e461eab03809a71e10c6fc9cb54cb5"

Produced following output
```
PR Labels:
{'ciflow/default', 'cla signed', 'release notes: quantization', 'topic: improvements'}
Repo release Labels:
{'release notes: distributed (fsdp)', 'release notes: python_frontend', 'release notes: mobile', 'release notes: linalg_frontend', 'release notes: performance_as_product', 'release notes: autograd', 'release notes: sparse', 'release notes: build', 'release notes: composability', 'release notes: lazy', 'release notes: visualization', 'release notes: cpp', 'release notes: package/deploy', 'release notes: distributed (sharded)', 'release notes: distributed (ddp)', 'release notes: rocm', 'release notes: memory format', 'release notes: foreach_frontend', 'release notes: vulkan', 'release notes: releng', 'release notes: profiler', 'release notes: distributed (rpc)', 'release notes: jit', 'release notes: onnx', 'release notes: dataloader', 'release notes: complex', 'release notes: benchmark', 'release notes: distributed (c10d)', 'release notes: fx', 'release notes: distributed (pipeline)', 'release notes: Meta API', 'release notes: quantization', 'release notes: cuda', 'release notes: nn'}
Intersection release labels:
{'release notes: quantization'}
Intersection topic labels:
{'topic: improvements'}
```