### PR TITLE
Back out "Extend jit::load to work on flatbuffer file"

### DIFF
--- a/test/cpp/api/serialize.cpp
+++ b/test/cpp/api/serialize.cpp
@@ -355,7 +355,6 @@ TEST(SerializeTest, ErrorOnMissingKey) {
   // We want the errors to contain hierarchy information, too.
   ASSERT_THROWS_WITH(
       torch::load(model2, stream), "No such serialized tensor 'a.b.x'");
-  stream.seekg(0, stream.beg);
   ASSERT_THROWS_WITH(
       torch::load(model3, stream), "No such serialized submodule: 'a.x'");
 }

--- a/test/cpp/jit/test_backend.cpp
+++ b/test/cpp/jit/test_backend.cpp
@@ -276,7 +276,6 @@ TEST(BackendTest, TestConsistencyOfCompositeWithSetStates) {
   c._save_for_mobile(ss);
   auto mc = _load_for_mobile(ss);
   auto res_mobile = mc.forward(inputs);
-  ss.seekg(0, ss.beg);
 
   // check if the methods names are always the same
   // by reloading the script module and saving it back as mobile

--- a/test/cpp/jit/test_flatbuffer.cpp
+++ b/test/cpp/jit/test_flatbuffer.cpp
@@ -1177,7 +1177,6 @@ Module jitModuleFromBuffer(void* data) {
       mobilem._ivalue(), files, constants, 8);
 }
 
