### PR TITLE
ci: Move ssh setup to it's own action

### DIFF
--- a/.github/actions/setup-linux/action.yml
+++ b/.github/actions/setup-linux/action.yml
@@ -2,11 +2,6 @@ name: Setup Linux
 
 description: Set up Docker workspace on EC2
 
-inputs:
-  github-secret:
-    description: GitHub token
-    required: true
-
 runs:
   using: composite
   steps:
@@ -45,11 +40,6 @@ runs:
         retry () { "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@") }
         retry aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS \
             --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"
-
-    - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
-      uses: seemethere/add-github-ssh-key@v1
-      with:
-        GITHUB_TOKEN: ${{ inputs.github-secret }}
 
     - name: Preserve github env variables for use in docker
       shell: bash

--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -1,0 +1,16 @@
+name: Setup SSH
+
+description: Adds ssh keys for current user to machine
+
+inputs:
+  github-secret:
+    description: GitHub token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: "Enable SSH (Click me for login details)"
+      uses: seemethere/add-github-ssh-key@v1
+      with:
+        GITHUB_TOKEN: ${{ inputs.github-secret }}

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -3,9 +3,6 @@ name: Setup Windows
 description: Set up for windows jobs
 
 inputs:
-  github-secret:
-    description: GitHub token
-    required: true
   cuda-version:
     description: which cuda version to install, 'cpu' for none
     required: true
@@ -27,11 +24,6 @@ runs:
         echo "instance-id: $(get_ec2_metadata instance-id)"
         echo "instance-type: $(get_ec2_metadata instance-type)"
         echo "system info $(uname -a)"
-
-    - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
-      uses: seemethere/add-github-ssh-key@v1
-      with:
-        GITHUB_TOKEN: ${{ inputs.github-secret }}
 
     # Needed for binary builds, see: https://github.com/pytorch/pytorch/issues/73339#issuecomment-1058981560
     - name: Enable long paths on Windows

--- a/.github/workflows/_android-build-test.yml
+++ b/.github/workflows/_android-build-test.yml
@@ -28,10 +28,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: ./pytorch/pytorch/.github/actions/setup-linux
+        uses: ./.github/actions/setup-linux
 
       - name: Setup SSH (Click me for login details)
-        uses: ./pytorch/pytorch/.github/actions/setup-ssh
+        uses: ./.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_android-build-test.yml
+++ b/.github/workflows/_android-build-test.yml
@@ -28,10 +28,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: ./.github/actions/setup-linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@master
 
       - name: Setup SSH (Click me for login details)
-        uses: ./.github/actions/setup-ssh
+        uses: pytorch/pytorch/.github/actions/setup-ssh@master
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_android-build-test.yml
+++ b/.github/workflows/_android-build-test.yml
@@ -28,7 +28,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: pytorch/pytorch/.github/actions/setup-linux@master
+        uses: ./pytorch/pytorch/.github/actions/setup-linux
+
+      - name: Setup SSH (Click me for login details)
+        uses: ./pytorch/pytorch/.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -45,10 +45,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: ./.github/actions/setup-linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@master
 
       - name: Setup SSH (Click me for login details)
-        uses: ./.github/actions/setup-ssh
+        uses: pytorch/pytorch/.github/actions/setup-ssh@master
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -45,7 +45,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: pytorch/pytorch/.github/actions/setup-linux@master
+        uses: ./pytorch/pytorch/.github/actions/setup-linux
+
+      - name: Setup SSH (Click me for login details)
+        uses: ./pytorch/pytorch/.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -45,10 +45,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: ./pytorch/pytorch/.github/actions/setup-linux
+        uses: ./.github/actions/setup-linux
 
       - name: Setup SSH (Click me for login details)
-        uses: ./pytorch/pytorch/.github/actions/setup-ssh
+        uses: ./.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -28,10 +28,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: ./pytorch/pytorch/.github/actions/setup-linux
+        uses: ./.github/actions/setup-linux
 
       - name: Setup SSH (Click me for login details)
-        uses: ./pytorch/pytorch/.github/actions/setup-ssh
+        uses: ./.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -28,10 +28,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: ./.github/actions/setup-linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@master
 
       - name: Setup SSH (Click me for login details)
