### PR TITLE
[Core ML] Attemp to fix the OOM issue

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
@@ -136,7 +136,7 @@ struct API_AVAILABLE(ios(11.0), macos(10.13)) CoreMLExecutorWrapper
         inputs_(inputs),
         outputs_(outputs),
         config_(config) {}
-  c10::List<torch::Tensor> execute(c10::impl::GenericList inputs) {
+  c10::List<torch::Tensor> execute(const c10::impl::GenericList& inputs) {
     std::vector<PTMCoreMLFeatureSpecs> inputSpecs;
     std::vector<PTMCoreMLFeatureSpecs> outputSpecs;
     int inputSpecIndex = 0;
@@ -144,7 +144,7 @@ struct API_AVAILABLE(ios(11.0), macos(10.13)) CoreMLExecutorWrapper
     for (int i = 0; i < inputs.size(); ++i) {
       auto val = inputs.get(i);
       if (val.isTuple()) {
-        auto tuples = val.toTupleRef().elements();
+        auto& tuples = val.toTupleRef().elements();
         for (auto& ival : tuples) {
           TORCH_CHECK(ival.isTensor());
           auto tensor = ival.toTensor();

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.mm
@@ -168,30 +168,32 @@ static NSString* gModelCacheDirectory = @"";
 
 - (id<MLFeatureProvider>)forwardWithInputs:
     (const std::vector<PTMCoreMLFeatureSpecs>&)inputs {
-  NSError* error = nil;
-  PTMCoreMLFeatureProvider* inputFeature = [[PTMCoreMLFeatureProvider alloc]
-      initWithFeatureSpecs:inputs
-             CoreMLVersion:self.coreMLVersion];
-  if (inputFeature == nil) {
-    return nil;
-  }
-  if (@available(iOS 11.0, macOS 10.13, *)) {
-    MLPredictionOptions* options = [[MLPredictionOptions alloc] init];
-    id<MLFeatureProvider> outputFeature =
-        [_mlModel predictionFromFeatures:inputFeature
-                                 options:options
-                                   error:&error];
-    if (error) {
-      TORCH_CHECK(
-          false,
-          "Error running the prediction",
-          error.localizedDescription.UTF8String);
+  @autoreleasepool {
+    NSError* error = nil;
+    PTMCoreMLFeatureProvider* inputFeature = [[PTMCoreMLFeatureProvider alloc]
+        initWithFeatureSpecs:inputs
+               CoreMLVersion:self.coreMLVersion];
+    if (inputFeature == nil) {
+      return nil;
     }
+    if (@available(iOS 11.0, macOS 10.13, *)) {
+      MLPredictionOptions* options = [[MLPredictionOptions alloc] init];
+      id<MLFeatureProvider> outputFeature =
+          [_mlModel predictionFromFeatures:inputFeature
+                                   options:options
+                                     error:&error];
+      if (error) {
+        TORCH_CHECK(
+            false,
+            "Error running the prediction",
+            error.localizedDescription.UTF8String);
+      }
 
-    return outputFeature;
-  } else {
-    TORCH_CHECK(false, "Core ML is not available on your device");
-    return nil;
+      return outputFeature;
+    } else {
+      TORCH_CHECK(false, "Core ML is not available on your device");
+      return nil;
+    }
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #73750

My intuition is that the delay release of input and intermediate tensors may cause memory being accumulated. Especially for camera-based memory intensive situations, the runloop is full of all sorts of events. Thus, default `autoreleasepool` may not be efficient. The fix here is to manually wrap the prediction call inside a `autoreleasepool` to force releasing intermediate objects. Apple's doc - https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmAutoreleasePools.html

Differential Revision: [D34605399](https://our.internmc.facebook.com/intern/diff/D34605399/)