### PR TITLE
Dynamo+LTC: bailout if found LTC fallbacks

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/core/tensor_factory_functions.py
+++ b/lazy_tensor_core/lazy_tensor_core/core/tensor_factory_functions.py
@@ -1,0 +1,48 @@
+import torch
+
+"""
+tensor_factory_functions defines the list of torch functions that create tensors.
+The list is grabbed by searching thru native_functions.yaml by the following
+regular expression:
+
+  cat native_functions.yaml | grep 'func:' | grep -v "Tensor.*->" | grep "[-]>.*Tensor"
+
+It's possible that new tensor factory functions are added making this list stale.
+Use at your own risk or regenerate the list.
+"""
+tensor_factory_functions = (
+    torch._cudnn_init_dropout_state,
+    torch.arange,
+    torch.bartlett_window,
+    torch.blackman_window,
+    torch._empty_affine_quantized,
+    torch.empty_strided,
+    torch.eye,
+    torch.full,
+    torch.from_file,
+    torch.hann_window,
+    torch.hamming_window,
+    torch.kaiser_window,
+    torch.linspace,
+    torch.logspace,
+    torch.ones,
+    torch.scalar_tensor,
+    torch.rand,
+    torch.randint,
+    torch.randn,
+    torch.randperm,
+    torch.range,
+    torch._efficientzerotensor,
+    torch.zeros,
+    torch.tril_indices,
+    torch.triu_indices,
+    # Note: the following functions match the regular expression search above but
+    # they are not available in the torch module. Comment out.
+    # torch._sparse_coo_tensor_with_dims,
+    # torch.fft_fftfreq,
+    # torch.fft_rfftfreq,
+) + (
+    # torch.tensor is special since it's not in native_functions.yaml
+    # add it separately
+    torch.tensor,
+)

--- a/lazy_tensor_core/test/test_extract_compiled_graph.py
+++ b/lazy_tensor_core/test/test_extract_compiled_graph.py
@@ -50,6 +50,20 @@ class ModuleReturnMulti(nn.Module):
 #         b = torch.randn(2, 3, device="cpu") # eager device
 #         return a + b
 
+# The module was planned to cover the case that a Fx graph return an eager
+# tensor on the default device. It's harder than ModuleEagerTensor because
+# we can not just override the device argument to Lazy since there is no
+# explicit device argument.
+#
+# Unfortunately, the default fx tracer convert the return value of the forward
+# method to a constant.. Comment out for now
+# class ModuleReturnEagerTensorOnDefaultDevice(nn.Module):
+#     def __init__(self):
+#         super(ModuleReturnEagerTensorOnDefaultDevice, self).__init__()
+#
+#     def forward(self):
+#         return torch.tensor((2, 3), dtype=torch.float32)
+
 class ModuleReturnDupTensor(nn.Module):
     """
     Handle the corner case that the same tensor appears multiple times in the


### PR DESCRIPTION
This PR is stacked on #74930 

When there are LTC fallbacks, some subgraph in the captured top level LTC IR graph will be replaced with a DeviceData node.  That DeviceData node does not match any parameters of the forward method, so the algorithm we build will assume it's a constant tensor. It's basically like we cached some computation results we should not. This has 2 effects
- perf for some benchmark will looks unrealistically good..
- the result of the model will be incorrect

There are some discussions about how to handle LTC fallbacks. I'll summarize them here but this PR just bailout 
- implement the fallback ops in LTC
- stitch the fallback graphs into the toplevel graph. Challenges are we need figure out a way to retrieve the fallback graphs; and there can be cascaded fallbacks which is tricky
- propagate the LTC fallback all the way up to dynamo. Hopefully dynamo will break the original Fx graph into graphs which does not cause LTC fallbacks (can dynamo already do that?) . Challenges are how to map LTC fallback ops to Fx nodes; we may need run dynamo 2 passes to collect LTC fallbacks and apply that

Test plan:
Unit test
```
pytest test/test_extract_compiled_graph.py -vsk test_ltc_fallback
```
Test thru dynamo:
```
LTC_TS_CUDA=1 gpui time python torchbench.py --speedup-ltc -dcuda --randomize-input --only dlrm
```
