### PR TITLE
[DataPipe] only apply special serialization when dill is installed

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -2009,6 +2009,27 @@ class TestGraph(TestCase):
         self.assertEqual(expected, graph)
 
 
+class TestCircularSerialization(TestCase):
+
+    class _CustomIterDataPipe(IterDataPipe):
+        def noop(self, x):
+            return x + 1
+
+        def __init__(self):
+            self._dp = dp.iter.IterableWrapper([1, 2, 4]).map(self.noop)
+
+        def __iter__(self):
+            yield from self._dp
+
+    def test_circular_serialization_with_pickle(self):
+        assert list(self._CustomIterDataPipe()) == list(pickle.loads(pickle.dumps(self._CustomIterDataPipe())))
+
+    # TODO: Ensure this works with `dill` installed
+    # @skipIfNoDill
+    # def test_circular_serialization_with_dill(self):
+    #     assert list(self._CustomIterDataPipe()) == list(dill.loads(dill.dumps(self._CustomIterDataPipe())))
+
+
 class TestSharding(TestCase):
 
     def _get_pipeline(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #74958

This is a quick fix. Only applies the custom serialization logic when `dill` is installed. The specific issue mentioned below should be resolved if `dill` is not installed in the local environment.

See the [issue in this comment](https://github.com/pytorch/data/issues/237#issuecomment-1080651807).

I also plan to add some test related to circular dependency in the serialization process.