### PR TITLE
[SR][Code Cleanup] Make all functions use the same naming convention

### DIFF
--- a/benchmarks/static_runtime/test_static_module.cc
+++ b/benchmarks/static_runtime/test_static_module.cc
@@ -106,8 +106,8 @@ TEST(StaticModule, ValueGroup) {
   torch::jit::StaticModule sm(input_graph);
   const Graph& graph = sm.graph();
   std::vector<const Node*> nodes(graph.nodes().begin(), graph.nodes().end());
-  auto* root_block = sm.root_block();
-  const auto& value_group = sm.block_info(root_block).value_group();
+  auto* root_block = sm.rootBlock();
+  const auto& value_group = sm.blockInfo(root_block).valueGroup();
 
   std::vector<const Value*> expected_input_aliases{
       graph.inputs()[0], graph.inputs()[1], nodes[0]->output()};
@@ -139,11 +139,11 @@ TEST(StaticModule, IsOptimizableContainerType_NonOptimizableInputs) {
 
   auto sm = makeStaticModuleFromScript(src);
   const auto& graph = sm.graph();
-  auto* root_block = sm.root_block();
-  const auto& block_info = sm.block_info(root_block);
+  auto* root_block = sm.rootBlock();
+  const auto& block_info = sm.blockInfo(root_block);
 
   for (const Node* n : graph.nodes()) {
-    EXPECT_FALSE(block_info.node_is_optimizable_container_type(n));
+    EXPECT_FALSE(block_info.nodeIsOptimizableContainerType(n));
   }
 }
 
@@ -161,11 +161,11 @@ TEST(StaticModule, IsOptimizableContainerType_WrongType) {
 
   auto sm = makeStaticModuleFromScript(src);
   const auto& graph = sm.graph();
-  auto* root_block = sm.root_block();
-  const auto& block_info = sm.block_info(root_block);
+  auto* root_block = sm.rootBlock();
+  const auto& block_info = sm.blockInfo(root_block);
 
   for (const Node* n : graph.nodes()) {
-    EXPECT_FALSE(block_info.node_is_optimizable_container_type(n));
+    EXPECT_FALSE(block_info.nodeIsOptimizableContainerType(n));
   }
 }
 
@@ -180,14 +180,14 @@ TEST(StaticModule, IsOptimizableContainerType_CanUseOutVariant) {
     )JIT";
   auto sm = makeStaticModuleFromScript(src);
   const auto& graph = sm.graph();
-  auto* root_block = sm.root_block();
-  const auto& block_info = sm.block_info(root_block);
+  auto* root_block = sm.rootBlock();
+  const auto& block_info = sm.blockInfo(root_block);
 
   for (const Node* n : graph.nodes()) {
     if (n->kind() == c10::prim::ListConstruct) {
-      EXPECT_TRUE(block_info.node_is_optimizable_container_type(n));
+      EXPECT_TRUE(block_info.nodeIsOptimizableContainerType(n));
     } else {
-      EXPECT_FALSE(block_info.node_is_optimizable_container_type(n));
+      EXPECT_FALSE(block_info.nodeIsOptimizableContainerType(n));
     }
   }
 }
