### PR TITLE
Sets rtol>0 for some tests that use tf32

### DIFF
--- a/test/distributed/test_data_parallel.py
+++ b/test/distributed/test_data_parallel.py
@@ -11,7 +11,7 @@ import torch
 from torch import nn
 from torch.cuda.amp import autocast
 import torch.nn.parallel as dp
-from torch.testing._internal.common_cuda import TEST_MULTIGPU, TEST_CUDA
+from torch.testing._internal.common_cuda import TEST_MULTIGPU, TEST_CUDA, tf32_is_not_fp32
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, onlyCUDA, skipMeta
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.common_utils import _assertGradAndGradgradChecks, gradcheck
@@ -792,6 +792,7 @@ class TestDataParallelDeviceType(TestCase):
         net = nn.DataParallel(l)
         out = net(i)
         self.assertEqual(out.get_device(), 0)
+        rtol = 0.006 if (dtype == torch.float and tf32_is_not_fp32() and torch.backends.cuda.matmul.allow_tf32) else 0
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
     @onlyCUDA
@@ -812,6 +813,7 @@ class TestDataParallelDeviceType(TestCase):
         n = nn.DataParallel(Net())
         out = n(input=i)
         self.assertEqual(out.get_device(), 0)
+        rtol = 0.006 if (dtype == torch.float and tf32_is_not_fp32() and torch.backends.cuda.matmul.allow_tf32) else 0
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
     @onlyCUDA
@@ -832,6 +834,7 @@ class TestDataParallelDeviceType(TestCase):
         n = nn.DataParallel(Net())
         out = n(input={'data': i, 'unused': []})
         self.assertEqual(out.get_device(), 0)
+        rtol = 0.006 if (dtype == torch.float and tf32_is_not_fp32() and torch.backends.cuda.matmul.allow_tf32) else 0
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
     @onlyCUDA
@@ -852,6 +855,7 @@ class TestDataParallelDeviceType(TestCase):
         n = nn.DataParallel(Net())
         out = n(input={'data': i, 'unused': {}})
         self.assertEqual(out.get_device(), 0)
+        rtol = 0.006 if (dtype == torch.float and tf32_is_not_fp32() and torch.backends.cuda.matmul.allow_tf32) else 0
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
     @onlyCUDA
@@ -872,6 +876,7 @@ class TestDataParallelDeviceType(TestCase):
         n = nn.DataParallel(Net())
         out = n(input={'data': i, 'unused': ()})
         self.assertEqual(out.get_device(), 0)
+        rtol = 0.006 if (dtype == torch.float and tf32_is_not_fp32() and torch.backends.cuda.matmul.allow_tf32) else 0
         self.assertEqual(out, expected_out, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
 

--- a/test/test_expanded_weights.py
+++ b/test/test_expanded_weights.py
@@ -246,7 +246,7 @@ class TestExpandedWeightFunctional(TestCase):
 
         expected = [torch.stack(grad) for grad in zip(*expected)]
         for (res, exp) in zip(result, expected):
-            self.assertEqual(res, exp, atol=1e-4, rtol=5e-5)
+            self.assertEqual(res, exp, atol=2e-4, rtol=5e-5)
 
     def test_group_norm_error(self, device):
         # group norm has to call native_group_norm. This checks that it hits the same errors

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12394,7 +12394,7 @@ def add_test(test, decorator=None):
             add(cuda_test_name + '_fp32', with_tf32_off)
 
             def with_tf32_on(self, test=test, kwargs=kwargs):
-                with tf32_on(self, test.tf32_precision):
+                with tf32_on(self, test.tf32_precision, test.tf32_rtol):
                     test.test_cuda(self, dtype=torch.float, **kwargs)
 
             add(cuda_test_name + '_tf32', with_tf32_on)
@@ -13962,7 +13962,11 @@ class TestNNDeviceType(NNTestCase):
             if mode == 'same':
                 actual = actual[:5, :5, :10]
 
-            self.assertEqual(actual, expected, rtol=2e-5, atol=5e-6)
+            atol = 0.05 if ("cuda" in device and
+                            dtype == torch.float and
+                            tf32_is_not_fp32() and
+                            torch.backends.matmul.allow_tf32) else 5e-6
+            self.assertEqual(actual, expected, rtol=2e-5, atol=atol)
 
         # Global dtype for this test suite is torch.double
         # This leads to change in type-promotion

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13965,7 +13965,7 @@ class TestNNDeviceType(NNTestCase):
             atol = 0.05 if ("cuda" in device and
                             dtype == torch.float and
                             tf32_is_not_fp32() and
-                            torch.backends.matmul.allow_tf32) else 5e-6
+                            torch.backends.cuda.matmul.allow_tf32) else 5e-6
             self.assertEqual(actual, expected, rtol=2e-5, atol=atol)
 
         # Global dtype for this test suite is torch.double

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -62,6 +62,8 @@ def tf32_is_not_fp32():
     return True
 
 
