### PR TITLE
[PyTorch] Add test for all-masked case for native softmax

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15964,6 +15964,12 @@ class TestNNDeviceType(NNTestCase):
                     rtol = None
                 self.assertEqual(grad, grad_check, msg=msg, atol=atol, rtol=rtol)
 
+    def _slow_masked_softmax(self, input, mask):
+        exp = torch.exp(input)
+        exp = exp * mask
+        s = exp.sum(dim=3, keepdim=True).expand(exp.size())
+        return exp / s
+
     def test_masked_softmax(self, device):
         sizes = [(1, 1, 32), (3, 16, 310), (12, 4, 1024), (4, 2, 1200)]
         for (B, num_heads, L) in sizes:
@@ -15977,12 +15983,18 @@ class TestNNDeviceType(NNTestCase):
             mask = ~mask
             mask = mask.float()
 
-            def slow_masked_softmax(input, mask):
-                exp = torch.exp(input)
-                exp = exp * mask
-                s = exp.sum(dim=3, keepdim=True).expand(exp.size())
-                return exp / s
-            pt_res = slow_masked_softmax(input, mask)
+            pt_res = self._slow_masked_softmax(input, mask)
+            self.assertEqual(pt_res, native_res, exact_dtype=True)
+
+    def test_masked_softmax_all_masked(self, device):
+        sizes = [(1, 1, 32), (3, 16, 310), (12, 4, 1024), (4, 2, 1200)]
+        for (B, num_heads, L) in sizes:
+            input = torch.randn((B, num_heads, L, L), device=device)
+            mask = torch.ones_like(input, device=device, dtype=torch.bool)
+            native_res = torch._masked_softmax(input, mask)
+            mask = ~mask
+            mask = mask.float()
+            pt_res = self._slow_masked_softmax(input, mask)
             self.assertEqual(pt_res, native_res, exact_dtype=True)
 
     @onlyCUDA
@@ -16001,12 +16013,7 @@ class TestNNDeviceType(NNTestCase):
         mask = ~mask
         mask = mask.float()
 
-        def slow_masked_softmax(input, mask):
-            exp = torch.exp(input)
-            exp = exp * mask
-            s = exp.sum(dim=3, keepdim=True).expand(exp.size())
-            return exp / s
-        pt_res = slow_masked_softmax(input, mask)
+        pt_res = self._slow_masked_softmax(input, mask)
         self.assertEqual(pt_res, native_res, exact_dtype=True)
 
     # Test fails on Vg20


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

It returns all NaNs. CUDA implementation required a fix for this.

Differential Revision: [D35327730](https://our.internmc.facebook.com/intern/diff/D35327730/)