### PR TITLE
[fx2trt] support for ne, logical_not, logical_and

### DIFF
--- a/torch/testing/_internal/common_fx2trt.py
+++ b/torch/testing/_internal/common_fx2trt.py
@@ -70,6 +70,8 @@ class TRTTestCase(TestCase):
                 outputs = [outputs]
 
             for out, ref in zip(outputs, ref_outputs):
+                if not isinstance(ref, torch.Tensor):
+                    ref = torch.tensor([ref])
                 torch.testing.assert_allclose(out.cpu(), ref, rtol=rtol, atol=atol)
 
     def run_test_custom_compare_results(


### PR DESCRIPTION
Summary:
as titled
1. support logical_and, logical_not
2. replace eq,gt,lt with python operator in acc_ops due to the fact that torch op needs input to be torch.Tensor but python op does not
3. add more test cases
4. add individual ne op without using combination of existing ops since there are limitations. For ex, in lowering it to equal+logical_not. It will fail the last test case in test_ne.py. The failure reason is that logical_not needs the input to be a tensor.
Also we can not use equal+operator.not since not is not tracable in FX with the error "symbolically traced variables cannot be used as inputs to control flow"
We also can not use equal+operator.invert since operator.invert(True)=-2

Test Plan:
buck test mode/dev-nosan deeplearning/trt/fx2trt_oss/test/converters:test_ne
buck test mode/dev-nosan deeplearning/trt/fx2trt_oss/test/converters:test_logical_and
buck test mode/dev-nosan deeplearning/trt/fx2trt_oss/test/converters:test_unary_ops

Reviewed By: 842974287

Differential Revision: D35232917

