### PR TITLE
Shape functions: Use friendlier clamping pattern

### DIFF
--- a/torch/csrc/jit/runtime/shape_functions.h
+++ b/torch/csrc/jit/runtime/shape_functions.h
@@ -77,7 +77,7 @@ def slice(
         end_val += self[dim]
     if start_val < 0:
         start_val = 0
-    elif start_val >= self[dim]:
+    elif start_val > self[dim]:
         start_val = self[dim]
     if end_val < start_val:
         end_val = start_val


### PR DESCRIPTION
When start_val == 0, using the comparison `start_val > self[dim]` can be folded easily (0 is never strictly greater than the result of `self[dim]`), but `start_val >= self[dim]` can't. Since we assign `start_val = sef[dim]` in the body anyway, both these are equivalent

