### PR TITLE
Back out D34696255 "[pyper] to + lengths_to_offsets"

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -226,33 +226,6 @@ C10_UNUSED void ClipRangesToGatherToOffsets(
   fuse.runOnGraph(graph);
 }
 
-C10_UNUSED void ToLengthsToOffsets(std::shared_ptr<torch::jit::Graph>& graph) {
-  std::string pattern = R"IR(
-    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy, %memoryformat):
-        %y0 : Tensor = aten::to(%a, %dtype, %nonblocking, %copy, %memoryformat)
-        %y1 : Tensor = fb::lengths_to_offsets(%y0, %includelastoffset)
-        return (%y1))IR";
-  std::string fused_pattern = R"IR(
-    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy, %memoryformat):
-        %y0 : Tensor = fb::to_lengths_to_offsets(%a, %includelastoffset, %dtype)
-        return (%y0))IR";
-  SubgraphRewriter fuse;
-  fuse.RegisterRewritePattern(pattern, fused_pattern);
-  fuse.runOnGraph(graph);
-
-  std::string pattern2 = R"IR(
-    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy):
-        %y0 : Tensor = aten::to(%a, %dtype, %nonblocking, %copy)
-        %y1 : Tensor = fb::lengths_to_offsets(%y0, %includelastoffset)
-        return (%y1))IR";
-  std::string fused_pattern2 = R"IR(
-    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy):
-        %y0 : Tensor = fb::to_lengths_to_offsets(%a, %includelastoffset, %dtype)
-        return (%y0))IR";
-  fuse.RegisterRewritePattern(pattern2, fused_pattern2);
-  fuse.runOnGraph(graph);
-}
-
 C10_UNUSED
 void ClipRangesGatherSigridHash(std::shared_ptr<torch::jit::Graph>& graph) {
   // TODO:: check restrictions for inputs; outputs not used elsewhere
@@ -362,8 +335,6 @@ void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
 
     ClipRangesToGatherToOffsets(graph);
   }
-
-  ToLengthsToOffsets(graph);
 #endif
 }
 


### PR DESCRIPTION
Summary:
Original commit changeset: a0dc4a8ff8f2

Original Phabricator Diff: D34696255 (https://github.com/pytorch/pytorch/commit/f2ca4341c9008472022227b43d943af3e5e46e81)

Test Plan: New models published can't be served on nnpi

Differential Revision: D35214444

