### PR TITLE
[BE] Fix bug in flaky test uploading

### DIFF
--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -791,7 +791,7 @@ def assemble_flaky_test_stats(duplicated_tests_by_file: Dict[str, DuplicatedDict
     if len(flaky_tests) > 0:
         # write to RDS
         register_rds_schema("flaky_tests", schema_from_sample(flaky_tests[0]))
-        # rds_write("flaky_tests", flaky_tests, only_on_master=False)
+        rds_write("flaky_tests", flaky_tests, only_on_master=False)
 
         # write to S3 to go to Rockset as well
         import uuid
@@ -800,7 +800,7 @@ def assemble_flaky_test_stats(duplicated_tests_by_file: Dict[str, DuplicatedDict
             flaky_test["workflow_id"] = workflow_id
             key = f"flaky_tests/{workflow_id}/{uuid.uuid4()}.json"
             obj = get_S3_object_from_bucket("ossci-raw-job-status", key)
-            # obj.put(Body=json.dumps(flaky_test), ContentType="application/json")
+            obj.put(Body=json.dumps(flaky_test), ContentType="application/json")
 
 
 def build_info() -> ReportMetaMeta:
@@ -855,7 +855,7 @@ def send_report_to_scribe(reports: Dict[str, TestFile]) -> None:
         ]
     )
     # no need to print send result as exceptions will be captured and print later.
-    # send_to_scribe(logs)
+    send_to_scribe(logs)
 
 
 def assemble_s3_object(
@@ -932,7 +932,7 @@ def upload_failures_to_rds(reports: Dict[str, TestFile]) -> None:
 
     if len(failures) > 0:
         register_rds_schema("test_failures", schema_from_sample(failures[0]))
-        # rds_write("test_failures", failures, only_on_master=False)
+        rds_write("test_failures", failures, only_on_master=False)
 
 
 def print_regressions(head_report: Report, *, num_prev_commits: int) -> None:

--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -574,6 +574,7 @@ def regression_info(
 class TestCase:
     def __init__(self, dom: Any) -> None:
         self.class_name = str(dom.attributes['classname'].value)
+        self.file = str(dom.attributes['file'].value)
         self.name = str(dom.attributes['name'].value)
         self.time = float(dom.attributes['time'].value)
         error_elements = dom.getElementsByTagName('error')
@@ -601,9 +602,9 @@ class TestCase:
         return self.__str__()
 
     def __str__(self) -> str:
-        return f'[TestCase name: {self.name} | class_name: {self.class_name} | time: {self.time} | ' \
+        return f'[TestCase name: {self.name} | class_name: {self.class_name} | file: {self.file} | time: {self.time} | ' \
             f'expected_failure: {self.expected_failure} | skipped: {self.skipped} | errored: {self.errored} | ' \
-            f'unexpected_success: {self.unexpected_success} | failed: {self.failed}]'
+            f'unexpected_success: {self.unexpected_success} | failed: {self.failed}]\n'
 
 class TestSuite:
     def __init__(self, name: str) -> None:
@@ -644,6 +645,17 @@ class TestSuite:
         self.test_cases[name].expected_failure |= test_case.expected_failure
 
 
+# Tests that spawn duplicates (usually only twice) intentionally
+MULTITESTS = [
+    'test_cpp_extensions_aot',
+    'distributed/test_distributed_spawn',
+    'distributed\\test_distributed_spawn',  # for windows
+    'distributed/test_c10d_gloo',
+    'distributed\\test_c10d_gloo',  # for windows
+    'cpp'  # The caffe2 cpp tests spawn duplicate test cases as well.
+]
+
+
 DuplicatedDict = Dict[str, Dict[str, List[TestCase]]]
 
 class TestFile:
@@ -653,27 +665,20 @@ class TestFile:
         self.test_suites: Dict[str, TestSuite] = dict()
 
     def append(self, test_case: TestCase, test_type: str, duplicated_tests_dict: DuplicatedDict) -> None:
-        is_multi_test = self.name == 'test_cpp_extensions_aot' or \
-            self.name == 'distributed/test_distributed_spawn' or \
-            self.name == 'distributed/test_c10d_gloo' or \
-            self.name == 'cpp'  # The caffe2 cpp tests spawn duplicate test cases as well.
-        if is_multi_test:
-            suite_name = test_case.class_name + '__' + test_type
-        else:
-            suite_name = test_case.class_name
+        suite_name = test_case.class_name
         if suite_name not in self.test_suites:
             self.test_suites[suite_name] = TestSuite(suite_name)
         if test_case.name in self.test_suites[suite_name].test_cases:
-            if is_multi_test:
+            if self.name in MULTITESTS:
                 self.test_suites[suite_name].update(test_case)
                 self.total_time += test_case.time
-            else:
-                # Gather up duplicated test cases
-                if suite_name not in duplicated_tests_dict:
-                    duplicated_tests_dict[suite_name] = dict()
-                if test_case.name not in duplicated_tests_dict[suite_name]:
-                    duplicated_tests_dict[suite_name][test_case.name] = [self.test_suites[suite_name].test_cases[test_case.name]]
-                duplicated_tests_dict[suite_name][test_case.name].append(test_case)
+
+            # Gather up duplicated test cases to parse for flaky reruns
+            if suite_name not in duplicated_tests_dict:
+                duplicated_tests_dict[suite_name] = dict()
+            if test_case.name not in duplicated_tests_dict[suite_name]:
+                duplicated_tests_dict[suite_name][test_case.name] = [self.test_suites[suite_name].test_cases[test_case.name]]
+            duplicated_tests_dict[suite_name][test_case.name].append(test_case)
         else:
             self.test_suites[suite_name].append(test_case)
             self.total_time += test_case.time
@@ -743,17 +748,9 @@ def process_intentional_test_runs(runs: List[TestCase]) -> Tuple[int, int]:
         else:
             num_pass += 1
 
-    REPEAT_TEST_FOR_TYPES_TESTS = [
-        "test_data_parallel_module",
-        "test_data_parallel_module_kwargs_only",
-        "test_data_parallel_module_kwargs_only_empty_list",
-        "test_data_parallel_module_kwargs_only_empty_dict",
-        "test_data_parallel_module_kwargs_only_empty_tuple"
-    ]
-
-    # Do not run checks for tests that use repeat_test_for_types decorator as they do not go well with our retry
-    # functionality. Once issue https://github.com/pytorch/pytorch/issues/69865 is fixed, we should remove the exception
-    if not any([x in test_run.name for x in REPEAT_TEST_FOR_TYPES_TESTS]):
+    # Do not run duplication checks for test files that spawn duplicate tests intentionally
+    # and are not necessarily flaky test reruns.
+    if not any(x in test_run.file for x in MULTITESTS):
         err_msg = f'Warning: unintentional test case duplicates found for {test_run.name} in suite {test_run.class_name}.'
         report_only = os.getenv('PYTORCH_OVERRIDE_FLAKY_SIGNAL') != '1'
         if report_only and num_fail + num_errored + num_unexpected_success < 1 or not report_only and num_expected_fail < 1:
@@ -780,7 +777,7 @@ def assemble_flaky_test_stats(duplicated_tests_by_file: Dict[str, DuplicatedDict
         for suite_name, testcase_to_runs in suite_to_dict.items():
             for testcase_name, list_of_runs in testcase_to_runs.items():
                 num_green, num_red = process_intentional_test_runs(list_of_runs)
-                if num_green > 0:   # Otherwise, it's likely just a failing test
+                if num_green > 0 and num_red > 0:   # Flaky tests show different results in consecutive reruns
                     flaky_tests.append({
                         "name": testcase_name,
                         "suite": suite_name,


### PR DESCRIPTION
I noticed that the latest windows c10_dist_gloo flakiness did not get caught by flaky test bot. https://hud.pytorch.org/pytorch/pytorch/commit/238d01ec9044d66c021baefd26f765b265ef35a7 The issue was because c10_dist_gloo is a test file that spawns duplicates intentionally, and I had excluded those in my "duplicate flaky test rerun" calculation.

I've now updated the logic to handle when those intentional duplicated tests are flaky as well.

This PR also cleans up some past outdated logic.