### PR TITLE
[PyTorch] Add test for all-masked case for native softmax

### DIFF
--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -9,6 +9,7 @@
 #include <ATen/NamedTensorUtils.h>
 
 #include <c10/core/TensorOptions.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/irange.h>
 
 namespace at {
@@ -148,7 +149,7 @@ void host_softmax(
   int64_t grain_size = std::min(internal::GRAIN_SIZE / dim_size, (int64_t)1);
   parallel_for(
       0, outer_size * inner_size, grain_size,
-      [&](int64_t begin, int64_t end) {
+      [&](int64_t begin, int64_t end) __ubsan_ignore_float_divide_by_zero__ {
         for (const auto i : c10::irange(begin, end)) {
           int64_t outer_idx = i / inner_size;
           int64_t inner_idx = i % inner_size;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16168,6 +16168,12 @@ class TestNNDeviceType(NNTestCase):
                     rtol = None
                 self.assertEqual(grad, grad_check, msg=msg, atol=atol, rtol=rtol)
 
+    def _slow_masked_softmax(self, input, mask):
+        exp = torch.exp(input)
+        exp = exp * mask
+        s = exp.sum(dim=3, keepdim=True).expand(exp.size())
+        return exp / s
+
     def test_masked_softmax(self, device):
         sizes = [(1, 1, 32), (3, 16, 310), (12, 4, 1024), (4, 2, 1200)]
         for (B, num_heads, L) in sizes:
@@ -16181,12 +16187,18 @@ class TestNNDeviceType(NNTestCase):
             mask = ~mask
             mask = mask.float()
 
-            def slow_masked_softmax(input, mask):
-                exp = torch.exp(input)
-                exp = exp * mask
-                s = exp.sum(dim=3, keepdim=True).expand(exp.size())
-                return exp / s
-            pt_res = slow_masked_softmax(input, mask)
+            pt_res = self._slow_masked_softmax(input, mask)
+            self.assertEqual(pt_res, native_res, exact_dtype=True)
+
+    def test_masked_softmax_all_masked(self, device):
+        sizes = [(1, 1, 32), (3, 16, 310), (12, 4, 1024), (4, 2, 1200)]
+        for (B, num_heads, L) in sizes:
+            input = torch.randn((B, num_heads, L, L), device=device)
+            mask = torch.ones_like(input, device=device, dtype=torch.bool)
+            native_res = torch._masked_softmax(input, mask)
+            mask = ~mask
+            mask = mask.float()
+            pt_res = self._slow_masked_softmax(input, mask)
             self.assertEqual(pt_res, native_res, exact_dtype=True)
 
     @onlyCUDA
@@ -16205,12 +16217,7 @@ class TestNNDeviceType(NNTestCase):
         mask = ~mask
         mask = mask.float()
 
-        def slow_masked_softmax(input, mask):
-            exp = torch.exp(input)
-            exp = exp * mask
-            s = exp.sum(dim=3, keepdim=True).expand(exp.size())
-            return exp / s
-        pt_res = slow_masked_softmax(input, mask)
+        pt_res = self._slow_masked_softmax(input, mask)
         self.assertEqual(pt_res, native_res, exact_dtype=True)
 
     # Test fails on Vg20


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75348

It returns all NaNs. CUDA implementation required a fix for this.

Differential Revision: [D35327730](https://our.internmc.facebook.com/intern/diff/D35327730/)