### PR TITLE
Codegen uniform_

### DIFF
--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -135,6 +135,7 @@ full_codegen:
   - tril
   - triu
   - trunc
+  - uniform_
   - upsample_bilinear2d
   - upsample_bilinear2d_backward
   - upsample_nearest2d

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -591,6 +591,10 @@ std::vector<Shape> compute_shape_repeat(const at::Tensor & self, at::IntArrayRef
   return {Shape(self.scalar_type(), target_size)};
 }
 
+std::vector<Shape> compute_shape_uniform_(at::Tensor & self, double from, double to, c10::optional<at::Generator> generator) {
+  return {Shape(self.scalar_type(), self.sizes().vec())};
+}
+
 // Restore unused-parameters warnings
 #pragma GCC diagnostic pop
 

--- a/torch/csrc/lazy/core/shape_inference.h
+++ b/torch/csrc/lazy/core/shape_inference.h
@@ -63,6 +63,7 @@ TORCH_API std::vector<Shape> compute_shape_std(const at::Tensor & self, c10::opt
 TORCH_API std::vector<Shape> compute_shape_sum(const at::Tensor & self, c10::optional<at::ScalarType> dtype);
 TORCH_API std::vector<Shape> compute_shape__to_copy(const at::Tensor & self, c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout, c10::optional<at::Device> device, c10::optional<bool> pin_memory, bool non_blocking, c10::optional<at::MemoryFormat> memory_format);
 TORCH_API std::vector<Shape> compute_shape_trace(const at::Tensor & self);
+TORCH_API std::vector<Shape> compute_shape_uniform_(at::Tensor & self, double from, double to, c10::optional<at::Generator> generator);
 TORCH_API std::vector<Shape> compute_shape_zero_(at::Tensor & self);
 
 } // namespace lazy


### PR DESCRIPTION
TorchBench is showing `aten::uniform_` as fallback (https://github.com/pytorch/pytorch/actions/runs/1995054679) after https://github.com/pytorch/pytorch/pull/73939 lands.

RUN_TORCHBENCH: ALL
TORCHBENCH_BRANCH: wconstab/ltc-noopt