### PR TITLE
check if owner is pytorch in jobs

### DIFF
--- a/.github/templates/android_ci_full_workflow.yml.j2
+++ b/.github/templates/android_ci_full_workflow.yml.j2
@@ -21,7 +21,7 @@ on:
   {%- endif %}
 {%- endfor %}
 
-{% block build %}
+{% block build +%}
   # building and testing in a single job since bazel runs only small subset of tests
   build-and-test:
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/templates/android_ci_full_workflow.yml.j2
+++ b/.github/templates/android_ci_full_workflow.yml.j2
@@ -21,9 +21,10 @@ on:
   {%- endif %}
 {%- endfor %}
 
-{% block build +%}
+{% block build %}
   # building and testing in a single job since bazel runs only small subset of tests
   build-and-test:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: !{{ test_runner_type }}
     env:
       JOB_BASE_NAME: !{{ build_environment }}-build-and-test

--- a/.github/templates/android_ci_workflow.yml.j2
+++ b/.github/templates/android_ci_workflow.yml.j2
@@ -21,7 +21,7 @@ on:
   {%- endif %}
 {%- endfor %}
 
-{% block build %}
+{% block build +%}
   # building and testing in a single job since bazel runs only small subset of tests
   build-and-test:
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/templates/android_ci_workflow.yml.j2
+++ b/.github/templates/android_ci_workflow.yml.j2
@@ -21,9 +21,10 @@ on:
   {%- endif %}
 {%- endfor %}
 
-{% block build +%}
+{% block build %}
   # building and testing in a single job since bazel runs only small subset of tests
   build-and-test:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: !{{ test_runner_type }}
     env:
       JOB_BASE_NAME: !{{ build_environment }}-build-and-test

--- a/.github/templates/bazel_ci_workflow.yml.j2
+++ b/.github/templates/bazel_ci_workflow.yml.j2
@@ -21,7 +21,7 @@ on:
   {%- endif %}
 {%- endfor %}
 
-{% block build %}
+{% block build +%}
   # building and testing in a single job since bazel runs only small subset of tests
   build-and-test:
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/templates/bazel_ci_workflow.yml.j2
+++ b/.github/templates/bazel_ci_workflow.yml.j2
@@ -21,9 +21,10 @@ on:
   {%- endif %}
 {%- endfor %}
 
-{% block build +%}
+{% block build %}
   # building and testing in a single job since bazel runs only small subset of tests
   build-and-test:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: !{{ test_runner_type }}
     env:
       JOB_BASE_NAME: !{{ build_environment }}-build-and-test

--- a/.github/templates/docker_builds_ci_workflow.yml.j2
+++ b/.github/templates/docker_builds_ci_workflow.yml.j2
@@ -24,8 +24,9 @@ env:
   AWS_DEFAULT_REGION: us-east-1
 
 jobs:
-{% block docker_build +%}
+{% block docker_build %}
   docker-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: !{{ common.timeout_minutes }}
     strategy:

--- a/.github/templates/docker_builds_ci_workflow.yml.j2
+++ b/.github/templates/docker_builds_ci_workflow.yml.j2
@@ -24,7 +24,7 @@ env:
   AWS_DEFAULT_REGION: us-east-1
 
 jobs:
-{% block docker_build %}
+{% block docker_build +%}
   docker-build:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge

--- a/.github/templates/ios_ci_workflow.yml.j2
+++ b/.github/templates/ios_ci_workflow.yml.j2
@@ -40,7 +40,7 @@ env:
 !{{ common.set_xcode_version(xcode_version) }}
 
 jobs:
-{% block build %}
+{% block build +%}
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
@@ -179,6 +179,6 @@ jobs:
             fastlane scan --only_testing TestAppTests/TestAppTests/testFullJIT
           fi
 {%- endif -%}
-{% endblock %}
+{% endblock +%}
 
 !{{ common.concurrency(build_environment) }}

--- a/.github/templates/ios_ci_workflow.yml.j2
+++ b/.github/templates/ios_ci_workflow.yml.j2
@@ -40,11 +40,11 @@ env:
 !{{ common.set_xcode_version(xcode_version) }}
 
 jobs:
