### PR TITLE
Add expecttest to conda install package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Other potentially useful environment variables may be found in `setup.py`.
 
 Common
 ```bash
-conda install astunparse numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six requests dataclasses
+conda install astunparse numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six requests dataclasses expecttest
 ```
 
 On Linux


### PR DESCRIPTION
It is required to run unit test.
