### PR TITLE
[fx][ShapeProp] make shapes and args/kwargs concrete for minimizer

### DIFF
--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -1,8 +1,11 @@
 import torch
 import torch.fx
+import traceback
+
 from torch.fx.node import Node, map_aggregate
 from typing import Any, Tuple, NamedTuple, Optional, Dict
 from torch.fx._compatibility import compatibility
+
 
 @compatibility(is_backward_compatible=True)
 class TensorMetadata(NamedTuple):
@@ -108,7 +111,14 @@ class ShapeProp(torch.fx.Interpreter):
 
     """
     def run_node(self, n : Node) -> Any:
-        result = super().run_node(n)
+        try:
+            result = super().run_node(n)
+        except Exception:
+            traceback.print_exc()
+            raise RuntimeError(
+                f"ShapeProp error for: node={n.format_node()} with "
+                f"meta={n.meta}"
+            )
 
         found_tensor = False
 


### PR DESCRIPTION
Summary: As the title. Also adds debugging messaging to `ShapeProp.run_node`

Test Plan:
In Amodel
````
buck run mode/opt //caffe2/torch/fb/acc_runtime/dbg:debug_min_net -- --model 10x_ctr_mbl_feed_tp --model_path /home/$USER/309786571_1.fp32.predictor.tooling.tp

````
fails later than before

Reviewed By: yuhc

Differential Revision: D34930081

