### PR TITLE
ci: Add lts for s3 index updating workflow

### DIFF
--- a/.github/workflows/update_s3_htmls.yml
+++ b/.github/workflows/update_s3_htmls.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     strategy:
       matrix:
-        prefix: ["whl", "whl/test", "whl/nightly"]
+        prefix: ["whl", "whl/test", "whl/nightly", "whl/lts/1.8"]
     steps:
       - name: Run updater image
         env:


### PR DESCRIPTION
This wasn't included but probably should be included considering it
doesn't currently have pep503 compliant indices right now

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
