### PR TITLE
[PyTorch] Add safe peek and drop for stack in codegen

### DIFF
--- a/aten/src/ATen/templates/UnboxingFunctions.h
+++ b/aten/src/ATen/templates/UnboxingFunctions.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <ATen/core/stack.h>
 namespace at {
 namespace unboxing {
 namespace {
@@ -23,6 +24,15 @@ std::array<T, N> as_array(const c10::List<c10::IValue>& list) {
     std::copy(vec.begin(), vec.end(), res.begin());
     return res;
 }
+
+static inline c10::IValue safe_peek(std::vector<c10::IValue>& stack, size_t i, size_t N) {
+  if (i < stack.size()) {
+    return torch::jit::peek(stack, i, std::min(N, stack.size()));
+  } else {
+    return c10::IValue(c10::nullopt);
+  }
+}
+
 }  // namespace <anonymous>
 using Stack = std::vector<c10::IValue>;
 // Generated function declaration

--- a/test/mobile/lightweight_dispatch/test_codegen_unboxing.cpp
+++ b/test/mobile/lightweight_dispatch/test_codegen_unboxing.cpp
@@ -214,6 +214,21 @@ TEST(LiteInterpreterTest, MultipleOps) {
   at::Tensor expected = torch::tensor({{1, 1, 1, 1, 1, 1, 1, 1}, {0, 0, 0, 0, 0, 0, 0, 0}}, c10::TensorOptions(c10::ScalarType::Float));
   AT_ASSERT(result.toTensor().equal(expected));
 }
+
+TEST(LiteInterpreterTest, StackOutOfBound) {
+  // Load check in model: randn_like.ptl
+  auto testModelFile = "randn_like.ptl";
+
+  //  class Model(torch.nn.Module):
+  //    def forward(self, b):
+  //      return b.randn_like()
+
+  Module bc = _load_for_mobile(testModelFile);
+  const auto result_1 = bc.forward({at::ones({1, 2})});
+
+  ASSERT_EQ(result_1.toTensor().size(0), 1);
+  ASSERT_EQ(result_1.toTensor().size(1), 2);
+}
 } // namespace mobile
 } // namespace jit
 } // namespace torch

--- a/test/mobile/lightweight_dispatch/tests_setup.py
+++ b/test/mobile/lightweight_dispatch/tests_setup.py
@@ -149,6 +149,18 @@ class ModelWithStringOptional(FileSetup):
         script_model = torch.jit.script(model)
         script_model._save_for_lite_interpreter(self.path)
 
+class ModelTestsPoppingMoreThanStackSize(FileSetup):
+    path = 'randn_like.ptl'
+
+    def setup(self):
+        class Model(torch.nn.Module):
+            def forward(self, b):
+                return b.randn_like()
+        model = Model()
+        # Script the model and save
+        script_model = torch.jit.script(model)
+        script_model._save_for_lite_interpreter(self.path)
+
 
 class ModelWithMultipleOps(FileSetup):
     path = 'multiple_ops.ptl'
@@ -182,6 +194,7 @@ tests = [
     ModelWithTensors(),
     ModelWithStringOptional(),
     ModelWithMultipleOps(),
+    ModelTestsPoppingMoreThanStackSize(),
 ]
 
 

--- a/tools/codegen/api/unboxing.py
+++ b/tools/codegen/api/unboxing.py
@@ -105,7 +105,7 @@ def name(f: NativeFunction) -> str:
 def convert_arguments(f: NativeFunction) -> Tuple[List[Binding], List[str]]:
     # we need the 'self' argument so method needs to be False
     args = CppSignatureGroup.from_native_function(f, method=False).most_faithful_signature().arguments()
-    code_list = [f"c10::IValue {args[i].name} = std::move(peek(stack, {i}, {len(args)}));" for i in
+    code_list = [f"c10::IValue {args[i].name} = safe_peek(stack, {i}, {len(args)});" for i in
                  range(len(args))] + [""]
     binding_list = []
     for i, arg in enumerate(args):

--- a/tools/jit/gen_unboxing.py
+++ b/tools/jit/gen_unboxing.py
@@ -67,7 +67,7 @@ TORCH_API void {f.func.name.unambiguous_name()}(Stack & stack);
 TORCH_API void {f.func.name.unambiguous_name()}(Stack & stack) {{
     {code_connector.join(code_list)}
 
-    drop(stack, {len(binding_list)});
+    drop(stack, {len(binding_list)} < stack.size() ? {len(binding_list)} : stack.size());
 
     {ret_str}{prefix}{sig.name()}({args_str});
     {push_str}


### PR DESCRIPTION
Summary:
A follow up PR for #69881. Basically we see issues such as trying to peek 6 elements in a stack with only 1 element, then trying to drop 6 elements from the same stack. Here I'm adding a small util to prevent these issues.

Example:

```
randn_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
```
And the stack only contains `self` Tensor.

Test Plan: Added unit test

Differential Revision: D34730802

