### PR TITLE
[JIT] pass stacktraces through the JIT interpreter

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -392,6 +392,7 @@ core_sources_full_mobile_no_backend_interface = [
     "torch/csrc/jit/tensorexpr/unique_name_manager.cpp",
     "torch/csrc/jit/testing/file_check.cpp",
     "torch/csrc/jit/testing/hooks_for_testing.cpp",
+    "torch/csrc/utils/cpp_stacktraces.cpp",
     "torch/csrc/utils/tensor_flatten.cpp",
     "torch/csrc/utils/variadic.cpp",
 ]

--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -43,26 +43,6 @@ could not be completed because the input matrix is singular.", PyExc_RuntimeErro
 
 namespace torch {
 
-static bool compute_cpp_stack_traces_enabled() {
-  auto envar = std::getenv("TORCH_SHOW_CPP_STACKTRACES");
-  if (envar) {
-    if (strcmp(envar, "0") == 0) {
-      return false;
-    }
-    if (strcmp(envar, "1") == 0) {
-      return true;
-    }
-    TORCH_WARN("ignoring invalid value for TORCH_SHOW_CPP_STACKTRACES: ", envar,
-               " valid values are 0 or 1.");
-  }
-  return false;
-}
-
-bool get_cpp_stacktraces_enabled() {
-  static bool enabled = compute_cpp_stack_traces_enabled();
-  return enabled;
-}
-
 void replaceAll(std::string & str,
     const std::string & old_str,
     const std::string & new_str) {

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -11,6 +11,7 @@
 #include <pybind11/pybind11.h>
 #include <torch/csrc/Export.h>
 #include <torch/csrc/utils/auto_gil.h>
+#include <torch/csrc/utils/cpp_stacktraces.h>
 #include <torch/csrc/jit/runtime/jit_exception.h>
 #include <c10/util/StringUtil.h>
 #include <ATen/detail/FunctionTraits.h>
@@ -279,8 +280,6 @@ namespace torch {
 TORCH_PYTHON_API void translate_exception_to_python(const std::exception_ptr &);
 
 TORCH_PYTHON_API std::string processErrorMsg(std::string str);
-
-TORCH_PYTHON_API bool get_cpp_stacktraces_enabled();
 
 // Abstract base class for exceptions which translate to specific Python types
 struct PyTorchError : public std::exception {

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -89,6 +89,7 @@
 #include <torch/csrc/jit/serialization/import.h>
 #include <torch/csrc/jit/tensorexpr/kernel.h>
 #include <torch/csrc/jit/tensorexpr/tensorexpr_init.h>
+#include <torch/csrc/utils/cpp_stacktraces.h>
 
 #include <c10/macros/Export.h>
 #include <c10/util/irange.h>

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -26,6 +26,7 @@
 #include <torch/csrc/jit/runtime/profiling_record.h>
 #include <torch/csrc/jit/runtime/script_profile.h>
 #include <torch/csrc/jit/runtime/vararg_functions.h>
+#include <torch/csrc/utils/cpp_stacktraces.h>
 #include <string>
 
 #ifdef USE_RPC
@@ -796,7 +797,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
         python_class_name = jit_exception->getPythonClassName();
       }
       handleError(
-          ExceptionMessage(e),
+          e,
           (bool)jit_exception,
           not_implemented_error,
           python_class_name);
@@ -816,10 +817,11 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
   }
 
   void handleError(
-      const ExceptionMessage& msg,
+      const std::exception& e,
       bool is_jit_exception,
       c10::NotImplementedError* not_implemented_error,
       c10::optional<std::string> python_class_name) {
+    ExceptionMessage msg(e);
     std::ostringstream ss;
     std::string class_name =
         python_class_name ? *python_class_name : "RuntimeError";
@@ -836,6 +838,9 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
           not_implemented_error->backtrace(),
           not_implemented_error->caller());
     } else {
+      if (get_cpp_stacktraces_enabled()) {
+        ss << e.what() << "\n";
+      }
       throw std::runtime_error(ss.str());
     }
   }

