### PR TITLE
[torch::deploy] Remove `c10::errors` from torch::deploy

### DIFF
--- a/torch/csrc/deploy/Exception.h
+++ b/torch/csrc/deploy/Exception.h
@@ -1,0 +1,47 @@
+#ifndef MULTIPY_EXCEPTION_H
+#define MULTIPY_EXCEPTION_H
+
+#include <exception>
+
+#define MULTIPY_INTERNAL_ASSERT_WITH_MESSAGE(condition, message)               \
+  if (!(condition)) {                                                          \
+    throw std::runtime_error(                                                  \
+        "Internal Assertion failed: (" + std::string(#condition) + "), " +     \
+        "function " + __FUNCTION__ + ", file " + __FILE__ + ", line " +        \
+        std::to_string(__LINE__) + ".\n" + "Please report bug to Pytorch.\n" + \
+        message + "\n");                                                       \
+  }
+
+#define MULTIPY_INTERNAL_ASSERT_NO_MESSAGE(condition) \
+  MULTIPY_INTERNAL_ASSERT_WITH_MESSAGE(#condition, "")
+
+#define MULTIPY_INTERNAL_ASSERT_(x, condition, message, FUNC, ...) FUNC
+
+#define MULTIPY_INTERNAL_ASSERT(...)                     \
+  MULTIPY_INTERNAL_ASSERT_(                              \
+      ,                                                  \
+      ##__VA_ARGS__,                                     \
+      MULTIPY_INTERNAL_ASSERT_WITH_MESSAGE(__VA_ARGS__), \
+      MULTIPY_INTERNAL_ASSERT_NO_MESSAGE(__VA_ARGS__));
+
+#define MULTIPY_CHECK_WITH_MESSAGE(condition, message)                      \
+  if (!(condition)) {                                                       \
+    throw std::runtime_error(                                               \
+        "Check failed: (" + std::string(#condition) + "), " + "function " + \
+        __FUNCTION__ + ", file " + __FILE__ + ", line " +                   \
+        std::to_string(__LINE__) + ".\n" + message + "\n");                 \
+  }
+
+#define MULTIPY_CHECK_NO_MESSAGE(condition) \
+  MULTIPY_CHECK_WITH_MESSAGE(#condition, "")
+
+#define MULTIPY_CHECK_(x, condition, message, FUNC, ...) FUNC
+
+#define MULTIPY_CHECK(...)                     \
+  MULTIPY_CHECK_(                              \
+      ,                                        \
+      ##__VA_ARGS__,                           \
+      MULTIPY_CHECK_WITH_MESSAGE(__VA_ARGS__), \
+      MULTIPY_CHECK_NO_MESSAGE(__VA_ARGS__));
+
+#endif // MULTIPY_EXCEPTION_H

--- a/torch/csrc/deploy/benchmark.cpp
+++ b/torch/csrc/deploy/benchmark.cpp
@@ -1,0 +1,336 @@
+#include <torch/deploy.h>
+
+#include <ATen/ATen.h>
+#include <ATen/TypeDefault.h>
+#include <c10/util/irange.h>
+
+#include <torch/script.h>
+
+#include <pthread.h>
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <iostream>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+typedef void (*function_type)(const char*);
+
+bool cuda = false;
+
+constexpr auto latency_p = {
+    25.,
+    50.,
+    95.}; //{1., 5., 25., 50., 75., 90., 95., 99., 99.25, 99.5, 99.75, 99.9};
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct Report {
+  std::string benchmark;
+  std::string strategy;
+  size_t n_threads;
+  size_t items_completed;
+  double work_items_per_second;
+  std::vector<double> latencies;
+  static void report_header(std::ostream& out) {
+    out << "benchmark, strategy, n_threads, work_items_completed, work_items_per_second";
+    for (double l : latency_p) {
+      out << ", p" << l << "_latency";
+    }
+    out << ", device\n";
+  }
+  void report(std::ostream& out) {
+    out << benchmark << ", " << strategy << ", " << n_threads << ", "
+        << items_completed << ", " << work_items_per_second;
+    for (double l : latencies) {
+      out << ", " << l;
+    }
+    out << ", " << (cuda ? "cuda" : "cpu") << "\n";
+  }
+};
+
+const int min_items_to_complete = 1;
+
+struct RunPython {
+  static torch::deploy::ReplicatedObj load_and_wrap(
+      torch::deploy::Package& package) {
+    auto I = package.acquireSession();
+    auto obj = I.self.attr("load_pickle")({"model", "model.pkl"});
+    if (cuda) {
+      obj = I.global("gpu_wrapper", "GPUWrapper")({obj});
+    }
+    return I.createMovable(obj);
+  }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+  RunPython(
+      torch::deploy::Package& package,
+      std::vector<at::IValue> eg,
+      const torch::deploy::Interpreter* interps)
+      : obj_(load_and_wrap(package)), eg_(std::move(eg)), interps_(interps) {}
+  void operator()(int i) {
+    auto I = obj_.acquireSession();
+    if (cuda) {
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+      std::vector<at::IValue> eg2 = {i};
+      eg2.insert(eg2.end(), eg_.begin(), eg_.end());
+      I.self(eg2);
+    } else {
+      I.self(eg_);
+    }
+  }
+  torch::deploy::ReplicatedObj obj_;
+  std::vector<at::IValue> eg_;
+  const torch::deploy::Interpreter* interps_;
+};
+
+// def to_device(i, d):
+//     if isinstance(i, torch.Tensor):
+//         return i.to(device=d)
+//     elif isinstance(i, (tuple, list)):
+//         return tuple(to_device(e, d) for e in i)
+//     else:
+//         raise RuntimeError('inputs are weird')
+
+static torch::IValue to_device(const torch::IValue& v, torch::Device to);
+
+static std::vector<torch::IValue> to_device_vec(
+    at::ArrayRef<torch::IValue> vs,
+    torch::Device to) {
+  std::vector<torch::IValue> results;
+  for (const torch::IValue& v : vs) {
+    results.push_back(to_device(v, to));
+  }
+  return results;
+}
+
+static torch::IValue to_device(const torch::IValue& v, torch::Device to) {
+  if (v.isTensor()) {
+    return v.toTensor().to(to);
+  } else if (v.isTuple()) {
+    auto tup = v.toTuple();
+    return c10::ivalue::Tuple::create(to_device_vec(tup->elements(), to));
+  } else if (v.isList()) {
+    auto converted = to_device_vec(v.toListRef(), to);
+    torch::List<torch::IValue> result(v.toList().elementType());
+    for (const torch::IValue& v : converted) {
+      result.push_back(v);
+    }
+    return result;
+  } else {
+    MULTIPY_INTERNAL_ASSERT(false, "cannot to_device");
+  }
+}
+
+static bool exists(const std::string& fname) {
+  std::fstream jit_file(fname);
+  return jit_file.good();
+}
+
+struct RunJIT {
+  RunJIT(const std::string& file_to_run, std::vector<torch::IValue> eg)
+      : eg_(std::move(eg)) {
+    if (!cuda) {
+      models_.push_back(torch::jit::load(file_to_run + "_jit"));
+    } else {
+      for (const auto i : c10::irange(2)) {
+        auto d = torch::Device(torch::DeviceType::CUDA, i);
+        std::stringstream qualified;
+        qualified << file_to_run << "_jit_" << i;
+        auto loaded = exists(qualified.str())
+            ? torch::jit::load(qualified.str(), d)
+            : torch::jit::load(file_to_run + "_jit", d);
+        loaded.to(d);
+        models_.push_back(loaded);
+      }
+    }
+  }
+  void operator()(int i) {
+    if (cuda) {
+      const auto device_id = i % models_.size();
+      auto d = torch::Device(torch::DeviceType::CUDA, device_id);
+      to_device(
+          models_[device_id].forward(to_device_vec(eg_, d)),
+          torch::DeviceType::CPU);
+    } else {
+      models_[0].forward(eg_);
+    }
+  }
+  std::vector<at::IValue> eg_;
+  std::vector<torch::jit::Module> models_;
+};
+
+struct Benchmark {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+  Benchmark(
+      torch::deploy::InterpreterManager& manager,
+      size_t n_threads,
+      std::string strategy,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
+      std::string file_to_run,
+      size_t n_seconds = 5)
+      : manager_(manager),
+        n_threads_(n_threads),
+        strategy_(strategy),
+        file_to_run_(file_to_run),
+        n_seconds_(n_seconds),
+        should_run_(true),
+        items_completed_(0),
+        reached_min_items_completed_(0) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+    if (strategy == "one_python") {
+      manager.debugLimitInterpreters(1);
+    } else if (strategy == "multi_python") {
+      manager.debugLimitInterpreters(n_threads_);
+    }
+  }
+
+  Report run() {
+    pthread_barrier_init(&first_run_, nullptr, n_threads_ + 1);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    torch::deploy::Package package = manager_.loadPackage(file_to_run_);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    std::vector<at::IValue> eg;
+    {
+      auto I = package.acquireSession();
+
+      eg = I.global("builtins", "tuple")(
+                I.self.attr("load_pickle")({"model", "example.pkl"}))
+               .toIValue()
+               .toTupleRef()
+               .elements();
+    }
+
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+    if (strategy_ == "jit") {
+      run_one_work_item = RunJIT(file_to_run_, std::move(eg));
+    } else {
+      run_one_work_item =
+          RunPython(package, std::move(eg), manager_.allInstances().data());
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    std::vector<std::vector<double>> latencies(n_threads_);
+
+    for (const auto i : c10::irange(n_threads_)) {
+      threads_.emplace_back([this, &latencies, i] {
+        torch::NoGradGuard guard;
+        // do initial work
+        run_one_work_item(i);
+
+        pthread_barrier_wait(&first_run_);
+        size_t local_items_completed = 0;
+        while (should_run_) {
+          auto begin = std::chrono::steady_clock::now();
+          run_one_work_item(i);
+          auto end = std::chrono::steady_clock::now();
+          double work_seconds =
+              std::chrono::duration<double>(end - begin).count();
+          latencies[i].push_back(work_seconds);
+          local_items_completed++;
+          if (local_items_completed == min_items_to_complete) {
+            reached_min_items_completed_++;
+          }
+        }
+        items_completed_ += local_items_completed;
+      });
+    }
+
+    pthread_barrier_wait(&first_run_);
+    auto begin = std::chrono::steady_clock::now();
+    auto try_stop_at = begin + std::chrono::seconds(n_seconds_);
+    std::this_thread::sleep_until(try_stop_at);
+    for (int i = 0; reached_min_items_completed_ < n_threads_; ++i) {
+      std::this_thread::sleep_until(
+          begin + (i + 2) * std::chrono::seconds(n_seconds_));
+    }
+    should_run_ = false;
+    for (std::thread& thread : threads_) {
+      thread.join();
+    }
+    auto end = std::chrono::steady_clock::now();
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    double total_seconds = std::chrono::duration<double>(end - begin).count();
+    Report report;
+    report.benchmark = file_to_run_;
+    report.strategy = strategy_;
+    report.n_threads = n_threads_;
+    report.items_completed = items_completed_;
+    report.work_items_per_second = items_completed_ / total_seconds;
+    reportLatencies(report.latencies, latencies);
+    run_one_work_item = nullptr;
+    return report;
+  }
+
+ private:
+  void reportLatencies(
+      std::vector<double>& results,
+      const std::vector<std::vector<double>>& latencies) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    std::vector<double> flat_latencies;
+    for (const auto& elem : latencies) {
+      flat_latencies.insert(flat_latencies.end(), elem.begin(), elem.end());
+    }
+    std::sort(flat_latencies.begin(), flat_latencies.end());
+    for (double target : latency_p) {
+      size_t idx = size_t(flat_latencies.size() * target / 100.0);
+      double time = flat_latencies.size() == 0
+          ? 0
+          : flat_latencies.at(std::min(flat_latencies.size() - 1, idx));
+      results.push_back(time);
+    }
+  }
+  torch::deploy::InterpreterManager& manager_;
+  size_t n_threads_;
+  std::string strategy_;
+  std::string file_to_run_;
+  size_t n_seconds_;
+  pthread_barrier_t first_run_;
+  std::atomic<bool> should_run_;
+  std::atomic<size_t> items_completed_;
+  std::atomic<size_t> reached_min_items_completed_;
+  std::vector<std::thread> threads_;
+  std::function<void(int)> run_one_work_item;
+};
+
+// NOLINTNEXTLINE(bugprone-exception-escape)
+int main(int argc, char* argv[]) {
+  int max_thread = atoi(argv[1]);
+  cuda = std::string(argv[2]) == "cuda";
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  bool jit_enable = std::string(argv[3]) == "jit";
+  Report::report_header(std::cout);
+  torch::deploy::InterpreterManager manager(max_thread);
+
+  // make sure gpu_wrapper.py is in the import path
+  for (auto& interp : manager.allInstances()) {
+    auto I = interp.acquireSession();
+    I.global("sys", "path").attr("append")({"torch/csrc/deploy/example"});
+  }
+
+  auto n_threads = {1, 2, 4, 8, 16, 32, 40};
+  for (const auto i : c10::irange(4, argc)) {
+    std::string model_file = argv[i];
+    for (int n_thread : n_threads) {
+      if (n_thread > max_thread) {
+        continue;
+      }
+      for (std::string strategy : {"one_python", "multi_python", "jit"}) {
+        if (strategy == "jit") {
+          if (!jit_enable) {
+            continue;
+          }
+          if (!exists(model_file + "_jit")) {
+            continue;
+          }
+        }
+        Benchmark b(manager, n_thread, strategy, model_file);
+        Report r = b.run();
+        r.report(std::cout);
+      }
+    }
+  }
+  return 0;
+}

--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -1,4 +1,4 @@
-#include <c10/util/Exception.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/deploy.h>
 #include <torch/csrc/deploy/elf_file.h>
 #include <torch/cuda.h>
@@ -59,7 +59,7 @@ static bool writeDeployInterpreter(FILE* dst) {
       payloadStart = payloadSection->start;
       customLoader = s.customLoader;
       size = payloadSection->len;
-      TORCH_CHECK(payloadSection.has_value(), "Missing the payload section");
+      MULTIPY_CHECK(payloadSection.has_value(), "Missing the payload section");
       break;
     }
   }
@@ -74,10 +74,10 @@ static bool writeDeployInterpreter(FILE* dst) {
         break;
       }
     }
-    TORCH_CHECK(
+    MULTIPY_CHECK(
         libStart != nullptr && libEnd != nullptr,
-        "torch::deploy requires a build-time dependency on embedded_interpreter or embedded_interpreter_cuda, neither of which were found.  torch::cuda::is_available()=",
-        torch::cuda::is_available());
+        "torch::deploy requires a build-time dependency on embedded_interpreter or embedded_interpreter_cuda, neither of which were found.  torch::cuda::is_available()=" +
+            std::to_string(torch::cuda::is_available()));
 
     size = libEnd - libStart;
     payloadStart = libStart;
@@ -189,11 +189,11 @@ void ReplicatedObj::unload(const Interpreter* onThisInterpreter) {
 
 ReplicatedObj InterpreterSession::createMovable(Obj obj) {
   TORCH_DEPLOY_TRY
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       manager_,
       "Can only create a movable object when the session was created from an interpreter that is part of a InterpreterManager");
 
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       impl_->isOwner(obj),
       "Cannot create movable from an object that lives in different session");
 

--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -95,7 +95,7 @@ struct TORCH_API LoadBalancer {
   }
   void setResourceLimit(size_t n) {
     TORCH_DEPLOY_TRY
-    TORCH_INTERNAL_ASSERT(n <= allocated_);
+    MULTIPY_INTERNAL_ASSERT(n <= allocated_);
     n_ = n;
     TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }

--- a/torch/csrc/deploy/elf_file.cpp
+++ b/torch/csrc/deploy/elf_file.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/irange.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/elf_file.h>
 
 namespace torch {
@@ -13,7 +14,7 @@ ElfFile::ElfFile(const char* filename) : memFile_(filename) {
   shdrList_ = (Elf64_Shdr*)(fileData + ehdr_->e_shoff);
 
   auto strtabSecNo = ehdr_->e_shstrndx;
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       strtabSecNo >= 0 && strtabSecNo < numSections_,
       "e_shstrndx out of range");
 
@@ -26,7 +27,7 @@ ElfFile::ElfFile(const char* filename) : memFile_(filename) {
 }
 
 at::optional<Section> ElfFile::findSection(const char* name) const {
-  TORCH_CHECK(name != nullptr, "Null name");
+  MULTIPY_CHECK(name != nullptr, "Null name");
   at::optional<Section> found = at::nullopt;
   for (const auto& section : sections_) {
     if (strcmp(name, section.name) == 0) {
@@ -40,13 +41,13 @@ at::optional<Section> ElfFile::findSection(const char* name) const {
 
 void ElfFile::checkFormat() const {
   // check the magic numbers
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       (ehdr_->e_ident[EI_MAG0] == ELFMAG0) &&
           (ehdr_->e_ident[EI_MAG1] == ELFMAG1) &&
           (ehdr_->e_ident[EI_MAG2] == ELFMAG2) &&
           (ehdr_->e_ident[EI_MAG3] == ELFMAG3),
       "Unexpected magic numbers");
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       ehdr_->e_ident[EI_CLASS] == ELFCLASS64, "Only support 64bit ELF file");
 }
 

--- a/torch/csrc/deploy/elf_file.h
+++ b/torch/csrc/deploy/elf_file.h
@@ -2,6 +2,7 @@
 
 #include <c10/util/Optional.h>
 #include <elf.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/mem_file.h>
 #include <vector>
 
@@ -40,7 +41,7 @@ class ElfFile {
     const char* name = "";
 
     if (strtabSection_) {
-      TORCH_CHECK(nameOff >= 0 && nameOff < strtabSection_.len);
+      MULTIPY_CHECK(nameOff >= 0 && nameOff < strtabSection_.len);
       name = strtabSection_.start + nameOff;
     }
     const char* start = memFile_.data() + shOff;
@@ -48,7 +49,7 @@ class ElfFile {
   }
 
   [[nodiscard]] const char* str(size_t off) const {
-    TORCH_CHECK(off < strtabSection_.len, "String table index out of range");
+    MULTIPY_CHECK(off < strtabSection_.len, "String table index out of range");
     return strtabSection_.start + off;
   }
   void checkFormat() const;

--- a/torch/csrc/deploy/environment.h
+++ b/torch/csrc/deploy/environment.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <fmt/format.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/elf_file.h>
 #include <fstream>
 #include <string>
@@ -27,7 +28,7 @@ class Environment {
     // load the zipped torch modules
     constexpr const char* ZIPPED_TORCH_NAME = ".torch_python_modules";
     auto zippedTorchSection = elfFile.findSection(ZIPPED_TORCH_NAME);
-    TORCH_CHECK(
+    MULTIPY_CHECK(
         zippedTorchSection.has_value(), "Missing the zipped torch section");
     const char* zippedTorchStart = zippedTorchSection->start;
     auto zippedTorchSize = zippedTorchSection->len;
@@ -35,7 +36,7 @@ class Environment {
     std::string zipArchive =
         std::string(pythonAppDir) + "/torch_python_modules.zip";
     auto zippedFile = fopen(zipArchive.c_str(), "wb");
-    TORCH_CHECK(
+    MULTIPY_CHECK(
         zippedFile != nullptr, "Fail to create file: ", strerror(errno));
     fwrite(zippedTorchStart, 1, zippedTorchSize, zippedFile);
     fclose(zippedFile);

--- a/torch/csrc/deploy/interpreter/builtin_registry.cpp
+++ b/torch/csrc/deploy/interpreter/builtin_registry.cpp
@@ -1,6 +1,7 @@
 #include <Python.h>
 #include <c10/util/Exception.h>
 #include <fmt/format.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/interpreter/builtin_registry.h>
 
 namespace torch {

--- a/torch/csrc/deploy/interpreter/import_find_sharedfuncptr.cpp
+++ b/torch/csrc/deploy/interpreter/import_find_sharedfuncptr.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/deploy/loader.h>
+#include <sstream>
 #include <vector>
 
 using torch::deploy::CustomLibrary;

--- a/torch/csrc/deploy/interpreter/interpreter_impl.cpp
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.cpp
@@ -9,6 +9,7 @@
 #include <pybind11/functional.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 
 #include <cassert>

--- a/torch/csrc/deploy/interpreter/interpreter_impl.h
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.h
@@ -15,8 +15,8 @@
    the client application.
 
    It is safe to throw exception types that are defined once in
-   the context of the client application, such as c10::Error, which is defined
-   in libtorch, which isn't duplicated in torch::deploy interpreters.
+   the context of the client application, such as std::runtime_error,
+   which isn't duplicated in torch::deploy interpreters.
 
    ==> Use TORCH_DEPLOY_TRY, _SAFE_CATCH_RETHROW around _ALL_ torch::deploy APIs
 
@@ -30,20 +30,17 @@
 
 */
 #define TORCH_DEPLOY_TRY try {
-#define TORCH_DEPLOY_SAFE_CATCH_RETHROW                                        \
-  }                                                                            \
-  catch (std::exception & err) {                                               \
-    throw c10::Error(                                                          \
-        std::string(                                                           \
-            "Exception Caught inside torch::deploy embedded library: \n") +    \
-            err.what(),                                                        \
-        "");                                                                   \
-  }                                                                            \
-  catch (...) {                                                                \
-    throw c10::Error(                                                          \
-        std::string(                                                           \
-            "Unknown Exception Caught inside torch::deploy embedded library"), \
-        "");                                                                   \
+#define TORCH_DEPLOY_SAFE_CATCH_RETHROW                                     \
+  }                                                                         \
+  catch (std::exception & err) {                                            \
+    throw std::runtime_error(                                               \
+        std::string(                                                        \
+            "Exception Caught inside torch::deploy embedded library: \n") + \
+        err.what());                                                        \
+  }                                                                         \
+  catch (...) {                                                             \
+    throw std::runtime_error(std::string(                                   \
+        "Unknown Exception Caught inside torch::deploy embedded library")); \
   }
 namespace torch {
 namespace deploy {

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -182,13 +182,14 @@ TEST(TorchpyTest, ErrorsReplicatingObj) {
   auto obj = session1.fromMovable(replicatedObj);
   // should throw an error when trying to access obj from different session
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(session2.createMovable(obj), c10::Error);
+  EXPECT_THROW(session2.createMovable(obj), std::runtime_error);
   try {
     session2.createMovable(obj);
-  } catch (c10::Error& error) {
+  } catch (std::runtime_error& error) {
     EXPECT_TRUE(
-        error.msg().find(
-            "Cannot create movable from an object that lives in different session") !=
+        std::string(error.what())
+            .find(
+                "Cannot create movable from an object that lives in different session") !=
         std::string::npos);
   }
 }
@@ -197,15 +198,15 @@ TEST(TorchpyTest, ThrowsSafely) {
   // See explanation in deploy.h
   torch::deploy::InterpreterManager manager(3);
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(manager.loadPackage("some garbage path"), c10::Error);
+  EXPECT_THROW(manager.loadPackage("some garbage path"), std::runtime_error);
 
   torch::deploy::Package p = manager.loadPackage(path("SIMPLE", simple));
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(p.loadPickle("some other", "garbage path"), c10::Error);
+  EXPECT_THROW(p.loadPickle("some other", "garbage path"), std::runtime_error);
 
   auto model = p.loadPickle("model", "model.pkl");
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(model(at::IValue("unexpected input")), c10::Error);
+  EXPECT_THROW(model(at::IValue("unexpected input")), std::runtime_error);
 }
 
 TEST(TorchpyTest, AcquireMultipleSessionsInTheSamePackage) {
@@ -238,7 +239,7 @@ TEST(TorchpyTest, TensorSharingNotAllowed) {
   auto t = obj.toIValue().toTensor();
   // try to feed it to the other interpreter, should error
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  ASSERT_THROW(I1.global("torch", "sigmoid")({t}), c10::Error);
+  ASSERT_THROW(I1.global("torch", "sigmoid")({t}), std::runtime_error);
 }
 
 TEST(TorchpyTest, TaggingRace) {
@@ -259,7 +260,7 @@ TEST(TorchpyTest, TaggingRace) {
         try {
           I.fromIValue(t);
           success++;
-        } catch (const c10::Error& e) {
+        } catch (const std::runtime_error& e) {
           failed++;
         }
       }
@@ -279,7 +280,7 @@ TEST(TorchpyTest, DisarmHook) {
   torch::deploy::InterpreterManager m(1);
   auto I = m.acquireOne();
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  ASSERT_THROW(I.fromIValue(t), c10::Error); // NOT a segfault
+  ASSERT_THROW(I.fromIValue(t), std::runtime_error); // NOT a segfault
 }
 
 TEST(TorchpyTest, RegisterModule) {

--- a/torch/csrc/deploy/test_deploy_missing_interpreter.cpp
+++ b/torch/csrc/deploy/test_deploy_missing_interpreter.cpp
@@ -10,5 +10,5 @@ int main(int argc, char* argv[]) {
 
 TEST(TorchDeployMissingInterpreter, Throws) {
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(torch::deploy::InterpreterManager(1), c10::Error);
+  EXPECT_THROW(torch::deploy::InterpreterManager(1), std::runtime_error);
 }

--- a/torch/csrc/deploy/unity/xar_environment.cpp
+++ b/torch/csrc/deploy/unity/xar_environment.cpp
@@ -2,6 +2,7 @@
 #include <dlfcn.h>
 #include <fmt/format.h>
 #include <sys/stat.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/elf_file.h>
 #include <torch/csrc/deploy/unity/xar_environment.h>
 
@@ -59,7 +60,7 @@ bool _fileExists(const std::string& filePath) {
 }
 
 void XarEnvironment::setupPythonApp() {
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       !alreadySetupPythonApp_,
       "Already setup the python application. It should only been done once!");
 
@@ -67,7 +68,7 @@ void XarEnvironment::setupPythonApp() {
   constexpr const char* SECTION_NAME = ".torch_deploy_payload.unity";
   ElfFile elfFile(exePath_.c_str());
   auto payloadSection = elfFile.findSection(SECTION_NAME);
-  TORCH_CHECK(payloadSection != at::nullopt, "Missing the payload section");
+  MULTIPY_CHECK(payloadSection != at::nullopt, "Missing the payload section");
   const char* pythonAppPkgStart = payloadSection->start;
   auto pythonAppPkgSize = payloadSection->len;
   LOG(INFO) << "Embedded binary size " << pythonAppPkgSize;
@@ -107,23 +108,26 @@ void XarEnvironment::setupPythonApp() {
    * past runs. It should be pretty safe to discard them.
    */
   std::string rmCmd = fmt::format("rm -rf {}", pythonAppDir_);
-  TORCH_CHECK(system(rmCmd.c_str()) == 0, "Fail to remove the directory.");
+  MULTIPY_CHECK(system(rmCmd.c_str()) == 0, "Fail to remove the directory.");
 
   // recreate the directory
   auto r = mkdir(pythonAppDir_.c_str(), 0777);
-  TORCH_CHECK(r == 0, "Failed to create directory: ", strerror(errno));
+  MULTIPY_CHECK(r == 0, "Failed to create directory: " + strerror(errno));
 
   std::string pythonAppArchive = std::string(pythonAppDir_) + "/python_app.xar";
   auto fp = fopen(pythonAppArchive.c_str(), "wb");
-  TORCH_CHECK(fp != nullptr, "Fail to create file: ", strerror(errno));
+  MULTIPY_CHECK(fp != nullptr, "Fail to create file: " + strerror(errno));
   auto written = fwrite(pythonAppPkgStart, 1, pythonAppPkgSize, fp);
-  TORCH_CHECK(written == pythonAppPkgSize, "Expected written == size");
+  MULTIPY_CHECK(written == pythonAppPkgSize, "Expected written == size");
   fclose(fp);
 
   std::string extractCommand = fmt::format(
       "unsquashfs -o 4096 -d {} {}", pythonAppRoot_, pythonAppArchive);
   r = system(extractCommand.c_str());
-  TORCH_CHECK(r == 0, "Fail to extract the python package");
+  MULTIPY_CHECK(
+      r == 0,
+      "Fail to extract the python package" + std::to_string(r) +
+          extractCommand.c_str());
 
   alreadySetupPythonApp_ = true;
 }
@@ -143,12 +147,9 @@ void XarEnvironment::preloadSharedLibraries() {
                 << " does not exist in the python app root, skip loading it";
       continue;
     }
-    TORCH_CHECK(
+    MULTIPY_CHECK(
         dlopen(preloadList[i], RTLD_GLOBAL | RTLD_LAZY) != nullptr,
-        "Fail to open the shared library ",
-        preloadList[i],
-        ": ",
-        dlerror());
+        "Fail to open the shared library " + preloadList[i] + ": " + dlerror());
   }
 }
 


### PR DESCRIPTION
Summary:
Remove `c10::errors` from torch::deploy and replace them with `multipy::errors` which is effectively a wrapper around `std::runtime_error.

Review History can be found with https://github.com/pytorch/pytorch/pull/73456

Test Plan: buck test //caffe2/torch/csrc/deploy:test_deploy

Differential Revision: D34905174

