### PR TITLE
[No CI] [DO NOT MERGE] Dispatcher Lab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,7 +339,7 @@ cmake_dependent_option(
 cmake_dependent_option(USE_CCACHE "Attempt using CCache to wrap the compilation" ON "UNIX" OFF)
 option(WERROR "Build with -Werror supported by the compiler" OFF)
 option(USE_COREML_DELEGATE "Use the CoreML backend through delegate APIs" OFF)
-option(USE_PER_OPERATOR_HEADERS "Whether ATen should generate separate headers for each operator" ON)
+option(USE_PER_OPERATOR_HEADERS "Whether ATen should generate separate headers for each operator" OFF)
 cmake_dependent_option(
     BUILD_LAZY_TS_BACKEND "Build the lazy Torchscript backend, not compatible with mobile builds" ON
     "NOT INTERN_BUILD_MOBILE" OFF)

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -608,6 +608,18 @@ Tensor& floor_divide_(Tensor& self, const Tensor& other) {
   return native::floor_divide_out(self, other, self);
 }
 
+Tensor mul(const Tensor& self, const Tensor& other) {
+  return at::mul(self, other);
+}
+
+Tensor& mul_(Tensor& self, const Tensor& other) {
+  return self.mul_(other);
+}
+
+Tensor& mul_out(const Tensor & self, const Tensor & other, Tensor & out) {
+  return at::mul_out(out, self, other);
+}
+
 // TODO: Make this structured to undo the perf regression from native:: removal
 // in call here
 Tensor mul(const Tensor& self, const Scalar& other) {
@@ -635,7 +647,11 @@ Tensor mul_zerotensor(const Tensor& self, const Tensor& other) {
   auto out_device = correct_out_device(self, other);
   // hack to use the TensorIterator to get the correct broadcasting and type promotion logic
   auto device_ = Device(DeviceType::Meta);
-  auto meta_out = at::redispatch::mul(c10::DispatchKeySet(at::DispatchKey::Meta), self.to(device_), other.to(device_));
+  // auto meta_out = at::redispatch::mul(c10::DispatchKeySet(at::DispatchKey::Meta), self.to(device_), other.to(device_));
+
+  // hack to work around at::redispatch::mul missing problem
+  auto meta_out = at::mul(self, other);
+
   return at::_efficientzerotensor(meta_out.sizes(), meta_out.options().device(out_device));
 }
 

--- a/aten/src/ATen/native/Blas.cpp
+++ b/aten/src/ATen/native/Blas.cpp
@@ -48,12 +48,12 @@ TORCH_IMPL_FUNC(addmv_out_cpu)(const Tensor &self, const Tensor &mat, const Tens
     if (betaval == 0.0) {
       result.zero_();
     } else {
-      at::cpu::mul_out(
-          // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-          const_cast<Tensor&>(result),
-          self,
-          at::native::scalar_tensor(
-              beta_, self.scalar_type(), c10::nullopt /* layout */, at::kCPU, c10::nullopt /* pin_memory */));
+      // at::cpu::mul_out(
+      //     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+      //     const_cast<Tensor&>(result),
+      //     self,
+      //     at::native::scalar_tensor(
+      //         beta_, self.scalar_type(), c10::nullopt /* layout */, at::kCPU, c10::nullopt /* pin_memory */));
     }
   } else {
     if (!result.is_same(*self_) && betaval != 0.0) { //if beta is 0, result contents is ignored

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3173,33 +3173,17 @@
 
 - func: mul.Tensor(Tensor self, Tensor other) -> Tensor
   device_check: NoCheck   # TensorIterator
-  structured_delegate: mul.out
   variants: function, method
-  dispatch:
-    SparseCPU, SparseCUDA: mul_sparse
-    SparseCsrCPU, SparseCsrCUDA: mul_sparse_csr
-    MkldnnCPU: mkldnn_mul
-    ZeroTensor: mul_zerotensor
+  manual_cpp_binding: True
 
 - func: mul_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
-  structured_delegate: mul.out
   variants: method
-  dispatch:
-    SparseCPU, SparseCUDA: mul_sparse_
-    SparseCsrCPU, SparseCsrCUDA: mul_sparse_csr_
-    MkldnnCPU: mkldnn_mul_
+  manual_cpp_binding: True
 
 - func: mul.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
-  structured: True
-  structured_inherits: TensorIteratorBase
-  dispatch:
-    CPU, CUDA: mul_out
-    SparseCPU: mul_out_sparse_cpu
-    SparseCUDA: mul_out_sparse_cuda
-    SparseCsrCPU, SparseCsrCUDA: mul_out_sparse_csr
-    MkldnnCPU: mkldnn_mul_out
+  manual_cpp_binding: True
 
   # For C++ only, until we have conversion from C++ numbers to Tensor
 - func: mul.Scalar(Tensor self, Scalar other) -> Tensor

--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -2,7 +2,7 @@
 
 #include <ATen/Functions.h>
 #include <ATen/Utils.h>
-#include <Aten/NativeFunctions.h>
+#include <ATen/NativeFunctions.h>
 #include <ATen/native/Resize.h>
 
 namespace at {

--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -2,6 +2,8 @@
 
 #include <ATen/Functions.h>
 #include <ATen/Utils.h>
+#include <Aten/NativeFunctions.h>
+#include <ATen/native/Resize.h>
 
 namespace at {
 
@@ -100,5 +102,70 @@ Tensor TensorMaker::make_tensor() {
    }
    return IntArrayRef(zeros, 1);
  }
+
+namespace  {
+
+// copied from RegisterCPU.cpp
+void resize_out(const Tensor &out, IntArrayRef sizes, IntArrayRef strides, const TensorOptions &options) {
+  TORCH_CHECK(options.dtype() == out.dtype(),
+      "Expected out tensor to have dtype ", options.dtype(), ", but got ", out.dtype(), " instead");
+  TORCH_CHECK(options.device() == out.device(),
+      "Expected out tensor to have device ", options.device(), ", but got ", out.device(), " instead");
+  const bool resized = at::native::resize_output(out, sizes);
+  // Only restride if a resize occurred; otherwise we ignore the (advisory)
+  // strides from the meta function and directly use the output tensor's
+  // preexisting strides
+  if (resized) {
+    if (!strides.empty()) {
+      TORCH_INTERNAL_ASSERT(!options.memory_format_opt().has_value());
+      at::native::as_strided_(out, sizes, strides);
+    } else if (options.memory_format_opt().has_value()) {
+      out.unsafeGetTensorImpl()->empty_tensor_restride(*options.memory_format_opt());
+    }
+  }
+}
+
+struct structured_mul_out_out final : public at::native::structured_mul_out {
+    structured_mul_out_out(Tensor& out0) : outputs_{ std::ref(out0) } {}
+
+    void set_output(int64_t output_idx, IntArrayRef sizes, IntArrayRef strides,
+                    TensorOptions options, DimnameList names) override {
+
+        const auto& out = outputs_[output_idx].get();
+        resize_out(out, sizes, strides, options);
+        if (!names.empty()) {
+          namedinference::propagate_names(outputs_[output_idx], names);
+        }
+        // super must happen after, so that downstream can use maybe_get_output
+        // to retrieve the output
+        at::native::structured_mul_out::set_output(output_idx, sizes, strides, options, names);
+    }
+
+    const Tensor& maybe_get_output(int64_t output_idx) override {
+        return outputs_[output_idx];
+    }
+    std::array<std::reference_wrapper<Tensor>, 1> outputs_;
+};
+
+at::Tensor & wrapper_mul_out_out(const at::Tensor & self, const at::Tensor & other, at::Tensor & out) {
+structured_mul_out_out op(out);
+op.meta(self, other);
+op.impl(self, other, op.outputs_[0]);
+return out;
+}
+
+} // namespace anonymous
+
+Tensor& mul_out(Tensor& out, const Tensor& self, const Tensor& other) {
+  return wrapper_mul_out_out(self, other, out);
+}
+
+Tensor& mul_outf(const Tensor& self, const Tensor& other, Tensor& out) {
+  return wrapper_mul_out_out(self, other, out);
+}
+
+Tensor mul(const Tensor& self, const Tensor& other) {
+  return self.mul(other);
+}
 
 } // namespace at

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -141,4 +141,8 @@ inline bool is_neg(const Tensor& tensor) {
   return tensor.is_neg();
 }
 
+TORCH_API Tensor mul(const Tensor& self, const Tensor& other);
+TORCH_API Tensor& mul_out(Tensor& out, const Tensor& self, const Tensor& other);
+TORCH_API Tensor& mul_outf(const Tensor& self, const Tensor& other, Tensor& out);
+
 }

--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -26,24 +26,12 @@
 #include <ATen/core/Reduction.h>
 #include <ATen/core/Tensor.h>
 
-#include <ATen/TensorIterator.h>
-// #include <ATen/NamedTensorUtils.h>
-// #include <ATen/native/Resize.h>
-// #include <ATen/EmptyTensor.h>
-
 #include <tuple>
 #include <vector>
 
 ${NativeFunctions_includes}
 
 namespace at {
-
-namespace meta {
-struct TORCH_API structured_mul_Tensor : public TensorIteratorBase {
-    void meta(const at::Tensor & self, const at::Tensor & other);
-};
-}
-
 namespace native {
 
 ${NativeFunctions_declarations}

--- a/aten/src/ATen/templates/NativeFunctions.h
+++ b/aten/src/ATen/templates/NativeFunctions.h
@@ -25,15 +25,33 @@
 #include <c10/core/QScheme.h>
 #include <ATen/core/Reduction.h>
 #include <ATen/core/Tensor.h>
+
+#include <ATen/TensorIterator.h>
+// #include <ATen/NamedTensorUtils.h>
+// #include <ATen/native/Resize.h>
+// #include <ATen/EmptyTensor.h>
+
 #include <tuple>
 #include <vector>
 
 ${NativeFunctions_includes}
 
 namespace at {
+
+namespace meta {
+struct TORCH_API structured_mul_Tensor : public TensorIteratorBase {
+    void meta(const at::Tensor & self, const at::Tensor & other);
+};
+}
+
 namespace native {
 
 ${NativeFunctions_declarations}
+
+struct TORCH_API structured_mul_out : public at::meta::structured_mul_Tensor {
+  void impl(const at::Tensor & self, const at::Tensor & other, const at::Tensor & out);
+};
+
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/templates/NativeMetaFunctions.h
+++ b/aten/src/ATen/templates/NativeMetaFunctions.h
@@ -15,9 +15,9 @@ namespace meta {
 
 ${NativeMetaFunctions_declarations}
 
-// struct TORCH_API structured_mul_Tensor : public TensorIteratorBase {
-//     void meta(const at::Tensor & self, const at::Tensor & other);
-// };
+struct TORCH_API structured_mul_Tensor : public TensorIteratorBase {
+    void meta(const at::Tensor & self, const at::Tensor & other);
+};
 
 } // namespace meta
 } // namespace at

--- a/aten/src/ATen/templates/NativeMetaFunctions.h
+++ b/aten/src/ATen/templates/NativeMetaFunctions.h
@@ -15,5 +15,9 @@ namespace meta {
 
 ${NativeMetaFunctions_declarations}
 
+// struct TORCH_API structured_mul_Tensor : public TensorIteratorBase {
+//     void meta(const at::Tensor & self, const at::Tensor & other);
+// };
+
 } // namespace meta
 } // namespace at

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -506,6 +506,9 @@ class TORCH_API Tensor: public TensorBase {
   //example
   //Tensor * add(Tensor & b);
   ${tensor_method_declarations}
+  at::Tensor mul(const at::Tensor & other) const;
+  at::Tensor & mul_(const at::Tensor & other) const;
+
 
   // Special C++ only overloads for std()-like functions (See gh-40287)
   // These are needed because int -> bool conversion takes precedence over int -> IntArrayRef

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -30,8 +30,10 @@ namespace at {
 
 } //namespace at
 
-#include <Aten/NativeFunctions.h>
-// #include <ATen/native/Resize.h>
+#include <ATen/NativeFunctions.h>
+#include <ATen/NamedTensorUtils.h>
+#include <ATen/EmptyTensor.h>
+
 
 namespace at {
 namespace {

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -28,4 +28,104 @@ namespace at {
  AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(DEFINE_ITEM)
  #undef DEFINE_ITEM
 
- } //namespace at
+} //namespace at
+
+#include <Aten/NativeFunctions.h>
+// #include <ATen/native/Resize.h>
+
+namespace at {
+namespace {
+// copied from RegisterCPU.cpp
+Tensor create_out(IntArrayRef sizes, IntArrayRef strides, const TensorOptions &options) {
+  if (strides.empty()) {
+      return at::detail::empty_cpu(sizes, options);
+  } else {
+      return at::detail::empty_strided_cpu(sizes, strides, options);
+  }
+}
+
+// copied from RegisterCPU.cpp
+void check_inplace(const Tensor &self, IntArrayRef sizes, const TensorOptions &options) {
+  // These checks are needed on those operators that:
+  //   1) don't use 'TensorIterator' (e.g. 'addmm' and 'baddbmm')
+  //   2) have particular typing rules (e.g. 'cumsum' and 'cumprod')
+  // For other operators (e.g. 'add'), 'TensorIterator' already checks
+  // these things separately.
+  TORCH_CHECK(options.dtype() == self.dtype(),
+      "Bad in-place call: ",
+      "input tensor dtype ", self.dtype(), " and output tensor dtype ", options.dtype(), " should match");
+  TORCH_CHECK(options.device() == self.device(),
+      "Bad in-place call: ",
+      "input tensor device ", self.device(), " and output tensor device ", options.device(), " should match");
+  TORCH_CHECK(sizes == self.sizes(),
+      "Bad in-place call: ",
+      "input tensor size ", self.sizes(), " and output tensor size ", sizes, " should match");
+}
+
+struct structured_mul_out_functional final : public at::native::structured_mul_out {
+
+    void set_output(int64_t output_idx, IntArrayRef sizes, IntArrayRef strides,
+                    TensorOptions options, DimnameList names) override {
+
+        outputs_[output_idx] = create_out(sizes, strides, options);
+        if (!names.empty()) {
+          namedinference::propagate_names(*outputs_[output_idx], names);
+        }
+        // super must happen after, so that downstream can use maybe_get_output
+        // to retrieve the output
+        at::native::structured_mul_out::set_output(output_idx, sizes, strides, options, names);
+    }
+
+    const Tensor& maybe_get_output(int64_t output_idx) override {
+        return *outputs_[output_idx];
+    }
+    std::array<c10::ExclusivelyOwned<Tensor>, 1> outputs_;
+};
+
+at::Tensor wrapper_mul_Tensor(const at::Tensor & self, const at::Tensor & other) {
+structured_mul_out_functional op;
+op.meta(self, other);
+op.impl(self, other, *op.outputs_[0]);
+return std::move(op.outputs_[0]).take();
+}
+
+struct structured_mul_out_inplace final : public at::native::structured_mul_out {
+    structured_mul_out_inplace(Tensor& self) : outputs_{std::ref(self)} {}
+
+    void set_output(int64_t output_idx, IntArrayRef sizes, IntArrayRef strides,
+                    TensorOptions options, DimnameList names) override {
+
+        const auto& out = outputs_[output_idx].get();
+        check_inplace(out, sizes, options);
+        if (!names.empty()) {
+          namedinference::propagate_names(outputs_[output_idx], names);
+        }
+        // super must happen after, so that downstream can use maybe_get_output
+        // to retrieve the output
+        at::native::structured_mul_out::set_output(output_idx, sizes, strides, options, names);
+    }
+
+    const Tensor& maybe_get_output(int64_t output_idx) override {
+        return outputs_[output_idx];
+    }
+    std::array<std::reference_wrapper<Tensor>, 1> outputs_;
+};
+
+at::Tensor & wrapper_mul__Tensor(at::Tensor & self, const at::Tensor & other) {
+structured_mul_out_inplace op(self);
+op.meta(self, other);
+op.impl(self, other, op.outputs_[0]);
+return self;
+}
+
+} // namespace anonymous
+
+Tensor Tensor::mul(const Tensor & other) const{
+  return wrapper_mul_Tensor(const_cast<Tensor&>(*this), other);
+}
+
+Tensor & Tensor::mul_(const Tensor & other) const{
+  return wrapper_mul__Tensor(const_cast<Tensor&>(*this), other);
+}
+
+}//namespace at

--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -143,7 +143,7 @@ if(INTERN_BUILD_ATEN_OPS)
 
   set(GEN_PER_OPERATOR_FLAG)
   if(USE_PER_OPERATOR_HEADERS)
-    list(APPEND GEN_PER_OPERATOR_FLAG "--per-operator-headers")
+    # list(APPEND GEN_PER_OPERATOR_FLAG "--per-operator-headers")
   endif()
 
   set(GEN_COMMAND
@@ -229,8 +229,8 @@ if(INTERN_BUILD_ATEN_OPS)
   add_dependencies(ATEN_CUDA_FILES_GEN_LIB ATEN_CUDA_FILES_GEN_TARGET)
 
   if(USE_PER_OPERATOR_HEADERS)
-    target_compile_definitions(ATEN_CPU_FILES_GEN_LIB INTERFACE AT_PER_OPERATOR_HEADERS)
-    target_compile_definitions(ATEN_CUDA_FILES_GEN_LIB INTERFACE AT_PER_OPERATOR_HEADERS)
+    # target_compile_definitions(ATEN_CPU_FILES_GEN_LIB INTERFACE AT_PER_OPERATOR_HEADERS)
+    # target_compile_definitions(ATEN_CUDA_FILES_GEN_LIB INTERFACE AT_PER_OPERATOR_HEADERS)
   endif()
 
   # Handle source files that need to be compiled multiple times for

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1061,11 +1061,6 @@
   self: value_selecting_reduction_backward(grad, dim, indices, self.sizes(), keepdim)
   values: gather_with_keepdimed_indices(self_t, dim, indices, keepdim)
 
-- name: mul.Tensor(Tensor self, Tensor other) -> Tensor
-  self: mul_tensor_backward(grad, other, self.scalar_type())
-  other: mul_tensor_backward(grad, self, other.scalar_type())
-  result: other_t * self_p + self_t * other_p
-
 - name: mul.Scalar(Tensor self, Scalar other) -> Tensor
   self: mul_tensor_backward(grad, at::scalar_to_tensor(other), self.scalar_type())
   result: self_t * other

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -268,7 +268,7 @@ Tensor& linear_out(
   }
   at::native::matmul_out(input, weight.t(), output);
   if (bias->defined()) {
-    // at::cpu::add_(output, *bias);
+    at::cpu::add_(output, *bias);
   }
   return output;
 }

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -268,7 +268,7 @@ Tensor& linear_out(
   }
   at::native::matmul_out(input, weight.t(), output);
   if (bias->defined()) {
-    at::cpu::add_(output, *bias);
+    // at::cpu::add_(output, *bias);
   }
   return output;
 }
@@ -573,12 +573,12 @@ REGISTER_OPERATOR_FUNCTOR(aten::mul, aten_mul, [](Node* n) -> SROperator {
     const auto& in0_t = p_node->Input(0).toTensor();
     const auto& in1_t = p_node->Input(1).toTensor();
     if (p_node->Output(0).isNone()) {
-      p_node->Output(0) = at::cpu::mul(in0_t, in1_t);
+      // p_node->Output(0) = at::cpu::mul(in0_t, in1_t);
       return;
     }
     auto& out_t = p_node->Output(0).toTensor();
     fastResizeToZero(out_t);
-    at::cpu::mul_out(out_t, in0_t, in1_t);
+    // at::cpu::mul_out(out_t, in0_t, in1_t);
   };
 });
 

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -593,17 +593,17 @@ std::vector<Shape> compute_shape_repeat(const at::Tensor & self, at::IntArrayRef
 
 std::vector<Shape> compute_shape_mul(const at::Tensor & self, const at::Tensor & other) {
   // TODO(bahuang): handle boardcast
-  return {Shape(self.scalar_type()), self.sizes().vec()};
+  return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
 std::vector<Shape> compute_shape_mul_(at::Tensor self, const at::Tensor & other) {
   // TODO(bahuang): handle boardcast
-  return {Shape(self.scalar_type()), self.sizes().vec()};
+  return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
 std::vector<Shape> compute_shape_mul_out(at::Tensor& out, const at::Tensor& self, const at::Tensor& other) {
   // TODO(bahuang): handle boardcast
-  return {Shape(self.scalar_type()), self.sizes().vec()};
+  return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
 // Restore unused-parameters warnings

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -591,6 +591,21 @@ std::vector<Shape> compute_shape_repeat(const at::Tensor & self, at::IntArrayRef
   return {Shape(self.scalar_type(), target_size)};
 }
 
+std::vector<Shape> compute_shape_mul(const at::Tensor & self, const at::Tensor & other) {
+  // TODO(bahuang): handle boardcast
+  return {Shape(self.scalar_type()), self.sizes().vec()};
+}
+
+std::vector<Shape> compute_shape_mul_(at::Tensor self, const at::Tensor & other) {
+  // TODO(bahuang): handle boardcast
+  return {Shape(self.scalar_type()), self.sizes().vec()};
+}
+
+std::vector<Shape> compute_shape_mul_out(at::Tensor& out, const at::Tensor& self, const at::Tensor& other) {
+  // TODO(bahuang): handle boardcast
+  return {Shape(self.scalar_type()), self.sizes().vec()};
+}
+
 // Restore unused-parameters warnings
 #pragma GCC diagnostic pop
 

--- a/torch/csrc/lazy/core/shape_inference.h
+++ b/torch/csrc/lazy/core/shape_inference.h
@@ -64,6 +64,9 @@ TORCH_API std::vector<Shape> compute_shape_sum(const at::Tensor & self, c10::opt
 TORCH_API std::vector<Shape> compute_shape__to_copy(const at::Tensor & self, c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout, c10::optional<at::Device> device, c10::optional<bool> pin_memory, bool non_blocking, c10::optional<at::MemoryFormat> memory_format);
 TORCH_API std::vector<Shape> compute_shape_trace(const at::Tensor & self);
 TORCH_API std::vector<Shape> compute_shape_zero_(at::Tensor & self);
+TORCH_API std::vector<Shape> compute_shape_mul(const at::Tensor & self, const at::Tensor & other);
+TORCH_API std::vector<Shape> compute_shape_mul_(at::Tensor & self, const at::Tensor & other);
+TORCH_API std::vector<Shape> compute_shape_mul_out(at::Tensor& out, const at::Tensor& self, const at::Tensor& other);
 
 } // namespace lazy
 } // namespace torch


### PR DESCRIPTION
### (gdb) break structured_mul_out::impl

**Before: 22 frames from Python Binding to CPU Kernel**
![image](https://user-images.githubusercontent.com/9906745/163029393-8c62160d-af6b-4b81-a088-b185524fa753.png)

**After: 4 frames from Python Binding to CPU Kernel**
![image](https://user-images.githubusercontent.com/9906745/163029459-803caeec-34e8-4095-b94b-c6d2c5ef5c44.png)


### Profiling
```
import torch
with torch.profiler.profile() as prof:
    a = torch.empty(2)
    b = torch.empty(2)
    c = torch.mul(a, b)
print(str(prof.events()))
```

**Before**
---------------  ------------  ------------  ------------  ------------  ------------  ------------  
           Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
    aten::empty         0.14%      41.000us         0.14%      41.000us      41.000us             1  
    aten::empty         0.00%       1.000us         0.00%       1.000us       1.000us             1  
      aten::mul        99.86%      29.180ms        99.86%      29.180ms      29.180ms             1  
Self CPU time total: 29.222ms

**After**
---------------  ------------  ------------  ------------  ------------  ------------  ------------  
           Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
    aten::empty        88.89%      64.000us        88.89%      64.000us      64.000us             1  
    aten::empty        11.11%       8.000us        11.11%       8.000us       8.000us             1  

Self CPU time total: 72.000us

### Benchmark
```
import torch
from torch.utils.benchmark import Timer

t = Timer(
    stmt="torch.mul(a, b)",
    setup="a=torch.empty(2);b=torch.empty(2)").timeit()
print(t)
```

**Before**
<torch.utils.benchmark.utils.common.Measurement object at 0x7fe8223e2a30>
torch.mul(a, b)
setup: a=torch.empty(2);b=torch.empty(2)
  2.26 us
  1 measurement, 1000000 runs , 1 thread

**After**
<torch.utils.benchmark.utils.common.Measurement object at 0x7fc42a808f10>
torch.mul(a, b)
setup: a=torch.empty(2);b=torch.empty(2)
  1.84 us
  1 measurement, 1000000 runs , 1 thread