### PR TITLE
use links to re-enable tests

### DIFF
--- a/tools/stats/import_test_stats.py
+++ b/tools/stats/import_test_stats.py
@@ -16,8 +16,8 @@ def get_disabled_issues() -> List[str]:
     # https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue.
     # E.g., "Close #62851", "fixES #62851" and "RESOLVED #62851" would all match, but not
     # "closes  #62851" --> extra space, "fixing #62851" --> not a keyword, nor "fix 62851" --> no #
-    regex = '(?i)(Close(d|s)?|Resolve(d|s)?|Fix(ed|es)?) #([0-9]+)'
-    issue_numbers = [x[4] for x in re.findall(regex, pr_body + commit_messages)]
+    regex = '(?i)(Close(d|s)?|Resolve(d|s)?|Fix(ed|es)?) (#|https://github.com/pytorch/pytorch/issues/)([0-9]+)'
+    issue_numbers = [x[5] for x in re.findall(regex, pr_body + commit_messages)]
     print("Ignoring disabled issues: ", issue_numbers)
     return issue_numbers
 

--- a/tools/test/test_import_test_stats.py
+++ b/tools/test/test_import_test_stats.py
@@ -34,14 +34,16 @@ class TestGetDisabledIssues(unittest.TestCase):
 
     # test strange spacing
     def test_spacing(self) -> None:
-        pr_body = 'resolve #123,resolveS #143eee'
-        commit_messages = 'Resolved #345\nRESOLVES #10283Fixed #2348fixes https://github.com/pytorch/pytorch/issues/75123resolveS #2134'
+        pr_body = 'resolve #123,resolveS #143Resolved #345\nRESOLVES #10283'
+        commit_messages = 'Fixed #2348fixes https://github.com/pytorch/pytorch/issues/75123resolveS #2134'
         self.run_assert_disabled_issues(pr_body, commit_messages, ['123', '143', '345', '10283', '2348', '75123', '2134'])
 
     # test bad things
     def test_not_accepted(self) -> None:
-        pr_body = 'resolve 234, resolves  #45, resolving #123 fixes189 fixeshttps://github.com/pytorch/pytorch/issues/75123 closedhttps://githubcom/pytorch/pytorch/issues/75123 '
-        commit_messages = 'fix 234, fixes # 45, fixing #123, close 234, closes#45, closing #123'
+        pr_body = 'fixes189 fixeshttps://github.com/pytorch/pytorch/issues/75123 ' \
+            'closedhttps://githubcom/pytorch/pytorch/issues/75123'
+        commit_messages = 'fix 234, fixes # 45, fixing #123, close 234, closes#45, closing #123 resolve 234, ' \
+            'resolves  #45, resolving #123'
         self.run_assert_disabled_issues(pr_body, commit_messages, [])
 
 

--- a/tools/test/test_import_test_stats.py
+++ b/tools/test/test_import_test_stats.py
@@ -27,15 +27,20 @@ class TestGetDisabledIssues(unittest.TestCase):
         commit_messages = 'REsolved #345 RESOLVES #10283'
         self.run_assert_disabled_issues(pr_body, commit_messages, ['123', '143', '345', '10283'])
 
+    # test links
+    def test_issue_links(self) -> None:
+        pr_body = 'closes https://github.com/pytorch/pytorch/issues/75198 fixes https://github.com/pytorch/pytorch/issues/75123'
+        self.run_assert_disabled_issues(pr_body, '', ['75198', '75123'])
+
     # test strange spacing
     def test_spacing(self) -> None:
         pr_body = 'resolve #123,resolveS #143eee'
-        commit_messages = 'Resolved #345\nRESOLVES #10283Fixed #2348'
-        self.run_assert_disabled_issues(pr_body, commit_messages, ['123', '143', '345', '10283', '2348'])
+        commit_messages = 'Resolved #345\nRESOLVES #10283Fixed #2348fixes https://github.com/pytorch/pytorch/issues/75123resolveS #2134'
+        self.run_assert_disabled_issues(pr_body, commit_messages, ['123', '143', '345', '10283', '2348', '75123', '2134'])
 
     # test bad things
     def test_not_accepted(self) -> None:
-        pr_body = 'resolve 234, resolves  #45, resolving #123 fixes189'
+        pr_body = 'resolve 234, resolves  #45, resolving #123 fixes189 fixeshttps://github.com/pytorch/pytorch/issues/75123 closedhttps://githubcom/pytorch/pytorch/issues/75123 '
         commit_messages = 'fix 234, fixes # 45, fixing #123, close 234, closes#45, closing #123'
         self.run_assert_disabled_issues(pr_body, commit_messages, [])
 


### PR DESCRIPTION
Adds ability to use links to PRs to re-enable disabled tests.  

Test Plan

Included "fixes <link to 74223>" in a commit message, which is a disabled test belonging to the periodic job linux-bionic-cuda11.5-py3.7-gcc7. Looking at the logs of this job will show that this test (test_exception_all) was run in the job.