### PR TITLE
[pytorch][cupti profiler 6/n] Changes to configure Kineto cupti profiler from pytorch profiler interface

### DIFF
--- a/torch/_C/_autograd.pyi
+++ b/torch/_C/_autograd.pyi
@@ -35,6 +35,14 @@ class DeviceType(Enum):
     Metal = ...
     ...
 
+class _ExperimentalConfig:
+    def __init__(
+        self,
+        profiler_metrics: List[str] = ...,
+        profiler_measure_per_kernel: bool = ...,
+    ) -> None: ...
+    ...
+
 class ProfilerConfig:
     def __init__(
         self,
@@ -43,7 +51,8 @@ class ProfilerConfig:
         profile_memory: bool,
         with_stack: bool,
         with_flops: bool,
-        with_modules: bool
+        with_modules: bool,
+        experimental_config: _ExperimentalConfig,
     ) -> None: ...
     ...
 

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -8,6 +8,7 @@ from torch.autograd import (
     kineto_available, _ProfilerResult, _disable_profiler, _enable_profiler,
     _prepare_profiler, _supported_activities, _kineto_step,
 )
+from torch._C._autograd import _ExperimentalConfig
 import torch
 import torch.cuda
 from torch.futures import Future
@@ -83,6 +84,10 @@ class profile(object):
         use_cpu (bool, optional): profile CPU events; setting to ``False`` requires
             ``use_kineto=True`` and can be used to lower the overhead for GPU-only profiling.
 
+        experimental_config (_ExperimentalConfig) : A set of experimental options
+            used by profiler libraries like Kineto. Note, backward compatibility is not guaranteed.
+
+
     .. warning:
         Enabling memory profiling or source attribution incurs additional profiler
         overhead
@@ -127,7 +132,8 @@ class profile(object):
             with_stack=False,
             with_modules=False,
             use_kineto=False,
-            use_cpu=True):
+            use_cpu=True,
+            experimental_config=None):
         self.enabled: bool = enabled
         if not self.enabled:
             return
@@ -141,6 +147,9 @@ class profile(object):
         self.with_stack = with_stack
         self.with_modules = with_modules
         self.use_cpu = use_cpu
+        if experimental_config is None:
+            experimental_config = _ExperimentalConfig()
+        self.experimental_config = experimental_config
         self.kineto_results: Optional[_ProfilerResult] = None
 
         if not self.use_cpu:
@@ -175,7 +184,8 @@ class profile(object):
             self.profile_memory,
             self.with_stack,
             self.with_flops,
-            self.with_modules)
+            self.with_modules,
+            self.experimental_config)
 
     def __enter__(self):
         if not self.enabled:
@@ -576,7 +586,8 @@ class emit_nvtx(object):
                 False,
                 False,
                 False,
-                False),
+                False,
+                _ExperimentalConfig()),
             set()
         )
         return self

--- a/torch/autograd/profiler_legacy.py
+++ b/torch/autograd/profiler_legacy.py
@@ -55,7 +55,10 @@ class profile(object):
             self.profile_memory,
             self.with_stack,
             self.with_flops,
