### PR TITLE
[NNC] call super().setUp() & tearDown() in test_tensorexpr.py

### DIFF
--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -13,11 +13,13 @@ from torch.testing._internal.jit_utils import JitTestCase, TensorExprTestOptions
 
 class BaseTestClass(JitTestCase):
     def setUp(self):
+        super(BaseTestClass, self).setUp()
         self.tensorexpr_options = TensorExprTestOptions()
         self.devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
 
     def tearDown(self):
         self.tensorexpr_options.restore()
+        super(BaseTestClass, self).tearDown()
 
     def assertLastGraphAllFused(self):
         self.assertAllFused(torch.jit.last_executed_optimized_graph())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #74504

Same as #73762. This will make these tests obey PYTORCH_TEST_WITH_SLOW
and PYTORCH_TEST_SKIP_FAST

Differential Revision: [D35036771](https://our.internmc.facebook.com/intern/diff/D35036771)