### PR TITLE
Introducing SymInt to Pytorch (for tracing size arithmetic) (master rebase)

### DIFF
--- a/aten/src/ATen/core/SymInt.h
+++ b/aten/src/ATen/core/SymInt.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+#include <c10/util/Exception.h>
+
+namespace c10 {
+
+// `SymInt` is a C++ wrapper class around int64_t data_ which  and is used to
+// represent concrete dimension values.
+//
+// `SymInt` is also a data type in Pytorch that can be used in function schemas
+// to enable tracing.
+//
+// `SymInt` is introduced to enable tracing arithmetic
+// operations on symbolic integers (e.g. sizes). Tracing symbolic sizes will
+// allow LTC and AOTAutograd representing dynamic shapes in expression graphs
+// faithfully without baking in concrete dimension values.
+//
+// To trace the operations, SymInt will overload arithmetic operators (e.g. +, -, *)
+// and will provide overloads taking SymInt for commonly used math functions.
+//
+// SymInt will be extenteded to represent a union structure Union[int64_t, SymbolicIntNode*]
+// which will be implemented as a single packed int64_t field named data_.
+//
+// data_ can be either a plain int64_t or (1 << 63 | `index`). `index` points to
+// SymbolicIntNode* that will be responsible for constructing an IR node for
+// a traced operation to represent it in LTC or Fx graphs.
+class TORCH_API SymInt {
+    public:
+        SymInt(int64_t d):
+        data_(d) {};
+
+        int64_t expect_int() const {
+            // we are dealing with concrete ints only for now
+            return data_;
+        }
+
+        bool is_symbolic() const {
+            return false;
+        }
+
+        bool operator==(const SymInt& p2) const
+        {
+            return data_ == p2.data_;
+        }
+
+        SymInt operator+(SymInt sci) const {
+            return data_ + sci.data_;
+        }
+
+        int64_t data() const {
+            return data_;
+        }
+
+    private:
+        int64_t data_;
+};
+
+TORCH_API std::ostream& operator<<(std::ostream& os, SymInt s);
+}