-        uses: ./.github/actions/setup-ssh
+        uses: pytorch/pytorch/.github/actions/setup-ssh@master
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -28,7 +28,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: pytorch/pytorch/.github/actions/setup-linux@master
+        uses: ./pytorch/pytorch/.github/actions/setup-linux
+
+      - name: Setup SSH (Click me for login details)
+        uses: ./pytorch/pytorch/.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -40,7 +40,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: pytorch/pytorch/.github/actions/setup-linux@master
+        uses: ./pytorch/pytorch/.github/actions/setup-linux
+
+      - name: Setup SSH (Click me for login details)
+        uses: ./pytorch/pytorch/.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -40,10 +40,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: ./.github/actions/setup-linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@master
 
       - name: Setup SSH (Click me for login details)
-        uses: ./.github/actions/setup-ssh
+        uses: pytorch/pytorch/.github/actions/setup-ssh@master
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -40,10 +40,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: ./pytorch/pytorch/.github/actions/setup-linux
+        uses: ./.github/actions/setup-linux
 
       - name: Setup SSH (Click me for login details)
-        uses: ./pytorch/pytorch/.github/actions/setup-ssh
+        uses: ./.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -48,10 +48,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: ./.github/actions/setup-linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@master
 
       - name: Setup SSH (Click me for login details)
-        uses: ./.github/actions/setup-ssh
+        uses: pytorch/pytorch/.github/actions/setup-ssh@master
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -48,10 +48,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: ./pytorch/pytorch/.github/actions/setup-linux
+        uses: ./.github/actions/setup-linux
 
       - name: Setup SSH (Click me for login details)
-        uses: ./pytorch/pytorch/.github/actions/setup-ssh
+        uses: ./.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -48,7 +48,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: pytorch/pytorch/.github/actions/setup-linux@master
+        uses: ./pytorch/pytorch/.github/actions/setup-linux
+
+      - name: Setup SSH (Click me for login details)
+        uses: ./pytorch/pytorch/.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -35,7 +35,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: pytorch/pytorch/.github/actions/setup-linux@master
+        uses: ./pytorch/pytorch/.github/actions/setup-linux
+
+      - name: Setup SSH (Click me for login details)
+        uses: ./pytorch/pytorch/.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -35,10 +35,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Setup Linux
-        uses: ./pytorch/pytorch/.github/actions/setup-linux
+        uses: pytorch/pytorch/.github/actions/setup-linux@master
 
       - name: Setup SSH (Click me for login details)
-        uses: ./pytorch/pytorch/.github/actions/setup-ssh
+        uses: pytorch/pytorch/.github/actions/setup-ssh@master
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -38,12 +38,12 @@ jobs:
           no-sudo: true
 
       - name: Setup Windows
-        uses: ./.github/actions/setup-win@master
+        uses: pytorch/pytorch/.github/actions/setup-win@master
         with:
           cuda-version: ${{ inputs.cuda-version }}
 
       - name: Setup SSH (Click me for login details)
-        uses: ./.github/actions/setup-ssh
+        uses: pytorch/pytorch/.github/actions/setup-ssh@master
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -38,12 +38,12 @@ jobs:
           no-sudo: true
 
       - name: Setup Windows
-        uses: pytorch/pytorch/.github/actions/setup-win@master
+        uses: ./.github/actions/setup-win@master
         with:
           cuda-version: ${{ inputs.cuda-version }}
 
       - name: Setup SSH (Click me for login details)
-        uses: pytorch/pytorch/.github/actions/setup-ssh
+        uses: ./.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -40,8 +40,12 @@ jobs:
       - name: Setup Windows
         uses: pytorch/pytorch/.github/actions/setup-win@master
         with:
-          github-secret: ${{ secrets.GITHUB_TOKEN }}
           cuda-version: ${{ inputs.cuda-version }}
+
+      - name: Setup SSH (Click me for login details)
+        uses: pytorch/pytorch/.github/actions/setup-ssh
+        with:
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Parse ref
         id: parse-ref

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -38,12 +38,12 @@ jobs:
           no-sudo: true
 
       - name: Setup Windows
