### PR TITLE
[ROCm] Update the magma commit

### DIFF
--- a/.circleci/docker/common/install_rocm.sh
+++ b/.circleci/docker/common/install_rocm.sh
@@ -6,8 +6,8 @@ install_magma() {
     # "install" hipMAGMA into /opt/rocm/magma by copying after build
     git clone https://bitbucket.org/icl/magma.git
     pushd magma
-    # fix for magma_queue memory leak issue
-    git checkout c62d700d880c7283b33fb1d615d62fc9c7f7ca21
+    # Mar 7 - Fixes memory leaks for many linalg UTs
+    git checkout 5959b8783e45f1809812ed96ae762f38ee701972
     cp make.inc-examples/make.inc.hip-gcc-mkl make.inc
     echo 'LIBDIR += -L$(MKLROOT)/lib' >> make.inc
     echo 'LIB += -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib -Wl,--rpath,$(MKLROOT)/lib -Wl,--rpath,/opt/rocm/magma/lib' >> make.inc


### PR DESCRIPTION
- This move later magma commit, fixes many memory leaks which
  were found while running linalg UT on ROCm 5.0 release. These memory issues were exposed by the PR https://github.com/pytorch/pytorch/pull/66933

cc @jeffdaily @jithunnair-amd 