### PR TITLE
[SR][easy] Delete StaticRuntime move ctors

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -2007,7 +2007,6 @@ StaticRuntime::StaticRuntime(const StaticModule& sm) {
   std::copy(sm.constants().begin(), sm.constants().end(), values_.begin());
   block_ = std::make_unique<BlockRunner>(
       sm, values_, sm.root_block(), /*is_root_block*/ true);
-  ;
 }
 
 c10::IValue StaticRuntime::operator()(

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -949,6 +949,12 @@ class TORCH_API StaticRuntime {
  public:
   explicit StaticRuntime(const StaticModule& sm);
 
+  StaticRuntime(const StaticRuntime&) = delete;
+  StaticRuntime(StaticRuntime&&) = delete;
+
+  StaticRuntime& operator=(const StaticRuntime&) = delete;
+  StaticRuntime& operator=(StaticRuntime&&) = delete;
+
   using KeywordArgs = std::unordered_map<std::string, c10::IValue>;
   c10::IValue operator()(
       const std::vector<c10::IValue>& args,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74915

The move constructor is broken because `BlockRunner` stores a reference to `values_`. When `StaticRuntime` is moved constructed, pointer to the root block is moved, but the reference is not updated, leading to confusing runtime errors.

The move assignment operator is broken for the same reason.

We can always fix this by heap-allocating `values_`, but I figured it's fine to just delete it since we typically work with pointers to runtimes (note for reviewers: if it's convenient to have a move ctor I can change this diff to make that change instead)

Differential Revision: [D35224396](https://our.internmc.facebook.com/intern/diff/D35224396/)