### PR TITLE
[Model Averaging] Fix post_localSGD_optimizer

### DIFF
--- a/torch/distributed/optim/post_localSGD_optimizer.py
+++ b/torch/distributed/optim/post_localSGD_optimizer.py
@@ -75,11 +75,12 @@ class PostLocalSGDOptimizer(torch.optim.Optimizer):
         Performs a single optimization step (parameter update).
         """
         self.optim.step()
-        params = []
-        for param_group in self.param_groups:
-            for param in param_group["params"]:
-                if param.grad is not None:
-                    params.append(param)
+        params = [
+            param
+            for param_group in self.param_groups
+            for param in param_group["params"]
+            if param.grad is not None
+        ]
         self.averager.average_parameters(iter(params))
 
     def zero_grad(self):

--- a/torch/distributed/optim/post_localSGD_optimizer.py
+++ b/torch/distributed/optim/post_localSGD_optimizer.py
@@ -75,11 +75,12 @@ class PostLocalSGDOptimizer(torch.optim.Optimizer):
         Performs a single optimization step (parameter update).
         """
         self.optim.step()
+        params = []
         for param_group in self.param_groups:
-            for params in param_group["params"]:
-                if params.grad is None:
-                    continue
-                self.averager.average_parameters(iter(params))
+            for param in param_group["params"]:
+                if param.grad is not None:
+                    params.append(param)
+        self.averager.average_parameters(iter(params))
 
     def zero_grad(self):
         self.optim.zero_grad()

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4840,7 +4840,8 @@ class DistributedTest:
         )
         @sandcastle_skip_if(
             IS_WINDOWS,
-            "Process group cannot be pickled on Windows when a model averager is deep copied: https://github.com/pytorch/pytorch/pull/74737#pullrequestreview-922487496",
+            "Process group cannot be pickled on Windows when a model averager is deep copied:"
+            "https://github.com/pytorch/pytorch/pull/74737#pullrequestreview-922487496",
         )
         def test_post_localSGD_optimizer_parity(self):
             torch.cuda.set_device(self.rank)
@@ -4855,7 +4856,8 @@ class DistributedTest:
         )
         @sandcastle_skip_if(
             IS_WINDOWS,
-            "Process group cannot be pickled on Windows when a model averager is deep copied: https://github.com/pytorch/pytorch/pull/74737#pullrequestreview-922487496",
+            "Process group cannot be pickled on Windows when a model averager is deep copied:"
+            "https://github.com/pytorch/pytorch/pull/74737#pullrequestreview-922487496",
         )
         def test_post_localSGD_optimizer_parity_grad_is_view(self):
             torch.cuda.set_device(self.rank)
@@ -4870,7 +4872,8 @@ class DistributedTest:
         )
         @sandcastle_skip_if(
             IS_WINDOWS,
-            "Process group cannot be pickled on Windows when a model averager is deep copied: https://github.com/pytorch/pytorch/pull/74737#pullrequestreview-922487496",
+            "Process group cannot be pickled on Windows when a model averager is deep copied:"
+            "https://github.com/pytorch/pytorch/pull/74737#pullrequestreview-922487496",
         )
         def test_post_localSGD_optimizer_parity_with_hierarchical_sgd(self):
             torch.cuda.set_device(self.rank)
@@ -4888,7 +4891,8 @@ class DistributedTest:
         )
         @sandcastle_skip_if(
             IS_WINDOWS,
-            "Process group cannot be pickled on Windows when a model averager is deep copied: https://github.com/pytorch/pytorch/pull/74737#pullrequestreview-922487496",
+            "Process group cannot be pickled on Windows when a model averager is deep copied:"
+            "https://github.com/pytorch/pytorch/pull/74737#pullrequestreview-922487496",
         )
         def test_post_localSGD_optimizer_parity_with_hierarchical_sgd_grad_is_view(self):
             torch.cuda.set_device(self.rank)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4799,11 +4799,11 @@ class DistributedTest:
                 gradient_as_bucket_view=grad_is_view,
             )
             opt = torch.optim.SGD(net.parameters(), lr=learning_rate)
+
             averager = averagers.PeriodicModelAverager(
                 period=period, warmup_steps=warmup_steps
             )
-
-            net_using_post_localSGD_opt = torch.nn.parallel.DistributedDataParallel(
+            post_localSGD_net = torch.nn.parallel.DistributedDataParallel(
                 copy.deepcopy(DDP_NET).cuda(),
                 device_ids=[self.rank],
                 gradient_as_bucket_view=grad_is_view,
@@ -4812,7 +4812,7 @@ class DistributedTest:
             # See: https://github.com/pytorch/pytorch/pull/74737#pullrequestreview-922487496
             averager2 = averagers.PeriodicModelAverager(
                 period=period, warmup_steps=warmup_steps
-            )            
+            )
             post_localSGD_opt = post_localSGD_optimizer.PostLocalSGDOptimizer(
                 optim=torch.optim.SGD(net_using_post_localSGD_opt.parameters(), lr=learning_rate),
                 averager=averager2,


### PR DESCRIPTION
I find that the original implementation of `post_localSGD_optimizer.step()` is incorrect:

Whenever `averager.average_parameters()` is called, the built-in step counter will be increased. Therefore, this should only be called exactly once per `optimizer.step()`. However, if a model has multiple param groups or params, the current implementation will call `averager.average_parameters()` multiple times and over-increase the step counter.

Relevant proposals since hierarchical SGD can be supported on `post_localSGD_optimizer`: https://github.com/pytorch/pytorch/issues/73382, https://github.com/pytorch/pytorch/issues/71325