### PR TITLE
Use higher timeout for test_tensorpipe_set_default_timeout

### DIFF
--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -4870,7 +4870,9 @@ class TensorPipeAgentRpcTest(RpcAgentTestFixture, RpcTestCommon):
     # FIXME Merge this test with the corresponding one in RpcTest.
     @dist_init(setup_rpc=False)
     def test_tensorpipe_set_default_timeout(self):
-        timeout = 0.5
+        # Set a high timeout since it doesn't affect test runtime and ensures
+        # the test doesn't erroneously timeout due to slow machines.
+        timeout = 100
         rpc_backend_options = rpc.TensorPipeRpcBackendOptions(
             init_method=self.rpc_backend_options.init_method,
             num_worker_threads=self.rpc_backend_options.num_worker_threads,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #73771

The runtime for this test doesn't actually depend on the timeout value
specified here. As a result, increasing the timeout to avoid flakiness.

https://ossci-raw-job-status.s3.amazonaws.com/log/4666724994 is an example of
where this test failed due to a small timeout as reported in
https://github.com/pytorch/pytorch/issues/70546

Differential Revision: [D34632204](https://our.internmc.facebook.com/intern/diff/D34632204/)