### PR TITLE
[Static Runtime] Use composite op for TE fusion

### DIFF
--- a/torch/csrc/jit/runtime/static/fusion.cpp
+++ b/torch/csrc/jit/runtime/static/fusion.cpp
@@ -345,7 +345,7 @@ void performTensorExprFusion(
   FuseTensorExprs(
       traced_graph,
       /*min_group_size*/ 2,
-      /*add_composed_op*/ false,
+      /*add_composed_op*/ true,
       /*fuse_to_dynamic_shapes*/ true);
   inlineFallbackGraphs(traced_graph);
   graph->block()->clear();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74126

When we perform fusion without the composite op, `TensorExprDynamicGroup`, it ends up not reusing the output tensor buffers. So, until we figure out a way to do that with `TensorExprGroup` op, it seems strictly better to use composite op, even though it involves going to the JIT.

Differential Revision: [D34831280](https://our.internmc.facebook.com/intern/diff/D34831280/)