-        uses: ./.github/actions/setup-win@master
+        uses: pytorch/pytorch/.github/actions/setup-win@master
         with:
           cuda-version: ${{ inputs.cuda-version }}
 
       - name: Setup SSH (Click me for login details)
-        uses: ./.github/actions/setup-ssh
+        uses: pytorch/pytorch/.github/actions/setup-ssh@master
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -38,12 +38,12 @@ jobs:
           no-sudo: true
 
       - name: Setup Windows
-        uses: pytorch/pytorch/.github/actions/setup-win@master
+        uses: ./.github/actions/setup-win@master
         with:
           cuda-version: ${{ inputs.cuda-version }}
 
       - name: Setup SSH (Click me for login details)
-        uses: pytorch/pytorch/.github/actions/setup-ssh
+        uses: ./.github/actions/setup-ssh
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -40,8 +40,12 @@ jobs:
       - name: Setup Windows
         uses: pytorch/pytorch/.github/actions/setup-win@master
         with:
-          github-secret: ${{ secrets.GITHUB_TOKEN }}
           cuda-version: ${{ inputs.cuda-version }}
+
+      - name: Setup SSH (Click me for login details)
+        uses: pytorch/pytorch/.github/actions/setup-ssh
+        with:
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download PyTorch Build Artifacts
         uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -16,14 +16,14 @@ concurrency:
 jobs:
   linux-xenial-py3_7-gcc5_4-build:
     name: linux-xenial-py3.7-gcc5.4
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-xenial-py3.7-gcc5.4
       docker-image-name: pytorch-linux-xenial-py3.7-gcc5.4
 
   linux-xenial-py3_7-gcc5_4-test:
     name: linux-xenial-py3.7-gcc5.4
-    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
+    uses: ./.github/workflows/_linux-test.yml
     needs: linux-xenial-py3_7-gcc5_4-build
     with:
       build-environment: linux-xenial-py3.7-gcc5.4
@@ -40,7 +40,7 @@ jobs:
 
   linux-docs:
     name: linux-docs
-    uses: pytorch/pytorch/.github/workflows/_docs.yml@master
+    uses: ./.github/workflows/_docs.yml
     needs: linux-xenial-py3_7-gcc5_4-build
     with:
       build-environment: linux-xenial-py3.7-gcc5.4
@@ -48,14 +48,14 @@ jobs:
 
   linux-xenial-py3_7-gcc7-build:
     name: linux-xenial-py3.7-gcc7
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-xenial-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-py3.7-gcc7
 
   linux-xenial-py3_7-gcc7-test:
     name: linux-xenial-py3.7-gcc7
-    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
+    uses: ./.github/workflows/_linux-test.yml
     needs: linux-xenial-py3_7-gcc7-build
     with:
       build-environment: linux-xenial-py3.7-gcc7
@@ -68,14 +68,14 @@ jobs:
 
   linux-xenial-py3_7-clang7-asan-build:
     name: linux-xenial-py3.7-clang7-asan
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-xenial-py3.7-clang7-asan
       docker-image-name: pytorch-linux-xenial-py3-clang7-asan
 
   linux-xenial-py3_7-clang7-asan-test:
     name: linux-xenial-py3.7-clang7-asan
-    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
+    uses: ./.github/workflows/_linux-test.yml
     needs: linux-xenial-py3_7-clang7-asan-build
     with:
       build-environment: linux-xenial-py3.7-clang7-asan
@@ -89,21 +89,21 @@ jobs:
 
   linux-xenial-py3_7-gcc7-no-ops:
     name: linux-xenial-py3.7-gcc7-no-ops
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-xenial-py3.7-gcc7-no-ops
       docker-image-name: pytorch-linux-xenial-py3.7-gcc7
 
   linux-xenial-py3_7-clang7-onnx-build:
     name: linux-xenial-py3.7-clang7-onnx
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-xenial-py3.7-clang7-onnx
       docker-image-name: pytorch-linux-xenial-py3-clang7-onnx
 
   linux-xenial-py3_7-clang7-onnx-test:
     name: linux-xenial-py3.7-clang7-onnx
-    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
+    uses: ./.github/workflows/_linux-test.yml
     needs: linux-xenial-py3_7-clang7-onnx-build
     with:
       build-environment: linux-xenial-py3.7-clang7-onnx
