### PR TITLE
[ci] run upload-test-stats on self-hosted runner

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   upload-test-stats:
     if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
-    runs-on: ubuntu-18.04
+    runs-on: [self-hosted, linux.2xlarge]
 
     steps:
       - name: Print workflow information
@@ -19,8 +19,6 @@ jobs:
 
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-
-      - uses: actions/setup-python@v3
 
       - run: |
           pip install requests==2.26


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #75452

I forgot we need AWS creds for it