### PR TITLE
[quant][core][gpu] Added broadcasting support for quantized add operator using cudnn

### DIFF
--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -832,9 +832,9 @@ class TestQuantizedOps(TestCase):
     """Tests the correctness of the cudnn add and add_relu op
     (Similar to test_qadd_relu_different_qparams, will probably merge in the future)"""
     @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
-    @unittest.skip("Local only - currently the qconv2d_cudnn op is bulid "
-                   "with USE_EXPERIMENTAL_CUDNN_V8_API, we can enable the test "
-                   "after it is built by default")
+    # @unittest.skip("Local only - currently the qconv2d_cudnn op is bulid "
+    #                "with USE_EXPERIMENTAL_CUDNN_V8_API, we can enable the test "
+    #                "after it is built by default")
     def test_qadd_relu_cudnn(self):
         dtype = torch.qint8
         add_relu = torch.ops.quantized.add_relu


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74611
* #74463
* #74543
* #73957

Summary plan:
**note: this PR is currently not working properly**

Previous implementation of quantized add in cudnn did not support broadcasting
for the multiplication operations. As of cudnn v. 8.3.3, broadcasting is properly supported.
This PR implements broadcasting support for the two multiplication operators in the quantized add op.

Test plan:
In pytorch main dir, execute
```
python test/test_quantization.py TestQuantizedOps.test_qadd_relu_cudnn
```