### PR TITLE
Update symbolics policy to emit aten::ATen for Caffe2 build only

### DIFF
--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -5,6 +5,7 @@
          ".jenkins/caffe2/*",
          "docs/source/onnx.rst",
          "test/onnx/**",
+         "test/jit/test_export_modes.py",
          "tools/onnx/**",
          "torch/_C/__init__.pyi.in",
          "torch/csrc/jit/passes/onnx.*",

--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -6,6 +6,7 @@
          "docs/source/onnx.rst",
          "test/onnx/**",
          "test/jit/test_export_modes.py",
+         "aten/src/ATen/core/interned_strings.h",
          "tools/onnx/**",
          "torch/_C/__init__.pyi.in",
          "torch/csrc/jit/passes/onnx.*",

--- a/test/jit/test_export_modes.py
+++ b/test/jit/test_export_modes.py
@@ -15,7 +15,7 @@ from torch.autograd import Variable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
 from torch.testing._internal.jit_utils import JitTestCase
-from torch.testing._internal.common_utils import skipIfNoLapack
+from torch.testing._internal.common_utils import skipIfNoLapack, skipIfCaffe2, skipIfNoCaffe2
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
@@ -68,6 +68,24 @@ class TestExportModes(JitTestCase):
         x = torch.ones(3)
         torch.onnx._export(foo, (x,), f)
 
+    @skipIfNoCaffe2
+    @skipIfNoLapack
+    def test_caffe2_aten_fallback(self):
+        class ModelWithAtenNotONNXOp(nn.Module):
+            def forward(self, x, y):
+                abcd = x + y
+                defg = torch.linalg.qr(abcd)
+                return defg
+
+        x = torch.rand(3, 4)
+        y = torch.rand(3, 4)
+        torch.onnx.export_to_pretty_string(
+            ModelWithAtenNotONNXOp(), (x, y),
+            add_node_names=False,
+            do_constant_folding=False,
+            operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK)
+
+    @skipIfCaffe2
     @skipIfNoLapack
     def test_aten_fallback(self):
         class ModelWithAtenNotONNXOp(nn.Module):

