### PR TITLE
[PyTorch] Avoid registering ops into dispatcher in lightweight dispatch

### DIFF
--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -1090,7 +1090,8 @@ def gen_aggregated_headers(
                         selector,
                         rocm=rocm,
                         cpp_namespace='at::native',
-                        class_method_name=None),
+                        class_method_name=None,
+                        skip_dispatcher_op_registration=False),
                     grouped_native_functions
                 )),
             })
@@ -1198,7 +1199,8 @@ def gen_per_operator_headers(
                     selector,
                     rocm=rocm,
                     cpp_namespace='at::native',
-                    class_method_name=None),
+                    class_method_name=None,
+                    skip_dispatcher_op_registration=False),
                 grouped_functions
             ))
 
@@ -1434,7 +1436,8 @@ def gen_source_files(
                     selector,
                     rocm=rocm,
                     cpp_namespace='at::native',
-                    class_method_name=None),
+                    class_method_name=None,
+                    skip_dispatcher_op_registration=skip_dispatcher_op_registration),
                 grouped_native_functions
             )),
             'dispatch_anonymous_definitions': list(concatMap(
@@ -1444,7 +1447,8 @@ def gen_source_files(
                     selector,
                     rocm=rocm,
                     cpp_namespace='at::native',
-                    class_method_name=None),
+                    class_method_name=None,
+                    skip_dispatcher_op_registration=skip_dispatcher_op_registration),
                 grouped_native_functions
             )),
             'dispatch_registrations': [] if skip_dispatcher_op_registration else list(concatMap(
@@ -1454,7 +1458,8 @@ def gen_source_files(
                     selector,
                     rocm=rocm,
                     cpp_namespace='at::native',
-                    class_method_name=None),
+                    class_method_name=None,
+                    skip_dispatcher_op_registration=skip_dispatcher_op_registration),
                 grouped_native_functions
             )),
         })

--- a/tools/codegen/gen_backend_stubs.py
+++ b/tools/codegen/gen_backend_stubs.py
@@ -272,7 +272,8 @@ def gen_dispatcher_registrations(
                 selector,
                 rocm=False,
                 cpp_namespace=cpp_namespace,
-                class_method_name=f'{class_name}'),
+                class_method_name=f'{class_name}',
+                skip_dispatcher_op_registration=False),
             grouped_native_functions
         )),
         'dispatch_registrations': list(concatMap(
@@ -282,7 +283,8 @@ def gen_dispatcher_registrations(
                 selector,
                 rocm=False,
                 cpp_namespace=cpp_namespace,
-                class_method_name=f'{class_name}'),
+                class_method_name=f'{class_name}',
+                skip_dispatcher_op_registration=False),
             grouped_native_functions
         )),
     })


### PR DESCRIPTION
Summary:
This change adds the following logic:

If lightweight dispatch is enabled, do not generate `TORCH_LIBARAY` API calls for operator schema and implementations, since these operators will be registered into JIT op registry.

`skip_dispatcher_op_registration` is an existing argument to `gen.py`. With that set, `RegisterDispatchKey.cpp` will not generate `m.def` and `m.impl` for each native function. This logic will be removed once we find a better way to skip op registration into dispatcher.

Test Plan: Rely on unit tests for lightweight dispatch.

Differential Revision: D34634300

