### PR TITLE
Deprecate bytecode v3 and bump kMinSupportedBytecodeVersion to 4

### DIFF
--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -134,7 +134,7 @@ constexpr uint64_t kProducedBytecodeVersion = 0x8L;
 // kMinSupportedBytecodeVersion <= model_version <= kMaxSupportedBytecodeVersion
 // (in loader), we should support this model_version. For example, we provide a
 // wrapper to handle an updated operator.
-constexpr uint64_t kMinSupportedBytecodeVersion = 0x3L;
+constexpr uint64_t kMinSupportedBytecodeVersion = 0x4L;
 constexpr uint64_t kMaxSupportedBytecodeVersion = 0x8L;
 
 } // namespace serialize


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #57775
* __->__ #75121
* #75120

Differential Revision: [D35321150](https://our.internmc.facebook.com/intern/diff/D35321150/)