### PR TITLE
[test] experiment without pre-loading context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ option(USE_LITE_INTERPRETER_PROFILER "Enable " ON)
 option(USE_VULKAN_FP16_INFERENCE "Vulkan - Use fp16 inference" OFF)
 option(USE_VULKAN_RELAXED_PRECISION "Vulkan - Use relaxed precision math in the kernels (mediump)" OFF)
 option(USE_VULKAN_SHADERC_RUNTIME "Vulkan - Use runtime shader compilation as opposed to build-time (needs libshaderc)" OFF)
-option(USE_VULKAN_NO_PRELOAD_CONTEXT "Vulkan - Do NOT trigger the Vulkan context to load upon application start" OFF)
+option(USE_VULKAN_NO_PRELOAD_CONTEXT "Vulkan - Do NOT trigger the Vulkan context to load upon application start" ON)
 # option USE_XNNPACK: try to enable xnnpack by default.
 set(XNNPACK_MIN_CMAKE_VER 3.12)
 cmake_dependent_option(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#74862 [test] experiment without pre-loading context**
* #74700 Add binary to benchmark model load speed
* #74769 [vulkan] Add option to trigger Vulkan context to load on application start
* #74699 [vulkan] Remove unnecessary include in vulkan_api_test

