### PR TITLE
[PyTorchEdge] Start writing magic to flatbuffer output

### DIFF
--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -362,7 +362,7 @@ flatbuffers::DetachedBuffer FlatbufferSerializer::serializeModule(
       tensor_data_.size(),
       storage_data_offset,
       fbb.CreateVector(obj_types_offset_));
-  fbb.Finish(mod);
+  FinishModuleBuffer(fbb, mod);
   return fbb.Release();
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74084
* #74048

Now that the schema includes a magic file header string, write it to the flatbuffer data generated by `flatbuffer_serializer`.

Differential Revision: [D34809318](https://our.internmc.facebook.com/intern/diff/D34809318/)