### PR TITLE
[FSDP][Easy] Fix return in docstrings

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -2095,10 +2095,10 @@ class FullyShardedDataParallel(nn.Module):
 
         Returns:
             Dict[str, Any]: A :class:`dict` containing the optimizer state for
-                ``model`` 's original unflattened parameters and including keys
-                "state" and "param_groups" following the convention of
-                :meth:`torch.optim.Optimizer.state_dict` if on rank 0, and an
-                empty :class:`dict` otherwise.
+            ``model`` 's original unflattened parameters and including keys
+            "state" and "param_groups" following the convention of
+            :meth:`torch.optim.Optimizer.state_dict` if on rank 0, and an empty
+            :class:`dict` otherwise.
         """
         osd = optim.state_dict()
         osd_state, osd_param_groups = osd["state"], osd["param_groups"]  # alias
@@ -2225,8 +2225,8 @@ class FullyShardedDataParallel(nn.Module):
 
         Returns:
             Dict[str, Any]: The full optimizer state dict remapped to flattened
-                parameters instead of unflattened parameters and restricted to
-                only include this rank's part of the optimizer state.
+            parameters instead of unflattened parameters and restricted to only
+            include this rank's part of the optimizer state.
         """
         full_osd = full_optim_state_dict  # alias
         if "state" not in full_osd or "param_groups" not in full_osd:
@@ -2326,7 +2326,7 @@ class FullyShardedDataParallel(nn.Module):
 
         Returns:
             Dict[str, Any]: The optimizer state dict re-keyed using the
-                parameter keys specified by ``optim_state_key_type``.
+            parameter keys specified by ``optim_state_key_type``.
         """
         assert optim_state_key_type in \
             (OptimStateKeyType.PARAM_NAME, OptimStateKeyType.PARAM_ID)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -2094,11 +2094,11 @@ class FullyShardedDataParallel(nn.Module):
                 ``model.parameters()``. (Default: ``None``)
 
         Returns:
-            full_osd (Dict[str, Any]): A :class:`dict` containing the optimizer
-                state for ``model`` 's original unflattened parameters and
-                including keys "state" and "param_groups" following the
-                convention of :meth:`torch.optim.Optimizer.state_dict` if on
-                rank 0, and an empty :class:`dict` otherwise.
+            Dict[str, Any]: A :class:`dict` containing the optimizer state for
+                ``model`` 's original unflattened parameters and including keys
+                "state" and "param_groups" following the convention of
+                :meth:`torch.optim.Optimizer.state_dict` if on rank 0, and an
+                empty :class:`dict` otherwise.
         """
         osd = optim.state_dict()
         osd_state, osd_param_groups = osd["state"], osd["param_groups"]  # alias
@@ -2224,10 +2224,9 @@ class FullyShardedDataParallel(nn.Module):
                 ``model.parameters()``. (Default: ``None``)
 
         Returns:
-            sharded_optim_state_dict (Dict[str, Any]): The full optimizer
-                state dict remapped to flattened parameters instead of
-                unflattened parameters and restricted to only include this
-                rank's part of the optimizer state.
+            Dict[str, Any]: The full optimizer state dict remapped to flattened
+                parameters instead of unflattened parameters and restricted to
+                only include this rank's part of the optimizer state.
         """
         full_osd = full_optim_state_dict  # alias
         if "state" not in full_osd or "param_groups" not in full_osd:
@@ -2326,8 +2325,8 @@ class FullyShardedDataParallel(nn.Module):
             >>> wrapped_optim.load_state_dict(sharded_osd)
 
         Returns:
-            rekeyed_osd (Dict[str, Any]): The optimizer state dict re-keyed
-                using the parameter keys specified by ``optim_state_key_type``.
+            Dict[str, Any]: The optimizer state dict re-keyed using the
+                parameter keys specified by ``optim_state_key_type``.
         """
         assert optim_state_key_type in \
             (OptimStateKeyType.PARAM_NAME, OptimStateKeyType.PARAM_ID)

