### PR TITLE
add pytorch directory into Exclusions of Windows Defender

### DIFF
--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -31,6 +31,12 @@ runs:
       run: |
         Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
 
+    - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+      shell: powershell
+      run: |
+        $pytorch_root=[string](Get-Location)
+        Add-MpPreference -ExclusionPath $pytorch_root
+
     - name: Install Visual Studio 2019 toolchain
       shell: powershell
       env:

--- a/.github/actions/setup-win/action.yml
+++ b/.github/actions/setup-win/action.yml
@@ -34,8 +34,7 @@ runs:
     - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
       shell: powershell
       run: |
-        $pytorch_root=[string](Get-Location)
-        Add-MpPreference -ExclusionPath $pytorch_root
+        Set-MpPreference -ExclusionPath $(Get-Location).tostring()
 
     - name: Install Visual Studio 2019 toolchain
       shell: powershell

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -131,6 +131,11 @@ on:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
 {%- endmacro -%}
 
 {%- macro setup_ec2_linux() -%}

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -134,8 +134,8 @@ on:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
 {%- endmacro -%}
 
 {%- macro setup_ec2_linux() -%}

--- a/.github/templates/common.yml.j2
+++ b/.github/templates/common.yml.j2
@@ -134,8 +134,7 @@ on:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
 {%- endmacro -%}
 
 {%- macro setup_ec2_linux() -%}

--- a/.github/workflows/generated-windows-binary-conda-nightly.yml
+++ b/.github/workflows/generated-windows-binary-conda-nightly.yml
@@ -77,8 +77,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -181,8 +180,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -407,8 +405,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -512,8 +509,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -739,8 +735,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -844,8 +839,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1070,8 +1064,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1174,8 +1167,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1400,8 +1392,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1505,8 +1496,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1732,8 +1722,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1837,8 +1826,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2063,8 +2051,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2167,8 +2154,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2393,8 +2379,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2498,8 +2483,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2725,8 +2709,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2830,8 +2813,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3056,8 +3038,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3160,8 +3141,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3386,8 +3366,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3491,8 +3470,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3718,8 +3696,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3823,8 +3800,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-conda-nightly.yml
+++ b/.github/workflows/generated-windows-binary-conda-nightly.yml
@@ -74,6 +74,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -173,6 +178,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -394,6 +404,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -494,6 +509,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -716,6 +736,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -816,6 +841,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1037,6 +1067,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1136,6 +1171,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1357,6 +1397,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1457,6 +1502,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1679,6 +1729,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1779,6 +1834,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2000,6 +2060,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2099,6 +2164,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2320,6 +2390,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2420,6 +2495,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2642,6 +2722,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2742,6 +2827,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2963,6 +3053,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3062,6 +3157,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3283,6 +3383,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3383,6 +3488,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3605,6 +3715,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3705,6 +3820,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-conda-nightly.yml
+++ b/.github/workflows/generated-windows-binary-conda-nightly.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -181,8 +181,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -407,8 +407,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -512,8 +512,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -739,8 +739,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -844,8 +844,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1070,8 +1070,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1174,8 +1174,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1400,8 +1400,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1505,8 +1505,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1732,8 +1732,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1837,8 +1837,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2063,8 +2063,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2167,8 +2167,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2393,8 +2393,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2498,8 +2498,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2725,8 +2725,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2830,8 +2830,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3056,8 +3056,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3160,8 +3160,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3386,8 +3386,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3491,8 +3491,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3718,8 +3718,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3823,8 +3823,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
@@ -73,6 +73,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -176,6 +181,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -184,8 +184,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
@@ -76,8 +76,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -184,8 +183,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -81,8 +81,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -189,8 +188,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -422,8 +420,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -530,8 +527,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -763,8 +759,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -871,8 +866,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1104,8 +1098,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1212,8 +1205,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1446,8 +1438,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1555,8 +1546,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1790,8 +1780,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1899,8 +1888,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2134,8 +2122,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2243,8 +2230,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2478,8 +2464,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2587,8 +2572,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2822,8 +2806,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2931,8 +2914,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3166,8 +3148,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3275,8 +3256,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3510,8 +3490,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3619,8 +3598,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3854,8 +3832,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3963,8 +3940,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -78,6 +78,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -181,6 +186,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -409,6 +419,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -512,6 +527,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -740,6 +760,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -843,6 +868,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1071,6 +1101,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1174,6 +1209,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1403,6 +1443,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1507,6 +1552,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1737,6 +1787,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1841,6 +1896,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2071,6 +2131,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2175,6 +2240,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2405,6 +2475,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2509,6 +2584,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2739,6 +2819,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2843,6 +2928,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3073,6 +3163,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3177,6 +3272,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3407,6 +3507,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3511,6 +3616,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3741,6 +3851,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3845,6 +3960,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -81,8 +81,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -189,8 +189,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -422,8 +422,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -530,8 +530,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -763,8 +763,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -871,8 +871,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1104,8 +1104,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1212,8 +1212,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1446,8 +1446,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1555,8 +1555,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1790,8 +1790,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1899,8 +1899,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2134,8 +2134,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2243,8 +2243,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2478,8 +2478,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2587,8 +2587,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2822,8 +2822,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2931,8 +2931,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3166,8 +3166,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3275,8 +3275,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3510,8 +3510,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3619,8 +3619,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3854,8 +3854,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3963,8 +3963,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-release-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-master.yml
@@ -73,6 +73,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -176,6 +181,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-release-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-master.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -184,8 +184,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-release-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-master.yml
@@ -76,8 +76,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -184,8 +183,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -81,8 +81,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -189,8 +188,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -422,8 +420,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -530,8 +527,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -763,8 +759,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -871,8 +866,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1104,8 +1098,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1212,8 +1205,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1446,8 +1438,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1555,8 +1546,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1790,8 +1780,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1899,8 +1888,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2134,8 +2122,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2243,8 +2230,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2478,8 +2464,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2587,8 +2572,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2822,8 +2806,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2931,8 +2914,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3166,8 +3148,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3275,8 +3256,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3510,8 +3490,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3619,8 +3598,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3854,8 +3832,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3963,8 +3940,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -78,6 +78,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -181,6 +186,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -409,6 +419,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -512,6 +527,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -740,6 +760,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -843,6 +868,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1071,6 +1101,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1174,6 +1209,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1403,6 +1443,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1507,6 +1552,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1737,6 +1787,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1841,6 +1896,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2071,6 +2131,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2175,6 +2240,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2405,6 +2475,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2509,6 +2584,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2739,6 +2819,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2843,6 +2928,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3073,6 +3163,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3177,6 +3272,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3407,6 +3507,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3511,6 +3616,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3741,6 +3851,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3845,6 +3960,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -81,8 +81,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -189,8 +189,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -422,8 +422,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -530,8 +530,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -763,8 +763,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -871,8 +871,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1104,8 +1104,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1212,8 +1212,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1446,8 +1446,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1555,8 +1555,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1790,8 +1790,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1899,8 +1899,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2134,8 +2134,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2243,8 +2243,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2478,8 +2478,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2587,8 +2587,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2822,8 +2822,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2931,8 +2931,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3166,8 +3166,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3275,8 +3275,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3510,8 +3510,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3619,8 +3619,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3854,8 +3854,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3963,8 +3963,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-wheel-master.yml
+++ b/.github/workflows/generated-windows-binary-wheel-master.yml
@@ -70,6 +70,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -170,6 +175,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-wheel-master.yml
+++ b/.github/workflows/generated-windows-binary-wheel-master.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -178,8 +178,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-wheel-master.yml
+++ b/.github/workflows/generated-windows-binary-wheel-master.yml
@@ -73,8 +73,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -178,8 +177,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -77,8 +77,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -181,8 +180,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -407,8 +405,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -512,8 +509,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -739,8 +735,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -844,8 +839,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1070,8 +1064,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1174,8 +1167,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1400,8 +1392,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1505,8 +1496,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1732,8 +1722,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1837,8 +1826,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2063,8 +2051,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2167,8 +2154,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2393,8 +2379,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2498,8 +2483,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2725,8 +2709,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2830,8 +2813,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3056,8 +3038,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3160,8 +3141,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3386,8 +3366,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3491,8 +3470,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3718,8 +3696,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3823,8 +3800,7 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          $pytorch_root=[string](Get-Location)
-          Add-MpPreference -ExclusionPath $pytorch_root
+          Set-MpPreference -ExclusionPath $(Get-Location).tostring()
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -74,6 +74,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -173,6 +178,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -394,6 +404,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -494,6 +509,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -716,6 +736,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -816,6 +841,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1037,6 +1067,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1136,6 +1171,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1357,6 +1397,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1457,6 +1502,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1679,6 +1729,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1779,6 +1834,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2000,6 +2060,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2099,6 +2164,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2320,6 +2390,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2420,6 +2495,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2642,6 +2722,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2742,6 +2827,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2963,6 +3053,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3062,6 +3157,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3283,6 +3383,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3383,6 +3488,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3605,6 +3715,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3705,6 +3820,11 @@ jobs:
         shell: powershell
         run: |
           Set-ItemProperty -Path "HKLM:\\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+      - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
