### PR TITLE
Make `torch.nn` importable on Python-3.7.0

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -8,7 +8,6 @@ from ..parameter import Parameter
 import torch.utils.hooks as hooks
 
 from torch import Tensor, device, dtype
-import typing
 from typing import Union, Tuple, Any, Callable, Iterator, Set, Optional, overload, TypeVar, Mapping, Dict, List
 from ...utils.hooks import RemovableHandle
 
@@ -1312,10 +1311,11 @@ class Module:
     def state_dict(self, destination: T_destination, prefix: str = ..., keep_vars: bool = ...) -> T_destination:
         ...
 
-    # TODO: Remove string escape once Python-3.6 no longer supported
-    # See https://github.com/python/mypy/issues/6904#issuecomment-496207426
+    # TODO: Remove string escape once Python-3.7.0 is no longer supported
+    # typing.OrderedDict with generics can be used in Python-3.7.2+ or later
+    # See https://github.com/pytorch/pytorch/issues/74087
     @overload
-    def state_dict(self, *, prefix: str = ..., keep_vars: bool = ...) -> typing.OrderedDict[str, Tensor]:
+    def state_dict(self, *, prefix: str = ..., keep_vars: bool = ...) -> "OrderedDict[str, Tensor]":
         ...
 
     def state_dict(self, *args, destination=None, prefix='', keep_vars=False):


### PR DESCRIPTION
As `typing.OrderedDict` were introduced by Python-3.7.2+, see
https://docs.python.org/3.10/library/typing.html#typing.OrderedDict

Fixes #74087
