### PR TITLE
ci: Bump linux runner availability to 750

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -30,7 +30,7 @@ runner_types:
   linux.2xlarge:
     instance_type: c5.2xlarge
     os: linux
-    max_available: 500
+    max_available: 750
     disk_size: 150
     is_ephemeral: false
   linux.4xlarge: # for binary-builds


### PR DESCRIPTION
Was noticing longer than average queuing times for linux.2xlarge and
also found out that we're hitting our max limit more often than not so
bumping this to 750 to give us more capacity to play around with.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

<details>
<summary> Number of times we've hit this in the last week </summary>

![Screen Shot 2022-04-04 at 3 44 30 PM](https://user-images.githubusercontent.com/1700823/161644454-eda8d3af-2e62-4e66-aea3-13ec37a41d7d.png)

Query: https://fburl.com/6cst46y0

</summary>