### PR TITLE
Process inputs and outputs in fx interpreter

### DIFF
--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -89,7 +89,7 @@ class Interpreter:
                 map_arg(node.kwargs, lambda n: register_last_uses(n, node))
 
     @compatibility(is_backward_compatible=True)
-    def run(self, *args, initial_env : Optional[Dict[Node, Any]] = None) -> Any:
+    def run(self, *args, initial_env : Optional[Dict[Node, Any]] = None, enable_io_processing : bool = True) -> Any:
         """
         Run `module` via interpretation and return the result.
 
@@ -108,6 +108,8 @@ class Interpreter:
         # Positional function args are consumed left-to-right by
         # `placeholder` nodes. Use an iterator to keep track of
         # position and extract those values.
+        if enable_io_processing:
+            args = self.module.graph.process_inputs(*args)
         self.args_iter : Iterator[Any] = iter(args)
 
         for node in self.module.graph.nodes:
@@ -126,7 +128,7 @@ class Interpreter:
 
             if node.op == 'output':
                 output_val = self.env[node]
-                return output_val
+                return self.module.graph.process_outputs(output_val) if enable_io_processing else output_val
 
     @compatibility(is_backward_compatible=True)
     def run_node(self, n : Node) -> Any:
@@ -447,7 +449,7 @@ class Transformer(Interpreter):
         Transform ``self.module`` and return the transformed
         ``GraphModule``.
         """
-        result = super().run()
+        result = super().run(enable_io_processing=False)
         if result is not None:
             def strip_proxy(a : Union[Argument, Proxy]) -> Any:
                 return a.node if isinstance(a, Proxy) else a


### PR DESCRIPTION
Summary: The inputs and outputs of the graph module might be different from the graph inputs and outputs if users are using custom codegen. In interpreter, it runs the graph instead of the generated forward function so it might not work if user provides the inputs to the graph module. To fill the gap, we call `process_inputs` and `process_outputs` inside interpreter.

Test Plan: unit test: test_interpreter_with_codegen

Differential Revision: D34898108

