### PR TITLE
[quant][core][gpu] Wrapped CacheKey in Conv.cpp with anonymous namespace

### DIFF
--- a/aten/src/ATen/native/quantized/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/Conv.cpp
@@ -39,6 +39,8 @@ cudnn_frontend::ConvDesc_v8 getConvDescriptor(cudnnDataType_t dataType, c10::Int
     .build();
 }
 
+// FIXME: make this thread-safe by reusing the benchmark cache in Conv_v7.cpp
+namespace {
 struct CacheKey {
   at::native::ConvolutionParams params;
   uint8_t input_alignment;
@@ -47,9 +49,6 @@ struct CacheKey {
   // default to -1 when no bias
   int8_t bias_alignment;
 };
-
-// FIXME: make this thread-safe by reusing the benchmark cache in Conv_v7.cpp
-namespace {
 std::unordered_map<CacheKey, cudnn_frontend::ManagedOpaqueDescriptor, at::native::ParamsHash<CacheKey>, at::native::ParamsEqual<CacheKey>> execution_plan_cache;
 }
 // TODO: we can use cudnn_frontend::ExecutionPlanCache when it supports caching


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #74611
* #74463
* __->__ #74543
* #73957

Summary:
This is done to prevent ODR issues with other cudnn ops and we want to make sure
that the CacheKey in Conv.cpp is only used within this file. Other cudnn ops will
also define CacheKey in their files.
This PR should introduce no functional changes.

Test plan:
In pytorch main directory, execute
```
python test/test_quantization.py TestQuantizedConv.test_qconv2d_cudnn
```
for accuracy testing and
```
python test/test_quantization.py TestQuantizedConv.test_benchmark
```
for benchmark testing.

Differential Revision: [D35066248](https://our.internmc.facebook.com/intern/diff/D35066248)