### PR TITLE
[android] improve unsupported scalar type error message for android

### DIFF
--- a/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_common.cpp
@@ -223,7 +223,8 @@ class TensorHybrid : public facebook::jni::HybridClass<TensorHybrid> {
     } else {
       facebook::jni::throwNewJavaException(
           facebook::jni::gJavaLangIllegalArgumentException,
-          "at::Tensor scalar type is not supported on java side");
+          "at::Tensor scalar type %s is not supported on java side",
+          c10::toString(scalarType));
     }
 
     const auto& tensorShape = tensor.sizes();


### PR DESCRIPTION
Summary: Android only support a few scalar types as model return value. This diff improved the error message so user can know which type is not supported.

Test Plan: verified unsupported scalar type is printed

Differential Revision: D35104788

