### PR TITLE
Print reason for test skipped in CI

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -646,6 +646,12 @@ def run_tests(argv=UNITTEST_ARGS):
     elif TEST_SAVE_XML is not None:
         # import here so that non-CI doesn't need xmlrunner installed
         import xmlrunner  # type: ignore[import]
+        from xmlrunner.result import _XMLTestResult  # type: ignore[import]
+
+        class XMLTestResultVerbose(_XMLTestResult):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
         test_filename = sanitize_test_filename(inspect.getfile(sys._getframe(1)))
         test_report_path = TEST_SAVE_XML + LOG_SUFFIX
         test_report_path = os.path.join(test_report_path, test_filename)
@@ -653,7 +659,10 @@ def run_tests(argv=UNITTEST_ARGS):
         verbose = '--verbose' in argv or '-v' in argv
         if verbose:
             print('Test results will be stored in {}'.format(test_report_path))
-        unittest.main(argv=argv, testRunner=xmlrunner.XMLTestRunner(output=test_report_path, verbosity=2 if verbose else 1))
+        unittest.main(argv=argv, testRunner=xmlrunner.XMLTestRunner(
+            output=test_report_path,
+            verbosity=2 if verbose else 1,
+            resultclass=XMLTestResultVerbose))
     elif REPEAT_COUNT > 1:
         for _ in range(REPEAT_COUNT):
             if not unittest.main(exit=False, argv=argv).result.wasSuccessful():

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -652,6 +652,12 @@ def run_tests(argv=UNITTEST_ARGS):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
 
+            def addSkip(self, test, reason):
+                super().addSkip(test, reason)
+                for c in self.callback.__closure__:
+                    if isinstance(c.cell_contents, str) and c.cell_contents == 'skip':
+                        c.cell_contents = f"skip: {reason}"
+
         test_filename = sanitize_test_filename(inspect.getfile(sys._getframe(1)))
         test_report_path = TEST_SAVE_XML + LOG_SUFFIX
         test_report_path = os.path.join(test_report_path, test_filename)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -649,6 +649,15 @@ def run_tests(argv=UNITTEST_ARGS):
         from xmlrunner.result import _XMLTestResult  # type: ignore[import]
 
         class XMLTestResultVerbose(_XMLTestResult):
+            """
+            Adding verbosity to test outputs:
+            by default test summary prints 'skip',
+            but we want to also print the skip reason.
+            GH issue: https://github.com/pytorch/pytorch/issues/69014
+
+            This works with unittest_xml_reporting<=3.2.0,>=2.0.0
+            (3.2.0 is latest at the moment)
+            """
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
 
@@ -656,6 +665,8 @@ def run_tests(argv=UNITTEST_ARGS):
                 super().addSkip(test, reason)
                 for c in self.callback.__closure__:
                     if isinstance(c.cell_contents, str) and c.cell_contents == 'skip':
+                        # this message is printed in test summary;
+                        # it stands for `verbose_str` captured in the closure
                         c.cell_contents = f"skip: {reason}"
 
         test_filename = sanitize_test_filename(inspect.getfile(sys._getframe(1)))


### PR DESCRIPTION
Issue: https://github.com/pytorch/pytorch/issues/69014 (skip reason is not printed for tests running in CI)

Cause: locally tests are fired with testrunner that is built into unittest. When IN_CI env variable is true - tests are fired with xml test runner from unittest-xml-reporting. They have different summary printing properties

Solution: patching printing logic in unittest-xml-reporting when a test is skipped

Test plan: examine CI run