-{% block build +%}
+{% block build %}
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: macos-10.15
     timeout-minutes: !{{ common.timeout_minutes }}
     env:
@@ -179,6 +179,6 @@ jobs:
             fastlane scan --only_testing TestAppTests/TestAppTests/testFullJIT
           fi
 {%- endif -%}
-{% endblock +%}
+{% endblock %}
 
 !{{ common.concurrency(build_environment) }}

--- a/.github/templates/ios_ci_workflow.yml.j2
+++ b/.github/templates/ios_ci_workflow.yml.j2
@@ -44,7 +44,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: !{{ common.timeout_minutes }}
     env:

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -38,8 +38,9 @@ env:
 !{{ common.concurrency(build_environment) }}
 
 jobs:
-{% block build +%}
+{% block build %}
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: !{{ common.timeout_minutes }}
     env:
@@ -147,9 +148,10 @@ jobs:
           docker system prune -af
 {%- endblock %}
 {%- if not exclude_test %}
-{% block test +%}
+{% block test %}
   {%- for test_job in test_jobs %}
   !{{ test_job.id }}:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: !{{ test_job.name }}
     needs: build
     runs-on: !{{ test_job.runner }}
@@ -323,6 +325,7 @@ jobs:
 {%- endif -%}
 {%- if enable_doc_jobs %}
   build-docs:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: !{{ common.timeout_minutes }}
     strategy:

--- a/.github/templates/linux_ci_workflow.yml.j2
+++ b/.github/templates/linux_ci_workflow.yml.j2
@@ -38,7 +38,7 @@ env:
 !{{ common.concurrency(build_environment) }}
 
 jobs:
-{% block build %}
+{% block build +%}
   build:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
@@ -148,7 +148,7 @@ jobs:
           docker system prune -af
 {%- endblock %}
 {%- if not exclude_test %}
-{% block test %}
+{% block test +%}
   {%- for test_job in test_jobs %}
   !{{ test_job.id }}:
     if: ${{ github.repository_owner == 'pytorch' }}

--- a/.github/templates/macos_binary_build_workflow.yml.j2
+++ b/.github/templates/macos_binary_build_workflow.yml.j2
@@ -59,6 +59,7 @@ env:
 jobs:
 {%- for config in build_configs %}
   !{{ config["build_name"] }}-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
 {%- if config["package_type"] == "libtorch" %}
     # libtorch builds take a long time on github hosted runners

--- a/.github/templates/macos_ci_workflow.yml.j2
+++ b/.github/templates/macos_ci_workflow.yml.j2
@@ -21,8 +21,9 @@ env:
 !{{ common.set_xcode_version(xcode_version) }}
 
 jobs:
-{% block build +%}
+{% block build %}
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: !{{ test_runner_type }}
     env:
       JOB_BASE_NAME: !{{ build_environment }}
@@ -62,11 +63,12 @@ jobs:
           path:
             artifacts.zip
 {%- endif %}
-{% endblock +%}
+{% endblock %}
 {%- if not exclude_test %}
-{% block test +%}
+{% block test %}
   {%- for test_job in test_jobs %}
   !{{ test_job.id }}:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: !{{ test_job.name }}
     needs: build
     runs-on: !{{ test_job.runner }}
@@ -102,7 +104,7 @@ jobs:
       !{{ common.upload_test_reports("macos", config=test_job.config, shard=test_job.shard, num_shards=test_job.num_shards, runner=test_job.runner, artifact_name="test-reports", use_s3=False) }}
       !{{ common.upload_test_statistics(build_environment, needs_credentials=True) }}
 {%- endfor %}
-{% endblock +%}
+{% endblock %}
 {%- endif %}
 
 !{{ common.concurrency(build_environment) }}

--- a/.github/templates/macos_ci_workflow.yml.j2
+++ b/.github/templates/macos_ci_workflow.yml.j2
@@ -21,7 +21,7 @@ env:
 !{{ common.set_xcode_version(xcode_version) }}
 
 jobs:
