### PR TITLE
Fix full Android builds (take 2)

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -24,11 +24,16 @@ inputs:
   branch:
     required: true
     description: What branch we are building on.
+outputs:
+  container_id:
+    description: Docker container identifier used to build the artifacts
+    value: ${{ steps.build.outputs.container_id }}
 
 runs:
   using: composite
   steps:
     - name: Build-${{ inputs.arch }}
+      id: build
       shell: bash
       env:
         BRANCH: ${{ inputs.branch }}
@@ -43,7 +48,7 @@ runs:
         MATRIX_ARCH: ${{ inputs.arch }}
       run: |
         # detached container should get cleaned up by teardown_ec2_linux
-        #!/bin/bash -eo pipefail
+        set -exo pipefail
         export container_name
         container_name=$(docker run \
           -e BUILD_ENVIRONMENT \
@@ -74,3 +79,4 @@ runs:
         # Copy install binaries back
         mkdir -p "${GITHUB_WORKSPACE}/build_android_install_${MATRIX_ARCH}"
         docker cp "${container_name}:/var/lib/jenkins/workspace/build_android/install" "${GITHUB_WORKSPACE}/build_android_install_${MATRIX_ARCH}"
+        echo "::set-output name=container_id::${container_name}"

--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -98,6 +98,7 @@ jobs:
           branch: ${{ steps.parse-ref.outputs.branch }}
 
       - name: Build x86_32
+        id: build-x86_32
         uses: pytorch/pytorch/.github/actions/build-android@master
         with:
           arch: x86_32
@@ -118,7 +119,6 @@ jobs:
           branch: ${{ steps.parse-ref.outputs.branch }}
 
       - name: Build final artifact
-        id: build-final
         env:
           BRANCH: ${{ steps.parse-ref.outputs.branch }}
           DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
@@ -127,23 +127,19 @@ jobs:
           SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
           CUSTOM_TEST_ARTIFACT_BUILD_DIR: build/custom_test_artifacts
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
+          ID_X86_32: ${{ steps.build-x86_32.outputs.container_id }}
         run: |
           set -eux
 
-          # x86_32
-          export id_x86_32
-          id_x86_32=$(docker run -e GRADLE_OFFLINE=1 --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -t -d -w /var/lib/jenkins "${DOCKER_IMAGE}")
-
           # Putting everything together
-          docker cp "${GITHUB_WORKSPACE}/." "${id_x86_32}:/var/lib/jenkins/workspace"
-          docker cp "${GITHUB_WORKSPACE}/build_android_install_arm_v7a" "${id_x86_32}:/var/lib/jenkins/workspace/build_android_install_arm_v7a"
-          docker cp "${GITHUB_WORKSPACE}/build_android_install_x86_64" "${id_x86_32}:/var/lib/jenkins/workspace/build_android_install_x86_64"
-          docker cp "${GITHUB_WORKSPACE}/build_android_install_arm_v8a" "${id_x86_32}:/var/lib/jenkins/workspace/build_android_install_arm_v8a"
-          docker cp "${GITHUB_WORKSPACE}/build_android_install_x86_32" "${id_x86_32}:/var/lib/jenkins/workspace/build_android_install_x86_32"
+          # ID_X86_32 container were created during build-x86_32 step
+          docker cp "${GITHUB_WORKSPACE}/build_android_install_arm_v7a" "${ID_X86_32}:/var/lib/jenkins/workspace/build_android_install_arm_v7a"
+          docker cp "${GITHUB_WORKSPACE}/build_android_install_x86_64" "${ID_X86_32}:/var/lib/jenkins/workspace/build_android_install_x86_64"
+          docker cp "${GITHUB_WORKSPACE}/build_android_install_arm_v8a" "${ID_X86_32}:/var/lib/jenkins/workspace/build_android_install_arm_v8a"
+          docker cp "${GITHUB_WORKSPACE}/build_android_install_x86_32" "${ID_X86_32}:/var/lib/jenkins/workspace/build_android_install_x86_32"
 
           # run gradle buildRelease
-          # shellcheck disable=SC1105
-          ((echo "sudo chown -R jenkins workspace && cd workspace && ./.circleci/scripts/build_android_gradle.sh") | docker exec \
+          (echo "./.circleci/scripts/build_android_gradle.sh" | docker exec \
             -e BUILD_ENVIRONMENT="pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build" \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e AWS_DEFAULT_REGION \
@@ -157,11 +153,10 @@ jobs:
             -e SKIP_SCCACHE_INITIALIZATION=1 \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
             --user jenkins \
-            -u jenkins -i "${id_x86_32}" bash) 2>&1
+            -u jenkins -i "${ID_X86_32}" bash) 2>&1
 
           mkdir -p "${GITHUB_WORKSPACE}/build_android_artifacts"
-          docker cp "${id_x86_32}:/var/lib/jenkins/workspace/android/artifacts.tgz" "${GITHUB_WORKSPACE}/build_android_artifacts/"
-          echo "::set-output name=id_x86_32::${id_x86_32}"
+          docker cp "${ID_X86_32}:/var/lib/jenkins/workspace/android/artifacts.tgz" "${GITHUB_WORKSPACE}/build_android_artifacts/"
 
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
@@ -198,11 +193,10 @@ jobs:
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ANDROID_SIGN_KEY: ${{ secrets.ANDROID_SIGN_KEY }}
           ANDROID_SIGN_PASS: ${{ secrets.ANDROID_SIGN_PASS }}
-          ID_X86_32: ${{ steps.build-final.outputs.id_x86_32 }}
+          ID_X86_32: ${{ steps.build-x86_32.outputs.container_id }}
         run: |
           set -eux
-          # shellcheck disable=SC2154
-          (echo "cd workspace && ./.circleci/scripts/publish_android_snapshot.sh" | docker exec \
+          (echo "./.circleci/scripts/publish_android_snapshot.sh" | docker exec \
             -e BUILD_ENVIRONMENT="pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-publish-snapshot" \
             -e SONATYPE_NEXUS_USERNAME \
             -e SONATYPE_NEXUS_PASSWORD \

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -114,7 +114,6 @@ jobs:
         ]}
 
   pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build:
-    if: ${{ false }}
     name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build
     uses: pytorch/pytorch/.github/workflows/_android-full-build-test.yml@master
     with:


### PR DESCRIPTION
Preserve container IDs from individual build runs and reuse them in final packaging step
Get rid of redundant `chown` steps in build-final and publish stages

Tested in: https://github.com/pytorch/pytorch/runs/5699505616?check_suite_focus=true