### PR TITLE
[ci] add env vars to upload test stats

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -29,5 +29,7 @@ jobs:
 
       - name: Upload test stats
         env:
+          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: python tools/stats/upload_test_stats.py --workflow-run-id "${WORKFLOW_RUN_ID}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #75408
* #75407
* __->__ #75403
* #75380
* #75376
* #75368

Surely this is the last fix, right?