@@ -116,14 +116,14 @@ jobs:
 
   linux-bionic-py3_7-clang9-build:
     name: linux-bionic-py3.7-clang9
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-bionic-py3.7-clang9
       docker-image-name: pytorch-linux-bionic-py3.7-clang9
 
   linux-bionic-py3_7-clang9-test:
     name: linux-bionic-py3.7-clang9
-    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
+    uses: ./.github/workflows/_linux-test.yml
     needs: linux-bionic-py3_7-clang9-build
     with:
       build-environment: linux-bionic-py3.7-clang9
@@ -137,14 +137,14 @@ jobs:
 
   linux-vulkan-bionic-py3_7-clang9-build:
     name: linux-vulkan-bionic-py3.7-clang9
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-vulkan-bionic-py3.7-clang9
       docker-image-name: pytorch-linux-bionic-py3.7-clang9
 
   linux-vulkan-bionic-py3_7-clang9-test:
     name: linux-vulkan-bionic-py3.7-clang9
-    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
+    uses: ./.github/workflows/_linux-test.yml
     needs: linux-vulkan-bionic-py3_7-clang9-build
     with:
       build-environment: linux-vulkan-bionic-py3.7-clang9
@@ -156,14 +156,14 @@ jobs:
 
   linux-xenial-cuda11_3-py3_7-gcc7-build:
     name: linux-xenial-cuda11.3-py3.7-gcc7
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
 
   linux-xenial-cuda11_3-py3_7-gcc7-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7
-    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
+    uses: ./.github/workflows/_linux-test.yml
     needs: linux-xenial-cuda11_3-py3_7-gcc7-build
     with:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7
@@ -177,14 +177,14 @@ jobs:
 
   linux-bionic-rocm4_5-py3_7-build:
     name: linux-bionic-rocm4.5-py3.7
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-bionic-rocm4.5-py3.7
       docker-image-name: pytorch-linux-bionic-rocm4.5-py3.7
 
   linux-bionic-rocm4_5-py3_7-test:
     name: linux-bionic-rocm4.5-py3.7
-    uses: pytorch/pytorch/.github/workflows/_rocm-test.yml@master
+    uses: ./.github/workflows/_rocm-test.yml
     needs: linux-bionic-rocm4_5-py3_7-build
     with:
       build-environment: linux-bionic-rocm4.5-py3.7
@@ -197,7 +197,7 @@ jobs:
 
   linux-xenial-py3-clang5-mobile-build:
     name: linux-xenial-py3-clang5-mobile-build
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-xenial-py3-clang5-mobile-build
       docker-image-name: pytorch-linux-xenial-py3-clang5-asan
@@ -205,7 +205,7 @@ jobs:
 
   linux-xenial-py3-clang5-mobile-custom-build-static:
     name: linux-xenial-py3-clang5-mobile-custom-build-static
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-xenial-py3-clang5-mobile-custom-build-static
       docker-image-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c
@@ -214,14 +214,14 @@ jobs:
   pytorch-xla-linux-bionic-py3_7-clang8-build:
     if: ${{ false }}
     name: pytorch-xla-linux-bionic-py3.7-clang8
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: pytorch-xla-linux-bionic-py3.7-clang8
       docker-image-name: xla_base
 
   pytorch-xla-linux-bionic-py3_7-clang8-test:
     name: pytorch-xla-linux-bionic-py3.7-clang8
-    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
+    uses: ./.github/workflows/_linux-test.yml
     needs: pytorch-xla-linux-bionic-py3_7-clang8-build
     with:
       build-environment: pytorch-xla-linux-bionic-py3.7-clang8
@@ -233,14 +233,14 @@ jobs:
 
   win-vs2019-cpu-py3-build:
     name: win-vs2019-cpu-py3
-    uses: pytorch/pytorch/.github/workflows/_win-build.yml@master
+    uses: ./.github/workflows/_win-build.yml
     with:
       build-environment: win-vs2019-cpu-py3
       cuda-version: cpu
 
   win-vs2019-cpu-py3-test:
     name: win-vs2019-cpu-py3
