### PR TITLE
Re-enable Windows debug libtorch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,7 +436,6 @@ binary_windows_params: &binary_windows_params
       default: "windows-xlarge-cpu-with-nvidia-cuda"
   environment:
     BUILD_ENVIRONMENT: << parameters.build_environment >>
-    BUILD_FOR_SYSTEM: windows
     JOB_EXECUTOR: <<parameters.executor>>
 
 promote_common: &promote_common

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -50,7 +50,7 @@ if [[ -z ${IS_GHA:-} ]]; then
   export PACKAGE_TYPE="${configs[0]}"
   export DESIRED_PYTHON="${configs[1]}"
   export DESIRED_CUDA="${configs[2]}"
-  if [[ "${BUILD_FOR_SYSTEM:-}" == "windows" ]]; then
+  if [[ "${OSTYPE}" == "msys" ]]; then
     export DESIRED_DEVTOOLSET=""
     export LIBTORCH_CONFIG="${configs[3]:-}"
     if [[ "$LIBTORCH_CONFIG" == 'debug' ]]; then
@@ -158,10 +158,14 @@ export DESIRED_PYTHON="${DESIRED_PYTHON:-}"
 export DESIRED_CUDA="$DESIRED_CUDA"
 export LIBTORCH_VARIANT="${LIBTORCH_VARIANT:-}"
 export BUILD_PYTHONLESS="${BUILD_PYTHONLESS:-}"
-export DESIRED_DEVTOOLSET="${DESIRED_DEVTOOLSET:-}"
-if [[ "${BUILD_FOR_SYSTEM:-}" == "windows" ]]; then
+if [[ "${OSTYPE}" == "msys" ]]; then
   export LIBTORCH_CONFIG="${LIBTORCH_CONFIG:-}"
-  export DEBUG="${DEBUG:-}"
+  if [[ "${LIBTORCH_CONFIG:-}" == 'debug' ]]; then
+    export DEBUG=1
+  fi
+  export DESIRED_DEVTOOLSET=""
+else
+  export DESIRED_DEVTOOLSET="${DESIRED_DEVTOOLSET:-}"
 fi
 
 export DATE="$DATE"

--- a/.circleci/verbatim-sources/build-parameters/binary-build-params.yml
+++ b/.circleci/verbatim-sources/build-parameters/binary-build-params.yml
@@ -62,5 +62,4 @@ binary_windows_params: &binary_windows_params
       default: "windows-xlarge-cpu-with-nvidia-cuda"
   environment:
     BUILD_ENVIRONMENT: << parameters.build_environment >>
-    BUILD_FOR_SYSTEM: windows
     JOB_EXECUTOR: <<parameters.executor>>

--- a/.github/generated-ciflow-ruleset.json
+++ b/.github/generated-ciflow-ruleset.json
@@ -61,8 +61,8 @@
       "linux-binary-libtorch-cxx11-abi",
       "linux-binary-libtorch-pre-cxx11",
       "linux-binary-manywheel",
