### PR TITLE
[NVFuser] fix incorrect vector size in chunk move

### DIFF
--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -664,7 +664,7 @@ struct CudaGraphFuser {
         auto input_c_strides = input_strides.concrete_sizes().value();
         auto output_c_sizes = producer_output_sizes.concrete_sizes().value();
         int output_index = int(output_c_sizes.size()) - 1;
-        strides.resize(output_index);
+        strides.resize(output_index + 1);
         AT_ASSERT(output_index >= int(input_c_sizes.size()) - 1);
         for (int input_index = int(input_c_sizes.size()) - 1; input_index >= 0;
              input_index--, output_index--) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #75766
* __->__ #75765

Internally there's some modes that run with -D_GLIBCXX_ASSERTIONS, which was throwing out of bounds errors at `strides[output_index]`