### PR TITLE
Deduplicate legacy _ctor and _new Python bindings

### DIFF
--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -399,7 +399,12 @@ void check_legacy_ctor_device(c10::DispatchKey dispatch_key, c10::optional<Devic
   }
 }
 
-Tensor legacy_sparse_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyObject* args, PyObject* kwargs) {
+enum class CtorOrNew {
+  CTOR,
+  NEW,
+};
+
+Tensor legacy_sparse_tensor_generic_ctor_new(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyObject* args, PyObject* kwargs, CtorOrNew ctor_or_new) {
   auto options = dispatchKeyToTensorOptions(dispatch_key);
   static PythonArgParser parser({
     "new(*, Device? device=None)",
@@ -408,6 +413,7 @@ Tensor legacy_sparse_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType s
     "new(Tensor indices, Tensor values, IntArrayRef size, *, Device? device=None)",
     "new(IntArrayRef size, *, Device? device=None)",
   });
+  if (ctor_or_new == CtorOrNew::NEW) check_base_legacy_new(dispatch_key, c10::kSparse);
   ParsedArgs<4> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {
@@ -418,11 +424,15 @@ Tensor legacy_sparse_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType s
     auto cdata = reinterpret_cast<void*>(r.toInt64(0));
     return at::unsafeTensorFromTH(cdata, true);
   } else if (r.idx == 2) {
+    // Note: this signature doesn't have a dtype, even though it has a device; it probably shouldn't
+    // have a device (we should infer it).
     auto deviceOptional = r.deviceOptional(2);
     check_legacy_ctor_device(dispatch_key, deviceOptional);
     at::OptionalDeviceGuard device_guard(deviceOptional);
     return at::sparse_coo_tensor(r.tensor(0), r.tensor(1));
   } else if (r.idx == 3) {
+    // Note: this signature doesn't have a dtype, even though it has a device; it probably shouldn't
+    // have a device (we should infer it).
     auto deviceOptional = r.deviceOptional(3);
     check_legacy_ctor_device(dispatch_key, deviceOptional);
     at::OptionalDeviceGuard device_guard(deviceOptional);
@@ -434,61 +444,25 @@ Tensor legacy_sparse_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType s
     if (!THPSize_Check(arg) && PyTuple_GET_SIZE(args) >= 1 && arg == PyTuple_GET_ITEM(args, 0)) {
       // new(sequence) binds to this signature but should be treated differently
       // unless the sequences is a torch.Size
-      throw TypeError("torch.SparseTensor(sequence) only accepts sizes.  Please use torch.sparse_coo_tensor() " \
-                      "or construct a strided tensor and convert it to sparse via to_sparse.");
+      if (ctor_or_new == CtorOrNew::CTOR) {
+        throw TypeError("torch.SparseTensor(sequence) only accepts sizes.  Please use torch.sparse_coo_tensor() " \
+                        "or construct a strided tensor and convert it to sparse via to_sparse.");
+      } else {
+        throw TypeError("SparseTensor.new(sequence) only accepts sizes.  Please use torch.sparse_coo_tensor() " \
+                        "or construct a strided tensor and convert it to sparse via to_sparse.");
+      }
     }
     return new_with_sizes(options, scalar_type, r.deviceOptional(1), r.intlist(0));
   }
   throw std::runtime_error("new(): invalid arguments");
 }
 
+Tensor legacy_sparse_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyObject* args, PyObject* kwargs) {
+  return legacy_sparse_tensor_generic_ctor_new(dispatch_key, scalar_type, args, kwargs, CtorOrNew::CTOR);
+}
+
 Tensor legacy_sparse_tensor_new(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyObject* args, PyObject* kwargs) {
-  auto options = dispatchKeyToTensorOptions(dispatch_key);
-  static PythonArgParser parser({
-    "new(*, Device? device=None)",
-    "new(*, int64_t cdata)|hidden",
-    "new(Tensor indices, Tensor values, *, Device? device=None)",
-    "new(Tensor indices, Tensor values, IntArrayRef size, *, Device? device=None)",
-    "new(IntArrayRef size, *, Device? device=None)",
-  });
-  check_base_legacy_new(dispatch_key, c10::kSparse);
-  ParsedArgs<5> parsed_args;
-  auto r = parser.parse(args, kwargs, parsed_args);
-  if (r.idx == 0) {
-    auto deviceOptional = r.deviceOptional(0);
-    check_legacy_ctor_device(dispatch_key, deviceOptional);
-    at::OptionalDeviceGuard device_guard(deviceOptional);
-    return at::empty({0}, build_options(options, scalar_type));
-  } else if (r.idx == 1) {
-    auto cdata = reinterpret_cast<void*>(r.toInt64(0));
-    return at::unsafeTensorFromTH(cdata, true);
-  } else if (r.idx == 2) {
-    // Note: this signature doesn't have a dtype, even though it has a device; it probably shouldn't
-    // have a device (we should infer it).
-    auto deviceOptional = r.deviceOptional(2);
-    check_legacy_ctor_device(dispatch_key, deviceOptional);
-    at::OptionalDeviceGuard device_guard(deviceOptional);
-    return at::sparse_coo_tensor(r.tensor(0), r.tensor(1));
-  } else if (r.idx == 3) {
-    // Note: this signature doesn't have a dtype, even though it has a device; it probably shouldn't
-    // have a device (we should infer it).
-    auto deviceOptional = r.deviceOptional(3);
-    check_legacy_ctor_device(dispatch_key, deviceOptional);
-    at::OptionalDeviceGuard device_guard(deviceOptional);
-    return at::sparse_coo_tensor(r.tensor(0), r.tensor(1), r.intlist(2));
-  } else if (r.idx == 4) {
-    PyObject* arg = r.pyobject(0);
-    auto deviceOptional = r.deviceOptional(1);
-    check_legacy_ctor_device(dispatch_key, deviceOptional);
-    if (!THPSize_Check(arg) && PyTuple_GET_SIZE(args) >= 1 && arg == PyTuple_GET_ITEM(args, 0)) {
-      // new(sequence) binds to this signature but should be treated differently
-      // unless the sequences is a torch.Size
-      throw TypeError("SparseTensor.new(sequence) only accepts sizes.  Please use torch.sparse_coo_tensor() " \
-                      "or construct a strided tensor and convert it to sparse via to_sparse.");
-    }
-    return new_with_sizes(options, scalar_type, r.deviceOptional(1), r.intlist(0));
-  }
-  throw std::runtime_error("new(): invalid arguments");
+  return legacy_sparse_tensor_generic_ctor_new(dispatch_key, scalar_type, args, kwargs, CtorOrNew::NEW);
 }
 
 // NB: device_idx here is NOT a DeviceIndex, but index into PythonArgs
