### PR TITLE
Fix sign-compare in nnapi backend

### DIFF
--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_lib.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_lib.cpp
@@ -31,7 +31,7 @@ class NnapiBackend : public PyTorchBackendInterface {
   c10::impl::GenericDict compile(
       c10::IValue processed,
       c10::impl::GenericDict method_compile_spec) override {
-    // Wrap procesed in dictionary: {"forward": processed}
+    // Wrap processed in dictionary: {"forward": processed}
     auto dict = processed.toGenericDict();
     c10::Dict<c10::IValue, c10::IValue> handles(
         c10::StringType::get(), c10::AnyType::get());
@@ -64,7 +64,7 @@ class NnapiBackend : public PyTorchBackendInterface {
     auto inp_mem_fmts = dict.at("inp_mem_fmts").toIntList();
     TORCH_CHECK(tensorInp.size() == inp_mem_fmts.size());
     std::vector<at::Tensor> fixed_inputs;
-    for (int i = 0; i < tensorInp.size(); i++) {
+    for (auto i = 0U; i < tensorInp.size(); i++) {
       int fmt = inp_mem_fmts[i];
       // These constants match the values in DimOrder in serializer.py
       // 0: NCHW, 1: NHWC
@@ -84,7 +84,7 @@ class NnapiBackend : public PyTorchBackendInterface {
     // Adjust output memory formats
     auto out_mem_fmts = dict.at("out_mem_fmts").toIntList();
     TORCH_CHECK(outputs.size() == out_mem_fmts.size());
-    for (int i = 0; i < outputs.size(); i++) {
+    for (auto i = 0U; i < outputs.size(); i++) {
       int fmt = out_mem_fmts[i];
       // These constants match the values in DimOrder in serializer.py
       // 0: NCHW, 1: NHWC

--- a/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
+++ b/torch/csrc/jit/backends/nnapi/nnapi_backend_preprocess.cpp
@@ -96,7 +96,7 @@ c10::IValue preprocess(
   // transform Python lists to C++ c10::List
   c10::List<at::Tensor> weights(
       py::cast<std::vector<at::Tensor>>(nnapi_processed[2]));
-  for (int i = 0; i < weights.size(); i++) {
+  for (auto i = 0U; i < weights.size(); i++) {
     weights.set(i, weights.get(i).contiguous());
   }
   c10::List<int64_t> inp_mem_fmts(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Prerequisite change for enabling `-Werror=sign-compare` across PyTorch repo