### PR TITLE
[FX] Make split_module preserve proper placeholder names

### DIFF
--- a/torch/fx/passes/split_module.py
+++ b/torch/fx/passes/split_module.py
@@ -238,7 +238,7 @@ def split_module(
         if node.op == 'placeholder':
             default_value = node.args[0] if len(node.args) > 0 else inspect.Signature.empty
             base_mod_env[node.name] = base_mod_graph.placeholder(
-                node.name, type_expr=node.type, default_value=default_value)
+                node.target, type_expr=node.type, default_value=default_value)
             base_mod_env[node.name].meta = node.meta.copy()
         elif node.op == 'get_attr':
             base_mod_env[node.name] = base_mod_graph.get_attr(node.target)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74736
* #74662

Previously, `split_module` would incorrectly carry over the `name` of placeholders rather than their `target`:

Original GraphModule

```
def forward(self, x, **kwargs):
    _kwargs = kwargs
    getitem = _kwargs['foo'];  _kwargs = None
    add = x + getitem;  x = getitem = None
    return add
```

After splitting:

```
def forward(self, x, _kwargs):
    submod_0 = self.submod_0(_kwargs);  _kwargs = None
    submod_1 = self.submod_1(x, submod_0);  x = submod_0 = None
    return submod_1
```

Notice that `**kwargs` is turned into `_kwargs`, which is incorrect and we lose the kwarg expansion behavior. This patch switches the erroneous code in `split_module`, resulting in the correct split code being emitted:

Original GraphModule

```
def forward(self, x, **kwargs):
    _kwargs = kwargs
    getitem = _kwargs['foo'];  _kwargs = None
    add = x + getitem;  x = getitem = None
    return add
```

After splitting:

```
def forward(self, x, **kwargs):
    _kwargs = kwargs
    submod_0 = self.submod_0(_kwargs);  _kwargs = None
    submod_1 = self.submod_1(x, submod_0);  x = submod_0 = None
    return submod_1
```

Differential Revision: [D35137361](https://our.internmc.facebook.com/intern/diff/D35137361)