### PR TITLE
[quant][ns] Add GRU and MultiheadAttention for ns test

### DIFF
--- a/test/quantization/eager/test_numeric_suite_eager.py
+++ b/test/quantization/eager/test_numeric_suite_eager.py
@@ -599,9 +599,9 @@ class TestNumericSuiteEager(QuantizationTestCase):
         """
         qengine = torch.backends.quantized.engine
 
-        def compare_and_validate_results(float_model, q_model, mha_input):
+        def compare_and_validate_results(float_model, q_model, q, k, v):
             act_compare_dict = compare_model_outputs(
-                float_model, q_model, mha_input
+                float_model, q_model, q, k, v
             )
             self.assertEqual(len(act_compare_dict), 0)
 
@@ -620,10 +620,6 @@ class TestNumericSuiteEager(QuantizationTestCase):
                         )
 
         q, k, v = torch.rand(10, 5, 16), torch.rand(10, 5, 16), torch.rand(10, 5, 16)
-        mha_input = [q, k, v]
-
-        # m = MultiheadAttentionwithHiddenDynamicModel()
-        # out, w = m(*mha_input)
 
         model_list = [MultiheadAttentionwithHiddenDynamicModel(qengine)]
         for model in model_list:
@@ -631,7 +627,7 @@ class TestNumericSuiteEager(QuantizationTestCase):
             if hasattr(model, "fuse_model"):
                 model.fuse_model()
             q_model = quantize_dynamic(model)
-            compare_and_validate_results(model, q_model, mha_input)
+            compare_and_validate_results(model, q_model, q, k, v)
 
     @override_qengines
     def test_output_logger(self):

--- a/test/quantization/eager/test_numeric_suite_eager.py
+++ b/test/quantization/eager/test_numeric_suite_eager.py
@@ -26,6 +26,8 @@ from torch.testing._internal.common_quantization import (
     AnnotatedConvTransposeModel,
     AnnotatedSingleLayerLinearModel,
     LSTMwithHiddenDynamicModel,
+    MultiheadAttentionwithHiddenDynamicModel,
+    GRUwithHiddenDynamicModel,
     AnnotatedTwoLayerLinearModel,
     QuantizationTestCase,
     SingleLayerLinearDynamicModel,
@@ -174,6 +176,54 @@ class TestNumericSuiteEager(QuantizationTestCase):
                     self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
 
         model_list = [LSTMwithHiddenDynamicModel(qengine)]
+        for model in model_list:
+            model.eval()
+            if hasattr(model, "fuse_model"):
+                model.fuse_model()
+            q_model = quantize_dynamic(model)
+            compare_and_validate_results(model, q_model)
+
+    @override_qengines
+    def test_compare_weights_gru_dynamic(self):
+        r"""Compare the weights of float and dynamic quantized LSTM layer"""
+
+        qengine = torch.backends.quantized.engine
+
+        def compare_and_validate_results(float_model, q_model):
+            weight_dict = compare_weights(
+                float_model.state_dict(), q_model.state_dict()
+            )
+            self.assertEqual(len(weight_dict), 1)
+            for k, v in weight_dict.items():
+                self.assertTrue(len(v["float"]) == len(v["quantized"]))
+                for i, val in enumerate(v["quantized"]):
+                    self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
+
+        model_list = [GRUwithHiddenDynamicModel(qengine)]
+        for model in model_list:
+            model.eval()
+            if hasattr(model, "fuse_model"):
+                model.fuse_model()
+            q_model = quantize_dynamic(model)
+            compare_and_validate_results(model, q_model)
+
+    @override_qengines
+    def test_compare_weights_mha_dynamic(self):
+        r"""Compare the weights of float and dynamic quantized LSTM layer"""
+
+        qengine = torch.backends.quantized.engine
+
+        def compare_and_validate_results(float_model, q_model):
+            weight_dict = compare_weights(
+                float_model.state_dict(), q_model.state_dict()
+            )
+            self.assertEqual(len(weight_dict), 1)
+            for k, v in weight_dict.items():
+                self.assertTrue(len(v["float"]) == len(v["quantized"]))
+                for i, val in enumerate(v["quantized"]):
+                    self.assertTrue(v["float"][i].shape == v["quantized"][i].shape)
+
+        model_list = [MultiheadAttentionwithHiddenDynamicModel(qengine)]
         for model in model_list:
             model.eval()
             if hasattr(model, "fuse_model"):

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -1104,11 +1104,11 @@ class MultiheadAttentionwithHiddenDynamicModel(torch.nn.Module):
     def __init__(self, qengine='fbgemm'):
         super().__init__()
         self.qconfig = torch.quantization.get_default_qconfig(qengine)
-        self.mha = torch.nn.MultiheadAttention(2, 2).to(dtype=torch.float)
+        self.mha = torch.nn.MultiheadAttention(16, 2).to(dtype=torch.float)
 
-    def forward(self, x, hid):
-        x, hid = self.mha(x, hid)
-        return x, hid
+    def forward(self, q, k, v):
+        out, weights = self.mha(q, k, v)
+        return out, weights
 
 class ConvModel(torch.nn.Module):
     def __init__(self):

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -1090,6 +1090,26 @@ class LSTMwithHiddenDynamicModel(torch.nn.Module):
         x, hid = self.lstm(x, hid)
         return x, hid
 
+class GRUwithHiddenDynamicModel(torch.nn.Module):
+    def __init__(self, qengine='fbgemm'):
+        super().__init__()
+        self.qconfig = torch.quantization.get_default_qconfig(qengine)
+        self.gru = torch.nn.GRU(2, 2).to(dtype=torch.float)
+
+    def forward(self, x, hid):
+        x, hid = self.gru(x, hid)
+        return x, hid
+
+class MultiheadAttentionwithHiddenDynamicModel(torch.nn.Module):
+    def __init__(self, qengine='fbgemm'):
+        super().__init__()
+        self.qconfig = torch.quantization.get_default_qconfig(qengine)
+        self.mha = torch.nn.MultiheadAttention(2, 2).to(dtype=torch.float)
+
+    def forward(self, x, hid):
+        x, hid = self.mha(x, hid)
+        return x, hid
+
 class ConvModel(torch.nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74648

Summary:
Add RNN related modules(GRU and MultiheadAttention) for NS test

Test Plan:
 python3 test/test_quantization.py TestNumericSuiteEager.test_compare_weights_gru_dynamic
 python3 test/test_quantization.py TestNumericSuiteEager.test_compare_weights_mha_dynamic

Reviewers:

Subscribers:

Tasks:

Tags: