### PR TITLE
[GHA] Do not chown for linux CI

### DIFF
--- a/.circleci/docker/common/install_user.sh
+++ b/.circleci/docker/common/install_user.sh
@@ -3,8 +3,9 @@
 set -ex
 
 # Mirror jenkins user in container
-echo "jenkins:x:1014:1014::/var/lib/jenkins:" >> /etc/passwd
-echo "jenkins:x:1014:" >> /etc/group
+# jenkins user as ec2-user should have the same user-id
+echo "jenkins:x:1000:1000::/var/lib/jenkins:" >> /etc/passwd
+echo "jenkins:x:1000:" >> /etc/group
 
 # Create $HOME
 mkdir -p /var/lib/jenkins

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -124,7 +124,7 @@ jobs:
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"
           )
-          docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && .jenkins/pytorch/build.sh'
+          docker exec -t "${container_name}" sh -c '.jenkins/pytorch/build.sh'
 
       - name: Display and upload binary build size statistics (Click Me)
         # temporary hack: set CIRCLE_* vars, until we update
@@ -138,10 +138,6 @@ jobs:
           export COMMIT_TIME
           pip3 install requests==2.26 boto3==1.16.34
           python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
-
-      - name: Chown workspace
-        uses: ./.github/actions/chown-workspace
-        if: always()
 
       - name: Archive artifacts into zip
         if: inputs.build-generates-artifacts

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -142,11 +142,7 @@ jobs:
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"
           )
-          docker exec -t "${container_name}" sh -c "sudo chown -R jenkins . && pip install dist/*.whl && ${TEST_COMMAND}"
-
-      - name: Chown workspace
-        uses: ./.github/actions/chown-workspace
-        if: always()
+          docker exec -t "${container_name}" sh -c "pip install dist/*.whl && ${TEST_COMMAND}"
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts


### PR DESCRIPTION
Set `jenkins` userid in container to be identical to `ec2-user` id (i.e.
1000)

This should eliminate unnecessary chowns back and forth

Fixes https://github.com/pytorch/pytorch/issues/64856