### PR TITLE
Dynamo+LTC: force lazy device for tensors created without specifying device

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/core/tensor_factory_functions.py
+++ b/lazy_tensor_core/lazy_tensor_core/core/tensor_factory_functions.py
@@ -1,0 +1,48 @@
+import torch
+
+"""
+tensor_factory_functions defines the list of torch functions that create tensors.
+The list is grabbed by searching thru native_functions.yaml by the following
+regular expression:
+
+  cat native_functions.yaml | grep 'func:' | grep -v "Tensor.*->" | grep "[-]>.*Tensor"
+
+It's possible that new tensor factory functions are added making this list stale.
+Use at your own risk or regenerate the list.
+"""
+tensor_factory_functions = (
+    torch._cudnn_init_dropout_state,
+    torch.arange,
+    torch.bartlett_window,
+    torch.blackman_window,
+    torch._empty_affine_quantized,
+    torch.empty_strided,
+    torch.eye,
+    torch.full,
+    torch.from_file,
+    torch.hann_window,
+    torch.hamming_window,
+    torch.kaiser_window,
+    torch.linspace,
+    torch.logspace,
+    torch.ones,
+    torch.scalar_tensor,
+    torch.rand,
+    torch.randint,
+    torch.randn,
+    torch.randperm,
+    torch.range,
+    torch._efficientzerotensor,
+    torch.zeros,
+    torch.tril_indices,
+    torch.triu_indices,
+    # Note: the following functions match the regular expression search above but
+    # they are not available in the torch module. Comment out.
+    # torch._sparse_coo_tensor_with_dims,
+    # torch.fft_fftfreq,
+    # torch.fft_rfftfreq,
+) + (
+    # torch.tensor is special since it's not in native_functions.yaml
+    # add it separately
+    torch.tensor,
+)

--- a/lazy_tensor_core/test/test_extract_compiled_graph.py
+++ b/lazy_tensor_core/test/test_extract_compiled_graph.py
@@ -50,6 +50,20 @@ class ModuleReturnMulti(nn.Module):
 #         b = torch.randn(2, 3, device="cpu") # eager device
 #         return a + b
 
+# The module was planned to cover the case that a Fx graph return an eager
+# tensor on the default device. It's harder than ModuleEagerTensor because
+# we can not just override the device argument to Lazy since there is no
+# explicit device argument.
+#
+# Unfortunately, the default fx tracer convert the return value of the forward
+# method to a constant.. Comment out for now
+# class ModuleReturnEagerTensorOnDefaultDevice(nn.Module):
+#     def __init__(self):
+#         super(ModuleReturnEagerTensorOnDefaultDevice, self).__init__()
+#
+#     def forward(self):
+#         return torch.tensor((2, 3), dtype=torch.float32)
+
 class ModuleReturnDupTensor(nn.Module):
     """
     Handle the corner case that the same tensor appears multiple times in the


### PR DESCRIPTION
In PR https://github.com/pytorch/pytorch/pull/72936 we already force tensors to be on lazy device if there is a device argument being specified in a call to aten methods. But it turns out that for some benchmarks (yolov3, hf_Bart), dynamo may generate Fx graphs that create eager tensors on the default device without specifying a device argument. 
- graph for yolov3: https://gist.github.com/shunting314/eabdf6c769c59bc384469717b8f9bb7f
- graph for hf_Bart: https://gist.github.com/shunting314/8d5e2d9348a3258959d3954186c48814

Ideally lazy mode should solve the issue here, but before that, this PR just add an explicit lazy device argument for a list of tensor factory methods. This makes sure we create lazy tensors rather than eager tensors on the default device.

Test plan:
test thru dynamo
```
LTC_TS_CUDA=1 gpui time python torchbench.py --speedup-ltc -dcuda --randomize-input --only yolov3
LTC_TS_CUDA=1 gpui time python torchbench.py --speedup-ltc -dcuda --randomize-input --only hf_Bart
```