### PR TITLE
Make all `.pyi.in` files exportable from torch/_C/ folder

### DIFF
--- a/torch/_C/build.bzl
+++ b/torch/_C/build.bzl
@@ -1,0 +1,6 @@
+def define_targets(rules):
+    rules.filegroup(
+        name = "pyi.in",
+        srcs = rules.glob(["*.pyi.in"]),
+        visibility = ["//visibility:public"],
+    )


### PR DESCRIPTION
Summary: This would eliminate the need for build system changes when new .pyi.in files is added

Test Plan: CI

Reviewed By: seemethere

Differential Revision: D35255502

