### PR TITLE
refining regrex of .gitignore core.* 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -312,7 +312,7 @@ bazel-*
 *.zip
 
 # core dump files
-core.*
+**/core.[1-9]*
 
 # Generated if you use the pre-commit script for clang-tidy
 pr.diff


### PR DESCRIPTION
- core.* regrex is changed to more refined command

Fixes #74890 
