### PR TITLE
[Quant][core][bc-breaking][improvements] Combined dispatch registration for max_pool2d & quantized_max_pool2d

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_int.h
@@ -55,6 +55,9 @@ public:
   Vectorized(int64_t val1, int64_t val2, int64_t val3, int64_t val4) {
     values = _mm256_setr_epi64x(val1, val2, val3, val4);
   }
+  Vectorized<int64_t> isnan() const {
+    return Vectorized<int64_t>(0);
+  }
   template <int64_t mask>
   static Vectorized<int64_t> blend(Vectorized<int64_t> a, Vectorized<int64_t> b) {
     __at_align__ int64_t tmp_values[size()];
@@ -177,6 +180,9 @@ public:
   Vectorized(int32_t val1, int32_t val2, int32_t val3, int32_t val4,
          int32_t val5, int32_t val6, int32_t val7, int32_t val8) {
     values = _mm256_setr_epi32(val1, val2, val3, val4, val5, val6, val7, val8);
+  }
+  Vectorized<int32_t> isnan() const {
+    return Vectorized<int32_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int32_t> blend(Vectorized<int32_t> a, Vectorized<int32_t> b) {
@@ -339,6 +345,9 @@ public:
          int16_t val13, int16_t val14, int16_t val15, int16_t val16) {
     values = _mm256_setr_epi16(val1, val2, val3, val4, val5, val6, val7, val8,
                                val9, val10, val11, val12, val13, val14, val15, val16);
+  }
+  Vectorized<int16_t> isnan() const {
+    return Vectorized<int16_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int16_t> blend(Vectorized<int16_t> a, Vectorized<int16_t> b) {
@@ -520,6 +529,9 @@ public:
                               val9, val10, val11, val12, val13, val14, val15, val16,
                               val17, val18, val19, val20, val21, val22, val23, val24,
                               val25, val26, val27, val28, val29, val30, val31, val32);
+  }
+  Vectorized<int8_t> isnan() const {
+    return Vectorized<int8_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int8_t> blend(Vectorized<int8_t> a, Vectorized<int8_t> b) {

--- a/aten/src/ATen/cpu/vec/vec512/vec512_int.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_int.h
@@ -56,6 +56,9 @@ public:
     values = _mm512_setr_epi64(val1, val2, val3, val4,
                                 val5, val6, val7, val8);
   }
+  Vectorized<int64_t> isnan() const {
+    return Vectorized<int64_t>(0);
+  }
   template <int64_t mask>
   static Vectorized<int64_t> blend(Vectorized<int64_t> a, Vectorized<int64_t> b) {
     return _mm512_mask_blend_epi64(mask, a.values, b.values);
@@ -189,6 +192,9 @@ public:
             int32_t val13, int32_t val14, int32_t val15, int32_t val16) {
     values = _mm512_setr_epi32(val1, val2, val3, val4, val5, val6, val7, val8,
                                val9, val10, val11, val12, val13, val14, val15, val16);
+  }
+  Vectorized<int32_t> isnan() const {
+    return Vectorized<int32_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int32_t> blend(Vectorized<int32_t> a, Vectorized<int32_t> b) {
@@ -384,6 +390,9 @@ public:
                               val24, val23, val22, val21, val20, val19, val18, val17,
                               val16, val15, val14, val13, val12, val11, val10, val9,
                               val8, val7, val6, val5, val4, val3, val2, val1);
+  }
+  Vectorized<int16_t> isnan() const {
+    return Vectorized<int16_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int16_t> blend(Vectorized<int16_t> a, Vectorized<int16_t> b) {
@@ -589,6 +598,9 @@ public:
                               val24, val23, val22, val21, val20, val19, val18, val17,
                               val16, val15, val14, val13, val12, val11, val10, val9,
                               val8, val7, val6, val5, val4, val3, val2, val1);
+  }
+  Vectorized<int8_t> isnan() const {
+    return Vectorized<int8_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int8_t> blend(Vectorized<int8_t> a, Vectorized<int8_t> b) {

--- a/aten/src/ATen/native/Pooling.cpp
+++ b/aten/src/ATen/native/Pooling.cpp
@@ -114,10 +114,6 @@ Tensor max_pool2d(
     IntArrayRef padding,
     IntArrayRef dilation,
     bool ceil_mode) {
-  if (self.is_quantized()) {
-    return at::quantized_max_pool2d(self, kernel_size, stride, padding,
-                                    dilation, ceil_mode);
-  }
   if (self.is_mkldnn()) {
     return at::mkldnn_max_pool2d(
         self, kernel_size, stride, padding, dilation, ceil_mode);

--- a/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
@@ -25,9 +25,8 @@ void cpu_max_pool(
   auto input = input_.contiguous();
   auto output = output_.contiguous();
   auto indices = indices_.contiguous();
-
-  auto input_data = input.data_ptr<scalar_t>();
-  auto output_data = output.data_ptr<scalar_t>();
+  auto input_data = input.is_quantized() ? reinterpret_cast<scalar_t*>(input.data_ptr()) : input.data_ptr<scalar_t>();
+  auto output_data = output.is_quantized() ? reinterpret_cast<scalar_t*>(output.data_ptr()) : output.data_ptr<scalar_t>();
   auto indices_data = indices.data_ptr<int64_t>();
 
   int64_t numel = output.numel();
@@ -56,10 +55,11 @@ void cpu_max_pool(
 
       // local pointers
       scalar_t* input_ptr = input_data + c * input_height * input_width;
-
       // compute local max
       int64_t maxindex = ih0 * input_width + iw0;
-      accscalar_t maxval = -std::numeric_limits<accscalar_t>::infinity();
+      accscalar_t maxval = input.is_quantized() ? std::numeric_limits<accscalar_t>::lowest()
+                                                : -std::numeric_limits<accscalar_t>::infinity();
+
       for (int64_t ih = ih0; ih < ih1; ih += dilationH) {
         for (int64_t iw = iw0; iw < iw1; iw += dilationW) {
           int64_t index = ih * input_width + iw;
@@ -104,8 +104,8 @@ void cpu_max_pool_channels_last(
   auto output = output_.contiguous(memory_format);
   auto indices = indices_.contiguous(memory_format);
 
-  auto input_data = input.data_ptr<scalar_t>();
-  auto output_data = output.data_ptr<scalar_t>();
+  auto input_data = input.is_quantized() ? reinterpret_cast<scalar_t*>(input.data_ptr()) : input.data_ptr<scalar_t>();
+  auto output_data = output.is_quantized() ? reinterpret_cast<scalar_t*>(output.data_ptr()) : output.data_ptr<scalar_t>();
   auto indices_data = indices.data_ptr<int64_t>();
 
   int64_t nbatch = input.size(0);
@@ -149,7 +149,7 @@ void cpu_max_pool_channels_last(
 
       // Pass I: init out lane
       iVec index0_vec = iVec(ih0 * input_width + iw0);
-      Vec out_vec = Vec(-std::numeric_limits<scalar_t>::infinity());
+      Vec out_vec = Vec(input.is_quantized() ? std::numeric_limits<scalar_t>::lowest() : -std::numeric_limits<scalar_t>::infinity());
       int64_t d1 = 0;
       for (; d1 < len; d1 += Vec::size()) {
         index0_vec.store(index_buffer.get() + d1);
@@ -157,7 +157,7 @@ void cpu_max_pool_channels_last(
       }
       for (; d1 < size; d1++) {
         ind[d1] = ih0 * input_width + iw0;
-        out[d1] = -std::numeric_limits<scalar_t>::infinity();
+        out[d1] = input.is_quantized() ? std::numeric_limits<scalar_t>::lowest() : -std::numeric_limits<scalar_t>::infinity();
       }
       // Pass II: compute local max
       for (int64_t ih = ih0; ih < ih1; ih += dilationH) {
@@ -171,7 +171,6 @@ void cpu_max_pool_channels_last(
             Vec val_vec = Vec::loadu(in + d2);
             iVec maxindex_vec = iVec::loadu(index_buffer.get() + d2);
             Vec maxval_vec = Vec::loadu(out + d2);
-
             // true = all ones, false = all zeros
             Vec mask = (val_vec > maxval_vec) | val_vec.isnan();
             iVec imask = vec::cast<integer_t>(mask);
@@ -461,19 +460,31 @@ void max_pool2d_kernel_impl(
     int dilationW, int dilationH) {
   switch (input.suggest_memory_format()) {
     case at::MemoryFormat::Contiguous: {
-      AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, input.scalar_type(), "max_pool2d", [&] {
-        if (input.scalar_type() == ScalarType::BFloat16) {
-          cpu_max_pool<BFloat16, /*accscalar_t*/float>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
-        } else {
-          cpu_max_pool<scalar_t, scalar_t>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
-        }
-      });
+      if (input.is_quantized()) {
+        AT_DISPATCH_QINT_TYPES(input.scalar_type(), "max_pool2d", [&] {
+          cpu_max_pool<scalar_t::underlying, scalar_t::underlying>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        });
+      } else {
+        AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, input.scalar_type(), "max_pool2d", [&] {
+          if (input.scalar_type() == ScalarType::BFloat16) {
+            cpu_max_pool<BFloat16, /*accscalar_t*/float>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+          } else {
+            cpu_max_pool<scalar_t, scalar_t>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+          }
+        });
+      }
       break;
     }
     case at::MemoryFormat::ChannelsLast: {
-      AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, input.scalar_type(), "max_pool2d_channels_last", [&] {
-        cpu_max_pool_channels_last<scalar_t>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
-      });
+      if (input.is_quantized()) {
+        AT_DISPATCH_QINT_TYPES(input.scalar_type(), "max_pool2d_channels_last", [&] {
+          cpu_max_pool_channels_last<scalar_t::underlying>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        });
+      } else {
+        AT_DISPATCH_ALL_TYPES_AND(ScalarType::BFloat16, input.scalar_type(), "max_pool2d_channels_last", [&] {
+          cpu_max_pool_channels_last<scalar_t>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        });
+      }
       break;
     }
     default:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2982,10 +2982,6 @@
   dispatch:
     QuantizedCPU: quantized_max_pool1d
 
-- func: quantized_max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
-  dispatch:
-    QuantizedCPU: quantized_max_pool2d
-
 - func: max_pool3d(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> Tensor
 
 # The CPU and GPU dispatch variants are named weirdly here because otherwise there
@@ -9371,6 +9367,7 @@
   dispatch:
     CPU: max_pool2d_with_indices_out_cpu
     CUDA: max_pool2d_with_indices_out_cuda
+    QuantizedCPU: max_pool2d_with_indices_out_quantized_cpu
 
 # Return: (Tensor output, Tensor indices)
 - func: max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -360,7 +360,6 @@ Pointwise Ops
     pow
     quantized_batch_norm
     quantized_max_pool1d
-    quantized_max_pool2d
     rad2deg
     real
     reciprocal

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -111,6 +111,7 @@ ALLOW_LIST = [
     ("aten::_transform_bias_rescale_qkv", datetime.date(9999, 1, 1)),
     ("aten::scatter_reduce.two", datetime.date(2022, 4, 15)),
     ("aten::_s_where", datetime.date(2022, 9, 30)),
+    ("aten::quantized_max_pool2d", datetime.date(2022, 4, 15)),
     ("quantized::conv2d_cudnn", datetime.date(2022, 3, 22)),
     ("quantized::conv2d_relu_cudnn", datetime.date(2022, 3, 22)),
     ("quantized::softmax", datetime.date(2022, 4, 15)),

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -111,7 +111,6 @@ ALLOW_LIST = [
     ("aten::_transform_bias_rescale_qkv", datetime.date(9999, 1, 1)),
     ("aten::scatter_reduce.two", datetime.date(2022, 4, 15)),
     ("aten::_s_where", datetime.date(2022, 9, 30)),
-    ("aten::quantized_max_pool2d", datetime.date(2022, 4, 15)),
     ("quantized::conv2d_cudnn", datetime.date(2022, 3, 22)),
     ("quantized::conv2d_relu_cudnn", datetime.date(2022, 3, 22)),
     ("quantized::softmax", datetime.date(2022, 4, 15)),

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -1262,10 +1262,22 @@ class TestQuantizedOps(TestCase):
             "nn.functional": torch.nn.functional.max_pool2d,
             "nn.quantized.functional": torch.nn.quantized.functional.max_pool2d
         }
+        ops_under_test_with_indices = {
+            "nn.functional with indices": torch.nn.functional.max_pool2d_with_indices,
+        }
 
         for name, op in ops_under_test.items():
             a_hat = op(qa, kernel_size=kernel, stride=stride, padding=padding,
                        dilation=dilation, ceil_mode=ceil_mode)
+            self.assertEqual(a_ref, a_hat.dequantize(),
+                             msg="{} results are off".format(name))
+        for name, op in ops_under_test_with_indices.items():
+            # we ignore the second value of returned tuple (indices);
+            # we cannot directly compare indices as multiple floating point values
+            # can map to the same integer, meaning that the indices we obtain aren't necessarily
+            # the same as operating on the fp tensor
+            a_hat = op(qa, kernel_size=kernel, stride=stride, padding=padding,
+                       dilation=dilation, ceil_mode=ceil_mode)[0]
             self.assertEqual(a_ref, a_hat.dequantize(),
                              msg="{} results are off".format(name))
         # Test the ops.quantized separately, because None is not treated.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11699,42 +11699,6 @@ Example::
         quantization_scheme=torch.per_tensor_affine, scale=1.5, zero_point=3)
 """)
 
-
-add_docstr(torch.quantized_max_pool2d,
-           r"""
-quantized_max_pool2d(input, kernel_size, stride=[], padding=0, dilation=1, ceil_mode=False) -> Tensor
-
-Applies a 2D max pooling over an input quantized tensor composed of several input planes.
-
-Arguments:
-    input (Tensor): quantized tensor
-    kernel_size (``list of int``): the size of the sliding window
-    stride (``list of int``, optional): the stride of the sliding window
-    padding (``list of int``, optional): padding to be added on both sides, must be >= 0 and <= kernel_size / 2
-    dilation (``list of int``, optional): The stride between elements within a sliding window, must be > 0. Default 1
-    ceil_mode (bool, optional):  If True, will use ceil instead of floor to compute the output shape.
-        Defaults to False.
-
-
-Returns:
-    Tensor: A quantized tensor with max_pool2d applied.
-
-Example::
-
-    >>> qx = torch.quantize_per_tensor(torch.rand(2, 2, 2, 2), 1.5, 3, torch.quint8)
-    >>> torch.quantized_max_pool2d(qx, [2,2])
-    tensor([[[[1.5000]],
-
-            [[1.5000]]],
-
-
-            [[[0.0000]],
-
-            [[0.0000]]]], size=(2, 2, 1, 1), dtype=torch.quint8,
-        quantization_scheme=torch.per_tensor_affine, scale=1.5, zero_point=3)
-""")
-
-
 add_docstr(torch.Generator,
            r"""
 Generator(device='cpu') -> Generator

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -862,8 +862,6 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
                                     col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1),
         torch.quantized_max_pool1d: (lambda input, kernel_size, stride=tuple(), padding=(0,),
                                      dilation=(1,), ceil_mode=False: -1),
-        torch.quantized_max_pool2d: (lambda input, kernel_size, stride=tuple(), padding=(0, 0),
-                                     dilation=(1, 1), ceil_mode=False: -1),
         torch.quantized_rnn_relu_cell: (lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih,
                                         col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1),
         torch.quantized_rnn_tanh_cell: (lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #75301
* __->__ #75300

Summary: This PR is part of a series of PRs addressing https://github.com/pytorch/pytorch/issues/54150,
related to using dispatcher for calls to quantized backends as opposed to if/else conditionals.
This particular PR removes the is_quantized check from max_pool2d, and implements a quantized
kernel for max_pool2d_with_indices. In addition, quantized_max_pool2d has
been removed from the frontend, which was previously not used anyways.

This PR also introduces isnan() support for vectorized int tensors.

This PR relies on https://github.com/pytorch/pytorch/pull/74560, which introduces
structured kernel support for quantized tensors.

Differential Revision: [D35419521](https://our.internmc.facebook.com/intern/diff/D35419521)