### PR TITLE
Make test_foreach account for NotImplementedError in ref tests

### DIFF
--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -109,6 +109,8 @@ class TestForeach(TestCase):
         try:
             actual = op(inputs, self.is_cuda, is_fastpath)
         except RuntimeError as e:
+            if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                self.skipTest(str(e))
             with self.assertRaisesRegex(type(e), re.escape(str(e))):
                 ref(ref_inputs)
         else:
@@ -120,6 +122,8 @@ class TestForeach(TestCase):
             try:
                 actual = op(inputs, self.is_cuda, is_fastpath, **kwargs)
             except RuntimeError as e:
+                if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                    self.skipTest(str(e))
                 with self.assertRaisesRegex(type(e), re.escape(str(e))):
                     ref(ref_inputs, **kwargs)
             else:
@@ -262,6 +266,8 @@ class TestForeach(TestCase):
         try:
             actual = op(inputs, self.is_cuda, is_fastpath)
         except RuntimeError as e:
+            if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                self.skipTest(str(e))
             with self.assertRaisesRegex(type(e), re.escape(str(e))):
                 ref(ref_inputs)
         else:
@@ -271,6 +277,8 @@ class TestForeach(TestCase):
             try:
                 actual = op(inputs + [values], self.is_cuda, is_fastpath)
             except RuntimeError as e:
+                if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                    self.skipTest(str(e))
                 with self.assertRaisesRegex(type(e), re.escape(str(e))):
                     ref(ref_inputs, values=values)
             else:
@@ -336,6 +344,8 @@ class TestForeach(TestCase):
         try:
             actual = op(inputs, self.is_cuda, is_fastpath)
         except RuntimeError as e:
+            if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                self.skipTest(str(e))
             with self.assertRaisesRegex(type(e), re.escape(str(e))):
                 ref(inputs)
         else:
@@ -353,6 +363,8 @@ class TestForeach(TestCase):
         try:
             inplace(inputs, self.is_cuda, is_fastpath)
         except RuntimeError as e:
+            if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                self.skipTest(str(e))
             with self.assertRaisesRegex(type(e), re.escape(str(e))):
                 inplace_ref(copied_inputs)
         else:
@@ -476,6 +488,8 @@ class TestForeach(TestCase):
         try:
             foreach_op(tensors, 1)
         except RuntimeError as e:
+            if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                self.skipTest(str(e))
             runtime_error = e
         self.assertIsNone(runtime_error)
 
@@ -514,11 +528,15 @@ class TestForeach(TestCase):
         try:
             foreach_op(tensors1, tensors2)
         except RuntimeError as e:
+            if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                self.skipTest(str(e))
             with self.assertRaisesRegex(type(e), re.escape(str(e))):
                 [ref(t1, t2) for t1, t2 in zip(tensors1, tensors2)]
         try:
             foreach_op_(tensors1, tensors2)
         except RuntimeError as e:
+            if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                self.skipTest(str(e))
             with self.assertRaisesRegex(type(e), re.escape(str(e))):
                 [ref_(t1, t2) for t1, t2 in zip(tensors1, tensors2)]
 
@@ -593,6 +611,8 @@ class TestForeach(TestCase):
         try:
             actual = method((tensors,), False, False)
         except RuntimeError as e:
+            if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                self.skipTest(str(e))
             with self.assertRaisesRegex(type(e), str(e)):
                 ref((tensors,))
         else:
@@ -602,6 +622,8 @@ class TestForeach(TestCase):
         try:
             inplace_method((tensors,), False, False)
         except RuntimeError as e:
+            if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                self.skipTest(str(e))
             with self.assertRaisesRegex(type(e), str(e)):
                 ref_inplace((tensors,))
         else:
@@ -621,6 +643,8 @@ class TestForeach(TestCase):
         try:
             actual = foreach_op(tensors1, tensors2)
         except RuntimeError as e:
+            if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                self.skipTest(str(e))
             with self.assertRaisesRegex(type(e), re.escape(str(e))):
                 [native_op(t1, t2) for t1, t2 in zip(tensors1, tensors2)]
         else:
@@ -629,6 +653,8 @@ class TestForeach(TestCase):
         try:
             foreach_op_(tensors1, tensors2)
         except RuntimeError as e:
+            if isinstance(e, NotImplementedError) and self.device_type == 'meta':
+                self.skipTest(str(e))
             with self.assertRaisesRegex(type(e), re.escape(str(e))):
                 [native_op_(t1, t2) for t1, t2 in zip(tensors1, tensors2)]
         else:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

If the operator raises a NotImplementedError and we're testing meta
tensors, don't require the reference implementation to raise the same
error; just skip the test (meta coverage isn't there yet!)

Signed-off-by: Edward Z. Yang <ezyang@fb.com>