### PR TITLE
[JIT] Prevent nvfuser registration on ROCm

### DIFF
--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -31,7 +31,7 @@ from torch.autograd.gradcheck import gradcheck
 
 from typing import List
 
-RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM and not IS_WINDOWS
+RUN_NVFUSER = RUN_CUDA and not IS_WINDOWS
 CUDA_MAJOR, CUDA_MINOR = 0, 0
 
 if RUN_NVFUSER and torch.version.cuda is not None:
@@ -4442,6 +4442,18 @@ class TestPassManagerCudaFuser(JitTestCase):
         self.assertTrue(torch._C._jit_set_nvfuser_enabled(False))
         self.assertFalse(torch._C._jit_nvfuser_enabled())
 
+    @unittest.skipIf(RUN_CUDA, "Testing on CPU only")
+    def test_register_fuser_cpu(self):
+        with self.assertRaises(RuntimeError):
+            torch._C._jit_set_nvfuser_enabled(True)
+            torch._C._jit_set_nvfuser_enabled(False)
+
+    @unittest.skipIf(not RUN_CUDA, "requires CUDA")
+    @unittest.skipIf(not TEST_WITH_ROCM, "ROCM test only")
+    def test_register_fuser_rocm(self):
+        with self.assertRaises(RuntimeError):
+            torch._C._jit_set_nvfuser_enabled(True)
+            torch._C._jit_set_nvfuser_enabled(False)
 
 class TestCudaFuserOpInfo(JitCommonTestCase):
     def setUp(self):

--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -31,7 +31,7 @@ from torch.autograd.gradcheck import gradcheck
 
 from typing import List
 
-RUN_NVFUSER = RUN_CUDA and not IS_WINDOWS
+RUN_NVFUSER = RUN_CUDA and not TEST_WITH_ROCM and not IS_WINDOWS
 CUDA_MAJOR, CUDA_MINOR = 0, 0
 
 if RUN_NVFUSER and torch.version.cuda is not None:

--- a/torch/csrc/jit/passes/cuda_graph_fuser.h
+++ b/torch/csrc/jit/passes/cuda_graph_fuser.h
@@ -16,8 +16,13 @@ struct TORCH_API RegisterCudaFuseGraph
   static bool registerPass(bool enabled) {
     bool old_flag = PassManager::isRegistered();
     if (enabled) {
+#ifdef USE_ROCM
+      bool has_rocm = true;
+#else
+      bool has_rocm = false;
+#endif
       TORCH_CHECK(
-          at::globalContext().hasCUDA() && !at::globalContext().hasHIP(),
+          at::globalContext().hasCUDA() && !has_rocm,
           "Running CUDA fuser is only supported on CUDA builds.");
       PassManager::registerPass(fuser::cuda::fuseGraph);
     } else {

--- a/torch/csrc/jit/passes/cuda_graph_fuser.h
+++ b/torch/csrc/jit/passes/cuda_graph_fuser.h
@@ -16,6 +16,9 @@ struct TORCH_API RegisterCudaFuseGraph
   static bool registerPass(bool enabled) {
     bool old_flag = PassManager::isRegistered();
     if (enabled) {
+      // TODO: this might not be the right place to put the ROCm logic.
+      // i.e. since this is built as part of libtorch cpu, USE_ROCM flag
+      // might not be available while building this lib.
 #ifdef USE_ROCM
       bool has_rocm = true;
 #else


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #75284

Previously, cuda_graph_fuser.h registration of the nvfuser pass used `at::globalContext().hasHIP()` to check whether we were using ROCm/HIP. However, I don't think that check actually does anything; on the ROCm CI jobs the registration would still succeed.

Instead it's replaced with `#ifdef USE_ROCM`.

Verified this by enabling the NVFuser tests on ROCm and running in CI.

Before this change: the NVFuser test in CI on ROCm would throw really long and complex errors.

Now, it errors out immediately when trying to enable nvfuser.