### PR TITLE
[ci] don't build pytorch twice on windows

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -28,13 +28,9 @@ call %INSTALLER_DIR%\install_sccache.bat
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 
-call :retry %INSTALLER_DIR%\install_miniconda3.bat
+call %INSTALLER_DIR%\install_miniconda3.bat
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
-
-:retry
-call %* || (powershell -nop -c "& {sleep 1}" && call %*) || (powershell -nop -c "& {sleep 2}" && call %*)
-exit /b
 
 :: Install ninja and other deps
 if "%REBUILD%"=="" ( pip install -q "ninja==1.10.0.post1" dataclasses typing_extensions "expecttest==0.1.3" )

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -30,11 +30,6 @@ if not errorlevel 0 exit /b
 
 call :retry %INSTALLER_DIR%\install_miniconda3.bat
 
-:retry
-call %* || (powershell -nop -c "& {sleep 1}" && call %*) || (powershell -nop -c "& {sleep 2}" && call %*)
-if errorlevel 1 exit /b
-if not errorlevel 0 exit /b
-
 :: Install ninja and other deps
 if "%REBUILD%"=="" ( pip install -q "ninja==1.10.0.post1" dataclasses typing_extensions "expecttest==0.1.3" )
 if errorlevel 1 exit /b
@@ -160,3 +155,8 @@ sccache --show-stats > stats.txt
 python -m tools.stats.upload_sccache_stats stats.txt
 sccache --stop-server
 rm stats.txt
+
+:retry
+call %* || (powershell -nop -c "& {sleep 1}" && call %*) || (powershell -nop -c "& {sleep 2}" && call %*)
+if errorlevel 1 exit /b
+if not errorlevel 0 exit /b

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -28,9 +28,13 @@ call %INSTALLER_DIR%\install_sccache.bat
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 
-call %INSTALLER_DIR%\install_miniconda3.bat
+call :retry %INSTALLER_DIR%\install_miniconda3.bat
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
+
+:retry
+call %* || (powershell -nop -c "& {sleep 1}" && call %*) || (powershell -nop -c "& {sleep 2}" && call %*)
+exit /b
 
 :: Install ninja and other deps
 if "%REBUILD%"=="" ( pip install -q "ninja==1.10.0.post1" dataclasses typing_extensions "expecttest==0.1.3" )

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -29,6 +29,8 @@ if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 
 call %INSTALLER_DIR%\install_miniconda3.bat
+if errorlevel 1 exit /b
+if not errorlevel 0 exit /b
 
 :: Install ninja and other deps
 if "%REBUILD%"=="" ( pip install -q "ninja==1.10.0.post1" dataclasses typing_extensions "expecttest==0.1.3" )

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -28,7 +28,7 @@ call %INSTALLER_DIR%\install_sccache.bat
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 
-call :retry %INSTALLER_DIR%\install_miniconda3.bat
+call %INSTALLER_DIR%\install_miniconda3.bat
 
 :: Install ninja and other deps
 if "%REBUILD%"=="" ( pip install -q "ninja==1.10.0.post1" dataclasses typing_extensions "expecttest==0.1.3" )
@@ -155,8 +155,3 @@ sccache --show-stats > stats.txt
 python -m tools.stats.upload_sccache_stats stats.txt
 sccache --stop-server
 rm stats.txt
-
-:retry
-call %* || (powershell -nop -c "& {sleep 1}" && call %*) || (powershell -nop -c "& {sleep 2}" && call %*)
-if errorlevel 1 exit /b
-if not errorlevel 0 exit /b


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73743

The implementation of `:retry` runs the entire rest of the file, causing
us to build pytorch twice.