### PR TITLE
Fix sign-compare in caffe2 cpp tests

### DIFF
--- a/caffe2/core/blob_test.cc
+++ b/caffe2/core/blob_test.cc
@@ -1264,7 +1264,7 @@ void TestDataType(
     std::string dataTypeName) {
   LOG(INFO) << dataTypeName;
   FLAGS_caffe2_serialize_using_bytes_as_holder = true;
-  size_t numEl = 1000;
+  int numEl = 1000;
   // Proto with int32
   auto protoInt32 = CreateProtoWithInt32Data(dataType, numEl, false);
   caffe2::Blob blobInt32;

--- a/caffe2/core/serialization_test.cc
+++ b/caffe2/core/serialization_test.cc
@@ -69,7 +69,7 @@ TEST(TensorSerialization, TestUnknownDType) {
     auto* blobTensor = BlobGetMutableTensor(&blob, CPU);
     blobTensor->Resize(kTestTensorSize, 1);
     auto *tensorData = blobTensor->mutable_data<int32_t>();
-    for (int n = 0; n < kTestTensorSize; ++n) {
+    for (unsigned n = 0; n < kTestTensorSize; ++n) {
       tensorData[n] = n;
     }
     auto data = SerializeBlob(blob, "test_blob");
@@ -85,7 +85,7 @@ TEST(TensorSerialization, TestUnknownDType) {
   EXPECT_EQ(kTestTensorSize, tensor.numel());
   EXPECT_EQ(TypeMeta::Make<int32_t>(), tensor.dtype());
   const auto* tensor_data = tensor.template data<int32_t>();
-  for (int i = 0; i < kTestTensorSize; ++i) {
+  for (unsigned i = 0; i < kTestTensorSize; ++i) {
     EXPECT_EQ(static_cast<float>(i), tensor_data[i]);
   }
 

--- a/caffe2/core/transform_test.cc
+++ b/caffe2/core/transform_test.cc
@@ -55,7 +55,7 @@ class DummyTransform : public Transform {
       return false;
     }
     // which index are we trying to append the new node to?
-    int pattern_idx = subgraph.size();
+    auto pattern_idx = subgraph.size();
     // type doesn't match
     if (g.node(idx).op.type() != pattern_chain[pattern_idx]) {
       return false;

--- a/caffe2/operators/quantized/int8_test.cc
+++ b/caffe2/operators/quantized/int8_test.cc
@@ -341,8 +341,8 @@ TEST(Int8, SumRelu) {
 }
 
 void setq(int8::Int8TensorCPU* dst, const std::vector<float>& vs) {
-  CHECK_EQ(vs.size(), dst->t.numel());
-  for (auto i = 0; i < vs.size(); ++i) {
+  CHECK_EQ(vs.size(), static_cast<size_t>(dst->t.numel()));
+  for (auto i = 0U; i < vs.size(); ++i) {
     uint8_t vq = std::max(
         std::numeric_limits<uint8_t>::min(),
         std::min(
@@ -354,8 +354,8 @@ void setq(int8::Int8TensorCPU* dst, const std::vector<float>& vs) {
 }
 
 void biassetq(int8::Int8TensorCPU* dst, const std::vector<float>& vs) {
-  CHECK_EQ(vs.size(), dst->t.numel());
-  for (auto i = 0; i < vs.size(); ++i) {
+  CHECK_EQ(vs.size(), static_cast<size_t>(dst->t.numel()));
+  for (auto i = 0U; i < vs.size(); ++i) {
     int32_t vq = std::max(
         std::numeric_limits<int32_t>::min(),
         std::min(

--- a/caffe2/opt/bound_shape_inference_test.cc
+++ b/caffe2/opt/bound_shape_inference_test.cc
@@ -45,7 +45,7 @@ void verifyShapeInfo(
   EXPECT_EQ(shape_info.getDimType(), t);
   const auto& shape = shape_info.shape;
   ASSERT_EQ(shape.dims_size(), dims.size());
-  for (int i = 0; i < dims.size(); ++i) {
+  for (unsigned i = 0; i < dims.size(); ++i) {
     EXPECT_EQ(dims[i], shape.dims(i));
   }
   EXPECT_EQ(shape.data_type(), dtype);

--- a/caffe2/serialize/inline_container_test.cc
+++ b/caffe2/serialize/inline_container_test.cc
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "caffe2/serialize/inline_container.h"
+#include "c10/util/irange.h"
 
 namespace caffe2 {
 namespace serialize {
@@ -22,14 +23,14 @@ TEST(PyTorchStreamWriterAndReader, SaveAndLoad) {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-avoid-magic-numbers)
   std::array<char, 127> data1;
 
-  for (int i = 0; i < data1.size(); ++i) {
+  for (auto i: c10::irange( data1.size())) {
     data1[i] = data1.size() - i;
   }
   writer.writeRecord("key1", data1.data(), data1.size());
 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-avoid-magic-numbers)
   std::array<char, 64> data2;
-  for (int i = 0; i < data2.size(); ++i) {
+  for (auto i: c10::irange(data2.size())) {
     data2[i] = data2.size() - i;
   }
   writer.writeRecord("key2", data2.data(), data2.size());
@@ -83,14 +84,14 @@ TEST(PytorchStreamWriterAndReader, GetNonexistentRecordThrows) {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-avoid-magic-numbers)
   std::array<char, 127> data1;
 
-  for (int i = 0; i < data1.size(); ++i) {
+  for (auto i: c10::irange(data1.size())) {
     data1[i] = data1.size() - i;
   }
   writer.writeRecord("key1", data1.data(), data1.size());
 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-avoid-magic-numbers)
   std::array<char, 64> data2;
-  for (int i = 0; i < data2.size(); ++i) {
+  for (auto i: c10::irange(data2.size())) {
     data2[i] = data2.size() - i;
   }
   writer.writeRecord("key2", data2.data(), data2.size());

--- a/caffe2/share/contrib/depthwise/depthwise3x3_conv_op_test.cc
+++ b/caffe2/share/contrib/depthwise/depthwise3x3_conv_op_test.cc
@@ -199,7 +199,7 @@ void runConv(
 
 } // unnamed namespace
 
-constexpr size_t kIters = 20;
+constexpr int  kIters = 20;
 
 TEST(DEPTHWISE3x3, Conv) {
   for (int i = 0; i < kIters; ++i) {

--- a/caffe2/share/contrib/nnpack/nnpack_test.cc
+++ b/caffe2/share/contrib/nnpack/nnpack_test.cc
@@ -236,7 +236,7 @@ void runConv(
 
 } // unnamed namespace
 
-constexpr size_t kIters = 20;
+constexpr int  kIters = 20;
 
 TEST(NNPACK, Conv_3x3s1) {
   for (int i = 0; i < kIters; ++i) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Prerequisite change for enabling `-Werror=sign-compare` across PyTorch repo