### PR TITLE
NVFuser/JIT debugging tools

### DIFF
--- a/demo/comparepass_demo.py
+++ b/demo/comparepass_demo.py
@@ -1,0 +1,40 @@
+import torch
+
+
+def callback(unfused_outputs, fused_outputs, graph):
+    # note: if _jit_nvfuser_set_comparison_callback(False, callback),
+    #       then unfused_outputs will be empty
+    found_mismatch = False
+    for i in range(len(fused_outputs)):
+        unfused = unfused_outputs[i]
+        fused = fused_outputs[i]
+        diff = torch.max(torch.abs(unfused - fused)).item()
+        if diff > 1e-9:
+            print(f"Found mismatch in NVFuser fusion output #{i}:")
+            print(f"Difference: {diff}")
+            print(f"Fusion group:\n{graph}")
+            found_mismatch = True
+    if not found_mismatch:
+        print(f"No issues found in this fusion group: {graph}")
+
+
+torch._C._jit_nvfuser_set_comparison_callback(True, callback)
+
+
+def fn(x, y):
+    a = torch.exp(x)
+    b = torch.exp(y)
+    return a + b + x
+
+
+x = torch.rand((10, 10), dtype=torch.half).cuda() + 5
+y = torch.rand((10, 10), dtype=torch.half).cuda() + 5
+
+with torch.jit.fuser("fuser2"):
+    fn_s = torch.jit.script(fn)
+    fn_s(x, y)
+    fn_s(x, y)
+    torch._C._jit_nvfuser_clear_comparison_callback()
+    print("There should be no more callback output after this:")
+    fn_s(x, y)
+    fn_s(x, y)

