### PR TITLE
[PT] Make error message from jit.trace more meaningful.

### DIFF
--- a/torch/csrc/autograd/TraceTypeManual.cpp
+++ b/torch/csrc/autograd/TraceTypeManual.cpp
@@ -283,7 +283,9 @@ void general_trace_function(
         AT_ASSERT(iter->isObject());
         tracer::addOutput(node, iter->toObject());
       } else {
-        throw std::runtime_error("unsupported output type: " + type->str());
+        throw std::runtime_error(
+            "unsupported output type: " + type->str() +
+            ", from operator: " + toString(op.operator_name()));
       }
     }
   }


### PR DESCRIPTION
Summary:
At the moment if jit.trace is failing on unsupported return types, it's going
to be super hard to find exact operator that is causing trobules for fixing
this.

This diff improves logging to include operator name in additiona to the failed
type.

Test Plan:
Tested on one of the failed models. See which exact operator is causing
troubles.

Differential Revision: D35302222

