### PR TITLE
Remove deprecated import_module hub function

### DIFF
--- a/torch/hub.py
+++ b/torch/hub.py
@@ -77,11 +77,6 @@ def _import_module(name, path):
     return module
 
 
-def import_module(name, path):
-    warnings.warn('The use of torch.hub.import_module is deprecated in v0.11 and will be removed in v0.12', DeprecationWarning)
-    return _import_module(name, path)
-
-
 def _remove_if_exists(path):
     if os.path.exists(path):
         if os.path.isfile(path):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #74431
* #74430
* #74429
* __->__ #74428
* #74427

Differential Revision: [D35011901](https://our.internmc.facebook.com/intern/diff/D35011901)