### PR TITLE
[foreach][mta] Implement `torch._foreach_global_norm`

### DIFF
--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -246,7 +246,7 @@ Tensor foreach_tensor_norm_slow(TensorList tensors, const Scalar& ord) {
   }
   check_foreach_api_restrictions(tensors);
   const auto result_scalar_type = toRealValueType(result_type(tensors));
-  auto result = std::accumulate(
+  const auto result = std::accumulate(
     tensors.begin(), tensors.end(),
     at::zeros({}, tensors[0].options().dtype(toOpMathType(result_scalar_type))),
     [&](const Tensor &cumulative_sum, const Tensor &t) {

--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -238,7 +238,7 @@ std::vector<Tensor> foreach_tensor_norm_slow(TensorList tensors, const Scalar& o
 Tensor foreach_tensor_global_norm_slow(TensorList tensors, const Scalar& ord) {
   TORCH_CHECK((ord.isIntegral(false) || ord.isFloatingPoint()), "foreach_norm supports int and float ord");
   double p;
-  if (ord.isIntegral(false)) {
+  if (ord.isIntegral(/* includeBool */false)) {
     p = static_cast<int64_t>(ord.to<int64_t>());
   }
   if (ord.isFloatingPoint()) {
@@ -254,7 +254,7 @@ Tensor foreach_tensor_global_norm_slow(TensorList tensors, const Scalar& ord) {
       return cumulative_sum + (p == 0.0 || p == 1.0 ? norm : at::pow(norm, ord));
     }
   );
-  return (p == 0.0 ? result : at::pow(result, 1 / p)).to(result_scalar_type);
+  return (p == 0.0 || p == 1.0 ? result : at::pow(result, 1 / p)).to(result_scalar_type);
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -226,7 +226,7 @@ void foreach_tensor_zero_slow_(TensorList tensors) {
 }
 
 std::vector<Tensor> foreach_tensor_norm_per_tensor_slow(TensorList tensors, const Scalar& ord) {
-  TORCH_CHECK((ord.isIntegral(false) || ord.isFloatingPoint()), "foreach_norm supports int and float ord");
+  TORCH_CHECK((ord.isIntegral(false) || ord.isFloatingPoint()), "foreach_norm_per_tensor supports int and float ord");
   check_foreach_api_restrictions(tensors);
   std::vector<Tensor> result;
   for (const auto& t : tensors) {
@@ -251,7 +251,7 @@ Tensor foreach_tensor_norm_slow(TensorList tensors, const Scalar& ord) {
     at::zeros({}, tensors[0].options().dtype(toOpMathType(result_scalar_type))),
     [&](const Tensor &cumulative_sum, const Tensor &t) {
       auto norm = at::linalg_vector_norm(t, ord);
-      return cumulative_sum + (p == 0.0 ? norm : at::pow(norm, ord));
+      return cumulative_sum + (p == 0.0 || p == 1.0 ? norm : at::pow(norm, ord));
     }
   );
   return (p == 0.0 ? result : at::pow(result, 1 / p)).to(result_scalar_type);

--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -225,7 +225,7 @@ void foreach_tensor_zero_slow_(TensorList tensors) {
   }
 }
 
-std::vector<Tensor> foreach_tensor_norm_per_tensor_slow(TensorList tensors, const Scalar& ord) {
+std::vector<Tensor> foreach_tensor_norm_slow(TensorList tensors, const Scalar& ord) {
   TORCH_CHECK((ord.isIntegral(false) || ord.isFloatingPoint()), "foreach_norm_per_tensor supports int and float ord");
   check_foreach_api_restrictions(tensors);
   std::vector<Tensor> result;
@@ -235,7 +235,7 @@ std::vector<Tensor> foreach_tensor_norm_per_tensor_slow(TensorList tensors, cons
   return result;
 }
 
-Tensor foreach_tensor_norm_slow(TensorList tensors, const Scalar& ord) {
+Tensor foreach_tensor_global_norm_slow(TensorList tensors, const Scalar& ord) {
   TORCH_CHECK((ord.isIntegral(false) || ord.isFloatingPoint()), "foreach_norm supports int and float ord");
   double p;
   if (ord.isIntegral(false)) {

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -33,7 +33,7 @@ double convert_ord_to_double(const Scalar& ord) {
   } else if (ord.isFloatingPoint()) {
     p = ord.to<double>();
   } else {
-    AT_ERROR("foreach_tensor_norm_cuda expects ord to be integer or float");
+    TORCH_CHECK(false, "foreach_tensor_norm_cuda expects ord to be integer or float");
   }
   return p;
 }

--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -26,6 +26,18 @@
 namespace at {
 namespace native {
 
+double convert_ord_to_double(const Scalar& ord) {
+  double p;
+  if (ord.isIntegral(false)) {
+    p = ord.to<int64_t>();
+  } else if (ord.isFloatingPoint()) {
+    p = ord.to<double>();
+  } else {
+    AT_ERROR("foreach_tensor_norm_cuda expects ord to be integer or float");
+  }
+  return p;
+}
+
 template<typename T, int NormType, int depth=1, int r_args_depth=1, int res_arg_index=0>
 struct LpNormFunctor {
   static_assert(NormType == 1 || NormType == 2, "foreach_norm supports only L1 and L2 norm");
@@ -33,7 +45,6 @@ struct LpNormFunctor {
   __device__ __forceinline__ void operator() (
       int chunk_size,
       TensorListMetadata<depth>& tl,
-      opmath_t* output_per_tensor,
       opmath_t* output,
       const int max_chunks_per_tensor,
       const bool per_tensor
@@ -85,7 +96,7 @@ struct LpNormFunctor {
 
     if (threadIdx.x == 0) {
       if (per_tensor) {
-        output_per_tensor[(tl.start_tensor_this_launch + tensor_loc) * max_chunks_per_tensor + chunk_idx] = final;
+        output[(tl.start_tensor_this_launch + tensor_loc) * max_chunks_per_tensor + chunk_idx] = final;
       } else {
         output[blockIdx.x] += final;
       }
@@ -95,25 +106,12 @@ struct LpNormFunctor {
 
 template<typename T, int NormType, typename opmath_t = at::opmath_type<T>>
 __global__ void lpnorm_cleanup(
-    opmath_t* output_per_tensor,
     opmath_t* output,
-    T* ret_per_tensor,
     T* ret,
     int max_chunks_per_tensor,
     const bool per_tensor) {
   __shared__ opmath_t vals[512];
-
-  if (per_tensor) {
-    opmath_t* output_this_tensor = output_per_tensor + blockIdx.x*max_chunks_per_tensor;
-    opmath_t val = 0;
-    for (int i = threadIdx.x; i < max_chunks_per_tensor; i += blockDim.x) {
-      val += output_this_tensor[i];
-    }
-    opmath_t final = at::native::cuda_utils::BlockReduceSum<opmath_t>(val, vals);
-    if(threadIdx.x == 0) {
-      ret_per_tensor[blockIdx.x] = NormType == 1 ? final : ::sqrt(final);
-    }
-  } else {
+  if (!per_tensor) {
     if (blockIdx.x == 0) {
       opmath_t val = 0;
       if (threadIdx.x < 320) {
@@ -121,17 +119,106 @@ __global__ void lpnorm_cleanup(
       }
       opmath_t final = at::native::cuda_utils::BlockReduceSum<opmath_t>(val, vals);
       if (threadIdx.x == 0) {
-        *ret = NormType == 1 ? final : ::sqrt(final);
+        *ret = NormType == 1 ? static_cast<T>(final) : static_cast<T>(::sqrt(final));
       }
     }
+  } else {
+    opmath_t* output_this_tensor = output + blockIdx.x*max_chunks_per_tensor;
+    opmath_t val = 0;
+    for (int i = threadIdx.x; i < max_chunks_per_tensor; i += blockDim.x) {
+      val += output_this_tensor[i];
+    }
+    opmath_t final = at::native::cuda_utils::BlockReduceSum<opmath_t>(val, vals);
+    if(threadIdx.x == 0) {
+      ret[blockIdx.x] = NormType == 1 ? static_cast<T>(final) : static_cast<T>(::sqrt(final));
+    }
   }
-
 }
 
 // note(mkozuki): Why excluding Int and Complex from fast path
 // - Int: at::norm does not support.
 // - Complex: __shfl_down_sync does not support complex and foreach does not support functions whose inputs dtypes and output dtype are different.
-std::tuple<std::vector<Tensor>, Tensor> foreach_tensor_norm_cuda_impl(TensorList tensors, const Scalar& ord, const bool per_tensor) {
+std::vector<Tensor> foreach_tensor_norm_per_tensor_cuda(TensorList tensors, const Scalar& ord) {
+  const auto p = convert_ord_to_double(ord);
+  check_foreach_api_restrictions(tensors);
+  const bool has_int_or_complex = std::any_of(tensors.begin(), tensors.end(), [](const auto & t) {
+      const auto scalar_type = t.scalar_type();
+      return at::isIntegralType(scalar_type, /*includeBool*/true) || at::isComplexType(scalar_type);
+  });
+  if (!can_use_fast_route(tensors) ||
+      has_int_or_complex ||
+      !(p == static_cast<double>(1) || p == static_cast<double>(2))) {
+    return foreach_tensor_norm_per_tensor_slow(tensors, ord);
+  }
+
+  const int ntensors = tensors.size();
+  int max_chunks_per_tensor = -1;
+
+  for (int t = 0; t < ntensors; t++) {
+    int max_chunks_this_tensor = (tensors[t].numel() + kChunkSize - 1) / kChunkSize;
+    if(max_chunks_this_tensor > max_chunks_per_tensor) {
+      max_chunks_per_tensor = max_chunks_this_tensor;
+    }
+  }
+  const auto options = tensors[0].options();
+  auto output_per_tensor = at::zeros({ntensors*max_chunks_per_tensor}, options.dtype(toOpMathType(tensors[0].scalar_type())));
+  auto ret_per_tensor = at::empty({ntensors}, options);
+  auto tensor_lists = std::vector<std::vector<Tensor>>{tensors.vec()};
+  constexpr bool per_tensor = true;
+
+  if (p == static_cast<double>(1)) {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+      kHalf, kBFloat16, tensor_lists[0][0].scalar_type(), "foreach_tensor_norm_cuda", [&]() {
+        using opmath_t = typename at::opmath_type<scalar_t>;
+        multi_tensor_apply<1>(
+          tensor_lists,
+          LpNormFunctor<scalar_t, 1>(),
+          output_per_tensor.data_ptr<opmath_t>(),
+          max_chunks_per_tensor,
+          per_tensor);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        const at::cuda::OptionalCUDAGuard device_guard(device_of(output_per_tensor));
+        auto stream = at::cuda::getCurrentCUDAStream();
+        lpnorm_cleanup<scalar_t, 1><<<ntensors, 512, 0, stream>>>(
+          output_per_tensor.data_ptr<opmath_t>(),
+          ret_per_tensor.data_ptr<scalar_t>(),
+          max_chunks_per_tensor,
+          per_tensor);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+  } else if (p == static_cast<double>(2)) {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+      kHalf, kBFloat16, tensor_lists[0][0].scalar_type(), "foreach_tensor_norm_cuda", [&]() {
+        using opmath_t = typename at::opmath_type<scalar_t>;
+        multi_tensor_apply<1>(
+          tensor_lists,
+          LpNormFunctor<scalar_t, 2>(),
+          output_per_tensor.data_ptr<opmath_t>(),
+          max_chunks_per_tensor,
+          per_tensor);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        const at::cuda::OptionalCUDAGuard device_guard(device_of(output_per_tensor));
+        auto stream = at::cuda::getCurrentCUDAStream();
+        lpnorm_cleanup<scalar_t, 2><<<ntensors, 512, 0, stream>>>(
+          output_per_tensor.data_ptr<opmath_t>(),
+          ret_per_tensor.data_ptr<scalar_t>(),
+          max_chunks_per_tensor,
+          per_tensor);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      });
+  } else {
+    AT_ERROR("foreach_tensor_norm_cuda fast path got unexpected ord value: ", p);
+  }
+
+  std::vector<Tensor> result;
+  result.reserve(ntensors);
+  for (const auto& i : c10::irange(ntensors)) {
+    result.emplace_back(ret_per_tensor[i]);
+  }
+  return result;
+}
+
+Tensor global_norm_cuda_impl(TensorList tensors, const Scalar& ord) {
   TORCH_CHECK((ord.isIntegral(false) || ord.isFloatingPoint()), "foreach_norm supports int and float ord");
   double p;
   if (ord.isIntegral(false)) {
@@ -148,36 +235,79 @@ std::tuple<std::vector<Tensor>, Tensor> foreach_tensor_norm_cuda_impl(TensorList
   if (!can_use_fast_route(tensors) ||
       has_int_or_complex ||
       !(p == static_cast<double>(1) || p == static_cast<double>(2))) {
-    Tensor ret;
-    std::vector<Tensor> result;
-    if (per_tensor) {
-      result = foreach_tensor_norm_per_tensor_slow(tensors, ord);
-    } else {
-      ret = foreach_tensor_norm_slow(tensors, ord);
+    return foreach_tensor_norm_slow(tensors, ord);
+  }
+
+  const int num_tensors = tensors.size();
+  int max_chunks_per_tensor = -1;
+
+  for (const int & t : c10::irange(num_tensors)) {
+    const int max_chunks_this_tensor = (tensors[0][t].numel() + kChunkSize - 1) / kChunkSize;
+    if (max_chunks_this_tensor > max_chunks_per_tensor) {
+      max_chunks_per_tensor = max_chunks_this_tensor;
     }
-    return {result, ret};
+  }
+  const auto options = tensors[0].options();
+  auto output = at::zeros({320}, options.dtype(toOpMathType(tensors[0].scalar_type())));
+  auto ret = at::empty({}, options);
+  auto tensor_lists = std::vector<std::vector<Tensor>>{tensors.vec()};
+  if (p == static_cast<double>(1)) {
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+      kHalf, kBFloat16, tensor_lists[0][0].scalar_type(), "global_norm_cuda_impl",
+      [&]() {
+        using opmath_t = typename at::opmath_type<scalar_t>;
+        multi_tensor_apply<1>(
+          tensor_lists,
+          LpNormFunctor<scalar_t, 1>(),
+          output.data_ptr<opmath_t>(),
+          max_chunks_per_tensor,
+          false);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+        const at::cuda::OptionalCUDAGuard device_guard(device_of(output));
+        auto stream = at::cuda::getCurrentCUDAStream();
+        lpnorm_cleanup<scalar_t, 1><<<num_tensors, 512, 0, stream>>>(
+          output.data_ptr<scalar_t>(),
+          ret.data_ptr<scalar_t>(),
+          max_chunks_per_tensor,
+          false);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      }
+    );
+  }
+  return ret;
+}
+
+Tensor foreach_tensor_norm_cuda(TensorList tensors, const Scalar& ord) {
+  const auto p = convert_ord_to_double(ord);
+  check_foreach_api_restrictions(tensors);
+
+  const bool has_int_or_complex = std::any_of(tensors.begin(), tensors.end(), [](const auto & t) {
+      const auto scalar_type = t.scalar_type();
+      return at::isIntegralType(scalar_type, /*includeBool*/true) || at::isComplexType(scalar_type);
+  });
+  if (!can_use_fast_route(tensors) ||
+      has_int_or_complex ||
+      !(p == static_cast<double>(1) || p == static_cast<double>(2))) {
+    return foreach_tensor_norm_slow(tensors, ord);
   }
 
   const int ntensors = tensors.size();
   int max_chunks_per_tensor = -1;
 
-  for (int t = 0; t < ntensors; t++) {
-    int max_chunks_this_tensor = (tensors[0][t].numel() + kChunkSize - 1) / kChunkSize;
-    if(max_chunks_this_tensor > max_chunks_per_tensor) {
+  for (const auto & t : tensors) {
+    const int max_chunks_this_tensor = (t.numel() + kChunkSize - 1) / kChunkSize;
+    if (max_chunks_this_tensor > max_chunks_per_tensor) {
       max_chunks_per_tensor = max_chunks_this_tensor;
     }
   }
-  const auto options = tensors[0].options();
-  Tensor output_per_tensor, output, ret_per_tensor, ret;
-  if (per_tensor) {
-    output_per_tensor = at::zeros({ntensors*max_chunks_per_tensor}, options.dtype(toOpMathType(tensors[0].scalar_type())));
-    ret_per_tensor = at::empty({ntensors}, options);
-  } else {
-    output = at::zeros({320}, options.dtype(toOpMathType(tensors[0].scalar_type())));
-    ret = at::empty({}, options);
-  }
 
+  const auto output_scalar_type = tensors[0].scalar_type();
+  const auto options = tensors[0].options();
+  auto output = at::zeros({320}, options.dtype(toOpMathType(output_scalar_type)));
+  auto ret = at::empty({0}, options);
   auto tensor_lists = std::vector<std::vector<Tensor>>{tensors.vec()};
+  constexpr bool per_tensor = false;
+
   if (p == static_cast<double>(1)) {
     AT_DISPATCH_FLOATING_TYPES_AND2(
       kHalf, kBFloat16, tensor_lists[0][0].scalar_type(), "foreach_tensor_norm_cuda", [&]() {
@@ -185,18 +315,15 @@ std::tuple<std::vector<Tensor>, Tensor> foreach_tensor_norm_cuda_impl(TensorList
         multi_tensor_apply<1>(
           tensor_lists,
           LpNormFunctor<scalar_t, 1>(),
-          per_tensor ? output_per_tensor.data_ptr<opmath_t>() : nullptr,
-          per_tensor ? nullptr : output.data_ptr<opmath_t>(),
+          output.data_ptr<opmath_t>(),
           max_chunks_per_tensor,
           per_tensor);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
-        const at::cuda::OptionalCUDAGuard device_guard(device_of(output_per_tensor));
+        const at::cuda::OptionalCUDAGuard device_guard(device_of(output));
         auto stream = at::cuda::getCurrentCUDAStream();
         lpnorm_cleanup<scalar_t, 1><<<ntensors, 512, 0, stream>>>(
-          per_tensor ? output_per_tensor.data_ptr<opmath_t>() : nullptr,
-          per_tensor ? nullptr : output.data_ptr<opmath_t>(),
-          per_tensor ? ret_per_tensor.data_ptr<scalar_t>() : nullptr,
-          per_tensor ? nullptr : ret.data_ptr<scalar_t>(),
+          output.data_ptr<opmath_t>(),
+          ret.data_ptr<scalar_t>(),
           max_chunks_per_tensor,
           per_tensor);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -208,18 +335,15 @@ std::tuple<std::vector<Tensor>, Tensor> foreach_tensor_norm_cuda_impl(TensorList
         multi_tensor_apply<1>(
           tensor_lists,
           LpNormFunctor<scalar_t, 2>(),
-          per_tensor ? output_per_tensor.data_ptr<opmath_t>() : nullptr,
-          per_tensor ? nullptr : output.data_ptr<opmath_t>(),
+          output.data_ptr<opmath_t>(),
           max_chunks_per_tensor,
           per_tensor);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
-        const at::cuda::OptionalCUDAGuard device_guard(device_of(output_per_tensor));
+        const at::cuda::OptionalCUDAGuard device_guard(device_of(output));
         auto stream = at::cuda::getCurrentCUDAStream();
         lpnorm_cleanup<scalar_t, 2><<<ntensors, 512, 0, stream>>>(
-          per_tensor ? output_per_tensor.data_ptr<opmath_t>() : nullptr,
-          per_tensor ? nullptr : output.data_ptr<opmath_t>(),
-          per_tensor ? ret_per_tensor.data_ptr<scalar_t>() : nullptr,
-          per_tensor ? nullptr : ret.data_ptr<scalar_t>(),
+          output.data_ptr<opmath_t>(),
+          ret.data_ptr<scalar_t>(),
           max_chunks_per_tensor,
           per_tensor);
         C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -227,21 +351,7 @@ std::tuple<std::vector<Tensor>, Tensor> foreach_tensor_norm_cuda_impl(TensorList
   } else {
     AT_ERROR("foreach_tensor_norm_cuda fast path got unexpected ord value: ", p);
   }
-
-  std::vector<Tensor> result;
-  result.reserve(ntensors);
-  for (const auto& i : c10::irange(ntensors)) {
-    result.emplace_back(ret_per_tensor[i]);
-  }
-  return {result, ret};
-}
-
-std::vector<Tensor> foreach_tensor_norm_per_tensor_cuda(TensorList tensors, const Scalar& ord) {
-  return std::get<0>(foreach_tensor_norm_cuda_impl(tensors, ord, /* per_tensor= */true));
-}
-
-Tensor foreach_tensor_norm_cuda(TensorList tensors, const Scalar& ord) {
-  return std::get<1>(foreach_tensor_norm_cuda_impl(tensors, ord, /* per_tensor= */false));
+  return ret;
 }
 
 } // namespace native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9216,19 +9216,19 @@
     CPU: foreach_tensor_minimum_slow
     CUDA: foreach_tensor_minimum_cuda
 
-- func: _foreach_norm_per_tensor.Scalar(Tensor[] tensors, Scalar ord=2) -> Tensor[]
-  device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
-  variants: function
-  dispatch:
-    CPU: foreach_tensor_norm_per_tensor_slow
-    CUDA: foreach_tensor_norm_per_tensor_cuda
-
-- func: _foreach_norm.Scalar(Tensor[] tensors, Scalar ord=2) -> Tensor
+- func: _foreach_norm.Scalar(Tensor[] tensors, Scalar ord=2) -> Tensor[]
   device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
   variants: function
   dispatch:
     CPU: foreach_tensor_norm_slow
     CUDA: foreach_tensor_norm_cuda
+
+- func: _foreach_global_norm.Scalar(Tensor[] tensors, Scalar ord=2) -> Tensor
+  device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
+  variants: function
+  dispatch:
+    CPU: foreach_tensor_global_norm_slow
+    CUDA: foreach_tensor_global_norm_cuda
 
 - func: bucketize.Tensor(Tensor self, Tensor boundaries, *, bool out_int32=False, bool right=False) -> Tensor
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9216,7 +9216,14 @@
     CPU: foreach_tensor_minimum_slow
     CUDA: foreach_tensor_minimum_cuda
 
-- func: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2) -> Tensor[]
+- func: _foreach_norm_per_tensor.Scalar(Tensor[] tensors, Scalar ord=2) -> Tensor[]
+  device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
+  variants: function
+  dispatch:
+    CPU: foreach_tensor_norm_per_tensor_slow
+    CUDA: foreach_tensor_norm_per_tensor_cuda
+
+- func: _foreach_norm.Scalar(Tensor[] tensors, Scalar ord=2) -> Tensor
   device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
   variants: function
   dispatch:

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -422,21 +422,6 @@ class TestForeach(TestCase):
         self._minmax_test(op, inputs, True, 1)
 
     def _reduce_test(self, device, dtype, opinfo, is_fastpath):
-<<<<<<< HEAD
-        for N, ord in itertools.product(N_values, (-2, -1, 0, 1, 2)):
-            if is_fastpath:
-                # note (mkozuki): Currently, only `ord` of 1 & 2 can go to the fast path, a.k.a. multi tensor apply
-                if ord in (1, 2) and dtype in (torch.bfloat16, torch.float16, torch.float32, torch.float64):
-                    # The number of cuda kernel launches by fast path.
-                    # 1 for tensor to store intermediate results, another for multi_tensor_apply, and the other for clean up kernel.
-                    n_expected_cudaLaunchKernels = 3
-                else:
-                    # TODO (mkozuki): Enable test  `n_expected_cudaLaunchKernels`.
-                    if opinfo.name == "_foreach_norm":
-                        n_expected_cudaLaunchKernels = 0
-                    else:
-                        n_expected_cudaLaunchKernels = N
-=======
 
         def calc_n_expected_cudaLaunchKernels(n, ord, dtype, is_fastpath, is_foreach_global_norm):
             if not is_fastpath:
@@ -446,7 +431,6 @@ class TestForeach(TestCase):
                 # The number of cuda kernel launches by fast path.
                 # 1 for tensor to store intermediate results, another for multi_tensor_apply, and the other for clean up kernel.
                 return 3
->>>>>>> f99dc87d53... fix n_expected_cudaLaunchKernels
             else:
                 if is_foreach_global_norm:
                     # for each tensor, slow path generally calculates the norm, applies power of ord, and accumulates before

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -69,11 +69,6 @@ class RegularFuncWrapper:
                 return sum(ret)
             else:
                 return self.func(torch.stack(ret), ord=ord)
-            # result = global_norm if ord == 0 else torch.pow(global_norm, 1 / ord).to(dtype)
-            # result = result.to(dtype=dtype)
-            # if result.is_complex():
-            #     result = torch.view_as_real(result)[0]
-            # return result
 
 
 class ForeachFuncWrapper:

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -468,7 +468,8 @@ class TestForeach(TestCase):
             inputs = opinfo.sample_inputs(device, dtype, num_tensors, noncontiguous=not is_fastpath, low=low, high=high),
             if dtype == torch.float16 and ord == 0:
                 inputs = [[(t > high - 1e-2).to(dtype) for t in tensors] for tensors in inputs]
-            n_expected_cudaLaunchKernels = calc_n_expected_cudaLaunchKernels(num_tensors, ord, dtype, is_fastpath, is_foreach_global_norm)
+            n_expected_cudaLaunchKernels = calc_n_expected_cudaLaunchKernels(
+                num_tensors, ord, dtype, is_fastpath, is_foreach_global_norm)
             op, ref, _, _ = self._get_funcs(opinfo, n_expected_cudaLaunchKernels)
             ref_output = ref(inputs, ord=ord, is_foreach_global_norm=is_foreach_global_norm)
             actual_output = op(inputs, self.is_cuda, is_fastpath, ord=ord)

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -433,9 +433,7 @@ class TestForeach(TestCase):
 
     @ops(foreach_reduce_op_db)
     def test_reduce_fastpath(self, device, dtype, op):
-        # for N, ord in itertools.product(N_values, (0, 1, 2, -1, -2)):
-        for N, ord in itertools.product(N_values, (-1, 0, 1, 2)):
-        # for N, ord in itertools.product(N_values, (1,)):
+        for N, ord in itertools.product(N_values, (-2, -1, 0, 1, 2)):
             # TODO (mkozuki): Fix `n_expected_cudaLaunchKernels`
             if ord in (1, 2) and dtype in torch.testing.get_all_fp_dtypes():
                 n_expected_cudaLaunchKernels = 3
@@ -446,9 +444,7 @@ class TestForeach(TestCase):
 
     @ops(foreach_reduce_op_db)
     def test_reduce_slowpath(self, device, dtype, op):
-        # for N, ord in itertools.product(N_values, (0, 1, 2, -1, -2)):
-        for N, ord in itertools.product(N_values, (-1, 0, 1, 2)):
-        # for N, ord in itertools.product(N_values, (2,)):
+        for N, ord in itertools.product(N_values, (-2, -1, 0, 1, 2)):
             inputs = op.sample_inputs(device, dtype, N // 2, noncontiguous=True, low=0, high=0.1),
             self._reduce_test(op, inputs, ord, False, 1)
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6658,20 +6658,7 @@ class ForeachFuncInfo(OpInfo):
         self.ref_inplace = torch_ref_inplace
         self.supports_alpha_param = supports_alpha_param
 
-        if name == "norm_per_tensor":
-            self.ref = torch.linalg.vector_norm
-        if name == "norm":
-
-            # def _ref_foreach_norm(tensor, ord):
-            #     dtype = torch.float32 if tensor.dtype in (torch.bfloat16, torch.float16) else tensor.dtype
-            #     norm = torch.linalg.vector_norm(tensor, ord, dtype=dtype)
-            #     if norm == 0:
-            #         return norm
-            #     else:
-            #         return torch.pow(norm, ord)
-
-            # self.ref = _ref_foreach_norm
-
+        if name in ("norm_per_tensor", "norm"):
             self.ref = torch.linalg.vector_norm
 
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6617,7 +6617,10 @@ def sample_inputs_foreach(self, device, dtype, N, *, noncontiguous=False, same_s
     if same_size:
         return [make_tensor((N, N), dtype=dtype, device=device, noncontiguous=noncontiguous, low=low, high=high) for _ in range(N)]
     else:
-        return [make_tensor((N - i, N - i), dtype=dtype, device=device, noncontiguous=noncontiguous, low=low, high=high) for i in range(N)]
+        return [
+            make_tensor((N - i, N - i), dtype=dtype, device=device, noncontiguous=noncontiguous, low=low, high=high)
+            for i in range(N)
+        ]
 
 
 def get_foreach_method_names(name):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6661,7 +6661,7 @@ class ForeachFuncInfo(OpInfo):
         self.ref_inplace = torch_ref_inplace
         self.supports_alpha_param = supports_alpha_param
 
-        if name in ("norm_per_tensor", "norm"):
+        if name in ("norm", "global_norm"):
             self.ref = torch.linalg.vector_norm
 
 
@@ -10085,15 +10085,11 @@ foreach_minmax_op_db: List[ForeachFuncInfo] = [
 foreach_reduce_op_db: List[ForeachFuncInfo] = [
     ForeachFuncInfo(
         "norm",
-        dtypesIfCPU=floating_and_complex_types_and(torch.float16, torch.bfloat16),
+        dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
         dtypesIfCUDA=floating_and_complex_types_and(torch.float16, torch.bfloat16),
     ),
     ForeachFuncInfo(
-        "norm",
-        dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-    ),
-    ForeachFuncInfo(
-        "norm_per_tensor",
+        "global_norm",
         dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
         dtypesIfCUDA=floating_and_complex_types_and(torch.float16, torch.bfloat16),
     ),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6658,8 +6658,18 @@ class ForeachFuncInfo(OpInfo):
         self.ref_inplace = torch_ref_inplace
         self.supports_alpha_param = supports_alpha_param
 
-        if name == "norm":
+        if name == "norm_per_tensor":
             self.ref = torch.linalg.vector_norm
+        if name == "norm":
+
+            def _ref_foreach_norm(tensor, ord):
+                norm = torch.linalg.vector_norm(tensor, ord)
+                if norm == 0:
+                    return norm
+                else:
+                    return torch.pow(norm, ord)
+
+            self.ref = _ref_foreach_norm
 
 
 def sample_inputs_linalg_cholesky_inverse(op_info, device, dtype, requires_grad=False, **kwargs):
@@ -10080,8 +10090,17 @@ foreach_minmax_op_db: List[ForeachFuncInfo] = [
 ]
 
 foreach_reduce_op_db: List[ForeachFuncInfo] = [
+    # ForeachFuncInfo(
+    #     "norm",
+    #     dtypesIfCPU=floating_and_complex_types_and(torch.float16, torch.bfloat16),
+    #     dtypesIfCUDA=floating_and_complex_types_and(torch.float16, torch.bfloat16),
+    # ),
     ForeachFuncInfo(
         "norm",
+        dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
+    ),
+    ForeachFuncInfo(
+        "norm_per_tensor",
         dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
         dtypesIfCUDA=floating_and_complex_types_and(torch.float16, torch.bfloat16),
     ),


### PR DESCRIPTION
# Summary
- Implement `torch._foreach_global_norm` which calculates the global norm of `List[Tensor]`.
    - Fast path only supports L1 & L2

This function can replace https://github.com/rwightman/pytorch-image-models/blob/01a0e25a67305b94ea767083f4113ff002e4435c/timm/optim/lamb.py#L110-L120
with 

```python
       grads = []
        for group in self.param_groups:
            for p in group['params']:
                if p.grad is None:
                    continue
                grad = p.grad
                if grad.is_sparse:
                    raise RuntimeError('Lamb does not support sparse gradients, consider SparseAdam instad.')
                grads.append(grad)
        global_grad_norm = torch._foreach_global_norm(grads)
```

<!--
# TODO
- [x] Fix the number of `cudaLaunchKernels` in slowpath
-->

# Benchmark

used commit: 50fe376dc31d3f22d2b62eb4388037e5fcd6842b

## Env
```
CUDA used to build PyTorch: 11.6
GPU : RTX 3070 Ti
```

## Reference implementation

```python
def reference_global_norm(tensors: List[Tensor]) -> Tensor:
    return torch.sqrt(sum(t.pow(2).sum() for t in tensors))
```

## Global Norm - fastpath
| dtype          |   num_tensors | tensor_shape   |   reference |     foreach |   speedup |
|:---------------|--------------:|:---------------|------------:|------------:|----------:|
| torch.float32  |            50 | 50 x 50        |   0.0428228 | 0.000941515 |   45.4829 |
| torch.float32  |           100 | 100 x 100      |   0.0846331 | 0.00120974  |   69.96   |
| torch.float16  |            50 | 50 x 50        |   0.043551  | 0.000976086 |   44.618  |
| torch.float16  |           100 | 100 x 100      |   0.0872855 | 0.00122571  |   71.2122 |
| torch.bfloat16 |            50 | 50 x 50        |   0.04457   | 0.00101542  |   43.8929 |
| torch.bfloat16 |           100 | 100 x 100      |   0.0857499 | 0.0011723   |   73.1464 |

## Global Norm - slowpath
| dtype          |   num_tensors | tensor_shape   |   reference |   foreach |   speedup |
|:---------------|--------------:|:---------------|------------:|----------:|----------:|
| torch.float32  |            50 | 50 x 50        |   0.0443747 | 0.0318217 |   1.39448 |
| torch.float32  |           100 | 100 x 100      |   0.0890992 | 0.062454  |   1.42664 |
| torch.float16  |            50 | 50 x 50        |   0.0443466 | 0.0321701 |   1.3785  |
| torch.float16  |           100 | 100 x 100      |   0.0917869 | 0.066494  |   1.38038 |
| torch.bfloat16 |            50 | 50 x 50        |   0.0460787 | 0.0340297 |   1.35407 |
| torch.bfloat16 |           100 | 100 x 100      |   0.0913305 | 0.0648458 |   1.40843 |

<!--

## Norm Per Tensor - fastpath
| dtype          |   num_tensors | tensor_shape   |   reference |    foreach |   speedup |
|:---------------|--------------:|:---------------|------------:|-----------:|----------:|
| torch.float32  |            50 | 50 x 50        |   0.0176275 | 0.00201941 |   8.72904 |
| torch.float32  |           100 | 100 x 100      |   0.033504  | 0.00326371 |  10.2656  |
| torch.float16  |            50 | 50 x 50        |   0.0168457 | 0.00200891 |   8.38547 |
| torch.float16  |           100 | 100 x 100      |   0.0330038 | 0.00327325 |  10.0829  |
| torch.bfloat16 |            50 | 50 x 50        |   0.0164759 | 0.00202084 |   8.15302 |
| torch.bfloat16 |           100 | 100 x 100      |   0.0335269 | 0.0033462  |  10.0194  |

## Norm Per Tensor - slwowpath
| dtype          |   num_tensors | tensor_shape   |   reference |   foreach |   speedup |
|:---------------|--------------:|:---------------|------------:|----------:|----------:|
| torch.float32  |            50 | 50 x 50        |   0.0171256 | 0.0130904 |   1.30826 |
| torch.float32  |           100 | 100 x 100      |   0.0339911 | 0.0258839 |   1.31321 |
| torch.float16  |            50 | 50 x 50        |   0.0170689 | 0.0126636 |   1.34787 |
| torch.float16  |           100 | 100 x 100      |   0.0338097 | 0.0255606 |   1.32272 |
| torch.bfloat16 |            50 | 50 x 50        |   0.0172422 | 0.0127335 |   1.35409 |
| torch.bfloat16 |           100 | 100 x 100      |   0.0341241 | 0.0256011 |   1.33291 |

-->

Rel: #58833

cc @ptrblck @mcarilli @ngimel 