### PR TITLE
Added proxy tensor 

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -27,6 +27,7 @@ from torch.fx.experimental.partitioner_utils import (
 from torch.fx.experimental.rewriter import RewritingTracer
 from torch.fx.experimental.schema_type_annotation import AnnotateTypesWithSchema
 from torch.fx.experimental.meta_tracer import MetaTracer
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.graph_module import GraphModule
 from torch.fx.node import Node
 from torch.fx.operator_schemas import (
@@ -689,6 +690,14 @@ class TestFXExperimental(JitTestCase):
             gm = torch.fx.GraphModule(mttm, graph)
             torch.testing.assert_close(gm(x), mttm(x))
 
+    def test_proxy_tensor(self):
+        def f(x):
+            val = x.cos().cos().sum()
+            return torch.autograd.grad(val, x)
+
+        traced_graph = make_fx(f)(torch.randn(3, requires_grad=True))
+        inp = torch.randn(3, requires_grad=True)
+        torch.testing.assert_close(traced_graph(inp), f(inp))
 
     def test_call_to_assert_with_msg(self):
         class M(torch.nn.Module):

--- a/torch/fx/_proxy_tensor.py
+++ b/torch/fx/_proxy_tensor.py
@@ -1,0 +1,201 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import functools
+from typing import Any, Dict, Optional, Tuple, Callable, Union
+import torch
+from torch._C import _disabled_torch_function_impl
+import torch.utils._pytree as pytree
+from torch.fx import Tracer, GraphModule
+import torch.fx as fx
+from torch.fx.passes.shape_prop import _extract_tensor_metadata
+from contextlib import contextmanager
+
+aten = torch.ops.aten
+
+CURRENT_DECOMPOSITION_TABLE = {}
+
+
+@contextmanager
+def no_dispatch():
+    guard = torch._C._DisableTorchDispatch()
+    try:
+        yield
+    finally:
+        del guard
+
+
+@contextmanager
+def pythonkey_decompose(decomposition_table):
+    global CURRENT_DECOMPOSITION_TABLE
+    CURRENT_DECOMPOSITION_TABLE = decomposition_table
+    try:
+        yield CURRENT_DECOMPOSITION_TABLE
+    finally:
+        CURRENT_DECOMPOSITION_TABLE = {}
+
+
+class ProxyTensor(torch.Tensor):
+    elem: torch.Tensor
+
+    __slots__ = ['elem', 'proxy']
+
+    @staticmethod
+    def __new__(cls, elem, proxy):
+        # Wrapping something in ProxyTensor implicitly detaches
+        # gradients.  If something required grad, we will collect it as if it
+        # were a leaf.  A consequence of detaching in this way is you
+        # need to maintain a parameter cache when translating tensors
+        # into ProxyTensor, so you don't create multiple copies of
+        # a gradient (they are aliased, but they would count as independent
+        # leaves).  An alternate strategy would be to avoid implicitly
+        # detaching and instead "catch" gradients as they exit the
+        # ProxyTensor boundary.
+        # assert not elem.requires_grad or not torch.is_grad_enabled()
+
+        r = torch.Tensor._make_subclass(cls, elem, elem.requires_grad)
+        r.proxy = proxy
+        proxy.node.meta['tensor_meta'] = _extract_tensor_metadata(r)
+        return r
+
+    def __repr__(self):
+        # This is a bit goofy but whatever.  Should fix up _tensor_str.py to
+        # work on subclasses when it calls tolist
+        return f"ProxyTensor({torch.Tensor._make_subclass(torch.Tensor, self)})"
+
+    __torch_function__ = _disabled_torch_function_impl
+
+    @classmethod
+    def __torch_dispatch__(cls, func_overload, types, args=(), kwargs=None):
+        func = func_overload.overloadpacket
+        if func_overload in CURRENT_DECOMPOSITION_TABLE:
+            return CURRENT_DECOMPOSITION_TABLE[func_overload](*args, **kwargs)
+        # Commenting this out for now since it causes some spurious failures (such as error checking)
+        # if func == aten._local_scalar_dense:
+        #     raise RuntimeError("It appears that you're trying to get value out of a tracing tensor - erroring out! "
+        #                        "It's likely that this is caused by data-dependent control flow or similar.")
+
+        def unwrap_proxy(e):
+            return e.proxy if isinstance(e, ProxyTensor) else e
+
+        proxy_args = pytree.tree_map(unwrap_proxy, args)
+        proxy_kwargs = pytree.tree_map(unwrap_proxy, kwargs)
+
+        proxy_out = func(*proxy_args, **proxy_kwargs)
+
+        # Kind of a hacky way to test if an op is in-place or not
+        if func.__name__[-1] == "_" and func.__name__[0] != "_":
+            args[0].proxy = proxy_out
+            proxy_out.node.meta['tensor_meta'] = _extract_tensor_metadata(args[0])
+
+        with no_dispatch():
+            real_out = func_overload(*args, **kwargs)
+
+        def wrap_with_proxy(e, proxy):
+            # Some ops (like native_batch_norm_backward) return undefined tensors that get
+            # converted into None in python.
+            # As the function signature expects tensors, if we directly return these None
+            # tensors back to C++, we'll error.
+            if e is None:
+                e = torch.empty(())
+            if type(e) == torch.Tensor:
+                return ProxyTensor(e, proxy)
+            else:
+                return e
+        if isinstance(real_out, tuple):
+            return tuple([wrap_with_proxy(e, proxy_out[idx]) for idx, e in enumerate(real_out)])
+        elif isinstance(real_out, list):
+            return list([wrap_with_proxy(e, proxy_out[idx]) for idx, e in enumerate(real_out)])
+        elif isinstance(real_out, torch.Tensor):
+            return wrap_with_proxy(real_out, proxy_out)
+        else:
+            return real_out
+
+
+class PythonKeyTracer(Tracer):
+    def __init__(self):
+        super().__init__()
+
+    def call_module(
+        self, m: torch.nn.Module, forward: Callable[..., Any], args: Tuple[Any, ...], kwargs: Dict[str, Any]
+    ) -> Any:
+        return forward(*args, **kwargs)
+
+    def _module_getattr(self, attr, attr_val, parameter_proxy_cache):
+        if isinstance(attr_val, torch.nn.Parameter):
+            for n, p in self.root.named_parameters():
+                if attr_val is p:
+                    if n not in parameter_proxy_cache:
+                        proxy = self.create_proxy('get_attr', n, (), {})
+                        parameter_proxy_cache[n] = ProxyTensor(attr_val, proxy)
+                    return parameter_proxy_cache[n]
+            return attr_val
+        return attr_val
+
+    # We need to do this so that parameters entering the `make_fx` context have
+    # a reference to them (and also have requires_grad set on them correctly
+    # I'm not actually sure if this is the right thing to do ...
+    def create_arg(self, a: Any):
+        if isinstance(a, torch.nn.Parameter):
+            for n, p in self.root.named_parameters():
+                if a is p:
+                    return self.create_node('get_attr', n, (), {})
+            qualname: Optional[str] = None
+
+            if not qualname:
+                i = 0
+                while True:
+                    qualname = f'_param_constant{i}'
+                    if not hasattr(self.root, qualname):
+                        break
+                    i += 1
+                setattr(self.root, qualname, a)
+
+            return self.create_node('get_attr', qualname, (), {})
+        return super().create_arg(a)
+
+
+def pythonkey_trace(
+    root: Union[torch.nn.Module, Callable], concrete_args: Optional[Dict[str, Any]] = None
+) -> GraphModule:
+    tracer = PythonKeyTracer()
+    graph = tracer.trace(root, concrete_args)
+    name = root.__class__.__name__ if isinstance(root, torch.nn.Module) else root.__name__
+    return GraphModule(tracer.root, graph, name)
+
+
+def wrap_key(f, inps):
+    flat_inps, _ = pytree.tree_flatten(inps)
+
+    @functools.wraps(f)
+    def wrapped(*args):
+        flat_args, args_spec = pytree.tree_flatten(args)
+        assert(len(flat_args) == len(flat_inps))
+        for idx, arg in enumerate(flat_args):
+            if isinstance(flat_inps[idx], torch.Tensor):
+                flat_args[idx] = ProxyTensor(flat_inps[idx], arg)
+            else:
+                flat_args[idx] = flat_inps[idx]
+
+        tree_args = pytree.tree_unflatten(flat_args, args_spec)
+        out = f(*tree_args)
+        flat_outs, out_spec = pytree.tree_flatten(out)
+        for idx in range(len(flat_outs)):
+            if isinstance(flat_outs[idx], torch.Tensor) and isinstance(flat_outs[idx], ProxyTensor):
+                flat_outs[idx] = flat_outs[idx].proxy
+        return pytree.tree_unflatten(flat_outs, out_spec)
+
+    return wrapped
+
+
+def make_fx(f, decomposition_table={}):
+    @functools.wraps(f)
+    def wrapped(*args):
+        phs = pytree.tree_map(lambda x: fx.PH, args)
+        with pythonkey_decompose(decomposition_table):
+            t = pythonkey_trace(wrap_key(f, args), concrete_args=tuple(phs))
+        return t
+
+    return wrapped

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -173,9 +173,10 @@ def wrap_key(f, inps):
 def make_fx(f, decomposition_table=None):
     if decomposition_table is None:
         decomposition_table = {}
+
     @functools.wraps(f)
     def wrapped(*args):
-        phs = pytree.tree_map(lambda x: fx.PH, args)  #type: ignore[attr-defined]
+        phs = pytree.tree_map(lambda x: fx.PH, args)  # type: ignore[attr-defined]
         with decompose(decomposition_table):
             t = dispatch_trace(wrap_key(f, args), concrete_args=tuple(phs))
         return t


### PR DESCRIPTION
This is the `__torch_dispatch__` subclass used for tracing by AOTAutograd (https://github.com/pytorch/functorch/blob/main/functorch/_src/python_key.py).

Given that a couple of folks are now interested in using this infra, it seems like a good idea to put it in core, and focus our efforts on a single implementation.

I put this up as a WIP, just for discussion, but some questions off the top of my head.

1. What should be the intended way of extending this tracer? Should we define extension points, or should folks simply copy paste and modify? If we do define extension points, what are the extension points we should define?
2. There are some open questions about the way we're overriding FX to resolve some lingering issues (i.e. dealing with `nn.Parameter` and `call_module` calls). @ezyang implemented an alternate version of this tensor in https://github.com/albanD/subclass_zoo/blob/main/tracer_tensor.py, but it appears he ran into some issues with it that led to me submitting this implementation. That being said, I think some of the things over there should still be ported.
3. Given that this is going to be shared infra, what other features should we put in here? One that comes to mind is to allow for meta-tensor tracing (perhaps by default?), with a more solid fallback.

Some of the other implementations (for reference on requirements).

1. FX2TRT: D34868356 (internal only)
2. Edge's? @gmagogsfm 

cc: @ezyang , @jamesr66a , @zou3519 , @gmagogsfm, @842974287 