### PR TITLE
[Model Averaging] Add a unit test that launches hierarchical SGD by PostLocalSGDOptimizer

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4834,25 +4834,27 @@ class DistributedTest:
             BACKEND not in DistTestCases.backend_feature["ddp"],
             f"The {BACKEND} backend does not support DistributedDataParallel"
         )
-        def test_post_localSGD_optimizer_parity(self, grad_is_view=False):
+        def test_post_localSGD_optimizer_parity(self, grad_is_view):
             torch.cuda.set_device(self.rank)
 
             averager = averagers.PeriodicModelAverager(period=4, warmup_steps=10)
-            self._test_post_localSGD_optimizer_parity(averager, grad_is_view)
+            self._test_post_localSGD_optimizer_parity(averager, grad_is_view=False)
+            self._test_post_localSGD_optimizer_parity(averager, grad_is_view=True)
 
         @skip_if_lt_x_gpu(4)
         @sandcastle_skip_if(
             BACKEND not in DistTestCases.backend_feature["ddp"],
             f"The {BACKEND} backend does not support DistributedDataParallel"
         )
-        def test_post_localSGD_optimizer_parity_with_hierarchical_sgd(self, grad_is_view=False):
+        def test_post_localSGD_optimizer_parity_with_hierarchical_sgd(self, grad_is_view):
             torch.cuda.set_device(self.rank)
 
             period_group_size_dict = OrderedDict([(2, 2), (4, dist.get_world_size())])
             averager = hierarchicalSGD.HierarchicalModelAverager(
                 period_group_size_dict=period_group_size_dict, warmup_steps=4
             )
-            self._test_post_localSGD_optimizer_parity(averager, grad_is_view)
+            self._test_post_localSGD_optimizer_parity(averager, grad_is_view=False)
+            self._test_post_localSGD_optimizer_parity(averager, grad_is_view=True)
 
         @sandcastle_skip_if(
             BACKEND not in DistTestCases.backend_feature["ddp"],

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4834,11 +4834,21 @@ class DistributedTest:
             BACKEND not in DistTestCases.backend_feature["ddp"],
             f"The {BACKEND} backend does not support DistributedDataParallel"
         )
-        def test_post_localSGD_optimizer_parity(self, grad_is_view):
+        def test_post_localSGD_optimizer_parity(self):
             torch.cuda.set_device(self.rank)
 
             averager = averagers.PeriodicModelAverager(period=4, warmup_steps=10)
             self._test_post_localSGD_optimizer_parity(averager, grad_is_view=False)
+
+        @skip_if_lt_x_gpu(2)
+        @sandcastle_skip_if(
+            BACKEND not in DistTestCases.backend_feature["ddp"],
+            f"The {BACKEND} backend does not support DistributedDataParallel"
+        )
+        def test_post_localSGD_optimizer_parity_grad_is_view(self):
+            torch.cuda.set_device(self.rank)
+
+            averager = averagers.PeriodicModelAverager(period=4, warmup_steps=10)
             self._test_post_localSGD_optimizer_parity(averager, grad_is_view=True)
 
         @skip_if_lt_x_gpu(4)
@@ -4846,7 +4856,7 @@ class DistributedTest:
             BACKEND not in DistTestCases.backend_feature["ddp"],
             f"The {BACKEND} backend does not support DistributedDataParallel"
         )
-        def test_post_localSGD_optimizer_parity_with_hierarchical_sgd(self, grad_is_view):
+        def test_post_localSGD_optimizer_parity_with_hierarchical_sgd(self):
             torch.cuda.set_device(self.rank)
 
             period_group_size_dict = OrderedDict([(2, 2), (4, dist.get_world_size())])
@@ -4854,6 +4864,19 @@ class DistributedTest:
                 period_group_size_dict=period_group_size_dict, warmup_steps=4
             )
             self._test_post_localSGD_optimizer_parity(averager, grad_is_view=False)
+
+        @skip_if_lt_x_gpu(4)
+        @sandcastle_skip_if(
+            BACKEND not in DistTestCases.backend_feature["ddp"],
+            f"The {BACKEND} backend does not support DistributedDataParallel"
+        )
+        def test_post_localSGD_optimizer_parity_with_hierarchical_sgd_grad_is_view(self):
+            torch.cuda.set_device(self.rank)
+
+            period_group_size_dict = OrderedDict([(2, 2), (4, dist.get_world_size())])
+            averager = hierarchicalSGD.HierarchicalModelAverager(
+                period_group_size_dict=period_group_size_dict, warmup_steps=4
+            )
             self._test_post_localSGD_optimizer_parity(averager, grad_is_view=True)
 
         @sandcastle_skip_if(

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4788,36 +4788,24 @@ class DistributedTest:
             )
             self._barrier()
 
