### PR TITLE
Respect the global std option if set.

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -407,7 +407,11 @@ endmacro()
 # Usage:
 #   torch_compile_options(lib_name)
 function(torch_compile_options libname)
-  set_property(TARGET ${libname} PROPERTY CXX_STANDARD 14)
+  if(DEFINED CMAKE_CXX_STANDARD)
+    set_property(TARGET ${libname} PROPERTY CXX_STANDARD ${CMAKE_CXX_STANDARD})
+  else()
+    set_property(TARGET ${libname} PROPERTY CXX_STANDARD 14)
+  endif()
   set(private_compile_options "")
 
   # ---[ Check if warnings should be errors.


### PR DESCRIPTION
This target-level setting is probably not needed anyway since caffe2/CMakeLists.txt is the only one using it and it does not create additional project.
But not a bad idea to be explicit either.
This change redirects it to use the global setup.

Background:
Static constexpr member `caffe2::TensorProto::UNDEFINED` in `caffe2/onnx/backend.cc` and `caffe2/onnx/onnx_exporter.cc` seems to be ODR-used.
By C++14, it has to be exported, but C++17 relaxed that requirement.
If we set C++17 at top level but 14 here, on CentOS 7 + gcc-9 (devtoolset-9), this leads to undefined references.

Related PR:
- https://github.com/pytorch/pytorch/pull/75519
