### PR TITLE
[quant] Fix the quant_min/quant_max override in FakeQuantize

### DIFF
--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -758,6 +758,17 @@ class TestFakeQuantize(TestCase):
         for key in state_dict:
             self.assertEqual(state_dict[key], loaded_dict[key])
 
+    def test_quant_min_max_override(self):
+        observer = default_per_channel_weight_observer
+        # test no override
+        fq_module = FakeQuantize(observer)
+        self.assertEqual(fq_module.activation_post_process.quant_min, -128)
+        self.assertEqual(fq_module.activation_post_process.quant_max, 127)
+        # test quant_min/quant_max override
+        fq_module = FakeQuantize(observer, quant_min=0, quant_max=127)
+        self.assertEqual(fq_module.activation_post_process.quant_min, -64)
+        self.assertEqual(fq_module.activation_post_process.quant_max, 63)
+
 def _get_buffer_ids(module):
     """
     Object addresses stay constant if and only if all modifications are in-place

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -299,6 +299,7 @@ def calculate_qmin_qmax(quant_min: int, quant_max: int, has_customized_qrange: b
     r"""Calculates actual qmin and qmax based on the quantization range,
     observer datatype and if range is reduced.
     """
+    # TODO(jerryzh): Figure out why custom quant_min/quant_max are still adjusted.
     if has_customized_qrange:
         # This initialization here is to be resolve TorchScript compilation issues and allow
         # using of refinement to decouple initial_qmin and initial_qmax from quantization range.


### PR DESCRIPTION
Summary: As title, currently the quant_min/quant_max of the FakeQuantize are not passed to the observer.

Test Plan:
```
[jiaxuzhu@devvm3400.frc0 /data/users/jiaxuzhu/fbsource/fbcode] buck test mode/dev //caffe2/test:quantization -- --exact 'caffe2/test:quantization - test_quant_min_max_override (quantization.core.test_workflow_module.TestFakeQuantize)'
Restarting Buck daemon because Buck version has changed...
Buck daemon started.
DEBUG: /data/users/jiaxuzhu/fbsource/tools/build_defs/fbcode_macros/build_defs/lib/cpp_common.bzl:287:14: Using disallowed linker flag 'ANativeActivity_onCreate' in library rule 'fbsource//third-party/toolchains/android-ndk:r18b_native_app_glue'
DEBUG: /data/users/jiaxuzhu/fbsource/tools/build_defs/fbcode_macros/build_defs/lib/cpp_common.bzl:287:14: Using disallowed linker flag 'arvr/third-party/toolchains/platform009/build/mesa/lib/libGL.so' in library rule 'fbsource//third-party/toolchains:opengl'
DEBUG: /data/users/jiaxuzhu/fbsource/tools/build_defs/fbcode_macros/build_defs/lib/cpp_common.bzl:287:14: Using disallowed linker flag 'arvr/third-party/freeglut/3.0.0/libs/x64-linux/libglut.a' in library rule 'fbsource//third-party/toolchains:GLUT'
Parsing buck files: finished in 20.4 sec
Creating action graph: finished in 44.0 sec
[RE] Metadata: Session ID=[https://fburl.com/b/reSessionID-bafd60fc-6119-4ae7-95b5-7e36b783310b]
[RE] Waiting on 0 remote actions. Completed 144 actions remotely, action cache hit rate: 94.59%.
Downloaded 10199/10203 artifacts, 1.08 Gbytes, 0.0% cache miss (for updated rules)
Building: finished in 02:10.2 min (100%) 21299/21299 jobs, 21299/21299 updated
  Total time: 03:14.7 min
More details at https://www.internalfb.com/intern/buck/build/a2325f91-fc53-40ec-bec1-d7bd5c931b0f
BUILD SUCCEEDED
Tpx test run coordinator for Facebook. See https://fburl.com/tpx for details.
Running with tpx session id: e1dd4647-9f9c-4f63-8390-6c13f3ebf7a1
Trace available for this run at /tmp/tpx-20220322-135414.576062-e1dd4647-9f9c-4f63-8390-6c13f3ebf7a1/trace.log
RemoteExecution session id: reSessionID-e1dd4647-9f9c-4f63-8390-6c13f3ebf7a1-tpx
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/6473924546262193
    ✓ ListingSuccess: caffe2/test:quantization : 483 tests discovered (31.784)
    ✓ Pass: caffe2/test:quantization - test_quant_min_max_override (quantization.core.test_workflow_module.TestFakeQuantize) (19.030)
Summary
  Pass: 1
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/6473924546262193
```

Differential Revision: D34971236