--- a/torch/csrc/utils/cpp_stacktraces.cpp
+++ b/torch/csrc/utils/cpp_stacktraces.cpp
@@ -1,0 +1,30 @@
+#include <torch/csrc/utils/cpp_stacktraces.h>
+
+#include <cstdlib>
+#include <cstring>
+
+#include <c10/util/Exception.h>
+
+namespace torch {
+namespace {
+bool compute_cpp_stack_traces_enabled() {
+  auto envar = std::getenv("TORCH_SHOW_CPP_STACKTRACES");
+  if (envar) {
+    if (strcmp(envar, "0") == 0) {
+      return false;
+    }
+    if (strcmp(envar, "1") == 0) {
+      return true;
+    }
+    TORCH_WARN("ignoring invalid value for TORCH_SHOW_CPP_STACKTRACES: ", envar,
+               " valid values are 0 or 1.");
+  }
+  return false;
+}
+} // namespace
+
+bool get_cpp_stacktraces_enabled() {
+  static bool enabled = compute_cpp_stack_traces_enabled();
+  return enabled;
+}
+} // namespace torch

--- a/torch/csrc/utils/cpp_stacktraces.h
+++ b/torch/csrc/utils/cpp_stacktraces.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <torch/csrc/Export.h>
+
+namespace torch {
+TORCH_API bool get_cpp_stacktraces_enabled();
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #75706
* __->__ #75682

If TORCH_SHOW_CPP_STACKTRACES=1, then dump e.what() into the RuntimeError, which should make it easier to debug exceptions that happen within interpreted sections.

Test:
```patch
diff --git a/test/cpp/jit/test_dce.cpp b/test/cpp/jit/test_dce.cpp
index 6f9161d0d9..7c574787cf 100644
--- a/test/cpp/jit/test_dce.cpp
+++ b/test/cpp/jit/test_dce.cpp
@@ -3,6 +3,10 @@
 #include <torch/csrc/jit/ir/irparser.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/testing/file_check.h>
+#include <torch/csrc/jit/runtime/interpreter.h>
+#include <test/cpp/jit/test_utils.h>
+
+#include <ATen/ATen.h>

 namespace torch {
 namespace jit {
@@ -48,5 +52,30 @@ graph():
   // Check that dead code elimin
   testing::FileCheck().run(input, *graph);
 }
+
+TEST(EliminateDeadCodeTest, interpreterfailure) {
+  const std::string input = R"IR(
+graph(%x.1 : Tensor):
+  %2 : int = prim::Constant[value=128]() # /data/users/dberard/scripts/DGB/sz.py:4:38
+  %3 : int = prim::Constant[value=256]() # /data/users/dberard/scripts/DGB/sz.py:4:43
+  %5 : int = prim::Constant[value=1]() # /data/users/dberard/scripts/DGB/sz.py:4:53
+  %4 : int[] = prim::ListConstruct(%2, %3)
+  %6 : Tensor[] = aten::split_with_sizes(%x.1, %4, %5) # /data/users/dberard/scripts/DGB/sz.py:4:11
+  return (%6)
+)IR";
+  auto graph = std::make_shared<Graph>();
+  parseIR(input, graph.get());
+
+  //auto stack = createStack({at::randn({2, 383}, at::kCPU)});
+  auto stack = createStack({at::Tensor{}});
+
+  Code code(graph, "");
+  InterpreterState interpreter{code};
+  interpreter.run(stack);
+ ASSERT_EQ(2, stack.size());
+  ASSERT_FALSE(stack[0].toTensor().defined());
+  ASSERT_FALSE(stack[1].toTensor().defined());
+}
+
 } // namespace jit
 } // namespace torch
```

^ use this to repro the interpreter issue: `TORCH_SHOW_CPP_STACKTRACES=1 ./bin/test_jit --gtest_filter="EliminateDeadCodeTest.interpreterfailure"` and the stack trace is shown.

Differential Revision: [D35587253](https://our.internmc.facebook.com/intern/diff/D35587253)