### PR TITLE
Fix c10 sign-compare violations

### DIFF
--- a/c10/core/impl/FakeGuardImpl.h
+++ b/c10/core/impl/FakeGuardImpl.h
@@ -9,7 +9,7 @@ namespace impl {
 
 // FakeGuardImpl is hardcoded to have eight devices.  Not for
 // any good reason, just to simplify code.
-constexpr size_t kFakeGuardImplMaxDevices = 8;
+constexpr DeviceIndex kFakeGuardImplMaxDevices = 8;
 
 /**
  * A fake implementation of DeviceGuardImplInterface suitable for testing.
@@ -21,7 +21,7 @@ struct FakeGuardImpl final : public DeviceGuardImplInterface {
   static constexpr DeviceType static_type = T;
   // Runtime device type is not used
   FakeGuardImpl(DeviceType) {}
-  FakeGuardImpl() {}
+  FakeGuardImpl() = default;
   DeviceType type() const override {
     return T;
   }

--- a/c10/test/util/ordered_preserving_dict_test.cpp
+++ b/c10/test/util/ordered_preserving_dict_test.cpp
@@ -48,7 +48,7 @@ dict_int_int test_dict(dict_int_int& dict) {
   }
   dict.erase(begin, end);
 
-  std::vector<size_t> order;
+  std::vector<int64_t> order;
   for (const auto i : c10::irange(100)) {
     if (!erase_set.count(i)) {
       order.push_back(i);
@@ -211,12 +211,12 @@ TEST(OrderedPreservingDictTest, test_range_erase) {
   using HMap =
       ska_ordered::order_preserving_flat_hash_map<std::string, std::int64_t>;
 
-  const std::size_t nb_values = 1000;
+  const int64_t nb_values = 1000;
   HMap map;
   for (const auto i : c10::irange(nb_values)) {
     map[c10::guts::to_string(i)] = i;
     auto begin = map.begin();
-    for (size_t j = 0; j <= i; ++j, begin++) {
+    for (int64_t j = 0; j <= i; ++j, begin++) {
       TORCH_INTERNAL_ASSERT(begin->second == j);
     }
   }

--- a/c10/util/accumulate.h
+++ b/c10/util/accumulate.h
@@ -82,7 +82,7 @@ template <
 inline int64_t numelements_from_dim(const int k, const C& dims) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(k >= 0);
 
-  if (k > dims.size()) {
+  if (k > static_cast<int>(dims.size())) {
     return 1;
   } else {
     auto cbegin = dims.cbegin();

--- a/c10/util/int128.cpp
+++ b/c10/util/int128.cpp
@@ -171,7 +171,7 @@ std::ostream& operator<<(std::ostream& o, const uint128& b) {
 
   // Add the requisite padding.
   std::streamsize width = o.width(0);
-  if (width > rep.size()) {
+  if (width > static_cast<std::streamsize>(rep.size())) {
     if ((flags & std::ios::adjustfield) == std::ios::left) {
       rep.append(width - rep.size(), o.fill());
     } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Prerequisite change for enabling `-Werror=sign-compare` across PyTorch repo