### PR TITLE
[quant] Always match the first matchable pattern in fuse

### DIFF
--- a/torch/ao/quantization/fx/fuse.py
+++ b/torch/ao/quantization/fx/fuse.py
@@ -136,5 +136,6 @@ def _find_matches(
                 matched_node_pattern: List[Node] = []
                 if is_match(modules, node, pattern):
                     apply_match(pattern, node, (node, pattern, value(node)), matched_node_pattern, node_to_subpattern)
+                    break
 
     return match_map


### PR DESCRIPTION
Summary:
As title, For instance,

We match two patterns
```
(add, (bn, conv), matchallnode)
(add, matchallnode, (bn, conv))
```

Against the model
```
conv1 -> bn1 |
conv2 -> bn2 + add
```

For the add node, both two patterns passes `is_match` and `apply_match` is executed twice. As a result, both `conv1 -> bn1` and `conv2 -> bn2` will be matched as `(bn, conv)` instead of one `(bn, conv)` one `matchallnode`.

To fix this, stop trying all the other pattners once a pattern is matched.

Test Plan: verified in D35252100

Differential Revision: D35300191

