### PR TITLE
Link missing FSDP functions/classing in documentation

### DIFF
--- a/docs/source/fsdp.rst
+++ b/docs/source/fsdp.rst
@@ -5,3 +5,18 @@ FullyShardedDataParallel
 
 .. autoclass:: torch.distributed.fsdp.FullyShardedDataParallel
   :members:
+
+.. autoclass:: torch.distributed.fsdp.CPUOffload
+  :members:
+
+.. autoclass:: torch.distributed.fsdp.BackwardPrefetch
+  :members:
+
+.. autofunction:: torch.distributed.wrap.always_wrap_policy
+
+.. autofunction:: torch.distributed.wrap.default_auto_wrap_policy
+
+.. autofunction:: torch.distributed.wrap.enable_wrap
+
+.. autofunction:: torch.distributed.wrap.wrap
+


### PR DESCRIPTION
Added links to FSDP related functions and classes to the documentation page (rst)