### PR TITLE
[Quant][core][improvements] Combined dispatch registration for max_pool2d & quantized_max_pool2d and implemented max_pool2d_with_indices_out_quantized_cpu

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_int.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_int.h
@@ -55,6 +55,9 @@ public:
   Vectorized(int64_t val1, int64_t val2, int64_t val3, int64_t val4) {
     values = _mm256_setr_epi64x(val1, val2, val3, val4);
   }
+  Vectorized<int64_t> isnan() const {
+    return Vectorized<int64_t>(0);
+  }
   template <int64_t mask>
   static Vectorized<int64_t> blend(Vectorized<int64_t> a, Vectorized<int64_t> b) {
     __at_align__ int64_t tmp_values[size()];
@@ -177,6 +180,9 @@ public:
   Vectorized(int32_t val1, int32_t val2, int32_t val3, int32_t val4,
          int32_t val5, int32_t val6, int32_t val7, int32_t val8) {
     values = _mm256_setr_epi32(val1, val2, val3, val4, val5, val6, val7, val8);
+  }
+  Vectorized<int32_t> isnan() const {
+    return Vectorized<int32_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int32_t> blend(Vectorized<int32_t> a, Vectorized<int32_t> b) {
@@ -339,6 +345,9 @@ public:
          int16_t val13, int16_t val14, int16_t val15, int16_t val16) {
     values = _mm256_setr_epi16(val1, val2, val3, val4, val5, val6, val7, val8,
                                val9, val10, val11, val12, val13, val14, val15, val16);
+  }
+  Vectorized<int16_t> isnan() const {
+    return Vectorized<int16_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int16_t> blend(Vectorized<int16_t> a, Vectorized<int16_t> b) {
@@ -520,6 +529,9 @@ public:
                               val9, val10, val11, val12, val13, val14, val15, val16,
                               val17, val18, val19, val20, val21, val22, val23, val24,
                               val25, val26, val27, val28, val29, val30, val31, val32);
+  }
+  Vectorized<int8_t> isnan() const {
+    return Vectorized<int8_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int8_t> blend(Vectorized<int8_t> a, Vectorized<int8_t> b) {

--- a/aten/src/ATen/cpu/vec/vec512/vec512_int.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_int.h
@@ -56,6 +56,9 @@ public:
     values = _mm512_setr_epi64(val1, val2, val3, val4,
                                 val5, val6, val7, val8);
   }
+  Vectorized<int64_t> isnan() const {
+    return Vectorized<int64_t>(0);
+  }
   template <int64_t mask>
   static Vectorized<int64_t> blend(Vectorized<int64_t> a, Vectorized<int64_t> b) {
     return _mm512_mask_blend_epi64(mask, a.values, b.values);
@@ -189,6 +192,9 @@ public:
             int32_t val13, int32_t val14, int32_t val15, int32_t val16) {
     values = _mm512_setr_epi32(val1, val2, val3, val4, val5, val6, val7, val8,
                                val9, val10, val11, val12, val13, val14, val15, val16);
+  }
+  Vectorized<int32_t> isnan() const {
+    return Vectorized<int32_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int32_t> blend(Vectorized<int32_t> a, Vectorized<int32_t> b) {
@@ -384,6 +390,9 @@ public:
                               val24, val23, val22, val21, val20, val19, val18, val17,
                               val16, val15, val14, val13, val12, val11, val10, val9,
                               val8, val7, val6, val5, val4, val3, val2, val1);
+  }
+  Vectorized<int16_t> isnan() const {
+    return Vectorized<int16_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int16_t> blend(Vectorized<int16_t> a, Vectorized<int16_t> b) {
@@ -589,6 +598,9 @@ public:
                               val24, val23, val22, val21, val20, val19, val18, val17,
                               val16, val15, val14, val13, val12, val11, val10, val9,
                               val8, val7, val6, val5, val4, val3, val2, val1);
+  }
+  Vectorized<int8_t> isnan() const {
+    return Vectorized<int8_t>(0);
   }
   template <int64_t mask>
   static Vectorized<int8_t> blend(Vectorized<int8_t> a, Vectorized<int8_t> b) {

--- a/aten/src/ATen/native/Pooling.cpp
+++ b/aten/src/ATen/native/Pooling.cpp
@@ -114,10 +114,6 @@ Tensor max_pool2d(
     IntArrayRef padding,
     IntArrayRef dilation,
     bool ceil_mode) {
-  if (self.is_quantized()) {
-    return at::quantized_max_pool2d(self, kernel_size, stride, padding,
-                                    dilation, ceil_mode);
-  }
   if (self.is_mkldnn()) {
     return at::mkldnn_max_pool2d(
         self, kernel_size, stride, padding, dilation, ceil_mode);

--- a/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
+++ b/aten/src/ATen/native/cpu/MaxPoolKernel.cpp
@@ -9,6 +9,8 @@
 #include <ATen/native/cpu/utils.h>
 #include <c10/util/irange.h>
 
+#include <type_traits>
+
 namespace at { namespace native {
 
 namespace {
@@ -25,9 +27,8 @@ void cpu_max_pool(
   auto input = input_.contiguous();
   auto output = output_.contiguous();
   auto indices = indices_.contiguous();
-
-  auto input_data = input.data_ptr<scalar_t>();
-  auto output_data = output.data_ptr<scalar_t>();
+  auto input_data = std::is_integral<scalar_t>::value ? reinterpret_cast<scalar_t*>(input.data_ptr()) : input.data_ptr<scalar_t>();
+  auto output_data = std::is_integral<scalar_t>::value ? reinterpret_cast<scalar_t*>(output.data_ptr()) : output.data_ptr<scalar_t>();
   auto indices_data = indices.data_ptr<int64_t>();
 
   int64_t numel = output.numel();
@@ -56,10 +57,11 @@ void cpu_max_pool(
 
       // local pointers
       scalar_t* input_ptr = input_data + c * input_height * input_width;
-
       // compute local max
       int64_t maxindex = ih0 * input_width + iw0;
-      accscalar_t maxval = -std::numeric_limits<accscalar_t>::infinity();
+      accscalar_t maxval = std::is_integral<scalar_t>::value ? std::numeric_limits<accscalar_t>::lowest()
+                                                : -std::numeric_limits<accscalar_t>::infinity();
+
       for (int64_t ih = ih0; ih < ih1; ih += dilationH) {
         for (int64_t iw = iw0; iw < iw1; iw += dilationW) {
           int64_t index = ih * input_width + iw;
@@ -104,8 +106,8 @@ void cpu_max_pool_channels_last(
   auto output = output_.contiguous(memory_format);
   auto indices = indices_.contiguous(memory_format);
 
-  auto input_data = input.data_ptr<scalar_t>();
-  auto output_data = output.data_ptr<scalar_t>();
+  auto input_data = std::is_integral<scalar_t>::value ? reinterpret_cast<scalar_t*>(input.data_ptr()) : input.data_ptr<scalar_t>();
+  auto output_data = std::is_integral<scalar_t>::value ? reinterpret_cast<scalar_t*>(output.data_ptr()) : output.data_ptr<scalar_t>();
   auto indices_data = indices.data_ptr<int64_t>();
 
   int64_t nbatch = input.size(0);
@@ -149,7 +151,7 @@ void cpu_max_pool_channels_last(
 
       // Pass I: init out lane
       iVec index0_vec = iVec(ih0 * input_width + iw0);
-      Vec out_vec = Vec(-std::numeric_limits<scalar_t>::infinity());
+      Vec out_vec = Vec(std::is_integral<scalar_t>::value ? std::numeric_limits<scalar_t>::lowest() : -std::numeric_limits<scalar_t>::infinity());
       int64_t d1 = 0;
       for (; d1 < len; d1 += Vec::size()) {
         index0_vec.store(index_buffer.get() + d1);
@@ -157,7 +159,7 @@ void cpu_max_pool_channels_last(
       }
       for (; d1 < size; d1++) {
         ind[d1] = ih0 * input_width + iw0;
-        out[d1] = -std::numeric_limits<scalar_t>::infinity();
+        out[d1] = std::is_integral<scalar_t>::value ? std::numeric_limits<scalar_t>::lowest() : -std::numeric_limits<scalar_t>::infinity();
       }
       // Pass II: compute local max
       for (int64_t ih = ih0; ih < ih1; ih += dilationH) {
@@ -171,7 +173,6 @@ void cpu_max_pool_channels_last(
             Vec val_vec = Vec::loadu(in + d2);
             iVec maxindex_vec = iVec::loadu(index_buffer.get() + d2);
             Vec maxval_vec = Vec::loadu(out + d2);
-
             // true = all ones, false = all zeros
             Vec mask = (val_vec > maxval_vec) | val_vec.isnan();
             iVec imask = vec::cast<integer_t>(mask);
@@ -461,19 +462,31 @@ void max_pool2d_kernel_impl(
     int dilationW, int dilationH) {
   switch (input.suggest_memory_format()) {
     case at::MemoryFormat::Contiguous: {
-      AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, input.scalar_type(), "max_pool2d", [&] {
-        if (input.scalar_type() == ScalarType::BFloat16) {
-          cpu_max_pool<BFloat16, /*accscalar_t*/float>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
-        } else {
-          cpu_max_pool<scalar_t, scalar_t>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
-        }
-      });
+      if (input.is_quantized()) {
+        AT_DISPATCH_QINT_TYPES(input.scalar_type(), "max_pool2d", [&] {
+          cpu_max_pool<scalar_t::underlying, scalar_t::underlying>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        });
+      } else {
+        AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, input.scalar_type(), "max_pool2d", [&] {
+          if (input.scalar_type() == ScalarType::BFloat16) {
+            cpu_max_pool<BFloat16, /*accscalar_t*/float>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+          } else {
+            cpu_max_pool<scalar_t, scalar_t>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+          }
+        });
+      }
       break;
     }
     case at::MemoryFormat::ChannelsLast: {
-      AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, input.scalar_type(), "max_pool2d_channels_last", [&] {
-        cpu_max_pool_channels_last<scalar_t>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
-      });
+      if (input.is_quantized()) {
+        AT_DISPATCH_QINT_TYPES(input.scalar_type(), "max_pool2d_channels_last", [&] {
+          cpu_max_pool_channels_last<scalar_t::underlying>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        });
+      } else {
+        AT_DISPATCH_ALL_TYPES_AND(ScalarType::BFloat16, input.scalar_type(), "max_pool2d_channels_last", [&] {
+          cpu_max_pool_channels_last<scalar_t>(output, indices, input, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        });
+      }
       break;
     }
     default:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9370,6 +9370,7 @@
   dispatch:
     CPU: max_pool2d_with_indices_out_cpu
     CUDA: max_pool2d_with_indices_out_cuda
+    QuantizedCPU: max_pool2d_with_indices_out_quantized_cpu
 
 # Return: (Tensor output, Tensor indices)
 - func: max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -1262,10 +1262,22 @@ class TestQuantizedOps(TestCase):
             "nn.functional": torch.nn.functional.max_pool2d,
             "nn.quantized.functional": torch.nn.quantized.functional.max_pool2d
         }
+        ops_under_test_with_indices = {
+            "nn.functional with indices": torch.nn.functional.max_pool2d_with_indices,
+        }
 
         for name, op in ops_under_test.items():
             a_hat = op(qa, kernel_size=kernel, stride=stride, padding=padding,
                        dilation=dilation, ceil_mode=ceil_mode)
+            self.assertEqual(a_ref, a_hat.dequantize(),
+                             msg="{} results are off".format(name))
+        for name, op in ops_under_test_with_indices.items():
+            # we ignore the second value of returned tuple (indices);
+            # we cannot directly compare indices as multiple floating point values
+            # can map to the same integer, meaning that the indices we obtain aren't necessarily
+            # the same as operating on the fp tensor
+            a_hat = op(qa, kernel_size=kernel, stride=stride, padding=padding,
+                       dilation=dilation, ceil_mode=ceil_mode)[0]
             self.assertEqual(a_ref, a_hat.dequantize(),
                              msg="{} results are off".format(name))
         # Test the ops.quantized separately, because None is not treated.

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -1236,7 +1236,7 @@ class TestQuantizedOps(TestCase):
            dilation=st.integers(1, 2),
            padding=st.integers(0, 2),
            ceil_mode=st.booleans())
-    def test_max_pool2d(self, X, kernel, stride, dilation, padding, ceil_mode):
+    def test_max_pool2d_mod(self, X, kernel, stride, dilation, padding, ceil_mode):
         X, (scale, zero_point, torch_type) = X
         # Check constraints
         assume(kernel // 2 >= padding)  # Kernel cannot be overhanging!


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #75349

Summary: This PR is part of a series of PRs addressing https://github.com/pytorch/pytorch/issues/54150,
related to using dispatcher for calls to quantized backends as opposed to if/else conditionals.
This particular PR removes the is_quantized check from max_pool2d, and implements a quantized
kernel for max_pool2d_with_indices.

This PR also introduces isnan() support for vectorized int tensors.

This PR relies on https://github.com/pytorch/pytorch/pull/74560, which introduces
structured kernel support for quantized tensors.

Test plan:
```
python test/test_quantization.py -k test_max_pool2d
```