### PR TITLE
Modify unique to return sizes when dim is zero-length

### DIFF
--- a/aten/src/ATen/native/Unique.cpp
+++ b/aten/src/ATen/native/Unique.cpp
@@ -182,7 +182,7 @@ std::tuple<Tensor, Tensor, Tensor> _unique_dim_cpu_template(
       TORCH_CHECK(
           num_zero_dims == 1,
           "Number of zero sized dimensions is more than one, so unique cannot be applied ")
-      Tensor output = at::empty({0}, self.options());
+      Tensor output = at::empty(sizes, self.options());
       Tensor inverse_indices =
           at::empty({0}, self.options().dtype(kLong));
       Tensor counts = at::empty({0}, self.options().dtype(kLong));

--- a/aten/src/ATen/native/cuda/Unique.cu
+++ b/aten/src/ATen/native/cuda/Unique.cu
@@ -117,7 +117,7 @@ std::tuple<Tensor, Tensor, Tensor> unique_dim_cuda_template(
     TORCH_CHECK(
         num_zero_dims == 1,
         "Number of zero sized dimensions is more than one, so unique cannot be applied ")
-    Tensor output = at::empty({0}, self.options());
+    Tensor output = at::empty(sizes, self.options());
     Tensor inverse_indices =
         at::empty({0}, self.options().dtype(kLong));
     Tensor counts = at::empty({0}, self.options().dtype(kLong));

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -432,7 +432,7 @@ class TestSortAndSelect(TestCase):
                                                 device=device)
             expected_inverse_dim2 = torch.tensor([0, 1])
             expected_counts_dim2 = torch.tensor([1, 1])
-            expected_unique_empty = torch.tensor([], dtype=dtype, device=device)
+            expected_unique_empty = torch.empty(5, 0, dtype=dtype, device=device)
             expected_inverse_empty = torch.tensor([], dtype=torch.long, device=device)
             expected_counts_empty = torch.tensor([], dtype=torch.long, device=device)
             if dtype in floating_types_and(torch.float16, torch.bfloat16):


### PR DESCRIPTION
Fixes #75730

Previously, `torch.unique` returned a tensor of size `[0]` when the dimension supplied to `dim` is zero length. Instead, I've changed `torch.unique` to return a tensor matching the input size.

Changes:
- Modify `torch.unique` to return an an empty tensor of size `sizes` as the values output, when `dim` is zero length in the input tensor.
- Make the same change in the CUDA implementation of `torch.unique`.
- Update `test_unique_dim` to expect an empty tensor with size matching the input tensor.