### PR TITLE
Eliminate unused parameters in PyTorch

### DIFF
--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -75,14 +75,15 @@ struct TORCH_API CUDAHooksInterface {
   }
 
   virtual const Generator& getDefaultCUDAGenerator(DeviceIndex device_index = -1) const {
+    (void)device_index; // Suppress unused variable warning
     TORCH_CHECK(false, "Cannot get default CUDA generator without ATen_cuda library. ", CUDA_HELP);
   }
 
-  virtual Device getDeviceFromPtr(void* data) const {
+  virtual Device getDeviceFromPtr(void* /*data*/) const {
     TORCH_CHECK(false, "Cannot get device of pointer on CUDA without ATen_cuda library. ", CUDA_HELP);
   }
 
-  virtual bool isPinnedPtr(void* data) const {
+  virtual bool isPinnedPtr(void* /*data*/) const {
     return false;
   }
 
@@ -159,19 +160,19 @@ struct TORCH_API CUDAHooksInterface {
         "Cannot query batchnormMinEpsilonCuDNN() without ATen_cuda library. ", CUDA_HELP);
   }
 
-  virtual int64_t cuFFTGetPlanCacheMaxSize(int64_t device_index) const {
+  virtual int64_t cuFFTGetPlanCacheMaxSize(int64_t /*device_index*/) const {
     TORCH_CHECK(false, "Cannot access cuFFT plan cache without ATen_cuda library. ", CUDA_HELP);
   }
 
-  virtual void cuFFTSetPlanCacheMaxSize(int64_t device_index, int64_t max_size) const {
+  virtual void cuFFTSetPlanCacheMaxSize(int64_t /*device_index*/, int64_t /*max_size*/) const {
     TORCH_CHECK(false, "Cannot access cuFFT plan cache without ATen_cuda library. ", CUDA_HELP);
   }
 
-  virtual int64_t cuFFTGetPlanCacheSize(int64_t device_index) const {
+  virtual int64_t cuFFTGetPlanCacheSize(int64_t /*device_index*/) const {
     TORCH_CHECK(false, "Cannot access cuFFT plan cache without ATen_cuda library. ", CUDA_HELP);
   }
 
-  virtual void cuFFTClearPlanCache(int64_t device_index) const {
+  virtual void cuFFTClearPlanCache(int64_t /*device_index*/) const {
     TORCH_CHECK(false, "Cannot access cuFFT plan cache without ATen_cuda library. ", CUDA_HELP);
   }
 
@@ -179,7 +180,7 @@ struct TORCH_API CUDAHooksInterface {
     return 0;
   }
 
-  virtual void deviceSynchronize(int64_t device_index) const {
+  virtual void deviceSynchronize(int64_t /*device_index*/) const {
     TORCH_CHECK(false, "Cannot synchronize CUDA device without ATen_cuda library. ", CUDA_HELP);
   }
 };

--- a/aten/src/ATen/native/Lerp.cpp
+++ b/aten/src/ATen/native/Lerp.cpp
@@ -18,7 +18,7 @@ TORCH_META_FUNC(lerp_Tensor)(
 }
 
 TORCH_META_FUNC(lerp_Scalar)(
-    const Tensor& self, const Tensor& end, const Scalar& weight) {
+    const Tensor& self, const Tensor& end, const Scalar& /*weight*/) {
   TORCH_CHECK(self.dtype() == end.dtype(), "expected dtype ", self.dtype(),
               " for `end` but got dtype ", end.dtype());
   build_binary_op(maybe_get_output(), self, end);
@@ -29,12 +29,12 @@ TORCH_META_FUNC(lerp_Scalar)(
 namespace native {
 
 TORCH_IMPL_FUNC(lerp_Tensor)(
-    const Tensor& self, const Tensor& end, const Tensor& weight, const Tensor &out) {
+    const Tensor& /*self*/, const Tensor& /*end*/, const Tensor& weight, const Tensor& /*out*/) {
   lerp_kernel_tensor_weight(device_type(), *this);
 }
 
 TORCH_IMPL_FUNC(lerp_Scalar)(
-    const Tensor& self, const Tensor& end, const Scalar& weight, const Tensor &out) {
+    const Tensor& /*self*/, const Tensor& /*end*/, const Scalar& weight, const Tensor& /*out*/) {
   lerp_kernel_scalar_weight(device_type(), *this, weight);
 }
 

--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -213,7 +213,7 @@ void batch_iterator_with_broadcasting(const Tensor& a, const Tensor& b, const fu
   auto a_broadcasts_over_b = (a_batch_sizes != b_batch_sizes);
   Tensor a_buffer, a_was_accessed, a_buffer_3d;
   std::function<void(int64_t)> check_if_copy_needed_for_a
-    = [](int64_t a_curr_linear_batch_idx){};
+    = [](int64_t /*a_curr_linear_batch_idx*/){};
   if (a_broadcasts_over_b) {
     a_buffer = at::empty_strided(a.sizes(), a.strides(), a.options())
       .copy_(a);

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -59,7 +59,7 @@ inline bool _dimreduce_return_trivial(const Tensor &result, const Tensor &self,
 }
 
 inline bool _dimreduce_return_trivial_no_ident(Tensor &result, const Tensor &self,
-                                               int64_t dim, bool keepdim, const char *fn_name) {
+                                               int64_t /*dim*/, bool /*keepdim*/, const char* /*fn_name*/) {
   if (self.numel() == 1 && self.ndimension() == 0) {
     result.resize_({});
     result.fill_(self);
@@ -128,7 +128,7 @@ inline DimVector shape_from_dim_mask(const Tensor& self, DimMask mask, bool keep
 
 static void resize_reduction_result(
     Tensor& result, const Tensor& self, DimMask mask, bool keepdim,
-    ScalarType dtype)
+    ScalarType /*dtype*/)
 {
   auto shape = shape_from_dim_mask(self, mask, keepdim);
   TORCH_CHECK(result.defined(), "Cannot create a new tensor inside a reduction op. You likely tried to call an operator with an out argument but the out argument was an undefined tensor.");
@@ -357,7 +357,7 @@ static TensorIterator make_reduction(
     IntArrayRef dims,
     bool keepdim,
     ScalarType dtype1,
-    ScalarType dtype2) {
+    ScalarType /*dtype2*/) {
   int64_t ndim = self.dim();
   auto mask = at::native::make_dim_mask(dims, ndim);
   auto viewed_result1 = at::native::review_reduce_result(result1, ndim, mask, keepdim);

--- a/aten/src/ATen/native/ReplicationPadding.cpp
+++ b/aten/src/ATen/native/ReplicationPadding.cpp
@@ -230,7 +230,7 @@ static void replication_pad1d_out_frame(
     long nslices,
     long iwidth,
     long owidth,
-    int pad_l, int pad_r)
+    int pad_l)
 {
   int iStartX = std::max(0, -pad_l);
   int oStartX = std::max(0, pad_l);
@@ -263,14 +263,14 @@ static void replication_pad1d_out_batch(
     long nslices,
     long iwidth,
     long owidth,
-    int pad_l, int pad_r,
+    int pad_l,
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
     for (const auto p : c10::irange(start, end)) {
       scalar_t *input_p = input_data+p*nslices*iwidth;
       scalar_t *output_p = output_data+p*nslices*owidth;
-      replication_pad1d_out_frame(input_p, output_p, nslices, iwidth, owidth, pad_l, pad_r);
+      replication_pad1d_out_frame(input_p, output_p, nslices, iwidth, owidth, pad_l);
     }
   });
 }
@@ -281,7 +281,7 @@ static void replication_pad1d_backward_out_frame(
     long nslices,
     long iwidth,
     long owidth,
-    int pad_l, int pad_r)
+    int pad_l)
 {
   int iStartX = std::max(0, -pad_l);
   int oStartX = std::max(0, pad_l);
@@ -322,7 +322,7 @@ static void replication_pad1d_backward_out_batch(
       scalar_t *ginput_p = ginput_data + p * nslices * iwidth;
       scalar_t *goutput_p = goutput_data + p * nslices * owidth;
       replication_pad1d_backward_out_frame(ginput_p, goutput_p,
-        nslices, iwidth, owidth, pad_l, pad_r);
+        nslices, iwidth, owidth, pad_l);
     }
   });
 }
@@ -334,7 +334,7 @@ static void replication_pad2d_out_frame(
     int64_t iwidth, int64_t iheight,
     int64_t owidth, int64_t oheight,
     int pad_l, int pad_r,
-    int pad_t, int pad_b)
+    int pad_t)
 {
   int iStartX = std::max(0, -pad_l);
   int iStartY = std::max(0, -pad_t);
@@ -381,7 +381,7 @@ static void replication_pad2d_out_batch(
     int64_t iwidth, int64_t iheight,
     int64_t owidth, int64_t oheight,
     int pad_l, int pad_r,
-    int pad_t, int pad_b,
+    int pad_t,
     int nbatch)
 {
   at::parallel_for(0, nbatch, 0, [&](int64_t start, int64_t end) {
@@ -389,7 +389,7 @@ static void replication_pad2d_out_batch(
       scalar_t *input_p = input_data+p*nslices*iwidth*iheight;
       scalar_t *output_p = output_data+p*nslices*owidth*oheight;
       replication_pad2d_out_frame(input_p, output_p, nslices,
-          iwidth, iheight, owidth, oheight, pad_l, pad_r, pad_t, pad_b);
+          iwidth, iheight, owidth, oheight, pad_l, pad_r, pad_t);
     }
   });
 }
@@ -811,7 +811,6 @@ TORCH_IMPL_FUNC(replication_pad1d_out_cpu) (
   constexpr int64_t dimslices = -2;
 
   int64_t pad_l = paddingSize[0];
-  int64_t pad_r = paddingSize[1];
 
   /* get contiguous input */
   auto input = input_.contiguous();
@@ -837,7 +836,7 @@ TORCH_IMPL_FUNC(replication_pad1d_out_cpu) (
         nslices,
         iwidth,
         owidth,
-        pad_l, pad_r);
+        pad_l);
       }
     );
   }
@@ -852,7 +851,7 @@ TORCH_IMPL_FUNC(replication_pad1d_out_cpu) (
         nslices,
         iwidth,
         owidth,
-        pad_l, pad_r,
+        pad_l,
         nbatch);
       }
     );
@@ -907,7 +906,7 @@ TORCH_IMPL_FUNC(replication_pad1d_backward_out_cpu) (
         nslices,
         iwidth,
         owidth,
-        pad_l, pad_r);
+        pad_l);
       }
     );
   }
