### PR TITLE
PyObject_FastGetAttrString: silence unused function warnings

### DIFF
--- a/torch/csrc/utils/python_strings.h
+++ b/torch/csrc/utils/python_strings.h
@@ -102,7 +102,7 @@ inline void THPUtils_internStringInPlace(PyObject** obj) {
  */
 
 // NOLINTNEXTLINE(clang-diagnostic-unused-function)
-static py::object PyObject_FastGetAttrString(PyObject *obj, const char *name)
+static inline py::object PyObject_FastGetAttrString(PyObject *obj, const char *name)
 {
     PyTypeObject *tp = Py_TYPE(obj);
     PyObject *res = (PyObject *)nullptr;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73768

Differential Revision: [D34631333](https://our.internmc.facebook.com/intern/diff/D34631333)