### PR TITLE
[PyTorchEdge] Backport from v9 flatbuffer to v8 pickle

### DIFF
--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -122,7 +122,7 @@ constexpr uint64_t kMinProducedFileFormatVersion = 0x3L;
 //  Refer. See https://github.com/pytorch/pytorch/pull/63651 for details
 //  0x8L: Emit promoted operators as instructions.
 //  See https://github.com/pytorch/pytorch/pull/71662 for details
-constexpr uint64_t kProducedBytecodeVersion = 0x8L;
+constexpr uint64_t kProducedBytecodeVersion = 0x9L;
 
 // static_assert(
 //     kProducedBytecodeVersion >= kProducedFileFormatVersion,
@@ -135,7 +135,7 @@ constexpr uint64_t kProducedBytecodeVersion = 0x8L;
 // (in loader), we should support this model_version. For example, we provide a
 // wrapper to handle an updated operator.
 constexpr uint64_t kMinSupportedBytecodeVersion = 0x3L;
-constexpr uint64_t kMaxSupportedBytecodeVersion = 0x8L;
+constexpr uint64_t kMaxSupportedBytecodeVersion = 0x9L;
 
 } // namespace serialize
 } // namespace caffe2

--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -355,6 +355,7 @@ TEST(SerializeTest, ErrorOnMissingKey) {
   // We want the errors to contain hierarchy information, too.
   ASSERT_THROWS_WITH(
       torch::load(model2, stream), "No such serialized tensor 'a.b.x'");
+  stream.seekg(0, stream.beg);
   ASSERT_THROWS_WITH(
       torch::load(model3, stream), "No such serialized submodule: 'a.x'");
 }

