### PR TITLE
ci: add repo-token for stale workflow

### DIFF
--- a/.github/workflows/stale_pull_requests.yml
+++ b/.github/workflows/stale_pull_requests.yml
@@ -22,6 +22,8 @@ jobs:
           days-before-issue-stale: -1
           days-before-issue-close: -1
           ascending: true
+          repo-token: ${{ secrets.GH_STALEBOT_TOKEN }}
+          operations-per-run: 1000
   stale-open-source:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     runs-on: ubuntu-18.04
@@ -40,3 +42,5 @@ jobs:
           days-before-issue-stale: -1
           days-before-issue-close: -1
           ascending: true
+          repo-token: ${{ secrets.GH_STALEBOT_TOKEN }}
+          operations-per-run: 1000


### PR DESCRIPTION
This should put us up to 5000 API actions per hour

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Fixes #ISSUE_NUMBER