-    uses: pytorch/pytorch/.github/workflows/_win-test.yml@master
+    uses: ./.github/workflows/_win-test.yml
     needs: win-vs2019-cpu-py3-build
     with:
       build-environment: win-vs2019-cpu-py3
@@ -253,14 +253,14 @@ jobs:
 
   win-vs2019-cuda11_3-py3-build:
     name: win-vs2019-cuda11.3-py3
-    uses: pytorch/pytorch/.github/workflows/_win-build.yml@master
+    uses: ./.github/workflows/_win-build.yml
     with:
       build-environment: win-vs2019-cuda11.3-py3
       cuda-version: "11.3"
 
   win-vs2019-cuda11_3-py3-test:
     name: win-vs2019-cuda11.3-py3
-    uses: pytorch/pytorch/.github/workflows/_win-test.yml@master
+    uses: ./.github/workflows/_win-test.yml
     needs: win-vs2019-cuda11_3-py3-build
     with:
       build-environment: win-vs2019-cuda11.3-py3
@@ -274,28 +274,28 @@ jobs:
 
   linux-xenial-cuda11_3-py3_7-gcc7-bazel-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7-bazel-test
-    uses: pytorch/pytorch/.github/workflows/_bazel-build-test.yml@master
+    uses: ./.github/workflows/_bazel-build-test.yml
     with:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7-bazel-test
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
 
   pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single:
     name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
-    uses: pytorch/pytorch/.github/workflows/_android-build-test.yml@master
+    uses: ./.github/workflows/_android-build-test.yml
     with:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
       docker-image-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c
 
   pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit:
     name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
-    uses: pytorch/pytorch/.github/workflows/_android-build-test.yml@master
+    uses: ./.github/workflows/_android-build-test.yml
     with:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
       docker-image-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c
 
   linux-xenial-py3_7-gcc5_4-mobile-lightweight-dispatch-build:
     name: linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build
       docker-image-name: pytorch-linux-xenial-py3.7-gcc5.4
@@ -303,14 +303,14 @@ jobs:
 
   deploy-linux-xenial-cuda11_3-py3_7-gcc7-build:
     name: deploy-linux-xenial-cuda11.3-py3.7-gcc7
-    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
+    uses: ./.github/workflows/_linux-build.yml
     with:
       build-environment: deploy-linux-xenial-cuda11.3-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
 
   deploy-linux-xenial-cuda11_3-py3_7-gcc7-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7
-    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
+    uses: ./.github/workflows/_linux-test.yml
     needs: deploy-linux-xenial-cuda11_3-py3_7-gcc7-build
     with:
       build-environment: deploy-linux-xenial-cuda11.3-py3.7-gcc7

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -16,14 +16,14 @@ concurrency:
 jobs:
   linux-xenial-py3_7-gcc5_4-build:
     name: linux-xenial-py3.7-gcc5.4
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-xenial-py3.7-gcc5.4
       docker-image-name: pytorch-linux-xenial-py3.7-gcc5.4
 
   linux-xenial-py3_7-gcc5_4-test:
     name: linux-xenial-py3.7-gcc5.4
-    uses: ./.github/workflows/_linux-test.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
     needs: linux-xenial-py3_7-gcc5_4-build
     with:
       build-environment: linux-xenial-py3.7-gcc5.4
@@ -40,7 +40,7 @@ jobs:
 
   linux-docs:
     name: linux-docs
-    uses: ./.github/workflows/_docs.yml
+    uses: pytorch/pytorch/.github/workflows/_docs.yml@master
     needs: linux-xenial-py3_7-gcc5_4-build
     with:
       build-environment: linux-xenial-py3.7-gcc5.4
@@ -48,14 +48,14 @@ jobs:
 
   linux-xenial-py3_7-gcc7-build:
     name: linux-xenial-py3.7-gcc7
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-xenial-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-py3.7-gcc7
 
   linux-xenial-py3_7-gcc7-test:
     name: linux-xenial-py3.7-gcc7
-    uses: ./.github/workflows/_linux-test.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
     needs: linux-xenial-py3_7-gcc7-build
     with:
       build-environment: linux-xenial-py3.7-gcc7
