### PR TITLE
[ATen][AMD] revert a change of USE_DIRECT_NVRTC

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -139,16 +139,14 @@ bool CUDAHooks::hasCuSOLVER() const {
 #endif
 }
 
-#if !defined(USE_ROCM)
 #if defined(USE_DIRECT_NVRTC)
 static std::pair<std::unique_ptr<at::DynamicLibrary>, at::cuda::NVRTC*> load_nvrtc() {
   return std::make_pair(nullptr, at::cuda::load_nvrtc());
 }
-#else
+#elif !defined(USE_ROCM)
 static std::pair<std::unique_ptr<at::DynamicLibrary>, at::cuda::NVRTC*> load_nvrtc() {
   return std::make_pair(nullptr, &at::cuda::detail::lazyNVRTC);
 }
-#endif
 #else
 static std::pair<std::unique_ptr<at::DynamicLibrary>, at::cuda::NVRTC*> load_nvrtc() {
 #if defined(_WIN32)


### PR DESCRIPTION
Summary: This patch reverts a change of `USE_DIRECT_NVRTC` in https://github.com/pytorch/pytorch/pull/71925. Note that `USE_DIRECT_NVRTC` is used only internally (i.e., it is always undefined for OSS compilation) as far as I checked, so this change should not affect any OSS build.

Test Plan: CI

Differential Revision: D34564267

