### PR TITLE
[torch deploy] Add -rdynamic option explicitly to CMakeLists.txt

### DIFF
--- a/torch/csrc/deploy/CMakeLists.txt
+++ b/torch/csrc/deploy/CMakeLists.txt
@@ -40,12 +40,16 @@ set(INTERPRETER_TEST_SOURCES_GPU
 add_executable(test_deploy ${INTERPRETER_TEST_SOURCES})
 target_compile_definitions(test_deploy PUBLIC TEST_CUSTOM_LIBRARY)
 target_include_directories(test_deploy PRIVATE ${PYTORCH_ROOT}/torch)
-target_link_libraries(test_deploy PUBLIC "-Wl,--no-as-needed" gtest dl torch_deploy)
+target_link_libraries(test_deploy
+  PUBLIC "-Wl,--no-as-needed -rdynamic" gtest dl torch_deploy
+)
 
 add_executable(test_deploy_gpu ${INTERPRETER_TEST_SOURCES_GPU})
 target_compile_definitions(test_deploy_gpu PUBLIC TEST_CUSTOM_LIBRARY)
 target_include_directories(test_deploy_gpu PRIVATE ${PYTORCH_ROOT}/torch)
-target_link_libraries(test_deploy_gpu PUBLIC "-Wl,--no-as-needed" gtest dl torch_deploy)
+target_link_libraries(test_deploy_gpu
+  PUBLIC "-Wl,--no-as-needed -rdynamic" gtest dl torch_deploy
+)
 
 add_library(test_deploy_lib SHARED test_deploy_lib.cpp)
 add_dependencies(test_deploy_lib cpython)
@@ -54,11 +58,15 @@ target_link_libraries(test_deploy_lib PRIVATE pybind::pybind11)
 
 add_executable(deploy_benchmark ${DEPLOY_DIR}/example/benchmark.cpp)
 target_include_directories(deploy_benchmark PRIVATE ${PYTORCH_ROOT}/torch)
-target_link_libraries(deploy_benchmark PUBLIC "-Wl,--no-as-needed" torch_deploy)
+target_link_libraries(deploy_benchmark
+  PUBLIC "-Wl,--no-as-needed -rdynamic" torch_deploy
+)
 
 add_executable(interactive_embedded_interpreter ${DEPLOY_DIR}/interactive_embedded_interpreter.cpp)
 target_include_directories(interactive_embedded_interpreter PRIVATE ${PYTORCH_ROOT}/torch)
-target_link_libraries(interactive_embedded_interpreter PUBLIC "-Wl,--no-as-needed" torch_deploy)
+target_link_libraries(interactive_embedded_interpreter
+  PUBLIC "-Wl,--no-as-needed -rdynamic" torch_deploy
+)
 
 if(INSTALL_TEST)
   install(TARGETS test_deploy DESTINATION bin)


### PR DESCRIPTION
Summary:
This flag is needed in the OSS example and it wasn't clear that it was needed because it wasn't explicitly used when linking to torch deploy for the tests.

 Since torch deploy builds the tests using `python setup.py develop`, Pytorch actually sets this flag in the `CMAKE_EXE_LINKER_FLAGS` variable somewhere along the build. I had to print out all the variables used in the pytorch build to realize that I did not have this flag set in my OSS torch deploy example.

I think having it explicit for the tests makes it clear which flags are actually necessary in an open source environment.

**What is -rdynamic?**

This flag (also known as `--export-dynamic` at the linker level) signals that the library it is targeting should export its symbols to the dynamic table. In doing so, shared libraries that are opened using `dlopen` (which is what torch deploy uses to launch subinterpreters: https://www.internalfb.com/code/fbsource/[ff6d5cfcc2b3]/xplat/caffe2/torch/csrc/deploy/deploy.cpp?lines=254), will be able to reference symbols defined in the modules that launched them.

Without this flag, the symbols from the  `torch::deploy` library that the subinterpreters need, remain `undefined`.

This leads to runtime errors like:

`/tmp/torch_XYZ: undefined symbol - torch::deploy::Etc.`

`/tmp/torch_XYZ` is a subinterpreter.

Test Plan:
Ran the tests in an OSS environment
`python torch/csrc/deploy/example/generate_examples.py`
`./build/bin/test_deploy`

Differential Revision: D35477135

