### PR TITLE
[ci] fixes to upload test stats workflow

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Print workflow information
         env:
           TRIGGERING_WORKFLOW: ${{ toJSON(github.event.workflow_run) }}
-        run: echo ${TRIGGERING_WORKFLOW}
+        run: echo "${TRIGGERING_WORKFLOW}"
 
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -8,9 +8,14 @@ on:
 
 jobs:
   upload-test-stats:
-    runs-on: [self-hosted, linux.2xlarge]
+    runs-on: ubuntu-18.04
 
     steps:
+      - name: Print workflow information
+        env:
+          TRIGGERING_WORKFLOW: ${{ toJSON(github.event.workflow_run) }}
+        run: echo ${TRIGGERING_WORKFLOW}
+
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #75368

This one can't be tested without committing, so it showed some problems:
- Print workflow info for debugging
- Use a managed GHA host