### PR TITLE
Enable faster cuBLAS path for torch.linalg.lstsq for batch of small matrices

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -3231,27 +3231,20 @@ void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& /*rank*/, Tensor& /*singul
         "Please rebuild with cuSOLVER.");
 #endif
   } else { // m >= n
-#if !AT_MAGMA_ENABLED()
-    // MAGMA is not available we can either use cuBLAS or cuSOLVER here
+#if !defined(USE_ROCM)
+    // On CUDA platform we use either cuBLAS or cuSOLVER here
     // the batched vs looped dispatch is implemented based on the following performance results
     // https://github.com/pytorch/pytorch/pull/54725#issuecomment-832234456
     if (m <= 256 && batchCount(b) >= std::max<int64_t>(2, m / 16)) {
-      // if CUDART_VERSION is defined then cuBLAS is available
-      #ifdef CUDART_VERSION
       gels_batched_cublas(a, b, infos);
-      #else
-      // this would either call cuSOLVER or MAGMA,
-      // if MAGMA is called a runtime error is thrown about not finding MAGMA in compilation
-      gels_looped(a, b, infos);
-      #endif // CUDART_VERSION
     } else {
       gels_looped(a, b, infos);
     }
 #else
-    // if both MAGMA and cuSOLVER are available this would call cuSOLVER
-    // MAGMA is called if cuSOLVER is not available
-    gels_looped(a, b, infos);
-#endif // AT_MAGMA_ENABLED()
+    // On ROCm platform we can only use MAGMA here
+    // If MAGMA is not available, an error will be thrown
+    gels_magma(a, b, infos);
+#endif // USE_ROCM()
   }
 }
 

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -3231,7 +3231,7 @@ void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& /*rank*/, Tensor& /*singul
         "Please rebuild with cuSOLVER.");
 #endif
   } else { // m >= n
-#if !defined(USE_ROCM)
+#if !AT_ROCM_ENABLED()
     // On CUDA platform we use either cuBLAS or cuSOLVER here
     // the batched vs looped dispatch is implemented based on the following performance results
     // https://github.com/pytorch/pytorch/pull/54725#issuecomment-832234456
@@ -3244,7 +3244,7 @@ void lstsq_kernel(const Tensor& a, Tensor& b, Tensor& /*rank*/, Tensor& /*singul
     // On ROCm platform we can only use MAGMA here
     // If MAGMA is not available, an error will be thrown
     gels_magma(a, b, infos);
-#endif // USE_ROCM()
+#endif // !AT_ROCM_ENABLED()
   }
 }
 


### PR DESCRIPTION
This PR enables cuBLAS path for `torch.linalg.lstsq`. Before this PR only cuSOLVER path was used for regular PyTorch builds (when built with MAGMA).

Performance results (also previously reported at https://github.com/pytorch/pytorch/pull/54725#issuecomment-832234456):
```
|                            | before current PR | current PR | speedup |
|----------------------------|-------------------|------------|---------|
| torch.Size([32, 32, 32])   | 870               | 440        | 2x      |
| torch.Size([64, 32, 32])   | 1340              | 450        | 3x      |
| torch.Size([32, 64, 64])   | 9040              | 1839       | 5x      |
| torch.Size([64, 64, 64])   | 17000             | 1830       | 9.2x    |
| torch.Size([32, 128, 128]) | 23210             | 8560       | 2.7x    |
| torch.Size([64, 128, 128]) | 40000             | 8662       | 4.6x    |
| torch.Size([32, 256, 256]) | 58160             | 46150      | 1.2x    |
| torch.Size([64, 256, 256]) | 73220             | 52080      | 1.4x    |
Times are in microseconds (us).
```
