### PR TITLE
[nit] Typo in common_utils.py

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -430,7 +430,7 @@ def prof_func_call(*args, **kwargs):
 def prof_meth_call(*args, **kwargs):
     return prof_callable(meth_call, *args, **kwargs)
 
-# TODO fix when https://github.com/python/mypy/issues/2427 is address
+# TODO fix when https://github.com/python/mypy/issues/2427 is addressed
 torch._C.ScriptFunction.__call__ = prof_func_call  # type: ignore[assignment]
 torch._C.ScriptMethod.__call__ = prof_meth_call  # type: ignore[assignment]
 


### PR DESCRIPTION
Summary:
Fixed a nit typo in common_utils.py. But also want to test how having
a GH team in codeowners works.

Test Plan: NA

Differential Revision: D35370672

