### PR TITLE
don't add extra shuffle in DataLoader2 if one is present

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -2188,7 +2188,7 @@ class TestDataLoader2(TestCase):
         self.assertEqual(items, list(dl))
 
         dl = DataLoader2(dp, batch_size=None, num_workers=2, shuffle=False,
-                        worker_init_fn=torch.utils.data.backward_compatibility.worker_init_fn)
+                         worker_init_fn=torch.utils.data.backward_compatibility.worker_init_fn)
         self.assertEqual(items, list(dl))
 
         dl = DataLoader2(dp, batch_size=None, num_workers=2, shuffle=True)
@@ -2196,20 +2196,15 @@ class TestDataLoader2(TestCase):
         self.assertEqual(items, sorted(list(dl)))
 
         dl = DataLoader2(dp, batch_size=None, num_workers=2, shuffle=True,
-                        worker_init_fn=torch.utils.data.backward_compatibility.worker_init_fn)
+                         worker_init_fn=torch.utils.data.backward_compatibility.worker_init_fn)
         self.assertNotEqual(items, list(dl))
         self.assertEqual(items, sorted(list(dl)))
 
         dl = DataLoader2(self.Sorter(dp), batch_size=None, num_workers=2, shuffle=True)
         self.assertEqual(list(dl), items)
 
-        dl = DataLoader2(
-            self.Sorter(dp),
-            batch_size=None,
-            num_workers=2,
-            shuffle=True,
-            worker_init_fn=torch.utils.data.backward_compatibility.worker_init_fn,
-        )
+        dl = DataLoader2(self.Sorter(dp), batch_size=None, num_workers=2, shuffle=True,
+                         worker_init_fn=torch.utils.data.backward_compatibility.worker_init_fn)
         self.assertEqual(list(dl), items)
 
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -229,7 +229,7 @@ class DataLoader(Generic[T_co]):
             # this, and support custom samplers that specify the assignments to
             # specific workers.
             if isinstance(dataset, IterDataPipe):
-                torch.utils.data.graph_settings.apply_shuffle_settings(dataset, shuffle=shuffle)
+                dataset = torch.utils.data.graph_settings.apply_shuffle_settings(dataset, shuffle=shuffle)
             elif shuffle is not False:
                 raise ValueError(
                     "DataLoader with IterableDataset: expected unspecified "

--- a/torch/utils/data/dataloader_experimental.py
+++ b/torch/utils/data/dataloader_experimental.py
@@ -9,6 +9,8 @@ import torch.utils.data.backward_compatibility
 import torch.utils.data.graph_settings
 from torch.utils.data import DataLoader, IterDataPipe, communication
 from torch.utils.data.datapipes.iter import IterableWrapper
+from torch.utils.data.graph import traverse
+from torch.utils.data.datapipes.iter import Shuffler
 
 
 class _ThreadingDataLoader2:
@@ -87,8 +89,11 @@ class DataLoader2:
                 raise Exception(
                     'sampler is not yet supported by DataPipes')
             datapipe = dataset
-            if shuffle:
-                # Enforce at least one shuffle in the graph
+            # Enforce at least one shuffle in the graph if shuffle=True
+            if shuffle and not any(
+                    isinstance(dp, Shuffler)
+                    for dp in torch.utils.data.graph_settings.get_all_graph_pipes(traverse(dataset, only_datapipe=True))
+            ):
                 datapipe = datapipe.shuffle()
             if batch_outside_worker and pin_memory:
                 raise Exception(

--- a/torch/utils/data/dataloader_experimental.py
+++ b/torch/utils/data/dataloader_experimental.py
@@ -87,6 +87,7 @@ class DataLoader2:
                 raise Exception(
                     'sampler is not yet supported by DataPipes')
             datapipe = dataset
+            datapipe = torch.utils.data.graph_settings.apply_shuffle_settings(datapipe, shuffle=shuffle)
             if batch_outside_worker and pin_memory:
                 raise Exception(
                     'pin_memory is not yet compatible with batch_outside_worker')
@@ -95,7 +96,6 @@ class DataLoader2:
                     datapipe = datapipe.batch(batch_size, drop_last=drop_last)
                     if collate_fn is None:
                         collate_fn = torch.utils.data._utils.collate.default_collate
-            datapipe = torch.utils.data.graph_settings.apply_shuffle_settings(datapipe, shuffle=shuffle)
             if parallelism_mode == 'mp' or num_workers == 0:
                 my_worker_init_fn = functools.partial(
                     _sharding_worker_init_fn, worker_init_fn)

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -1,6 +1,6 @@
 import torch.utils.data.graph
 from torch.utils.data.datapipes.iter import Shuffler
-
+import warnings
 
 def get_all_graph_pipes(graph):
     results = set()
@@ -28,9 +28,21 @@ def apply_sharding(datapipe, num_of_instances, instance_id):
 
 
 def apply_shuffle_settings(datapipe, shuffle):
-    if shuffle is not None:
-        graph = torch.utils.data.graph.traverse(datapipe, only_datapipe=True)
-        all_pipes = get_all_graph_pipes(graph)
-        for pipe in all_pipes:
-            if isinstance(pipe, Shuffler):
-                pipe.set_shuffle(shuffle)
+    if shuffle is None:
+        return datapipe
+
+    graph = torch.utils.data.graph.traverse(datapipe, only_datapipe=True)
+    all_pipes = get_all_graph_pipes(graph)
+    shufflers = {pipe for pipe in all_pipes if isinstance(pipe, Shuffler)}
+    if not shufflers and shuffle:
+        warnings.warn(
+            "`shuffle=True` was set, but the datapipe does not contain a `Shuffler`. Adding one at the end. "
+            "Be aware that the default buffer size might not be sufficient for your task."
+        )
+        datapipe = datapipe.shuffle()
+        shufflers = {datapipe}
+
+    for shuffler in shufflers:
+        shuffler.set_shuffle(shuffle)
+
+    return datapipe


### PR DESCRIPTION
Without this, `DataLoader2` will just add an `Shuffler` to the end of the datapipe if `shuffle=True`:

```py
from torch.utils.data.dataloader_experimental import DataLoader2

from torchdata.datapipes.iter import IterableWrapper, IterDataPipe, Shuffler


class Sorter(IterDataPipe):
    def __init__(self, datapipe):
        self.datapipe = datapipe

    def __iter__(self):
        return iter(sorted(self.datapipe))


data = list(range(1000))
dp = IterableWrapper(data)
dp = Shuffler(dp).set_shuffle(False)
dp = Sorter(dp)

dl2 = DataLoader2(dp, shuffle=True, batch_size=None)

assert list(dl2) == data  # fails unless you hit a lucky random seed
```

This example is somewhat non-sensical, but demonstrates we cannot simply add a `Shuffler`.