+# Warning: tf32_off should not be nested inside a tf32_on context, because it doesn't
+# save and restore self.precision or self.rtol_maybe_tf32.
 @contextlib.contextmanager
 def tf32_off():
     old_allow_tf32_matmul = torch.backends.cuda.matmul.allow_tf32
@@ -121,13 +123,13 @@ def tf32_on(self, tf32_precision=1e-5, tf32_rtol=None):
 # if device is specified, it will check if device is cuda
 # if dtype is specified, it will check if dtype is float32 or complex64
 # tf32 and fp32 are different only when all the three checks pass
-def tf32_on_and_off(tf32_precision=1e-5):
+def tf32_on_and_off(tf32_precision=1e-5, tf32_rtol=None):
     def with_tf32_disabled(self, function_call):
         with tf32_off():
             function_call()
 
     def with_tf32_enabled(self, function_call):
-        with tf32_on(self, tf32_precision):
+        with tf32_on(self, tf32_precision, tf32_rtol=tf32_rtol):
             function_call()
 
     def wrapper(f):

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -74,17 +74,21 @@ def tf32_off():
 
 
 @contextlib.contextmanager
-def tf32_on(self, tf32_precision=1e-5):
+def tf32_on(self, tf32_precision=1e-5, tf32_rtol=None):
     old_allow_tf32_matmul = torch.backends.cuda.matmul.allow_tf32
     old_precison = self.precision
+    old_tf32_rtol = self.rtol_maybe_tf32
     try:
         torch.backends.cuda.matmul.allow_tf32 = True
         self.precision = tf32_precision
+        if tf32_rtol is not None:
+            self.rtol_maybe_tf32 = tf32_rtol
         with torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=True):
             yield
     finally:
         torch.backends.cuda.matmul.allow_tf32 = old_allow_tf32_matmul
-        self.precision = old_precison
+        self.precision = old_precision
+        self.rtol_maybe_tf32 = old_tf32_rtol
 
 
 # This is a wrapper that wraps a test to run this test twice, one with

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -77,18 +77,20 @@ def tf32_off():
 def tf32_on(self, tf32_precision=1e-5, tf32_rtol=None):
     old_allow_tf32_matmul = torch.backends.cuda.matmul.allow_tf32
     old_precison = self.precision
-    old_tf32_rtol = self.rtol_maybe_tf32
+    if hasattr(self, "rtol_maybe_tf32"):
+        old_tf32_rtol = self.rtol_maybe_tf32
     try:
         torch.backends.cuda.matmul.allow_tf32 = True
         self.precision = tf32_precision
-        if tf32_rtol is not None:
+        if hasattr(self, "rtol_maybe_tf32") and tf32_rtol is not None:
             self.rtol_maybe_tf32 = tf32_rtol
         with torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=True):
             yield
     finally:
         torch.backends.cuda.matmul.allow_tf32 = old_allow_tf32_matmul
         self.precision = old_precision
-        self.rtol_maybe_tf32 = old_tf32_rtol
+        if hasattr(self, "rtol_maybe_tf32"):
+            self.rtol_maybe_tf32 = old_tf32_rtol
 
 
 # This is a wrapper that wraps a test to run this test twice, one with

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -6130,7 +6130,7 @@ class NewModuleTest(InputVariableMixin, ModuleTest):  # type: ignore[misc]
         self.skip_half = kwargs.get('skip_half', False)
         self.with_tf32 = kwargs.get('with_tf32', False)
         self.tf32_precision = kwargs.get('tf32_precision', 0.001)
