### PR TITLE
[c10d] fix nccl gather outputs on non-root ranks

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -2282,6 +2282,9 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::gather(
       invalidArgument("requires empty output on non-root");
     }
     outputs = {};
+    // append a empty tensor to the list, we don't use it but
+    // collective function requires it to invoke its macros
+    outputs.emplace_back();
   }
 
   return collective(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #73703
* __->__ #75535

we need to fill a empty tensor to outputs list bc collective macro requires it

Differential Revision: [D35508587](https://our.internmc.facebook.com/intern/diff/D35508587/)