@@ -969,7 +968,7 @@ TORCH_IMPL_FUNC(replication_pad2d_out_cpu) (
         iwidth, iheight,
         owidth, oheight,
         pad_l, pad_r,
-        pad_t, pad_b);
+        pad_t);
       }
     );
   }
@@ -983,7 +982,7 @@ TORCH_IMPL_FUNC(replication_pad2d_out_cpu) (
         iwidth, iheight,
         owidth, oheight,
         pad_l, pad_r,
-        pad_t, pad_b,
+        pad_t,
         nbatch);
       }
     );

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -344,17 +344,17 @@ template<typename acc_t>
 struct AbsSwitch {};
 
 template<typename scalar_t, typename acc_t>
-inline C10_DEVICE acc_t abs_if_complex(scalar_t data, AbsSwitch<acc_t> s) {
+inline C10_DEVICE acc_t abs_if_complex(scalar_t data, AbsSwitch<acc_t>) {
   return static_cast<acc_t>(data);
 }
 
 template<typename scalar_t, typename acc_t>
-inline C10_DEVICE acc_t abs_if_complex(std::complex<scalar_t> data, AbsSwitch<acc_t> s) {
+inline C10_DEVICE acc_t abs_if_complex(std::complex<scalar_t> data, AbsSwitch<acc_t>) {
   return static_cast<acc_t>(std::abs(data));
 }
 
 template<typename scalar_t, typename acc_t>
-inline C10_DEVICE acc_t abs_if_complex(c10::complex<scalar_t> data, AbsSwitch<acc_t> s) {
+inline C10_DEVICE acc_t abs_if_complex(c10::complex<scalar_t> data, AbsSwitch<acc_t>) {
   return static_cast<acc_t>(std::abs(data));
 }
 

--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -34,7 +34,7 @@ const OptionalScalarRef max) {
 }
 
 TORCH_META_FUNC2(isin, Tensor_Tensor) (
-  const Tensor& elements, const Tensor& test_elements, bool assume_unique, bool invert
+  const Tensor& elements, const Tensor& test_elements, bool /*assume_unique*/, bool /*invert*/
 ) {
   check_for_unsupported_isin_dtype(elements.scalar_type());
   check_for_unsupported_isin_dtype(test_elements.scalar_type());
@@ -42,7 +42,7 @@ TORCH_META_FUNC2(isin, Tensor_Tensor) (
 }
 
 TORCH_META_FUNC2(isin, Tensor_Scalar) (
-  const Tensor& elements, const c10::Scalar& test_elements, bool assume_unique, bool invert
+  const Tensor& elements, const c10::Scalar& test_elements, bool /*assume_unique*/, bool /*invert*/
 ) {
   check_for_unsupported_isin_dtype(elements.scalar_type());
   check_for_unsupported_isin_dtype(test_elements.type());
@@ -50,7 +50,7 @@ TORCH_META_FUNC2(isin, Tensor_Scalar) (
 }
 
 TORCH_META_FUNC2(isin, Scalar_Tensor) (
-  const c10::Scalar& elements, const Tensor& test_elements, bool assume_unique, bool invert
+  const c10::Scalar& elements, const Tensor& test_elements, bool /*assume_unique*/, bool /*invert*/
 ) {
   check_for_unsupported_isin_dtype(elements.type());
   check_for_unsupported_isin_dtype(test_elements.scalar_type());
@@ -485,10 +485,10 @@ std::tuple<Tensor, Tensor> _aminmax(const Tensor& self, int64_t dim, bool keepdi
 
 TORCH_IMPL_FUNC(clamp_out)
 (
- const Tensor& self,
+ const Tensor& /*self*/,
  const OptionalScalarRef min,
  const OptionalScalarRef max,
- const Tensor& result) {
+ const Tensor& /*result*/) {
   using at::native::detail::ClampLimits;
   if (min && max) {
     clamp_scalar_stub(device_type(), *this, min.get(), max.get());
@@ -646,13 +646,13 @@ std::tuple<Tensor, Tensor> max(const Tensor& self, Dimname dim, bool keepdim) {
 std::tuple<Tensor&, Tensor&> max_out(const Tensor& self, Dimname dim, bool keepdim, Tensor& max, Tensor& max_indices) {
   return at::max_out(max, max_indices, self, dimname_to_position(self, dim), keepdim);
 }
-Tensor argmax(const Tensor& self, Dimname dim, bool keepdim) {
+Tensor argmax(const Tensor& /*self*/, Dimname /*dim*/, bool /*keepdim*/) {
   reportNYIDimnameOverload("argmax");
 }
-Tensor argmin(const Tensor& self, Dimname dim, bool keepdim) {
+Tensor argmin(const Tensor& /*self*/, Dimname /*dim*/, bool /*keepdim*/) {
   reportNYIDimnameOverload("argmin");
 }
-Tensor argsort(const Tensor& self, Dimname dim, bool keepdim) {
+Tensor argsort(const Tensor& /*self*/, Dimname /*dim*/, bool /*keepdim*/) {
   reportNYIDimnameOverload("argsort");
 }
 std::tuple<Tensor, Tensor> mode(const Tensor& self, Dimname dim, bool keepdim) {

--- a/aten/src/ATen/native/TensorFactories.h
+++ b/aten/src/ATen/native/TensorFactories.h
@@ -95,7 +95,7 @@ struct ZeroTensorAllocator final : public at::Allocator {
   static void deleter(void* const pointer) {
     TORCH_INTERNAL_ASSERT(!pointer);
   }
-  DataPtr allocate(const size_t nbytes) const override {
+  DataPtr allocate(const size_t /*nbytes*/) const override {
     return {nullptr, nullptr, &deleter, device_};
   }
   DeleterFnPtr raw_deleter() const override {

--- a/aten/src/ATen/native/UnfoldBackward.h
+++ b/aten/src/ATen/native/UnfoldBackward.h
@@ -106,8 +106,8 @@ static C10_UNUSED TensorIterator _make_unfold_backward_iter_over_grad_in(
   Tensor& grad_out,
   const Tensor& grad_in,
   int64_t dim,
-  int64_t size,
-  int64_t step
+  int64_t /*size*/,
+  int64_t /*step*/
 ) {
   dim = maybe_wrap_dim(dim, grad_out.dim());
   // last dim stores the folds

--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -72,7 +72,7 @@ void copy_same_dtype(TensorIteratorBase &iter, bool requires_conj, bool requires
   }
 }
 
-void copy_kernel(TensorIterator& iter, bool non_blocking) {
+void copy_kernel(TensorIterator& iter, bool /*non_blocking*/) {
   ScalarType dtype = iter.dtype(0);
   const bool requires_conj = (
       isComplexType(dtype) && (iter.tensor_base(0).is_conj() != iter.tensor_base(1).is_conj()));

--- a/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/DistanceOpsKernel.cpp
@@ -91,7 +91,7 @@ struct Dist {
   struct zdist_calc {
     static inline data_t map(const data_t& diff, const data_t& p) { return min(ceil(abs(diff)), 1); }
     static inline data_t red(const data_t& agg, const data_t& up) { return agg + up; }
-    static inline scalar_t finish(const scalar_t agg, const scalar_t p) { return agg; }
+    static inline scalar_t finish(const scalar_t agg, const scalar_t /*p*/) { return agg; }
   };
 
   // One norm
@@ -99,8 +99,8 @@ struct Dist {
   struct odist_calc {
     static inline data_t map(const data_t& diff, const data_t& p) { return diff; }
     static inline data_t red(const data_t& agg, const data_t& up) { return agg + up; }
-    static inline scalar_t finish(const scalar_t agg, const scalar_t p) { return agg; }
-    static inline Vec backward(const Vec& diff, const scalar_t grad, const scalar_t dist, const Vec& p) { return Vec(grad) * sign(diff); }
+    static inline scalar_t finish(const scalar_t agg, const scalar_t /*p*/) { return agg; }
+    static inline Vec backward(const Vec& diff, const scalar_t grad, const scalar_t /*dist*/, const Vec& /*p*/) { return Vec(grad) * sign(diff); }
   };
 
   // Special general pnorm derivative if p is less than two

--- a/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
+++ b/aten/src/ATen/native/cpu/GridSamplerKernel.cpp
@@ -770,7 +770,7 @@ struct ApplyGridSample<scalar_t, 2, GridSamplerInterpolation::Nearest,
   inline void backward(TensorAccessor<scalar_t, 3>* gInp_slice_ptr,
                        TensorAccessor<scalar_t, 3>& gGrid_slice,
                        const TensorAccessor<scalar_t, 3>& gOut_slice,
-                       const TensorAccessor<scalar_t, 3>& inp_slice,
+                       const TensorAccessor<scalar_t, 3>& /*inp_slice*/,
                        int64_t offset, const Vec& grid_x, const Vec& grid_y,
                        int64_t len) const {
     if (input_requires_grad) {

--- a/aten/src/ATen/native/cpu/IsContiguous.h
+++ b/aten/src/ATen/native/cpu/IsContiguous.h
@@ -25,7 +25,7 @@ struct IsContiguous<0, 0, traits, s> {
 // will be called when there is no output
 template <typename traits, int s>
 struct IsContiguous<0, -1, traits, s> {
-  static bool eval(const int64_t* strides) {
+  static bool eval(const int64_t* /*strides*/) {
     return true;
   }
 };

--- a/aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp
+++ b/aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp
@@ -20,7 +20,7 @@ void addr_kernel(TensorIterator &iter,
     // nans and infs in self should not propagate.
     if (beta_val == false) {
       cpu_kernel(iter,
-        [=](scalar_t self_val,
+        [=](scalar_t /*self_val*/,
             scalar_t vec1_val,
             scalar_t vec2_val) __ubsan_ignore_undefined__ -> scalar_t {
           return alpha_val && vec1_val && vec2_val;
@@ -53,12 +53,12 @@ void addr_kernel(TensorIterator &iter,
       // nans and infs in self should not propagate.
       if (beta_val == zero_val) {
         cpu_kernel_vec(iter,
-          [=](scalar_t self_val,
+          [=](scalar_t /*self_val*/,
               scalar_t vec1_val,
               scalar_t vec2_val) __ubsan_ignore_undefined__ -> scalar_t {
             return alpha_val * vec1_val * vec2_val;
           },
-          [=](Vec self_vec,
+          [=](Vec /*self_vec*/,
               Vec vec1_vec,
               Vec vec2_vec) __ubsan_ignore_undefined__ {
             return alpha_vec * vec1_vec * vec2_vec;

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -231,7 +231,7 @@ vectorized_loop(char** C10_RESTRICT data_, int64_t n, int64_t S, func_t&& op, ve
 
 template <typename traits, typename cb_t>
 static inline void unroll_contiguous_scalar_checks(
-    const int64_t* strides,
+    const int64_t* /*strides*/,
     std::index_sequence<>,
     cb_t&& cb) {
   cb(0);

--- a/aten/src/ATen/native/cpu/Reduce.h
+++ b/aten/src/ATen/native/cpu/Reduce.h
@@ -133,7 +133,7 @@ static void set_results(const res_t result, const TensorIteratorBase &iter, cons
 
 template<typename traits, std::size_t i = 0, typename... tuple_t>
 static inline typename std::enable_if<i == sizeof...(tuple_t), std::size_t>::type
-for_each_in_tuple(const std::tuple<tuple_t...>& t, const TensorIteratorBase &iter, const int num_outputs) {
+for_each_in_tuple(const std::tuple<tuple_t...>& /*t*/, const TensorIteratorBase& /*iter*/, const int /*num_outputs*/) {
   return i;
 }
 

--- a/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
@@ -30,7 +30,7 @@ inline void reduce_all_impl_vec(
   auto input_data = input.data_ptr<scalar_t>();
   // NOTE: parallel_reduce not support bool type
   scalar_t result = at::parallel_reduce(0, input_numel, internal::GRAIN_SIZE, ident_v,
-    [&](int64_t start, int64_t end, const scalar_t ident) -> scalar_t {
+    [&](int64_t start, int64_t end, const scalar_t /*ident*/) -> scalar_t {
       scalar_t partial_out = vec::reduce_all<scalar_t>(
         [=](Vec x, Vec y) { return vop(x, y); },
         input_data + start,

--- a/aten/src/ATen/native/cpu/UpSampleKernel.cpp
+++ b/aten/src/ATen/native/cpu/UpSampleKernel.cpp
@@ -147,7 +147,6 @@ template <typename scalar_t, typename index_t>
 static inline scalar_t interpolate_aa_single_dim_zero_strides(
     char* src,
     char** data,
-    int64_t i,
     const index_t ids_stride) {
   const index_t ids_min = *(index_t*)&data[0][0];
   const index_t ids_size = *(index_t*)&data[1][0];
@@ -259,7 +258,7 @@ struct CheckAlmostAllZeroStrides {
 
 template <int non_zero_stride_dim, typename scalar_t, typename index_t, int interp_size>
 struct CheckAlmostAllZeroStrides<0, non_zero_stride_dim, scalar_t, index_t, interp_size> {
-  static inline bool eval(const int64_t* strides) {
+  static inline bool eval(const int64_t* /*strides*/) {
     return true;
   }
 };
@@ -293,7 +292,7 @@ static inline void basic_loop_aa_single_dim_zero_strides(
   for (const auto i : c10::irange(n)) {
     *(scalar_t*)&dst[i * strides[0]] =
         interpolate_aa_single_dim_zero_strides<scalar_t, index_t>(
-            src + i * strides[1], &data[2], i, ids_stride);
+            src + i * strides[1], &data[2], ids_stride);
   }
 }
 
@@ -675,7 +674,7 @@ struct HelperInterpBase {
   template <typename scalar_t, typename aa_filter_fn_t>
   static inline std::vector<Tensor> _compute_indices_weights_aa(
     int64_t input_size, int64_t output_size, int64_t stride, int64_t ndims,
-    int64_t reshape_dim, bool align_corners, scalar_t scale,
+    int64_t reshape_dim, scalar_t scale,
     int interp_size, aa_filter_fn_t aa_filter_fn
   ) {
 
@@ -956,7 +955,6 @@ struct HelperInterpLinear : public HelperInterpBase {
             stride,
             ndims,
             reshape_dim,
-            align_corners,
             scale,
             interp_size,
             &HelperInterpLinear::aa_filter<scalar_t>);
@@ -1068,7 +1066,6 @@ struct HelperInterpCubic : public HelperInterpBase {
             stride,
             ndims,
             reshape_dim,
-            align_corners,
             scale,
             interp_size,
             &HelperInterpCubic::aa_filter<scalar_t>);

--- a/aten/src/ATen/native/cpu/zmath.h
+++ b/aten/src/ATen/native/cpu/zmath.h
@@ -94,7 +94,7 @@ constexpr double real_impl <c10::complex<double>, double> (c10::complex<double> 
 }
 
 template <typename SCALAR_TYPE, typename VALUE_TYPE=SCALAR_TYPE>
-constexpr VALUE_TYPE imag_impl (SCALAR_TYPE z) {
+constexpr VALUE_TYPE imag_impl (SCALAR_TYPE /*z*/) {
   return 0;
 }
 

--- a/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CusolverDnHandlePool.cpp
@@ -11,6 +11,7 @@ void createCusolverDnHandle(cusolverDnHandle_t *handle) {
 }
 
 void destroyCusolverDnHandle(cusolverDnHandle_t handle) {
+  (void)handle; // Suppress unused variable warning
 // this is because of something dumb in the ordering of
 // destruction. Sometimes atexit, the cuda context (or something)
 // would already be destroyed by the time this gets destroyed. It

--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.h
@@ -100,15 +100,15 @@ struct TORCH_API PackedLinearWeightFp16 : public LinearPackedParamsBase {
   c10::optional<at::Tensor> bias_;
 
   at::Tensor apply(
-      at::Tensor input,
-      double output_scale,
-      int64_t output_zero_point) override {
+      at::Tensor /*input*/,
+      double /*output_scale*/,
+      int64_t /*output_zero_point*/) override {
     TORCH_INTERNAL_ASSERT(false);
   }
   at::Tensor apply_relu(
-      at::Tensor input,
-      double output_scale,
-      int64_t output_zero_point) override {
+      at::Tensor /*input*/,
+      double /*output_scale*/,
+      int64_t /*output_zero_point*/) override {
     TORCH_INTERNAL_ASSERT(false);
   }
 

--- a/aten/src/ATen/native/quantized/cpu/packed_params.h
+++ b/aten/src/ATen/native/quantized/cpu/packed_params.h
@@ -14,9 +14,9 @@ struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
 
   // out variant of LinearPackedParamsBase::apply
   virtual at::Tensor& apply_out(
-      const at::Tensor& input,
-      double output_scale,
-      int64_t output_zero_point,
+      const at::Tensor& /*input*/,
+      double /*output_scale*/,
+      int64_t /*output_zero_point*/,
       at::Tensor& output) {
     throw std::runtime_error(
         "apply_out is not implemented for this packed "
@@ -25,9 +25,9 @@ struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
   }
 
   virtual at::Tensor& apply_relu_out(
-      const at::Tensor& input,
-      double output_scale,
-      int64_t output_zero_point,
+      const at::Tensor& /*input*/,
+      double /*output_scale*/,
+      int64_t /*output_zero_point*/,
       at::Tensor& output) {
     throw std::runtime_error(
         "apply_relu_out is not implemented for this packed "
@@ -65,7 +65,7 @@ struct LinearPackedParamsBase : public torch::jit::CustomClassHolder {
 
   virtual c10::optional<at::Tensor> bias() = 0;
 
-  virtual void set_bias(c10::optional<at::Tensor> bias) {
+  virtual void set_bias(c10::optional<at::Tensor> /*bias*/) {
     throw std::runtime_error(
         "set_bias is not implemented for this packed "
         "parameter type");

--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
@@ -160,7 +160,7 @@ std::array<int64_t, kSpatialDim> MakeInputShape(
     int64_t W);
 
 template <>
-std::array<int64_t, 2> MakeInputShape(int64_t _, int64_t H, int64_t W) {
+std::array<int64_t, 2> MakeInputShape(int64_t /*D*/, int64_t H, int64_t W) {
   return {H, W};
 }
 template <>
@@ -929,10 +929,10 @@ class QConvInt8ForBC final {
   static Tensor run(
       Tensor act,
       const c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>>& packed_weight,
-      torch::List<int64_t> stride,
-      torch::List<int64_t> padding,
-      torch::List<int64_t> dilation,
-      int64_t groups,
+      torch::List<int64_t> /*stride*/,
+      torch::List<int64_t> /*padding*/,
+      torch::List<int64_t> /*dilation*/,
+      int64_t /*groups*/,
       double output_scale,
       int64_t output_zero_point) {
     if (kReluFused) {

--- a/aten/src/ATen/nnapi/nnapi_model_loader.cpp
+++ b/aten/src/ATen/nnapi/nnapi_model_loader.cpp
@@ -97,9 +97,9 @@ int load_nnapi_model(
     size_t num_buffers,
     const void** buffer_ptrs,
     int32_t* buffer_sizes,
-    size_t num_memories,
-    ANeuralNetworksMemory** memories,
-    int32_t* memory_sizes,
+    size_t /*num_memories*/,
+    ANeuralNetworksMemory** /*memories*/,
+    int32_t* /*memory_sizes*/,
     int32_t* out_input_count,
     int32_t* out_output_count,
     size_t* out_bytes_consumed) {

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -674,7 +674,7 @@ struct MaybeOwnedTraits<at::Tensor> {
     return &borrow;
   }
 
-  static bool debugBorrowIsValid(const borrow_type& borrow) {
+  static bool debugBorrowIsValid(const borrow_type& /*borrow*/) {
     return true;
   }
 };

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -14,7 +14,7 @@ struct C10_API Storage {
 
   // Allocates memory buffer using given allocator and creates a storage with it
   Storage(
-      use_byte_size_t use_byte_size,
+      use_byte_size_t /*use_byte_size*/,
       size_t size_bytes,
       Allocator* allocator = nullptr,
       bool resizable = false)
@@ -28,7 +28,7 @@ struct C10_API Storage {
   // potential future reallocations, however it can be nullptr if the storage
   // is non-resizable
   Storage(
-      use_byte_size_t use_byte_size,
+      use_byte_size_t /*use_byte_size*/,
       size_t size_bytes,
       at::DataPtr data_ptr,
       at::Allocator* allocator = nullptr,

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -35,7 +35,7 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   struct use_byte_size_t {};
 
   StorageImpl(
-      use_byte_size_t use_byte_size,
+      use_byte_size_t /*use_byte_size*/,
       size_t size_bytes,
       at::DataPtr data_ptr,
       at::Allocator* allocator,
@@ -52,7 +52,7 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   }
 
   StorageImpl(
-      use_byte_size_t use_byte_size,
+      use_byte_size_t /*use_byte_size*/,
       size_t size_bytes,
       at::Allocator* allocator,
       bool resizable)

--- a/c10/core/impl/DeviceGuardImplInterface.h
+++ b/c10/core/impl/DeviceGuardImplInterface.h
@@ -117,6 +117,7 @@ struct C10_API DeviceGuardImplInterface {
    */
   virtual Stream getStreamFromGlobalPool(Device, bool isHighPriority = false)
       const {
+    (void)isHighPriority; // Suppress unused varaible warning
     TORCH_CHECK(false, "Backend doesn't support acquiring a stream from pool.")
   }
 
@@ -130,7 +131,7 @@ struct C10_API DeviceGuardImplInterface {
   /**
    * Destroys the given event.
    */
-  virtual void destroyEvent(void* event, const DeviceIndex device_index)
+  virtual void destroyEvent(void* /*event*/, const DeviceIndex /*device_index*/)
       const noexcept {}
 
   /**
@@ -140,10 +141,10 @@ struct C10_API DeviceGuardImplInterface {
    * event to continue and marks that version as recorded.
    * */
   virtual void record(
-      void** event,
-      const Stream& stream,
-      const DeviceIndex device_index,
-      const c10::EventFlag flag) const {
+      void** /*event*/,
+      const Stream& /*stream*/,
+      const DeviceIndex /*device_index*/,
+      const c10::EventFlag /*flag*/) const {
     TORCH_CHECK(false, "Backend doesn't support events.");
   }
 
@@ -155,7 +156,7 @@ struct C10_API DeviceGuardImplInterface {
    * When the stream reaches this command it will stop processing
    * additional commands until that version of the event is marked as recorded.
    */
-  virtual void block(void* event, const Stream& stream) const {
+  virtual void block(void* /*event*/, const Stream& /*stream*/) const {
     TORCH_CHECK(false, "Backend doesn't support events.");
   }
 
@@ -165,7 +166,7 @@ struct C10_API DeviceGuardImplInterface {
    *  (2) the current version is marked as recorded.
    * Returns false otherwise.
    */
-  virtual bool queryEvent(void* event) const {
+  virtual bool queryEvent(void* /*event*/) const {
     TORCH_CHECK(false, "Backend doesn't support events.");
   }
 
@@ -180,7 +181,7 @@ struct C10_API DeviceGuardImplInterface {
    * Return true if all the work previously enqueued on the stream for
    * asynchronous execution has completed running on the device.
    */
-  virtual bool queryStream(const Stream& stream) const {
+  virtual bool queryStream(const Stream& /*stream*/) const {
     TORCH_CHECK(false, "Backend doesn't support querying streams.");
   }
 
@@ -188,7 +189,7 @@ struct C10_API DeviceGuardImplInterface {
    * Wait (by blocking the calling thread) until all the work previously
    * enqueued on the stream has completed running on the device.
    */
-  virtual void synchronizeStream(const Stream& stream) const {
+  virtual void synchronizeStream(const Stream& /*stream*/) const {
     TORCH_CHECK(false, "Backend doesn't support synchronizing streams.");
   }
 
@@ -225,15 +226,15 @@ struct NoOpDeviceGuardImpl final : public DeviceGuardImplInterface {
   void setDevice(Device) const override {
     // no-op
   }
-  void uncheckedSetDevice(Device d) const noexcept override {
+  void uncheckedSetDevice(Device) const noexcept override {
     // no-op
   }
-  Stream getStream(Device d) const noexcept override {
+  Stream getStream(Device) const noexcept override {
     // no-op
     return Stream(Stream::DEFAULT, Device(D, -1));
   }
   // NB: These do NOT set the current device
-  Stream exchangeStream(Stream s) const noexcept override {
+  Stream exchangeStream(Stream) const noexcept override {
     // no-op
     return Stream(Stream::DEFAULT, Device(D, -1));
   }
@@ -243,26 +244,26 @@ struct NoOpDeviceGuardImpl final : public DeviceGuardImplInterface {
 
   // Event-related functions
   void record(
-      void** event,
-      const Stream& stream,
-      const DeviceIndex device_index,
-      const EventFlag flag) const override {
+      void** /*event*/,
+      const Stream& /*stream*/,
+      const DeviceIndex /*device_index*/,
+      const EventFlag /*flag*/) const override {
     TORCH_CHECK(false, D, " backend doesn't support events.");
   }
-  void block(void* event, const Stream& stream) const override {
+  void block(void* /*event*/, const Stream& /*stream*/) const override {
     TORCH_CHECK(false, D, " backend doesn't support events.")
   }
-  bool queryEvent(void* event) const override {
+  bool queryEvent(void* /*event*/) const override {
     TORCH_CHECK(false, D, " backend doesn't support events.")
   }
-  void destroyEvent(void* event, const DeviceIndex device_index)
+  void destroyEvent(void* /*event*/, const DeviceIndex /*device_index*/)
       const noexcept override {}
 
   // Stream-related functions
-  bool queryStream(const Stream& stream) const override {
+  bool queryStream(const Stream& /*stream*/) const override {
     return true;
   }
-  void synchronizeStream(const Stream& stream) const override {
+  void synchronizeStream(const Stream& /*stream*/) const override {
     // Don't wait for anything.
   }
 };

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -375,7 +375,7 @@ C10_API std::string GetExceptionString(const std::exception& e);
 namespace c10 {
 namespace detail {
 template <typename... Args>
-decltype(auto) torchCheckMsgImpl(const char* msg, const Args&... args) {
+decltype(auto) torchCheckMsgImpl(const char* /*msg*/, const Args&... args) {
   return ::c10::str(args...);
 }
 inline C10_API const char* torchCheckMsgImpl(const char* msg) {
@@ -383,7 +383,7 @@ inline C10_API const char* torchCheckMsgImpl(const char* msg) {
 }
 // If there is just 1 user-provided C-string argument, use it.
 inline C10_API const char* torchCheckMsgImpl(
-    const char* msg,
+    const char* /*msg*/,
     const char* args) {
   return args;
 }
@@ -433,7 +433,7 @@ namespace detail {
     const char* file,
     uint32_t line,
     const char* condMsg,
-    ::c10::detail::CompileTimeEmptyString userMsg) {
+    ::c10::detail::CompileTimeEmptyString /*userMsg*/) {
   torchCheckFail(func, file, line, condMsg);
 }
 [[noreturn]] C10_API void torchInternalAssertFail(

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -442,7 +442,7 @@ struct alignas(4) complex<Half> {
 // for `f > limit::max()` below
 template <typename To, typename From>
 typename std::enable_if<std::is_same<From, bool>::value, bool>::type overflows(
-    From f) {
+    From /*f*/) {
   return false;
 }
 

--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -80,7 +80,7 @@ C10_API void UpdateLoggingLevelsFromFlags();
     const char* file,
     const int line,
     const char* condition,
-    detail::CompileTimeEmptyString msg,
+    detail::CompileTimeEmptyString /*msg*/,
     const void* caller = nullptr) {
   ThrowEnforceNotMet(file, line, condition, "", caller);
 }
@@ -103,7 +103,7 @@ C10_API void UpdateLoggingLevelsFromFlags();
     const char* file,
     const int line,
     const char* condition,
-    detail::CompileTimeEmptyString msg,
+    detail::CompileTimeEmptyString /*msg*/,
     const void* caller = nullptr) {
   ThrowEnforceFiniteNotMet(file, line, condition, "", caller);
 }

--- a/c10/util/MaybeOwned.h
+++ b/c10/util/MaybeOwned.h
@@ -24,7 +24,7 @@ struct MaybeOwnedTraitsGenericImpl {
     lhs = rhs;
   }
 
-  static void destroyBorrow(borrow_type& toDestroy) {}
+  static void destroyBorrow(borrow_type& /*toDestroy*/) {}
 
   static const owned_type& referenceFromBorrow(const borrow_type& borrow) {
     return *borrow;

--- a/c10/util/Metaprogramming.h
+++ b/c10/util/Metaprogramming.h
@@ -398,7 +398,7 @@ template <
         index<std::tuple_size<HeadTuple>::value, int> = 0> decltype(auto)
         extract_tuple_element_by_index(
             HeadTuple&& head_tuple,
-            TailTuples&&... tail_tuples) {
+            TailTuples&&... /*tail_tuples*/) {
   // TODO if constexpr instead of enable_if
   return std::get<index>(std::forward<HeadTuple>(head_tuple));
 }
@@ -409,7 +409,7 @@ template <
     class... TailTuples,
     std::enable_if_t<index >= std::tuple_size<HeadTuple>::value, int> = 0>
 decltype(auto) extract_tuple_element_by_index(
-    HeadTuple&& head_tuple,
+    HeadTuple&& /*head_tuple*/,
     TailTuples&&... tail_tuples) {
   // TODO if constexpr instead of enable_if
   return extract_tuple_element_by_index<

--- a/c10/util/SmallVector.h
+++ b/c10/util/SmallVector.h
@@ -193,6 +193,8 @@ class SmallVectorTemplateCommon
 
   /// Check whether Elt will be invalidated by resizing the vector to NewSize.
   void assertSafeToReferenceAfterResize(const void* Elt, size_t NewSize) {
+    (void)Elt; // Suppress unused variable warning
+    (void)NewSize; // Suppress unused variable warning
     assert(
         isSafeToReferenceAfterResize(Elt, NewSize) &&
         "Attempting to reference an element of the vector in an operation "

--- a/c10/util/TypeSafeSignMath.h
+++ b/c10/util/TypeSafeSignMath.h
@@ -17,8 +17,8 @@ namespace c10 {
 /// Returns false since we cannot have x < 0 if x is unsigned.
 template <typename T>
 static inline constexpr bool is_negative(
-    const T& x,
-    std::true_type is_unsigned) {
+    const T& /*x*/,
+    std::true_type /*is_unsigned*/) {
   return false;
 }
 
@@ -26,7 +26,7 @@ static inline constexpr bool is_negative(
 template <typename T>
 static inline constexpr bool is_negative(
     const T& x,
-    std::false_type is_unsigned) {
+    std::false_type /*is_unsigned*/) {
   return x < T(0);
 }
 
@@ -42,13 +42,15 @@ inline constexpr bool is_negative(const T& x) {
 
 /// Returns the sign of an unsigned variable x as 0, 1
 template <typename T>
-static inline constexpr int signum(const T& x, std::true_type is_unsigned) {
+static inline constexpr int signum(const T& x, std::true_type /*is_unsigned*/) {
   return T(0) < x;
 }
 
 /// Returns the sign of a signed variable x as -1, 0, 1
 template <typename T>
-static inline constexpr int signum(const T& x, std::false_type is_unsigned) {
+static inline constexpr int signum(
+    const T& x,
+    std::false_type /*is_unsigned*/) {
   return (T(0) < x) - (x < T(0));
 }
 
@@ -80,8 +82,8 @@ inline constexpr bool greater_than_max(const T& x) {
 template <typename Limit, typename T>
 static inline constexpr bool less_than_lowest(
     const T& x,
-    std::false_type limit_is_unsigned,
-    std::false_type x_is_unsigned) {
+    std::false_type /*limit_is_unsigned*/,
+    std::false_type /*x_is_unsigned*/) {
   return x < std::numeric_limits<Limit>::lowest();
 }
 
@@ -89,9 +91,9 @@ static inline constexpr bool less_than_lowest(
 /// negative values but x cannot be negative because it is unsigned
 template <typename Limit, typename T>
 static inline constexpr bool less_than_lowest(
-    const T& x,
-    std::false_type limit_is_unsigned,
-    std::true_type x_is_unsigned) {
+    const T& /*x*/,
+    std::false_type /*limit_is_unsigned*/,
+    std::true_type /*x_is_unsigned*/) {
   return false;
 }
 
@@ -100,17 +102,17 @@ static inline constexpr bool less_than_lowest(
 template <typename Limit, typename T>
 static inline constexpr bool less_than_lowest(
     const T& x,
-    std::true_type limit_is_unsigned,
-    std::false_type x_is_unsigned) {
+    std::true_type /*limit_is_unsigned*/,
+    std::false_type /*x_is_unsigned*/) {
   return x < T(0);
 }
 
 /// Returns false sign both types are unsigned
 template <typename Limit, typename T>
 static inline constexpr bool less_than_lowest(
-    const T& x,
-    std::true_type limit_is_unsigned,
-    std::true_type x_is_unsigned) {
+    const T& /*x*/,
+    std::true_type /*limit_is_unsigned*/,
+    std::true_type /*x_is_unsigned*/) {
   return false;
 }
 

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -146,14 +146,18 @@ class C10_API intrusive_ptr_target {
   // intrusive_ptr_target supports copy and move: but refcount and weakcount
   // don't participate (since they are intrinsic properties of the memory
   // location)
-  intrusive_ptr_target(intrusive_ptr_target&& other) noexcept
+  intrusive_ptr_target(intrusive_ptr_target&& /*other*/) noexcept
       : intrusive_ptr_target() {}
-  intrusive_ptr_target& operator=(intrusive_ptr_target&& other) noexcept {
+
+  intrusive_ptr_target& operator=(intrusive_ptr_target&& /*other*/) noexcept {
     return *this;
   }
-  intrusive_ptr_target(const intrusive_ptr_target& other) noexcept
+
+  intrusive_ptr_target(const intrusive_ptr_target& /*other*/) noexcept
       : intrusive_ptr_target() {}
-  intrusive_ptr_target& operator=(const intrusive_ptr_target& other) noexcept {
+
+  intrusive_ptr_target& operator=(
+      const intrusive_ptr_target& /*other*/) noexcept {
     return *this;
   }
 
@@ -624,7 +628,7 @@ struct MaybeOwnedTraits<c10::intrusive_ptr<T>> {
     return &borrow;
   }
 
-  static bool debugBorrowIsValid(const borrow_type& borrow) {
+  static bool debugBorrowIsValid(const borrow_type& /*borrow*/) {
     return true;
   }
 };

--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -371,7 +371,7 @@ constexpr inline typename std::enable_if<(N < 64), bool>::type isUInt(
 }
 template <unsigned N>
 constexpr inline typename std::enable_if<N >= 64, bool>::type isUInt(
-    uint64_t X) {
+    uint64_t /*X*/) {
   return true;
 }
 

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -147,7 +147,7 @@ struct SchemaParser {
     return result;
   }
 
-  Argument parseArgument(size_t idx, bool is_return, bool kwarg_only) {
+  Argument parseArgument(size_t /*idx*/, bool is_return, bool kwarg_only) {
     auto p = type_parser.parseType();
     auto type = std::move(p.first);
     auto alias_info = std::move(p.second);
@@ -282,7 +282,7 @@ struct SchemaParser {
     return convertToList(type, kind, tok.range, vs);
   }
 
-  IValue parseTensorDefault(const SourceRange& range) {
+  IValue parseTensorDefault(const SourceRange& /*range*/) {
     L.expect(TK_NONE);
     return IValue();
   }

--- a/torch/library.h
+++ b/torch/library.h
@@ -686,7 +686,7 @@ class TORCH_API Library final {
   }
 
   template <typename Name, typename Func>
-  Library& impl_UNBOXED(Name name, Func* raw_f) & {
+  Library& impl_UNBOXED(Name /*name*/, Func* /*raw_f*/) & {
     static_assert(
         c10::guts::false_t<Func>(),
         ".impl_UNBOXED(...) was removed. Please use .impl(...) instead.");
@@ -703,7 +703,7 @@ class TORCH_API Library final {
     return def(raw_schema.operator const char*());
   }
   template <typename Func>
-  Library& def(detail::SelectiveStr<false>, Func&& raw_f) & {
+  Library& def(detail::SelectiveStr<false>, Func&& /*raw_f*/) & {
     return *this;
   }
   template <typename Func>
@@ -713,15 +713,15 @@ class TORCH_API Library final {
   }
 
   template <typename Func>
-  Library& impl(detail::SelectiveStr<false>, Func&& raw_f) & {
+  Library& impl(detail::SelectiveStr<false>, Func&& /*raw_f*/) & {
     return *this;
   }
   template <typename Dispatch, typename Func>
-  Library& impl(detail::SelectiveStr<false>, Dispatch&& key, Func&& raw_f) & {
+  Library& impl(detail::SelectiveStr<false>, Dispatch&& /*key*/, Func&& /*raw_f*/) & {
     return *this;
   }
   template <typename Func>
-  Library& impl_UNBOXED(detail::SelectiveStr<false> name, Func* raw_f) & {
+  Library& impl_UNBOXED(detail::SelectiveStr<false> /*name*/, Func* /*raw_f*/) & {
     static_assert(
         c10::guts::false_t<Func>(),
         ".impl_UNBOXED(...) was removed. Please use .impl(...) instead.");
@@ -743,7 +743,7 @@ class TORCH_API Library final {
         std::forward<Func>(raw_f));
   }
   template <typename Func>
-  Library& impl_UNBOXED(detail::SelectiveStr<true> name, Func* raw_f) & {
+  Library& impl_UNBOXED(detail::SelectiveStr<true> /*name*/, Func* /*raw_f*/) & {
     static_assert(
         c10::guts::false_t<Func>(),
         ".impl_UNBOXED(...) was removed. Please use .impl(...) instead.");


### PR DESCRIPTION
Summary: Unused parameters cause compiler warnings which distract from real issues. Let's remove unused parameters!

Test Plan: Sandcastle

Reviewed By: ngimel

Differential Revision: D34567731

