### PR TITLE
[pt] Add half precision support for nn.EmbeddingBag (CPU)

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -10,6 +10,7 @@
 
 #ifdef USE_FBGEMM
 #include <fbgemm/Fbgemm.h>
+#include <fbgemm/FbgemmConvert.h>
 #else
 #include <caffe2/perfkernels/embedding_lookup_idx.h>
 #endif
@@ -60,14 +61,14 @@ std::pair<Tensor, Tensor> promoteIndicesAndOffsets(
 // is only applicable if special conditions are met
 template<typename index_t>
 bool is_fast_path_index_select(const Tensor& src, Tensor& output, index_t padding_idx) {
-  return src.scalar_type() == kFloat && src.strides()[1] == 1 && output.strides()[1] == 1 && padding_idx < static_cast<index_t>(0);
+  return (src.scalar_type() == kFloat || src.scalar_type() == kHalf) && src.strides()[1] == 1 && output.strides()[1] == 1 && padding_idx < static_cast<index_t>(0);
 }
 
 // Determines if we can use a fast implementation for index_select_scale_add,
 // which is only applicable if special conditions are met
 template<typename index_t>
 bool is_fast_path_index_select_scale(const Tensor& src, const Tensor& scale, Tensor& output, index_t padding_idx) {
-  return src.scalar_type() == kFloat && src.strides()[1] == 1 && output.strides()[1] == 1 && scale.strides()[0] == 1 && padding_idx < static_cast<index_t>(0);
+  return (src.scalar_type() == kFloat || src.scalar_type() == kHalf) && src.strides()[1] == 1 && output.strides()[1] == 1 && scale.strides()[0] == 1 && padding_idx < static_cast<index_t>(0);
 }
 
 template<typename index_t>
@@ -81,7 +82,7 @@ bool is_fast_path(const Tensor& src, const c10::optional<Tensor>& scale, Tensor&
 // index_add (using add_indices as the index), without creating an intermediary
 // tensor to hold the selected embeddings
 template<typename data_t, typename index_t>
-typename std::enable_if<!std::is_same<data_t, float>::value, void>::type
+typename std::enable_if<!std::is_same<data_t, float>::value && !std::is_same<data_t, at::Half>::value, void>::type
 index_select_add(const Tensor &select_indices,
                              const Tensor &add_indices,
                              const Tensor &src,
@@ -96,12 +97,12 @@ index_select_add(const Tensor &select_indices,
   auto* src_data = src.data_ptr<data_t>();
   auto* output_data = output.data_ptr<data_t>();
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  index_t* bag_size_data;
+  index_t* bag_size_data = nullptr;
   if (bag_size.defined()) {
     bag_size_data = bag_size.data_ptr<index_t>();
   }
   auto numel = add_indices.numel();
-  int64_t ddim = src.sizes()[1];
+  int64_t ddim = src.size(1);
   auto vocab_size = src.size(0);
   auto src_stride0 = src.strides()[0];
   auto src_stride1 = src.strides()[1];
@@ -158,6 +159,155 @@ void fbgemm_spmdm_report_error_(
 } // namespace
 
 template<typename data_t, typename index_t>
+typename std::enable_if<std::is_same<data_t, at::Half>::value, void>::type
+index_select_add(const Tensor &select_indices,
+                             const Tensor &add_indices,
+                             const Tensor &src,
+                             Tensor &output,
+                             const Tensor& offsets,
+                             bool include_last_offset,
+                             Tensor &bag_size,
+                             index_t padding_idx) {
+  int64_t ddim = src.size(1);
+  auto* select_indices_data = select_indices.data_ptr<index_t>();
+  auto* output_data = output.data_ptr<at::Half>();
+
+  if (is_fast_path_index_select(src, output, padding_idx)) {
+    auto src_contig = src.contiguous();
+    auto* src_data = src_contig.data_ptr<at::Half>();
+    int64_t output_size = offsets.numel() - 1;
+    auto* offsets_data = offsets.data_ptr<index_t>();
+    std::vector<index_t> offsets_include_last;
+
+    if (include_last_offset) {
+      output_size = offsets.numel() - 1;
+    } else {
+      output_size = offsets.numel();
+      offsets_include_last.resize(offsets.numel() + 1);
+      if (offsets.numel() > 0) {
+        std::memcpy(
+            offsets_include_last.data(),
+            offsets.data_ptr<index_t>(),
+            sizeof(index_t) * offsets.numel());
+      }
+      offsets_include_last[offsets.numel()] = select_indices.numel();
+      offsets_data = offsets_include_last.data();
+    }
+
+#ifdef USE_FBGEMM
+    using float16 = uint16_t;
+    auto kernel_fp16_index_t =
+      fbgemm::GenerateEmbeddingSpMDM<float16, index_t, index_t, float16>(
+        /* block_size */ddim,
+        /* has_weight */false,
+        /* normalize_by_lengths */false,
+        /* prefetch */16,
+        /* is_weight_positional */false,
+        /* use_offsets */true
+      );
+#else
+    // Initialize the intermediate output buffer to be 0.
+    Tensor output_fp32 = at::zeros({output_size, ddim}, output.options().dtype(at::kFloat));
+    auto* output_data_fp32 = output_fp32.data_ptr<float>();
+#endif
+    at::parallel_for(
+        0, output_size, 1, [&](index_t start_idx, index_t end_idx) {
+#ifdef USE_FBGEMM
+          bool success = kernel_fp16_index_t(
+            /* output_size */end_idx - start_idx,
+            /* index_size */offsets_data[end_idx] - offsets_data[start_idx],
+            /* data_size */src.size(0),
+            /* input */reinterpret_cast<const float16*>(src_data),
+            /* indices */select_indices_data + offsets_data[start_idx],
+            /* offsets_or_lengths */offsets_data + start_idx,
+            /* weights */nullptr,
+            /* output */reinterpret_cast<float16*>(output_data + start_idx * ddim));
+          if (!success) {
+            fbgemm_spmdm_report_error_(
+                end_idx - start_idx,
+                offsets_data[end_idx] - offsets_data[start_idx],
+                src.size(0),
+                offsets_data + start_idx,
+                select_indices_data + offsets_data[start_idx]);
+          }
+#else
+          caffe2::EmbeddingLookupIdx(
+              /*block_size=*/ddim,
+              /*output_size=*/end_idx - start_idx,
+              /*index_size=*/offsets_data[end_idx] - offsets_data[start_idx],
+              /*data_size=*/src.size(0),
+              /*input=*/src_data,
+              /*indices=*/select_indices_data + offsets_data[start_idx],
+              /*offsets=*/offsets_data + start_idx,
+              /*weights=*/nullptr,
+              /*scale_bias=*/nullptr,
+              /*normalize_by_lengths=*/false,
+              /*out=*/output_data_fp32 + start_idx * ddim);
+          for (const auto i : c10::irange(output_size)) {
+            // Convert FP32 intermediate buffer result back to FP16 for output dtype
+            for (const auto d : c10::irange(ddim)) {
+              (output_data + i * ddim)[d] = static_cast<at::Half>((output_data_fp32 + ddim * i)[d]);
+            }
+          }
+#endif
+        });
+
+  } else {
+    TORCH_CHECK(select_indices.numel() == add_indices.numel());
+    auto* src_data = src.data_ptr<at::Half>();
+    auto* add_indices_data = add_indices.data_ptr<index_t>();
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    index_t* bag_size_data = nullptr;
+    if (bag_size.defined()) {
+      bag_size_data = bag_size.data_ptr<index_t>();
+    }
+    auto vocab_size = src.size(0);
+    auto src_stride0 = src.strides()[0];
+    auto src_stride1 = src.strides()[1];
+    auto output_stride0 = output.strides()[0];
+    auto output_stride1 = output.strides()[1];
+    auto numel = add_indices.numel();
+
+    Tensor src_fp32 = at::empty({ddim}, src.options().dtype(at::kFloat));
+    auto* src_data_fp32 = src_fp32.data_ptr<float>();
+
+    // Initialize the intermediate output buffer to be 0.
+    Tensor output_fp32 = at::zeros({output.size(0), ddim}, output.options().dtype(at::kFloat));
+    auto* output_data_fp32 = output_fp32.data_ptr<float>();
+
+    for (const auto i : c10::irange(numel)) {
+      // We can skip indices equal to padding_idx so they are not included in
+      // the reduction
+      auto idx = select_indices_data[i];
+      TORCH_CHECK(
+          idx >= 0 && idx < vocab_size,
+          "embedding_bag: Expected idx >= 0 && idx < num_embeddings but found idx to be ",
+          idx);
+      if (idx != padding_idx) {
+        // Copy src_data + src_stride0 * idx to src_data_fp32
+        for (const auto d : c10::irange(ddim)) {
+          src_data_fp32[d] = static_cast<float>((src_data + src_stride0 * idx)[d * src_stride1]);
+        }
+        at::native::cpublas::axpy<float>(ddim, 1,
+                src_data_fp32, 1,
+                output_data_fp32 + ddim * add_indices_data[i], 1);
+
+      } else if (bag_size.defined()) {
+        // Decrement bag_size to reflect that the index is padded
+        // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
+        bag_size_data[add_indices_data[i]]--;
+      }
+    }
+    for (const auto i : c10::irange(output.size(0))) {
+      // Convert FP32 intermediate buffer result back to FP16 for output dtype
+      for (const auto d : c10::irange(ddim)) {
+        (output_data + output_stride0 * i)[d * output_stride1] = static_cast<at::Half>((output_data_fp32 + ddim * i)[d]);
+      }
+    }
+  }
+}
+
+template<typename data_t, typename index_t>
 typename std::enable_if<std::is_same<data_t, float>::value, void>::type
 index_select_add(const Tensor &select_indices,
                              const Tensor &add_indices,
@@ -167,7 +317,7 @@ index_select_add(const Tensor &select_indices,
                              bool include_last_offset,
                              Tensor &bag_size,
                              index_t padding_idx) {
-  int64_t ddim = src.sizes()[1];
+  int64_t ddim = src.size(1);
   auto* select_indices_data = select_indices.data_ptr<index_t>();
   auto* output_data = output.data_ptr<float>();
 
@@ -210,7 +360,7 @@ index_select_add(const Tensor &select_indices,
           bool success = kernel_fp32_index_t(
             /* output_size */end_idx - start_idx,
             /* index_size */offsets_data[end_idx] - offsets_data[start_idx],
-            /* data_size */src.sizes()[0],
+            /* data_size */src.size(0),
             /* input */src_data,
             /* indices */select_indices_data + offsets_data[start_idx],
             /* offsets_or_lengths */offsets_data + start_idx,
@@ -220,7 +370,7 @@ index_select_add(const Tensor &select_indices,
             fbgemm_spmdm_report_error_(
                 end_idx - start_idx,
                 offsets_data[end_idx] - offsets_data[start_idx],
-                src.sizes()[0],
+                src.size(0),
                 offsets_data + start_idx,
                 select_indices_data + offsets_data[start_idx]);
           }
@@ -229,7 +379,7 @@ index_select_add(const Tensor &select_indices,
               /*block_size=*/ddim,
               /*output_size=*/end_idx - start_idx,
               /*index_size=*/offsets_data[end_idx] - offsets_data[start_idx],
-              /*data_size=*/src.sizes()[0],
+              /*data_size=*/src.size(0),
               /*input=*/src_data,
               /*indices=*/select_indices_data + offsets_data[start_idx],
               /*offsets=*/offsets_data + start_idx,
@@ -244,7 +394,7 @@ index_select_add(const Tensor &select_indices,
     auto* src_data = src.data_ptr<float>();
     auto* add_indices_data = add_indices.data_ptr<index_t>();
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    index_t* bag_size_data;
+    index_t* bag_size_data = nullptr;
     if (bag_size.defined()) {
       bag_size_data = bag_size.data_ptr<index_t>();
     }
@@ -284,7 +434,7 @@ index_select_add(const Tensor &select_indices,
 // mul (scaling by per_sample_weights)
 // index_add (using add_indices as the index)
 template<typename data_t, typename index_t>
-static typename std::enable_if<!std::is_same<data_t, float>::value, void>::type
+static typename std::enable_if<!std::is_same<data_t, float>::value && !std::is_same<data_t, at::Half>::value, void>::type
 index_select_scale_add(const Tensor &select_indices,
                                    const Tensor &add_indices,
                                    const Tensor &scale,
@@ -300,7 +450,7 @@ index_select_scale_add(const Tensor &select_indices,
   auto* src_data = src.data_ptr<data_t>();
   auto* output_data = output.data_ptr<data_t>();
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  index_t* bag_size_data;
+  index_t* bag_size_data = nullptr;
   if (bag_size.defined()) {
     bag_size_data = bag_size.data_ptr<index_t>();
   }
@@ -339,6 +489,158 @@ index_select_scale_add(const Tensor &select_indices,
 }
 
 template<typename data_t, typename index_t>
+typename std::enable_if<std::is_same<data_t, at::Half>::value, void>::type
+index_select_scale_add(const Tensor &select_indices,
+                       const Tensor &add_indices,
+                       const Tensor &scale,
+                       const Tensor &src,
+                       Tensor &output,
+                       const Tensor& offsets,
+                       bool include_last_offset,
+                       Tensor &bag_size,
+                       index_t padding_idx) {
+  int64_t ddim = src.size(1);
+  auto* scale_data = scale.data_ptr<at::Half>();
+  auto* select_indices_data = select_indices.data_ptr<index_t>();
+  auto* output_data = output.data_ptr<at::Half>();
+
+  if (is_fast_path_index_select_scale(src, scale, output, padding_idx)) {
+    auto src_contig = src.contiguous();
+    auto* src_data = src_contig.data_ptr<at::Half>();
+    int64_t output_size = offsets.numel() - 1;
+    auto* offsets_data = offsets.data_ptr<index_t>();
+    std::vector<index_t> offsets_include_last;
+
+    if (include_last_offset) {
+      output_size = offsets.numel() - 1;
+    } else {
+      output_size = offsets.numel();
+      offsets_include_last.resize(offsets.numel() + 1);
+      std::memcpy(
+          offsets_include_last.data(),
+          offsets.data_ptr<index_t>(),
+          sizeof(index_t) * offsets.numel());
+      offsets_include_last[offsets.numel()] = select_indices.numel();
+      offsets_data = offsets_include_last.data();
+    }
+
+    Tensor scale_fp32 = at::empty(scale.sizes(), scale.options().dtype(at::kFloat));
+    auto* scale_data_fp32 = scale_fp32.data_ptr<float>();
+
+#ifdef USE_FBGEMM
+    using float16 = uint16_t;
+    fbgemm::Float16ToFloat_simd(reinterpret_cast<const float16*>(scale_data), scale_data_fp32, scale_fp32.numel());
+    auto kernel_fp16_index_t =
+      fbgemm::GenerateEmbeddingSpMDM<float16, index_t, index_t, float16>(
+        /* block_size */ddim,
+        /* has_weight */true,
+        /* normalize_by_lengths */false,
+        /* prefetch */16,
+        /* is_weight_positional */false,
+        /* use_offsets */true
+      );
+#else
+    // Initialize the intermediate output buffer to be 0.
+    Tensor output_fp32 = at::zeros({output_size, ddim}, output.options().dtype(at::kFloat));
+    auto* output_data_fp32 = output_fp32.data_ptr<float>();
+    for (const auto i : c10::irange(scale.numel())) {
+      scale_data_fp32[i] = static_cast<float>(scale_data[i]);
+    }
+#endif
+    at::parallel_for(
+        0, output_size, 1, [&](index_t start_idx, index_t end_idx) {
+#ifdef USE_FBGEMM
+          bool success = kernel_fp16_index_t(
+            /* output_size */end_idx - start_idx,
+            /* index_size */offsets_data[end_idx] - offsets_data[start_idx],
+            /* data_size */src.size(0),
+            /* input */reinterpret_cast<const float16*>(src_data),
+            /* indices */select_indices_data + offsets_data[start_idx],
+            /* offsets_or_lengths */offsets_data + start_idx,
+            /* weights */scale_data_fp32 + offsets_data[start_idx],
+            /* output */reinterpret_cast<float16*>(output_data + start_idx * ddim));
+          if (!success) {
+            fbgemm_spmdm_report_error_(
+                end_idx - start_idx,
+                offsets_data[end_idx] - offsets_data[start_idx],
+                src.size(0),
+                offsets_data + start_idx,
+                select_indices_data + offsets_data[start_idx]);
+          }
+#else
+          caffe2::EmbeddingLookupIdx(
+              /*block_size=*/ddim,
+              /*output_size=*/end_idx - start_idx,
+              /*index_size=*/offsets_data[end_idx] - offsets_data[start_idx],
+              /*data_size=*/src.size(0),
+              /*input=*/src_data,
+              /*indices=*/select_indices_data + offsets_data[start_idx],
+              /*offsets=*/offsets_data + start_idx,
+              /*weights=*/scale_data_fp32 + offsets_data[start_idx],
+              /*scale_bias=*/nullptr,
+              /*normalize_by_lengths=*/false,
+              /*out=*/output_data_fp32 + start_idx * ddim);
+          for (const auto i : c10::irange(output_size)) {
+            // Convert FP32 intermediate buffer result back to FP16 for output dtype
+            for (const auto d : c10::irange(ddim)) {
+              (output_data + i * ddim)[d] = static_cast<at::Half>((output_data_fp32 + ddim * i)[d]);
+            }
+          }
+#endif
+        });
+  } else {
+    AT_ASSERT(select_indices.numel() == add_indices.numel());
+    auto* src_data = src.data_ptr<at::Half>();
+    auto* add_indices_data = add_indices.data_ptr<index_t>();
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    index_t* bag_size_data = nullptr;
+    if (bag_size.defined()) {
+      bag_size_data = bag_size.data_ptr<index_t>();
+    }
+    auto vocab_size = src.size(0);
+    auto src_stride0 = src.strides()[0];
+    auto src_stride1 = src.strides()[1];
+    auto output_stride0 = output.strides()[0];
+    auto output_stride1 = output.strides()[1];
+    auto scale_stride = scale.strides()[0];
+    auto numel = add_indices.numel();
+
+    // Initialize the intermediate output buffer to be 0.
+    Tensor output_fp32 = at::zeros({output.size(0), ddim}, output.options().dtype(at::kFloat));
+    auto* output_data_fp32 = output_fp32.data_ptr<float>();
+
+    for (const auto i : c10::irange(numel)) {
+      // We can skip indices equal to padding_idx so they are not included in
+      // the reduction
+      auto idx = select_indices_data[i];
+      TORCH_CHECK(
+          idx >= 0 && idx < vocab_size,
+          "embedding_bag: Expected idx >= 0 && idx < num_embeddings but found idx to be ",
+          idx);
+      if (idx != padding_idx) {
+
+        auto* src_base = src_data + src_stride0 * idx;
+        auto* output_base_fp32 = output_data_fp32 + ddim * add_indices_data[i];
+        auto scale = scale_data[i * scale_stride];
+        for (const auto j : c10::irange(ddim)) {
+          output_base_fp32[j] += static_cast<float>(src_base[j * src_stride1]) * static_cast<float>(scale);
+        }
+      } else if (bag_size.defined()) {
+        // Decrement bag_size to reflect that the index is padded
+        // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
+        bag_size_data[add_indices_data[i]]--;
+      }
+    }
+    for (const auto i : c10::irange(output.size(0))) {
+      // Convert FP32 intermediate buffer result back to FP16 for output dtype
+      for (const auto d : c10::irange(ddim)) {
+        (output_data + output_stride0 * i)[d * output_stride1] = static_cast<at::Half>((output_data_fp32 + ddim * i)[d]);
+      }
+    }
+  }
+}
+
+template<typename data_t, typename index_t>
 typename std::enable_if<std::is_same<data_t, float>::value, void>::type
 index_select_scale_add(const Tensor &select_indices,
                                           const Tensor &add_indices,
@@ -349,7 +651,7 @@ index_select_scale_add(const Tensor &select_indices,
                                           bool include_last_offset,
                                           Tensor &bag_size,
                                           index_t padding_idx) {
-  int64_t ddim = src.sizes()[1];
+  int64_t ddim = src.size(1);
   auto* scale_data = scale.data_ptr<float>();
   auto* select_indices_data = select_indices.data_ptr<index_t>();
   auto* output_data = output.data_ptr<float>();
@@ -391,7 +693,7 @@ index_select_scale_add(const Tensor &select_indices,
           bool success = kernel_fp32_index_t(
             /* output_size */end_idx - start_idx,
             /* index_size */offsets_data[end_idx] - offsets_data[start_idx],
-            /* data_size */src.sizes()[0],
+            /* data_size */src.size(0),
             /* input */src_data,
             /* indices */select_indices_data + offsets_data[start_idx],
             /* offsets_or_lengths */offsets_data + start_idx,
@@ -401,7 +703,7 @@ index_select_scale_add(const Tensor &select_indices,
             fbgemm_spmdm_report_error_(
                 end_idx - start_idx,
                 offsets_data[end_idx] - offsets_data[start_idx],
-                src.sizes()[0],
+                src.size(0),
                 offsets_data + start_idx,
                 select_indices_data + offsets_data[start_idx]);
           }
@@ -410,7 +712,7 @@ index_select_scale_add(const Tensor &select_indices,
               /*block_size=*/ddim,
               /*output_size=*/end_idx - start_idx,
               /*index_size=*/offsets_data[end_idx] - offsets_data[start_idx],
-              /*data_size=*/src.sizes()[0],
+              /*data_size=*/src.size(0),
               /*input=*/src_data,
               /*indices=*/select_indices_data + offsets_data[start_idx],
               /*offsets=*/offsets_data + start_idx,
@@ -425,7 +727,7 @@ index_select_scale_add(const Tensor &select_indices,
     auto* src_data = src.data_ptr<float>();
     auto* add_indices_data = add_indices.data_ptr<index_t>();
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    index_t* bag_size_data;
+    index_t* bag_size_data = nullptr;
     if (bag_size.defined()) {
       bag_size_data = bag_size.data_ptr<index_t>();
     }
@@ -477,17 +779,17 @@ void check_arguments(
   checkScalarTypes("embedding_bag", offsets_arg, {kLong, kInt});
   checkSameType("embedding_bag", indices_arg, offsets_arg);
   auto weight_arg = TensorArg(weight, "weight", 1);
-  checkScalarTypes("embedding_bag", weight_arg, {kFloat, kDouble});
+  checkScalarTypes("embedding_bag", weight_arg, {kHalf, kFloat, kDouble});
 
   AT_DISPATCH_INDEX_TYPES(offsets.scalar_type(), "_embedding_bag_cpu_impl", [&]() {
-    if (offsets.sizes()[0] > 0) {
+    if (offsets.size(0) > 0) {
       index_t offset_0 = offsets.data_ptr<index_t>()[0];
-      index_t offset_n = offsets.data_ptr<index_t>()[offsets.sizes()[0]-1];
+      index_t offset_n = offsets.data_ptr<index_t>()[offsets.size(0)-1];
       TORCH_CHECK(offset_0 == 0, "offsets[0] has to be 0, i.e., the first sequence "
                                 "in the mini-batch has to start from position 0. "
                                 "However, got ", offsets[0]);
-      TORCH_CHECK(offset_n <= indices.sizes()[0], "offsets[-1] can not "
-                  "be greater than input's length ", indices.sizes()[0], " but got offsets[-1] of ",
+      TORCH_CHECK(offset_n <= indices.size(0), "offsets[-1] can not "
+                  "be greater than input's length ", indices.size(0), " but got offsets[-1] of ",
                   offset_n);
     }
   });
@@ -504,7 +806,7 @@ void check_arguments(
 
   if (include_last_offset) {
     TORCH_CHECK(
-        offsets.sizes()[0] >= 1,
+        offsets.size(0) >= 1,
         "include_last_offset: number of offset should be at least 1");
   }
 }
@@ -517,16 +819,16 @@ void make_bag_size_out(
     const bool include_last_offset,
     const bool requires_grad) {
   if (requires_grad || mode == MODE_MEAN || mode == MODE_MAX) {
-    auto num_bags = offsets.sizes()[0] - (include_last_offset ? 1 : 0);
+    auto num_bags = offsets.size(0) - (include_last_offset ? 1 : 0);
     at::native::resize_(bag_size_out, {num_bags}, c10::nullopt);
     // Compute this for MODE_MEAN and MODE_MAX (latter needed for backwards)
     if (num_bags != 1) {
-      bag_size_out.slice(0, 0, bag_size_out.sizes()[0] - 1, 1) =
+      bag_size_out.slice(0, 0, bag_size_out.size(0) - 1, 1) =
           offsets.slice(0, 1, num_bags, 1) -
           offsets.slice(0, 0, num_bags - 1, 1);
     }
     if (num_bags > 0) {
-      bag_size_out[-1] = indices.sizes()[0] - offsets[num_bags - 1];
+      bag_size_out[-1] = indices.size(0) - offsets[num_bags - 1];
     }
   } else {
     at::native::resize_(bag_size_out, offsets.sizes(), c10::nullopt);
@@ -541,7 +843,7 @@ void make_max_indices_out(
     const Tensor& bag_size,
     const int64_t mode,
     bool include_last_offset) {
-  int64_t numBags = offsets.sizes()[0];
+  int64_t numBags = offsets.size(0);
   if (mode == MODE_MAX) {
     if (include_last_offset) {
       TORCH_CHECK(
@@ -569,13 +871,11 @@ void make_offset2bag_out(
   bool fast_path_sum = is_fast_path(weight, per_sample_weights, output, padding_idx);
 
   if (mode == MODE_MEAN || mode == MODE_MAX || !fast_path_sum) {
-    at::native::resize_(offset2bag, {indices.sizes()[0] + 1}, c10::nullopt);
+    at::native::resize_(offset2bag, {indices.size(0) + 1}, c10::nullopt);
     at::native::zero_(offset2bag);
-  }
 
-  if (mode == MODE_MEAN || mode == MODE_MAX || !fast_path_sum) {
     make_offset2bag(offsets, offset2bag);
-    at::native::resize_(offset2bag, {indices.sizes()[0]}, c10::nullopt);
+    at::native::resize_(offset2bag, {indices.size(0)}, c10::nullopt);
     // only initialize output in slow path
     at::native::zero_(output);
   }
@@ -711,7 +1011,7 @@ void _embedding_bag_cpu_impl_out(Tensor& output, Tensor& offset2bag,
                             const c10::optional<Tensor>& per_sample_weights,
                             bool include_last_offset, int64_t padding_idx) {
   if (mode == MODE_MEAN || mode == MODE_SUM) {
-    AT_DISPATCH_FLOATING_TYPES(weight.scalar_type(), "embedding_bag_no_grad_cpu_out",
+    AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, weight.scalar_type(), "embedding_bag_no_grad_cpu_out",
       [&indices, &offset2bag, &per_sample_weights, &weight, &output, &offsets, &include_last_offset, &mode, &bag_size, &padding_idx]() {
       AT_DISPATCH_INDEX_TYPES(indices.scalar_type(), "embedding_bag_no_grad_cpu_out",
         [&indices, &offset2bag, &per_sample_weights, &weight, &output, &offsets, &include_last_offset, &mode, &bag_size, &padding_idx]() {
@@ -756,7 +1056,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> _embedding_bag_cpu_impl(
   check_arguments(weight, indices, offsets, mode, per_sample_weights, include_last_offset);
 
   Tensor output = at::empty(
-      {include_last_offset ? offsets.sizes()[0] - 1 : offsets.sizes()[0],
+      {include_last_offset ? offsets.size(0) - 1 : offsets.size(0),
        weight.sizes()[1]},
       weight.options());
 
@@ -894,10 +1194,10 @@ Tensor _embedding_bag_backward(const Tensor &grad, const Tensor &indices_,
   Tensor offset2bag_;
   if (indices.numel() != 0 && offset2bag.numel() == 0) {
     offset2bag_ = at::zeros(
-       {indices.sizes()[0] + 1}, offsets.options()); // offset2bag = [0 0 0 0 0]
+       {indices.size(0) + 1}, offsets.options()); // offset2bag = [0 0 0 0 0]
 
     make_offset2bag(offsets, offset2bag_);
-    offset2bag_.resize_({indices.sizes()[0]});
+    offset2bag_.resize_({indices.size(0)});
   } else {
     auto offset2bag_arg = TensorArg(offset2bag, "offset2bag", 1);
     checkScalarTypes("embedding_bag", offset2bag_arg, {kLong, kInt});
@@ -1081,7 +1381,7 @@ Tensor _embedding_bag_dense_backward_cpu(const Tensor &grad_, const Tensor &indi
   // for more details.
   auto grad = grad_.contiguous();
   auto grad_arg = TensorArg(grad, "grad_", 1);
-  checkScalarTypes("embedding_bag", grad_arg, {kFloat, kDouble});
+  checkScalarTypes("embedding_bag", grad_arg, {kHalf, kFloat, kDouble});
 
   if (mode == MODE_MAX) {
     return _embedding_bag_dense_backward_cpu_max(
@@ -1092,12 +1392,24 @@ Tensor _embedding_bag_dense_backward_cpu(const Tensor &grad_, const Tensor &indi
   auto index_grad_weight =
       at::zeros({num_weights, grad.sizes()[1]}, grad.options());
 
-  AT_DISPATCH_FLOATING_TYPES(grad.scalar_type(), "embedding_bag_backward", [&] {
-      _embedding_bag_dense_backward_cpu_sum_mean<scalar_t>(
-          grad, indices_, offset2bag__, bag_size_, num_weights,
-          scale_grad_by_freq, mode, per_sample_weights_, index_grad_weight,
-          padding_idx);
-  });
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      grad.scalar_type(),
+      "embedding_bag_backward",
+      [&] {
+        _embedding_bag_dense_backward_cpu_sum_mean<scalar_t>(
+            grad,
+            indices_,
+            offset2bag__,
+            bag_size_,
+            num_weights,
+            scale_grad_by_freq,
+            mode,
+            per_sample_weights_,
+            index_grad_weight,
+            padding_idx);
+      });
   return index_grad_weight;
 }
 
@@ -1120,7 +1432,7 @@ Tensor _embedding_bag_per_sample_weights_backward_cpu_template(
   Tensor indices, offsets;
   std::tie(indices, offsets) = promoteIndicesAndOffsets(indices_, offsets_);
   AT_ASSERT(indices.dim() == 1);
-  auto num_samples = indices.sizes()[0];
+  auto num_samples = indices.size(0);
 
   AT_ASSERT(weight.dim() == 2);
   AT_ASSERT(weight.sizes()[1] == embedding_features);
@@ -1134,11 +1446,11 @@ Tensor _embedding_bag_per_sample_weights_backward_cpu_template(
   Tensor offset2bag_;
   if (indices.numel() != 0 && offset2bag.numel() == 0) {
     offset2bag_ = at::zeros(
-       {indices.sizes()[0] + 1}, offset2bag.options()); // offset2bag = [0 0 0 0 0]
+       {indices.size(0) + 1}, offset2bag.options()); // offset2bag = [0 0 0 0 0]
 
     make_offset2bag(offsets, offset2bag_);
 
-    at::native::resize_(offset2bag_, {indices.sizes()[0]}, c10::nullopt);
+    at::native::resize_(offset2bag_, {indices.size(0)}, c10::nullopt);
   } else {
     auto offset2bag_arg = TensorArg(offset2bag, "offset2bag", 1);
     checkScalarTypes("embedding_bag", offset2bag_arg, {kLong, kInt});
@@ -1194,12 +1506,16 @@ Tensor _embedding_bag_per_sample_weights_backward_cpu(
     const Tensor& offset2bag,
     int64_t mode,
     int64_t padding_idx) {
-  return AT_DISPATCH_FLOATING_TYPES(
-    grad.scalar_type(), "_embedding_bag_per_sample_weights_backward_cpu", [&]() {
-      return _embedding_bag_per_sample_weights_backward_cpu_template<scalar_t>(
-          grad, weight, indices, offsets, offset2bag, mode, padding_idx);
-    }
-  );
+  return AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      grad.scalar_type(),
+      "_embedding_bag_per_sample_weights_backward_cpu",
+      [&]() {
+        return _embedding_bag_per_sample_weights_backward_cpu_template<
+            scalar_t>(
+            grad, weight, indices, offsets, offset2bag, mode, padding_idx);
+      });
 }
 
 Tensor _embedding_bag_sparse_backward(
@@ -1229,6 +1545,5 @@ Tensor _embedding_bag_sparse_backward(
   return native::embedding_backward(index_grad, indices, num_weights, padding_idx,
                                     scale_grad_by_freq, true);
 }
-
 }
 } // namespace at::native

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15150,7 +15150,7 @@ op_db: List[OpInfo] = [
         # This is because currently only the `input` field of SampleInput
         # is tested in gradient tests.
         op=lambda weight, idx, **kwargs: torch.nn.functional.embedding_bag(idx, weight, **kwargs),
-        dtypes=floating_types(),
+        dtypes=floating_types_and(torch.float16),
         dtypesIfCUDA=floating_types_and(torch.bfloat16, torch.float16),
         # backward is not supported for mode `max` and dtype `bfloat16`
         backward_dtypesIfCUDA=floating_types_and(torch.float16),


### PR DESCRIPTION
Summary:

This PR adds the half precision support for nn.EmbedingBag (CPU) op.

- Use FBGEMM/perf kernel implementation for the fast path.
- Use FP32 accumulation for FP16 weight embeddings (index_select_add and index_select_scale_add).
- Add the unit test coverage.

Test Plan:
```
import torch

embedding_sum = torch.nn.EmbeddingBag(10, 3, mode='sum').half()
input = torch.tensor([1,2,4,5,4,3,2,9], dtype=torch.long)
offsets = torch.tensor([0,4], dtype=torch.long)
print(embedding_sum(input, offsets))

embedding = torch.nn.Embedding(10, 3).half()
input = torch.LongTensor([[1,2,4,5],[4,3,2,9]])
print(embedding(input))
```

Differential Revision: D35190299

