### PR TITLE
[ONNX] Raise exception for unimplemented ops for non-caffe2 builds

### DIFF
--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -359,10 +359,9 @@ def _get_tensor_dim_size(x, dim):
 
 def _unimplemented(op, msg):
     # For BC reasons, the behavior for Caffe2 does not raise exception for unimplemented operators
-    if (_operator_export_type != torch.onnx.OperatorExportTypes.ONNX and
-            torch.onnx._CAFFE2_ATEN_FALLBACK):
+    if torch.onnx._CAFFE2_ATEN_FALLBACK:
         warnings.warn("ONNX export failed on " + op + " because " + msg + " not supported")
-    else:
+    elif _operator_export_type == torch.onnx.OperatorExportTypes.ONNX:
         _onnx_unsupported(f"{op}, {msg}")
 
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -358,7 +358,12 @@ def _get_tensor_dim_size(x, dim):
     return None
 
 def _unimplemented(op, msg):
-    warnings.warn("ONNX export failed on " + op + " because " + msg + " not supported")
+    # For BC reasons, the behavior for Caffe2 does not raise exception for unimplemented operators
+    if (_operator_export_type != torch.onnx.OperatorExportTypes.ONNX and
+            torch.onnx._CAFFE2_ATEN_FALLBACK):
+        warnings.warn("ONNX export failed on " + op + " because " + msg + " not supported")
+    else:
+        _onnx_unsupported(f"{op}, {msg}")
 
 
 def _onnx_unsupported(op_name):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1037,10 +1037,7 @@ def _adaptive_pool(name, type, tuple_fn, fn=None):
         if mod != [0] * len(mod):
             if output_size == [1] * len(output_size):
                 return g.op("GlobalMaxPool", input), None
-            if sym_help.is_caffe2_aten_fallback():
-                return _unimplemented(name, "output size that are not factor of input size")
-            else:
-                return sym_help._onnx_unsupported(name + ", since output size is not factor of input size")
+            return _unimplemented(name, "output size that are not factor of input size")
         k = [int(dim[i] / output_size[i]) for i in range(0, len(dim))]
         # call max_poolxd_with_indices to get indices in the output
         if type == "MaxPool":


### PR DESCRIPTION
Currently, when an operator symbolic hits an unimplemented scenario, the symbolic may print a warning and return, allowing a non-ONNX operator be emitted into the graph

This PRs maintains this behavior for 1) Caffe2 builds or 2) non-caffe2 builds with `operator_export_type != ONNX`. If none of the conditions above are met, the converter raises a `RuntimeError` exception otherwise. This is needed so that exporter can detect detect unsupported ONNX operators when ATEN fallback is used (for non-caffe2 scenarios)