### PR TITLE
[WIP][fx2trt] Replacing fp16 and int8 mode with enum type (#24)

### DIFF
--- a/torch/testing/_internal/common_fx2trt.py
+++ b/torch/testing/_internal/common_fx2trt.py
@@ -10,6 +10,7 @@ from fx2trt_oss.fx import (
     TRTModule,
 )
 from fx2trt_oss.fx.passes.pass_utils import chain_passes
+from fx2trt_oss.fx.utils import LowerPrecision
 from torch.testing._internal.common_utils import TestCase
 from torch.fx.experimental.normalize import NormalizeArgs
 from torch.fx.passes import shape_prop
@@ -54,7 +55,7 @@ class TRTTestCase(TestCase):
             if unexpected_ops:
                 self.assert_unexpected_op(mod, unexpected_ops)
 
-            interpreter_result = interpreter.run(fp16_mode=False)
+            interpreter_result = interpreter.run(lower_precision=LowerPrecision.FP16)
             trt_mod = TRTModule(
                 interpreter_result.engine,
                 interpreter_result.input_names,
@@ -101,7 +102,7 @@ class TRTTestCase(TestCase):
             if len(expected_ops):
                 self.assert_has_op(mod, expected_ops)
 
-            interpreter_result = interpreter.run(fp16_mode=fp16_mode)
+            interpreter_result = interpreter.run(lower_precision=LowerPrecision.FP16)
             trt_mod = TRTModule(
                 interpreter_result.engine,
                 interpreter_result.input_names,
@@ -126,7 +127,7 @@ class TRTTestCase(TestCase):
                     cuda_inputs.append(i.cuda())
 
                 mod.eval()
-                interpreter.run(fp16_mode=False)
+                interpreter.run(lower_precision=LowerPrecision.FP32)
 
     def assert_has_op(self, mod, ops):
         ops_in_mod = set()


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/fx2trt/pull/24

X-link: https://github.com/pytorch/benchmark/pull/805

Test Plan: CI

Differential Revision: D34929680