-{% block build %}
+{% block build +%}
   build:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: !{{ test_runner_type }}
@@ -63,9 +63,9 @@ jobs:
           path:
             artifacts.zip
 {%- endif %}
-{% endblock %}
+{% endblock +%}
 {%- if not exclude_test %}
-{% block test %}
+{% block test +%}
   {%- for test_job in test_jobs %}
   !{{ test_job.id }}:
     if: ${{ github.repository_owner == 'pytorch' }}
@@ -104,7 +104,7 @@ jobs:
       !{{ common.upload_test_reports("macos", config=test_job.config, shard=test_job.shard, num_shards=test_job.num_shards, runner=test_job.runner, artifact_name="test-reports", use_s3=False) }}
       !{{ common.upload_test_statistics(build_environment, needs_credentials=True) }}
 {%- endfor %}
-{% endblock %}
+{% endblock +%}
 {%- endif %}
 
 !{{ common.concurrency(build_environment) }}

--- a/.github/templates/windows_binary_build_workflow.yml.j2
+++ b/.github/templates/windows_binary_build_workflow.yml.j2
@@ -58,6 +58,7 @@ env:
 jobs:
 {%- for config in build_configs %}
   !{{ config["build_name"] }}-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: !{{ common.timeout_minutes }}
     !{{ upload.binary_env(config, True) }}

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -53,6 +53,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: "windows.4xlarge"
     timeout-minutes: !{{ common.timeout_minutes }}
     env:
@@ -115,6 +116,7 @@ jobs:
 
   {%- for test_job in test_jobs %}
   !{{ test_job.id }}:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: !{{ test_job.name }}
     timeout-minutes: !{{ timeout_after + 30 }}
     env:

--- a/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-caffe2-linux-xenial-py3.7-gcc5.4.yml
@@ -42,6 +42,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-docker-builds.yml
+++ b/.github/workflows/generated-docker-builds.yml
@@ -23,6 +23,7 @@ env:
 jobs:
 
   docker-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     strategy:

