### PR TITLE
Abate spurious resize warnings in `MultiMarginLoss` on CUDA

### DIFF
--- a/aten/src/ATen/native/cuda/MultiMarginLoss.cu
+++ b/aten/src/ATen/native/cuda/MultiMarginLoss.cu
@@ -114,7 +114,7 @@ __global__ void MultiMarginLoss_backward_kernel(
   }
 }
 
-void multi_margin_loss_shape_check(
+void multi_margin_loss_shape_check(int &nframe,
     const Tensor &input, const Tensor &target) {
   auto in_sizes = input.sizes();
   auto dims = in_sizes.size();
@@ -124,7 +124,7 @@ void multi_margin_loss_shape_check(
       "Expected non-empty vector or matrix with optional 0-dim batch size, but got: ",
       in_sizes);
 
-  int64_t nframe = dims <= 1 ? 1 : in_sizes[0];
+  nframe = dims <= 1 ? 1 : in_sizes[0];
   TORCH_CHECK(
       target.dim() <= 1 && target.numel() == nframe,
       "inconsistent target size, expected ", nframe, " but got ",
@@ -138,21 +138,19 @@ Tensor& multi_margin_loss_cuda_out(
     const c10::optional<Tensor> &weights_, int64_t reduction, Tensor& out_) {
   auto p = p_.toLong();
   TORCH_CHECK(p == 1 || p == 2, "multi_margin_loss: Invalid p, expected 1 or 2 but got ", p);
-  multi_margin_loss_shape_check(input_, target_);
 
-  if (reduction == at::Reduction::None) {
-    resize_output(out_, target_.sizes());
-  } else if (input_.dim() == 2) {
-    resize_output(out_, {input_.sizes()[0]});
+  int nframe;
+  multi_margin_loss_shape_check(nframe, input_, target_);
+
+  // produce a scalar output for 1d input
+  if (reduction == Reduction::None && target_.dim() > 0) {
+    resize_output(out_, {nframe});
   } else {
     resize_output(out_, {});
   }
-
   if (input_.numel() == 0) {
     return out_;
   }
-
-  bool need_resize_ = false;
 
   auto input = input_.contiguous();
   auto target = target_.contiguous();
@@ -168,7 +166,6 @@ Tensor& multi_margin_loss_cuda_out(
   AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(), "multi_margin_loss_cuda", [&] {
     const scalar_t margin = margin_.to<scalar_t>();
     if (input.dim() <= 1) {
-      int nframe = 1;
       TORCH_CHECK(target.dim() <= 1 && target.numel() == nframe, "inconsistent target size");
       dim3 blocks(1);
       dim3 threads(MULTIMARGIN_THREADS);
@@ -198,7 +195,6 @@ Tensor& multi_margin_loss_cuda_out(
     } else {
       auto in_sizes = input.sizes();
       TORCH_INTERNAL_ASSERT(in_sizes.size() == 2);
-      int nframe = in_sizes[0];
       // allow zero-dim target for 2D input.
       TORCH_CHECK(in_sizes[1] != 0 && target.dim() <= 1 && target.numel() == nframe,
                 "inconsistent target size");
@@ -250,17 +246,13 @@ Tensor& multi_margin_loss_cuda_out(
               margin);
           C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
-        out = at::sum(tmp_output, /*dims=*/IntArrayRef{});
-        need_resize_ = true;
+        at::sum_out(out, tmp_output, IntArrayRef{});
       }
     }
   });
 
   if (!out.is_alias_of(out_)) {
     out_.copy_(out);
-    if (need_resize_) {
-        out_.resize_({});
-    }
   }
   return out_;
 }
@@ -280,7 +272,8 @@ Tensor& multi_margin_loss_cuda_backward_out(
   auto p = p_.toLong();
   TORCH_CHECK(p == 1 || p == 2,
               "multi_margin_loss_backward: Invalid p, expected 1 or 2 but got ", p);
-  multi_margin_loss_shape_check(input_, target_);
+  int nframe;
+  multi_margin_loss_shape_check(nframe, input_, target_);
   resize_output(grad_input_, input_.sizes());
 
   if (input_.numel() == 0) {
@@ -337,7 +330,6 @@ Tensor& multi_margin_loss_cuda_backward_out(
     } else {
       auto in_sizes = input.sizes();
       TORCH_INTERNAL_ASSERT(in_sizes.size() == 2);
-      int nframe = in_sizes[0];
       TORCH_CHECK((in_sizes[1] != 0) && (target.dim() <= 1) && (target.numel() == nframe),
                   "inconsistent target size");
       dim3 blocks(in_sizes[0]);

--- a/aten/src/ATen/native/cuda/MultiMarginLoss.cu
+++ b/aten/src/ATen/native/cuda/MultiMarginLoss.cu
@@ -248,6 +248,7 @@ Tensor& multi_margin_loss_cuda_out(
               margin);
           C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
+        out = at::empty({0}, out.options());
         at::sum_out(out, tmp_output, /*dims=*/IntArrayRef{});
       }
     }
@@ -262,7 +263,7 @@ Tensor& multi_margin_loss_cuda_out(
 Tensor multi_margin_loss_cuda(
     const Tensor &input, const Tensor &target, const Scalar &p, const Scalar &margin,
     const c10::optional<Tensor> &weights, int64_t reduction) {
-  auto out = at::empty({}, input.options());
+  auto out = at::empty({0}, input.options());
   multi_margin_loss_cuda_out(input, target, p, margin, weights, reduction, out);
   return out;
 }


### PR DESCRIPTION
The current `multi_margin_loss_cuda_out` implementation has a few cases where an output is intended to have shape `{0}` before resizing but is improperly set before this step, triggering `UserWarning`s. This PR changes the initial `at::empty` call to avoid this warning and alters the current resizing logic to match that of the CPU version to avoid the warning when calling `at::sum_out`.

The original issue was reported from the user forum by @hadaev8 [here](https://discuss.pytorch.org/t/warning-spam-then-using-multimarginloss/147492).

CC @ptrblck

Original repro provided by @hadaev8:
```
import torch
from torch import nn
from torch.nn import functional as F

bs = 56
model = nn.Linear(128, 22).cuda()
loss = nn.MultiMarginLoss()
x = torch.rand((bs, 128)).cuda()
targets = torch.randint(22, (bs,)).cuda()
out = model(x)
print(targets.shape)
print(out.shape)
loss(out, targets)
```