### PR TITLE
[PTE] Ensure the stream points to the beginning before calling getFileFormat

### DIFF
--- a/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
@@ -74,6 +74,7 @@ uint64_t _get_model_bytecode_version(
 
 uint64_t _get_model_bytecode_version(std::istream& in) {
   auto orig_pos = in.tellg();
+  in.seekg(0, in.beg);
   auto format = getFileFormat(in);
   switch (format) {
     case FileFormat::FlatbufferFileFormat: {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75437

To avoid potential FileFormatError when geting the format of the input stream, move the pointer to the beg of the stream to read the magic bytes

Differential Revision: [D35469481](https://our.internmc.facebook.com/intern/diff/D35469481/)