### PR TITLE
Miscellaneous __torch_function__ fixes

### DIFF
--- a/test/autograd/test_functional.py
+++ b/test/autograd/test_functional.py
@@ -50,6 +50,12 @@ FIXME_xfail_vectorized_logging_tensor = (
                                             decorators=[unittest.expectedFailure]),
                                     subtest((False, logging_tensor_ctors), name="logging_tensor")]))
 
+vectorized_logging_tensor = (
+    parametrize("vectorize,ctors", [subtest((True, base_ctors), name="vectorized_base_tensor"),
+                                    subtest((False, base_ctors), name="base_tensor"),
+                                    subtest((True, logging_tensor_ctors), name="vectorized_logging_tensor"),
+                                    subtest((False, logging_tensor_ctors), name="logging_tensor")]))
+
 
 class TestAutogradFunctional(TestCase):
     def _assert_same_struct(self, res, base):
@@ -517,11 +523,11 @@ class TestAutogradFunctional(TestCase):
             result = api(foo, x, vectorize=True)
         self.assertEqual(len(wa), 0)
 
-    @FIXME_base_and_xfail_logging_tensor
+    @base_and_logging_tensor
     def test_jacobian_vectorize_raises_no_warnings(self, ctors):
         return self._test_vectorize_raises_no_warnings(autogradF.jacobian, ctors)
 
-    @FIXME_base_and_xfail_logging_tensor
+    @base_and_logging_tensor
     def test_hessian_vectorize_raises_no_warnings(self, ctors):
         return self._test_vectorize_raises_no_warnings(autogradF.hessian, ctors)
 
@@ -609,7 +615,7 @@ class TestAutogradFunctional(TestCase):
         self.assertIsNotNone(res.grad_fn)
         self.assertNotEqual(res, ctors.zeros(4, 4))
 
-    @FIXME_xfail_vectorized_logging_tensor
+    @vectorized_logging_tensor
     def test_jacobian_output(self, vectorize, ctors):
         def exp_reducer(x):
             return x.exp().sum(dim=1)
@@ -637,7 +643,7 @@ class TestAutogradFunctional(TestCase):
         self.assertIsNone(res[0].grad_fn)
         self.assertIsNone(res[1].grad_fn)
 
-    @FIXME_xfail_vectorized_logging_tensor
+    @vectorized_logging_tensor
     def test_jacobian_scalar(self, vectorize, ctors):
         def reducer(x):
             return x.sum()
@@ -768,7 +774,7 @@ class TestAutogradFunctional(TestCase):
         y = ctors.randn(3)
         self._check_jacobian_vectorize_correctness(f, (x, y))
 
-    @FIXME_base_and_xfail_logging_tensor
+    @base_and_logging_tensor
     def test_jacobian_vectorize_correctness_different_dtype(self, ctors):
         def f(x, y):
             return (x * y).float(), (x * y).double()
@@ -925,7 +931,7 @@ class TestAutogradFunctional(TestCase):
         self.assertIsNotNone(res[1][1].grad_fn)
         self.assertNotEqual(res, ctors.zeros(2, 2, 2))
 
-    @FIXME_xfail_vectorized_logging_tensor
+    @vectorized_logging_tensor
     def test_hessian_output(self, vectorize, ctors):
         def pow_reducer(x):
             return x.pow(3).sum()

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -569,8 +569,8 @@ class TestTorchFunctionOverride(TestCase):
             @classmethod
             def __torch_function__(cls, func, types, args=(), kwargs=None):
                 inputs, outputs = args
-                self.assertIs(inputs[0], x)
-                self.assertIs(outputs[0], x)
+                self.assertIs(inputs, x)
+                self.assertIs(outputs, x)
                 return -1
 
         x = Dummy()
@@ -783,7 +783,8 @@ class Wrapper:
             elif isinstance(a, collections.abc.Sequence):
                 args_of_this_cls.extend(el for el in a if isinstance(el, cls))
         assert len(args_of_this_cls) > 0
