### PR TITLE
[quant][fx] Fix lowering pass for cases when `to` is not called with positional args

### DIFF
--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -823,7 +823,8 @@ def special_pattern_replacement(model: QuantizedGraphModule):
     for n in model.graph.nodes:
         q_node = n
         is_quantize = q_node.target == torch.quantize_per_tensor
-        is_to_fp16 = q_node.op == "call_method" and q_node.target == "to" and len(q_node.args) == 2 and q_node.args[1] == torch.float16
+        is_to_fp16 = q_node.op == "call_method" and q_node.target == "to" and \
+            len(q_node.args) == 2 and q_node.args[1] == torch.float16
         if not (is_quantize or is_to_fp16):
             continue
         ref_node = q_node.args[0]

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -823,7 +823,7 @@ def special_pattern_replacement(model: QuantizedGraphModule):
     for n in model.graph.nodes:
         q_node = n
         is_quantize = q_node.target == torch.quantize_per_tensor
-        is_to_fp16 = q_node.op == "call_method" and q_node.target == "to" and q_node.args[1] == torch.float16
+        is_to_fp16 = q_node.op == "call_method" and q_node.target == "to" and len(q_node.args) == 2 and q_node.args[1] == torch.float16
         if not (is_quantize or is_to_fp16):
             continue
         ref_node = q_node.args[0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75146

Summary:
Previously we assume `to` must be called with positioanl args, but this may not be the case,
e.g. we can do `to(dtype=?)` or `to(memory_format=?)`

Test Plan:
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D35342088](https://our.internmc.facebook.com/intern/diff/D35342088)