### PR TITLE
[WIP] Convert DDP parameters to ReplicatedTensor during forward pass.

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -13,10 +13,10 @@ from torch.distributed._shard import (
     shard_parameter,
     sharded_tensor,
     _shard_tensor,
+    load_with_process_group,
 )
 from torch.distributed._shard.sharded_tensor import (
     sharded_op_impl,
-    load_with_process_group,
     pre_load_state_dict_hook,
     state_dict_hook,
     ShardedTensor,

--- a/test/distributed/_shard/test_replicated_tensor.py
+++ b/test/distributed/_shard/test_replicated_tensor.py
@@ -3,7 +3,9 @@
 import torch
 
 import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
 
+from torch.distributed._shard.replicated_tensor import ReplicatedTensor
 from torch.testing._internal.common_distributed import (
     requires_nccl,
     skip_if_lt_x_gpu,
@@ -13,7 +15,6 @@ from torch.testing._internal.distributed._shard.sharded_tensor import (
     ShardedTensorTestBase,
     with_comms,
 )
-from torch.distributed._shard.replicated_tensor import ReplicatedTensor
 
 
 class TestReplicatedTensor(ShardedTensorTestBase):
@@ -74,3 +75,89 @@ class TestReplicatedTensor(ShardedTensorTestBase):
         self.assertNotIsInstance(new_tensor, ReplicatedTensor)
 
         self.assertEqual(new_tensor, local_tensor + local_rand_tensor)
+
+    @with_comms(init_rpc=False)
+    @skip_if_lt_x_gpu(4)
+    @requires_nccl()
+    def test_with_ddp(self):
+        # Test Replicated params for DDP
+        replica_tensor = ReplicatedTensor(torch.rand(4, 8, device=self.rank))
+        model = torch.nn.Linear(8, 2).cuda(self.rank)
+        optim = torch.optim.SGD(model.parameters(), lr=0.1)
+        ddp = DDP(model)
+
+        # Test module.parameters.
+        params = list(ddp.parameters())
+        self.assertEqual(2, len(params))
+        self.assertEqual(ddp.module.weight, params[0])
+        self.assertEqual(ddp.module.bias, params[1])
+
+        params = list(model.parameters())
+        self.assertEqual(2, len(params))
+        self.assertEqual(model.weight, params[0])
+        self.assertEqual(model.bias, params[1])
+
+        # Validate output
+        out = ddp(replica_tensor)
+        self.assertIsInstance(out, ReplicatedTensor)
+
+        # Test backward and optimizer.
+
+        # Validate backward.
+        out.sum().backward()
+        self.assertIsNotNone(model.weight.grad)
+        self.assertIsNotNone(model.bias.grad)
+        self.assertIsNotNone(ddp.module.weight.grad)
+        self.assertIsNotNone(ddp.module.bias.grad)
+
+        original_params = []
+        for param_group in optim.param_groups:
+            for original_param in param_group['params']:
+                self.assertIsNotNone(original_param.grad)
+                original_params.append(original_param)
+
+        self.assertEqual(model.weight.grad, original_params[0].grad)
+        self.assertEqual(model.bias.grad, original_params[1].grad)
+        self.assertEqual(model.weight.grad, ddp.module.weight.grad)
+        self.assertEqual(model.bias.grad, ddp.module.bias.grad)
+
+        # Validate optimizer.
+        optim.step()
+        self.assertEqual(model.weight, ddp.module.weight)
+        self.assertEqual(model.weight, original_params[0])
+
+        self.assertEqual(model.bias, ddp.module.bias)
+        self.assertEqual(model.bias, original_params[1])
+
+        # Validate zero_grad
+        optim.zero_grad()
+        self.assertEqual(model.weight.grad, torch.zeros_like(model.weight.grad))
+        self.assertEqual(model.weight.grad, ddp.module.weight.grad)
+        self.assertEqual(model.weight.grad, original_params[0].grad)
+
+        self.assertEqual(model.bias.grad, torch.zeros_like(model.bias.grad))
+        self.assertEqual(model.bias.grad, ddp.module.bias.grad)
+        self.assertEqual(model.bias.grad, original_params[1].grad)
+
+        # Validate zero_grad set_to_none
+        optim.zero_grad(set_to_none=True)
+        self.assertIsNone(model.weight.grad)
+        self.assertEqual(model.weight.grad, ddp.module.weight.grad)
+        self.assertEqual(model.weight.grad, original_params[0].grad)
+
+        self.assertIsNone(model.bias.grad)
+        self.assertEqual(model.bias.grad, ddp.module.bias.grad)
+        self.assertEqual(model.bias.grad, original_params[1].grad)
+
+        # Validate during forward pass
+        def hook(module, input):
+            self.assertIsInstance(ddp.module.weight, ReplicatedTensor)
+            self.assertIsInstance(module.weight, ReplicatedTensor)
+
+            self.assertIsInstance(ddp.module.bias, ReplicatedTensor)
+            self.assertIsInstance(module.bias, ReplicatedTensor)
+
+        model.register_forward_pre_hook(hook)
+        for _ in range(2):
+            out = ddp(replica_tensor)
+            self.assertIsInstance(out, ReplicatedTensor)

--- a/torch/distributed/_shard/__init__.py
+++ b/torch/distributed/_shard/__init__.py
@@ -1,1 +1,1 @@
-from .api import shard_parameter, _shard_tensor, _replicate_tensor
+from .api import shard_parameter, _shard_tensor, _replicate_tensor, load_with_process_group

--- a/torch/distributed/_shard/replicated_tensor.py
+++ b/torch/distributed/_shard/replicated_tensor.py
@@ -1,10 +1,9 @@
 import torch
 import torch.distributed as dist
 
-from torch.overrides import get_default_nowrap_functions
 from torch.distributed._shard.sharded_tensor.api import ShardedTensor
 from torch.distributed import distributed_c10d
-
+from torch.overrides import get_default_nowrap_functions
 
 class ReplicatedTensor(torch.Tensor):
     """
@@ -33,13 +32,21 @@ class ReplicatedTensor(torch.Tensor):
     def __new__(cls, data=None, process_group=None):
         if data is None:
             data = torch.empty(0)
-        r = torch.Tensor._make_subclass(cls, data)      # type: ignore[arg-type]
+        r = torch.Tensor._make_subclass(cls, data, data.requires_grad)      # type: ignore[arg-type]
         r.process_group = (     # type: ignore[attr-defined]
             process_group
             if process_group is not None
             else distributed_c10d._get_default_group()
         )
         return r
+
+    def __deepcopy__(self, memo):
+        if id(self) in memo:
+            return memo[id(self)]
+        else:
+            result = type(self)(self.data.clone(memory_format=torch.preserve_format), self.process_group)
+            memo[id(self)] = result
+            return result
 
     def __repr__(self):
         return f"ReplicatedTensor({super(ReplicatedTensor, self).__repr__()})"
@@ -90,7 +97,7 @@ class ReplicatedTensor(torch.Tensor):
                 # if all operands are ReplicatedTensors and does not get dispatched to ShardedTensor
                 # __torch_function__, result is a torch.Tensor, then we convert and return a
                 # ReplicatedTensor according to our inter-op rule
-                rs = rs.as_subclass(cls)        # type: ignore[arg-type]
+                rs = rs.as_subclass(ReplicatedTensor)        # type: ignore[arg-type]
                 # propagate the process_group field to result
                 rs.process_group = replicated_pg        # type: ignore[attr-defined]
 
@@ -123,3 +130,45 @@ class ReplicatedTensor(torch.Tensor):
                     f"ReplicatedTensor have different values on rank {current_rank} and {rank}")
 
         return True
+
+    def __setstate__(self, state):
+        with torch._C.DisableTorchFunction():
+            self.data = state
+            self.requires_grad = state.requires_grad
+            from torch.distributed._shard.api import _get_current_process_group
+            self.process_group = _get_current_process_group()
+
+    def __getstate__(self):
+        return self.data
+
+
+class ReplicatedTensorParametrization(torch.nn.Module):
+    """
+    Parametrization module to convert Tensors into ReplicatedTensors while
+    running the forward pass of nn.Module.
+
+    The parametrization ensures that gradients are shared across the
+    original Tensor and the parametrized one.
+    """
+    def __init__(self, process_group=None):
+        super(ReplicatedTensorParametrization, self).__init__()
+        self.process_group = process_group
+
+    class Function(torch.autograd.Function):
+        """
+        Autograd function to ensure gradients are replicated between the
+        parameterized tensor and the original one.
+        """
+        @staticmethod
+        def forward(ctx, inp, process_group=None):
+            return ReplicatedTensor(inp, process_group)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            return grad_output, None
+
+    def forward(self, tensor: torch.Tensor):
+        replicated_tensor = ReplicatedTensorParametrization.Function.apply(tensor, self.process_group)
+        # Pick up grad from the original tensor.
+        replicated_tensor.grad = tensor.grad
+        return replicated_tensor

--- a/torch/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/distributed/_shard/sharded_tensor/__init__.py
@@ -16,7 +16,6 @@ from .api import (
 )
 from .metadata import ShardMetadata  # noqa: F401
 from .partial_tensor import _PartialTensor
-from .utils import load_with_process_group
 
 
 def empty(sharding_spec: shard_spec.ShardingSpec,

--- a/torch/distributed/_shard/sharded_tensor/_ops/math_ops.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/math_ops.py
@@ -1,0 +1,88 @@
+import torch
+from torch import Tensor
+from torch.distributed._shard.sharded_tensor import (
+    ShardedTensor,
+    sharded_op_impl
+)
+from torch.distributed._shard.sharding_spec import ChunkShardingSpec
+from torch.distributed._shard.replicated_tensor import ReplicatedTensor
+
+def register_math_op(op):
+    @sharded_op_impl(op)
+    def binary_math_op(types, args=(), kwargs=None, pg=None):
+        """
+        Handles ``__torch_function__`` dispatch for the binary math ops
+        such as `torch.add`, `torch.mul`, `torch.div`, etc.
+        This method computes on ShardedTensor, or ShardedTensor op ReplicatedTensor
+        """
+        if len(args) != 2:
+            raise ValueError("Only support binary math op on ShardedTensor for now!")
+        lhs = args[0]
+        rhs = args[1]
+        # Validate types
+        if isinstance(lhs, ShardedTensor) and isinstance(rhs, ShardedTensor):
+            lhs_spec = lhs.sharding_spec()
+            rhs_spec = rhs.sharding_spec()
+            if not isinstance(lhs_spec, ChunkShardingSpec) or not isinstance(rhs_spec, ChunkShardingSpec):
+                raise TypeError("Only ShardedTensor with ChunkShardingSpec supports"
+                                " two ShardedTensor together")
+
+            if lhs.size() == rhs.size() and lhs_spec.dim == rhs_spec.dim:
+                # perform local element-wise math op
+                res = op(lhs.local_tensor(), rhs.local_tensor())
+                return ShardedTensor._init_from_local_tensor(
+                    res, lhs_spec, list(lhs.size()), process_group=pg)  # type: ignore[arg-type]
+            else:
+                raise RuntimeError("Implicit broadcasting not supported yet!")
+
+        elif isinstance(lhs, ReplicatedTensor):
+            assert isinstance(rhs, ShardedTensor)
+            res = op(lhs, rhs.local_tensor())
+            return ShardedTensor._init_from_local_tensor(
+                res, rhs.sharding_spec(), list(rhs.size()), process_group=pg)  # type: ignore[arg-type]
+
+        elif isinstance(rhs, ReplicatedTensor):
+            assert isinstance(lhs, ShardedTensor)
+            res = op(lhs.local_tensor(), rhs)
+            return ShardedTensor._init_from_local_tensor(
+                res, lhs.sharding_spec(), list(lhs.size()), process_group=pg)  # type: ignore[arg-type]
+
+        elif isinstance(lhs, (int, float)):
+            assert isinstance(rhs, ShardedTensor)
+            res = op(lhs, rhs.local_tensor())
+            return ShardedTensor._init_from_local_tensor(
+                res, rhs.sharding_spec(), list(rhs.size()), process_group=pg)  # type: ignore[arg-type]
+
+        elif isinstance(rhs, (int, float)):
+            assert isinstance(lhs, ShardedTensor)
+            res = op(lhs.local_tensor(), rhs)
+            return ShardedTensor._init_from_local_tensor(
+                res, lhs.sharding_spec(), list(lhs.size()), process_group=pg)  # type: ignore[arg-type]
+        else:
+            raise RuntimeError(
+                f"torch function '{op.__name__}', with args: {args} and "
+                f"kwargs: {kwargs} not supported yet for ShardedTensor!")
+
+binary_ops = [
+    # add
+    torch.add,
+    Tensor.add,
+    Tensor.__add__,
+    # sub
+    torch.sub,
+    Tensor.sub,
+    Tensor.__sub__,
+    Tensor.__rsub__,
+    # mul
+    torch.mul,
+    Tensor.mul,
+    Tensor.__mul__,
+    # div
+    torch.div,
+    Tensor.div,
+    Tensor.__div__,
+    Tensor.__rdiv__,
+]
+
+for op in binary_ops:
+    register_math_op(op)

--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -24,7 +24,6 @@ from .metadata import TensorProperties, ShardedTensorMetadata
 from .shard import Shard
 from .reshard import reshuffle_local_shard, reshard_local_shard
 from .utils import (
-    get_current_process_group,
     _flatten_tensor_size,
     _parse_and_validate_remote_device,
     _validate_output_tensor_for_gather,
@@ -820,7 +819,8 @@ class ShardedTensor(object):
         self._local_shards, self._metadata, pg_state, self._sharding_spec, self._init_rrefs = state
 
         # Setup process group
-        self._process_group = get_current_process_group()
+        from torch.distributed._shard.api import _get_current_process_group
+        self._process_group = _get_current_process_group()
 
         # Validate process group.
         local_rank = distributed_c10d.get_rank(self._process_group)

--- a/torch/distributed/_shard/sharded_tensor/utils.py
+++ b/torch/distributed/_shard/sharded_tensor/utils.py
@@ -1,6 +1,5 @@
 import collections.abc
 import copy
-from contextlib import contextmanager
 from typing import Optional, List, Sequence
 
 import torch
@@ -14,36 +13,6 @@ from torch.distributed._shard.sharding_spec._internals import (
 from torch.distributed._shard.metadata import ShardMetadata
 from .metadata import TensorProperties, ShardedTensorMetadata
 from .shard import Shard
-
-# Tracks the current process group in the load context manager.
-_CURRENT_PROCESS_GROUP = None
-
-@contextmanager
-def load_with_process_group(process_group):
-    """
-    Context manager to set the process group with which to load a ShardedTensor.
-    """
-    global _CURRENT_PROCESS_GROUP
-    if _CURRENT_PROCESS_GROUP is not None:
-        raise RuntimeError(
-            'ProcessGroup already set by previous "load_with_process_group" '
-            'context manager')
-    _CURRENT_PROCESS_GROUP = process_group
-    try:
-        yield process_group
-    finally:
-        _CURRENT_PROCESS_GROUP = None
-
-def get_current_process_group():
-    """
-    Retrieves the current process group set by ``load_with_process_group``.
-    If not set, it just returns the default group.
-    """
-    global _CURRENT_PROCESS_GROUP
-    if _CURRENT_PROCESS_GROUP is None:
-        return distributed_c10d._get_default_group()
-    else:
-        return _CURRENT_PROCESS_GROUP
 
 def _parse_and_validate_remote_device(pg, remote_device):
 

--- a/torch/distributed/nn/__init__.py
+++ b/torch/distributed/nn/__init__.py
@@ -1,2 +1,4 @@
-from .api.remote_module import RemoteModule
+import torch
+if torch.distributed.rpc.is_available():
+    from .api.remote_module import RemoteModule
 from .functional import *  # noqa: F403

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -154,7 +154,8 @@ class ParametrizationList(ModuleList):
             # Set the original to original so that the user does not need to re-register the parameter
             # manually in the optimiser
             with torch.no_grad():
-                original.set_(new)  # type: ignore[call-overload]
+                if original is not new:
+                    original.set_(new)  # type: ignore[call-overload]
             _register_parameter_or_buffer(self, "original", original)
         else:
             for i, originali in enumerate(new):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75299

As per the design in https://github.com/pytorch/pytorch/issues/72138, during
the forward pass of DDP ensure its parameters are wrapped by ReplicatedTensor.

This is done via the parametrizations API and the parametrizations are removed
after the forward pass is done.

Differential Revision: [D35162813](https://our.internmc.facebook.com/intern/diff/D35162813/)