### PR TITLE
Preserve codegen on fx graph in transformer

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -3358,6 +3358,34 @@ def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
         ts_f = torch.jit.script(nf)
         self.assertEqual(nf(vals), ts_f(vals))
 
+    def test_custom_codegen_with_transformer(self):
+        class ListCodeGen(CodeGen):
+            def gen_fn_def(self, free_vars, maybe_return_annotation):
+                lst_unpack = f"""
+def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
+    {', '.join(free_vars)} = args_list"""
+                return lst_unpack
+
+            def additional_globals(self):
+                return [('List', typing.List)]
+
+            def process_inputs(self, *inputs):
+                assert(len(inputs) == 1)
+                return inputs[0]
+
+        def f(a, b):
+            return a + b
+
+        nf = symbolic_trace(f)
+        vals = [torch.randn(3), torch.randn(3)]
+        self.assertEqual(nf(*vals), f(*vals))
+
+        nf.graph.set_codegen(ListCodeGen())
+        nf.recompile()
+        self.assertEqual(nf(vals), f(*vals))
+
+        transformed_gm = Transformer(nf).transform()
+        self.assertEqual(nf(vals), transformed_gm(vals))
 
     def test_imul_code_print(self):
         graph = torch.fx.Graph()

--- a/torch/fx/experimental/normalize.py
+++ b/torch/fx/experimental/normalize.py
@@ -34,7 +34,7 @@ class NormalizeArgs(Transformer):
     """
 
     def __init__(
-        self, module: torch.nn.Module, normalize_to_only_use_kwargs: bool = True
+        self, module: torch.fx.GraphModule, normalize_to_only_use_kwargs: bool = True
     ):
         super().__init__(module)
         self.node_map: Dict[Proxy, Node] = {}

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -382,6 +382,7 @@ class Transformer(Interpreter):
     def __init__(self, module):
         super().__init__(module)
         self.new_graph = Graph()
+        self.new_graph.set_codegen(module.graph._codegen)
 
         class TransformerTracer(Tracer):
             def __init__(self, graph: Graph):


### PR DESCRIPTION
Summary: Use the codegen on the original graph module for the new graph module produced by transformer.

Test Plan: Added a unit test: test_custom_codegen_with_transformer

Differential Revision: D34867938

