### PR TITLE
[Profiler] Switch to thread local subqueues to reduce lock contention.

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -148,6 +148,7 @@ libtorch_profiler_sources = [
     "torch/csrc/autograd/profiler_legacy.cpp",
     "torch/csrc/autograd/profiler_kineto.cpp",
     "torch/csrc/profiler/api.cpp",
+    "torch/csrc/profiler/collection.cpp",
     "torch/csrc/profiler/kineto_shim.cpp",
     "torch/csrc/profiler/nvtx_observer.cpp",
     "torch/csrc/monitor/counters.cpp",

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -1,0 +1,82 @@
+#include <torch/csrc/profiler/collection.h>
+
+#include <algorithm>
+
+#include <ATen/record_function.h>
+
+namespace torch {
+namespace profiler {
+namespace impl {
+namespace {
+// See `RecordQueue::getSubqueue()` for an overview of this cache.
+struct SubQueueThreadCache {
+  uint32_t key_;
+  ThreadLocalSubqueue* ref_;
+};
+
+// The astute observer will note that this leaves a dangling reference; nothing
+// in the teardown of `RecordQueue` or `ThreadLocalSubqueue` clears this value.
+// (And the raw pointer in `SubQueueThreadCache` will not extend the lifetime
+// of `*ref_`.) This is safe, however, because `getSubqueue` will check
+// `sub_queue_cache_.key_` before attempting to access `ref_`, and if `key_`
+// does not match the RecordQueue's *unique* `id_` it will evict
+// `sub_queue_cache_` and fall back to a different mechanism.
+std::atomic<uint32_t> queue_id_{0};
+thread_local SubQueueThreadCache sub_queue_cache_{0, nullptr};
+} // namespace
+
+RecordQueue::RecordQueue() : id_(++queue_id_) {}
+
+ThreadLocalSubqueue* RecordQueue::getSubqueue() {
+  // In the most common case, a thread will want to write to the same sub-queue
+  // that it wrote to last call. The only time that isn't true is if:
+  //  A) The profiler context has ended and we are in a new one.
+  //  B) Two profilers are active in different TLS contexts, and this thread
+  //     is a worker helping with intra-op parallelism.
+  // Since we expect this to be the OVERWHELMINGLY common case (>99%), we add a
+  // special thread_local cache so that we can skip the overall `flat_hash_map`
+  // (and corresponding lock).
+  if (id_ == sub_queue_cache_.key_) {
+    return sub_queue_cache_.ref_;
+  }
+
+  const auto tid = at::RecordFunction::currentThreadId();
+  std::lock_guard<std::mutex> guard(sub_queue_mutex_);
+  auto it = sub_queues_.find(tid);
+  if (it == sub_queues_.end()) {
+    it =
+        sub_queues_.emplace(tid, std::make_unique<ThreadLocalSubqueue>()).first;
+  }
+
+  sub_queue_cache_ = SubQueueThreadCache{id_, it->second.get()};
+  return it->second.get();
+}
+
+std::deque<OpEventData> RecordQueue::getRecords(
+    std::function<time_t(approx_time_t)> time_converter) {
+  auto converter = [&](approx_time_t t) {
+    return t == std::numeric_limits<approx_time_t>::min()
+        ? std::numeric_limits<int64_t>::min()
+        : time_converter(t) / 1000; // ns to ms
+  };
+  std::deque<OpEventData> out;
+  for (auto& subqueue_it : sub_queues_) {
+    for (auto& i : subqueue_it.second->data_) {
+      if (!i.backend_.has_value()) {
+        i.start_time_.us_ = converter(i.start_time_.count_);
+        i.end_time_.us_ = converter(i.end_time_.count_);
+      }
+      out.emplace_back(std::move(i));
+    }
+    subqueue_it.second->data_.clear();
+  }
+
+  std::stable_sort(out.begin(), out.end(), [](const auto& a, const auto& b) {
+    return a.start_time_.us_ < b.start_time_.us_;
+  });
+  return out;
+}
+
+} // namespace impl
+} // namespace profiler
+} // namespace torch

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <utility>
+
+#include <c10/macros/Macros.h>
+#include <c10/util/flat_hash_map.h>
+#include <torch/csrc/profiler/containers.h>
+#include <torch/csrc/profiler/kineto_shim.h>
+#include <torch/csrc/profiler/util.h>
+
+namespace torch {
+namespace profiler {
+namespace impl {
+
+// `reportBackendEventToActiveKinetoProfiler` reports times rather than counts,
+// so `OpEventData` has to be able to store both cases.
+union TimeStamp {
+  int64_t us_; // Backend event.
+  approx_time_t count_;
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct TORCH_API OpEventData {
+  OpEventData() = default;
+
+  OpEventData(
+      const uint64_t correlation_id,
+      const uint64_t start_thread_id,
+      const int64_t sequence_number,
+      const uint64_t forward_thread_id,
+      const at::RecordScope scope,
+      const bool is_async,
+      const int64_t debug_handle,
+      const std::string name)
+      : correlation_id_{correlation_id},
+        start_thread_id_{start_thread_id},
+        sequence_number_{sequence_number},
+        forward_thread_id_{forward_thread_id},
+        record_function_scope_{(uint8_t)scope},
+        is_async_{is_async},
+        debug_handle_{debug_handle},
+        kineto_info_{kineto::kineto_ids()},
+        name_{std::move(name)} {
+    end_time_.count_ = std::numeric_limits<approx_time_t>::min();
+  }
+
+  OpEventData(
+      const int64_t start_time,
+      const int64_t end_time,
+      const at::RecordScope scope,
+      const int64_t debug_handle,
+      const std::string name,
+      const std::string backend)
+      : correlation_id_{std::numeric_limits<uint64_t>::max()},
+        start_thread_id_{at::RecordFunction::currentThreadId()},
+        end_thread_id_{start_thread_id_},
+        sequence_number_{-1},
+        forward_thread_id_{start_thread_id_},
+        record_function_scope_{(uint8_t)scope},
+        is_async_{false},
+        debug_handle_{debug_handle},
+        kineto_info_{kineto::kineto_ids()},
+        name_{std::move(name)},
+        backend_{std::move(backend)} {
+    start_time_.us_ = start_time;
+    end_time_.us_ = end_time;
+  }
+
+  // POD members
+  TimeStamp start_time_;
+  TimeStamp end_time_;
+  uint64_t correlation_id_;
+  uint64_t start_thread_id_;
+  uint64_t end_thread_id_;
+  int64_t sequence_number_;
+  uint64_t forward_thread_id_;
+  uint8_t record_function_scope_;
+  bool is_async_;
+  int64_t debug_handle_;
+  kineto::DeviceAndResource kineto_info_;
+
+  std::string name_;
+
+  // report_input_shapes
+  std::vector<std::vector<int64_t>> shapes_;
+  std::vector<std::string> dtypes_;
+
+  // with_stack
+  std::vector<std::string> stack_;
+
+  // with_modules
+  c10::optional<std::vector<std::string>> module_hierarchy_;
+
+  // with_flops
+  std::unordered_map<std::string, c10::IValue> extra_args_;
+
+  // reportBackendEventToActiveKinetoProfiler
+  c10::optional<std::string> backend_;
+
+  // ProfilerState::KINETO_GPU_FALLBACK
+  torch::profiler::impl::CUDAEventStub cuda_event_start_ = nullptr;
+  torch::profiler::impl::CUDAEventStub cuda_event_end_ = nullptr;
+};
+
+class TORCH_API ThreadLocalSubqueue {
+ public:
+  template <class... Args>
+  OpEventData* emplace_back(Args&&... args) {
+    return data_.emplace_back(std::forward<Args>(args)...);
+  }
+
+ private:
+  friend class RecordQueue;
+
+  // See `containers.h` for block size benchmarks.
+  static constexpr size_t BlockSize = 1024;
+  AppendOnlyList<OpEventData, BlockSize> data_;
+};
+
+class TORCH_API RecordQueue {
+ public:
+  RecordQueue();
+  ThreadLocalSubqueue* getSubqueue();
+  std::deque<OpEventData> getRecords(std::function<time_t(approx_time_t)> time_converter);
+
+ private:
+  uint32_t id_;
+  ska::flat_hash_map<uint64_t, std::unique_ptr<ThreadLocalSubqueue>> sub_queues_;
+  std::mutex sub_queue_mutex_;
+};
+
+} // namespace impl
+} // namespace profiler
+} // namespace torch


### PR DESCRIPTION
Summary: The first of several changes to move to an optimized recording data structure to back profiler. This PR keeps the existing monolithic `OpEventData` struct, but splits storage into thread local subqueues so we don't have to lock to insert.

Test Plan: Unit tests and benchmarks. The single threaded benchmark is unchanged, and the multithreaded stress test dropped from ~21 us to ~6us.

Reviewed By: chaekit

Differential Revision: D34720171

