### PR TITLE
[Tracer][ONNX] Enable numel tracing

### DIFF
--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -377,6 +377,18 @@ class TestTracer(JitTestCase):
     def test_trace_size_with_grad(self):
         self.do_trace_size(True)
 
+    def test_trace_numel(self):
+        def fn(x):
+            return x.numel()
+
+        x = torch.randn(2, 3, 4)
+        y = torch.randn(4, 5, 6)
+
+        # Check that it behaves as expected
+        traced_fn = torch.jit.trace(fn, x)
+        self.assertEqual(traced_fn(y), fn(y))
+        self.assertEqual(traced_fn(x), fn(x))
+
     def do_trace_arange(self, requires_grad):
         def arange(x):
             return torch.arange(x.shape[0])

--- a/test/onnx/expect/TestOperators.test_view_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_view_flatten.expect
@@ -3,21 +3,103 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    input: "onnx::Reshape_0"
-    input: "onnx::Reshape_9"
-    output: "6"
-    name: "Reshape_0"
+    input: "onnx::Shape_0"
+    output: "onnx::ReduceProd_2"
+    name: "Shape_0"
+    op_type: "Shape"
+  }
+  node {
+    input: "onnx::ReduceProd_2"
+    output: "onnx::Div_3"
+    name: "ReduceProd_1"
+    op_type: "ReduceProd"
+    attribute {
+      name: "keepdims"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    output: "onnx::Div_4"
+    name: "Constant_2"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 7
+        raw_data: "\001\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "onnx::Div_3"
+    input: "onnx::Div_4"
+    output: "onnx::Cast_5"
+    name: "Div_3"
+    op_type: "Div"
+  }
+  node {
+    input: "onnx::Cast_5"
+    output: "onnx::Cast_6"
+    name: "Cast_4"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 7
+      type: INT
+    }
+  }
+  node {
+    input: "onnx::Cast_6"
+    output: "onnx::Unsqueeze_7"
+    name: "Cast_5"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 7
+      type: INT
+    }
+  }
+  node {
+    input: "onnx::Unsqueeze_7"
+    output: "onnx::Concat_9"
+    name: "Unsqueeze_6"
+    op_type: "Unsqueeze"
+    attribute {
+      name: "axes"
+      ints: 0
+      type: INTS
+    }
+  }
+  node {
+    input: "onnx::Concat_12"
+    input: "onnx::Concat_9"
+    output: "onnx::Reshape_10"
+    name: "Concat_7"
+    op_type: "Concat"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    input: "onnx::Shape_0"
+    input: "onnx::Reshape_10"
+    output: "11"
+    name: "Reshape_8"
     op_type: "Reshape"
   }
   name: "torch_jit"
   initializer {
-    dims: 2
+    dims: 1
     data_type: 7
-    name: "onnx::Reshape_9"
-    raw_data: "\001\000\000\000\000\000\000\000\030\000\000\000\000\000\000\000"
+    name: "onnx::Concat_12"
+    raw_data: "\001\000\000\000\000\000\000\000"
   }
   input {
-    name: "onnx::Reshape_0"
+    name: "onnx::Shape_0"
     type {
       tensor_type {
         elem_type: 1
@@ -39,16 +121,16 @@ graph {
     }
   }
   output {
-    name: "6"
+    name: "11"
     type {
       tensor_type {
         elem_type: 1
         shape {
           dim {
-            dim_value: 1
+            dim_param: "Reshape11_dim_0"
           }
           dim {
-            dim_value: 24
+            dim_param: "Reshape11_dim_1"
           }
         }
       }

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -231,7 +231,11 @@ static PyObject * THPVariable_numel(PyObject* self, PyObject* args)
      return handle_torch_function(self, "numel", args);
    }
    auto& self_ = THPVariable_Unpack(self);
-   return THPUtils_packInt64(self_.numel());
+   if (jit::tracer::isTracing()) {
+     return wrap(jit::tracer::getNumelOf(self_));
+   } else {
+     return THPUtils_packInt64(self_.numel());
+   }
    END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -894,6 +894,27 @@ autograd::Variable getSizeOf(const autograd::Variable& var, int64_t dim) {
   return size_var;
 }
 
+autograd::Variable getNumelOf(const autograd::Variable& var) {
+  auto& tracing_state = getTracingState();
+  auto& graph = tracing_state->graph;
+
+  Variable numel_var;
+  {
+    // Make sure this scalar to tensor isn't traced!
+    at::AutoDispatchBelowADInplaceOrView guard;
+    numel_var = scalar_to_tensor(at::Scalar(var.numel()));
+  }
+  auto* value = getValueTrace(var);
+  auto* node = graph->insertNode(graph->create(Symbol::aten("numel"), {value}));
+  recordSourceLocation(node);
+  node->output()->setType(jit::IntType::get());
+
+  auto ten =
+      graph->insertNode(graph->createNumToTensor(node->output()))->output();
+  setValueTrace(numel_var, ten);
+  return numel_var;
+}
+
 void ensureUniqueIfOutOfPlaced(const char* name, const at::Tensor& tensor) {
   auto& state = getTracingState();
   if (state && state->force_outplace == false) {

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -385,6 +385,8 @@ TORCH_API autograd::Variable getSizeOf(
     const autograd::Variable& var,
     int64_t dim);
 
+TORCH_API autograd::Variable getNumelOf(const autograd::Variable& var);
+
 } // namespace tracer
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Fixes #74047

Trace `tensor.numel()` as `aten::numel`, instead of a constant value. The logic is similar to tracing `tensor.size(dim)`. 