### PR TITLE
[static-runtime] skip entering empty sub-blocks of prim::If nodes

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -53,6 +53,7 @@ namespace c10 {
   _(prim, TensorExprGroup)           \
   _(prim, TensorExprDynamicGroup)    \
   _(prim, StaticSubgraph)            \
+  _(prim, SingleBlockIf)             \
   _(prim, If)                        \
   _(prim, Jump) /* debug */          \
   _(prim, JumpNZ) /* debug */        \

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -618,6 +618,8 @@ void AliasDb::analyzeImpl(Node* node) {
   switch (node->kind()) {
     case prim::If:
       return analyzeIf(node);
+    case prim::SingleBlockIf:
+      return analyzeSingleBlockIf(node);
     case prim::Loop:
       return analyzeLoop(node);
     case prim::FusionGroup:
@@ -943,6 +945,14 @@ void AliasDb::analyzeIf(Node* node) {
     makePointerTo(nodeOutput, trueOutput);
     makePointerTo(nodeOutput, falseOutput);
   }
+}
+
+void AliasDb::analyzeSingleBlockIf(Node* node) {
+  DCHECK_EQ(node->blocks().size(), 1);
+  Block* subBlock = node->blocks().at(0);
+  DCHECK_EQ(subBlock->outputs().size(), 1);
+  analyze(subBlock);
+  makePointerTo(node->output(), subBlock->outputs().at(0));
 }
 
 void AliasDb::analyzeLoop(Node* node) {

--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -216,6 +216,7 @@ class AliasDb {
   void analyze(Node* node);
   void analyzeImpl(Node* node);
   void analyzeIf(Node* node);
+  void analyzeSingleBlockIf(Node* node);
   void analyzeLoop(Node* node);
   void analyzeSubgraph(Node* node, std::shared_ptr<Graph> subgraph);
   void analyzeSubgraph(Node* node);

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -279,6 +279,7 @@ bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
   // added a case for the unschematized node in AliasDb::analyze
   const static std::unordered_set<Symbol> handled = {
       prim::If,
+      prim::SingleBlockIf,
       prim::Loop,
       prim::FusionGroup,
       prim::CudaFusionGroup,

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -176,6 +176,7 @@ void OptimizeGraph(
       graph, /* custom_ops */ {fromQualString("fb::scale_gradient")});
   AddIfThenElseOp(graph);
   UseSplitAndSqueeze(graph);
+  TransformIfsToSingleBlockIfs(graph);
   GRAPH_DUMP("Final graph after optimizations: ", graph);
 }
 
@@ -839,7 +840,9 @@ BlockRunner::BlockRunner(
     if (num_blocks == 0) {
       continue;
     }
-    DCHECK(node->kind() == prim::If || node->kind() == prim::Loop);
+    DCHECK(
+        node->kind() == prim::If || node->kind() == prim::Loop ||
+        node->kind() == prim::SingleBlockIf);
     auto block_runners = std::make_unique<std::vector<BlockRunner>>();
     block_runners->reserve(num_blocks);
 

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -735,6 +735,24 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(prim::If, prim_If, [](Node*) -> SROperator {
   };
 });
 
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    prim::SingleBlockIf,
+    prim_SingleBlockIf,
+    [](Node*) -> SROperator {
+      return [](ProcessedNode* p_node) {
+        const bool condition = p_node->Input(0).toBool();
+        const bool block_is_run = p_node->Input(1).toBool();
+        if (condition == block_is_run) {
+          std::vector<BlockRunner>* block_runners = p_node->block_runners();
+          DCHECK(block_runners);
+          DCHECK_EQ(block_runners->size(), 1);
+          const c10::IValue output = block_runners->front()({});
+          DCHECK(output.isNone());
+        }
+        p_node->Output(0) = c10::IValue();
+      };
+    });
+
 namespace {
 
 std::vector<IValue> collectLoopSubBlockInputs(const ProcessedNode& p_node) {

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -65,5 +65,7 @@ TORCH_API void EliminateExtraPermuteOps(std::shared_ptr<Graph>& graph);
 
 TORCH_API void UseSplitAndSqueeze(std::shared_ptr<Graph>& graph);
 
+TORCH_API void TransformIfsToSingleBlockIfs(std::shared_ptr<Graph> graph);
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
Rewrite IR patterns like
```
= prim::If(%condition)
  block0():
     // Do something that produces side effect, but return nothing
     // (i.e. raise exception, do IO, mutate state)
     -> ()
  block1():
     // Do nothing
     -> ()
```
with
```
= prim::SingleBlockIf(%condition)
  block0():
     // Do something that produces side effect, but return nothing
     -> ()
```
To avoid book keeping associated with an empty block.
To that end,
* Create an op and check if static runtime still compiles
* Add an optimization pass that rewrites `prim::If` having 2 blocks with `prim::SingleBlockIf` having 1 block
   * One of the original blocks must be empty
   * Both original blocks must not return any values
* Make AliasDb aware of the new node kind

Test Plan:
`buck build //caffe2:torch-cpp-cpu`
`buck test //caffe2/benchmarks/static_runtime/...`

Add unit test:
`buck test //caffe2/benchmarks/static_runtime:static_runtime_cpptest -- StaticRuntime.EmptyIfBlockPruning`

Differential Revision: D35156174

