### PR TITLE
[pyper] to + lengths_to_offsets

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -225,6 +225,33 @@ C10_UNUSED void ClipRangesToGatherToOffsets(
   fuse.runOnGraph(graph);
 }
 
+C10_UNUSED void ToLengthsToOffsets(std::shared_ptr<torch::jit::Graph>& graph) {
+  std::string pattern = R"IR(
+    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy, %memoryformat):
+        %y0 : Tensor = aten::to(%a, %dtype, %nonblocking, %copy, %memoryformat)
+        %y1 : Tensor = fb::lengths_to_offsets(%y0, %includelastoffset)
+        return (%y1))IR";
+  std::string fused_pattern = R"IR(
+    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy, %memoryformat):
+        %y0 : Tensor = fb::to_lengths_to_offsets(%a, %includelastoffset, %dtype)
+        return (%y0))IR";
+  SubgraphRewriter fuse;
+  fuse.RegisterRewritePattern(pattern, fused_pattern);
+  fuse.runOnGraph(graph);
+
+  std::string pattern2 = R"IR(
+    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy):
+        %y0 : Tensor = aten::to(%a, %dtype, %nonblocking, %copy)
+        %y1 : Tensor = fb::lengths_to_offsets(%y0, %includelastoffset)
+        return (%y1))IR";
+  std::string fused_pattern2 = R"IR(
+    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy):
+        %y0 : Tensor = fb::to_lengths_to_offsets(%a, %includelastoffset, %dtype)
+        return (%y0))IR";
+  fuse.RegisterRewritePattern(pattern2, fused_pattern2);
+  fuse.runOnGraph(graph);
+}
+
 C10_UNUSED
 void ClipRangesGatherSigridHash(std::shared_ptr<torch::jit::Graph>& graph) {
   // TODO:: check restrictions for inputs; outputs not used elsewhere
@@ -334,6 +361,8 @@ void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
 
     ClipRangesToGatherToOffsets(graph);
   }
+
+  ToLengthsToOffsets(graph);
 #endif
 }
 


### PR DESCRIPTION
Summary:
Fuse the following pattern:
```
%1994 : Tensor = aten::to(%getattr_78.1, %188, %189, %189) # <eval_with_key>.50:11:0
%1995 : Tensor = fb::lengths_to_offsets(%1994, %190) # /mnt/xarfuse/uid-1994
```

This pattern is applied after all the applicable clip_ranges+gather_ranges patterns

Additional context in https://fb.quip.com/DSCbAozMBwUi

Test Plan:
> ./caffe2/caffe2/fb/predictor/scripts/run_disagg_model_benchmarks.sh 321004917 27 /data/users/ansha/tmp/ads_tail sr_only

~0.007ms overall reduction in tail model runtime
(321004917_27 oemae_long_attr_win_2d_7d_aux_model)

**Local  (25 fused nodes)**
Before: 2.04ms/iter
      0.0112739 ms.   0.543996%. fb::lengths_to_offsets (31 nodes, out variant)
     0.00805597 ms.   0.388722%. static_runtime::to_maybe_copy_out (30 nodes, out variant)

After: 1.96256ms/iter
      0.0100853 ms.   0.498655%. fb::to_lengths_to_offsets (25 nodes, out variant)
     0.00328385 ms.   0.157536%. fb::lengths_to_offsets (6 nodes, out variant)
     0.00239722 ms.   0.115002%. static_runtime::to_maybe_copy_out (5 nodes, out variant)

**Local_RO  (43 fused nodes)**
Before: 0.11427
      0.0110696 ms.    9.42255%. fb::lengths_to_offsets (43 nodes, out variant)
     0.00638323 ms.    5.43349%. static_runtime::to_maybe_copy_out (43 nodes, out variant)
After: 0.112098ms/iter
       0.014206 ms.    12.6795%. fb::to_lengths_to_offsets (43 nodes, out variant)

**Remote_RO (17 fused nodes)**
Before: 0.24
      0.0534883 ms.    23.0586%. static_runtime::to_maybe_copy_out (136 nodes, out variant)
     0.00216992 ms.   0.935446%. fb::lengths_to_offsets (17 nodes, out variant)
After: 0.240225
      0.0525392 ms.    23.2864%. static_runtime::to_maybe_copy_out (119 nodes, out variant)
     0.00265347 ms.    1.17607%. fb::to_lengths_to_offsets (17 nodes, out variant)

Remote_Other (3 fused nodes)
Not much affect

Differential Revision: D34696255

