### PR TITLE
[ONNX] Modify int[] listConstruct to support tensor arg

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5630,24 +5630,14 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(OnesModel(), x, remained_onnx_input_idx=[])
 
     @skipIfUnsupportedMinOpsetVersion(9)
-    @disableScriptTest()
-    def test_zeros_with_tensorinput(self):
-        class Zero_(torch.nn.Module):
+    @disableScriptTest()  # torch.zeros/torch.ones with size tensor of dim != 0 not torchScript compatible.
+    def test_zeros_ones_with_tensor_input(self):
+        class ZeroAndOnes(torch.nn.Module):
             def forward(self, x):
-                return x, torch.zeros(x, 1)
+                return torch.zeros(x, 1), torch.ones(x, 1)
 
         x = torch.tensor([2])
-        self.run_test(Zero_(), (x, ))
-
-    @skipIfUnsupportedMinOpsetVersion(9)
-    @disableScriptTest()
-    def test_ones_with_tensorinput(self):
-        class Ones_(torch.nn.Module):
-            def forward(self, x):
-                return x, torch.ones(x, 1)
-
-        x = torch.tensor([2])
-        self.run_test(Ones_(), (x, ))
+        self.run_test(ZeroAndOnes(), (x, ))
 
     @skipIfONNXShapeInference(True)
     @skipIfUnsupportedMinOpsetVersion(9)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5620,16 +5620,6 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(Zero_(), x, remained_onnx_input_idx=[])
 
     @skipIfUnsupportedMinOpsetVersion(9)
-    @disableScriptTest()
-    def test_zeros_with_tensorinput(self):
-        class Zero_(torch.nn.Module):
-            def forward(self, x):
-                return x, torch.zeros(x, 1)
-
-        x = torch.tensor([2])
-        self.run_test(Zero_(), (x, ))
-
-    @skipIfUnsupportedMinOpsetVersion(9)
     def test_new_ones(self):
         class OnesModel(torch.nn.Module):
             def forward(self, x):
@@ -5649,6 +5639,16 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor([2])
         self.run_test(Zero_(), (x, ))
 
+    @skipIfUnsupportedMinOpsetVersion(9)
+    @disableScriptTest()
+    def test_ones_with_tensorinput(self):
+        class Ones_(torch.nn.Module):
+            def forward(self, x):
+                return x, torch.ones(x, 1)
+
+        x = torch.tensor([2])
+        self.run_test(Ones_(), (x, ))
+
     @skipIfONNXShapeInference(True)
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_tolist(self):
@@ -5662,16 +5662,6 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(2, 3)
         self.run_test(List(), (x,))
