### PR TITLE
Fix tsan issue

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -1137,9 +1137,14 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             for i in range(len(inputs))
         ]
         tmp = {}
+        input_holder = {}
         for i in range(len(inputs)):
-            tmp[i] = [fn(inputs[i])]
-            fut = pg.allgather(outputs[i], tmp[i]).get_future()
+            # Note that this works around the data race discussed in
+            # https://github.com/pytorch/pytorch/issues/75529, but we should
+            # actually be able to pass the list directly into allgather when
+            # that race is fixed.
+            input_holder[i] = [fn(inputs[i])]
+            fut = pg.allgather(outputs[i], input_holder[i]).get_future()
             future_handles.append(fut)
 
         for i, future_handle in enumerate(future_handles):

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -1136,8 +1136,10 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             [[torch.tensor([i + j]) for j in range(self.world_size)]]
             for i in range(len(inputs))
         ]
+        tmp = {}
         for i in range(len(inputs)):
-            fut = pg.allgather(outputs[i], [fn(inputs[i])]).get_future()
+            tmp[i] = [fn(inputs[i])]
+            fut = pg.allgather(outputs[i], tmp[i]).get_future()
             future_handles.append(fut)
 
         for i, future_handle in enumerate(future_handles):
@@ -1148,6 +1150,8 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
                 [result],
                 msg=("Mismatch in iteration %d" % i),
             )
+
+        print(" -- passed --")
 
     @requires_gloo()
     def test_allgather_stress(self):

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -1136,7 +1136,6 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
             [[torch.tensor([i + j]) for j in range(self.world_size)]]
             for i in range(len(inputs))
         ]
-        tmp = {}
         input_holder = {}
         for i in range(len(inputs)):
             # Note that this works around the data race discussed in
@@ -1155,8 +1154,6 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
                 [result],
                 msg=("Mismatch in iteration %d" % i),
             )
-
-        print(" -- passed --")
 
     @requires_gloo()
     def test_allgather_stress(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75528

- Running into a race in `TensorImpl` described here: https://github.com/pytorch/pytorch/issues/75529 that is triggered by passing in a temporary list of tensor into allgather, which results in a race when python deallocation runs concurrently with gloo's io thread reading/writing from the tensor. This was identified by @kumpera 
- Workaround is to allocate the python tensor as a local variable so deallocation does not run until after the allgather async call is completed. This fixes the distributed test but the proper fix should be in TensorImpl.

Differential Revision: [D35504430](https://our.internmc.facebook.com/intern/diff/D35504430/)