### PR TITLE
[pkg] Improve mocked module detection by combining mocked object errors with the rest of the errors in PackageExporter

### DIFF
--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -182,7 +182,7 @@ class TestDependencyAPI(PackageTestCase):
         obj2 = package_a.PackageAObject(obj)
 
         buffer = BytesIO()
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(PackagingError):
             with PackageExporter(buffer) as he:
                 he.mock(include="package_a.subpackage")
                 he.intern("**")

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -84,6 +84,11 @@ class PackagingErrorReason(Enum):
         "Module did not match against any action pattern. Extern, mock, or intern it."
     )
     DENIED = "Module was denied by a pattern."
+    MOCKED_BUT_STILL_USED = (
+        "Module was mocked out, but is still being used in the package. "
+        "Please intern or extern the mocked modules if objects are supposed to be in "
+        "the package."
+    )
 
 
 @dataclass
@@ -586,7 +591,7 @@ class PackageExporter:
         pickler.persistent_id = self._persistent_id
         pickler.dump(obj)
         data_value = data_buf.getvalue()
-
+        mocked_modules = defaultdict(list)
         name_in_dependency_graph = f"<{package}.{resource}>"
         self.dependency_graph.add_node(
             name_in_dependency_graph,
@@ -596,6 +601,15 @@ class PackageExporter:
         )
 
         def _check_mocked_error(module: Optional[str], field: Optional[str]):
+            """
+            checks if an object (field) comes from a mocked module and then adds
+            the pair to mocked_modules which contains mocked modules paired with their
+            list of mocked objects present in the pickle.
+
+            We also hold the invariant that the first user defined rule that applies
+            to the module is the one we use.
+            """
+
             assert isinstance(module, str)
             assert isinstance(field, str)
             if self._can_implicitly_extern(module):
@@ -603,15 +617,8 @@ class PackageExporter:
             for pattern, pattern_info in self.patterns.items():
                 if pattern.matches(module):
                     if pattern_info.action == _ModuleProviderAction.MOCK:
-                        raise NotImplementedError(
-                            f"Object '{field}' from module {module} was mocked out during packaging "
-                            f"but is being used in resource - {resource} in package {package}. "
-                            "If this error is happening during 'save_pickle', please ensure that your "
-                            "pickled object doesn't contain any mocked objects. Try interning or externing"
-                            f"{module} if {field} is supposed to be in the package."
-                        )
-                    else:
-                        return
+                        mocked_modules[module].append(field)
+                    return
 
         if dependencies:
             all_dependencies = []
@@ -655,7 +662,22 @@ class PackageExporter:
                     _check_mocked_error(module, field)
             for module_name in all_dependencies:
                 self.dependency_graph.add_edge(name_in_dependency_graph, module_name)
-                self.add_dependency(module_name)
+
+                """ If an object happens to come from a mocked module, then we collect these errors and spit them
+                    out with the other errors found by package exporter.
+                """
+                if module in mocked_modules:
+                    fields = mocked_modules[module]
+                    self.dependency_graph.add_node(
+                        module_name,
+                        action=_ModuleProviderAction.MOCK,
+                        error=PackagingErrorReason.MOCKED_BUT_STILL_USED,
+                        error_context=f"Object(s) '{fields}' from module `{module_name}` was mocked out during packaging "
+                                      f"but is being used in resource - `{resource}` in package `{package}`. ",
+                        provided=True,
+                    )
+                else:
+                    self.add_dependency(module_name)
 
         self._write(filename, data_value)
 

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -667,6 +667,7 @@ class PackageExporter:
                     out with the other errors found by package exporter.
                 """
                 if module in mocked_modules:
+                    assert isinstance(module, str)
                     fields = mocked_modules[module]
                     self.dependency_graph.add_node(
                         module_name,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74315

Now instead of spitting out a NotImplemented Error when the Package Exporter finds an object for a mocked module, it combines these errors with the rest of the Packaging Errors of PackageExporter to get something like 

```
torch.package.package_exporter.PackagingError: 
* Module was mocked out, but is still being used in the package.Please intern or extern the mocked modules if objects are supposed to be inthe package.
    package_a
      Context: Object(s) '['PackageASubpackageObject']' from module package_a was mocked out during packaging but is being used in resource - obj.pkl in package obj. 
    package_a.subpackage
      Context: Object(s) '['PackageASubpackageObject']' from module package_a.subpackage was mocked out during packaging but is being used in resource - obj.pkl in package obj. 
```

This makes it significantly easier to fix mocked object errors as they all should appear at once.

Differential Revision: [D34951973](https://our.internmc.facebook.com/intern/diff/D34951973)