--- a/.github/workflows/generated-ios-12-5-1-arm64-coreml.yml
+++ b/.github/workflows/generated-ios-12-5-1-arm64-coreml.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-ios-12-5-1-arm64-coreml.yml
+++ b/.github/workflows/generated-ios-12-5-1-arm64-coreml.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-ios-12-5-1-arm64-custom-ops.yml
+++ b/.github/workflows/generated-ios-12-5-1-arm64-custom-ops.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-ios-12-5-1-arm64-custom-ops.yml
+++ b/.github/workflows/generated-ios-12-5-1-arm64-custom-ops.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-ios-12-5-1-arm64-metal.yml
+++ b/.github/workflows/generated-ios-12-5-1-arm64-metal.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-ios-12-5-1-arm64-metal.yml
+++ b/.github/workflows/generated-ios-12-5-1-arm64-metal.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-ios-12-5-1-arm64.yml
+++ b/.github/workflows/generated-ios-12-5-1-arm64.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-ios-12-5-1-arm64.yml
+++ b/.github/workflows/generated-ios-12-5-1-arm64.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-ios-12-5-1-x86-64-coreml.yml
+++ b/.github/workflows/generated-ios-12-5-1-x86-64-coreml.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-ios-12-5-1-x86-64-coreml.yml
+++ b/.github/workflows/generated-ios-12-5-1-x86-64-coreml.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-ios-12-5-1-x86-64.yml
+++ b/.github/workflows/generated-ios-12-5-1-x86-64.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-ios-12-5-1-x86-64.yml
+++ b/.github/workflows/generated-ios-12-5-1-x86-64.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
-    if: ${{ github.repository_owner == 'pytorch' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda10.2-py3.7-gcc7.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-libtorch-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
+++ b/.github/workflows/generated-linux-bionic-cuda10.2-py3.9-gcc7.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -260,6 +261,7 @@ jobs:
           docker system prune -af
 
   test_jit_legacy_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (jit_legacy, 1, 1, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu
@@ -537,6 +539,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_multigpu_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (multigpu, 1, 1, linux.16xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.16xlarge.nvidia.gpu
@@ -814,6 +817,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_nogpu_NO_AVX_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (nogpu_NO_AVX, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -1082,6 +1086,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_nogpu_NO_AVX2_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (nogpu_NO_AVX2, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -1350,6 +1355,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_distributed_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (distributed, 1, 1, linux.8xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.8xlarge.nvidia.gpu
@@ -1627,6 +1633,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_slow_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (slow, 1, 1, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu
@@ -1904,6 +1911,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu
@@ -2181,6 +2189,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu

--- a/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-bionic-py3.7-clang9.yml
@@ -44,6 +44,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -261,6 +262,7 @@ jobs:
           docker system prune -af
 
   test_noarch_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (noarch, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -529,6 +531,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -797,6 +800,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7-distributed.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7-distributed.yml
@@ -42,6 +42,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -259,6 +260,7 @@ jobs:
           docker system prune -af
 
   test_distributed_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (distributed, 1, 1, linux.rocm.gpu)
     needs: build
     runs-on: linux.rocm.gpu

--- a/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
+++ b/.github/workflows/generated-linux-bionic-rocm4.5-py3.7.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -260,6 +261,7 @@ jobs:
           docker system prune -af
 
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, linux.rocm.gpu)
     needs: build
     runs-on: linux.rocm.gpu
@@ -487,6 +489,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, linux.rocm.gpu)
     needs: build
     runs-on: linux.rocm.gpu

--- a/.github/workflows/generated-linux-docs-push.yml
+++ b/.github/workflows/generated-linux-docs-push.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -259,6 +260,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   build-docs:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     strategy:

--- a/.github/workflows/generated-linux-docs.yml
+++ b/.github/workflows/generated-linux-docs.yml
@@ -44,6 +44,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -260,6 +261,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   build-docs:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     strategy:

--- a/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
+++ b/.github/workflows/generated-linux-vulkan-bionic-py3.7-clang9.yml
@@ -44,6 +44,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -261,6 +262,7 @@ jobs:
           docker system prune -af
 
   test_default_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-bazel-test.yml
@@ -45,6 +45,7 @@ jobs:
 
   # building and testing in a single job since bazel runs only small subset of tests
   build-and-test:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     env:
       JOB_BASE_NAME: linux-xenial-cuda11.3-py3.7-gcc7-bazel-test-build-and-test

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7-no-ops.yml
@@ -42,6 +42,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -260,6 +261,7 @@ jobs:
           docker system prune -af
 
   test_distributed_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (distributed, 1, 1, linux.8xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.8xlarge.nvidia.gpu
@@ -537,6 +539,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu
@@ -814,6 +817,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-build.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
+++ b/.github/workflows/generated-linux-xenial-py3-clang5-mobile-custom-build-static.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-asan.yml
@@ -44,6 +44,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -261,6 +262,7 @@ jobs:
           docker system prune -af
 
   test_default_1_3:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 3, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -529,6 +531,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_2_3:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 3, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -797,6 +800,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_3_3:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 3, 3, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge

--- a/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-clang7-onnx.yml
@@ -44,6 +44,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -261,6 +262,7 @@ jobs:
           docker system prune -af
 
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -529,6 +531,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build.yml
@@ -45,6 +45,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc5.4.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -260,6 +261,7 @@ jobs:
           docker system prune -af
 
   test_jit_legacy_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (jit_legacy, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -528,6 +530,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_distributed_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (distributed, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -796,6 +799,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_docs_test_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (docs_test, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -1064,6 +1068,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_backwards_compat_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (backwards_compat, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -1332,6 +1337,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -1600,6 +1606,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7-no-ops.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
+++ b/.github/workflows/generated-linux-xenial-py3.7-gcc7.yml
@@ -43,6 +43,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -260,6 +261,7 @@ jobs:
           docker system prune -af
 
   test_distributed_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (distributed, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -528,6 +530,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -796,6 +799,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge

--- a/.github/workflows/generated-macos-10-15-py3-arm64.yml
+++ b/.github/workflows/generated-macos-10-15-py3-arm64.yml
@@ -30,6 +30,7 @@ env:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     env:
       JOB_BASE_NAME: macos-10-15-py3-arm64

--- a/.github/workflows/generated-macos-10-15-py3-lite-interpreter-x86-64.yml
+++ b/.github/workflows/generated-macos-10-15-py3-lite-interpreter-x86-64.yml
@@ -32,6 +32,7 @@ env:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     env:
       JOB_BASE_NAME: macos-10-15-py3-lite-interpreter-x86-64

--- a/.github/workflows/generated-macos-11-py3-x86-64.yml
+++ b/.github/workflows/generated-macos-11-py3-x86-64.yml
@@ -32,6 +32,7 @@ env:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-11
     env:
       JOB_BASE_NAME: macos-11-py3-x86-64
@@ -87,6 +88,7 @@ jobs:
 
 
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, macos-11)
     needs: build
     runs-on: macos-11
@@ -204,6 +206,7 @@ jobs:
           export GHA_WORKFLOW_JOB_ID
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, macos-11)
     needs: build
     runs-on: macos-11

--- a/.github/workflows/generated-macos-arm64-binary-conda-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-conda-nightly.yml
@@ -38,6 +38,7 @@ concurrency:
 
 jobs:
   conda-py3_8-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:
@@ -243,6 +244,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_9-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:
@@ -448,6 +450,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_10-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -38,6 +38,7 @@ concurrency:
 
 jobs:
   wheel-py3_7-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:
@@ -243,6 +244,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_8-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:
@@ -448,6 +450,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_9-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:
@@ -653,6 +656,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_10-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-macos-binary-conda-nightly.yml
+++ b/.github/workflows/generated-macos-binary-conda-nightly.yml
@@ -36,6 +36,7 @@ concurrency:
 
 jobs:
   conda-py3_7-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:
@@ -241,6 +242,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_8-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:
@@ -446,6 +448,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_9-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:
@@ -651,6 +654,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_10-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-macos-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-macos-binary-libtorch-cxx11-abi-nightly.yml
@@ -36,6 +36,7 @@ concurrency:
 
 jobs:
   libtorch-cpu-shared-with-deps-cxx11-abi-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     # libtorch builds take a long time on github hosted runners
     timeout-minutes: 720
@@ -247,6 +248,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-shared-without-deps-cxx11-abi-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     # libtorch builds take a long time on github hosted runners
     timeout-minutes: 720
@@ -458,6 +460,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-static-with-deps-cxx11-abi-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     # libtorch builds take a long time on github hosted runners
     timeout-minutes: 720
@@ -669,6 +672,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-static-without-deps-cxx11-abi-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     # libtorch builds take a long time on github hosted runners
     timeout-minutes: 720

--- a/.github/workflows/generated-macos-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-macos-binary-libtorch-pre-cxx11-nightly.yml
@@ -36,6 +36,7 @@ concurrency:
 
 jobs:
   libtorch-cpu-shared-with-deps-pre-cxx11-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     # libtorch builds take a long time on github hosted runners
     timeout-minutes: 720
@@ -247,6 +248,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-shared-without-deps-pre-cxx11-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     # libtorch builds take a long time on github hosted runners
     timeout-minutes: 720
@@ -458,6 +460,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-static-with-deps-pre-cxx11-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     # libtorch builds take a long time on github hosted runners
     timeout-minutes: 720
@@ -669,6 +672,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-static-without-deps-pre-cxx11-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     # libtorch builds take a long time on github hosted runners
     timeout-minutes: 720

--- a/.github/workflows/generated-macos-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-binary-wheel-nightly.yml
@@ -36,6 +36,7 @@ concurrency:
 
 jobs:
   wheel-py3_7-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:
@@ -241,6 +242,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_8-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:
@@ -446,6 +448,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_9-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:
@@ -651,6 +654,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_10-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: macos-10.15
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
+++ b/.github/workflows/generated-parallelnative-linux-xenial-py3.7-gcc5.4.yml
@@ -42,6 +42,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -259,6 +260,7 @@ jobs:
           docker system prune -af
 
   test_distributed_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (distributed, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge
@@ -527,6 +529,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge

--- a/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -41,6 +41,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
+++ b/.github/workflows/generated-periodic-linux-bionic-cuda11.5-py3.7-gcc7.yml
@@ -40,6 +40,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -257,6 +258,7 @@ jobs:
           docker system prune -af
 
   test_distributed_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (distributed, 1, 1, linux.8xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.8xlarge.nvidia.gpu
@@ -534,6 +536,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu
@@ -811,6 +814,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu

--- a/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck.yml
@@ -42,6 +42,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -259,6 +260,7 @@ jobs:
           docker system prune -af
 
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu
@@ -536,6 +538,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu

--- a/.github/workflows/generated-periodic-linux-xenial-cuda11.3-py3.7-gcc7-debug.yml
+++ b/.github/workflows/generated-periodic-linux-xenial-cuda11.3-py3.7-gcc7-debug.yml
@@ -41,6 +41,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -258,6 +259,7 @@ jobs:
           docker system prune -af
 
   test_distributed_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (distributed, 1, 1, linux.8xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.8xlarge.nvidia.gpu
@@ -535,6 +537,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu
@@ -812,6 +815,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, linux.4xlarge.nvidia.gpu)
     needs: build
     runs-on: linux.4xlarge.nvidia.gpu

--- a/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
+++ b/.github/workflows/generated-periodic-win-vs2019-cuda11.5-py3.yml
@@ -47,6 +47,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: "windows.4xlarge"
     timeout-minutes: 240
     env:
@@ -141,6 +142,7 @@ jobs:
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
           rm -rf ./*
   test_force_on_cpu_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (force_on_cpu, 1, 1, windows.4xlarge)
     timeout-minutes: 270
     env:
@@ -295,6 +297,7 @@ jobs:
         run: |
           rm -rf ./*
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, windows.8xlarge.nvidia.gpu)
     timeout-minutes: 270
     env:
@@ -457,6 +460,7 @@ jobs:
         run: |
           rm -rf ./*
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, windows.8xlarge.nvidia.gpu)
     timeout-minutes: 270
     env:

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build.yml
@@ -44,6 +44,7 @@ jobs:
 
   # building and testing in a single job since bazel runs only small subset of tests
   build-and-test:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     env:
       JOB_BASE_NAME: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build-build-and-test

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit.yml
@@ -45,6 +45,7 @@ jobs:
 
   # building and testing in a single job since bazel runs only small subset of tests
   build-and-test:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     env:
       JOB_BASE_NAME: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit-build-and-test

--- a/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
+++ b/.github/workflows/generated-pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single.yml
@@ -45,6 +45,7 @@ jobs:
 
   # building and testing in a single job since bazel runs only small subset of tests
   build-and-test:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     env:
       JOB_BASE_NAME: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-build-and-test

--- a/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
+++ b/.github/workflows/generated-pytorch-xla-linux-bionic-py3.7-clang8.yml
@@ -47,6 +47,7 @@ concurrency:
 jobs:
 
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: linux.2xlarge
     timeout-minutes: 240
     env:
@@ -227,6 +228,7 @@ jobs:
           docker system prune -af
 
   test_xla_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (xla, 1, 1, linux.2xlarge)
     needs: build
     runs-on: linux.2xlarge

--- a/.github/workflows/generated-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cpu-py3.yml
@@ -46,6 +46,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: "windows.4xlarge"
     timeout-minutes: 240
     env:
@@ -132,6 +133,7 @@ jobs:
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
           rm -rf ./*
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, windows.4xlarge)
     timeout-minutes: 270
     env:
@@ -286,6 +288,7 @@ jobs:
         run: |
           rm -rf ./*
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, windows.4xlarge)
     timeout-minutes: 270
     env:

--- a/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
+++ b/.github/workflows/generated-win-vs2019-cuda11.3-py3.yml
@@ -47,6 +47,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: "windows.4xlarge"
     timeout-minutes: 240
     env:
@@ -141,6 +142,7 @@ jobs:
           rm -rf "${PYTORCH_FINAL_PACKAGE_DIR}"
           rm -rf ./*
   test_force_on_cpu_1_1:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (force_on_cpu, 1, 1, windows.4xlarge)
     timeout-minutes: 300
     env:
@@ -295,6 +297,7 @@ jobs:
         run: |
           rm -rf ./*
   test_default_1_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 1, 2, windows.8xlarge.nvidia.gpu)
     timeout-minutes: 300
     env:
@@ -457,6 +460,7 @@ jobs:
         run: |
           rm -rf ./*
   test_default_2_2:
+    if: ${{ github.repository_owner == 'pytorch' }}
     name: test (default, 2, 2, windows.8xlarge.nvidia.gpu)
     timeout-minutes: 300
     env:

--- a/.github/workflows/generated-windows-binary-conda-nightly.yml
+++ b/.github/workflows/generated-windows-binary-conda-nightly.yml
@@ -37,6 +37,7 @@ concurrency:
 
 jobs:
   conda-py3_7-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -355,6 +356,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_7-cuda11_3-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -676,6 +678,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_7-cuda11_5-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -997,6 +1000,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_8-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1315,6 +1319,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_8-cuda11_3-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1636,6 +1641,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_8-cuda11_5-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1957,6 +1963,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_9-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2275,6 +2282,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_9-cuda11_3-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2596,6 +2604,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_9-cuda11_5-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2917,6 +2926,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_10-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3235,6 +3245,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_10-cuda11_3-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3556,6 +3567,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   conda-py3_10-cuda11_5-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   libtorch-cpu-shared-with-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -37,6 +37,7 @@ concurrency:
 
 jobs:
   libtorch-cpu-shared-with-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -367,6 +368,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-shared-without-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -697,6 +699,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-static-with-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1027,6 +1030,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-static-without-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1357,6 +1361,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_3-shared-with-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1690,6 +1695,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_3-shared-without-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2023,6 +2029,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_3-static-with-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2356,6 +2363,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_3-static-without-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2689,6 +2697,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_5-shared-with-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3022,6 +3031,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_5-shared-without-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3355,6 +3365,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_5-static-with-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3688,6 +3699,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_5-static-without-deps-debug-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-windows-binary-libtorch-release-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-master.yml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   libtorch-cpu-shared-with-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -37,6 +37,7 @@ concurrency:
 
 jobs:
   libtorch-cpu-shared-with-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -367,6 +368,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-shared-without-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -697,6 +699,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-static-with-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1027,6 +1030,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cpu-static-without-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1357,6 +1361,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_3-shared-with-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1690,6 +1695,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_3-shared-without-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2023,6 +2029,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_3-static-with-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2356,6 +2363,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_3-static-without-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2689,6 +2697,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_5-shared-with-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3022,6 +3031,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_5-shared-without-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3355,6 +3365,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_5-static-with-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3688,6 +3699,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   libtorch-cuda11_5-static-without-deps-release-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-windows-binary-wheel-master.yml
+++ b/.github/workflows/generated-windows-binary-wheel-master.yml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   wheel-py3_7-cuda11_3-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -37,6 +37,7 @@ concurrency:
 
 jobs:
   wheel-py3_7-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -355,6 +356,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_7-cuda11_3-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -676,6 +678,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_7-cuda11_5-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -997,6 +1000,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_8-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1315,6 +1319,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_8-cuda11_3-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1636,6 +1641,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_8-cuda11_5-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -1957,6 +1963,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_9-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2275,6 +2282,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_9-cuda11_3-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2596,6 +2604,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_9-cuda11_5-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -2917,6 +2926,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_10-cpu-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3235,6 +3245,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_10-cuda11_3-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:
@@ -3556,6 +3567,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   wheel-py3_10-cuda11_5-build:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: windows.4xlarge
     timeout-minutes: 240
     env:


### PR DESCRIPTION
Fixes #72661 

Adds check that pytorch is repo owner to jobs.  Ran `.github/regenerate.sh` to regenerate workflows.

Also removed `+` from various places to make jinja2 happy (doesn't seem to change anything about the generated workflows). Added them back in b/c I was using the wrong version of jinja2


