### PR TITLE
[FX] Fix type of argument min_acc_module_size

### DIFF
--- a/torch/fx/passes/splitter_base.py
+++ b/torch/fx/passes/splitter_base.py
@@ -35,6 +35,7 @@ class _SplitterSettingBase:
         parser.add_argument(
             "--min_acc_module_size",
             default=1,
+            type=int,
             help="Minimum size limit of an accelerator subgraph.",
         )
         parser.add_argument(


### PR DESCRIPTION
Summary:
As title, otherwise the below error is thrown:
```
TypeError: '>=' not supported between instances of 'int' and 'str'
```

Test Plan: easy

Differential Revision: D35206473

