### PR TITLE
[PyTorch] Update Synchronized<T>::withLock() to return the type/value from the aceepted callable

### DIFF
--- a/c10/util/Synchronized.h
+++ b/c10/util/Synchronized.h
@@ -42,9 +42,9 @@ class Synchronized final {
    * provided callback safely.
    */
   template <typename CB>
-  void withLock(CB cb) {
+  typename std::result_of<CB(T&)>::type withLock(CB cb) {
     std::lock_guard<std::mutex> guard(this->mutex_);
-    cb(this->data_);
+    return cb(this->data_);
   }
 
   /**
@@ -53,9 +53,9 @@ class Synchronized final {
    * the provided callback safely.
    */
   template <typename CB>
-  void withLock(CB cb) const {
+  typename std::result_of<CB(T const&)>::type withLock(CB cb) const {
     std::lock_guard<std::mutex> guard(this->mutex_);
-    cb(this->data_);
+    return cb(this->data_);
   }
 };
 } // end namespace c10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Currently, `void c10::Synchronized<T>::withLock(CB)` accepts a callback but returns `void`. For a callback (CB) returning a value, `withLock()` can not be used to retrieve the returned value. This change makes it possible for the caller to retrieve that value. The only gotcha is that if the value has only move semantics (such as `std::unique_ptr<T>`, then this won't work as currently written). To be able to do that, one needs to use `std::enable_if<T>` to enable a separate overload that works only for moveable types (detectable using `std::is_move_constructible<T>`).

Differential Revision: [D34645509](https://our.internmc.facebook.com/intern/diff/D34645509/)