--- a/test/cpp/jit/test_backend.cpp
+++ b/test/cpp/jit/test_backend.cpp
@@ -276,6 +276,7 @@ TEST(BackendTest, TestConsistencyOfCompositeWithSetStates) {
   c._save_for_mobile(ss);
   auto mc = _load_for_mobile(ss);
   auto res_mobile = mc.forward(inputs);
+  ss.seekg(0, ss.beg);
 
   // check if the methods names are always the same
   // by reloading the script module and saving it back as mobile

--- a/test/cpp/jit/test_flatbuffer.cpp
+++ b/test/cpp/jit/test_flatbuffer.cpp
@@ -249,6 +249,23 @@ TEST(FlatbufferTest, Inline) {
   AT_ASSERT(output.toTensor().item<float>() == 7.0);
 }
 
+#if defined ENABLE_FLATBUFFER
+TEST(FlatbufferTest, GetByteCodeVersion) {
+  Module m("m");
+  m.define(R"(
+    def forward(self, input: Tensor):
+      return input + 1
+  )");
+  std::stringstream ss;
+  m._save_for_mobile(ss, {}, false, true);
+  auto version = _get_model_bytecode_version(ss);
+  AT_ASSERT(version == caffe2::serialize::kProducedBytecodeVersion);
+  ss.seekg(0, ss.beg);
+  auto version_again = _get_model_bytecode_version(ss);
+  AT_ASSERT(version == version_again);
+}
+#endif
+
 TEST(FlatbufferTest, Tuple) {
   Module m("m");
   m.define(R"JIT(

--- a/test/cpp/jit/test_flatbuffer.cpp
+++ b/test/cpp/jit/test_flatbuffer.cpp
@@ -1177,6 +1177,7 @@ Module jitModuleFromBuffer(void* data) {
       mobilem._ivalue(), files, constants, 8);
 }
 
+#if defined(ENABLE_FLATBUFFER)
 TEST(TestSourceFlatbuffer, UpsampleNearest2d) {
   Module m("m");
   m.define(R"(
@@ -1189,20 +1190,21 @@ TEST(TestSourceFlatbuffer, UpsampleNearest2d) {
   inputs.emplace_back(at::Scalar(2.0));
   auto ref = m.forward(inputs);
 
-  auto data = save_jit_module_to_bytes(m);
-  Module m2 = jitModuleFromBuffer(data.data());
+  std::stringstream ss;
+  m._save_for_mobile(ss, {}, false, /*use_fatbuffer=*/true);
+  auto mm = _load_for_mobile(ss);
+  auto m2 = load(ss);
+
   auto res = m2.forward(inputs);
+  auto resm = mm.forward(inputs);
 
   auto resd = res.toTensor();
   auto refd = ref.toTensor();
+  auto resmd = resm.toTensor();
   ASSERT_TRUE(resd.equal(refd));
-
-  mobile::Module m3 = parse_mobile_module(data.data(), data.size());
-  res = m3.forward(inputs);
-  resd = res.toTensor();
-  refd = ref.toTensor();
-  ASSERT_TRUE(resd.equal(refd));
+  ASSERT_TRUE(resmd.equal(refd));
 }
+#endif
 
 TEST(TestSourceFlatbuffer, CheckAttrAccess) {
   Module m("m");

--- a/test/cpp/jit/test_flatbuffer.cpp
+++ b/test/cpp/jit/test_flatbuffer.cpp
@@ -23,6 +23,7 @@
 #include <torch/custom_class.h>
 #include <torch/torch.h>
 
+#include <caffe2/serialize/versions.h>
 #include <torch/csrc/jit/serialization/import_export_functions.h>
 #include <unordered_set>
 // Tests go in torch::jit
@@ -136,6 +137,23 @@ TEST(FlatbufferTest, MethodInvocation) { // NOLINT (use =delete in gtest)
     AT_ASSERT(resd2 == refd);
   }
 }
+
+#if defined(ENABLE_FLATBUFFER)
+TEST(FlatbufferTest, FlatbufferBackPortTest) {
+  Module m("m");
+  m.define(R"(
+    def forward(self, input: Tensor, scale:float):
+      return torch.upsample_nearest2d(input, [1, 1], float(scale), float(scale))
+  )");
+  std::stringstream ss;
+  m._save_for_mobile(ss, {}, false, true);
+
+  std::stringstream oss;
+  bool backPortSuccess = _backport_for_mobile(
+      ss, oss, caffe2::serialize::kMinSupportedBytecodeVersion + 1);
+  ASSERT_TRUE(backPortSuccess);
+}
+#endif // defined(ENABLE_FLATBUFFER)
 
 TEST(FlatbufferTest, ExtraFiles) {
   const auto script = R"JIT(

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -720,7 +720,7 @@ TEST(LiteInterpreterTest, BackPortByteCodeModelAllVersions) {
   torch::jit::Module module_freeze = freeze(module);
 
   std::stringstream input_model_stream;
-  module_freeze._save_for_mobile(input_model_stream);
+  module_freeze._save_for_mobile(input_model_stream, {}, false, true);
   std::vector<IValue> input_data =
       std::vector<IValue>({torch::ones({1, 1, 28, 28})});
   std::vector<IValue> expect_result_list;

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -655,13 +655,18 @@ void backportAllVersionCheck(
     AT_ASSERT(backPortSuccess);
 
     // Check backport model version
+    auto before = oss.tellg();
     auto backport_version = _get_model_bytecode_version(oss);
+    auto after = oss.tellg();
+    AT_ASSERT(before == after);
+    backport_version = _get_model_bytecode_version(oss);
     AT_ASSERT(backport_version == current_to_version);
 
     // Load and run the backport model, then compare the result with expect
     // result
     runAndCheckBytecodeModel(
         oss, input_data, expect_result_list, current_to_version);
+    oss.seekg(0, oss.beg);
     runAndCheckTorchScriptModel(
         oss, input_data, expect_result_list, current_to_version);
 

--- a/torch/csrc/jit/mobile/compatibility/backport.cpp
+++ b/torch/csrc/jit/mobile/compatibility/backport.cpp
@@ -21,7 +21,7 @@ const static BackportManager backportManager;
 // Forward declare so that _backport_for_mobile() overloads can
 // call this method directly.
 bool _backport_for_mobile_impl(
-    std::shared_ptr<IStreamAdapter> istream_adapter,
+    std::istream& oss,
     PyTorchStreamWriter& writer,
     const int64_t to_version);
 
@@ -29,24 +29,20 @@ bool _backport_for_mobile(
     std::istream& in,
     std::ostream& out,
     const int64_t to_version) {
-  std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
   auto writer_func = [&](const void* buf, size_t nbytes) -> size_t {
     out.write(static_cast<const char*>(buf), nbytes);
     return !out ? 0 : nbytes;
   };
   PyTorchStreamWriter writer(writer_func);
-  return _backport_for_mobile_impl(std::move(rai), writer, to_version);
+  return _backport_for_mobile_impl(in, writer, to_version);
 }
 
 bool _backport_for_mobile(
     std::istream& in,
     const std::string& output_filename,
     const int64_t to_version) {
-  std::unique_ptr<IStreamAdapter> istream_adapter =
-      std::make_unique<IStreamAdapter>(&in);
   PyTorchStreamWriter writer(output_filename);
-  return _backport_for_mobile_impl(
-      std::move(istream_adapter), writer, to_version);
+  return _backport_for_mobile_impl(in, writer, to_version);
 }
 
 bool _backport_for_mobile(
@@ -59,15 +55,13 @@ bool _backport_for_mobile(
   if (!file_stream) {
     AT_ERROR("open file failed, file path: ", input_filename);
   }
-  istream_adapter = std::make_unique<IStreamAdapter>(&file_stream);
-
   auto writer_func = [&](const void* buf, size_t nbytes) -> size_t {
     out.write(static_cast<const char*>(buf), nbytes);
     return !out ? 0 : nbytes;
   };
+
   PyTorchStreamWriter writer(writer_func);
-  return _backport_for_mobile_impl(
-      std::move(istream_adapter), writer, to_version);
+  return _backport_for_mobile_impl(file_stream, writer, to_version);
 }
 
 bool _backport_for_mobile(
@@ -75,28 +69,25 @@ bool _backport_for_mobile(
     const std::string& output_filename,
     const int64_t to_version) {
   std::ifstream file_stream;
-  std::unique_ptr<IStreamAdapter> istream_adapter;
   file_stream.open(input_filename, std::ifstream::in | std::ifstream::binary);
   if (!file_stream) {
     AT_ERROR("open file failed, file path: ", input_filename);
   }
-  istream_adapter = std::make_unique<IStreamAdapter>(&file_stream);
 
   PyTorchStreamWriter writer(output_filename);
-  return _backport_for_mobile_impl(
-      std::move(istream_adapter), writer, to_version);
+  return _backport_for_mobile_impl(file_stream, writer, to_version);
 }
 
 bool _backport_for_mobile_impl(
-    std::shared_ptr<IStreamAdapter> istream_adapter,
+    std::istream& oss,
     PyTorchStreamWriter& writer,
     const int64_t to_version) {
   if (!backportManager.hasBytecodeBackportFunction(to_version + 1)) {
     return false;
   }
-  auto from_version = _get_model_bytecode_version(istream_adapter);
-  return backportManager.backport(
-      istream_adapter, writer, from_version, to_version);
+  oss.seekg(0, oss.beg);
+  auto from_version = _get_model_bytecode_version(oss);
+  return backportManager.backport(oss, writer, from_version, to_version);
 }
 
 } // namespace jit

--- a/torch/csrc/jit/mobile/compatibility/backport_manager.h
+++ b/torch/csrc/jit/mobile/compatibility/backport_manager.h
@@ -34,7 +34,7 @@ class BackportManager final {
   bytecodeBackportFunctions() const;
 
   bool backport(
-      std::shared_ptr<caffe2::serialize::IStreamAdapter> istream_adapter,
+      std::istream& oss,
       caffe2::serialize::PyTorchStreamWriter& final_writer,
       int64_t from_version,
       int64_t to_version) const;

--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -663,5 +663,27 @@ mobile::Module load_mobile_module_from_file(
   return parse_and_initialize_mobile_module(std::move(data), size, device);
 }
 
+uint64_t get_bytecode_version(std::istream& in) {
+  std::shared_ptr<char> data;
+  size_t size = 0;
+  std::tie(data, size) = get_stream_content(in);
+  TORCH_CHECK(
+      mobile::serialization::ModuleBufferHasIdentifier(data.get()),
+      "Format error");
+  auto* flatbuffer_module = mobile::serialization::GetMutableModule(data.get());
+  return flatbuffer_module->bytecode_version();
+}
+
+uint64_t get_bytecode_version(const std::string& filename) {
+  std::shared_ptr<char> data;
+  size_t size = 0;
+  std::tie(data, size) = get_file_content(filename.c_str());
+  TORCH_CHECK(
+      mobile::serialization::ModuleBufferHasIdentifier(data.get()),
+      "Format error");
+  auto* flatbuffer_module = mobile::serialization::GetMutableModule(data.get());
+  return flatbuffer_module->bytecode_version();
+}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/mobile/flatbuffer_loader.h
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.h
@@ -62,6 +62,9 @@ TORCH_API std::tuple<std::shared_ptr<char>, size_t> get_file_content(
 TORCH_API std::tuple<std::shared_ptr<char>, size_t> get_stream_content(
     std::istream& in);
 
+TORCH_API uint64_t get_bytecode_version(std::istream& in);
+TORCH_API uint64_t get_bytecode_version(const std::string& filename);
+
 class TORCH_API FlatbufferLoader {
  public:
   FlatbufferLoader();

--- a/torch/csrc/jit/mobile/module.h
+++ b/torch/csrc/jit/mobile/module.h
@@ -135,12 +135,21 @@ class TORCH_API Module {
     mem_to_delete_ = delete_mem;
   }
 
+  void set_bytecode_version(int64_t version) {
+    bytecode_version_ = version;
+  }
+
+  int64_t bytecode_version() const {
+    return bytecode_version_;
+  }
+
  private:
   c10::intrusive_ptr<c10::ivalue::Object> object_;
   std::unordered_map<std::string, std::string> metadata_;
   std::shared_ptr<CompilationUnit> cu_;
   MobileDebugTable debug_table_;
   bool has_debug_handles_ = false;
+  int64_t bytecode_version_;
 
   // Extra handle for the module to delete when itself is deleted
   std::shared_ptr<char> mem_to_delete_;

--- a/torch/csrc/jit/serialization/export_bytecode.cpp
+++ b/torch/csrc/jit/serialization/export_bytecode.cpp
@@ -377,6 +377,8 @@ mobile::Module jitModuleToMobile(
       backend_debug_info_map.begin(), backend_debug_info_map.end());
   m.setDebugTable(MobileDebugTable(
       debug_handle_cs_ptr_map.begin(), debug_handle_cs_ptr_map.end()));
+
+  m.set_bytecode_version(options.model_version);
   return m;
 }
 

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -797,9 +797,13 @@ void save_mobile_module_to(
     const ExtraFilesMap& extra_files,
     bool save_mobile_debug_info,
     const std::function<size_t(const void*, size_t)>& writer_func) {
+  ExtraFilesMap jitFiles;
   CompilationOptions options = getOptionsFromGlobal();
+  std::vector<IValue> constants;
+  jitModuleToPythonCodeAndConstants(module, &jitFiles, &constants);
   mobile::Module mod = jitModuleToMobile(module, options);
-  auto buffer = save_mobile_module_to_bytes(mod, extra_files);
+  auto buffer =
+      save_mobile_module_to_bytes(mod, extra_files, jitFiles, constants);
   writer_func(reinterpret_cast<void*>(buffer.data()), buffer.size());
 }
 #endif

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -764,11 +764,13 @@ flatbuffers::DetachedBuffer save_mobile_module_to_bytes(
 
 Module parse_and_initialize_jit_module(
     std::shared_ptr<char> data,
-    size_t,
-    c10::optional<at::Device>) {
+    size_t size,
+    c10::optional<at::Device> device,
+    ExtraFilesMap& extra_files) {
   auto* flatbuffer_module = mobile::serialization::GetMutableModule(data.get());
   FlatbufferLoader loader;
   mobile::Module mobilem = loader.parseModule(flatbuffer_module);
+  parseExtraFiles(flatbuffer_module, extra_files);
   ExtraFilesMap files;
   std::vector<IValue> constants;
   loader.extractJitSourceAndConstants(&files, &constants);
@@ -783,18 +785,20 @@ Module parse_and_initialize_jit_module(
 
 Module load_jit_module_from_file(
     const std::string& filename,
+    ExtraFilesMap& extra_files,
     c10::optional<at::Device> device) {
   auto data = get_file_content(filename.c_str());
   return parse_and_initialize_jit_module(
-      std::move(std::get<0>(data)), std::get<1>(data), device);
+      std::move(std::get<0>(data)), std::get<1>(data), device, extra_files);
 }
 
 Module load_jit_module_from_stream(
     std::istream& in,
+    ExtraFilesMap& extra_files,
     c10::optional<at::Device> device) {
   auto data = get_stream_content(in);
   return parse_and_initialize_jit_module(
-      std::move(std::get<0>(data)), std::get<1>(data), device);
+      std::move(std::get<0>(data)), std::get<1>(data), device, extra_files);
 }
 
 void save_jit_module(

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -386,9 +386,12 @@ flatbuffers::DetachedBuffer FlatbufferSerializer::serializeModule(
     jit_constants_indexes.emplace_back(storeIValueAndGetIndex(fbb, ival));
   }
 
+  const uint32_t bytecode_version =
+      static_cast<uint32_t>(module.bytecode_version());
+
   auto mod = CreateModule(
       fbb,
-      0, /* version */
+      /*bytecode_version=*/bytecode_version,
       extra_files_offset, /* extra_files */
       functions_offset,
       ivalue_index,
@@ -770,7 +773,10 @@ Module parse_and_initialize_jit_module(
   std::vector<IValue> constants;
   loader.extractJitSourceAndConstants(&files, &constants);
   Module m = jitModuleFromSourceAndConstants(
-      mobilem._ivalue(), files, constants, flatbuffer_module->version());
+      mobilem._ivalue(),
+      files,
+      constants,
+      flatbuffer_module->bytecode_version());
   m.set_delete_memory(data);
   return m;
 }

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -789,6 +789,14 @@ Module load_jit_module_from_file(
       std::move(std::get<0>(data)), std::get<1>(data), device);
 }
 
+Module load_jit_module_from_stream(
+    std::istream& in,
+    c10::optional<at::Device> device) {
+  auto data = get_stream_content(in);
+  return parse_and_initialize_jit_module(
+      std::move(std::get<0>(data)), std::get<1>(data), device);
+}
+
 void save_jit_module(
     const Module& module,
     const std::string& filename,

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.h
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.h
@@ -41,14 +41,17 @@ TORCH_API flatbuffers::DetachedBuffer save_jit_module_to_bytes(
 TORCH_API Module parse_and_initialize_jit_module(
     std::shared_ptr<char> data,
     size_t size,
+    ExtraFilesMap& extra_files,
     c10::optional<at::Device> device = c10::nullopt);
 
 TORCH_API Module load_jit_module_from_file(
     const std::string& filename,
+    ExtraFilesMap& extra_files,
     c10::optional<at::Device> device = c10::nullopt);
 
 TORCH_API Module load_jit_module_from_stream(
     std::istream& in,
+    ExtraFilesMap& extra_files,
     c10::optional<at::Device> device = c10::nullopt);
 
 } // namespace jit

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.h
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.h
@@ -47,5 +47,9 @@ TORCH_API Module load_jit_module_from_file(
     const std::string& filename,
     c10::optional<at::Device> device = c10::nullopt);
 
+TORCH_API Module load_jit_module_from_stream(
+    std::istream& in,
+    c10::optional<at::Device> device = c10::nullopt);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -366,7 +366,7 @@ Module load(
   switch (format) {
     case FileFormat::FlatbufferFileFormat: {
 #if defined(ENABLE_FLATBUFFER)
-      return load_jit_module_from_stream(in, device);
+      return load_jit_module_from_stream(in, extra_files, device);
 #else
       TORCH_CHECK(
           false, "Flatbuffer input file but the build hasn't enable flatbuffer")
@@ -397,7 +397,7 @@ Module load(
   switch (format) {
     case FileFormat::FlatbufferFileFormat: {
 #if defined(ENABLE_FLATBUFFER)
-      return load_jit_module_from_file(filename, device);
+      return load_jit_module_from_file(filename, extra_files, device);
 #else
       TORCH_CHECK(
           false, "Flatbuffer input file but the build hasn't enable flatbuffer")

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -10,6 +10,7 @@
 #endif
 #include <torch/csrc/jit/frontend/script_type_parser.h>
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/mobile/file_format.h>
 #include <torch/csrc/jit/operator_upgraders/upgraders_entry.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/serialization/import_read.h>
@@ -17,6 +18,10 @@
 #include <torch/csrc/jit/serialization/pickle.h>
 #include <torch/csrc/jit/serialization/source_range_serialization.h>
 #include <torch/csrc/jit/serialization/unpickler.h>
+
+#if defined(ENABLE_FLATBUFFER)
+#include <torch/csrc/jit/serialization/flatbuffer_serializer.h>
+#endif
 
 #include <caffe2/serialize/file_adapter.h>
 #include <caffe2/serialize/inline_container.h>
@@ -357,9 +362,26 @@ Module load(
     std::istream& in,
     c10::optional<at::Device> device,
     ExtraFilesMap& extra_files) {
-  std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
-  auto module = load(std::move(rai), device, extra_files);
-  return module;
+  auto format = getFileFormat(in);
+  switch (format) {
+    case FileFormat::FlatbufferFileFormat: {
+#if defined(ENABLE_FLATBUFFER)
+      return load_jit_module_from_stream(in, device);
+#else
+      TORCH_CHECK(
+          false, "Flatbuffer input file but the build hasn't enable flatbuffer")
+#endif
+    }
+    case FileFormat::ZipFileFormat: {
+      std::unique_ptr<IStreamAdapter> rai =
+          std::make_unique<IStreamAdapter>(&in);
+      auto module = load(std::move(rai), device, extra_files);
+      return module;
+    }
+
+    default:
+      TORCH_CHECK(false, "Unrecognized data format");
+  }
 }
 
 Module load(const std::string& filename, c10::optional<at::Device> device) {
@@ -371,9 +393,27 @@ Module load(
     const std::string& filename,
     c10::optional<at::Device> device,
     ExtraFilesMap& extra_files) {
-  std::unique_ptr<FileAdapter> rai = std::make_unique<FileAdapter>(filename);
-  auto module = load(std::move(rai), device, extra_files);
-  return module;
+  auto format = getFileFormat(filename);
+  switch (format) {
+    case FileFormat::FlatbufferFileFormat: {
+#if defined(ENABLE_FLATBUFFER)
+      return load_jit_module_from_file(filename, device);
+#else
+      TORCH_CHECK(
+          false, "Flatbuffer input file but the build hasn't enable flatbuffer")
+#endif
+
+      case FileFormat::ZipFileFormat: {
+        std::unique_ptr<FileAdapter> rai =
+            std::make_unique<FileAdapter>(filename);
+        auto module = load(std::move(rai), device, extra_files);
+        return module;
+      }
+
+      default:
+        TORCH_CHECK(false, "Unrecognized data format");
+    }
+  }
 }
 
 Module load(
@@ -387,8 +427,8 @@ Module load(
     std::shared_ptr<ReadAdapterInterface> rai,
     c10::optional<c10::Device> device,
     ExtraFilesMap& extra_files) {
-  // Verify that we're loading a zip archive and not a torch.save pickle archive
-  // (marked by the 0x80 0x02 bytes at the start)
+  // Verify that we're loading a zip archive and not a torch.save pickle
+  // archive (marked by the 0x80 0x02 bytes at the start)
   // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
   TORCH_CHECK(
       check_zip_file(rai),

--- a/torch/csrc/jit/serialization/mobile_bytecode.fbs
+++ b/torch/csrc/jit/serialization/mobile_bytecode.fbs
@@ -186,7 +186,11 @@ table ExtraFile {
 }
 
 table Module {
-  version:int;
+  // denotes the bytecode version of the mobile Module
+  // this starts from 9 for a flatbuffer file
+  // versions 8 and below are reserved pickle
+  bytecode_version:uint;
+
   extra_files:[ExtraFile];
   methods:[uint];  // index to ivalues
   state_obj:uint; // index to ivalues
@@ -196,6 +200,10 @@ table Module {
   object_types:[ObjectType];
   jit_sources:[ExtraFile];
   jit_constants:[uint];  // index to ivalues
+
+  // version of operator, depends on operators used
+  // this is used for operator versioning
+  operator_version:uint;
 }
 
 root_type Module;

--- a/torch/csrc/jit/serialization/mobile_bytecode_generated.h
+++ b/torch/csrc/jit/serialization/mobile_bytecode_generated.h
@@ -2218,7 +2218,7 @@ inline flatbuffers::Offset<ExtraFile> CreateExtraFileDirect(
 struct Module FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef ModuleBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_VERSION = 4,
+    VT_BYTECODE_VERSION = 4,
     VT_EXTRA_FILES = 6,
     VT_METHODS = 8,
     VT_STATE_OBJ = 10,
@@ -2227,13 +2227,14 @@ struct Module FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_STORAGE_DATA = 16,
     VT_OBJECT_TYPES = 18,
     VT_JIT_SOURCES = 20,
-    VT_JIT_CONSTANTS = 22
+    VT_JIT_CONSTANTS = 22,
+    VT_OPERATOR_VERSION = 24
   };
-  int32_t version() const {
-    return GetField<int32_t>(VT_VERSION, 0);
+  uint32_t bytecode_version() const {
+    return GetField<uint32_t>(VT_BYTECODE_VERSION, 0);
   }
-  bool mutate_version(int32_t _version = 0) {
-    return SetField<int32_t>(VT_VERSION, _version, 0);
+  bool mutate_bytecode_version(uint32_t _bytecode_version = 0) {
+    return SetField<uint32_t>(VT_BYTECODE_VERSION, _bytecode_version, 0);
   }
   const flatbuffers::Vector<flatbuffers::Offset<torch::jit::mobile::serialization::ExtraFile>> *extra_files() const {
     return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<torch::jit::mobile::serialization::ExtraFile>> *>(VT_EXTRA_FILES);
@@ -2289,9 +2290,15 @@ struct Module FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   flatbuffers::Vector<uint32_t> *mutable_jit_constants() {
     return GetPointer<flatbuffers::Vector<uint32_t> *>(VT_JIT_CONSTANTS);
   }
+  uint32_t operator_version() const {
+    return GetField<uint32_t>(VT_OPERATOR_VERSION, 0);
+  }
+  bool mutate_operator_version(uint32_t _operator_version = 0) {
+    return SetField<uint32_t>(VT_OPERATOR_VERSION, _operator_version, 0);
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<int32_t>(verifier, VT_VERSION) &&
+           VerifyField<uint32_t>(verifier, VT_BYTECODE_VERSION) &&
            VerifyOffset(verifier, VT_EXTRA_FILES) &&
            verifier.VerifyVector(extra_files()) &&
            verifier.VerifyVectorOfTables(extra_files()) &&
@@ -2313,6 +2320,7 @@ struct Module FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVectorOfTables(jit_sources()) &&
            VerifyOffset(verifier, VT_JIT_CONSTANTS) &&
            verifier.VerifyVector(jit_constants()) &&
+           VerifyField<uint32_t>(verifier, VT_OPERATOR_VERSION) &&
            verifier.EndTable();
   }
 };
@@ -2321,8 +2329,8 @@ struct ModuleBuilder {
   typedef Module Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_version(int32_t version) {
-    fbb_.AddElement<int32_t>(Module::VT_VERSION, version, 0);
+  void add_bytecode_version(uint32_t bytecode_version) {
+    fbb_.AddElement<uint32_t>(Module::VT_BYTECODE_VERSION, bytecode_version, 0);
   }
   void add_extra_files(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<torch::jit::mobile::serialization::ExtraFile>>> extra_files) {
     fbb_.AddOffset(Module::VT_EXTRA_FILES, extra_files);
@@ -2351,6 +2359,9 @@ struct ModuleBuilder {
   void add_jit_constants(flatbuffers::Offset<flatbuffers::Vector<uint32_t>> jit_constants) {
     fbb_.AddOffset(Module::VT_JIT_CONSTANTS, jit_constants);
   }
+  void add_operator_version(uint32_t operator_version) {
+    fbb_.AddElement<uint32_t>(Module::VT_OPERATOR_VERSION, operator_version, 0);
+  }
   explicit ModuleBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -2364,7 +2375,7 @@ struct ModuleBuilder {
 
 inline flatbuffers::Offset<Module> CreateModule(
     flatbuffers::FlatBufferBuilder &_fbb,
-    int32_t version = 0,
+    uint32_t bytecode_version = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<torch::jit::mobile::serialization::ExtraFile>>> extra_files = 0,
     flatbuffers::Offset<flatbuffers::Vector<uint32_t>> methods = 0,
     uint32_t state_obj = 0,
@@ -2373,8 +2384,10 @@ inline flatbuffers::Offset<Module> CreateModule(
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<torch::jit::mobile::serialization::StorageData>>> storage_data = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<torch::jit::mobile::serialization::ObjectType>>> object_types = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<torch::jit::mobile::serialization::ExtraFile>>> jit_sources = 0,
-    flatbuffers::Offset<flatbuffers::Vector<uint32_t>> jit_constants = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<uint32_t>> jit_constants = 0,
+    uint32_t operator_version = 0) {
   ModuleBuilder builder_(_fbb);
+  builder_.add_operator_version(operator_version);
   builder_.add_jit_constants(jit_constants);
   builder_.add_jit_sources(jit_sources);
   builder_.add_object_types(object_types);
@@ -2384,13 +2397,13 @@ inline flatbuffers::Offset<Module> CreateModule(
   builder_.add_state_obj(state_obj);
   builder_.add_methods(methods);
   builder_.add_extra_files(extra_files);
-  builder_.add_version(version);
+  builder_.add_bytecode_version(bytecode_version);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<Module> CreateModuleDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    int32_t version = 0,
+    uint32_t bytecode_version = 0,
     const std::vector<flatbuffers::Offset<torch::jit::mobile::serialization::ExtraFile>> *extra_files = nullptr,
     const std::vector<uint32_t> *methods = nullptr,
     uint32_t state_obj = 0,
@@ -2399,7 +2412,8 @@ inline flatbuffers::Offset<Module> CreateModuleDirect(
     const std::vector<flatbuffers::Offset<torch::jit::mobile::serialization::StorageData>> *storage_data = nullptr,
     const std::vector<flatbuffers::Offset<torch::jit::mobile::serialization::ObjectType>> *object_types = nullptr,
     const std::vector<flatbuffers::Offset<torch::jit::mobile::serialization::ExtraFile>> *jit_sources = nullptr,
-    const std::vector<uint32_t> *jit_constants = nullptr) {
+    const std::vector<uint32_t> *jit_constants = nullptr,
+    uint32_t operator_version = 0) {
   auto extra_files__ = extra_files ? _fbb.CreateVector<flatbuffers::Offset<torch::jit::mobile::serialization::ExtraFile>>(*extra_files) : 0;
   auto methods__ = methods ? _fbb.CreateVector<uint32_t>(*methods) : 0;
   auto ivalues__ = ivalues ? _fbb.CreateVector<flatbuffers::Offset<torch::jit::mobile::serialization::IValue>>(*ivalues) : 0;
@@ -2409,7 +2423,7 @@ inline flatbuffers::Offset<Module> CreateModuleDirect(
   auto jit_constants__ = jit_constants ? _fbb.CreateVector<uint32_t>(*jit_constants) : 0;
   return torch::jit::mobile::serialization::CreateModule(
       _fbb,
-      version,
+      bytecode_version,
       extra_files__,
       methods__,
       state_obj,
@@ -2418,7 +2432,8 @@ inline flatbuffers::Offset<Module> CreateModuleDirect(
       storage_data__,
       object_types__,
       jit_sources__,
-      jit_constants__);
+      jit_constants__,
+      operator_version);
 }
 
 inline bool VerifyIValueUnion(flatbuffers::Verifier &verifier, const void *obj, IValueUnion type) {
@@ -2509,18 +2524,6 @@ inline const torch::jit::mobile::serialization::Module *GetModule(const void *bu
 inline Module* GetMutableModule(void* buf) {
   return flatbuffers::GetMutableRoot<Module>(buf);
 }
-
-// inline const torch::jit::mobile::serialization::Module
-// *GetSizePrefixedModule(const void *buf) {
-//   return
-//   flatbuffers::GetSizePrefixedRoot<torch::jit::mobile::serialization::Module>(buf);
-// }
-
-// inline torch::jit::mobile::serialization::Module
-// *GetMutableSizePrefixedModule(void *buf) {
-//   return
-//   flatbuffers::GetMutableSizePrefixedRoot<torch::jit::mobile::serialization::Module>(buf);
-// }
 
 inline const char *ModuleIdentifier() {
   return "PTMF";


### PR DESCRIPTION
Test Plan:
fb:
```
~/fbsource/fbcode] cd ~/fbsource/fbcode/ && buck test  -c fbcode.caffe2_enable_flatbuffer=1 caffe2/test/cpp/jit:jit -- LiteInterpreterTest.BackPortByteCodeModelAllVersions
Parsing buck files: finished in 0.7 sec
Downloaded 0/25 artifacts, 0.00 bytes, 100.0% cache miss (for updated rules)
Building: finished in 20.7 sec (100%) 21783/21783 jobs, 5/21783 updated
[pavithran@devvm5216.vll0 ~/fbsource/fbcode] cd ~/fbsource/fbcode/ && buck test caffe2/test/cpp/jit:jit -- FlatbufferTest.FlatbufferBackPortTest
Parsing buck files: finished in 0.7 sec
Building: finished in 4.5 sec (100%) 12972/53298 jobs, 0/53298 updated
  Total time: 5.3 sec
More details at https://www.internalfb.com/intern/buck/build/b658d597-d358-4293-97cb-28e7612b96e8
BUILD SUCCEEDED
Tpx test run coordinator for Facebook. See https://fburl.com/tpx for details.
Running with tpx session id: 35d5542d-6ee3-4c28-be10-1d822c7a6fef
Trace available for this run at /tmp/tpx-20220308-090347.891303-35d5542d-6ee3-4c28-be10-1d822c7a6fef/trace.log
RemoteExecution session id: reSessionID-35d5542d-6ee3-4c28-be10-1d822c7a6fef-tpx
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/8444249379196000
    ✓ ListingSuccess: caffe2/test/cpp/jit:jit : 490 tests discovered (22.838)
    ✓ Pass: caffe2/test/cpp/jit:jit - FlatbufferTest.FlatbufferBackPortTest (0.289)
Summary
  Pass: 1
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/8444249379196000
```

Differential Revision: D34702597

