### PR TITLE
`reflection_pad2`: port to structured kernel

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9456,28 +9456,27 @@
 
 - func: reflection_pad2d.out(Tensor self, int[4] padding, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn
+  structured: True
   dispatch:
     CPU, QuantizedCPU: reflection_pad2d_out_cpu
     CUDA: reflection_pad2d_out_cuda
 
 - func: reflection_pad2d(Tensor self, int[4] padding) -> Tensor
   python_module: nn
+  structured_delegate: reflection_pad2d.out
   dispatch:
-    CPU: reflection_pad2d_cpu
-    QuantizedCPU: reflection_pad2d_quantized_cpu
-    CUDA: reflection_pad2d_cuda
+    QuantizedCPU: reflection_pad2d_cpu
 
 - func: reflection_pad2d_backward.grad_input(Tensor grad_output, Tensor self, int[4] padding, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn
+  structured: True
   dispatch:
     CPU: reflection_pad2d_backward_out_cpu
     CUDA: reflection_pad2d_backward_out_cuda
 
 - func: reflection_pad2d_backward(Tensor grad_output, Tensor self, int[4] padding) -> Tensor
   python_module: nn
-  dispatch:
-    CPU: reflection_pad2d_backward_cpu
-    CUDA: reflection_pad2d_backward_cuda
+  structured_delegate: reflection_pad2d_backward.grad_input
 
 - func: reflection_pad3d.out(Tensor self, int[6] padding, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn


### PR DESCRIPTION
Following https://github.com/pytorch/rfcs/blob/rfc-0005/RFC-0005-structured-kernel-definitions.md

Tracking issue https://github.com/pytorch/pytorch/issues/55070
