### PR TITLE
fx quant: add workflow integration for quantized softmax

### DIFF
--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -58,6 +58,7 @@ def is_fixed_qparams_node(node, modules):
         torch.nn.Hardsigmoid,
         torch.nn.Sigmoid,
         torch.nn.Tanh,
+        torch.nn.Softmax,
     ]
     return _is_node_in_list(node, modules, func_list, method_list, module_type_list)
 
@@ -236,6 +237,7 @@ SPECIAL_PATTERN_LOWER_MODULE_MAP = {
     nn.InstanceNorm3d: nnq.InstanceNorm3d,
     nn.LayerNorm: nnq.LayerNorm,
     nn.Dropout: nnq.Dropout,
+    nn.Softmax: nnq.Softmax,
     nni.BNReLU2d: nniq.BNReLU2d,
     nni.BNReLU3d: nniq.BNReLU3d,
 }

--- a/torch/ao/quantization/fx/quantization_patterns.py
+++ b/torch/ao/quantization/fx/quantization_patterns.py
@@ -318,6 +318,7 @@ class DefaultNodeQuantizeHandler(QuantizeHandler):
 @register_quant_pattern(torch.sigmoid, default_affine_fixed_qparams_observer)
 @register_quant_pattern('sigmoid', default_affine_fixed_qparams_observer)
 @register_quant_pattern('sigmoid_', default_affine_fixed_qparams_observer)
+@register_quant_pattern(torch.nn.Softmax, default_affine_fixed_qparams_observer)
 @register_quant_pattern(torch.nn.Tanh, default_symmetric_fixed_qparams_observer)
 @register_quant_pattern(torch.tanh, default_symmetric_fixed_qparams_observer)
 @register_quant_pattern('tanh', default_symmetric_fixed_qparams_observer)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#75107 fx quant: add workflow integration for quantized softmax**
* #75106 eager quant: add quantized Softmax workflow integration

Summary:

The previous PR added workflow integration for quantized softmax to
Eager mode quantization. This PR adds it to FX graph mode quantization.

Note: for now, only the module version is supported. This is because
the function fp32 version has some extra arguments which are not supported
in the quantized equivalent.

Test plan:

```
python test/test_quantization.py TestQuantizeFxOps.test_fixed_qparams_ops
```