### PR TITLE
clarify hardtanh's definition

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -174,13 +174,10 @@ class Hardtanh(Module):
 
     .. math::
         \text{HardTanh}(x) = \begin{cases}
-            1 & \text{ if } x > 1 \\
-            -1 & \text{ if } x < -1 \\
+            \text{max\_val} & \text{ if } x > \text{ max\_val } \\
+            \text{min\_val} & \text{ if } x < \text{ min\_val } \\
             x & \text{ otherwise } \\
         \end{cases}
-
-    The range of the linear region :math:`[-1, 1]` can be adjusted using
-    :attr:`min_val` and :attr:`max_val`.
 
     Args:
         min_val: minimum value of the linear region range. Default: -1


### PR DESCRIPTION
From the doc of https://pytorch.org/docs/stable/generated/torch.nn.Hardtanh.html#torch.nn.Hardtanh, the definition is very confused which seems to mean if ```x > max_val```, the output is ```1```,  if  ```x < min_val```, the output is ```-1```, I think we need to clarify the definition as this PR:  if ```x > max_val```, the output is ```max_val```,  if  ```x < min_val```, the output is ```min_val```.