### PR TITLE
[Profiler] Limit calls to `recordThreadInfo`

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -631,7 +631,6 @@ void pushProfilingCallbacks(const std::unordered_set<at::RecordScope>& scopes) {
             }
 
             torch::profiler::impl::kineto::popCorrelationId();
-            torch::profiler::impl::kineto::recordThreadInfo();
           })
           .needsInputs(registration_state_ptr->config().report_input_shapes)
           .scopes(scopes));
@@ -667,8 +666,6 @@ void reportBackendEventToActiveKinetoProfiler(
     ctx_ptr->dtypes = inputTypes(fn);
   }
   */
-
-  torch::profiler::impl::kineto::recordThreadInfo();
 }
 
 void prepareProfiler(

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -141,7 +141,9 @@ uint64_t Result::correlation_id() const {
 ThreadLocalSubqueue::ThreadLocalSubqueue(
     const uint64_t tid,
     const ProfilerConfig& config)
-    : tid_{tid}, config_{config}, kineto_info_{kineto::kineto_ids()} {}
+    : tid_{tid}, config_{config}, kineto_info_{kineto::kineto_ids()} {
+  torch::profiler::impl::kineto::recordThreadInfo();
+}
 
 std::unique_ptr<KinetoObserverContext> ThreadLocalSubqueue::begin_op(
     const at::RecordFunction& fn,


### PR DESCRIPTION
Summary: So far as I can tell, `recordThreadInfo` only needs to be called once per thread. Once we have thread local subqueues we can easily manage this by simply calling it in the subqueue constructor.

Test Plan: The effect on single threaded overhead is pretty minimal, but it improves stress test overhead from ~6.1 us to ~1.4us  since we're no contending over the lock in Kineto.

Reviewed By: chaekit

Differential Revision: D34811694

