### PR TITLE
baby steps on patching inf/nan behavior & aten::amin support in nvfuser

### DIFF
--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -4393,12 +4393,19 @@ class TestCudaFuser(JitTestCase):
         self.assertEqual(prof.events().table().find("fallback"), -1)
         torch._C._jit_set_nvfuser_guard_mode(old_guard)
 
+    # TODO: generalize this
     @unittest.skipIf(not RUN_NVFUSER, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
                      "Requires fusion optimization pass to be effective")
     @unittest.skipIf(is_pre_volta(), "reduction not supported in pre volta device")
     def test_inf_quick_patch(self):
-        x = torch.tensor([-float('inf'), -float('inf'), 4.0], device="cuda")
+        inputs = [torch.tensor([-float('inf'), float('inf'), 4.0], device="cuda"),
+                  torch.tensor([1.0, float('inf'), 4.0], device="cuda"),
+                  torch.tensor([-float('inf'), -1.5, 4.0], device="cuda"),
+                  torch.tensor([1.0, -3.0, float('nan')], device="cuda"),
+                  torch.tensor([-float('inf'), -float('inf'), -float('inf')], device="cuda"),
+                  torch.tensor([float('inf'), float('inf'), float('inf')], device="cuda"),
+                  torch.tensor([float('nan'), float('nan'), float('nan')], device="cuda")]
 
         def fn_amax(x):
             return x.amax(dim=0)
@@ -4406,13 +4413,17 @@ class TestCudaFuser(JitTestCase):
         def fn_amin(x):
             return x.amin(dim=0)
 
-        def fn_add(x):
+        def fn_add_nan(x):
             return x.relu() + float('nan')
 
+        def fn_add(x):
+            return x + 1.0
+
         with nvfuser_singleton_fusion(True):
-            for t in [fn_amax, fn_amin, fn_add]:
-                t_jit = torch.jit.script(t)
-                self._run_helper(t_jit, t, x)
+            for t in [fn_amax, fn_amin, fn_add, fn_add_nan]:
+                for x in inputs:
+                    t_jit = torch.jit.script(t)
+                    self._run_helper(t_jit, t, x)
 
     @unittest.skipIf(not RUN_NVFUSER, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,

--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -4396,6 +4396,7 @@ class TestCudaFuser(JitTestCase):
     @unittest.skipIf(not RUN_NVFUSER, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
                      "Requires fusion optimization pass to be effective")
+    @unittest.skipIf(is_pre_volta(), "reduction not supported in pre volta device")
     def test_inf_quick_patch(self):
         x = torch.tensor([-float('inf'), -float('inf'), 4.0], device="cuda")
 

--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -4397,7 +4397,7 @@ class TestCudaFuser(JitTestCase):
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
                      "Requires fusion optimization pass to be effective")
     def test_inf_quick_patch(self):
-        a=torch.tensor([-float('inf'), -float('inf'), 4.0], device="cuda")
+        x = torch.tensor([-float('inf'), -float('inf'), 4.0], device="cuda")
 
         def fn_amax(x):
             return x.amax(dim=0)
@@ -4406,7 +4406,7 @@ class TestCudaFuser(JitTestCase):
             return x.amin(dim=0)
 
         def fn_add(x):
-            return x.relu()+float('nan')
+            return x.relu() + float('nan')
 
         with nvfuser_singleton_fusion(True):
             for t in [fn_amax, fn_amin, fn_add]:

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -725,10 +725,11 @@ TensorView* max(
   Val* init = nullptr;
   switch (v1->getDataType().value()) {
     case (DataType::Double):
-      init = IrBuilder::create<Double>(std::numeric_limits<double>::lowest());
+      init =
+          IrBuilder::create<Double>(-std::numeric_limits<double>::infinity());
       break;
     case (DataType::Float):
-      init = IrBuilder::create<Double>(std::numeric_limits<float>::lowest());
+      init = IrBuilder::create<Double>(-std::numeric_limits<float>::infinity());
       break;
     case (DataType::Int):
       init = IrBuilder::create<Int>(std::numeric_limits<int64_t>::lowest());
@@ -756,10 +757,10 @@ TensorView* min(
   Val* init = nullptr;
   switch (v1->getDataType().value()) {
     case (DataType::Double):
-      init = IrBuilder::create<Double>(DBL_MAX);
+      init = IrBuilder::create<Double>(std::numeric_limits<double>::infinity());
       break;
     case (DataType::Float):
-      init = IrBuilder::create<Double>(FLT_MAX);
+      init = IrBuilder::create<Double>(std::numeric_limits<float>::infinity());
       break;
     case (DataType::Int):
       init = IrBuilder::create<Int>(std::numeric_limits<int64_t>::max());

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -378,8 +378,20 @@ class CudaKernelGenerator : private OptOutConstDispatch {
     if (def != nullptr && !has_alloc) {
       code_ << "(" << gen(def) << ")";
     } else if (d->isConst()) {
-      const int digits = std::numeric_limits<Double::ScalarType>::max_digits10;
-      code_ << std::setprecision(digits) << *d->value();
+      auto val = *d->value();
+      // note: default inf/nan doesn't work and should be replaced with macros
+      // `NAN`, `POS_INFINITY` and `NEG_INFINITY` instead.
+      if (val == INFINITY) {
+        code_ << "POS_INFINITY";
+      } else if (val == -INFINITY) {
+        code_ << "NEG_INFINITY";
+      } else if (std::isnan(val)) {
+        code_ << "NAN";
+      } else {
+        const int digits =
+            std::numeric_limits<Double::ScalarType>::max_digits10;
+        code_ << std::setprecision(digits) << val;
+      }
     } else {
       code_ << varName(d);
     }

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -381,10 +381,12 @@ class CudaKernelGenerator : private OptOutConstDispatch {
       auto val = *d->value();
       // note: default inf/nan doesn't work and should be replaced with macros
       // `NAN`, `POS_INFINITY` and `NEG_INFINITY` instead.
-      if (val == INFINITY) {
-        code_ << "POS_INFINITY";
-      } else if (val == -INFINITY) {
-        code_ << "NEG_INFINITY";
+      if (std::isinf(val)) {
+        if (val > 0) {
+          code_ << "POS_INFINITY";
+        } else {
+          code_ << "NEG_INFINITY";
+        }
       } else if (std::isnan(val)) {
         code_ << "NAN";
       } else {

--- a/torch/csrc/jit/codegen/cuda/type_inference.cpp
+++ b/torch/csrc/jit/codegen/cuda/type_inference.cpp
@@ -410,6 +410,7 @@ class NaiveTypePropagator {
         break;
       }
       case aten::amax:
+      case aten::amin:
       case aten::mean:
       case aten::sum: {
         auto out_type = getInputTensorType(node, 0);


### PR DESCRIPTION
Fixes #75622 

1. Instead of getting max/min_value for reduction init value, we go with (-)infinity instead so we can properly preserve inf inputs;
2. Adding inf/(-)inf/nan for float value.
3. Adding aten::amin in nvfuser (@kevinstephano @rdspring1 for review)