-        @skip_if_lt_x_gpu(2)
-        @sandcastle_skip_if(
-            BACKEND not in DistTestCases.backend_feature["ddp"],
-            f"The {BACKEND} backend does not support DistributedDataParallel"
-        )
-        def test_post_localSGD_optimizer_parity(self, grad_is_view=False):
+        def _test_post_localSGD_optimizer_parity(self, averager, grad_is_view):
             learning_rate = 0.03
-            period = 4
-            warmup_steps = 10
-            torch.cuda.set_device(self.rank)
+
             net = torch.nn.parallel.DistributedDataParallel(
                 copy.deepcopy(DDP_NET).cuda(),
                 device_ids=[self.rank],
                 gradient_as_bucket_view=grad_is_view,
             )
             opt = torch.optim.SGD(net.parameters(), lr=learning_rate)
-            averager = averagers.PeriodicModelAverager(
-                period=period, warmup_steps=warmup_steps
-            )
 
-            post_localSGD_net = torch.nn.parallel.DistributedDataParallel(
+            net_using_post_localSGD_opt = torch.nn.parallel.DistributedDataParallel(
                 copy.deepcopy(DDP_NET).cuda(),
                 device_ids=[self.rank],
                 gradient_as_bucket_view=grad_is_view,
             )
             post_localSGD_opt = post_localSGD_optimizer.PostLocalSGDOptimizer(
-                optim=torch.optim.SGD(post_localSGD_net.parameters(), lr=learning_rate),
-                averager=averagers.PeriodicModelAverager(
-                    period=period, warmup_steps=warmup_steps
-                )
+                optim=torch.optim.SGD(net_using_post_localSGD_opt.parameters(), lr=learning_rate),
+                averager=averager
             )
 
             input = torch.randn(dist.get_world_size() * 2, 2).cuda()
@@ -4833,13 +4821,38 @@ class DistributedTest:
                 averager.average_parameters(net.parameters())
 
                 post_localSGD_opt.zero_grad()
-                post_localSGD_output = post_localSGD_net(input)
-                post_localSGD_loss = loss_fn(post_localSGD_output, target)
-                post_localSGD_loss.backward()
+                output_using_post_localSGD_opt = net_using_post_localSGD_opt(input)
+                loss_using_post_localSGD_opt = loss_fn(output_using_post_localSGD_opt, target)
+                loss_using_post_localSGD_opt.backward()
                 post_localSGD_opt.step()
 
-                for p1, p2 in zip(net.parameters(), post_localSGD_net.parameters()):
+                for p1, p2 in zip(net.parameters(), net_using_post_localSGD_opt.parameters()):
                     self.assertEqual(p1.data, p2.data)
+
+        @skip_if_lt_x_gpu(2)
+        @sandcastle_skip_if(
+            BACKEND not in DistTestCases.backend_feature["ddp"],
+            f"The {BACKEND} backend does not support DistributedDataParallel"
+        )
+        def test_post_localSGD_optimizer_parity(self, grad_is_view=False):
+            torch.cuda.set_device(self.rank)
+
+            averager = averagers.PeriodicModelAverager(period=4, warmup_steps=10)
+            self._test_post_localSGD_optimizer_parity(averager, grad_is_view)
+
+        @skip_if_lt_x_gpu(4)
+        @sandcastle_skip_if(
+            BACKEND not in DistTestCases.backend_feature["ddp"],
+            f"The {BACKEND} backend does not support DistributedDataParallel"
+        )
+        def test_post_localSGD_optimizer_parity_with_hierarchical_sgd(self, grad_is_view=False):
+            torch.cuda.set_device(self.rank)
+
+            period_group_size_dict = OrderedDict([(2, 2), (4, dist.get_world_size())])
+            averager = hierarchicalSGD.HierarchicalModelAverager(
+                period_group_size_dict=period_group_size_dict, warmup_steps=4
+            )
+            self._test_post_localSGD_optimizer_parity(averager, grad_is_view)
 
         @sandcastle_skip_if(
             BACKEND not in DistTestCases.backend_feature["ddp"],


### PR DESCRIPTION
As title.

The added unit test requires 4 GPUs. Please add `ciflow/all` to enable this test.

Proposal: https://github.com/pytorch/pytorch/issues/73382
Parent proposal: https://github.com/pytorch/pytorch/issues/71325