### PR TITLE
set fetch-depth: 1

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -31,6 +31,6 @@ runs:
       uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
       with:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        # deep clone, to allow use of git merge-base
-        fetch-depth: 0
+        # --depth=1 for speed, manually fetch history and other refs in workflows as necessary
+        fetch-depth: 1
         submodules: ${{ inputs.submodules }}

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -10,6 +10,16 @@ inputs:
     description: Works as stated in actions/checkout, but the default value is recursive
     required: false
     default: recursive
+  needs-history-and-master:
+    description: If history of this commit and master should be checked out.  Usually used because the job calls git merge-base
+    required: false
+    default: false
+    type: boolean
+  needs-viable-strict:
+    description: If viable/strict should be checked out.  Usually used because the job queries for test stats
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: composite
@@ -31,6 +41,16 @@ runs:
       uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
       with:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        # --depth=1 for speed, manually fetch history and other refs in workflows as necessary
+        # --depth=1 for speed, manually fetch history and other refs as necessary
         fetch-depth: 1
         submodules: ${{ inputs.submodules }}
+
+    - name: Checkout the rest of history and master
+      if: ${{ inputs.needs-history-and-master }}
+      env:
+        HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+      run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
+
+    - name: Checkout viable/strict
+      if: ${{ inputs.needs-viable-strict }}
+      run: git fetch --no-tags --prune --no-recurse-submodules origin viable/strict

--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -46,11 +46,13 @@ runs:
         submodules: ${{ inputs.submodules }}
 
     - name: Checkout the rest of history and master
+      shell: bash
       if: ${{ inputs.needs-history-and-master }}
       env:
         HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
 
     - name: Checkout viable/strict
+      shell: bash
       if: ${{ inputs.needs-viable-strict }}
       run: git fetch --no-tags --prune --no-recurse-submodules origin viable/strict

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
+      - name: Checkout the rest of history and master
+        env:
+          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+        run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
+
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
 

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -26,11 +26,8 @@ jobs:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-
-      - name: Checkout the rest of history and master
-        env:
-          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
-        run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
+        with:
+          needs-history-and-master: true
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -21,6 +21,11 @@ on:
         type: boolean
         default: false
         description: If set, build in debug mode.
+      needs-viable-strict:
+        required: false
+        type: boolean
+        default: false
+        description: checks out viable/strict
 
     outputs:
       docker-image:
@@ -46,6 +51,10 @@ jobs:
       # checkout. In other cases you should prefer a local checkout.
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+
+      - name: Checkout viable/strict
+        if: ${{ inputs.needs-viable-strict }}
+        run: git fetch --no-tags --prune --no-recurse-submodules origin viable/strict
 
       - name: Check for new workflows
         run: |

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -51,10 +51,8 @@ jobs:
       # checkout. In other cases you should prefer a local checkout.
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-
-      - name: Checkout viable/strict
-        if: ${{ inputs.needs-viable-strict }}
-        run: git fetch --no-tags --prune --no-recurse-submodules origin viable/strict
+        with:
+          needs-viable-strict: ${{ inputs.needs-viable-strict }}
 
       - name: Check for new workflows
         run: |

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -15,6 +15,11 @@ on:
         required: true
         type: string
         description: Docker image to run in.
+      needs-viable-strict:
+        required: false
+        type: boolean
+        default: false
+        description: checks out viable/strict
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
@@ -33,6 +38,15 @@ jobs:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+
+      - name: Checkout viable/strict
+        if: ${{ inputs.needs-viable-strict }}
+        run: git fetch --no-tags --prune --no-recurse-submodules origin viable/strict
+
+      - name: Checkout the rest of history and master
+        env:
+          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+        run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux
@@ -164,7 +178,7 @@ jobs:
           name: coredumps-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}
           retention-days: 14
           if-no-files-found: ignore
-          path:
+          path: 
             ./**/core.[1-9]*
 
       - name: Upload test statistics

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -178,8 +178,7 @@ jobs:
           name: coredumps-${{ matrix.config }}-${{ matrix.shard }}-${{ matrix.num_shards }}-${{ matrix.runner }}
           retention-days: 14
           if-no-files-found: ignore
-          path: 
-            ./**/core.[1-9]*
+          path: ./**/core.[1-9]*
 
       - name: Upload test statistics
         if: always()

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -38,15 +38,9 @@ jobs:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-
-      - name: Checkout viable/strict
-        if: ${{ inputs.needs-viable-strict }}
-        run: git fetch --no-tags --prune --no-recurse-submodules origin viable/strict
-
-      - name: Checkout the rest of history and master
-        env:
-          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
-        run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
+        with:
+          needs-viable-strict: ${{ inputs.needs-viable-strict }}
+          needs-history-and-master: true
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
+      - name: Checkout the rest of history and master
+        env:
+          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+        run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
+
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts
         with:

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -52,11 +52,8 @@ jobs:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-
-      - name: Checkout the rest of history and master
-        env:
-          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
-        run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
+        with:
+          needs-history-and-master: true
 
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           no-sudo: true
 