@@ -68,14 +68,14 @@ jobs:
 
   linux-xenial-py3_7-clang7-asan-build:
     name: linux-xenial-py3.7-clang7-asan
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-xenial-py3.7-clang7-asan
       docker-image-name: pytorch-linux-xenial-py3-clang7-asan
 
   linux-xenial-py3_7-clang7-asan-test:
     name: linux-xenial-py3.7-clang7-asan
-    uses: ./.github/workflows/_linux-test.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
     needs: linux-xenial-py3_7-clang7-asan-build
     with:
       build-environment: linux-xenial-py3.7-clang7-asan
@@ -89,21 +89,21 @@ jobs:
 
   linux-xenial-py3_7-gcc7-no-ops:
     name: linux-xenial-py3.7-gcc7-no-ops
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-xenial-py3.7-gcc7-no-ops
       docker-image-name: pytorch-linux-xenial-py3.7-gcc7
 
   linux-xenial-py3_7-clang7-onnx-build:
     name: linux-xenial-py3.7-clang7-onnx
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-xenial-py3.7-clang7-onnx
       docker-image-name: pytorch-linux-xenial-py3-clang7-onnx
 
   linux-xenial-py3_7-clang7-onnx-test:
     name: linux-xenial-py3.7-clang7-onnx
-    uses: ./.github/workflows/_linux-test.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
     needs: linux-xenial-py3_7-clang7-onnx-build
     with:
       build-environment: linux-xenial-py3.7-clang7-onnx
@@ -116,14 +116,14 @@ jobs:
 
   linux-bionic-py3_7-clang9-build:
     name: linux-bionic-py3.7-clang9
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-bionic-py3.7-clang9
       docker-image-name: pytorch-linux-bionic-py3.7-clang9
 
   linux-bionic-py3_7-clang9-test:
     name: linux-bionic-py3.7-clang9
-    uses: ./.github/workflows/_linux-test.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
     needs: linux-bionic-py3_7-clang9-build
     with:
       build-environment: linux-bionic-py3.7-clang9
@@ -137,14 +137,14 @@ jobs:
 
   linux-vulkan-bionic-py3_7-clang9-build:
     name: linux-vulkan-bionic-py3.7-clang9
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-vulkan-bionic-py3.7-clang9
       docker-image-name: pytorch-linux-bionic-py3.7-clang9
 
   linux-vulkan-bionic-py3_7-clang9-test:
     name: linux-vulkan-bionic-py3.7-clang9
-    uses: ./.github/workflows/_linux-test.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
     needs: linux-vulkan-bionic-py3_7-clang9-build
     with:
       build-environment: linux-vulkan-bionic-py3.7-clang9
@@ -156,14 +156,14 @@ jobs:
 
   linux-xenial-cuda11_3-py3_7-gcc7-build:
     name: linux-xenial-cuda11.3-py3.7-gcc7
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
 
   linux-xenial-cuda11_3-py3_7-gcc7-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7
-    uses: ./.github/workflows/_linux-test.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
     needs: linux-xenial-cuda11_3-py3_7-gcc7-build
     with:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7
@@ -177,14 +177,14 @@ jobs:
 
   linux-bionic-rocm4_5-py3_7-build:
     name: linux-bionic-rocm4.5-py3.7
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-bionic-rocm4.5-py3.7
       docker-image-name: pytorch-linux-bionic-rocm4.5-py3.7
 
   linux-bionic-rocm4_5-py3_7-test:
     name: linux-bionic-rocm4.5-py3.7
-    uses: ./.github/workflows/_rocm-test.yml
+    uses: pytorch/pytorch/.github/workflows/_rocm-test.yml@master
     needs: linux-bionic-rocm4_5-py3_7-build
     with:
       build-environment: linux-bionic-rocm4.5-py3.7
@@ -197,7 +197,7 @@ jobs:
 
   linux-xenial-py3-clang5-mobile-build:
     name: linux-xenial-py3-clang5-mobile-build
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-xenial-py3-clang5-mobile-build
       docker-image-name: pytorch-linux-xenial-py3-clang5-asan
@@ -205,7 +205,7 @@ jobs:
 
   linux-xenial-py3-clang5-mobile-custom-build-static:
     name: linux-xenial-py3-clang5-mobile-custom-build-static
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-xenial-py3-clang5-mobile-custom-build-static
       docker-image-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c
