### PR TITLE
[2] remove caffe2 math.h from maskrcnn ops

### DIFF
--- a/caffe2/operators/generate_proposals_op_util_boxes.h
+++ b/caffe2/operators/generate_proposals_op_util_boxes.h
@@ -2,7 +2,6 @@
 #define CAFFE2_OPERATORS_UTILS_BOXES_H_
 
 #include "caffe2/utils/eigen_utils.h"
-#include "caffe2/utils/math.h"
 
 #include <c10/util/irange.h>
 

--- a/caffe2/operators/generate_proposals_op_util_nms.h
+++ b/caffe2/operators/generate_proposals_op_util_nms.h
@@ -6,7 +6,6 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/macros.h"
 #include "caffe2/utils/eigen_utils.h"
-#include "caffe2/utils/math.h"
 
 #include <c10/util/irange.h>
 


### PR DESCRIPTION
Summary:
caffe2/utils/math.h depends on protobuf which is not needed for pytorch, so we want to get rid of it.
It turns out maskrcnn ops only need the StorageOrder enum from math.h, so just copy it.

Test Plan:
buck build //xplat/caffe2/fb/custom_ops/maskrcnn:maskrcnnAndroid#android-armv7,shared
buck build //xplat/caffe2/fb/custom_ops/maskrcnn:maskrcnn_aabbAndroid#android-armv7,shared
buck build //xplat/caffe2/fb/custom_ops/maskrcnn:maskrcnn_int8Android#android-armv7,shared

Differential Revision: D35624743

