### PR TITLE
[ci] Only upload test stats on workflow success/failure

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -22,7 +22,9 @@ jobs:
 
       - uses: actions/setup-python@v3
 
-      - run: pip install requests==2.26
+      - run: |
+          pip install requests==2.26
+          pip install rockset==0.8.3
 
       - name: Upload test stats
         env:

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   upload-test-stats:
+    if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-18.04
 
     steps:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #75376
* #75368

Otherwise just skip the workflow (if, e.g. the workflow was cancelled).