### PR TITLE
Disable __torch_function__ wrapping if __torch_dispatch__ is defined

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -290,8 +290,6 @@ $6 = torch._ops.aten.add_.Tensor($1, $5)''')
 
     def test_new_ones(self) -> None:
         class MyTensor(torch.Tensor):
-            __torch_function__ = torch._C._disabled_torch_function_impl
-
             @classmethod
             def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
                 return MyTensor(3)
@@ -300,8 +298,6 @@ $6 = torch._ops.aten.add_.Tensor($1, $5)''')
 
     def test_like(self) -> None:
         class MyTensor(torch.Tensor):
-            __torch_function__ = torch._C._disabled_torch_function_impl
-
             @classmethod
             def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
                 return MyTensor(3)
@@ -421,7 +417,6 @@ $6 = torch._ops.aten.add_.Tensor($1, $5)''')
         called_funcs = []
 
         class MyTensor(torch.Tensor):
-            __torch_function__ = torch._C._disabled_torch_function_impl
             elem: torch.Tensor
             __slots__ = ['elem']
 
@@ -649,8 +644,6 @@ $6 = torch._ops.aten.add_.Tensor($1, $5)''')
             def __new__(cls, elem):
                 return torch.Tensor._make_subclass(cls, elem)
 
-            __torch_function__ = torch._C._disabled_torch_function_impl
-
             @classmethod
             def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
                 called.append(func)
@@ -668,8 +661,6 @@ $6 = torch._ops.aten.add_.Tensor($1, $5)''')
             @staticmethod
             def __new__(cls, elem):
                 return torch.Tensor._make_subclass(cls, elem, elem.requires_grad)
-
-            __torch_function__ = torch._C._disabled_torch_function_impl
 
             @classmethod
             def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
@@ -700,8 +691,6 @@ $6 = torch._ops.aten.add_.Tensor($1, $5)''')
             def __new__(cls, elem):
                 r = torch.Tensor._make_subclass(cls, elem)
                 return r
-
-            __torch_function__ = torch._C._disabled_torch_function_impl
 
             @classmethod
             def __torch_dispatch__(cls, func, types, args=(), kwargs=None):

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1176,7 +1176,10 @@ class Tensor(torch._C._TensorBase):
 
         with _C.DisableTorchFunction():
             ret = func(*args, **kwargs)
-            if func in get_default_nowrap_functions():
+            # Don't wrap outputs if a custom __torch_dispatch__ is defined;
+            # it is almost never the right thing to do (if you did want this,
+            # implement __torch_function__ from scratch yourself)
+            if func in get_default_nowrap_functions() or cls.__torch_dispatch__ is not _C._disabled_torch_dispatch_impl:
                 return ret
             else:
                 return _convert(ret, cls)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #73942
* #73874
* #73850

This is never what you want and has led us to have to spray
`__torch_function__ = _disabled_torch_function_impl` everywhere.
Fortunately the fix is simple.

You might still want to overwrite `__torch_function__` for performance
reasons, as you can bypass having to run the Python code associated with
the default `__torch_function__`.  It might be a good performance
optimization to bypass this by default if we detect you have the
default `__torch_function__` and a `__torch_dispatch__`, but that is
left for future work.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D34730883](https://our.internmc.facebook.com/intern/diff/D34730883)