### PR TITLE
Skip specifying rcond for gelsy driver in tests

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -264,7 +264,8 @@ class TestLinalg(TestCase):
                 else:
                     # driver == 'gelsy'
                     # QR based algorithm; setting the value too high might lead to non-unique solutions and flaky tests
-                    rcond = 1e-4
+                    # so we skip this case
+                    continue
 
             # specifying rcond value has no effect for gels driver so no need to run the tests again
             if driver == 'gels' and rcond is not None:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/72281
