### PR TITLE
supporting complex with requires_grad in autodiff

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1094,22 +1094,6 @@ class TestJit(JitTestCase):
         checkBackwardTwiceScript(test_script_backward_twice_with_saved_values, (inp1, inp2), False)
         checkBackwardTwiceScript(test_script_backward_twice_with_saved_values, (inp1, inp2), True)
 
-    def test_autodiff_complex(self):
-        def foo(x: torch.Tensor, y: torch.Tensor, W: torch.Tensor):
-            return torch.exp(torch.mm(torch.complex(x, y), W.cfloat()))
-        
-        @torch.jit.script
-        def jitted_foo(x: torch.Tensor, y: torch.Tensor, W: torch.Tensor):
-            return torch.exp(torch.mm(torch.complex(x, y), W.cfloat()))
-        
-        x = torch.randn(128, 16, dtype=torch.float32, device='cuda:0')
-        y = torch.randn(128, 16, dtype=torch.float32, device='cuda:0')
-        W = torch.randn(16, 1, dtype=torch.float32, device='cuda:0', requires_grad=True)
-        W.data /= 4
-
-        for i in range(4):
-          self.assertTrue((foo(x, y, W).grad_fn is None) and (jitted_foo(x, y, W).grad_fn is None))
-
     def test_diff_subgraph_clones_constants(self):
         @torch.jit.script
         def f(x, y):
@@ -11063,6 +11047,25 @@ dedent """
         if GRAPH_EXECUTOR != ProfilingMode.SIMPLE:
             FileCheck().check("Double(*, *, requires_grad=0, device=cpu)") \
                        .check_not("Float(*, *, requires_grad=0, device=cpu)").run(randint.graph_for())
+
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING, "skip if profiling isn't enabled")
+    def test_autodiff_complex(self):
+        def foo(x: torch.Tensor, y: torch.Tensor, W: torch.Tensor):
+            return torch.exp(torch.mm(torch.complex(x, y), W.cfloat()))
+
+        @torch.jit.script
+        def jitted_foo(x: torch.Tensor, y: torch.Tensor, W: torch.Tensor):
+            return torch.exp(torch.mm(torch.complex(x, y), W.cfloat()))
+
+        x = torch.randn(128, 16, dtype=torch.float32, device='cuda:0')
+        y = torch.randn(128, 16, dtype=torch.float32, device='cuda:0')
+        W = torch.randn(16, 1, dtype=torch.float32, device='cuda:0', requires_grad=True)
+        W.data /= 4
+
+        with enable_profiling_mode_for_profiling_tests():
+            for i in range(4):
+                self.assertTrue((foo(x, y, W).grad_fn is None) == (jitted_foo(x, y, W).grad_fn is None))
+
 
     def test_linear_grad(self):
         with enable_profiling_mode_for_profiling_tests():

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -11048,6 +11048,7 @@ dedent """
             FileCheck().check("Double(*, *, requires_grad=0, device=cpu)") \
                        .check_not("Float(*, *, requires_grad=0, device=cpu)").run(randint.graph_for())
 
+    @unittest.skipIf(not RUN_CUDA, "no CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING, "skip if profiling isn't enabled")
     def test_autodiff_complex(self):
         def foo(x: torch.Tensor, y: torch.Tensor, W: torch.Tensor):

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -322,7 +322,8 @@ struct DifferentiableGraphBackward : public autograd::Node {
     // NB: since our requires_grad setting is only a heuristic we might end
     // up wanting to differentiate through integral tensors, which is
     // generally a hard error in autograd.
-    if (at::isFloatingType(output.scalar_type())) {
+    if (at::isFloatingType(output.scalar_type())
+        || at::isComplexType(output.scalar_type())) {
       autograd::create_gradient_edge(output, shared_from_this());
       output.set_requires_grad(true);
     } else {


### PR DESCRIPTION
Fixes #65480

autodiff should propagate requires_grad for complex tensors as well as float tensors.