### PR TITLE
[do not merge] repro mobile-only dispatcher segfault

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -268,7 +268,6 @@ RegistrationHandleRAII Dispatcher::registerFallback(DispatchKey dispatchKey, Ker
   std::lock_guard<std::mutex> lock(mutex_);
 
   auto idx = getDispatchTableIndexForDispatchKey(dispatchKey);
-  TORCH_CHECK(idx >= 0 && static_cast<uint64_t>(idx) < backendFallbackKernels_.size(), "idx=", idx);
   TORCH_CHECK(
     !backendFallbackKernels_[idx].kernel.isValid(),
     "Tried to register multiple backend fallbacks for the same dispatch key ", dispatchKey, "; previous registration ",

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -284,9 +284,6 @@ std::pair<const AnnotatedKernel&, const char*> OperatorEntry::computeDispatchTab
 
   // 3. Backend fallback
   auto dispatch_ix = getDispatchTableIndexForDispatchKey(dispatch_key);
-  if (dispatch_ix < 0) {
-    return {missingKernel(), "backend fallback not registered on mobile"};
-  }
   if (dispatcher.backendFallbackKernels_[dispatch_ix].kernel.isValid()) {
     return {dispatcher.backendFallbackKernels_[dispatch_ix], "backend fallback"};
   }

--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -235,9 +235,6 @@ Library& Library::_fallback(CppFunction&& f) & {
   // Note if dispatch_key is DispatchKey::Undefined, it'll be ignored here since Undefined
   // isn't a runtime key, you shouldn't register anything to it at all.
   for (auto k : c10::getRuntimeDispatchKeySet(*dispatch_key)) {
-    // mobile doesn't use all dispatch keys, so skip any fallback registrations for the unused keys.
-    auto idx = getDispatchTableIndexForDispatchKey(k);
-    if (idx < 0) continue;
     registrars_.emplace_back(
       c10::Dispatcher::singleton().registerFallback(
         k,


### PR DESCRIPTION
This should repro the memory corruption bug that was fixed in https://github.com/pytorch/pytorch/pull/74963

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#75102 repro mobile-only dispatcher segfault**

Differential Revision: [D35397293](https://our.internmc.facebook.com/intern/diff/D35397293)