### PR TITLE
[LT] Move the DDP fallback prototype into a ProcessGroup extension

### DIFF
--- a/torch/csrc/distributed/c10d/logger.cpp
+++ b/torch/csrc/distributed/c10d/logger.cpp
@@ -268,9 +268,7 @@ void Logger::set_runtime_stats_and_log() {
   // Sync with reducer's data
   std::lock_guard<std::mutex> lock(reducer_->mutex_);
   // Set runtime stats at the sampling iterations.
-  // FIXME(alanwaketan): Enable reducer_->timer_ for lazy device.
-  // Currently timers are tied to the specific device, e.g., CudaTimer, CpuTimer.
-  if (!reducer_->should_collect_runtime_stats() || !reducer_->timer_) {
+  if (!reducer_->should_collect_runtime_stats()) {
     return;
   }
   num_iterations_stats_recorded_++;
@@ -328,6 +326,14 @@ void Logger::set_runtime_stats_and_log() {
   if (reducer_->params_[0].is_cuda() && reducer_->is_multi_device_module_) {
     TORCH_WARN_ONCE(
       "Cuda time stats are not collected for multi-device modules."
+    );
+    return;
+  }
+  if (!reducer_->params_[0].is_cuda() && !reducer_->params_[0].is_cpu()) {
+    TORCH_WARN_ONCE(
+      "Time stats are currently only collected for CPU and CUDA devices. "
+      "Please refer to CpuTimer or CudaTimer for how to register timer "
+      "for other device type."
     );
     return;
   }

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1063,11 +1063,6 @@ class DistributedDataParallel(Module, Joinable):
 
         def to_map(obj):
             if isinstance(obj, torch.Tensor):
-                if obj.device.type == 'lazy':
-                    assert obj.device.index == target_gpu, (
-                        f"Tensor should be on rank: {target_gpu} instead of rank: {obj.device.index}"
-                    )
-                    return (obj,)
                 if obj.device == torch.device("cuda", target_gpu):
                     return (obj,)
                 if not self.use_side_stream_for_tensor_copies:

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -1270,7 +1270,7 @@ class DistributedTest:
             rank = dist.get_rank()
             if rank == 0:
                 with self.assertRaisesRegex(
-                    RuntimeError, "Tensors must be CUDA/Lazy and dense"
+                    RuntimeError, "Tensors must be CUDA and dense"
                 ):
                     send_tensor = _build_tensor(rank + 1)
                     send_op = dist.P2POp(dist.isend, send_tensor, 1)


### PR DESCRIPTION
Summary:
This commit moves the DDP fallback prototype into a ProcessGroup Python
extension such that it's less invasive to torch.distributed. And hopefully
this is ready to upstream.

Test Plan:
LTC_TS_CUDA=1 python lazy_tensor_core/test/ddp/ddp.py
