### PR TITLE
[FX] Fix bare generic type annotations

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1027,6 +1027,24 @@ class TestFX(JitTestCase):
         traced_scripted = torch.jit.script(traced)
         self.assertEqual(traced_scripted(torch.rand(4)), 2)
 
+    def test_tuple_no_subscript(self):
+        def foo(x : Tuple):
+            return x[0]
+
+        traced = torch.fx.symbolic_trace(foo)
+        x = (torch.randn(5, 3),)
+        torch.testing.assert_allclose(traced(x), x[0])
+
+        bio = io.BytesIO()
+
+        torch.save(traced, bio)
+
+        bio.seek(0)
+
+        loaded = torch.load(bio)
+
+        torch.testing.assert_allclose(loaded(x), x[0])
+
     def test_torch_fx_len(self):
         class FXLenTest(torch.nn.Module):
             def forward(self, x):

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -7,6 +7,7 @@ import functools
 import inspect
 import math
 import numbers
+import io
 import operator
 import os
 import pickle

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -346,9 +346,15 @@ class CodeGen(object):
                     # Assign global names for each of the inner type variables.
                     args = [type_repr(arg) for arg in o.__args__]
 
+                    if len(args) == 0:
+                        # Bare type, such as `typing.Tuple` with no subscript
+                        # This code-path used in Python < 3.9
+                        return origin_typename
+
                     return f'{origin_typename}[{",".join(args)}]'
                 else:
                     # Bare type, such as `typing.Tuple` with no subscript
+                    # This code-path used in Python 3.9+
                     return origin_typename
 
             # Common case: this is a regular module name like 'foo.bar.baz'

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -337,11 +337,11 @@ class CodeGen(object):
 
             typename = _type_repr(o)
 
-            origin_type = _origin_type_map.get(o.__origin__, o.__origin__)
-            origin_typename = add_global(_type_repr(origin_type), origin_type)
-
             if hasattr(o, '__origin__'):
                 # This is a generic type, e.g. typing.List[torch.Tensor]
+                origin_type = _origin_type_map.get(o.__origin__, o.__origin__)
+                origin_typename = add_global(_type_repr(origin_type), origin_type)
+
                 if hasattr(o, '__args__'):
                     # Assign global names for each of the inner type variables.
                     args = [type_repr(arg) for arg in o.__args__]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #74135

Previously, if a user had annotated a type with `typing.Tuple` (no subscript), the generated code in fx would throw a syntax error like:

```
File "/torch/fx/graph.py", line 346, in type_repr
    args = [type_repr(arg) for arg in o.__args__]
  File "/python3.9/typing.py", line 706, in _getattr_
    raise AttributeError(attr)
AttributeError: _args_
```

or

```
File "<eval_with_key>.0", line 4
    def forward(self, input_ids : typing_Union[torch.Tensor,NoneType]) -> typing_Union[typing_Tuple[],transformers_modeling_outputs_BaseModelOutputWithPoolingAndCrossAttentions]:
```

This fixes that by emitting the same syntax for these type annotation as they were written, i.e. `typing.Tuple` -> `typing.Tuple`

Differential Revision: [D34839339](https://our.internmc.facebook.com/intern/diff/D34839339)