--- a/demo/logextract_demo.sh
+++ b/demo/logextract_demo.sh
@@ -1,0 +1,42 @@
+#!/usr/bash
+set -x
+
+# pass the path of 
+if [[ $# < 1 ]]; then
+  echo "Usage: bash logextract_demo.sh [path/to/pytorch/repo]"
+  echo ""
+  echo "Error: missing path to pytorch repo"
+  exit 1
+fi
+
+echo "First, we write a test python file to logextract_demo_script.py"
+cat > logextract_demo_script.py <<EOF
+import torch
+
+def fn(x, y):
+    x1 = torch.exp(x)
+    y1 = torch.cos(y)
+    return x1 + y1
+
+x = torch.rand((400, 400)).cuda()
+y = torch.rand((400, 400)).cuda()
+
+# with fuser2 enables nvfuser
+with torch.jit.fuser("fuser2"):
+    fn_s = torch.jit.script(fn)
+    fn_s(x, y)
+    print(fn_s(x, y))
+EOF
+
+cat logextract_demo_script.py
+
+echo "Next, we run the example python file with PYTORCH_JIT_LOG_LEVEL=>>graph_fuser and pipe the output to logextract_demo_logs.txt"
+PYTORCH_JIT_LOG_LEVEL=">>graph_fuser" python logextract_demo_script.py &> logextract_demo_logs.txt
+
+echo "Now we run log_extract."
+
+echo "First, let's just dump the fusion group"
+python "${1}/scripts/jit/log_extract.py" logextract_demo_logs.txt --output
+
+echo "Now, try benchmarking against the no-fusion implementation"
+python "${1}/scripts/jit/log_extract.py" logextract_demo_logs.txt --baseline --nvfuser


### PR DESCRIPTION
We've added two NVFuser/JIT debugging tools - log_extract.py , and a NVFuser comparison pass.

## log_extract.py:

[log_extract.py](https://github.com/pytorch/pytorch/blob/28a4b4759add0b3eb0f4c34a1e042be4f93e976e/scripts/jit/log_extract.py) extracts subgraphs from log files so they can be re-run or benchmarked. It will automatically generate test inputs for benchmarking purposes by using the shape information available in the exported IR. You can see a demo of how to use it at [logextract_demo.sh](https://github.com/pytorch/pytorch/pull/75266/files#diff-bea0c04760e6865216e47dc40be7ecdc2a048cb7b8513ec8689f0edb85e17508R1)

How to use log_extract.py:

1. At runtime, dump extra logs containing all the subgraphs you're interested in. Currently log dumping is implemented for [nvfuser](https://github.com/pytorch/pytorch/blob/28a4b4759add0b3eb0f4c34a1e042be4f93e976e/torch/csrc/jit/codegen/cuda/graph_fuser.cpp#L1721) and [NNC](https://github.com/pytorch/pytorch/blob/28a4b4759add0b3eb0f4c34a1e042be4f93e976e/torch/csrc/jit/passes/tensorexpr_fuser.cpp#L750). To get these logs, run with `PYTORCH_JIT_LOG_LEVEL=">>graph_fuser"` for nvfuser, or `">>tensorexpr_fuser"` for NNC. For example: `PYTORCH_JIT_LOG_LEVEL=">>graph_fuser" python test_file.py &> log_dump.txt`
2. Load the dumped log file with log_extract. From pytorch root directory, run: `python scripts/jit/log_extract.py log_dump.txt [options]`. Note that the script only works with IR that contains shape information.

Available options:
* Dumping output:
  + --output: dump the extracted subgraph IR to stdout for later use
* Benchmarking:
  + --baseline: benchmark the subgraphs with no fusers
  + --nvfuser: benchmark the subgraphs with nvfuser
  + --nnc: benchmark the subgraphs with NNC

Potential uses:

* **Identify fusion groups with bad performance**: Run `python log_extract.py [log_file.txt] --baseline --nvfuser` to find cases where nvfuser makes performance worse compared to unfused implementations
* **Isolate fusion groups that fail to fallbacks:**
  + First, run your test script with fallbacks enabled: `$ PYTORCH_JIT_LOG_LEVEL=”>>graph_fuser” python test_script.py &> log_dump.txt`
  + Then run log_extract with fallbacks disabled to see which subgraph it falls on: `$ PYTORCH_NVFUSER_DISABLE_FALLBACK=1 python log_extract.py log_dump.txt --nvfuser`

## comparison pass

For accuracy comparisons, you can enable an optional comparison that runs after every fusion pass for comparing the fused and unfused implementations. Demo: [comparepass_demo.py](https://github.com/pytorch/pytorch/pull/75266/files#diff-a2fa91d1b30f082373fd461cfc91011dc304bc91726329f1135cd3aead7ed5d6R1)

```python
import torch
 
def callback(unfused_outputs, fused_outputs, graph):
    # note: if _jit_nvfuser_set_comparison_callback(False, callback),
    #       then unfused_outputs will be empty
    found_mismatch = False
    for i in range(len(fused_outputs)):
        unfused = unfused_outputs[i]
        fused = fused_outputs[i]
        diff = torch.max(torch.abs(unfused - fused)).item()
        if diff > 1e-9:
            print(f"Found mismatch in NVFuser fusion output #{i}:")
            print(f"Difference: {diff}")
            print(f"Fusion group:\n{graph}")
            found_mismatch = True
    if not found_mismatch:
        print(f"No issues found in this fusion group: {graph}")
 
torch._C._jit_nvfuser_set_comparison_callback(True, callback)
 
def fn(x, y):
    a = torch.exp(x)
    b = torch.exp(y)
    return a + b + x
 
x = torch.rand((10, 10), dtype=torch.half).cuda() + 5
y = torch.rand((10, 10), dtype=torch.half).cuda() + 5
 
with torch.jit.fuser("fuser2"):
    fn_s = torch.jit.script(fn)
    fn_s(x, y)
    fn_s(x, y)
    torch._C._jit_nvfuser_clear_comparison_callback()
    print("There should be no more callback output after this:")
    fn_s(x, y)
    fn_s(x, y)
```

You can also use the same callback to report fusion groups as they run, e.g.

```python
torch._C._jit_nvfuser_set_comparison_callback(False, callback)
```

In this case, the first argument to the callback will be an empty list.