### PR TITLE
[PyTorch] Only select root ops in codegen unboxing

### DIFF
--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -1090,7 +1090,8 @@ def gen_aggregated_headers(
                         selector,
                         rocm=rocm,
                         cpp_namespace='at::native',
-                        class_method_name=None),
+                        class_method_name=None,
+                        skip_dispatcher_op_registration=False),
                     grouped_native_functions
                 )),
             })
@@ -1198,7 +1199,8 @@ def gen_per_operator_headers(
                     selector,
                     rocm=rocm,
                     cpp_namespace='at::native',
-                    class_method_name=None),
+                    class_method_name=None,
+                    skip_dispatcher_op_registration=False),
                 grouped_functions
             ))
 
@@ -1434,7 +1436,8 @@ def gen_source_files(
                     selector,
                     rocm=rocm,
                     cpp_namespace='at::native',
-                    class_method_name=None),
+                    class_method_name=None,
+                    skip_dispatcher_op_registration=skip_dispatcher_op_registration),
                 grouped_native_functions
             )),
             'dispatch_anonymous_definitions': list(concatMap(
@@ -1444,7 +1447,8 @@ def gen_source_files(
                     selector,
                     rocm=rocm,
                     cpp_namespace='at::native',
-                    class_method_name=None),
+                    class_method_name=None,
+                    skip_dispatcher_op_registration=skip_dispatcher_op_registration),
                 grouped_native_functions
             )),
             'dispatch_registrations': [] if skip_dispatcher_op_registration else list(concatMap(
@@ -1454,7 +1458,8 @@ def gen_source_files(
                     selector,
                     rocm=rocm,
                     cpp_namespace='at::native',
-                    class_method_name=None),
+                    class_method_name=None,
+                    skip_dispatcher_op_registration=skip_dispatcher_op_registration),
                 grouped_native_functions
             )),
         })

--- a/tools/codegen/gen_backend_stubs.py
+++ b/tools/codegen/gen_backend_stubs.py
@@ -272,7 +272,8 @@ def gen_dispatcher_registrations(
                 selector,
                 rocm=False,
                 cpp_namespace=cpp_namespace,
-                class_method_name=f'{class_name}'),
+                class_method_name=f'{class_name}',
+                skip_dispatcher_op_registration=False),
             grouped_native_functions
         )),
         'dispatch_registrations': list(concatMap(
@@ -282,7 +283,8 @@ def gen_dispatcher_registrations(
                 selector,
                 rocm=False,
                 cpp_namespace=cpp_namespace,
-                class_method_name=f'{class_name}'),
+                class_method_name=f'{class_name}',
+                skip_dispatcher_op_registration=False),
             grouped_native_functions
         )),
     })

--- a/tools/jit/gen_unboxing.py
+++ b/tools/jit/gen_unboxing.py
@@ -24,7 +24,7 @@ class ComputeUnboxingFunctions:
 
     @method_with_native_function
     def __call__(self, f: NativeFunction) -> str:
-        if not self.selector.is_native_function_selected(f):
+        if not self.selector.is_root_operator(f"aten::{f.func.name}"):
             return ""
 
         if self.target is Target.DECLARATION:
@@ -86,7 +86,7 @@ class ComputeCodegenUnboxedKernels:
 
     @method_with_native_function
     def __call__(self, f: NativeFunction) -> str:
-        if not self.selector.is_native_function_selected(f):
+        if not self.selector.is_root_operator(f"aten::{f.func.name}"):
             return ""
         # We unconditionally generate function wrappers,
         sig_group = CppSignatureGroup.from_native_function(


### PR DESCRIPTION
Summary: In lightweight dispatch, we only need to register root ops. Unlike in the dispatcher world, the transitive closure of the operators doesn't need to go through dispatcher or op registry.

Test Plan: Rely on unit tests

Differential Revision: D35104401

