### PR TITLE
Load state dict post hook

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -20633,6 +20633,44 @@ class TestStateDictHooks(TestCase):
             m.load_state_dict(state_dict)
             self.assertEqual(hook_called_offset + 2, hook_called)
 
+    def test_load_state_dict_post_hook(self):
+        hook_called = 0
+
+        class MyModule(nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+                self.foo = torch.nn.Parameter(torch.rand(10))
+
+            def my_post_load_hook(self):
+                nonlocal hook_called
+                hook_called += 1
+
+            def my_post_load_hook_with_module(self, module):
+                assert module is self
+                nonlocal hook_called
+                hook_called += 1
+
+        class MyModuleContainer(nn.Module):
+            def __init__(self, mod):
+                super().__init__()
+                self.mod = mod
+
+        nested = MyModule()
+        wrapped = MyModuleContainer(nested)
+        nested._register_load_state_dict_post_hook(
+            nested.my_post_load_hook,
+        )
+        wrapped.load_state_dict(wrapped.state_dict())
+        self.assertEqual(hook_called, 1)
+        nested._register_load_state_dict_post_hook(
+            nested.my_post_load_hook_with_module,
+            with_module=True
+        )
+        wrapped.load_state_dict(wrapped.state_dict())
+        # Since both hooks are called, incremented by 2
+        self.assertEqual(hook_called, 3)
+        # TODO: test that post hook is called even if load state dict throws.
+
 
 instantiate_device_type_tests(TestNNDeviceType, globals())
 instantiate_parametrized_tests(TestNN)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -267,6 +267,7 @@ class Module:
         self._forward_pre_hooks: Dict[int, Callable] = OrderedDict()
         self._state_dict_hooks: Dict[int, Callable] = OrderedDict()
         self._load_state_dict_pre_hooks: Dict[int, Callable] = OrderedDict()
+        self._load_state_dict_post_hooks: Dict[int, Callable] = OrderedDict()
         self._modules: Dict[str, Optional['Module']] = OrderedDict()
 
     forward: Callable[..., Any] = _forward_unimplemented
@@ -1164,6 +1165,8 @@ class Module:
             self._state_dict_hooks = OrderedDict()
         if '_load_state_dict_pre_hooks' not in self.__dict__:
             self._load_state_dict_pre_hooks = OrderedDict()
+        if '_load_state_dict_post_hooks' not in self.__dict__:
+            self._load_state_dict_post_hooks = OrderedDict()
         if '_non_persistent_buffers_set' not in self.__dict__:
             self._non_persistent_buffers_set = set()
         if '_is_full_backward_hook' not in self.__dict__:
@@ -1407,6 +1410,27 @@ class Module:
         self._load_state_dict_pre_hooks[handle.id] = hook
         return handle
 
+    def _register_load_state_dict_post_hook(self, hook, with_module=False):
+        r"""These hooks will be called with no arguments after loading
+        `state_dict` into `self`.
+
+        If ``with_module`` is ``True``, then the first argument to the hook is
+        an instance of the module. In this case the hook should take in a
+        ``nn.Module`` as the first argument.
+
+        Arguments:
+            hook (Callable): Callable hook that will be invoked after
+                loading the state dict.
+            with_module (bool, optional): Whether or not to pass the module
+                instance to the hook as the first parameter.
+        """
+        handle = hooks.RemovableHandle(self._load_state_dict_post_hooks)
+        if with_module:
+            hook = functools.partial(hook, self)
+        self._load_state_dict_post_hooks[handle.id] = hook
+        return handle
+
+
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
         r"""Copies parameters and buffers from :attr:`state_dict` into only
@@ -1501,6 +1525,7 @@ class Module:
                     if input_name not in self._modules and input_name not in local_state:
                         unexpected_keys.append(key)
 
+
     def load_state_dict(self, state_dict: 'OrderedDict[str, Tensor]',
                         strict: bool = True):
         r"""Copies parameters and buffers from :attr:`state_dict` into
@@ -1537,12 +1562,18 @@ class Module:
             state_dict._metadata = metadata  # type: ignore[attr-defined]
 
         def load(module, prefix=''):
-            local_metadata = {} if metadata is None else metadata.get(prefix[:-1], {})
-            module._load_from_state_dict(
-                state_dict, prefix, local_metadata, True, missing_keys, unexpected_keys, error_msgs)
-            for name, child in module._modules.items():
-                if child is not None:
-                    load(child, prefix + name + '.')
+            try:
+                local_metadata = {} if metadata is None else metadata.get(prefix[:-1], {})
+                module._load_from_state_dict(
+                    state_dict, prefix, local_metadata, True, missing_keys, unexpected_keys, error_msgs)
+                for name, child in module._modules.items():
+                    if child is not None:
+                        load(child, prefix + name + '.')
+            finally:
+                # Note that post hooks for a module are called after self _and_ all
+                # all child modules are loaded.
+                for hook in module._load_state_dict_post_hooks.values():
+                    hook()
 
         load(self)
         del load


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Adds load_state_dict_post_hook. Proposal: https://github.com/pytorch/pytorch/issues/75287

Went with no args except for module optionally for now. Additional args can be
added on use case basis.

A few notes:
- Similar to state_dict post hook, we run it after this module and all submodule children have been loaded.
- Added try/finally to ensure the hook runs even if load_state_dict throws.

Differential Revision: [D35439200](https://our.internmc.facebook.com/intern/diff/D35439200/)