### PR TITLE
Fix distributions/test_distributions.py for Python 3.10

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3111,12 +3111,12 @@ class TestDistributions(TestCase):
                 'alpha': torch.tensor([1, 1, 1])
             }),
             (StudentT, {
-                'df': torch.tensor([1, 1]),
-                'scale': torch.tensor([1, 1, 1])
+                'df': torch.tensor([1., 1.]),
+                'scale': torch.tensor([1., 1., 1.])
             }),
             (StudentT, {
-                'df': torch.tensor([1, 1]),
-                'loc': torch.tensor([1, 1, 1])
+                'df': torch.tensor([1., 1.]),
+                'loc': torch.tensor([1., 1., 1.])
             })
         ]
 


### PR DESCRIPTION
This is a partial fix for https://github.com/pytorch/pytorch/issues/66424

Without this PR,  on Python 3.10 `python run_test.py -i distributions/test_distributions` fails with "TypeError: 'float' object cannot be interpreted as an integer".

The change is only needed for StudenT distribution because it has default float parameters.
