### PR TITLE
[PyTorch Edge] Make contexts thread local for quantized matmul

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/ruy_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/ruy_utils.cpp
@@ -1,0 +1,37 @@
+#ifdef USE_RUY_QMATMUL
+
+#include <ATen/ATen.h>
+#include <ATen/native/quantized/cpu/ruy_utils.h>
+
+namespace at {
+namespace native {
+namespace ruy_utils {
+
+static thread_local ruy::Context context;
+
+ruy::Context* get_ruy_context() {
+  return &context;
+}
+
+// Adopted from Ruy:
+// https://github.com/google/ruy/blob/2d950b3bfa7ebfbe7a97ecb44b1cc4da5ac1d6f0/ruy/test.h#L1602
+void quantize_multiplier(double scale,
+                         int* multiplier_fixedpoint,
+                         int* multiplier_exponent) {
+  TORCH_CHECK(scale > 0, "Quantization scale (", scale, ") must be positive.");
+  const double q = std::frexp(scale, multiplier_exponent);
+  auto q_fixed = static_cast<std::int64_t>(std::round(q * (1ll << 31)));
+  TORCH_CHECK(q_fixed <= (1ll << 31));
+  if (q_fixed == (1ll << 31)) {
+    q_fixed /= 2;
+    ++*multiplier_exponent;
+  }
+  TORCH_CHECK(q_fixed <= std::numeric_limits<std::int32_t>::max());
+  *multiplier_fixedpoint = static_cast<std::int32_t>(q_fixed);
+}
+
+} // namespace ruy_utils
+} // namespace native
+} // namesplace
+
+#endif // USE_RUY_QMATMUL

--- a/aten/src/ATen/native/quantized/cpu/ruy_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/ruy_utils.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifdef USE_RUY_QMATMUL
+
+#include <ruy/ruy.h>
+
+namespace at {
+namespace native {
+namespace ruy_utils {
+
+ruy::Context* get_ruy_context();
+
+void quantize_multiplier(double scale,
+                         int* multiplier_fixedpoint,
+                         int* multiplier_exponent);
+
+} // namespace ruy_utils
+} // namespace native
+} // namesplace
+
+#endif // USE_RUY_QMATMUL

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -1222,6 +1222,7 @@ aten_native_source_non_codegen_list = [
     "aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp",
     "aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp",
     "aten/src/ATen/native/quantized/library.cpp",
+    "aten/src/ATen/native/quantized/cpu/ruy_utils.cpp",
     "aten/src/ATen/native/quantized/cpu/xnnpack_utils.cpp",
     "aten/src/ATen/native/quantized/qlinear_unpack.cpp",
     "aten/src/ATen/quantized/QTensorImpl.cpp",


### PR DESCRIPTION
Summary: We don't want to create and destroy a new context with each multiplication

Test Plan:
From fbcode:
```buck test caffe2/test:quantization -- test_qmatmul```

# Performance Improvement
*Benchmarking done by on a model which performs matmuls of the same shapes and counts as Transformer Model, as determined in D30901505*

*Notebook in which Benchmarking was performed: https://www.internalfb.com/intern/anp/view/?id=1582075&revision_id=1891629751047842*

**Improvement from this diff alone**
~9.71% Reduction in Latency
- Non Thread Local Contexts (before this diff, D35087184 v2): [8.5410ms](https://www.internalfb.com/intern/aibench/details/661728682381311
)
- Thread Local Contexts (this diff, v12): [7.7113ms](https://www.internalfb.com/intern/aibench/details/956655867696198)

**FP32 Matmul vs Quantized Matmul, Overall Improvement from this diff stack**
56% reduction in latency compared to FP32 Matmul, 71% reduction in latency compared to Naive QMatmul
- FP32 Matmul: [17.4910ms](https://www.internalfb.com/intern/aibench/details/875394396322469)
- Quantized Matmul (after this diff): [7.7113ms](https://www.internalfb.com/intern/aibench/details/956655867696198
)
- Naive Quantized Matmul (dequantize → fp32matmul → quantize): [26.8639ms](https://www.internalfb.com/intern/aibench/details/52181682131461
)

Reviewed By: kimishpatel

Differential Revision: D34756288

