### PR TITLE
[ONNX] Fix 1d case flatten export

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4904,6 +4904,9 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randint(10, (1, 2, 3, 4))
         self.run_test(FlattenModel(), x)
 
+        x = torch.randn(4)
+        self.run_test(FlattenModel(), x)
+
     def test_flatten2d(self):
         class FlattenModel(torch.nn.Module):
             def forward(self, input):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -801,12 +801,14 @@ def narrow(g, input, dim, start, length):
 @parse_args("v", "i", "i")
 def flatten(g, input, start_dim, end_dim):
     dim = sym_help._get_tensor_rank(input)
+    if dim == 1:
+        return input
     # use ONNX's Flatten operator for cases where the output shape is 2D
     if start_dim == 1:
-        if (end_dim == -1 or (end_dim > 0 and dim is not None and end_dim == dim - 1)):
+        if (end_dim == -1 or (dim is not None and end_dim == dim - 1)):
             return g.op("Flatten", input, axis_i=start_dim)
     elif start_dim == 0:
-        if (end_dim == -2 or (end_dim > 0 and dim is not None and end_dim == dim - 2)):
+        if (end_dim == -2 or (dim is not None and end_dim == dim - 2)):
             return g.op("Flatten", input, axis_i=end_dim + 1)
     if dim is None:
         return _unimplemented("dim",

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -803,10 +803,10 @@ def flatten(g, input, start_dim, end_dim):
     dim = sym_help._get_tensor_rank(input)
     # use ONNX's Flatten operator for cases where the output shape is 2D
     if start_dim == 1:
-        if (end_dim == -1 or (dim is not None and end_dim == dim - 1)):
+        if (end_dim == -1 or (end_dim > 0 and dim is not None and end_dim == dim - 1)):
             return g.op("Flatten", input, axis_i=start_dim)
     elif start_dim == 0:
-        if (end_dim == -2 or (dim is not None and end_dim == dim - 2)):
+        if (end_dim == -2 or (end_dim > 0 and dim is not None and end_dim == dim - 2)):
             return g.op("Flatten", input, axis_i=end_dim + 1)
     if dim is None:
         return _unimplemented("dim",


### PR DESCRIPTION
Fixes #74142

Previous check `dim is not None and end_dim == dim - 2` didn't consider `end_dim` being negative. However the error only occurs when input tensor has rank 1, and the rank is known to symbolic function. So a better fix is to return `input` directly when rank is 1.
