### PR TITLE
[ci] temporarily pin get-workflow-job-id to master

### DIFF
--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Get workflow job id
         id: get-job-id
-        uses: ./.github/actions/get-workflow-job-id
+        uses: pytorch/pytorch/.github/actions/get-workflow-job-id@master
         if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Get workflow job id
         id: get-job-id
-        uses: ./.github/actions/get-workflow-job-id
+        uses: pytorch/pytorch/.github/actions/get-workflow-job-id@master
         if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Get workflow job id
         id: get-job-id
-        uses: ./.github/actions/get-workflow-job-id
+        uses: pytorch/pytorch/.github/actions/get-workflow-job-id@master
         if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Get workflow job id
         id: get-job-id
-        uses: ./.github/actions/get-workflow-job-id
+        uses: pytorch/pytorch/.github/actions/get-workflow-job-id@master
         if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Get workflow job id
         id: get-job-id
-        uses: ./.github/actions/get-workflow-job-id
+        uses: pytorch/pytorch/.github/actions/get-workflow-job-id@master
         if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -25,6 +25,7 @@ jobs:
       - run: |
           pip install requests==2.26
           pip install rockset==0.8.3
+          pip install six==1.16.0
 
       - name: Upload test stats
         env:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #75380
* #75376
* #75368

This is for forward compatibility, so that older PRs will still have the
ability to run this action even if their head sha doesn't have the file.