--- a/aten/src/ATen/core/dynamic_type.cpp
+++ b/aten/src/ATen/core/dynamic_type.cpp
@@ -227,6 +227,8 @@ TypePtr DynamicType::fallback() const {
       return BoolType::get();
     case Tag::Int:
       return IntType::get();
+    case Tag::SymInt:
+      return SymIntType::get();
     case Tag::Float:
       return FloatType::get();
     case Tag::Complex:
@@ -320,6 +322,8 @@ DynamicType::Ptr IValue::TagType<c10::DynamicType>::get(const c10::IValue& v) {
       return DynamicTypeTrait<ComplexType>::getBaseType();
     case Tag::Int:
       return DynamicTypeTrait<IntType>::getBaseType();
+    case Tag::SymInt:
+      return DynamicTypeTrait<SymIntType>::getBaseType();
     case Tag::Bool:
       return DynamicTypeTrait<BoolType>::getBaseType();
     case Tag::String:

--- a/aten/src/ATen/core/dynamic_type.h
+++ b/aten/src/ATen/core/dynamic_type.h
@@ -16,6 +16,7 @@ constexpr DynamicTypeBits kDynamicAnyTypeBit = DYNAMIC_TYPE_BIT(30);
 
 constexpr DynamicTypeBits kDynamicNoneTypeBit = DYNAMIC_TYPE_BIT(1);
 constexpr DynamicTypeBits kDynamicIntTypeBit = DYNAMIC_TYPE_BIT(3);
+constexpr DynamicTypeBits kDynamicSymIntTypeBit = DYNAMIC_TYPE_BIT(23);
 constexpr DynamicTypeBits kDynamicFloatTypeBit = DYNAMIC_TYPE_BIT(4);
 constexpr DynamicTypeBits kDynamicComplexTypeBit = DYNAMIC_TYPE_BIT(5);
 constexpr DynamicTypeBits kDynamicListTypeBit = DYNAMIC_TYPE_BIT(7);
@@ -28,6 +29,7 @@ constexpr DynamicTypeBits kDynamicClassTypeBit = DYNAMIC_TYPE_BIT(10);
   _(Bool, DYNAMIC_TYPE_BIT(2), 1)                                            \
   _(Int, kDynamicIntTypeBit, 1)                                              \
   _(Float, kDynamicFloatTypeBit, 1)                                          \
+  _(SymInt, kDynamicSymIntTypeBit, 1)                                        \
   _(Complex, kDynamicComplexTypeBit, 1)                                      \
   _(Number,                                                                  \
     (kDynamicIntTypeBit | kDynamicFloatTypeBit | kDynamicComplexTypeBit),    \

--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -91,6 +91,8 @@ c10::TypePtr IValue::TagType<c10::Type>::get(const IValue& v) {
         return ComplexType::get();
       case Tag::Int:
         return IntType::get();
+      case Tag::SymInt:
+        return c10::SymIntType::get();
       case Tag::Bool:
         return BoolType::get();
       case Tag::String:
@@ -298,6 +300,8 @@ IValue IValue::equals(const IValue& rhs) const {
       return rhs.isComplexDouble() && lhs.toComplexDouble() == rhs.toComplexDouble();
     case Tag::Int:
       return rhs.isInt() && lhs.toInt() == rhs.toInt();
+    case Tag::SymInt:
+      return rhs.isSymInt() && lhs.toSymInt() == rhs.toSymInt();
     case Tag::Bool:
       return rhs.isBool() && lhs.toBool() == rhs.toBool();
     case Tag::String:
@@ -348,6 +352,8 @@ size_t IValue::hash(const IValue& v) {
     case Tag::Storage:
       return c10::get_hash(v.payload.u.as_int);
     case Tag::Int:
+      return c10::get_hash(v.payload.u.as_int);
+    case Tag::SymInt:
       return c10::get_hash(v.payload.u.as_int);
     case Tag::String:
       return c10::get_hash(v.toStringRef());
@@ -567,6 +573,8 @@ std::ostream& IValue::repr(
     }
     case IValue::Tag::Int:
       return out << v.toInt();
+    case IValue::Tag::SymInt:
+      return out << v.toSymInt();
     case IValue::Tag::Bool:
       return out << (v.toBool() ? "True" : "False");
     case IValue::Tag::Tuple: {
@@ -753,6 +761,8 @@ std::ostream& operator<<(std::ostream & out, const IValue & v) {
       return printComplex(out, v);
     } case IValue::Tag::Int:
       return out << v.toInt();
+    case IValue::Tag::SymInt:
+      return out << v.toSymInt();
     case IValue::Tag::Bool:
       return out << (v.toBool() ? "True" : "False");
     case IValue::Tag::Tuple: {
@@ -886,6 +896,7 @@ IValue IValue::deepcopy(
     case IValue::Tag::None:
     case IValue::Tag::Double:
     case IValue::Tag::Int:
+    case IValue::Tag::SymInt:
     case IValue::Tag::Bool:
     case IValue::Tag::Device:
     case IValue::Tag::Uninitialized: {

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -144,6 +144,7 @@ struct Capsule {
   _(Double)                  \
   _(ComplexDouble)           \
   _(Int)                     \
+  _(SymInt)   \
   _(Bool)                    \
   _(Tuple)                   \
   _(String)                  \
@@ -558,6 +559,18 @@ public:
   // Int
   IValue(int64_t i) : tag(Tag::Int), is_intrusive_ptr(false) {
     payload.u.as_int = i;
+  }
+
+  IValue(c10::SymInt i) : tag(Tag::SymInt), is_intrusive_ptr(false) {
+    payload.u.as_int = i.data();
+  }
+
+  bool isSymInt() const {
+    return Tag::SymInt == tag;
+  }
+
+  c10::SymInt toSymInt() const {
+    return c10::SymInt(payload.u.as_int);
   }
 
   // allow you to pass literals (3, 4) without ambiguity

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1584,6 +1584,7 @@ DEFINE_TO(at::MemoryFormat, toMemoryFormat)
 DEFINE_TO(at::QScheme, toQScheme)
 DEFINE_TO(at::Dimname, toDimname)
 DEFINE_TO(at::Generator, toGenerator)
+DEFINE_TO(c10::SymInt, toSymInt)
 
 template <class T>
 struct _fake_type {};

--- a/aten/src/ATen/core/jit_type_base.h
+++ b/aten/src/ATen/core/jit_type_base.h
@@ -6,6 +6,7 @@
 
 #include <ATen/core/qualified_name.h>
 #include <ATen/core/type_ptr.h>
+#include <ATen/core/SymInt.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>
@@ -48,6 +49,7 @@ namespace c10 {
   _(AnyListType)            \
   _(AnyTupleType)           \
   _(AnyClassType)           \
+  _(SymIntType)             \
   _(UnionType)              \
   _(DynamicType)
 

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -143,6 +143,11 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
   return out;
 }
 
+std::ostream& operator<<(std::ostream& os, SymInt s) {
+  os << "SymInt(" << s.data() << ")";
+  return os;
+}
+
 AnyTypePtr AnyType::get() {
   static AnyTypePtr value(new AnyType());
   return value;
@@ -254,6 +259,11 @@ AnyClassTypePtr AnyClassType::get() {
 
 AnyEnumTypePtr AnyEnumType::get() {
   static AnyEnumTypePtr value(new AnyEnumType());
+  return value;
+}
+
+SymIntTypePtr SymIntType::get() {
+  static SymIntTypePtr value(new SymIntType());
   return value;
 }
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -892,8 +892,20 @@ const Tensor &as_strided_(const Tensor& self, IntArrayRef size, IntArrayRef stri
   return self;
 }
 
-Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, SymInt sym_length) {
-  const int64_t length = sym_length.expect_int();
+Tensor narrow_copy_symint(const Tensor& self, int64_t dim, int64_t start, SymInt sym_length) {
+  return narrow_copy(self, dim, start, sym_length.expect_int());
+}
+
+Tensor narrow_copy_dense(const Tensor& self, int64_t dim, int64_t start, int64_t length) {
+  return self.narrow(dim, start, length).clone(at::MemoryFormat::Contiguous);
+}
+
+Tensor narrow_copy_dense_cpu(const Tensor& self, int64_t dim, int64_t start, int64_t length){
+  auto output = at::empty_like(self);
+  return narrow_copy_dense_cpu_out(self, dim, start, length, output);
+}
+
+Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, int64_t length) {
   int64_t allDim = self.dim();
   int64_t end = start+length;
   TORCH_CHECK(allDim > 0, "narrow() cannot be applied to a 0-dim tensor.");
@@ -928,13 +940,12 @@ Tensor narrow_copy_sparse(const Tensor& self, int64_t dim, int64_t start, SymInt
 }
 
 Tensor& narrow_copy_dense_cpu_out(
-  const Tensor& self, int64_t dim, int64_t start, SymInt sym_length, Tensor& output
+  const Tensor& self, int64_t dim, int64_t start, int64_t length, Tensor& output
 ) {
 
   TORCH_CHECK(self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
   TORCH_CHECK(self.dtype() == output.dtype());
 
-  const int64_t length = sym_length.expect_int();
   auto self_contig = self.expect_contiguous();
   const auto self_sizes = self_contig->sizes();
 
@@ -1007,29 +1018,6 @@ Tensor& narrow_copy_dense_cpu_out(
         local_dst_offset_bytes, local_src_offset_bytes, dst_block_size_bytes);
   }
   return output;
-}
-
-Tensor narrow_copy_symint(const Tensor& self, int64_t dim, int64_t start, int64_t length) {
-  return narrow_copy(self, dim, start, c10::SymInt{length});
-}
-
-Tensor narrow_copy_dense(const Tensor& self, int64_t dim, int64_t start, SymInt sym_length){
-  // TODO: we should also fix `narrow` to accept `SymInt`
-  // When we do introduce SymIntNode, real symints can flow
-  // into this function
-  const int64_t length = sym_length.expect_int();
-  return self.narrow(dim, start, length).clone(at::MemoryFormat::Contiguous);
-}
-
-Tensor& narrow_copy_dense_cpu_symint_out(
-  const Tensor& self, int64_t dim, int64_t start, int64_t sym_length, Tensor& output
-) {
-  return narrow_copy_dense_cpu_out(self, dim, start, sym_length, output);
-}
-
-Tensor narrow_copy_dense_cpu(const Tensor& self, int64_t dim, int64_t start, SymInt length){
-  auto output = at::empty_like(self);
-  return narrow_copy_dense_cpu_out(self, dim, start, length, output);
 }
 
 Tensor narrow(const Tensor& self, int64_t dim, int64_t start, int64_t length) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3251,17 +3251,17 @@
   dispatch:
     CompositeExplicitAutograd: mvlgamma_
 
-- func: narrow_copy.SymInt(Tensor self, int dim, int start, SymInt length) -> Tensor
-  variants: function, method
-  dispatch:
-    CompositeExplicitAutograd: narrow_copy_symint
-
-- func: narrow_copy.int(Tensor self, int dim, int start, int length) -> Tensor
+- func: narrow_copy(Tensor self, int dim, int start, int length) -> Tensor
   variants: function, method
   dispatch:
     CPU: narrow_copy_dense_cpu
     SparseCPU, SparseCUDA: narrow_copy_sparse
     CompositeExplicitAutograd: narrow_copy_dense
+
+- func: narrow_copy.SymInt(Tensor self, int dim, int start, SymInt length) -> Tensor
+  variants: function, method
+  dispatch:
+    CompositeExplicitAutograd: narrow_copy_symint
 
 - func: narrow_copy.out(Tensor self, int dim, int start, int length, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3251,14 +3251,23 @@
   dispatch:
     CompositeExplicitAutograd: mvlgamma_
 
-- func: narrow_copy(Tensor self, int dim, int start, int length) -> Tensor
+- func: narrow_copy.int(Tensor self, int dim, int start, int length) -> Tensor
+  variants: function, method
+  dispatch:
+    CompositeExplicitAutograd: narrow_copy_symint
+
+- func: narrow_copy.SymInt(Tensor self, int dim, int start, SymInt length) -> Tensor
   variants: function, method
   dispatch:
     CPU: narrow_copy_dense_cpu
     SparseCPU, SparseCUDA: narrow_copy_sparse
     CompositeExplicitAutograd: narrow_copy_dense
 
-- func: narrow_copy.out(Tensor self, int dim, int start, int length, *, Tensor(a!) out) -> Tensor(a!)
+- func: narrow_copy.int_out(Tensor self, int dim, int start, int length, *, Tensor(a!) out) -> Tensor(a!)
+  dispatch:
+    CPU: narrow_copy_dense_cpu_symint_out
+
+- func: narrow_copy.SymInt_out(Tensor self, int dim, int start, SymInt length, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: narrow_copy_dense_cpu_out
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3251,23 +3251,19 @@
   dispatch:
     CompositeExplicitAutograd: mvlgamma_
 
-- func: narrow_copy.int(Tensor self, int dim, int start, int length) -> Tensor
+- func: narrow_copy.SymInt(Tensor self, int dim, int start, SymInt length) -> Tensor
   variants: function, method
   dispatch:
     CompositeExplicitAutograd: narrow_copy_symint
 
-- func: narrow_copy.SymInt(Tensor self, int dim, int start, SymInt length) -> Tensor
+- func: narrow_copy.int(Tensor self, int dim, int start, int length) -> Tensor
   variants: function, method
   dispatch:
     CPU: narrow_copy_dense_cpu
     SparseCPU, SparseCUDA: narrow_copy_sparse
     CompositeExplicitAutograd: narrow_copy_dense
 
-- func: narrow_copy.int_out(Tensor self, int dim, int start, int length, *, Tensor(a!) out) -> Tensor(a!)
-  dispatch:
-    CPU: narrow_copy_dense_cpu_symint_out
-
-- func: narrow_copy.SymInt_out(Tensor self, int dim, int start, SymInt length, *, Tensor(a!) out) -> Tensor(a!)
+- func: narrow_copy.out(Tensor self, int dim, int start, int length, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: narrow_copy_dense_cpu_out
 

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -62,6 +62,7 @@
 #include <ATen/TracerMode.h>
 #include <ATen/core/Generator.h>
 #include <ATen/core/Reduction.h>
+#include <ATen/core/SymInt.h>
 #include <ATen/core/Tensor.h>
 #include <c10/core/Scalar.h>
 #include <c10/core/Storage.h>

--- a/aten/src/ATen/templates/Operator.h
+++ b/aten/src/ATen/templates/Operator.h
@@ -3,6 +3,7 @@
 // ${generated_comment}
 
 #include <c10/core/QScheme.h>
+#include <ATen/core/jit_type_base.h>
 #include <tuple>
 #include <vector>
 

--- a/aten/src/ATen/templates/Operators.h
+++ b/aten/src/ATen/templates/Operators.h
@@ -17,6 +17,7 @@
   and see NOTE [TORCH_ASSERT_ONLY_METHOD_OPERATORS].
 #endif
 
+#include <ATen/core/SymInt.h>
 #include <c10/core/Scalar.h>
 #include <c10/core/TensorOptions.h>
 #include <c10/core/QScheme.h>

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -32,7 +32,9 @@
 #include <ATen/core/DeprecatedTypeProperties.h>
 #include <ATen/core/NamedTensor.h>
 #include <ATen/core/QuantizerBase.h>
+#include <ATen/core/SymInt.h>
 #include <ATen/core/TensorBase.h>
+
 
 #include <ATen/MethodOperators.h>
 

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -5,7 +5,6 @@
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/ivalue.h>
 #include <ATen/core/jit_type_base.h>
-#include <ATen/ops/allclose.h>
 #include <test/cpp/jit/test_utils.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -14884,6 +14884,12 @@ dedent """
         with self.assertRaisesRegex(Exception, "Overloads are not useable when a module"):
             a = torch.jit.script(W2())
 
+    def test_narrow_copy(self):
+        def foo(a):
+            return a.narrow_copy(0, 0, 5)
+
+        self.checkScript(foo, [torch.rand(10)])
+
     def test_select_after_chunk(self):
         def foo(x):
             chunked = torch.chunk(x, 1)

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -138,6 +138,7 @@ class TestPublicBindings(TestCase):
             "InterfaceType",
             "IntStorageBase",
             "IntType",
+            "SymIntType",
             "IODescriptor",
             "is_anomaly_enabled",
             "is_autocast_cache_enabled",

--- a/tools/codegen/api/python.py
+++ b/tools/codegen/api/python.py
@@ -571,7 +571,7 @@ def argument_type_str(t: Type, *, simple_type: bool = False) -> str:
         elif t.name in [BaseTy.bool, BaseTy.QScheme, BaseTy.Scalar,
                         BaseTy.ScalarType, BaseTy.Generator, BaseTy.Storage,
                         BaseTy.Layout, BaseTy.Device, BaseTy.MemoryFormat,
-                        BaseTy.Dimname, BaseTy.Stream, BaseTy.ConstQuantizerPtr]:
+                        BaseTy.Dimname, BaseTy.Stream, BaseTy.ConstQuantizerPtr, BaseTy.SymInt]:
             # These python schema type names line up with their function schema names
             return t.name.name
 
@@ -754,6 +754,8 @@ def argument_type_str_pyi(t: Type) -> str:
     if isinstance(t, BaseType):
         if t.name == BaseTy.int:
             ret = '_int'
+        if t.name == BaseTy.SymInt:
+            ret = 'SymInt'
         elif t.name == BaseTy.float:
             ret = '_float'
         elif t.name == BaseTy.str:
@@ -1034,6 +1036,8 @@ def arg_parser_unpack_method(t: Type, has_default: bool) -> str:
             return 'deviceWithDefault' if has_default else 'device'
         elif t.name == BaseTy.int:
             return 'toInt64'
+        elif t.name == BaseTy.SymInt:
+            return 'toSymInt'
         elif t.name == BaseTy.bool:
             return 'toBool'
         elif t.name == BaseTy.float:

--- a/tools/codegen/api/types.py
+++ b/tools/codegen/api/types.py
@@ -68,6 +68,7 @@ optionalIntArrayRefT = BaseCppType('at', 'OptionalIntArrayRef')
 tensorOptionsT = BaseCppType('at', 'TensorOptions')
 typeAndSizeT = BaseCppType('torch::autograd::generated', 'TypeAndSize')
 tensorGeometryT = BaseCppType('at', 'TensorGeometry')
+SymIntT = BaseCppType('c10', 'SymInt')
 
 # Types representing template parameters.  Technically, we probably shouldn't
 # represent them this way in codegen, but it was pretty convenient.
@@ -106,6 +107,7 @@ BaseTypeToCppMapping: Dict[BaseTy, BaseCppType] = {
     BaseTy.QScheme: qschemeT,
     BaseTy.Storage: storageT,
     BaseTy.Stream: streamT,
+    BaseTy.SymInt: SymIntT,
 }
 
 # CTypes encode C++ type structure as needed for translation.

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -1181,6 +1181,7 @@ BaseTy = Enum('BaseTy', (
     'QScheme',
     'Storage',
     'Stream',
+    'SymInt',
     'ConstQuantizerPtr',  # TODO: rename
 ))
 

--- a/torch/_C/_VariableFunctions.pyi.in
+++ b/torch/_C/_VariableFunctions.pyi.in
@@ -5,7 +5,7 @@ from typing import List, Tuple, Optional, Union, Any, ContextManager, Callable, 
 from typing_extensions import Literal
 from torch._six import inf
 
-from torch.types import _int, _float, _bool, Number, _dtype, _device, _qscheme, _size, _layout
+from torch.types import _int, _float, _bool, Number, _dtype, _device, _qscheme, _size, _layout, SymInt
 import torch
 
 import builtins

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -12,7 +12,7 @@ from typing import (
 from typing_extensions import Literal
 from torch._six import inf
 
-from torch.types import _int, _float, _bool, _dtype, _device, _qscheme, _size, _layout, Device, Number, Storage
+from torch.types import _int, _float, _bool, _dtype, _device, _qscheme, _size, _layout, Device, Number, Storage, SymInt
 from torch.storage import _TypedStorage
 
 import builtins

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/jit/frontend/builtin_functions.h>
 #include <torch/csrc/jit/frontend/error_report.h>
 #include <torch/csrc/jit/frontend/function_schema_parser.h>
+#include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/operator_upgraders/utils.h>
 #include <torch/csrc/jit/operator_upgraders/version_map.h>
 #include <torch/csrc/jit/runtime/operator.h>
@@ -158,6 +159,11 @@ static Value* tryMatchArgument(
     bool allow_conversions,
     TypeEnv& type_env) {
   Value* value = named_value.value(graph);
+
+  if (arg.type()->kind() == TypeKind::SymIntType &&
+      value->type()->kind() == TypeKind::IntType) {
+    return value;
+  }
 
   // Some functions that take lists of integers or floats for fixed size arrays
   // also allow single ints/floats to be passed in their place. The single

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -160,11 +160,6 @@ static Value* tryMatchArgument(
     TypeEnv& type_env) {
   Value* value = named_value.value(graph);
 
-  if (arg.type()->kind() == TypeKind::SymIntType &&
-      value->type()->kind() == TypeKind::IntType) {
-    return value;
-  }
-
   // Some functions that take lists of integers or floats for fixed size arrays
   // also allow single ints/floats to be passed in their place. The single
   // int/float is then repeated to the length of the list

--- a/torch/csrc/jit/frontend/schema_type_parser.cpp
+++ b/torch/csrc/jit/frontend/schema_type_parser.cpp
@@ -35,6 +35,7 @@ using c10::TensorType;
 using c10::TupleType;
 using c10::UnionType;
 using c10::VarType;
+using c10::SymIntType;
 
 namespace torch {
 namespace jit {
@@ -61,6 +62,7 @@ TypePtr SchemaTypeParser::parseBaseType() {
       {"float", c10::TypeFactory::get<FloatType>()},
       {"complex", c10::TypeFactory::get<ComplexType>()},
       {"int", c10::TypeFactory::get<IntType>()},
+      {"SymInt", c10::TypeFactory::get<SymIntType>()},
       {"bool", c10::TypeFactory::get<BoolType>()},
       {"None", c10::TypeFactory::get<NoneType>()},
       {"NoneType", c10::TypeFactory::get<NoneType>()},

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -599,6 +599,16 @@ void addInputs(Node* n, const char* name, int64_t value) {
   }
 }
 
+void addInputs(Node* n, const char* name, c10::SymInt value) {
+  using ArgumentStash = jit::tracer::ArgumentStash;
+  if (ArgumentStash::hasValue(name)) {
+    Value* v = ArgumentStash::popValue(name);
+    n->addInput(v);
+  } else {
+    detail::genericAddInput(n, value);
+  }
+}
+
 void addInputs(Node* n, const char* name, c10::optional<int64_t> value) {
   using ArgumentStash = jit::tracer::ArgumentStash;
   if (ArgumentStash::hasValue(name)) {

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -235,6 +235,7 @@ TORCH_API void abandon();
 // NB: those serve both as an intermediate steps in addInputs below,
 // as well as the overloads that terminate template recursion
 TORCH_API void addInputs(Node* n, const char* name, int64_t value);
+TORCH_API void addInputs(Node* n, const char* name, c10::SymInt value);
 TORCH_API void addInputs(
     Node* n,
     const char* name,

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1029,7 +1029,9 @@ bool Node::matches(const FunctionSchema& schema) const {
     // we will not succeed at matching T. However None <: Optional[T] so this
     // check can still succeed.
 
-    if (!actuals[i]->type()->isSubtypeOf(*formal)) {
+    bool skip_int2symint = formal->kind() == TypeKind::SymIntType &&
+        actuals[i]->type()->kind() == TypeKind::IntType;
+    if (!actuals[i]->type()->isSubtypeOf(*formal) && !skip_int2symint) {
       return false;
     }
   }

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1029,9 +1029,7 @@ bool Node::matches(const FunctionSchema& schema) const {
     // we will not succeed at matching T. However None <: Optional[T] so this
     // check can still succeed.
 
-    bool skip_int2symint = formal->kind() == TypeKind::SymIntType &&
-        actuals[i]->type()->kind() == TypeKind::IntType;
-    if (!actuals[i]->type()->isSubtypeOf(*formal) && !skip_int2symint) {
+    if (!actuals[i]->type()->isSubtypeOf(*formal)) {
       return false;
     }
   }

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -42,6 +42,8 @@ IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_t> N) {
       auto c_obj = py::cast<std::complex<double>>(obj.ptr());
       return static_cast<c10::complex<double>>(c_obj);
     }
+    case TypeKind::SymIntType:
+      return py::cast<int64_t>(obj);
     case TypeKind::IntType:
     // TODO(xintchen): Handling LayoutType and ScalarTypeType correctly.
     case TypeKind::LayoutType:

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -204,7 +204,6 @@ void initPythonIRBindings(PyObject* module_) {
           "has_writers",
           [&](AliasDb& db, Value* v1) { return db.hasWriters(v1); })
       .def("__str__", &AliasDb::toString);
-
 #define GS(name) def(#name, &Graph ::name)
   py::class_<Graph, std::shared_ptr<Graph>>(m, "Graph")
       .def(py::init<>())
@@ -951,6 +950,8 @@ void initPythonIRBindings(PyObject* module_) {
       .def_static("get", &NumberType::get);
   py::class_<IntType, Type, IntTypePtr>(m, "IntType")
       .def_static("get", &IntType::get);
+  py::class_<SymIntType, Type, SymIntTypePtr>(m, "SymIntType")
+      .def_static("get", &SymIntType::get);
   py::class_<FloatType, Type, FloatTypePtr>(m, "FloatType")
       .def_static("get", &FloatType::get);
   py::class_<ComplexType, Type, ComplexTypePtr>(m, "ComplexType")

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -86,6 +86,10 @@ void restoreAccurateTypeTags(const IValue& root, const TypePtr& type_tag) {
       case AnyEnumType::Kind:
         // no op, there is nothing to tag
         break;
+      case c10::SymIntType::Kind:
+        TORCH_CHECK(!w.value.toSymInt().is_symbolic());
+        // no op, there is nothing to tag
+        break;
       case DynamicType::Kind:
       case UnionType::Kind:
       case EnumType::Kind:

--- a/torch/csrc/lazy/core/tensor.cpp
+++ b/torch/csrc/lazy/core/tensor.cpp
@@ -12,6 +12,7 @@
 #include <torch/csrc/lazy/ts_backend/ops/device_data.h>
 #include <torch/csrc/lazy/ts_backend/ops/scalar.h>
 
+
 namespace torch {
 namespace lazy {
 namespace {

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -40,6 +40,7 @@ static std::unordered_map<std::string, ParameterType> type_map = {
   {"Stream", ParameterType::STREAM},
   {"std::string", ParameterType::STRING},
   {"c10::string_view", ParameterType::STRING},
+  {"SymInt", ParameterType::SYM_INT},
   {"Dimname", ParameterType::DIMNAME},
   {"DimnameList", ParameterType::DIMNAME_LIST},
   {"ScalarList", ParameterType::SCALAR_LIST},
@@ -477,6 +478,15 @@ static bool is_int_list(PyObject* obj, int broadcast_size) {
   return broadcast_size > 0 && THPUtils_checkLong(obj);
 }
 
+static bool is_int_or_symbolic_or_concrete_int(PyObject* obj) {
+  if (THPUtils_checkLong(obj)) {
+      return true;
+  }
+
+  // TODO: test if it's the Python binding for SymbolicIntNode
+  return false;
+}
+
 // argnum is needed for raising the TypeError, it's used in the error message.
 auto FunctionParameter::check(PyObject* obj, std::vector<py::handle> &overloaded_args, int argnum) -> bool
 {
@@ -543,6 +553,9 @@ auto FunctionParameter::check(PyObject* obj, std::vector<py::handle> &overloaded
     case ParameterType::SCALAR_LIST: {
       return is_scalar_list(obj);
     }
+    case ParameterType::SYM_INT: {
+      return is_int_or_symbolic_or_concrete_int(obj);
+    }
   }
 }
 
@@ -551,6 +564,7 @@ std::string FunctionParameter::type_name() const {
     case ParameterType::TENSOR: return "Tensor";
     case ParameterType::SCALAR: return "Number";
     case ParameterType::INT64: return "int";
+    case ParameterType::SYM_INT: return "SymInt";
     case ParameterType::DOUBLE: return "float";
     case ParameterType::COMPLEX: return "complex";
     case ParameterType::TENSOR_LIST: return "tuple of Tensors";

--- a/torch/types.py
+++ b/torch/types.py
@@ -22,7 +22,8 @@ _qscheme = torch.qscheme
 _size = Union[torch.Size, List[_int], Tuple[_int, ...]]
 _layout = torch.layout
 
-SymInt = int
+class SymInt:
+    pass
 
 # Meta-type for "numeric" things; matches our docs
 Number = Union[builtins.int, builtins.float, builtins.bool]

--- a/torch/types.py
+++ b/torch/types.py
@@ -22,6 +22,8 @@ _qscheme = torch.qscheme
 _size = Union[torch.Size, List[_int], Tuple[_int, ...]]
 _layout = torch.layout
 
+SymInt = int
+
 # Meta-type for "numeric" things; matches our docs
 Number = Union[builtins.int, builtins.float, builtins.bool]
 


### PR DESCRIPTION
This PR introduces `SymInt` type to Pytorch which will be used by LTC and AOTAutograd for tracing size arithmetic and tests. 
`SymInt` is a C++ union structure [int64_t, SymbolicIntNode*] that wraps around an int64_t field where the value of the field could be an index into a list of `shared_ptr<SymbolicIntNode>` or a real int. 
This PR doesn't add any support for actually tracing symbolic ints. i.e. data_ for now can only contain real ints.

```
Goal 1: just to show we can add a type to PyTorch core. (wraps int) LANDEABLE
Finalize the naming - symint
Want the name to be short
Does invoke “size” - NO
SInt/SymInt/SymbolicInt
SInt could mean signed int
sym_int or symint or SymInt (originally it was “int”; capitalized implies object semantics, whereas lowercase implies value semantics)
JIT schema - symint
C++ - symint
```

See more details here: https://docs.google.com/document/d/1iiLNwR5ohAsw_ymfnOpDsyF6L9RTUaHMpD8YLw-jxEw