### PR TITLE
fix: no duplicate final LayerNorm in Transformer

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -63,8 +63,7 @@ class Transformer(Module):
             encoder_layer = TransformerEncoderLayer(d_model, nhead, dim_feedforward, dropout,
                                                     activation, layer_norm_eps, batch_first, norm_first,
                                                     **factory_kwargs)
-            encoder_norm = LayerNorm(d_model, eps=layer_norm_eps, **factory_kwargs)
-            self.encoder = TransformerEncoder(encoder_layer, num_encoder_layers, encoder_norm)
+            self.encoder = TransformerEncoder(encoder_layer, num_encoder_layers)
 
         if custom_decoder is not None:
             self.decoder = custom_decoder
@@ -72,8 +71,7 @@ class Transformer(Module):
             decoder_layer = TransformerDecoderLayer(d_model, nhead, dim_feedforward, dropout,
                                                     activation, layer_norm_eps, batch_first, norm_first,
                                                     **factory_kwargs)
-            decoder_norm = LayerNorm(d_model, eps=layer_norm_eps, **factory_kwargs)
-            self.decoder = TransformerDecoder(decoder_layer, num_decoder_layers, decoder_norm)
+            self.decoder = TransformerDecoder(decoder_layer, num_decoder_layers)
 
         self._reset_parameters()
 


### PR DESCRIPTION
## Description

This pull request solves #24930 and #74092 by implementing the third solution (the minimal and backward-compatible one) among the ones listed [here](https://github.com/pytorch/pytorch/issues/74092#issuecomment-1066609080).
