### PR TITLE
[quant][core][gpu][bug-fix] Added additional caching support in quantized cudnn add_relu op

### DIFF
--- a/aten/src/ATen/native/quantized/cudnn/BinaryOps.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/BinaryOps.cpp
@@ -42,8 +42,6 @@ struct CacheKey {
 void setAddParams(
     AddParams* params, const at::Tensor& input_a, const at::Tensor& input_b,
     bool deterministic, bool allow_tf32) {
-  // operator datatype needs to be int32 for int8 matmul, but we can
-  // set the datatype for output tensor to int32 or fp32
   memset(params, 0, sizeof(AddParams));
   params->device_id = at::cuda::current_device();
   params->input_dim = input_a.dim();

--- a/aten/src/ATen/native/quantized/cudnn/BinaryOps.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/BinaryOps.cpp
@@ -13,6 +13,7 @@
 #include <ATen/native/utils/ParamsHash.h>
 #include <ATen/TensorUtils.h>
 #include <c10/core/QScheme.h>
+#include <c10/cuda/CUDAFunctions.h>
 #include <c10/util/ArrayRef.h>
 #include <torch/library.h>
 
@@ -21,16 +22,43 @@
 namespace at {
 namespace native {
 namespace {
-// FIXME: make this thread-safe by reusing the benchmark cache in Conv_v7.cpp
-namespace {
+constexpr uint8_t max_num_input_dim = 5;
+struct AddParams {
+  c10::DeviceIndex device_id;
+  int input_a_size[max_num_input_dim];
+  int input_b_size[max_num_input_dim];
+  uint8_t input_dim; // we currently assume both inputs are given as the same size (i.e., no broadcasting)
+  at::MemoryFormat memory_format;
+  bool deterministic;
+  bool allow_tf32;
+};
 struct CacheKey {
+  AddParams params;
   uint8_t input_a_alignment;
   uint8_t input_b_alignment;
   uint8_t output_alignment;
   bool kReluFused;
 };
-std::unordered_map<CacheKey, cudnn_frontend::ManagedOpaqueDescriptor, at::native::ParamsHash<CacheKey>, at::native::ParamsEqual<CacheKey>> execution_plan_cache;
+void setAddParams(
+    AddParams* params, const at::Tensor& input_a, const at::Tensor& input_b,
+    bool deterministic, bool allow_tf32) {
+  // operator datatype needs to be int32 for int8 matmul, but we can
+  // set the datatype for output tensor to int32 or fp32
+  memset(params, 0, sizeof(AddParams));
+  params->device_id = at::cuda::current_device();
+  params->input_dim = input_a.dim();
+  params->memory_format = input_a.suggest_memory_format();
+  for (int i = 0; i < params->input_dim; ++i) {
+    params->input_a_size[i] = input_a.sizes()[i];
+    params->input_b_size[i] = input_b.sizes()[i];
+  }
+  params->deterministic = deterministic;
+  params->allow_tf32 = allow_tf32;
 }
+// FIXME: make this thread-safe by reusing the benchmark cache in Conv_v7.cpp
+// we currently set the maximum number of input dimensions to 5
+// this can be increased, if necessary
+std::unordered_map<CacheKey, cudnn_frontend::ManagedOpaqueDescriptor, at::native::ParamsHash<CacheKey>, at::native::ParamsEqual<CacheKey>> execution_plan_cache;
 
 // TODO: this is also in qadd.cpp and some other cpp files in quantized/cpu/. I think we should
 // move everything into a utilities file in quantized/ directory later.
@@ -91,6 +119,7 @@ Tensor add(Tensor qa, Tensor qb, double output_scale, int64_t output_zero_point)
   CacheKey key;
   bool deterministic{true};
   bool allow_tf32{false};
+  setAddParams(&key.params, qa, qb, deterministic, allow_tf32);
   key.kReluFused = kReluFused;
   key.input_a_alignment = cudnn_utils::getAlignment(qa);
   key.input_b_alignment = cudnn_utils::getAlignment(qb);

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -831,10 +831,10 @@ class TestQuantizedOps(TestCase):
 
     """Tests the correctness of the cudnn add and add_relu op
     (Similar to test_qadd_relu_different_qparams, will probably merge in the future)"""
-    # @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
-    # @unittest.skip("Local only - currently the qconv2d_cudnn op is bulid "
-    #                "with USE_EXPERIMENTAL_CUDNN_V8_API, we can enable the test "
-    #                "after it is built by default")
+    @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
+    @unittest.skip("Local only - currently the qconv2d_cudnn op is bulid "
+                   "with USE_EXPERIMENTAL_CUDNN_V8_API, we can enable the test "
+                   "after it is built by default")
     def test_qadd_relu_cudnn(self):
         dtype = torch.qint8
         add_relu = torch.ops.quantized.add_relu

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -831,18 +831,15 @@ class TestQuantizedOps(TestCase):
 
     """Tests the correctness of the cudnn add and add_relu op
     (Similar to test_qadd_relu_different_qparams, will probably merge in the future)"""
-    @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
-    @unittest.skip("Local only - currently the qconv2d_cudnn op is bulid "
-                   "with USE_EXPERIMENTAL_CUDNN_V8_API, we can enable the test "
-                   "after it is built by default")
+    # @unittest.skipIf(not TEST_CUDNN, "cudnn is not enabled.")
+    # @unittest.skip("Local only - currently the qconv2d_cudnn op is bulid "
+    #                "with USE_EXPERIMENTAL_CUDNN_V8_API, we can enable the test "
+    #                "after it is built by default")
     def test_qadd_relu_cudnn(self):
         dtype = torch.qint8
         add_relu = torch.ops.quantized.add_relu
         add = torch.ops.quantized.add
 
-        # NB: This is a strange size so that we exercise both the vectorized
-        # implementation (64-element chunks at at time) as well as the scalar
-        # implementation
         A = torch.arange(-128, 130, dtype=torch.float).to(torch.device("cuda"))
         B = torch.arange(-128, 130, dtype=torch.float).to(torch.device("cuda"))
         scale_A = 2.5


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75772

Summary:
Previous caching strategy for quantized cudnn add_relu operator was insufficient
as it did not properly record all the necesary information. This PR adds several
items to the CacheKey (e.g., input sizes, input dimensions, etc..) that enables
proper caching

Test plan:
```
python test/test_quantization.py -k test_qadd_relu_cudnn
```

Differential Revision: [D35634278](https://our.internmc.facebook.com/intern/diff/D35634278)