### PR TITLE
utils: Only check for xnnpack if torch installed

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -294,8 +294,11 @@ def get_cachingallocator_config():
     return ca_config
 
 def is_xnnpack_available():
-    import torch.backends.xnnpack
-    return str(torch.backends.xnnpack.enabled)  # type: ignore[attr-defined]
+    if TORCH_AVAILABLE:
+        import torch.backends.xnnpack
+        return str(torch.backends.xnnpack.enabled)  # type: ignore[attr-defined]
+    else:
+        return "N/A"
 
 def get_env_info():
     run_lambda = run


### PR DESCRIPTION
Fixes a bug where collect_env.py was not able to be run without having
torch installed

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
