### PR TITLE
[Draft] A new custom fusion API

### DIFF
--- a/torch/csrc/jit/passes/graph_fuser.h
+++ b/torch/csrc/jit/passes/graph_fuser.h
@@ -33,5 +33,13 @@ TORCH_API void CustomFuseGraph(
     Symbol kind,
     size_t arg_limit = std::numeric_limits<size_t>::max());
 
+// A modified version of CustomFuseGraph.
+// It supports multi-output operators.
+TORCH_API void SimpleFuseGraph(
+    std::shared_ptr<Graph>& graph,
+    const std::function<bool(Node*)>& fn,
+    Symbol kind,
+    size_t arg_limit = std::numeric_limits<size_t>::max());
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
The current flow to embed custom computation engine into torch::jit::GraphExecutor
1. Register a custom fusion pass to fuse targeted ops into sub-graph symbols (e.g., `prim::FusionGroup` or custom symbol).
2. Register an executor for that sub-graph symbol. This executor calls custom computation engine.
Before this PR, step 1 is done by calling `CustomFuseGraph`. However, `CustomFuseGraph` only support operators in [this list](https://github.com/pytorch/pytorch/blob/2d885ab73da455c31b91d6b58c1e1629f05e6bcd/torch/csrc/jit/passes/graph_fuser.cpp#L35). It also impose several restrictive assumptions such as [op can only has one tensor output](https://github.com/pytorch/pytorch/blob/2d885ab73da455c31b91d6b58c1e1629f05e6bcd/torch/csrc/jit/passes/graph_fuser.cpp#L451). To direct more operators to custom engine, this PR proposes a more general fusion function, which
1. supports multi-output ops
2. drops the [white list](https://github.com/pytorch/pytorch/blob/2d885ab73da455c31b91d6b58c1e1629f05e6bcd/torch/csrc/jit/passes/graph_fuser.cpp#L35).