### PR TITLE
[quant][fx] Refactor _convert_fx_do_not_use

### DIFF
--- a/torch/ao/quantization/fx/_convert_do_not_use.py
+++ b/torch/ao/quantization/fx/_convert_do_not_use.py
@@ -66,6 +66,110 @@ def insert_dequantize_node(
             if user_node is not dequantize_node:
                 user_node.replace_input_with(node, dequantize_node)
 
+
+def convert_standalone_module(
+        node: Node,
+        modules: Dict[str, torch.nn.Module]):
+    convert = torch.ao.quantization._quantize_fx_do_not_use._convert_do_not_use  # type: ignore[attr-defined]
+    # We know that observed standalone module is a GraphModule since
+    # it's produced by us
+    observed_standalone_module : GraphModule = modules[str(node.target)]  # type: ignore[assignment]
+    sm_input_quantized_idxs = \
+        observed_standalone_module \
+        ._standalone_module_input_quantized_idxs\
+        .tolist()  # type: ignore[operator]
+    # remove the dequantize nodes for inputs
+    args = list(node.args)
+    for idx in range(len(args)):
+        if idx in sm_input_quantized_idxs:
+            arg = args[idx]
+            if arg.op == "call_method" and arg.target == "dequantize":
+                quantize_node = arg.args[0]
+                node.replace_input_with(arg, quantize_node)
+                if len(arg.users) == 0:
+                    model.graph.erase_node(arg)
+    # add dequantize node for output
+    sm_output_quantized_idxs = \
+        observed_standalone_module \
+        ._standalone_module_output_quantized_idxs \
+        .tolist()  # type: ignore[operator]
+    if len(sm_output_quantized_idxs) > 0:
+        assert sm_output_quantized_idxs[0] == 0, "Currently only quantized"
+        "output idxs = [0] is supported"
+
+        # if it's non-empty, then it means the output is kept in quantized form
+        # we'll just add a dequantize node after this node
+        insert_dequantize_node(node, model.graph)
+
+    # TODO: allow convert_custom_config_dict to override backend_config_dict
+    # for standalone module
+    quantized_standalone_module = convert(
+        observed_standalone_module,
+        is_reference=True,
+        backend_config_dict=backend_config_dict)
+    parent_name, name = _parent_name(node.target)
+    # update the modules dict
+    setattr(modules[parent_name], name, quantized_standalone_module)
+    modules[str(node.target)] = quantized_standalone_module
+
+def convert_weighted_module(
+        node: Node,
+        modules: Dict[str, torch.nn.Module],
+        observed_node_names: Dict[str]):
+    original_module = modules[node.target]
+    qconfig = original_module.qconfig
+
+    is_observed = node.name in observed_node_names
+    is_activation_quantized = activation_is_int8_quantized(qconfig)
+    is_weight_quantized = weight_is_statically_quantized(qconfig)
+    # TODO: rename weight_is_statically_quantized to weight_is_int8_quantized
+    if qconfig is None or \
+       not is_observed or \
+       not is_weight_quantized or \
+       not is_activation_quantized:
+        continue
+
+    float_module = original_module
+    fused_module = None
+    if isinstance(
+            original_module,
+            QAT_MODULE_CLASSES):
+        # case 1. converting qat module to
+        # a float module, we need to attch
+        # weight fake_quant to the module,
+        # weight fake_quant is assumed to be run during
+        # QAT so we don't need to run it again here
+        float_module = original_module.to_float()  # type: ignore[operator]
+        # change qat conv to conv
+        parent_name, name = _parent_name(node.target)
+        setattr(modules[parent_name], name, float_module)
+        if isinstance(float_module, torch.nn.intrinsic._FusedModule):
+            fused_module = float_module
+            float_module = fused_module[0]
+        weight_post_process = original_module.weight_fake_quant
+    else:
+        # case 2. converting a float module/fused float module
+        # to float module, we need to attach
+        # weight observer to the conv module and run it
+        # with conv weight
+        if isinstance(original_module, torch.nn.intrinsic._FusedModule):
+            fused_module = original_module
+            float_module = fused_module[0]  # type: ignore[index]
+        assert qconfig is not None
+        weight_post_process = qconfig.weight()
+        # run weight observer
+        weight_post_process(float_module.weight)  # type: ignore[operator]
+    weight_qparams = get_qparam_dict(weight_post_process)
+    # TODO: may need to change the mapping when we support dynamic quantization
+    ref_qmodule_cls = quantized_reference_module_mapping.get(type(float_module), None)
+    assert ref_qmodule_cls is not None, f"No reference quantized module class configured for {type(float_module)}"
+    ref_qmodule = ref_qmodule_cls.from_float(float_module, weight_qparams)  # type: ignore[attr-defined]
+    if fused_module is not None:
+        fused_module[0] = ref_qmodule
+    else:
+        parent_name, name = _parent_name(node.target)
+        setattr(modules[parent_name], name, ref_qmodule)
+
 def _convert_do_not_use(
         model: GraphModule, is_reference: bool = False,
         convert_custom_config_dict: Dict[str, Any] = None,
@@ -210,103 +314,10 @@ def _convert_do_not_use(
                 replace_observer_with_quantize_dequantize_node(model.graph, node, modules)
             elif is_observed_standalone_module(modules[node.target]):
                 # TODO: move this to a separate function
-                convert = torch.ao.quantization._quantize_fx_do_not_use._convert_do_not_use  # type: ignore[attr-defined]
-                # We know that observed standalone module is a GraphModule since
-                # it's produced by us
-                observed_standalone_module : GraphModule = modules[str(node.target)]  # type: ignore[assignment]
-                sm_input_quantized_idxs = \
-                    observed_standalone_module \
-                    ._standalone_module_input_quantized_idxs\
-                    .tolist()  # type: ignore[operator]
-                # remove the dequantize nodes for inputs
-                args = list(node.args)
-                for idx in range(len(args)):
-                    if idx in sm_input_quantized_idxs:
-                        arg = args[idx]
-                        if arg.op == "call_method" and arg.target == "dequantize":
-                            quantize_node = arg.args[0]
-                            node.replace_input_with(arg, quantize_node)
-                            if len(arg.users) == 0:
-                                model.graph.erase_node(arg)
-                # add dequantize node for output
-                sm_output_quantized_idxs = \
-                    observed_standalone_module \
-                    ._standalone_module_output_quantized_idxs \
-                    .tolist()  # type: ignore[operator]
-                if len(sm_output_quantized_idxs) > 0:
-                    assert sm_output_quantized_idxs[0] == 0, "Currently only quantized"
-                    "output idxs = [0] is supported"
-
-                    # if it's non-empty, then it means the output is kept in quantized form
-                    # we'll just add a dequantize node after this node
-                    insert_dequantize_node(node, model.graph)
-
-                # TODO: allow convert_custom_config_dict to override backend_config_dict
-                # for standalone module
-                quantized_standalone_module = convert(
-                    observed_standalone_module,
-                    is_reference=True,
-                    backend_config_dict=backend_config_dict)
-                parent_name, name = _parent_name(node.target)
-                # update the modules dict
-                setattr(modules[parent_name], name, quantized_standalone_module)
-                modules[str(node.target)] = quantized_standalone_module
+                convert_standalone_module(node, modules)
             elif type(modules[node.target]) in set(
                     weighted_module_classes).union(QAT_MODULE_CLASSES).union(FUSED_MODULE_CLASSES):
-                # TODO: refactor this part to a function
-                original_module = modules[node.target]
-                qconfig = original_module.qconfig
-
-                is_observed = node.name in observed_node_names
-                is_activation_quantized = activation_is_int8_quantized(qconfig)
-                is_weight_quantized = weight_is_statically_quantized(qconfig)
-                # TODO: rename weight_is_statically_quantized to weight_is_int8_quantized
-                if qconfig is None or \
-                   not is_observed or \
-                   not is_weight_quantized or \
-                   not is_activation_quantized:
-                    continue
-
-                float_module = original_module
-                fused_module = None
-                if isinstance(
-                        original_module,
-                        QAT_MODULE_CLASSES):
-                    # case 1. converting qat module to
-                    # a float module, we need to attch
-                    # weight fake_quant to the module,
-                    # weight fake_quant is assumed to be run during
-                    # QAT so we don't need to run it again here
-                    float_module = original_module.to_float()  # type: ignore[operator]
-                    # change qat conv to conv
-                    parent_name, name = _parent_name(node.target)
-                    setattr(modules[parent_name], name, float_module)
-                    if isinstance(float_module, torch.nn.intrinsic._FusedModule):
-                        fused_module = float_module
-                        float_module = fused_module[0]
-                    weight_post_process = original_module.weight_fake_quant
-                else:
-                    # case 2. converting a float module/fused float module
-                    # to float module, we need to attach
-                    # weight observer to the conv module and run it
-                    # with conv weight
-                    if isinstance(original_module, torch.nn.intrinsic._FusedModule):
-                        fused_module = original_module
-                        float_module = fused_module[0]  # type: ignore[index]
-                    assert qconfig is not None
-                    weight_post_process = qconfig.weight()
-                    # run weight observer
-                    weight_post_process(float_module.weight)  # type: ignore[operator]
-                weight_qparams = get_qparam_dict(weight_post_process)
-                # TODO: may need to change the mapping when we support dynamic quantization
-                ref_qmodule_cls = quantized_reference_module_mapping.get(type(float_module), None)
-                assert ref_qmodule_cls is not None, f"No reference quantized module class configured for {type(float_module)}"
-                ref_qmodule = ref_qmodule_cls.from_float(float_module, weight_qparams)  # type: ignore[attr-defined]
-                if fused_module is not None:
-                    fused_module[0] = ref_qmodule
-                else:
-                    parent_name, name = _parent_name(node.target)
-                    setattr(modules[parent_name], name, ref_qmodule)
+                convert_weighted_module(node, modules)
 
     # removes qconfig and activation_post_process modules
     if _remove_qconfig_flag:

--- a/torch/ao/quantization/fx/_convert_do_not_use.py
+++ b/torch/ao/quantization/fx/_convert_do_not_use.py
@@ -86,10 +86,10 @@ def convert_standalone_module(
     for idx in range(len(args)):
         if idx in sm_input_quantized_idxs:
             arg = args[idx]
-            if arg.op == "call_method" and arg.target == "dequantize":
-                quantize_node = arg.args[0]
+            if arg.op == "call_method" and arg.target == "dequantize":  # type: ignore[union-attr]
+                quantize_node = arg.args[0]  # type: ignore[union-attr]
                 node.replace_input_with(arg, quantize_node)
-                if len(arg.users) == 0:
+                if len(arg.users) == 0:  # type: ignore[union-attr]
                     model.graph.erase_node(arg)
     # add dequantize node for output
     sm_output_quantized_idxs = \
@@ -120,7 +120,7 @@ def convert_weighted_module(
         modules: Dict[str, torch.nn.Module],
         observed_node_names: Set[str],
         quantized_reference_module_mapping: Dict[Callable, Any]):
-    original_module = modules[node.target]
+    original_module = modules[str(node.target)]
     qconfig = original_module.qconfig
 
     is_observed = node.name in observed_node_names
@@ -160,7 +160,7 @@ def convert_weighted_module(
             fused_module = original_module
             float_module = fused_module[0]  # type: ignore[index]
         assert qconfig is not None
-        weight_post_process = qconfig.weight()
+        weight_post_process = qconfig.weight()  # type: ignore[union-attr, operator]
         # run weight observer
         weight_post_process(float_module.weight)  # type: ignore[operator]
     weight_qparams = get_qparam_dict(weight_post_process)
@@ -322,7 +322,7 @@ def _convert_do_not_use(
 
             elif type(modules[node.target]) in set(
                     weighted_module_classes).union(QAT_MODULE_CLASSES).union(FUSED_MODULE_CLASSES):
-                convert_weighted_module(node, modules, observed_node_names, quantized_reference_module_mapping):
+                convert_weighted_module(node, modules, observed_node_names, quantized_reference_module_mapping)
 
     # removes qconfig and activation_post_process modules
     if _remove_qconfig_flag:

--- a/torch/ao/quantization/fx/_convert_do_not_use.py
+++ b/torch/ao/quantization/fx/_convert_do_not_use.py
@@ -127,7 +127,7 @@ def convert_weighted_module(
        not is_observed or \
        not is_weight_quantized or \
        not is_activation_quantized:
-        continue
+        return
 
     float_module = original_module
     fused_module = None
@@ -317,7 +317,7 @@ def _convert_do_not_use(
                 convert_standalone_module(node, modules)
             elif type(modules[node.target]) in set(
                     weighted_module_classes).union(QAT_MODULE_CLASSES).union(FUSED_MODULE_CLASSES):
-                convert_weighted_module(node, modules)
+                convert_weighted_module(node, modules):
 
     # removes qconfig and activation_post_process modules
     if _remove_qconfig_flag:

--- a/torch/ao/quantization/fx/_convert_do_not_use.py
+++ b/torch/ao/quantization/fx/_convert_do_not_use.py
@@ -322,7 +322,7 @@ def _convert_do_not_use(
 
             elif type(modules[node.target]) in set(
                     weighted_module_classes).union(QAT_MODULE_CLASSES).union(FUSED_MODULE_CLASSES):
-                convert_weighted_module(node, modules, observed_module_names):
+                convert_weighted_module(node, modules, observed_node_names, quantized_reference_module_mapping):
 
     # removes qconfig and activation_post_process modules
     if _remove_qconfig_flag:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #73777

Summary:
att, this is to prepare for the migration of current convert to this function

Test Plan:
regression tests to make sure the refactor doesn't break anything
internal only, since tensorrt tests are moved to a separate repo

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D34636000](https://our.internmc.facebook.com/intern/diff/D34636000)