### PR TITLE
nvfuser parser skip api

### DIFF
--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -3683,7 +3683,7 @@ class TestCudaFuser(JitTestCase):
             self.assertFalse(torch._C._jit_set_nvfuser_skip_node_kind("aten::add", True))
 
             def fn_1(x):
-                t1 = x + 2.0 # change const value so we'll not reuse plan 
+                t1 = x + 2.0  # change const value so we'll not reuse plan
                 return t1.relu()
 
             fn_1_jit = torch.jit.script(fn_1)
@@ -3693,11 +3693,11 @@ class TestCudaFuser(JitTestCase):
             self.assertGraphContains(fn_1_jit.graph_for(x), FUSION_GUARD)
             self.assertGraphContainsExactly(fn_1_jit.graph_for(x), 'aten::add', 1)
 
-            # flips skip parse for `aten::add`, next fusion should fuse add node 
+            # flips skip parse for `aten::add`, next fusion should fuse add node
             self.assertTrue(torch._C._jit_set_nvfuser_skip_node_kind("aten::add", True))
 
             def fn_2(x):
-                t1 = x + 2.0 # change const value so we'll not reuse plan 
+                t1 = x + 2.0  # change const value so we'll not reuse plan
                 return t1.relu()
 
             fn_2_jit = torch.jit.script(fn_2)

--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -3660,6 +3660,54 @@ class TestCudaFuser(JitTestCase):
         for t in [t_unsqueeze, t_squeeze, t_squeeze_dim, t_squeeze_dim_no_op]:
             run(t)
 
+    @unittest.skipIf(not RUN_CUDA, "requires CUDA")
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
+                     "Requires fusion optimization pass to be effective")
+    def test_skip_parser(self):
+        x = torch.randn(4, 12, device="cuda")
+
+        with nvfuser_singleton_fusion(True):
+            def fn(x):
+                t1 = x + 1.0
+                return t1.relu()
+
+            fn_jit = torch.jit.script(fn)
+            self._run_helper(fn_jit, fn, x)
+
+            # add node should have been merged into fusion
+            self.assertGraphContains(fn_jit.graph_for(x), FUSION_GUARD)
+            self.assertGraphContainsExactly(fn_jit.graph_for(x), 'aten::add', 0)
+
+            # flips skip parse for `aten::add`, following fusion should skip the
+            # add node
+            self.assertFalse(torch._C._jit_set_nvfuser_skip_node_kind("aten::add", True))
+
+            def fn_1(x):
+                t1 = x + 2.0 # change const value so we'll not reuse plan 
+                return t1.relu()
+
+            fn_1_jit = torch.jit.script(fn_1)
+            self._run_helper(fn_1_jit, fn_1, x)
+
+            # add node should have been merged into fusion
+            self.assertGraphContains(fn_1_jit.graph_for(x), FUSION_GUARD)
+            self.assertGraphContainsExactly(fn_1_jit.graph_for(x), 'aten::add', 1)
+
+            # flips skip parse for `aten::add`, next fusion should fuse add node 
+            self.assertTrue(torch._C._jit_set_nvfuser_skip_node_kind("aten::add", True))
+
+            def fn_2(x):
+                t1 = x + 2.0 # change const value so we'll not reuse plan 
+                return t1.relu()
+
+            fn_2_jit = torch.jit.script(fn_2)
+            self._run_helper(fn_2_jit, fn_2, x)
+
+            # add node should have been merged into fusion
+            self.assertGraphContains(fn_2_jit.graph_for(x), FUSION_GUARD)
+            self.assertGraphContainsExactly(fn_2_jit.graph_for(x), 'aten::add', 0)
+
+
 class TestPassManagerCudaFuser(JitTestCase):
 
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -90,6 +90,11 @@ bool profileNode(const Node* node) {
       getFuserInterface()->fn_profile_n(node);
 }
 
+bool skipNode(const std::string& symbol_str, bool flip) {
+  return getFuserInterface()->fn_skip_n != nullptr &&
+      getFuserInterface()->fn_skip_n(symbol_str, flip);
+}
+
 //! [ Note -- type guard logic in CudaFusionGuard ]
 //!
 //! CudaFusionGuard is used to Guard input tensor to `CudaFusionGroup` so that

--- a/torch/csrc/jit/codegen/cuda/interface.h
+++ b/torch/csrc/jit/codegen/cuda/interface.h
@@ -32,6 +32,7 @@ struct CudaFuserInterface {
   bool (*fn_can_fuse_n)(const Node*) = nullptr;
   void (*fn_insert_profile_inodes)(ProfilingRecord* pr) = nullptr;
   bool (*fn_profile_n)(const Node*) = nullptr;
+  bool (*fn_skip_n)(const std::string&, bool flip) = nullptr;
 };
 
 // Get interface, this is used by registration and user facing API internally
