### PR TITLE
Add TORCH_CHECK for floating point exception in native_group_norm

### DIFF
--- a/aten/src/ATen/native/group_norm.cpp
+++ b/aten/src/ATen/native/group_norm.cpp
@@ -23,6 +23,9 @@ void check_group_norm_inputs(
     int64_t C,
     int64_t num_groups) {
   TORCH_CHECK(
+      num_groups > 0,
+      "Expected num groups to be greater than 0, got ", num_groups);
+  TORCH_CHECK(
       C % num_groups == 0,
       "Expected number of channels in input to be divisible by ",
       "num_groups, but got input of shape ",


### PR DESCRIPTION
This fixes #73194, but it should also be sufficient for `torch.group_norm` (#73188) since it has to call `native_group_norm`. Using `torch.nn.GroupNorm` throws instead a ZeroDivisionError when `num_groups=0`, we should add a nice error message also there?
