### PR TITLE
Add missing LTC headers, re-enble xla configuration

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -212,7 +212,6 @@ jobs:
       build-generates-artifacts: false
 
   pytorch-xla-linux-bionic-py3_7-clang8-build:
-    if: ${{ false }}
     name: pytorch-xla-linux-bionic-py3.7-clang8
     uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:

--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -92,6 +92,6 @@ function checkout_install_torchvision() {
 
 function clone_pytorch_xla() {
   if [[ ! -d ./xla ]]; then
-    git clone --recursive https://github.com/pytorch/xla.git
+    git clone --recursive -b test-lazy-tensor-device https://github.com/pytorch/xla.git
   fi
 }

--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -92,6 +92,6 @@ function checkout_install_torchvision() {
 
 function clone_pytorch_xla() {
   if [[ ! -d ./xla ]]; then
-    git clone --recursive -b test-lazy-tensor-device https://github.com/pytorch/xla.git
+    git clone --recursive https://github.com/pytorch/xla.git
   fi
 }

--- a/setup.py
+++ b/setup.py
@@ -1051,6 +1051,7 @@ if __name__ == '__main__':
                 'include/torch/csrc/profiler/*.h',
                 'include/torch/csrc/utils/*.h',
                 'include/torch/csrc/tensor/*.h',
+                'include/torch/csrc/lazy/backend/*.h',
                 'include/torch/csrc/lazy/core/*.h',
                 'include/pybind11/*.h',
                 'include/pybind11/detail/*.h',


### PR DESCRIPTION
Addresses XLA test failures due to missing PyTorch lazy tensor backend headers:
```
“fatal error: ‘torch/csrc/lazy/backend/backend_device.h’ file not found” from pytorch-xla-linux-bionic-py3.7-clang8
```
