### PR TITLE
[WIP] Implement complex support in DDP

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -2241,6 +2241,7 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         target += torch.arange(60, dtype=torch.float64, device=device).chunk(5)
         target += torch.arange(60, dtype=half, device=device).chunk(5)
         target += torch.arange(60, dtype=torch.float32, device=device).chunk(5)
+        target += torch.view_as_complex(torch.arange(12, dtype=torch.float, device=device).view(-1, 2)).chunk(5)
 
         # The tensors to pass to broadcast are idential to the target
         # only on the process that is the root of the broadcast.
@@ -2252,8 +2253,8 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
         if self.rank != root_rank:
             self.assertNotEqual(tensors, target)
 
-        c10d._broadcast_coalesced(
-            process_group, tensors, buffer_size=256, src=root_rank
+        c10d.broadcast_coalesced(
+            tensors, buffer_size=256, src=root_rank, group=process_group
         )
 
         if self.rank != root_rank:

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -1467,6 +1467,10 @@ void Reducer::finalize_backward() {
     auto future_result = comm_hook_ == nullptr
         ? detail::parseCppCommHookResult(bucket.future_work->value())
         : comm_hook_->parseHookResult(bucket.future_work->value());
+    // Convert back to complex as the collective might have not conveted it.
+    if (bucket.gradients.is_complex() && !future_result.is_complex()) {
+      future_result = at::view_as_complex(future_result);
+    }
     if (bucket.expect_sparse_gradient) {
       bucket.gradients.copy_(future_result);
     } else {

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -36,7 +36,6 @@ if is_available():
         _DEFAULT_FIRST_BUCKET_BYTES,
         _register_comm_hook,
         _register_builtin_comm_hook,
-        _broadcast_coalesced,
         _compute_bucket_assignment_by_size,
         _verify_params_across_processes,
         _test_python_store,

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1561,9 +1561,7 @@ class DistributedDataParallel(Module, Joinable):
     def _distributed_broadcast_coalesced(
         self, tensors, buffer_size, authoritative_rank=0
     ):
-        dist._broadcast_coalesced(
-            self.process_group, tensors, buffer_size, authoritative_rank
-        )
+        dist.broadcast_coalesced(tensors, buffer_size, authoritative_rank, self.process_group)
 
     def _check_sync_bufs_post_fwd(self):
         return (


### PR DESCRIPTION
Summary:
Add Complex support for DDP.

This involved fixing a pair of issues:

First, DDP usage broadcast_coalesced needs to be made complex aware.
This wasd one by introducing a wrapper in `torch.dist` like other comm primitives and using it instead.

Second, the reducer needed to be fixed. The main complication here is that ProcessGroup::Work exposes the result tensor and this is used by Reducers.
Since we sneak a complex->real conversion before collectives, we need to convert the resulting tensor back to avoid copy tearing.

Finally, this approach doesn't help custom hooks as they will need to deal with complex tensors by themselves.

Fixes https://github.com/pytorch/pytorch/issues/71613

Test Plan: Automated tests to be added.

Differential Revision: D34790249

