### PR TITLE
Report the names of unsupported operators in flatbuffer_loader.cpp

### DIFF
--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -225,7 +225,10 @@ std::unique_ptr<mobile::Function> FlatbufferLoader::parseFunction(
     }
   }
 
-  AT_ASSERT(unsupported_op_names.empty());
+  TORCH_CHECK(
+      unsupported_op_names.empty(),
+      "Unsupported ops: ",
+      c10::Join(", ", unsupported_op_names));
 
   for (const auto i : *method->type_annotations()) {
     function->append_type(getOrCreateTypeAnnotations(i));


### PR DESCRIPTION
Summary:
- Report the names of unsupported operators in `flatbuffer_loader.cpp`:
```
TORCH_CHECK(
  unsupported_op_names.empty(),
  "Unsupported ops: ",
  c10::Join(", ", unsupported_op_names));
```

- Use `TORCH_CHECK` instead of `AT_ASSERT` because `AT_ASSERT` is deprecated (see https://www.internalfb.com/code/fbsource/[9fbf30fa6401f8b341c3100c90f9d929a8ad7f9b]/fbcode/caffe2/c10/util/Exception.h?lines=585)

Test Plan: CI

Differential Revision: D34635838

