### PR TITLE
Move `_outputs` to Node

### DIFF
--- a/test/cpp/lazy/test_cache.cpp
+++ b/test/cpp/lazy/test_cache.cpp
@@ -17,11 +17,11 @@ class CacheNode : public Node {
         str_(str) {}
   ~CacheNode() override = default;
 
-  const std::vector<Output>& operands() const override {
+  const std::vector<Output>& operands() const {
     TORCH_INTERNAL_ASSERT(false, "Can't access operands of test node");
   }
 
-  const Output& operand(size_t i) const override {
+  const Output& operand(size_t i) const {
     TORCH_INTERNAL_ASSERT(false, "Can't access operand[i] of test node");
   }
   const Shape& shape(size_t i) const override { return shape_; }

--- a/test/cpp/lazy/test_ir.cpp
+++ b/test/cpp/lazy/test_ir.cpp
@@ -16,11 +16,11 @@ class TestLeafNode : public Node {
         param_(param) {}
   ~TestLeafNode() override = default;
 
-  const std::vector<Output>& operands() const override {
+  const std::vector<Output>& operands() const {
     TORCH_INTERNAL_ASSERT(false, "Can't access operands of leaf node");
   }
 
-  const Output& operand(size_t i) const override {
+  const Output& operand(size_t i) const {
     TORCH_INTERNAL_ASSERT(false, "Can't access operand[i] of leaf node");
   }
   const Shape& shape(size_t i) const override { return shape_; }

--- a/test/cpp/lazy/test_ir_util.cpp
+++ b/test/cpp/lazy/test_ir_util.cpp
@@ -23,11 +23,11 @@ class IrUtilNode : public Node {
     operands_.push_back(std::move(v.node));
   }
 
-  const std::vector<Output>& operands() const override {
+  const std::vector<Output>& operands() const {
     return operands_as_outputs_;
   }
 
-  const Output& operand(size_t i) const override {
+  const Output& operand(size_t i) const {
     return operands_as_outputs_.at(i);
   }
 

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -6,6 +6,25 @@ C10_DEFINE_bool(ltc_enable_dynamic_shapes, false, "Whether dynamic shape is enab
 namespace torch {
 namespace lazy {
 
+hash_t OperandHashes(const OpList& operands, const hash_t& seed, bool bakeInSizes) {
+  hash_t hash = seed;
+  for (auto& operand : operands) {
+    if (!operand) {
+      hash = HashCombine(hash, static_cast<uint64_t>(kNullOpt));
+      continue;
+    }
+    auto operand_hash = bakeInSizes ? operand.hash_with_sizes() : operand.hash_without_sizes();
+    hash = HashCombine(hash, operand_hash);
+  }
+  return hash;
+}
+
+void Node::AddOperand(NodePtr node, size_t index) {
+  CHECK_LT(index, node->num_outputs());
+  operands_.push_back(std::move(node));
+  operands_as_outputs_.emplace_back(operands_.back().get(), index);
+}
+
 size_t Output::Hasher::operator()(const Output& output) const {
   return StdHashCombine(
       reinterpret_cast<std::ptrdiff_t>(output.node), output.index);
@@ -46,21 +65,49 @@ bool Node::enableDynamicShape() {
   return enabled || FLAGS_ltc_enable_dynamic_shapes;
 }
 
-Node::Node(OpKind op, size_t num_outputs, hash_t node_hash, std::function<hash_t(bool)> dag_hash_fn)
+Node::Node(OpKind op, OpList operands, size_t num_outputs, hash_t node_hash, std::function<hash_t(bool)> dag_hash_fn)
     : op_(op),
       num_outputs_(num_outputs),
       node_hash_(node_hash),
       dag_hash_without_sizes_(dag_hash_fn(false)),
       dag_hash_with_sizes_(dag_hash_fn(true)),
-      metadata_(GetMetaDataIfDebugging()) {}
+      metadata_(GetMetaDataIfDebugging()) {
+  for (auto& operand : operands) {
+    // Ideally, optional operands should be filtered by the leaf node classes,
+    // but it's just much easier to do it here.
+    // TODO(alanwaketan): Find a way to move the below logic to the leaf node
+    // classes.
+    if (!operand) {
+      continue;
+    }
+    AddOperand(operand.node, operand.index);
+  }
+}
 
-Node::Node(OpKind op, size_t num_outputs, std::function<hash_t(bool)> node_hash_fn)
+Node::Node(OpKind op, size_t num_outputs, hash_t node_hash, std::function<hash_t(bool)> dag_hash_fn)
+    : Node(op, OpList{}, num_outputs, node_hash, dag_hash_fn) {}
+
+Node::Node(OpKind op, OpList operands, size_t num_outputs, std::function<hash_t(bool)> node_hash_fn)
     : op_(op),
       num_outputs_(num_outputs),
       node_hash_(node_hash_fn(!enableDynamicShape())),
       dag_hash_without_sizes_(node_hash_fn(false)),
       dag_hash_with_sizes_(node_hash_fn(true)),
-      metadata_(GetMetaDataIfDebugging()) {}
+      metadata_(GetMetaDataIfDebugging())  {
+  for (auto& operand : operands) {
+    // Ideally, optional operands should be filtered by the leaf node classes,
+    // but it's just much easier to do it here.
+    // TODO(alanwaketan): Find a way to move the below logic to the leaf node
+    // classes.
+    if (!operand) {
+      continue;
+    }
+    AddOperand(operand.node, operand.index);
+  }
+}
+
+Node::Node(OpKind op, size_t num_outputs, std::function<hash_t(bool)> node_hash_fn)
+    : Node(op, OpList{}, num_outputs, node_hash_fn) {}
 
 Node::~Node() = default;
 

--- a/torch/csrc/lazy/ts_backend/ts_node.h
+++ b/torch/csrc/lazy/ts_backend/ts_node.h
@@ -52,13 +52,6 @@ class TORCH_API TsNode : public lazy::Node {
 
   static hash_t GetOpHash(OpKind op, const Shape& shape, hash_t hash_seed, bool bakeInSizes);
 
-  const std::vector<Output>& operands() const override {
-    return operands_as_outputs_;
-  }
-  const Output& operand(size_t i) const override {
-    return operands_as_outputs_.at(i);
-  }
-
   const std::string& getPythonStacktrace() const {
          return python_stacktrace_;
   }
@@ -70,15 +63,7 @@ class TORCH_API TsNode : public lazy::Node {
                            TSLoweringContext* loctx) const;
 
  private:
-  // Adds node's index output number as operand.
-  void AddOperand(NodePtr node, size_t index = 0);
-
   std::vector<Shape> shapes_;
-  // A node holds a real reference to its operands.
-  std::vector<NodePtr> operands_;
-  // Outputs do not hold references on the nodes, and neither do the uses, since
-  // otherwise we get into circular reference counting.
-  std::vector<Output> operands_as_outputs_;
   std::string python_stacktrace_;
 };
 


### PR DESCRIPTION
This change is in regard to the comment [here](https://github.com/pytorch/pytorch/pull/74175/files#r828269462)