@@ -43,6 +44,8 @@ TORCH_API void fuseGraph(std::shared_ptr<Graph>&);
 TORCH_API bool canFuseNode(const Node* node);
 TORCH_API void InsertProfileNodesForCUDAFuser(ProfilingRecord* pr);
 TORCH_API bool profileNode(const Node* node);
+
+TORCH_API bool skipNode(const std::string& symbol_str, bool flip = true);
 
 TORCH_API bool complyWith(
     const at::Tensor& tensor,

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -3015,7 +3015,8 @@ bool shouldProfileNode(const Node* node) {
 }
 
 bool skipNodeKind(const std::string& symbol_str, bool flip) {
-  return IrParser::querySkipSymbolSet(c10::Symbol::fromQualString(symbol_str), flip);
+  return IrParser::querySkipSymbolSet(
+      c10::Symbol::fromQualString(symbol_str), flip);
 }
 
 bool insertProfileIValue(ProfilingRecord* pr, Node* node, size_t offset) {

--- a/torch/csrc/jit/codegen/cuda/parser.h
+++ b/torch/csrc/jit/codegen/cuda/parser.h
@@ -44,6 +44,8 @@ TORCH_CUDA_CU_API bool isElementWiseNode(const Node* node);
 TORCH_CUDA_CU_API bool isNodeParsible(const Node* node);
 TORCH_CUDA_CU_API bool shouldProfileNode(const Node* node);
 
+TORCH_CUDA_CU_API bool skipNodeKind(const std::string& symbol_str, bool flip);
+
 void InsertProfileNodes(ProfilingRecord* pr);
 
 // lowers PyTorch jit graph to `Fusion`.

--- a/torch/csrc/jit/codegen/cuda/register_interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/register_interface.cpp
@@ -25,6 +25,7 @@ class RegisterInterface {
     ptr->fn_can_fuse_n = &isFusibleCudaFusionGroup;
     ptr->fn_insert_profile_inodes = &InsertProfileNodes;
     ptr->fn_profile_n = &shouldProfileNode;
+    ptr->fn_skip_n = &skipNodeKind;
   }
 };
 

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -602,8 +602,7 @@ void initJITBindings(PyObject* module) {
           })
       .def(
           "_jit_set_nvfuser_skip_node_kind",
-          [](const std::string& op_name,
-             bool flip = true) {
+          [](const std::string& op_name, bool flip = true) {
             return fuser::cuda::skipNode(op_name, flip);
           })
       .def("_jit_set_nvfuser_enabled", &RegisterCudaFuseGraph::registerPass)

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -602,6 +602,13 @@ void initJITBindings(PyObject* module) {
           })
       .def(
           "_jit_set_nvfuser_skip_node_kind",
+            // Args:
+            //     `op_name`: Symbol of op;
+            //     `flip`: flag indicating whether to flip the given op in the
+            //             skip list.
+            // Returns:
+            //     a bool flag indicating if `op_name` was already in the skip
+            //     list.
           [](const std::string& op_name, bool flip = true) {
             return fuser::cuda::skipNode(op_name, flip);
           })

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -600,6 +600,12 @@ void initJITBindings(PyObject* module) {
             auto stack = toTraceableStack(args);
             checkAliasAnnotation(g, std::move(stack), unqualified_op_name);
           })
+      .def(
+          "_jit_set_nvfuser_skip_node_kind",
+          [](const std::string& op_name,
+             bool flip = true) {
+            return fuser::cuda::skipNode(op_name, flip);
+          })
       .def("_jit_set_nvfuser_enabled", &RegisterCudaFuseGraph::registerPass)
       .def(
           "_jit_set_nvfuser_single_node_mode",


### PR DESCRIPTION
added python API to disable nvfuser on certain opkind.

```
          "_jit_set_nvfuser_skip_node_kind",
          [](const std::string& op_name, bool flip = true) {
            return fuser::cuda::skipNode(op_name, flip);
          })
```

Args:
    `op_name`: Symbol of op;
    `flip`: flag indicating whether to flip the given op in the skip list.
Returns:
    a bool flag indicating if `op_name` was already in the skip list.

The python example that disables the fusion of `aten::add` afterwards.
`torch._C._jit_set_nvfuser_skip_node_kind("aten::add", True)  # returns False, as no op is in skip list by default`