### PR TITLE
[quant][core][gpu][improvement] Added broadcasting support for quantized conv2d operator using cudnn

### DIFF
--- a/aten/src/ATen/native/quantized/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/Conv.cpp
@@ -95,6 +95,7 @@ void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& qua
   }
   at::Tensor conv_output = at::empty(quantized_output.sizes(), at::device(at::kCUDA).dtype(at::kFloat), at::MemoryFormat::ChannelsLast);
   // TODO: combine empty & fill_ using full_like or full
+  // std::vector<int> broadcast_size(quantized_output.ndim(), 1);
   at::Tensor requantize_multiplier_tensor = at::empty(quantized_output.sizes(), at::device(at::kCUDA).dtype(at::kFloat), at::MemoryFormat::ChannelsLast);
   auto act_scale = input.q_scale();
   auto weight_scale = orig_weight_.q_scale();
@@ -112,7 +113,7 @@ void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& qua
     broadcasted_bias = bias_.value().reshape(new_size);
     broadcasted_bias.value() = broadcasted_bias.value().broadcast_to(quantized_output.sizes());
     broadcasted_bias.value() = broadcasted_bias.value().contiguous(c10::MemoryFormat::ChannelsLast);
-    bias_multiplier_tensor = at::empty(quantized_output.sizes(), at::device(at::kCUDA).dtype(at::kFloat), at::MemoryFormat::ChannelsLast);
+    bias_multiplier_tensor = at::empty(broadcasted_bias.value().sizes(), at::device(at::kCUDA).dtype(at::kFloat), at::MemoryFormat::ChannelsLast);
     auto bias_multiplier = 1.0 / (act_scale * weight_scale);
     bias_multiplier_tensor.value().fill_(bias_multiplier);
   }

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -4238,9 +4238,9 @@ class TestQuantizedConv(TestCase):
            use_channelwise=st.sampled_from([False]))
     @skipIfNoFBGEMM
     @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
-    @unittest.skip("Local only - currently the qconv2d_cudnn op is bulid "
-                   "with USE_EXPERIMENTAL_CUDNN_V8_API, we can enable the test "
-                   "after it is built by default")
+    # @unittest.skip("Local only - currently the qconv2d_cudnn op is bulid "
+    #                "with USE_EXPERIMENTAL_CUDNN_V8_API, we can enable the test "
+    #                "after it is built by default")
     def test_qconv2d_cudnn(
             self,
             batch_size,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74631

Summary plan:
Previous implementation of quantized conv2d in cudnn did not support broadcasting
for the multiplication operations. As of cudnn v. 8.3.3, broadcasting is properly supported.
This PR implements broadcasting support for the multiplication operators in the quantized conv2d op.

Adding broadcast support for requantize_multiplier tensor reduced int8 run times by about 40x, which is very strange.
We'll put this on hold for now.

I think we're also blocked on the bias_mult_op broadcasting for the same reason as
quantized add op. We're waiting to hear back from NVIDIA regarding that. Also there's some issues with the strides
of broadcasted_bias not matching bias_multiplier_tensor.
What if we did the multiplicaiton of bias and the multiplier before broadcasting so that we don't have to create a 4D
bias_multiplier_tensor even though it's only a single element? We can explore this later

Current benchmark results:
```
int8 benchmark result:
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
                                  cudaDeviceSynchronize        61.05%       5.731ms        61.05%       5.731ms       5.731ms       0.000us         0.00%       0.000us       0.000us             1
                                          ProfilerStep*        16.89%       1.585ms        37.86%       3.554ms     177.700us       0.000us         0.00%      80.000us       4.000us            20
                                      quantized::conv2d        10.61%     996.000us        20.73%       1.946ms      97.300us       0.000us         0.00%      80.000us       4.000us            20
                                            aten::empty         3.53%     331.000us         3.53%     331.000us       3.310us       0.000us         0.00%       0.000us       0.000us           100
                                       cudaLaunchKernel         2.34%     220.000us         2.34%     220.000us      11.000us       0.000us         0.00%       0.000us       0.000us            20
                                            aten::fill_         2.06%     193.000us         4.40%     413.000us      20.650us      80.000us         0.81%      80.000us       4.000us            20
                          aten::_empty_affine_quantized         1.96%     184.000us         1.96%     184.000us       9.200us       0.000us         0.00%       0.000us       0.000us            20
                                          aten::q_scale         0.87%      82.000us         0.87%      82.000us       2.050us       0.000us         0.00%       0.000us       0.000us            40
                                            aten::zeros         0.63%      59.000us         1.09%     102.000us       5.100us       0.000us         0.00%       0.000us       0.000us            20
                                            aten::zero_         0.06%       6.000us         0.06%       6.000us       0.300us       0.000us         0.00%       0.000us       0.000us            20
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 9.387ms
Self CUDA time total: 9.886ms
```

Test plan:
In pytorch main dir, execute
```
python test/test_quantization.py TestQuantizedConv.test_qconv2d_cudnn
```
for accuracy testing and
```
python test/test_quantization.py TestQuantizedConv.test_benchmark
```
for benchmarking.

Differential Revision: [D35419165](https://our.internmc.facebook.com/intern/diff/D35419165)