### PR TITLE
[Easy][FSDP] Update full osd warning

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -2088,7 +2088,8 @@ class FullyShardedDataParallel(nn.Module):
             full_osd (Dict[str, Any]): A :class:`dict` containing the optimizer
                 state for ``model`` 's original unflattened parameters and
                 including keys "state" and "param_groups" following the
-                convention of :meth:`torch.optim.Optimizer.state_dict`.
+                convention of :meth:`torch.optim.Optimizer.state_dict` if on
+                rank 0, and an empty :class:`dict` otherwise.
         """
         osd = optim.state_dict()
         osd_state, osd_param_groups = osd["state"], osd["param_groups"]  # alias

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -2056,7 +2056,8 @@ class FullyShardedDataParallel(nn.Module):
         contained in ``model`` are mapped back to their unflattened parameters.
 
         .. warning:: This needs to be called on all ranks since synchronization
-            primitives are used.
+            primitives are used. However, the state dict is only populated on
+            rank 0. All other ranks return an empty :class:`dict`.
 
         .. warning:: Unlike ``torch.optim.Optimizer.state_dict()``, this method
             uses full parameter names as keys instead of parameter IDs.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#75109 [Easy][FSDP] Update full osd warning**

Clarify that only rank 0 receives a populated optimizer state dict to avoid confusion.

Differential Revision: [D35319158](https://our.internmc.facebook.com/intern/diff/D35319158)