### PR TITLE
[Deploy] Change `numModules` type to `unsigned`

### DIFF
--- a/tools/linter/clang_format_all.py
+++ b/tools/linter/clang_format_all.py
@@ -23,6 +23,7 @@ CLANG_FORMAT_ALLOWLIST = [
     "c10/",
     "ios/",
     "torch/csrc/jit/",
+    "torch/csrc/deploy/",
     "test/cpp/jit/",
     "test/cpp/tensorexpr/"
 ]

--- a/tools/linter/clang_format_ci.sh
+++ b/tools/linter/clang_format_ci.sh
@@ -9,6 +9,7 @@ find . -type f \
   -path './c10/*' -or \
   -path './ios/*' -or \
   -path './torch/csrc/jit/!(serialization/mobile_bytecode_generated.h)' -or \
+  -path './torch/csrc/deploy/*' -or \
   -path './test/cpp/jit/*' -or \
   -path './test/cpp/tensorexpr/*' \
   | xargs tools/linter/git-clang-format --verbose "$1" --

--- a/torch/csrc/deploy/interpreter/builtin_registry.cpp
+++ b/torch/csrc/deploy/interpreter/builtin_registry.cpp
@@ -45,7 +45,7 @@ BuiltinRegistryItem::BuiltinRegistryItem(
 
   fprintf(
       stderr,
-      "torch::deploy builtin %s contains %d modules\n",
+      "torch::deploy builtin %s contains %u modules\n",
       name,
       numModules);
 }
@@ -110,8 +110,8 @@ BuiltinRegistryItem* BuiltinRegistry::getItem(const std::string& name) {
                                        : get()->items_[itr->second].get();
 }
 
-int BuiltinRegistry::totalNumModules() {
-  int tot = 0;
+unsigned BuiltinRegistry::totalNumModules() {
+  unsigned tot = 0;
   for (const auto& itemptr : get()->items_) {
     tot += itemptr->numModules;
   }
@@ -120,7 +120,7 @@ int BuiltinRegistry::totalNumModules() {
 
 struct _frozen* BuiltinRegistry::getAllFrozenModules() {
   /* Allocate new memory for the combined table */
-  int totNumModules = totalNumModules();
+  size_t totNumModules = totalNumModules();
   struct _frozen* p = nullptr;
   if (totNumModules > 0 &&
       totNumModules <= SIZE_MAX / sizeof(struct _frozen) - 1) {
@@ -135,7 +135,7 @@ struct _frozen* BuiltinRegistry::getAllFrozenModules() {
   memset(&p[0], 0, sizeof(p[0]));
 
   /* Copy the tables into the new memory */
-  int off = 0;
+  unsigned off = 0;
   for (const auto& itemptr : items()) {
     if (itemptr->numModules > 0) {
       memcpy(

--- a/torch/csrc/deploy/interpreter/builtin_registry.h
+++ b/torch/csrc/deploy/interpreter/builtin_registry.h
@@ -49,7 +49,7 @@ struct BuiltinRegistryItem {
       std::vector<std::pair<const char*, void*>>&& _builtinModules);
   const char* name;
   const struct _frozen* frozenModules;
-  int numModules;
+  unsigned numModules;
   std::vector<std::pair<const char*, void*>> builtinModules;
 };
 
@@ -77,7 +77,7 @@ class BuiltinRegistry {
   static const std::vector<std::unique_ptr<BuiltinRegistryItem>>& items() {
     return get()->items_;
   }
-  static int totalNumModules();
+  static unsigned totalNumModules();
   static BuiltinRegistry* get();
   static BuiltinRegistryItem* getItem(const std::string& name);
   static std::vector<std::pair<const char*, void*>> getAllBuiltinModules();


### PR DESCRIPTION
As it should never be negative, should it?
Also, add `torch/csrc/deploy` to the list of clang-format checked folders (as they are internally)

Last but not least: clang-tidy correctly identifies `totNumModules <= SIZE_MAX / sizeof(struct _frozen) - 1` as unneeded always true check (as `totNumModules` is int32, while SIZE_MAX is int64 and `sizeof(sturct_frozen)` is less than 4Gb ;) )