### PR TITLE
docs: unambiguous tensor definition

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -1,7 +1,7 @@
 torch
 =====
-The torch package contains data structures for multi-dimensional
-tensors and defines mathematical operations over these tensors.
+The torch package contains data structures for tensors (multi-dimensional
+arrays) and defines mathematical operations over these tensors.
 Additionally, it provides many utilities for efficient serializing of
 Tensors and arbitrary types, and other useful utilities.
 

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -1,7 +1,7 @@
 torch
 =====
-The torch package contains data structures for tensors (multi-dimensional
-arrays) and defines mathematical operations over these tensors.
+The torch package contains data structures for multi-dimensional
+tensors and defines mathematical operations over these tensors.
 Additionally, it provides many utilities for efficient serializing of
 Tensors and arbitrary types, and other useful utilities.
 

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1,7 +1,7 @@
 
 r"""
-The torch package contains data structures for multi-dimensional
-tensors and defines mathematical operations over these tensors.
+The torch package contains data structures for tensors (multi-dimensional
+arrays) and defines mathematical operations over these tensors.
 Additionally, it provides many utilities for efficient serializing of
 Tensors and arbitrary types, and other useful utilities.
 


### PR DESCRIPTION
## Why This Pull Request?

Tensors are by definition multidimensional. This removes ambiguity and redundancy, adding clarity.

Reference for the definition of "tensors" as "multi-dimensional arrays":
https://en.wikipedia.org/wiki/Tensor#As_multidimensional_arrays

## Documentation Changes Preview

### Before:
![before](https://user-images.githubusercontent.com/59971270/156915101-e9f60c49-3e76-433e-be09-87250771ec1b.png)

### After:
![after](https://user-images.githubusercontent.com/59971270/156915129-51967107-773b-444a-8542-ffbd339096ff.png)
