### PR TITLE
Make LazyTensor create/unwrap methods backend-extensible

### DIFF
--- a/tools/codegen/dest/__init__.py
+++ b/tools/codegen/dest/__init__.py
@@ -1,6 +1,4 @@
-from .lazy_ir import GenLazyIR as GenLazyIR
 from .lazy_ir import GenLazyShapeInferenceDefinition as GenLazyShapeInferenceDefinition
-from .lazy_ir import GenLazyNativeFuncDefinition as GenLazyNativeFuncDefinition
 from .register_dispatch_key import (
     RegisterDispatchKey as RegisterDispatchKey,
     gen_registration_helpers as gen_registration_helpers,

--- a/tools/codegen/dest/lazy_ir.py
+++ b/tools/codegen/dest/lazy_ir.py
@@ -179,7 +179,15 @@ class GenTSLazyIR(GenLazyIR):
 
 
 @dataclass(frozen=True)
-class GenLazyNativeFuncDefinition(ABC):
+class GenLazyNativeFunc(ABC):
+    """
+    A note on subclassing:
+    It is possible for a backend to override codegen functionality by subclassing, but this is not a maintainable
+    approach since there is no clear API surface.  Consider this a last resort escape hatch, and try to design
+    for the right backend interface APIs to allow the same generated code to work on multiple backends.
+
+    We can't gaurantee we don't break your backend if you subclass here.
+    """
     class_method_name: str
     backend_index: BackendIndex
     tensor_class: str

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -5,7 +5,7 @@ import re
 import yaml
 from collections import namedtuple, Counter
 from typing import List, Dict, Union, Sequence, Optional, Callable, Iterable, Iterator, Tuple, Type
-from tools.codegen.dest.lazy_ir import GenLazyIR, GenTSLazyIR
+from tools.codegen.dest.lazy_ir import GenLazyIR, GenTSLazyIR, GenLazyNativeFunc
 from tools.codegen.gen import get_grouped_native_functions, parse_native_yaml, NamespaceHelper
 from tools.codegen.model import (FunctionSchema,
                                  NativeFunction, NativeFunctionsGroup, OperatorName)
@@ -127,6 +127,7 @@ class default_args:
     tensor_class: str = "torch::lazy::LazyTensor"
     tensor_class_hdr: str = "torch/csrc/lazy/core/tensor.h"
     lazy_ir_generator: Type[GenLazyIR] = GenLazyIR
+    lazy_nativefunc_generator: Type[GenLazyNativeFunc] = GenLazyNativeFunc
     backend_name: str = "TorchScript"
 
 def main() -> None:
@@ -177,21 +178,24 @@ def main() -> None:
                         lazy_ir_generator, options.backend_name)
 
 
-def run_gen_lazy_tensor(aten_path: str, source_yaml: str, output_dir: str,
-                        dry_run: bool, impl_path: Optional[str],
-                        node_base: str = default_args.node_base,
-                        node_base_hdr: Optional[str] = default_args.node_base_hdr,
-                        tensor_class: str = default_args.tensor_class,
-                        tensor_class_hdr: str = default_args.tensor_class_hdr,
-                        shape_inference_hdr: str = default_args.shape_inference_hdr,
-                        lazy_ir_generator: Type[GenLazyIR] = default_args.lazy_ir_generator,
-                        # build_in_tree is true for TS backend and affects include paths
-                        build_in_tree: bool = False,
-                        # per_operator_headers changes whether ATen/Functions.h or individual operator headers are used
-                        # it must match how ATen was built
-                        per_operator_headers: bool = False,
-                        backend_name: str = default_args.backend_name,
-                        gen_forced_fallback_code: bool = False) -> None:
+def run_gen_lazy_tensor(
+    aten_path: str, source_yaml: str, output_dir: str,
+    dry_run: bool, impl_path: Optional[str],
+    node_base: str = default_args.node_base,
+    node_base_hdr: Optional[str] = default_args.node_base_hdr,
+    tensor_class: str = default_args.tensor_class,
+    tensor_class_hdr: str = default_args.tensor_class_hdr,
+    shape_inference_hdr: str = default_args.shape_inference_hdr,
+    lazy_ir_generator: Type[GenLazyIR] = default_args.lazy_ir_generator,
+    lazy_nativefunc_generator: Type[GenLazyNativeFunc] = default_args.lazy_nativefunc_generator,
+    # build_in_tree is true for TS backend and affects include paths
+    build_in_tree: bool = False,
+    # per_operator_headers changes whether ATen/Functions.h or individual operator headers are used
+    # it must match how ATen was built
+    per_operator_headers: bool = False,
+    backend_name: str = default_args.backend_name,
+    gen_forced_fallback_code: bool = False
+) -> None:
 
     template_dir = os.path.join(aten_path, "templates")
 