-      "windows-binary-libtorch-cxx11-abi",
-      "windows-binary-libtorch-pre-cxx11",
+      "windows-binary-libtorch-debug",
+      "windows-binary-libtorch-release",
       "windows-binary-wheel"
     ],
     "ciflow/binaries_conda": [
@@ -71,8 +71,8 @@
     "ciflow/binaries_libtorch": [
       "linux-binary-libtorch-cxx11-abi",
       "linux-binary-libtorch-pre-cxx11",
-      "windows-binary-libtorch-cxx11-abi",
-      "windows-binary-libtorch-pre-cxx11"
+      "windows-binary-libtorch-debug",
+      "windows-binary-libtorch-release"
     ],
     "ciflow/binaries_wheel": [
       "linux-binary-manywheel",
@@ -134,8 +134,8 @@
       "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
       "win-vs2019-cpu-py3",
       "win-vs2019-cuda11.3-py3",
-      "windows-binary-libtorch-cxx11-abi",
-      "windows-binary-libtorch-pre-cxx11",
+      "windows-binary-libtorch-debug",
+      "windows-binary-libtorch-release",
       "windows-binary-wheel"
     ],
     "ciflow/docs": [

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -47,6 +47,8 @@ CONDA_CONTAINER_IMAGES = {
 
 PRE_CXX11_ABI = "pre-cxx11"
 CXX11_ABI = "cxx11-abi"
+RELEASE = "release"
+DEBUG = "debug"
 
 LIBTORCH_CONTAINER_IMAGES: Dict[Tuple[str, str], str] = {
     **{
@@ -137,10 +139,11 @@ def generate_libtorch_matrix(os: str, abi_version: str) -> List[Dict[str, str]]:
                         gpu_arch_type, gpu_arch_version
                     ),
                     "libtorch_variant": libtorch_variant,
-                    "devtoolset": abi_version,
+                    "libtorch_config": abi_version if os == "windows" else "",
+                    "devtoolset": abi_version if os != "windows" else "",
                     "container_image": LIBTORCH_CONTAINER_IMAGES[
                         (arch_version, abi_version)
-                    ],
+                    ] if os != "windows" else "",
                     "package_type": "libtorch",
                     "build_name": f"libtorch-{gpu_arch_type}{gpu_arch_version}-{libtorch_variant}-{abi_version}".replace(
                         ".", "_"

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -943,9 +943,9 @@ WINDOWS_BINARY_BUILD_WORKFLOWS = [
     BinaryBuildWorkflow(
         os=OperatingSystem.WINDOWS,
         package_type="libtorch",
-        abi_version=generate_binary_build_matrix.CXX11_ABI,
+        abi_version=generate_binary_build_matrix.RELEASE,
         build_configs=generate_binary_build_matrix.generate_libtorch_matrix(
-            OperatingSystem.WINDOWS, generate_binary_build_matrix.CXX11_ABI
+            OperatingSystem.WINDOWS, generate_binary_build_matrix.RELEASE
         ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},
@@ -955,9 +955,9 @@ WINDOWS_BINARY_BUILD_WORKFLOWS = [
     BinaryBuildWorkflow(
         os=OperatingSystem.WINDOWS,
         package_type="libtorch",
-        abi_version=generate_binary_build_matrix.PRE_CXX11_ABI,
+        abi_version=generate_binary_build_matrix.DEBUG,
         build_configs=generate_binary_build_matrix.generate_libtorch_matrix(
-            OperatingSystem.WINDOWS, generate_binary_build_matrix.PRE_CXX11_ABI
+            OperatingSystem.WINDOWS, generate_binary_build_matrix.DEBUG
         ),
         ciflow_config=CIFlowConfig(
             labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_BINARIES, LABEL_CIFLOW_BINARIES_LIBTORCH},

--- a/.github/templates/windows_binary_build_workflow.yml.j2
+++ b/.github/templates/windows_binary_build_workflow.yml.j2
@@ -20,8 +20,13 @@ name: !{{ build_environment }}
       GPU_ARCH_TYPE: !{{ config["gpu_arch_type"] }}
       SKIP_ALL_TESTS: 1
 {%- if config["package_type"] == "libtorch" %}
+{%- if config["libtorch_config"] %}
+      LIBTORCH_CONFIG: !{{ config["libtorch_config"] }}
+{%- endif %}
       LIBTORCH_VARIANT: !{{ config["libtorch_variant"] }}
+{%- if config["devtoolset"] %}
       DESIRED_DEVTOOLSET: !{{ config["devtoolset"] }}
+{%- endif %}
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"

--- a/.github/workflows/generated-windows-binary-libtorch-debug.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug.yml
@@ -1,7 +1,7 @@
 # @generated DO NOT EDIT MANUALLY
 # Template is at:    .github/templates/windows_binary_build_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: windows-binary-libtorch-pre-cxx11
+name: windows-binary-libtorch-debug
 
 on:
   push:
@@ -21,7 +21,7 @@ env:
   ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
   ANACONDA_USER: pytorch
   AWS_DEFAULT_REGION: us-east-1
-  BUILD_ENVIRONMENT: windows-binary-libtorch-pre-cxx11
+  BUILD_ENVIRONMENT: windows-binary-libtorch-debug
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
   IS_GHA: 1
@@ -31,11 +31,11 @@ env:
   SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
   SKIP_ALL_TESTS: 1
 concurrency:
-  group: windows-binary-libtorch-pre-cxx11-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: windows-binary-libtorch-debug-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
 jobs:
-  libtorch-cpu-shared-with-deps-pre-cxx11-build:
+  libtorch-cpu-shared-with-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -47,8 +47,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -101,7 +101,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cpu-shared-with-deps-pre-cxx11
+          name: libtorch-cpu-shared-with-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -118,9 +118,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-shared-with-deps-pre-cxx11-test:  # Testing
+  libtorch-cpu-shared-with-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-shared-with-deps-pre-cxx11-build
+    needs: libtorch-cpu-shared-with-deps-debug-build
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -132,8 +132,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -167,7 +167,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-shared-with-deps-pre-cxx11
+          name: libtorch-cpu-shared-with-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -201,10 +201,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-shared-with-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cpu-shared-with-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-shared-with-deps-pre-cxx11-test
+    needs: libtorch-cpu-shared-with-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -214,8 +214,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -268,7 +268,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-shared-with-deps-pre-cxx11
+          name: libtorch-cpu-shared-with-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -321,7 +321,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cpu-shared-without-deps-pre-cxx11-build:
+  libtorch-cpu-shared-without-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -333,8 +333,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -387,7 +387,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cpu-shared-without-deps-pre-cxx11
+          name: libtorch-cpu-shared-without-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -404,9 +404,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-shared-without-deps-pre-cxx11-test:  # Testing
+  libtorch-cpu-shared-without-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-shared-without-deps-pre-cxx11-build
+    needs: libtorch-cpu-shared-without-deps-debug-build
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -418,8 +418,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -453,7 +453,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-shared-without-deps-pre-cxx11
+          name: libtorch-cpu-shared-without-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -487,10 +487,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-shared-without-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cpu-shared-without-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-shared-without-deps-pre-cxx11-test
+    needs: libtorch-cpu-shared-without-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -500,8 +500,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -554,7 +554,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-shared-without-deps-pre-cxx11
+          name: libtorch-cpu-shared-without-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -607,7 +607,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cpu-static-with-deps-pre-cxx11-build:
+  libtorch-cpu-static-with-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -619,8 +619,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -673,7 +673,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cpu-static-with-deps-pre-cxx11
+          name: libtorch-cpu-static-with-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -690,9 +690,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-static-with-deps-pre-cxx11-test:  # Testing
+  libtorch-cpu-static-with-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-static-with-deps-pre-cxx11-build
+    needs: libtorch-cpu-static-with-deps-debug-build
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -704,8 +704,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -739,7 +739,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-static-with-deps-pre-cxx11
+          name: libtorch-cpu-static-with-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -773,10 +773,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-static-with-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cpu-static-with-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-static-with-deps-pre-cxx11-test
+    needs: libtorch-cpu-static-with-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -786,8 +786,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -840,7 +840,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-static-with-deps-pre-cxx11
+          name: libtorch-cpu-static-with-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -893,7 +893,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cpu-static-without-deps-pre-cxx11-build:
+  libtorch-cpu-static-without-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -905,8 +905,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -959,7 +959,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cpu-static-without-deps-pre-cxx11
+          name: libtorch-cpu-static-without-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -976,9 +976,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-static-without-deps-pre-cxx11-test:  # Testing
+  libtorch-cpu-static-without-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-static-without-deps-pre-cxx11-build
+    needs: libtorch-cpu-static-without-deps-debug-build
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -990,8 +990,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1025,7 +1025,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-static-without-deps-pre-cxx11
+          name: libtorch-cpu-static-without-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -1059,10 +1059,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-static-without-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cpu-static-without-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-static-without-deps-pre-cxx11-test
+    needs: libtorch-cpu-static-without-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -1072,8 +1072,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1126,7 +1126,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-static-without-deps-pre-cxx11
+          name: libtorch-cpu-static-without-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -1179,7 +1179,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_1-shared-with-deps-pre-cxx11-build:
+  libtorch-cuda11_1-shared-with-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1192,8 +1192,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1246,7 +1246,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_1-shared-with-deps-pre-cxx11
+          name: libtorch-cuda11_1-shared-with-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -1263,9 +1263,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-shared-with-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_1-shared-with-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-shared-with-deps-pre-cxx11-build
+    needs: libtorch-cuda11_1-shared-with-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -1278,8 +1278,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1313,7 +1313,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-shared-with-deps-pre-cxx11
+          name: libtorch-cuda11_1-shared-with-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -1347,10 +1347,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-shared-with-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_1-shared-with-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-shared-with-deps-pre-cxx11-test
+    needs: libtorch-cuda11_1-shared-with-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -1361,8 +1361,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1415,7 +1415,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-shared-with-deps-pre-cxx11
+          name: libtorch-cuda11_1-shared-with-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -1468,7 +1468,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_1-shared-without-deps-pre-cxx11-build:
+  libtorch-cuda11_1-shared-without-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1481,8 +1481,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1535,7 +1535,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_1-shared-without-deps-pre-cxx11
+          name: libtorch-cuda11_1-shared-without-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -1552,9 +1552,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-shared-without-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_1-shared-without-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-shared-without-deps-pre-cxx11-build
+    needs: libtorch-cuda11_1-shared-without-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -1567,8 +1567,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1602,7 +1602,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-shared-without-deps-pre-cxx11
+          name: libtorch-cuda11_1-shared-without-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -1636,10 +1636,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-shared-without-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_1-shared-without-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-shared-without-deps-pre-cxx11-test
+    needs: libtorch-cuda11_1-shared-without-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -1650,8 +1650,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1704,7 +1704,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-shared-without-deps-pre-cxx11
+          name: libtorch-cuda11_1-shared-without-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -1757,7 +1757,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_1-static-with-deps-pre-cxx11-build:
+  libtorch-cuda11_1-static-with-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1770,8 +1770,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1824,7 +1824,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_1-static-with-deps-pre-cxx11
+          name: libtorch-cuda11_1-static-with-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -1841,9 +1841,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-static-with-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_1-static-with-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-static-with-deps-pre-cxx11-build
+    needs: libtorch-cuda11_1-static-with-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -1856,8 +1856,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1891,7 +1891,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-static-with-deps-pre-cxx11
+          name: libtorch-cuda11_1-static-with-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -1925,10 +1925,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-static-with-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_1-static-with-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-static-with-deps-pre-cxx11-test
+    needs: libtorch-cuda11_1-static-with-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -1939,8 +1939,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1993,7 +1993,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-static-with-deps-pre-cxx11
+          name: libtorch-cuda11_1-static-with-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -2046,7 +2046,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_1-static-without-deps-pre-cxx11-build:
+  libtorch-cuda11_1-static-without-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2059,8 +2059,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2113,7 +2113,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_1-static-without-deps-pre-cxx11
+          name: libtorch-cuda11_1-static-without-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -2130,9 +2130,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-static-without-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_1-static-without-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-static-without-deps-pre-cxx11-build
+    needs: libtorch-cuda11_1-static-without-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -2145,8 +2145,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2180,7 +2180,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-static-without-deps-pre-cxx11
+          name: libtorch-cuda11_1-static-without-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -2214,10 +2214,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-static-without-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_1-static-without-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-static-without-deps-pre-cxx11-test
+    needs: libtorch-cuda11_1-static-without-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -2228,8 +2228,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2282,7 +2282,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-static-without-deps-pre-cxx11
+          name: libtorch-cuda11_1-static-without-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -2335,7 +2335,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_3-shared-with-deps-pre-cxx11-build:
+  libtorch-cuda11_3-shared-with-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2348,8 +2348,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2402,7 +2402,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_3-shared-with-deps-pre-cxx11
+          name: libtorch-cuda11_3-shared-with-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -2419,9 +2419,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-shared-with-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_3-shared-with-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-shared-with-deps-pre-cxx11-build
+    needs: libtorch-cuda11_3-shared-with-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -2434,8 +2434,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2469,7 +2469,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-shared-with-deps-pre-cxx11
+          name: libtorch-cuda11_3-shared-with-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -2503,10 +2503,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-shared-with-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_3-shared-with-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-shared-with-deps-pre-cxx11-test
+    needs: libtorch-cuda11_3-shared-with-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -2517,8 +2517,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2571,7 +2571,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-shared-with-deps-pre-cxx11
+          name: libtorch-cuda11_3-shared-with-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -2624,7 +2624,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_3-shared-without-deps-pre-cxx11-build:
+  libtorch-cuda11_3-shared-without-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2637,8 +2637,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2691,7 +2691,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_3-shared-without-deps-pre-cxx11
+          name: libtorch-cuda11_3-shared-without-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -2708,9 +2708,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-shared-without-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_3-shared-without-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-shared-without-deps-pre-cxx11-build
+    needs: libtorch-cuda11_3-shared-without-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -2723,8 +2723,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2758,7 +2758,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-shared-without-deps-pre-cxx11
+          name: libtorch-cuda11_3-shared-without-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -2792,10 +2792,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-shared-without-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_3-shared-without-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-shared-without-deps-pre-cxx11-test
+    needs: libtorch-cuda11_3-shared-without-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -2806,8 +2806,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2860,7 +2860,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-shared-without-deps-pre-cxx11
+          name: libtorch-cuda11_3-shared-without-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -2913,7 +2913,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_3-static-with-deps-pre-cxx11-build:
+  libtorch-cuda11_3-static-with-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2926,8 +2926,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2980,7 +2980,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_3-static-with-deps-pre-cxx11
+          name: libtorch-cuda11_3-static-with-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -2997,9 +2997,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-static-with-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_3-static-with-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-static-with-deps-pre-cxx11-build
+    needs: libtorch-cuda11_3-static-with-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -3012,8 +3012,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3047,7 +3047,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-static-with-deps-pre-cxx11
+          name: libtorch-cuda11_3-static-with-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -3081,10 +3081,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-static-with-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_3-static-with-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-static-with-deps-pre-cxx11-test
+    needs: libtorch-cuda11_3-static-with-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -3095,8 +3095,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3149,7 +3149,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-static-with-deps-pre-cxx11
+          name: libtorch-cuda11_3-static-with-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -3202,7 +3202,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_3-static-without-deps-pre-cxx11-build:
+  libtorch-cuda11_3-static-without-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3215,8 +3215,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3269,7 +3269,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_3-static-without-deps-pre-cxx11
+          name: libtorch-cuda11_3-static-without-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -3286,9 +3286,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-static-without-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_3-static-without-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-static-without-deps-pre-cxx11-build
+    needs: libtorch-cuda11_3-static-without-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -3301,8 +3301,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3336,7 +3336,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-static-without-deps-pre-cxx11
+          name: libtorch-cuda11_3-static-without-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -3370,10 +3370,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-static-without-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_3-static-without-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-static-without-deps-pre-cxx11-test
+    needs: libtorch-cuda11_3-static-without-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -3384,8 +3384,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3438,7 +3438,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-static-without-deps-pre-cxx11
+          name: libtorch-cuda11_3-static-without-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -3491,7 +3491,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_5-shared-with-deps-pre-cxx11-build:
+  libtorch-cuda11_5-shared-with-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3504,8 +3504,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3558,7 +3558,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_5-shared-with-deps-pre-cxx11
+          name: libtorch-cuda11_5-shared-with-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -3575,9 +3575,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-shared-with-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_5-shared-with-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-shared-with-deps-pre-cxx11-build
+    needs: libtorch-cuda11_5-shared-with-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -3590,8 +3590,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3625,7 +3625,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-shared-with-deps-pre-cxx11
+          name: libtorch-cuda11_5-shared-with-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -3659,10 +3659,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-shared-with-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_5-shared-with-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-shared-with-deps-pre-cxx11-test
+    needs: libtorch-cuda11_5-shared-with-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -3673,8 +3673,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3727,7 +3727,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-shared-with-deps-pre-cxx11
+          name: libtorch-cuda11_5-shared-with-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -3780,7 +3780,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_5-shared-without-deps-pre-cxx11-build:
+  libtorch-cuda11_5-shared-without-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3793,8 +3793,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3847,7 +3847,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_5-shared-without-deps-pre-cxx11
+          name: libtorch-cuda11_5-shared-without-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -3864,9 +3864,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-shared-without-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_5-shared-without-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-shared-without-deps-pre-cxx11-build
+    needs: libtorch-cuda11_5-shared-without-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -3879,8 +3879,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3914,7 +3914,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-shared-without-deps-pre-cxx11
+          name: libtorch-cuda11_5-shared-without-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -3948,10 +3948,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-shared-without-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_5-shared-without-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-shared-without-deps-pre-cxx11-test
+    needs: libtorch-cuda11_5-shared-without-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -3962,8 +3962,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4016,7 +4016,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-shared-without-deps-pre-cxx11
+          name: libtorch-cuda11_5-shared-without-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -4069,7 +4069,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_5-static-with-deps-pre-cxx11-build:
+  libtorch-cuda11_5-static-with-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -4082,8 +4082,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4136,7 +4136,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_5-static-with-deps-pre-cxx11
+          name: libtorch-cuda11_5-static-with-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -4153,9 +4153,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-static-with-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_5-static-with-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-static-with-deps-pre-cxx11-build
+    needs: libtorch-cuda11_5-static-with-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -4168,8 +4168,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4203,7 +4203,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-static-with-deps-pre-cxx11
+          name: libtorch-cuda11_5-static-with-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -4237,10 +4237,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-static-with-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_5-static-with-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-static-with-deps-pre-cxx11-test
+    needs: libtorch-cuda11_5-static-with-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -4251,8 +4251,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4305,7 +4305,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-static-with-deps-pre-cxx11
+          name: libtorch-cuda11_5-static-with-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -4358,7 +4358,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_5-static-without-deps-pre-cxx11-build:
+  libtorch-cuda11_5-static-without-deps-debug-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -4371,8 +4371,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4425,7 +4425,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_5-static-without-deps-pre-cxx11
+          name: libtorch-cuda11_5-static-without-deps-debug
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -4442,9 +4442,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-static-without-deps-pre-cxx11-test:  # Testing
+  libtorch-cuda11_5-static-without-deps-debug-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-static-without-deps-pre-cxx11-build
+    needs: libtorch-cuda11_5-static-without-deps-debug-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -4457,8 +4457,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4492,7 +4492,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-static-without-deps-pre-cxx11
+          name: libtorch-cuda11_5-static-without-deps-debug
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -4526,10 +4526,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-static-without-deps-pre-cxx11-upload:  # Uploading
+  libtorch-cuda11_5-static-without-deps-debug-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-static-without-deps-pre-cxx11-test
+    needs: libtorch-cuda11_5-static-without-deps-debug-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -4540,8 +4540,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: debug
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: pre-cxx11
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4594,7 +4594,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-static-without-deps-pre-cxx11
+          name: libtorch-cuda11_5-static-without-deps-debug
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}

--- a/.github/workflows/generated-windows-binary-libtorch-release.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release.yml
@@ -1,7 +1,7 @@
 # @generated DO NOT EDIT MANUALLY
 # Template is at:    .github/templates/windows_binary_build_workflow.yml.j2
 # Generation script: .github/scripts/generate_ci_workflows.py
-name: windows-binary-libtorch-cxx11-abi
+name: windows-binary-libtorch-release
 
 on:
   push:
@@ -21,7 +21,7 @@ env:
   ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
   ANACONDA_USER: pytorch
   AWS_DEFAULT_REGION: us-east-1
-  BUILD_ENVIRONMENT: windows-binary-libtorch-cxx11-abi
+  BUILD_ENVIRONMENT: windows-binary-libtorch-release
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
   IS_GHA: 1
@@ -31,11 +31,11 @@ env:
   SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
   SKIP_ALL_TESTS: 1
 concurrency:
-  group: windows-binary-libtorch-cxx11-abi-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  group: windows-binary-libtorch-release-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
 jobs:
-  libtorch-cpu-shared-with-deps-cxx11-abi-build:
+  libtorch-cpu-shared-with-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -47,8 +47,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -101,7 +101,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cpu-shared-with-deps-cxx11-abi
+          name: libtorch-cpu-shared-with-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -118,9 +118,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-shared-with-deps-cxx11-abi-test:  # Testing
+  libtorch-cpu-shared-with-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-shared-with-deps-cxx11-abi-build
+    needs: libtorch-cpu-shared-with-deps-release-build
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -132,8 +132,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -167,7 +167,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-shared-with-deps-cxx11-abi
+          name: libtorch-cpu-shared-with-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -201,10 +201,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-shared-with-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cpu-shared-with-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-shared-with-deps-cxx11-abi-test
+    needs: libtorch-cpu-shared-with-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -214,8 +214,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -268,7 +268,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-shared-with-deps-cxx11-abi
+          name: libtorch-cpu-shared-with-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -321,7 +321,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cpu-shared-without-deps-cxx11-abi-build:
+  libtorch-cpu-shared-without-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -333,8 +333,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -387,7 +387,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cpu-shared-without-deps-cxx11-abi
+          name: libtorch-cpu-shared-without-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -404,9 +404,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-shared-without-deps-cxx11-abi-test:  # Testing
+  libtorch-cpu-shared-without-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-shared-without-deps-cxx11-abi-build
+    needs: libtorch-cpu-shared-without-deps-release-build
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -418,8 +418,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -453,7 +453,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-shared-without-deps-cxx11-abi
+          name: libtorch-cpu-shared-without-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -487,10 +487,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-shared-without-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cpu-shared-without-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-shared-without-deps-cxx11-abi-test
+    needs: libtorch-cpu-shared-without-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -500,8 +500,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -554,7 +554,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-shared-without-deps-cxx11-abi
+          name: libtorch-cpu-shared-without-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -607,7 +607,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cpu-static-with-deps-cxx11-abi-build:
+  libtorch-cpu-static-with-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -619,8 +619,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -673,7 +673,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cpu-static-with-deps-cxx11-abi
+          name: libtorch-cpu-static-with-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -690,9 +690,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-static-with-deps-cxx11-abi-test:  # Testing
+  libtorch-cpu-static-with-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-static-with-deps-cxx11-abi-build
+    needs: libtorch-cpu-static-with-deps-release-build
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -704,8 +704,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -739,7 +739,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-static-with-deps-cxx11-abi
+          name: libtorch-cpu-static-with-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -773,10 +773,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-static-with-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cpu-static-with-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-static-with-deps-cxx11-abi-test
+    needs: libtorch-cpu-static-with-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -786,8 +786,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -840,7 +840,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-static-with-deps-cxx11-abi
+          name: libtorch-cpu-static-with-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -893,7 +893,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cpu-static-without-deps-cxx11-abi-build:
+  libtorch-cpu-static-without-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -905,8 +905,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -959,7 +959,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cpu-static-without-deps-cxx11-abi
+          name: libtorch-cpu-static-without-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -976,9 +976,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-static-without-deps-cxx11-abi-test:  # Testing
+  libtorch-cpu-static-without-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-static-without-deps-cxx11-abi-build
+    needs: libtorch-cpu-static-without-deps-release-build
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -990,8 +990,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1025,7 +1025,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-static-without-deps-cxx11-abi
+          name: libtorch-cpu-static-without-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -1059,10 +1059,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cpu-static-without-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cpu-static-without-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cpu-static-without-deps-cxx11-abi-test
+    needs: libtorch-cpu-static-without-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -1072,8 +1072,8 @@ jobs:
       DESIRED_CUDA: cpu
       GPU_ARCH_TYPE: cpu
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1126,7 +1126,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cpu-static-without-deps-cxx11-abi
+          name: libtorch-cpu-static-without-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -1179,7 +1179,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_1-shared-with-deps-cxx11-abi-build:
+  libtorch-cuda11_1-shared-with-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1192,8 +1192,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1246,7 +1246,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_1-shared-with-deps-cxx11-abi
+          name: libtorch-cuda11_1-shared-with-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -1263,9 +1263,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-shared-with-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_1-shared-with-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-shared-with-deps-cxx11-abi-build
+    needs: libtorch-cuda11_1-shared-with-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -1278,8 +1278,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1313,7 +1313,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-shared-with-deps-cxx11-abi
+          name: libtorch-cuda11_1-shared-with-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -1347,10 +1347,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-shared-with-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_1-shared-with-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-shared-with-deps-cxx11-abi-test
+    needs: libtorch-cuda11_1-shared-with-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -1361,8 +1361,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1415,7 +1415,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-shared-with-deps-cxx11-abi
+          name: libtorch-cuda11_1-shared-with-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -1468,7 +1468,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_1-shared-without-deps-cxx11-abi-build:
+  libtorch-cuda11_1-shared-without-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1481,8 +1481,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1535,7 +1535,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_1-shared-without-deps-cxx11-abi
+          name: libtorch-cuda11_1-shared-without-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -1552,9 +1552,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-shared-without-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_1-shared-without-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-shared-without-deps-cxx11-abi-build
+    needs: libtorch-cuda11_1-shared-without-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -1567,8 +1567,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1602,7 +1602,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-shared-without-deps-cxx11-abi
+          name: libtorch-cuda11_1-shared-without-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -1636,10 +1636,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-shared-without-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_1-shared-without-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-shared-without-deps-cxx11-abi-test
+    needs: libtorch-cuda11_1-shared-without-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -1650,8 +1650,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1704,7 +1704,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-shared-without-deps-cxx11-abi
+          name: libtorch-cuda11_1-shared-without-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -1757,7 +1757,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_1-static-with-deps-cxx11-abi-build:
+  libtorch-cuda11_1-static-with-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1770,8 +1770,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1824,7 +1824,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_1-static-with-deps-cxx11-abi
+          name: libtorch-cuda11_1-static-with-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -1841,9 +1841,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-static-with-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_1-static-with-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-static-with-deps-cxx11-abi-build
+    needs: libtorch-cuda11_1-static-with-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -1856,8 +1856,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1891,7 +1891,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-static-with-deps-cxx11-abi
+          name: libtorch-cuda11_1-static-with-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -1925,10 +1925,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-static-with-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_1-static-with-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-static-with-deps-cxx11-abi-test
+    needs: libtorch-cuda11_1-static-with-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -1939,8 +1939,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -1993,7 +1993,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-static-with-deps-cxx11-abi
+          name: libtorch-cuda11_1-static-with-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -2046,7 +2046,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_1-static-without-deps-cxx11-abi-build:
+  libtorch-cuda11_1-static-without-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2059,8 +2059,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2113,7 +2113,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_1-static-without-deps-cxx11-abi
+          name: libtorch-cuda11_1-static-without-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -2130,9 +2130,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-static-without-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_1-static-without-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-static-without-deps-cxx11-abi-build
+    needs: libtorch-cuda11_1-static-without-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -2145,8 +2145,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2180,7 +2180,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-static-without-deps-cxx11-abi
+          name: libtorch-cuda11_1-static-without-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -2214,10 +2214,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_1-static-without-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_1-static-without-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_1-static-without-deps-cxx11-abi-test
+    needs: libtorch-cuda11_1-static-without-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -2228,8 +2228,8 @@ jobs:
       GPU_ARCH_VERSION: 11.1
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2282,7 +2282,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_1-static-without-deps-cxx11-abi
+          name: libtorch-cuda11_1-static-without-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -2335,7 +2335,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_3-shared-with-deps-cxx11-abi-build:
+  libtorch-cuda11_3-shared-with-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2348,8 +2348,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2402,7 +2402,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_3-shared-with-deps-cxx11-abi
+          name: libtorch-cuda11_3-shared-with-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -2419,9 +2419,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-shared-with-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_3-shared-with-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-shared-with-deps-cxx11-abi-build
+    needs: libtorch-cuda11_3-shared-with-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -2434,8 +2434,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2469,7 +2469,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-shared-with-deps-cxx11-abi
+          name: libtorch-cuda11_3-shared-with-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -2503,10 +2503,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-shared-with-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_3-shared-with-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-shared-with-deps-cxx11-abi-test
+    needs: libtorch-cuda11_3-shared-with-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -2517,8 +2517,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2571,7 +2571,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-shared-with-deps-cxx11-abi
+          name: libtorch-cuda11_3-shared-with-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -2624,7 +2624,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_3-shared-without-deps-cxx11-abi-build:
+  libtorch-cuda11_3-shared-without-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2637,8 +2637,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2691,7 +2691,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_3-shared-without-deps-cxx11-abi
+          name: libtorch-cuda11_3-shared-without-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -2708,9 +2708,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-shared-without-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_3-shared-without-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-shared-without-deps-cxx11-abi-build
+    needs: libtorch-cuda11_3-shared-without-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -2723,8 +2723,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2758,7 +2758,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-shared-without-deps-cxx11-abi
+          name: libtorch-cuda11_3-shared-without-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -2792,10 +2792,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-shared-without-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_3-shared-without-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-shared-without-deps-cxx11-abi-test
+    needs: libtorch-cuda11_3-shared-without-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -2806,8 +2806,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2860,7 +2860,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-shared-without-deps-cxx11-abi
+          name: libtorch-cuda11_3-shared-without-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -2913,7 +2913,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_3-static-with-deps-cxx11-abi-build:
+  libtorch-cuda11_3-static-with-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2926,8 +2926,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -2980,7 +2980,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_3-static-with-deps-cxx11-abi
+          name: libtorch-cuda11_3-static-with-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -2997,9 +2997,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-static-with-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_3-static-with-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-static-with-deps-cxx11-abi-build
+    needs: libtorch-cuda11_3-static-with-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -3012,8 +3012,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3047,7 +3047,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-static-with-deps-cxx11-abi
+          name: libtorch-cuda11_3-static-with-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -3081,10 +3081,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-static-with-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_3-static-with-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-static-with-deps-cxx11-abi-test
+    needs: libtorch-cuda11_3-static-with-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -3095,8 +3095,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3149,7 +3149,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-static-with-deps-cxx11-abi
+          name: libtorch-cuda11_3-static-with-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -3202,7 +3202,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_3-static-without-deps-cxx11-abi-build:
+  libtorch-cuda11_3-static-without-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3215,8 +3215,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3269,7 +3269,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_3-static-without-deps-cxx11-abi
+          name: libtorch-cuda11_3-static-without-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -3286,9 +3286,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-static-without-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_3-static-without-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-static-without-deps-cxx11-abi-build
+    needs: libtorch-cuda11_3-static-without-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -3301,8 +3301,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3336,7 +3336,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-static-without-deps-cxx11-abi
+          name: libtorch-cuda11_3-static-without-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -3370,10 +3370,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_3-static-without-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_3-static-without-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_3-static-without-deps-cxx11-abi-test
+    needs: libtorch-cuda11_3-static-without-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -3384,8 +3384,8 @@ jobs:
       GPU_ARCH_VERSION: 11.3
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3438,7 +3438,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_3-static-without-deps-cxx11-abi
+          name: libtorch-cuda11_3-static-without-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -3491,7 +3491,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_5-shared-with-deps-cxx11-abi-build:
+  libtorch-cuda11_5-shared-with-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3504,8 +3504,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3558,7 +3558,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_5-shared-with-deps-cxx11-abi
+          name: libtorch-cuda11_5-shared-with-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -3575,9 +3575,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-shared-with-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_5-shared-with-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-shared-with-deps-cxx11-abi-build
+    needs: libtorch-cuda11_5-shared-with-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -3590,8 +3590,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3625,7 +3625,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-shared-with-deps-cxx11-abi
+          name: libtorch-cuda11_5-shared-with-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -3659,10 +3659,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-shared-with-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_5-shared-with-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-shared-with-deps-cxx11-abi-test
+    needs: libtorch-cuda11_5-shared-with-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -3673,8 +3673,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3727,7 +3727,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-shared-with-deps-cxx11-abi
+          name: libtorch-cuda11_5-shared-with-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -3780,7 +3780,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_5-shared-without-deps-cxx11-abi-build:
+  libtorch-cuda11_5-shared-without-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3793,8 +3793,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3847,7 +3847,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_5-shared-without-deps-cxx11-abi
+          name: libtorch-cuda11_5-shared-without-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -3864,9 +3864,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-shared-without-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_5-shared-without-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-shared-without-deps-cxx11-abi-build
+    needs: libtorch-cuda11_5-shared-without-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -3879,8 +3879,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -3914,7 +3914,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-shared-without-deps-cxx11-abi
+          name: libtorch-cuda11_5-shared-without-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -3948,10 +3948,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-shared-without-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_5-shared-without-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-shared-without-deps-cxx11-abi-test
+    needs: libtorch-cuda11_5-shared-without-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -3962,8 +3962,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: shared-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4016,7 +4016,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-shared-without-deps-cxx11-abi
+          name: libtorch-cuda11_5-shared-without-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -4069,7 +4069,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_5-static-with-deps-cxx11-abi-build:
+  libtorch-cuda11_5-static-with-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -4082,8 +4082,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4136,7 +4136,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_5-static-with-deps-cxx11-abi
+          name: libtorch-cuda11_5-static-with-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -4153,9 +4153,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-static-with-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_5-static-with-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-static-with-deps-cxx11-abi-build
+    needs: libtorch-cuda11_5-static-with-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -4168,8 +4168,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4203,7 +4203,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-static-with-deps-cxx11-abi
+          name: libtorch-cuda11_5-static-with-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -4237,10 +4237,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-static-with-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_5-static-with-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-static-with-deps-cxx11-abi-test
+    needs: libtorch-cuda11_5-static-with-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -4251,8 +4251,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-with-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4305,7 +4305,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-static-with-deps-cxx11-abi
+          name: libtorch-cuda11_5-static-with-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}
@@ -4358,7 +4358,7 @@ jobs:
           docker stop $(docker ps -q) || true
           # Prune all of the docker images
           docker system prune -af
-  libtorch-cuda11_5-static-without-deps-cxx11-abi-build:
+  libtorch-cuda11_5-static-without-deps-release-build:
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -4371,8 +4371,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4425,7 +4425,7 @@ jobs:
       - uses: seemethere/upload-artifact-s3@v3
         if: always()
         with:
-          name: libtorch-cuda11_5-static-without-deps-cxx11-abi
+          name: libtorch-cuda11_5-static-without-deps-release
           retention-days: 14
           if-no-files-found: error
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
@@ -4442,9 +4442,9 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-static-without-deps-cxx11-abi-test:  # Testing
+  libtorch-cuda11_5-static-without-deps-release-test:  # Testing
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-static-without-deps-cxx11-abi-build
+    needs: libtorch-cuda11_5-static-without-deps-release-build
     runs-on: windows.8xlarge.nvidia.gpu
     timeout-minutes: 240
     env:
@@ -4457,8 +4457,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4492,7 +4492,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-static-without-deps-cxx11-abi
+          name: libtorch-cuda11_5-static-without-deps-release
           path: "${{ env.PYTORCH_FINAL_PACKAGE_DIR }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -4526,10 +4526,10 @@ jobs:
         if: always()
         run: |
           .github\scripts\kill_active_ssh_sessions.ps1
-  libtorch-cuda11_5-static-without-deps-cxx11-abi-upload:  # Uploading
+  libtorch-cuda11_5-static-without-deps-release-upload:  # Uploading
     runs-on: linux.2xlarge  # self hosted runner to download ec2 artifacts
     if: ${{ github.repository_owner == 'pytorch' }}
-    needs: libtorch-cuda11_5-static-without-deps-cxx11-abi-test
+    needs: libtorch-cuda11_5-static-without-deps-release-test
     env:
       PYTORCH_ROOT: ${{ github.workspace }}/pytorch
       BUILDER_ROOT: ${{ github.workspace }}/builder
@@ -4540,8 +4540,8 @@ jobs:
       GPU_ARCH_VERSION: 11.5
       GPU_ARCH_TYPE: cuda
       SKIP_ALL_TESTS: 1
+      LIBTORCH_CONFIG: release
       LIBTORCH_VARIANT: static-without-deps
-      DESIRED_DEVTOOLSET: cxx11-abi
       # This is a dummy value for libtorch to work correctly with our batch scripts
       # without this value pip does not get installed for some reason
       DESIRED_PYTHON: "3.7"
@@ -4594,7 +4594,7 @@ jobs:
       - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
         name: Download Build Artifacts
         with:
-          name: libtorch-cuda11_5-static-without-deps-cxx11-abi
+          name: libtorch-cuda11_5-static-without-deps-release
           path: "${{ runner.temp }}/artifacts/"
       - name: Set DRY_RUN (only for tagged pushes)
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')}}


### PR DESCRIPTION
This is cherry pick of #73805 to release branch
Get rid of BUILD_FOR_SYSTEM environment variable
Pass libtorch_config environment variable for Windows builds

Please note small difference between original PR: is changes that where in [.github/templates/upload.yml.j2](https://github.com/pytorch/pytorch/commit/bebfdca093e7e3f81326a11a6f00fc1142154673#diff-964ada811375c35165a15fafea11daf9a5dfcea2ada19913a0acf441dafdf0f3)

Are now in
[.github/templates/windows_binary_build_workflow.yml.j2](https://github.com/pytorch/pytorch/pull/73900/files#diff-77e9719ba591dcb60b0f563bb7a6668044ddc427673fb4acaeef2bf41154435d)

this is because release branch is based on the older codebase.