### PR TITLE
[Model Averaging] Add a reference to hierarchical SGD

### DIFF
--- a/torch/distributed/algorithms/model_averaging/hierarchical_model_averager.py
+++ b/torch/distributed/algorithms/model_averaging/hierarchical_model_averager.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class HierarchicalModelAverager:
     r"""
-    A group of model averagers used for hierarchical model averaging (hierarchical SGD).
+    Runs hierarchical model averaging (`hierarchical SGD <https://arxiv.org/pdf/2010.12998.pdf>`_).
     Process groups of different sizes are organized in a hierarhicy, and they average parameters
     by using different periods concurrently after the warm-up stage.
     This is an extension of :class:`~torch.distributed.algorithms.model_averaging.averagers.PeriodicModelAverager`


### PR DESCRIPTION
Add a reference.

Also fix the comment: unlike `averagers.py`, currently this is not a base class that can inherit many subclasses.

Proposal: https://github.com/pytorch/pytorch/issues/71325