### PR TITLE
Remove default parameter of ShufflerIterDataPipe

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1579,7 +1579,7 @@ class TestFunctionalMapDataPipe(TestCase):
 
         #  Functional Test: deactivate shuffling via set_shuffle
         shuffler_dp = dp.iter.Shuffler(input_dp1).set_shuffle(False)
-        self.assertEqual(list(shuffler_dp), list(range(10)))
+        self.assertEqual(list(shuffler_dp), list(input_dp1))
 
         # # Reset Test:
         shuffler_dp = input_dp1.shuffle()

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1577,6 +1577,10 @@ class TestFunctionalMapDataPipe(TestCase):
         shuffler_dp = dp.map.Shuffler(input_dp2, indices=['a', 'b', 'c', 'd', 'e'])
         self.assertEqual(set(range(1, 6)), set(shuffler_dp))
 
+        #  Functional Test: deactivate shuffling via set_shuffle
+        shuffler_dp = dp.iter.Shuffler(input_dp1).set_shuffle(False)
+        self.assertEqual(list(shuffler_dp), list(range(10)))
+
         # # Reset Test:
         shuffler_dp = input_dp1.shuffle()
         n_elements_before_reset = 5

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1407,6 +1407,10 @@ class TestFunctionalIterDataPipe(TestCase):
         with self.assertRaisesRegex(TypeError, r"instance doesn't have valid length$"):
             len(shuffle_dp_nl)
 
+        # Test: deactivate shuffling via set_shuffle
+        unshuffled_dp = input_ds.shuffle().set_shuffle(False)
+        self.assertEqual(list(unshuffled_dp), list(input_ds))
+
     def test_zip_iterdatapipe(self):
 
         # Functional Test: raises TypeError when an input is not of type `IterDataPipe`
@@ -1576,10 +1580,6 @@ class TestFunctionalMapDataPipe(TestCase):
         # Functional Test: Custom indices are working
         shuffler_dp = dp.map.Shuffler(input_dp2, indices=['a', 'b', 'c', 'd', 'e'])
         self.assertEqual(set(range(1, 6)), set(shuffler_dp))
-
-        #  Functional Test: deactivate shuffling via set_shuffle
-        shuffler_dp = dp.iter.Shuffler(input_dp1).set_shuffle(False)
-        self.assertEqual(list(shuffler_dp), list(input_dp1))
 
         # # Reset Test:
         shuffler_dp = input_dp1.shuffle()

--- a/torch/utils/data/datapipes/iter/combinatorics.py
+++ b/torch/utils/data/datapipes/iter/combinatorics.py
@@ -84,7 +84,6 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
     def __init__(self,
                  datapipe: IterDataPipe[T_co],
                  *,
-                 default: bool = True,
                  buffer_size: int = 10000,
                  unbatch_level: int = 0
                  ) -> None:
@@ -95,7 +94,7 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         else:
             self.datapipe = datapipe.unbatch(unbatch_level=unbatch_level)
         self.buffer_size = buffer_size
-        self._shuffle_enabled = default
+        self._shuffle_enabled = True
 
     @staticmethod
     def buffer_replace(buffer, x):
@@ -104,8 +103,9 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         buffer[idx] = x
         return val
 
-    def set_shuffle_settings(self, shuffle=True):
+    def set_shuffle(self, shuffle=True):
         self._shuffle_enabled = shuffle
+        return self
 
     def __iter__(self) -> Iterator[T_co]:
         if not self._shuffle_enabled:

--- a/torch/utils/data/datapipes/iter/combinatorics.py
+++ b/torch/utils/data/datapipes/iter/combinatorics.py
@@ -94,7 +94,7 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         else:
             self.datapipe = datapipe.unbatch(unbatch_level=unbatch_level)
         self.buffer_size = buffer_size
-        self._shuffle_enabled = True
+        self._enabled = True
 
     @staticmethod
     def buffer_replace(buffer, x):
@@ -104,11 +104,11 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         return val
 
     def set_shuffle(self, shuffle=True):
-        self._shuffle_enabled = shuffle
+        self._enabled = shuffle
         return self
 
     def __iter__(self) -> Iterator[T_co]:
-        if not self._shuffle_enabled:
+        if not self._enabled:
             for x in self.datapipe:
                 yield x
         else:

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -31,5 +31,5 @@ def apply_shuffle_settings(datapipe, shuffle):
         graph = torch.utils.data.graph.traverse(datapipe, only_datapipe=True)
         all_pipes = get_all_graph_pipes(graph)
         for pipe in all_pipes:
-            if hasattr(pipe, 'set_shuffle_settings'):
-                pipe.set_shuffle_settings(shuffle)
+            if hasattr(pipe, 'set_shuffle'):
+                pipe.set_shuffle(shuffle)

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -1,4 +1,5 @@
 import torch.utils.data.graph
+from torch.utils.data.datapipes.iter import Shuffler
 
 
 def get_all_graph_pipes(graph):
@@ -31,5 +32,5 @@ def apply_shuffle_settings(datapipe, shuffle):
         graph = torch.utils.data.graph.traverse(datapipe, only_datapipe=True)
         all_pipes = get_all_graph_pipes(graph)
         for pipe in all_pipes:
-            if hasattr(pipe, 'set_shuffle'):
+            if isinstance(pipe, Shuffler):
                 pipe.set_shuffle(shuffle)


### PR DESCRIPTION
Closes https://github.com/pytorch/data/issues/298. This PR:

- removes the `default` parameter of `ShufflerIterDataPipe`
- renames `set_shuffle_setting()` into `set_shuffle()`
- let `set_shuffle()` return `self`.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74370

Differential Revision: [D35073666](https://our.internmc.facebook.com/intern/diff/D35073666)