### PR TITLE
[Easy][FSDP] Fix warning render

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -161,7 +161,7 @@ class FullyShardedDataParallel(nn.Module):
         since FSDP will shard parameters in-place and this will break any
         previously initialized optimizers.
 
-    .. warning:
+    .. warning::
         Module should be already placed on the destination device or
         device is set properly using torch.cuda.set_device(device_id).
         FSDP will get compute device from module first, if module device


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #73787 [FSDP][BE] Change assert to assertEqual
* **#73786 [Easy][FSDP] Fix warning render**
* #73535 [FSDP] Add grad accumulation without `no_sync()`

If you check the `master` docs (https://pytorch.org/docs/master/fsdp.html?highlight=fsdp#module-torch.distributed.fsdp), the warning does not render due to missing a `:`.

Differential Revision: [D34643837](https://our.internmc.facebook.com/intern/diff/D34643837)