### PR TITLE
WIP: Use a queue to schedule JIT graph executions

### DIFF
--- a/torch/csrc/lazy/core/config.cpp
+++ b/torch/csrc/lazy/core/config.cpp
@@ -14,7 +14,7 @@ C10_DEFINE_bool(
 
 C10_DEFINE_bool(
     torch_lazy_use_thread_pool,
-    false,
+    true,
     "Use thread pool to schedule backend execution");
 
 C10_DEFINE_int(


### PR DESCRIPTION
RUN_TORCHBENCH: ALL
TORCHBENCH_BRANCH: wconstab/ltc-noopt


Note:
The nsys profiled result shows before the change, every tracing iteration is broken into two parts because of calling `LockDevices`.

![Screen Shot 2022-03-28 at 10 35 16 AM](https://user-images.githubusercontent.com/3659962/160422353-9b3c8754-ea76-4186-acce-3fa2412c3594.png)


The new profiled result after this change shows the tracing is done without pausing in the middle.

![Screen Shot 2022-03-28 at 10 40 04 AM](https://user-images.githubusercontent.com/3659962/160423125-2b6800a4-a915-4069-9c8f-be3465b7c6a4.png)

