### PR TITLE
Fix: Make `nn.init.orthogonal_` no-op for empty input

### DIFF
--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -465,10 +465,10 @@ def orthogonal_(tensor, gain=1):
     if tensor.ndimension() < 2:
         raise ValueError("Only tensors with 2 or more dimensions are supported")
 
-    rows = tensor.size(0)
-    if rows == 0:
+    if tensor.numel() == 0:
         # no-op
         return tensor
+    rows = tensor.size(0)
     cols = tensor.numel() // rows
     flattened = tensor.new(rows, cols).normal_(0, 1)
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -466,6 +466,9 @@ def orthogonal_(tensor, gain=1):
         raise ValueError("Only tensors with 2 or more dimensions are supported")
 
     rows = tensor.size(0)
+    if rows == 0:
+        # no-op
+        return tensor
     cols = tensor.numel() // rows
     flattened = tensor.new(rows, cols).normal_(0, 1)
 


### PR DESCRIPTION
Fixes #73503.
