### PR TITLE
Make default codegen behavior skip Lower function

### DIFF
--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import List, Union
 from dataclasses import dataclass
 from tools.codegen.context import method_with_native_function

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -84,18 +84,16 @@ def aten_symbol(schema: LazyIrSchema) -> str:
 class LazyIR(ABC):
     backend_index: BackendIndex
     node_base: str
-    lowering_function_type: str = ""
-    lowering_context_type: str = ""
-    lowering_return_type: str = ""
 
     @method_with_native_function
     def __call__(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> List[str]:
         func = f.functional.func if isinstance(f, NativeFunctionsGroup) else f.func
         return self.gen(f)
 
-    @abstractmethod
-    def lowering_body(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> str:
-        pass
+    # there is no lowering functionality generated unless this IR base class is subclassed and
+    # implemented as a backend-specific node
+    def lowering_function(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> str:
+        return ""
 
     def gen(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> List[str]:
         # for now, we just want one IR class decl and soon after also the method defs
@@ -159,10 +157,7 @@ class {schema.node_name} : public {self.node_base} {{
     return ss.str();
   }}
 
-  {self.lowering_return_type} Lower({self.lowering_function_type} function,
-                   {self.lowering_context_type} loctx) const override {{
-    {self.lowering_body(f)}
-  }}
+  {self.lowering_function(f)}
 
   {scalar_decls}
   {has_optional_decls}
@@ -174,13 +169,12 @@ class {schema.node_name} : public {self.node_base} {{
 
 @dataclass(frozen=True)
 class TSLazyIR(LazyIR):
-    lowering_function_type: str = "std::shared_ptr<torch::jit::GraphFunction>"
-    lowering_context_type: str = "torch::lazy::TSLoweringContext*"
-    lowering_return_type: str = "torch::lazy::TSOpVector"
 
-    def lowering_body(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> str:
-        return ts_lowering_body(f)
-
+    def lowering_function(self, f: Union[NativeFunctionsGroup, NativeFunction]) -> str:
+        return f"""torch::lazy::TSOpVector Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const override {{
+    {ts_lowering_body(f)}
+  }}"""
 
 def lazy_tensor_decls(value_args: List[LazyArgument], tensor_class: str) -> str:
     lazy_tensor_decls: List[str] = []

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -109,7 +109,10 @@ def main() -> None:
     # Assumes that this file lives at PYTORCH_ROOT/tools/codegen/gen_backend_stubs.py
     torch_root = pathlib.Path(__file__).parent.parent.parent.absolute()
     aten_path = str(torch_root / "aten" / "src" / "ATen")
-    ir_gen_class: Type[LazyIR] = TSLazyIR if options.gen_ts_lowerings else default_args.lazy_ir_cls
+    ir_gen_class: Type[LazyIR] = default_args.lazy_ir_cls
+    if options.gen_ts_lowerings:
+        ir_gen_class = TSLazyIR
+
     run_gen_lazy_tensor(aten_path, options.source_yaml, options.output_dir, options.dry_run, options.impl_path,
                         options.node_base, options.node_base_hdr,
                         options.tensor_class, options.tensor_class_hdr, options.shape_inference_hdr,

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -68,7 +68,7 @@ class default_args:
     shape_inference_hdr: str = "torch/csrc/lazy/core/shape_inference.h"
     tensor_class: str = "torch::lazy::LazyTensor"
     tensor_class_hdr: str = "torch/csrc/lazy/core/tensor.h"
-    lazy_ir_cls: Type[LazyIR] = TSLazyIR
+    lazy_ir_cls: Type[LazyIR] = LazyIR
     backend_name: str = "TorchScript"
 
 def main() -> None:
@@ -109,16 +109,15 @@ def main() -> None:
     # Assumes that this file lives at PYTORCH_ROOT/tools/codegen/gen_backend_stubs.py
     torch_root = pathlib.Path(__file__).parent.parent.parent.absolute()
     aten_path = str(torch_root / "aten" / "src" / "ATen")
-
+    ir_gen_class = TSLazyIR if options.gen_ts_lowerings else default_args.lazy_ir_cls
     run_gen_lazy_tensor(aten_path, options.source_yaml, options.output_dir, options.dry_run, options.impl_path,
-                        options.gen_ts_lowerings, options.node_base, options.node_base_hdr,
+                        options.node_base, options.node_base_hdr,
                         options.tensor_class, options.tensor_class_hdr, options.shape_inference_hdr,
-                        default_args.lazy_ir_cls, options.backend_name)
+                        ir_gen_class, options.backend_name)
 
 
 def run_gen_lazy_tensor(aten_path: str, source_yaml: str, output_dir: str,
                         dry_run: bool, impl_path: Optional[str],
-                        gen_ts_lowerings: bool,
                         node_base: str = default_args.node_base,
                         node_base_hdr: Optional[str] = default_args.node_base_hdr,
                         tensor_class: str = default_args.tensor_class,

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -109,7 +109,7 @@ def main() -> None:
     # Assumes that this file lives at PYTORCH_ROOT/tools/codegen/gen_backend_stubs.py
     torch_root = pathlib.Path(__file__).parent.parent.parent.absolute()
     aten_path = str(torch_root / "aten" / "src" / "ATen")
-    ir_gen_class = TSLazyIR if options.gen_ts_lowerings else default_args.lazy_ir_cls
+    ir_gen_class: Type[LazyIR] = TSLazyIR if options.gen_ts_lowerings else default_args.lazy_ir_cls
     run_gen_lazy_tensor(aten_path, options.source_yaml, options.output_dir, options.dry_run, options.impl_path,
                         options.node_base, options.node_base_hdr,
                         options.tensor_class, options.tensor_class_hdr, options.shape_inference_hdr,

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -196,7 +196,8 @@ def main() -> None:
 
         assert os.path.isfile(ts_backend_yaml), f"Unable to access ts_backend_yaml: {ts_backend_yaml}"
         assert os.path.isfile(ts_native_functions), f"Unable to access {ts_native_functions}"
-        from tools.codegen.gen_lazy_tensor import run_gen_lazy_tensor, TSLazyIR
+        from tools.codegen.gen_lazy_tensor import run_gen_lazy_tensor
+        from tools.codegen.dest.lazy_ir import TSLazyIR
         run_gen_lazy_tensor(aten_path=aten_path,
                             source_yaml=ts_backend_yaml,
                             backend_name="TorchScript",

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -196,17 +196,17 @@ def main() -> None:
 
         assert os.path.isfile(ts_backend_yaml), f"Unable to access ts_backend_yaml: {ts_backend_yaml}"
         assert os.path.isfile(ts_native_functions), f"Unable to access {ts_native_functions}"
-        from tools.codegen.gen_lazy_tensor import run_gen_lazy_tensor
+        from tools.codegen.gen_lazy_tensor import run_gen_lazy_tensor, TSLazyIR
         run_gen_lazy_tensor(aten_path=aten_path,
                             source_yaml=ts_backend_yaml,
                             backend_name="TorchScript",
                             output_dir=lazy_install_dir,
                             dry_run=False,
                             impl_path=ts_native_functions,
-                            gen_ts_lowerings=True,
                             node_base="TsNode",
                             node_base_hdr=ts_node_base,
                             build_in_tree=True,
+                            lazy_ir_cls=TSLazyIR,
                             per_operator_headers=options.per_operator_headers)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #75274
* __->__ #75267
* #75264

- clean up arguments relating to ts backend generation
- make entire lowering function rather than just body be a part of
  backend-IR class

Differential Revision: [D35411212](https://our.internmc.facebook.com/intern/diff/D35411212)