-        self.tf32_rtol = kwargs.get('tf32_rtol', 0.)
+        self.tf32_rtol = kwargs.get('tf32_rtol', None)
         self.test_cpu = kwargs.get('test_cpu', True)
         self.has_sparse_gradients = kwargs.get('has_sparse_gradients', False)
         self.check_batched_grad = kwargs.get('check_batched_grad', True)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -2207,6 +2207,7 @@ new_module_tests = [
         cudnn=True,
         with_tf32=True,
         tf32_precision=0.005,
+        tf32_rtol=0.0008,
     ),
     dict(
         module_name='ConvTranspose2d',
@@ -2235,6 +2236,7 @@ new_module_tests = [
         check_with_long_tensor=True,
         with_tf32=True,
         tf32_precision=0.005,
+        tf32_rtol=0.08,
     ),
     dict(
         module_name='ConvTranspose2d',
@@ -2247,6 +2249,7 @@ new_module_tests = [
         check_with_long_tensor=True,
         with_tf32=True,
         tf32_precision=0.005,
+        tf32_rtol=0.009,
     ),
     dict(
         fullname='ConvTranspose2d_groups',
@@ -4185,6 +4188,7 @@ new_module_tests = [
         desc='relu_activation',
         with_tf32=True,
         tf32_precision=0.1,
+        tf32_rtol=0.006,
         # TODO(#50743): figure out the error
         # RuntimeError: The size of tensor a (6) must match the size of tensor b (4)
         # at non-singleton dimension 2
@@ -4244,6 +4248,7 @@ new_module_tests = [
         desc='multilayer_coder',
         with_tf32=True,
         tf32_precision=0.01,
+        tf32_rtol=0.004,
     ),
     dict(
         module_name='Linear',
@@ -6125,6 +6130,7 @@ class NewModuleTest(InputVariableMixin, ModuleTest):  # type: ignore[misc]
         self.skip_half = kwargs.get('skip_half', False)
         self.with_tf32 = kwargs.get('with_tf32', False)
         self.tf32_precision = kwargs.get('tf32_precision', 0.001)
+        self.tf32_rtol = kwargs.get('tf32_rtol', 0.)
         self.test_cpu = kwargs.get('test_cpu', True)
         self.has_sparse_gradients = kwargs.get('has_sparse_gradients', False)
         self.check_batched_grad = kwargs.get('check_batched_grad', True)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -6410,8 +6410,7 @@ class CriterionTest(InputVariableMixin, TestBase):  # type: ignore[misc]
         # dtype used to be able to be None, so set precision in this way instead of a precision map
         # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
         test_case.assertEqualIgnoreType(cpu_output, gpu_output,
-                                        atol=1e-1 if dtype in {torch.half, torch.bfloat16} else 4e-4,
-                                        rtol=self.rtol_maybe_tf32)
+                                        atol=1e-1 if dtype in {torch.half, torch.bfloat16} else 4e-4, rtol=0)
 
         cpu_gradInput = test_case._backward_criterion(
             cpu_module, cpu_input, cpu_output, cpu_target, extra_args=extra_args)
@@ -6420,8 +6419,7 @@ class CriterionTest(InputVariableMixin, TestBase):  # type: ignore[misc]
         # dtype used to be able to be None, so set precision in this way instead of a precision map
         # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
         test_case.assertEqualIgnoreType(cpu_gradInput, gpu_gradInput,
-                                        atol=1e-1 if dtype in {torch.half, torch.bfloat16} else 4e-4,
-                                        rtol=self.rtol_maybe_tf32)
+                                        atol=1e-1 if dtype in {torch.half, torch.bfloat16} else 4e-4, rtol=0)
 
     def _get_target(self):
         return self._get_arg('target', False)


### PR DESCRIPTION
In internal CI we've seen a need to adjust rtol as well as atol for some tests that use tf32. For example, comparisons of large values may fail atol checks even when their relative difference is small. In such cases it's better to set rtol and atol to modest values than to hold rtol fixed (currently it's fixed at 0 for many of the failures we observe) and dial up atol alone.

I tried to tailor the increased rtols narrowly (ie, only to tests that need it). For autogenerated test_nn tests with [configs](https://github.com/pytorch/pytorch/pull/75612/files#diff-11ee877cc67e12111c2867dea31c9215b12b1c751e1f913802edc36f598905efR2207-R4254) heavily abstracted from the [comparisons that use rtol](https://github.com/pytorch/pytorch/pull/75612/files#diff-11ee877cc67e12111c2867dea31c9215b12b1c751e1f913802edc36f598905efR2207-R4254), this was tricky, but I think I wrote something that works. We'll see how it needs to be expanded if/when failures occur in other tests.

Per-test rtols are chosen based on our CI. Most are reasonable. [This one](https://github.com/pytorch/pytorch/pull/75612/files#diff-11ee877cc67e12111c2867dea31c9215b12b1c751e1f913802edc36f598905efR2239), for (what becomes) `TestNN.test_ConvTranspose2d_dilated_cuda_tf32`, is eyebrow-raising, and may expose a legitimate bug. We'll have to check with cudnn internally.