### PR TITLE
Reuse Lazy IR nodes for faster tracing

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/init_python_bindings.cpp
@@ -666,6 +666,9 @@ void InitLtcModuleBindings(py::module m) {
   m.def("_ltc_enable_thread_pool", []() {
     FLAGS_torch_lazy_use_thread_pool = true;
   });
+  m.def("_ltc_enable_reuse_ir", []() {
+    FLAGS_torch_lazy_reuse_ir = true;
+  });
   /*
    * Return tensor ids and tensors for DeviceData nodes.
    * TODO(shunting) revisit this API for XLA

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/squeeze.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/squeeze.h
@@ -14,6 +14,11 @@ class Squeeze : public torch::lazy::TsNode {
   // Squeeze out the specified dimension index, -1 for all trivial dimensions.
   Squeeze(const torch::lazy::Value& input, int dim);
 
+  bool Equal(const torch::lazy::Value& input, int dim) const {
+    size_t i = 0;
+    return (operand(i++) == input && dim_ == dim);
+  }
+
   std::string ToString() const override;
 
   int dim() const { return dim_; }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/to_copy.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/to_copy.h
@@ -25,6 +25,20 @@ class ToCopy : public torch::lazy::TsNode {
         non_blocking(non_blocking),
         memory_format(memory_format) {}
 
+  bool Equal(const torch::lazy::Value& self,
+             const c10::optional<at::ScalarType>& dtype,
+             const c10::optional<at::Layout>& layout,
+             const c10::optional<at::Device>& device,
+             const c10::optional<bool>& pin_memory, const bool& non_blocking,
+             const c10::optional<at::MemoryFormat>& memory_format) const {
+    size_t i = 0;
+    return (operand(i++) == self && this->dtype == dtype &&
+            this->layout == layout && this->device == device &&
+            this->pin_memory == pin_memory &&
+            this->non_blocking == non_blocking &&
+            this->memory_format == memory_format);
+  }
+
   std::string ToString() const override {
     std::stringstream ss;
     ss << torch::lazy::TsNode::ToString();

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ts_native_batch_norm_backward.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ts_native_batch_norm_backward.h
@@ -22,6 +22,33 @@ class TSNativeBatchNormBackward : public torch::lazy::TsNode {
                             const torch::lazy::Value& save_invstd, bool training, double eps,
                             std::array<bool, 3> output_mask);
 
+  bool Equal(const torch::lazy::Value& grad_out,
+             const torch::lazy::Value& input, const torch::lazy::Value& weight,
+             const torch::lazy::Value& running_mean,
+             const torch::lazy::Value& running_var,
+             const torch::lazy::Value& save_mean,
+             const torch::lazy::Value& save_invstd, bool training, double eps,
+             std::array<bool, 3> output_mask) const {
+    size_t i = 0;
+    return (operand(i++) == grad_out && operand(i++) == input &&
+            operand(i++) == weight && operand(i++) == running_mean &&
+            operand(i++) == running_var && operand(i++) == save_mean &&
+            operand(i++) == save_invstd && training_ == training &&
+            eps_ == eps && output_mask_ == output_mask);
+  }
+
+  bool Equal(const torch::lazy::Value& grad_out,
+             const torch::lazy::Value& input, const torch::lazy::Value& weight,
+             const torch::lazy::Value& save_mean,
+             const torch::lazy::Value& save_invstd, bool training, double eps,
+             std::array<bool, 3> output_mask) const {
+    size_t i = 0;
+    return (operand(i++) == grad_out && operand(i++) == input &&
+            operand(i++) == weight && operand(i++) == save_mean &&
+            operand(i++) == save_invstd && training_ == training &&
+            eps_ == eps && output_mask_ == output_mask);
+  }
+
   std::string ToString() const override;
 
   bool training() const { return training_; }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/ts_native_batch_norm_forward.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/ts_native_batch_norm_forward.h
@@ -13,6 +13,18 @@ class TSNativeBatchNormForward : public torch::lazy::TsNode {
                            const torch::lazy::Value& running_var, bool training,
                            double momentum, double eps);
 
+  bool Equal(const torch::lazy::Value& input, const torch::lazy::Value& weight,
+             const torch::lazy::Value& bias,
+             const torch::lazy::Value& running_mean,
+             const torch::lazy::Value& running_var, bool training,
+             double momentum, double eps) const {
+    size_t i = 0;
+    return (operand(i++) == input && operand(i++) == weight &&
+            operand(i++) == bias && operand(i++) == running_mean &&
+            operand(i++) == running_var && training_ == training &&
+            momentum_ == momentum && eps == eps_);
+  }
+
   std::string ToString() const override;
 
   bool training() const { return training_; }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/unsqueeze.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/unsqueeze.h
@@ -14,6 +14,11 @@ class Unsqueeze : public torch::lazy::TsNode {
   // Insert a dimension of size one at the specified position.
   Unsqueeze(const torch::lazy::Value& input, int dim);
 
+  bool Equal(const torch::lazy::Value& input, int dim) const {
+    size_t i = 0;
+    return (operand(i++) == input && dim_ == dim);
+  }
+
   std::string ToString() const override;
 
   int dim() const { return dim_; }

--- a/lazy_tensor_core/test/test_reuse_ir.py
+++ b/lazy_tensor_core/test/test_reuse_ir.py
@@ -1,0 +1,37 @@
+import torch
+import lazy_tensor_core
+import lazy_tensor_core.core.lazy_model as ltm
+import lazy_tensor_core.debug.metrics as metrics
+
+lazy_tensor_core._LAZYC._ltc_init_ts_backend()
+lazy_tensor_core._LAZYC._ltc_enable_reuse_ir()
+
+def testAddSub():
+    device = 'cuda'
+    x = torch.randn(2, 3, 4, device=device)
+    y = torch.randn(2, 3, 4, device=device)
+    z = torch.zeros(2, 3, 4, device=device)
+
+    device = 'lazy'
+    x_lazy = x.detach().clone().to(device=device)
+    y_lazy = y.detach().clone().to(device=device)
+    z_lazy = z.detach().clone().to(device=device)
+
+    for i in range(10):
+        if i < 5:
+            z += (x + y)
+        else:
+            z += (x - y)
+
+    for i in range(10):
+        if i < 5:
+            z_lazy += (x_lazy + y_lazy)
+        else:
+            z_lazy += (x_lazy - y_lazy)
+        ltm.mark_step()
+
+    torch.testing.assert_close(z.cpu(), z_lazy.cpu())
+    print(metrics.metrics_report())
+
+if __name__ == '__main__':
+    testAddSub()

--- a/test/cpp/lazy/test_cache.cpp
+++ b/test/cpp/lazy/test_cache.cpp
@@ -81,17 +81,16 @@ TEST(CacheTest, ShapeCacheTestForDynamicShape) {
   // enable dynamic shape
   FLAGS_ltc_enable_dynamic_shapes = true;
 
-  CacheNodeWithShape nodes[] = {
-    CacheNodeWithShape(Shape(c10::kFloat, {2, 4})),
-    CacheNodeWithShape(Shape(c10::kFloat, {4, 2})) };
+  CacheNodeWithShape a(Shape(c10::kFloat, {2, 4}));
+  CacheNodeWithShape b(Shape(c10::kFloat, {4, 2}));
+  CacheNodeWithShape* nodes[] = {&a, &b};
 
   /*
    * Make sure the cached shape for node (2, 4) is not used for node (4, 2)
    */
   for (auto& node : nodes) {
-    EXPECT_EQ(node.getShape(), node.GetOpShape([&]() {
-      return node.getShape();
-    }));
+    EXPECT_EQ(
+        node->getShape(), node->GetOpShape([&]() { return node->getShape(); }));
   }
 
   // reset the flag

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -421,6 +421,7 @@ lazy_tensor_core_sources = [
     "torch/csrc/lazy/core/tensor_impl.cpp",
     "torch/csrc/lazy/core/tensor_util.cpp",
     "torch/csrc/lazy/core/thread_pool.cpp",
+    "torch/csrc/lazy/core/trie.cpp",
     "torch/csrc/lazy/core/view_ops/as_strided.cpp",
     "torch/csrc/lazy/core/view_ops/as_strided_view_update.cpp",
     "torch/csrc/lazy/core/view_ops/diagonal.cpp",

--- a/torch/csrc/lazy/core/config.cpp
+++ b/torch/csrc/lazy/core/config.cpp
@@ -17,6 +17,11 @@ C10_DEFINE_bool(
     false,
     "Use thread pool to schedule backend execution");
 
+C10_DEFINE_bool(
+    torch_lazy_reuse_ir,
+    false,
+    "Reuse IR node from previous tracing");
+
 C10_DEFINE_int(
     torch_lazy_compilation_cache_size,
     1024,

--- a/torch/csrc/lazy/core/config.h
+++ b/torch/csrc/lazy/core/config.h
@@ -5,6 +5,7 @@ C10_DECLARE_bool(torch_lazy_ir_debug);
 C10_DECLARE_bool(torch_lazy_handle_special_scalars);
 C10_DECLARE_bool(torch_lazy_param_aliasing);
 C10_DECLARE_bool(torch_lazy_use_thread_pool);
+C10_DECLARE_bool(torch_lazy_reuse_ir);
 
 C10_DECLARE_int(torch_lazy_compilation_cache_size);
 C10_DECLARE_int(torch_lazy_device_data_cache_size);

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -21,6 +21,10 @@ std::string Output::ToString() const {
   return ss.str();
 }
 
+bool Output::operator==(const Value& rhs) const {
+  return node->hash() == rhs.node->hash() && index == rhs.index;
+}
+
 hash_t Value::hash() const {
   return HashCombine(node->hash(), Hash(index));
 }

--- a/torch/csrc/lazy/core/trie.cpp
+++ b/torch/csrc/lazy/core/trie.cpp
@@ -1,0 +1,74 @@
+#include <torch/csrc/lazy/core/trie.h>
+
+#include <fstream>
+#include <sstream>
+#include <torch/csrc/lazy/core/hash.h>
+#include <torch/csrc/lazy/core/internal_ops/ltc_ops.h>
+#include <torch/csrc/lazy/core/ir_metadata.h>
+#include "utils/memory.h"
+
+namespace torch {
+namespace lazy {
+namespace {
+void TraverseTrie(TrieNode* node, std::stringstream& ss) {
+  if (!node) {
+    return;
+  }
+  for (auto &successor : node->successors) {
+    if (node->ir_node) {
+      ss << node->unique_id << "[label=\"" << node->ir_node->op().ToString() << "\"]\n";
+    }
+    ss << node->unique_id << " -> " << successor->unique_id << "\n";
+    TraverseTrie(successor.get(), ss);
+  }
+}
+}
+
+Trie* Trie::Get() {
+  static Trie* trie = new Trie();
+  return trie;
+}
+
+Trie::Trie() : root_(std::make_unique<TrieNode>()), current_(root_.get()) {
+}
+
+TrieNode* Trie::Current() const {
+  return current_;
+}
+
+void Trie::SetCurrent(std::deque<std::unique_ptr<TrieNode>>::iterator iter) {
+  auto& successors = current_->successors;
+  current_ = (*iter).get();
+
+  // Move *it to the front of the queue to achieve a LRU cache behavior
+  if (iter != successors.begin()) {
+    successors.push_front(std::move(*iter));
+    successors.erase(iter);
+  }
+}
+
+void Trie::ResetCurrent() {
+  current_ = root_.get();
+}
+
+void Trie::Insert(NodePtr ir_node) {
+  TORCH_CHECK(current_);
+  if (!current_->successors.empty()) {
+    TORCH_LAZY_COUNTER("ForkTrie", 1);
+  }
+  current_->successors.push_front(std::make_unique<TrieNode>(std::move(ir_node)));
+  current_ = current_->successors.front().get();
+}
+
+void Trie::DumpToDotFile(const std::string& file_name) {
+  std::stringstream ss;
+  ss << "digraph G {\n";
+  TraverseTrie(root_.get(), ss);
+  ss << "}\n";
+
+  std::ofstream graph_file(file_name);
+  graph_file << ss.str();
+}
+
+} // namespace lazy
+} // namespace torch

--- a/torch/csrc/lazy/core/trie.h
+++ b/torch/csrc/lazy/core/trie.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <deque>
+#include <atomic>
+
+#include <c10/core/ScalarType.h>
+
+namespace torch {
+namespace lazy {
+
+class Node;
+using NodePtr = std::shared_ptr<Node>;
+
+struct TORCH_API TrieNode {
+  static int64_t GetNextUniqueId() {
+    static size_t thread_local id_generator = 0;
+    return id_generator++;
+  }
+
+  int64_t unique_id;
+  NodePtr ir_node;
+  std::deque<std::unique_ptr<TrieNode>> successors;
+
+  TrieNode() : unique_id(GetNextUniqueId()), ir_node(nullptr) { }
+  explicit TrieNode(NodePtr node) : unique_id(GetNextUniqueId()), ir_node(std::move(node)) { }
+};
+
+class TORCH_API Trie {
+public:
+  static Trie* Get();
+
+  TrieNode* Current() const;
+  void SetCurrent(std::deque<std::unique_ptr<TrieNode>>::iterator iter);
+  void ResetCurrent();
+
+  // Create a new TrieNode for ir_node and insert into the Trie
+  void Insert(NodePtr ir_node);
+
+  void DumpToDotFile(const std::string& file_name);
+
+private:
+  Trie();
+
+  std::unique_ptr<TrieNode> root_;
+  TrieNode* current_;
+};
+
+} // namespace lazy
+} // namespace torch

--- a/torch/csrc/lazy/core/view_ops/as_strided.h
+++ b/torch/csrc/lazy/core/view_ops/as_strided.h
@@ -15,6 +15,17 @@ class TORCH_API AsStrided : public TsNode {
       std::vector<int64_t> stride,
       int64_t storage_offset);
 
+  bool Equal(
+      const Value& input,
+      std::vector<int64_t> size,
+      std::vector<int64_t> stride,
+      int64_t storage_offset) const {
+    size_t i = 0;
+    return (
+        operand(i++) == input && size_ == size && stride_ == stride &&
+        storage_offset_ == storage_offset);
+  }
+
   std::string ToString() const override;
 
   const std::vector<int64_t>& size() const {

--- a/torch/csrc/lazy/core/view_ops/as_strided_view_update.h
+++ b/torch/csrc/lazy/core/view_ops/as_strided_view_update.h
@@ -16,6 +16,18 @@ class TORCH_API AsStridedViewUpdate : public TsNode {
       std::vector<int64_t> stride,
       int64_t storage_offset);
 
+  bool Equal(
+      const Value& target,
+      const Value& input,
+      std::vector<int64_t> size,
+      std::vector<int64_t> stride,
+      int64_t storage_offset) const {
+    size_t i = 0;
+    return (
+        operand(i++) == target && operand(i++) == input && size_ == size &&
+        stride_ == stride && storage_offset_ == storage_offset);
+  }
+
   std::string ToString() const override;
 
   const std::vector<int64_t>& size() const {

--- a/torch/csrc/lazy/core/view_ops/diagonal.h
+++ b/torch/csrc/lazy/core/view_ops/diagonal.h
@@ -9,6 +9,14 @@ class TORCH_API Diagonal : public TsNode {
  public:
   Diagonal(const Value& input, int64_t offset, int64_t dim1, int64_t dim2);
 
+  bool Equal(const Value& input, int64_t offset, int64_t dim1, int64_t dim2)
+      const {
+    size_t i = 0;
+    return (
+        operand(i++) == input && offset_ == offset && dim1_ == dim1 &&
+        dim2_ == dim2);
+  }
+
   std::string ToString() const override;
 
   int64_t offset() const {

--- a/torch/csrc/lazy/core/view_ops/diagonal_view_update.h
+++ b/torch/csrc/lazy/core/view_ops/diagonal_view_update.h
@@ -14,6 +14,18 @@ class TORCH_API DiagonalViewUpdate : public TsNode {
       int64_t dim1,
       int64_t dim2);
 
+  bool Equal(
+      const Value& target,
+      const Value& input,
+      int64_t offset,
+      int64_t dim1,
+      int64_t dim2) const {
+    size_t i = 0;
+    return (
+        operand(i++) == target && operand(i++) == input && offset_ == offset &&
+        dim1_ == dim1 && dim2_ == dim2);
+  }
+
   std::string ToString() const override;
 
   int64_t offset() const {

--- a/torch/csrc/lazy/core/view_ops/narrow.h
+++ b/torch/csrc/lazy/core/view_ops/narrow.h
@@ -12,6 +12,16 @@ class TORCH_API Narrow : public TsNode {
       c10::ArrayRef<int64_t> base_indices,
       c10::ArrayRef<int64_t> sizes);
 
+  bool Equal(
+      const Value& input,
+      c10::ArrayRef<int64_t> base_indices,
+      c10::ArrayRef<int64_t> sizes) const {
+    size_t i = 0;
+    return (
+        operand(i++) == input && base_indices_ == base_indices &&
+        sizes_ == sizes);
+  }
+
   std::string ToString() const override;
 
   const std::vector<int64_t>& base_indices() const {

--- a/torch/csrc/lazy/core/view_ops/narrow_view_update.h
+++ b/torch/csrc/lazy/core/view_ops/narrow_view_update.h
@@ -12,6 +12,16 @@ class TORCH_API NarrowViewUpdate : public TsNode {
       const Value& source,
       c10::ArrayRef<int64_t> base_indices);
 
+  bool Equal(
+      const Value& input,
+      const Value& source,
+      c10::ArrayRef<int64_t> base_indices) const {
+    size_t i = 0;
+    return (
+        operand(i++) == input && operand(i++) == source &&
+        base_indices_ == base_indices);
+  }
+
   std::string ToString() const override;
 
   const std::vector<int64_t>& base_indices() const {

--- a/torch/csrc/lazy/core/view_ops/permute.h
+++ b/torch/csrc/lazy/core/view_ops/permute.h
@@ -9,6 +9,11 @@ class TORCH_API Permute : public TsNode {
  public:
   Permute(const Value& input, std::vector<int64_t> dims);
 
+  bool Equal(const Value& input, c10::ArrayRef<int64_t> dims) const {
+    size_t i = 0;
+    return (operand(i++) == input && dims_ == dims);
+  }
+
   std::string ToString() const override;
 
   const std::vector<int64_t>& dims() const {

--- a/torch/csrc/lazy/core/view_ops/resize.h
+++ b/torch/csrc/lazy/core/view_ops/resize.h
@@ -9,6 +9,11 @@ class TORCH_API Resize : public TsNode {
  public:
   Resize(const Value& input, std::vector<int64_t> size);
 
+  bool Equal(const Value& input, c10::ArrayRef<int64_t> size) const {
+    size_t i = 0;
+    return (operand(i++) == input && size_ == size);
+  }
+
   std::string ToString() const override;
 
   const std::vector<int64_t>& size() const {

--- a/torch/csrc/lazy/core/view_ops/select.h
+++ b/torch/csrc/lazy/core/view_ops/select.h
@@ -14,6 +14,18 @@ class TORCH_API Select : public TsNode {
       int64_t end,
       int64_t stride);
 
+  bool Equal(
+      const Value& input,
+      int64_t dim,
+      int64_t start,
+      int64_t end,
+      int64_t stride) const {
+    size_t i = 0;
+    return (
+        operand(i++) == input && dim_ == dim && start_ == start &&
+        end_ == end && stride_ == stride);
+  }
+
   std::string ToString() const override;
 
   int64_t dim() const {

--- a/torch/csrc/lazy/core/view_ops/select_view_update.h
+++ b/torch/csrc/lazy/core/view_ops/select_view_update.h
@@ -15,6 +15,19 @@ class TORCH_API SelectViewUpdate : public TsNode {
       int64_t end,
       int64_t stride);
 
+  bool Equal(
+      const Value& target,
+      const Value& source,
+      int64_t dim,
+      int64_t start,
+      int64_t end,
+      int64_t stride) const {
+    size_t i = 0;
+    return (
+        operand(i++) == target && operand(i++) == source && dim_ == dim &&
+        start_ == start && end_ == end && stride_ == stride);
+  }
+
   std::string ToString() const override;
 
   int64_t dim() const {

--- a/torch/csrc/lazy/core/view_ops/squeeze.h
+++ b/torch/csrc/lazy/core/view_ops/squeeze.h
@@ -13,6 +13,11 @@ class TORCH_API Squeeze : public TsNode {
   // Squeeze out the specified dimension index, -1 for all trivial dimensions.
   Squeeze(const torch::lazy::Value& input, int dim);
 
+  bool Equal(const Value& input, int dim) const {
+    size_t i = 0;
+    return (operand(i++) == input && dim_ == dim);
+  }
+
   std::string ToString() const override;
 
   int dim() const { return dim_; }

--- a/torch/csrc/lazy/core/view_ops/unsqueeze.h
+++ b/torch/csrc/lazy/core/view_ops/unsqueeze.h
@@ -13,6 +13,11 @@ class TORCH_API Unsqueeze : public TsNode {
  public:
   Unsqueeze(const torch::lazy::Value& input, int dim);
 
+  bool Equal(const Value& input, int dim) const {
+    size_t i = 0;
+    return (operand(i++) == input && dim_ == dim);
+  }
+
   std::string ToString() const override;
 
   int dim() const {

--- a/torch/csrc/lazy/core/view_ops/view.h
+++ b/torch/csrc/lazy/core/view_ops/view.h
@@ -11,6 +11,11 @@ class TORCH_API View : public TsNode {
  public:
   View(const Value& input, std::vector<int64_t> output_size);
 
+  bool Equal(const Value& input, std::vector<int64_t> output_size) const {
+    size_t i = 0;
+    return (operand(i++) == input && output_size_ == output_size);
+  }
+
   std::string ToString() const override;
 
   const std::vector<int64_t>& output_size() const {

--- a/torch/csrc/lazy/ts_backend/ops/cast.h
+++ b/torch/csrc/lazy/ts_backend/ops/cast.h
@@ -14,6 +14,14 @@ class TORCH_API Cast : public TsNode {
       at::ScalarType dtype,
       c10::optional<at::ScalarType> stype = c10::nullopt);
 
+  bool Equal(
+      const Value& input,
+      at::ScalarType dtype,
+      c10::optional<at::ScalarType> stype = c10::nullopt) const {
+    size_t i = 0;
+    return (operand(i++) == input && dtype_ == dtype && stype_ == stype);
+  }
+
   std::string ToString() const override;
 
   at::ScalarType dtype() const {

--- a/torch/csrc/lazy/ts_backend/ops/device_data.cpp
+++ b/torch/csrc/lazy/ts_backend/ops/device_data.cpp
@@ -1,6 +1,8 @@
 #include <torch/csrc/lazy/ts_backend/ops/device_data.h>
 
+#include <torch/csrc/lazy/core/config.h>
 #include <torch/csrc/lazy/core/internal_ops/ltc_ops.h>
+#include <torch/csrc/lazy/core/trie.h>
 
 #include <sstream>
 
@@ -23,6 +25,18 @@ std::string DeviceData::ToString() const {
 
 const DeviceData* DeviceData::Cast(const Node* node) {
   return NodeCast<DeviceData>(node, ltc_device_data);
+}
+
+NodePtr DeviceData::Create(std::shared_ptr<BackendData> data) {
+  NodePtr node = ReuseOrMakeNode<DeviceData>(OpKind(ltc_device_data), data);
+  // ReuseOrMakeNode may return a reused node which has the same shape,
+  // however, we need to replace the old data_ with the new one.
+  // Ditching the old data_ is safe because tracing is done iteration
+  // by iteration, and after we lauch the async device execution for the
+  // previous iteration, data_ in DeviceData nodes are not needed anymore.
+  DeviceData* device_data = static_cast<DeviceData*>(node.get());
+  device_data->SetData(data);
+  return node;
 }
 
 } // namespace lazy

--- a/torch/csrc/lazy/ts_backend/ops/device_data.h
+++ b/torch/csrc/lazy/ts_backend/ops/device_data.h
@@ -10,13 +10,23 @@ class TORCH_API DeviceData : public TsNode {
  public:
   explicit DeviceData(std::shared_ptr<BackendData> data);
 
+  bool Equal(std::shared_ptr<BackendData> data) const {
+    return data_->shape() == data->shape();
+  }
+
   std::string ToString() const override;
 
   const std::shared_ptr<BackendData>& data() const {
     return data_;
   }
 
+  void SetData(std::shared_ptr<BackendData> data) {
+    data_ = data;
+  }
+
   static const DeviceData* Cast(const Node* node);
+
+  static NodePtr Create(std::shared_ptr<BackendData> data);
 
  private:
   std::shared_ptr<BackendData> data_;

--- a/torch/csrc/lazy/ts_backend/ops/expand.h
+++ b/torch/csrc/lazy/ts_backend/ops/expand.h
@@ -11,6 +11,16 @@ class TORCH_API Expand : public TsNode {
  public:
   Expand(const Value& input, std::vector<int64_t> size, bool is_scalar_expand);
 
+  bool Equal(
+      const Value& input,
+      std::vector<int64_t> size,
+      bool is_scalar_expand) const {
+    size_t i = 0;
+    return (
+        operand(i++) == input && size_ == size &&
+        is_scalar_expand_ == is_scalar_expand);
+  }
+
   std::string ToString() const override;
 
   const std::vector<int64_t>& size() const {

--- a/torch/csrc/lazy/ts_backend/ops/generic.h
+++ b/torch/csrc/lazy/ts_backend/ops/generic.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <torch/csrc/lazy/core/internal_ops/ltc_ops.h>
 #include <torch/csrc/lazy/ts_backend/ts_node.h>
 
 namespace torch {
@@ -34,6 +35,16 @@ class TORCH_API Generic : public TsNode {
 
   Generic(OpKind op, Shape shape, size_t num_outputs, hash_t hash_seed);
 
+  bool Equal(
+      OpKind op,
+      OpList operands,
+      Shape shape,
+      size_t num_outputs = 1,
+      hash_t hash_seed = static_cast<uint32_t>(0x5a2d296e9)) const {
+    TORCH_INTERNAL_ASSERT(false, "Reusing Generic nodes is unsupported")
+    return false;
+  }
+
  private:
   hash_t hash_seed_;
 };
@@ -44,8 +55,13 @@ inline NodePtr GenericOp(
     Shape shape,
     size_t num_outputs = 1,
     hash_t hash_seed = static_cast<uint32_t>(0x5a2d296e9)) {
-  return MakeNode<Generic>(
-      op, operands, std::move(shape), num_outputs, hash_seed);
+  return ReuseOrMakeNode<Generic>(
+      torch::lazy::OpKind(ltc_tensor_data),
+      op,
+      operands,
+      std::move(shape),
+      num_outputs,
+      hash_seed);
 }
 
 } // namespace lazy

--- a/torch/csrc/lazy/ts_backend/ops/scalar.h
+++ b/torch/csrc/lazy/ts_backend/ops/scalar.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/core/Scalar.h>
+#include <c10/util/Exception.h>
 #include <torch/csrc/lazy/ts_backend/ts_node.h>
 
 namespace torch {
@@ -14,6 +15,16 @@ class TORCH_API Scalar : public TsNode {
  public:
   Scalar(const at::Scalar& value, Shape shape);
   Scalar(const at::Scalar& value, c10::ScalarType type);
+
+  bool Equal(const at::Scalar& value, Shape shape) const {
+    TORCH_INTERNAL_ASSERT(false, "Reusing Scalar nodes is unsupported")
+    return false;
+  }
+
+  bool Equal(const at::Scalar& value, c10::ScalarType type) const {
+    TORCH_INTERNAL_ASSERT(false, "Reusing Scalar nodes is unsupported")
+    return false;
+  }
 
   std::string ToString() const override;
 

--- a/torch/csrc/lazy/ts_backend/ts_node.h
+++ b/torch/csrc/lazy/ts_backend/ts_node.h
@@ -101,6 +101,10 @@ struct TORCH_API TensorList : public TsNode {
   TensorList() = delete;
   TensorList(OpList values);
 
+  bool Equal(OpList values) const {
+    return operands() == std::vector<Output>(values.begin(), values.end());
+  }
+
   TSOpVector Lower(std::shared_ptr<torch::jit::GraphFunction> function,
                    TSLoweringContext* loctx) const override;
 };


### PR DESCRIPTION
Summary: Use a trie to store IR nodes from previous tracings, and the trie serves as a cache for looking up IR nodes and reuse them if possible.
