### PR TITLE
Add names to lint jobs so we could require them pass

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   quick-checks:
+    name: Lint / quick-checks
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -113,6 +114,7 @@ jobs:
           .github/scripts/lint_test_ownership.py
 
   clang-format:
+    name: Lint / clang-format
     runs-on: ubuntu-18.04
     if: ${{ github.event_name == 'pull_request' }}
     steps:
@@ -153,6 +155,7 @@ jobs:
           exit 1
 
   py2-setup-validate-errormsg:
+    name: Lint / py2-setup-validate-errormsg
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -172,6 +175,7 @@ jobs:
         run: python2 -m py_compile torch/utils/collect_env.py
 
   shellcheck:
+    name: Lint / shellcheck
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -251,6 +255,7 @@ jobs:
           rm actionlint
 
   toc:
+    name: Lint / toc
     runs-on: ubuntu-18.04
     # https://github.com/actions/virtual-environments/issues/599#issuecomment-602754687
     env:
@@ -287,6 +292,7 @@ jobs:
           fi
 
   flake8-py3:
+    name: Lint / flake8-py3
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -347,6 +353,7 @@ jobs:
           mode: json
 
   clang-tidy:
+    name: Lint / clang-tidy
     runs-on: linux.2xlarge
     container:
       # ubuntu20.04-cuda11.2-py3.8-tidy11
@@ -440,6 +447,7 @@ jobs:
           mode: json
 
   cmakelint:
+    name: Lint / cmakelint
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -462,6 +470,7 @@ jobs:
           xargs -0 cmakelint --config=.cmakelintrc --spaces=2 --quiet
 
   mypy:
+    name: Lint / mypy
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   quick-checks:
-    name: Lint / quick-checks
+    name: quick-checks
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -114,7 +114,7 @@ jobs:
           .github/scripts/lint_test_ownership.py
 
   clang-format:
-    name: Lint / clang-format
+    name: clang-format
     runs-on: ubuntu-18.04
     if: ${{ github.event_name == 'pull_request' }}
     steps:
@@ -155,7 +155,7 @@ jobs:
           exit 1
 
   py2-setup-validate-errormsg:
-    name: Lint / py2-setup-validate-errormsg
+    name: py2-setup-validate-errormsg
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -175,7 +175,7 @@ jobs:
         run: python2 -m py_compile torch/utils/collect_env.py
 
   shellcheck:
-    name: Lint / shellcheck
+    name: shellcheck
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -255,7 +255,7 @@ jobs:
           rm actionlint
 
   toc:
-    name: Lint / toc
+    name: toc
     runs-on: ubuntu-18.04
     # https://github.com/actions/virtual-environments/issues/599#issuecomment-602754687
     env:
@@ -292,7 +292,7 @@ jobs:
           fi
 
   flake8-py3:
-    name: Lint / flake8-py3
+    name: flake8-py3
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -353,7 +353,7 @@ jobs:
           mode: json
 
   clang-tidy:
-    name: Lint / clang-tidy
+    name: clang-tidy
     runs-on: linux.2xlarge
     container:
       # ubuntu20.04-cuda11.2-py3.8-tidy11
@@ -447,7 +447,7 @@ jobs:
           mode: json
 
   cmakelint:
-    name: Lint / cmakelint
+    name: cmakelint
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python
@@ -470,7 +470,7 @@ jobs:
           xargs -0 cmakelint --config=.cmakelintrc --spaces=2 --quiet
 
   mypy:
-    name: Lint / mypy
+    name: mypy
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python


### PR DESCRIPTION
GitHub settings require status checks picks checks based on job names.
Add names to lint jobs so we could add these are requirements.

I didn't add a lint prefix as it would make the signal appear like
![image](https://user-images.githubusercontent.com/31798555/158260211-7b117da0-ad26-47e3-8acd-f2e8dbdcd40a.png)