### PR TITLE
[PyTorchEdge] Backport v9 (flatbuffer) to v8 (pickle)

### DIFF
--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -122,7 +122,7 @@ constexpr uint64_t kMinProducedFileFormatVersion = 0x3L;
 //  Refer. See https://github.com/pytorch/pytorch/pull/63651 for details
 //  0x8L: Emit promoted operators as instructions.
 //  See https://github.com/pytorch/pytorch/pull/71662 for details
-constexpr uint64_t kProducedBytecodeVersion = 0x8L;
+constexpr uint64_t kProducedBytecodeVersion = 0x9L;
 
 // static_assert(
 //     kProducedBytecodeVersion >= kProducedFileFormatVersion,
@@ -135,7 +135,7 @@ constexpr uint64_t kProducedBytecodeVersion = 0x8L;
 // (in loader), we should support this model_version. For example, we provide a
 // wrapper to handle an updated operator.
 constexpr uint64_t kMinSupportedBytecodeVersion = 0x4L;
-constexpr uint64_t kMaxSupportedBytecodeVersion = 0x8L;
+constexpr uint64_t kMaxSupportedBytecodeVersion = 0x9L;
 
 } // namespace serialize
 } // namespace caffe2

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -717,7 +717,15 @@ TEST(LiteInterpreterTest, BackPortByteCodeModelAllVersions) {
   torch::jit::Module module_freeze = freeze(module);
 
   std::stringstream input_model_stream;
+#if defined(ENABLE_FLATBUFFER)
+  module_freeze._save_for_mobile(
+      input_model_stream,
+      /*extra_files=*/{},
+      /*save_mobile_debug_info=*/false,
+      /*use_flatbuffer=*/true);
+#else
   module_freeze._save_for_mobile(input_model_stream);
+#endif
   std::vector<IValue> input_data =
       std::vector<IValue>({torch::ones({1, 1, 28, 28})});
   std::vector<IValue> expect_result_list;

--- a/torch/csrc/init_flatbuffer_module.cpp
+++ b/torch/csrc/init_flatbuffer_module.cpp
@@ -1,78 +1,77 @@
 #include <torch/csrc/python_headers.h>
 
-#include <cstdlib>
 #include <libshm.h>
+#include <cstdlib>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include <pybind11/detail/common.h>
-#include <pybind11/pytypes.h>
 #include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 
-#include <Python.h>  // NOLINT
+#include <Python.h> // NOLINT
+#include <torch/csrc/jit/mobile/flatbuffer_loader.h>
 #include <torch/csrc/jit/python/module_python.h>
 #include <torch/csrc/jit/python/python_ivalue.h>
 #include <torch/csrc/jit/python/python_sugared_value.h>
-#include <torch/csrc/jit/mobile/flatbuffer_loader.h>
 #include <torch/csrc/jit/serialization/flatbuffer_serializer.h>
 
 namespace py = pybind11;
 
 static std::shared_ptr<char> copyStr(const std::string& bytes) {
-  size_t size = (bytes.size() / FLATBUFFERS_MAX_ALIGNMENT + 1) * FLATBUFFERS_MAX_ALIGNMENT;
+  size_t size = (bytes.size() / FLATBUFFERS_MAX_ALIGNMENT + 1) *
+      FLATBUFFERS_MAX_ALIGNMENT;
 #ifdef _WIN32
-  std::shared_ptr<char> bytes_copy(static_cast<char*>(_aligned_malloc(size, FLATBUFFERS_MAX_ALIGNMENT)), _aligned_free);
+  std::shared_ptr<char> bytes_copy(
+      static_cast<char*>(_aligned_malloc(size, FLATBUFFERS_MAX_ALIGNMENT)),
+      _aligned_free);
 #else
-  std::shared_ptr<char> bytes_copy(static_cast<char*>(aligned_alloc(FLATBUFFERS_MAX_ALIGNMENT, size)), free);
+  std::shared_ptr<char> bytes_copy(
+      static_cast<char*>(aligned_alloc(FLATBUFFERS_MAX_ALIGNMENT, size)), free);
 #endif
   memcpy(bytes_copy.get(), bytes.data(), bytes.size());
   return bytes_copy;
 }
 
-
-
 extern "C"
 #ifdef _WIN32
-__declspec(dllexport)
+    __declspec(dllexport)
 #endif
-PyObject* initModuleFlatbuffer() {
+        PyObject* initModuleFlatbuffer() {
   using namespace torch::jit;
-  PyMethodDef m[] = {{nullptr, nullptr, 0, nullptr}};  // NOLINT
+  PyMethodDef m[] = {{nullptr, nullptr, 0, nullptr}}; // NOLINT
   static struct PyModuleDef torchmodule = {
-     PyModuleDef_HEAD_INIT,
-     "torch._C_flatbuffer",
-     nullptr,
-     -1,
-     m,
-  };  // NOLINT
+      PyModuleDef_HEAD_INIT,
+      "torch._C_flatbuffer",
+      nullptr,
+      -1,
+      m,
+  }; // NOLINT
   PyObject* module = PyModule_Create(&torchmodule);
   auto pym = py::handle(module).cast<py::module>();
-  pym.def(
-      "_load_mobile_module_from_file",
-      [](const std::string& filename) {
-        return torch::jit::load_mobile_module_from_file(filename);
-      });
-  pym.def(
-      "_load_mobile_module_from_bytes",
-      [](const std::string& bytes) {
-        auto bytes_copy = copyStr(bytes);
-        return torch::jit::parse_and_initialize_mobile_module(bytes_copy, bytes.size());
-      });
-  pym.def(
-      "_load_jit_module_from_file",
-      [](const std::string& filename) {
-        return torch::jit::load_jit_module_from_file(filename);
-      });
-  pym.def(
-      "_load_jit_module_from_bytes",
-      [](const std::string& bytes) {
-        auto bytes_copy = copyStr(bytes);
-        return torch::jit::parse_and_initialize_jit_module(bytes_copy, bytes.size());
-      });
+  pym.def("_load_mobile_module_from_file", [](const std::string& filename) {
+    return torch::jit::load_mobile_module_from_file(filename);
+  });
+  pym.def("_load_mobile_module_from_bytes", [](const std::string& bytes) {
+    auto bytes_copy = copyStr(bytes);
+    return torch::jit::parse_and_initialize_mobile_module(
+        bytes_copy, bytes.size());
+  });
+  pym.def("_load_jit_module_from_file", [](const std::string& filename) {
+    ExtraFilesMap extra_files = ExtraFilesMap();
+    return torch::jit::load_jit_module_from_file(filename, extra_files);
+  });
+  pym.def("_load_jit_module_from_bytes", [](const std::string& bytes) {
+    auto bytes_copy = copyStr(bytes);
+    ExtraFilesMap extra_files = ExtraFilesMap();
+    return torch::jit::parse_and_initialize_jit_module(
+        bytes_copy, bytes.size(), extra_files);
+  });
   pym.def(
       "_save_mobile_module",
-      [](const torch::jit::mobile::Module& module, const std::string& filename) {
+      [](const torch::jit::mobile::Module& module,
+         const std::string& filename) {
         return torch::jit::save_mobile_module(module, filename);
       });
   pym.def(
@@ -84,13 +83,15 @@ PyObject* initModuleFlatbuffer() {
       "_save_mobile_module_to_bytes",
       [](const torch::jit::mobile::Module& module) {
         auto detached_buffer = torch::jit::save_mobile_module_to_bytes(module);
-        return py::bytes(reinterpret_cast<char*>(detached_buffer.data()), detached_buffer.size());
+        return py::bytes(
+            reinterpret_cast<char*>(detached_buffer.data()),
+            detached_buffer.size());
       });
-  pym.def(
-      "_save_jit_module_to_bytes",
-      [](const torch::jit::Module& module) {
-        auto detached_buffer = torch::jit::save_jit_module_to_bytes(module);
-        return py::bytes(reinterpret_cast<char*>(detached_buffer.data()), detached_buffer.size());
-      });
+  pym.def("_save_jit_module_to_bytes", [](const torch::jit::Module& module) {
+    auto detached_buffer = torch::jit::save_jit_module_to_bytes(module);
+    return py::bytes(
+        reinterpret_cast<char*>(detached_buffer.data()),
+        detached_buffer.size());
+  });
   return module;
 }

--- a/torch/csrc/jit/mobile/compatibility/backport.cpp
+++ b/torch/csrc/jit/mobile/compatibility/backport.cpp
@@ -21,7 +21,7 @@ const static BackportManager backportManager;
 // Forward declare so that _backport_for_mobile() overloads can
 // call this method directly.
 bool _backport_for_mobile_impl(
-    std::shared_ptr<IStreamAdapter> istream_adapter,
+    std::istream& oss,
     PyTorchStreamWriter& writer,
     const int64_t to_version);
 
@@ -29,24 +29,20 @@ bool _backport_for_mobile(
     std::istream& in,
     std::ostream& out,
     const int64_t to_version) {
-  std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
   auto writer_func = [&](const void* buf, size_t nbytes) -> size_t {
     out.write(static_cast<const char*>(buf), nbytes);
     return !out ? 0 : nbytes;
   };
   PyTorchStreamWriter writer(writer_func);
-  return _backport_for_mobile_impl(std::move(rai), writer, to_version);
+  return _backport_for_mobile_impl(in, writer, to_version);
 }
 
 bool _backport_for_mobile(
     std::istream& in,
     const std::string& output_filename,
     const int64_t to_version) {
-  std::unique_ptr<IStreamAdapter> istream_adapter =
-      std::make_unique<IStreamAdapter>(&in);
   PyTorchStreamWriter writer(output_filename);
-  return _backport_for_mobile_impl(
-      std::move(istream_adapter), writer, to_version);
+  return _backport_for_mobile_impl(in, writer, to_version);
 }
 
 bool _backport_for_mobile(
@@ -59,15 +55,13 @@ bool _backport_for_mobile(
   if (!file_stream) {
     AT_ERROR("open file failed, file path: ", input_filename);
   }
-  istream_adapter = std::make_unique<IStreamAdapter>(&file_stream);
-
   auto writer_func = [&](const void* buf, size_t nbytes) -> size_t {
     out.write(static_cast<const char*>(buf), nbytes);
     return !out ? 0 : nbytes;
   };
+
   PyTorchStreamWriter writer(writer_func);
-  return _backport_for_mobile_impl(
-      std::move(istream_adapter), writer, to_version);
+  return _backport_for_mobile_impl(file_stream, writer, to_version);
 }
 
 bool _backport_for_mobile(
@@ -75,28 +69,25 @@ bool _backport_for_mobile(
     const std::string& output_filename,
     const int64_t to_version) {
   std::ifstream file_stream;
-  std::unique_ptr<IStreamAdapter> istream_adapter;
   file_stream.open(input_filename, std::ifstream::in | std::ifstream::binary);
   if (!file_stream) {
     AT_ERROR("open file failed, file path: ", input_filename);
   }
-  istream_adapter = std::make_unique<IStreamAdapter>(&file_stream);
 
   PyTorchStreamWriter writer(output_filename);
-  return _backport_for_mobile_impl(
-      std::move(istream_adapter), writer, to_version);
+  return _backport_for_mobile_impl(file_stream, writer, to_version);
 }
 
 bool _backport_for_mobile_impl(
-    std::shared_ptr<IStreamAdapter> istream_adapter,
+    std::istream& oss,
     PyTorchStreamWriter& writer,
     const int64_t to_version) {
   if (!backportManager.hasBytecodeBackportFunction(to_version + 1)) {
     return false;
   }
-  auto from_version = _get_model_bytecode_version(istream_adapter);
-  return backportManager.backport(
-      istream_adapter, writer, from_version, to_version);
+  oss.seekg(0, oss.beg);
+  auto from_version = _get_model_bytecode_version(oss);
+  return backportManager.backport(oss, writer, from_version, to_version);
 }
 
 } // namespace jit

--- a/torch/csrc/jit/mobile/compatibility/backport_manager.h
+++ b/torch/csrc/jit/mobile/compatibility/backport_manager.h
@@ -34,7 +34,7 @@ class BackportManager final {
   bytecodeBackportFunctions() const;
 
   bool backport(
-      std::shared_ptr<caffe2::serialize::IStreamAdapter> istream_adapter,
+      std::istream& oss,
       caffe2::serialize::PyTorchStreamWriter& final_writer,
       int64_t from_version,
       int64_t to_version) const;

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -764,11 +764,13 @@ flatbuffers::DetachedBuffer save_mobile_module_to_bytes(
 
 Module parse_and_initialize_jit_module(
     std::shared_ptr<char> data,
-    size_t,
-    c10::optional<at::Device>) {
+    size_t size,
+    c10::optional<at::Device> device,
+    ExtraFilesMap& extra_files) {
   auto* flatbuffer_module = mobile::serialization::GetMutableModule(data.get());
   FlatbufferLoader loader;
   mobile::Module mobilem = loader.parseModule(flatbuffer_module);
+  parseExtraFiles(flatbuffer_module, extra_files);
   ExtraFilesMap files;
   std::vector<IValue> constants;
   loader.extractJitSourceAndConstants(&files, &constants);
@@ -783,18 +785,20 @@ Module parse_and_initialize_jit_module(
 
 Module load_jit_module_from_file(
     const std::string& filename,
+    ExtraFilesMap& extra_files,
     c10::optional<at::Device> device) {
   auto data = get_file_content(filename.c_str());
   return parse_and_initialize_jit_module(
-      std::move(std::get<0>(data)), std::get<1>(data), device);
+      std::move(std::get<0>(data)), std::get<1>(data), device, extra_files);
 }
 
 Module load_jit_module_from_stream(
     std::istream& in,
+    ExtraFilesMap& extra_files,
     c10::optional<at::Device> device) {
   auto data = get_stream_content(in);
   return parse_and_initialize_jit_module(
-      std::move(std::get<0>(data)), std::get<1>(data), device);
+      std::move(std::get<0>(data)), std::get<1>(data), device, extra_files);
 }
 
 void save_jit_module(

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -765,8 +765,8 @@ flatbuffers::DetachedBuffer save_mobile_module_to_bytes(
 Module parse_and_initialize_jit_module(
     std::shared_ptr<char> data,
     size_t size,
-    c10::optional<at::Device> device,
-    ExtraFilesMap& extra_files) {
+    ExtraFilesMap& extra_files,
+    c10::optional<at::Device> device) {
   auto* flatbuffer_module = mobile::serialization::GetMutableModule(data.get());
   FlatbufferLoader loader;
   mobile::Module mobilem = loader.parseModule(flatbuffer_module);

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.h
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.h
@@ -41,14 +41,17 @@ TORCH_API flatbuffers::DetachedBuffer save_jit_module_to_bytes(
 TORCH_API Module parse_and_initialize_jit_module(
     std::shared_ptr<char> data,
     size_t size,
+    ExtraFilesMap& extra_files,
     c10::optional<at::Device> device = c10::nullopt);
 
 TORCH_API Module load_jit_module_from_file(
     const std::string& filename,
+    ExtraFilesMap& extra_files,
     c10::optional<at::Device> device = c10::nullopt);
 
 TORCH_API Module load_jit_module_from_stream(
     std::istream& in,
+    ExtraFilesMap& extra_files,
     c10::optional<at::Device> device = c10::nullopt);
 
 } // namespace jit

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -299,7 +299,7 @@ Module import_ir_module(
   switch (format) {
     case FileFormat::FlatbufferFileFormat: {
 #if defined(ENABLE_FLATBUFFER)
-      return load_jit_module_from_stream(in, device);
+      return load_jit_module_from_stream(in, extra_files, device);
 #else
       TORCH_CHECK(
           false, "Flatbuffer input file but the build hasn't enable flatbuffer")
@@ -350,7 +350,7 @@ Module import_ir_module(
   switch (format) {
     case FileFormat::FlatbufferFileFormat: {
 #if defined(ENABLE_FLATBUFFER)
-      return load_jit_module_from_file(filename, device);
+      return load_jit_module_from_file(filename, extra_files, device);
 #else
       TORCH_CHECK(
           false, "Flatbuffer input file but the build hasn't enable flatbuffer")
@@ -398,7 +398,7 @@ Module load(
   switch (format) {
     case FileFormat::FlatbufferFileFormat: {
 #if defined(ENABLE_FLATBUFFER)
-      return load_jit_module_from_stream(in, device);
+      return load_jit_module_from_stream(in, extra_files, device);
 #else
       TORCH_CHECK(
           false, "Flatbuffer input file but the build hasn't enable flatbuffer")
@@ -429,7 +429,7 @@ Module load(
   switch (format) {
     case FileFormat::FlatbufferFileFormat: {
 #if defined(ENABLE_FLATBUFFER)
-      return load_jit_module_from_file(filename, device);
+      return load_jit_module_from_file(filename, extra_files, device);
 #else
       TORCH_CHECK(
           false, "Flatbuffer input file but the build hasn't enable flatbuffer")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75207

In this diff:
Bump supported version to 9, which will serve as a placeholder for upcoming version bump to v9 for flatbuffer format migration.
Implements backport from v9 flatbuffer file to v8 pickle file.

Differential Revision: [D35366210](https://our.internmc.facebook.com/intern/diff/D35366210/)