### PR TITLE
Make LazyIr.h use provided backend namespace

### DIFF
--- a/aten/src/ATen/templates/LazyIr.h
+++ b/aten/src/ATen/templates/LazyIr.h
@@ -4,8 +4,7 @@
 ${lazy_ir_sysinc}
 ${lazy_ir_inc}
 
-namespace torch {
-namespace lazy {
+${namespace_prologue}
 using at::operator<<;
 
 // kNullValue is used to contribute a static hash value any time
@@ -17,5 +16,4 @@ static const torch::lazy::Value kNullValue = torch::lazy::Value();
 
 ${ir_declarations}
 
-} // namespace lazy
-} // namespace torch
+${namespace_epilogue}

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -291,6 +291,8 @@ def run_gen_lazy_tensor(aten_path: str, source_yaml: str, output_dir: str,
             lazy_ir_cls(backend_indices[backend_key], node_base),
             grouped_native_functions
         )),
+        'namespace_prologue': ns_helper.prologue,
+        'namespace_epilogue': ns_helper.epilogue,
     })
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #75274
* #75267
* __->__ #75264

Fixes one of the issues in https://github.com/pytorch/xla/issues/3472

Differential Revision: [D35411210](https://our.internmc.facebook.com/intern/diff/D35411210)