### PR TITLE
[quant][ns] Rename the weight tensor name to match fx NS tool

### DIFF
--- a/test/quantization/eager/test_numeric_suite_eager.py
+++ b/test/quantization/eager/test_numeric_suite_eager.py
@@ -371,7 +371,7 @@ class TestNumericSuiteEager(QuantizationTestCase):
 
         def compare_and_validate_results(float_model, q_model, data):
             act_compare_dict = compare_model_outputs(float_model, q_model, data)
-            expected_act_compare_dict_keys = {"conv.stats", "quant.stats"}
+            expected_act_compare_dict_keys = {"conv", "quant"}
 
             self.assertTrue(act_compare_dict.keys() == expected_act_compare_dict_keys)
             for k, v in act_compare_dict.items():
@@ -394,7 +394,7 @@ class TestNumericSuiteEager(QuantizationTestCase):
 
         def compare_and_validate_results(float_model, q_model, data):
             act_compare_dict = compare_model_outputs(float_model, q_model, data)
-            expected_act_compare_dict_keys = {"fc1.quant.stats", "fc1.module.stats"}
+            expected_act_compare_dict_keys = {"fc1.quant", "fc1.module"}
 
             self.assertTrue(act_compare_dict.keys() == expected_act_compare_dict_keys)
             for k, v in act_compare_dict.items():
@@ -426,11 +426,11 @@ class TestNumericSuiteEager(QuantizationTestCase):
         act_compare_dict = compare_model_outputs(model, q_model, self.img_data_2d[0][0])
         self.assertEqual(len(act_compare_dict), 5)
         expected_act_compare_dict_keys = {
-            "mycat.stats",
-            "myadd.stats",
-            "mymul.stats",
-            "myadd_relu.stats",
-            "quant.stats",
+            "mycat",
+            "myadd",
+            "mymul",
+            "myadd_relu",
+            "quant",
         }
         self.assertTrue(act_compare_dict.keys() == expected_act_compare_dict_keys)
         for k, v in act_compare_dict.items():
@@ -447,7 +447,7 @@ class TestNumericSuiteEager(QuantizationTestCase):
 
         def compare_and_validate_results(float_model, q_model, data):
             act_compare_dict = compare_model_outputs(float_model, q_model, data)
-            expected_act_compare_dict_keys = {"fc1.stats"}
+            expected_act_compare_dict_keys = {"fc1"}
 
             self.assertTrue(act_compare_dict.keys() == expected_act_compare_dict_keys)
             for k, v in act_compare_dict.items():
@@ -476,7 +476,7 @@ class TestNumericSuiteEager(QuantizationTestCase):
             act_compare_dict = compare_model_outputs(
                 float_model, q_model, input, hidden
             )
-            expected_act_compare_dict_keys = {"lstm.stats"}
+            expected_act_compare_dict_keys = {"lstm"}
 
             self.assertTrue(act_compare_dict.keys() == expected_act_compare_dict_keys)
             for k, v in act_compare_dict.items():

--- a/torch/ao/ns/_numeric_suite.py
+++ b/torch/ao/ns/_numeric_suite.py
@@ -115,7 +115,9 @@ def compare_weights(
                     quantized_dict[key].__getstate__()[0][4][1].__getstate__()[0][0]
                 )
     # To match the key name with FX ns
-    weight_dict = { k.replace('.weight', '').replace('._packed_params._packed_params', ''): v for k, v in weight_dict.items()}
+    weight_dict = {
+        k.replace('.weight', '').replace('._packed_params._packed_params', ''): v for k, v in weight_dict.items()
+    }
     return weight_dict
 
 
@@ -523,5 +525,5 @@ def compare_model_outputs(
     float_model(*data)
     q_model(*data)
     act_compare_dict = get_matching_activations(float_model, q_model)
-    act_compare_dict = { k.replace('.stats', ''): v for k, v in act_compare_dict.items()}
+    act_compare_dict = {k.replace('.stats', ''): v for k, v in act_compare_dict.items()}
     return act_compare_dict

--- a/torch/ao/ns/_numeric_suite.py
+++ b/torch/ao/ns/_numeric_suite.py
@@ -523,4 +523,5 @@ def compare_model_outputs(
     float_model(*data)
     q_model(*data)
     act_compare_dict = get_matching_activations(float_model, q_model)
+    act_compare_dict = { k.replace('.stats', ''): v for k, v in act_compare_dict.items()}
     return act_compare_dict

--- a/torch/ao/ns/_numeric_suite.py
+++ b/torch/ao/ns/_numeric_suite.py
@@ -114,7 +114,8 @@ def compare_weights(
                 weight_dict[key]["quantized"] = (
                     quantized_dict[key].__getstate__()[0][4][1].__getstate__()[0][0]
                 )
-
+    # To match the key name with FX ns
+    weight_dict = { k.replace('.weight', '').replace('._packed_params._packed_params', ''): v for k, v in weight_dict.items()}
     return weight_dict
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75530

Summary:
Rename the weight tensor name to match fx NS tool

Test Plan:
python3 test/test_quantization.py TestNumericSuiteEager

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D35510535](https://our.internmc.facebook.com/intern/diff/D35510535)