+      - name: Checkout the rest of history and master
+        env:
+          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+        run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
+
       - name: Setup ROCm
         uses: ./.github/actions/setup-rocm
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -40,11 +40,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           no-sudo: true
-
-      - name: Checkout the rest of history and master
-        env:
-          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
-        run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
+          needs-history-and-master: true
 
       - name: Setup ROCm
         uses: ./.github/actions/setup-rocm

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -36,11 +36,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           no-sudo: true
-
-      - name: Checkout the rest of history and master
-        env:
-          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
-        run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
+          needs-history-and-master: true
 
       - name: Setup Windows
         uses: ./.github/actions/setup-win

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           no-sudo: true
 
+      - name: Checkout the rest of history and master
+        env:
+          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+        run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
+
       - name: Setup Windows
         uses: ./.github/actions/setup-win
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -195,6 +195,10 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
+      - name: Checkout rest of history and master
+        env:
+          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+        run: git fetch --no-tags --prune --no-recurse-submodules --unshallow origin "${HASH}" master
       - name: Install dependencies
         # mypy and boto3 versions copied from
         # .circleci/docker/common/install_conda.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -195,10 +195,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
-      - name: Checkout rest of history and master
-        env:
-          HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
-        run: git fetch --no-tags --prune --no-recurse-submodules --unshallow origin "${HASH}" master
+          needs-history-and-master: true
       - name: Install dependencies
         # mypy and boto3 versions copied from
         # .circleci/docker/common/install_conda.sh

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -76,6 +76,7 @@ jobs:
     with:
       build-environment: linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck
       docker-image-name: pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7
+      needs-viable-strict: true
 
   linux-xenial-cuda10_2-py3-gcc7-slow-gradcheck-test:
     name: linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck
@@ -97,6 +98,7 @@ jobs:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7-debug
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
       build-with-debug: true
+      needs-viable-strict: true
 
   linux-xenial-cuda11_3-py3_7-gcc7-debug-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7-debug

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -20,6 +20,7 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-gcc5.4
       docker-image-name: pytorch-linux-xenial-py3.7-gcc5.4
+      needs-viable-strict: true
 
   linux-xenial-py3_7-gcc5_4-test:
     name: linux-xenial-py3.7-gcc5.4
@@ -52,6 +53,7 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-py3.7-gcc7
+      needs-viable-strict: true
 
   linux-xenial-py3_7-gcc7-test:
     name: linux-xenial-py3.7-gcc7
@@ -72,6 +74,7 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-clang7-asan
       docker-image-name: pytorch-linux-xenial-py3-clang7-asan
+      needs-viable-strict: true
 
   linux-xenial-py3_7-clang7-asan-test:
     name: linux-xenial-py3.7-clang7-asan
@@ -80,6 +83,7 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-clang7-asan
       docker-image: ${{ needs.linux-xenial-py3_7-clang7-asan-build.outputs.docker-image }}
+      needs-viable-strict: true
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 3, runner: "linux.2xlarge" },
@@ -93,6 +97,7 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-gcc7-no-ops
       docker-image-name: pytorch-linux-xenial-py3.7-gcc7
+      needs-viable-strict: true
 
   linux-xenial-py3_7-clang7-onnx-build:
     name: linux-xenial-py3.7-clang7-onnx
@@ -100,6 +105,7 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-clang7-onnx
       docker-image-name: pytorch-linux-xenial-py3-clang7-onnx
+      needs-viable-strict: true
 
   linux-xenial-py3_7-clang7-onnx-test:
     name: linux-xenial-py3.7-clang7-onnx
@@ -167,6 +173,7 @@ jobs:
     with:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
+      needs-viable-strict: true
 
   linux-xenial-cuda11_3-py3_7-gcc7-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7
@@ -313,6 +320,7 @@ jobs:
     with:
       build-environment: deploy-linux-xenial-cuda11.3-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
+      needs-viable-strict: true
 
   deploy-linux-xenial-cuda11_3-py3_7-gcc7-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       build-environment: parallelnative-linux-xenial-py3.7-gcc5.4
       docker-image-name: pytorch-linux-xenial-py3.7-gcc5.4
+      needs-viable-strict: true
 
   parallelnative-linux-xenial-py3_7-gcc5_4-test:
     name: parallelnative-linux-xenial-py3.7-gcc5.4
@@ -43,6 +44,7 @@ jobs:
     with:
       build-environment: caffe2-linux-xenial-py3.7-gcc5.4
       docker-image-name: pytorch-linux-xenial-py3.7-gcc5.4
+      needs-viable-strict: true
 
   linux-bionic-cuda10_2-py3_9-gcc7-build:
     name: linux-bionic-cuda10.2-py3.9-gcc7
@@ -93,6 +95,7 @@ jobs:
     with:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7-no-ops
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
+      needs-viable-strict: true
 
   linux-bionic-rocm4_5-py3_7-distributed-build:
     name: linux-bionic-rocm5.0-py3.7-distributed


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

tested via #75232 b/c need to change the source of the workflow
- set fetch-depth: 1
- manually checkout additional branches/history (usually either viable/strict, or master and the rest of the commit's history) when needed
- seems to reduce checkout time by about 30s for jobs that don't need additional branches/history, but minimal improvement otherwise
  - checkouts for most lint jobs now takes <15s



Rough estimates for how long different parts of checkout take on linux (windows is similar, but scaled up):
- just the commit, no history: <15s, seems to be around 6-7s
- viable/strict: 25-30s
- submodules: 80-120s
- master + commit history: 40-50s (if checked out viable/strict before this, then this time is much smaller, <10s)