-        args_of_this_cls[0].used_calls.add(func)
+        for a in args_of_this_cls:
+            a.used_calls.add(func)
         args = unwrap(tuple(args))
         kwargs = {k: unwrap(v) for k, v in kwargs.items()}
 

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -559,6 +559,38 @@ class TestTorchFunctionOverride(TestCase):
         self.assertTrue(c._is_view())
         self.assertTrue(c._base is a)
 
+    def test_grad(self):
+        # Previously, Tensor-like objects that did not subclass from Tensor
+        # did not get wrapped into unary tuples before being passed into
+        # handle_torch_function, in contradiction with how Tensor-likes
+        # were handled
+
+        class Dummy:
+            @classmethod
+            def __torch_function__(cls, func, types, args=(), kwargs=None):
+                inputs, outputs = args
+                self.assertIs(inputs[0], x)
+                self.assertIs(outputs[0], x)
+                return -1
+
+        x = Dummy()
+        self.assertEqual(torch.autograd.grad(x, x), -1)
+
+    def test_pow_rpow(self):
+        class NothingImplemented(torch.Tensor):
+            @classmethod
+            def __torch_function__(cls, func, types, args=(), kwargs=None):
+                return NotImplemented
+
+        class RPowOnly(torch.Tensor):
+            @classmethod
+            def __torch_function__(cls, func, types, args=(), kwargs=None):
+                if func is torch.Tensor.__rpow__:
+                    return -1
+                return NotImplemented
+
+        self.assertEqual(NothingImplemented() ** RPowOnly(), -1)
+
 
 def generate_tensor_like_override_tests(cls):
     from torch.testing._internal.generated.annotated_fn_args import annotated_args
@@ -1209,6 +1241,88 @@ class TestTorchFunctionMode(TestCase):
             torch.sub(x, y)
         # add hits the torch function again!
         self.assertEqual(log, [torch.sub, torch.add])
+
+    def test_nn_parse_to(self):
+        # This failed because the parser thinks the function is called to()
+        # but it's actually called _parse_to()
+
+        called = False
+
+        class A(TorchFunctionMode):
+            def __torch_function__(self, func, types, args=(), kwargs=None):
+                nonlocal called
+                if kwargs is None:
+                    kwargs = {}
+                called = True
+                return func(*args, **kwargs)
+
+        with torch.overrides.push_torch_function_mode(A):
+            torch._C._nn._parse_to('cpu')
+
+        self.assertTrue(called)
+
+    def test_distributions_bernoulli(self):
+        # This failed because improper use of has_torch_function when
+        # is_tensor_like should have been used instead, inside the
+        # broadcasting logic called by distributions (Bernoulli doesn't
+        # matter per se)
+
+        called = False
+
+        class A(TorchFunctionMode):
+            def __torch_function__(self, func, types, args=(), kwargs=None):
+                nonlocal called
+                if kwargs is None:
+                    kwargs = {}
+                called = True
+                return func(*args, **kwargs)
+
+        with torch.overrides.push_torch_function_mode(A):
+            torch.distributions.Bernoulli(0.3)
+
+        self.assertTrue(called)
+
+    def test_mode_notimplemented_loop(self):
+        # Default tensor subclass implementation disables torch function;
+        # when we redispatch to mode we must not treat the objects as
+        # eligible
+
+        called = 0
+
+        class A(TorchFunctionMode):
+            def __torch_function__(self, func, types, args=(), kwargs=None):
+                nonlocal called
+                if kwargs is None:
+                    kwargs = {}
+                called += 1
+                # The first time we call, the mode sees an active type that
+                # it doesn't know how to deal with.  The second time, we're
+                # instructed to treat it "as if it were a tensor", and so
+                # we keep going.  I'm not entirely clear if the subclasses
+                # disappearing from types is the correct way to do it.
+                if any(t is not torch.Tensor for t in types):
+                    return NotImplemented
+                else:
+                    return func(*args, **kwargs)
+
+        class B(torch.Tensor):
+            pass
+
+        b = B()
+
+        with torch.overrides.push_torch_function_mode(A):
+            r = torch.neg(b)
+
+        self.assertIs(type(r), B)
+        self.assertEqual(called, 2)
+
+        called = 0
+
+        with torch.overrides.push_torch_function_mode(A):
+            r = bar(b)
+
+        self.assertIs(type(r), B)
+        self.assertEqual(called, 2)
 
 
 if __name__ == '__main__':