--- a/torch/distributed/fsdp/optim_utils.py
+++ b/torch/distributed/fsdp/optim_utils.py
@@ -88,7 +88,7 @@ def _communicate_optim_state(
     otherwise (where the plus 1 comes from all-gathering the padding per rank).
 
     Args:
-        flat_param (FlatParameter): The flattened parameter. flat_param_state
+        flat_param (FlatParameter): The flattened parameter.
         flat_param_state (Dict[str, Any]): The entry in the "state" part of the
             optimizer state dict corresponding to the flattened parameter.
 

--- a/torch/distributed/fsdp/optim_utils.py
+++ b/torch/distributed/fsdp/optim_utils.py
@@ -89,8 +89,8 @@ def _communicate_optim_state(
 
     Args:
         flat_param (FlatParameter): The flattened parameter. flat_param_state
-        (Dict[str, Any]): The entry in the "state" part of the optimizer state
-        dict corresponding to the flattened parameter.
+        flat_param_state (Dict[str, Any]): The entry in the "state" part of the
+            optimizer state dict corresponding to the flattened parameter.
 
     Returns:
         ConsolidatedOptimState: Consolidated optimizer state for

--- a/torch/distributed/fsdp/optim_utils.py
+++ b/torch/distributed/fsdp/optim_utils.py
@@ -52,13 +52,12 @@ def _unflatten_optim_state(
             in the "state" part of the optimizer state dict.
 
     Returns:
-        unflat_param_state (List[Dict[str, Any]]): A :class:`list` holding
-            the entries in the "state" part of the optimizer state dict
-            corresponding to the unflattened parameters comprising the
-            flattened parameter ``flat_param`` if on the target rank or an
-            empty :class:`list` otherwise. The final optimizer state dict will
-            need to map these entries using the proper unflattened parameter
-            IDs.
+        List[Dict[str, Any]]: A :class:`list` holding the entries in the
+            "state" part of the optimizer state dict corresponding to the
+            unflattened parameters comprising the flattened parameter
+            ``flat_param`` if on the target rank or an empty :class:`list`
+            otherwise. The final optimizer state dict will need to map these
+            entries using the proper unflattened parameter IDs.
     """
     assert sum(p is flat_param for p in fsdp_module.params) == 1, \
         "`fsdp_module` must own `flat_param`"
@@ -94,7 +93,7 @@ def _communicate_optim_state(
         the optimizer state dict corresponding to the flattened parameter.
 
     Returns:
-        state (ConsolidatedOptimState): Consolidated optimizer state for
+        ConsolidatedOptimState: Consolidated optimizer state for
             ``flat_param``; the state is not populated for non-target ranks.
     """
     param_index = -1
@@ -158,12 +157,11 @@ def _unflatten_communicated_optim_state(
         state (ConsolidatedOptimState): Consolidated optimizer state.
 
     Returns:
-        unflat_param_state (List[Dict[str, Any]]): A :class:`list` holding
-            the entries in the "state" part of the optimizer state dict
-            corresponding to the unflattened parameters comprising the
-            flattened parameter ``flat_param``. The final optimizer state dict
-            will need to map these entries using the proper unflattened
-            parameter IDs.
+        List[Dict[str, Any]]: A :class:`list` holding the entries in the
+            "state" part of the optimizer state dict corresponding to the
+            unflattened parameters comprising the flattened parameter
+            ``flat_param``. The final optimizer state dict will need to map
+            these entries using the proper unflattened parameter IDs.
     """
     assert sum(p is flat_param for p in fsdp_module.params) == 1, \
         "`fsdp_module` must own `flat_param`"
@@ -216,10 +214,10 @@ def _flatten_optim_state(
         flat_param (FlatParameter): The flattened parameter.
 
     Returns:
-        flat_state (Dict[str, Any]): A :class:`dict` mapping state names to
-            their values for a particular flattened parameter. The sharded
-            optimizer state dict's "state" part will map the flattened
-            parameter ID to this returned value.
+        Dict[str, Any]: A :class:`dict` mapping state names to their values
+            for a particular flattened parameter. The sharded optimizer state
+            dict's "state" part will map the flattened parameter ID to this
+            returned value.
     """
     num_unflat_params = len(unflat_param_names)
     assert num_unflat_params > 0, \
@@ -339,11 +337,10 @@ def _flatten_tensor_optim_state(
         flat_param (FlatParameter): The flattened parameter.
 
     Returns:
-        flat_tensor (torch.Tensor): A flattened tensor containing the optimizer
-            state corresponding to ``state_name`` constructed by concatenating
-            the unflattened parameter tensor states in ``pos_dim_tensors``
-            (using zero tensors for any unflattened parameters without the
-            state).
+        torch.Tensor: A flattened tensor containing the optimizer state
+            corresponding to ``state_name`` constructed by concatenating the
+            unflattened parameter tensor states in ``pos_dim_tensors`` (using
+            zero tensors for any unflattened parameters without the state).
     """
     non_none_tensors = [t for t in pos_dim_tensors if t is not None]
     # Check that all are tensors with the same dtype
@@ -429,9 +426,9 @@ def _flatten_zero_dim_tensor_optim_state(
             parameter names corresponding to the single flattened parameter.
 
     Returns:
-        zero_dim_tensor (torch.Tensor): A zero-dimensional tensor giving the
-            value of the state ``state_name`` for all unflattened parameters
-            corresponding to the names ``unflat_param_names``.
+        torch.Tensor: A zero-dimensional tensor giving the value of the state
+            ``state_name`` for all unflattened parameters corresponding to the
+            names ``unflat_param_names``.
     """
     non_none_tensors = [t for t in zero_dim_tensors if t is not None]
     # Enforce that all have the same value and dtype
@@ -472,9 +469,9 @@ def _flatten_non_tensor_optim_state(
             parameter names corresponding to the single flattened parameter.
 
     Returns:
-        non_tensor (Any): A non-tensor giving the value of the state
-            ``state_name`` for all unflattened parameters corresponding to the
-            names ``unflat_param_names``.
+        Any: A non-tensor giving the value of the state ``state_name`` for all
+            unflattened parameters corresponding to the names
+            ``unflat_param_names``.
     """
     non_none_non_tensors = [nt for nt in non_tensors if nt is not None]
     # Enforce that all have the same value (same type already checked)
@@ -538,9 +535,9 @@ def _get_param_id_to_param(
             input was ``model.parameters()``. (Default: ``None``)
 
     Returns:
-        param_id_to_param (List[torch.nn.Parameter]): Mapping from parameter
-            IDs to parameters, where the parameter ID is implicitly the index
-            in the :class:`list`.
+        List[torch.nn.Parameter]: Mapping from parameter IDs to parameters,
+            where the parameter ID is implicitly the index in the
+            :class:`list`.
     """
     # Assume the standard case of passing `model.parameters()` to the optimizer
     # if `optim_input` is not specified
@@ -610,9 +607,9 @@ def _get_unflat_to_flat_param_ids(
             unflattened parameter IDs.
 
     Returns:
-        unflat_to_flat_param_ids (List[int]): A mapping from unflattened
-            parameter ID to flattened parameter ID, where the unflattened
-            parameter ID is the index in the :class:`list`.
+        List[int]: A mapping from unflattened parameter ID to flattened
+            parameter ID, where the unflattened parameter ID is the index in
+            the :class:`list`.
     """
     # Construct as a dict and then convert to list
     unflat_to_flat_param_ids = {}

--- a/torch/distributed/fsdp/optim_utils.py
+++ b/torch/distributed/fsdp/optim_utils.py
@@ -53,11 +53,11 @@ def _unflatten_optim_state(
 
     Returns:
         List[Dict[str, Any]]: A :class:`list` holding the entries in the
-            "state" part of the optimizer state dict corresponding to the
-            unflattened parameters comprising the flattened parameter
-            ``flat_param`` if on the target rank or an empty :class:`list`
-            otherwise. The final optimizer state dict will need to map these
-            entries using the proper unflattened parameter IDs.
+        "state" part of the optimizer state dict corresponding to the
+        unflattened parameters comprising the flattened parameter
+        ``flat_param`` if on the target rank or an empty :class:`list`
+        otherwise. The final optimizer state dict will need to map these
+        entries using the proper unflattened parameter IDs.
     """
     assert sum(p is flat_param for p in fsdp_module.params) == 1, \
         "`fsdp_module` must own `flat_param`"
@@ -88,13 +88,13 @@ def _communicate_optim_state(
     otherwise (where the plus 1 comes from all-gathering the padding per rank).
 
     Args:
-        flat_param (FlatParameter): The flattened parameter.
-        flat_param_state (Dict[str, Any]): The entry in the "state" part of
-        the optimizer state dict corresponding to the flattened parameter.
+        flat_param (FlatParameter): The flattened parameter. flat_param_state
+        (Dict[str, Any]): The entry in the "state" part of the optimizer state
+        dict corresponding to the flattened parameter.
 
     Returns:
         ConsolidatedOptimState: Consolidated optimizer state for
-            ``flat_param``; the state is not populated for non-target ranks.
+        ``flat_param``; the state is not populated for non-target ranks.
     """
     param_index = -1
     for i, param in enumerate(fsdp_module.params):
@@ -158,10 +158,10 @@ def _unflatten_communicated_optim_state(
 
     Returns:
         List[Dict[str, Any]]: A :class:`list` holding the entries in the
-            "state" part of the optimizer state dict corresponding to the
-            unflattened parameters comprising the flattened parameter
-            ``flat_param``. The final optimizer state dict will need to map
-            these entries using the proper unflattened parameter IDs.
+        "state" part of the optimizer state dict corresponding to the
+        unflattened parameters comprising the flattened parameter
+        ``flat_param``. The final optimizer state dict will need to map these
+        entries using the proper unflattened parameter IDs.
     """
     assert sum(p is flat_param for p in fsdp_module.params) == 1, \
         "`fsdp_module` must own `flat_param`"
@@ -214,10 +214,10 @@ def _flatten_optim_state(
         flat_param (FlatParameter): The flattened parameter.
 
     Returns:
-        Dict[str, Any]: A :class:`dict` mapping state names to their values
-            for a particular flattened parameter. The sharded optimizer state
-            dict's "state" part will map the flattened parameter ID to this
-            returned value.
+        Dict[str, Any]: A :class:`dict` mapping state names to their values for
+        a particular flattened parameter. The sharded optimizer state dict's
+        "state" part will map the flattened parameter ID to this returned
+        value.
     """
     num_unflat_params = len(unflat_param_names)
     assert num_unflat_params > 0, \
@@ -338,9 +338,9 @@ def _flatten_tensor_optim_state(
 
     Returns:
         torch.Tensor: A flattened tensor containing the optimizer state
-            corresponding to ``state_name`` constructed by concatenating the
-            unflattened parameter tensor states in ``pos_dim_tensors`` (using
-            zero tensors for any unflattened parameters without the state).
+        corresponding to ``state_name`` constructed by concatenating the
+        unflattened parameter tensor states in ``pos_dim_tensors`` (using zero
+        tensors for any unflattened parameters without the state).
     """
     non_none_tensors = [t for t in pos_dim_tensors if t is not None]
     # Check that all are tensors with the same dtype
@@ -427,8 +427,8 @@ def _flatten_zero_dim_tensor_optim_state(
 
     Returns:
         torch.Tensor: A zero-dimensional tensor giving the value of the state
-            ``state_name`` for all unflattened parameters corresponding to the
-            names ``unflat_param_names``.
+        ``state_name`` for all unflattened parameters corresponding to the
+        names ``unflat_param_names``.
     """
     non_none_tensors = [t for t in zero_dim_tensors if t is not None]
     # Enforce that all have the same value and dtype
@@ -470,8 +470,8 @@ def _flatten_non_tensor_optim_state(
 
     Returns:
         Any: A non-tensor giving the value of the state ``state_name`` for all
-            unflattened parameters corresponding to the names
-            ``unflat_param_names``.
+        unflattened parameters corresponding to the names
+        ``unflat_param_names``.
     """
     non_none_non_tensors = [nt for nt in non_tensors if nt is not None]
     # Enforce that all have the same value (same type already checked)
@@ -536,8 +536,7 @@ def _get_param_id_to_param(
 
     Returns:
         List[torch.nn.Parameter]: Mapping from parameter IDs to parameters,
-            where the parameter ID is implicitly the index in the
-            :class:`list`.
+        where the parameter ID is implicitly the index in the :class:`list`.
     """
     # Assume the standard case of passing `model.parameters()` to the optimizer
     # if `optim_input` is not specified
@@ -608,8 +607,8 @@ def _get_unflat_to_flat_param_ids(
 
     Returns:
         List[int]: A mapping from unflattened parameter ID to flattened
-            parameter ID, where the unflattened parameter ID is the index in
-            the :class:`list`.
+        parameter ID, where the unflattened parameter ID is the index in the
+        :class:`list`.
     """
     # Construct as a dict and then convert to list
     unflat_to_flat_param_ids = {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #75431 [FSDP] Add `ignored_modules` ctor arg
* #75430 [FSDP] Fix `_get_param_to_unflat_param_names()` for shared params
* **#75327 [FSDP][Easy] Fix return in docstrings**

- This fixes the return docstrings for optim state checkpointing, following https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html as described in the contributing guide.
    - The return value name should not be specified, and there should not be an additional indent for lines after the first.
- I am unable to fix my docs rendering locally, so I am opening the PR directly.
- We can normalize the documentation for the rest of FSDP in later follow-ups.

Differential Revision: [D35431794](https://our.internmc.facebook.com/intern/diff/D35431794)