### PR TITLE
[Static Runtime] Use IValue::toListRef for aten::len to address comment on D34705231

### DIFF
--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -965,8 +965,8 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema("aten::len.t(t[] a) -> int")) ||
           n->matches(torch::schema("aten::len.any(Any[] a) -> int"))) {
         return [](ProcessedNode* pnode) {
-          c10::List<IValue> a = pnode->Input(0).to<c10::List<IValue>>();
-          const int64_t size = a.size();
+          const auto list = pnode->Input(0).toListRef();
+          const int64_t size = list.size();
           pnode->Output(0) = size;
         };
       }


### PR DESCRIPTION
Summary: This change uses toListRef() to avoid creating a new list object for `aten::len` to address hlu1's comment on D34705231 (https://github.com/pytorch/pytorch/commit/87564a1bd7ab2843e51e1502705c56b860138724)

Test Plan: Existing tests, StaticRuntime.Len*

Reviewed By: mikeiovine

Differential Revision: D34863266

