### PR TITLE
Fix `test_reduce_add_coalesced ` failure

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3941,8 +3941,7 @@ class TestCudaComm(TestCase):
         r_tensors = [comm.reduce_add(t) for t in zip(*dup_tensors)]
         for r, t in zip(r_tensors, tensors):
             self.assertEqualTypeString(r, t)
-            maybe_coalesce = lambda x: x.coalesce() if x.is_sparse else x
-            self.assertEqual(maybe_coalesce(r), t * 2)
+            self.assertEqual(r.coalesce() if r.is_sparse else r, t * 2)
 
         rc_tensors = comm.reduce_add_coalesced(dup_tensors, buffer_size=buffer_size)
         self.assertEqual(r_tensors, rc_tensors)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3941,7 +3941,8 @@ class TestCudaComm(TestCase):
         r_tensors = [comm.reduce_add(t) for t in zip(*dup_tensors)]
         for r, t in zip(r_tensors, tensors):
             self.assertEqualTypeString(r, t)
-            self.assertEqual(r, t * 2)
+            maybe_coalesce = lambda x: x.coalesce() if x.is_sparse else x
+            self.assertEqual(maybe_coalesce(r), t * 2)
 
         rc_tensors = comm.reduce_add_coalesced(dup_tensors, buffer_size=buffer_size)
         self.assertEqual(r_tensors, rc_tensors)


### PR DESCRIPTION
Recent change (https://github.com/pytorch/pytorch/pull/69751) introduced the requirement of using `.coalesce()` explicitly in the tests. Unfortunately, not all tests are run in the current CI configuration and one test failure slipped through.
Fixes https://github.com/pytorch/pytorch/issues/74015.
