### PR TITLE
Make dir work on torch.ops.aten

### DIFF
--- a/test/test_per_overload_api.py
+++ b/test/test_per_overload_api.py
@@ -60,5 +60,9 @@ class TestPerOverloadAPI(TestCase):
 
         self.assertRaises(RuntimeError, lambda: add_tensoroverload(a, a, out=b))
 
+    def test_dir(self):
+        for n in dir(torch.ops.aten):
+            self.assertTrue(hasattr(torch.ops.aten, n), n)
+
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74469

There is some potential inefficiency if you query the operators for
many, many namespaces (the cost is O(number operators * number
namespaces), but fortunately there are not too many namespaces. However,
because of this I didn't make dir work on torch.ops.aten.func under the
same strategy.

Fixes https://github.com/pytorch/pytorch/issues/74248

Signed-off-by: Edward Z. Yang <ezyang@fb.com>