### PR TITLE
Fix compilation on macos

### DIFF
--- a/torch/csrc/init_flatbuffer_module.cpp
+++ b/torch/csrc/init_flatbuffer_module.cpp
@@ -27,6 +27,11 @@ static std::shared_ptr<char> copyStr(const std::string& bytes) {
   std::shared_ptr<char> bytes_copy(
       static_cast<char*>(_aligned_malloc(size, FLATBUFFERS_MAX_ALIGNMENT)),
       _aligned_free);
+#elif defined(__APPLE__)
+  void* p;
+  ::posix_memalign(&p, FLATBUFFERS_MAX_ALIGNMENT, size);
+  TORCH_INTERNAL_ASSERT(p, "Could not allocate memory for flatbuffer");
+  std::shared_ptr<char> bytes_copy(static_cast<char*>(p), free);
 #else
   std::shared_ptr<char> bytes_copy(
       static_cast<char*>(aligned_alloc(FLATBUFFERS_MAX_ALIGNMENT, size)), free);


### PR DESCRIPTION
Fixes #75762

Inspired by the boost version of this: https://github.com/steinwurf/boost/blob/master/boost/align/detail/aligned_alloc_posix.hpp#L19 that uses this function for all the macos versions that we support: https://github.com/steinwurf/boost/blob/master/boost/align/aligned_alloc.hpp#L27