### PR TITLE
Dynamoc+LTC: handle duplicate tensors returned

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/core/extract_compiled_graph.py
+++ b/lazy_tensor_core/lazy_tensor_core/core/extract_compiled_graph.py
@@ -39,6 +39,46 @@ class GraphInputMatcher:
             real_input.append(inp)
         return real_input
 
+class ReturnValueHandler:
+    r"""
+    When _LAZYC._ltc_sync_multi is called on multi tensors, the compiled graph
+    will contain output only for unique tensors - if a tensor appears multiple
+    times in the input to _ltc_sync_multi, only the first occurance matters.
+
+    However from python level, we still expect multi tensors returned with duplciation
+    even if the TS graph dedup the output. e.g. for method:
+
+      def forward(self, a):
+        return a, a
+
+    the TS graph captured by LTC will return a single tensor, but Python method expects 2.
+
+    This class dedup the lazy tensors first to get the index that will be used
+    to duplicate the eager tensors later.
+    """
+    def __init__(self, lazy_out_list):
+        self.index = []
+        self.total_count = len(lazy_out_list)
+
+        tensor_id_to_idx = dict()
+        for dup_idx, lazy_tensor in enumerate(lazy_out_list):
+            uniq_idx = tensor_id_to_idx.get(id(lazy_tensor), None)
+            if uniq_idx is not None:
+                self.index[uniq_idx].append(dup_idx)
+            else:
+                uniq_idx = len(self.index)
+                self.index.append([dup_idx])
+                tensor_id_to_idx[id(lazy_tensor)] = uniq_idx
+
+    def duplicate_eager_tensors(self, eager_tensor_list):
+        duplicated_list = [None] * self.total_count
+        assert len(eager_tensor_list) == len(self.index)
+
+        for uniq_idx, eager_tensor in enumerate(eager_tensor_list):
+            for dup_idx in self.index[uniq_idx]:
+                duplicated_list[dup_idx] = eager_tensor
+        return duplicated_list
+
 def force_lazy_device(model: fx.GraphModule):
     """
     Factory methods in a Fx graph may create tensors for a specific eager devices.
@@ -74,6 +114,7 @@ def extract_compiled_graph(model: fx.GraphModule, example_inputs) -> Callable:
     if not isinstance(lazy_out, (tuple, list)):
         lazy_out = (lazy_out,)
 
+    return_value_handler = ReturnValueHandler(lazy_out)
     if debug:
         print("LTC IR:", _LAZYC._get_ltc_tensors_text(lazy_out))
 
@@ -97,6 +138,6 @@ def extract_compiled_graph(model: fx.GraphModule, example_inputs) -> Callable:
         if len(lazy_out) == 0:
             return ()
         graph_input = graph_input_matcher(args)
-        return _LAZYC._run_cached_graph(graph_hash, graph_input)
+        return return_value_handler.duplicate_eager_tensors(_LAZYC._run_cached_graph(graph_hash, graph_input))
 
     return optimized_mod

--- a/lazy_tensor_core/test/test_extract_compiled_graph.py
+++ b/lazy_tensor_core/test/test_extract_compiled_graph.py
@@ -50,6 +50,19 @@ class ModuleReturnMulti(nn.Module):
 #         b = torch.randn(2, 3, device="cpu") # eager device
 #         return a + b
 
+class ModuleReturnDupTensor(nn.Module):
+    """
+    Handle the corner case that the same tensor appears multiple times in the
+    returned tuple. torchbench like drq will hit this corner case when running
+    thru torchdynamo..
+    """
+    def __init__(self):
+        super(ModuleReturnDupTensor, self).__init__()
+
+    def forward(self, a, b):
+        c = a + b
+        return a - b, c, a + 1, c
+
 def gen_rand_args(mod):
     args = []
     for _ in range(len(inspect.signature(mod.forward).parameters)):
@@ -105,3 +118,4 @@ class OptimizeTest(unittest.TestCase):
     test_const_scale = maketest(ModuleConstScale)
     test_addcmul = maketest(ModuleAddcmul)
     test_return_multi = maketest(ModuleReturnMulti)
+    test_return_dup_tensor = maketest(ModuleReturnDupTensor)


### PR DESCRIPTION
To extract a compiled graph for a model, we convert the model to lazy device, run it to get a list of lazy tensors LAZY_TENSOR_LIST, and then extract the compiled graph from LAZY_TENSOR_LIST . An issue happens if LAZY_TENSOR_LIST contains duplications
- from one hand, LTC will dedup the tensors in LAZY_TENSOR_LIST. Each of the unique tensors (i.e. the first occurrence of each tensor) on LAZY_TENSOR_LIST will be mapped to a graph output. But the duplicated tensors will be ignored.
- from the other hand, if we run the generated graph in Python, we get less returned value then expected. The Python method still expect all the tensors including the duplicated ones.

Take the following simple method as an example:
```
      def forward(self, a):
        return a, a
```

The TS graph captured by LTC will return a single tensor, but Python method expects 2.

To handle this corner case, this PR will 
- analyze LAZY_TENSOR_LIST to get an index that shows which tensors are duplicated
- duplicate the returned eager tensors by running the TS graph using the index get from the previous step

Test plan:
Unit test
```
pytest test/test_extract_compiled_graph.py -vsk test_return_dup_tensor
```
Test thru torch dynamo
```
LTC_TS_CUDA=1 gpui time python torchbench.py --speedup-ltc -dcuda --randomize-input --only drq
```
