### PR TITLE
DOCS: copy to directory with complete version including rcX

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -77,8 +77,8 @@ jobs:
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
         run: |
           set -ex
-          # Convert refs/tags/v1.12.0rc3 into 1.12
-          if [[ "${GITHUB_REF}" =~ ^refs/tags/v([0-9]+\.[0-9]+)\.* ]]; then
+          # Convert refs/tags/v1.12.0rc3 into 1.12.0rc3
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/v(.*) ]]; then
             target="${BASH_REMATCH[1]}"
           else
             target="master"


### PR DESCRIPTION
Fixes pytorch/pytorch.github.io#994

Tagging this repo creates a documentation set in a directory at [pytorch.github.io/docs](https://github.com/pytorch/pytorch.github.io/tree/site/docs). The name of the directory should have the complete version (1.12.0rc1) and not just major.minor (1.12) in order to avoid overriding previous versions' documentation when tagging a new release version (1.12.1rc1). The version in the documentation is controlled by the parsing in [conf.py](https://github.com/pytorch/pytorch/blob/f42bdff0166ef503c844353c32b6725391e440ac/docs/source/conf.py#L285) so this change is only about the directory used in the [upload script](https://github.com/pytorch/pytorch/blob/f42bdff0166ef503c844353c32b6725391e440ac/.circleci/scripts/python_doc_push_script.sh#L34)
