### PR TITLE
Add `.jenkins/caffe2/*` to ONNX merge rules

### DIFF
--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -10,7 +10,8 @@
          "torch/csrc/jit/serialization/export.*",
          "torch/csrc/jit/serialization/onnx.*",
          "torch/_C/__init__.pyi.in",
-         "torch/csrc/onnx/**"
+         "torch/csrc/onnx/**",
+         ".jenkins/caffe2/*"
       ],
       "approved_by": ["BowenBao", "garymm"],
       "mandatory_app_id": 12274


### PR DESCRIPTION
Because it is right now used exclusively for ONNX testing