@@ -326,10 +330,10 @@ def run_gen_lazy_tensor(aten_path: str, source_yaml: str, output_dir: str,
         'namespace_epilogue': ns_helper.epilogue,
         'native_function_definitions':
         list(concat_map_codegen(
-            dest.GenLazyNativeFuncDefinition(f'{backend_key}NativeFunctions',
-                                             backend_indices[backend_key],
-                                             tensor_class,
-                                             gen_forced_fallback_code),
+            lazy_nativefunc_generator(f'{backend_key}NativeFunctions',
+                                      backend_indices[backend_key],
+                                      tensor_class,
+                                      gen_forced_fallback_code),
             grouped_native_functions,
             codegenInplaceVariant=True
         )),

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -197,7 +197,7 @@ def main() -> None:
         assert os.path.isfile(ts_backend_yaml), f"Unable to access ts_backend_yaml: {ts_backend_yaml}"
         assert os.path.isfile(ts_native_functions), f"Unable to access {ts_native_functions}"
         from tools.codegen.gen_lazy_tensor import run_gen_lazy_tensor
-        from tools.codegen.dest.lazy_ir import GenTSLazyIR
+        from tools.codegen.dest.lazy_ir import GenTSLazyIR, GenLazyNativeFunc
         run_gen_lazy_tensor(aten_path=aten_path,
                             source_yaml=ts_backend_yaml,
                             backend_name="TorchScript",
@@ -208,6 +208,7 @@ def main() -> None:
                             node_base_hdr=ts_node_base,
                             build_in_tree=True,
                             lazy_ir_generator=GenTSLazyIR,
+                            lazy_nativefunc_generator=GenLazyNativeFunc,
                             per_operator_headers=options.per_operator_headers,
                             gen_forced_fallback_code=True)
 

--- a/torch/csrc/lazy/backend/backend_interface.cpp
+++ b/torch/csrc/lazy/backend/backend_interface.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/lazy/backend/backend_interface.h>
+#include <torch/csrc/lazy/core/tensor_impl.h>
 
 namespace torch {
 namespace lazy {
@@ -22,6 +23,27 @@ BackendRegistrar::BackendRegistrar(
   backend_impl_registry.store(backend_impl_interface);
 }
 
+const TensorBuilder& BackendImplInterface::GetTensorBuilder() const{
+  static TensorBuilder tensor_builder;
+  return tensor_builder;
+}
+
+LazyTensorPtr TensorBuilder::TryGetLtcTensor(const at::Tensor& tensor) const {
+  auto* impl = dynamic_cast<LTCTensorImpl*>(tensor.unsafeGetTensorImpl());
+  if (impl == nullptr) {
+    return LazyTensorPtr();
+  }
+  return impl->tensor();
+}
+
+LazyTensorPtr BackendImplInterface::UnwrapLazyTensor(const at::Tensor& tensor, bool create) const {
+  auto* impl = dynamic_cast<LTCTensorImpl*>(tensor.unsafeGetTensorImpl());
+  if (impl == nullptr) {
+    return LazyTensorPtr();
+  }
+  return impl->tensor();
+}
+
 at::Tensor MakeTensorFromComputationData(
     const BackendDataPtr data,
     c10::optional<at::ScalarType> logical_scalar_type) {
@@ -42,6 +64,7 @@ std::unique_ptr<LoweringContext> LoweringContext::Create(
     BackendDevice device) {
   return getBackend()->CreateLoweringContext(name, device);
 }
+
 
 }  // namespace lazy
 }  // namespace torch

--- a/torch/csrc/lazy/backend/backend_interface.h
+++ b/torch/csrc/lazy/backend/backend_interface.h
@@ -6,9 +6,14 @@
 #include <torch/csrc/lazy/backend/backend_device.h>
 #include <torch/csrc/lazy/backend/lowering_context.h>
 #include <torch/csrc/lazy/core/shape.h>
+#include <torch/csrc/lazy/core/tensor.h>
 
 namespace torch {
 namespace lazy {
+
+struct TORCH_API TensorBuilder {
+    virtual LazyTensorPtr TryGetLtcTensor(const at::Tensor& tensor) const;
+};
 
 /**
  * Work in progress- don't treat this as a stable interface yet!
@@ -48,6 +53,12 @@ class TORCH_API BackendImplInterface {
   virtual at::Tensor MakeTensorFromComputationData(
       const BackendDataPtr data,
       c10::optional<at::ScalarType> logical_scalar_type) const = 0;
+
+  virtual const TensorBuilder& GetTensorBuilder() const;
+  
+  // Unwraps a LazyTensor object hidden inside an at::Tensor
+  //   (or, if create=True, creates one in a backend-specific way)
+  virtual LazyTensorPtr UnwrapLazyTensor(const at::Tensor& tensor, bool create=false) const;
 
   /**
    * Lowering, Compilation, Execution

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <c10/util/intrusive_ptr.h>
+#include <torch/csrc/lazy/backend/backend_data.h>
 #include <torch/csrc/lazy/backend/backend_device.h>
-#include <torch/csrc/lazy/backend/backend_interface.h>
+// #include <torch/csrc/lazy/backend/backend_interface.h>
 #include <torch/csrc/lazy/core/ir.h>
 #include <torch/csrc/lazy/core/lazy_view.h>
 #include <torch/csrc/lazy/core/util.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75396
* #75397
* #75343

This enables backends to customize the tensor creation process and extend the LazyTensor class.