### PR TITLE
Fix sign-compare violations in python_list.h

### DIFF
--- a/torch/csrc/jit/python/python_list.h
+++ b/torch/csrc/jit/python/python_list.h
@@ -197,7 +197,7 @@ class ScriptList final {
       idx += len();
     }
 
-    if (idx < 0 || (size_type)idx > len()) {
+    if (idx < 0 || idx > len()) {
       throw std::out_of_range("list index out of range");
     }
 
@@ -217,7 +217,7 @@ class ScriptList final {
       idx += sz;
     }
 
-    if (idx < 0 || (size_type)idx >= sz) {
+    if (idx < 0 || idx >= sz) {
       throw std::out_of_range("list index out of range");
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #75085
* #75084
* #75083
* #75082
* #75081
* #75080
* #75079
* #75078
* #75077
* __->__ #75076
* #75075

`idx` is signed type as well as `len()`, so no need to cast one of the
two two unsigned.
Prerequisite change for enabling `-Werror=sign-compare` across PyTorch repo