### PR TITLE
get_bazel: Add download path for Mac

### DIFF
--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -61,10 +61,17 @@ function get_pr_change_files() {
 }
 
 function get_bazel() {
-  # download bazel version
-  wget https://ossci-linux.s3.amazonaws.com/bazel-4.2.1-linux-x86_64 -O tools/bazel
-  # verify content
-  echo '1a4f3a3ce292307bceeb44f459883859c793436d564b95319aacb8af1f20557c tools/bazel' | sha256sum --quiet -c
+  if [[ $(uname) == "Darwin" ]]; then
+    # download bazel version
+    curl https://github.com/bazelbuild/bazel/releases/download/4.2.1/bazel-4.2.1-darwin-x86_64  -Lo tools/bazel
+    # verify content
+    echo '74d93848f0c9d592e341e48341c53c87e3cb304a54a2a1ee9cff3df422f0b23c  tools/bazel' | shasum -a 256 -c >/dev/null
+  else
+    # download bazel version
+    curl https://ossci-linux.s3.amazonaws.com/bazel-4.2.1-linux-x86_64 -o tools/bazel
+    # verify content
+    echo '1a4f3a3ce292307bceeb44f459883859c793436d564b95319aacb8af1f20557c  tools/bazel' | shasum -a 256 -c >/dev/null
+  fi
 
   chmod +x tools/bazel
 }


### PR DESCRIPTION
Test Plan: On MacOS machine, run `source .jenkins/pytorch/common_utils.sh ; get_bazel; ./tools/bazel build //c10/test/...`

Fixes #ISSUE_NUMBER
