### PR TITLE
Add super() calls for Fx TestCases

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -143,6 +143,7 @@ class Foo(object):  # noqa: B209
 
 class TestFX(JitTestCase):
     def setUp(self):
+        super().setUp()
         # Checking for mutable operations whil tracing is feature flagged
         # Enable it in testing but not by default
         self.orig_tracer_mutable_flag = torch.fx.proxy.TracerBase.check_mutable_operations
@@ -153,6 +154,7 @@ class TestFX(JitTestCase):
             torch.ops.load_library(str(lib_file_path))
 
     def tearDown(self):
+        super().tearDown()
         torch.fx.proxy.TracerBase.check_mutable_operations = self.orig_tracer_mutable_flag
 
     def checkGraphModule(self, m: torch.nn.Module, args, kwargs=None):
@@ -3436,6 +3438,7 @@ class TestOperatorSignatures(JitTestCase):
 
 class TestFXAPIBackwardCompatibility(JitTestCase):
     def setUp(self):
+        super().setUp()
         self.maxDiff = None
 
         # Checking for mutable operations whil tracing is feature flagged
@@ -3444,6 +3447,7 @@ class TestFXAPIBackwardCompatibility(JitTestCase):
         torch.fx.proxy.TracerBase.check_mutable_operations = True
 
     def tearDown(self):
+        super().tearDown()
         torch.fx.proxy.TracerBase.check_mutable_operations = self.orig_tracer_mutable_flag
 
 
@@ -3682,12 +3686,14 @@ class TestFXAPIBackwardCompatibility(JitTestCase):
 
 class TestFunctionalTracing(JitTestCase):
     def setUp(self):
+        super().setUp()
         # Checking for mutable operations whil tracing is feature flagged
         # Enable it in testing but not by default
         self.orig_tracer_mutable_flag = torch.fx.proxy.TracerBase.check_mutable_operations
         torch.fx.proxy.TracerBase.check_mutable_operations = True
 
     def tearDown(self):
+        super().tearDown()
         torch.fx.proxy.TracerBase.check_mutable_operations = self.orig_tracer_mutable_flag
 
     IGNORE_FUNCS = ("has_torch_function", "has_torch_function_unary",


### PR DESCRIPTION
The fx test case wasn't disabled properly because it didn't call the parent class' setUp().