### PR TITLE
Skip only hop of __torch_function__ at a time

### DIFF
--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -656,7 +656,7 @@ def gen_has_torch_function_check(
     if noarg:
         if method:
             return f"""\
-if(check_has_torch_function(self_)) {{
+if (has_torch_function(self_)) {{
   return handle_torch_function(self_, "{name}");
 }}
 """

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -64,7 +64,7 @@ namespace torch { namespace autograd {
 static PyObject * THPVariable__is_view(PyObject *self, PyObject* args)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "_is_view", args);
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -81,7 +81,7 @@ static PyObject * THPVariable__is_view(PyObject *self, PyObject* args)
 static PyObject * THPVariable_apply_(PyObject* self, PyObject* arg)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     auto args = py::make_tuple(py::handle(arg));
     return handle_torch_function(self, "apply_", args.ptr());
   }
@@ -168,7 +168,7 @@ static PyObject * THPVariable_stride(PyObject* self, PyObject* args, PyObject* k
 static PyObject * THPVariable_get_device(PyObject* self_, PyObject* args)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self_)) {
+  if (has_torch_function(self_)) {
     return handle_torch_function(self_, "get_device", args, nullptr);
   }
   auto& self = THPVariable_Unpack(self_);
@@ -179,7 +179,7 @@ static PyObject * THPVariable_get_device(PyObject* self_, PyObject* args)
 static PyObject * THPVariable_has_names(PyObject* self_, PyObject* args)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self_)) {
+  if (has_torch_function(self_)) {
     return handle_torch_function(self_, "has_names", args);
   }
   auto& self = THPVariable_Unpack(self_);
@@ -191,7 +191,7 @@ static PyObject * THPVariable_has_names(PyObject* self_, PyObject* args)
 static PyObject * THPVariable_data_ptr(PyObject* self_, PyObject* args)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self_)) {
+  if (has_torch_function(self_)) {
     return handle_torch_function(self_, "data_ptr", args);
   }
   auto& self = THPVariable_Unpack(self_);
@@ -203,7 +203,7 @@ static PyObject * THPVariable_data_ptr(PyObject* self_, PyObject* args)
 static PyObject * THPVariable_storage_offset(PyObject* self_, PyObject* args)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self_)) {
+  if (has_torch_function(self_)) {
     return handle_torch_function(self_, "storage_offset");
   }
   auto& self = THPVariable_Unpack(self_);
@@ -215,7 +215,7 @@ static PyObject * THPVariable_storage_offset(PyObject* self_, PyObject* args)
 static PyObject * THPVariable_dim(PyObject* self, PyObject* args)
 {
    HANDLE_TH_ERRORS
-   if (check_has_torch_function(self)) {
+   if (has_torch_function(self)) {
      return handle_torch_function(self, "dim", args);
    }
    auto& self_ = THPVariable_Unpack(self);
@@ -227,7 +227,7 @@ static PyObject * THPVariable_dim(PyObject* self, PyObject* args)
 static PyObject * THPVariable_numel(PyObject* self, PyObject* args)
 {
    HANDLE_TH_ERRORS
-   if (check_has_torch_function(self)) {
+   if (has_torch_function(self)) {
      return handle_torch_function(self, "numel", args);
    }
    auto& self_ = THPVariable_Unpack(self);
@@ -342,7 +342,7 @@ static bool dispatch_to_Bool(const Tensor & self) {
 
 static PyObject * THPVariable_float_scalar(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "__float__", args);
   }
   jit::tracer::warn("Converting a tensor to a Python float", jit::tracer::WARN_PYTHON_DATAFLOW);
@@ -353,7 +353,7 @@ static PyObject * THPVariable_float_scalar(PyObject* self, PyObject* args) {
 
 static PyObject * THPVariable_complex_scalar(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "__complex__", args);
   }
   jit::tracer::warn("Converting a tensor to a Python complex", jit::tracer::WARN_PYTHON_DATAFLOW);
@@ -364,7 +364,7 @@ static PyObject * THPVariable_complex_scalar(PyObject* self, PyObject* args) {
 
 static PyObject * THPVariable_integral_scalar(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "__int__", args);
   }
   jit::tracer::warn("Converting a tensor to a Python integer", jit::tracer::WARN_PYTHON_DATAFLOW);
@@ -383,7 +383,7 @@ static PyObject * THPVariable_integral_scalar(PyObject* self, PyObject* args) {
 // called when used as a slice.
 static PyObject * THPVariable_index_scalar(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "__index__", args);
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -404,7 +404,7 @@ static Tensor dispatch_invert(const Tensor & self) {
 
 static PyObject * THPVariable_invert(PyObject* self, PyObject* args) {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "__invert__", args);
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -755,7 +755,7 @@ static PyObject * THPVariable_bfloat16(PyObject* self, PyObject* args, PyObject*
 static PyObject * THPVariable_element_size(PyObject* self, PyObject* args)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "element_size", args);
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -768,7 +768,7 @@ static PyObject * THPVariable_element_size(PyObject* self, PyObject* args)
 static PyObject * THPVariable_numpy(PyObject* self, PyObject* arg)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "numpy");
   }
   jit::tracer::warn("Converting a tensor to a NumPy array", jit::tracer::WARN_PYTHON_DATAFLOW);
@@ -839,7 +839,7 @@ static PyObject * THPVariable_is_contiguous(PyObject* self_, PyObject* args, PyO
 static PyObject * THPVariable_item(PyObject* self, PyObject* args)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "item", args);
   }
   jit::tracer::warn("Converting a tensor to a Python number", jit::tracer::WARN_PYTHON_DATAFLOW);
@@ -908,7 +908,7 @@ static PyObject * THPVariable_map2_(PyObject* self, PyObject* args, PyObject* kw
 static PyObject * THPVariable_new(PyObject* self, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "new", args, kwargs);
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -920,7 +920,7 @@ static PyObject * THPVariable_new(PyObject* self, PyObject* args, PyObject* kwar
 static PyObject * THPVariable_new_tensor(PyObject* self, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "new_tensor", args, kwargs);
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -932,8 +932,8 @@ static PyObject * THPVariable_new_tensor(PyObject* self, PyObject* args, PyObjec
 static PyObject * THPVariable_storage(PyObject* self, PyObject* arg)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
-    return handle_torch_function(self, "storage");
+  if (has_torch_function(self)) {
+    return handle_torch_function(self, "_storage");
   }
   auto& self_ = THPVariable_Unpack(self);
   return createPyObject(self_.storage());
@@ -985,7 +985,7 @@ static PyObject * THPVariable_to(PyObject* self, PyObject* args, PyObject* kwarg
 static PyObject * THPVariable_tolist(PyObject* self, PyObject* args)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function(self, "tolist", args);
   }
   jit::tracer::warn("Converting a tensor to a Python list", jit::tracer::WARN_PYTHON_DATAFLOW);
@@ -1053,7 +1053,7 @@ static PyObject * THPVariable_type(PyObject* self, PyObject* args, PyObject* kwa
 ${py_methods}
 
 static PyObject * THPVariable_bool_scalar(PyObject* self, PyObject* args) {
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     HANDLE_TH_ERRORS
     return handle_torch_function(self, "__bool__", args);
     END_HANDLE_TH_ERRORS

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1155,18 +1155,16 @@ class Tensor(torch._C._TensorBase):
 
         While not mandatory, we recommend making `__torch_function__` a classmethod.
         """
-        if kwargs is None:
-            kwargs = {}
-
         if not all(issubclass(cls, t) for t in types):
             return NotImplemented
 
-        with _C.DisableTorchFunction():
-            ret = func(*args, **kwargs)
-            if func in get_default_nowrap_functions():
-                return ret
-            else:
-                return _convert(ret, cls)
+        ret = torch._C._skip_one_hop_torch_function(
+            func, types, args, kwargs)
+
+        if func in get_default_nowrap_functions():
+            return ret
+
+        return _convert(ret, cls)
 
     __torch_dispatch__ = _C._disabled_torch_dispatch_impl
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -712,6 +712,7 @@ static PyMethodDef TorchMethods[] = {
   {"_is_torch_function_enabled", THPModule_isEnabledTorchFunction, METH_NOARGS, nullptr},
   {"_disabled_torch_function_impl", THPModule_disable_torch_function, METH_VARARGS, nullptr},
   {"_disabled_torch_dispatch_impl", THPModule_disable_torch_dispatch, METH_VARARGS, nullptr},
+  {"_skip_one_hop_torch_function", THPModule_skip_one_hop_torch_function, METH_VARARGS, nullptr},
   {"_has_torch_function", THPModule_has_torch_function, METH_O, nullptr},
   {"_has_torch_function_unary", THPModule_has_torch_function_unary, METH_O, nullptr},
   {"_has_torch_function_variadic", MAYBE_WRAP_FASTCALL(THPModule_has_torch_function_variadic), MAYBE_METH_FASTCALL, nullptr},

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -465,7 +465,7 @@ PyObject *THPVariable_get_python_dispatch(THPVariable *self, void *unused)
 PyObject *THPVariable_get_T(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "T");
   }
   const auto& var = THPVariable_Unpack(self);
@@ -476,7 +476,7 @@ PyObject *THPVariable_get_T(THPVariable *self, void *unused)
 PyObject *THPVariable_get_H(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "H");
   }
   const auto& var = THPVariable_Unpack(self);
@@ -487,7 +487,7 @@ PyObject *THPVariable_get_H(THPVariable *self, void *unused)
 PyObject *THPVariable_get_mT(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "mT");
   }
   const auto& var = THPVariable_Unpack(self);
@@ -498,7 +498,7 @@ PyObject *THPVariable_get_mT(THPVariable *self, void *unused)
 PyObject *THPVariable_get_mH(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "mH");
   }
   const auto& var = THPVariable_Unpack(self);
@@ -509,7 +509,7 @@ PyObject *THPVariable_get_mH(THPVariable *self, void *unused)
 PyObject *THPVariable_get_cdata(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "_cdata");
   }
   const auto& var = THPVariable_Unpack(self);
@@ -520,7 +520,7 @@ PyObject *THPVariable_get_cdata(THPVariable *self, void *unused)
 PyObject *THPVariable_get_version(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "_version");
   }
   const auto& var = THPVariable_Unpack(self);
@@ -531,7 +531,7 @@ PyObject *THPVariable_get_version(THPVariable *self, void *unused)
 PyObject *THPVariable_get_grad_fn(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "grad_fn");
   }
   const auto& var = THPVariable_Unpack(self);
@@ -545,7 +545,7 @@ PyObject *THPVariable_get_grad_fn(THPVariable *self, void *unused)
 static int THPVariable_set_grad_fn(THPVariable *self, PyObject *obj, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_setter(self, "_grad_fn", obj);
   }
   THPUtils_assertRet(-1, obj, "Deletion of _grad_fn not allowed. Detach tensor instead!");
@@ -558,7 +558,7 @@ static int THPVariable_set_grad_fn(THPVariable *self, PyObject *obj, void *unuse
 static PyObject *THPVariable_is_leaf(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_leaf");
   }
   return PyBool_FromLong(!THPVariable_Unpack(self).grad_fn());
@@ -568,7 +568,7 @@ static PyObject *THPVariable_is_leaf(THPVariable *self, void *unused)
 static PyObject * THPVariable_get_data(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "data");
   }
   const auto& var = THPVariable_Unpack(self).variable_data();
@@ -579,7 +579,7 @@ static PyObject * THPVariable_get_data(THPVariable *self, void *unused)
 int THPVariable_set_data(THPVariable *self, PyObject *data, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_setter(self, "data", data);
   }
   THPUtils_assertRet(-1, data, "Deleting tensor data is not allowed. Delete tensor instead!");
@@ -595,7 +595,7 @@ int THPVariable_set_data(THPVariable *self, PyObject *data, void *unused)
 PyObject *THPVariable_get_grad(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "grad");
   }
   return THPVariable_Wrap(THPVariable_Unpack(self).grad());
@@ -605,7 +605,7 @@ PyObject *THPVariable_get_grad(THPVariable *self, void *unused)
 int THPVariable_set_grad(THPVariable *self, PyObject *py_grad, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_setter(self, "grad", py_grad);
   }
   const auto& var = THPVariable_Unpack(self);
@@ -640,7 +640,7 @@ int THPVariable_set_grad(THPVariable *self, PyObject *py_grad, void *unused)
 PyObject *THPVariable_get_volatile(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "volatile");
   }
   const char* msg = "volatile was removed (Variable.volatile is always False)";
@@ -653,7 +653,7 @@ PyObject *THPVariable_get_volatile(THPVariable *self, void *unused)
 int THPVariable_set_volatile(THPVariable *self, PyObject *obj, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_setter(self, "volatile", obj);
   }
   auto r = PyErr_WarnEx(PyExc_UserWarning, VOLATILE_WARNING, 1);
@@ -665,7 +665,7 @@ int THPVariable_set_volatile(THPVariable *self, PyObject *obj, void *unused)
 PyObject *THPVariable_get_output_nr(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "output_nr");
   }
   const auto output_nr = static_cast<long>(THPVariable_Unpack(self).output_nr());
@@ -676,7 +676,7 @@ PyObject *THPVariable_get_output_nr(THPVariable *self, void *unused)
 PyObject *THPVariable_get_requires_grad(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "requires_grad");
   }
   if(THPVariable_Unpack(self).requires_grad()) {
@@ -690,7 +690,7 @@ PyObject *THPVariable_get_requires_grad(THPVariable *self, void *unused)
 PyObject *THPVariable_retains_grad(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "retains_grad");
   }
   if(THPVariable_Unpack(self).retains_grad()) {
@@ -704,7 +704,7 @@ PyObject *THPVariable_retains_grad(THPVariable *self, void *unused)
 PyObject *THPVariable_get_ndim(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "ndim");
   }
   return PyInt_FromLong(THPVariable_Unpack(self).dim());
@@ -714,7 +714,7 @@ PyObject *THPVariable_get_ndim(THPVariable *self, void *unused)
 PyObject *THPVariable_get_names(PyObject *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function_getter((THPVariable*)self, "names");
   }
   // The long-term plan is to return a list of (python) torch.Dimname.
@@ -750,7 +750,7 @@ PyObject *THPVariable_get_names(PyObject *self, void *unused)
 
 int THPVariable_set_names(PyObject *self, PyObject *names, void *unused) {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function_setter((THPVariable*)self, "names", names);
   }
   const auto& var = THPVariable_Unpack(self);
@@ -769,7 +769,7 @@ int THPVariable_set_names(PyObject *self, PyObject *names, void *unused) {
 int THPVariable_set_requires_grad(THPVariable *self, PyObject *obj, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_setter(self, "requires_grad", obj);
   }
   THPUtils_assertRet(-1, obj && PyBool_Check(obj), "requires_grad must be a bool");
@@ -790,7 +790,7 @@ int THPVariable_set_requires_grad(THPVariable *self, PyObject *obj, void *unused
 
 PyObject *THPVariable_get_name(THPVariable* self, void *unused)
 {
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     HANDLE_TH_ERRORS
     return handle_torch_function_getter(self, "name");
     END_HANDLE_TH_ERRORS
@@ -804,7 +804,7 @@ PyObject *THPVariable_get_name(THPVariable* self, void *unused)
 PyObject *THPVariable_get_backwards_hooks(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "_backward_hooks");
   }
   if (self->backward_hooks) {
@@ -818,7 +818,7 @@ PyObject *THPVariable_get_backwards_hooks(THPVariable *self, void *unused)
 int THPVariable_set_backwards_hooks(THPVariable *self, PyObject *obj, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_setter(self, "_backward_hooks", obj);
   }
   THPUtils_assertRet(-1, obj, "Deletion of _backwards_hooks not allowed!");
@@ -840,7 +840,7 @@ int THPVariable_set_backwards_hooks(THPVariable *self, PyObject *obj, void *unus
 PyObject *THPVariable_get_base(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "_base");
   }
   const auto& tensor = THPVariable_Unpack(self);
@@ -881,7 +881,7 @@ static c10::impl::PythonGILHooksRegisterer python_gil_hooks_registerer(&python_g
 PyObject *THPVariable_get_shape(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "shape");
   }
   return THPSize_New(THPVariable_Unpack(self));
@@ -891,7 +891,7 @@ PyObject *THPVariable_get_shape(THPVariable *self, void *unused)
 PyObject *THPVariable_is_cuda(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_cuda");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -901,7 +901,7 @@ PyObject *THPVariable_is_cuda(THPVariable *self, void *unused)
 
 PyObject* THPVariable_is_xpu(THPVariable* self, void* unused) {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject*)self)) {
+  if (has_torch_function((PyObject*)self)) {
     return handle_torch_function_getter(self, "is_xpu");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -912,7 +912,7 @@ PyObject* THPVariable_is_xpu(THPVariable* self, void* unused) {
 PyObject *THPVariable_is_sparse(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_sparse");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -923,7 +923,7 @@ PyObject *THPVariable_is_sparse(THPVariable *self, void *unused)
 PyObject *THPVariable_is_sparse_csr(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_sparse_csr");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -934,7 +934,7 @@ PyObject *THPVariable_is_sparse_csr(THPVariable *self, void *unused)
 PyObject *THPVariable_is_mkldnn(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_mkldnn");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -945,7 +945,7 @@ PyObject *THPVariable_is_mkldnn(THPVariable *self, void *unused)
 PyObject *THPVariable_is_mlc(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_mlc");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -956,7 +956,7 @@ PyObject *THPVariable_is_mlc(THPVariable *self, void *unused)
 PyObject *THPVariable_is_ort(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_ort");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -967,7 +967,7 @@ PyObject *THPVariable_is_ort(THPVariable *self, void *unused)
 PyObject *THPVariable_is_vulkan(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_vulkan");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -978,7 +978,7 @@ PyObject *THPVariable_is_vulkan(THPVariable *self, void *unused)
 PyObject *THPVariable_is_quantized(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_quantized");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -989,7 +989,7 @@ PyObject *THPVariable_is_quantized(THPVariable *self, void *unused)
 PyObject *THPVariable_is_meta(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_meta");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -1000,7 +1000,7 @@ PyObject *THPVariable_is_meta(THPVariable *self, void *unused)
 PyObject *THPVariable_is_complex(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_complex");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -1011,7 +1011,7 @@ PyObject *THPVariable_is_complex(THPVariable *self, void *unused)
 PyObject *THPVariable_is_nested(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "is_nested");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -1022,7 +1022,7 @@ PyObject *THPVariable_is_nested(THPVariable *self, void *unused)
 static PyObject *THPVariable_dtype(THPVariable *self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "dtype");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -1032,7 +1032,7 @@ static PyObject *THPVariable_dtype(THPVariable *self, void *unused)
 
 static PyObject * THPVariable_layout(THPVariable* self, void *unused) {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "layout");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -1042,7 +1042,7 @@ static PyObject * THPVariable_layout(THPVariable* self, void *unused) {
 
 static PyObject * THPVariable_device(THPVariable* self, void *unused) {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "device");
   }
   return THPDevice_New(THPVariable_Unpack(self).device());
@@ -1052,7 +1052,7 @@ static PyObject * THPVariable_device(THPVariable* self, void *unused) {
 PyObject *THPVariable_get_real(THPVariable* self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "real");
   }
   auto& self_ = THPVariable_Unpack(self);
@@ -1064,7 +1064,7 @@ PyObject *THPVariable_get_real(THPVariable* self, void *unused)
 PyObject *THPVariable_get_imag(THPVariable* self, void *unused)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function((PyObject *)self)) {
+  if (has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "imag");
   }
   auto& self_ = THPVariable_Unpack(self);

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -32,7 +32,7 @@ namespace torch { namespace autograd {
 
 Py_ssize_t THPVariable_length(PyObject* self) {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     py::object ret = py::reinterpret_steal<py::object>(handle_torch_function(self, "__len__"));
     Py_ssize_t length = PyLong_AsSsize_t(ret.ptr());
     if (PyErr_Occurred()) {
@@ -272,7 +272,7 @@ static inline THPObjectPtr wrapTuple(PyObject* index) {
 // indexing is needed, it calls C++ `at::indexing::dispatch_index`.
 PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
   HANDLE_TH_ERRORS
-  if (!THPVariable_CheckExact(self) && check_has_torch_function(self)) {
+  if (has_torch_function(self)) {
     return handle_torch_function_indexing(self, index);
   }
   const auto& self_ = THPVariable_Unpack(self);
@@ -359,8 +359,7 @@ int THPVariable_setitem(PyObject* self, PyObject* index, PyObject* py_value) {
   if (py_value == nullptr) {
     throw TypeError("Tensor does not support deleting items");
   }
-  if ((!THPVariable_CheckExact(self) && check_has_torch_function(self)) ||
-      (!THPVariable_CheckExact(py_value) && check_has_torch_function(py_value))) {
+  if (has_torch_function({self, py_value})) {
     py::object ret = py::reinterpret_steal<py::object>(
       handle_torch_function_indexing(self, index, py_value)
     );

--- a/torch/csrc/utils/disable_torch_function.h
+++ b/torch/csrc/utils/disable_torch_function.h
@@ -2,6 +2,7 @@
 #include <torch/csrc/python_headers.h>
 #include <c10/core/DispatchKey.h>
 #include <c10/core/impl/LocalDispatchKeySet.h>
+#include <c10/util/ArrayRef.h>
 
 namespace torch {
   // Sometimes we don't want infinite recursion for subclasses,
@@ -9,11 +10,14 @@ namespace torch {
 
   // This is an internal utility, not exposed to users.
   bool torch_function_enabled();
+  bool should_skip_torch_function();
   PyObject* disabled_torch_function_impl();
   PyObject* disabled_torch_dispatch_impl();
   void set_disabled_torch_function_impl(PyObject* value);
   void set_disabled_torch_dispatch_impl(PyObject* value);
   bool check_has_torch_function(PyObject* obj);
+  bool has_torch_function(PyObject* obj);
+  bool has_torch_function(c10::ArrayRef<PyObject*> args);
 
   struct DisableTorchDispatch {
     DisableTorchDispatch() : guard_(c10::DispatchKey::Python),
@@ -27,6 +31,7 @@ PyObject* THPModule_isEnabledTorchFunction(PyObject* self, PyObject *unused);
 PyObject* THPModule_DisableTorchFunctionType();
 PyObject* THPModule_disable_torch_function(PyObject *self, PyObject *args);
 PyObject* THPModule_disable_torch_dispatch(PyObject *self, PyObject *args);
+PyObject* THPModule_skip_one_hop_torch_function(PyObject *self, PyObject *args);
 PyObject* THPModule_has_torch_function(PyObject*, PyObject *arg);
 PyObject* THPModule_has_torch_function_unary(PyObject*, PyObject *obj);
 PyObject* THPModule_has_torch_function_variadic(PyObject*, PyObject *const *args, Py_ssize_t nargs);

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -271,7 +271,9 @@ inline PythonArgs PythonArgParser::parse(PyObject* self, ParsedArgs<0>& dst) {
 }
 
 inline bool PythonArgs::has_torch_function(){
-  return !this->signature.overloaded_args.empty();
+  return (
+    !torch::should_skip_torch_function() &&
+    !this->signature.overloaded_args.empty());
 }
 
 inline std::string PythonArgs::get_func_name(){


### PR DESCRIPTION
Closes #55093

This changes `Tensor.__torch_function__` to skip only one level of
`__torch_function__` calls. This is achieved by adding a new state variable
`skip_next_torch_function` which is reset to false every time
`has_torch_function` is checked, which works both in C++ and Python.

In the issue we discussed making `DisableTorchFunction` public, but with this
you can just write `super().__torch_function__(func, types, args, kwargs)`
to achieve the intended effect whilst being clear that this is
intended for use in `__torch_function__` implementations only
