### PR TITLE
fix 'pytorch/tools/code_coverage/README.md' for renamed options

### DIFF
--- a/tools/code_coverage/README.md
+++ b/tools/code_coverage/README.md
@@ -30,11 +30,11 @@ This part will introduce about the arguments you can use when run this tool. The
 We have two different compilers, `gcc` and `clang`, and this tool supports both. But it is recommended to use `gcc` because it's much faster and use less disk place. The examples will also be divided to two parts, for `gcc` and `clang`.
 
 ## Preparation
-The first step is to [build *Pytorch* from source](https://github.com/pytorch/pytorch#from-source) with `CODE_COVERAGE` option `ON`. You may also want to set `BUILD_TEST` option `ON` to get the test binaries. Besides, if you are under `gcc` compiler, to get accurate result, it is recommended to also select `CMAKE_BUILD_CONFIG=Debug`.
+The first step is to [build *Pytorch* from source](https://github.com/pytorch/pytorch#from-source) with `USE_CPP_CODE_COVERAGE` option `ON`. You may also want to set `BUILD_TEST` option `ON` to get the test binaries. Besides, if you are under `gcc` compiler, to get accurate result, it is recommended to also select `CMAKE_BUILD_TYPE=Debug`.
 See: [how to adjust build options](https://github.com/pytorch/pytorch#adjust-build-options-optional) for reference. Following is one way to adjust build option:
 ```
 # in build/ folder (all build artifacts must in `build/` folder)
-cmake .. -DCODE_COVERAGE=ON -DBUILD_TEST=ON -DCMAKE_BUILD_CONFIG=Debug
+cmake .. -DUSE_CPP_CODE_COVERAGE=ON -DBUILD_TEST=ON -DCMAKE_BUILD_TYPE=Debug
 ```
 
 
@@ -53,7 +53,7 @@ python oss_coverage.py --run-only=atest
 ```
 This command will run `atest` binary in `build/bin/` folder and generate reoports over the entire *Pytorch* folder. You can find the reports in `profile/summary`. But you may only be interested in the `aten` folder, in this case, try:
 ```
-python oss_coverage.py --run-only=atest --interested-only=aten
+python oss_coverage.py --run-only=atest --interest-only=aten
 ```
 In *Pytorch*, `c++` tests located in `build/bin/` and `python` tests located in `test/`. If you want to run `python` test, try:
 ```
@@ -62,7 +62,7 @@ python oss_coverage.py --run-only=test_complex.py
 
 You may also want to specify more than one test or interested folder, in this case, try:
 ```
-python oss_coverage.py --run-only=atest c10_logging_test --interested-only aten/src/Aten c10/core
+python oss_coverage.py --run-only=atest c10_logging_test --interest-only aten/src/Aten c10/core
 ```
 That it is! With these two simple options, you can customize many different functionality according to your need.
 By default, the tool will run all tests in `build/bin` folder (by running all executable binaries in it) and `test/` folder (by running `run_test.py`), and then collect coverage over the entire *Pytorch* folder. If this is what you want, try:
@@ -84,9 +84,9 @@ By default all steps will be run, but you can specify only run one of them. Foll
 `—summary` is useful when you have different interested folder. For example,
 ```bash
 # after run this command
-python oss_coverage.py --run-only=atest --interested-folder=aten
+python oss_coverage.py --run-only=atest --interest-only=aten
 # you may then want to learn atest's coverage over c10, instead of running the test again, you can:
-python oss_coverage.py --run-only=atest --interested-folder=c10 --summary
+python oss_coverage.py --run-only=atest --interest-only=c10 --summary
 ```
 
 


### PR DESCRIPTION
README Instructions of the coverage tool should be fixed.

1. Some CMAKE options are not consistent with 'pytorch/CmakeLists.txt'.

- 'CODE_COVERAGE' should be 'USE_CPP_CODE_COVERAGE'.
- 'CMAKE_BUILD_CONFIG' should be 'CMAKE_BUILD_TYPE'.

2. Some arguments of 'oss_coverage.py' are incorrect.

- Both '--interested-only' and '--interested-folder' doesn't work. I guess both of them were meant to be '--interest-only'