### PR TITLE
Update mixture_same_family.py

### DIFF
--- a/torch/distributions/mixture_same_family.py
+++ b/torch/distributions/mixture_same_family.py
@@ -179,8 +179,8 @@ class MixtureSameFamily(Distribution):
         return x.unsqueeze(-1 - self._event_ndims)
 
     def _pad_mixture_dimensions(self, x):
-        dist_batch_ndims = self.batch_shape.numel()
-        cat_batch_ndims = self.mixture_distribution.batch_shape.numel()
+        dist_batch_ndims = len(self.batch_shape)
+        cat_batch_ndims = len(self.mixture_distribution.batch_shape)
         pad_ndims = 0 if cat_batch_ndims == 1 else \
             dist_batch_ndims - cat_batch_ndims
         xs = x.shape


### PR DESCRIPTION
Fixes _pad_mixture_dimensions incorrectly calling numel() on a torch.Size object to get a number of dimensions

Fixes #73792
