### PR TITLE
[Static Runtime] Add profile metric for ops directly supported from Static Runtime ((out variant count + native op count) / total op count)

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1354,6 +1354,15 @@ void BlockRunner::benchmark(
             << 100.0 * (results.out_nodes_count) /
           static_cast<float>(results.total_nodes_count)
             << "%)" << std::endl;
+  std::cout
+      << "Total number of 'out' variant nodes + 'native` nodes/total number of nodes: "
+      << (results.out_nodes_count + results.native_nodes_count) << "/"
+      << results.total_nodes_count << " ("
+      << 100.0 *
+          (static_cast<double>(
+               results.out_nodes_count + results.native_nodes_count) /
+           static_cast<double>(results.total_nodes_count))
+      << "%)" << std::endl;
 
   check_for_memory_leak();
 
@@ -1493,6 +1502,7 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
         results.out_nodes_count++;
       } else if (nodes_[i].has_native()) {
         results.native_nodes.insert(kind);
+        results.native_nodes_count++;
       }
       results.total_time += results.time_per_node[i];
     }
@@ -1606,6 +1616,7 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
       results.out_nodes_count++;
     } else if (nodes_[i].has_native()) {
       results.native_nodes.insert(kind);
+      results.native_nodes_count++;
     }
     results.total_time += results.time_per_node[i];
   }

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -551,6 +551,7 @@ class TORCH_API BlockRunner {
     float first_iter_time{0.0};
     float total_time{0.0};
     size_t out_nodes_count{0};
+    size_t native_nodes_count{0};
     size_t total_nodes_count{0};
     std::vector<float> time_per_node;
     std::unordered_map<std::string, float> time_per_node_type;

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -31,6 +31,9 @@ void initStaticModuleBindings(PyObject* module) {
       .def_readonly(
           "out_nodes_count", &StaticRuntime::IndividualMetrics::out_nodes_count)
       .def_readonly(
+          "native_nodes_count",
+          &StaticRuntime::IndividualMetrics::native_nodes_count)
+      .def_readonly(
           "total_nodes_count",
           &StaticRuntime::IndividualMetrics::total_nodes_count)
       .def_readonly(


### PR DESCRIPTION
Summary: The out variant coverage rate is useful but we need more information on what ops are "natively" supported from Static Runtime without delegating to the interpreter. This change adds this metric.

Test Plan:
Confirmed that ptvsc2 bench tool outputs an expected result from a PT4ALL model:

```
...
Total number of 'out' variant nodes/total number of nodes: 645/855 (75.4386%)
Total number of 'out' variant nodes + 'native` nodes/total number of nodes: 833/855 (97.4269%)
```

Differential Revision: D34929185

