### PR TITLE
Split SILU OpInfo

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11823,6 +11823,30 @@ op_db: List[OpInfo] = [
         'nn.functional.silu',
         ref=lambda x, inplace=False:
             x / (1 + np.exp(-x)),
+        dtypes=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
+        supports_forward_ad=True,
+        supports_autograd=True,
+        supports_fwgrad_bwgrad=True,
+        assert_autodiffed=False,
+        supports_out=False,
+        inplace_variant=lambda x: torch.nn.functional.silu(x, inplace=True),
+        decorators=[
+            DecorateInfo(
+                toleranceOverride({
+                    torch.float16: tol(atol=1e-3, rtol=1e-3),
+                    torch.bfloat16: tol(atol=1e-4, rtol=1e-4)
+                }),
+                'TestUnaryUfuncs', device_type='cuda',
+            ), ],
+    ),
+    # TODO: combine this with the nn.functional.silu OpInfo when
+    # complex autodiff for silu is supported.
+    UnaryUfuncInfo(
+        'nn.functional.silu',
+        variant_test_name='complex',
+        ref=lambda x, inplace=False:
+            x / (1 + np.exp(-x)),
         dtypes=floating_and_complex_types_and(torch.bfloat16),
         dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
         supports_forward_ad=False,


### PR DESCRIPTION
Motivation
==========

We would like to test autograd support (forward-mode AD and reverse-mode
AD) of SILU in functorch. Unfortunately the OpInfo for
nn.functional.silu has supports_autograd and supports_forward_ad as
False. This is due to nn.functional.silu not supporting complex
autograd.

Solution
========

This PR splits the OpInfo for nn.functional.silu into two. One OpInfo
tests non-complex dtypes and the other ones test complex dtypes.

Alternatives
============

- We could manually add tests in functorch
- We can add complex autograd support for SILU (I don't know how to do
this but if this is easy to do I'm happy to try)

Test Plan
=========

Run tests

Fixes #ISSUE_NUMBER
