### PR TITLE
[NS] Mark output logger impure to avoid being removed in acc tracer

### DIFF
--- a/torch/ao/ns/_numeric_suite_fx.py
+++ b/torch/ao/ns/_numeric_suite_fx.py
@@ -131,6 +131,9 @@ class OutputLogger(nn.Module):
     stats: List[torch.Tensor]
     stats_rnn: List[RNNReturnType]
 
+    # Mark as impure so that calls to it will not be removed during DCE.
+    _is_impure = True
+
     def __init__(
         self,
         ref_node_name: str,


### PR DESCRIPTION
Summary: Mark output logger as impure, which will help prevent it and the shadow ops from being removed in acc tracer.

Test Plan: Tested in N1611591

Differential Revision: D34616990

