### PR TITLE
[PyTorchEdge] Version bump and make flatbuffer deafult for targets that enable faltbuffer

### DIFF
--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -127,7 +127,11 @@ constexpr uint64_t kMinProducedFileFormatVersion = 0x3L;
 //  0x9L: Change serialization format from pickle to format This version is to
 //  serve migration. v8 pickle and v9 flatbuffer are the same. Refer to the
 //  summary of https://github.com/pytorch/pytorch/pull/75201 for more details.
+#if defined(ENABLE_FLATBUFFER)
+constexpr uint64_t kProducedBytecodeVersion = 0x9L;
+#else
 constexpr uint64_t kProducedBytecodeVersion = 0x8L;
+#endif
 
 // static_assert(
 //     kProducedBytecodeVersion >= kProducedFileFormatVersion,

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -224,13 +224,23 @@ struct TORCH_API Module : public Object {
       std::ostream& out,
       const ExtraFilesMap& extra_files = ExtraFilesMap(),
       bool save_mobile_debug_info = false,
-      bool use_flatbuffer = false) const;
+#if defined(ENABLE_FLATBUFFER)
+      bool use_flatbuffer = true
+#else
+      bool use_flatbuffer = false
+#endif
+  ) const;
 
   void _save_for_mobile(
       const std::string& filename,
       const ExtraFilesMap& extra_files = ExtraFilesMap(),
       bool save_mobile_debug_info = false,
-      bool use_flatbuffer = false) const;
+#if defined(ENABLE_FLATBUFFER)
+      bool use_flatbuffer = true
+#else
+      bool use_flatbuffer = false
+#endif
+  ) const;
 
   Module copy() const;
 

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -159,6 +159,9 @@ TORCH_API void ExportModule(
     const ExtraFilesMap& metadata = ExtraFilesMap(),
     bool bytecode_format = false,
     bool save_mobile_debug_info = false,
+#if defined(ENABLE_FLATBUFFER)
+    bool use_flatbuffer = true
+#endif
     bool use_flatbuffer = false);
 
 TORCH_API void ExportModule(
@@ -167,6 +170,9 @@ TORCH_API void ExportModule(
     const ExtraFilesMap& metadata = ExtraFilesMap(),
     bool bytecode_format = false,
     bool save_mobile_debug_info = false,
+#if defined(ENABLE_FLATBUFFER)
+    bool use_flatbuffer = true
+#endif
     bool use_flatbuffer = false);
 
 TORCH_API void ExportModule(
@@ -175,6 +181,9 @@ TORCH_API void ExportModule(
     const ExtraFilesMap& metadata = ExtraFilesMap(),
     bool bytecode_format = false,
     bool save_mobile_debug_info = false,
+#if defined(ENABLE_FLATBUFFER)
+    bool use_flatbuffer = true
+#endif
     bool use_flatbuffer = false);
 
 // Write the bytes of a pickle archive and the tensors referenced inside that

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -161,8 +161,10 @@ TORCH_API void ExportModule(
     bool save_mobile_debug_info = false,
 #if defined(ENABLE_FLATBUFFER)
     bool use_flatbuffer = true
+#else
+    bool use_flatbuffer = false
 #endif
-    bool use_flatbuffer = false);
+);
 
 TORCH_API void ExportModule(
     const Module& module,
@@ -172,8 +174,10 @@ TORCH_API void ExportModule(
     bool save_mobile_debug_info = false,
 #if defined(ENABLE_FLATBUFFER)
     bool use_flatbuffer = true
+#else
+    bool use_flatbuffer = false
 #endif
-    bool use_flatbuffer = false);
+);
 
 TORCH_API void ExportModule(
     const Module& module,
@@ -183,8 +187,10 @@ TORCH_API void ExportModule(
     bool save_mobile_debug_info = false,
 #if defined(ENABLE_FLATBUFFER)
     bool use_flatbuffer = true
+#else
+    bool use_flatbuffer = false
 #endif
-    bool use_flatbuffer = false);
+);
 
 // Write the bytes of a pickle archive and the tensors referenced inside that
 // archive


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75742

Version bump and make flatbuffer deafult for targets that enable faltbuffer.

Differential Revision: [D35615545](https://our.internmc.facebook.com/intern/diff/D35615545/)