### PR TITLE
[torch::deploy] Replace ArrayRef with local implementation to torch::deploy

### DIFF
--- a/torch/csrc/deploy/Exception.h
+++ b/torch/csrc/deploy/Exception.h
@@ -1,0 +1,47 @@
+#ifndef MULTIPY_EXCEPTION_H
+#define MULTIPY_EXCEPTION_H
+
+#include <exception>
+
+#define MULTIPY_INTERNAL_ASSERT_WITH_MESSAGE(condition, message)               \
+  if (!(condition)) {                                                          \
+    throw std::runtime_error(                                                  \
+        "Internal Assertion failed: (" + std::string(#condition) + "), " +     \
+        "function " + __FUNCTION__ + ", file " + __FILE__ + ", line " +        \
+        std::to_string(__LINE__) + ".\n" + "Please report bug to Pytorch.\n" + \
+        message + "\n");                                                       \
+  }
+
+#define MULTIPY_INTERNAL_ASSERT_NO_MESSAGE(condition) \
+  MULTIPY_INTERNAL_ASSERT_WITH_MESSAGE(#condition, "")
+
+#define MULTIPY_INTERNAL_ASSERT_(x, condition, message, FUNC, ...) FUNC
+
+#define MULTIPY_INTERNAL_ASSERT(...)                     \
+  MULTIPY_INTERNAL_ASSERT_(                              \
+      ,                                                  \
+      ##__VA_ARGS__,                                     \
+      MULTIPY_INTERNAL_ASSERT_WITH_MESSAGE(__VA_ARGS__), \
+      MULTIPY_INTERNAL_ASSERT_NO_MESSAGE(__VA_ARGS__));
+
+#define MULTIPY_CHECK_WITH_MESSAGE(condition, message)                      \
+  if (!(condition)) {                                                       \
+    throw std::runtime_error(                                               \
+        "Check failed: (" + std::string(#condition) + "), " + "function " + \
+        __FUNCTION__ + ", file " + __FILE__ + ", line " +                   \
+        std::to_string(__LINE__) + ".\n" + message + "\n");                 \
+  }
+
+#define MULTIPY_CHECK_NO_MESSAGE(condition) \
+  MULTIPY_CHECK_WITH_MESSAGE(#condition, "")
+
+#define MULTIPY_CHECK_(x, condition, message, FUNC, ...) FUNC
+
+#define MULTIPY_CHECK(...)                     \
+  MULTIPY_CHECK_(                              \
+      ,                                        \
+      ##__VA_ARGS__,                           \
+      MULTIPY_CHECK_WITH_MESSAGE(__VA_ARGS__), \
+      MULTIPY_CHECK_NO_MESSAGE(__VA_ARGS__));
+
+#endif // MULTIPY_EXCEPTION_H

--- a/torch/csrc/deploy/benchmark.cpp
+++ b/torch/csrc/deploy/benchmark.cpp
@@ -1,0 +1,336 @@
+#include <torch/deploy.h>
+
+#include <ATen/ATen.h>
+#include <ATen/TypeDefault.h>
+#include <c10/util/irange.h>
+
+#include <torch/script.h>
+
+#include <pthread.h>
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <iostream>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+typedef void (*function_type)(const char*);
+
+bool cuda = false;
+
+constexpr auto latency_p = {
+    25.,
+    50.,
+    95.}; //{1., 5., 25., 50., 75., 90., 95., 99., 99.25, 99.5, 99.75, 99.9};
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct Report {
+  std::string benchmark;
+  std::string strategy;
+  size_t n_threads;
+  size_t items_completed;
+  double work_items_per_second;
+  std::vector<double> latencies;
+  static void report_header(std::ostream& out) {
+    out << "benchmark, strategy, n_threads, work_items_completed, work_items_per_second";
+    for (double l : latency_p) {
+      out << ", p" << l << "_latency";
+    }
+    out << ", device\n";
+  }
+  void report(std::ostream& out) {
+    out << benchmark << ", " << strategy << ", " << n_threads << ", "
+        << items_completed << ", " << work_items_per_second;
+    for (double l : latencies) {
+      out << ", " << l;
+    }
+    out << ", " << (cuda ? "cuda" : "cpu") << "\n";
+  }
+};
+
+const int min_items_to_complete = 1;
+
+struct RunPython {
+  static torch::deploy::ReplicatedObj load_and_wrap(
+      torch::deploy::Package& package) {
+    auto I = package.acquireSession();
+    auto obj = I.self.attr("load_pickle")({"model", "model.pkl"});
+    if (cuda) {
+      obj = I.global("gpu_wrapper", "GPUWrapper")({obj});
+    }
+    return I.createMovable(obj);
+  }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+  RunPython(
+      torch::deploy::Package& package,
+      std::vector<at::IValue> eg,
+      const torch::deploy::Interpreter* interps)
+      : obj_(load_and_wrap(package)), eg_(std::move(eg)), interps_(interps) {}
+  void operator()(int i) {
+    auto I = obj_.acquireSession();
+    if (cuda) {
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+      std::vector<at::IValue> eg2 = {i};
+      eg2.insert(eg2.end(), eg_.begin(), eg_.end());
+      I.self(eg2);
+    } else {
+      I.self(eg_);
+    }
+  }
+  torch::deploy::ReplicatedObj obj_;
+  std::vector<at::IValue> eg_;
+  const torch::deploy::Interpreter* interps_;
+};
+
+// def to_device(i, d):
+//     if isinstance(i, torch.Tensor):
+//         return i.to(device=d)
+//     elif isinstance(i, (tuple, list)):
+//         return tuple(to_device(e, d) for e in i)
+//     else:
+//         raise RuntimeError('inputs are weird')
+
+static torch::IValue to_device(const torch::IValue& v, torch::Device to);
+
+static std::vector<torch::IValue> to_device_vec(
+    at::ArrayRef<torch::IValue> vs,
+    torch::Device to) {
+  std::vector<torch::IValue> results;
+  for (const torch::IValue& v : vs) {
+    results.push_back(to_device(v, to));
+  }
+  return results;
+}
+
+static torch::IValue to_device(const torch::IValue& v, torch::Device to) {
+  if (v.isTensor()) {
+    return v.toTensor().to(to);
+  } else if (v.isTuple()) {
+    auto tup = v.toTuple();
+    return c10::ivalue::Tuple::create(to_device_vec(tup->elements(), to));
+  } else if (v.isList()) {
+    auto converted = to_device_vec(v.toListRef(), to);
+    torch::List<torch::IValue> result(v.toList().elementType());
+    for (const torch::IValue& v : converted) {
+      result.push_back(v);
+    }
+    return result;
+  } else {
+    MULTIPY_INTERNAL_ASSERT(false, "cannot to_device");
+  }
+}
+
+static bool exists(const std::string& fname) {
+  std::fstream jit_file(fname);
+  return jit_file.good();
+}
+
+struct RunJIT {
+  RunJIT(const std::string& file_to_run, std::vector<torch::IValue> eg)
+      : eg_(std::move(eg)) {
+    if (!cuda) {
+      models_.push_back(torch::jit::load(file_to_run + "_jit"));
+    } else {
+      for (const auto i : c10::irange(2)) {
+        auto d = torch::Device(torch::DeviceType::CUDA, i);
+        std::stringstream qualified;
+        qualified << file_to_run << "_jit_" << i;
+        auto loaded = exists(qualified.str())
+            ? torch::jit::load(qualified.str(), d)
+            : torch::jit::load(file_to_run + "_jit", d);
+        loaded.to(d);
+        models_.push_back(loaded);
+      }
+    }
+  }
+  void operator()(int i) {
+    if (cuda) {
+      const auto device_id = i % models_.size();
+      auto d = torch::Device(torch::DeviceType::CUDA, device_id);
+      to_device(
+          models_[device_id].forward(to_device_vec(eg_, d)),
+          torch::DeviceType::CPU);
+    } else {
+      models_[0].forward(eg_);
+    }
+  }
+  std::vector<at::IValue> eg_;
+  std::vector<torch::jit::Module> models_;
+};
+
+struct Benchmark {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+  Benchmark(
+      torch::deploy::InterpreterManager& manager,
+      size_t n_threads,
+      std::string strategy,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
+      std::string file_to_run,
+      size_t n_seconds = 5)
+      : manager_(manager),
+        n_threads_(n_threads),
+        strategy_(strategy),
+        file_to_run_(file_to_run),
+        n_seconds_(n_seconds),
+        should_run_(true),
+        items_completed_(0),
+        reached_min_items_completed_(0) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+    if (strategy == "one_python") {
+      manager.debugLimitInterpreters(1);
+    } else if (strategy == "multi_python") {
+      manager.debugLimitInterpreters(n_threads_);
+    }
+  }
+
+  Report run() {
+    pthread_barrier_init(&first_run_, nullptr, n_threads_ + 1);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    torch::deploy::Package package = manager_.loadPackage(file_to_run_);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    std::vector<at::IValue> eg;
+    {
+      auto I = package.acquireSession();
+
+      eg = I.global("builtins", "tuple")(
+                I.self.attr("load_pickle")({"model", "example.pkl"}))
+               .toIValue()
+               .toTupleRef()
+               .elements();
+    }
+
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+    if (strategy_ == "jit") {
+      run_one_work_item = RunJIT(file_to_run_, std::move(eg));
+    } else {
+      run_one_work_item =
+          RunPython(package, std::move(eg), manager_.allInstances().data());
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    std::vector<std::vector<double>> latencies(n_threads_);
+
+    for (const auto i : c10::irange(n_threads_)) {
+      threads_.emplace_back([this, &latencies, i] {
+        torch::NoGradGuard guard;
+        // do initial work
+        run_one_work_item(i);
+
+        pthread_barrier_wait(&first_run_);
+        size_t local_items_completed = 0;
+        while (should_run_) {
+          auto begin = std::chrono::steady_clock::now();
+          run_one_work_item(i);
+          auto end = std::chrono::steady_clock::now();
+          double work_seconds =
+              std::chrono::duration<double>(end - begin).count();
+          latencies[i].push_back(work_seconds);
+          local_items_completed++;
+          if (local_items_completed == min_items_to_complete) {
+            reached_min_items_completed_++;
+          }
+        }
+        items_completed_ += local_items_completed;
+      });
+    }
+
+    pthread_barrier_wait(&first_run_);
+    auto begin = std::chrono::steady_clock::now();
+    auto try_stop_at = begin + std::chrono::seconds(n_seconds_);
+    std::this_thread::sleep_until(try_stop_at);
+    for (int i = 0; reached_min_items_completed_ < n_threads_; ++i) {
+      std::this_thread::sleep_until(
+          begin + (i + 2) * std::chrono::seconds(n_seconds_));
+    }
+    should_run_ = false;
+    for (std::thread& thread : threads_) {
+      thread.join();
+    }
+    auto end = std::chrono::steady_clock::now();
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    double total_seconds = std::chrono::duration<double>(end - begin).count();
+    Report report;
+    report.benchmark = file_to_run_;
+    report.strategy = strategy_;
+    report.n_threads = n_threads_;
+    report.items_completed = items_completed_;
+    report.work_items_per_second = items_completed_ / total_seconds;
+    reportLatencies(report.latencies, latencies);
+    run_one_work_item = nullptr;
+    return report;
+  }
+
+ private:
+  void reportLatencies(
+      std::vector<double>& results,
+      const std::vector<std::vector<double>>& latencies) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    std::vector<double> flat_latencies;
+    for (const auto& elem : latencies) {
+      flat_latencies.insert(flat_latencies.end(), elem.begin(), elem.end());
+    }
+    std::sort(flat_latencies.begin(), flat_latencies.end());
+    for (double target : latency_p) {
+      size_t idx = size_t(flat_latencies.size() * target / 100.0);
+      double time = flat_latencies.size() == 0
+          ? 0
+          : flat_latencies.at(std::min(flat_latencies.size() - 1, idx));
+      results.push_back(time);
+    }
+  }
+  torch::deploy::InterpreterManager& manager_;
+  size_t n_threads_;
+  std::string strategy_;
+  std::string file_to_run_;
+  size_t n_seconds_;
+  pthread_barrier_t first_run_;
+  std::atomic<bool> should_run_;
+  std::atomic<size_t> items_completed_;
+  std::atomic<size_t> reached_min_items_completed_;
+  std::vector<std::thread> threads_;
+  std::function<void(int)> run_one_work_item;
+};
+
+// NOLINTNEXTLINE(bugprone-exception-escape)
+int main(int argc, char* argv[]) {
+  int max_thread = atoi(argv[1]);
+  cuda = std::string(argv[2]) == "cuda";
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  bool jit_enable = std::string(argv[3]) == "jit";
+  Report::report_header(std::cout);
+  torch::deploy::InterpreterManager manager(max_thread);
+
+  // make sure gpu_wrapper.py is in the import path
+  for (auto& interp : manager.allInstances()) {
+    auto I = interp.acquireSession();
+    I.global("sys", "path").attr("append")({"torch/csrc/deploy/example"});
+  }
+
+  auto n_threads = {1, 2, 4, 8, 16, 32, 40};
+  for (const auto i : c10::irange(4, argc)) {
+    std::string model_file = argv[i];
+    for (int n_thread : n_threads) {
+      if (n_thread > max_thread) {
+        continue;
+      }
+      for (std::string strategy : {"one_python", "multi_python", "jit"}) {
+        if (strategy == "jit") {
+          if (!jit_enable) {
+            continue;
+          }
+          if (!exists(model_file + "_jit")) {
+            continue;
+          }
+        }
+        Benchmark b(manager, n_thread, strategy, model_file);
+        Report r = b.run();
+        r.report(std::cout);
+      }
+    }
+  }
+  return 0;
+}

--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -1,4 +1,4 @@
-#include <c10/util/Exception.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/deploy.h>
 #include <torch/csrc/deploy/elf_file.h>
 #include <torch/cuda.h>
@@ -59,7 +59,7 @@ static bool writeDeployInterpreter(FILE* dst) {
       payloadStart = payloadSection->start;
       customLoader = s.customLoader;
       size = payloadSection->len;
-      TORCH_CHECK(payloadSection.has_value(), "Missing the payload section");
+      MULTIPY_CHECK(payloadSection.has_value(), "Missing the payload section");
       break;
     }
   }
@@ -74,10 +74,10 @@ static bool writeDeployInterpreter(FILE* dst) {
         break;
       }
     }
-    TORCH_CHECK(
+    MULTIPY_CHECK(
         libStart != nullptr && libEnd != nullptr,
-        "torch::deploy requires a build-time dependency on embedded_interpreter or embedded_interpreter_cuda, neither of which were found.  torch::cuda::is_available()=",
-        torch::cuda::is_available());
+        "torch::deploy requires a build-time dependency on embedded_interpreter or embedded_interpreter_cuda, neither of which were found.  torch::cuda::is_available()=" +
+            std::to_string(torch::cuda::is_available()));
 
     size = libEnd - libStart;
     payloadStart = libStart;
@@ -189,11 +189,11 @@ void ReplicatedObj::unload(const Interpreter* onThisInterpreter) {
 
 ReplicatedObj InterpreterSession::createMovable(Obj obj) {
   TORCH_DEPLOY_TRY
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       manager_,
       "Can only create a movable object when the session was created from an interpreter that is part of a InterpreterManager");
 
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       impl_->isOwner(obj),
       "Cannot create movable from an object that lives in different session");
 

--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -1,6 +1,8 @@
 #include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/deploy.h>
 #include <torch/csrc/deploy/elf_file.h>
+#include <torch/csrc/deploy/interpreter/Optional.hpp>
+
 #include <torch/cuda.h>
 
 #include <dlfcn.h>
@@ -54,8 +56,9 @@ static bool writeDeployInterpreter(FILE* dst) {
   std::ifstream("/proc/self/cmdline") >> exePath;
   ElfFile elfFile(exePath.c_str());
   for (const auto& s : pythonInterpreterSection) {
-    at::optional<Section> payloadSection = elfFile.findSection(s.sectionName);
-    if (payloadSection != at::nullopt) {
+    multipy::optional<Section> payloadSection =
+        elfFile.findSection(s.sectionName);
+    if (payloadSection != multipy::nullopt) {
       payloadStart = payloadSection->start;
       customLoader = s.customLoader;
       size = payloadSection->len;
@@ -99,12 +102,12 @@ InterpreterManager::InterpreterManager(
     // can be used for balancing work across GPUs
     I.global("torch", "version").attr("__setattr__")({"interp", int(i)});
     instances_.back().pImpl_->setFindModule(
-        [this](const std::string& name) -> at::optional<std::string> {
+        [this](const std::string& name) -> multipy::optional<std::string> {
           auto it = registeredModuleSource_.find(name);
           if (it != registeredModuleSource_.end()) {
             return it->second;
           } else {
-            return at::nullopt;
+            return multipy::nullopt;
           }
         });
   }

--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <c10/util/Optional.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/api/include/torch/imethod.h>
+#include <torch/csrc/deploy/interpreter/Optional.hpp>
 #include <torch/csrc/deploy/interpreter/interpreter_impl.h>
 #include <torch/csrc/deploy/noop_environment.h>
 #include <torch/csrc/jit/serialization/import.h>

--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -95,7 +95,7 @@ struct TORCH_API LoadBalancer {
   }
   void setResourceLimit(size_t n) {
     TORCH_DEPLOY_TRY
-    TORCH_INTERNAL_ASSERT(n <= allocated_);
+    MULTIPY_INTERNAL_ASSERT(n <= allocated_);
     n_ = n;
     TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }

--- a/torch/csrc/deploy/elf_file.cpp
+++ b/torch/csrc/deploy/elf_file.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/irange.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/elf_file.h>
 
 namespace torch {
@@ -13,7 +14,7 @@ ElfFile::ElfFile(const char* filename) : memFile_(filename) {
   shdrList_ = (Elf64_Shdr*)(fileData + ehdr_->e_shoff);
 
   auto strtabSecNo = ehdr_->e_shstrndx;
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       strtabSecNo >= 0 && strtabSecNo < numSections_,
       "e_shstrndx out of range");
 
@@ -26,7 +27,7 @@ ElfFile::ElfFile(const char* filename) : memFile_(filename) {
 }
 
 at::optional<Section> ElfFile::findSection(const char* name) const {
-  TORCH_CHECK(name != nullptr, "Null name");
+  MULTIPY_CHECK(name != nullptr, "Null name");
   at::optional<Section> found = at::nullopt;
   for (const auto& section : sections_) {
     if (strcmp(name, section.name) == 0) {
@@ -40,13 +41,13 @@ at::optional<Section> ElfFile::findSection(const char* name) const {
 
 void ElfFile::checkFormat() const {
   // check the magic numbers
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       (ehdr_->e_ident[EI_MAG0] == ELFMAG0) &&
           (ehdr_->e_ident[EI_MAG1] == ELFMAG1) &&
           (ehdr_->e_ident[EI_MAG2] == ELFMAG2) &&
           (ehdr_->e_ident[EI_MAG3] == ELFMAG3),
       "Unexpected magic numbers");
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       ehdr_->e_ident[EI_CLASS] == ELFCLASS64, "Only support 64bit ELF file");
 }
 

--- a/torch/csrc/deploy/elf_file.cpp
+++ b/torch/csrc/deploy/elf_file.cpp
@@ -1,6 +1,7 @@
 #include <c10/util/irange.h>
 #include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/elf_file.h>
+#include <torch/csrc/deploy/interpreter/Optional.hpp>
 
 namespace torch {
 namespace deploy {
@@ -26,9 +27,9 @@ ElfFile::ElfFile(const char* filename) : memFile_(filename) {
   }
 }
 
-at::optional<Section> ElfFile::findSection(const char* name) const {
+multipy::optional<Section> ElfFile::findSection(const char* name) const {
   MULTIPY_CHECK(name != nullptr, "Null name");
-  at::optional<Section> found = at::nullopt;
+  multipy::optional<Section> found = multipy::nullopt;
   for (const auto& section : sections_) {
     if (strcmp(name, section.name) == 0) {
       found = section;

--- a/torch/csrc/deploy/elf_file.h
+++ b/torch/csrc/deploy/elf_file.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <c10/util/Optional.h>
 #include <elf.h>
 #include <torch/csrc/deploy/Exception.h>
+#include <torch/csrc/deploy/interpreter/Optional.hpp>
 #include <torch/csrc/deploy/mem_file.h>
 #include <vector>
 
@@ -31,7 +31,7 @@ struct Section {
 class ElfFile {
  public:
   explicit ElfFile(const char* filename);
-  at::optional<Section> findSection(const char* name) const;
+  multipy::optional<Section> findSection(const char* name) const;
 
  private:
   Section toSection(Elf64_Shdr* shdr) {

--- a/torch/csrc/deploy/elf_file.h
+++ b/torch/csrc/deploy/elf_file.h
@@ -2,6 +2,7 @@
 
 #include <c10/util/Optional.h>
 #include <elf.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/mem_file.h>
 #include <vector>
 
@@ -40,7 +41,7 @@ class ElfFile {
     const char* name = "";
 
     if (strtabSection_) {
-      TORCH_CHECK(nameOff >= 0 && nameOff < strtabSection_.len);
+      MULTIPY_CHECK(nameOff >= 0 && nameOff < strtabSection_.len);
       name = strtabSection_.start + nameOff;
     }
     const char* start = memFile_.data() + shOff;
@@ -48,7 +49,7 @@ class ElfFile {
   }
 
   [[nodiscard]] const char* str(size_t off) const {
-    TORCH_CHECK(off < strtabSection_.len, "String table index out of range");
+    MULTIPY_CHECK(off < strtabSection_.len, "String table index out of range");
     return strtabSection_.start + off;
   }
   void checkFormat() const;

--- a/torch/csrc/deploy/environment.h
+++ b/torch/csrc/deploy/environment.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <fmt/format.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/elf_file.h>
 #include <fstream>
 #include <string>
@@ -27,7 +28,7 @@ class Environment {
     // load the zipped torch modules
     constexpr const char* ZIPPED_TORCH_NAME = ".torch_python_modules";
     auto zippedTorchSection = elfFile.findSection(ZIPPED_TORCH_NAME);
-    TORCH_CHECK(
+    MULTIPY_CHECK(
         zippedTorchSection.has_value(), "Missing the zipped torch section");
     const char* zippedTorchStart = zippedTorchSection->start;
     auto zippedTorchSize = zippedTorchSection->len;
@@ -35,7 +36,7 @@ class Environment {
     std::string zipArchive =
         std::string(pythonAppDir) + "/torch_python_modules.zip";
     auto zippedFile = fopen(zipArchive.c_str(), "wb");
-    TORCH_CHECK(
+    MULTIPY_CHECK(
         zippedFile != nullptr, "Fail to create file: ", strerror(errno));
     fwrite(zippedTorchStart, 1, zippedTorchSize, zippedFile);
     fclose(zippedFile);

--- a/torch/csrc/deploy/interpreter/Optional.hpp
+++ b/torch/csrc/deploy/interpreter/Optional.hpp
@@ -1,0 +1,1107 @@
+// Copyright (C) 2011 - 2012 Andrzej Krzemienski.
+//
+// Use, modification, and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// The idea and interface is based on Boost.Optional library
+// authored by Fernando Luis Cacciola Carballal
+//
+// Source: https://github.com/akrzemi1/Optional
+
+#ifndef ___OPTIONAL_HPP___
+#define ___OPTIONAL_HPP___
+
+#include <cassert>
+#include <functional>
+#include <initializer_list>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#define TR2_OPTIONAL_REQUIRES(...) \
+  typename std::enable_if<__VA_ARGS__::value, bool>::type = false
+
+#if defined __GNUC__ // NOTE: GNUC is also defined for Clang
+#if (__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)
+#define TR2_OPTIONAL_GCC_4_8_AND_HIGHER___
+#elif (__GNUC__ > 4)
+#define TR2_OPTIONAL_GCC_4_8_AND_HIGHER___
+#endif
+
+#if (__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)
+#define TR2_OPTIONAL_GCC_4_7_AND_HIGHER___
+#elif (__GNUC__ > 4)
+#define TR2_OPTIONAL_GCC_4_7_AND_HIGHER___
+#endif
+
+#if (__GNUC__ == 4) && (__GNUC_MINOR__ == 8) && (__GNUC_PATCHLEVEL__ >= 1)
+#define TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#elif (__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)
+#define TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#elif (__GNUC__ > 4)
+#define TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#endif
+#endif
+
+#if defined __clang_major__
+#if (__clang_major__ == 3 && __clang_minor__ >= 5)
+#define TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_
+#elif (__clang_major__ > 3)
+#define TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_
+#endif
+#if defined TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_
+#define TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+#elif ( \
+    __clang_major__ == 3 && __clang_minor__ == 4 && __clang_patchlevel__ >= 2)
+#define TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+#endif
+#endif
+
+#if defined _MSC_VER
+#if (_MSC_VER >= 1900)
+#define TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+#endif
+#endif
+
+#if defined __clang__
+#if (__clang_major__ > 2) || (__clang_major__ == 2) && (__clang_minor__ >= 9)
+#define OPTIONAL_HAS_THIS_RVALUE_REFS 1
+#else
+#define OPTIONAL_HAS_THIS_RVALUE_REFS 0
+#endif
+#elif defined TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#define OPTIONAL_HAS_THIS_RVALUE_REFS 1
+#elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+#define OPTIONAL_HAS_THIS_RVALUE_REFS 1
+#else
+#define OPTIONAL_HAS_THIS_RVALUE_REFS 0
+#endif
+
+#if defined TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
+#define OPTIONAL_HAS_CONSTEXPR_INIT_LIST 1
+#define OPTIONAL_CONSTEXPR_INIT_LIST constexpr
+#else
+#define OPTIONAL_HAS_CONSTEXPR_INIT_LIST 0
+#define OPTIONAL_CONSTEXPR_INIT_LIST
+#endif
+
+#if defined TR2_OPTIONAL_CLANG_3_5_AND_HIGHTER_ && (defined __cplusplus) && \
+    (__cplusplus != 201103L)
+#define OPTIONAL_HAS_MOVE_ACCESSORS 1
+#else
+#define OPTIONAL_HAS_MOVE_ACCESSORS 0
+#endif
+
+// In C++11 constexpr implies const, so we need to make non-const members also
+// non-constexpr
+#if (defined __cplusplus) && (__cplusplus == 201103L)
+#define OPTIONAL_MUTABLE_CONSTEXPR
+#else
+#define OPTIONAL_MUTABLE_CONSTEXPR constexpr
+#endif
+
+namespace multipy {
+
+// BEGIN workaround for missing std::is_trivially_destructible
+#if defined TR2_OPTIONAL_GCC_4_8_AND_HIGHER___
+// leave it: it is already there
+#elif defined TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+// leave it: it is already there
+#elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+// leave it: it is already there
+#elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
+// leave it: the user doesn't want it
+#else
+template <typename T>
+using std::is_trivially_destructible = std::has_trivial_destructor<T>;
+#endif
+// END workaround for missing std::is_trivially_destructible
+
+#if (defined TR2_OPTIONAL_GCC_4_7_AND_HIGHER___)
+// leave it; our metafunctions are already defined.
+#elif defined TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
+// leave it; our metafunctions are already defined.
+#elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+// leave it: it is already there
+#elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
+// leave it: the user doesn't want it
+#else
+
+// workaround for missing traits in GCC and CLANG
+template <class T>
+struct std::is_nothrow_move_constructible {
+  constexpr static bool value = std::is_nothrow_constructible<T, T&&>::value;
+};
+
+template <class T, class U>
+struct is_assignable {
+  template <class X, class Y>
+  constexpr static bool has_assign(...) {
+    return false;
+  }
+
+  template <
+      class X,
+      class Y,
+      size_t S = sizeof((std::declval<X>() = std::declval<Y>(), true))>
+  // the comma operator is necessary for the cases where operator= returns void
+  constexpr static bool has_assign(bool) {
+    return true;
+  }
+
+  constexpr static bool value = has_assign<T, U>(true);
+};
+
+template <class T>
+struct std::is_nothrow_move_assignable {
+  template <class X, bool has_any_move_assign>
+  struct has_nothrow_move_assign {
+    constexpr static bool value = false;
+  };
+
+  template <class X>
+  struct has_nothrow_move_assign<X, true> {
+    constexpr static bool value =
+        noexcept(std::declval<X&>() = std::declval<X&&>());
+  };
+
+  constexpr static bool value =
+      has_nothrow_move_assign<T, is_assignable<T&, T&&>::value>::value;
+};
+// end workaround
+
+#endif
+
+// 20.5.4, optional for object types
+template <class T>
+class optional;
+
+// 20.5.5, optional for lvalue reference types
+template <class T>
+class optional<T&>;
+
+// workaround: std utility functions aren't constexpr yet
+template <class T>
+inline constexpr T&& constexpr_forward(
+    typename std::remove_reference<T>::type& t) noexcept {
+  return static_cast<T&&>(t);
+}
+
+template <class T>
+inline constexpr T&& constexpr_forward(
+    typename std::remove_reference<T>::type&& t) noexcept {
+  static_assert(!std::is_lvalue_reference<T>::value, "!!");
+  return static_cast<T&&>(t);
+}
+
+template <class T>
+inline constexpr typename std::remove_reference<T>::type&& constexpr_move(
+    T&& t) noexcept {
+  return static_cast<typename std::remove_reference<T>::type&&>(t);
+}
+
+#if defined NDEBUG
+#define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) (EXPR)
+#else
+#define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) \
+  ((CHECK) ? (EXPR) : ([] { assert(!#CHECK); }(), (EXPR)))
+#endif
+
+namespace detail_ {
+
+// static_addressof: a constexpr version of addressof
+template <typename T>
+struct has_overloaded_addressof {
+  template <class X>
+  constexpr static bool has_overload(...) {
+    return false;
+  }
+
+  template <class X, size_t S = sizeof(std::declval<X&>().operator&())>
+  constexpr static bool has_overload(bool) {
+    return true;
+  }
+
+  constexpr static bool value = has_overload<T>(true);
+};
+
+template <typename T, TR2_OPTIONAL_REQUIRES(!has_overloaded_addressof<T>)>
+constexpr T* static_addressof(T& ref) {
+  return &ref;
+}
+
+template <typename T, TR2_OPTIONAL_REQUIRES(has_overloaded_addressof<T>)>
+T* static_addressof(T& ref) {
+  return std::addressof(ref);
+}
+
+// the call to convert<A>(b) has return type A and converts b to type A iff b
+// decltype(b) is implicitly convertible to A
+template <class U>
+constexpr U convert(U v) {
+  return v;
+}
+
+namespace swap_ns {
+using std::swap;
+
+template <class T>
+void adl_swap(T& t, T& u) noexcept(noexcept(swap(t, u))) {
+  swap(t, u);
+}
+
+} // namespace swap_ns
+
+} // namespace detail_
+
+constexpr struct trivial_init_t {
+} trivial_init{};
+
+// 20.5.6, In-place construction
+constexpr struct in_place_t {
+} in_place{};
+
+// 20.5.7, Disengaged state indicator
+struct nullopt_t {
+  struct init {};
+  constexpr explicit nullopt_t(init) {}
+};
+constexpr nullopt_t nullopt{nullopt_t::init()};
+
+// 20.5.8, class bad_optional_access
+class bad_optional_access : public std::logic_error {
+ public:
+  explicit bad_optional_access(const std::string& what_arg)
+      : std::logic_error{what_arg} {}
+  explicit bad_optional_access(const char* what_arg)
+      : std::logic_error{what_arg} {}
+};
+
+template <class T>
+union storage_t {
+  unsigned char dummy_;
+  T value_;
+
+  constexpr storage_t(trivial_init_t) noexcept : dummy_(){};
+
+  template <class... Args>
+  constexpr storage_t(Args&&... args)
+      : value_(constexpr_forward<Args>(args)...) {}
+
+  ~storage_t() {}
+};
+
+template <class T>
+union constexpr_storage_t {
+  unsigned char dummy_;
+  T value_;
+
+  constexpr constexpr_storage_t(trivial_init_t) noexcept : dummy_(){};
+
+  template <class... Args>
+  constexpr constexpr_storage_t(Args&&... args)
+      : value_(constexpr_forward<Args>(args)...) {}
+
+  ~constexpr_storage_t() = default;
+};
+
+template <class T>
+struct optional_base {
+  bool init_;
+  storage_t<T> storage_;
+
+  constexpr optional_base() noexcept : init_(false), storage_(trivial_init){};
+
+  explicit constexpr optional_base(const T& v) : init_(true), storage_(v) {}
+
+  explicit constexpr optional_base(T&& v)
+      : init_(true), storage_(constexpr_move(v)) {}
+
+  template <class... Args>
+  explicit optional_base(in_place_t, Args&&... args)
+      : init_(true), storage_(constexpr_forward<Args>(args)...) {}
+
+  template <
+      class U,
+      class... Args,
+      TR2_OPTIONAL_REQUIRES(std::is_constructible<T, std::initializer_list<U>>)>
+  explicit optional_base(
+      in_place_t,
+      std::initializer_list<U> il,
+      Args&&... args)
+      : init_(true), storage_(il, std::forward<Args>(args)...) {}
+
+  ~optional_base() {
+    if (init_)
+      storage_.value_.T::~T();
+  }
+};
+
+template <class T>
+struct constexpr_optional_base {
+  bool init_;
+  constexpr_storage_t<T> storage_;
+
+  constexpr constexpr_optional_base() noexcept
+      : init_(false), storage_(trivial_init){};
+
+  explicit constexpr constexpr_optional_base(const T& v)
+      : init_(true), storage_(v) {}
+
+  explicit constexpr constexpr_optional_base(T&& v)
+      : init_(true), storage_(constexpr_move(v)) {}
+
+  template <class... Args>
+  explicit constexpr constexpr_optional_base(in_place_t, Args&&... args)
+      : init_(true), storage_(constexpr_forward<Args>(args)...) {}
+
+  template <
+      class U,
+      class... Args,
+      TR2_OPTIONAL_REQUIRES(std::is_constructible<T, std::initializer_list<U>>)>
+  OPTIONAL_CONSTEXPR_INIT_LIST explicit constexpr_optional_base(
+      in_place_t,
+      std::initializer_list<U> il,
+      Args&&... args)
+      : init_(true), storage_(il, std::forward<Args>(args)...) {}
+
+  ~constexpr_optional_base() = default;
+};
+
+template <class T>
+using OptionalBase = typename std::conditional<
+    std::is_trivially_destructible<T>::value, // if possible
+    constexpr_optional_base<typename std::remove_const<
+        T>::type>, // use base with trivial destructor
+    optional_base<typename std::remove_const<T>::type>>::type;
+
+template <class T>
+class optional : private OptionalBase<T> {
+  static_assert(
+      !std::is_same<typename std::decay<T>::type, nullopt_t>::value,
+      "bad T");
+  static_assert(
+      !std::is_same<typename std::decay<T>::type, in_place_t>::value,
+      "bad T");
+
+  constexpr bool initialized() const noexcept {
+    return OptionalBase<T>::init_;
+  }
+  typename std::remove_const<T>::type* dataptr() {
+    return std::addressof(OptionalBase<T>::storage_.value_);
+  }
+  constexpr const T* dataptr() const {
+    return detail_::static_addressof(OptionalBase<T>::storage_.value_);
+  }
+
+#if OPTIONAL_HAS_THIS_RVALUE_REFS == 1
+  constexpr const T& contained_val() const& {
+    return OptionalBase<T>::storage_.value_;
+  }
+#if OPTIONAL_HAS_MOVE_ACCESSORS == 1
+  OPTIONAL_MUTABLE_CONSTEXPR T&& contained_val() && {
+    return std::move(OptionalBase<T>::storage_.value_);
+  }
+  OPTIONAL_MUTABLE_CONSTEXPR T& contained_val() & {
+    return OptionalBase<T>::storage_.value_;
+  }
+#else
+  T& contained_val() & {
+    return OptionalBase<T>::storage_.value_;
+  }
+  T&& contained_val() && {
+    return std::move(OptionalBase<T>::storage_.value_);
+  }
+#endif
+#else
+  constexpr const T& contained_val() const {
+    return OptionalBase<T>::storage_.value_;
+  }
+  T& contained_val() {
+    return OptionalBase<T>::storage_.value_;
+  }
+#endif
+
+  void clear() noexcept {
+    if (initialized())
+      dataptr()->T::~T();
+    OptionalBase<T>::init_ = false;
+  }
+
+  template <class... Args>
+  void initialize(Args&&... args) noexcept(
+      noexcept(T(std::forward<Args>(args)...))) {
+    assert(!OptionalBase<T>::init_);
+    ::new (static_cast<void*>(dataptr())) T(std::forward<Args>(args)...);
+    OptionalBase<T>::init_ = true;
+  }
+
+  template <class U, class... Args>
+  void initialize(std::initializer_list<U> il, Args&&... args) noexcept(
+      noexcept(T(il, std::forward<Args>(args)...))) {
+    assert(!OptionalBase<T>::init_);
+    ::new (static_cast<void*>(dataptr())) T(il, std::forward<Args>(args)...);
+    OptionalBase<T>::init_ = true;
+  }
+
+ public:
+  typedef T value_type;
+
+  // 20.5.5.1, constructors
+  constexpr optional() noexcept : OptionalBase<T>(){};
+  constexpr optional(nullopt_t) noexcept : OptionalBase<T>(){};
+
+  optional(const optional& rhs) : OptionalBase<T>() {
+    if (rhs.initialized()) {
+      ::new (static_cast<void*>(dataptr())) T(*rhs);
+      OptionalBase<T>::init_ = true;
+    }
+  }
+
+  optional(optional&& rhs) noexcept(
+      std::is_nothrow_move_constructible<T>::value)
+      : OptionalBase<T>() {
+    if (rhs.initialized()) {
+      ::new (static_cast<void*>(dataptr())) T(std::move(*rhs));
+      OptionalBase<T>::init_ = true;
+    }
+  }
+
+  constexpr optional(const T& v) : OptionalBase<T>(v) {}
+
+  constexpr optional(T&& v) : OptionalBase<T>(constexpr_move(v)) {}
+
+  template <class... Args>
+  explicit constexpr optional(in_place_t, Args&&... args)
+      : OptionalBase<T>(in_place_t{}, constexpr_forward<Args>(args)...) {}
+
+  template <
+      class U,
+      class... Args,
+      TR2_OPTIONAL_REQUIRES(std::is_constructible<T, std::initializer_list<U>>)>
+  OPTIONAL_CONSTEXPR_INIT_LIST explicit optional(
+      in_place_t,
+      std::initializer_list<U> il,
+      Args&&... args)
+      : OptionalBase<T>(in_place_t{}, il, constexpr_forward<Args>(args)...) {}
+
+  // 20.5.4.2, Destructor
+  ~optional() = default;
+
+  // 20.5.4.3, assignment
+  optional& operator=(nullopt_t) noexcept {
+    clear();
+    return *this;
+  }
+
+  optional& operator=(const optional& rhs) {
+    if (initialized() == true && rhs.initialized() == false)
+      clear();
+    else if (initialized() == false && rhs.initialized() == true)
+      initialize(*rhs);
+    else if (initialized() == true && rhs.initialized() == true)
+      contained_val() = *rhs;
+    return *this;
+  }
+
+  optional& operator=(optional&& rhs) noexcept(
+      std::is_nothrow_move_assignable<T>::value&&
+          std::is_nothrow_move_constructible<T>::value) {
+    if (initialized() == true && rhs.initialized() == false)
+      clear();
+    else if (initialized() == false && rhs.initialized() == true)
+      initialize(std::move(*rhs));
+    else if (initialized() == true && rhs.initialized() == true)
+      contained_val() = std::move(*rhs);
+    return *this;
+  }
+
+  template <class U>
+  auto operator=(U&& v) -> typename std::enable_if<
+      std::is_same<typename std::decay<U>::type, T>::value,
+      optional&>::type {
+    if (initialized()) {
+      contained_val() = std::forward<U>(v);
+    } else {
+      initialize(std::forward<U>(v));
+    }
+    return *this;
+  }
+
+  template <class... Args>
+  void emplace(Args&&... args) {
+    clear();
+    initialize(std::forward<Args>(args)...);
+  }
+
+  template <class U, class... Args>
+  void emplace(std::initializer_list<U> il, Args&&... args) {
+    clear();
+    initialize<U, Args...>(il, std::forward<Args>(args)...);
+  }
+
+  // 20.5.4.4, Swap
+  void swap(optional<T>& rhs) noexcept(
+      std::is_nothrow_move_constructible<T>::value&& noexcept(
+          detail_::swap_ns::adl_swap(std::declval<T&>(), std::declval<T&>()))) {
+    if (initialized() == true && rhs.initialized() == false) {
+      rhs.initialize(std::move(**this));
+      clear();
+    } else if (initialized() == false && rhs.initialized() == true) {
+      initialize(std::move(*rhs));
+      rhs.clear();
+    } else if (initialized() == true && rhs.initialized() == true) {
+      using std::swap;
+      swap(**this, *rhs);
+    }
+  }
+
+  // 20.5.4.5, Observers
+
+  explicit constexpr operator bool() const noexcept {
+    return initialized();
+  }
+  constexpr bool has_value() const noexcept {
+    return initialized();
+  }
+
+  constexpr T const* operator->() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), dataptr());
+  }
+
+#if OPTIONAL_HAS_MOVE_ACCESSORS == 1
+
+  OPTIONAL_MUTABLE_CONSTEXPR T* operator->() {
+    assert(initialized());
+    return dataptr();
+  }
+
+  constexpr T const& operator*() const& {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), contained_val());
+  }
+
+  OPTIONAL_MUTABLE_CONSTEXPR T& operator*() & {
+    assert(initialized());
+    return contained_val();
+  }
+
+  OPTIONAL_MUTABLE_CONSTEXPR T&& operator*() && {
+    assert(initialized());
+    return constexpr_move(contained_val());
+  }
+
+  constexpr T const& value() const& {
+    return initialized()
+        ? contained_val()
+        : (throw bad_optional_access("bad optional access"), contained_val());
+  }
+
+  OPTIONAL_MUTABLE_CONSTEXPR T& value() & {
+    return initialized()
+        ? contained_val()
+        : (throw bad_optional_access("bad optional access"), contained_val());
+  }
+
+  OPTIONAL_MUTABLE_CONSTEXPR T&& value() && {
+    if (!initialized())
+      throw bad_optional_access("bad optional access");
+    return std::move(contained_val());
+  }
+
+#else
+
+  T* operator->() {
+    assert(initialized());
+    return dataptr();
+  }
+
+  constexpr T const& operator*() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(initialized(), contained_val());
+  }
+
+  T& operator*() {
+    assert(initialized());
+    return contained_val();
+  }
+
+  constexpr T const& value() const {
+    return initialized()
+        ? contained_val()
+        : (throw bad_optional_access("bad optional access"), contained_val());
+  }
+
+  T& value() {
+    return initialized()
+        ? contained_val()
+        : (throw bad_optional_access("bad optional access"), contained_val());
+  }
+
+#endif
+
+#if OPTIONAL_HAS_THIS_RVALUE_REFS == 1
+
+  template <class V>
+  constexpr T value_or(V&& v) const& {
+    return *this ? **this : detail_::convert<T>(constexpr_forward<V>(v));
+  }
+
+#if OPTIONAL_HAS_MOVE_ACCESSORS == 1
+
+  template <class V>
+  OPTIONAL_MUTABLE_CONSTEXPR T value_or(V&& v) && {
+    return *this
+        ? constexpr_move(const_cast<optional<T>&>(*this).contained_val())
+        : detail_::convert<T>(constexpr_forward<V>(v));
+  }
+
+#else
+
+  template <class V>
+  T value_or(V&& v) && {
+    return *this
+        ? constexpr_move(const_cast<optional<T>&>(*this).contained_val())
+        : detail_::convert<T>(constexpr_forward<V>(v));
+  }
+
+#endif
+
+#else
+
+  template <class V>
+  constexpr T value_or(V&& v) const {
+    return *this ? **this : detail_::convert<T>(constexpr_forward<V>(v));
+  }
+
+#endif
+
+  // 20.6.3.6, modifiers
+  void reset() noexcept {
+    clear();
+  }
+};
+
+template <class T>
+class optional<T&> {
+  static_assert(!std::is_same<T, nullopt_t>::value, "bad T");
+  static_assert(!std::is_same<T, in_place_t>::value, "bad T");
+  T* ref;
+
+ public:
+  // 20.5.5.1, construction/destruction
+  constexpr optional() noexcept : ref(nullptr) {}
+
+  constexpr optional(nullopt_t) noexcept : ref(nullptr) {}
+
+  constexpr optional(T& v) noexcept : ref(detail_::static_addressof(v)) {}
+
+  optional(T&&) = delete;
+
+  constexpr optional(const optional& rhs) noexcept : ref(rhs.ref) {}
+
+  explicit constexpr optional(in_place_t, T& v) noexcept
+      : ref(detail_::static_addressof(v)) {}
+
+  explicit optional(in_place_t, T&&) = delete;
+
+  ~optional() = default;
+
+  // 20.5.5.2, mutation
+  optional& operator=(nullopt_t) noexcept {
+    ref = nullptr;
+    return *this;
+  }
+
+  // optional& operator=(const optional& rhs) noexcept {
+  // ref = rhs.ref;
+  // return *this;
+  // }
+
+  // optional& operator=(optional&& rhs) noexcept {
+  // ref = rhs.ref;
+  // return *this;
+  // }
+
+  template <typename U>
+  auto operator=(U&& rhs) noexcept -> typename std::enable_if<
+      std::is_same<typename std::decay<U>::type, optional<T&>>::value,
+      optional&>::type {
+    ref = rhs.ref;
+    return *this;
+  }
+
+  template <typename U>
+  auto operator=(U&& rhs) noexcept -> typename std::enable_if<
+      !std::is_same<typename std::decay<U>::type, optional<T&>>::value,
+      optional&>::type = delete;
+
+  void emplace(T& v) noexcept {
+    ref = detail_::static_addressof(v);
+  }
+
+  void emplace(T&&) = delete;
+
+  void swap(optional<T&>& rhs) noexcept {
+    std::swap(ref, rhs.ref);
+  }
+
+  // 20.5.5.3, observers
+  constexpr T* operator->() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(ref, ref);
+  }
+
+  constexpr T& operator*() const {
+    return TR2_OPTIONAL_ASSERTED_EXPRESSION(ref, *ref);
+  }
+
+  constexpr T& value() const {
+    return ref ? *ref
+               : (throw bad_optional_access("bad optional access"), *ref);
+  }
+
+  explicit constexpr operator bool() const noexcept {
+    return ref != nullptr;
+  }
+
+  constexpr bool has_value() const noexcept {
+    return ref != nullptr;
+  }
+
+  template <class V>
+  constexpr typename std::decay<T>::type value_or(V&& v) const {
+    return *this ? **this
+                 : detail_::convert<typename std::decay<T>::type>(
+                       constexpr_forward<V>(v));
+  }
+
+  // x.x.x.x, modifiers
+  void reset() noexcept {
+    ref = nullptr;
+  }
+};
+
+template <class T>
+class optional<T&&> {
+  static_assert(sizeof(T) == 0, "optional rvalue references disallowed");
+};
+
+// 20.5.8, Relational operators
+template <class T>
+constexpr bool operator==(const optional<T>& x, const optional<T>& y) {
+  return bool(x) != bool(y) ? false : bool(x) == false ? true : *x == *y;
+}
+
+template <class T>
+constexpr bool operator!=(const optional<T>& x, const optional<T>& y) {
+  return !(x == y);
+}
+
+template <class T>
+constexpr bool operator<(const optional<T>& x, const optional<T>& y) {
+  return (!y) ? false : (!x) ? true : *x < *y;
+}
+
+template <class T>
+constexpr bool operator>(const optional<T>& x, const optional<T>& y) {
+  return (y < x);
+}
+
+template <class T>
+constexpr bool operator<=(const optional<T>& x, const optional<T>& y) {
+  return !(y < x);
+}
+
+template <class T>
+constexpr bool operator>=(const optional<T>& x, const optional<T>& y) {
+  return !(x < y);
+}
+
+// 20.5.9, Comparison with nullopt
+template <class T>
+constexpr bool operator==(const optional<T>& x, nullopt_t) noexcept {
+  return (!x);
+}
+
+template <class T>
+constexpr bool operator==(nullopt_t, const optional<T>& x) noexcept {
+  return (!x);
+}
+
+template <class T>
+constexpr bool operator!=(const optional<T>& x, nullopt_t) noexcept {
+  return bool(x);
+}
+
+template <class T>
+constexpr bool operator!=(nullopt_t, const optional<T>& x) noexcept {
+  return bool(x);
+}
+
+template <class T>
+constexpr bool operator<(const optional<T>&, nullopt_t) noexcept {
+  return false;
+}
+
+template <class T>
+constexpr bool operator<(nullopt_t, const optional<T>& x) noexcept {
+  return bool(x);
+}
+
+template <class T>
+constexpr bool operator<=(const optional<T>& x, nullopt_t) noexcept {
+  return (!x);
+}
+
+template <class T>
+constexpr bool operator<=(nullopt_t, const optional<T>&) noexcept {
+  return true;
+}
+
+template <class T>
+constexpr bool operator>(const optional<T>& x, nullopt_t) noexcept {
+  return bool(x);
+}
+
+template <class T>
+constexpr bool operator>(nullopt_t, const optional<T>&) noexcept {
+  return false;
+}
+
+template <class T>
+constexpr bool operator>=(const optional<T>&, nullopt_t) noexcept {
+  return true;
+}
+
+template <class T>
+constexpr bool operator>=(nullopt_t, const optional<T>& x) noexcept {
+  return (!x);
+}
+
+// 20.5.10, Comparison with T
+template <class T>
+constexpr bool operator==(const optional<T>& x, const T& v) {
+  return bool(x) ? *x == v : false;
+}
+
+template <class T>
+constexpr bool operator==(const T& v, const optional<T>& x) {
+  return bool(x) ? v == *x : false;
+}
+
+template <class T>
+constexpr bool operator!=(const optional<T>& x, const T& v) {
+  return bool(x) ? *x != v : true;
+}
+
+template <class T>
+constexpr bool operator!=(const T& v, const optional<T>& x) {
+  return bool(x) ? v != *x : true;
+}
+
+template <class T>
+constexpr bool operator<(const optional<T>& x, const T& v) {
+  return bool(x) ? *x < v : true;
+}
+
+template <class T>
+constexpr bool operator>(const T& v, const optional<T>& x) {
+  return bool(x) ? v > *x : true;
+}
+
+template <class T>
+constexpr bool operator>(const optional<T>& x, const T& v) {
+  return bool(x) ? *x > v : false;
+}
+
+template <class T>
+constexpr bool operator<(const T& v, const optional<T>& x) {
+  return bool(x) ? v < *x : false;
+}
+
+template <class T>
+constexpr bool operator>=(const optional<T>& x, const T& v) {
+  return bool(x) ? *x >= v : false;
+}
+
+template <class T>
+constexpr bool operator<=(const T& v, const optional<T>& x) {
+  return bool(x) ? v <= *x : false;
+}
+
+template <class T>
+constexpr bool operator<=(const optional<T>& x, const T& v) {
+  return bool(x) ? *x <= v : true;
+}
+
+template <class T>
+constexpr bool operator>=(const T& v, const optional<T>& x) {
+  return bool(x) ? v >= *x : true;
+}
+
+// Comparison of optional<T&> with T
+template <class T>
+constexpr bool operator==(const optional<T&>& x, const T& v) {
+  return bool(x) ? *x == v : false;
+}
+
+template <class T>
+constexpr bool operator==(const T& v, const optional<T&>& x) {
+  return bool(x) ? v == *x : false;
+}
+
+template <class T>
+constexpr bool operator!=(const optional<T&>& x, const T& v) {
+  return bool(x) ? *x != v : true;
+}
+
+template <class T>
+constexpr bool operator!=(const T& v, const optional<T&>& x) {
+  return bool(x) ? v != *x : true;
+}
+
+template <class T>
+constexpr bool operator<(const optional<T&>& x, const T& v) {
+  return bool(x) ? *x < v : true;
+}
+
+template <class T>
+constexpr bool operator>(const T& v, const optional<T&>& x) {
+  return bool(x) ? v > *x : true;
+}
+
+template <class T>
+constexpr bool operator>(const optional<T&>& x, const T& v) {
+  return bool(x) ? *x > v : false;
+}
+
+template <class T>
+constexpr bool operator<(const T& v, const optional<T&>& x) {
+  return bool(x) ? v < *x : false;
+}
+
+template <class T>
+constexpr bool operator>=(const optional<T&>& x, const T& v) {
+  return bool(x) ? *x >= v : false;
+}
+
+template <class T>
+constexpr bool operator<=(const T& v, const optional<T&>& x) {
+  return bool(x) ? v <= *x : false;
+}
+
+template <class T>
+constexpr bool operator<=(const optional<T&>& x, const T& v) {
+  return bool(x) ? *x <= v : true;
+}
+
+template <class T>
+constexpr bool operator>=(const T& v, const optional<T&>& x) {
+  return bool(x) ? v >= *x : true;
+}
+
+// Comparison of optional<T const&> with T
+template <class T>
+constexpr bool operator==(const optional<const T&>& x, const T& v) {
+  return bool(x) ? *x == v : false;
+}
+
+template <class T>
+constexpr bool operator==(const T& v, const optional<const T&>& x) {
+  return bool(x) ? v == *x : false;
+}
+
+template <class T>
+constexpr bool operator!=(const optional<const T&>& x, const T& v) {
+  return bool(x) ? *x != v : true;
+}
+
+template <class T>
+constexpr bool operator!=(const T& v, const optional<const T&>& x) {
+  return bool(x) ? v != *x : true;
+}
+
+template <class T>
+constexpr bool operator<(const optional<const T&>& x, const T& v) {
+  return bool(x) ? *x < v : true;
+}
+
+template <class T>
+constexpr bool operator>(const T& v, const optional<const T&>& x) {
+  return bool(x) ? v > *x : true;
+}
+
+template <class T>
+constexpr bool operator>(const optional<const T&>& x, const T& v) {
+  return bool(x) ? *x > v : false;
+}
+
+template <class T>
+constexpr bool operator<(const T& v, const optional<const T&>& x) {
+  return bool(x) ? v < *x : false;
+}
+
+template <class T>
+constexpr bool operator>=(const optional<const T&>& x, const T& v) {
+  return bool(x) ? *x >= v : false;
+}
+
+template <class T>
+constexpr bool operator<=(const T& v, const optional<const T&>& x) {
+  return bool(x) ? v <= *x : false;
+}
+
+template <class T>
+constexpr bool operator<=(const optional<const T&>& x, const T& v) {
+  return bool(x) ? *x <= v : true;
+}
+
+template <class T>
+constexpr bool operator>=(const T& v, const optional<const T&>& x) {
+  return bool(x) ? v >= *x : true;
+}
+
+// 20.5.12, Specialized algorithms
+template <class T>
+void swap(optional<T>& x, optional<T>& y) noexcept(noexcept(x.swap(y))) {
+  x.swap(y);
+}
+
+template <class T>
+constexpr optional<typename std::decay<T>::type> make_optional(T&& v) {
+  return optional<typename std::decay<T>::type>(constexpr_forward<T>(v));
+}
+
+template <class X>
+constexpr optional<X&> make_optional(std::reference_wrapper<X> v) {
+  return optional<X&>(v.get());
+}
+
+} // namespace multipy
+
+namespace std {
+template <typename T>
+struct hash<multipy::optional<T>> {
+  typedef typename hash<T>::result_type result_type;
+  typedef multipy::optional<T> argument_type;
+
+  constexpr result_type operator()(argument_type const& arg) const {
+    return arg ? std::hash<T>{}(*arg) : result_type{};
+  }
+};
+
+template <typename T>
+struct hash<multipy::optional<T&>> {
+  typedef typename hash<T>::result_type result_type;
+  typedef multipy::optional<T&> argument_type;
+
+  constexpr result_type operator()(argument_type const& arg) const {
+    return arg ? std::hash<T>{}(*arg) : result_type{};
+  }
+};
+} // namespace std
+
+#undef TR2_OPTIONAL_REQUIRES
+#undef TR2_OPTIONAL_ASSERTED_EXPRESSION
+
+#endif //___OPTIONAL_HPP___

--- a/torch/csrc/deploy/interpreter/builtin_registry.cpp
+++ b/torch/csrc/deploy/interpreter/builtin_registry.cpp
@@ -1,6 +1,7 @@
 #include <Python.h>
 #include <c10/util/Exception.h>
 #include <fmt/format.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/interpreter/builtin_registry.h>
 
 namespace torch {

--- a/torch/csrc/deploy/interpreter/import_find_sharedfuncptr.cpp
+++ b/torch/csrc/deploy/interpreter/import_find_sharedfuncptr.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/deploy/loader.h>
+#include <sstream>
 #include <vector>
 
 using torch::deploy::CustomLibrary;

--- a/torch/csrc/deploy/interpreter/interpreter_impl.cpp
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.cpp
@@ -220,8 +220,8 @@ struct __attribute__((visibility("hidden"))) ConcreteInterpreterImpl
   }
 
   void setFindModule(
-      std::function<at::optional<std::string>(const std::string&)> find_module)
-      override {
+      std::function<multipy::optional<std::string>(const std::string&)>
+          find_module) override {
     std::function<py::object(const std::string&)> wrapped_find_module =
         [=](const std::string& name) -> py::object {
       auto r = find_module(name);

--- a/torch/csrc/deploy/interpreter/interpreter_impl.cpp
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.cpp
@@ -9,6 +9,7 @@
 #include <pybind11/functional.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 
 #include <cassert>

--- a/torch/csrc/deploy/interpreter/interpreter_impl.h
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.h
@@ -15,8 +15,8 @@
    the client application.
 
    It is safe to throw exception types that are defined once in
-   the context of the client application, such as c10::Error, which is defined
-   in libtorch, which isn't duplicated in torch::deploy interpreters.
+   the context of the client application, such as std::runtime_error,
+   which isn't duplicated in torch::deploy interpreters.
 
    ==> Use TORCH_DEPLOY_TRY, _SAFE_CATCH_RETHROW around _ALL_ torch::deploy APIs
 
@@ -30,20 +30,17 @@
 
 */
 #define TORCH_DEPLOY_TRY try {
-#define TORCH_DEPLOY_SAFE_CATCH_RETHROW                                        \
-  }                                                                            \
-  catch (std::exception & err) {                                               \
-    throw c10::Error(                                                          \
-        std::string(                                                           \
-            "Exception Caught inside torch::deploy embedded library: \n") +    \
-            err.what(),                                                        \
-        "");                                                                   \
-  }                                                                            \
-  catch (...) {                                                                \
-    throw c10::Error(                                                          \
-        std::string(                                                           \
-            "Unknown Exception Caught inside torch::deploy embedded library"), \
-        "");                                                                   \
+#define TORCH_DEPLOY_SAFE_CATCH_RETHROW                                     \
+  }                                                                         \
+  catch (std::exception & err) {                                            \
+    throw std::runtime_error(                                               \
+        std::string(                                                        \
+            "Exception Caught inside torch::deploy embedded library: \n") + \
+        err.what());                                                        \
+  }                                                                         \
+  catch (...) {                                                             \
+    throw std::runtime_error(std::string(                                   \
+        "Unknown Exception Caught inside torch::deploy embedded library")); \
   }
 namespace torch {
 namespace deploy {

--- a/torch/csrc/deploy/interpreter/interpreter_impl.h
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.h
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <ATen/core/ivalue.h>
 #include <caffe2/serialize/inline_container.h>
+#include <torch/csrc/deploy/interpreter/Optional.hpp>
 
 /* Torch Deploy intentionally embeds multiple copies of c++ libraries
    providing python bindings necessary for torch::deploy users in the same
@@ -129,7 +130,7 @@ struct InterpreterSessionImpl {
 struct InterpreterImpl {
   virtual InterpreterSessionImpl* acquireSession() = 0;
   virtual void setFindModule(
-      std::function<at::optional<std::string>(const std::string&)>
+      std::function<multipy::optional<std::string>(const std::string&)>
           find_module) = 0;
   virtual ~InterpreterImpl() = default; // this will uninitialize python
 };

--- a/torch/csrc/deploy/loader.h
+++ b/torch/csrc/deploy/loader.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <c10/util/Optional.h>
 #include <dlfcn.h>
 #include <elf.h>
+#include <torch/csrc/deploy/interpreter/Optional.hpp>
 #include <memory>
 
 namespace torch {
@@ -19,8 +19,8 @@ struct TLSIndex {
 
 struct SymbolProvider {
   SymbolProvider() = default;
-  virtual at::optional<Elf64_Addr> sym(const char* name) const = 0;
-  virtual at::optional<TLSIndex> tls_sym(const char* name) const = 0;
+  virtual multipy::optional<Elf64_Addr> sym(const char* name) const = 0;
+  virtual multipy::optional<TLSIndex> tls_sym(const char* name) const = 0;
   SymbolProvider(const SymbolProvider&) = delete;
   SymbolProvider& operator=(const SymbolProvider&) = delete;
   virtual ~SymbolProvider() = default;

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -182,13 +182,14 @@ TEST(TorchpyTest, ErrorsReplicatingObj) {
   auto obj = session1.fromMovable(replicatedObj);
   // should throw an error when trying to access obj from different session
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(session2.createMovable(obj), c10::Error);
+  EXPECT_THROW(session2.createMovable(obj), std::runtime_error);
   try {
     session2.createMovable(obj);
-  } catch (c10::Error& error) {
+  } catch (std::runtime_error& error) {
     EXPECT_TRUE(
-        error.msg().find(
-            "Cannot create movable from an object that lives in different session") !=
+        std::string(error.what())
+            .find(
+                "Cannot create movable from an object that lives in different session") !=
         std::string::npos);
   }
 }
@@ -197,15 +198,15 @@ TEST(TorchpyTest, ThrowsSafely) {
   // See explanation in deploy.h
   torch::deploy::InterpreterManager manager(3);
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(manager.loadPackage("some garbage path"), c10::Error);
+  EXPECT_THROW(manager.loadPackage("some garbage path"), std::runtime_error);
 
   torch::deploy::Package p = manager.loadPackage(path("SIMPLE", simple));
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(p.loadPickle("some other", "garbage path"), c10::Error);
+  EXPECT_THROW(p.loadPickle("some other", "garbage path"), std::runtime_error);
 
   auto model = p.loadPickle("model", "model.pkl");
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(model(at::IValue("unexpected input")), c10::Error);
+  EXPECT_THROW(model(at::IValue("unexpected input")), std::runtime_error);
 }
 
 TEST(TorchpyTest, AcquireMultipleSessionsInTheSamePackage) {
@@ -238,7 +239,7 @@ TEST(TorchpyTest, TensorSharingNotAllowed) {
   auto t = obj.toIValue().toTensor();
   // try to feed it to the other interpreter, should error
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  ASSERT_THROW(I1.global("torch", "sigmoid")({t}), c10::Error);
+  ASSERT_THROW(I1.global("torch", "sigmoid")({t}), std::runtime_error);
 }
 
 TEST(TorchpyTest, TaggingRace) {
@@ -259,7 +260,7 @@ TEST(TorchpyTest, TaggingRace) {
         try {
           I.fromIValue(t);
           success++;
-        } catch (const c10::Error& e) {
+        } catch (const std::runtime_error& e) {
           failed++;
         }
       }
@@ -279,7 +280,7 @@ TEST(TorchpyTest, DisarmHook) {
   torch::deploy::InterpreterManager m(1);
   auto I = m.acquireOne();
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  ASSERT_THROW(I.fromIValue(t), c10::Error); // NOT a segfault
+  ASSERT_THROW(I.fromIValue(t), std::runtime_error); // NOT a segfault
 }
 
 TEST(TorchpyTest, RegisterModule) {

--- a/torch/csrc/deploy/test_deploy_missing_interpreter.cpp
+++ b/torch/csrc/deploy/test_deploy_missing_interpreter.cpp
@@ -10,5 +10,5 @@ int main(int argc, char* argv[]) {
 
 TEST(TorchDeployMissingInterpreter, Throws) {
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(torch::deploy::InterpreterManager(1), c10::Error);
+  EXPECT_THROW(torch::deploy::InterpreterManager(1), std::runtime_error);
 }

--- a/torch/csrc/deploy/unity/xar_environment.cpp
+++ b/torch/csrc/deploy/unity/xar_environment.cpp
@@ -2,6 +2,7 @@
 #include <dlfcn.h>
 #include <fmt/format.h>
 #include <sys/stat.h>
+#include <torch/csrc/deploy/Exception.h>
 #include <torch/csrc/deploy/elf_file.h>
 #include <torch/csrc/deploy/unity/xar_environment.h>
 
@@ -59,7 +60,7 @@ bool _fileExists(const std::string& filePath) {
 }
 
 void XarEnvironment::setupPythonApp() {
-  TORCH_CHECK(
+  MULTIPY_CHECK(
       !alreadySetupPythonApp_,
       "Already setup the python application. It should only been done once!");
 
@@ -67,7 +68,7 @@ void XarEnvironment::setupPythonApp() {
   constexpr const char* SECTION_NAME = ".torch_deploy_payload.unity";
   ElfFile elfFile(exePath_.c_str());
   auto payloadSection = elfFile.findSection(SECTION_NAME);
-  TORCH_CHECK(payloadSection != at::nullopt, "Missing the payload section");
+  MULTIPY_CHECK(payloadSection != at::nullopt, "Missing the payload section");
   const char* pythonAppPkgStart = payloadSection->start;
   auto pythonAppPkgSize = payloadSection->len;
   LOG(INFO) << "Embedded binary size " << pythonAppPkgSize;
@@ -107,23 +108,26 @@ void XarEnvironment::setupPythonApp() {
    * past runs. It should be pretty safe to discard them.
    */
   std::string rmCmd = fmt::format("rm -rf {}", pythonAppDir_);
-  TORCH_CHECK(system(rmCmd.c_str()) == 0, "Fail to remove the directory.");
+  MULTIPY_CHECK(system(rmCmd.c_str()) == 0, "Fail to remove the directory.");
 
   // recreate the directory
   auto r = mkdir(pythonAppDir_.c_str(), 0777);
-  TORCH_CHECK(r == 0, "Failed to create directory: ", strerror(errno));
+  MULTIPY_CHECK(r == 0, "Failed to create directory: " + strerror(errno));
 
   std::string pythonAppArchive = std::string(pythonAppDir_) + "/python_app.xar";
   auto fp = fopen(pythonAppArchive.c_str(), "wb");
-  TORCH_CHECK(fp != nullptr, "Fail to create file: ", strerror(errno));
+  MULTIPY_CHECK(fp != nullptr, "Fail to create file: " + strerror(errno));
   auto written = fwrite(pythonAppPkgStart, 1, pythonAppPkgSize, fp);
-  TORCH_CHECK(written == pythonAppPkgSize, "Expected written == size");
+  MULTIPY_CHECK(written == pythonAppPkgSize, "Expected written == size");
   fclose(fp);
 
   std::string extractCommand = fmt::format(
       "unsquashfs -o 4096 -d {} {}", pythonAppRoot_, pythonAppArchive);
   r = system(extractCommand.c_str());
-  TORCH_CHECK(r == 0, "Fail to extract the python package");
+  MULTIPY_CHECK(
+      r == 0,
+      "Fail to extract the python package" + std::to_string(r) +
+          extractCommand.c_str());
 
   alreadySetupPythonApp_ = true;
 }
@@ -143,12 +147,9 @@ void XarEnvironment::preloadSharedLibraries() {
                 << " does not exist in the python app root, skip loading it";
       continue;
     }
-    TORCH_CHECK(
+    MULTIPY_CHECK(
         dlopen(preloadList[i], RTLD_GLOBAL | RTLD_LAZY) != nullptr,
-        "Fail to open the shared library ",
-        preloadList[i],
-        ": ",
-        dlerror());
+        "Fail to open the shared library " + preloadList[i] + ": " + dlerror());
   }
 }
 

--- a/torch/csrc/deploy/unity/xar_environment.cpp
+++ b/torch/csrc/deploy/unity/xar_environment.cpp
@@ -68,7 +68,8 @@ void XarEnvironment::setupPythonApp() {
   constexpr const char* SECTION_NAME = ".torch_deploy_payload.unity";
   ElfFile elfFile(exePath_.c_str());
   auto payloadSection = elfFile.findSection(SECTION_NAME);
-  MULTIPY_CHECK(payloadSection != at::nullopt, "Missing the payload section");
+  MULTIPY_CHECK(
+      payloadSection != multipy::nullopt, "Missing the payload section");
   const char* pythonAppPkgStart = payloadSection->start;
   auto pythonAppPkgSize = payloadSection->len;
   LOG(INFO) << "Embedded binary size " << pythonAppPkgSize;


### PR DESCRIPTION
Summary:
This diff replaces `c10::optional` with the implementation it's based on in https://github.com/akrzemi1/Optional
 in order to help torch::deploy function without a dependency on `torch`

https://github.com/pytorch/pytorch/pull/74002

Test Plan: buck test //caffe2/torch/csrc/deploy:test_deploy

Differential Revision: D34907002