-#if defined(ENABLE_FLATBUFFER)
 TEST(TestSourceFlatbuffer, UpsampleNearest2d) {
   Module m("m");
   m.define(R"(
@@ -1190,21 +1189,20 @@ TEST(TestSourceFlatbuffer, UpsampleNearest2d) {
   inputs.emplace_back(at::Scalar(2.0));
   auto ref = m.forward(inputs);
 
-  std::stringstream ss;
-  m._save_for_mobile(ss, {}, false, /*use_fatbuffer=*/true);
-  auto mm = _load_for_mobile(ss);
-  auto m2 = load(ss);
-
+  auto data = save_jit_module_to_bytes(m);
+  Module m2 = jitModuleFromBuffer(data.data());
   auto res = m2.forward(inputs);
-  auto resm = mm.forward(inputs);
 
   auto resd = res.toTensor();
   auto refd = ref.toTensor();
-  auto resmd = resm.toTensor();
   ASSERT_TRUE(resd.equal(refd));
-  ASSERT_TRUE(resmd.equal(refd));
+
+  mobile::Module m3 = parse_mobile_module(data.data(), data.size());
+  res = m3.forward(inputs);
+  resd = res.toTensor();
+  refd = ref.toTensor();
+  ASSERT_TRUE(resd.equal(refd));
 }
-#endif
 
 TEST(TestSourceFlatbuffer, CheckAttrAccess) {
   Module m("m");

--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -16,8 +16,6 @@ sys.path.append(pytorch_test_dir)
 from torch.testing._internal.jit_utils import (JitTestCase,
                                                clear_class_registry)
 
-ENABLE_FLATBUFFER = os.environ.get('ENABLE_FLATBUFFER', '0') == '1'
-
 if __name__ == "__main__":
     raise RuntimeError(
         "This test file is not meant to be run directly, use:\n\n"
@@ -532,20 +530,6 @@ class TestSaveLoad(JitTestCase):
         self.assertTrue(m_loaded_buffers['buffer'].is_meta)
 
 
-def script_module_to_buffer(script_module):
-    module_buffer = io.BytesIO()
-    if ENABLE_FLATBUFFER:
-        module_buffer = io.BytesIO(
-            script_module._save_to_buffer_for_lite_interpreter(
-                _use_flatbuffer=True
-            )
-        )
-    else:
-        torch.jit.save_jit_module_to_flatbuffer(script_module, module_buffer)
-    module_buffer.seek(0)
-    return module_buffer
-
-
 class TestSaveLoadFlatbuffer(JitTestCase):
     def test_different_modules(self):
         """
@@ -564,7 +548,9 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 return x
 
         first_script_module = torch.jit.script(Foo())
-        first_saved_module = script_module_to_buffer(first_script_module)
+        first_saved_module = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(first_script_module, first_saved_module)
+        first_saved_module.seek(0)
 
         clear_class_registry()
 
@@ -578,7 +564,9 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 return x
 
         second_script_module = torch.jit.script(Foo())
-        second_saved_module = script_module_to_buffer(second_script_module)
+        second_saved_module = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(torch.jit.script(Foo()), second_saved_module)
+        second_saved_module.seek(0)
 
         clear_class_registry()
 
@@ -598,7 +586,9 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 return x
 
         sm = torch.jit.script(ContainsBoth())
-        contains_both = script_module_to_buffer(sm)
+        contains_both = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(sm, contains_both)
+        contains_both.seek(0)
         sm = torch.jit.jit_module_from_flatbuffer(contains_both)
 
     def test_different_functions(self):
@@ -614,7 +604,10 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 return lol(x)
 
         first_script_module = torch.jit.script(Foo())
-        first_saved_module = script_module_to_buffer(first_script_module)
+        first_saved_module = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(first_script_module, first_saved_module)
+        first_saved_module.seek(0)
+
         clear_class_registry()
 
         def lol(x):  # noqa: F811
@@ -625,7 +618,9 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 return lol(x)
 
         second_script_module = torch.jit.script(Foo())
-        second_saved_module = script_module_to_buffer(second_script_module)
+        second_saved_module = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(torch.jit.script(Foo()), second_saved_module)
+        second_saved_module.seek(0)
 
         clear_class_registry()
 
@@ -645,7 +640,9 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 return x
 
         sm = torch.jit.script(ContainsBoth())
-        contains_both = script_module_to_buffer(sm)
+        contains_both = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(sm, contains_both)
+        contains_both.seek(0)
         sm = torch.jit.jit_module_from_flatbuffer(contains_both)
 
     def test_different_interfaces(self):
@@ -677,7 +674,10 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 return self.interface.bar(x)
 
         first_script_module = torch.jit.script(Foo())
-        first_saved_module = script_module_to_buffer(first_script_module)
+        first_saved_module = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(first_script_module, first_saved_module)
+        first_saved_module.seek(0)
+
         clear_class_registry()
 
         @torch.jit.interface
@@ -704,7 +704,9 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 return self.interface.not_bar(x)
 
         second_script_module = torch.jit.script(Foo())
-        second_saved_module = script_module_to_buffer(second_script_module)
+        second_saved_module = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(torch.jit.script(Foo()), second_saved_module)
+        second_saved_module.seek(0)
 
         clear_class_registry()
 
@@ -724,7 +726,9 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 return x
 
         sm = torch.jit.script(ContainsBoth())
-        contains_both = script_module_to_buffer(sm)
+        contains_both = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(sm, contains_both)
+        contains_both.seek(0)
         sm = torch.jit.jit_module_from_flatbuffer(contains_both)
 
     def test_many_collisions(self):
@@ -766,7 +770,9 @@ class TestSaveLoadFlatbuffer(JitTestCase):
 
 
         first_script_module = torch.jit.script(Foo())
-        first_saved_module = script_module_to_buffer(first_script_module)
+        first_saved_module = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(first_script_module, first_saved_module)
+        first_saved_module.seek(0)
 
         clear_class_registry()
 
@@ -804,7 +810,9 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 return x, MyCoolNamedTuple(a="hello")
 
         second_script_module = torch.jit.script(Foo())
-        second_saved_module = script_module_to_buffer(second_script_module)
+        second_saved_module = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(second_script_module, second_saved_module)
+        second_saved_module.seek(0)
 
         clear_class_registry()
 
@@ -824,7 +832,9 @@ class TestSaveLoadFlatbuffer(JitTestCase):
                 return len(x + named_tuple_2.a) + named_tuple_1.a
 
         sm = torch.jit.script(ContainsBoth())
-        contains_both = script_module_to_buffer(sm)
+        contains_both = io.BytesIO()
+        torch.jit.save_jit_module_to_flatbuffer(sm, contains_both)
+        contains_both.seek(0)
         sm = torch.jit.jit_module_from_flatbuffer(contains_both)
 
     def test_save_load_using_pathlib(self):

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -797,13 +797,9 @@ void save_mobile_module_to(
     const ExtraFilesMap& extra_files,
     bool save_mobile_debug_info,
     const std::function<size_t(const void*, size_t)>& writer_func) {
-  ExtraFilesMap jitFiles;
   CompilationOptions options = getOptionsFromGlobal();
-  std::vector<IValue> constants;
-  jitModuleToPythonCodeAndConstants(module, &jitFiles, &constants);
   mobile::Module mod = jitModuleToMobile(module, options);
-  auto buffer =
-      save_mobile_module_to_bytes(mod, extra_files, jitFiles, constants);
+  auto buffer = save_mobile_module_to_bytes(mod, extra_files);
   writer_func(reinterpret_cast<void*>(buffer.data()), buffer.size());
 }
 #endif

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -789,14 +789,6 @@ Module load_jit_module_from_file(
       std::move(std::get<0>(data)), std::get<1>(data), device);
 }
 
-Module load_jit_module_from_stream(
-    std::istream& in,
-    c10::optional<at::Device> device) {
-  auto data = get_stream_content(in);
-  return parse_and_initialize_jit_module(
-      std::move(std::get<0>(data)), std::get<1>(data), device);
-}
-
 void save_jit_module(
     const Module& module,
     const std::string& filename,

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.h
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.h
@@ -47,9 +47,5 @@ TORCH_API Module load_jit_module_from_file(
     const std::string& filename,
     c10::optional<at::Device> device = c10::nullopt);
 
-TORCH_API Module load_jit_module_from_stream(
-    std::istream& in,
-    c10::optional<at::Device> device = c10::nullopt);
-
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -10,7 +10,6 @@
 #endif
 #include <torch/csrc/jit/frontend/script_type_parser.h>
 #include <torch/csrc/jit/ir/ir.h>
-#include <torch/csrc/jit/mobile/file_format.h>
 #include <torch/csrc/jit/operator_upgraders/upgraders_entry.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/serialization/import_read.h>
@@ -18,10 +17,6 @@
 #include <torch/csrc/jit/serialization/pickle.h>
 #include <torch/csrc/jit/serialization/source_range_serialization.h>
 #include <torch/csrc/jit/serialization/unpickler.h>
-
-#if defined(ENABLE_FLATBUFFER)
-#include <torch/csrc/jit/serialization/flatbuffer_serializer.h>
-#endif
 
 #include <caffe2/serialize/file_adapter.h>
 #include <caffe2/serialize/inline_container.h>
@@ -295,25 +290,9 @@ Module import_ir_module(
     std::istream& in,
     c10::optional<at::Device> device,
     ExtraFilesMap& extra_files) {
-  auto format = getFileFormat(in);
-  switch (format) {
-    case FileFormat::FlatbufferFileFormat: {
-#if defined(ENABLE_FLATBUFFER)
-      return load_jit_module_from_stream(in, device);
-#else
-      TORCH_CHECK(
-          false, "Flatbuffer input file but the build hasn't enable flatbuffer")
-#endif
-    }
-    case FileFormat::ZipFileFormat: {
-      auto reader = torch::make_unique<PyTorchStreamReader>(&in);
-      ScriptModuleDeserializer deserializer(std::move(cu), std::move(reader));
-      return deserializer.deserialize(device, extra_files);
-    }
-
-    default:
-      TORCH_CHECK(false, "Unrecognized data format");
-  }
+  auto reader = torch::make_unique<PyTorchStreamReader>(&in);
+  ScriptModuleDeserializer deserializer(std::move(cu), std::move(reader));
+  return deserializer.deserialize(device, extra_files);
 }
 
 // For reading unified serialization format from torch.Package.
@@ -346,25 +325,9 @@ Module import_ir_module(
     const std::string& filename,
     c10::optional<at::Device> device,
     ExtraFilesMap& extra_files) {
-  auto format = getFileFormat(filename);
-  switch (format) {
-    case FileFormat::FlatbufferFileFormat: {
-#if defined(ENABLE_FLATBUFFER)
-      return load_jit_module_from_file(filename, device);
-#else
-      TORCH_CHECK(
-          false, "Flatbuffer input file but the build hasn't enable flatbuffer")
-#endif
-    }
-    case FileFormat::ZipFileFormat: {
-      auto reader = torch::make_unique<PyTorchStreamReader>(filename);
-      ScriptModuleDeserializer deserializer(std::move(cu), std::move(reader));
-      return deserializer.deserialize(device, extra_files);
-    }
-
-    default:
-      TORCH_CHECK(false, "Unrecognized data format");
-  }
+  auto reader = torch::make_unique<PyTorchStreamReader>(filename);
+  ScriptModuleDeserializer deserializer(std::move(cu), std::move(reader));
+  return deserializer.deserialize(device, extra_files);
 }
 
 Module import_ir_module(
@@ -394,26 +357,9 @@ Module load(
     std::istream& in,
     c10::optional<at::Device> device,
     ExtraFilesMap& extra_files) {
-  auto format = getFileFormat(in);
-  switch (format) {
-    case FileFormat::FlatbufferFileFormat: {
-#if defined(ENABLE_FLATBUFFER)
-      return load_jit_module_from_stream(in, device);
-#else
-      TORCH_CHECK(
-          false, "Flatbuffer input file but the build hasn't enable flatbuffer")
-#endif
-    }
-    case FileFormat::ZipFileFormat: {
-      std::unique_ptr<IStreamAdapter> rai =
-          std::make_unique<IStreamAdapter>(&in);
-      auto module = load(std::move(rai), device, extra_files);
-      return module;
-    }
-
-    default:
-      TORCH_CHECK(false, "Unrecognized data format");
-  }
+  std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
+  auto module = load(std::move(rai), device, extra_files);
+  return module;
 }
 
 Module load(const std::string& filename, c10::optional<at::Device> device) {
@@ -425,27 +371,9 @@ Module load(
     const std::string& filename,
     c10::optional<at::Device> device,
     ExtraFilesMap& extra_files) {
-  auto format = getFileFormat(filename);
-  switch (format) {
-    case FileFormat::FlatbufferFileFormat: {
-#if defined(ENABLE_FLATBUFFER)
-      return load_jit_module_from_file(filename, device);
-#else
-      TORCH_CHECK(
-          false, "Flatbuffer input file but the build hasn't enable flatbuffer")
-#endif
-
-      case FileFormat::ZipFileFormat: {
-        std::unique_ptr<FileAdapter> rai =
-            std::make_unique<FileAdapter>(filename);
-        auto module = load(std::move(rai), device, extra_files);
-        return module;
-      }
-
-      default:
-        TORCH_CHECK(false, "Unrecognized data format");
-    }
-  }
+  std::unique_ptr<FileAdapter> rai = std::make_unique<FileAdapter>(filename);
+  auto module = load(std::move(rai), device, extra_files);
+  return module;
 }
 
 Module load(
@@ -459,8 +387,8 @@ Module load(
     std::shared_ptr<ReadAdapterInterface> rai,
     c10::optional<c10::Device> device,
     ExtraFilesMap& extra_files) {
-  // Verify that we're loading a zip archive and not a torch.save pickle
-  // archive (marked by the 0x80 0x02 bytes at the start)
+  // Verify that we're loading a zip archive and not a torch.save pickle archive
+  // (marked by the 0x80 0x02 bytes at the start)
   // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
   TORCH_CHECK(
       check_zip_file(rai),


### PR DESCRIPTION
Summary:
Original commit changeset: d653a5af662a

Original Phabricator Diff: D35060736 (https://github.com/pytorch/pytorch/commit/d9d34922a08af88f0dc68ad7ebe353990ebc1226)

Test Plan: Model loading test, verified that D35060736 (https://github.com/pytorch/pytorch/commit/d9d34922a08af88f0dc68ad7ebe353990ebc1226) will cause the torch::save => torch::load failure.

Reviewed By: yinghai, jianyuh

Differential Revision: D35387009

