### PR TITLE
ci: Fix cudatoolkit issue, make docker builds testable

### DIFF
--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -xeuo pipefail
 
@@ -25,18 +25,20 @@ docker tag ghcr.io/pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
 docker tag ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION} \
        ghcr.io/pytorch/pytorch-nightly:latest
 
-# Push the nightly docker to GitHub Container Registry
-echo $GHCR_PAT | docker login ghcr.io -u pytorch --password-stdin
-make -f docker.Makefile \
-     DOCKER_REGISTRY=ghcr.io \
-     DOCKER_ORG=pytorch \
-     DOCKER_IMAGE=pytorch-nightly \
-     DOCKER_TAG=${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION} \
-     devel-push
+if [[ ${WITH_PUSH:-} == "true" ]]; then
+    # Push the nightly docker to GitHub Container Registry
+    echo $GHCR_PAT | docker login ghcr.io -u pytorch --password-stdin
+    make -f docker.Makefile \
+         DOCKER_REGISTRY=ghcr.io \
+         DOCKER_ORG=pytorch \
+         DOCKER_IMAGE=pytorch-nightly \
+         DOCKER_TAG=${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION} \
+         devel-push
 
-make -f docker.Makefile \
-     DOCKER_REGISTRY=ghcr.io \
-     DOCKER_ORG=pytorch \
-     DOCKER_IMAGE=pytorch-nightly \
-     DOCKER_TAG=latest \
-     devel-push
+    make -f docker.Makefile \
+         DOCKER_REGISTRY=ghcr.io \
+         DOCKER_ORG=pytorch \
+         DOCKER_IMAGE=pytorch-nightly \
+         DOCKER_TAG=latest \
+         devel-push
+fi

--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -3,7 +3,7 @@
 set -xeuo pipefail
 
 PYTORCH_DOCKER_TAG=$(git describe --tags --always)-devel
-CUDA_VERSION=11.3.0
+CUDA_VERSION=11.3.1
 
 # Build PyTorch nightly docker
 make -f docker.Makefile \

--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -32,3 +32,7 @@ jobs:
           command: |
             set -ex
             bash .github/scripts/build_publish_nightly_docker.sh
+
+concurrency:
+  group: push-nightly-docker-ghcr-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true

--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -6,9 +6,10 @@ on:
   # Trigger when we modify something related to these images
   pull_request:
     paths:
+      - .github/scripts/build_publish_nightly_docker.sh
+      - .github/workflows/push_nightly_docker_ghcr.yml
       - Dockerfile
       - docker.Makefile
-      - .github/scripts/build_publish_nightly_docker.sh
   # Have the ability to trigger this job manually using the API as well
   workflow_dispatch:
 
@@ -20,10 +21,10 @@ jobs:
       GHCR_PAT: ${{ secrets.GHCR_PAT }}
       WITH_PUSH: ${{ github.event_name == 'schedule' }}
     steps:
-      - name: Checkout
+      - name: Checkout PyTorch
         uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
         with:
-          ref: master
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: nick-fields/retry@71062288b76e2b6214ebde0e673ce0de1755740a
         name: Build and upload nightly docker
         with:

--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -1,17 +1,24 @@
-name: Build PyTorch nightly Docker image and push to GitHub Container Registry
+name: docker-release-builds
 on:
   schedule:
     # Push the nightly docker daily at 1 PM UTC
     - cron: '0 13 * * *'
+  # Trigger when we modify something related to these images
+  pull_request:
+    paths:
+      - Dockerfile
+      - docker.Makefile
+      - .github/scripts/build_publish_nightly_docker.sh
   # Have the ability to trigger this job manually using the API as well
   workflow_dispatch:
 
 jobs:
-  build-publish-docker:
+  docker-release-build:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     runs-on: linux.2xlarge
     env:
       GHCR_PAT: ${{ secrets.GHCR_PAT }}
+      WITH_PUSH: ${{ github.event_name == 'schedule' }}
     steps:
       - name: Checkout
         uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ARG CUDA_VERSION=11.3
 ARG CUDA_CHANNEL=nvidia
 ARG INSTALL_CHANNEL=pytorch-nightly
 ENV CONDA_OVERRIDE_CUDA=${CUDA_VERSION}
-RUN /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -c "${CUDA_CHANNEL}" -y python=${PYTHON_VERSION} pytorch torchvision torchtext "cudatoolkit=${CUDA_VERSION%.*}" && \
+RUN /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -c "${CUDA_CHANNEL}" -y python=${PYTHON_VERSION} pytorch torchvision torchtext "cudatoolkit=${CUDA_VERSION}" && \
     /opt/conda/bin/conda clean -ya
 RUN /opt/conda/bin/pip install torchelastic
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ARG CUDA_VERSION=11.3
 ARG CUDA_CHANNEL=nvidia
 ARG INSTALL_CHANNEL=pytorch-nightly
 ENV CONDA_OVERRIDE_CUDA=${CUDA_VERSION}
-RUN /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -c "${CUDA_CHANNEL}" -y python=${PYTHON_VERSION} pytorch torchvision torchtext "cudatoolkit=${CUDA_VERSION}" && \
+RUN /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -c "${CUDA_CHANNEL}" -y python=${PYTHON_VERSION} pytorch torchvision torchtext "cudatoolkit=${CUDA_VERSION%.*}" && \
     /opt/conda/bin/conda clean -ya
 RUN /opt/conda/bin/pip install torchelastic
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #73974

nightly docker builds were failing due to cudatoolkit=11.3.0 not
actually being available using conda.

This remedies that and adds the ability to actually test this workflow
in a pull request

Resolves #73971 

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>