### PR TITLE
[kineto] ClientInterface stub for ProfilerKineto

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -163,6 +163,7 @@ libtorch_profiler_sources = [
     "torch/csrc/profiler/collection.cpp",
     "torch/csrc/profiler/kineto_shim.cpp",
     "torch/csrc/profiler/nvtx_observer.cpp",
+    "torch/csrc/profiler/kineto_client_interface.cpp",
     "torch/csrc/monitor/counters.cpp",
     "torch/csrc/monitor/events.cpp",
 ]

--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -1,0 +1,45 @@
+#ifdef USE_KINETO
+#include <libkineto.h>
+
+namespace torch {
+namespace profiler {
+namespace impl {
+
+namespace {
+
+class LibKinetoClient : public libkineto::ClientInterface {
+ public:
+  void init() override {
+    // TODO: implement
+  }
+
+  void warmup(bool setupOpInputsCollection) override {
+    // TODO: implement
+  }
+
+  void start() override {
+    // TODO: implement
+  }
+
+  void stop() override {
+    // TODO: implement
+  }
+};
+
+} // namespace
+
+
+} // namespace impl
+} // namespace profiler
+
+#ifdef ENABLE_LIBKINETO_CLIENT
+struct RegisterLibKinetoClient {
+  RegisterLibKinetoClient() {
+    static profiler::impl::LibKinetoClient client;
+    libkineto::api().registerClient(&client);
+  }
+} register_libkineto_client;
+#endif // ENABLE_LIBKINETO_CLIENT
+
+} // namespace torch
+#endif // USE_KINETO


### PR DESCRIPTION
Summary: Creating injection point for ProfilerKineto to attach global callback. We'll disable the KinetoObserver via `'kineto.disable_libkineto_observer=1'` and enable this to swap out the implementations.

Test Plan:
1. add temporary logs in the stub + registration method
2. `buck build mode/opt //kineto/libkineto/fb/integration_tests:trace_tester --config 'kineto.disable_libkineto_observer=1' --config "kineto.enable_libkineto_client=1`
3. `./buck-out/gen/kineto/libkineto/fb/integration_tests/trace_tester --test_ondemand --libkineto_runner_iterations 1000000` should see log for registration
4. `dyno gputrace` should see log for start/stop

Differential Revision: D35456304

