### PR TITLE
Add fastpath for stack and cat JVP computation

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -4733,7 +4733,7 @@ Tensor cat_jvp(at::TensorList tensors, int64_t dim) {
     std::vector<Tensor> fw_grads;
 
     for (auto& t: tensors) {
-      fw_grads.push_back(isFwGradDefined(t)? t._fw_grad(/*level*/ 0): at::zeros_like(t));
+      fw_grads.push_back(isFwGradDefined(t)? t._fw_grad(/*level*/ 0): at::_efficientzerotensor(t.sizes(), t.options()));
     }
 
     out_fw_grad = at::cat(fw_grads, dim);
@@ -4756,7 +4756,7 @@ Tensor stack_jvp(at::TensorList tensors, int64_t dim) {
     std::vector<Tensor> fw_grads;
 
     for (auto& t: tensors) {
-      fw_grads.push_back(isFwGradDefined(t)? t._fw_grad(/*level*/ 0): at::zeros_like(t));
+      fw_grads.push_back(isFwGradDefined(t)? t._fw_grad(/*level*/ 0): at::_efficientzerotensor(t.sizes(), t.options()));
     }
     out_fw_grad = at::stack(fw_grads, dim);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #75590

[5-6x perf gain on CPU across a wide range of sizes for cat JVP computation with four tensors](https://github.com/pytorch/pytorch/pull/75590#issuecomment-1094514293).
[5-10x perf gain on CPU across a wide range of sizes for stack JVP computation with four tensors.](https://github.com/pytorch/pytorch/pull/75590#issuecomment-1094527645)
In future, when there are more instances of `zeros_like` which should be replaced with EZT constructors, we should consider adding an `_like` API for efficient zero tensors. This is most commonly used in backward mode. We could replace all those instances if we decide to make grad immutable.