### PR TITLE
[JIT] make RegisterCudaFuseGraph use TORCH_API instead of C10_EXPORT

### DIFF
--- a/torch/csrc/jit/passes/cuda_graph_fuser.h
+++ b/torch/csrc/jit/passes/cuda_graph_fuser.h
@@ -9,7 +9,7 @@ namespace torch {
 namespace jit {
 
 // Register CudaFuseGraph in custom passes
-struct C10_EXPORT RegisterCudaFuseGraph
+struct TORCH_API RegisterCudaFuseGraph
     : public PassManager<RegisterCudaFuseGraph> {
   static bool registerPass(bool enabled) {
     bool old_flag = PassManager::isRegistered();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73322
* __->__ #73742

I think this was causing multiple implementations of
RegisterCudaFuseGraph on windows. It looks like both torch_cpu.dll and
torch_python.dll were exporting RegisterCudaFuseGraph implementations,
so RegisterCudaFuseGraph::isRegistered() would refer to a _different_
static bool depending on whether the caller was in torch_cpu.dll or
torch_python.dll. See #73717 for a demonstration.

Differential Revision: [D34618623](https://our.internmc.facebook.com/intern/diff/D34618623)