### PR TITLE
Revert "Update tls logic to work better with guarded call (#73925)"

### DIFF
--- a/aten/src/ATen/core/PythonFallbackKernel.cpp
+++ b/aten/src/ATen/core/PythonFallbackKernel.cpp
@@ -6,59 +6,23 @@
 
 namespace {
 
-// This TLS is used to track the state of the dispatcher to be able to restore
-// it when calling back into python.
-// It has the following invariant:
-//  - It must be empty while python code is executed.
-//  - It should only be set once even for multiple dispatcher calls that do not come
-//    back to python.
-// To achieve this, we ensure that the tls is empty by default and emptied again both when
-// we call into user torch_dispatch or returning back to python after this call.
+// TLS saving the state of the include/exclude sets on entry to the dispatcher
+// This is set in the pythonTLSSnapshot fallback and used by the Python fallback.
+thread_local std::stack<c10::impl::LocalDispatchKeySet> tls_on_entry;
 
-thread_local c10::optional<c10::impl::LocalDispatchKeySet> tls_on_entry;
-
-// RAII guard to make working with the above TLS safer.
-struct MaybeSetTLSOnEntryGuard {
-public:
-  MaybeSetTLSOnEntryGuard() {
-    if (tls_on_entry.has_value()) {
-      value_set_ = false;
-    } else {
-      value_set_ = true;
-      tls_on_entry = c10::impl::tls_local_dispatch_key_set();
-    }
+struct StashTLSStateGuard {
+ public:
+  StashTLSStateGuard(const c10::impl::LocalDispatchKeySet& key_set) {
+    tls_on_entry.push(key_set);
   }
-  ~MaybeSetTLSOnEntryGuard() {
-    if (value_set_) {
-      TORCH_INTERNAL_ASSERT(tls_on_entry.has_value());
-      tls_on_entry = c10::nullopt;
-    }
+  ~StashTLSStateGuard() {
+    tls_on_entry.pop();
   }
-
-private:
-  bool value_set_;
-};
-
-// This guard assumes that tls_on_entry has a value.
-struct StashTLSOnEntryGuard {
-public:
-  StashTLSOnEntryGuard(): saved_(tls_on_entry.value()) {
-    tls_on_entry = c10::nullopt;
-  }
-
-  ~StashTLSOnEntryGuard() {
-    TORCH_INTERNAL_ASSERT(!tls_on_entry.has_value());
-    tls_on_entry = saved_;
-  }
-
-private:
-  c10::impl::LocalDispatchKeySet saved_;
 };
 
 void pythonFallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
-  TORCH_INTERNAL_ASSERT(tls_on_entry.has_value());
-  c10::impl::ForceDispatchKeyGuard dispatcher_guard(tls_on_entry.value());
-  StashTLSOnEntryGuard stash_guard;
+  TORCH_INTERNAL_ASSERT(tls_on_entry.size() > 0);
+  c10::impl::ForceDispatchKeyGuard guard(tls_on_entry.top());
 
   // If Python Mode is active, use its PyInterpreter for dispatch
   const auto& maybe_python_mode_state = at::impl::PythonModeTLS::get_state();
@@ -99,9 +63,10 @@ void pythonFallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
 
 void pythonTLSSnapshotFallback(const c10::OperatorHandle& op, c10::DispatchKeySet dispatch_keys, torch::jit::Stack* stack) {
   // It is ok for the tls to be already set here.
-  // It means that there are multiple calls into the dispatcher not originating from python code.
-  // The guard below will properly ignore such calls.
-  MaybeSetTLSOnEntryGuard guard;
+  // A CompositeImplicitAutograd function may have been called just before this and so the tls here were never cleared
+  // This is also why we don't need an RAII to ensure the tls is reset when exceptions happen
+
+  StashTLSStateGuard guard(c10::impl::tls_local_dispatch_key_set());
 
   op.redispatchBoxed(dispatch_keys & c10::DispatchKeySet(c10::DispatchKeySet::FULL_AFTER, c10::DispatchKey::PythonTLSSnapshot), stack);
 }

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6669,16 +6669,13 @@ class TestAutogradForwardMode(TestCase):
             def __new__(cls, data=None):
                 return torch.Tensor._make_subclass(cls, data)
 
-            __torch_function__ = torch._C._disabled_torch_function_impl
-
             @classmethod
             def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
                 if func.overloadpacket == torch.ops.aten.alias:
                     counter[0] += 1
 
-                    # Make sure autograd is not disabled here
-                    foo = torch.rand(1, requires_grad=True)
-                    self.assertIsNotNone(foo.exp().grad_fn)
+                    with no_dispatch():
+                        return MySubclass(torch.ops.aten.alias(*args))
 
                 with no_dispatch():
                     return func(*args, **kwargs)
@@ -6687,11 +6684,10 @@ class TestAutogradForwardMode(TestCase):
         s = MySubclass(a)
 
         with fwAD.dual_level():
-            # Only the primal has "alias" called on it
             fwAD.make_dual(s, torch.rand_like(s))
             self.assertEqual(counter[0], 1)
             fwAD.make_dual(torch.rand_like(s), s)
-            self.assertEqual(counter[0], 1)
+            self.assertEqual(counter[0], 2)
 
     def test_print(self):
         with fwAD.dual_level() as level:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #74268

This reverts commit dff02851d10505cd5d5900b97486703e1a2b0fa1.

Differential Revision: [D34914754](https://our.internmc.facebook.com/intern/diff/D34914754)