-
-    @skipIfUnsupportedMinOpsetVersion(9)
-    @disableScriptTest()
-    def test_ones_with_tensorinput(self):
-        class Ones_(torch.nn.Module):
-            def forward(self, x):
-                return x, torch.ones(x, 1)
-
-        x = torch.tensor([2])
-        self.run_test(Ones_(), (x, ))
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_list_pass(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5620,6 +5620,16 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(Zero_(), x, remained_onnx_input_idx=[])
 
     @skipIfUnsupportedMinOpsetVersion(9)
+    @disableScriptTest()
+    def test_zeros_with_tensorinput(self):
+        class Zero_(torch.nn.Module):
+            def forward(self, x):
+                return x, torch.zeros(x, 1)
+
+        x = torch.tensor([2])
+        self.run_test(Zero_(), (x, ))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_new_ones(self):
         class OnesModel(torch.nn.Module):
             def forward(self, x):
@@ -5628,6 +5638,16 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_test(OnesModel(), x, input_names=["x"], dynamic_axes={"x": [0, 1, 2]})
         self.run_test(OnesModel(), x, remained_onnx_input_idx=[])
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    @disableScriptTest()
+    def test_zeros_with_tensorinput(self):
+        class Zero_(torch.nn.Module):
+            def forward(self, x):
+                return x, torch.zeros(x, 1)
+
+        x = torch.tensor([2])
+        self.run_test(Zero_(), (x, ))
 
     @skipIfONNXShapeInference(True)
     @skipIfUnsupportedMinOpsetVersion(9)
@@ -5642,6 +5662,16 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(2, 3)
         self.run_test(List(), (x,))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    @disableScriptTest()
+    def test_ones_with_tensorinput(self):
+        class Ones_(torch.nn.Module):
+            def forward(self, x):
+                return x, torch.ones(x, 1)
+
+        x = torch.tensor([2])
+        self.run_test(Ones_(), (x, ))
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_list_pass(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5630,7 +5630,7 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(OnesModel(), x, remained_onnx_input_idx=[])
 
     @skipIfUnsupportedMinOpsetVersion(9)
-    @disableScriptTest()  # torch.zeros/torch.ones with size tensor of dim != 0 not torchScript compatible.
+    @disableScriptTest()  # torch.zeros/torch.ones with size tensor of dim != 0 not scriptable.
     def test_zeros_ones_with_tensor_input(self):
         class ZeroAndOnes(torch.nn.Module):
             def forward(self, x):

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -186,7 +186,10 @@ Node* transformToONNXConcatNode(
   for (auto* input : lc_node->inputs()) {
     auto new_input =
         need_new_input ? g->addInput()->copyMetadata(input) : input;
-    // Skip unsqueeze for input node if input dim is already 1 or more
+    // ONNX Concat requires tensor inputs with rank > axis(=0). Certain inputs from
+    // ListConstruct Int[] output case are scalars and require an unsqueeze node
+    // to convert them to a tensor. For inputs that are already tensors, we skip
+    // the step of creating a corresponding unsqueeze node
     if (auto type = new_input->type()->cast<TensorType>()) {
       if (type->dim() && type->dim() > 0) {
         unsqueezed.emplace_back(new_input);

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -186,12 +186,14 @@ Node* transformToONNXConcatNode(
   for (auto* input : lc_node->inputs()) {
     auto new_input =
         need_new_input ? g->addInput()->copyMetadata(input) : input;
-    // ONNX Concat requires tensor inputs with rank > axis(=0). Certain inputs from
-    // ListConstruct Int[] output case are scalars and require an unsqueeze node
-    // to convert them to a tensor. For inputs that are already tensors, we skip
-    // the step of creating a corresponding unsqueeze node
+    // This particular Concat operation concats along axis=0 and this requires
+    // inputs to the node to have the same shape along dim-0. To ensure this,
+    // unsqueeze nodes are added such that all shapes along dim-0 are 1.
+    // Certain inputs from ListConstruct Int[] could be combinations of scalars and 1-D tensors,
+    // For inputs that are already 1-D tensors, we skip the step of creating a
+    // corresponding unsqueeze node.
     if (auto type = new_input->type()->cast<TensorType>()) {
-      if (type->dim() && type->dim() > 0) {
+      if (type->dim() && type->dim() == 1) {
         unsqueezed.emplace_back(new_input);
         continue;
       }

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -186,7 +186,13 @@ Node* transformToONNXConcatNode(
   for (auto* input : lc_node->inputs()) {
     auto new_input =
         need_new_input ? g->addInput()->copyMetadata(input) : input;
-
+    // Skip unsqueeze for input node if input dim is already 1 or more
+    if (auto type = new_input->type()->cast<TensorType>()) {
+      if (type->dim() && type->dim() > 0) {
+        unsqueezed.emplace_back(new_input);
+        continue;
+      }
+    }
     Node* unsqueezed_node =
         createONNXUnsqueeze(g, new_node, new_input, 0, opset_version);
     unsqueezed_node->copyMetadata(lc_node);


### PR DESCRIPTION
Avoid creating unsqueeze nodes for ListConstruct Int[] ouput case with tensor inputs
For example, if the listConstruct is (tensor[2], 1, 5), avoid adding unsqueeze nodes for tensor[2]
