### PR TITLE
Add LongPathsEnabled setting for windows workflow

### DIFF
--- a/.circleci/scripts/vs_install.ps1
+++ b/.circleci/scripts/vs_install.ps1
@@ -1,6 +1,9 @@
 # https://developercommunity.visualstudio.com/t/install-specific-version-of-vs-component/1142479
 # Where to find the links: https://docs.microsoft.com/en-us/visualstudio/releases/2019/history#release-dates-and-build-numbers
 
+#Make sure we can handle Long Paths
+Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+
 # BuildTools from S3
 $VS_DOWNLOAD_LINK = "https://s3.amazonaws.com/ossci-windows/vs${env:VS_VERSION}_BuildTools.exe"
 $COLLECT_DOWNLOAD_LINK = "https://aka.ms/vscollect.exe"


### PR DESCRIPTION
Fixes: 73339 
This is based on the following PR: 73342

The windows fails instaiing windows conda with following error:


Tested by:
```
PS C:\Windows\system32> Set-ItemProperty 'HKLM:\System\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -value 1

(env1) C:\Users\runneruser>conda install -y pytorch-1.12.0.dev20220303-py3.7_cuda11.5_cudnn8_0.tar.bz2

Downloading and Extracting Packages
############################################################################################################### | 100%
Preparing transaction: done
Verifying transaction: done
Executing transaction: done```