### PR TITLE
fix onnx on macOS fastbuild

### DIFF
--- a/third_party/onnx.BUILD
+++ b/third_party/onnx.BUILD
@@ -97,6 +97,14 @@ cc_library(
         "ONNX_ML=1",
         "ONNX_NAMESPACE=onnx_torch",
     ],
+    copts = select({
+        "@platforms//os:linux": [],
+        # convert.h has an identifier named "DEBUG". This would
+        # conflict with any preprocessor definition by the same
+        # name. Compilations with --compilation_mode=fastbuild on
+        # macOS define this.
+        "@platforms//os:macos": ["-UDEBUG"],
+    }),
     includes = [
         ".",
         "onnx/",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#73929**
* #73597
* #73596
* #73594
* #73799
* #73592
* #73797

It uses the DEBUG identifier which will get overridden with `-DDEBUG`
in macOS --compilation_mode=fastbuild.