### PR TITLE
re-enable disabled test via commit message

### DIFF
--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -112,6 +112,8 @@ jobs:
         run: |
           # detached container should get cleaned up by teardown_ec2_linux
           export SHARD_NUMBER=0
+          COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH}")
+          export COMMIT_MESSAGES
           # TODO: Stop building test binaries as part of the build phase
           # Make sure we copy test results from bazel-testlogs symlink to
           # a regular directory ./test/test-reports

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -97,6 +97,9 @@ jobs:
             TEST_COMMAND=.jenkins/pytorch/test.sh
           fi
 
+          COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH}")
+          export COMMIT_MESSAGES
+
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice
@@ -118,6 +121,7 @@ jobs:
             -e TEST_CONFIG \
             -e NUM_TEST_SHARDS \
             -e PR_BODY \
+            -e COMMIT_MESSAGES \
             -e PYTORCH_RETRY_TEST_CASES \
             -e PR_LABELS \
             -e MAX_JOBS="$(nproc --ignore=2)" \

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Test
         run: |
+          COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH}")
+          export COMMIT_MESSAGES
           python3 -mpip install dist/*.whl
           .jenkins/pytorch/macos-test.sh
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -86,6 +86,9 @@ jobs:
             TEST_COMMAND=.jenkins/pytorch/test.sh
           fi
 
+          COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH}")
+          export COMMIT_MESSAGES
+
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
           # Used for GPU_FLAG since that doesn't play nice
@@ -107,6 +110,7 @@ jobs:
             -e TEST_CONFIG \
             -e NUM_TEST_SHARDS \
             -e PR_BODY \
+            -e COMMIT_MESSAGES \
             -e PYTORCH_RETRY_TEST_CASES \
             -e PR_LABELS \
             -e MAX_JOBS="$(nproc --ignore=2)" \

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -84,6 +84,8 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           TORCH_CUDA_ARCH_LIST: "7.0"
         run: |
+          COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH}")
+          export COMMIT_MESSAGES
           .jenkins/pytorch/win-test.sh
 
       - name: Upload test artifacts

--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -10,13 +10,14 @@ from urllib.request import urlopen
 
 def get_disabled_issues() -> List[str]:
     pr_body = os.getenv('PR_BODY', '')
+    commit_messages = os.getenv('COMMIT_MESSAGES', '')
     # The below regex is meant to match all *case-insensitive* keywords that
     # GitHub has delineated would link PRs to issues, more details here:
     # https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue.
     # E.g., "Close #62851", "fixES #62851" and "RESOLVED #62851" would all match, but not
     # "closes  #62851" --> extra space, "fixing #62851" --> not a keyword, nor "fix 62851" --> no #
     regex = '(?i)(Close(d|s)?|Resolve(d|s)?|Fix(ed|es)?) #([0-9]+)'
-    issue_numbers = [x[4] for x in re.findall(regex, pr_body)]
+    issue_numbers = [x[4] for x in re.findall(regex, pr_body + commit_messages)]
     print("Ignoring disabled issues: ", issue_numbers)
     return issue_numbers
 

--- a/tools/test/test_import_test_stats.py
+++ b/tools/test/test_import_test_stats.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+from tools.stats.import_test_stats import get_disabled_issues
+from typing import List
+from unittest.mock import patch
+
+class TestGetDisabledIssues(unittest.TestCase):
+
+    def run_assert_disabled_issues(self, pr_body: str, commit_messages: str, expected: List[str]) -> None:
+        with patch.dict(os.environ, {"PR_BODY": pr_body, "COMMIT_MESSAGES": commit_messages}):
+            disabled_issues = get_disabled_issues()
+        self.assertEqual(disabled_issues, expected)
+
+    # test variations of close in PR_BODY
+    def test_closes_pr_body(self) -> None:
+        pr_body = 'closes #123 Close #143 ClOsE #345 closed #10283'
+        self.run_assert_disabled_issues(pr_body, '', ['123', '143', '345', '10283'])
+
+    # test variations of fix in COMMIT_MESSAGES
+    def test_fixes_commit_messages(self) -> None:
+        commit_messages = 'fix #123 FixEd #143 fixes #345 FiXeD #10283'
+        self.run_assert_disabled_issues('', commit_messages, ['123', '143', '345', '10283'])
+
+    # test variations of resolve in PR_BODY and COMMIT_MESSAGES
+    def test_resolves_pr_commits(self) -> None:
+        pr_body = 'resolve #123 resolveS #143'
+        commit_messages = 'REsolved #345 RESOLVES #10283'
+        self.run_assert_disabled_issues(pr_body, commit_messages, ['123', '143', '345', '10283'])
+
+    # test strange spacing
+    def test_spacing(self) -> None:
+        pr_body = 'resolve #123,resolveS #143eee'
+        commit_messages = 'Resolved #345\nRESOLVES #10283Fixed #2348'
+        self.run_assert_disabled_issues(pr_body, commit_messages, ['123', '143', '345', '10283', '2348'])
+
+    # test bad things
+    def test_not_accepted(self) -> None:
+        pr_body = 'resolve 234, resolves  #45, resolving #123 fixes189'
+        commit_messages = 'fix 234, fixes # 45, fixing #123, close 234, closes#45, closing #123'
+        self.run_assert_disabled_issues(pr_body, commit_messages, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #[74132](https://github.com/pytorch/pytorch/issues/74132)

Allows for re-enabling disabled tests using commit messages.  Previously, this done in the PR body by writing something similar to "Fixes #<issue number that disables a test>" and the test would be re-enabled.  Now, this re-enabling can be done in either the commit message or the PR body.  

Test Plan

One of the commits in this PR contains "fixes 74223" (the # is ommited because github would mistakenly close that issue), which is a disabled test belonging to the periodic job linux-bionic-cuda11.5-py3.7-gcc7.  Looking at the logs of this job will show that this test (test_exception_all) was run in the job.

