### PR TITLE
More folders in clang-tidy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -405,10 +405,12 @@ jobs:
 
           python3 -m tools.linter.clang_tidy \
             --paths \
+              torch/csrc/cuda \
               torch/csrc/fx \
               torch/csrc/utils \
               torch/csrc/generic \
               torch/csrc/deploy \
+              torch/csrc/onnx \
               torch/csrc/tensor \
             --clang-tidy-exe "$(which clang-tidy)" \
             --disable-progress-bar 2>&1 | tee -a "${GITHUB_WORKSPACE}"/clang-tidy-output.txt

--- a/tools/linter/clang_tidy/__main__.py
+++ b/tools/linter/clang_tidy/__main__.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import re
 import sys
+from sysconfig import get_paths as gp
 from typing import List
 
 
@@ -13,6 +14,9 @@ from tools.linter.clang_tidy.generate_build_files import generate_build_files
 from tools.linter.install.clang_tidy import INSTALLATION_PATH
 from tools.linter.install.download_bin import PYTORCH_ROOT
 
+# Returns '/usr/local/include/python<version number>'
+def get_python_include_dir() -> str:
+    return gp()['include']
 
 def clang_search_dirs() -> List[str]:
     # Compilers are ordered based on fallback preference
@@ -93,7 +97,11 @@ DEFAULTS = {
         "-torch/csrc/deploy/test_deploy_python_ext.cpp",
     ],
     "paths": ["torch/csrc/"],
-    "include-dir": ["/usr/lib/llvm-11/include/openmp"] + clang_search_dirs(),
+    "include-dir": [
+        "/usr/lib/llvm-11/include/openmp",
+        get_python_include_dir(),
+        os.path.join(PYTORCH_ROOT, "third_party/pybind11/include")
+    ] + clang_search_dirs(),
     "clang-tidy-exe": INSTALLATION_PATH,
     "compile-commands-dir": "build",
     "config-file": ".clang-tidy",

--- a/torch/csrc/cuda/Event.cpp
+++ b/torch/csrc/cuda/Event.cpp
@@ -119,7 +119,7 @@ static PyObject * THCPEvent_wait(PyObject *_self, PyObject *_stream) {
   {
     auto self = (THCPEvent*)_self;
     auto stream = (THCPStream*)_stream;
-    pybind11::gil_scoped_release no_gil;
+    pybind11::gil_scoped_release no_gil{};
     self->cuda_event.block(stream->cuda_stream);
   }
   Py_RETURN_NONE;
@@ -145,7 +145,7 @@ static PyObject * THCPEvent_synchronize(PyObject *_self, PyObject *noargs) {
   HANDLE_TH_ERRORS
   {
     auto self = (THCPEvent*)_self;
-    pybind11::gil_scoped_release no_gil;
+    pybind11::gil_scoped_release no_gil{};
     self->cuda_event.synchronize();
   }
   Py_RETURN_NONE;

--- a/torch/csrc/cuda/shared/cudart.cpp
+++ b/torch/csrc/cuda/shared/cudart.cpp
@@ -49,8 +49,8 @@ void initCudartBindings(PyObject* module) {
 #endif
   cudart.def("cuda" "MemGetInfo", [](int device) -> std::pair<size_t, size_t> {
     c10::cuda::CUDAGuard guard(device);
-    size_t device_free;
-    size_t device_total;
+    size_t device_free = 0;
+    size_t device_total = 0;
     cudaMemGetInfo(&device_free, &device_total);
     return {device_free, device_total};
   });


### PR DESCRIPTION
1. Added folders torch/csrc/onnx and torch/csrc/cuda to clang-tidy.
2. Fixed clang-tidy violations in torch/csrc/cuda
3. Fixed(added Python import paths) in clang-tidy Python runner

Fixes some of #62011
