### PR TITLE
Optimize size(dim) and stride(dim)

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -156,15 +156,17 @@ class TORCH_API TensorBase {
   }
 
   int64_t size(int64_t dim) const {
+    const auto sizes = this->sizes();
+    const auto ndim = static_cast<int64_t>(sizes.size());
     // false is passed to maybe_wrap_dim so behavior is identical to array access (but with wrapping)
-    dim = c10::maybe_wrap_dim(dim, this->dim(), false);
-    return sizes()[dim];
+    return sizes[c10::maybe_wrap_dim(dim, ndim, /*wrap_scalar=*/false)];
   }
 
   int64_t stride(int64_t dim) const {
+    const auto strides = this->strides();
+    const auto ndim = static_cast<int64_t>(strides.size());
     // false is passed to maybe_wrap_dim so behavior is identical to array access (but with wrapping)
-    dim = c10::maybe_wrap_dim(dim, this->dim(), false);
-    return strides()[dim];
+    return strides[c10::maybe_wrap_dim(dim, ndim, /*wrap_scalar=*/false)];
   }
 
   TensorImpl * unsafeGetTensorImpl() const {

--- a/c10/core/WrapDimMinimal.cpp
+++ b/c10/core/WrapDimMinimal.cpp
@@ -1,0 +1,36 @@
+#include <c10/core/WrapDimMinimal.h>
+
+namespace c10 {
+namespace detail {
+
+int64_t maybe_wrap_dim_slow(
+    int64_t dim,
+    int64_t dim_post_expr,
+    bool wrap_scalar) {
+  if (dim_post_expr <= 0) {
+    TORCH_CHECK_INDEX(
+        wrap_scalar,
+        "dimension specified as ",
+        dim,
+        " but tensor has no dimensions");
+    return c10::maybe_wrap_dim(dim, /*dim_post_expr=*/1, /*wrap_scalar=*/false);
+  }
+
+  int64_t min = -dim_post_expr;
+  int64_t max = dim_post_expr - 1;
+  TORCH_CHECK_INDEX(
+      min <= dim && dim <= max,
+      "Dimension out of range (expected to be in range of [",
+      min,
+      ", ",
+      max,
+      "], but got ",
+      dim,
+      ")");
+  if (dim < 0)
+    dim += dim_post_expr;
+  return dim;
+}
+
+} // namespace detail
+} // namespace c10

--- a/c10/core/WrapDimMinimal.cpp
+++ b/c10/core/WrapDimMinimal.cpp
@@ -27,9 +27,9 @@ int64_t maybe_wrap_dim_slow(
       "], but got ",
       dim,
       ")");
-  if (dim < 0)
-    dim += dim_post_expr;
-  return dim;
+
+  TORCH_INTERNAL_ASSERT(
+      false, "should never reach here as dim should be out-of-bounds");
 }
 
 } // namespace detail

--- a/c10/core/WrapDimMinimal.h
+++ b/c10/core/WrapDimMinimal.h
@@ -18,7 +18,7 @@ static inline int64_t maybe_wrap_dim(
     // Branch-less version of dim + (dim < 0 ? dim_post_expr : 0)
     return dim + dim_post_expr * (dim < 0);
   }
-  // Check for edge-cases out-of-line
+  // Check edge-cases out-of-line (wrapping scalars and out-of-bounds errors)
   return c10::detail::maybe_wrap_dim_slow(dim, dim_post_expr, wrap_scalar);
 }
 

--- a/c10/core/WrapDimMinimal.h
+++ b/c10/core/WrapDimMinimal.h
@@ -4,37 +4,22 @@
 
 namespace c10 {
 
+namespace detail {
+C10_API int64_t
+maybe_wrap_dim_slow(int64_t dim, int64_t dim_post_expr, bool wrap_scalar);
+}
+
 static inline int64_t maybe_wrap_dim(
     int64_t dim,
     int64_t dim_post_expr,
     bool wrap_scalar = true) {
-  if (dim_post_expr <= 0) {
-    if (!wrap_scalar) {
-      TORCH_CHECK_INDEX(
-          false,
-          "dimension specified as ",
-          dim,
-          " but tensor has no dimensions");
-    }
-    dim_post_expr = 1; // this will make range [-1, 0]
+  // Inline the fast paths
+  if (C10_LIKELY(-dim_post_expr <= dim && dim < dim_post_expr)) {
+    // Branch-less version of dim + (dim < 0 ? dim_post_expr : 0)
+    return dim + dim_post_expr * (dim < 0);
   }
-
-  int64_t min = -dim_post_expr;
-  int64_t max = dim_post_expr - 1;
-  if (dim < min || dim > max) {
-    TORCH_CHECK_INDEX(
-        false,
-        "Dimension out of range (expected to be in range of [",
-        min,
-        ", ",
-        max,
-        "], but got ",
-        dim,
-        ")");
-  }
-  if (dim < 0)
-    dim += dim_post_expr;
-  return dim;
+  // Check for edge-cases out-of-line
+  return c10::detail::maybe_wrap_dim_slow(dim, dim_post_expr, wrap_scalar);
 }
 
 } // namespace c10


### PR DESCRIPTION
This improves `c10::maybe_wrap_dim` to short-cut the "happy path"
where dim is in the correct range, and also moves the error and scalar
edge-cases out-of-line. These changes cut callgrind instruction counts
for `size(i)` from 5200 to 2000.

In the `size` and `stride` methods themselves, I also avoid calling
`TensorImpl::dim()` since it may be a virtual call. This further
reduced the instruction count from 2000 to 1500.

For comparison, `tensor.sizes()[0]` takes 1200 instructions so
`tensor.size(0)` is still marginally slower. This is unavoidable
though since it has to handle dimension wrapping.
