### PR TITLE
[FSDP] Add re-key btw param names/IDs for optim state dict

### DIFF
--- a/torch/distributed/fsdp/__init__.py
+++ b/torch/distributed/fsdp/__init__.py
@@ -1,4 +1,4 @@
 from .flatten_params_wrapper import FlatParameter
 from .fully_sharded_data_parallel import FullyShardedDataParallel
 from .fully_sharded_data_parallel import CPUOffload, BackwardPrefetch, ShardingStrategy
-from .fully_sharded_data_parallel import StateDictType
+from .fully_sharded_data_parallel import StateDictType, OptimStateKeyType


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#74912 [FSDP] Add re-key btw param names/IDs for optim state dict**
* #74879 [FSDP] Optim state chkpt: key by param name, not ID
* #74215 [FSDP] Add full optim state dict
* #74834 [Easy][FSDP] (Reland) Doc fixes

**Overview**
This introduces a new static method `FSDP.rekey_optim_state_dict()` as a utility for interoperating between local/DDP (non-wrapped) models and FSDP (wrapped) models.

To load from a wrapped model to a non-wrapped model:
```
wrapped_model, wrapped_optim = ...
full_osd = FSDP.full_optim_state_dict(wrapped_model, wrapped_optim)
nonwrapped_model, nonwrapped_optim = ...
rekeyed_osd = FSDP.rekey_optim_state_dict(full_osd, OptimStateKeyType.PARAM_ID, nonwrapped_model)
nonwrapped_optim.load_state_dict(rekeyed_osd)
```
To load from a non-wrapped model to a wrapped model:
```
nonwrapped_model, nonwrapped_optim = ...
osd = nonwrapped_optim.state_dict()
rekeyed_osd = FSDP.rekey_optim_state_dict(osd, OptimStateKeyType.PARAM_NAME, nonwrapped_model)
wrapped_model, wrapped_optim = ...
sharded_osd = FSDP.shard_full_optim_state_dict(rekeyed_osd, wrapped_model)
wrapped_optim.load_state_dict(sharded_osd)
```

**Test Plan**
`test_rekey_optim_state_dict_to_ids()` and `test_rekey_optim_state_dict_to_names()`.

Differential Revision: [D35225819](https://our.internmc.facebook.com/intern/diff/D35225819)