### PR TITLE
add DispatchKeySet function to get highest backend key

### DIFF
--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -732,14 +732,15 @@ constexpr auto autograd_privateuse3_ks =
 constexpr auto autograd_other_ks = DispatchKeySet(DispatchKey::AutogradOther);
 
 // This keyset has:
-// (1) the functionality bits corresponding to backends (dense, sparse, quantized)
-// (2) all of the backend bits set
-constexpr DispatchKeySet backend_functionality_keys = DispatchKeySet({
-    DispatchKey::Dense,
-    DispatchKey::Quantized,
-    DispatchKey::Sparse,
-}) | DispatchKeySet(DispatchKeySet::RAW, full_backend_mask);
-
+// (1) the functionality bits corresponding to backends (dense, sparse,
+// quantized) (2) all of the backend bits set
+constexpr DispatchKeySet backend_functionality_keys =
+    DispatchKeySet({
+        DispatchKey::Dense,
+        DispatchKey::Quantized,
+        DispatchKey::Sparse,
+    }) |
+    DispatchKeySet(DispatchKeySet::RAW, full_backend_mask);
 
 struct OpTableOffsetAndMask {
   uint16_t offset;
@@ -818,8 +819,7 @@ inline DispatchKeySet getAutocastRelatedKeySetFromBackend(BackendComponent t) {
 // This is basically like highestBackendKey(), except that we have some
 // "functionality" bits that correspond to backends (Sparse, Quantized)
 inline DispatchKey highestPriorityBackendTypeId(DispatchKeySet ks) {
-  auto backend_key = (ks & backend_functionality_keys).highestPriorityTypeId();
-  return backend_key;
+  return (ks & backend_functionality_keys).highestPriorityTypeId();
 }
 
 // This API exists because we have a use case for checking

--- a/c10/test/core/DispatchKeySet_test.cpp
+++ b/c10/test/core/DispatchKeySet_test.cpp
@@ -316,6 +316,20 @@ TEST(DispatchKeySet, IteratorBasicOps) {
   ASSERT_TRUE(full_set.begin() != ++full_set.begin());
 }
 
+TEST(DispatchKeySet, getHighestPriorityBackendTypeId) {
+  // AutogradCPU isn't a backend key so it is ignored
+  DispatchKeySet dense_cpu({DispatchKey::AutogradCPU, DispatchKey::CPU});
+  ASSERT_EQ(DispatchKey::CPU, c10::highestPriorityBackendTypeId(dense_cpu));
+
+  // Functionalize isn't a backend key so it is ignored
+  DispatchKeySet sparse_cuda({DispatchKey::Functionalize, DispatchKey::SparseCUDA});
+  ASSERT_EQ(DispatchKey::SparseCUDA, c10::highestPriorityBackendTypeId(sparse_cuda));
+
+  // quantizedCUDA has higher priority than CUDA
+  DispatchKeySet quantized_cuda({DispatchKey::CUDA, DispatchKey::QuantizedCUDA});
+  ASSERT_EQ(DispatchKey::QuantizedCUDA, c10::highestPriorityBackendTypeId(quantized_cuda));
+}
+
 TEST(DispatchKeySet, IteratorEmpty) {
   DispatchKeySet empty_set;
   uint8_t i = 0;

--- a/c10/test/core/DispatchKeySet_test.cpp
+++ b/c10/test/core/DispatchKeySet_test.cpp
@@ -322,12 +322,17 @@ TEST(DispatchKeySet, getHighestPriorityBackendTypeId) {
   ASSERT_EQ(DispatchKey::CPU, c10::highestPriorityBackendTypeId(dense_cpu));
 
   // Functionalize isn't a backend key so it is ignored
-  DispatchKeySet sparse_cuda({DispatchKey::Functionalize, DispatchKey::SparseCUDA});
-  ASSERT_EQ(DispatchKey::SparseCUDA, c10::highestPriorityBackendTypeId(sparse_cuda));
+  DispatchKeySet sparse_cuda(
+      {DispatchKey::Functionalize, DispatchKey::SparseCUDA});
+  ASSERT_EQ(
+      DispatchKey::SparseCUDA, c10::highestPriorityBackendTypeId(sparse_cuda));
 
   // quantizedCUDA has higher priority than CUDA
-  DispatchKeySet quantized_cuda({DispatchKey::CUDA, DispatchKey::QuantizedCUDA});
-  ASSERT_EQ(DispatchKey::QuantizedCUDA, c10::highestPriorityBackendTypeId(quantized_cuda));
+  DispatchKeySet quantized_cuda(
+      {DispatchKey::CUDA, DispatchKey::QuantizedCUDA});
+  ASSERT_EQ(
+      DispatchKey::QuantizedCUDA,
+      c10::highestPriorityBackendTypeId(quantized_cuda));
 }
 
 TEST(DispatchKeySet, IteratorEmpty) {


### PR DESCRIPTION
Adds a `c10::highestPriorityBackendTypeId(DispatchKeySet)` API that returns the highest priority *backend* dispatch key. A version of this used to exist before my recent dispatch key changes, but I deleted it because it wasn't actually needed anywhere in core. This is useful to mobile's static dispatch use case (cc @larryliu0820, @priyaramani).

This is similar to `getBackendKey()`, but `getBackendKey()` only returns a `BackendComponent`, which means that it can't distinguish between dense/sparse/quantized backends.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #75233

