### PR TITLE
Enable XLA CI tests

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -212,7 +212,6 @@ jobs:
       build-generates-artifacts: false
 
   pytorch-xla-linux-bionic-py3_7-clang8-build:
-    if: ${{ false }}
     name: pytorch-xla-linux-bionic-py3.7-clang8
     uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -13,6 +13,7 @@ TORCH_INSTALL_DIR=$(python -c "import site; print(site.getsitepackages()[0])")/t
 TORCH_BIN_DIR="$TORCH_INSTALL_DIR"/bin
 TORCH_LIB_DIR="$TORCH_INSTALL_DIR"/lib
 TORCH_TEST_DIR="$TORCH_INSTALL_DIR"/test
+XLA_DIR="$TORCH_INSTALL_DIR"/xla
 
 BUILD_DIR="build"
 BUILD_RENAMED_DIR="build_renamed"
@@ -424,7 +425,7 @@ test_torch_function_benchmark() {
 }
 
 build_xla() {
-  XLA_DIR=xla
+  XLA_DIR
   clone_pytorch_xla
   # shellcheck disable=SC1091
   source "xla/.circleci/common.sh"
@@ -545,6 +546,9 @@ elif [[ "${BUILD_ENVIRONMENT}" == *backward* ]]; then
   test_forward_backward_compatibility
   # Do NOT add tests after bc check tests, see its comment.
 elif [[ "${TEST_CONFIG}" == *xla* ]]; then
+  echo "WONJOO"
+  ls
+  pwd
   install_torchvision
   build_xla
   test_xla


### PR DESCRIPTION
XLA CI tests has been disabled of https://github.com/pytorch/pytorch/pull/74472.

The faulty PR has been reverted on XLA's end, so we were enabling the XLI tests again. 