### PR TITLE
[Model Averaging] Code simplification for _find_process_group function

### DIFF
--- a/torch/distributed/algorithms/model_averaging/hierarchical_model_averager.py
+++ b/torch/distributed/algorithms/model_averaging/hierarchical_model_averager.py
@@ -131,16 +131,17 @@ class HierarchicalModelAverager(averagers.ModelAverager):
 
     def _find_process_group(self):
         """
-        Returns a tuple consisting of whether ``step`` can be divided by
-        a period in the keys of ``period_process_group_dict`` and the associated process group if any.
+        Returns a process group as the value of an ``period_process_group_dict`` entry,
+        if ``step`` can be divided by a period in the keys of ``period_process_group_dict``.
         If ``step`` can be divided by multiple periods in the keys of ``period_process_group_dict``,
         then the returned process group is the one corresponding to the largest period,
         since this process group will be used for averaging parameters at this ``step``.
+        Returns ``None`` if not found.
         """
         for period in reversed(self._periods):
             if self.step % period == 0:
-                return (True, self.period_process_group_dict[period])
-        return (False, None)
+                return self.period_process_group_dict[period]
+        return None
 
     def average_parameters(self, params):
         r"""
@@ -151,7 +152,7 @@ class HierarchicalModelAverager(averagers.ModelAverager):
         only the largest period is used, and the corresponding process group is used for averaging parameters.
         """
         if self.step >= self.warmup_steps:
-            found, group = self._find_process_group()
-            if found:
+            group = self._find_process_group()
+            if group is not None:
                 utils.average_parameters(iter(params), group)
         self.step += 1


### PR DESCRIPTION
Previously the highest-level process group in `period_process_group_dict` could be `None`, indicating the global group. Now `period_process_group_dict` cannot contain `None` as a process group, so the function `_find_process_group` can just return a process group instead of a tuple -- when not found, just return `None`, because now the returned process group cannot be `None`.

Proposal: https://github.com/pytorch/pytorch/issues/71325