+        shell: powershell
+        run: |
+          echo ${{ pytorch_directory }}
+          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -181,8 +181,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -407,8 +407,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -512,8 +512,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -739,8 +739,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -844,8 +844,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1070,8 +1070,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1174,8 +1174,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1400,8 +1400,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1505,8 +1505,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1732,8 +1732,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -1837,8 +1837,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2063,8 +2063,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2167,8 +2167,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2393,8 +2393,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2498,8 +2498,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2725,8 +2725,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -2830,8 +2830,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3056,8 +3056,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3160,8 +3160,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3386,8 +3386,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3491,8 +3491,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3718,8 +3718,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.
@@ -3823,8 +3823,8 @@ jobs:
       - name: Disables Windows Defender scheduled and real-time scanning for files in pytorch directory.
         shell: powershell
         run: |
-          echo ${{ pytorch_directory }}
-          Add-MpPreference -ExclusionPath ${{ pytorch_directory }}
+          $pytorch_root=[string](Get-Location)
+          Add-MpPreference -ExclusionPath $pytorch_root
       # NOTE: These environment variables are put here so that they can be applied on every job equally
       #       They are also here because setting them at a workflow level doesn't give us access to the
       #       runner.temp variable, which we need.


### PR DESCRIPTION
There's still [mt.exe exception in nightly CI](https://github.com/pytorch/pytorch/runs/5783636743?check_suite_focus=true#step:11:7204)
It looks that issue #66278 hasn't been resolved.
It might have something with windows defender.

So,  we could try adding the pytorch directory into Windows defender exclusions and see the data in the next weeks.

verification link:
https://github.com/pytorch/pytorch/runs/5854202308?check_suite_focus=true#step:3:55
