### PR TITLE
Pin cmake on windows

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_miniconda3.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_miniconda3.bat
@@ -22,7 +22,7 @@ if "%INSTALL_FRESH_CONDA%"=="1" (
   call conda install -y -q python=%PYTHON_VERSION% numpy cffi pyyaml boto3 libuv
   if errorlevel 1 exit /b
   if not errorlevel 0 exit /b
-  call conda install -y -q -c conda-forge cmake
+  call conda install -y -q -c conda-forge cmake=3.22.3
   if errorlevel 1 exit /b
   if not errorlevel 0 exit /b
 )


### PR DESCRIPTION
Quick fix to rectify trunk health.

Broken jobs look like: https://github.com/pytorch/pytorch/runs/5751970985?check_suite_focus=true
Previously successful job uses version 3.22.3: https://github.com/pytorch/pytorch/runs/5746840621?check_suite_focus=true