### PR TITLE
[libkineto] Re-enable user-annotations in PyTorch

### DIFF
--- a/benchmarks/fastrnns/bench.py
+++ b/benchmarks/fastrnns/bench.py
@@ -6,6 +6,7 @@ import sys
 import json
 import copy
 import time
+from torch.autograd.profiler import record_function
 
 from .fuser import set_fuser
 from .runner import get_nn_runners
@@ -73,7 +74,8 @@ def trainbench(name, rnn_creator, nloops=100, warmup=10,
         gc.collect()
 
         fwd_start_event.record()
-        forward_output = modeldef.forward(*modeldef.inputs)
+        with record_function("## forward ##"):
+            forward_output = modeldef.forward(*modeldef.inputs)
         fwd_end_event.record()
 
         # XXX: Use if need to print something

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -131,6 +131,10 @@ std::string Result::name() const {
   return c10::visit([](auto& e){ return e.name_; }, event_);
 }
 
+uint8_t Result::record_function_scope() const {
+  return c10::visit([](auto& e){ return e.record_function_scope_; }, event_);
+}
+
 uint64_t Result::correlation_id() const {
   return c10::visit(c10::overloaded(
       [](const OpEvent& e){ return e.correlation_id_; },

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -71,6 +71,7 @@ struct BackendEvent {
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct Result {
   std::string name() const;
+  uint8_t record_function_scope() const;
   uint64_t correlation_id() const;
 
   int64_t start_time_us_;

--- a/torch/csrc/profiler/kineto_shim.h
+++ b/torch/csrc/profiler/kineto_shim.h
@@ -68,6 +68,7 @@ struct TraceWrapper {
   // addMemoryUsageActivity.
   void addCPUActivity(
       const std::string& name,
+      const uint8_t scope,
       const DeviceAndResource device_and_resource,
       const uint64_t correlation_id,
       const int64_t start_time,
@@ -120,7 +121,9 @@ void prepareTrace(
 void startTrace();
 ActivityTraceWrapper stopTrace();
 void pushCorrelationId(uint64_t correlation_id);
+void pushUserCorrelationId(uint64_t correlation_id);
 void popCorrelationId();
+void popUserCorrelationId();
 void recordThreadInfo();
 
 } // namespace kineto


### PR DESCRIPTION
Summary: User annotations was previously pushed down to the GPU timelines but was disabled during a refactoring some time back. This patch re-enables it in PyTorch Profiler.

Test Plan: CI Tests

Differential Revision: D34591916

Pulled By: aaronenyeshi

