### PR TITLE
Add Hpu to the rebuild component list

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -219,7 +219,7 @@ class Tensor(torch._C._TensorBase):
         # 2. Python list is not a good fit due to performance reason.
         #    `tolist()` converts every single element in the tensor into python objects
         #    and serialize them one by one.
-        if self.device.type in ['xla', 'ort', 'mlc']:
+        if self.device.type in ['xla', 'ort', 'mlc', 'hpu']:
             return (torch._utils._rebuild_device_tensor_from_numpy, (self.cpu().numpy(),
                                                                      self.dtype,
                                                                      str(self.device),


### PR DESCRIPTION
Numpy array is chosen to be the rebuild component for
HPU. so add it to the backend list.

Signed-off-by: Ayman Yousef<ayousef@habana.ai>
Signed-off-by: Jeeja <jeejakp@habana.ai>

Fixes #ISSUE_NUMBER