--- a/tools/autograd/templates/python_nn_functions.cpp
+++ b/tools/autograd/templates/python_nn_functions.cpp
@@ -43,7 +43,7 @@ static PyObject * THPVariable__parse_to(PyObject* module, PyObject* args, PyObje
   ParsedArgs<5> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.has_torch_function()) {
-    return handle_torch_function(r, args, kwargs, THPNNVariableFunctionsModule, "torch.nn");
+    return handle_torch_function(r, args, kwargs, THPNNVariableFunctionsModule, "torch.nn", "_parse_to");
   }
   auto parsed = parse_to_conversion(r, /*allow_copy*/ false); // we don't want copy for nn.Module.to
   auto& device = std::get<0>(parsed);

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -18,7 +18,7 @@ from torch.overrides import (
 import torch.utils.hooks as hooks
 
 
-def _wrap_type_error_to_not_implemented(f):
+def _handle_torch_function_and_handle_torch_function_and_wrap_type_error_to_not_implemented(f):
     # functools.wraps doesn't work well with methods in python 2
     method_assignments = ('__name__', '__doc__')
     assigned = functools.WRAPPER_ASSIGNMENTS
@@ -630,20 +630,20 @@ class Tensor(torch._C._TensorBase):
             )
         return torch.unique_consecutive(self, return_inverse=return_inverse, return_counts=return_counts, dim=dim)
 
-    @_wrap_type_error_to_not_implemented
+    @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __rsub__(self, other):
         return _C._VariableFunctions.rsub(self, other)
 
-    @_wrap_type_error_to_not_implemented
+    @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __rdiv__(self, other):
         return self.reciprocal() * other
 
     __rtruediv__ = __rdiv__
     __itruediv__ = _C._TensorBase.__idiv__
 
-    __pow__ = _wrap_type_error_to_not_implemented(_C._TensorBase.pow)
+    __pow__ = _handle_torch_function_and_wrap_type_error_to_not_implemented(_C._TensorBase.pow)
 
-    @_wrap_type_error_to_not_implemented
+    @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __rmod__(self, other):
         return torch.remainder(other, self)
 
@@ -654,18 +654,16 @@ class Tensor(torch._C._TensorBase):
             return self.item().__format__(format_spec)
         return object.__format__(self, format_spec)
 
-    @_wrap_type_error_to_not_implemented
+    @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __ipow__(self, other):  # type: ignore[misc]
-        if has_torch_function_variadic(self, other):
-            return handle_torch_function(Tensor.__ipow__, (self, other), self, other)
         return NotImplemented
 
-    @_wrap_type_error_to_not_implemented
+    @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __rpow__(self, other):
         dtype = torch.result_type(other, self)
         return torch.tensor(other, dtype=dtype, device=self.device) ** self
 
-    @_wrap_type_error_to_not_implemented
+    @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __floordiv__(self, other):
         warnings.warn("__floordiv__ is deprecated, and its behavior will change in a future version of pytorch. "
                       "It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). "
@@ -674,7 +672,7 @@ class Tensor(torch._C._TensorBase):
                       "or for actual floor division, use torch.div(a, b, rounding_mode='floor').", stacklevel=3)
         return torch.div(self, other, rounding_mode='trunc')
 
-    @_wrap_type_error_to_not_implemented
+    @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __rfloordiv__(self, other):
         warnings.warn("__rfloordiv__ is deprecated, and its behavior will change in a future version of pytorch. "
                       "It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). "
@@ -683,15 +681,15 @@ class Tensor(torch._C._TensorBase):
                       "or for actual floor division, use torch.div(a, b, rounding_mode='floor').", stacklevel=3)
         return torch.div(other, self, rounding_mode='trunc')
 
-    @_wrap_type_error_to_not_implemented
+    @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __rlshift__(self, other):
         return torch.bitwise_left_shift(other, self)
 
-    @_wrap_type_error_to_not_implemented
+    @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __rrshift__(self, other):
         return torch.bitwise_right_shift(other, self)
 
