### PR TITLE
[JIT][easy] comment about where nvfuser is called in profiling_graph_executor_impl.cpp

### DIFF
--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -424,6 +424,7 @@ void ProfilingGraphExecutorImpl::runNoGradOptimizations(
   // runNondiffOptimization
   {
     // Run custom passes that different backends can register.
+    // e.g. NVFuser
     for (const auto& passPair : getCustomPrePasses()) {
       passPair.first(graph);
     }

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -424,7 +424,6 @@ void ProfilingGraphExecutorImpl::runNoGradOptimizations(
   // runNondiffOptimization
   {
     // Run custom passes that different backends can register.
-    // e.g. NVFuser
     for (const auto& passPair : getCustomPrePasses()) {
       passPair.first(graph);
     }
@@ -473,6 +472,7 @@ void ProfilingGraphExecutorImpl::runNoGradOptimizations(
     }
 
     // Run custom post-fusion passes
+    // e.g. NVFuser
     for (const auto& passPair : getCustomPostPasses()) {
       passPair.first(graph);
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #74719

Will make it easier to figure out where NVFuser is getting called from.