### PR TITLE
[GHA] Small updates to syncbranches.yml

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -193,8 +193,15 @@ class GitRepo:
                 while len(from_values) > 0 and len(to_values) > 0:
                     frc = self.get_commit(from_values.pop())
                     toc = self.get_commit(to_values.pop())
-                    if frc.title != toc.title or frc.author_date != toc.author_date:
-                        raise RuntimeError(f"Unexpected differences between {frc} and {toc}")
+                    # FRC branch might have PR number added to the title
+                    if not frc.title != toc.title or frc.author_date != toc.author_date:
+                        # HACK: Same commit were merged, reverted and landed again
+                        # which creates a tracking problem
+                        if (
+                            "pytorch/pytorch" not in self.remote_url() or
+                            frc.commit_hash != "0a6a1b27a464ba5be5f587cce2ee12ab8c504dbf"
+                        ):
+                            raise RuntimeError(f"Unexpected differences between {frc} and {toc}")
                     from_commits.remove(frc.commit_hash)
                     to_commits.remove(toc.commit_hash)
                 continue

--- a/.github/scripts/syncbranches.py
+++ b/.github/scripts/syncbranches.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from gitutils import get_git_repo_dir, GitRepo
+from gitutils import get_git_repo_dir, get_git_remote_name, GitRepo
 from typing import Any
 
 
@@ -16,7 +16,7 @@ def parse_args() -> Any:
 
 def main() -> None:
     args = parse_args()
-    repo = GitRepo(get_git_repo_dir(), debug=args.debug)
+    repo = GitRepo(get_git_repo_dir(), get_git_remote_name(), debug=args.debug)
     repo.cherry_pick_commits(args.sync_branch, args.default_branch)
     repo.push(args.default_branch, args.dry_run)
 


### PR DESCRIPTION
Make it accept origin environment variable
Add explicit skip for https://github.com/pytorch/pytorch/commit/0a6a1b27a464ba5be5f587cce2ee12ab8c504dbf as its a rare case of same commit landed/reverted twice
