### PR TITLE
[Lazy][JIT] Do not crash when target device is unsupported by fuser

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -840,9 +840,8 @@ class TensorExprFuser {
       return canFuseOnGPU();
     } else if (device->is_xpu()) {
       return false;
-    } else {
-      TORCH_CHECK_NOT_IMPLEMENTED(false, "Unknown device for tensorexpr fuser")
     }
+    return false;
   }
 
   bool isFusableOnDevice(Node* node) {


### PR DESCRIPTION
The `canFuseOnDevice` function now crashes when the device is not covered (i.e., CPU, GPU, XPU). However, now we have some devices, such as XLA and Lazy, that could perform fusion by themselves. This checker then prevents these devices from working on the models partially implemented in `jit.script`.

This PR proposes to remove this checker and simply return false for all uncovered cases. Another alternative is adding the following logic if it is unsafe to simply remove the checker:
```
else if (device-> type() == DeviceType::XLA || device-> type() == DeviceType::Lazy) {
  return false;
} else {
  TORCH_CHECK_NOT_IMPLEMENTED(false, "Unknown device for tensorexpr fuser")
}
```

cc @wconstab