### PR TITLE
Use explicit USE_LAZY_TS_BACKEND feature flag

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -976,6 +976,10 @@ if(NOT MSVC AND USE_XNNPACK)
   TARGET_LINK_LIBRARIES(torch_cpu PRIVATE fxdiv)
 endif()
 
+if(BUILD_LAZY_TS_BACKEND)
+  # TODO(whc) is this the only library I need to modify, and is this the best place to do it?
+  target_compile_definitions(torch_cpu PUBLIC USE_LAZY_TS_BACKEND)
+endif()
 # ==========================================================
 # formerly-libtorch flags
 # ==========================================================

--- a/test/cpp/lazy/test_backend_device.cpp
+++ b/test/cpp/lazy/test_backend_device.cpp
@@ -75,12 +75,12 @@ TEST(BackendDeviceTest, FromAten) {
   EXPECT_THROW(atenDeviceToBackendDevice(device), c10::Error);
 
   device = c10::Device(c10::kLazy);
-#ifndef FBCODE_CAFFE2
+#ifdef USE_LAZY_TS_BACKEND
   auto backend_device = atenDeviceToBackendDevice(device);
 #else
   // Lazy Tensor is disabled in FBCODE until addressing non-virtual methods (e.g. sizes) in TensorImpl
   EXPECT_THROW(atenDeviceToBackendDevice(device), c10::Error);
-#endif // FBCODE_CAFFE2
+#endif // USE_LAZY_TS_BACKEND
 }
 
 TEST(BackendDeviceTest, ToAten) {

--- a/test/cpp/lazy/test_lazy_ops.cpp
+++ b/test/cpp/lazy/test_lazy_ops.cpp
@@ -15,7 +15,7 @@ namespace lazy {
 
 
 // Lazy Tensor is disabled in FBCODE until addressing non-virtual methods (e.g. sizes) in TensorImpl
-#ifndef FBCODE_CAFFE2
+#ifdef USE_LAZY_TS_BACKEND
 
 namespace {
   // This registers the torchscript backend, without which lazy device won't work
@@ -10700,7 +10700,7 @@ TEST_F(LazyOpsTest, TestLerpScalarOut) {
   ExpectCounterChanged("lazy::lerp", GetIgnoredCounters());
 }
 
-#endif // FBCODE_CAFFE2
+#endif // USE_LAZY_TS_BACKEND
 
 }  // namespace lazy
 }  // namespace torch

--- a/test/cpp/lazy/test_tensor_impl.cpp
+++ b/test/cpp/lazy/test_tensor_impl.cpp
@@ -6,14 +6,14 @@
 namespace torch {
 namespace lazy {
 
-#ifdef FBCODE_CAFFE2
+#ifndef USE_LAZY_TS_BACKEND
 // Lazy Tensor is disabled in FBCODE until addressing non-virtual methods (e.g. sizes) in TensorImpl
 TEST(LazyTensorImplTest, BasicThrow) {
   EXPECT_THROW({
     auto input = torch::rand({0, 1, 3, 0}, torch::TensorOptions(torch::kFloat).device("lazy"));
   }, ::c10::Error);
 }
-#endif // FBCODE_CAFFE2
+#endif // USE_LAZY_TS_BACKEND
 
 }  // namespace lazy
 }  // namespace torch

--- a/torch/csrc/lazy/python/init.cpp
+++ b/torch/csrc/lazy/python/init.cpp
@@ -165,7 +165,7 @@ void initLazyBindings(PyObject* module){
       torch::lazy::InitTorchScriptBackend();
 #else
       TORCH_CHECK(false, "TorchScript backend not yet supported in FBCODE/OVRSOURCE builds");
-#endif // FBCODE_CAFFE2
+#endif  // !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
     });
 
   /*
@@ -174,7 +174,7 @@ void initLazyBindings(PyObject* module){
    */
   lazy_ts_backend.def("_get_tensors_ts_device_data_node",
         [](const std::vector<at::Tensor>& tensors) -> std::pair<std::vector<int64_t>, std::vector<at::IValue>> {
-        #ifndef FBCODE_CAFFE2
+#if !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
           std::vector<Node*> roots;
           for (auto& tensor : tensors) {
             auto xtensor = TryGetLtcTensor(tensor);
@@ -215,10 +215,10 @@ void initLazyBindings(PyObject* module){
             }
           }
           return std::make_pair(tensor_ids, ivalues);
-        #else
+#else
           TORCH_CHECK(false, "TorchScript backend not yet supported in FBCODE builds");
           return std::make_pair(std::vector<int64_t>(), std::vector<at::IValue>());
-        #endif
+#endif  // !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
         });
   // TODO(shunting) revisit this part for XLA
   lazy_ts_backend.def("_run_cached_graph", [](const std::string& hash_str, const std::vector<at::IValue>& graph_inputs) {

--- a/torch/csrc/lazy/python/init.cpp
+++ b/torch/csrc/lazy/python/init.cpp
@@ -11,9 +11,9 @@
 #include <torch/csrc/lazy/core/ir_dump_util.h>
 #include <torch/csrc/lazy/core/internal_ops/ltc_ops.h>
 #include <torch/csrc/lazy/ts_backend/ops/device_data.h>
-#if !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
+#ifdef USE_LAZY_TS_BACKEND
 #include <torch/csrc/lazy/ts_backend/ts_backend_impl.h>
-#endif // FBCODE_CAFFE2 || OVRSOURCE
+#endif  // USE_LAZY_TS_BACKEND
 #include <string>
 #include <vector>
 
@@ -161,11 +161,11 @@ void initLazyBindings(PyObject* module){
   lazy_ts_backend.def(
     "_init",
     []() {
-#if !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
+#ifdef USE_LAZY_TS_BACKEND
       torch::lazy::InitTorchScriptBackend();
 #else
       TORCH_CHECK(false, "TorchScript backend not yet supported in FBCODE/OVRSOURCE builds");
-#endif  // !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
+#endif  // USE_LAZY_TS_BACKEND
     });
 
   /*
@@ -174,7 +174,7 @@ void initLazyBindings(PyObject* module){
    */
   lazy_ts_backend.def("_get_tensors_ts_device_data_node",
         [](const std::vector<at::Tensor>& tensors) -> std::pair<std::vector<int64_t>, std::vector<at::IValue>> {
-#if !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
+#ifdef USE_LAZY_TS_BACKEND
           std::vector<Node*> roots;
           for (auto& tensor : tensors) {
             auto xtensor = TryGetLtcTensor(tensor);
@@ -218,7 +218,7 @@ void initLazyBindings(PyObject* module){
 #else
           TORCH_CHECK(false, "TorchScript backend not yet supported in FBCODE builds");
           return std::make_pair(std::vector<int64_t>(), std::vector<at::IValue>());
-#endif  // !(defined(FBCODE_CAFFE2) || defined(OVRSOURCE))
+#endif  // USE_LAZY_TS_BACKEND
         });
   // TODO(shunting) revisit this part for XLA
   lazy_ts_backend.def("_run_cached_graph", [](const std::string& hash_str, const std::vector<at::IValue>& graph_inputs) {


### PR DESCRIPTION
Summary: instead of using ifdef (FBCODE..) to guard TS backend, define an explicit feature flag and set it only in OSS build

Test Plan: verify lazy TS tests still running in OSS CI and internal CI is happy

Differential Revision: D35379107

