### PR TITLE
[quant][fx] Remove should_insert_output_observers

### DIFF
--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -701,9 +701,7 @@ def maybe_insert_output_observer_for_node(
         isinstance(qhandler, StandaloneModuleQuantizeHandler)
 
     dtype = node_name_to_target_dtype[node.name]["output_activation_dtype"]
-    should_insert_observer = \
-        qhandler.should_insert_observer_for_output(
-            qconfig, is_qat) and dtype not in DO_NOT_OBS_DTYPE_LIST + [torch.float]
+    should_insert_observer = dtype not in DO_NOT_OBS_DTYPE_LIST + [torch.float]
     # TODO(future PR): move the following logic to
     # should_insert_observer_for_output
     should_insert_observer = should_insert_observer and \

--- a/torch/ao/quantization/fx/quantization_patterns.py
+++ b/torch/ao/quantization/fx/quantization_patterns.py
@@ -76,20 +76,6 @@ class QuantizeHandler(ABC):
         """
         return False
 
-    def should_insert_observer_for_output(
-        self,
-        qconfig: Any,
-        model_is_training: bool,
-    ) -> bool:
-        """
-        Returns true if an observer should be inserted for the output of
-        the pattern matched to this QuantizeHandler instance during the
-        prepare step.
-        """
-        # TODO(future PR): potentially clean up and deduplicate these
-        # mappings.
-        return self.all_node_args_are_tensors and self.input_output_observed()
-
     def get_activation_ctr(
         self,
         qconfig: Any,
@@ -209,26 +195,6 @@ class BinaryOpQuantizeHandler(QuantizeHandler):
                 self.num_tensor_args += 1
         self.all_node_args_are_tensors = \
             (self.num_tensor_args == len(self.binary_op_node.args))
-
-    def should_insert_observer_for_output(
-        self,
-        qconfig: Any,
-        model_is_training: bool,
-    ) -> bool:
-        """
-        Returns true if an observer should be inserted for the output of
-        the pattern matched to this QuantizeHandler instance during the
-        prepare step.
-        """
-        dtypes = get_qconfig_dtypes(qconfig)
-        if not (self.binary_op in binary_op_supported_dtypes and dtypes in binary_op_supported_dtypes[self.binary_op]):
-            return False
-        if self.num_tensor_args == 1:
-            return True
-        elif self.all_node_args_are_tensors and self.input_output_observed():
-            return True
-        else:
-            return False
 
     def is_general_tensor_value_op(self) -> bool:
         return self.num_tensor_args == 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #74776
* __->__ #74775

Summary:
We have simplified the way we insert observers, for add_scalar it now behaves the same way
as general_tensor_value ops, which means we only need to keep is_general_tensor_value_op now,
the other methods can be removed

Test Plan:
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D35153532](https://our.internmc.facebook.com/intern/diff/D35153532)