@@ -503,7 +477,7 @@ c10::TensorOptions typeIdWithDefault(PythonArgs& r, int64_t device_idx, c10::Dis
 
 } // namespace
 
-Tensor legacy_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyObject* args, PyObject* kwargs) {
+Tensor legacy_tensor_generic_ctor_new(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyObject* args, PyObject* kwargs, CtorOrNew ctor_or_new) {
   auto options = dispatchKeyToTensorOptions(dispatch_key);
   static PythonArgParser parser({
     "new(*, Device? device=None)",
@@ -516,8 +490,10 @@ Tensor legacy_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_t
   });
 
   if (isSparse(dispatchKeyToBackend(dispatch_key))) {
-    return legacy_sparse_tensor_ctor(dispatch_key, scalar_type, args, kwargs);
+    return legacy_sparse_tensor_generic_ctor_new(dispatch_key, scalar_type, args, kwargs, ctor_or_new);
   }
+
+  if (ctor_or_new == CtorOrNew::NEW) check_base_legacy_new(dispatch_key, c10::kStrided);
 
   ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
@@ -544,8 +520,13 @@ Tensor legacy_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_t
   } else if (r.idx == 3) {
     return new_with_tensor(options, scalar_type, r.tensor(0));
   } else if (r.idx == 4) {
-    TORCH_CHECK(false, "Legacy tensor constructor of the form torch.Tensor(tensor, device=device) " \
-                "is not supported.  Use torch.tensor(...) or torch.as_tensor(...) instead.");
+    if (ctor_or_new == CtorOrNew::CTOR) {
+      TORCH_CHECK(false, "Legacy tensor constructor of the form torch.Tensor(tensor, device=device) " \
+                  "is not supported.  Use torch.tensor(...) or torch.as_tensor(...) instead.");
+    } else {
+      TORCH_CHECK(false, "Legacy tensor new of the form tensor.new(tensor, device=device) " \
+                  "is not supported.  Use torch.as_tensor(...) instead.");
+    }
   } else if (r.idx == 5) {
     PyObject* arg = r.pyobject(0);
     auto deviceOptional = r.deviceOptional(1);
@@ -564,66 +545,12 @@ Tensor legacy_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_t
   throw std::runtime_error("new(): invalid arguments");
 }
 
+Tensor legacy_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyObject* args, PyObject* kwargs) {
+  return legacy_tensor_generic_ctor_new(dispatch_key, scalar_type, args, kwargs, CtorOrNew::CTOR);
+}
+
 Tensor legacy_tensor_new(c10::DispatchKey dispatch_key, at::ScalarType scalar_type, PyObject* args, PyObject* kwargs) {
-  auto options = dispatchKeyToTensorOptions(dispatch_key);
-  static PythonArgParser parser({
-    "new(*, Device? device=None)",
-    "new(Storage storage)",
-    "new(*, int64_t cdata)|hidden",
-    "new(Tensor other)",  // this doesn't have a dtype/device because it creates an alias.
-    "new(Tensor other, *, Device? device=None)|hidden",  // prevent Tensor matching with IntArrayRef, PyObject*
-    "new(IntArrayRef size, *, Device? device=None)",
-    "new(PyObject* data, *, Device? device=None)",
-  });
-
-  if (isSparse(dispatchKeyToBackend(dispatch_key))) {
-    return legacy_sparse_tensor_new(dispatch_key, scalar_type, args, kwargs);
-  }
-
-  check_base_legacy_new(dispatch_key, c10::kStrided);
-  ParsedArgs<3> parsed_args;
-  auto r = parser.parse(args, kwargs, parsed_args);
-  if (r.idx == 0) {
-    auto deviceOptional = r.deviceOptional(0);
-    check_legacy_ctor_device(dispatch_key, deviceOptional);
-    at::OptionalDeviceGuard device_guard(deviceOptional);
-    return at::empty({0}, build_options(options, scalar_type));
-  } else if (r.idx == 1) {
-    at::ScalarType storage_scalar_type;
-    bool is_typed_storage = false;
-    at::Storage storage = r.storage(0, storage_scalar_type, is_typed_storage);
-    if (storage_scalar_type != at::ScalarType::Undefined && is_typed_storage) {
-      TORCH_CHECK(
-        storage_scalar_type == scalar_type,
-        "Expected a Storage of type ", scalar_type,
-        " or an _UntypedStorage, but got type ", storage_scalar_type,
-        " for argument 1 'storage'");
-    }
-    return new_with_storage(options, scalar_type, storage);
-  } else if (r.idx == 2) {
-    auto cdata = reinterpret_cast<void*>(r.toInt64(0));
-    return at::unsafeTensorFromTH(cdata, true);
-  } else if (r.idx == 3) {
-    return new_with_tensor(options, scalar_type, r.tensor(0));
-  } else if (r.idx == 4) {
-      TORCH_CHECK(false, "Legacy tensor new of the form tensor.new(tensor, device=device) " \
-                  "is not supported.  Use torch.as_tensor(...) instead.");
-  } else if (r.idx == 5) {
-    PyObject* arg = r.pyobject(0);
-    auto deviceOptional = r.deviceOptional(1);
-    check_legacy_ctor_device(dispatch_key, deviceOptional);
-    if (!THPSize_Check(arg) && PyTuple_GET_SIZE(args) >= 1 && arg == PyTuple_GET_ITEM(args, 0)) {
-      // new(sequence) binds to this signature but should be treated differently
-      // unless the sequences is a torch.Size
-      return legacy_new_from_sequence(options, scalar_type, deviceOptional, r.pyobject(0));
-    }
-    return new_with_sizes(options, scalar_type, r.deviceOptional(1), r.intlist(0));
-  } else if (r.idx == 6) {
-    auto deviceOptional = r.deviceOptional(1);
-    check_legacy_ctor_device(dispatch_key, deviceOptional);
-    return legacy_new_from_sequence(options, scalar_type, r.deviceOptional(1), r.pyobject(0));
-  }
-  throw std::runtime_error("new(): invalid arguments");
+  return legacy_tensor_generic_ctor_new(dispatch_key, scalar_type, args, kwargs, CtorOrNew::NEW);
 }
 
 Tensor indexing_tensor_from_data(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #73874
* #73850
* __->__ #73822

I guess hypothetically the logic duplication here is a faux
amis because we could say that the constructor and new method
should evolve APIs independently... but nah, it's not worth it.
There is only very slight differences between the two functions:
different error messages, and the new method does extra checks
to make sure the requested types are consistent with the base
Tensor.  But I need to refactor this code and I really don't want
to do the refactor twice.  So dedupe first.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D34665171](https://our.internmc.facebook.com/intern/diff/D34665171)