### PR TITLE
[PyTorch] Use c10::Synchronized<T> in RWSafeLeftRightWrapper

### DIFF
--- a/c10/util/LeftRight.h
+++ b/c10/util/LeftRight.h
@@ -1,4 +1,6 @@
+#include "c10/util/Synchronized.h"
 #include <c10/macros/Macros.h>
+#include <c10/util/Synchronized.h>
 #include <array>
 #include <atomic>
 #include <functional>
@@ -192,13 +194,9 @@ class LeftRight final {
 // read-write lock to protect T (data).
 template <class T>
 class RWSafeLeftRightWrapper final {
-  using mutexType = std::mutex;
-  using rLockType = std::unique_lock<std::mutex>;
-  using wLockType = std::unique_lock<std::mutex>;
-
  public:
   template <class... Args>
-  explicit RWSafeLeftRightWrapper(const Args&... args) : _data{args...} {}
+  explicit RWSafeLeftRightWrapper(const Args&... args) : data_{args...} {}
 
   // RWSafeLeftRightWrapper is not copyable or moveable since LeftRight
   // is not copyable or moveable.
@@ -209,19 +207,20 @@ class RWSafeLeftRightWrapper final {
 
   template <typename F>
   auto read(F&& readFunc) const -> typename std::result_of<F(const T&)>::type {
-    rLockType lock(mutex_);
-    return readFunc(_data);
+    return data_.withLock([&readFunc](T const& data) {
+      return readFunc(data);
+    });
   }
 
   template <typename F>
   auto write(F&& writeFunc) -> typename std::result_of<F(T&)>::type {
-    wLockType lock(mutex_);
-    return writeFunc(_data);
+    return data_.withLock([&writeFunc](T& data) {
+      return writeFunc(data);
+    });
   }
 
  private:
-  T _data;
-  mutable mutexType mutex_;
+  c10::Synchronized<T> data_;
 };
 
 } // namespace c10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

As the title says - to prevent unintentional usage of the `data_` member without the lock held.

Differential Revision: [D34645508](https://our.internmc.facebook.com/intern/diff/D34645508/)