### PR TITLE
[torch.package] add utility for determining where bad modules may come from

### DIFF
--- a/torch/package/_digraph.py
+++ b/torch/package/_digraph.py
@@ -1,5 +1,5 @@
 from collections import deque
-from typing import Set
+from typing import Set, List
 
 
 class DiGraph:
@@ -18,6 +18,11 @@ class DiGraph:
         # Nested dict of node -> predecessor node -> nothing.
         self._pred = {}
 
+        # Keep track of the order in which nodes are added to
+        # the graph.
+        self._node_order = {}
+        self._insertion_idx = 0
+
     def add_node(self, n, **kwargs):
         """Add a node to the graph.
 
@@ -29,6 +34,8 @@ class DiGraph:
             self._node[n] = kwargs
             self._succ[n] = {}
             self._pred[n] = {}
+            self._node_order[n] = self._insertion_idx
+            self._insertion_idx += 1
         else:
             self._node[n].update(kwargs)
 
@@ -38,14 +45,8 @@ class DiGraph:
         ``u`` and ``v`` will be created if they do not already exist.
         """
         # add nodes
-        if u not in self._node:
-            self._node[u] = {}
-            self._succ[u] = {}
-            self._pred[u] = {}
-        if v not in self._node:
-            self._node[v] = {}
-            self._succ[v] = {}
-            self._pred[v] = {}
+        self.add_node(u)
+        self.add_node(v)
 
         # add the edge
         self._succ[u][v] = True
@@ -137,6 +138,24 @@ class DiGraph:
                     working_set.append(n)
 
         return result_graph.to_dot()
+
+    def first_path(self, dst: str) -> List[str]:
+        """Returns a list of nodes that show the first path that resulted in dst being added to the graph."""
+        path = []
+
+        while dst:
+            path.append(dst)
+            candidates = self._pred[dst].keys()
+            dst, min_idx = "", None
+            for candidate in candidates:
+                idx = self._node_order.get(candidate, None)
+                if idx is None:
+                    break
+                if min_idx is None or idx < min_idx:
+                    min_idx = idx
+                    dst = candidate
+
+        return list(reversed(path))
 
     def to_dot(self) -> str:
         """Returns the dot representation of the graph.

--- a/torch/package/analyze/__init__.py
+++ b/torch/package/analyze/__init__.py
@@ -1,3 +1,6 @@
+from .find_first_use_of_broken_modules import (
+    find_first_use_of_broken_modules,
+)
 from .trace_dependencies import (
     trace_dependencies,
 )

--- a/torch/package/analyze/find_first_use_of_broken_modules.py
+++ b/torch/package/analyze/find_first_use_of_broken_modules.py
@@ -1,0 +1,29 @@
+from typing import Dict, List
+
+from ..package_exporter import PackagingError
+
+
+def find_first_use_of_broken_modules(exc: PackagingError) -> Dict[str, List[str]]:
+    """
+    Find all broken modules in a PackagingError, and for each one, return the
+    dependency path in which the module was first encountered.
+
+    E.g. broken module m.n.o was added to a dependency graph while processing a.b.c,
+    then re-encountered while processing d.e.f. This method would return
+    {'m.n.o': ['a', 'b', 'c']}
+
+    Args:
+        exc: a PackagingError
+
+    Returns: A dict from broken module names to lists of module names in the path.
+    """
+
+    assert isinstance(exc, PackagingError), "exception must be a PackagingError"
+    uses = {}
+    broken_module_names = [
+        m for m, attr in exc.dependency_graph.nodes.items() if attr.get("error", False)
+    ]
+    for module_name in broken_module_names:
+        path = exc.dependency_graph.first_path(module_name)
+        uses[module_name] = path
+    return uses


### PR DESCRIPTION
Summary: this is a cleaned-up version of a util that I commonly use to figure out where new transitive (surprise!) dependencies come from when a model breaks, since it can be difficult in large models to tell exactly what code change indirectly added the depdendency. I tried to keep the opinionated bits out of OSS as much as possible.

Differential Revision: D35265017

