### PR TITLE
[FSDP] exclude from typing

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -41,7 +41,7 @@ files =
 #
 # `exclude` is a regex, not a list of paths like `files` (sigh)
 #
-exclude = torch/include/|torch/csrc/|torch/distributed/elastic/agent/server/api.py|torch/testing/_internal
+exclude = torch/include/|torch/csrc/|torch/distributed/elastic/agent/server/api.py|torch/testing/_internal|torch/distributed/fsdp/fully_sharded_data_parallel.py
 
 # Minimum version supported - variable annotations were introduced
 # in Python 3.7


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #74452
* __->__ #74833

FSDP has 74 type ignores and more being added, it may be better to
exclude from typechecking until we can type it properly.

Differential Revision: [D35186441](https://our.internmc.facebook.com/intern/diff/D35186441/)