-    @_wrap_type_error_to_not_implemented
+    @_handle_torch_function_and_wrap_type_error_to_not_implemented
     def __rmatmul__(self, other):
         return torch.matmul(other, self)
 

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -18,7 +18,7 @@ from torch.overrides import (
 import torch.utils.hooks as hooks
 
 
-def _handle_torch_function_and_handle_torch_function_and_wrap_type_error_to_not_implemented(f):
+def _handle_torch_function_and_wrap_type_error_to_not_implemented(f):
     # functools.wraps doesn't work well with methods in python 2
     method_assignments = ('__name__', '__doc__')
     assigned = functools.WRAPPER_ASSIGNMENTS

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -10,7 +10,7 @@ import torch
 import warnings
 
 from torch.types import _TensorOrTensors
-from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Union, cast
 
 from .variable import Variable
 from .function import Function, NestedIOFunction
@@ -235,9 +235,9 @@ def grad(
             to show any performance warnings and file an issue on github if warnings exist
             for your use case. Defaults to ``False``.
     """
-    tupled_outputs = (outputs,) if is_tensor_like(outputs) else tuple(outputs)
-    tupled_inputs = (inputs,) if is_tensor_like(inputs) else tuple(inputs)
-    overridable_args = tupled_outputs + tupled_inputs
+    t_outputs = cast(Tuple[torch.Tensor, ...], (outputs,) if is_tensor_like(outputs) else tuple(outputs))
+    t_inputs = cast(Tuple[torch.Tensor, ...], (inputs,) if is_tensor_like(inputs) else tuple(inputs))
+    overridable_args = t_outputs + t_inputs
     if has_torch_function(overridable_args):
         return handle_torch_function(
             grad,
@@ -252,16 +252,13 @@ def grad(
             is_grads_batched=is_grads_batched,
         )
 
-    outputs = tupled_outputs
-    inputs = tupled_inputs
-
     if not only_inputs:
         warnings.warn("only_inputs argument is deprecated and is ignored now "
                       "(defaults to True). To accumulate gradient for other "
                       "parts of the graph, please use torch.autograd.backward.")
 
-    grad_outputs_ = _tensor_or_tensors_to_tuple(grad_outputs, len(outputs))
-    grad_outputs_ = _make_grads(outputs, grad_outputs_, is_grads_batched=is_grads_batched)
+    grad_outputs_ = _tensor_or_tensors_to_tuple(grad_outputs, len(t_outputs))
+    grad_outputs_ = _make_grads(t_outputs, grad_outputs_, is_grads_batched=is_grads_batched)
 
     if retain_graph is None:
         retain_graph = create_graph
@@ -272,12 +269,12 @@ def grad(
     if is_grads_batched:
         def vjp(gO):
             return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
-                outputs, gO, retain_graph, create_graph, inputs,
+                t_outputs, gO, retain_graph, create_graph, t_inputs,
                 allow_unused, accumulate_grad=False)  # Calls into the C++ engine to run the backward pass
         return _vmap_internals._vmap(vjp, 0, 0, allow_none_pass_through=True)(grad_outputs)
     else:
         return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
-            outputs, grad_outputs_, retain_graph, create_graph, inputs,
+            t_outputs, grad_outputs_, retain_graph, create_graph, t_inputs,
             allow_unused, accumulate_grad=False)  # Calls into the C++ engine to run the backward pass
 
 

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -235,9 +235,9 @@ def grad(
             to show any performance warnings and file an issue on github if warnings exist
             for your use case. Defaults to ``False``.
     """
-    outputs = (outputs,) if is_tensor_like(outputs) else tuple(outputs)
-    inputs = (inputs,) if is_tensor_like(inputs) else tuple(inputs)
-    overridable_args = outputs + inputs
+    tupled_outputs = (outputs,) if is_tensor_like(outputs) else tuple(outputs)
+    tupled_inputs = (inputs,) if is_tensor_like(inputs) else tuple(inputs)
+    overridable_args = tupled_outputs + tupled_inputs
     if has_torch_function(overridable_args):
         return handle_torch_function(
             grad,
@@ -251,6 +251,9 @@ def grad(
             allow_unused=allow_unused,
             is_grads_batched=is_grads_batched,
         )
+
+    outputs = tupled_outputs
+    inputs = tupled_inputs
 
     if not only_inputs:
         warnings.warn("only_inputs argument is deprecated and is ignored now "

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -17,7 +17,7 @@ from .function import Function, NestedIOFunction
 from .gradcheck import gradcheck, gradgradcheck
 from .grad_mode import no_grad, enable_grad, set_grad_enabled, inference_mode
 from .anomaly_mode import detect_anomaly, set_detect_anomaly
-from ..overrides import has_torch_function, handle_torch_function
+from ..overrides import has_torch_function, handle_torch_function, is_tensor_like
 from . import functional
 from . import forward_ad
 from . import graph
@@ -235,8 +235,8 @@ def grad(
             to show any performance warnings and file an issue on github if warnings exist
             for your use case. Defaults to ``False``.
     """
-    outputs = (outputs,) if isinstance(outputs, torch.Tensor) else tuple(outputs)
-    inputs = (inputs,) if isinstance(inputs, torch.Tensor) else tuple(inputs)
+    outputs = (outputs,) if is_tensor_like(outputs) else tuple(outputs)
+    inputs = (inputs,) if is_tensor_like(inputs) else tuple(inputs)
     overridable_args = outputs + inputs
     if has_torch_function(overridable_args):
         return handle_torch_function(
@@ -249,6 +249,7 @@ def grad(
             create_graph=create_graph,
             only_inputs=only_inputs,
             allow_unused=allow_unused,
+            is_grads_batched=is_grads_batched,
         )
 
     if not only_inputs:

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -342,7 +342,7 @@ auto handle_torch_function_no_python_arg_parser(
 auto handle_torch_function(PythonArgs &r, PyObject* self, PyObject* args, PyObject* kwargs, PyObject* torch_api, const char* module_name, const char* func_name_override) -> PyObject* {
   py::object torch_api_function = PyObject_FastGetAttrString(
     torch_api,
-    const_cast<char*>(
+    (char*)(
       func_name_override ? func_name_override : r.get_func_name().c_str()
     )
   );

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -339,8 +339,13 @@ auto handle_torch_function_no_python_arg_parser(
   return ret.release().ptr();
 }
 
-auto handle_torch_function(PythonArgs &r, PyObject* self, PyObject* args, PyObject* kwargs, PyObject* torch_api, const char* module_name) -> PyObject* {
-  py::object torch_api_function = PyObject_FastGetAttrString(torch_api, (char*)r.get_func_name().c_str());
+auto handle_torch_function(PythonArgs &r, PyObject* self, PyObject* args, PyObject* kwargs, PyObject* torch_api, const char* module_name, const char* func_name_override) -> PyObject* {
+  py::object torch_api_function = PyObject_FastGetAttrString(
+    torch_api,
+    const_cast<char*>(
+      func_name_override ? func_name_override : r.get_func_name().c_str()
+    )
+  );
   TORCH_INTERNAL_ASSERT(torch_api_function.ptr() != nullptr, "torch API function must exist");
   py::object ret;
   py::tuple args_ = combine_self_args(self, args);
@@ -354,9 +359,9 @@ auto handle_torch_function(PythonArgs &r, PyObject* self, PyObject* args, PyObje
   return handle_torch_function_no_python_arg_parser(r.signature.overloaded_args, args_.ptr(), kwargs, r.get_func_name().c_str(), torch_api_function.ptr(), module_name);
 }
 
-auto handle_torch_function(PythonArgs &r, PyObject* args, PyObject* kwargs, PyObject* torch_api, const char* module_name) -> PyObject*
+auto handle_torch_function(PythonArgs &r, PyObject* args, PyObject* kwargs, PyObject* torch_api, const char* module_name, const char* func_name_override) -> PyObject*
 {
-  return handle_torch_function(r, nullptr, args, kwargs, torch_api, module_name);
+  return handle_torch_function(r, nullptr, args, kwargs, torch_api, module_name, func_name_override);
 }
 
 auto handle_torch_function_indexing(PyObject* self, PyObject* index, PyObject* val) -> PyObject* {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -274,8 +274,7 @@ inline PythonArgs PythonArgParser::parse(PyObject* self, ParsedArgs<0>& dst) {
 
 inline bool PythonArgs::has_torch_function(){
   return !this->signature.overloaded_args.empty() ||
-      (torch::torch_function_enabled() &&
-       at::impl::PythonTorchFunctionTLS::get_mode());
+       at::impl::PythonTorchFunctionTLS::get_mode();
 }
 
 inline std::string PythonArgs::get_func_name(){
@@ -791,10 +790,10 @@ inline PyObject* PythonArgs::pyobject(int i) {
  *
  */
 // Used for Tensor methods with arguments.
-auto handle_torch_function(PythonArgs &r, PyObject* self, PyObject* args, PyObject* kwargs, PyObject* torch_api, const char* module_name) -> PyObject*;
+auto handle_torch_function(PythonArgs &r, PyObject* self, PyObject* args, PyObject* kwargs, PyObject* torch_api, const char* module_name, const char* func_name_override = nullptr) -> PyObject*;
 
 // Used for functions which needs to parse python args.
-auto handle_torch_function(PythonArgs &r, PyObject* args, PyObject* kwargs, PyObject* torch_api, const char* module_name) -> PyObject*;
+auto handle_torch_function(PythonArgs &r, PyObject* args, PyObject* kwargs, PyObject* torch_api, const char* module_name, const char* func_name_override = nullptr) -> PyObject*;
 
 // Used for functions that have no argument parsing.
 auto handle_torch_function(PyObject* self, const std::string& func_name, PyObject* args=nullptr, PyObject* kwargs=nullptr, PyObject* torch_api=THPVariableClass, const std::string& module_name="torch.Tensor") -> PyObject*;

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -3,7 +3,7 @@ from numbers import Number
 import torch
 import torch.nn.functional as F
 from typing import Dict, Any
-from torch.overrides import has_torch_function
+from torch.overrides import is_tensor_like
 
 euler_constant = 0.57721566490153286060  # Euler Mascheroni Constant
 
@@ -24,17 +24,17 @@ def broadcast_all(*values):
         ValueError: if any of the values is not a `numbers.Number` instance,
             a `torch.*Tensor` instance, or an instance implementing __torch_function__
     """
-    if not all(isinstance(v, torch.Tensor) or has_torch_function((v,)) or isinstance(v, Number)
+    if not all(is_tensor_like(v) or isinstance(v, Number)
                for v in values):
         raise ValueError('Input arguments must all be instances of numbers.Number, '
                          'torch.Tensor or objects implementing __torch_function__.')
-    if not all([isinstance(v, torch.Tensor) or has_torch_function((v,)) for v in values]):
+    if not all(is_tensor_like(v) for v in values):
         options: Dict[str, Any] = dict(dtype=torch.get_default_dtype())
         for value in values:
             if isinstance(value, torch.Tensor):
                 options = dict(dtype=value.dtype, device=value.device)
                 break
-        new_values = [v if isinstance(v, torch.Tensor) or has_torch_function((v,)) else torch.tensor(v, **options)
+        new_values = [v if is_tensor_like(v) else torch.tensor(v, **options)
                       for v in values]
         return torch.broadcast_tensors(*new_values)
     return torch.broadcast_tensors(*values)

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1147,7 +1147,7 @@ def tensordot(a, b, dims=2, out: Optional[torch.Tensor] = None):  # noqa: F811
                 [ -0.2850,   4.2573,  -3.5997]])
     """
     if has_torch_function_variadic(a, b):
-        return handle_torch_function(tensordot, (a, b), a, b, dims=dims)
+        return handle_torch_function(tensordot, (a, b), a, b, dims=dims, out=out)
 
     if not isinstance(dims, (tuple, list, torch.Tensor, int)):
         raise RuntimeError("tensordot expects dims to be int or "

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5176,6 +5176,7 @@ def multi_head_attention_forward(
             v_proj_weight=v_proj_weight,
             static_k=static_k,
             static_v=static_v,
+            average_attn_weights=average_attn_weights,
         )
 
     is_batched = _mha_shape_check(query, key, value, key_padding_mask, attn_mask, num_heads)

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1313,6 +1313,9 @@ def _get_overloaded_args(relevant_args: Iterable[Any]) -> List[Any]:
     .. _NEP-0018:
        https://numpy.org/neps/nep-0018-array-function-protocol.html
     """
+    # If torch function is not enabled, there are no overloaded types
+    if not torch._C._is_torch_function_enabled():
+        return []
     # Runtime is O(num_arguments * num_unique_types)
     overloaded_types: Set[Type] = set()
     overloaded_args: List[Any] = []
@@ -1424,8 +1427,11 @@ def handle_torch_function(
 
 has_torch_function = _add_docstr(
     _has_torch_function,
-    r"""Check for __torch_function__ implementations in the elements of an iterable.
-    Considers exact ``Tensor`` s and ``Parameter`` s non-dispatchable.
+    r"""Check for __torch_function__ implementations in the elements of an iterable
+    or if a __torch_function__ mode is enabled.  Considers exact ``Tensor`` s
+    and ``Parameter`` s non-dispatchable.  Use this to guard a call to
+    :func:`handle_torch_function`; don't use it to test if something
+    is Tensor-like, use :func:`is_tensor_like` instead.
     Arguments
     ---------
     relevant_args : iterable

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -777,7 +777,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
             lambda query, key, value, embed_dim_to_check, num_heads, in_proj_weight, in_proj_bias, bias_k, bias_v,
             add_zero_attn, dropout_p, out_proj_weight, out_proj_bias, training=True, key_padding_mask=None,
             need_weights=True, attn_mask=None, use_separate_proj_weight=False, q_proj_weight=None, k_proj_weight=None,
-            v_proj_weight=None, static_k=None, static_v=None: -1),
+            v_proj_weight=None, static_k=None, static_v=None, average_attn_weights=None: -1),
         torch.nn.functional.multi_margin_loss: (lambda input, target, p=1, margin=1.0, weight=None, size_average=None,
                                                 reduce=None, reduction='mean': -1),
         torch.nn.functional.multilabel_margin_loss: (lambda input, target, size_average=None, reduce=None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75484

I figured these out by unconditionally turning on a no-op torch function
mode on the test suite and then fixing errors as they showed up.  Here's
what I found:

- _parse_to failed internal assert when __torch_function__'ed because it
  claims its name is "to" to the argument parser; added a name override
  so we know how to find the correct name

- Infix operator magic methods on Tensor did not uniformly handle
  __torch_function__ and TypeError to NotImplemented.  Now, we always
  do the __torch_function__ handling in
  _wrap_type_error_to_not_implemented and your implementation of
  __torch_function__ gets its TypeErrors converted to NotImplemented
  (for better or for worse; see
  https://github.com/pytorch/pytorch/issues/75462 )

- A few cases where code was incorrectly testing if a Tensor was
  Tensor-like in the wrong way, now use is_tensor_like (in grad
  and in distributions).  Also update docs for has_torch_function to
  push people to use is_tensor_like.

- is_grads_batched was dropped from grad in handle_torch_function, now
  fixed

- Report that you have a torch function even if torch function is
  disabled if a mode is enabled.  This makes it possible for a mode
  to return NotImplemented, pass to a subclass which does some
  processing and then pass back to the mode even after the subclass
  disables __torch_function__ (so the tensors are treated "as if"
  they are regular Tensors).  This brings the C++ handling behavior
  in line with the Python behavior.

- Make the Python implementation of overloaded types computation match
  the C++ version: when torch function is disabled, there are no
  overloaded types (because they all report they are not overloaded).

- torch.autograd.grad did not faithfully report its arguments to handle_torch_function; now it does

- Wrapper in test/test_overrides.py did not record usages for all arguments, leading to spurious failure when torch.autograd.grad started correctly wrapping Wrapper in a tuple (and not only true Tensors)

- tensordot did not forward out kwarg to handle_torch_function

- multi_head_attention_forward did not forward average_attn_weights kwarg to handle_torch_function

Signed-off-by: Edward Z. Yang <ezyang@fb.com>