### PR TITLE
LTC+Dynamo: dedup device data

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/core/extract_compiled_graph.py
+++ b/lazy_tensor_core/lazy_tensor_core/core/extract_compiled_graph.py
@@ -78,6 +78,7 @@ def extract_compiled_graph(model: fx.GraphModule, example_inputs) -> Callable:
         print("LTC IR:", _LAZYC._get_ltc_tensors_text(lazy_out))
 
     graph_input_tensor_ids, graph_input_ivalues = _LAZYC._get_ltc_tensors_ts_device_data_node(lazy_out)
+    assert len(graph_input_tensor_ids) == len(graph_input_ivalues)
     graph_input_matcher = GraphInputMatcher(tensor_id_to_arg_idx, graph_input_tensor_ids, graph_input_ivalues)
 
     graph_hash = _LAZYC._get_graph_hash(lazy_out)

--- a/lazy_tensor_core/test/test_extract_compiled_graph.py
+++ b/lazy_tensor_core/test/test_extract_compiled_graph.py
@@ -88,6 +88,7 @@ def verify_reusing_compiled_graph(mod, ncase=10):
         actual = optimized_mod(*rand_args)
 
         if not allclose(expected, actual):
+            print(f"Incorrect results. expected {expected}, actual {actual}")
             failed_index.append(i)
 
     if len(failed_index) > 0:
@@ -99,10 +100,8 @@ def maketest(module_cls):
 
     return wrapper
 
-# import pdb; pdb.set_trace()
 class OptimizeTest(unittest.TestCase):
     test_sub = maketest(ModuleSub)
     test_const_scale = maketest(ModuleConstScale)
     test_addcmul = maketest(ModuleAddcmul)
     test_return_multi = maketest(ModuleReturnMulti)
-    # test_eager_tensor = maketest(ModuleEagerTensor)


### PR DESCRIPTION
Cover the case that device data nodes with the same handle occurs multiple times in the LTC IR. Those device data instances will be mapped to a single TS graph input. We need dedup them when setting up the IValue stack for the TS graph so that the state in IValue stack matches the TS graph inputs.

BTW, ehe dedup logic is already implement in the ts lowering of DeviceData. This PR just make things consistent.

Test:
```
pytest test/test_extract_compiled_graph.py
```

Run thru dynamo. A few previous failing models now pass. (e.g. pyhpc_equation_of_state )
```
LTC_TS_CUDA=1 time python torchbench.py --speedup-ltc -dcuda --nvfuser --randomize-input --only pyhpc_equation_of_state
```