### PR TITLE
Excluding ASAN and periodic jobs from slow job calculation

### DIFF
--- a/tools/stats/export_slow_tests.py
+++ b/tools/stats/export_slow_tests.py
@@ -12,6 +12,7 @@ from urllib.request import urlopen
 SLOW_TESTS_FILE = '.pytorch-slow-tests.json'
 SLOW_TEST_CASE_THRESHOLD_SEC = 60.0
 RELATIVE_DIFFERENCE_THRESHOLD = 0.1
+IGNORED_JOBS = ["asan", "periodic"]
 
 def get_test_case_times() -> Dict[str, float]:
     reports: List[Report] = get_previous_reports_for_branch('origin/viable/strict', "")
@@ -21,6 +22,10 @@ def get_test_case_times() -> Dict[str, float]:
         if report.get('format_version', 1) != 2:  # type: ignore[misc]
             raise RuntimeError("S3 format currently handled is version 2 only")
         v2report = cast(Version2Report, report)
+
+        if any(job_name in str(report['build_job']) for job_name in IGNORED_JOBS):
+            continue
+
         for test_file in v2report['files'].values():
             for suitename, test_suite in test_file['suites'].items():
                 for casename, test_case in test_suite['cases'].items():


### PR DESCRIPTION
Mitigates #72368

As per discussion here  #72368 
Some ASAN tests take much longer then same tests that not run under ASAN:

```
test_fn_gradgrad_pca_lowrank_cpu_float64 (__main__.TestGradientsCPU) ... ok (60.780s)
test_fn_gradgrad_svd_cpu_complex128 (__main__.TestGradientsCPU) ... ok (69.131s)
test_inplace_gradgrad_cumprod_cpu_complex128 (__main__.TestGradientsCPU) ... ok (211.554s)
test_variant_consistency_jit_diff_cpu_complex64 (__main__.TestJitCPU) ... ok (67.640s)
2022-03-12T21:46:25.3026906Z   test_variant_consistency_jit_linalg_solve_triangular_cpu_float32 (__main__.TestJitCPU) ... ok (125.208s)
2022-03-12T21:48:58.0469092Z   test_variant_consistency_jit_linalg_svd_cpu_complex64 (__main__.TestJitCPU) ... ok (152.744s)
2022-03-12T21:50:11.6688335Z   test_variant_consistency_jit_linalg_svd_cpu_float32 (__main__.TestJitCPU) ... ok (73.622s)
2022-03-12T21:54:44.5263321Z   test_variant_consistency_jit_lu_solve_cpu_complex64 (__main__.TestJitCPU) ... ok (102.051s)
2022-03-12T21:55:35.6167891Z   test_variant_consistency_jit_lu_solve_cpu_float32 (__main__.TestJitCPU) ... ok (51.090s)
2022-03-12T22:00:58.4220662Z   test_variant_consistency_jit_nanquantile_cpu_float32 (__main__.TestJitCPU) ... ok (47.142s)
2022-03-12T22:12:25.8979944Z   test_variant_consistency_jit_nn_functional_max_pool1d_cpu_float32 (__main__.TestJitCPU) ... ok (494.579s)
2022-03-12T22:32:45.9750642Z   test_variant_consistency_jit_nn_functional_max_pool2d_cpu_float32 (__main__.TestJitCPU) ... ok (1220.077s)
2022-03-12T22:40:31.3121960Z   test_variant_consistency_jit_nn_functional_max_pool3d_cpu_float32 (__main__.TestJitCPU) ... ok (465.337s)
2022-03-12T22:41:56.5711967Z   test_variant_consistency_jit_nn_functional_pad_circular_cpu_complex64 (__main__.TestJitCPU) ... ok (58.542s)
2022-03-12T22:45:48.7048047Z   test_variant_consistency_jit_nn_functional_pad_constant_cpu_complex64 (__main__.TestJitCPU) ... ok (232.128s)
2022-03-12T22:47:49.1422719Z   test_variant_consistency_jit_nn_functional_pad_constant_cpu_float32 (__main__.TestJitCPU) ... ok (120.437s)
2022-03-12T22:48:48.9686822Z   test_variant_consistency_jit_nn_functional_pad_reflect_cpu_complex64 (__main__.TestJitCPU) ... ok (59.826s)
2022-03-12T22:49:49.2502012Z   test_variant_consistency_jit_nn_functional_pad_replicate_cpu_complex64 (__main__.TestJitCPU) ... ok (60.272s)
2022-03-12T22:51:02.5255728Z   test_variant_consistency_jit_nn_functional_poisson_nll_loss_cpu_float32 (__main__.TestJitCPU) ... ok (73.208s)
2022-03-12T22:54:23.8291811Z   test_variant_consistency_jit_norm_cpu_complex64 (__main__.TestJitCPU) ... ok (136.107s)
2022-03-12T22:55:33.0800761Z   test_variant_consistency_jit_norm_cpu_float32 (__main__.TestJitCPU) ... ok (69.251s)
2022-03-12T22:57:50.4699741Z   test_variant_consistency_jit_ormqr_cpu_complex64 (__main__.TestJitCPU) ... ok (105.720s)
2022-03-12T22:58:46.2191192Z   test_variant_consistency_jit_ormqr_cpu_float32 (__main__.TestJitCPU) ... ok (55.749s)
2022-03-12T23:01:40.5424782Z   test_variant_consistency_jit_prod_cpu_complex64 (__main__.TestJitCPU) ... ok (89.440s)
2022-03-12T23:03:20.2300845Z   test_variant_consistency_jit_put_cpu_complex64 (__main__.TestJitCPU) ... ok (55.004s)
2022-03-12T23:05:34.2481242Z   test_variant_consistency_jit_qr_cpu_complex64 (__main__.TestJitCPU) ... ok (106.490s)
2022-03-12T23:06:26.1268335Z   test_variant_consistency_jit_qr_cpu_float32 (__main__.TestJitCPU) ... ok (51.879s)
2022-03-12T23:07:51.5261184Z   test_variant_consistency_jit_quantile_cpu_float32 (__main__.TestJitCPU) ... ok (85.399s)
test_variant_consistency_jit_sort_cpu_float32 (__main__.TestJitCPU) ... ok (84.378s)
2022-03-12T23:23:48.6314435Z   test_variant_consistency_jit_sum_cpu_complex64 (__main__.TestJitCPU) ... ok (55.706s)
2022-03-12T23:24:19.2219967Z   test_variant_consistency_jit_sum_cpu_float32 (__main__.TestJitCPU) ... ok (30.590s)
2022-03-12T23:36:45.9809917Z   test_variant_consistency_jit_svd_cpu_complex64 (__main__.TestJitCPU) ... ok (746.744s)
2022-03-12T23:42:42.7827088Z   test_variant_consistency_jit_svd_cpu_float32 (__main__.TestJitCPU) ... ok (356.802s)
2022-03-12T23:47:12.7248896Z   test_variant_consistency_jit_tile_cpu_complex64 (__main__.TestJitCPU) ... ok (85.721s) 
```
-------------

This PR ignores ASAN and periodic job for slow job calculation.


Tested  by printing the matched jobs rather then continue:

```
python export_slow_test.py 
Overwriting existent file: .pytorch-slow-tests.json
linux-xenial-py3.7-clang7-asan-test
linux-xenial-py3.7-clang7-asan-test
linux-xenial-py3.7-clang7-asan-test
periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck-test
periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck-test
```