### PR TITLE
prevent overriding shuffle settings in DataLoader for datapipes

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1448,7 +1448,7 @@ except RuntimeError as e:
 
         dataset = TestMultiEpochDataset(batch_size * num_workers)
         dataloader = self._get_data_loader(dataset, batch_size=batch_size,
-                                           num_workers=num_workers)
+                                           shuffle=False, num_workers=num_workers)
 
         for ind in range(num_epochs):
             for batch_idx, sample in enumerate(dataloader):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1448,7 +1448,7 @@ except RuntimeError as e:
 
         dataset = TestMultiEpochDataset(batch_size * num_workers)
         dataloader = self._get_data_loader(dataset, batch_size=batch_size,
-                                           shuffle=False, num_workers=num_workers)
+                                           num_workers=num_workers)
 
         for ind in range(num_epochs):
             for batch_idx, sample in enumerate(dataloader):

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -228,9 +228,12 @@ class DataLoader(Generic[T_co]):
             # option. If this turns out to be useful in future, we can re-enable
             # this, and support custom samplers that specify the assignments to
             # specific workers.
-            if isinstance(dataset, IterDataPipe) and shuffle is not None:
-                dataset = torch.utils.data.graph_settings.apply_shuffle_settings(dataset, shuffle=shuffle)
-            elif shuffle:
+            if isinstance(dataset, IterDataPipe):
+                if shuffle is not None:
+                    dataset = torch.utils.data.graph_settings.apply_shuffle_settings(dataset, shuffle=shuffle)
+                else:
+                    shuffle = False
+            if shuffle is not False:
                 raise ValueError(
                     "DataLoader with IterableDataset: expected unspecified "
                     "shuffle option, but got shuffle={}".format(shuffle))
@@ -246,6 +249,7 @@ class DataLoader(Generic[T_co]):
                     "DataLoader with IterableDataset: expected unspecified "
                     "batch_sampler option, but got batch_sampler={}".format(batch_sampler))
         else:
+            shuffle = bool(shuffle)
             self._dataset_kind = _DatasetKind.Map
 
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -230,7 +230,7 @@ class DataLoader(Generic[T_co]):
             # specific workers.
             if isinstance(dataset, IterDataPipe) and shuffle is not None:
                 dataset = torch.utils.data.graph_settings.apply_shuffle_settings(dataset, shuffle=shuffle)
-            elif shuffle is not None:
+            elif shuffle:
                 raise ValueError(
                     "DataLoader with IterableDataset: expected unspecified "
                     "shuffle option, but got shuffle={}".format(shuffle))

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -164,7 +164,7 @@ class DataLoader(Generic[T_co]):
     __initialized = False
 
     def __init__(self, dataset: Dataset[T_co], batch_size: Optional[int] = 1,
-                 shuffle: bool = False, sampler: Union[Sampler, Iterable, None] = None,
+                 shuffle: Optional[bool] = None, sampler: Union[Sampler, Iterable, None] = None,
                  batch_sampler: Union[Sampler[Sequence], Iterable[Sequence], None] = None,
                  num_workers: int = 0, collate_fn: Optional[_collate_fn_t] = None,
                  pin_memory: bool = False, drop_last: bool = False,
@@ -228,9 +228,9 @@ class DataLoader(Generic[T_co]):
             # option. If this turns out to be useful in future, we can re-enable
             # this, and support custom samplers that specify the assignments to
             # specific workers.
-            if isinstance(dataset, IterDataPipe):
+            if isinstance(dataset, IterDataPipe) and shuffle is not None:
                 dataset = torch.utils.data.graph_settings.apply_shuffle_settings(dataset, shuffle=shuffle)
-            elif shuffle is not False:
+            elif shuffle is not None:
                 raise ValueError(
                     "DataLoader with IterableDataset: expected unspecified "
                     "shuffle option, but got shuffle={}".format(shuffle))

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -231,7 +231,8 @@ class DataLoader(Generic[T_co]):
             if isinstance(dataset, IterDataPipe):
                 if shuffle is not None:
                     dataset = torch.utils.data.graph_settings.apply_shuffle_settings(dataset, shuffle=shuffle)
-            elif shuffle is not False:
+            # We cannot check `shuffle is not None` here, since previously `shuffle=False` was the default.
+            elif shuffle not in {False, None}:
                 raise ValueError(
                     "DataLoader with IterableDataset: expected unspecified "
                     "shuffle option, but got shuffle={}".format(shuffle))

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -231,9 +231,7 @@ class DataLoader(Generic[T_co]):
             if isinstance(dataset, IterDataPipe):
                 if shuffle is not None:
                     dataset = torch.utils.data.graph_settings.apply_shuffle_settings(dataset, shuffle=shuffle)
-                else:
-                    shuffle = False
-            if shuffle is not False:
+            elif shuffle is not False:
                 raise ValueError(
                     "DataLoader with IterableDataset: expected unspecified "
                     "shuffle option, but got shuffle={}".format(shuffle))


### PR DESCRIPTION
Fixes https://github.com/pytorch/data/issues/295

Follow-up to https://github.com/pytorch/pytorch/pull/75014#issuecomment-1091921305. We only need to update locations where we actually check `shuffle` for identity with a boolean value, i.e. `shuffle is False`. For bool-ish checks like `if shuffle:`, `None` behaves just like `False`.

`IterDataPipe`'s are currently not mentioned in the docstring. Since this change only applies to them, I didn't update it. LMK, if I should do that.
