### PR TITLE
Print reason for test skipped in CI

### DIFF
--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -748,7 +748,9 @@ def process_intentional_test_runs(runs: List[TestCase]) -> Tuple[int, int]:
         "test_data_parallel_module_kwargs_only",
         "test_data_parallel_module_kwargs_only_empty_list",
         "test_data_parallel_module_kwargs_only_empty_dict",
-        "test_data_parallel_module_kwargs_only_empty_tuple"
+        "test_data_parallel_module_kwargs_only_empty_tuple",
+        "test_cpp_extensions_aot_ninja",
+        "test_cpp_extensions_aot_no_ninja",
     ]
 
     # Do not run checks for tests that use repeat_test_for_types decorator as they do not go well with our retry


### PR DESCRIPTION
Issue: https://github.com/pytorch/pytorch/issues/69014 (skip reason is not printed for tests running in CI)

Cause: locally tests are fired with testrunner that is built into unittest. When IN_CI env variable is true - tests are fired with xml test runner from unittest-xml-reporting. They have different summary printing properties

Solution: patching printing logic in unittest-xml-reporting when a test is skipped

Test plan: examine CI run

<img width="1105" alt="Screen Shot 2022-03-17 at 9 46 22 AM" src="https://user-images.githubusercontent.com/4273004/158851723-5e8dce28-0a5c-4f15-b5bd-d0666c98071c.png">

Please merge after https://github.com/pytorch/pytorch/pull/74330 (which pins unittest-xml-reporting version)