### PR TITLE
ci: Add 5 minute sleep to allow user logins

### DIFF
--- a/.github/scripts/wait_for_ssh_to_drain.ps1
+++ b/.github/scripts/wait_for_ssh_to_drain.ps1
@@ -9,6 +9,9 @@ function Get-SSH-Users {
 
 $usersLoggedOn = Get-SSH-Users
 
+Write-Output "Holding runner for 5 minutes to give an opportunity to log in..."
+Start-Sleep -s 300
+
 Write-Output "Holding runner until all ssh sessions have logged out"
 while ($usersLoggedOn.Count -gt 0) {
     $usersLoggedOn = Get-SSH-Users

--- a/.github/scripts/wait_for_ssh_to_drain.sh
+++ b/.github/scripts/wait_for_ssh_to_drain.sh
@@ -2,6 +2,9 @@
 
 set -eou pipefail
 
+echo "Holding runner for 5 minutes to give an opportunity to log in..."
+sleep 300
+
 echo "Holding runner for 2 hours until all ssh sessions have logged out"
 for _ in $(seq 1440); do
     # Break if no ssh session exists anymore


### PR DESCRIPTION
Appears as though we weren't giving users enough time to actually log
into machines especially if they were experiencing an immediate failure
for their workflows. This gives users at least a 5 minute grace period
to log in prior to the node releasing itself

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Fixes #ISSUE_NUMBER
