### PR TITLE
Remove use of force_reload parameter from torchhub tests

### DIFF
--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -72,7 +72,7 @@ class TestHub(TestCase):
 
     @retry(Exception, tries=3)
     def test_list_entrypoints(self):
-        entry_lists = hub.list('ailzhang/torchhub_example', force_reload=True)
+        entry_lists = hub.list('ailzhang/torchhub_example')
         self.assertObjectIn('mnist', entry_lists)
 
     @retry(Exception, tries=3)
@@ -130,4 +130,4 @@ class TestHub(TestCase):
     @retry(Exception, tries=3)
     def test_load_commit_from_forked_repo(self):
         with self.assertRaisesRegex(ValueError, 'If it\'s a commit from a forked repo'):
-            torch.hub.load('pytorch/vision:4e2c216', 'resnet18', force_reload=True)
+            torch.hub.load('pytorch/vision:4e2c216', 'resnet18')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74828
* #74826

This is not needed anymore thanks to the new setup/teardown logic.