--- a/test/onnx/expect/TestOperators.test_embedding_bags.expect
+++ b/test/onnx/expect/TestOperators.test_embedding_bags.expect
@@ -3,29 +3,8 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    output: "onnx::Cast_3"
-    op_type: "Constant"
-    attribute {
-      name: "value"
-      t {
-        data_type: 7
-        raw_data: "\001\000\000\000\000\000\000\000"
-      }
-      type: TENSOR
-    }
-  }
-  node {
-    input: "onnx::Cast_3"
-    output: "onnx::Loop_4"
-    op_type: "Cast"
-    attribute {
-      name: "to"
-      i: 9
-      type: INT
-    }
-  }
-  node {
     output: "5"
+    name: "Constant_0"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -40,10 +19,12 @@ graph {
   node {
     input: "input"
     output: "onnx::Gather_6"
+    name: "Shape_1"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_7"
+    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -58,6 +39,7 @@ graph {
     input: "onnx::Gather_6"
     input: "onnx::Gather_7"
     output: "onnx::Unsqueeze_8"
+    name: "Gather_3"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -67,6 +49,7 @@ graph {
   }
   node {
     output: "onnx::Unsqueeze_9"
+    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -82,12 +65,14 @@ graph {
     input: "onnx::Unsqueeze_8"
     input: "onnx::Unsqueeze_9"
     output: "onnx::Concat_10"
+    name: "Unsqueeze_5"
     op_type: "Unsqueeze"
   }
   node {
     input: "offsets"
     input: "onnx::Concat_10"
     output: "onnx::Slice_11"
+    name: "Concat_6"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -97,6 +82,7 @@ graph {
   }
   node {
     output: "onnx::Slice_12"
+    name: "Constant_7"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -110,6 +96,7 @@ graph {
   }
   node {
     output: "onnx::Slice_13"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -123,6 +110,7 @@ graph {
   }
   node {
     output: "onnx::Slice_14"
+    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -136,6 +124,7 @@ graph {
   }
   node {
     output: "onnx::Slice_15"
+    name: "Constant_10"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -154,15 +143,18 @@ graph {
     input: "onnx::Slice_12"
     input: "onnx::Slice_15"
     output: "onnx::Shape_16"
+    name: "Slice_11"
     op_type: "Slice"
   }
   node {
     input: "onnx::Shape_16"
     output: "onnx::Gather_17"
+    name: "Shape_12"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_18"
+    name: "Constant_13"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -177,6 +169,7 @@ graph {
     input: "onnx::Gather_17"
     input: "onnx::Gather_18"
     output: "onnx::Loop_19"
+    name: "Gather_14"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -186,8 +179,9 @@ graph {
   }
   node {
     input: "onnx::Loop_19"
-    input: "onnx::Loop_4"
+    input: "onnx::Loop_33"
     output: "20"
+    name: "Loop_15"
     op_type: "Loop"
     attribute {
       name: "body"
@@ -196,7 +190,7 @@ graph {
           input: "onnx::Slice_11"
           input: "21"
           output: "23"
-          name: "Gather_0"
+          name: "Gather_16"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -208,7 +202,7 @@ graph {
           input: "onnx::Shape_16"
           input: "21"
           output: "24"
-          name: "Gather_1"
+          name: "Gather_17"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -218,7 +212,7 @@ graph {
         }
         node {
           output: "25"
-          name: "Constant_2"
+          name: "Constant_18"
           op_type: "Constant"
           attribute {
             name: "value"
@@ -234,12 +228,12 @@ graph {
           input: "23"
           input: "25"
           output: "26"
-          name: "Unsqueeze_3"
+          name: "Unsqueeze_19"
           op_type: "Unsqueeze"
         }
         node {
           output: "27"
-          name: "Constant_4"
+          name: "Constant_20"
           op_type: "Constant"
           attribute {
             name: "value"
@@ -255,7 +249,7 @@ graph {
           input: "24"
           input: "27"
           output: "28"
-          name: "Unsqueeze_5"
+          name: "Unsqueeze_21"
           op_type: "Unsqueeze"
         }
         node {
@@ -264,14 +258,14 @@ graph {
           input: "28"
           input: "5"
           output: "29"
-          name: "Slice_6"
+          name: "Slice_22"
           op_type: "Slice"
         }
         node {
           input: "weight"
           input: "29"
           output: "30"
-          name: "Gather_7"
+          name: "Gather_23"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -282,7 +276,7 @@ graph {
         node {
           input: "30"
           output: "31"
-          name: "ReduceMean_8"
+          name: "ReduceMean_24"
           op_type: "ReduceMean"
           attribute {
             name: "axes"
@@ -296,9 +290,9 @@ graph {
           }
         }
         node {
-          input: "onnx::Loop_4"
+          input: "onnx::Loop_33"
           output: "32"
-          name: "Cast_9"
+          name: "Cast_25"
           op_type: "Cast"
           attribute {
             name: "to"
@@ -362,6 +356,11 @@ graph {
     name: "weight"
     raw_data: "\264\314\344\275\017A\376\276\313\374&>J\266a\277s\306\\=\212\032+?\211[t\275\344[\357\276Dk\\\276OKb?\234\'B\277A\334\274\2767N\257\276\320s\263\277\371+\244>:\314\202\277K\200L??\001\275\275\236u4\2774\032\315\277\214\004\224>Z\320\372>\267B\305\276\346G6\277N\265.\276\343\316\272\277t\364a>\201)|>p\223\251\277Qm2?\346\275)\277\354\235\233?\027X\277\277\253\206a?\354\335\226\277L\032o\277\251J\021\277\311\360\215\276\312\274\013\300\252\320\273>\220\"p?\267\020\000<R\262\240\276\343\016\224\2779\241\353?8;\202\277\023\020\234?E\370#>\222\233\314?\334\360?\275|t\303\277\214\351\000\300\3065\302\2775\206\306>X\251\227\277x\2160?U^\251?d\221\350?\237F.?\rp9?9X\004=/c\324\277SL\360\277\'\274<?t\375l?\342\270l?\240\352:>\332\356\226\275\211\035\241>*\271\204\277>\025W>\036K\035?\036\233\200=\035\313\250\276\017\003\346\277\374p_?\313WD?!\006\351\275\232\\q\277\230\007A?"
   }
+  initializer {
+    data_type: 9
+    name: "onnx::Loop_33"
+    raw_data: "\001"
+  }
   input {
     name: "input"
     type {
@@ -400,6 +399,16 @@ graph {
           dim {
             dim_value: 8
           }
+        }
+      }
+    }
+  }
+  input {
+    name: "onnx::Loop_33"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
         }
       }
     }

--- a/test/onnx/expect/TestOperators.test_embedding_bags.expect
+++ b/test/onnx/expect/TestOperators.test_embedding_bags.expect
@@ -3,8 +3,29 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
+    output: "onnx::Cast_3"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 7
+        raw_data: "\001\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "onnx::Cast_3"
+    output: "onnx::Loop_4"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 9
+      type: INT
+    }
+  }
+  node {
     output: "5"
-    name: "Constant_0"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -19,12 +40,10 @@ graph {
   node {
     input: "input"
     output: "onnx::Gather_6"
-    name: "Shape_1"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_7"
-    name: "Constant_2"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -39,7 +58,6 @@ graph {
     input: "onnx::Gather_6"
     input: "onnx::Gather_7"
     output: "onnx::Unsqueeze_8"
-    name: "Gather_3"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -49,7 +67,6 @@ graph {
   }
   node {
     output: "onnx::Unsqueeze_9"
-    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -65,14 +82,12 @@ graph {
     input: "onnx::Unsqueeze_8"
     input: "onnx::Unsqueeze_9"
     output: "onnx::Concat_10"
-    name: "Unsqueeze_5"
     op_type: "Unsqueeze"
   }
   node {
     input: "offsets"
     input: "onnx::Concat_10"
     output: "onnx::Slice_11"
-    name: "Concat_6"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -82,7 +97,6 @@ graph {
   }
   node {
     output: "onnx::Slice_12"
-    name: "Constant_7"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -96,7 +110,6 @@ graph {
   }
   node {
     output: "onnx::Slice_13"
-    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -110,7 +123,6 @@ graph {
   }
   node {
     output: "onnx::Slice_14"
-    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -124,7 +136,6 @@ graph {
   }
   node {
     output: "onnx::Slice_15"
-    name: "Constant_10"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -143,18 +154,15 @@ graph {
     input: "onnx::Slice_12"
     input: "onnx::Slice_15"
     output: "onnx::Shape_16"
-    name: "Slice_11"
     op_type: "Slice"
   }
   node {
     input: "onnx::Shape_16"
     output: "onnx::Gather_17"
-    name: "Shape_12"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_18"
-    name: "Constant_13"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -169,7 +177,6 @@ graph {
     input: "onnx::Gather_17"
     input: "onnx::Gather_18"
     output: "onnx::Loop_19"
-    name: "Gather_14"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -179,9 +186,8 @@ graph {
   }
   node {
     input: "onnx::Loop_19"
-    input: "onnx::Loop_33"
+    input: "onnx::Loop_4"
     output: "20"
-    name: "Loop_15"
     op_type: "Loop"
     attribute {
       name: "body"
@@ -190,7 +196,7 @@ graph {
           input: "onnx::Slice_11"
           input: "21"
           output: "23"
-          name: "Gather_16"
+          name: "Gather_0"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -202,7 +208,7 @@ graph {
           input: "onnx::Shape_16"
           input: "21"
           output: "24"
-          name: "Gather_17"
+          name: "Gather_1"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -212,7 +218,7 @@ graph {
         }
         node {
           output: "25"
-          name: "Constant_18"
+          name: "Constant_2"
           op_type: "Constant"
           attribute {
             name: "value"
@@ -228,12 +234,12 @@ graph {
           input: "23"
           input: "25"
           output: "26"
-          name: "Unsqueeze_19"
+          name: "Unsqueeze_3"
           op_type: "Unsqueeze"
         }
         node {
           output: "27"
-          name: "Constant_20"
+          name: "Constant_4"
           op_type: "Constant"
           attribute {
             name: "value"
@@ -249,7 +255,7 @@ graph {
           input: "24"
           input: "27"
           output: "28"
-          name: "Unsqueeze_21"
+          name: "Unsqueeze_5"
           op_type: "Unsqueeze"
         }
         node {
@@ -258,14 +264,14 @@ graph {
           input: "28"
           input: "5"
           output: "29"
-          name: "Slice_22"
+          name: "Slice_6"
           op_type: "Slice"
         }
         node {
           input: "weight"
           input: "29"
           output: "30"
-          name: "Gather_23"
+          name: "Gather_7"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -276,7 +282,7 @@ graph {
         node {
           input: "30"
           output: "31"
-          name: "ReduceMean_24"
+          name: "ReduceMean_8"
           op_type: "ReduceMean"
           attribute {
             name: "axes"
@@ -290,9 +296,9 @@ graph {
           }
         }
         node {
-          input: "onnx::Loop_33"
+          input: "onnx::Loop_4"
           output: "32"
-          name: "Cast_25"
+          name: "Cast_9"
           op_type: "Cast"
           attribute {
             name: "to"
@@ -356,11 +362,6 @@ graph {
     name: "weight"
     raw_data: "\264\314\344\275\017A\376\276\313\374&>J\266a\277s\306\\=\212\032+?\211[t\275\344[\357\276Dk\\\276OKb?\234\'B\277A\334\274\2767N\257\276\320s\263\277\371+\244>:\314\202\277K\200L??\001\275\275\236u4\2774\032\315\277\214\004\224>Z\320\372>\267B\305\276\346G6\277N\265.\276\343\316\272\277t\364a>\201)|>p\223\251\277Qm2?\346\275)\277\354\235\233?\027X\277\277\253\206a?\354\335\226\277L\032o\277\251J\021\277\311\360\215\276\312\274\013\300\252\320\273>\220\"p?\267\020\000<R\262\240\276\343\016\224\2779\241\353?8;\202\277\023\020\234?E\370#>\222\233\314?\334\360?\275|t\303\277\214\351\000\300\3065\302\2775\206\306>X\251\227\277x\2160?U^\251?d\221\350?\237F.?\rp9?9X\004=/c\324\277SL\360\277\'\274<?t\375l?\342\270l?\240\352:>\332\356\226\275\211\035\241>*\271\204\277>\025W>\036K\035?\036\233\200=\035\313\250\276\017\003\346\277\374p_?\313WD?!\006\351\275\232\\q\277\230\007A?"
   }
-  initializer {
-    data_type: 9
-    name: "onnx::Loop_33"
-    raw_data: "\001"
-  }
   input {
     name: "input"
     type {
@@ -399,16 +400,6 @@ graph {
           dim {
             dim_value: 8
           }
-        }
-      }
-    }
-  }
-  input {
-    name: "onnx::Loop_33"
-    type {
-      tensor_type {
-        elem_type: 9
-        shape {
         }
       }
     }

--- a/test/onnx/expect/TestOperators.test_layer_norm_aten.expect
+++ b/test/onnx/expect/TestOperators.test_layer_norm_aten.expect
@@ -4,37 +4,101 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     input: "input"
-    input: "weight"
-    input: "bias"
-    output: "3"
-    op_type: "ATen"
+    output: "onnx::Sub_3"
+    name: "ReduceMean_0"
+    op_type: "ReduceMean"
     attribute {
-      name: "cudnn_enable"
-      i: 1
-      type: INT
-    }
-    attribute {
-      name: "eps"
-      f: 1e-05
-      type: FLOAT
-    }
-    attribute {
-      name: "normalized_shape"
-      ints: 10
-      ints: 10
+      name: "axes"
+      ints: -2
+      ints: -1
       type: INTS
     }
+  }
+  node {
+    input: "input"
+    input: "onnx::Sub_3"
+    output: "onnx::Pow_4"
+    name: "Sub_1"
+    op_type: "Sub"
+  }
+  node {
+    output: "onnx::Pow_5"
+    name: "Constant_2"
+    op_type: "Constant"
     attribute {
-      name: "operator"
-      s: "layer_norm"
-      type: STRING
+      name: "value"
+      t {
+        data_type: 1
+        raw_data: "\000\000\000@"
+      }
+      type: TENSOR
     }
+  }
+  node {
+    input: "onnx::Pow_4"
+    input: "onnx::Pow_5"
+    output: "onnx::ReduceMean_6"
+    name: "Pow_3"
+    op_type: "Pow"
+  }
+  node {
+    input: "onnx::ReduceMean_6"
+    output: "onnx::Add_7"
+    name: "ReduceMean_4"
+    op_type: "ReduceMean"
     attribute {
-      name: "overload_name"
-      s: ""
-      type: STRING
+      name: "axes"
+      ints: -2
+      ints: -1
+      type: INTS
     }
-    domain: "org.pytorch.aten"
+  }
+  node {
+    output: "onnx::Add_8"
+    name: "Constant_5"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 1
+        raw_data: "\254\305\'7"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "onnx::Add_7"
+    input: "onnx::Add_8"
+    output: "onnx::Sqrt_9"
+    name: "Add_6"
+    op_type: "Add"
+  }
+  node {
+    input: "onnx::Sqrt_9"
+    output: "onnx::Div_10"
+    name: "Sqrt_7"
+    op_type: "Sqrt"
+  }
+  node {
+    input: "onnx::Pow_4"
+    input: "onnx::Div_10"
+    output: "onnx::Mul_11"
+    name: "Div_8"
+    op_type: "Div"
+  }
+  node {
+    input: "onnx::Mul_11"
+    input: "weight"
+    output: "onnx::Add_12"
+    name: "Mul_9"
+    op_type: "Mul"
+  }
+  node {
+    input: "onnx::Add_12"
+    input: "bias"
+    output: "13"
+    name: "Add_10"
+    op_type: "Add"
   }
   name: "torch_jit"
   initializer {
@@ -106,7 +170,7 @@ graph {
     }
   }
   output {
-    name: "3"
+    name: "13"
     type {
       tensor_type {
         elem_type: 1
@@ -130,8 +194,4 @@ graph {
 }
 opset_import {
   version: 13
-}
-opset_import {
-  domain: "org.pytorch.aten"
-  version: 1
 }

--- a/test/onnx/expect/TestOperators.test_layer_norm_aten.expect
+++ b/test/onnx/expect/TestOperators.test_layer_norm_aten.expect
@@ -7,7 +7,6 @@ graph {
     input: "weight"
     input: "bias"
     output: "3"
-    name: "ATen_0"
     op_type: "ATen"
     attribute {
       name: "cudnn_enable"

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -20,13 +20,15 @@ import os
 import shutil
 import tempfile
 import torch.testing._internal.common_utils as common
-from torch.testing._internal.common_utils import skipIfCaffe2, skipIfNoCaffe2
+from torch.testing._internal.common_utils import skipIfCaffe2
 
 '''Usage: python test/onnx/test_operators.py [--no-onnx] [--produce-onnx-test-data]
           --no-onnx: no onnx python dependence
           --produce-onnx-test-data: generate onnx test data
           --accept: accept onnx updates and overwrite models
 '''
+
+# Full diff for expect files
 import unittest
 unittest.TestCase.maxDiff = None
 
@@ -593,7 +595,7 @@ class TestOperators(TestCase):
         self.assertONNX(nn.BatchNorm2d(128, affine=False, momentum=0.3), x,
                         keep_initializers_as_inputs=True)
 
-    @skipIfNoCaffe2
+    @skipIfCaffe2
     def test_embedding_bags(self):
         emb_bag = nn.EmbeddingBag(10, 8)
         input = torch.tensor([1, 2, 3, 4]).long()
@@ -793,7 +795,7 @@ class TestOperators(TestCase):
         input2 = torch.arange(24, dtype=torch.uint8).reshape(3, 4, 2)
         self.assertONNX(BitshiftModel(), (input, input2), opset_version=11)
 
-    @skipIfNoCaffe2
+    @skipIfCaffe2
     def test_layer_norm_aten(self):
         model = torch.nn.LayerNorm([10, 10])
         x = torch.randn(20, 5, 10, 10)

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -20,7 +20,7 @@ import os
 import shutil
 import tempfile
 import torch.testing._internal.common_utils as common
-from torch.testing._internal.common_utils import skipIfCaffe2
+from torch.testing._internal.common_utils import skipIfCaffe2, skipIfNoCaffe2
 
 '''Usage: python test/onnx/test_operators.py [--no-onnx] [--produce-onnx-test-data]
           --no-onnx: no onnx python dependence
@@ -593,7 +593,7 @@ class TestOperators(TestCase):
         self.assertONNX(nn.BatchNorm2d(128, affine=False, momentum=0.3), x,
                         keep_initializers_as_inputs=True)
 
-    @skipIfCaffe2
+    @skipIfNoCaffe2
     def test_embedding_bags(self):
         emb_bag = nn.EmbeddingBag(10, 8)
         input = torch.tensor([1, 2, 3, 4]).long()
@@ -793,7 +793,7 @@ class TestOperators(TestCase):
         input2 = torch.arange(24, dtype=torch.uint8).reshape(3, 4, 2)
         self.assertONNX(BitshiftModel(), (input, input2), opset_version=11)
 
-    @skipIfCaffe2
+    @skipIfNoCaffe2
     def test_layer_norm_aten(self):
         model = torch.nn.LayerNorm([10, 10])
         x = torch.randn(20, 5, 10, 10)

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -100,7 +100,7 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
         indices_list = sym_help._unpack_list(indices_list_value)
     else:
         indices_list = [indices_list_value]
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         args = [self] + indices_list + [values, accumulate]
         return g.at("index_put", *args)
 
@@ -225,7 +225,7 @@ def __interpolate(g, input, size, scale_factor, mode, align_corners, recompute_s
 def gather(g, self, dim, index, sparse_grad=False):
     if sym_help._maybe_get_const(sparse_grad, "i"):
         return _unimplemented("gather", "sparse_grad == True")
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("gather", self, dim, index, sparse_grad)
     return g.op("GatherElements", self, index, axis_i=dim)
 
@@ -233,7 +233,7 @@ def gather(g, self, dim, index, sparse_grad=False):
 @parse_args("v", "i", "v", "v")
 def scatter(g, self, dim, index, src):
     from torch.onnx.symbolic_opset9 import expand_as
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("scatter", self, dim, index, src, overload_name="src")
     src_type = src.type().scalarType()
     src = sym_help._maybe_get_scalar(src)
@@ -618,7 +618,7 @@ def mm(g, self, other):
 
 
 def index(g, self, index):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("index", self, index, overload_name="Tensor")
 
     if sym_help._is_packed_list(index):
@@ -639,7 +639,7 @@ def index(g, self, index):
 
 def index_fill(g, self, dim, index, value):
     dim_value = sym_help._parse_arg(dim, "i")
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("index_fill", self, index, value, overload_name="int_Scalar", dim_i=dim_value)
 
     expanded_index_shape, expanded_index = sym_help._index_fill_reshape_helper(g, self, dim, index)
@@ -651,7 +651,7 @@ def index_fill(g, self, dim, index, value):
 
 def index_copy(g, self, dim, index, source):
     dim_value = sym_help._parse_arg(dim, "i")
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("index_copy", self, index, source, dim_i=dim_value)
     expanded_index_shape, expanded_index = sym_help._index_fill_reshape_helper(g, self, dim, index)
     return scatter(g, self, dim, expanded_index, source)

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -173,7 +173,7 @@ def unfold(g, input, dimension, size, step):
     if not sym_help._is_value(const_size) and not sym_help._is_value(const_step):
         from torch.onnx.symbolic_opset9 import unfold as _unfold
         return _unfold(g, input, dimension, const_size, const_step)
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("unfold", input, dimension_i=dimension, size_i=size, step_i=step)
 
     sizedim = sym_help._get_tensor_dim_size(input, dimension)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -435,7 +435,7 @@ prod = _reduce_with_dtype("ReduceProd", "prod", allow_multi_dim_support=False)
 
 @parse_args("v", "i", "none")
 def cumsum(g, input, dim, dtype):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         if dtype.node().kind() != "prim::Constant":
             return _unimplemented(name, "dtype")
         return g.at("cumsum", input, dim_i=dim)
@@ -444,7 +444,7 @@ def cumsum(g, input, dim, dtype):
 
 
 def _sample_dirichlet(g, self, generator):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         if not sym_help._is_none(generator):
             return _unimplemented("_sample_dirichlet",
                                   "We are not able to export generator")
@@ -454,7 +454,7 @@ def _sample_dirichlet(g, self, generator):
 
 
 def _standard_gamma(g, self, generator):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         if not sym_help._is_none(generator):
             return _unimplemented("_standard_gamma",
                                   "We are not able to export generator")
@@ -524,7 +524,7 @@ def embedding_bag(g,
                   padding_idx):
     if not sym_help._is_none(per_sample_weights):
         return sym_help._onnx_unsupported("embedding_bag  with per_sample_weights")
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("embedding_bag",
                     embedding_matrix,
                     indices,
@@ -564,7 +564,7 @@ def transpose(g, self, dim0, dim1):
     else:
         # if we don't have dim information we cannot
         # output a permute so use ATen instead
-        if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+        if sym_help.is_caffe2_aten_fallback():
             return g.at("transpose", self, overload_name="int", dim0_i=dim0, dim1_i=dim1)
         else:
             raise RuntimeError("Unsupported: ONNX export of transpose for tensor "
@@ -1037,7 +1037,7 @@ def _adaptive_pool(name, type, tuple_fn, fn=None):
         if mod != [0] * len(mod):
             if output_size == [1] * len(output_size):
                 return g.op("GlobalMaxPool", input), None
-            if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+            if sym_help.is_caffe2_aten_fallback():
                 return _unimplemented(name, "output size that are not factor of input size")
             else:
                 return sym_help._onnx_unsupported(name + ", since output size is not factor of input size")
@@ -1445,7 +1445,7 @@ def batch_norm(g, input, weight, bias, running_mean, running_var, training, mome
 
 @parse_args("v", "is", "v", "v", "f", "i")
 def layer_norm(g, input, normalized_shape, weight, bias, eps, cudnn_enable):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("layer_norm", input, weight, bias, normalized_shape_i=normalized_shape,
                     eps_f=eps, cudnn_enable_i=cudnn_enable)
 
@@ -1515,7 +1515,7 @@ def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_s
 
 @parse_args("v", "i", "i", "i")
 def unfold(g, input, dimension, size, step):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("unfold", input, dimension_i=dimension, size_i=size, step_i=step)
     sizes = sym_help._get_tensor_sizes(input)
     try:
@@ -1563,7 +1563,7 @@ def index_put(g, self, indices_list_value, values, accumulate):
         indices_list = sym_help._unpack_list(indices_list_value)
     else:
         indices_list = [indices_list_value]
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         args = [self] + indices_list + [values, accumulate]
         return g.at("index_put", *args)
 
@@ -1580,7 +1580,7 @@ def index_put(g, self, indices_list_value, values, accumulate):
 
 def index_fill(g, self, dim, index, value):
     dim_value = sym_help._parse_arg(dim, "i")
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("index_fill", self, index, value, overload_name="int_Scalar", dim_i=dim_value)
 
     expanded_index_shape, expanded_index = sym_help._index_fill_reshape_helper(g, self, dim, index)
@@ -1593,7 +1593,7 @@ def index_fill(g, self, dim, index, value):
 
 def index_copy(g, self, dim, index, source):
     dim_value = sym_help._parse_arg(dim, "i")
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("index_copy", self, index, source, dim_i=dim_value)
     expanded_index_shape, expanded_index = sym_help._index_fill_reshape_helper(g, self, dim, index)
     return scatter(g, self, dim, expanded_index, source)
@@ -1637,7 +1637,7 @@ def type_as(g, self, other):
     if other_dtype is not None:
         return g.op("Cast", self, to_i=sym_help.cast_pytorch_to_onnx[other_dtype])
     else:
-        if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+        if sym_help.is_caffe2_aten_fallback():
             # We don't know the type of other, bail by emitting ATen
             return g.at("type_as", self, other)
         else:
@@ -1648,7 +1648,7 @@ def type_as(g, self, other):
 
 @parse_args("v", "v", "i", "f")
 def cosine_similarity(g, x1, x2, dim, eps):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("cosine_similarity", x1, x2, dim_i=dim, eps_f=eps)
     cross = sym_help._reducesum_helper(g, mul(g, x1, x2),
                                        axes_i=[dim], keepdims_i=0)
@@ -1842,7 +1842,7 @@ def norm(g, self, p, dim, keepdim):
 
 @parse_args("v", "v", "v", "i")
 def conv_tbc(g, input, weight, bias, pad):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("conv_tbc", input, weight, bias, pad_i=pad)
     else:
         # input must have 3 dimensions, see:
@@ -1858,7 +1858,7 @@ def conv_tbc(g, input, weight, bias, pad):
 
 @parse_args("v", "i", "i")
 def _unique(g, input, sorted, return_inverse):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("_unique", input, sorted_i=sorted,
                     return_inverse_i=return_inverse, outputs=2)
     else:
@@ -1867,7 +1867,7 @@ def _unique(g, input, sorted, return_inverse):
 
 @parse_args("v", "i", "i", "i")
 def _unique2(g, input, sorted, return_inverse, return_counts):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("_unique2", input, sorted_i=sorted,
                     return_inverse_i=return_inverse, return_counts_i=return_counts,
                     outputs=3)
@@ -2941,7 +2941,7 @@ def logsumexp(g, input, dim, keepdim):
 
 
 def arange(g, *args):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("arange", *args)
 
     def _get_arange_dtype(dtype):
@@ -3007,7 +3007,7 @@ def masked_fill(g, self, mask, value):
 
 
 def index(g, self, index):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("index", self, index, overload_name="Tensor")
 
     if sym_help._is_packed_list(index):
@@ -3286,7 +3286,7 @@ def gelu(g, self, approximate):
 
 @parse_args("v", "i", "v", "v", "f", "i")
 def group_norm(g, input, num_groups, weight, bias, eps, cudnn_enabled):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help.is_caffe2_aten_fallback():
         return g.at("group_norm", input, weight, bias, num_groups_i=num_groups,
                     eps_f=eps, cudnn_enabled_i=cudnn_enabled)
 
@@ -3344,7 +3344,7 @@ def _weight_norm(g, weight_v, weight_g, dim):
         norm_v = norm(g, weight_v, 2, axes, 1)
         div = g.op("Div", weight_v, norm_v)
         return g.op("Mul", div, weight_g)
-    elif sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    elif sym_help.is_caffe2_aten_fallback():
         return g.at("_weight_norm", weight_v, weight_g, dim_i=dim)
     else:
         raise RuntimeError("Unsupported: ONNX export of _weight_norm for tensor "


### PR DESCRIPTION
Currently ONNX exporter symbolics can emit ATen operators when `operator_export_type==ONNX_ATEN_FALLBACK`. However, this is a behavior specific to Caffe2 builds, as the intend use of `ONNX_ATEN_FALLBACK` is to emit ATen operators only when there is no ONNX equivalent.

The reason Caffe2 choses to emit ATen operators when ONNX counterpart exists is for performance on their particular engine implementation, which might not be true for other implementations. e.g. ONNX Runtime can optimize the generated ONNX graph into something more efficient

This PR must be merged only after https://github.com/pytorch/pytorch/pull/73954