### PR TITLE
[PyTorch] Avoid schema parsing in lightweight dispatch

### DIFF
--- a/torch/csrc/jit/runtime/operator.h
+++ b/torch/csrc/jit/runtime/operator.h
@@ -27,6 +27,7 @@ namespace torch {
 namespace jit {
 
 struct Node;
+using ::c10::Argument;
 using ::c10::FunctionSchema;
 using ::c10::Symbol;
 
@@ -83,6 +84,23 @@ struct TORCH_API Operator {
       : op_(c10::make_right<C10Operator, JitOnlyOperator>(JitOnlyOperator{
             c10::make_right<FunctionSchema, UnparsedFunctionSchema>(
                 UnparsedFunctionSchema{std::move(schema), alias_analysis}),
+            c10::make_left<Operation, OperationCreator>(std::move(op))})) {}
+
+  Operator(
+      std::string name,
+      std::string overload_name,
+      std::vector<Argument> arguments,
+      std::vector<Argument> returns,
+      Operation op,
+      c10::AliasAnalysisKind alias_analysis)
+      : op_(c10::make_right<C10Operator, JitOnlyOperator>(JitOnlyOperator{
+            c10::make_left<FunctionSchema, UnparsedFunctionSchema>(
+                varArgSchemaWithName(
+                    name,
+                    overload_name,
+                    arguments,
+                    returns,
+                    alias_analysis)),
             c10::make_left<Operation, OperationCreator>(std::move(op))})) {}
 
   Operator(
@@ -180,6 +198,23 @@ struct TORCH_API Operator {
     return result;
   }
 
+  static FunctionSchema varArgSchemaWithName(
+      std::string name,
+      std::string overload_name,
+      std::vector<Argument> arguments,
+      std::vector<Argument> returns,
+      AliasAnalysisKind alias_analysis) {
+    auto result = FunctionSchema(
+        name,
+        overload_name,
+        arguments,
+        returns,
+        /*is_vararg*/ false,
+        /*is_varret*/ false);
+    result.setAliasAnalysis(alias_analysis);
+    return result;
+  }
+
   c10::either<C10Operator, JitOnlyOperator> op_;
 };
 
@@ -243,6 +278,23 @@ c10::optional<Operator> OperatorGenerator(
     Func&& op,
     AliasAnalysisKind alias_analysis) {
   return c10::nullopt;
+}
+
+template <typename Func>
+c10::optional<Operator> OperatorGenerator(
+    const std::string name,
+    const std::string overload_name,
+    const std::vector<c10::Argument> arguments,
+    const std::vector<c10::Argument> returns,
+    Func&& op,
+    AliasAnalysisKind alias_analysis) {
+  return c10::optional<Operator>(Operator(
+      name,
+      overload_name,
+      arguments,
+      returns,
+      std::forward<Func>(op),
+      alias_analysis));
 }
 
 } // namespace jit


### PR DESCRIPTION
Summary:
RFC: pytorch/rfcs#40
In #69881 we added the ability to generate codegen unboxing source files. Notice that the generated code to register an operator looks like this:
```
    // aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
    OperatorGenerator(
        TORCH_SELECTIVE_SCHEMA("aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor"),
        [](Stack & stack) {
            RECORD_FUNCTION("add", std::vector<c10::IValue>());
            at::unboxing::add_Tensor(stack);
        },
        aliasAnalysisFromSchema()
    ),
```
However, this means we have to parse the schema and get back arguments with default values in static init time. As written in the RFC, there's a more performant option: providing these arguments with default values using codegen, then we don't have to do expensive regex pattern matching in parsing. Here's how it looks like:
```
    // aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
    OperatorGenerator(
        "aten::add",
        "Tensor",
        {
            c10::Argument("self", nullptr, c10::nullopt, c10::IValue(c10::nullopt)),
    	    c10::Argument("other", nullptr, c10::nullopt, c10::IValue(c10::nullopt)),
    	    c10::Argument("alpha", nullptr, c10::nullopt, c10::IValue(1))
        },
        {
            c10::Argument("")
        },
        [](Stack & stack) {
            RECORD_FUNCTION("add", std::vector<c10::IValue>());
            at::unboxing::add_Tensor(stack);
        },
        aliasAnalysisFromSchema()
    ),
```

We also added corresponding APIs in `operator.h` to take in the arguments.

Test Plan: Rely on CI

Differential Revision: D33077733

