### PR TITLE
Pin unittest-xml-reporting to freeze printing test summary logic

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -97,11 +97,12 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Pin SciPy because of failing distribution tests (see #60347)
   # Pin MyPy version because new errors are likely to appear with each release
   # Pin hypothesis to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
+  # Pin unittest-xml-reporting to freeze printing test summary logic, related: https://github.com/pytorch/pytorch/issues/69014
   as_jenkins pip install --progress-bar off pytest \
     scipy==1.6.3 \
     scikit-image \
     psutil \
-    unittest-xml-reporting \
+    "unittest-xml-reporting<=3.2.0,>=2.0.0" \
     boto3==1.16.34 \
     hypothesis==4.53.2 \
     expecttest==0.1.3 \

--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -10,7 +10,9 @@ conda install -y six
 pip install -q hypothesis "expecttest==0.1.3" "librosa>=0.6.2" "numba<=0.49.1" psutil "scipy==1.6.3"
 
 # TODO move this to docker
-pip install unittest-xml-reporting pytest
+# Pin unittest-xml-reporting to freeze printing test summary logic, related: https://github.com/pytorch/pytorch/issues/69014
+pip install "unittest-xml-reporting<=3.2.0,>=2.0.0" \
+  pytest
 
 if [ -z "${IN_CI}" ]; then
   rm -rf "${WORKSPACE_DIR}"/miniconda3/lib/python3.6/site-packages/torch*

--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -13,7 +13,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 echo "Testing pytorch (distributed only)"
 if [ -n "${IN_CI}" ]; then
   # TODO move this to docker
-  pip_install unittest-xml-reporting
+  # Pin unittest-xml-reporting to freeze printing test summary logic, related: https://github.com/pytorch/pytorch/issues/69014
+  pip_install "unittest-xml-reporting<=3.2.0,>=2.0.0"
 fi
 
 # Disabling tests to see if they solve timeout issues; see https://github.com/pytorch/pytorch/issues/70015

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -34,7 +34,9 @@ popd
 
 :: The version is fixed to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
 =======
-pip install "ninja==1.10.0.post1" future "hypothesis==4.53.2" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" psutil pillow unittest-xml-reporting pytest
+:: Pin unittest-xml-reporting to freeze printing test summary logic, related: https://github.com/pytorch/pytorch/issues/69014
+
+pip install "ninja==1.10.0.post1" future "hypothesis==4.53.2" "expecttest==0.1.3" "librosa>=0.6.2" "scipy==1.6.3" psutil pillow "unittest-xml-reporting<=3.2.0,>=2.0.0" pytest
 if errorlevel 1 exit /b
 if not errorlevel 0 exit /b
 


### PR DESCRIPTION
In PR https://github.com/pytorch/pytorch/pull/74254 I mitigate issue https://github.com/pytorch/pytorch/issues/69014 by changing internals of unittest-xml-runner package, so that skip reason is printed in the summary. The package version is pinned to avoid breaking if unittest-xml-runner implementation details change. unittest-xml-runner==2.0.0 introduces testinfo property that is necessary so it should be the earliest version that works. unittest-xml-runner==3.2.0 is the current latest version

Please merge before https://github.com/pytorch/pytorch/pull/74254