### PR TITLE
[ci] add an easier-to-understand error for workflow consolidation FC breaks

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -47,6 +47,13 @@ jobs:
       - name: Checkout PyTorch
         uses: ./.github/actions/checkout-pytorch
 
+      - name: Check for new workflows
+        run: |
+          if [ ! -f "./.github/actions/setup-linux/action.yml" ]; then
+            echo "::error::Your PR is based on a version of master that is too old for our CI to work. Please rebase your PR on latest master and resubmit."
+            exit 1
+          fi
+
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #74872
* __->__ #74818
* #74817
* #74816

If a PR is based against a version of master from before last week (3/21), then our CI will not work as the workflows will depend on files that will not be available in the source tree. We initially mitigated this by retrieving the relevant workflows directly from pytorch master. After we unpin these workflows (#74817), stale PRs will start erroring if they are based on an old version of master. This PR adds an easier-to-understand error for those cases.