### PR TITLE
[Quant][core][bc-breaking][improvements] Combined dispatch registration for max_pool1d & quantized_max_pool1d

### DIFF
--- a/aten/src/ATen/native/MaxPooling.cpp
+++ b/aten/src/ATen/native/MaxPooling.cpp
@@ -97,10 +97,6 @@ Tensor max_pool1d(
     IntArrayRef padding,
     IntArrayRef dilation,
     bool ceil_mode) {
-  if (self.is_quantized()) {
-    return at::quantized_max_pool1d(
-        self, kernel_size, stride, padding, dilation, ceil_mode);
-  }
   if ((self.requires_grad() && at::GradMode::is_enabled()) ||
       self._fw_grad(/*level */ 0).defined() ||
       !self.device().is_cpu()) {

--- a/aten/src/ATen/native/cpu/MaxPooling.cpp
+++ b/aten/src/ATen/native/cpu/MaxPooling.cpp
@@ -4,6 +4,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/MaxPooling.h>
+#include <ATen/quantized/Quantizer.h>
 #include <c10/util/irange.h>
 
 namespace at {
@@ -32,25 +33,46 @@ void max_pool1d_impl(
     Tensor& output,
     const Tensor& input,
     const PoolingParams1D& p) {
-  AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "max_pool1d_impl", [&] {
-    const Tensor in = input.contiguous();
-    scalar_t* const OP = output.data_ptr<scalar_t>();
-    const scalar_t* const IP = in.data_ptr<scalar_t>();
+  if (input.is_quantized()) {
+    AT_DISPATCH_QINT_TYPES(input.scalar_type(), "max_pool1d_impl", [&] {
+      set_quantizer_(output, make_per_tensor_affine_quantizer(input.q_scale(), input.q_zero_point(), output.scalar_type()));
+      const Tensor in = input.contiguous();
+      const auto OP = reinterpret_cast<scalar_t::underlying*>(output.data_ptr());
+      const auto IP = reinterpret_cast<scalar_t::underlying*>(in.data_ptr());
 
-    // Value used for padding
-    constexpr scalar_t FILL = std::numeric_limits<scalar_t>::has_infinity
-        ? -std::numeric_limits<scalar_t>::infinity()
-        : std::numeric_limits<scalar_t>::lowest();
+      // Value used for padding
+      constexpr auto FILL = std::numeric_limits<scalar_t::underlying>::lowest();
 
-    at::parallel_for(0, p.NB * p.NC, 0, [&](int64_t begin, int64_t end) {
-      for (const auto it : c10::irange(begin, end)) {
-        scalar_t* op = OP + it * p.OW;
-        const scalar_t* ip = IP + it * p.IW;
-        std::fill_n(op, p.OW, FILL);
-        max_pool1d_kernel(op, ip, p);
-      }
+      at::parallel_for(0, p.NB * p.NC, 0, [&](int64_t begin, int64_t end) {
+        for (const auto it : c10::irange(begin, end)) {
+          scalar_t::underlying* op = OP + it * p.OW;
+          const scalar_t::underlying* ip = IP + it * p.IW;
+          std::fill_n(op, p.OW, FILL);
+          max_pool1d_kernel(op, ip, p);
+        }
+      });
     });
-  });
+  } else {
+    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "max_pool1d_impl", [&] {
+      const Tensor in = input.contiguous();
+      scalar_t* const OP = output.data_ptr<scalar_t>();
+      const scalar_t* const IP = in.data_ptr<scalar_t>();
+
+      // Value used for padding
+      constexpr scalar_t FILL = std::numeric_limits<scalar_t>::has_infinity
+          ? -std::numeric_limits<scalar_t>::infinity()
+          : std::numeric_limits<scalar_t>::lowest();
+
+      at::parallel_for(0, p.NB * p.NC, 0, [&](int64_t begin, int64_t end) {
+        for (const auto it : c10::irange(begin, end)) {
+          scalar_t* op = OP + it * p.OW;
+          const scalar_t* ip = IP + it * p.IW;
+          std::fill_n(op, p.OW, FILL);
+          max_pool1d_kernel(op, ip, p);
+        }
+      });
+    });
+  }
 }
 
 } // namespace

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2978,10 +2978,6 @@
   dispatch:
     MkldnnCPU: mkldnn_max_pool3d_backward
 
-- func: quantized_max_pool1d(Tensor self, int[1] kernel_size, int[1] stride=[], int[1] padding=0, int[1] dilation=1, bool ceil_mode=False) -> Tensor
-  dispatch:
-    QuantizedCPU: quantized_max_pool1d
-
 - func: max_pool3d(Tensor self, int[3] kernel_size, int[3] stride=[], int[3] padding=0, int[3] dilation=1, bool ceil_mode=False) -> Tensor
 
 # The CPU and GPU dispatch variants are named weirdly here because otherwise there

--- a/aten/src/ATen/native/quantized/cpu/qpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qpool.cpp
@@ -469,7 +469,7 @@ class QMaxPool_arr_args final {
       std::vector<int64_t> dilation,
       bool ceil_mode) {
     if (kSpatialDim == 1) {
-      return at::quantized_max_pool1d(qx, kernel_size, stride, padding,
+      return at::native::quantized_max_pool1d(qx, kernel_size, stride, padding,
                                       dilation, ceil_mode);
     } else if (kSpatialDim == 2) {
       return at::native::quantized_max_pool2d(qx, kernel_size, stride, padding,

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -359,7 +359,6 @@ Pointwise Ops
     positive
     pow
     quantized_batch_norm
-    quantized_max_pool1d
     rad2deg
     real
     reciprocal

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -112,6 +112,7 @@ ALLOW_LIST = [
     ("aten::scatter_reduce.two", datetime.date(2022, 4, 15)),
     ("aten::_s_where", datetime.date(2022, 9, 30)),
     ("aten::quantized_max_pool2d", datetime.date(2022, 4, 15)),
+    ("aten::quantized_max_pool1d", datetime.date(2022, 4, 15)),
     ("quantized::conv2d_cudnn", datetime.date(2022, 3, 22)),
     ("quantized::conv2d_relu_cudnn", datetime.date(2022, 3, 22)),
     ("quantized::softmax", datetime.date(2022, 4, 15)),

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -1212,10 +1212,23 @@ class TestQuantizedOps(TestCase):
             "nn.functional": torch.nn.functional.max_pool1d,
             "nn.quantized.functional": torch.nn.quantized.functional.max_pool1d
         }
+        ops_under_test_with_indices = {
+            "torch": torch.max_pool1d_with_indices,
+            "nn.functional": torch.nn.functional.max_pool1d_with_indices,
+        }
 
         for name, op in ops_under_test.items():
             a_hat = op(qa, kernel_size=kernel, stride=stride, padding=padding,
                        dilation=dilation, ceil_mode=ceil_mode)
+            self.assertEqual(a_ref, a_hat.dequantize(),
+                             msg="{} results are off".format(name))
+        for name, op in ops_under_test_with_indices.items():
+            # we ignore the second value of returned tuple (indices);
+            # we cannot directly compare indices as multiple floating point values
+            # can map to the same integer, meaning that the indices we obtain aren't necessarily
+            # the same as operating on the fp tensor
+            a_hat = op(qa, kernel_size=kernel, stride=stride, padding=padding,
+                       dilation=dilation, ceil_mode=ceil_mode)[0]
             self.assertEqual(a_ref, a_hat.dequantize(),
                              msg="{} results are off".format(name))
         # Test the ops.quantized separately, because None is not treated.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11671,34 +11671,6 @@ Example::
 """)
 
 
-add_docstr(torch.quantized_max_pool1d,
-           r"""
-quantized_max_pool1d(input, kernel_size, stride=[], padding=0, dilation=1, ceil_mode=False) -> Tensor
-
-Applies a 1D max pooling over an input quantized tensor composed of several input planes.
-
-Arguments:
-    input (Tensor): quantized tensor
-    kernel_size (list of int): the size of the sliding window
-    stride (``list of int``, optional): the stride of the sliding window
-    padding (``list of int``, opttional): padding to be added on both sides, must be >= 0 and <= kernel_size / 2
-    dilation (``list of int``, optional): The stride between elements within a sliding window, must be > 0. Default 1
-    ceil_mode (bool, optional):  If True, will use ceil instead of floor to compute the output shape.
-        Defaults to False.
-
-
-Returns:
-    Tensor: A quantized tensor with max_pool1d applied.
-
-Example::
-
-    >>> qx = torch.quantize_per_tensor(torch.rand(2, 2), 1.5, 3, torch.quint8)
-    >>> torch.quantized_max_pool1d(qx, [2])
-    tensor([[0.0000],
-            [1.5000]], size=(2, 1), dtype=torch.quint8,
-        quantization_scheme=torch.per_tensor_affine, scale=1.5, zero_point=3)
-""")
-
 add_docstr(torch.Generator,
            r"""
 Generator(device='cpu') -> Generator

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -860,8 +860,6 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
 
         torch.quantized_lstm_cell: (lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih,
                                     col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1),
-        torch.quantized_max_pool1d: (lambda input, kernel_size, stride=tuple(), padding=(0,),
-                                     dilation=(1,), ceil_mode=False: -1),
         torch.quantized_rnn_relu_cell: (lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih,
                                         col_offsets_hh, scale_ih, scale_hh, zero_point_ih, zero_point_hh: -1),
         torch.quantized_rnn_tanh_cell: (lambda input, hx, w_ih, w_hh, b_ih, b_hh, packed_ih, packed_hh, col_offsets_ih,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75301
* #75300

Summary: This PR is part of a series of PRs addressing https://github.com/pytorch/pytorch/issues/54150,
related to using dispatcher for calls to quantized backends as opposed to if/else conditionals.
This particular PR removes the is_quantized check from max_pool1d and modifies
max_pool1d_impl to be compatible with int tensors.
In addition, quantized_max_pool1d has
been removed from the frontend, which was previously not used anyways.

This PR relies on https://github.com/pytorch/pytorch/pull/74560, which introduces
structured kernel support for quantized tensors and https://github.com/pytorch/pytorch/pull/72353.

Differential Revision: [D35419522](https://our.internmc.facebook.com/intern/diff/D35419522)