### PR TITLE
Throw python_error if the call returns nullptr.

### DIFF
--- a/torch/csrc/utils/disable_torch_function.cpp
+++ b/torch/csrc/utils/disable_torch_function.cpp
@@ -169,7 +169,9 @@ PyObject* THPModule_disable_torch_dispatch(PyObject *self, PyObject *a) {
       // included in AFTER, so it is included in the negation (and that's
       // correct: we want to exclude Python key and everything BEFORE it.)
   );
-  return PyObject_Call(func, py_args.ptr(), kwargs);
+  auto r = PyObject_Call(func, py_args.ptr(), kwargs);
+  if (r == nullptr) throw python_error();
+  return r;
   END_HANDLE_TH_ERRORS
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74357

It's necessary to throw an exception so that PyWarningHandler
knows that there is already an exception and it properly
propagates it.

I need to think about how to lint for this situation in the
future.  I also need to work out how to test this fix (my
local repro is fixed after this change).

Fixes https://github.com/pytorch/pytorch/issues/74334

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D34949272](https://our.internmc.facebook.com/intern/diff/D34949272)