### PR TITLE
[PyTorch Distributed][improvement] User configured sigterm escalation time in Rdzv_conf

### DIFF
--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -102,12 +102,14 @@ class LocalElasticAgent(SimpleElasticAgent):
         self,
         spec: WorkerSpec,
         start_method="spawn",
+        sigterm_timeout: float = 30,
         exit_barrier_timeout: float = 300,
         log_dir: Optional[str] = None,
     ):
         super().__init__(spec, exit_barrier_timeout)
         self._start_method = start_method
         self._pcontext: Optional[PContext] = None
+        self._sigterm_timeout = sigterm_timeout
         rdzv_run_id = spec.rdzv_handler.get_run_id()
         self._log_dir = self._make_log_dir(log_dir, rdzv_run_id)
 
@@ -181,6 +183,7 @@ class LocalElasticAgent(SimpleElasticAgent):
             args=args,
             envs=envs,
             log_dir=attempt_log_dir,
+            sigterm_timeout=self._sigterm_timeout,
             start_method=self._start_method,
             redirects=spec.redirects,
             tee=spec.tee,

--- a/torch/distributed/elastic/multiprocessing/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/__init__.py
@@ -88,6 +88,7 @@ def start_processes(
     args: Dict[int, Tuple],
     envs: Dict[int, Dict[str, str]],
     log_dir: str,
+    sigterm_timeout: float = 30.0,
     start_method: str = "spawn",
     redirects: Union[Std, Dict[int, Std]] = Std.NONE,
     tee: Union[Std, Dict[int, Std]] = Std.NONE,
@@ -179,6 +180,8 @@ def start_processes(
         envs: env vars to each replica
         log_dir: directory used to write log files
         nprocs: number of copies to create (one on each process)
+        sigterm_timeout: time before a sigterm is escalated to a sigkill,
+                         useful to delay killing to clean up
         start_method: multiprocessing start method (spawn, fork, forkserver)
                       ignored for binaries
         redirects: which std streams to redirect to a log file
@@ -252,6 +255,7 @@ def start_processes(
             tee_stdouts=tee_stdouts,
             tee_stderrs=tee_stderrs,
             error_files=error_files,
+            sigterm_timeout=sigterm_timeout,
         )
     else:
         context = MultiprocessContext(
@@ -265,6 +269,7 @@ def start_processes(
             tee_stderrs=tee_stderrs,
             error_files=error_files,
             start_method=start_method,
+            sigterm_timeout=sigterm_timeout,
         )
 
     try:

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -79,6 +79,7 @@ class LaunchConfig:
     max_restarts: int = 3
     monitor_interval: float = 30
     start_method: str = "spawn"
+    sigterm_timeout: float = 30
     log_dir: Optional[str] = None
     redirects: Union[Std, Dict[int, Std]] = Std.NONE
     tee: Union[Std, Dict[int, Std]] = Std.NONE
@@ -226,7 +227,10 @@ def launch_agent(
     )
 
     agent = LocalElasticAgent(
-        spec=spec, start_method=config.start_method, log_dir=config.log_dir
+        spec=spec,
+        start_method=config.start_method,
+        sigterm_timeout=config.sigterm_timeout,
+        log_dir=config.log_dir,
     )
 
     shutdown_rdzv = True


### PR DESCRIPTION
Based off [issue](https://github.com/pytorch/pytorch/issues/68258) I've come across, "sigterm_timeout" parameter has been added to LaunchConfig and propagated to start_processes() during an Elastic Launch. This allows users a customiseable grace period from when they recieve a sigterm to do any clean up in their own program. So now this can be defined with `--rdzv_conf sigterm_timeout=300`. Unit testing is included to check the sigterm escalation timeout behaviour, but not the --rdzv_conf propagation.

For example, if my kubernetes pod is evicted through preemption or general killing, a pod first recieves a sigterm, which is later escalated to sigkill after a grace period. I can easly change this grace period in the pod to give enough time to send checkpoints to a remote machine, but now the elastic agent killing the process after recieving a sigterm is a limiting factor.