### PR TITLE
[BE] Fix deprecated usages of `isIntegral`

### DIFF
--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -1099,7 +1099,7 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
           throw std::runtime_error(
               "Cannot convert a tensor of dimension > 0 to scalar");
         }
-        if (!isIntegralType(tensor.scalar_type())) {
+        if (!isIntegralType(tensor.scalar_type(), /*includeBool=*/false)) {
           std::stringstream ss;
           ss << "Cannot input a tensor of type " << tensor.scalar_type()
              << " as an integral argument";

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
@@ -50,7 +50,7 @@ torch::jit::Value* TSLoweringContext::GetParameter(BackendDataPtr data) {
       auto scalarType = ts_data->scalar.value().type();
       if (isFloatingType(scalarType)) {
         param->setType(c10::FloatType::get());
-      } else if (isIntegralType(scalarType) || (scalarType == c10::kBool)) {
+      } else if (isIntegralType(scalarType, /*includeBool=*/true)) {
         param->setType(c10::IntType::get());
       } else {
         TORCH_CHECK(


### PR DESCRIPTION
By passing `includeBool=` parameter
