### PR TITLE
[JIT][easy] clean up tensorexpr_fuser.cpp

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -220,6 +220,7 @@ void removeProfileNodesAndSpecializeTypes(Block* b) {
       // In the future we could consider unifying the types of uses, or adding a
       // type refinement node so uses can have the correct corresponding type.
       if (profiled_type == TensorType::get()) {
+        it.destroyCurrent();
         continue;
       }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #74924
* #74794

just for consistency, destroy profiling nodes while removing them.

(they would get cleaned up by DCE anyway)

Differential Revision: [D35228827](https://our.internmc.facebook.com/intern/diff/D35228827)