### PR TITLE
[ONNX] Adjust `is_train` flag for onnx pass deduplicate initializers

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -1284,6 +1284,13 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         graph = onnx.load(io.BytesIO(f.getvalue()))
         self.assertSetEqual(set([i.name for i in graph.graph.initializer]), param_name_set)
 
+        model.train()
+        f = io.BytesIO()
+        torch.onnx.export(model, (x,), f, training=TrainingMode.PRESERVE,
+                          opset_version=self.opset_version)
+        graph = onnx.load(io.BytesIO(f.getvalue()))
+        self.assertSetEqual(set([i.name for i in graph.graph.initializer]), param_name_set)
+
         # Test eval mode.
         model.eval()
         f = io.BytesIO()

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -819,7 +819,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
                 node_attr_to_name = torch._C._jit_pass_onnx_function_extraction(
                     graph, export_modules_as_functions, list(params_dict.keys()))
             params_dict = torch._C._jit_pass_onnx_deduplicate_initializers(
-                graph, params_dict, hasattr(model, "training") and model.training)
+                graph, params_dict, getattr(model, "training", False))
             if export_params:
                 proto, export_map, val_use_external_data_format, node_names = graph._export_onnx(
                     params_dict, opset_version, dynamic_axes, defer_weight_export,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -818,8 +818,8 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
                 # NOTE: cannot call DCE after this pass. DCE will remove function definition nodes.
                 node_attr_to_name = torch._C._jit_pass_onnx_function_extraction(
                     graph, export_modules_as_functions, list(params_dict.keys()))
-            params_dict = torch._C._jit_pass_onnx_deduplicate_initializers(graph, params_dict,
-                                                                           model.training)
+            params_dict = torch._C._jit_pass_onnx_deduplicate_initializers(
+                graph, params_dict, hasattr(model, "training") and model.training)
             if export_params:
                 proto, export_map, val_use_external_data_format, node_names = graph._export_onnx(
                     params_dict, opset_version, dynamic_axes, defer_weight_export,

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -819,7 +819,7 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
                 node_attr_to_name = torch._C._jit_pass_onnx_function_extraction(
                     graph, export_modules_as_functions, list(params_dict.keys()))
             params_dict = torch._C._jit_pass_onnx_deduplicate_initializers(graph, params_dict,
-                                                                           training == TrainingMode.TRAINING)
+                                                                           model.training)
             if export_params:
                 proto, export_map, val_use_external_data_format, node_names = graph._export_onnx(
                     params_dict, opset_version, dynamic_axes, defer_weight_export,


### PR DESCRIPTION
Previous logic didn't consider the case for TrainingMode.PRESERVE.
A more direct way is to check `model.training`, which is the accurate
training mode, set by `exporter_context(model, training)`.