-            self.with_modules)
+            self.with_modules,
+            # avoid exposing _ExperimentalConfig this in legacy public API
+            torch._C._autograd._ExperimentalConfig(),
+        )
 
     def __enter__(self):
         if not self.enabled:

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -30,6 +30,7 @@
 
 PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject *unused) {
   using namespace torch::autograd::profiler;
+  using namespace torch::profiler::impl;
   auto tensor_module = THPObjectPtr(PyImport_ImportModule("torch._tensor"));
   if (!tensor_module)
     return nullptr;
@@ -82,13 +83,56 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject *unused) {
       .value("CPU", ActivityType::CPU)
       .value("CUDA", ActivityType::CUDA);
 
+  py::class_<ExperimentalConfig>(m, "_ExperimentalConfig")
+      .def(py::init<
+          std::vector<std::string> /* profiler_metrics */,
+          bool  /* profiler_measure_per_kernel */
+          >(),
+          "An experimental config for Kineto features. Please note that"
+          "backward compatibility is not guaranteed.\n"
+          "    profiler_metrics : a list of CUPTI profiler metrics used\n"
+          "       to measure GPU performance events.\n"
+          "       If this list contains values Kineto runs in CUPTI profiler mode\n"
+          "    profiler_measure_per_kernel (bool) : whether to profile metrics per kernel\n"
+          "       or for the entire measurement duration.",
+          py::arg("profiler_metrics") = std::vector<std::string>(),
+          py::arg("profiler_measure_per_kernel") = false)
+    .def(py::pickle(
+        [](const ExperimentalConfig &p) { // __getstate__
+            py::list py_metrics;
+            for (const auto& metric : p.profiler_metrics) {
+              py::bytes mbytes(metric);
+              py_metrics.append(mbytes);
+            }
+            /* Return a tuple that fully encodes the state of the config */
+            return py::make_tuple(
+                py_metrics, p.profiler_measure_per_kernel);
+        },
+        [](py::tuple t) { // __setstate__
+            if (t.size() != 2) {
+                throw std::runtime_error("Expected 2 values in state");
+            }
+
+            py::list py_metrics = t[0].cast<py::list>();
+            std::vector<std::string> metrics{py_metrics.size()};
+
+            for (const auto& py_metric : py_metrics) {
+              metrics.push_back(py::str(py_metric));
+            }
+
+            return ExperimentalConfig(std::move(metrics), t[1].cast<bool>());
+        }
+    ));
+
+
   py::class_<ProfilerConfig>(m, "ProfilerConfig")
       .def(py::init<ProfilerState,
           bool, /* record_input_shapes */
           bool, /* profile_memory */
           bool, /* with_stack */
           bool, /* with_flops */
-          bool  /* with_modules */
+          bool, /* with_modules */
+          ExperimentalConfig /* experimental_config */
           >());
 
   py::class_<LegacyEvent>(m, "ProfilerEvent")

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -679,7 +679,7 @@ void prepareProfiler(
           config.state == ProfilerState::KINETO_GPU_FALLBACK,
       "Supported only in Kineto profiler");
   torch::profiler::impl::kineto::prepareTrace(
-      /*cpuOnly=*/!at::hasCUDA(), activities);
+      /*cpuOnly=*/!at::hasCUDA(), activities, config.experimental_config);
 }
 
 void enableProfilerWithEventPostProcess(

--- a/torch/csrc/profiler/api.h
+++ b/torch/csrc/profiler/api.h
@@ -35,6 +35,21 @@ enum class C10_API_ENUM ActiveProfilerType {
   NVTX
 };
 
+struct TORCH_API ExperimentalConfig {
+  explicit ExperimentalConfig(
+      std::vector<std::string> profiler_metrics = {},
+      bool profiler_measure_per_kernel = false)
+    : profiler_metrics(std::move(profiler_metrics)),
+      profiler_measure_per_kernel(profiler_measure_per_kernel) {}
+  ~ExperimentalConfig() = default;
+  std::vector<std::string> profiler_metrics;
+  bool profiler_measure_per_kernel = false;
+
+  bool hasOptions() const {
+    return profiler_metrics.size() > 0;
+  }
+};
+
 struct TORCH_API ProfilerConfig {
   explicit ProfilerConfig(
       ProfilerState state,
@@ -42,8 +57,10 @@ struct TORCH_API ProfilerConfig {
       bool profile_memory = false,
       bool with_stack = false,
       bool with_flops = false,
-      bool with_modules = false)
+      bool with_modules = false,
+      ExperimentalConfig experimental_config = ExperimentalConfig())
       : state(state),
+        experimental_config(experimental_config),
         report_input_shapes(report_input_shapes),
         profile_memory(profile_memory),
         with_stack(with_stack),
@@ -51,6 +68,7 @@ struct TORCH_API ProfilerConfig {
         with_modules(with_modules) {}
   ~ProfilerConfig() = default;
   ProfilerState state;
+  ExperimentalConfig experimental_config;
   bool report_input_shapes;
   bool profile_memory;
   bool with_stack;

--- a/torch/csrc/profiler/kineto_shim.h
+++ b/torch/csrc/profiler/kineto_shim.h
@@ -114,7 +114,9 @@ struct ActivityTraceWrapper {
 };
 
 using ActivitySet = std::set<torch::autograd::profiler::ActivityType>;
-void prepareTrace(const bool cpuOnly, const ActivitySet& activities);
+void prepareTrace(
+    const bool cpuOnly, const ActivitySet& activities,
+    const torch::profiler::impl::ExperimentalConfig& config);
 void startTrace();
 ActivityTraceWrapper stopTrace();
 void pushCorrelationId(uint64_t correlation_id);

--- a/torch/distributed/rpc/server_process_global_profiler.py
+++ b/torch/distributed/rpc/server_process_global_profiler.py
@@ -118,7 +118,8 @@ class _server_process_global_profile(profile):
             self.profile_memory,
             False,
             False,
-            False)
+            False,
+            torch.profiler._ExperimentalConfig())
         _enable_server_process_global_profiler(profiler_config)
         return self
 

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -9,6 +9,7 @@ examine their input shapes and stack traces, study device kernel activity and vi
 '''
 
 from .profiler import profile, _KinetoProfile, \
-    schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, ProfilerActivity
+    schedule, supported_activities, tensorboard_trace_handler, ProfilerAction,\
+    ProfilerActivity, _ExperimentalConfig
 from torch.autograd import kineto_available, _supported_activities, DeviceType
 from torch.autograd.profiler import record_function

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -10,6 +10,7 @@ from warnings import warn
 import torch
 import torch.autograd.profiler as prof
 from torch.autograd import ProfilerActivity, kineto_available
+from torch._C._autograd import _ExperimentalConfig
 
 
 def supported_activities():
@@ -45,6 +46,9 @@ class _KinetoProfile(object):
             Note that this support exist, at the moment, only for TorchScript models
             and not eager mode models.
 
+        experimental_config (_ExperimentalConfig) : A set of experimental options
+            used by profiler libraries like Kineto. Note, backward compatibility is not guaranteed.
+
     .. note::
         This API is an experimental and subject to change in future.
 
@@ -61,13 +65,15 @@ class _KinetoProfile(object):
             profile_memory: bool = False,
             with_stack: bool = False,
             with_flops: bool = False,
-            with_modules: bool = False):
+            with_modules: bool = False,
+            experimental_config: Optional[_ExperimentalConfig] = None):
         self.activities = set(activities) if activities else supported_activities()
         self.record_shapes = record_shapes
         self.with_flops = with_flops
         self.profile_memory = profile_memory
         self.with_stack = with_stack
         self.with_modules = with_modules
+        self.experimental_config = experimental_config
         self.profiler: Optional[prof.profile] = None
 
     def start(self):
@@ -87,6 +93,7 @@ class _KinetoProfile(object):
             with_stack=self.with_stack,
             with_modules=self.with_modules,
             use_kineto=True,
+            experimental_config=self.experimental_config,
         )
         self.profiler._prepare_trace()
 
@@ -281,6 +288,9 @@ class profile(_KinetoProfile):
             then aten::add's module hierarchy is A.B
             Note that this support exist, at the moment, only for TorchScript models
             and not eager mode models.
+        experimental_config (_ExperimentalConfig) : A set of experimental options
+            used for Kineto library features. Note, backward compatibility is not guaranteed.
+
         use_cuda (bool):
             .. deprecated:: 1.8.1
                 use ``activities`` instead.
@@ -376,6 +386,7 @@ class profile(_KinetoProfile):
             with_stack: bool = False,
             with_flops: bool = False,
             with_modules: bool = False,
+            experimental_config: Optional[_ExperimentalConfig] = None,
             # deprecated:
             use_cuda: Optional[bool] = None):
 
@@ -394,7 +405,8 @@ class profile(_KinetoProfile):
             profile_memory=profile_memory,
             with_stack=with_stack,
             with_flops=with_flops,
-            with_modules=with_modules
+            with_modules=with_modules,
+            experimental_config=experimental_config,
         )
 
         if schedule:


### PR DESCRIPTION
Summary:
Kineto introduced a new profiler to read performance counters from NVIDIA GPUs (CUPTI Range Profiler API)
Here we are adding support to configure this Kineto range profiler mode

Example
```
    with torch.profiler.profile(
        activities=[ProfilerActivity.CUDA],
        record_shapes=True,
        on_trace_ready=trace_handler,
        experimental_config=torch.profiler.ExperimentalConfig(
            profiler_metrics=[
                "kineto__tensor_core_insts",
                "dram__bytes_read.sum",
                "dram__bytes_write.sum"],
            profiler_measure_per_kernel=False),
    ) as prof:
        res = train_batch(modeldef)
        prof.step()
```

## Details
* Introduce a new structure `ExperimentalConfig` so users can configure Kineto specific options, keeps profiler API consistent.
* Populate configuration options for Kineto.

Test Plan: CI and tested on resnet50

Differential Revision: D34489487

