### PR TITLE
[Quant][test] Added test to check if fp16 packing->unpacking yields the same result as to(torch.float16).to(torch.float32) [reland]

### DIFF
--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -2880,6 +2880,19 @@ class TestDynamicQuantizedOps(TestCase):
         self.assertEqual(Y_fp32, Y_fp32_ref,
                          msg="torch.ops.quantized.fbgemm_linear_dynamic results are off")
 
+    @override_qengines
+    @given(
+        input_channels=st.integers(16, 32),
+        output_channels=st.integers(4, 8),
+        exponent=st.integers(0, 8))
+    def test_linear_prepack_fp16_numerics(self, input_channels, output_channels, exponent):
+        w = torch.randn(output_channels, input_channels) * 10**exponent
+        bias = None
+        w_packed_fp16 = torch.ops.quantized.linear_prepack_fp16(w, bias)
+        w_unpacked_fp16 = torch.ops.quantized.linear_unpack_fp16(w_packed_fp16)
+        w_fp16 = w.to(torch.float16).to(torch.float32)
+        self.assertTrue(torch.equal(w_fp16, w_unpacked_fp16[0]))
+
     @skipIfNoFBGEMM
     def test_qlinear_dynamic_fp16(self):
 

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -2880,7 +2880,7 @@ class TestDynamicQuantizedOps(TestCase):
         self.assertEqual(Y_fp32, Y_fp32_ref,
                          msg="torch.ops.quantized.fbgemm_linear_dynamic results are off")
 
-    @override_qengines
+    @skipIfNoFBGEMM
     @given(
         input_channels=st.integers(16, 32),
         output_channels=st.integers(4, 8),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73808

Summary:
A test was added in test_quantized_op.py that checks whether the fp16 packing and subsequent unpacking of a given fp32 tensor produces the same result as to(torch.float16).to(torch.float32)

Test Plan:
in pytorch main directory, execute
```
python test/test_quantization.py TestDynamicQuantizedOps.test_linear_prepack_fp16_numerics

```

Reviewed By: jerryzh168

Pulled By: dzdang

fbshipit-source-id: 5da453e5db4801dde196424282140726c8a4ef1f
(cherry picked from commit ac8910e7feb4eebf677c99f287d48915165a87bf)

Differential Revision: [D34650372](https://our.internmc.facebook.com/intern/diff/D34650372)