### PR TITLE
[DO NOT MERGE] try to flush out mobile-only error in OSS CI

### DIFF
--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -591,13 +591,8 @@ constexpr uint8_t numPerBackendFunctionalityKeys() {
   return count;
 }
 
-#if defined(C10_MOBILE_TRIM_DISPATCH_KEYS)
 // See [Note: Trimmed Mobile Dispatch Keys]
 constexpr uint16_t num_runtime_entries = 8;
-#else
-constexpr uint16_t num_runtime_entries = num_functionality_keys +
-    (numPerBackendFunctionalityKeys() * (num_backends - 1));
-#endif
 
 // See Note [No More Than 16 Backends]
 constexpr uint16_t full_backend_mask =

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -419,7 +419,6 @@ class DispatchKeySet final {
     return 64 - llvm::countLeadingZeros(repr_);
   }
 
-#if defined(C10_MOBILE_TRIM_DISPATCH_KEYS)
   // [Note: Trimmed Mobile Dispatch Keys]
   /**
    * The method below maps the dispatch key in the enum DispatchKey to an
@@ -451,24 +450,6 @@ class DispatchKeySet final {
         return -1;
     }
   }
-#else
-  // returns the index in the operator table of highest priority key in the the
-  // keyset Note that we could in theory implement this using
-  // highestPriorityTypeId(), but this code is very hotpath and we can do it
-  // faster without it.
-  int getDispatchTableIndexForDispatchKeySet() const {
-    auto functionality_idx =
-        DispatchKeySet(repr_ >> num_backends).indexOfHighestBit();
-    auto offset_and_mask = offsetsAndMasks()[functionality_idx];
-    // Mask the functionality bits out first, then right-shift by 1.
-    // right-shifting by 1 because everything is zero-indexed.
-    // E.g. 000001 (CPU) should give us an offset of 0, 000010 (CUDA) should
-    // give us an offset of 1, etc.
-    auto backend_idx =
-        DispatchKeySet((repr_ & offset_and_mask.mask) >> 1).indexOfHighestBit();
-    return offset_and_mask.offset + backend_idx;
-  }
-#endif
 
   // returns the "index" of the highest priority backend in the keyset.
   // This is pretty similar to getBackendKey(), but:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#74965 [DO NOT MERGE] try to flush out mobile-only error in OSS CI**
* #74963 Back out "Back out "free up dispatch key space (in C++)""

