### PR TITLE
Raise meaningfull error if `enumerate_support` is not defined

### DIFF
--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -211,7 +211,8 @@ class Distribution(object):
         Returns:
             Tensor iterating over dimension 0.
         """
-        raise NotImplementedError
+        raise NotImplementedError(f"enumerate_support is defined only for discrete distributions" 
+                                  f" and \"{self.__class__.__name__}\" is a continuous distribution.")
 
     def entropy(self):
         """

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -211,7 +211,7 @@ class Distribution(object):
         Returns:
             Tensor iterating over dimension 0.
         """
-        raise NotImplementedError(f"enumerate_support is defined only for discrete distributions" 
+        raise NotImplementedError(f"enumerate_support is defined only for discrete distributions"
                                   f" and \"{self.__class__.__name__}\" is a continuous distribution.")
 
     def entropy(self):


### PR DESCRIPTION
Fixes #73070 by raising a meaningful error if `enumerate_support` is not implemented for a distribution.

### Code example

```py
import torch
dist = torch.distributions.Normal(0,1)
dist.enumerate_support()
```

### Output before this PR

```py
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
<ipython-input-1-8dbad179c865> in <module>
----> 1 import torch;torch.distributions.Normal(0,1).enumerate_support()

~/pytorch/torch/distributions/distribution.py in enumerate_support(self, expand)
    212             Tensor iterating over dimension 0.
    213         """
--> 214         raise NotImplementedError
    215 
    216     def entropy(self):

NotImplementedError: 
```

### Output after this PR

```py
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
<ipython-input-1-8dbad179c865> in <module>
----> 1 import torch;torch.distributions.Normal(0,1).enumerate_support()

~/pytorch/torch/distributions/distribution.py in enumerate_support(self, expand)
    212             Tensor iterating over dimension 0.
    213         """
--> 214         raise NotImplementedError(f"enumerate_support is defined only for discrete distributions" 
    215                                   f" and \"{self.__class__.__name__}\" is a continuous distribution.")
    216 

NotImplementedError: enumerate_support is defined only for discrete distributions and "Normal" is a continuous distribution.
```