@@ -224,7 +224,7 @@ TEST(StaticRuntime, ReplaceWithCopy_replaces_reshape) {
     EXPECT_TRUE(graphHasOp(graph, "aten::reshape"));
     EXPECT_FALSE(graphHasOp(graph, "static_runtime::reshape_copy"));
 
-    ReplaceWithCopy(graph);
+    replaceWithCopy(graph);
 
     // aten::reshape -> static_runtime::reshape_copy
     EXPECT_FALSE(graphHasOp(graph, "aten::reshape"));
@@ -261,7 +261,7 @@ TEST(
     EXPECT_TRUE(graphHasOp(graph, "aten::reshape"));
     EXPECT_FALSE(graphHasOp(graph, "static_runtime::reshape_copy"));
 
-    ReplaceWithCopy(graph);
+    replaceWithCopy(graph);
 
     // No Replacement
     EXPECT_TRUE(graphHasOp(graph, "aten::reshape"));
@@ -438,7 +438,7 @@ TEST(StaticRuntime, LongModel) {
   std::vector<c10::IValue> input_tensors({a, b, c});
   torch::jit::StaticModule smod(mod);
   at::Tensor output_2 = smod(input_tensors, {}).toTensor();
-  smod.runtime().check_for_memory_leak();
+  smod.runtime().checkForMemoryLeak();
   EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
 }
 
@@ -456,7 +456,7 @@ TEST(StaticRuntime, TrivialModel) {
   std::vector<c10::IValue> input_tensors({a, b, c});
   torch::jit::StaticModule smod(mod);
   at::Tensor output_2 = smod(input_tensors, {}).toTensor();
-  smod.runtime().check_for_memory_leak();
+  smod.runtime().checkForMemoryLeak();
   EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
 }
 
@@ -481,7 +481,7 @@ TEST(StaticRuntime, DeepWide) {
       auto outputs = smod(input_tensors, {}).toTupleRef().elements();
       ASSERT_TRUE(outputs.size() > 0);
       at::Tensor output_2 = outputs[0].toTensor();
-      smod.runtime().check_for_memory_leak();
+      smod.runtime().checkForMemoryLeak();
       EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
     }
   }
@@ -506,7 +506,7 @@ TEST(StaticRuntime, KWargsAPI_1) {
 
         // run static runtime
         c10::IValue output_ivalue = smod(inputs, {});
-        smod.runtime().check_for_memory_leak();
+        smod.runtime().checkForMemoryLeak();
 
         at::Tensor output_2 = getTensor(output_ivalue);
         EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
@@ -550,7 +550,7 @@ TEST(StaticRuntime, KWargsAPI_2) {
 
         // run static runtime
         c10::IValue output_ivalue = smod(std::vector<IValue>{}, kwargs);
-        smod.runtime().check_for_memory_leak();
+        smod.runtime().checkForMemoryLeak();
 
         at::Tensor output_2 = getTensor(output_ivalue);
         EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
@@ -629,7 +629,7 @@ TEST(StaticRuntime, CleanUpMemory) {
             auto outputs = runtime(input_tensors, {}).toTupleRef().elements();
             ASSERT_TRUE(outputs.size() > 0);
             auto output_2 = outputs[0].toTensor();
-            runtime.check_for_memory_leak();
+            runtime.checkForMemoryLeak();
             EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
             if (manage_output_tensors) {
               runtime.deallocateOutputTensors();
@@ -732,7 +732,7 @@ TEST(StaticRuntime, ManageOutputTensorsWithDeallocateOutputTensors) {
     auto wide = torch::randn({batch_size, num_features});
     std::vector<c10::IValue> input_tensors({ad_emb_packed, user_emb, wide});
     runtime(input_tensors, {});
-    runtime.check_for_memory_leak();
+    runtime.checkForMemoryLeak();
     runtime.deallocateOutputTensors();
     runtime.checkOutputTensorMemoryLeaks();
   }
@@ -910,10 +910,10 @@ TEST(
   StaticNodeInfo static_node_info(
       sigmoid_node, &fn, createProcessedNodeInputs({0}), 1);
   ProcessedNode pnode(static_node_info, values.data());
-  EXPECT_TRUE(pnode.verify_no_memory_overlap(/* force_check*/ true));
+  EXPECT_TRUE(pnode.verifyNoMemoryOverlap(/* force_check*/ true));
 
-  pnode.Output(0) = values[0];
-  EXPECT_FALSE(pnode.verify_no_memory_overlap(/* force_check*/ true));
+  pnode.output(0) = values[0];
+  EXPECT_FALSE(pnode.verifyNoMemoryOverlap(/* force_check*/ true));
 }
 
 TEST(ProcessedNode, VerifyNoMemoryOverlapWithImmutableInputsWithInplaceOps) {
@@ -931,11 +931,11 @@ TEST(ProcessedNode, VerifyNoMemoryOverlapWithImmutableInputsWithInplaceOps) {
       sigmoid_node, &fn, createProcessedNodeInputs({0}), 1);
   ProcessedNode pnode(static_node_info, values.data());
 
-  ASSERT_EQ(&pnode.Output(0), &values[1]);
-  EXPECT_TRUE(pnode.verify_no_memory_overlap());
+  ASSERT_EQ(&pnode.output(0), &values[1]);
+  EXPECT_TRUE(pnode.verifyNoMemoryOverlap());
 
-  pnode.Output(0) = values[0];
-  EXPECT_TRUE(pnode.verify_no_memory_overlap());
+  pnode.output(0) = values[0];
+  EXPECT_TRUE(pnode.verifyNoMemoryOverlap());
 }
 
 TEST(ProcessedNode, VerifyNoMemoryOverlapWithOverlappingOutputs) {
@@ -961,7 +961,7 @@ TEST(ProcessedNode, VerifyNoMemoryOverlapWithOverlappingOutputs) {
         list_unpack_static_node_info, values.data());
     ASSERT_EQ(list_unpack_pnode.outputs().size(), 2);
     EXPECT_TRUE(
-        list_unpack_pnode.verify_no_memory_overlap(/* force_check*/ true));
+        list_unpack_pnode.verifyNoMemoryOverlap(/* force_check*/ true));
   }
   {
     std::array<IValue, 3> values = {
@@ -975,10 +975,10 @@ TEST(ProcessedNode, VerifyNoMemoryOverlapWithOverlappingOutputs) {
     ProcessedNode list_unpack_pnode(
         list_unpack_static_node_info, values.data());
     auto b = at::randn({2, 3});
-    list_unpack_pnode.Output(0) = b;
-    list_unpack_pnode.Output(1) = b;
+    list_unpack_pnode.output(0) = b;
+    list_unpack_pnode.output(1) = b;
     EXPECT_FALSE(
-        list_unpack_pnode.verify_no_memory_overlap(/* force_check*/ true));
+        list_unpack_pnode.verifyNoMemoryOverlap(/* force_check*/ true));
   }
 }
 
@@ -1615,7 +1615,7 @@ TEST(CreateOwnedRefsForSpecialValues, TopLevel) {
   )IR";
 
   auto graph = getGraphFromIR(src);
-  CreateOwnedRefsForSpecialValues(*graph);
+  createOwnedRefsForSpecialIValues(*graph);
   EXPECT_TRUE(hasNodeWithKind(graph, "static_runtime::create_owned_ref"));
 }
 
@@ -1632,7 +1632,7 @@ TEST(CreateOwnedRefsForSpecialValues, ValueFromOuterScope) {
   )IR";
 
   auto graph = getGraphFromIR(src);
-  CreateOwnedRefsForSpecialValues(*graph);
+  createOwnedRefsForSpecialIValues(*graph);
   EXPECT_TRUE(hasNodeWithKind(graph, "static_runtime::create_owned_ref"));
 }
 
@@ -1653,7 +1653,7 @@ TEST(ForceNonEmptyOutputs, TwoSubBlocks) {
   )IR";
 
   auto graph = getGraphFromIR(src);
-  ForceNonEmptyOutputs(*graph);
+  forceNonEmptyOutputs(*graph);
 
   for (auto* node : graph->nodes()) {
     if (node->blocks().empty()) {
@@ -1679,7 +1679,7 @@ TEST(EliminateExtraPermuteOps, FusesCorrectly) {
   auto graph = mod.get_method("forward").graph();
   // turn the ListConstruct(%constant) into proper constant lists
   ConstantPropagation(graph);
-  EliminateExtraPermuteOps(graph);
+  eliminateExtraPermuteOps(graph);
 
   EXPECT_FALSE(hasNodeWithKind(graph, "aten::permute"));
   auto* sum = getNodeWithKind(graph, "aten::sum");
@@ -1702,7 +1702,7 @@ TEST(EliminateExtraPermuteOps, DoesNotFuseWrongDim) {
   auto graph = mod.get_method("forward").graph();
   // turn the ListConstruct(%constant) into proper constant lists
   ConstantPropagation(graph);
-  EliminateExtraPermuteOps(graph);
+  eliminateExtraPermuteOps(graph);
 
   EXPECT_TRUE(hasNodeWithKind(graph, "aten::permute"));
 }
@@ -1720,7 +1720,7 @@ TEST(EliminateExtraPermuteOps, DoesNotFuseNonConstantDim) {
   auto graph = mod.get_method("forward").graph();
   // turn the ListConstruct(%constant) into proper constant lists
   ConstantPropagation(graph);
-  EliminateExtraPermuteOps(graph);
+  eliminateExtraPermuteOps(graph);
 
   EXPECT_TRUE(hasNodeWithKind(graph, "aten::permute"));
 }
@@ -1737,7 +1737,7 @@ TEST(UseSplitAndSqueeze, Fusion) {
       return (%c, %d)
   )IR";
   auto graph = getGraphFromIR(src);
-  UseSplitAndSqueeze(graph);
+  useSplitAndSqueeze(graph);
   EXPECT_TRUE(
       hasNodeWithKind(graph, "static_runtime::fused_split_and_squeeze"));
   EXPECT_FALSE(hasNodeWithKind(graph, "aten::split"));

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1497,7 +1497,7 @@ TEST(StaticRuntime, LeakyReLU) {
   std::vector<c10::IValue> input_tensors({inputs});
   torch::jit::StaticModule smod(mod);
   at::Tensor output_2 = smod(input_tensors, {}).toTensor();
-  smod.runtime().check_for_memory_leak();
+  smod.runtime().checkForMemoryLeak();
   EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
 }
 
@@ -2594,13 +2594,13 @@ TEST(StaticRuntime, ModelCrashOnFirstRun) {
   EXPECT_THROW(runtime(args_crash, {}), std::runtime_error);
 
   // The run didn't finish, we didn't allocate the memory planner
-  EXPECT_EQ(runtime.get_memory_planner(), nullptr);
-  runtime.check_for_memory_leak();
+  EXPECT_EQ(runtime.getMemoryPlanner(), nullptr);
+  runtime.checkForMemoryLeak();
 
   // We guarantee that the runtime is still usable after the crash.
   // Run again to verify this.
   compareResultsWithJIT(runtime, graph, args_no_crash);
-  EXPECT_NE(runtime.get_memory_planner(), nullptr);
+  EXPECT_NE(runtime.getMemoryPlanner(), nullptr);
 }
 
 TEST(StaticRuntime, ModelCrashOnSecondRun) {
@@ -2620,11 +2620,11 @@ TEST(StaticRuntime, ModelCrashOnSecondRun) {
   std::vector<IValue> args_crash{at::randn({1}), true};
   std::vector<IValue> args_no_crash{at::randn({1}), false};
   runtime(args_no_crash, {});
-  EXPECT_NE(runtime.get_memory_planner(), nullptr);
-  runtime.check_for_memory_leak();
+  EXPECT_NE(runtime.getMemoryPlanner(), nullptr);
+  runtime.checkForMemoryLeak();
 
   EXPECT_THROW(runtime(args_crash, {}), std::runtime_error);
-  runtime.check_for_memory_leak();
+  runtime.checkForMemoryLeak();
 
   // We guarantee that the runtime is still usable after the crash.
   // Run again to verify this.
@@ -2690,7 +2690,7 @@ TEST(StaticRuntime, ReplaceWithMaybeCopy) {
   // Static Runtime.
   torch::jit::StaticModule smodule(g);
   auto actual = smodule(args, {}).toTensor();
-  smodule.runtime().check_for_memory_leak();
+  smodule.runtime().checkForMemoryLeak();
 
   EXPECT_TRUE(expected.equal(actual));
   EXPECT_FALSE(hasProcessedNodeWithName(smodule, "aten::to"));
@@ -3153,7 +3153,7 @@ TEST(StaticRuntime, MemoryPlannerFallback) {
   // First run, profiling.
   runtime(args1);
 
-  const auto* first_memory_planner = runtime.get_memory_planner();
+  const auto* first_memory_planner = runtime.getMemoryPlanner();
   EXPECT_NE(first_memory_planner, nullptr);
   EXPECT_NE(
       dynamic_cast<const PrecomputedOffsetsMemoryPlanner*>(
@@ -3165,7 +3165,7 @@ TEST(StaticRuntime, MemoryPlannerFallback) {
 
   // Run again to reset the memory planner
   runtime(args1);
-  const auto* second_memory_planner = runtime.get_memory_planner();
+  const auto* second_memory_planner = runtime.getMemoryPlanner();
   EXPECT_NE(second_memory_planner, nullptr);
   EXPECT_NE(
       dynamic_cast<const StandardMemoryPlanner*>(second_memory_planner),

--- a/benchmarks/static_runtime/test_utils.cc
+++ b/benchmarks/static_runtime/test_utils.cc
@@ -264,7 +264,7 @@ void compareResultsWithJIT(
   GraphExecutorWrapper graph_exec(graph);
   auto expected = graph_exec(args);
   auto actual = runtime(args, {});
-  runtime.check_for_memory_leak();
+  runtime.checkForMemoryLeak();
   compareResults(expected, actual, use_allclose, use_equalnan);
 }
 
@@ -311,12 +311,12 @@ void testStaticRuntime(
           StaticRuntime runtime(smodule);
           auto actual = runtime(args, {});
           if (actual.isTensor()) {
-            EXPECT_GE(smodule.num_nodes(), 2)
+            EXPECT_GE(smodule.numNodes(), 2)
                 << "If we only have one node, the output of the op we are testing is "
                 << "not being managed by the memory planner! A failure here "
                 << "can typically be fixed by clone()ing the output of the test script.";
           }
-          runtime.check_for_memory_leak();
+          runtime.checkForMemoryLeak();
           // first run
           VLOG(2) << "enable_out_variant: " << enable_out_variant;
           VLOG(2) << "manage_output_tensors: " << manage_output_tensors;
@@ -334,14 +334,14 @@ void testStaticRuntime(
           }
 
           if (!args2.empty()) {
-            auto* memory_planner = runtime.get_memory_planner();
+            auto* memory_planner = runtime.getMemoryPlanner();
             size_t managed_bytes =
-                memory_planner ? memory_planner->total_managed() : 0;
+                memory_planner ? memory_planner->totalManaged() : 0;
 
             // Run static runtime again with inputs of a different shape.
             expect = test_context->getExpected(args2);
             actual = runtime(args2, {});
-            runtime.check_for_memory_leak();
+            runtime.checkForMemoryLeak();
             VLOG(2) << "comparing with args2";
             compareResults(expect, actual, use_allclose, use_equalnan);
             VLOG(2) << "second run comparison done";
@@ -352,9 +352,9 @@ void testStaticRuntime(
             }
 
             // The memory planner is allowed to get reallocated
-            auto* new_memory_planner = runtime.get_memory_planner();
+            auto* new_memory_planner = runtime.getMemoryPlanner();
             size_t new_managed_bytes =
-                new_memory_planner ? new_memory_planner->total_managed() : 0;
+                new_memory_planner ? new_memory_planner->totalManaged() : 0;
             if (algorithm != MemoryPlannerAlgorithm::kPrecomputedOffsets &&
                 check_resize && new_managed_bytes > 0) {
               EXPECT_GT(new_managed_bytes, managed_bytes);
@@ -364,7 +364,7 @@ void testStaticRuntime(
             // during the profile run.
             expect = test_context->getExpected(args);
             actual = runtime(args, {});
-            runtime.check_for_memory_leak();
+            runtime.checkForMemoryLeak();
             // third run
             VLOG(2) << "comparing third run";
             compareResults(expect, actual, use_allclose, use_equalnan);
@@ -378,7 +378,7 @@ void testStaticRuntime(
             // run static runtime again to exercise the memory planner
             // and allocate managed tensors.
             actual = runtime(args, {});
-            runtime.check_for_memory_leak();
+            runtime.checkForMemoryLeak();
             VLOG(2) << "comparing second run with same args";
             compareResults(expect, actual, use_allclose, use_equalnan);
             VLOG(2) << "second run comparison done";
@@ -389,7 +389,7 @@ void testStaticRuntime(
             }
             // third run to use the allocated managed tensors.
             actual = runtime(args, {});
-            runtime.check_for_memory_leak();
+            runtime.checkForMemoryLeak();
             if (manage_output_tensors) {
               actual = IValue();
               runtime.deallocateOutputTensors();

--- a/tools/codegen/static_runtime/gen_structured.py
+++ b/tools/codegen/static_runtime/gen_structured.py
@@ -170,7 +170,7 @@ def generate_arg_extraction(g: NativeFunctionsGroup) -> str:
         assert maybe_method
         is_reference, type_conversion_method = maybe_method
         reference = "&" if is_reference else ""
-        arg_populations.append(f'const auto{reference} {arg.name} = p_node->Input({i}).{type_conversion_method}')
+        arg_populations.append(f'const auto{reference} {arg.name} = p_node->input({i}).{type_conversion_method}')
     return ";\n    ".join(arg_populations) + ";"
 
 def generate_non_out_variant_call(g: NativeFunctionsGroup) -> str:
@@ -223,7 +223,7 @@ REGISTER_OPERATOR_FUNCTOR(
     aten_{op_name},
     [](Node* n) -> SROperator {{
       {body}
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     }});
 """
@@ -242,11 +242,11 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema("aten::{schema}"))) {{
         return [](ProcessedNode* p_node) {{
           {populated_argument}
-          if (p_node->Output(0).isNone()) {{
-            p_node->Output(0) = {functional_variant_call};
+          if (p_node->output(0).isNone()) {{
+            p_node->output(0) = {functional_variant_call};
             return;
           }}
-          auto& {out_variable_name} = p_node->Output(0).toTensor();
+          auto& {out_variable_name} = p_node->output(0).toTensor();
           fastResizeToZero({out_variable_name});
           {out_variant_call};
         }};

--- a/torch/csrc/jit/runtime/static/ProcessedNodeInputs.h
+++ b/torch/csrc/jit/runtime/static/ProcessedNodeInputs.h
@@ -35,7 +35,7 @@ class ProcessedNodeInputs {
   }
 
   uint16_t& operator[](uint16_t idx) {
-    if (C10_LIKELY(repr_.is_inline())) {
+    if (C10_LIKELY(repr_.isInline())) {
       DCHECK_LT(idx, repr_.inline_repr_.size);
       return repr_.inline_repr_.inputs[idx];
     } else {
@@ -44,7 +44,7 @@ class ProcessedNodeInputs {
   }
 
   C10_NODISCARD uint16_t size() const {
-    if (C10_LIKELY(repr_.is_inline())) {
+    if (C10_LIKELY(repr_.isInline())) {
       return repr_.inline_repr_.size;
     } else {
       return repr_.outline_repr_.size();
@@ -137,7 +137,7 @@ class ProcessedNodeInputs {
   // awkward.
 #pragma pack(push, 2)
   union Repr {
-    C10_NODISCARD bool is_inline() const {
+    C10_NODISCARD bool isInline() const {
       uint8_t tag;
       // Use of reinterpret_cast to pointer to char or unsigned char
       // is defined behavior; see
@@ -160,7 +160,7 @@ class ProcessedNodeInputs {
     }
 
     Repr(const Repr& rhs) {
-      if (rhs.is_inline()) {
+      if (rhs.isInline()) {
         std::memcpy(&inline_repr_, &rhs.inline_repr_, sizeof(inline_repr_));
       } else {
         new (&outline_repr_) OutlineRepr(rhs.outline_repr_);
@@ -171,12 +171,12 @@ class ProcessedNodeInputs {
       if (&rhs == this) {
         return *this;
       }
-      if (rhs.is_inline()) {
+      if (rhs.isInline()) {
         destroyIfOutline();
         new (&inline_repr_) InlineRepr();
         std::memcpy(&inline_repr_, &rhs.inline_repr_, sizeof(inline_repr_));
       } else {
-        if (is_inline()) {
+        if (isInline()) {
           new (&outline_repr_) OutlineRepr(rhs.outline_repr_);
         } else {
           outline_repr_ = rhs.outline_repr_;
@@ -186,7 +186,7 @@ class ProcessedNodeInputs {
     }
 
     Repr(Repr&& rhs) noexcept {
-      if (rhs.is_inline()) {
+      if (rhs.isInline()) {
         std::memcpy(&inline_repr_, &rhs.inline_repr_, sizeof(inline_repr_));
       } else {
         new (&outline_repr_) OutlineRepr(std::move(rhs.outline_repr_));
@@ -198,12 +198,12 @@ class ProcessedNodeInputs {
         return *this;
       }
 
-      if (rhs.is_inline()) {
+      if (rhs.isInline()) {
         destroyIfOutline();
         new (&inline_repr_) InlineRepr();
         std::memcpy(&inline_repr_, &rhs.inline_repr_, sizeof(inline_repr_));
       } else {
-        if (is_inline()) {
+        if (isInline()) {
           new (&outline_repr_) OutlineRepr(std::move(rhs.outline_repr_));
         } else {
           outline_repr_ = std::move(rhs.outline_repr_);
@@ -226,7 +226,7 @@ class ProcessedNodeInputs {
 
    private:
     void destroyIfOutline() {
-      if (!is_inline()) {
+      if (!isInline()) {
         outline_repr_.~OutlineRepr();
       }
     }

--- a/torch/csrc/jit/runtime/static/fusion.cpp
+++ b/torch/csrc/jit/runtime/static/fusion.cpp
@@ -24,8 +24,8 @@ void createFusionGroups(Block* block, AliasDb* aliasDb, size_t min_size);
 
 void fuseStaticSubgraphs(std::shared_ptr<Graph> graph, size_t min_size) {
   Inline(*graph);
-  ReplaceWithCopy(graph);
-  ReplaceWithMaybeCopy(graph);
+  replaceWithCopy(graph);
+  replaceWithMaybeCopy(graph);
   ConstantPropagation(graph);
   Canonicalize(graph);
   ConstantPropagation(graph);
@@ -42,7 +42,7 @@ void fuseStaticSubgraphs(std::shared_ptr<Graph> graph, size_t min_size) {
 Operation createStaticSubgraphRuntime(const Node* node) {
   auto g = node->g(attr::Subgraph);
   auto module = std::make_shared<torch::jit::StaticModule>(g);
-  auto num_inputs = module->num_inputs();
+  auto num_inputs = module->numInputs();
   return [module, num_inputs](Stack& stack) {
     RECORD_FUNCTION("Static Runtime", std::vector<c10::IValue>());
     auto inps = torch::jit::last(stack, num_inputs);
@@ -50,7 +50,7 @@ Operation createStaticSubgraphRuntime(const Node* node) {
     auto outputs = (*module)(inps.vec(), {});
     torch::jit::drop(stack, num_inputs);
 
-    if (module->num_outputs() > 1) {
+    if (module->numOutputs() > 1) {
       for (auto& o : outputs.toTupleRef().elements()) {
         push_one(stack, std::move(o));
       }

--- a/torch/csrc/jit/runtime/static/generated_ops.cpp
+++ b/torch/csrc/jit/runtime/static/generated_ops.cpp
@@ -40,34 +40,34 @@ namespace jit {
 REGISTER_OPERATOR_FUNCTOR(aten::sgn, aten_sgn, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::sgn(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::sgn(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::sgn(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::sgn_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::acos, aten_acos, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::acos(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::acos(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::acos(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::acos_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -75,21 +75,21 @@ REGISTER_OPERATOR_FUNCTOR(aten::addmv, aten_addmv, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& mat = p_node->Input(1).toTensor();
-      const auto& vec = p_node->Input(2).toTensor();
-      const auto beta = p_node->Input(3).toScalar();
-      const auto alpha = p_node->Input(4).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::addmv(self, mat, vec, beta, alpha);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& mat = p_node->input(1).toTensor();
+      const auto& vec = p_node->input(2).toTensor();
+      const auto beta = p_node->input(3).toScalar();
+      const auto alpha = p_node->input(4).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::addmv(self, mat, vec, beta, alpha);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::addmv_out(out, self, mat, vec, beta, alpha);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -97,104 +97,104 @@ REGISTER_OPERATOR_FUNCTOR(aten::argmax, aten_argmax, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toOptional<int64_t>();
-      const auto keepdim = p_node->Input(2).toBool();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::argmax(self, dim, keepdim);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toOptional<int64_t>();
+      const auto keepdim = p_node->input(2).toBool();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::argmax(self, dim, keepdim);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::argmax_out(out, self, dim, keepdim);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::acosh, aten_acosh, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::acosh(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::acosh(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::acosh(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::acosh_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::asinh, aten_asinh, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::asinh(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::asinh(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::asinh(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::asinh_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::atanh, aten_atanh, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::atanh(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::atanh(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::atanh(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::atanh_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::asin, aten_asin, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::asin(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::asin(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::asin(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::asin_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::atan, aten_atan, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::atan(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::atan(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::atan(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::atan_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -202,21 +202,21 @@ REGISTER_OPERATOR_FUNCTOR(aten::baddbmm, aten_baddbmm, [](Node* n) -> SROperator
   if (n->matches(torch::schema(
           "aten::baddbmm(Tensor self, Tensor batch1, Tensor batch2, *, Scalar beta=1, Scalar alpha=1) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& batch1 = p_node->Input(1).toTensor();
-      const auto& batch2 = p_node->Input(2).toTensor();
-      const auto beta = p_node->Input(3).toScalar();
-      const auto alpha = p_node->Input(4).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::baddbmm(self, batch1, batch2, beta, alpha);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& batch1 = p_node->input(1).toTensor();
+      const auto& batch2 = p_node->input(2).toTensor();
+      const auto beta = p_node->input(3).toScalar();
+      const auto alpha = p_node->input(4).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::baddbmm(self, batch1, batch2, beta, alpha);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::baddbmm_out(out, self, batch1, batch2, beta, alpha);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -227,17 +227,17 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(
               torch::schema("aten::bitwise_not(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::bitwise_not(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::bitwise_not(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::bitwise_not_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -248,69 +248,69 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::copysign.Tensor(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::copysign(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::copysign(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::copysign_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
 REGISTER_OPERATOR_FUNCTOR(aten::ceil, aten_ceil, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::ceil(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::ceil(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::ceil(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::ceil_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::cos, aten_cos, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::cos(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::cos(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::cos(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::cos_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::cosh, aten_cosh, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::cosh(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::cosh(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::cosh(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::cosh_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -318,138 +318,138 @@ REGISTER_OPERATOR_FUNCTOR(aten::cumprod, aten_cumprod, [](Node* n) -> SROperator
   if (n->matches(torch::schema(
           "aten::cumprod(Tensor self, int dim, *, ScalarType? dtype=None) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      const auto dtype = p_node->Input(2).toOptional<at::ScalarType>();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::cumprod(self, dim, dtype);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      const auto dtype = p_node->input(2).toOptional<at::ScalarType>();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::cumprod(self, dim, dtype);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::cumprod_out(out, self, dim, dtype);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::erf, aten_erf, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::erf(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::erf(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::erf(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::erf_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::erfc, aten_erfc, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::erfc(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::erfc(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::erfc(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::erfc_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::exp, aten_exp, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::exp(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::exp(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::exp(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::exp_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::exp2, aten_exp2, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::exp2(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::exp2(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::exp2(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::exp2_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::expm1, aten_expm1, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::expm1(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::expm1(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::expm1(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::expm1_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::floor, aten_floor, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::floor(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::floor(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::floor(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::floor_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::frac, aten_frac, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::frac(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::frac(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::frac(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::frac_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -457,18 +457,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::gcd, aten_gcd, [](Node* n) -> SROperator {
   if (n->matches(
           torch::schema("aten::gcd(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::gcd(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::gcd(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::gcd_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -476,18 +476,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::lcm, aten_lcm, [](Node* n) -> SROperator {
   if (n->matches(
           torch::schema("aten::lcm(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::lcm(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::lcm(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::lcm_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -495,20 +495,20 @@ REGISTER_OPERATOR_FUNCTOR(aten::index_copy, aten_index_copy, [](Node* n) -> SROp
   if (n->matches(torch::schema(
           "aten::index_copy(Tensor self, int dim, Tensor index, Tensor source) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      const auto& index = p_node->Input(2).toTensor();
-      const auto& source = p_node->Input(3).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::index_copy(self, dim, index, source);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      const auto& index = p_node->input(2).toTensor();
+      const auto& source = p_node->input(3).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::index_copy(self, dim, index, source);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::index_copy_out(out, self, dim, index, source);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -516,16 +516,16 @@ REGISTER_OPERATOR_FUNCTOR(aten::isin, aten_isin, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::isin.Tensor_Tensor(Tensor elements, Tensor test_elements, *, bool assume_unique=False, bool invert=False) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& elements = p_node->Input(0).toTensor();
-      const auto& test_elements = p_node->Input(1).toTensor();
-      const auto assume_unique = p_node->Input(2).toBool();
-      const auto invert = p_node->Input(3).toBool();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) =
+      const auto& elements = p_node->input(0).toTensor();
+      const auto& test_elements = p_node->input(1).toTensor();
+      const auto assume_unique = p_node->input(2).toBool();
+      const auto invert = p_node->input(3).toBool();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) =
             at::cpu::isin(elements, test_elements, assume_unique, invert);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::isin_out(out, elements, test_elements, assume_unique, invert);
     };
@@ -534,16 +534,16 @@ REGISTER_OPERATOR_FUNCTOR(aten::isin, aten_isin, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::isin.Tensor_Scalar(Tensor elements, Scalar test_element, *, bool assume_unique=False, bool invert=False) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& elements = p_node->Input(0).toTensor();
-      const auto test_element = p_node->Input(1).toScalar();
-      const auto assume_unique = p_node->Input(2).toBool();
-      const auto invert = p_node->Input(3).toBool();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) =
+      const auto& elements = p_node->input(0).toTensor();
+      const auto test_element = p_node->input(1).toScalar();
+      const auto assume_unique = p_node->input(2).toBool();
+      const auto invert = p_node->input(3).toBool();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) =
             at::cpu::isin(elements, test_element, assume_unique, invert);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::isin_out(out, elements, test_element, assume_unique, invert);
     };
@@ -552,72 +552,72 @@ REGISTER_OPERATOR_FUNCTOR(aten::isin, aten_isin, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::isin.Scalar_Tensor(Scalar element, Tensor test_elements, *, bool assume_unique=False, bool invert=False) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto element = p_node->Input(0).toScalar();
-      const auto& test_elements = p_node->Input(1).toTensor();
-      const auto assume_unique = p_node->Input(2).toBool();
-      const auto invert = p_node->Input(3).toBool();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) =
+      const auto element = p_node->input(0).toScalar();
+      const auto& test_elements = p_node->input(1).toTensor();
+      const auto assume_unique = p_node->input(2).toBool();
+      const auto invert = p_node->input(3).toBool();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) =
             at::cpu::isin(element, test_elements, assume_unique, invert);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::isin_out(out, element, test_elements, assume_unique, invert);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::log10, aten_log10, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::log10(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::log10(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::log10(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::log10_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::log1p, aten_log1p, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::log1p(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::log1p(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::log1p(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::log1p_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::log2, aten_log2, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::log2(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::log2(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::log2(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::log2_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -628,18 +628,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::logaddexp(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::logaddexp(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::logaddexp(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::logaddexp_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -650,18 +650,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::logaddexp2(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::logaddexp2(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::logaddexp2(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::logaddexp2_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -669,18 +669,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::xlogy, aten_xlogy, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::xlogy.Tensor(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::xlogy(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::xlogy(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::xlogy_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -691,19 +691,19 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::_log_softmax(Tensor self, int dim, bool half_to_float) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto dim = p_node->Input(1).toInt();
-          const auto half_to_float = p_node->Input(2).toBool();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::_log_softmax(self, dim, half_to_float);
+          const auto& self = p_node->input(0).toTensor();
+          const auto dim = p_node->input(1).toInt();
+          const auto half_to_float = p_node->input(2).toBool();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::_log_softmax(self, dim, half_to_float);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::_log_softmax_out(out, self, dim, half_to_float);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -714,22 +714,22 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::_log_softmax_backward_data(Tensor grad_output, Tensor output, int dim, ScalarType input_dtype) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& output = p_node->Input(1).toTensor();
-          const auto dim = p_node->Input(2).toInt();
-          const auto input_dtype = p_node->Input(3).toScalarType();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::_log_softmax_backward_data(
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& output = p_node->input(1).toTensor();
+          const auto dim = p_node->input(2).toInt();
+          const auto input_dtype = p_node->input(3).toScalarType();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::_log_softmax_backward_data(
                 grad_output, output, dim, input_dtype);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::_log_softmax_backward_data_out(
               out, grad_output, output, dim, input_dtype);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -737,18 +737,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::mm, aten_mm, [](Node* n) -> SROperator {
   if (n->matches(
           torch::schema("aten::mm(Tensor self, Tensor mat2) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& mat2 = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::mm(self, mat2);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& mat2 = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::mm(self, mat2);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::mm_out(out, self, mat2);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -759,46 +759,46 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(
               torch::schema("aten::reciprocal(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::reciprocal(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::reciprocal(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::reciprocal_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
 REGISTER_OPERATOR_FUNCTOR(aten::neg, aten_neg, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::neg(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::neg(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::neg(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::neg_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::round, aten_round, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::round(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::round(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::round(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::round_out(out, self);
     };
@@ -807,18 +807,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::round, aten_round, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::round.decimals(Tensor self, *, int decimals) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto decimals = p_node->Input(1).toInt();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::round(self, decimals);
+      const auto& self = p_node->input(0).toTensor();
+      const auto decimals = p_node->input(1).toInt();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::round(self, decimals);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::round_out(out, self, decimals);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -826,18 +826,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::gelu, aten_gelu, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::gelu(Tensor self, *, str approximate='none') -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto approximate = p_node->Input(1).toStringView();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::gelu(self, approximate);
+      const auto& self = p_node->input(0).toTensor();
+      const auto approximate = p_node->input(1).toStringView();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::gelu(self, approximate);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::gelu_out(out, self, approximate);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -848,21 +848,21 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::gelu_backward(Tensor grad_output, Tensor self, *, str approximate='none') -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& self = p_node->Input(1).toTensor();
-          const auto approximate = p_node->Input(2).toStringView();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) =
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& self = p_node->input(1).toTensor();
+          const auto approximate = p_node->input(2).toStringView();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) =
                 at::cpu::gelu_backward(grad_output, self, approximate);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::gelu_backward_out(
               grad_input, grad_output, self, approximate);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -873,18 +873,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::hardshrink(Tensor self, Scalar lambd=0.5) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto lambd = p_node->Input(1).toScalar();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::hardshrink(self, lambd);
+          const auto& self = p_node->input(0).toTensor();
+          const auto lambd = p_node->input(1).toScalar();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::hardshrink(self, lambd);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::hardshrink_out(out, self, lambd);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -895,54 +895,54 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::hardshrink_backward(Tensor grad_out, Tensor self, Scalar lambd) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_out = p_node->Input(0).toTensor();
-          const auto& self = p_node->Input(1).toTensor();
-          const auto lambd = p_node->Input(2).toScalar();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) =
+          const auto& grad_out = p_node->input(0).toTensor();
+          const auto& self = p_node->input(1).toTensor();
+          const auto lambd = p_node->input(2).toScalar();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) =
                 at::cpu::hardshrink_backward(grad_out, self, lambd);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::hardshrink_backward_out(grad_input, grad_out, self, lambd);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
 REGISTER_OPERATOR_FUNCTOR(aten::rsqrt, aten_rsqrt, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::rsqrt(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::rsqrt(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::rsqrt(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::rsqrt_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::silu, aten_silu, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::silu(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::silu(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::silu(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::silu_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -953,86 +953,86 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::silu_backward(Tensor grad_output, Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& self = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::silu_backward(grad_output, self);
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& self = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::silu_backward(grad_output, self);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::silu_backward_out(grad_input, grad_output, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
 REGISTER_OPERATOR_FUNCTOR(aten::mish, aten_mish, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::mish(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::mish(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::mish(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::mish_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::sin, aten_sin, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::sin(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::sin(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::sin(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::sin_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::sinc, aten_sinc, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::sinc(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::sinc(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::sinc(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::sinc_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::sinh, aten_sinh, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::sinh(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::sinh(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::sinh(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::sinh_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1040,19 +1040,19 @@ REGISTER_OPERATOR_FUNCTOR(aten::_softmax, aten__softmax, [](Node* n) -> SROperat
   if (n->matches(torch::schema(
           "aten::_softmax(Tensor self, int dim, bool half_to_float) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      const auto half_to_float = p_node->Input(2).toBool();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::_softmax(self, dim, half_to_float);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      const auto half_to_float = p_node->input(2).toBool();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::_softmax(self, dim, half_to_float);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::_softmax_out(out, self, dim, half_to_float);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1063,39 +1063,39 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::_softmax_backward_data(Tensor grad_output, Tensor output, int dim, ScalarType input_dtype) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& output = p_node->Input(1).toTensor();
-          const auto dim = p_node->Input(2).toInt();
-          const auto input_dtype = p_node->Input(3).toScalarType();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::_softmax_backward_data(
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& output = p_node->input(1).toTensor();
+          const auto dim = p_node->input(2).toInt();
+          const auto input_dtype = p_node->input(3).toScalarType();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::_softmax_backward_data(
                 grad_output, output, dim, input_dtype);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::_softmax_backward_data_out(
               grad_input, grad_output, output, dim, input_dtype);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
 REGISTER_OPERATOR_FUNCTOR(aten::sqrt, aten_sqrt, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::sqrt(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::sqrt(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::sqrt(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::sqrt_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1103,37 +1103,37 @@ REGISTER_OPERATOR_FUNCTOR(aten::prod, aten_prod, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::prod.dim_int(Tensor self, int dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      const auto keepdim = p_node->Input(2).toBool();
-      const auto dtype = p_node->Input(3).toOptional<at::ScalarType>();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::prod(self, dim, keepdim, dtype);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      const auto keepdim = p_node->input(2).toBool();
+      const auto dtype = p_node->input(3).toOptional<at::ScalarType>();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::prod(self, dim, keepdim, dtype);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::prod_out(out, self, dim, keepdim, dtype);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::tan, aten_tan, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::tan(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::tan(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::tan(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::tan_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1141,19 +1141,19 @@ REGISTER_OPERATOR_FUNCTOR(aten::threshold, aten_threshold, [](Node* n) -> SROper
   if (n->matches(torch::schema(
           "aten::threshold(Tensor self, Scalar threshold, Scalar value) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto threshold = p_node->Input(1).toScalar();
-      const auto value = p_node->Input(2).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::threshold(self, threshold, value);
+      const auto& self = p_node->input(0).toTensor();
+      const auto threshold = p_node->input(1).toScalar();
+      const auto value = p_node->input(2).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::threshold(self, threshold, value);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::threshold_out(out, self, threshold, value);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1164,38 +1164,38 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::threshold_backward(Tensor grad_output, Tensor self, Scalar threshold) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& self = p_node->Input(1).toTensor();
-          const auto threshold = p_node->Input(2).toScalar();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) =
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& self = p_node->input(1).toTensor();
+          const auto threshold = p_node->input(2).toScalar();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) =
                 at::cpu::threshold_backward(grad_output, self, threshold);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::threshold_backward_out(
               grad_input, grad_output, self, threshold);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
 REGISTER_OPERATOR_FUNCTOR(aten::trunc, aten_trunc, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::trunc(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::trunc(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::trunc(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::trunc_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1206,18 +1206,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::heaviside(Tensor self, Tensor values) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& values = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::heaviside(self, values);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& values = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::heaviside(self, values);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::heaviside_out(out, self, values);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -1225,21 +1225,21 @@ REGISTER_OPERATOR_FUNCTOR(aten::index_add, aten_index_add, [](Node* n) -> SROper
   if (n->matches(torch::schema(
           "aten::index_add(Tensor self, int dim, Tensor index, Tensor source, *, Scalar alpha=1) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      const auto& index = p_node->Input(2).toTensor();
-      const auto& source = p_node->Input(3).toTensor();
-      const auto alpha = p_node->Input(4).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::index_add(self, dim, index, source, alpha);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      const auto& index = p_node->input(2).toTensor();
+      const auto& source = p_node->input(3).toTensor();
+      const auto alpha = p_node->input(4).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::index_add(self, dim, index, source, alpha);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::index_add_out(out, self, dim, index, source, alpha);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1247,15 +1247,15 @@ REGISTER_OPERATOR_FUNCTOR(aten::scatter, aten_scatter, [](Node* n) -> SROperator
   if (n->matches(torch::schema(
           "aten::scatter.src(Tensor self, int dim, Tensor index, Tensor src) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      const auto& index = p_node->Input(2).toTensor();
-      const auto& src = p_node->Input(3).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::scatter(self, dim, index, src);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      const auto& index = p_node->input(2).toTensor();
+      const auto& src = p_node->input(3).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::scatter(self, dim, index, src);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::scatter_out(out, self, dim, index, src);
     };
@@ -1264,15 +1264,15 @@ REGISTER_OPERATOR_FUNCTOR(aten::scatter, aten_scatter, [](Node* n) -> SROperator
   if (n->matches(torch::schema(
           "aten::scatter.value(Tensor self, int dim, Tensor index, Scalar value) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      const auto& index = p_node->Input(2).toTensor();
-      const auto value = p_node->Input(3).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::scatter(self, dim, index, value);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      const auto& index = p_node->input(2).toTensor();
+      const auto value = p_node->input(3).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::scatter(self, dim, index, value);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::scatter_out(out, self, dim, index, value);
     };
@@ -1281,16 +1281,16 @@ REGISTER_OPERATOR_FUNCTOR(aten::scatter, aten_scatter, [](Node* n) -> SROperator
   if (n->matches(torch::schema(
           "aten::scatter.reduce(Tensor self, int dim, Tensor index, Tensor src, *, str reduce) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      const auto& index = p_node->Input(2).toTensor();
-      const auto& src = p_node->Input(3).toTensor();
-      const auto reduce = p_node->Input(4).toStringView();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::scatter(self, dim, index, src, reduce);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      const auto& index = p_node->input(2).toTensor();
+      const auto& src = p_node->input(3).toTensor();
+      const auto reduce = p_node->input(4).toStringView();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::scatter(self, dim, index, src, reduce);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::scatter_out(out, self, dim, index, src, reduce);
     };
@@ -1299,21 +1299,21 @@ REGISTER_OPERATOR_FUNCTOR(aten::scatter, aten_scatter, [](Node* n) -> SROperator
   if (n->matches(torch::schema(
           "aten::scatter.value_reduce(Tensor self, int dim, Tensor index, Scalar value, *, str reduce) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      const auto& index = p_node->Input(2).toTensor();
-      const auto value = p_node->Input(3).toScalar();
-      const auto reduce = p_node->Input(4).toStringView();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::scatter(self, dim, index, value, reduce);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      const auto& index = p_node->input(2).toTensor();
+      const auto value = p_node->input(3).toScalar();
+      const auto reduce = p_node->input(4).toStringView();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::scatter(self, dim, index, value, reduce);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::scatter_out(out, self, dim, index, value, reduce);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1321,20 +1321,20 @@ REGISTER_OPERATOR_FUNCTOR(aten::scatter_add, aten_scatter_add, [](Node* n) -> SR
   if (n->matches(torch::schema(
           "aten::scatter_add(Tensor self, int dim, Tensor index, Tensor src) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      const auto& index = p_node->Input(2).toTensor();
-      const auto& src = p_node->Input(3).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::scatter_add(self, dim, index, src);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      const auto& index = p_node->input(2).toTensor();
+      const auto& src = p_node->input(3).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::scatter_add(self, dim, index, src);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::scatter_add_out(out, self, dim, index, src);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1342,13 +1342,13 @@ REGISTER_OPERATOR_FUNCTOR(aten::eq, aten_eq, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::eq.Scalar(Tensor self, Scalar other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto other = p_node->Input(1).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::eq(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto other = p_node->input(1).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::eq(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::eq_out(out, self, other);
     };
@@ -1357,18 +1357,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::eq, aten_eq, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::eq.Tensor(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::eq(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::eq(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::eq_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1379,18 +1379,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::bitwise_and.Tensor(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::bitwise_and(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::bitwise_and(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::bitwise_and_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -1401,18 +1401,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::bitwise_or.Tensor(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::bitwise_or(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::bitwise_or(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::bitwise_or_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -1423,18 +1423,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::bitwise_xor.Tensor(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::bitwise_xor(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::bitwise_xor(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::bitwise_xor_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -1445,18 +1445,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::bitwise_left_shift.Tensor(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::bitwise_left_shift(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::bitwise_left_shift(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::bitwise_left_shift_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -1467,18 +1467,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::bitwise_right_shift.Tensor(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::bitwise_right_shift(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::bitwise_right_shift(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::bitwise_right_shift_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -1486,18 +1486,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::tril, aten_tril, [](Node* n) -> SROperator {
   if (n->matches(
           torch::schema("aten::tril(Tensor self, int diagonal=0) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto diagonal = p_node->Input(1).toInt();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::tril(self, diagonal);
+      const auto& self = p_node->input(0).toTensor();
+      const auto diagonal = p_node->input(1).toInt();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::tril(self, diagonal);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::tril_out(out, self, diagonal);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1505,18 +1505,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::triu, aten_triu, [](Node* n) -> SROperator {
   if (n->matches(
           torch::schema("aten::triu(Tensor self, int diagonal=0) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto diagonal = p_node->Input(1).toInt();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::triu(self, diagonal);
+      const auto& self = p_node->input(0).toTensor();
+      const auto diagonal = p_node->input(1).toInt();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::triu(self, diagonal);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::triu_out(out, self, diagonal);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1526,17 +1526,17 @@ REGISTER_OPERATOR_FUNCTOR(
     [](Node* n) -> SROperator {
       if (n->matches(torch::schema("aten::digamma(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::digamma(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::digamma(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::digamma_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -1544,14 +1544,14 @@ REGISTER_OPERATOR_FUNCTOR(aten::lerp, aten_lerp, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::lerp.Scalar(Tensor self, Tensor end, Scalar weight) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& end = p_node->Input(1).toTensor();
-      const auto weight = p_node->Input(2).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::lerp(self, end, weight);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& end = p_node->input(1).toTensor();
+      const auto weight = p_node->input(2).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::lerp(self, end, weight);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::lerp_out(out, self, end, weight);
     };
@@ -1560,19 +1560,19 @@ REGISTER_OPERATOR_FUNCTOR(aten::lerp, aten_lerp, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::lerp.Tensor(Tensor self, Tensor end, Tensor weight) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& end = p_node->Input(1).toTensor();
-      const auto& weight = p_node->Input(2).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::lerp(self, end, weight);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& end = p_node->input(1).toTensor();
+      const auto& weight = p_node->input(2).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::lerp(self, end, weight);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::lerp_out(out, self, end, weight);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1580,13 +1580,13 @@ REGISTER_OPERATOR_FUNCTOR(aten::ne, aten_ne, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::ne.Scalar(Tensor self, Scalar other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto other = p_node->Input(1).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::ne(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto other = p_node->input(1).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::ne(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::ne_out(out, self, other);
     };
@@ -1595,18 +1595,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::ne, aten_ne, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::ne.Tensor(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::ne(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::ne(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::ne_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1614,13 +1614,13 @@ REGISTER_OPERATOR_FUNCTOR(aten::ge, aten_ge, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::ge.Scalar(Tensor self, Scalar other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto other = p_node->Input(1).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::ge(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto other = p_node->input(1).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::ge(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::ge_out(out, self, other);
     };
@@ -1629,18 +1629,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::ge, aten_ge, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::ge.Tensor(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::ge(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::ge(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::ge_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1648,13 +1648,13 @@ REGISTER_OPERATOR_FUNCTOR(aten::le, aten_le, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::le.Scalar(Tensor self, Scalar other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto other = p_node->Input(1).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::le(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto other = p_node->input(1).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::le(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::le_out(out, self, other);
     };
@@ -1663,18 +1663,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::le, aten_le, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::le.Tensor(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::le(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::le(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::le_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1682,13 +1682,13 @@ REGISTER_OPERATOR_FUNCTOR(aten::gt, aten_gt, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::gt.Scalar(Tensor self, Scalar other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto other = p_node->Input(1).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::gt(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto other = p_node->input(1).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::gt(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::gt_out(out, self, other);
     };
@@ -1697,18 +1697,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::gt, aten_gt, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::gt.Tensor(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::gt(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::gt(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::gt_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1716,13 +1716,13 @@ REGISTER_OPERATOR_FUNCTOR(aten::lt, aten_lt, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::lt.Scalar(Tensor self, Scalar other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto other = p_node->Input(1).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::lt(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto other = p_node->input(1).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::lt(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::lt_out(out, self, other);
     };
@@ -1731,18 +1731,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::lt, aten_lt, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::lt.Tensor(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::lt(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::lt(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::lt_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1750,20 +1750,20 @@ REGISTER_OPERATOR_FUNCTOR(aten::gather, aten_gather, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::gather(Tensor self, int dim, Tensor index, *, bool sparse_grad=False) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      const auto& index = p_node->Input(2).toTensor();
-      const auto sparse_grad = p_node->Input(3).toBool();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::gather(self, dim, index, sparse_grad);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      const auto& index = p_node->input(2).toTensor();
+      const auto sparse_grad = p_node->input(3).toBool();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::gather(self, dim, index, sparse_grad);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::gather_out(out, self, dim, index, sparse_grad);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1771,20 +1771,20 @@ REGISTER_OPERATOR_FUNCTOR(aten::addcmul, aten_addcmul, [](Node* n) -> SROperator
   if (n->matches(torch::schema(
           "aten::addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& tensor1 = p_node->Input(1).toTensor();
-      const auto& tensor2 = p_node->Input(2).toTensor();
-      const auto value = p_node->Input(3).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::addcmul(self, tensor1, tensor2, value);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& tensor1 = p_node->input(1).toTensor();
+      const auto& tensor2 = p_node->input(2).toTensor();
+      const auto value = p_node->input(3).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::addcmul(self, tensor1, tensor2, value);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::addcmul_out(out, self, tensor1, tensor2, value);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1792,37 +1792,37 @@ REGISTER_OPERATOR_FUNCTOR(aten::addcdiv, aten_addcdiv, [](Node* n) -> SROperator
   if (n->matches(torch::schema(
           "aten::addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& tensor1 = p_node->Input(1).toTensor();
-      const auto& tensor2 = p_node->Input(2).toTensor();
-      const auto value = p_node->Input(3).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::addcdiv(self, tensor1, tensor2, value);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& tensor1 = p_node->input(1).toTensor();
+      const auto& tensor2 = p_node->input(2).toTensor();
+      const auto value = p_node->input(3).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::addcdiv(self, tensor1, tensor2, value);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::addcdiv_out(out, self, tensor1, tensor2, value);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::lgamma, aten_lgamma, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::lgamma(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::lgamma(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::lgamma(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::lgamma_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1833,52 +1833,52 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(
               torch::schema("aten::polygamma(int n, Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto n = p_node->Input(0).toInt();
-          const auto& self = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::polygamma(n, self);
+          const auto n = p_node->input(0).toInt();
+          const auto& self = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::polygamma(n, self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::polygamma_out(out, n, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
 REGISTER_OPERATOR_FUNCTOR(aten::erfinv, aten_erfinv, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::erfinv(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::erfinv(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::erfinv(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::erfinv_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::i0, aten_i0, [](Node* n) -> SROperator {
   if (n->matches(torch::schema("aten::i0(Tensor self) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::i0(self);
+      const auto& self = p_node->input(0).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::i0(self);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::i0_out(out, self);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1888,17 +1888,17 @@ REGISTER_OPERATOR_FUNCTOR(
     [](Node* n) -> SROperator {
       if (n->matches(torch::schema("aten::signbit(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::signbit(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::signbit(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::signbit_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -1906,18 +1906,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::atan2, aten_atan2, [](Node* n) -> SROperator {
   if (n->matches(
           torch::schema("aten::atan2(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::atan2(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::atan2(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::atan2_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1925,18 +1925,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::hypot, aten_hypot, [](Node* n) -> SROperator {
   if (n->matches(
           torch::schema("aten::hypot(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::hypot(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::hypot(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::hypot_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1944,18 +1944,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::igamma, aten_igamma, [](Node* n) -> SROperator {
   if (n->matches(
           torch::schema("aten::igamma(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::igamma(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::igamma(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::igamma_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -1966,18 +1966,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::igammac(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::igammac(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::igammac(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::igammac_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -1988,18 +1988,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::nextafter(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::nextafter(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::nextafter(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::nextafter_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2007,18 +2007,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::fmin, aten_fmin, [](Node* n) -> SROperator {
   if (n->matches(
           torch::schema("aten::fmin(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::fmin(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::fmin(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::fmin_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -2026,18 +2026,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::fmax, aten_fmax, [](Node* n) -> SROperator {
   if (n->matches(
           torch::schema("aten::fmax(Tensor self, Tensor other) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& other = p_node->Input(1).toTensor();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::fmax(self, other);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& other = p_node->input(1).toTensor();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::fmax(self, other);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::fmax_out(out, self, other);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -2048,18 +2048,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::maximum(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::maximum(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::maximum(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::maximum_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2070,18 +2070,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::minimum(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::minimum(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::minimum(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::minimum_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2089,20 +2089,20 @@ REGISTER_OPERATOR_FUNCTOR(aten::renorm, aten_renorm, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::renorm(Tensor self, Scalar p, int dim, Scalar maxnorm) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto p = p_node->Input(1).toScalar();
-      const auto dim = p_node->Input(2).toInt();
-      const auto maxnorm = p_node->Input(3).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::renorm(self, p, dim, maxnorm);
+      const auto& self = p_node->input(0).toTensor();
+      const auto p = p_node->input(1).toScalar();
+      const auto dim = p_node->input(2).toInt();
+      const auto maxnorm = p_node->input(3).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::renorm(self, p, dim, maxnorm);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::renorm_out(out, self, p, dim, maxnorm);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -2113,21 +2113,21 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::_convert_indices_from_coo_to_csr(Tensor self, int size, *, bool out_int32=False) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto size = p_node->Input(1).toInt();
-          const auto out_int32 = p_node->Input(2).toBool();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::_convert_indices_from_coo_to_csr(
+          const auto& self = p_node->input(0).toTensor();
+          const auto size = p_node->input(1).toInt();
+          const auto out_int32 = p_node->input(2).toBool();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::_convert_indices_from_coo_to_csr(
                 self, size, out_int32);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::_convert_indices_from_coo_to_csr_out(
               out, self, size, out_int32);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2138,22 +2138,22 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::_convert_indices_from_csr_to_coo(Tensor crow_indices, Tensor col_indices, *, bool out_int32=False, bool transpose=False) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& crow_indices = p_node->Input(0).toTensor();
-          const auto& col_indices = p_node->Input(1).toTensor();
-          const auto out_int32 = p_node->Input(2).toBool();
-          const auto transpose = p_node->Input(3).toBool();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::_convert_indices_from_csr_to_coo(
+          const auto& crow_indices = p_node->input(0).toTensor();
+          const auto& col_indices = p_node->input(1).toTensor();
+          const auto out_int32 = p_node->input(2).toBool();
+          const auto transpose = p_node->input(3).toBool();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::_convert_indices_from_csr_to_coo(
                 crow_indices, col_indices, out_int32, transpose);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::_convert_indices_from_csr_to_coo_out(
               out, crow_indices, col_indices, out_int32, transpose);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2161,19 +2161,19 @@ REGISTER_OPERATOR_FUNCTOR(aten::mse_loss, aten_mse_loss, [](Node* n) -> SROperat
   if (n->matches(torch::schema(
           "aten::mse_loss(Tensor self, Tensor target, int reduction=Mean) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto& target = p_node->Input(1).toTensor();
-      const auto reduction = p_node->Input(2).toInt();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::mse_loss(self, target, reduction);
+      const auto& self = p_node->input(0).toTensor();
+      const auto& target = p_node->input(1).toTensor();
+      const auto reduction = p_node->input(2).toInt();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::mse_loss(self, target, reduction);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::mse_loss_out(out, self, target, reduction);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -2184,15 +2184,15 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::nll_loss_backward(Tensor grad_output, Tensor self, Tensor target, Tensor? weight, int reduction, int ignore_index, Tensor total_weight) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& self = p_node->Input(1).toTensor();
-          const auto& target = p_node->Input(2).toTensor();
-          const auto weight = p_node->Input(3).toOptional<at::Tensor>();
-          const auto reduction = p_node->Input(4).toInt();
-          const auto ignore_index = p_node->Input(5).toInt();
-          const auto& total_weight = p_node->Input(6).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::nll_loss_backward(
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& self = p_node->input(1).toTensor();
+          const auto& target = p_node->input(2).toTensor();
+          const auto weight = p_node->input(3).toOptional<at::Tensor>();
+          const auto reduction = p_node->input(4).toInt();
+          const auto ignore_index = p_node->input(5).toInt();
+          const auto& total_weight = p_node->input(6).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::nll_loss_backward(
                 grad_output,
                 self,
                 target,
@@ -2202,7 +2202,7 @@ REGISTER_OPERATOR_FUNCTOR(
                 total_weight);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::nll_loss_backward_out(
               grad_input,
@@ -2215,7 +2215,7 @@ REGISTER_OPERATOR_FUNCTOR(
               total_weight);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2223,20 +2223,20 @@ REGISTER_OPERATOR_FUNCTOR(aten::elu, aten_elu, [](Node* n) -> SROperator {
   if (n->matches(torch::schema(
           "aten::elu(Tensor self, Scalar alpha=1, Scalar scale=1, Scalar input_scale=1) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto alpha = p_node->Input(1).toScalar();
-      const auto scale = p_node->Input(2).toScalar();
-      const auto input_scale = p_node->Input(3).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::elu(self, alpha, scale, input_scale);
+      const auto& self = p_node->input(0).toTensor();
+      const auto alpha = p_node->input(1).toScalar();
+      const auto scale = p_node->input(2).toScalar();
+      const auto input_scale = p_node->input(3).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::elu(self, alpha, scale, input_scale);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::elu_out(out, self, alpha, scale, input_scale);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -2247,14 +2247,14 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::elu_backward(Tensor grad_output, Scalar alpha, Scalar scale, Scalar input_scale, bool is_result, Tensor self_or_result) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto alpha = p_node->Input(1).toScalar();
-          const auto scale = p_node->Input(2).toScalar();
-          const auto input_scale = p_node->Input(3).toScalar();
-          const auto is_result = p_node->Input(4).toBool();
-          const auto& self_or_result = p_node->Input(5).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::elu_backward(
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto alpha = p_node->input(1).toScalar();
+          const auto scale = p_node->input(2).toScalar();
+          const auto input_scale = p_node->input(3).toScalar();
+          const auto is_result = p_node->input(4).toBool();
+          const auto& self_or_result = p_node->input(5).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::elu_backward(
                 grad_output,
                 alpha,
                 scale,
@@ -2263,7 +2263,7 @@ REGISTER_OPERATOR_FUNCTOR(
                 self_or_result);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::elu_backward_out(
               grad_input,
@@ -2275,7 +2275,7 @@ REGISTER_OPERATOR_FUNCTOR(
               self_or_result);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2283,18 +2283,18 @@ REGISTER_OPERATOR_FUNCTOR(aten::glu, aten_glu, [](Node* n) -> SROperator {
   if (n->matches(
           torch::schema("aten::glu(Tensor self, int dim=-1) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto dim = p_node->Input(1).toInt();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::glu(self, dim);
+      const auto& self = p_node->input(0).toTensor();
+      const auto dim = p_node->input(1).toInt();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::glu(self, dim);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::glu_out(out, self, dim);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -2305,17 +2305,17 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(
               torch::schema("aten::hardsigmoid(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::hardsigmoid(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::hardsigmoid(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::hardsigmoid_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2326,19 +2326,19 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::hardsigmoid_backward(Tensor grad_output, Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& self = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) =
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& self = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) =
                 at::cpu::hardsigmoid_backward(grad_output, self);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::hardsigmoid_backward_out(grad_input, grad_output, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2349,22 +2349,22 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::leaky_relu_backward(Tensor grad_output, Tensor self, Scalar negative_slope, bool self_is_result) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& self = p_node->Input(1).toTensor();
-          const auto negative_slope = p_node->Input(2).toScalar();
-          const auto self_is_result = p_node->Input(3).toBool();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::leaky_relu_backward(
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& self = p_node->input(1).toTensor();
+          const auto negative_slope = p_node->input(2).toScalar();
+          const auto self_is_result = p_node->input(3).toBool();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::leaky_relu_backward(
                 grad_output, self, negative_slope, self_is_result);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::leaky_relu_backward_out(
               grad_input, grad_output, self, negative_slope, self_is_result);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2372,19 +2372,19 @@ REGISTER_OPERATOR_FUNCTOR(aten::softplus, aten_softplus, [](Node* n) -> SROperat
   if (n->matches(torch::schema(
           "aten::softplus(Tensor self, Scalar beta=1, Scalar threshold=20) -> Tensor"))) {
     return [](ProcessedNode* p_node) {
-      const auto& self = p_node->Input(0).toTensor();
-      const auto beta = p_node->Input(1).toScalar();
-      const auto threshold = p_node->Input(2).toScalar();
-      if (p_node->Output(0).isNone()) {
-        p_node->Output(0) = at::cpu::softplus(self, beta, threshold);
+      const auto& self = p_node->input(0).toTensor();
+      const auto beta = p_node->input(1).toScalar();
+      const auto threshold = p_node->input(2).toScalar();
+      if (p_node->output(0).isNone()) {
+        p_node->output(0) = at::cpu::softplus(self, beta, threshold);
         return;
       }
-      auto& out = p_node->Output(0).toTensor();
+      auto& out = p_node->output(0).toTensor();
       fastResizeToZero(out);
       at::cpu::softplus_out(out, self, beta, threshold);
     };
   }
-  LogAndDumpSchema(n);
+  logAndDumpSchema(n);
   return nullptr;
 });
 
@@ -2395,22 +2395,22 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::softplus_backward(Tensor grad_output, Tensor self, Scalar beta, Scalar threshold) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& self = p_node->Input(1).toTensor();
-          const auto beta = p_node->Input(2).toScalar();
-          const auto threshold = p_node->Input(3).toScalar();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) =
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& self = p_node->input(1).toTensor();
+          const auto beta = p_node->input(2).toScalar();
+          const auto threshold = p_node->input(3).toScalar();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) =
                 at::cpu::softplus_backward(grad_output, self, beta, threshold);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::softplus_backward_out(
               grad_input, grad_output, self, beta, threshold);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2421,18 +2421,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::softshrink(Tensor self, Scalar lambd=0.5) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto lambd = p_node->Input(1).toScalar();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::softshrink(self, lambd);
+          const auto& self = p_node->input(0).toTensor();
+          const auto lambd = p_node->input(1).toScalar();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::softshrink(self, lambd);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::softshrink_out(out, self, lambd);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2443,21 +2443,21 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::softshrink_backward(Tensor grad_output, Tensor self, Scalar lambd) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& self = p_node->Input(1).toTensor();
-          const auto lambd = p_node->Input(2).toScalar();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) =
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& self = p_node->input(1).toTensor();
+          const auto lambd = p_node->input(2).toScalar();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) =
                 at::cpu::softshrink_backward(grad_output, self, lambd);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::softshrink_backward_out(
               grad_input, grad_output, self, lambd);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2468,21 +2468,21 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::adaptive_max_pool2d_backward(Tensor grad_output, Tensor self, Tensor indices) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& self = p_node->Input(1).toTensor();
-          const auto& indices = p_node->Input(2).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::adaptive_max_pool2d_backward(
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& self = p_node->input(1).toTensor();
+          const auto& indices = p_node->input(2).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::adaptive_max_pool2d_backward(
                 grad_output, self, indices);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::adaptive_max_pool2d_backward_out(
               grad_input, grad_output, self, indices);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2493,21 +2493,21 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::adaptive_max_pool3d_backward(Tensor grad_output, Tensor self, Tensor indices) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& self = p_node->Input(1).toTensor();
-          const auto& indices = p_node->Input(2).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::adaptive_max_pool3d_backward(
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& self = p_node->input(1).toTensor();
+          const auto& indices = p_node->input(2).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::adaptive_max_pool3d_backward(
                 grad_output, self, indices);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::adaptive_max_pool3d_backward_out(
               grad_input, grad_output, self, indices);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2518,18 +2518,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::sigmoid_backward(Tensor grad_output, Tensor output) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& output = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::sigmoid_backward(grad_output, output);
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& output = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::sigmoid_backward(grad_output, output);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::sigmoid_backward_out(grad_input, grad_output, output);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2540,18 +2540,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::tanh_backward(Tensor grad_output, Tensor output) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& grad_output = p_node->Input(0).toTensor();
-          const auto& output = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::tanh_backward(grad_output, output);
+          const auto& grad_output = p_node->input(0).toTensor();
+          const auto& output = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::tanh_backward(grad_output, output);
             return;
           }
-          auto& grad_input = p_node->Output(0).toTensor();
+          auto& grad_input = p_node->output(0).toTensor();
           fastResizeToZero(grad_input);
           at::cpu::tanh_backward_out(grad_input, grad_output, output);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2561,17 +2561,17 @@ REGISTER_OPERATOR_FUNCTOR(
     [](Node* n) -> SROperator {
       if (n->matches(torch::schema("aten::isposinf(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::isposinf(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::isposinf(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::isposinf_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2581,17 +2581,17 @@ REGISTER_OPERATOR_FUNCTOR(
     [](Node* n) -> SROperator {
       if (n->matches(torch::schema("aten::isneginf(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::isneginf(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::isneginf(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::isneginf_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2602,17 +2602,17 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(
               torch::schema("aten::special_entr(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::special_entr(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::special_entr(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::special_entr_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2623,17 +2623,17 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(
               torch::schema("aten::special_ndtri(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::special_ndtri(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::special_ndtri(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::special_ndtri_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2644,17 +2644,17 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(
               torch::schema("aten::special_erfcx(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::special_erfcx(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::special_erfcx(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::special_erfcx_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2665,18 +2665,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::special_xlog1py(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::special_xlog1py(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::special_xlog1py(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::special_xlog1py_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2687,18 +2687,18 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::special_zeta(Tensor self, Tensor other) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::special_zeta(self, other);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::special_zeta(self, other);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::special_zeta_out(out, self, other);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2709,17 +2709,17 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(
               torch::schema("aten::special_i0e(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::special_i0e(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::special_i0e(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::special_i0e_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2730,17 +2730,17 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(
               torch::schema("aten::special_i1(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::special_i1(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::special_i1(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::special_i1_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2751,17 +2751,17 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(
               torch::schema("aten::special_i1e(Tensor self) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::special_i1e(self);
+          const auto& self = p_node->input(0).toTensor();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::special_i1e(self);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::special_i1e_out(out, self);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 
@@ -2772,19 +2772,19 @@ REGISTER_OPERATOR_FUNCTOR(
       if (n->matches(torch::schema(
               "aten::linalg_cross(Tensor self, Tensor other, *, int dim=-1) -> Tensor"))) {
         return [](ProcessedNode* p_node) {
-          const auto& self = p_node->Input(0).toTensor();
-          const auto& other = p_node->Input(1).toTensor();
-          const auto dim = p_node->Input(2).toInt();
-          if (p_node->Output(0).isNone()) {
-            p_node->Output(0) = at::cpu::linalg_cross(self, other, dim);
+          const auto& self = p_node->input(0).toTensor();
+          const auto& other = p_node->input(1).toTensor();
+          const auto dim = p_node->input(2).toInt();
+          if (p_node->output(0).isNone()) {
+            p_node->output(0) = at::cpu::linalg_cross(self, other, dim);
             return;
           }
-          auto& out = p_node->Output(0).toTensor();
+          auto& out = p_node->output(0).toTensor();
           fastResizeToZero(out);
           at::cpu::linalg_cross_out(out, self, other, dim);
         };
       }
-      LogAndDumpSchema(n);
+      logAndDumpSchema(n);
       return nullptr;
     });
 

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -122,7 +122,7 @@ std::string dumpValueSet(
 
 namespace {
 
-void OptimizeGraph(
+void optimizeGraph(
     std::shared_ptr<torch::jit::Graph>& graph,
     const StaticModuleOptions& opts,
     std::vector<IValue> sample_inputs) {
@@ -142,44 +142,44 @@ void OptimizeGraph(
   RemoveTensorMutation(graph);
   ConstantPropagation(graph);
   EliminateDeadCode(graph);
-  FuseInferenceOpsForSparseNN(graph);
+  fuseInferenceOpsForSparseNN(graph);
   UseVariadicCat(graph);
   UseVariadicStack(graph);
-  EliminateTrivialEquallySplit(graph);
-  EliminateExtraPermuteOps(graph);
+  eliminateTrivialEquallySplit(graph);
+  eliminateExtraPermuteOps(graph);
 
   if (opts.enable_out_variant) {
     UseVariadicOp(
         graph,
         fromQualString("fb::sigrid_transforms_torch_bind"),
         fromQualString("fb::variadic_sigrid_transforms_torch_bind"));
-    FuseSignLog1P(graph);
+    fuseSignLog1P(graph);
 
     // TODO: we can avoid this guard by moving operations
     // to exposed folders.
 #ifdef FBCODE_CAFFE2
     if (opts.use_copy_variants && !opts.enable_tensorexpr_fusion) {
-      ReplaceWithCopy(graph);
+      replaceWithCopy(graph);
     }
     if (opts.use_maybe_copy_variants && !opts.enable_tensorexpr_fusion) {
-      ReplaceWithMaybeCopy(graph);
+      replaceWithMaybeCopy(graph);
     }
-    FuseListUnpack(graph);
+    fuseListUnpack(graph);
 #endif
   }
 
   ConstantPropagation(graph);
-  RemoveImmutableInputDictLookups(graph);
-  UseVariadicTupleUnpack(graph);
-  UseVariadicGroupedAccessor(graph);
+  removeImmutableInputDictLookups(graph);
+  useVariadicTupleUnpack(graph);
+  useVariadicGroupedAccessor(graph);
   EliminateNoOps(
       graph, /* custom_ops */ {fromQualString("fb::scale_gradient")});
   AddIfThenElseOp(graph);
-  UseSplitAndSqueeze(graph);
+  useSplitAndSqueeze(graph);
   GRAPH_DUMP("Final graph after optimizations: ", graph);
 }
 
-bool IsSelfInGraphInput(std::shared_ptr<torch::jit::Graph>& graph) {
+bool isSelfInGraphInput(std::shared_ptr<torch::jit::Graph>& graph) {
   return !graph->inputs().empty() && graph->inputs().at(0)->type()->is_module();
 }
 
@@ -218,12 +218,12 @@ bool mayContainAlias(
   return db.mayContainAlias(const_cast<Value*>(a), valueVecFromFastSet(b));
 }
 
-void PrepareGraphForStaticModule(
+void prepareGraphForStaticModule(
     std::shared_ptr<torch::jit::Graph> graph,
     const StaticModuleOptions& opts,
     std::vector<IValue> sample_inputs) {
   TORCH_CHECK(canEnableStaticRuntime(graph));
-  OptimizeGraph(graph, opts, std::move(sample_inputs));
+  optimizeGraph(graph, opts, std::move(sample_inputs));
 
   // Static runtime moves its outputs out of the runtime
   // by default. In some rare cases, this is not actually safe to
@@ -232,14 +232,14 @@ void PrepareGraphForStaticModule(
   // to handle this rare case, we use this pass to detect it and
   // create an owned reference that can be safely moved out of the
   // runtime.
-  CreateOwnedRefsForSpecialValues(*graph);
+  createOwnedRefsForSpecialIValues(*graph);
 
   // We assume that each sub-block has at least one output. If we
   // detect any that have 0, force the sub-block to return None.
-  ForceNonEmptyOutputs(*graph);
+  forceNonEmptyOutputs(*graph);
 }
 
-std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
+std::pair<std::shared_ptr<Graph>, c10::optional<Module>> prepareForStaticModule(
     const torch::jit::Module& m,
     bool is_frozen,
     const StaticModuleOptions& opts,
@@ -261,19 +261,19 @@ std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
   Method method = module.get_method("forward");
   auto graph = module.get_method("forward").graph();
 
-  if (!sample_inputs.empty() && IsSelfInGraphInput(graph)) {
+  if (!sample_inputs.empty() && isSelfInGraphInput(graph)) {
     sample_inputs.insert(sample_inputs.begin(), m._ivalue());
   }
-  PrepareGraphForStaticModule(graph, opts, std::move(sample_inputs));
+  prepareGraphForStaticModule(graph, opts, std::move(sample_inputs));
 
   return std::make_pair(graph, module);
 }
 
-std::pair<std::shared_ptr<Graph>, c10::optional<Module>> PrepareForStaticModule(
+std::pair<std::shared_ptr<Graph>, c10::optional<Module>> prepareForStaticModule(
     std::shared_ptr<torch::jit::Graph> graph,
     const StaticModuleOptions& opts,
     std::vector<IValue> sample_inputs) {
-  PrepareGraphForStaticModule(graph, opts, std::move(sample_inputs));
+  prepareGraphForStaticModule(graph, opts, std::move(sample_inputs));
   return std::make_pair(graph, c10::nullopt);
 }
 
@@ -491,7 +491,7 @@ StaticModule::StaticModule(
     const StaticModuleOptions& opts,
     std::vector<IValue> sample_inputs)
     : StaticModule(
-          PrepareForStaticModule(g->copy(), opts, std::move(sample_inputs)),
+          prepareForStaticModule(g->copy(), opts, std::move(sample_inputs)),
           opts) {}
 
 StaticModule::StaticModule(
@@ -500,7 +500,7 @@ StaticModule::StaticModule(
     const StaticModuleOptions& opts,
     std::vector<IValue> sample_inputs)
     : StaticModule(
-          PrepareForStaticModule(m, is_frozen, opts, std::move(sample_inputs)),
+          prepareForStaticModule(m, is_frozen, opts, std::move(sample_inputs)),
           opts) {}
 
 StaticModule::StaticModule(
@@ -566,7 +566,7 @@ StaticModule::StaticModule(
 
   for (auto& block_and_info : block_infos_) {
     auto& block_info = block_and_info.second;
-    block_info.prepare_for_memory_planner(alias_db, opts);
+    block_info.prepareForMemoryPlanner(alias_db, opts);
   }
 }
 
@@ -576,11 +576,11 @@ size_t StaticModule::prepareBlockInfo(
     FastMap<const Value*, uint32_t>& value_to_index) {
   block_infos_.emplace(block, BlockInfo(start_idx, *block));
 
-  const auto num_inputs = block->inputs().size();
-  for (const auto i : c10::irange(num_inputs)) {
+  const auto numInputs = block->inputs().size();
+  for (const auto i : c10::irange(numInputs)) {
     value_to_index.emplace(block->inputs()[i], start_idx + i);
   }
-  auto cur_idx = start_idx + num_inputs;
+  auto cur_idx = start_idx + numInputs;
 
   for (auto* node : block->nodes()) {
     for (auto* sub_block : node->blocks()) {
@@ -597,11 +597,11 @@ size_t StaticModule::prepareBlockInfo(
         cur_idx,
         " would overflow 2-byte index storage");
 
-    const auto num_outputs = node->outputs().size();
-    for (const auto i : c10::irange(num_outputs)) {
+    const auto numOutputs = node->outputs().size();
+    for (const auto i : c10::irange(numOutputs)) {
       value_to_index.emplace(node->outputs()[i], cur_idx + i);
     }
-    cur_idx += num_outputs;
+    cur_idx += numOutputs;
   }
 
   std::vector<uint16_t> output_indices;
@@ -616,7 +616,7 @@ size_t StaticModule::prepareBlockInfo(
     output_indices.push_back(output_idx);
   }
 
-  block_infos_.at(block).set_output_indices(std::move(output_indices));
+  block_infos_.at(block).setOutputIndices(std::move(output_indices));
   return cur_idx - start_idx;
 }
 
@@ -656,7 +656,7 @@ size_t StaticModule::prepareStaticNodeInfos(
 
   auto& block_info = block_infos_.at(block);
   std::vector<StaticNodeInfo> nodes;
-  FastMap<Node*, bool> node_has_out_variant;
+  FastMap<Node*, bool> node_hasOutVariant;
 
   for (auto* node : block->nodes()) {
     if (node->kind() == prim::Constant) {
@@ -689,29 +689,29 @@ size_t StaticModule::prepareStaticNodeInfos(
         : value_to_index.at(node->output(0));
     nodes.emplace_back(node, fn, std::move(input_indices), node_output_idx);
 
-    node_has_out_variant.emplace(node, nodes.back().has_out_variant());
+    node_hasOutVariant.emplace(node, nodes.back().hasOutVariant());
     ++node_idx;
   }
 
-  block_info.set_nodes(std::move(nodes), node_has_out_variant);
-  block_info.init_value_group(alias_db);
+  block_info.setNodes(std::move(nodes), node_hasOutVariant);
+  block_info.initValueGroup(alias_db);
 
   return node_idx - node_start;
 }
 
-void BlockInfo::set_nodes(
+void BlockInfo::setNodes(
     std::vector<StaticNodeInfo> nodes,
-    const FastMap<Node*, bool>& node_has_out_variant) {
+    const FastMap<Node*, bool>& node_hasOutVariant) {
   nodes_ = std::move(nodes);
 
   for (auto& node : nodes_) {
-    if (node.num_outputs() == 1 &&
-        isOptimizableContainerType(node.node(), node_has_out_variant)) {
+    if (node.numOutputs() == 1 &&
+        isOptimizableContainerType(node.node(), node_hasOutVariant)) {
       node_is_optimizable_container_type_.emplace(node.node());
     }
   }
 }
-void BlockInfo::prepare_for_memory_planner(
+void BlockInfo::prepareForMemoryPlanner(
     const AliasDb& alias_db,
     const StaticModuleOptions& opts) {
   if (!opts.enable_out_variant) {
@@ -725,7 +725,7 @@ void BlockInfo::prepare_for_memory_planner(
 
   // collect register indices of outputs of ops with out variant
   for (StaticNodeInfo& pnode : nodes_) {
-    if (!pnode.has_out_variant()) {
+    if (!pnode.hasOutVariant()) {
       continue;
     }
     auto outputs = pnode.node()->outputs();
@@ -744,7 +744,7 @@ void BlockInfo::prepare_for_memory_planner(
       }
       if (is_tensor_type) {
         managed_tensor_values_.insert(out_v);
-      } else if (node_is_optimizable_container_type(pnode.node())) {
+      } else if (nodeIsOptimizableContainerType(pnode.node())) {
         // We "leak" certain container types because their allocations
         // take a long time
         leaked_values_.insert(out_v);
@@ -768,11 +768,11 @@ const StaticModuleOptions& StaticModule::opts() const {
   return opts_;
 }
 
-size_t StaticModule::num_outputs() const {
+size_t StaticModule::numOutputs() const {
   return graph_->outputs().size();
 }
 
-size_t StaticModule::num_inputs() const {
+size_t StaticModule::numInputs() const {
   return num_inputs_;
 }
 
@@ -783,7 +783,7 @@ StaticRuntime& StaticModule::runtime() {
   return *cached_runtime_;
 }
 
-StaticRuntime StaticModule::clone_runtime_from_cached() {
+StaticRuntime StaticModule::cloneRuntimeFromCached() {
   return runtime().clone();
 }
 
@@ -817,11 +817,10 @@ BlockRunner::BlockRunner(
     Block* block,
     bool is_root_block)
     : static_module_(sm),
-      block_info_(static_module_.block_info(block)),
+      block_info_(static_module_.blockInfo(block)),
       is_root_block_(is_root_block),
-      first_input_is_self_(
-          is_root_block_ && static_module_.first_input_is_self()),
-      inputs_begin_(block_info_.block_inputs_idx()),
+      first_input_is_self_(is_root_block_ && static_module_.firstInputIsSelf()),
+      inputs_begin_(block_info_.blockInputsIdx()),
       // TODO(T108633124): Turn on manage output tensors for sub-blocks.
       manage_output_tensors_enabled_(
           is_root_block_ && sm.opts().manage_output_tensors),
@@ -832,7 +831,7 @@ BlockRunner::BlockRunner(
     nodes_.emplace_back(pre_pnode, values_);
   }
 
-  for (auto index : block_info_.block_output_indices()) {
+  for (auto index : block_info_.blockOutputIndices()) {
     outputs_.emplace_back(&values_[index]);
   }
 
@@ -850,7 +849,7 @@ BlockRunner::BlockRunner(
     for (auto* b : blocks) {
       block_runners->emplace_back(sm, values_, b);
     }
-    pnode.set_block_runners(std::move(block_runners));
+    pnode.setBlockRunners(std::move(block_runners));
   }
 }
 
@@ -859,31 +858,31 @@ BlockRunner::BlockRunner(BlockRunner&&) noexcept = default;
 
 BlockRunner::~BlockRunner() = default;
 
-void BlockRunner::maybe_clone_memory_planner(
+void BlockRunner::maybeCloneMemoryPlanner(
     const BlockRunner& src,
     const FastMap<at::Tensor*, at::Tensor*>& old_tensor_to_new) {
   if (!src.planner_) {
     return;
   }
-  planner_ = src.planner_->maybe_clone(this, old_tensor_to_new);
+  planner_ = src.planner_->maybeClone(this, old_tensor_to_new);
 }
 
-void BlockRunner::set_arg(const size_t idx, std::vector<IValue>&& args) {
+void BlockRunner::setArg(const size_t idx, std::vector<IValue>&& args) {
   DCHECK(idx < args.size());
-  Input(idx + first_input_is_self_) = std::move(args[idx]);
+  input(idx + first_input_is_self_) = std::move(args[idx]);
 }
 
-void BlockRunner::set_arg(const size_t idx, const std::vector<IValue>& args) {
+void BlockRunner::setArg(const size_t idx, const std::vector<IValue>& args) {
   DCHECK(idx < args.size());
-  Input(idx + first_input_is_self_) = args[idx];
+  input(idx + first_input_is_self_) = args[idx];
 }
 
-void BlockRunner::set_arg(const size_t idx, const IValue& arg) {
-  Input(idx + first_input_is_self_) = arg;
+void BlockRunner::setArg(const size_t idx, const IValue& arg) {
+  input(idx + first_input_is_self_) = arg;
 }
 
 namespace {
-void check_type(const Argument& schema_arg, const IValue& arg) {
+void checkType(const Argument& schema_arg, const IValue& arg) {
   // Fast path for most common case
   if (arg.isTensor() &&
       schema_arg.type()->kind() == c10::TypeKind::TensorType) {
@@ -894,23 +893,23 @@ void check_type(const Argument& schema_arg, const IValue& arg) {
 } // namespace
 
 template <typename IValueList>
-void BlockRunner::set_inputs(
+void BlockRunner::setInputs(
     IValueList&& args,
     const std::unordered_map<std::string, c10::IValue>& kwargs) {
   const auto& schema = static_module_.schema();
   if (first_input_is_self_) {
-    Input(0) = static_module_.module()._ivalue();
+    input(0) = static_module_.module()._ivalue();
   }
 
   if (!is_root_block_ || C10_UNLIKELY(!schema)) {
     TORCH_CHECK(
         kwargs.empty(), "Schema is not available, but BlockRunner got kwargs.");
 
-    const auto total_num_inputs = args.size() + first_input_is_self_;
-    TORCH_CHECK(total_num_inputs == block_info_.num_inputs());
+    const auto total_numInputs = args.size() + first_input_is_self_;
+    TORCH_CHECK(total_numInputs == block_info_.numInputs());
 
     for (size_t i = 0; i < args.size(); ++i) {
-      set_arg(i, std::forward<IValueList>(args));
+      setArg(i, std::forward<IValueList>(args));
     }
     return;
   }
@@ -926,22 +925,22 @@ void BlockRunner::set_inputs(
     const auto& schema_arg = schema_args[i + 1];
 
     if (i < args.size()) {
-      check_type(schema_arg, args[i]);
-      set_arg(i, std::forward<IValueList>(args));
+      checkType(schema_arg, args[i]);
+      setArg(i, std::forward<IValueList>(args));
       continue;
     }
 
     auto it = kwargs.find(schema_arg.name());
     if (it != kwargs.end()) {
-      check_type(schema_arg, it->second);
-      set_arg(i, it->second);
+      checkType(schema_arg, it->second);
+      setArg(i, it->second);
       ++consumed_kwargs;
       continue;
     }
 
     auto maybe_default_val = schema_arg.default_value();
     if (maybe_default_val) {
-      set_arg(i, *maybe_default_val);
+      setArg(i, *maybe_default_val);
       continue;
     }
 
@@ -952,7 +951,7 @@ void BlockRunner::set_inputs(
 }
 
 namespace {
-std::unique_ptr<MemoryPlanner> memory_planner_factory(
+std::unique_ptr<MemoryPlanner> memoryPlannerFactory(
     MemoryPlannerAlgorithm algorithm,
     BlockRunner* block_runner,
     const BlockInfo& block_info,
@@ -982,10 +981,10 @@ std::unique_ptr<MemoryPlanner> memory_planner_factory(
 }
 } // namespace
 
-void BlockRunner::create_memory_planner() {
+void BlockRunner::createMemoryPlanner() {
   if (!planner_) {
     const auto& opts = static_module_.opts();
-    planner_ = memory_planner_factory(
+    planner_ = memoryPlannerFactory(
         memory_planner_algorithm_,
         this,
         block_info_,
@@ -994,12 +993,12 @@ void BlockRunner::create_memory_planner() {
   }
 }
 
-void BlockRunner::maybe_allocate() {
+void BlockRunner::maybeAllocate() {
   DCHECK(planner_);
   if (planner_->shouldFallBackToStandardStrategy()) {
     for (auto& n : nodes_) {
       for (const auto i : c10::irange(n.outputs().size())) {
-        n.Output(i) = IValue();
+        n.output(i) = IValue();
       }
     }
     planner_ = nullptr;
@@ -1013,8 +1012,8 @@ namespace {
 
 void destroyNodeOutputs(ProcessedNode& p_node) {
   const auto borrows_outputs = borrowsOutputs(p_node.node()->kind());
-  for (const auto i : c10::irange(p_node.num_outputs())) {
-    auto& output = p_node.Output(i);
+  for (const auto i : c10::irange(p_node.numOutputs())) {
+    auto& output = p_node.output(i);
     if (doesNotHeapAllocateWhenStoredInIValue(*output.type())) {
       continue;
     }
@@ -1031,7 +1030,7 @@ void destroyNodeOutputs(ProcessedNode& p_node) {
 
 } // namespace
 
-void BlockRunner::clean_up_intermediate_ivalues() noexcept {
+void BlockRunner::cleanUpIntermediateIValues() noexcept {
   // We have to iterate in reverse order here due to borrowed
   // IValues - we don't want to destroy a value until all of its
   // borrows are cleaned up!
@@ -1045,12 +1044,12 @@ void BlockRunner::resetMemory() noexcept {
   // We must clean up intermediate values before inputs in case
   // there are borrowed inputs and static runtime owns the only
   // reference (e.g. the inputs were std::move'd into the runtime)
-  clean_up_intermediate_ivalues();
-  clean_up_input_ivalues();
+  cleanUpIntermediateIValues();
+  cleanUpInputIValues();
 }
 
-c10::IValue BlockRunner::move_outputs_to_tuple(uint32_t num_outputs) {
-  switch (num_outputs) {
+c10::IValue BlockRunner::moveOutputsToTuple(uint32_t numOutputs) {
+  switch (numOutputs) {
     case 1:
       return c10::ivalue::Tuple::create(IValue(std::move(*outputs_[0])));
     case 2:
@@ -1063,8 +1062,8 @@ c10::IValue BlockRunner::move_outputs_to_tuple(uint32_t num_outputs) {
           IValue(std::move(*outputs_[2])));
     default: {
       std::vector<c10::IValue> outputs;
-      outputs.reserve(num_outputs);
-      for (const auto i : c10::irange(num_outputs)) {
+      outputs.reserve(numOutputs);
+      for (const auto i : c10::irange(numOutputs)) {
         // use move here. Otherwise, clean up outputs_[i] explicitly
         outputs.emplace_back(std::move(*outputs_[i]));
       }
@@ -1139,47 +1138,46 @@ c10::IValue BlockRunner::move_outputs_to_tuple(uint32_t num_outputs) {
 /// buffer) fails. There is still a corner case that fails with the added flag.
 /// If a resize is triggered at the same time as the op creating an alias at the
 /// same time, the current checks would fail to detect the alias.
-void BlockRunner::verify_and_correct_memory_overlap(ProcessedNode& n) {
+void BlockRunner::verifyAndCorrectMemoryOverlap(ProcessedNode& n) {
   // The slow check can be removed once the internal/output buffers are merged
-  if (C10_UNLIKELY(n.check_outputs_for_memory_overlap())) {
+  if (C10_UNLIKELY(n.checkOutputsForMemoryOverlap())) {
     if (C10_UNLIKELY(!planner_)) {
       // slow check, for first iter only
-      n.verify_and_correct_memory_overlap();
+      n.verifyAndCorrectMemoryOverlap();
     } else {
       bool overlap_detected_with_fast_check = false;
       for (size_t i = 0; i < n.outputs().size(); i++) {
-        auto& output = n.Output(i);
+        auto& output = n.output(i);
         if (output.isTensor()) {
           overlap_detected_with_fast_check |=
-              fast_check_and_correct_overlap_with(n, output);
+              fastCheckAndCorrectOverlapWith(n, output);
         } else if (output.isTensorList()) {
           auto tensor_list = output.toListRef();
           for (auto& ival : tensor_list) {
-            overlap_detected_with_fast_check |=
-                fast_check_and_correct_overlap_with(
-                    n,
-                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-                    const_cast<c10::IValue&>(ival));
+            overlap_detected_with_fast_check |= fastCheckAndCorrectOverlapWith(
+                n,
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+                const_cast<c10::IValue&>(ival));
           }
         }
       }
-      if (n.outputs_memory_overlap_detected() &&
+      if (n.outputsMemoryOverlapDetected() &&
           !overlap_detected_with_fast_check) {
         // slow check. Only run when the fast check fails.
-        n.verify_and_correct_memory_overlap();
+        n.verifyAndCorrectMemoryOverlap();
       }
     }
   }
 }
 
-bool BlockRunner::fast_check_and_correct_overlap_with(
+bool BlockRunner::fastCheckAndCorrectOverlapWith(
     ProcessedNode& n,
     c10::IValue& tensor_ival) {
   auto& tensor = tensor_ival.toTensor();
   if (planner_->overlapWithInternalBuffer(tensor.data_ptr())) {
     DLOG(INFO) << "Detected alias for node: " << PrintNode(n.node());
     tensor_ival = at::native::clone(tensor, c10::nullopt);
-    n.set_outputs_memory_overlap_detected();
+    n.setOutputsMemoryOverlapDetected();
     return true;
   }
   return false;
@@ -1189,7 +1187,7 @@ BlockRunner::Deallocator::~Deallocator() {
   // Assume cleanup cannot throw.
   cleanupImpl();
 #ifndef NDEBUG
-  block_runner_.check_for_memory_leak(/*output_returned*/ false);
+  block_runner_.checkForMemoryLeak(/*output_returned*/ false);
 #endif
 }
 
@@ -1198,7 +1196,7 @@ void BlockRunner::Deallocator::cleanupImpl() {
   // is done intentionally because MemoryPlanner uses `Tensor` sizes of
   // the previous `run()` for memory planning of subsequent runs
   if (C10_LIKELY(finished_)) {
-    block_runner_.create_memory_planner();
+    block_runner_.createMemoryPlanner();
   }
 
   if (C10_LIKELY(block_runner_.planner_)) {
@@ -1209,16 +1207,14 @@ void BlockRunner::Deallocator::cleanupImpl() {
     block_runner_.resetMemory();
   }
   // clean up owning refs of input tensors
-  block_runner_.clean_up_input_ivalues();
+  block_runner_.cleanUpInputIValues();
   if (C10_UNLIKELY(!finished_)) {
     block_runner_.deallocateOutputTensors();
   }
 }
 
 template <typename IValueList>
-c10::IValue BlockRunner::run_impl(
-    IValueList&& args,
-    const KeywordArgs& kwargs) {
+c10::IValue BlockRunner::runImpl(IValueList&& args, const KeywordArgs& kwargs) {
   // We assume inference workloads, so we do not need
   // autograd. Enabling this is a significant win on dispatcher
   // overhead because it saves a round of dispatch for at least some
@@ -1230,33 +1226,33 @@ c10::IValue BlockRunner::run_impl(
 
     if (planner_) {
       DCHECK(!manage_output_tensors_enabled_ || checkOutputTensorMemoryLeaks());
-      maybe_allocate();
+      maybeAllocate();
     }
 
-    set_inputs(std::forward<IValueList>(args), kwargs);
+    setInputs(std::forward<IValueList>(args), kwargs);
 
     for (auto& n : nodes_) {
       // LOG(INFO) << "Running node: " << PrintNode(n.node());
       n.run();
       // Check for incorrect schema alias info.
-      verify_and_correct_memory_overlap(n);
+      verifyAndCorrectMemoryOverlap(n);
     }
     on_exit.setFinished();
   }
 
   // no need to keep references of outputs in static runtime anymore
-  if (block_info_.num_outputs() > 1) {
-    return move_outputs_to_tuple(block_info_.num_outputs());
+  if (block_info_.numOutputs() > 1) {
+    return moveOutputsToTuple(block_info_.numOutputs());
   }
 
-  DCHECK(check_for_memory_leak(/*output_returned*/ false));
+  DCHECK(checkForMemoryLeak(/*output_returned*/ false));
 
   // use move here. Otherwise, clean up outputs_[0] explicitly
   return std::move(*outputs_[0]);
 }
 
 template <typename IValueList>
-c10::IValue BlockRunner::run_impl_record_functions(
+c10::IValue BlockRunner::runImplWithRecordFunctions(
     IValueList&& args,
     const KeywordArgs& kwargs) {
   bool pre_sampled = false;
@@ -1270,18 +1266,18 @@ c10::IValue BlockRunner::run_impl_record_functions(
         guard.before("forward");
       }
     }
-    return run_impl(std::forward<IValueList>(args), kwargs);
+    return runImpl(std::forward<IValueList>(args), kwargs);
   }
-  return run_impl(std::forward<IValueList>(args), kwargs);
+  return runImpl(std::forward<IValueList>(args), kwargs);
 }
 
 c10::IValue BlockRunner::operator()(
     const std::vector<c10::IValue>& args,
     const KeywordArgs& kwargs) {
 #ifdef PYTORCH_DISABLE_NET_PROFILING
-  return run_impl(args, kwargs);
+  return runImpl(args, kwargs);
 #else
-  return run_impl_record_functions(args, kwargs);
+  return runImplWithRecordFunctions(args, kwargs);
 #endif
 }
 
@@ -1289,15 +1285,15 @@ c10::IValue BlockRunner::operator()(
     std::vector<c10::IValue>&& args,
     const KeywordArgs& kwargs) {
 #ifdef PYTORCH_DISABLE_NET_PROFILING
-  return run_impl(std::move(args), kwargs);
+  return runImpl(std::move(args), kwargs);
 #else
-  return run_impl_record_functions(std::move(args), kwargs);
+  return runImplWithRecordFunctions(std::move(args), kwargs);
 #endif
 }
 
 namespace {
 
-std::string generate_latency_json(const std::string& label, double millis) {
+std::string generateLatencyJSON(const std::string& label, double millis) {
 #ifdef FBCODE_CAFFE2
   folly::dynamic json = folly::dynamic::object();
   json["type"] = label;
@@ -1323,12 +1319,12 @@ void BlockRunner::benchmark(
       kwargs_list.size() == 0 || args_list.size() == kwargs_list.size());
   std::cout << "Input size: " << args_list.size() << std::endl;
   float time_per_iter =
-      benchmark_model(args_list, kwargs_list, warmup_runs, main_runs);
+      benchmarkModel(args_list, kwargs_list, warmup_runs, main_runs);
   std::cout << "Static runtime ms per iter: " << time_per_iter
             << ". Iters per second: " << 1000.0 / time_per_iter << std::endl;
 
   IndividualMetrics results =
-      benchmark_individual_ops(args_list, kwargs_list, warmup_runs, main_runs);
+      benchmarkIndividualOps(args_list, kwargs_list, warmup_runs, main_runs);
 
   if (print_per_node_time) {
     for (const auto i : c10::irange(nodes_.size())) {
@@ -1371,11 +1367,11 @@ void BlockRunner::benchmark(
     }
 
     if (generate_ai_pep_output) {
-      LOG(INFO) << generate_latency_json(kind, ms);
+      LOG(INFO) << generateLatencyJSON(kind, ms);
     }
   }
   if (generate_ai_pep_output) {
-    LOG(INFO) << generate_latency_json(
+    LOG(INFO) << generateLatencyJSON(
         "static_runtime_first_iter", results.first_iter_time);
   }
   std::cout << std::setw(15) << results.total_time << " ms. in Total"
@@ -1394,20 +1390,20 @@ void BlockRunner::benchmark(
 
   if (planner_) {
     std::cout << "Total number of managed tensors: "
-              << planner_->total_num_managed_tensors() << std::endl;
+              << planner_->totalNumManagedTensors() << std::endl;
     std::cout << "Total number of managed output tensors: "
-              << planner_->total_num_managed_output_tensors() << std::endl;
+              << planner_->totalNumManagedOutputTensors() << std::endl;
     std::cout << "Total number of unmanaged values: "
-              << planner_->total_num_unmanaged() << std::endl;
+              << planner_->totalNumUnmanaged() << std::endl;
     std::cout << "Number of unmanaged values requiring cleanup: "
-              << planner_->num_unmanaged_non_scalars() << std::endl;
+              << planner_->numUnmanagedNonScalars() << std::endl;
     std::cout << "Number of unmanaged values not requiring cleanup: "
-              << planner_->num_unmanaged_scalars() << std::endl;
-    std::cout << "Total memory managed: " << planner_->total_managed()
+              << planner_->numUnmanagedScalars() << std::endl;
+    std::cout << "Total memory managed: " << planner_->totalManaged()
               << " bytes" << std::endl;
     if (static_module_.opts().optimize_memory) {
       std::cout << "Total number of reused tensors: "
-                << planner_->total_reused_tensors() << std::endl;
+                << planner_->totalReusedTensors() << std::endl;
     }
   }
   std::cout << "Total number of 'out' variant nodes/total number of nodes: "
@@ -1417,16 +1413,16 @@ void BlockRunner::benchmark(
           static_cast<float>(results.total_nodes_count)
             << "%)" << std::endl;
 
-  check_for_memory_leak();
+  checkForMemoryLeak();
 
 #ifndef NDEBUG
   KeywordArgs empty_kwargs;
-  display_nodes(
+  displayNodes(
       args_list[0], kwargs_list.size() > 0 ? kwargs_list[0] : empty_kwargs);
 #endif
 }
 
-float BlockRunner::benchmark_model(
+float BlockRunner::benchmarkModel(
     const std::vector<std::vector<c10::IValue>>& args_list,
     const std::vector<KeywordArgs>& kwargs_list,
     const int warmup_runs,
@@ -1460,7 +1456,7 @@ float BlockRunner::benchmark_model(
   return millis / (static_cast<float>(main_runs) * args_list.size());
 }
 
-bool display_ivalue(const IValue& iv) {
+bool displayIValue(const IValue& iv) {
   if (iv.isTensor()) {
     std::cout << "Tensor " << iv.toTensor().toString() << " {";
     for (const auto i : c10::irange(iv.toTensor().sizes().size())) {
@@ -1493,24 +1489,24 @@ bool display_ivalue(const IValue& iv) {
   return false;
 }
 
-void display_pnode_info(const ProcessedNode& pnode) {
+void displayProcessedNodeInfo(const ProcessedNode& pnode) {
   pnode.node()->print(std::cout, 0, nullptr, false);
-  for (const auto i : c10::irange(pnode.num_inputs())) {
+  for (const auto i : c10::irange(pnode.numInputs())) {
     std::cout << "\ti" << i << ": ";
-    if (!display_ivalue(pnode.Input(i))) {
+    if (!displayIValue(pnode.input(i))) {
       std::cout << *(pnode.node()->inputs()[i]->type()) << '\n';
     }
   }
   const auto outputs = pnode.outputs();
   for (const auto i : c10::irange(outputs.size())) {
     std::cout << "\to" << i << ": ";
-    if (!display_ivalue(outputs[i])) {
+    if (!displayIValue(outputs[i])) {
       std::cout << *(pnode.node()->outputs()[i]->type()) << '\n';
     }
   }
 }
 
-void BlockRunner::display_nodes(
+void BlockRunner::displayNodes(
     const std::vector<c10::IValue>& args,
     const KeywordArgs& kwargs) {
   c10::InferenceMode mode;
@@ -1520,16 +1516,16 @@ void BlockRunner::display_nodes(
   if (planner_) {
     planner_->allocate();
   }
-  set_inputs(args, kwargs);
+  setInputs(args, kwargs);
 
   for (auto& node : nodes_) {
     node.run();
-    display_pnode_info(node);
+    displayProcessedNodeInfo(node);
   }
   on_exit.setFinished();
 }
 
-BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
+BlockRunner::IndividualMetrics BlockRunner::benchmarkIndividualOps(
     const std::vector<std::vector<c10::IValue>>& args_list,
     const std::vector<KeywordArgs>& kwargs_list,
     const int warmup_runs,
@@ -1550,10 +1546,10 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
       results.time_per_node[i] = 0;
       results.time_per_node_type[kind] = 0;
       results.instances_per_node_type[kind]++;
-      if (nodes_[i].has_out_variant()) {
+      if (nodes_[i].hasOutVariant()) {
         results.out_nodes.insert(kind);
         results.out_nodes_count++;
-      } else if (nodes_[i].has_native()) {
+      } else if (nodes_[i].hasNative()) {
         results.native_nodes.insert(kind);
       }
       results.total_time += results.time_per_node[i];
@@ -1579,7 +1575,7 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
   // setup time
   caffe2::Timer timer;
 
-  set_inputs(args_list[0], is_kwargs_empty ? empty_kwargs : kwargs_list[0]);
+  setInputs(args_list[0], is_kwargs_empty ? empty_kwargs : kwargs_list[0]);
 
   results.setup_time = timer.MilliSeconds();
 
@@ -1609,7 +1605,7 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
     (void)i; // Suppress unused variable warning
 
     for (const auto j : c10::irange(args_list.size())) {
-      set_inputs(args_list[j], is_kwargs_empty ? empty_kwargs : kwargs_list[j]);
+      setInputs(args_list[j], is_kwargs_empty ? empty_kwargs : kwargs_list[j]);
 
       timer.Start();
       if (planner_) {
@@ -1623,13 +1619,13 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
         nodes_[k].run();
         millis = timer.MilliSeconds();
         results.time_per_node[k] += millis;
-        verify_and_correct_memory_overlap(nodes_[k]);
+        verifyAndCorrectMemoryOverlap(nodes_[k]);
       }
       timer.Start();
-      create_memory_planner();
+      createMemoryPlanner();
       planner_->deallocate();
       // clean up owning refs of input tensors
-      clean_up_input_ivalues();
+      cleanUpInputIValues();
       if (manage_output_tensors) {
         deallocateOutputTensors();
       }
@@ -1639,11 +1635,11 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
       timer.Start();
       // no need to keep references of outputs in static runtime anymore
       c10::IValue output;
-      if (static_module_.num_outputs() > 1) {
-        output = move_outputs_to_tuple(static_module_.num_outputs());
+      if (static_module_.numOutputs() > 1) {
+        output = moveOutputsToTuple(static_module_.numOutputs());
       }
 
-      DCHECK(check_for_memory_leak(/*output_returned*/ false));
+      DCHECK(checkForMemoryLeak(/*output_returned*/ false));
 
       // use move here. Otherwise, clean up outputs_[0] explicitly
       output = std::move(*outputs_[0]);
@@ -1663,10 +1659,10 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
     results.time_per_node[i] /= num_total_iters;
     results.time_per_node_type[kind] += results.time_per_node[i];
     results.instances_per_node_type[kind]++;
-    if (nodes_[i].has_out_variant()) {
+    if (nodes_[i].hasOutVariant()) {
       results.out_nodes.insert(kind);
       results.out_nodes_count++;
-    } else if (nodes_[i].has_native()) {
+    } else if (nodes_[i].hasNative()) {
       results.native_nodes.insert(kind);
     }
     results.total_time += results.time_per_node[i];
@@ -1682,13 +1678,13 @@ BlockRunner::IndividualMetrics BlockRunner::benchmark_individual_ops(
   return results;
 }
 
-bool BlockRunner::check_for_memory_leak(
+bool BlockRunner::checkForMemoryLeak(
     bool output_returned,
     bool recurse_on_sub_blocks) {
   // check for inputs
-  for (const auto i : c10::irange(block_info_.num_inputs())) {
+  for (const auto i : c10::irange(block_info_.numInputs())) {
     TORCH_CHECK(
-        values_[i + block_info_.block_inputs_idx()].isNone(),
+        values_[i + block_info_.blockInputsIdx()].isNone(),
         "Input ",
         i,
         " was not cleaned up");
@@ -1696,8 +1692,8 @@ bool BlockRunner::check_for_memory_leak(
   FastSet<const IValue*> output_ivalues(outputs_.begin(), outputs_.end());
   for (const auto n : c10::irange(nodes_.size())) {
     auto& pnode = nodes_[n];
-    for (const auto i : c10::irange(pnode.num_outputs())) {
-      const IValue* ival = &pnode.Output(i);
+    for (const auto i : c10::irange(pnode.numOutputs())) {
+      const IValue* ival = &pnode.output(i);
       const Value* val = pnode.node()->output(i);
       // subtlety: isManagedOutputTensorValue may give a false
       // negative here if an output is an alias of this value, so
@@ -1719,8 +1715,7 @@ bool BlockRunner::check_for_memory_leak(
         if (!ival->isNone()) {
           TORCH_CHECK(
               ival->isTensor() ||
-                  block_info_.node_is_optimizable_container_type(
-                      pnode.node()) ||
+                  block_info_.nodeIsOptimizableContainerType(pnode.node()) ||
                   doesNotHeapAllocateWhenStoredInIValue(*val->type()),
               error_msg);
           if (ival->isTensor()) {
@@ -1743,11 +1738,10 @@ bool BlockRunner::check_for_memory_leak(
       }
     }
 
-    auto* block_runners = pnode.block_runners();
+    auto* block_runners = pnode.blockRunners();
     if (recurse_on_sub_blocks && block_runners) {
       for (auto& block_runner : *block_runners) {
-        block_runner.check_for_memory_leak(
-            output_returned, recurse_on_sub_blocks);
+        block_runner.checkForMemoryLeak(output_returned, recurse_on_sub_blocks);
       }
     }
   }
@@ -1774,8 +1768,8 @@ bool BlockRunner::checkOutputTensorMemoryLeaks() {
   }
   for (const auto n : c10::irange(nodes_.size())) {
     auto& pnode = nodes_[n];
-    for (const auto i : c10::irange(pnode.num_outputs())) {
-      const IValue* ival = &pnode.Output(i);
+    for (const auto i : c10::irange(pnode.numOutputs())) {
+      const IValue* ival = &pnode.output(i);
       const Value* val = pnode.node()->output(i);
       if (!isManagedOutputTensorValue(val)) {
         continue;
@@ -1804,7 +1798,7 @@ bool BlockRunner::isManagedOutputTensorValue(const Value* value) const {
   if (!planner_ || !manage_output_tensors_enabled_) {
     return false;
   }
-  const auto& managed_outputs = block_info_.managed_output_tensor_values();
+  const auto& managed_outputs = block_info_.manageOutputTensorValues();
   return managed_outputs.find(value) != managed_outputs.end();
 }
 
@@ -1820,7 +1814,7 @@ void BlockRunner::disableManageOutputTensors() {
   // the next run.
   for (auto& n : nodes_) {
     for (const auto i : c10::irange(n.outputs().size())) {
-      n.Output(i) = IValue();
+      n.output(i) = IValue();
     }
   }
   planner_.reset();
@@ -1859,19 +1853,19 @@ ProcessedFunction::ProcessedFunction(
     f_ = [node_op = op.getOperation(node),
           has_var_args = hasVarArgs(node)](ProcessedNode* pnode) mutable {
       std::vector<IValue> stack;
-      const size_t size = pnode->num_inputs();
+      const size_t size = pnode->numInputs();
       stack.reserve(size + has_var_args);
       for (const auto i : c10::irange(size)) {
-        stack.emplace_back(pnode->Input(i));
+        stack.emplace_back(pnode->input(i));
       }
       // Need to store the number of inputs in stack for variadic ops.
       if (has_var_args) {
         stack.emplace_back(static_cast<int>(size));
       }
       node_op(stack);
-      DCHECK_EQ(stack.size(), pnode->num_outputs());
-      for (const auto i : c10::irange(pnode->num_outputs())) {
-        pnode->Output(i) = std::move(stack[i]);
+      DCHECK_EQ(stack.size(), pnode->numOutputs());
+      for (const auto i : c10::irange(pnode->numOutputs())) {
+        pnode->output(i) = std::move(stack[i]);
       }
     };
     kind_ = ProcessedFunction::Kind::kInterpreterFallback;
@@ -1888,14 +1882,14 @@ StaticNodeInfo::StaticNodeInfo(
       fn_(fn),
       inputs_(std::move(inputs)),
       outputs_offset_(outputs_offset) {
-  TORCH_CHECK(num_outputs() == node->outputs().size());
+  TORCH_CHECK(numOutputs() == node->outputs().size());
 }
 
-std::vector<IValue> ProcessedNode::inputs_ivalue_vec() const {
+std::vector<IValue> ProcessedNode::inputIValueVec() const {
   std::vector<IValue> result;
   result.reserve(inputs_.size());
-  for (const auto idx : c10::irange(num_inputs())) {
-    result.emplace_back(Input(idx));
+  for (const auto idx : c10::irange(numInputs())) {
+    result.emplace_back(input(idx));
   }
   return result;
 }
@@ -1907,9 +1901,9 @@ void ProcessedNode::run() {
     at::RecordFunction guard(at::RecordScope::STATIC_RUNTIME_OP, pre_sampled);
     if (guard.isActive()) {
       if (guard.needsInputs()) {
-        guard.before(get_op_name(), inputs_ivalue_vec());
+        guard.before(getOpName(), inputIValueVec());
       } else {
-        guard.before(get_op_name());
+        guard.before(getOpName());
       }
     }
     fn_->run(this);
@@ -1922,9 +1916,9 @@ void ProcessedNode::run() {
 #ifndef NDEBUG
   if (FLAGS_static_runtime_disable_debug_memory_overlap_check) {
     // run check but do not enforce
-    verify_no_memory_overlap();
+    verifyNoMemoryOverlap();
   } else {
-    DCHECK(verify_no_memory_overlap());
+    DCHECK(verifyNoMemoryOverlap());
   }
 #endif
 }
@@ -1941,7 +1935,7 @@ static bool checkNoMemoryOverlap(const at::Tensor& a, const at::Tensor& b) {
   return true;
 }
 
-bool ProcessedNode::verify_no_memory_overlap(bool force_check) const {
+bool ProcessedNode::verifyNoMemoryOverlap(bool force_check) const {
   const static std::array<c10::Symbol, 7> special_case_ops = {
       fromQualString("prim::TypeCheck"),
       fromQualString("prim::IfThenElse"),
@@ -1957,21 +1951,21 @@ bool ProcessedNode::verify_no_memory_overlap(bool force_check) const {
     return true;
   }
 
-  return verify_outputs_dont_overlap_each_other() &&
-      verify_inputs_dont_overlap_outputs(force_check);
+  return verifyOutputsDontOverlapEachOther() &&
+      verifyInputsDontOverlapOutputs(force_check);
 }
 
-bool ProcessedNode::verify_outputs_dont_overlap_each_other() const {
-  for (const auto i : c10::irange(num_outputs())) {
-    if (!Output(i).isTensor()) {
+bool ProcessedNode::verifyOutputsDontOverlapEachOther() const {
+  for (const auto i : c10::irange(numOutputs())) {
+    if (!output(i).isTensor()) {
       continue;
     }
-    const auto& out0_t = Output(i).toTensor();
-    for (const auto j : c10::irange(i + 1, num_outputs())) {
-      if (!Output(j).isTensor()) {
+    const auto& out0_t = output(i).toTensor();
+    for (const auto j : c10::irange(i + 1, numOutputs())) {
+      if (!output(j).isTensor()) {
         continue;
       }
-      const auto& out1_t = Output(j).toTensor();
+      const auto& out1_t = output(j).toTensor();
       if (!checkNoMemoryOverlap(out0_t, out1_t)) {
         LOG(INFO) << "Node output " << i << " overlaps with output " << j
                   << ", " << PrintNode(node_);
@@ -1982,12 +1976,12 @@ bool ProcessedNode::verify_outputs_dont_overlap_each_other() const {
   return true;
 }
 
-bool ProcessedNode::verify_inputs_dont_overlap_outputs(bool force_check) const {
+bool ProcessedNode::verifyInputsDontOverlapOutputs(bool force_check) const {
   auto schema = node()->maybeSchema();
   // skip memory overlap check for mutable or view ops with only one output
   bool skip_check = !schema ||
       ((schema->is_mutable() || !fn_->checkMemoryOverlap()) &&
-       num_outputs() == 1);
+       numOutputs() == 1);
   if (!force_check && skip_check) {
     if (!schema) {
       VLOG(2) << "Detected that op schema is null";
@@ -1995,18 +1989,18 @@ bool ProcessedNode::verify_inputs_dont_overlap_outputs(bool force_check) const {
     }
     VLOG(2) << "schema->is_mutable: " << schema->is_mutable()
             << ", fn_->checkMemoryOverlap: " << fn_->checkMemoryOverlap()
-            << ", num_outputs_: " << num_outputs();
+            << ", numOutputs_: " << numOutputs();
     return true;
   }
 
   for (const auto i : c10::irange(inputs_.size())) {
-    const IValue* in = &Input(i);
+    const IValue* in = &input(i);
     if (!in->isTensor()) {
       continue;
     }
     const auto& in_t = in->toTensor();
-    for (const auto j : c10::irange(num_outputs())) {
-      const IValue& out = Output(j);
+    for (const auto j : c10::irange(numOutputs())) {
+      const IValue& out = output(j);
       if (!out.isTensor()) {
         continue;
       }
@@ -2022,38 +2016,38 @@ bool ProcessedNode::verify_inputs_dont_overlap_outputs(bool force_check) const {
   return true;
 }
 
-bool ProcessedNode::check_and_correct_overlap_with(
+bool ProcessedNode::checkAndCorrectOverlapWith(
     const at::Tensor& input,
     c10::IValue& output_ival) {
   auto& tensor = output_ival.toTensor();
   if (!checkNoMemoryOverlap(input, tensor)) {
     DLOG(INFO) << "Detected alias for node: " << PrintNode(node());
     output_ival = at::native::clone(tensor, c10::nullopt);
-    set_outputs_memory_overlap_detected();
+    setOutputsMemoryOverlapDetected();
     return true;
   }
   return false;
 }
 
-void ProcessedNode::verify_and_correct_memory_overlap() {
+void ProcessedNode::verifyAndCorrectMemoryOverlap() {
   for (const auto i : c10::irange(inputs_.size())) {
-    const IValue& in = Input(i);
+    const IValue& in = input(i);
     if (!in.isTensor()) {
       continue;
     }
     const auto& in_t = in.toTensor();
-    for (const auto j : c10::irange(num_outputs())) {
-      auto& output = Output(j);
-      if (output.isTensor()) {
-        check_and_correct_overlap_with(in_t, output);
-      } else if (output.isTensorList()) {
-        auto tensors = output.toListRef();
+    for (const auto j : c10::irange(numOutputs())) {
+      auto& output_val = output(j);
+      if (output_val.isTensor()) {
+        checkAndCorrectOverlapWith(in_t, output_val);
+      } else if (output_val.isTensorList()) {
+        auto tensors = output_val.toListRef();
         for (const auto& ival : tensors) {
           // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-          check_and_correct_overlap_with(in_t, const_cast<c10::IValue&>(ival));
+          checkAndCorrectOverlapWith(in_t, const_cast<c10::IValue&>(ival));
         }
 #ifdef FBCODE_CAFFE2
-        if (outputs_memory_overlap_detected()) {
+        if (outputsMemoryOverlapDetected()) {
           LOG_EVERY_MS(WARNING, 60000)
               << "Detected alias for node: " << PrintNode(node());
         }
@@ -2064,10 +2058,10 @@ void ProcessedNode::verify_and_correct_memory_overlap() {
 }
 
 StaticRuntime::StaticRuntime(const StaticModule& sm)
-    : values_(sm.value_buffer_size()), parent_module_(sm) {
+    : values_(sm.valueBufferSize()), parent_module_(sm) {
   std::copy(sm.constants().begin(), sm.constants().end(), values_.data());
   block_ = std::make_unique<BlockRunner>(
-      sm, values_.data(), sm.root_block(), /*is_root_block*/ true);
+      sm, values_.data(), sm.rootBlock(), /*is_root_block*/ true);
 }
 
 StaticRuntime StaticRuntime::clone() const {
@@ -2084,7 +2078,7 @@ StaticRuntime StaticRuntime::clone() const {
        c10::irange(parent_module_.constants().size(), values_.size())) {
     if (values[i].isTensor()) {
       auto& old_tensor = values[i].toTensor();
-      new_values[i] = create_empty_from(old_tensor.sizes(), old_tensor);
+      new_values[i] = createEmptyFrom(old_tensor.sizes(), old_tensor);
       old_tensor_to_new.emplace(
           // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
           const_cast<at::Tensor*>(&values[i].toTensor()),
@@ -2093,7 +2087,7 @@ StaticRuntime StaticRuntime::clone() const {
   }
   DCHECK(runtime.block_ != nullptr);
   DCHECK(block_ != nullptr);
-  runtime.block_->maybe_clone_memory_planner(*block_, old_tensor_to_new);
+  runtime.block_->maybeCloneMemoryPlanner(*block_, old_tensor_to_new);
   return runtime;
 }
 
@@ -2109,8 +2103,8 @@ c10::IValue StaticRuntime::operator()(
   return (*block_)(std::move(args), kwargs);
 }
 
-bool StaticRuntime::check_for_memory_leak(bool output_returned) {
-  return block_->check_for_memory_leak(
+bool StaticRuntime::checkForMemoryLeak(bool output_returned) {
+  return block_->checkForMemoryLeak(
       output_returned, /* recurse_on_sub_blocks */ true);
 }
 
@@ -2130,8 +2124,8 @@ void StaticRuntime::disableManageOutputTensors() {
   block_->disableManageOutputTensors();
 }
 
-const MemoryPlanner* StaticRuntime::get_memory_planner() const {
-  return block_->get_memory_planner();
+const MemoryPlanner* StaticRuntime::getMemoryPlanner() const {
+  return block_->getMemoryPlanner();
 }
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -263,7 +263,7 @@ class BlockInfo {
   BlockInfo(uint32_t input_idx, Block& block)
       : input_idx_(input_idx), block_(block) {}
 
-  void set_nodes(
+  void setNodes(
       std::vector<StaticNodeInfo> nodes,
       const FastMap<Node*, bool>& node_has_out_variant);
 
@@ -271,72 +271,72 @@ class BlockInfo {
     return nodes_;
   }
 
-  size_t num_nodes() const {
+  size_t numNodes() const {
     return nodes_.size();
   }
 
-  size_t num_inputs() const {
+  size_t numInputs() const {
     return block_.inputs().size();
   }
 
-  size_t num_outputs() const {
+  size_t numOutputs() const {
     return block_.outputs().size();
   }
 
-  graph_node_list node_ptrs() const {
+  graph_node_list nodePtrs() const {
     return block_.nodes();
   }
 
-  void set_output_indices(std::vector<uint16_t> indices) {
+  void setOutputIndices(std::vector<uint16_t> indices) {
     output_indices_ = std::move(indices);
   }
 
-  const std::vector<uint16_t>& block_output_indices() const {
+  const std::vector<uint16_t>& blockOutputIndices() const {
     return output_indices_;
   }
 
-  auto block_inputs_idx() const {
+  auto blockInputsIdx() const {
     return input_idx_;
   }
 
-  bool node_is_optimizable_container_type(const Node* node) const {
+  bool nodeIsOptimizableContainerType(const Node* node) const {
     return node_is_optimizable_container_type_.find(node) !=
         node_is_optimizable_container_type_.end();
   }
 
-  bool value_is_managed_tensor(const Value* value) const {
+  bool valueIsManagedTensor(const Value* value) const {
     return managed_tensor_values_.find(value) != managed_tensor_values_.end();
   }
 
-  bool value_is_leaked_container(const Value* value) const {
+  bool valueIsLeakedContainer(const Value* value) const {
     return leaked_values_.find(value) != leaked_values_.end();
   }
 
-  const ValueGroup& value_group() const {
+  const ValueGroup& valueGroup() const {
     return value_group_;
   }
 
-  const ManagedTensorRanges& managed_tensor_ranges() const {
+  const ManagedTensorRanges& managedTensorRanges() const {
     return managed_tensor_ranges_;
   }
 
-  void init_value_group(const AliasDb& alias_db) {
+  void initValueGroup(const AliasDb& alias_db) {
     value_group_.init(block_, alias_db);
   }
 
-  void prepare_for_memory_planner(
+  void prepareForMemoryPlanner(
       const AliasDb& alias_db,
       const StaticModuleOptions& opt);
 
-  const auto& managed_output_tensor_values() const {
+  const auto& manageOutputTensorValues() const {
     return managed_output_tensor_values_;
   }
 
-  const auto& managed_tensor_values() const {
+  const auto& managedTensorValues() const {
     return managed_tensor_values_;
   }
 
-  const auto& leaked_values() const {
+  const auto& leakedValues() const {
     return leaked_values_;
   }
 
@@ -398,22 +398,22 @@ class TORCH_API StaticModule {
 
   const StaticModuleOptions& opts() const;
 
-  size_t num_inputs() const;
-  size_t num_outputs() const;
+  size_t numInputs() const;
+  size_t numOutputs() const;
 
-  size_t num_constants() const {
+  size_t numConstants() const {
     return constants_.size();
   }
 
-  size_t num_intermediate_values() const {
+  size_t numIntermediateValues() const {
     return num_intermediate_values_;
   }
 
-  size_t total_num_values() const {
-    return num_inputs() + num_constants() + num_intermediate_values();
+  size_t totalNumValues() const {
+    return numInputs() + numConstants() + numIntermediateValues();
   }
 
-  C10_NODISCARD const std::vector<uint16_t>& output_indices() const {
+  C10_NODISCARD const std::vector<uint16_t>& outputIndices() const {
     return output_indices_;
   }
 
@@ -421,11 +421,11 @@ class TORCH_API StaticModule {
     return constants_;
   }
 
-  const BlockInfo& block_info(Block* block) const {
+  const BlockInfo& blockInfo(Block* block) const {
     return block_infos_.at(block);
   }
 
-  Block* root_block() const {
+  Block* rootBlock() const {
     return graph_->block();
   }
 
@@ -434,14 +434,14 @@ class TORCH_API StaticModule {
   friend class BlockRunner;
 
  public:
-  auto num_nodes() const {
+  auto numNodes() const {
     return std::accumulate(
         block_infos_.begin(),
         block_infos_.end(),
         0,
         [](size_t sum, const auto& block_and_info) {
           auto& block_info = block_and_info.second;
-          return sum + block_info.num_nodes();
+          return sum + block_info.numNodes();
         });
   }
 
@@ -451,15 +451,15 @@ class TORCH_API StaticModule {
     return schema_;
   }
 
-  bool first_input_is_self() const {
+  bool firstInputIsSelf() const {
     return module_.has_value();
   }
 
   StaticRuntime& runtime();
-  StaticRuntime clone_runtime_from_cached();
+  StaticRuntime cloneRuntimeFromCached();
 
   // See [Shared values array]
-  size_t value_buffer_size() const {
+  size_t valueBufferSize() const {
     return value_buffer_size_;
   }
 
@@ -574,25 +574,25 @@ class TORCH_API BlockRunner {
     std::unordered_set<std::string> native_nodes;
   };
 
-  IndividualMetrics benchmark_individual_ops(
+  IndividualMetrics benchmarkIndividualOps(
       const std::vector<std::vector<c10::IValue>>& args_list,
       const std::vector<KeywordArgs>& kwargs_list,
       const int warmup_runs,
       const int main_runs);
 
   // Input is readwrite
-  IValue& Input(uint32_t i) {
-    DCHECK_LT(i, block_info_.num_inputs());
-    return values_[i + block_info_.block_inputs_idx()];
+  IValue& input(uint32_t i) {
+    DCHECK_LT(i, block_info_.numInputs());
+    return values_[i + block_info_.blockInputsIdx()];
   }
 
   // Output is readonly. The writing process happens inside ProcessedNodes
-  C10_NODISCARD const IValue& Output(uint32_t i) const {
+  const IValue& output(uint32_t i) const {
     DCHECK(i < outputs_.size());
     return *outputs_[i];
   }
 
-  const std::vector<IValue*> outputs() const {
+  const std::vector<IValue*>& outputs() const {
     return outputs_;
   }
 
@@ -604,23 +604,23 @@ class TORCH_API BlockRunner {
     return nodes_;
   }
 
-  graph_node_list node_ptrs() const {
-    return block_info_.node_ptrs();
+  graph_node_list nodePtrs() const {
+    return block_info_.nodePtrs();
   }
 
   const Graph& graph() const {
     return static_module_.graph();
   }
 
-  const MemoryPlanner* get_memory_planner() const {
+  const MemoryPlanner* getMemoryPlanner() const {
     return planner_.get();
   }
 
-  void maybe_clone_memory_planner(
+  void maybeCloneMemoryPlanner(
       const BlockRunner& src,
       const FastMap<at::Tensor*, at::Tensor*>& old_tensor_to_new);
 
-  bool check_for_memory_leak(
+  bool checkForMemoryLeak(
       bool output_returned = true,
       bool recurse_on_sub_blocks = false);
 
@@ -674,53 +674,53 @@ class TORCH_API BlockRunner {
   };
 
   template <typename IValueList>
-  c10::IValue run_impl(IValueList&& args, const KeywordArgs& kwargs);
+  c10::IValue runImpl(IValueList&& args, const KeywordArgs& kwargs);
 
   template <typename IValueList>
-  c10::IValue run_impl_record_functions(
+  c10::IValue runImplWithRecordFunctions(
       IValueList&& args,
       const KeywordArgs& kwargs);
 
   // helper method for copying input args/kwargs into inputs_
   template <typename IValueList>
-  void set_inputs(
+  void setInputs(
       IValueList&& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs);
 
   // Set Input(idx) to args[idx]. Invoked by set_inputs. Copies or moves
   // depending on overload.
-  void set_arg(const size_t idx, std::vector<IValue>&& args);
-  void set_arg(const size_t idx, const std::vector<IValue>& args);
+  void setArg(const size_t idx, std::vector<IValue>&& args);
+  void setArg(const size_t idx, const std::vector<IValue>& args);
 
   // Set Input(idx) to arg. Always copies. Used for kwargs.
-  void set_arg(const size_t idx, const IValue& arg);
+  void setArg(const size_t idx, const IValue& arg);
 
-  bool fast_check_and_correct_overlap_with(
+  bool fastCheckAndCorrectOverlapWith(
       ProcessedNode& n,
       c10::IValue& tensor_ival);
-  void verify_and_correct_memory_overlap(ProcessedNode& n);
+  void verifyAndCorrectMemoryOverlap(ProcessedNode& n);
 
   // clean up owning refs of input IValues
-  void clean_up_input_ivalues() noexcept {
-    for (const auto idx : c10::irange(block_info_.num_inputs())) {
+  void cleanUpInputIValues() noexcept {
+    for (const auto idx : c10::irange(block_info_.numInputs())) {
       values_[idx + inputs_begin_] = IValue();
     }
   }
 
-  void clean_up_intermediate_ivalues() noexcept;
+  void cleanUpIntermediateIValues() noexcept;
 
-  IValue move_outputs_to_tuple(uint32_t num_outputs);
+  IValue moveOutputsToTuple(uint32_t num_outputs);
 
-  void create_memory_planner();
-  void maybe_allocate();
+  void createMemoryPlanner();
+  void maybeAllocate();
 
-  float benchmark_model(
+  float benchmarkModel(
       const std::vector<std::vector<c10::IValue>>& args_list,
       const std::vector<KeywordArgs>& kwargs_list,
       const int warmup_runs,
       const int main_runs);
 
-  void display_nodes(
+  void displayNodes(
       const std::vector<c10::IValue>& args,
       const KeywordArgs& kwargs);
 
@@ -779,7 +779,7 @@ class TORCH_API ProcessedFunction {
     return check_memory_overlap_;
   }
 
-  size_t num_outputs() const {
+  size_t numOutputs() const {
     return num_outputs_;
   }
 
@@ -804,12 +804,12 @@ class TORCH_API StaticNodeInfo {
     return node_;
   }
 
-  size_t num_outputs() const {
+  size_t numOutputs() const {
     DCHECK(fn_ != nullptr);
-    return fn_->num_outputs();
+    return fn_->numOutputs();
   }
 
-  bool has_out_variant() const {
+  bool hasOutVariant() const {
     return fn_->kind() == ProcessedFunction::Kind::kOutVariant;
   }
 
@@ -854,93 +854,93 @@ class TORCH_API ProcessedNode {
   }
 
   // Input is readonly
-  C10_NODISCARD const IValue& Input(uint32_t i) const {
+  const IValue& input(uint32_t i) const {
     return values_[inputs_[i]];
   }
 
   // Output is readwrite
-  IValue& Output(uint32_t i) {
-    DCHECK(i < num_outputs());
+  IValue& output(uint32_t i) {
+    DCHECK(i < numOutputs());
     return values_[outputs_offset_ + i];
   }
 
-  C10_NODISCARD const IValue& Output(uint32_t i) const {
-    DCHECK(i < num_outputs());
+  const IValue& output(uint32_t i) const {
+    DCHECK(i < numOutputs());
     return values_[outputs_offset_ + i];
   }
 
-  size_t num_outputs() const {
+  size_t numOutputs() const {
     DCHECK(fn_ != nullptr);
-    return fn_->num_outputs();
+    return fn_->numOutputs();
   }
 
-  C10_NODISCARD c10::ArrayRef<const IValue> outputs() const {
+  c10::ArrayRef<const IValue> outputs() const {
     return c10::ArrayRef<const IValue>(
-        values_ + outputs_offset_, num_outputs());
+        values_ + outputs_offset_, numOutputs());
   }
 
-  C10_NODISCARD uint16_t num_inputs() const {
+  uint16_t numInputs() const {
     return inputs_.size();
   }
 
-  std::vector<IValue> inputs_ivalue_vec() const;
+  std::vector<IValue> inputIValueVec() const;
 
-  bool has_out_variant() const {
+  bool hasOutVariant() const {
     return fn_->kind() == ProcessedFunction::Kind::kOutVariant;
   }
 
-  bool has_native() const {
+  bool hasNative() const {
     return fn_->kind() == ProcessedFunction::Kind::kNativeFunction;
   }
 
 #ifndef PYTORCH_DISABLE_PER_OP_PROFILING
-  const char* get_op_name() const {
+  const char* getOpName() const {
     return node_->kind().toQualString();
   }
 #endif
 
-  bool check_outputs_for_memory_overlap() const {
+  bool checkOutputsForMemoryOverlap() const {
     return fn_->checkMemoryOverlap();
   }
 
-  void set_outputs_memory_overlap_detected() {
+  void setOutputsMemoryOverlapDetected() {
     overlap_detected_ = true;
   }
 
-  bool outputs_memory_overlap_detected() {
+  bool outputsMemoryOverlapDetected() {
     return overlap_detected_;
   }
 
-  bool check_and_correct_overlap_with(
+  bool checkAndCorrectOverlapWith(
       const at::Tensor& input,
       c10::IValue& output);
-  void verify_and_correct_memory_overlap();
+  void verifyAndCorrectMemoryOverlap();
 
-  void set_values(IValue* values) {
+  void setValues(IValue* values) {
     DCHECK(values_ == nullptr);
     values_ = values;
   }
 
-  C10_NODISCARD uint16_t output_ivalue_index(uint16_t i) const {
-    DCHECK(i < num_outputs());
+  uint16_t outputIValueIndex(uint16_t i) const {
+    DCHECK(i < numOutputs());
     return outputs_offset_ + i;
   }
   // used in debug mode
-  bool verify_no_memory_overlap(bool force_check = false) const;
+  bool verifyNoMemoryOverlap(bool force_check = false) const;
 
-  std::vector<BlockRunner>* block_runners() {
+  std::vector<BlockRunner>* blockRunners() {
     return block_runners_.get();
   }
 
-  void set_block_runners(
+  void setBlockRunners(
       std::unique_ptr<std::vector<BlockRunner>> block_runners) {
     block_runners_ = std::move(block_runners);
   }
 
  private:
-  C10_NODISCARD bool verify_outputs_dont_overlap_each_other() const;
+  C10_NODISCARD bool verifyOutputsDontOverlapEachOther() const;
 
-  C10_NODISCARD bool verify_inputs_dont_overlap_outputs(bool force_check) const;
+  C10_NODISCARD bool verifyInputsDontOverlapOutputs(bool force_check) const;
 
   Node* node_;
   const ProcessedFunction* fn_;
@@ -972,7 +972,7 @@ class TORCH_API StaticRuntime {
       std::vector<c10::IValue>&& args,
       const KeywordArgs& kwargs = KeywordArgs());
 
-  bool check_for_memory_leak(bool output_returned = true);
+  bool checkForMemoryLeak(bool output_returned = true);
   bool checkOutputTensorMemoryLeaks();
 
   void deallocateOutputTensors();
@@ -980,7 +980,7 @@ class TORCH_API StaticRuntime {
   void disableManageOutputTensors();
 
   // Gets the top-level memory planner. Used for testing.
-  const MemoryPlanner* get_memory_planner() const;
+  const MemoryPlanner* getMemoryPlanner() const;
 
   // Clone this static runtime instance. Not to be used concurrently with
   // operator(). Useful when the precompute_offsets option is on (to
@@ -1005,12 +1005,12 @@ class TORCH_API StaticRuntime {
 
   using IndividualMetrics = BlockRunner::IndividualMetrics;
 
-  IndividualMetrics benchmark_individual_ops(
+  IndividualMetrics benchmarkIndividualOps(
       const std::vector<std::vector<c10::IValue>>& args_list,
       const std::vector<KeywordArgs>& kwargs_list,
       const int warmup_runs,
       const int main_runs) {
-    return block_->benchmark_individual_ops(
+    return block_->benchmarkIndividualOps(
         args_list, kwargs_list, warmup_runs, main_runs);
   }
 

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -87,7 +87,7 @@ void initStaticModuleBindings(PyObject* module) {
             std::vector<c10::IValue> arg_ivalues{args.begin(), args.end()};
             std::unordered_map<std::string, c10::IValue> kwarg_ivalues{
                 kwargs.begin(), kwargs.end()};
-            return self.runtime().benchmark_individual_ops(
+            return self.runtime().benchmarkIndividualOps(
                 {arg_ivalues}, {kwarg_ivalues}, warmup_runs, main_runs);
           });
   m.def(

--- a/torch/csrc/jit/runtime/static/memory_planner.h
+++ b/torch/csrc/jit/runtime/static/memory_planner.h
@@ -105,7 +105,7 @@ class MemoryPlanner {
   MemoryPlanner& operator=(MemoryPlanner&&) = delete;
   virtual ~MemoryPlanner() = default;
 
-  virtual std::unique_ptr<MemoryPlanner> maybe_clone(
+  virtual std::unique_ptr<MemoryPlanner> maybeClone(
       BlockRunner* /*new_block_runner*/,
       const FastMap<at::Tensor*, at::Tensor*>& /*old_tensor_to_new*/) const {
     return nullptr;
@@ -124,31 +124,31 @@ class MemoryPlanner {
   // does _all_ required cleanup.
   virtual bool shouldFallBackToStandardStrategy() const = 0;
 
-  size_t total_num_managed_tensors() const {
+  size_t totalNumManagedTensors() const {
     return num_managed_tensors_;
   }
 
-  size_t total_reused_tensors() const {
+  size_t totalReusedTensors() const {
     return reused_tensors_;
   }
 
-  size_t total_num_managed_output_tensors() const {
+  size_t totalNumManagedOutputTensors() const {
     return managed_output_tensors_.size();
   }
 
-  C10_NODISCARD size_t total_num_unmanaged() const {
-    return num_unmanaged_non_scalars() + num_unmanaged_scalars();
+  size_t totalNumUnmanaged() const {
+    return numUnmanagedNonScalars() + numUnmanagedScalars();
   }
 
-  C10_NODISCARD size_t num_unmanaged_non_scalars() const {
+  size_t numUnmanagedNonScalars() const {
     return unmanaged_ivalues_.size() + unmanaged_borrowed_ivalues_.size();
   }
 
-  C10_NODISCARD size_t num_unmanaged_scalars() const {
+  size_t numUnmanagedScalars() const {
     return num_unmanaged_scalar_ivalues_;
   }
 
-  size_t total_managed() const {
+  size_t totalManaged() const {
     return managed_bytes_;
   }
 
@@ -297,7 +297,7 @@ class PrecomputedOffsetsMemoryPlanner : public MemoryPlanner {
     size_t offset;
   };
 
-  std::unique_ptr<MemoryPlanner> maybe_clone(
+  std::unique_ptr<MemoryPlanner> maybeClone(
       BlockRunner* new_block_runner,
       const FastMap<at::Tensor*, at::Tensor*>& old_tensor_to_new)
       const override;

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -54,7 +54,7 @@ C10_DECLARE_REGISTRY(SRNativeOperatorRegistry, SROperatorFunctor);
   C10_REGISTER_CLASS(                                              \
       SRNativeOperatorRegistry, name, SRNativeOperatorFunctor_##id);
 
-inline at::Tensor create_empty_from(const at::Tensor& t) {
+inline at::Tensor createEmptyFrom(const at::Tensor& t) {
   return at::detail::empty_cpu(
       {0},
       c10::typeMetaToScalarType(t.dtype()),
@@ -64,9 +64,7 @@ inline at::Tensor create_empty_from(const at::Tensor& t) {
       c10::nullopt);
 }
 
-inline at::Tensor create_empty_from(
-    at::IntArrayRef sizes,
-    const at::Tensor& t) {
+inline at::Tensor createEmptyFrom(at::IntArrayRef sizes, const at::Tensor& t) {
   return at::detail::empty_cpu(
       sizes,
       c10::typeMetaToScalarType(t.dtype()),
@@ -81,14 +79,12 @@ inline at::Tensor create_empty(c10::ScalarType dtype) {
       {0}, dtype, c10::nullopt, c10::nullopt, c10::nullopt, c10::nullopt);
 }
 
-inline at::Tensor create_empty_from(
-    const at::Tensor& t,
-    c10::ScalarType dtype) {
+inline at::Tensor createEmptyFrom(const at::Tensor& t, c10::ScalarType dtype) {
   return at::detail::empty_cpu(
       {0}, dtype, t.layout(), t.device(), c10::nullopt, c10::nullopt);
 }
 
-inline at::Tensor create_empty_from(const at::Tensor& t, c10::Layout layout) {
+inline at::Tensor createEmptyFrom(const at::Tensor& t, c10::Layout layout) {
   return at::detail::empty_cpu(
       {0},
       c10::typeMetaToScalarType(t.dtype()),
@@ -98,7 +94,7 @@ inline at::Tensor create_empty_from(const at::Tensor& t, c10::Layout layout) {
       c10::nullopt);
 }
 
-inline at::Tensor create_empty_from(const at::Tensor& t, c10::Device device) {
+inline at::Tensor createEmptyFrom(const at::Tensor& t, c10::Device device) {
   return at::detail::empty_cpu(
       {0},
       c10::typeMetaToScalarType(t.dtype()),
@@ -108,7 +104,7 @@ inline at::Tensor create_empty_from(const at::Tensor& t, c10::Device device) {
       c10::nullopt);
 }
 
-inline at::Tensor create_empty_from(
+inline at::Tensor createEmptyFrom(
     const at::Tensor& t,
     c10::MemoryFormat memory_format) {
   return at::detail::empty_cpu(
@@ -120,7 +116,7 @@ inline at::Tensor create_empty_from(
       memory_format);
 }
 
-inline at::Tensor create_empty_from(
+inline at::Tensor createEmptyFrom(
     const at::Tensor& t,
     c10::ScalarType dtype,
     c10::MemoryFormat memory_format) {
@@ -164,7 +160,7 @@ inline std::string PrintNode(const Node* node) {
   return ss.str();
 }
 
-inline void LogAndDumpSchema(const Node* node) {
+inline void logAndDumpSchema(const Node* node) {
   VLOG(1) << "Found schema mismatch";
   node->schema().dump();
 }

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -39,7 +39,7 @@ bool forwardHasOp(
 
 namespace {
 C10_UNUSED
-void ConcatAddMulReplaceNaNClip(std::shared_ptr<torch::jit::Graph>& graph) {
+void concatAddMulReplaceNaNClip(std::shared_ptr<torch::jit::Graph>& graph) {
   // TODO:: check restrictions for inputs; outputs not used elsewhere
   std::string pattern = R"IR(
     graph(%a, %b, %c, %d, %e, %f, %g, %h, %i, %j):
@@ -93,7 +93,7 @@ void ConcatAddMulReplaceNaNClip(std::shared_ptr<torch::jit::Graph>& graph) {
 }
 
 C10_UNUSED
-void CastedBatchOneHotLengths(std::shared_ptr<torch::jit::Graph>& graph) {
+void castedBatchOneHotLengths(std::shared_ptr<torch::jit::Graph>& graph) {
   // TODO:: check restrictions for inputs; outputs not used elsewhere
   std::string pattern = R"IR(
     graph(%a, %b, %c, %d, %e, %f, %g):
@@ -124,7 +124,7 @@ void CastedBatchOneHotLengths(std::shared_ptr<torch::jit::Graph>& graph) {
 }
 
 C10_UNUSED
-void ConcatBatchMatMulBatchGather(std::shared_ptr<torch::jit::Graph>& graph) {
+void concatBatchMatMulBatchGather(std::shared_ptr<torch::jit::Graph>& graph) {
   // TODO:: check restrictions for inputs; outputs not used elsewhere
   std::string pattern = R"IR(
     graph(%a, %b, %c, %d, %e, %f):
@@ -143,7 +143,7 @@ void ConcatBatchMatMulBatchGather(std::shared_ptr<torch::jit::Graph>& graph) {
   fuse.runOnGraph(graph);
 }
 
-C10_UNUSED void ClipRangesGatherRangesLengthsToOffsets(
+C10_UNUSED void clipRangesGatherRangesLengthsToOffsets(
     std::shared_ptr<torch::jit::Graph>& graph) {
   // TODO:: check restrictions for inputs; outputs not used elsewhere
   std::string pattern = R"IR(
@@ -161,7 +161,7 @@ C10_UNUSED void ClipRangesGatherRangesLengthsToOffsets(
   fuse.runOnGraph(graph);
 }
 
-C10_UNUSED void ClipRangesGather(std::shared_ptr<torch::jit::Graph>& graph) {
+C10_UNUSED void clipRangesGather(std::shared_ptr<torch::jit::Graph>& graph) {
   // TODO:: check restrictions for inputs; outputs not used elsewhere
   // fuse without lengths-to-offsets
   std::string pattern = R"IR(
@@ -178,7 +178,7 @@ C10_UNUSED void ClipRangesGather(std::shared_ptr<torch::jit::Graph>& graph) {
   fuse.runOnGraph(graph);
 }
 
-C10_UNUSED void PrecomputeMultiplierShiftForSigridHash(
+C10_UNUSED void precomputeMultiplierShiftForSigridHash(
     std::shared_ptr<torch::jit::Graph>& graph) {
   std::string pattern = R"IR(
     graph(%a, %b, %c, %d):
@@ -196,7 +196,7 @@ C10_UNUSED void PrecomputeMultiplierShiftForSigridHash(
   fuse.runOnGraph(graph);
 }
 
-C10_UNUSED void ClipRangesToGatherToOffsets(
+C10_UNUSED void clipRangesToGatherToOffsets(
     std::shared_ptr<torch::jit::Graph>& graph) {
   std::string pattern = R"IR(
     graph(%a, %b, %c, %d, %to0_in0, %to0_in1, %to0_in2):
@@ -227,7 +227,7 @@ C10_UNUSED void ClipRangesToGatherToOffsets(
 }
 
 C10_UNUSED
-void ClipRangesGatherSigridHash(std::shared_ptr<torch::jit::Graph>& graph) {
+void clipRangesGatherSigridHash(std::shared_ptr<torch::jit::Graph>& graph) {
   // TODO:: check restrictions for inputs; outputs not used elsewhere
   std::string pattern = R"IR(
     graph(%a, %b, %c, %d, %e, %f, %g, %h):
@@ -243,7 +243,7 @@ void ClipRangesGatherSigridHash(std::shared_ptr<torch::jit::Graph>& graph) {
   fuse.runOnGraph(graph);
 }
 
-C10_UNUSED void ClipRangesGatherRangesSigridHash(
+C10_UNUSED void clipRangesGatherRangesSigridHash(
     std::shared_ptr<torch::jit::Graph>& graph) {
   std::string pattern = R"IR(
     graph(%a, %b, %c, %d, %e, %f, %g):
@@ -261,7 +261,7 @@ C10_UNUSED void ClipRangesGatherRangesSigridHash(
   fuse.runOnGraph(graph);
 }
 
-C10_UNUSED void ClipRangesGatherRangesX2SigridHashPrecompute(
+C10_UNUSED void clipRangesGatherRangesX2SigridHashPrecompute(
     std::shared_ptr<torch::jit::Graph>& graph) {
   // Placeholder is a dummy op used to capture the first subgraph
   std::string pattern = R"IR(
@@ -302,38 +302,38 @@ C10_UNUSED void ClipRangesGatherRangesX2SigridHashPrecompute(
   fuse.runOnGraph(graph);
 }
 
-C10_UNUSED void SplitOutPrecomputeOpsForSparseNN(
+C10_UNUSED void splitOutPrecomputeOpsForSparseNN(
     std::shared_ptr<torch::jit::Graph>& graph) {
 #ifdef FBCODE_CAFFE2
-  PrecomputeMultiplierShiftForSigridHash(graph);
+  precomputeMultiplierShiftForSigridHash(graph);
   ConstantPropagation(graph);
   ConstantPooling(graph);
 #endif
 }
 } // namespace
 
-void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
+void fuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
 #ifdef FBCODE_CAFFE2
-  SplitOutPrecomputeOpsForSparseNN(graph);
+  splitOutPrecomputeOpsForSparseNN(graph);
 
-  ConcatAddMulReplaceNaNClip(graph);
-  CastedBatchOneHotLengths(graph);
-  ConcatBatchMatMulBatchGather(graph);
+  concatAddMulReplaceNaNClip(graph);
+  castedBatchOneHotLengths(graph);
+  concatBatchMatMulBatchGather(graph);
 
   if (FLAGS_enable_clip_ranges_gather_fusions) {
-    ClipRangesGatherRangesLengthsToOffsets(graph);
+    clipRangesGatherRangesLengthsToOffsets(graph);
   }
-  ClipRangesGatherSigridHash(graph);
-  ClipRangesGatherRangesSigridHash(graph);
+  clipRangesGatherSigridHash(graph);
+  clipRangesGatherRangesSigridHash(graph);
 
-  ClipRangesGatherRangesX2SigridHashPrecompute(graph);
+  clipRangesGatherRangesX2SigridHashPrecompute(graph);
 
   if (FLAGS_enable_clip_ranges_gather_fusions) {
     // prioritize clip_ranges+gather_ranges+sigrid_hash fusion over
     // clip_ranges+gather_ranges
-    ClipRangesGather(graph);
+    clipRangesGather(graph);
 
-    ClipRangesToGatherToOffsets(graph);
+    clipRangesToGatherToOffsets(graph);
   }
 #endif
 }
@@ -391,7 +391,7 @@ TORCH_LIBRARY_FRAGMENT(static_runtime, m) {
   m.def(torch::schema("static_runtime::create_owned_ref(...) -> ..."));
 }
 
-void FuseSignLog1P(std::shared_ptr<torch::jit::Graph>& graph) {
+void fuseSignLog1P(std::shared_ptr<torch::jit::Graph>& graph) {
   std::string pattern = R"IR(
     graph(%input):
         %0 : Tensor = aten::sign(%input)
@@ -416,7 +416,7 @@ namespace {
 
 using TupleUnpackBlock = std::vector<Node*>;
 
-std::vector<TupleUnpackBlock> CollectVariadicTupleUnpackFusionCandidates(
+std::vector<TupleUnpackBlock> collectVariadicTupleUnpackFusionCandidates(
     const std::shared_ptr<Graph>& graph) {
   std::vector<TupleUnpackBlock> candidates;
   auto nodes = graph->nodes();
@@ -435,7 +435,7 @@ std::vector<TupleUnpackBlock> CollectVariadicTupleUnpackFusionCandidates(
   return candidates;
 }
 
-void FuseTupleUnpackBlock(const TupleUnpackBlock& nodes) {
+void fuseTupleUnpackBlock(const TupleUnpackBlock& nodes) {
   TORCH_CHECK(nodes.size() > 0);
   auto graph = nodes[0]->owningGraph();
   auto var_unpack = graph->create(
@@ -458,9 +458,9 @@ void FuseTupleUnpackBlock(const TupleUnpackBlock& nodes) {
 
 } // namespace
 
-void UseVariadicTupleUnpack(const std::shared_ptr<Graph>& graph) {
-  for (auto& c : CollectVariadicTupleUnpackFusionCandidates(graph)) {
-    FuseTupleUnpackBlock(c);
+void useVariadicTupleUnpack(const std::shared_ptr<Graph>& graph) {
+  for (auto& c : collectVariadicTupleUnpackFusionCandidates(graph)) {
+    fuseTupleUnpackBlock(c);
   }
 }
 
@@ -514,7 +514,7 @@ void UseVariadicTupleUnpack(const std::shared_ptr<Graph>& graph) {
 //                         |
 //                         v
 
-void ReplaceWithMaybeCopy(
+void replaceWithMaybeCopy(
     std::shared_ptr<Graph>& graph,
     bool outputs_are_immutable) {
   AliasDb db(graph);
@@ -597,7 +597,7 @@ void ReplaceWithMaybeCopy(
 #endif
 }
 
-void ReplaceWithCopy(
+void replaceWithCopy(
     std::shared_ptr<Graph>& graph,
     bool outputs_are_immutable) {
   AliasDb db(graph);
@@ -685,7 +685,7 @@ void ReplaceWithCopy(
 #endif
 }
 
-void EliminateTrivialEquallySplit(std::shared_ptr<torch::jit::Graph>& graph) {
+void eliminateTrivialEquallySplit(std::shared_ptr<torch::jit::Graph>& graph) {
   const auto equally_split = fromQualString("fb::equally_split");
   std::vector<Node*> to_remove;
   DepthFirstGraphNodeIterator graph_it(graph);
@@ -753,7 +753,7 @@ bool shouldNotFuseListUnpackSpecialCase(const Node* node) {
 
 } // namespace
 
-void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
+void fuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
   const FastMap<c10::Symbol, c10::Symbol> unfused_to_fused = {
       OP_PAIR("fb::equally_split", "static_runtime::fused_equally_split"),
       OP_PAIR(
@@ -833,7 +833,7 @@ void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
   }
 } // namespace jit
 
-void RemoveImmutableInputDictLookups(
+void removeImmutableInputDictLookups(
     std::shared_ptr<torch::jit::Graph>& graph) {
   auto nodes = graph->nodes();
   AliasDb db(graph);
@@ -904,7 +904,7 @@ void RemoveImmutableInputDictLookups(
   marker->destroy();
 }
 
-void UseVariadicGroupedAccessor(const std::shared_ptr<Graph>& graph) {
+void useVariadicGroupedAccessor(const std::shared_ptr<Graph>& graph) {
   // Migration to v2 is still in progress. For now, SR will support
   // both versions of this op.
   UseVariadicOp(
@@ -919,10 +919,10 @@ void UseVariadicGroupedAccessor(const std::shared_ptr<Graph>& graph) {
 
 namespace {
 
-void CreateOwnedRefsForSpecialValuesHelper(Graph& graph, Block* block) {
+void createOwnedRefsForSpecialValuesHelper(Graph& graph, Block* block) {
   for (auto* node : block->nodes()) {
     for (auto* sub_block : node->blocks()) {
-      CreateOwnedRefsForSpecialValuesHelper(graph, sub_block);
+      createOwnedRefsForSpecialValuesHelper(graph, sub_block);
     }
   }
 
@@ -951,7 +951,7 @@ void CreateOwnedRefsForSpecialValuesHelper(Graph& graph, Block* block) {
   }
 }
 
-void ForceNonEmptyOutputsHelper(Value* none_value, Block* block) {
+void forceNonEmptyOutputsHelper(Value* none_value, Block* block) {
   for (auto* node : block->nodes()) {
     bool needs_output = false;
     for (auto* sub_block : node->blocks()) {
@@ -960,7 +960,7 @@ void ForceNonEmptyOutputsHelper(Value* none_value, Block* block) {
         needs_output = true;
       }
 
-      ForceNonEmptyOutputsHelper(none_value, sub_block);
+      forceNonEmptyOutputsHelper(none_value, sub_block);
     }
 
     if (needs_output) {
@@ -994,19 +994,19 @@ Node* findOrCreateNoneConstant(Graph& graph) {
 
 } // namespace
 
-void CreateOwnedRefsForSpecialValues(Graph& graph) {
-  CreateOwnedRefsForSpecialValuesHelper(graph, graph.block());
+void createOwnedRefsForSpecialIValues(Graph& graph) {
+  createOwnedRefsForSpecialValuesHelper(graph, graph.block());
 }
 
-void ForceNonEmptyOutputs(Graph& graph) {
+void forceNonEmptyOutputs(Graph& graph) {
   auto* none_node = findOrCreateNoneConstant(graph);
-  ForceNonEmptyOutputsHelper(none_node->output(), graph.block());
+  forceNonEmptyOutputsHelper(none_node->output(), graph.block());
   if (!none_node->hasUses()) {
     none_node->destroy();
   }
 }
 
-void EliminateExtraPermuteOps(std::shared_ptr<Graph>& graph) {
+void eliminateExtraPermuteOps(std::shared_ptr<Graph>& graph) {
   auto input_is_constant_list =
       [](Node* node, size_t input_idx, const c10::List<int64_t>& expected) {
         auto input_opt = toIValue(node->input(input_idx));
@@ -1066,7 +1066,7 @@ Node* maybeUserWithKind(Value* value, c10::Symbol kind) {
 
 } // namespace
 
-void UseSplitAndSqueeze(std::shared_ptr<Graph>& graph) {
+void useSplitAndSqueeze(std::shared_ptr<Graph>& graph) {
   std::vector<Node*> to_erase;
   for (auto* node : graph->nodes()) {
     if (node->kind() != aten::split) {

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -3,34 +3,34 @@
 namespace torch {
 namespace jit {
 
-TORCH_API void FuseInferenceOpsForSparseNN(
+TORCH_API void fuseInferenceOpsForSparseNN(
     std::shared_ptr<torch::jit::Graph>& graph);
 
-TORCH_API void EliminateTrivialEquallySplit(
+TORCH_API void eliminateTrivialEquallySplit(
     std::shared_ptr<torch::jit::Graph>& graph);
 
-TORCH_API void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph);
+TORCH_API void fuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph);
 
 // If outputs_are_immutable is set to false, don't replace the view ops that
 // produce aliases of graph outputs with the copy version.
-TORCH_API void ReplaceWithCopy(
+TORCH_API void replaceWithCopy(
     std::shared_ptr<torch::jit::Graph>& graph,
     bool outputs_are_immutable = true);
 
-void ReplaceWithMaybeCopy(
+void replaceWithMaybeCopy(
     std::shared_ptr<torch::jit::Graph>& graph,
     bool outputs_are_immutable = true);
 
-TORCH_API void RemoveImmutableInputDictLookups(
+TORCH_API void removeImmutableInputDictLookups(
     std::shared_ptr<torch::jit::Graph>& graph);
 
 TORCH_API bool graphHasOp(std::shared_ptr<Graph>& graph, const char* op_name);
 
 TORCH_API bool forwardHasOp(const Module& module, const char* op_name);
 
-TORCH_API void FuseSignLog1P(std::shared_ptr<Graph>& graph);
+TORCH_API void fuseSignLog1P(std::shared_ptr<Graph>& graph);
 
-TORCH_API void UseVariadicTupleUnpack(const std::shared_ptr<Graph>& graph);
+TORCH_API void useVariadicTupleUnpack(const std::shared_ptr<Graph>& graph);
 
 // c10::Symbol::fromQualString is a bit long to type everywhere, and
 // we can't use a `using` statement since it's a static class function.
@@ -50,20 +50,20 @@ inline c10::Symbol fromQualString(const std::string& qual_string) {
 // this actually does a copy.
 // Note that we have to do the same thing if we are returning a value from an
 // outer scope in a sub-block.
-TORCH_API void CreateOwnedRefsForSpecialValues(Graph& graph);
+TORCH_API void createOwnedRefsForSpecialIValues(Graph& graph);
 
 // [Force non-empty outputs]
 // It is technically possible for sub-blocks to not return anything. This is
 // problematic for StaticRuntimeBlockRunner because it assumes that at least one
 // output is being returned. Rather than slowing down SR with special logic for
 // this corner case, we simply force blocks that return nothing to return None.
-TORCH_API void ForceNonEmptyOutputs(Graph& graph);
+TORCH_API void forceNonEmptyOutputs(Graph& graph);
 
-TORCH_API void UseVariadicGroupedAccessor(const std::shared_ptr<Graph>& graph);
+TORCH_API void useVariadicGroupedAccessor(const std::shared_ptr<Graph>& graph);
 
-TORCH_API void EliminateExtraPermuteOps(std::shared_ptr<Graph>& graph);
+TORCH_API void eliminateExtraPermuteOps(std::shared_ptr<Graph>& graph);
 
-TORCH_API void UseSplitAndSqueeze(std::shared_ptr<Graph>& graph);
+TORCH_API void useSplitAndSqueeze(std::shared_ptr<Graph>& graph);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/static/processed_node_wrapper.h
+++ b/torch/csrc/jit/runtime/static/processed_node_wrapper.h
@@ -139,26 +139,26 @@ class ProcessedNodeInputWrapper
         num_ignored_elems_(num_ignored_elems) {}
 
   size_t size() const {
-    return pnode_.num_inputs() - num_ignored_elems_;
+    return pnode_.numInputs() - num_ignored_elems_;
   }
 
   const at::Tensor& operator[](size_t idx) const {
     TORCH_CHECK(idx < size());
-    return pnode_.Input(idx).toTensor();
+    return pnode_.input(idx).toTensor();
   }
 
   const at::Tensor& front() const {
     TORCH_CHECK(
         !empty(),
         "Attempted to access front() of empty ProcessedNodeInputWrapper");
-    return pnode_.Input(0).toTensor();
+    return pnode_.input(0).toTensor();
   }
 
   const at::Tensor& back() const {
     TORCH_CHECK(
         !empty(),
         "Attempted to access back() of empty ProcessedNodeInputWrapper");
-    return pnode_.Input(size() - 1).toTensor();
+    return pnode_.input(size() - 1).toTensor();
   }
 
  private:
@@ -174,26 +174,26 @@ class ProcessedNodeOutputWrapper
       ProcessedNodeOutputWrapper>::ProcessedNodeWrapperBase;
 
   size_t size() const {
-    return pnode_.num_outputs();
+    return pnode_.numOutputs();
   }
 
   at::Tensor& operator[](size_t idx) const {
     TORCH_CHECK(idx < size());
-    return pnode_.Output(idx).toTensor();
+    return pnode_.output(idx).toTensor();
   }
 
   at::Tensor& front() const {
     TORCH_CHECK(
         !empty(),
         "Attempted to access front() of empty ProcessedNodeOutputWrapper");
-    return pnode_.Output(0).toTensor();
+    return pnode_.output(0).toTensor();
   }
 
   at::Tensor& back() const {
     TORCH_CHECK(
         !empty(),
         "Attempted to access back() of empty ProcessedNodeOutputWrapper");
-    return pnode_.Output(size() - 1).toTensor();
+    return pnode_.output(size() - 1).toTensor();
   }
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #75283
* #75271
* __->__ #75191
* #75037
* #74928
* #74782
* #74730
* #74927

Make all static runtime functions use the `camelCase` convention. Most of these changes were done automatically via VSCode

Why? Because this has been driving me crazy. Will work on more meaningful code cleanup after this diff

Differential Revision: [D35301986](https://our.internmc.facebook.com/intern/diff/D35301986/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D35301986/)!