### PR TITLE
[pyper] to + lengths_to_offsets with nnpi shape inference support (#5931)

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -226,6 +226,33 @@ C10_UNUSED void ClipRangesToGatherToOffsets(
   fuse.runOnGraph(graph);
 }
 
+C10_UNUSED void ToLengthsToOffsets(std::shared_ptr<torch::jit::Graph>& graph) {
+  std::string pattern = R"IR(
+    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy, %memoryformat):
+        %y0 : Tensor = aten::to(%a, %dtype, %nonblocking, %copy, %memoryformat)
+        %y1 : Tensor = fb::lengths_to_offsets(%y0, %includelastoffset)
+        return (%y1))IR";
+  std::string fused_pattern = R"IR(
+    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy, %memoryformat):
+        %y0 : Tensor = fb::to_lengths_to_offsets(%a, %includelastoffset, %dtype)
+        return (%y0))IR";
+  SubgraphRewriter fuse;
+  fuse.RegisterRewritePattern(pattern, fused_pattern);
+  fuse.runOnGraph(graph);
+
+  std::string pattern2 = R"IR(
+    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy):
+        %y0 : Tensor = aten::to(%a, %dtype, %nonblocking, %copy)
+        %y1 : Tensor = fb::lengths_to_offsets(%y0, %includelastoffset)
+        return (%y1))IR";
+  std::string fused_pattern2 = R"IR(
+    graph(%a, %includelastoffset, %dtype, %nonblocking, %copy):
+        %y0 : Tensor = fb::to_lengths_to_offsets(%a, %includelastoffset, %dtype)
+        return (%y0))IR";
+  fuse.RegisterRewritePattern(pattern2, fused_pattern2);
+  fuse.runOnGraph(graph);
+}
+
 C10_UNUSED
 void ClipRangesGatherSigridHash(std::shared_ptr<torch::jit::Graph>& graph) {
   // TODO:: check restrictions for inputs; outputs not used elsewhere
@@ -335,6 +362,8 @@ void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
 
     ClipRangesToGatherToOffsets(graph);
   }
+
+  ToLengthsToOffsets(graph);
 #endif
 }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/glow/pull/5931

Revert: D35214444 (https://github.com/pytorch/pytorch/commit/91a72e9021c73b19b2db2a72e65e53e514c8abe0) Revert commit changeset: f2f8d96918f3
Original diff: D34696255 (https://github.com/pytorch/pytorch/commit/f2ca4341c9008472022227b43d943af3e5e46e81)

Test Plan:
In addition to the test plan of D34696255 (https://github.com/pytorch/pytorch/commit/f2ca4341c9008472022227b43d943af3e5e46e81), ran the following for glow shape inference support:

`buck test glow/fb/torch_glow/tests/model_tests:basic_shape_tests -- ShapeInferenceTest.TestToLengthsToOffsets`

`servicelab create cogwheel_pyper_inference_fullsync_ads_inline_cvr_post_imp -a D35226685`
https://www.internalfb.com/intern/servicelab/1002759356/

`servicelab create cogwheel_pyper_inference_fullsync_ads_10x_ctr_mbl_feed_non_mimo -a D35226685`
https://www.internalfb.com/intern/servicelab/1002759361/

Model published: f335674524. Inference check job finished: f335693514.
Inference test tw tasks: https://fburl.com/tupperware/8pb3ep45.
I checked that replayer and storage tier task logs look good. Nnpi tier logs (https://fburl.com/tupperware/4grcwoil, P493812547) have various printouts related other longstanding operators missing shape inference inference support. I'll ask Oleg to sanity check these.

Reviewed By: khabinov

Differential Revision: D35226685

