### PR TITLE
fix: nn.Module allowing for expected Mixin MRO

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -256,6 +256,8 @@ class Module:
         """
         Initializes internal Module state, shared by both nn.Module and ScriptModule.
         """
+        super().__init__()
+
         torch._C._log_api_usage_once("python.nn_module")
 
         self.training = True


### PR DESCRIPTION
## Description

This pull request solves #74036


## How Functionality Changes Were Tested

Running:
```
from torch import nn


class A:
    def __init__(self):
        super().__init__()
        self.a = True


class B(A, nn.Module):
    def __init__(self):
        super().__init__()
        self.b = True


class C(nn.Module, A):
    def __init__(self):
        super().__init__()
        self.c = True


b = B()
c = C()

print(b.b)
print(b.a)

print(c.c)
print(c.a)
```

- ### Results - Before:
  ```
  >>> from torch import nn
  >>>
  >>>
  >>> class A:
  ...     def __init__(self):
  ...         super().__init__()
  ...         self.a = True
  ...
  >>>
  >>> class B(A, nn.Module):
  ...     def __init__(self):
  ...         super().__init__()
  ...         self.b = True
  ...
  >>>
  >>> class C(nn.Module, A):
  ...     def __init__(self):
  ...         super().__init__()
  ...         self.c = True
  ...
  >>>
  >>> b = B()
  >>> c = C()
  >>>
  >>> print(b.b)
  True
  >>> print(b.a)
  True
  >>>
  >>> print(c.c)
  True
  >>> print(c.a)
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    File "/pytorch/torch/nn/modules/module.py", line 1188, in __getattr__
      raise AttributeError("'{}' object has no attribute '{}'".format(
  AttributeError: 'C' object has no attribute 'a'
  ```

- ### Results - After:
  ```
  >>> from torch import nn
  >>>
  >>>
  >>> class A:
  ...     def __init__(self):
  ...         super().__init__()
  ...         self.a = True
  ...
  >>>
  >>> class B(A, nn.Module):
  ...     def __init__(self):
  ...         super().__init__()
  ...         self.b = True
  ...
  >>>
  >>> class C(nn.Module, A):
  ...     def __init__(self):
  ...         super().__init__()
  ...         self.c = True
  ...
  >>>
  >>> b = B()
  >>> c = C()
  >>>
  >>> print(b.b)
  True
  >>> print(b.a)
  True
  >>>
  >>> print(c.c)
  True
  >>> print(c.a)
  True
  ```
