### PR TITLE
[ONNX] Support aminmax

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4370,6 +4370,15 @@ class _TestONNXRuntime:
         x = torch.randn(4, 4)
         self.run_test(model, x)
 
+    def test_aminmax(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.aminmax(x, dim=1, keepdim=True), torch.aminmax(x, keepdim=False)
+
+        model = Model()
+        x = torch.randn(3, 4)
+        self.run_test(model, x)
+
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_arange_end(self):
         class ArangeScript(torch.jit.ScriptModule):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1783,6 +1783,16 @@ def amin(g, self, dim, keepdim):
     return g.op("ReduceMin", self, axes_i=dim, keepdims_i=keepdim)
 
 
+@parse_args("v", "v", "i")
+def aminmax(g, self, dim, keepdim):
+    reduce_kwargs = {"keepdims_i": keepdim}
+    if not sym_help._is_none(dim):
+        dim = sym_help._get_const(dim, "i", "dim")
+        reduce_kwargs["axes_i"] = [dim]
+
+    return g.op("ReduceMin", self, **reduce_kwargs), g.op("ReduceMax", self, **reduce_kwargs)
+
+
 def exp(g, self):
     return g.op("Exp", self)
 


### PR DESCRIPTION
Support exporting `torch.aminmax`.
One of the use case is exporting fake quantized models. The observer calls https://github.com/pytorch/pytorch/blob/1601a4dc9f689db3912190dcc8fdc70814896292/torch/ao/quantization/observer.py#L447. 
