### PR TITLE
Raise meaningful error for bad sample_shape

### DIFF
--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -241,6 +241,9 @@ class Distribution(object):
         Args:
             sample_shape (torch.Size): the size of the sample to be drawn.
         """
+        if isinstance(sample_shape, int):
+            raise TypeError(f"sample_shape {sample_shape} of type int is not supported. "
+                            f"Did you mean ({sample_shape},)?")
         if not isinstance(sample_shape, torch.Size):
             sample_shape = torch.Size(sample_shape)
         return sample_shape + self._batch_shape + self._event_shape

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -4,6 +4,7 @@ from torch.distributions import constraints
 from torch.distributions.utils import lazy_property
 from typing import Dict, Optional, Any
 
+from ..distributed._shard.sharded_tensor.utils import _flatten_tensor_size
 
 class Distribution(object):
     r"""
@@ -241,11 +242,7 @@ class Distribution(object):
         Args:
             sample_shape (torch.Size): the size of the sample to be drawn.
         """
-        if isinstance(sample_shape, int):
-            raise TypeError(f"sample_shape {sample_shape} of type int is not supported. "
-                            f"Did you mean ({sample_shape},)?")
-        if not isinstance(sample_shape, torch.Size):
-            sample_shape = torch.Size(sample_shape)
+        sample_shape = _flatten_tensor_size(sample_shape)
         return sample_shape + self._batch_shape + self._event_shape
 
     def _validate_sample(self, value):


### PR DESCRIPTION
Fixes #73826 by raising a meaningful error message when `dist.sample(sample_shape)` receives `sample_shape` of type `int`.

### Code Example
```py
import torch
dist = torch.distributions
dist.Normal(0.5, 1).sample(100)
```
### Output before this PR

```py
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-92539ca3d3c2> in <module>
      3 dist=torch.distributions
      4 
----> 5 dist.Normal(0.5, 1).sample(100)

~/pytorch/torch/distributions/normal.py in sample(self, sample_shape)
     60 
     61     def sample(self, sample_shape=torch.Size()):
---> 62         shape = self._extended_shape(sample_shape)
     63         with torch.no_grad():
     64             return torch.normal(self.loc.expand(shape), self.scale.expand(shape))

~/pytorch/torch/distributions/distribution.py in _extended_shape(self, sample_shape)
    243         """
    244         if not isinstance(sample_shape, torch.Size):
--> 245             sample_shape = torch.Size(sample_shape)
    246         return sample_shape + self._batch_shape + self._event_shape
    247 

TypeError: 'int' object is not iterable
```

### Output after this PR

```py
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-92539ca3d3c2> in <module>
      3 dist=torch.distributions
      4 
----> 5 dist.Normal(0.5, 1).sample(100)

~/pytorch/torch/distributions/normal.py in sample(self, sample_shape)
     60 
     61     def sample(self, sample_shape=torch.Size()):
---> 62         shape = self._extended_shape(sample_shape)
     63         with torch.no_grad():
     64             return torch.normal(self.loc.expand(shape), self.scale.expand(shape))

~/pytorch/torch/distributions/distribution.py in _extended_shape(self, sample_shape)
    243         """
    244         if isinstance(sample_shape, int):
--> 245             raise TypeError(f"sample_shape {sample_shape} of type int is not supported. "
    246                             f"Did you mean ({sample_shape},)?")
    247         if not isinstance(sample_shape, torch.Size):

TypeError: sample_shape 100 of type int is not supported. Did you mean (100,)?
```