### PR TITLE
[JIT] enable NNC cpu fusion with torch.jit.fuser("fuser1")

### DIFF
--- a/torch/jit/_fuser.py
+++ b/torch/jit/_fuser.py
@@ -39,7 +39,7 @@ def fuser(name):
     elif name == 'fuser1':  # NNC
         old_profiling_executor = torch._C._jit_set_profiling_executor(True)
         old_profiling_mode = torch._C._jit_set_profiling_mode(True)
-        torch._C._jit_override_can_fuse_on_cpu(False)
+        torch._C._jit_override_can_fuse_on_cpu(True)
         torch._C._jit_override_can_fuse_on_gpu(True)
         torch._C._jit_set_texpr_fuser_enabled(True)
         torch._C._jit_set_nvfuser_enabled(False)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #74078

torch.jit.fuser("fuser1") is supposed to enable NNC fusion, but it currently only enables gpu fusion. This will enable CPU fusion as well.

Differential Revision: [D34808602](https://our.internmc.facebook.com/intern/diff/D34808602)