### PR TITLE
Fix nightly docker publish build

### DIFF
--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -3,7 +3,7 @@
 set -xeuo pipefail
 
 PYTORCH_DOCKER_TAG=$(git describe --tags --always)-devel
-CUDA_VERSION=11.3
+CUDA_VERSION=11.3.0
 
 # Build PyTorch nightly docker
 make -f docker.Makefile \


### PR DESCRIPTION
The build-publish-docker step is broken because 
```
docker.io/nvidia/cuda:11.3-cudnn8-devel-ubuntu18.04
```
should be 
```
docker.io/nvidia/cuda:11.3.0-cudnn8-devel-ubuntu18.04
```
See https://hub.docker.com/r/nvidia/cuda/tags?page=1&ordering=-name&name=11.3

The regression was introduced by https://github.com/pytorch/pytorch/commit/197764b35db68dee21ccc542d88a338f813623e7