### PR TITLE
Revert D34929680: Multisect successfully blamed D34929680 for test failures

### DIFF
--- a/torch/testing/_internal/common_fx2trt.py
+++ b/torch/testing/_internal/common_fx2trt.py
@@ -10,7 +10,6 @@ from fx2trt_oss.fx import (
     TRTModule,
 )
 from fx2trt_oss.fx.passes.pass_utils import chain_passes
-from fx2trt_oss.fx.utils import LowerPrecision
 from torch.testing._internal.common_utils import TestCase
 from torch.fx.experimental.normalize import NormalizeArgs
 from torch.fx.passes import shape_prop
@@ -55,7 +54,7 @@ class TRTTestCase(TestCase):
             if unexpected_ops:
                 self.assert_unexpected_op(mod, unexpected_ops)
 
-            interpreter_result = interpreter.run(lower_precision=LowerPrecision.FP16)
+            interpreter_result = interpreter.run(fp16_mode=False)
             trt_mod = TRTModule(
                 interpreter_result.engine,
                 interpreter_result.input_names,
@@ -102,7 +101,7 @@ class TRTTestCase(TestCase):
             if len(expected_ops):
                 self.assert_has_op(mod, expected_ops)
 
-            interpreter_result = interpreter.run(lower_precision=LowerPrecision.FP16)
+            interpreter_result = interpreter.run(fp16_mode=fp16_mode)
             trt_mod = TRTModule(
                 interpreter_result.engine,
                 interpreter_result.input_names,
@@ -127,7 +126,7 @@ class TRTTestCase(TestCase):
                     cuda_inputs.append(i.cuda())
 
                 mod.eval()
-                interpreter.run(lower_precision=LowerPrecision.FP32)
+                interpreter.run(fp16_mode=False)
 
     def assert_has_op(self, mod, ops):
         ops_in_mod = set()


### PR DESCRIPTION
Test Plan: NA

Reviewed By: brad-mengchi

Differential Revision: D34966585

