### PR TITLE
Install ffmpeg=4.4.1 because torchvision doesn't compile on ffmpeg-5

### DIFF
--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -40,6 +40,9 @@ jobs:
                            future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
           # install magma
           conda install -y -c pytorch "${MAGMA_VERSION}"
+          # install ffmpeg-4.4.1
+          # torchvision doesn't compile on ffmpeg-5: https://github.com/pytorch/vision/issues/5616
+          conda install -y ffmpeg=4.4.1
       - name: Setup TorchBench branch
         run: |
           # shellcheck disable=SC1091


### PR DESCRIPTION
TorchBench ondemand CI is broken because torchvision doesn't build on ffmpeg-5.
This PR forces install ffmpeg=4.4.1 so that torchvision can build.