### PR TITLE
add QuantizedXPU to dispatch key set autogradother_backends

### DIFF
--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -253,6 +253,7 @@ constexpr DispatchKeySet autogradother_backends = DispatchKeySet(
      DispatchKey::Metal,
      DispatchKey::QuantizedCPU,
      DispatchKey::QuantizedCUDA,
+     DispatchKey::QuantizedXPU,
      DispatchKey::CustomRNGKeyId,
      DispatchKey::MkldnnCPU,
      DispatchKey::SparseCPU,


### PR DESCRIPTION
According to dispatch table computation logic, if no kernel register to a certain dispatch key, will use CompositeExplicitAutograd backend kernel, so we need add QuantizedXPU key to the alias key pool.
