### PR TITLE
ci: Lower number of stale actions per hour

### DIFF
--- a/.github/workflows/stale_pull_requests.yml
+++ b/.github/workflows/stale_pull_requests.yml
@@ -23,7 +23,7 @@ jobs:
           days-before-issue-close: -1
           ascending: true
           repo-token: ${{ secrets.GH_STALEBOT_TOKEN }}
-          operations-per-run: 1000
+          operations-per-run: 100
   stale-open-source:
     if: ${{ github.repository == 'pytorch/pytorch' }}
     runs-on: ubuntu-18.04
@@ -43,4 +43,4 @@ jobs:
           days-before-issue-close: -1
           ascending: true
           repo-token: ${{ secrets.GH_STALEBOT_TOKEN }}
-          operations-per-run: 1000
+          operations-per-run: 100


### PR DESCRIPTION
Appears as though we quickly run out of our API operations so let's
lower this by a magnitude of 10 and ramp up if we feel necessary

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Fixes #ISSUE_NUMBER
