### PR TITLE
[DataPipe] apply dill serialization for _Demux and add cache to traverse

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -2025,7 +2025,10 @@ class TestCircularSerialization(TestCase):
             yield from self._dp
 
     def test_circular_reference(self):
-        assert list(TestCircularSerialization.CustomIterDataPipe()) == list(pickle.loads(pickle.dumps(TestCircularSerialization.CustomIterDataPipe())))
+        self.assertEqual(
+            list(TestCircularSerialization.CustomIterDataPipe()),
+            list(pickle.loads(pickle.dumps(TestCircularSerialization.CustomIterDataPipe())))
+        )
         _ = traverse(TestCircularSerialization.CustomIterDataPipe(), only_datapipe=True)
         _ = traverse(TestCircularSerialization.CustomIterDataPipe(), only_datapipe=False)
 

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -3,7 +3,7 @@ import pickle
 
 from torch.utils.data import IterDataPipe, MapDataPipe
 
-from typing import Any, Dict
+from typing import Any, Dict, Set
 
 reduce_ex_hook = None
 
@@ -52,7 +52,7 @@ def list_connected_datapipes(scan_obj, only_datapipe, cache):
 
 
 def traverse(datapipe, only_datapipe=False):
-    cache = set()
+    cache: Set[IterDataPipe] = set()
     return _traverse_helper(datapipe, only_datapipe, cache)
 
 

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -52,11 +52,12 @@ def list_connected_datapipes(scan_obj, only_datapipe, cache):
 
 
 def traverse(datapipe, only_datapipe=False):
-    return _traverse_helper(datapipe, only_datapipe)
+    cache = set()
+    return _traverse_helper(datapipe, only_datapipe, cache)
 
 
 # Add cache here to prevent infinite recursion on DataPipe
-def _traverse_helper(datapipe, only_datapipe=False, cache=set()):
+def _traverse_helper(datapipe, only_datapipe=False, cache=None):
     if not isinstance(datapipe, IterDataPipe):
         raise RuntimeError("Expected `IterDataPipe`, but {} is found".format(type(datapipe)))
 

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -57,7 +57,7 @@ def traverse(datapipe, only_datapipe=False):
 
 
 # Add cache here to prevent infinite recursion on DataPipe
-def _traverse_helper(datapipe, only_datapipe=False, cache=None):
+def _traverse_helper(datapipe, only_datapipe, cache):
     if not isinstance(datapipe, IterDataPipe):
         raise RuntimeError("Expected `IterDataPipe`, but {} is found".format(type(datapipe)))
 
@@ -65,5 +65,7 @@ def _traverse_helper(datapipe, only_datapipe=False, cache=None):
     items = list_connected_datapipes(datapipe, only_datapipe, cache)
     d: Dict[IterDataPipe, Any] = {datapipe: {}}
     for item in items:
+        # Using cache.copy() here is to prevent recursion on a single path rather than global graph
+        # Single DataPipe can present multiple times in different paths in graph
         d[datapipe].update(_traverse_helper(item, only_datapipe, cache.copy()))
     return d


### PR DESCRIPTION
- Fix _Demux can not be pickled with DILL presented https://github.com/pytorch/pytorch/pull/74958#issuecomment-1084637227  
- And add cache to traverse function to prevent infinite recursion for circular reference of DataPipe (Fixes https://github.com/pytorch/data/issues/237)