### PR TITLE
Add zipfile to MacOS tests

### DIFF
--- a/.jenkins/pytorch/macos-common.sh
+++ b/.jenkins/pytorch/macos-common.sh
@@ -19,7 +19,8 @@ retry conda install -y \
   ninja \
   typing_extensions \
   dataclasses \
-  pip
+  pip \
+  zipfile
 
 # The torch.hub tests make requests to GitHub.
 #


### PR DESCRIPTION
Summary: This PR is a response to https://github.com/pytorch/pytorch/pull/72237 and https://github.com/pytorch/pytorch/pull/74929 getting reverted as they were breaking MacOS testing builds due to the lack of the `zipfile` package. It does effectively the same thing. However, it also  installs `zipfile` to MacOS builds in `.jenkins/pytorch/macos-common.sh`

Test Plan: External CI

Differential Revision: D35474261

