### PR TITLE
[quant][fx][fix] Add additional checks when tracing back during maybe share output observer function

### DIFF
--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -959,6 +959,9 @@ def maybe_make_input_output_share_observers(
                 continue
             iteration_guard = 0
             while not is_activation_post_process_node(input_arg, modules):
+                # failed to trace back since no input arg for the current node
+                if len(input_arg.args) < 1:
+                    return False
                 input_arg = input_arg.args[0]
                 iteration_guard += 1
                 if iteration_guard > 10000:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75650

Summary:
Currently in `maybe_make_input_output_share_observers`  we trace back from a node to find the activation_post_process
of the input node, we have internal use case which would error out during tracing back, this PR is adding a guard
during this process to return False early when the node doesn't have any input

Test Plan:
not sure when this would happen, verify within the internal test case

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D35571933](https://our.internmc.facebook.com/intern/diff/D35571933)