### PR TITLE
[LT] Skip tacotron2 and demucs in lazy_bench.py

### DIFF
--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -64,9 +64,11 @@ SKIP = {
     "densenet121": "OOMs on eager CUDA CI machine (T4 GPU)",
     "timm_nfnet": "OOMs on eager CUDA CI machine (T4 GPU)",
     "moco": "Distributed/ProcessGroupNCCL: Tensors must be CUDA and dense",
+    "tacotron2": "OOMs on eager CUDA CI machine (T4 GPU)",
 }
 SKIP_TRAIN_ONLY = {
     "squeezenet1_1": "OOMs on eager CUDA CI machine (T4 GPU)",
+    "demucs": "OOMs on eager CUDA CI machine (T4 GPU)",
 }
 
 current_name = ""

--- a/lazy_tensor_core/lazy_bench.py
+++ b/lazy_tensor_core/lazy_bench.py
@@ -61,14 +61,14 @@ log = logging.getLogger(__name__)
 # Models that are known to crash or otherwise not work with lazy tensor are
 # disabled, but should be removed from these lists once fixed
 SKIP = {
-    "densenet121": "OOMs on eager CUDA CI machine (T4 GPU)",
-    "timm_nfnet": "OOMs on eager CUDA CI machine (T4 GPU)",
+    "densenet121": "Disabled by torchbench upstream due to OOM on T4 CI machine",
+    "timm_nfnet": "Disabled by torchbench upstream due to OOM on T4 CI machine",
     "moco": "Distributed/ProcessGroupNCCL: Tensors must be CUDA and dense",
-    "tacotron2": "OOMs on eager CUDA CI machine (T4 GPU)",
+    "tacotron2": "Disabled by torchbench upstream due to OOM on T4 CI machine",
 }
 SKIP_TRAIN_ONLY = {
-    "squeezenet1_1": "OOMs on eager CUDA CI machine (T4 GPU)",
-    "demucs": "OOMs on eager CUDA CI machine (T4 GPU)",
+    "squeezenet1_1": "Disabled by torchbench upstream due to OOM on T4 CI machine",
+    "demucs": "Disabled by torchbench upstream due to OOM on T4 CI machine",
 }
 
 current_name = ""


### PR DESCRIPTION
Summary:
Skip tacotron2 and demucs in lazy_bench.py because of OOMs on eager CUDA
CI machine (T4 GPU).

Test Plan:
CI.

Fixes #74182.