@@ -214,14 +214,14 @@ jobs:
   pytorch-xla-linux-bionic-py3_7-clang8-build:
     if: ${{ false }}
     name: pytorch-xla-linux-bionic-py3.7-clang8
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: pytorch-xla-linux-bionic-py3.7-clang8
       docker-image-name: xla_base
 
   pytorch-xla-linux-bionic-py3_7-clang8-test:
     name: pytorch-xla-linux-bionic-py3.7-clang8
-    uses: ./.github/workflows/_linux-test.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
     needs: pytorch-xla-linux-bionic-py3_7-clang8-build
     with:
       build-environment: pytorch-xla-linux-bionic-py3.7-clang8
@@ -233,14 +233,14 @@ jobs:
 
   win-vs2019-cpu-py3-build:
     name: win-vs2019-cpu-py3
-    uses: ./.github/workflows/_win-build.yml
+    uses: pytorch/pytorch/.github/workflows/_win-build.yml@master
     with:
       build-environment: win-vs2019-cpu-py3
       cuda-version: cpu
 
   win-vs2019-cpu-py3-test:
     name: win-vs2019-cpu-py3
-    uses: ./.github/workflows/_win-test.yml
+    uses: pytorch/pytorch/.github/workflows/_win-test.yml@master
     needs: win-vs2019-cpu-py3-build
     with:
       build-environment: win-vs2019-cpu-py3
@@ -253,14 +253,14 @@ jobs:
 
   win-vs2019-cuda11_3-py3-build:
     name: win-vs2019-cuda11.3-py3
-    uses: ./.github/workflows/_win-build.yml
+    uses: pytorch/pytorch/.github/workflows/_win-build.yml@master
     with:
       build-environment: win-vs2019-cuda11.3-py3
       cuda-version: "11.3"
 
   win-vs2019-cuda11_3-py3-test:
     name: win-vs2019-cuda11.3-py3
-    uses: ./.github/workflows/_win-test.yml
+    uses: pytorch/pytorch/.github/workflows/_win-test.yml@master
     needs: win-vs2019-cuda11_3-py3-build
     with:
       build-environment: win-vs2019-cuda11.3-py3
@@ -274,28 +274,28 @@ jobs:
 
   linux-xenial-cuda11_3-py3_7-gcc7-bazel-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7-bazel-test
-    uses: ./.github/workflows/_bazel-build-test.yml
+    uses: pytorch/pytorch/.github/workflows/_bazel-build-test.yml@master
     with:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7-bazel-test
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
 
   pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single:
     name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
-    uses: ./.github/workflows/_android-build-test.yml
+    uses: pytorch/pytorch/.github/workflows/_android-build-test.yml@master
     with:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
       docker-image-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c
 
   pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit:
     name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
-    uses: ./.github/workflows/_android-build-test.yml
+    uses: pytorch/pytorch/.github/workflows/_android-build-test.yml@master
     with:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
       docker-image-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c
 
   linux-xenial-py3_7-gcc5_4-mobile-lightweight-dispatch-build:
     name: linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build
       docker-image-name: pytorch-linux-xenial-py3.7-gcc5.4
@@ -303,14 +303,14 @@ jobs:
 
   deploy-linux-xenial-cuda11_3-py3_7-gcc7-build:
     name: deploy-linux-xenial-cuda11.3-py3.7-gcc7
-    uses: ./.github/workflows/_linux-build.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-build.yml@master
     with:
       build-environment: deploy-linux-xenial-cuda11.3-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
 
   deploy-linux-xenial-cuda11_3-py3_7-gcc7-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7
-    uses: ./.github/workflows/_linux-test.yml
+    uses: pytorch/pytorch/.github/workflows/_linux-test.yml@master
     needs: deploy-linux-xenial-cuda11_3-py3_7-gcc7-build
     with:
       build-environment: deploy-linux-xenial-cuda11.3-py3.7-gcc7


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #74774
* __->__ #74773

SSH setup was being hidden away in the setup step for both linux and
windows, this moves it out to it's own step so that users can know where
to click to get ssh details

Fixes https://github.com/pytorch/pytorch/issues/74476

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>