### PR TITLE
Fix `lkj_cholesky` device error

### DIFF
--- a/torch/distributions/lkj_cholesky.py
+++ b/torch/distributions/lkj_cholesky.py
@@ -112,7 +112,7 @@ class LKJCholesky(Distribution):
         if self._validate_args:
             self._validate_sample(value)
         diag_elems = value.diagonal(dim1=-1, dim2=-2)[..., 1:]
-        order = torch.arange(2, self.dim + 1)
+        order = torch.arange(2, self.dim + 1, device=self.concentration.device)
         order = 2 * (self.concentration - 1).unsqueeze(-1) + self.dim - order
         unnormalized_log_pdf = torch.sum(order * diag_elems.log(), dim=-1)
         # Compute normalization constant (page 1999 of [1])


### PR DESCRIPTION
Summary: Fix missing device arg to `torch.arange` in `lkj_cholesky`.

Differential Revision: D34763123

