### PR TITLE
Fix docstring for torch.roll

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -9797,10 +9797,10 @@ add_docstr(torch.roll,
            r"""
 roll(input, shifts, dims=None) -> Tensor
 
-Roll the tensor along the given dimension(s). Elements that are shifted beyond the
-last position are re-introduced at the first position. If a dimension is not
-specified, the tensor will be flattened before rolling and then restored
-to the original shape.
+Roll the tensor :attr:`input` along the given dimension(s). Elements that are
+shifted beyond the last position are re-introduced at the first position. If
+:attr:`dims` is `None`, the tensor will be flattened before rolling and then
+restored to the original shape.
 
 Args:
     {input}
@@ -9818,6 +9818,11 @@ Example::
             [3, 4],
             [5, 6],
             [7, 8]])
+    >>> torch.roll(x, 1)
+    tensor([[8, 1],
+            [2, 3],
+            [4, 5],
+            [6, 7]])
     >>> torch.roll(x, 1, 0)
     tensor([[7, 8],
             [1, 2],


### PR DESCRIPTION
The doc was indicating "If a dimension is not specified, the tensor will
be flattened", whereas the actual behavior is that the input tensor is
flattened only if the `dims` argument is not provided at all.
