### PR TITLE
[FSDP] Remove unnecesary case

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1352,8 +1352,6 @@ class FullyShardedDataParallel(nn.Module):
 
         elif self._state_dict_type == StateDictType.LOCAL_STATE_DICT:
             return super().load_state_dict(state_dict, *args)
-        elif self._state_dict_type == StateDictType.SHARDED_STATE_DICT:
-            raise NotImplementedError("Will be implemented as part of https://github.com/pytorch/pytorch/issues/73518.")
         else:
             raise ValueError(f"Unknown StateDictType {self._state_dict_type}.")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #75426
* __->__ #75425
* #75424
* #75423
* #75422
* #75421

This case is already covered by sharded_pre_load_state_dict_hook
logic. i.e., before sharded_load_state_dict hook runs, the pre-hook for this will run, which already throws.

Differential Revision: [D35444540](https://our.internmc.facebook.com/intern/diff/D35444540/)