### PR TITLE
[SR] Make sub-blocks properly extend tensor lifetimes

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -3134,3 +3134,41 @@ TEST(StaticRuntime, ReshapeAs) {
   )JIT";
   testStaticRuntime(src, {at::randn({2, 2}), at::randn({4})});
 }
+
+TEST(StaticRuntime, LifetimeExtendedThroughIf) {
+  // The last use of `b` is in a sub-block, its lifetime needs
+  // to be extended so `c` doesn't overwrite it
+  const auto src = R"JIT(
+    def forward(self, a, cond: bool):
+        b = torch.abs(a)
+        c = torch.argmin(a)
+        if cond:
+            d = torch.linear(b, b)
+        else:
+            b = a.view((1, 1))
+            d = b * c
+        return c.clone(), d.clone()
+  )JIT";
+  testStaticRuntime(src, {at::tensor({5.0, 10.0, 42.0}), true});
+}
+
+TEST(StaticRuntime, LifetimeExtendedThroughIfDeeplyNested) {
+  // The last use of `b` is in a nested sub-block, its lifetime needs
+  // to be extended so `c` doesn't overwrite it
+  const auto src = R"JIT(
+    def forward(self, a, cond1: bool, cond2: bool):
+        b = torch.abs(a)
+        c = torch.argmin(a)
+        if cond1:
+            if cond2:
+                d = torch.linear(b, b)
+            else:
+                d = torch.linear(c, c)
+                d = d * d
+        else:
+            b = a.view((1, 1))
+            d = b * c
+        return c.clone(), d.clone()
+  )JIT";
+  testStaticRuntime(src, {at::tensor({5.0, 10.0, 42.0}), true, true});
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75379

Another day, another liveness analysis bug.

This one is quite subtle and hard to trigger. It can only happen when the last use of a managed tensor (including all aliases) is buried inside a node with sub-blocks like `prim::If`. If this is the case, the lifetime of that tensor needs to be extended to the index of node with sub-blocks.

I've modified the first pass of the liveness analysis (the one that doesn't consider aliases) to consider nodes referenced from outside the sub-block's scope. So in this graph

```
b = some_op() # (node 1)
c = some_op() # (node 2)
if condition: # (node 3)
    x = another_op(b)
else:
    x = some_op()
ret = c.clone() # (node 4)
return ret
```

The lifetime of `b` is `[1, 3]` instead of `[1, 1]`. The memory planner correctly recognizes `b` as overlapping with `c`, and we return the correct result.

Nested sub-blocks are considered too; we would get the same result in the graph above if we instead had:
```
if condition1: # (node 3)
    if condition2:
        x = another_op(b)
```

Differential Revision: [D35448776](https://our.internmc.facebook.com/intern/diff/D35448776/)