### PR TITLE
c10d: retry dns lookup failures

### DIFF
--- a/test/distributed/test_store.py
+++ b/test/distributed/test_store.py
@@ -404,6 +404,14 @@ class RendezvousTCPTest(TestCase):
             gen = dist.rendezvous("tcp://127.0.0.1:23456?rank=0")
             next(gen)
 
+    def test_dns_timeout(self):
+        with self.assertRaisesRegex(TimeoutError, "client socket has timed out after.*dnsnotexist"):
+            gen = dist.rendezvous(
+                "tcp://dnsnotexist:23456?world_size=2&rank=0",
+                timeout=timedelta(seconds=1),
+            )
+            next(gen)
+
     @retry_on_connect_failures
     def test_nominal(self):
         url = self.create_tcp_url()

--- a/torch/csrc/distributed/c10d/socket.cpp
+++ b/torch/csrc/distributed/c10d/socket.cpp
@@ -613,27 +613,10 @@ std::unique_ptr<SocketImpl> SocketConnectOp::run() {
 }
 
 bool SocketConnectOp::tryConnect(int family) {
-  ::addrinfo hints{}, *naked_result = nullptr;
-
+  ::addrinfo hints{};
   hints.ai_flags = AI_V4MAPPED | AI_ALL | AI_NUMERICSERV;
   hints.ai_family = family;
   hints.ai_socktype = SOCK_STREAM;
-
-  int r = ::getaddrinfo(host_, port_.c_str(), &hints, &naked_result);
-  if (r != 0) {
-    const char* gai_err = ::gai_strerror(r);
-
-    recordError("The {}network addresses of ({}, {}) cannot be retrieved (gai error: {} - {}).",
-                family == AF_INET ? "IPv4 " : family == AF_INET6 ? "IPv6 " : "",
-                host_,
-                port_,
-                r,
-                gai_err);
-
-    return false;
-  }
-
-  addrinfo_ptr result{naked_result};
 
   deadline_ = Clock::now() + opts_->connect_timeout();
 
@@ -645,16 +628,33 @@ bool SocketConnectOp::tryConnect(int family) {
 
     errors_.clear();
 
-    for (::addrinfo* addr = naked_result; addr != nullptr; addr = addr->ai_next) {
-      C10D_TRACE("The client socket is attempting to connect to {}.", *addr);
+    ::addrinfo *naked_result = nullptr;
+    // patternlint-disable cpp-dns-deps
+    int r = ::getaddrinfo(host_, port_.c_str(), &hints, &naked_result);
+    if (r != 0) {
+      const char* gai_err = ::gai_strerror(r);
 
-      ConnectResult cr = tryConnect(*addr);
-      if (cr == ConnectResult::Success) {
-        return true;
-      }
+      recordError("The {}network addresses of ({}, {}) cannot be retrieved (gai error: {} - {}).",
+                  family == AF_INET ? "IPv4 " : family == AF_INET6 ? "IPv6 " : "",
+                  host_,
+                  port_,
+                  r,
+                  gai_err);
+      retry = true;
+    } else {
+      addrinfo_ptr result{naked_result};
 
-      if (cr == ConnectResult::Retry) {
-        retry = true;
+      for (::addrinfo* addr = naked_result; addr != nullptr; addr = addr->ai_next) {
+        C10D_TRACE("The client socket is attempting to connect to {}.", *addr);
+
+        ConnectResult cr = tryConnect(*addr);
+        if (cr == ConnectResult::Success) {
+          return true;
+        }
+
+        if (cr == ConnectResult::Retry) {
+          retry = true;
+        }
       }
     }
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -3109,20 +3109,17 @@ def sandcastle_skip_if(condition, reason):
     skipping continuously.
     """
     def decorator(func):
-
-        if not IS_SANDCASTLE and condition:
-            func.__unittest_skip__ = True
-            func.__unittest_skip_why__ = reason
-            return func
-
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            if condition and IS_SANDCASTLE:
-                print(f'Skipping {func.__name__} on sandcastle for following reason: {reason}', file=sys.stderr)
-                return
+        if condition:
+            if IS_SANDCASTLE:
+                @wraps(func)
+                def wrapper(*args, **kwargs):
+                    print(f'Skipping {func.__name__} on sandcastle for following reason: {reason}', file=sys.stderr)
+                return wrapper
             else:
-                return func(*args, **kwargs)
-        return wrapper
+                func.__unittest_skip__ = True
+                func.__unittest_skip_why__ = reason
+
+        return func
 
     return decorator
 


### PR DESCRIPTION
Summary:
This makes dns hostname lookup failures retryable since in some environments such as Kubernetes they're not guaranteed to be resolvable until the job starts. Retrying this eliminates the race condition.

Fixes https://github.com/pytorch/pytorch/issues/73682

Test Plan:
Added a unit test

```
buck test //caffe2/test/distributed:test_store
```

Reviewed By: aivanou

Differential Revision: D35092284

