### PR TITLE
Revert "[PyTorch] Remove the List/Dict move operations (#69370)"

### DIFF
--- a/aten/src/ATen/core/Dict.h
+++ b/aten/src/ATen/core/Dict.h
@@ -239,6 +239,8 @@ public:
 
   Dict(const Dict&) = default;
   Dict& operator=(const Dict&) = default;
+  Dict(Dict&&) noexcept;
+  Dict& operator=(Dict&&) noexcept;
 
   /**
    * Create a new Dict pointing to a deep copy of the same data.

--- a/aten/src/ATen/core/Dict_inl.h
+++ b/aten/src/ATen/core/Dict_inl.h
@@ -83,7 +83,19 @@ Dict<Key, Value>::Dict(TypePtr keyType, TypePtr valueType)
 }
 
 template<class Key, class Value>
+Dict<Key, Value>::Dict(Dict&& rhs) noexcept: impl_(std::move(rhs.impl_)) {
+  rhs.impl_ = make_intrusive<detail::DictImpl>(detail::DictImpl::dict_map_type(), impl_->elementTypes);
+}
+
+template<class Key, class Value>
 Dict<Key, Value>::Dict(c10::intrusive_ptr<detail::DictImpl>&& impl): impl_(std::move(impl)) {}
+
+template<class Key, class Value>
+Dict<Key, Value>& Dict<Key, Value>::operator=(Dict&& rhs) noexcept {
+  impl_ = std::move(rhs.impl_);
+  rhs.impl_ = make_intrusive<detail::DictImpl>(detail::DictImpl::dict_map_type(), impl_->elementTypes);
+  return *this;
+}
 
 template<class Key, class Value>
 Dict<Key, Value> Dict<Key, Value>::copy() const {

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -259,6 +259,8 @@ public:
 
   List(const List&) = default;
   List& operator=(const List&) = default;
+  List(List&&) noexcept;
+  List& operator=(List&&) noexcept;
 
   /**
    * Create a new List pointing to a deep copy of the same data.

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -79,6 +79,18 @@ impl::GenericList toList(const List<T>& list) {
 }
 
 template<class T>
+List<T>::List(List&& rhs) noexcept: impl_(std::move(rhs.impl_)) {
+  rhs.impl_ = make_intrusive<c10::detail::ListImpl>(std::vector<IValue>{}, impl_->elementType);
+}
+
+template<class T>
+List<T>& List<T>::operator=(List&& rhs) noexcept {
+  impl_ = std::move(rhs.impl_);
+  rhs.impl_ = make_intrusive<c10::detail::ListImpl>(std::vector<IValue>{}, impl_->elementType);
+  return *this;
+}
+
+template<class T>
 List<T> List<T>::copy() const {
   return List<T>(impl_->copy());
 }

--- a/aten/src/ATen/core/List_test.cpp
+++ b/aten/src/ATen/core/List_test.cpp
@@ -341,23 +341,21 @@ TEST(ListTest_IValueBasedList, whenMoveAssigningList_thenNewIsCorrect) {
   EXPECT_EQ("4", list2.get(1));
 }
 
-TEST(ListTest_IValueBasedList, whenMoveConstructingList_thenOldIsUnchanged) {
+TEST(ListTest_IValueBasedList, whenMoveConstructingList_thenOldIsEmpty) {
   List<string> list1({"3", "4"});
 
   List<string> list2(std::move(list1));
-  EXPECT_EQ(2, list1.size());
-  EXPECT_EQ("3", list1.get(0));
-  EXPECT_EQ("4", list1.get(1));
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  EXPECT_TRUE(list1.empty());
 }
 
-TEST(ListTest_IValueBasedList, whenMoveAssigningList_thenOldIsUnchanged) {
+TEST(ListTest_IValueBasedList, whenMoveAssigningList_thenOldIsEmpty) {
   List<string> list1({"3", "4"});
 
   List<string> list2;
   list2 = std::move(list1);
-  EXPECT_EQ(2, list1.size());
-  EXPECT_EQ("3", list1.get(0));
-  EXPECT_EQ("4", list1.get(1));
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  EXPECT_TRUE(list1.empty());
 }
 
 TEST(ListTest_IValueBasedList, givenIterator_whenPostfixIncrementing_thenMovesToNextAndReturnsOldPosition) {
@@ -889,23 +887,21 @@ TEST(ListTest_NonIValueBasedList, whenMoveAssigningList_thenNewIsCorrect) {
   EXPECT_EQ(4, list2.get(1));
 }
 
-TEST(ListTest_NonIValueBasedList, whenMoveConstructingList_thenOldIsUnchanged) {
+TEST(ListTest_NonIValueBasedList, whenMoveConstructingList_thenOldIsEmpty) {
   List<int64_t> list1({3, 4});
 
   List<int64_t> list2(std::move(list1));
-  EXPECT_EQ(2, list1.size());
-  EXPECT_EQ(3, list1.get(0));
-  EXPECT_EQ(4, list1.get(1));
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  EXPECT_TRUE(list1.empty());
 }
 
-TEST(ListTest_NonIValueBasedList, whenMoveAssigningList_thenOldIsUnchanged) {
+TEST(ListTest_NonIValueBasedList, whenMoveAssigningList_thenOldIsEmpty) {
   List<int64_t> list1({3, 4});
 
   List<int64_t> list2;
   list2 = std::move(list1);
-  EXPECT_EQ(2, list1.size());
-  EXPECT_EQ(3, list1.get(0));
-  EXPECT_EQ(4, list1.get(1));
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  EXPECT_TRUE(list1.empty());
 }
 
 TEST(ListTest_NonIValueBasedList, givenIterator_whenPostfixIncrementing_thenMovesToNextAndReturnsOldPosition) {

--- a/aten/src/ATen/test/Dict_test.cpp
+++ b/aten/src/ATen/test/Dict_test.cpp
@@ -354,27 +354,25 @@ TEST(DictTest, whenMoveAssigningDict_thenNewIsCorrect) {
   EXPECT_EQ("4", dict2.at(4));
 }
 
-TEST(DictTest, whenMoveConstructingDict_thenOldIsUnchanged) {
+TEST(DictTest, whenMoveConstructingDict_thenOldIsEmpty) {
   Dict<int64_t, string> dict1;
   dict1.insert(3, "3");
   dict1.insert(4, "4");
 
   Dict<int64_t, string> dict2(std::move(dict1));
-  EXPECT_EQ(2, dict1.size());
-  EXPECT_EQ("3", dict1.at(3));
-  EXPECT_EQ("4", dict1.at(4));
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  EXPECT_TRUE(dict1.empty());
 }
 
-TEST(DictTest, whenMoveAssigningDict_thenOldIsUnchanged) {
+TEST(DictTest, whenMoveAssigningDict_thenOldIsEmpty) {
   Dict<int64_t, string> dict1;
   dict1.insert(3, "3");
   dict1.insert(4, "4");
 
   Dict<int64_t, string> dict2;
   dict2 = std::move(dict1);
-  EXPECT_EQ(2, dict1.size());
-  EXPECT_EQ("3", dict1.at(3));
-  EXPECT_EQ("4", dict1.at(4));
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  EXPECT_TRUE(dict1.empty());
 }
 
 TEST(DictTest, givenIterator_whenPostfixIncrementing_thenMovesToNextAndReturnsOldPosition) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #74790
* __->__ #74789

This reverts commit a5bc44422a7e51504cfd0fa1b933c373accc7813.