### PR TITLE
[quant][fx] Remove input_output_observed from BinaryOpQuantizeHandler

### DIFF
--- a/torch/ao/quantization/fx/quantization_patterns.py
+++ b/torch/ao/quantization/fx/quantization_patterns.py
@@ -199,10 +199,6 @@ class BinaryOpQuantizeHandler(QuantizeHandler):
     def is_general_tensor_value_op(self) -> bool:
         return self.num_tensor_args == 1
 
-    def input_output_observed(self):
-        # for x + y where x and y are scalars, we do not observe anything
-        return self.num_tensor_args > 0
-
     def is_output_quantized(self, qconfig):
         dtypes = get_qconfig_dtypes(qconfig)
         return self.binary_op in binary_op_supported_dtypes and \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74776
* #74775

Summary:
when both inputs are scalars, fx tracing will directly calculate the result, instead of generating an op in the fx graph
so num_tensor_args will always be greater than 1 for binary ops, so the input_output_observed will always return True
for BinaryQuantizeHandler

We will remove input_output_observed method after dynamic quantization in qconfig is properly supported

Test Plan:
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D35153531](https://our.internmc.facebook.com/intern/diff/D35153531)