### PR TITLE
Add M1 Py3.10 build definitions

### DIFF
--- a/.circleci/cimodel/data/binary_build_data.py
+++ b/.circleci/cimodel/data/binary_build_data.py
@@ -42,10 +42,12 @@ CONFIG_TREE_DATA = OrderedDict(
         wheel=[
             "3.8",
             "3.9",
+            "3.10",
         ],
         conda=[
             "3.8",
             "3.9",
+            "3.10",
         ],
     )),
     windows=(

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2017,6 +2017,16 @@ workflows:
               only:
                 - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
       - binary_macos_arm64_build:
+          name: binary_macos_arm64_wheel_3_10_cpu_nightly_build
+          build_environment: "wheel 3.10 cpu"
+          filters:
+            branches:
+              only:
+                - /.*/
+            tags:
+              only:
+                - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+      - binary_macos_arm64_build:
           name: binary_macos_arm64_conda_3_8_cpu_nightly_build
           build_environment: "conda 3.8 cpu"
           filters:
@@ -2029,6 +2039,16 @@ workflows:
       - binary_macos_arm64_build:
           name: binary_macos_arm64_conda_3_9_cpu_nightly_build
           build_environment: "conda 3.9 cpu"
+          filters:
+            branches:
+              only:
+                - /.*/
+            tags:
+              only:
+                - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+      - binary_macos_arm64_build:
+          name: binary_macos_arm64_conda_3_10_cpu_nightly_build
+          build_environment: "conda 3.10 cpu"
           filters:
             branches:
               only:
@@ -2555,6 +2575,20 @@ workflows:
           package_type: wheel
           upload_subfolder: cpu
       - binary_upload:
+          name: binary_macos_arm64_wheel_3_10_cpu_nightly_upload
+          context: org-member
+          requires:
+            - binary_macos_arm64_wheel_3_10_cpu_nightly_build
+          filters:
+            branches:
+              only:
+                - nightly
+            tags:
+              only:
+                - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          package_type: wheel
+          upload_subfolder: cpu
+      - binary_upload:
           name: binary_macos_arm64_conda_3_8_cpu_nightly_upload
           context: org-member
           requires:
@@ -2573,6 +2607,20 @@ workflows:
           context: org-member
           requires:
             - binary_macos_arm64_conda_3_9_cpu_nightly_build
+          filters:
+            branches:
+              only:
+                - nightly
+            tags:
+              only:
+                - /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
+          package_type: conda
+          upload_subfolder: cpu
+      - binary_upload:
+          name: binary_macos_arm64_conda_3_10_cpu_nightly_upload
+          context: org-member
+          requires:
+            - binary_macos_arm64_conda_3_10_cpu_nightly_build
           filters:
             branches:
               only:


### PR DESCRIPTION
This change is specific to `release/1.11` as on master those builds are
already unified
