### PR TITLE
Emit std::string instead of c10::string_view for Lazy IR class

### DIFF
--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -105,7 +105,8 @@ class LazyIR(ABC):
         node_ctor_args = ", ".join([f"const {i.cpp_type()}& {i.name}" for i in all_types])
         scalar_initializers = ",\n        ".join([f"{t.name}({t.name})" for t in scalar_types])
         comma_if_scalar_initializers = ",\n" if len(scalar_initializers) else ""
-        scalar_decls = "\n  ".join([f"{t.cpp_type()} {t.name};" for t in scalar_types])
+        scalar_decls = "\n  ".join([f"std::string {t.name};" if t.cpp_type() == "c10::string_view" else f"{t.cpp_type()} {t.name};"
+                                    for t in scalar_types])
         scalar_hashes = ", ".join([f"{f.name}" for f in scalar_types])
         base_ctor_value_args_list = []
         optional_values = []


### PR DESCRIPTION
Summary: c10::string_view may be pointing to a temp string, which is not
guaranteed to be valid when accessed later, so we store the passed-in
string_view into a string.

Fixes #73963 
