### PR TITLE
[Profiler] Pay for what you use (v2)

### DIFF
--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 
 #include <ATen/record_function.h>
+#include <c10/util/overloaded.h>
+#include <torch/csrc/jit/runtime/interpreter.h>
 
 namespace torch {
 namespace profiler {
@@ -25,7 +27,74 @@ std::atomic<uint32_t> queue_id_{0};
 thread_local SubQueueThreadCache sub_queue_cache_{0, nullptr};
 } // namespace
 
-RecordQueue::RecordQueue() : id_(++queue_id_) {}
+std::string Result::name() const {
+  return c10::visit([](auto& e){ return e.name_; }, event_);
+}
+
+uint64_t Result::correlation_id() const {
+  return c10::visit(c10::overloaded(
+      [](const OpEvent& e){ return e.correlation_id_; },
+      [](const BackendEvent& e) { return std::numeric_limits<uint64_t>::max(); }
+  ), event_);
+}
+
+ThreadLocalSubqueue::ThreadLocalSubqueue(
+    const uint64_t tid,
+    const ProfilerConfig& config)
+    : tid_{tid}, config_{config}, kineto_info_{kineto::kineto_ids()} {}
+
+std::unique_ptr<KinetoObserverContext> ThreadLocalSubqueue::begin_op(
+    const at::RecordFunction& fn,
+    uint64_t correlation_id) {
+  auto event = op_events_.emplace_back(
+      correlation_id,
+      fn.threadId(),
+      fn.seqNr(),
+      fn.forwardThreadId(),
+      fn.scope(),
+      fn.isAsync(),
+      fn.debugHandle(),
+      fn.name());
+  if (config_.report_input_shapes) {
+    inputs_.emplace_back(
+        torch::profiler::impl::inputSizes(fn),
+        torch::profiler::impl::inputTypes(fn));
+  }
+
+#if !defined BUILD_LITE_INTERPRETER && !defined C10_MOBILE
+  // backward nodes source range corresponds to the forward node
+  // TODO: consider using C++ stack trace
+  if (config_.with_stack && fn.scope() != at::RecordScope::BACKWARD_FUNCTION) {
+    auto cs = torch::profiler::impl::prepareCallstack(jit::currentCallstack());
+    jit_stack_.emplace_back(callstackStr(cs));
+  }
+  if (config_.with_modules &&
+      fn.scope() != at::RecordScope::BACKWARD_FUNCTION) {
+    jit_modules_.emplace_back(jit::currentModuleHierarchy());
+  }
+#endif
+  if (config_.with_flops) {
+    extra_args_.emplace_back(torch::profiler::impl::saveExtraArgs(fn));
+  }
+
+  auto out = std::make_unique<KinetoObserverContext>(event);
+
+  if (config_.state == ProfilerState::KINETO_GPU_FALLBACK) {
+    try {
+      out->fallback_ = gpu_fallback_.emplace_back();
+      torch::profiler::impl::cudaStubs()->record(
+          nullptr, &out->fallback_->cuda_event_start_, nullptr);
+    } catch (const std::exception& e) {
+      LOG(WARNING) << "Failed to record CUDA event. " << e.what();
+    }
+  }
+
+  event->start_time_ = torch::profiler::impl::getApproximateTime();
+  return out;
+}
+
+RecordQueue::RecordQueue(const ProfilerConfig& config)
+    : id_(++queue_id_), config_{config} {}
 
 ThreadLocalSubqueue* RecordQueue::getSubqueue() {
   // In the most common case, a thread will want to write to the same sub-queue
@@ -45,34 +114,74 @@ ThreadLocalSubqueue* RecordQueue::getSubqueue() {
   auto it = sub_queues_.find(tid);
   if (it == sub_queues_.end()) {
     it =
-        sub_queues_.emplace(tid, std::make_unique<ThreadLocalSubqueue>()).first;
+        sub_queues_.emplace(tid, std::make_unique<ThreadLocalSubqueue>(tid, config_)).first;
   }
 
   sub_queue_cache_ = SubQueueThreadCache{id_, it->second.get()};
   return it->second.get();
 }
 
-std::deque<OpEventData> RecordQueue::getRecords(
+template <typename T>
+auto steal_or_default(T& it) {
+  if (it.exhausted()) {
+    return typename T::value_type();
+  } else {
+    auto result = std::move(*it);
+    ++it;
+    return result;
+  }
+}
+
+std::deque<Result> RecordQueue::getRecords(
     std::function<time_t(approx_time_t)> time_converter) {
   auto converter = [&](approx_time_t t) {
     return t == std::numeric_limits<approx_time_t>::min()
         ? std::numeric_limits<int64_t>::min()
         : time_converter(t) / 1000; // ns to ms
   };
-  std::deque<OpEventData> out;
+  std::deque<Result> out;
   for (auto& subqueue_it : sub_queues_) {
-    for (auto& i : subqueue_it.second->data_) {
-      if (!i.backend_.has_value()) {
-        i.start_time_.us_ = converter(i.start_time_.count_);
-        i.end_time_.us_ = converter(i.end_time_.count_);
-      }
-      out.emplace_back(std::move(i));
+    auto& queue = *subqueue_it.second;
+    for (auto& i : queue.backend_events_) {
+      Result r;
+      r.start_time_us_ = i.start_time_us_;
+      r.end_time_us_ = i.end_time_us_;
+      r.start_tid_ = queue.tid();
+      r.kineto_info_ = queue.kineto_info();
+      r.event_ = std::move(i);
+      out.push_back(std::move(r));
     }
-    subqueue_it.second->data_.clear();
+
+    auto input_it = queue.inputs_.begin();
+    auto jit_stack_it = queue.jit_stack_.begin();
+    auto jit_module_it = queue.jit_modules_.begin();
+    auto extra_args_it = queue.extra_args_.begin();
+    auto gpu_fallback_it = queue.gpu_fallback_.begin();
+    for (auto& i : queue.op_events_) {
+      Result r;
+      r.start_time_us_ = converter(i.start_time_);
+      r.end_time_us_ = converter(i.end_time_);
+      r.start_tid_ = queue.tid();
+      r.kineto_info_ = queue.kineto_info();
+      r.event_ = std::move(i);
+      r.inputs_ = steal_or_default(input_it);
+      r.jit_stack_ = steal_or_default(jit_stack_it);
+      r.jit_modules_ = steal_or_default(jit_module_it);
+      r.extra_args_ = steal_or_default(extra_args_it);
+      r.gpu_fallback_ = steal_or_default(gpu_fallback_it);
+
+      out.push_back(std::move(r));
+    }
+    queue.op_events_.clear();
+    queue.inputs_.clear();
+    queue.jit_stack_.clear();
+    queue.jit_modules_.clear();
+    queue.extra_args_.clear();
+    queue.gpu_fallback_.clear();
   }
 
   std::stable_sort(out.begin(), out.end(), [](const auto& a, const auto& b) {
-    return a.start_time_.us_ < b.start_time_.us_;
+    return a.start_time_us_ < b.start_time_us_;
   });
   return out;
 }

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -6,6 +6,7 @@
 
 #include <c10/macros/Macros.h>
 #include <c10/util/flat_hash_map.h>
+#include <c10/util/variant.h>
 #include <torch/csrc/profiler/containers.h>
 #include <torch/csrc/profiler/kineto_shim.h>
 #include <torch/csrc/profiler/util.h>
@@ -14,18 +15,9 @@ namespace torch {
 namespace profiler {
 namespace impl {
 
-// `reportBackendEventToActiveKinetoProfiler` reports times rather than counts,
-// so `OpEventData` has to be able to store both cases.
-union TimeStamp {
-  int64_t us_; // Backend event.
-  approx_time_t count_;
-};
-
-// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-struct TORCH_API OpEventData {
-  OpEventData() = default;
-
-  OpEventData(
+struct OpEvent {
+  OpEvent() = default;
+  OpEvent(
       const uint64_t correlation_id,
       const uint64_t start_thread_id,
       const int64_t sequence_number,
@@ -41,36 +33,10 @@ struct TORCH_API OpEventData {
         record_function_scope_{(uint8_t)scope},
         is_async_{is_async},
         debug_handle_{debug_handle},
-        kineto_info_{kineto::kineto_ids()},
-        name_{std::move(name)} {
-    end_time_.count_ = std::numeric_limits<approx_time_t>::min();
-  }
+        name_{name} {}
 
-  OpEventData(
-      const int64_t start_time,
-      const int64_t end_time,
-      const at::RecordScope scope,
-      const int64_t debug_handle,
-      const std::string name,
-      const std::string backend)
-      : correlation_id_{std::numeric_limits<uint64_t>::max()},
-        start_thread_id_{at::RecordFunction::currentThreadId()},
-        end_thread_id_{start_thread_id_},
-        sequence_number_{-1},
-        forward_thread_id_{start_thread_id_},
-        record_function_scope_{(uint8_t)scope},
-        is_async_{false},
-        debug_handle_{debug_handle},
-        kineto_info_{kineto::kineto_ids()},
-        name_{std::move(name)},
-        backend_{std::move(backend)} {
-    start_time_.us_ = start_time;
-    end_time_.us_ = end_time;
-  }
-
-  // POD members
-  TimeStamp start_time_;
-  TimeStamp end_time_;
+  approx_time_t start_time_;
+  approx_time_t end_time_{std::numeric_limits<approx_time_t>::min()};
   uint64_t correlation_id_;
   uint64_t start_thread_id_;
   uint64_t end_thread_id_;
@@ -79,54 +45,116 @@ struct TORCH_API OpEventData {
   uint8_t record_function_scope_;
   bool is_async_;
   int64_t debug_handle_;
-  kineto::DeviceAndResource kineto_info_;
-
   std::string name_;
+};
 
-  // report_input_shapes
+struct Inputs {
   std::vector<std::vector<int64_t>> shapes_;
   std::vector<std::string> dtypes_;
+};
 
-  // with_stack
-  std::vector<std::string> stack_;
+struct FallbackPair {
+  CUDAEventStub cuda_event_start_ = nullptr;
+  CUDAEventStub cuda_event_end_ = nullptr;
+};
 
-  // with_modules
-  c10::optional<std::vector<std::string>> module_hierarchy_;
+struct BackendEvent {
+  int64_t start_time_us_;
+  int64_t end_time_us_;
+  uint8_t record_function_scope_;
+  int64_t debug_handle_;
+  std::string name_;
+  std::string backend_;
+};
 
-  // with_flops
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct Result {
+  std::string name() const;
+  uint64_t correlation_id() const;
+
+  int64_t start_time_us_;
+  int64_t end_time_us_;
+  uint64_t start_tid_;
+  kineto::DeviceAndResource kineto_info_;
+
+  c10::variant<OpEvent, BackendEvent> event_;
+
+  // OpEvent only.
+  Inputs inputs_;
+  std::vector<std::string> jit_stack_;
+  std::vector<std::string> jit_modules_;
   std::unordered_map<std::string, c10::IValue> extra_args_;
+  FallbackPair gpu_fallback_;
+};
 
-  // reportBackendEventToActiveKinetoProfiler
-  c10::optional<std::string> backend_;
+struct KinetoObserverContext : public at::ObserverContext {
+  explicit KinetoObserverContext(OpEvent* event)
+    : event_{event} {}
 
-  // ProfilerState::KINETO_GPU_FALLBACK
-  torch::profiler::impl::CUDAEventStub cuda_event_start_ = nullptr;
-  torch::profiler::impl::CUDAEventStub cuda_event_end_ = nullptr;
+  OpEvent* event_;
+  FallbackPair* fallback_ {nullptr};
 };
 
 class TORCH_API ThreadLocalSubqueue {
  public:
+  ThreadLocalSubqueue(const uint64_t tid, const ProfilerConfig& config);
+
+  std::unique_ptr<KinetoObserverContext> begin_op(const at::RecordFunction& fn, uint64_t correlation_id);
+
   template <class... Args>
-  OpEventData* emplace_back(Args&&... args) {
-    return data_.emplace_back(std::forward<Args>(args)...);
+  void emplace_backend_event(Args&&... args) {
+    backend_events_.emplace_back(std::forward<Args>(args)...);
+  }
+
+  uint64_t tid() const {
+    return tid_;
+  }
+
+  const kineto::DeviceAndResource& kineto_info() const {
+    return kineto_info_;
   }
 
  private:
-  friend class RecordQueue;
+  uint64_t tid_;
+  ProfilerConfig config_;
+  kineto::DeviceAndResource kineto_info_;
 
+  friend class RecordQueue;
   // See `containers.h` for block size benchmarks.
-  static constexpr size_t BlockSize = 1024;
-  AppendOnlyList<OpEventData, BlockSize> data_;
+  static constexpr size_t BlockSize = 512;
+  AppendOnlyList<OpEvent, BlockSize> op_events_;
+
+  // report_input_shapes
+  AppendOnlyList<Inputs, BlockSize> inputs_;
+
+  // with_stack
+  AppendOnlyList<std::vector<std::string>, BlockSize> jit_stack_;
+
+  // with_modules
+  AppendOnlyList<std::vector<std::string>, BlockSize> jit_modules_;
+
+  // with_flops
+  AppendOnlyList<std::unordered_map<std::string, c10::IValue>, BlockSize> extra_args_;
+
+  // ProfilerState::KINETO_GPU_FALLBACK
+  AppendOnlyList<FallbackPair, BlockSize> gpu_fallback_;
+
+  // reportBackendEventToActiveKinetoProfiler
+  AppendOnlyList<BackendEvent, BlockSize> backend_events_;
 };
 
 class TORCH_API RecordQueue {
  public:
-  RecordQueue();
+  explicit RecordQueue(const ProfilerConfig& config);
+
   ThreadLocalSubqueue* getSubqueue();
-  std::deque<OpEventData> getRecords(std::function<time_t(approx_time_t)> time_converter);
+
+  // NB: This is a destructive operation.
+  std::deque<Result> getRecords(std::function<time_t(approx_time_t)> time_converter);
 
  private:
   uint32_t id_;
+  ProfilerConfig config_;
   ska::flat_hash_map<uint64_t, std::unique_ptr<ThreadLocalSubqueue>> sub_queues_;
   std::mutex sub_queue_mutex_;
 };

--- a/torch/csrc/profiler/containers.h
+++ b/torch/csrc/profiler/containers.h
@@ -79,6 +79,10 @@ class AppendOnlyList {
     // End iterator.
     Iterator() = default;
 
+    bool exhausted() const {
+      return current_ >= size_;
+    }
+
     reference operator*() const { return *current_ptr(/*checked=*/true); }
     pointer operator->() { return current_ptr(/*checked=*/true); }
 


### PR DESCRIPTION
Summary:
In my first attempt at this in December I stamped out specializations using variadic templates. However I'm able to get comparable performance using simple conditionals since the branch is very predictable and AppendOnlyList::emplace_back is low enough overhead that multiple calls don't cause an issue.

This is also a chance to do some BE: rather than force ops and backend events to use the same fields (which in practice means setting a bunch of default values when reporting backend events), I just split them and use a variant.

Test Plan: The single threaded benchmark (with no extra options set) improved considerably from ~0.88 us to ~0.62 us. The stress test benchmark improved modestly from ~6.1 us to ~5.8 us. So the bottleneck for multi-threading is somewhere else, but doing less wasted work is still able to move the needle a little bit.

Reviewed By: swolchok

Differential Revision: D34779994

