### PR TITLE
[torch][elastic] Make final agent barrier to shutdown properly

### DIFF
--- a/test/distributed/elastic/utils/util_test.py
+++ b/test/distributed/elastic/utils/util_test.py
@@ -7,48 +7,77 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from unittest import mock
+
 import torch.distributed.elastic.utils.store as store_util
 from torch.distributed.elastic.utils.logging import get_logger
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
-class TestStore:
-    def get(self, key: str):
-        return f"retrieved:{key}"
-
-
 class StoreUtilTest(TestCase):
-    def test_get_data(self):
-        store = TestStore()
-        data = store_util.get_all(store, "test/store", 10)
-        for idx in range(0, 10):
-            self.assertEqual(f"retrieved:test/store{idx}", data[idx])
+    def test_get_all_rank_0(self):
+        store = mock.MagicMock()
+        world_size = 3
+        store_util.get_all(store, 0, "test/store", world_size)
+        # omit empty kwargs, get only key
+        actual_set_call_args = [
+            call_args[0][0] for call_args in store.set.call_args_list
+        ]
+        self.assertListEqual(["test/store0.FIN"], actual_set_call_args)
+
+        actual_get_call_args = [call_args[0] for call_args in store.get.call_args_list]
+        expected_get_call_args = [
+            ("test/store0",),
+            ("test/store1",),
+            ("test/store2",),
+            ("test/store0.FIN",),
+            ("test/store1.FIN",),
+            ("test/store2.FIN",),
+        ]
+        self.assertListEqual(expected_get_call_args, actual_get_call_args)
+
+    def test_get_all_rank_n(self):
+        store = mock.MagicMock()
+        world_size = 3
+        store_util.get_all(store, 1, "test/store", world_size)
+        # omit empty kwargs, get only key
+        actual_set_call_args = [
+            call_args[0][0] for call_args in store.set.call_args_list
+        ]
+        self.assertListEqual(["test/store1.FIN"], actual_set_call_args)
+
+        actual_get_call_args = [call_args[0] for call_args in store.get.call_args_list]
+        expected_get_call_args = [
+            ("test/store0",),
+            ("test/store1",),
+            ("test/store2",),
+        ]
+        self.assertListEqual(expected_get_call_args, actual_get_call_args)
 
     def test_synchronize(self):
-        class DummyStore:
-            def __init__(self):
-                self._data = {
-                    "torchelastic/test0": "data0".encode(encoding="UTF-8"),
-                    "torchelastic/test1": "data1".encode(encoding="UTF-8"),
-                    "torchelastic/test2": "data2".encode(encoding="UTF-8"),
-                }
-
-            def set(self, key, value):
-                self._data[key] = value
-
-            def get(self, key):
-                return self._data[key]
-
-            def set_timeout(self, timeout):
-                pass
-
+        store_mock = mock.MagicMock()
         data = "data0".encode(encoding="UTF-8")
-        store = DummyStore()
-        res = store_util.synchronize(store, data, 0, 3, key_prefix="torchelastic/test")
-        self.assertEqual(3, len(res))
-        for idx, res_data in enumerate(res):
-            actual_str = res_data.decode(encoding="UTF-8")
-            self.assertEqual(f"data{idx}", actual_str)
+        store_util.synchronize(store_mock, data, 0, 3, key_prefix="torchelastic/test")
+        actual_set_call_args = store_mock.set.call_args_list
+        # omit empty kwargs
+        actual_set_call_args = [call_args[0] for call_args in actual_set_call_args]
+        expected_set_call_args = [
+            ("torchelastic/test0", b"data0"),
+            ("torchelastic/test0.FIN", b"FIN"),
+        ]
+        self.assertListEqual(expected_set_call_args, actual_set_call_args)
+
+        expected_get_call_args = [
+            ("torchelastic/test0",),
+            ("torchelastic/test1",),
+            ("torchelastic/test2",),
+            ("torchelastic/test0.FIN",),
+            ("torchelastic/test1.FIN",),
+            ("torchelastic/test2.FIN",),
+        ]
+        actual_get_call_args = store_mock.get.call_args_list
+        actual_get_call_args = [call_args[0] for call_args in actual_get_call_args]
+        self.assertListEqual(expected_get_call_args, actual_get_call_args)
 
 
 class UtilTest(TestCase):

--- a/torch/distributed/elastic/utils/store.py
+++ b/torch/distributed/elastic/utils/store.py
@@ -10,11 +10,14 @@ from datetime import timedelta
 from typing import List
 
 
-def get_all(store, prefix: str, size: int):
+def get_all(store, rank: int, prefix: str, size: int):
     r"""
     Given a store and a prefix, the method goes through the array of keys
     of the following format: ``{prefix}{idx}``, where idx is in a range
     from 0 to size, and tries to retrieve the data.
+
+    The Rank0 process waits at the end to make sure all other processes
+    finished the procedure before exiting.
 
     Usage
 
@@ -30,6 +33,14 @@ def get_all(store, prefix: str, size: int):
     for idx in range(size):
         data = store.get(f"{prefix}{idx}")
         data_arr.append(data)
+    store.set(f"{prefix}{rank}.FIN", b"FIN")
+    if rank == 0:
+        # Rank0 runs the TCPStore daemon, as a result it needs to exit last.
+        # Otherwise, the barrier may timeout if rank0 process finished the work
+        # before other processes finished `get_all` method
+        for node_rank in range(size):
+            store.get(f"{prefix}{node_rank}.FIN")
+
     return data_arr
 
 
@@ -50,7 +61,7 @@ def synchronize(
     """
     store.set_timeout(timedelta(seconds=barrier_timeout))
     store.set(f"{key_prefix}{rank}", data)
-    agent_data = get_all(store, key_prefix, world_size)
+    agent_data = get_all(store, rank, key_prefix, world_size)
     return agent_data
 
 


### PR DESCRIPTION
Summary:
When workers finish their work TE agent will start `synchronize_barrier` procedure. The barrier will wait for other agents at the end of the execution.

There is a race condition may happen: The barrier uses TCPStore which is located on Rank0. When Rank0 finishes the work, other ranks may still be in a process of executing `get_all` method. This means that some of them will fail because the TCPStore will be destroyed.

The fix adds additional check on Rank0 process: Rank0 process now waits for all other ranks to finish before terminating the process.

Test Plan: unit tests

Differential Revision: D35227180

