### PR TITLE
Add overflow check to `TensorImpl::compute_numel`

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2247,9 +2247,15 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    */
   int64_t compute_numel() const {
     int64_t n = 1;
+    bool overflow = false;
     for (auto s : sizes()) {
+#if defined(_MSC_VER) || defined(C10_ANDROID) || defined(C10_IPHONE)
       n *= s;
+#else
+      overflow |= __builtin_mul_overflow(n, s, &n);
+#endif
     }
+    TORCH_CHECK(overflow == false, "int64 overflow while computing numel");
     return n;
   }
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8249,6 +8249,12 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertEqual(y1, y1_expect.tolist())
         self.assertEqual(y2, y1_expect.imag.tolist())
 
+    @unittest.skipIf(IS_WINDOWS, 'MSVC does not support fast overflow checks')
+    def test_numel_overflow(self):
+        with self.assertRaisesRegex(RuntimeError, "overflow"):
+            torch.empty(0x100000000, 0x10000000, 0x10)
+
+
 # The following block extends TestTorch with negative dim wrapping tests
 # FIXME: replace these with OpInfo sample inputs or systemic OpInfo tests
 # Functions to test negative dimension wrapping


### PR DESCRIPTION
On all platforms but Windows, one can use integer overflow builtin
which is at least on x86_64 platform is very performance efficient, see https://godbolt.org/z/d1xqTf7ch

Skip those checks on mobile platforms as this is not a reasonable
usecase scenario there

Addresses, among other things crashes reported in https://github.com/pytorch/pytorch/issues/73190 , https://github.com/pytorch/pytorch/issues/73191 and https://github.com/pytorch/pytorch/issues/73192
