### PR TITLE
[quant] add checking number of args when checking observer in same graph

### DIFF
--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -175,7 +175,7 @@ def is_observer_in_same_graph(node, modules, node_name_to_target_dtype):
     in a different place rather than not observed.
     """
     node_output_dtype = get_arg_target_dtype_as_output(node, modules, node_name_to_target_dtype)
-    if isinstance(node.args[0], Node):
+    if len(node.args) > 0 and isinstance(node.args[0], Node):
         if node_output_dtype == torch.quint8 and node.args[0].op == 'placeholder':
             return False
     return True


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75460

Summary:
add checking for number of args checking observer in same graph

Test Plan:
python3 test/test_quantization.py TestQuantizeFx
python3 test/test_quantization.py TestQuantizeFxOps

the error is hit by some internal use cases as well

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D35479504](https://our.internmc.facebook.com/intern/diff/D35479504)