### PR TITLE
[pytorch] flatten_indices function should use vector::resize instead of reserve

### DIFF
--- a/aten/src/ATen/SparseTensorUtils.cpp
+++ b/aten/src/ATen/SparseTensorUtils.cpp
@@ -30,7 +30,7 @@ Tensor flatten_indices(const Tensor& indices, IntArrayRef full_size, bool force_
     }
   } else {
     std::vector<int64_t> indices_mult_cpu_vec;
-    indices_mult_cpu_vec.reserve(sparse_dim);
+    indices_mult_cpu_vec.resize(sparse_dim);
     int64_t mult = 1;
     for (int64_t i = sparse_dim - 1; i >= 0; i--) {
       indices_mult_cpu_vec[i] = mult;


### PR DESCRIPTION
Summary:
stderr:
test_jagged_2d_to_dense_truncation (deeplearning.fbgemm.fbgemm_gpu.test.sparse_ops_test.SparseOpsTest) ... third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/stl_vector.h:1045: std::vector::reference std::vector<long>::operator[](std::vector::size_type) [_Tp = long, _Alloc = std::allocator<long>]: Assertion '__n < this->size()' failed.

After some digging, we found the issue is not caused by fbgemm.  It is caused by the underlying coo_sparse_tensor.to_dense() function, which fails for all sparse tensors on platform010, because of the misuse of vector::reserve in flatten_indices function.

Test Plan: buck test mode/dev -c fbcode.platform=platform010 //deeplearning/fbgemm/fbgemm_gpu:sparse_ops_test -- test_jagged_2d_to_dense_truncation

Reviewed By: jspark1105

Differential Revision: D34665804

