### PR TITLE
Remove histogramdd functional wrapper

### DIFF
--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -7,7 +7,6 @@ import functools
 import pprint
 import pickle
 import collections
-import unittest
 
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch.overrides import (
@@ -729,9 +728,6 @@ def generate_tensor_like_override_tests(cls):
         setattr(cls, name, test_method)
 
 generate_tensor_like_override_tests(TestTorchFunctionOverride)
-TestTorchFunctionOverride.test_torch_functional_histogramdd = unittest.skip(
-    "histogramdd is missing __torch_function__ support")(
-        TestTorchFunctionOverride.test_torch_functional_histogramdd)
 
 class Wrapper:
     "Basic data container that knows how to unwrap itself"

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -78,7 +78,6 @@ blocklist = [
     'range',
     # defined in functional
     'einsum',
-    'histogramdd',
     # reduction argument; these bindings don't make sense
     'binary_cross_entropy_with_logits',
     'ctc_loss',

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4526,6 +4526,97 @@ Example::
     (tensor([ 0.,  0.9524,  0.3810,  0.]), tensor([0., 0.75, 1.5, 2.25, 3.]))
 """.format(**common_args))
 
+add_docstr(torch.histogramdd,
+           r"""
+histogramdd(input, bins, *, range=None, weight=None, density=False, out=None) -> (Tensor, Tensor[])
+
+Computes a multi-dimensional histogram of the values in a tensor.
+
+Interprets the elements of an input tensor whose innermost dimension has size N
+as a collection of N-dimensional points. Maps each of the points into a set of
+N-dimensional bins and returns the number of points (or total weight) in each bin.
+
+:attr:`input` must be a tensor with at least 2 dimensions.
+If input has shape (M, N), each of its M rows defines a point in N-dimensional space.
+If input has three or more dimensions, all but the last dimension are flattened.
+
+Each dimension is independently associated with its own strictly increasing sequence
+of bin edges. Bin edges may be specified explicitly by passing a sequence of 1D
+tensors. Alternatively, bin edges may be constructed automatically by passing a
+sequence of integers specifying the number of equal-width bins in each dimension.
+
+For each N-dimensional point in input:
+    - Each of its coordinates is binned independently among the bin edges
+        corresponding to its dimension
+    - Binning results are combined to identify the N-dimensional bin (if any)
+        into which the point falls
+    - If the point falls into a bin, the bin's count (or total weight) is incremented
+    - Points which do not fall into any bin do not contribute to the output
+
+:attr:`bins` can be a sequence of N 1D tensors, a sequence of N ints, or a single int.
+
+If :attr:`bins` is a sequence of N 1D tensors, it explicitly specifies the N sequences
+of bin edges. Each 1D tensor should contain a strictly increasing sequence with at
+least one element. A sequence of K bin edges defines K-1 bins, explicitly specifying
+the left and right edges of all bins. Every bin is exclusive of its left edge. Only
+the rightmost bin is inclusive of its right edge.
+
+If :attr:`bins` is a sequence of N ints, it specifies the number of equal-width bins
+in each dimension. By default, the leftmost and rightmost bin edges in each dimension
+are determined by the minimum and maximum elements of the input tensor in the
+corresponding dimension. The :attr:`range` argument can be provided to manually
+specify the leftmost and rightmost bin edges in each dimension.
+
+If :attr:`bins` is an int, it specifies the number of equal-width bins for all dimensions.
+
+.. note::
+    See also :func:`torch.histogram`, which specifically computes 1D histograms.
+    While :func:`torch.histogramdd` infers the dimensionality of its bins and
+    binned values from the shape of :attr:`input`, :func:`torch.histogram`
+    accepts and flattens :attr:`input` of any shape.
+
+Args:
+    {input}
+    bins: Tensor[], int[], or int.
+            If Tensor[], defines the sequences of bin edges.
+            If int[], defines the number of equal-width bins in each dimension.
+            If int, defines the number of equal-width bins for all dimensions.
+Keyword args:
+    range (sequence of float): Defines the leftmost and rightmost bin edges
+                                in each dimension.
+    weight (Tensor): By default, each value in the input has weight 1. If a weight
+                        tensor is passed, each N-dimensional coordinate in input
+                        contributes its associated weight towards its bin's result.
+                        The weight tensor should have the same shape as the :attr:`input`
+                        tensor excluding its innermost dimension N.
+    density (bool): If False (default), the result will contain the count (or total weight)
+                    in each bin. If True, each count (weight) is divided by the total count
+                    (total weight), then divided by the volume of its associated bin.
+Returns:
+    hist (Tensor): N-dimensional Tensor containing the values of the histogram.
+    bin_edges(Tensor[]): sequence of N 1D Tensors containing the bin edges.
+
+Example::
+    >>> torch.histogramdd(torch.tensor([[0., 1.], [1., 0.], [2., 0.], [2., 2.]]), bins=[3, 3],
+    ...                   weight=torch.tensor([1., 2., 4., 8.]))
+        torch.return_types.histogramdd(
+            hist=tensor([[0., 1., 0.],
+                         [2., 0., 0.],
+                         [4., 0., 8.]]),
+            bin_edges=(tensor([0.0000, 0.6667, 1.3333, 2.0000]),
+                       tensor([0.0000, 0.6667, 1.3333, 2.0000])))
+
+    >>> torch.histogramdd(torch.tensor([[0., 0.], [1., 1.], [2., 2.]]), bins=[2, 2],
+    ...                   range=[0., 1., 0., 1.], density=True)
+        torch.return_types.histogramdd(
+           hist=tensor([[2., 0.],
+                        [0., 2.]]),
+           bin_edges=(tensor([0.0000, 0.5000, 1.0000]),
+                      tensor([0.0000, 0.5000, 1.0000])))
+
+""")
+torch.histogramdd.__module__ = "torch"
+
 add_docstr(torch.hypot,
            r"""
 hypot(input, other, *, out=None) -> Tensor

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -546,11 +546,15 @@ static bool is_int_list(PyObject* obj, int broadcast_size) {
     }
     auto item = py::reinterpret_steal<py::object>(
         PySequence_GetItem(obj, 0));
+    if (THPUtils_checkIndex(item.ptr())) {
+      return true;
+    }
+    // NOTE: JIT tracer allows arbitrary scalar tensors to act as ints
+    // in an intlist argument. Even float or complex scalar tensors.
     return (
-      THPUtils_checkIndex(item.ptr()) ||
-      // NOTE: JIT tracer allows arbitrary scalar tensors to act as ints
-      // in an intlist argument. Even float or complex scalar tensors.
-      (jit::tracer::isTracing() && THPVariable_Check(item.ptr())));
+        jit::tracer::isTracing() &&
+        THPVariable_Check(item.ptr()) &&
+        THPVariable_Unpack(item.ptr()).sizes() == c10::IntArrayRef{});
   }
   // if a size is specified (e.g. IntArrayRef[2]) we also allow passing a single int
   return broadcast_size > 0 && THPUtils_checkLong(obj);

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1,7 +1,6 @@
 from typing import (
     Tuple, Optional, Union, Any, Sequence, TYPE_CHECKING
 )
-import itertools
 
 import torch
 from torch._C import _add_docstr
@@ -28,7 +27,6 @@ __all__ = [
     'cdist',
     'chain_matmul',
     'einsum',
-    'histogramdd',
     'istft',
     'lu',
     'norm',
@@ -359,126 +357,6 @@ def einsum(*args):
 
     return _VF.einsum(equation, operands)  # type: ignore[attr-defined]
 
-# Wrapper around _histogramdd and _histogramdd_bin_edges needed due to (Tensor, Tensor[]) return type.
-if TYPE_CHECKING:
-    # The JIT doesn't understand Union, so only add type annotation for mypy
-    def histogramdd(input: Tensor,
-                    bins: Union[List[Tensor], List[int], int],
-                    range: Optional[List[float]] = None,
-                    weight: Optional[Tensor] = None,
-                    density: bool = False):
-        pass
-else:
-    def histogramdd(input, bins, range=None, weight=None, density=False):
-        r"""
-        histogramdd(input, bins, *, range=None, weight=None, density=False, out=None) -> (Tensor, Tensor[])
-
-        Computes a multi-dimensional histogram of the values in a tensor.
-
-        Interprets the elements of an input tensor whose innermost dimension has size N
-        as a collection of N-dimensional points. Maps each of the points into a set of
-        N-dimensional bins and returns the number of points (or total weight) in each bin.
-
-        :attr:`input` must be a tensor with at least 2 dimensions.
-        If input has shape (M, N), each of its M rows defines a point in N-dimensional space.
-        If input has three or more dimensions, all but the last dimension are flattened.
-
-        Each dimension is independently associated with its own strictly increasing sequence
-        of bin edges. Bin edges may be specified explicitly by passing a sequence of 1D
-        tensors. Alternatively, bin edges may be constructed automatically by passing a
-        sequence of integers specifying the number of equal-width bins in each dimension.
-
-        For each N-dimensional point in input:
-            - Each of its coordinates is binned independently among the bin edges
-              corresponding to its dimension
-            - Binning results are combined to identify the N-dimensional bin (if any)
-              into which the point falls
-            - If the point falls into a bin, the bin's count (or total weight) is incremented
-            - Points which do not fall into any bin do not contribute to the output
-
-        :attr:`bins` can be a sequence of N 1D tensors, a sequence of N ints, or a single int.
-
-        If :attr:`bins` is a sequence of N 1D tensors, it explicitly specifies the N sequences
-        of bin edges. Each 1D tensor should contain a strictly increasing sequence with at
-        least one element. A sequence of K bin edges defines K-1 bins, explicitly specifying
-        the left and right edges of all bins. Every bin is exclusive of its left edge. Only
-        the rightmost bin is inclusive of its right edge.
-
-        If :attr:`bins` is a sequence of N ints, it specifies the number of equal-width bins
-        in each dimension. By default, the leftmost and rightmost bin edges in each dimension
-        are determined by the minimum and maximum elements of the input tensor in the
-        corresponding dimension. The :attr:`range` argument can be provided to manually
-        specify the leftmost and rightmost bin edges in each dimension.
-
-        If :attr:`bins` is an int, it specifies the number of equal-width bins for all dimensions.
-
-        .. note::
-            See also :func:`torch.histogram`, which specifically computes 1D histograms.
-            While :func:`torch.histogramdd` infers the dimensionality of its bins and
-            binned values from the shape of :attr:`input`, :func:`torch.histogram`
-            accepts and flattens :attr:`input` of any shape.
-
-        Args:
-            {input}
-            bins: Tensor[], int[], or int.
-                  If Tensor[], defines the sequences of bin edges.
-                  If int[], defines the number of equal-width bins in each dimension.
-                  If int, defines the number of equal-width bins for all dimensions.
-        Keyword args:
-            range (sequence of float): Defines the leftmost and rightmost bin edges
-                                       in each dimension.
-            weight (Tensor): By default, each value in the input has weight 1. If a weight
-                             tensor is passed, each N-dimensional coordinate in input
-                             contributes its associated weight towards its bin's result.
-                             The weight tensor should have the same shape as the :attr:`input`
-                             tensor excluding its innermost dimension N.
-            density (bool): If False (default), the result will contain the count (or total weight)
-                            in each bin. If True, each count (weight) is divided by the total count
-                            (total weight), then divided by the volume of its associated bin.
-        Returns:
-            hist (Tensor): N-dimensional Tensor containing the values of the histogram.
-            bin_edges(Tensor[]): sequence of N 1D Tensors containing the bin edges.
-
-        Example::
-            >>> torch.histogramdd(torch.tensor([[0., 1.], [1., 0.], [2., 0.], [2., 2.]]), bins=[3, 3],
-            ...                   weight=torch.tensor([1., 2., 4., 8.]))
-                torch.return_types.histogramdd(
-                    hist=tensor([[0., 1., 0.],
-                                 [2., 0., 0.],
-                                 [4., 0., 8.]]),
-                    bin_edges=(tensor([0.0000, 0.6667, 1.3333, 2.0000]),
-                               tensor([0.0000, 0.6667, 1.3333, 2.0000])))
-
-            >>> torch.histogramdd(torch.tensor([[0., 0.], [1., 1.], [2., 2.]]), bins=[2, 2],
-            ...                   range=[0., 1., 0., 1.], density=True)
-                torch.return_types.histogramdd(
-                    hist=tensor([[2., 0.],
-                                 [0., 2.]]),
-                    bin_edges=(tensor([0.0000, 0.5000, 1.0000]),
-                               tensor([0.0000, 0.5000, 1.0000])))
-
-        """
-        if isinstance(bins, int):
-            # If a single int is passed, repeat it for all dimensions
-            bins = list(itertools.repeat(bins, input.size()[-1]))
-
-        if bins and isinstance(bins[0], int):
-            """
-            If bins is int[], the histogram kernel runs faster knowing that the bin edges form
-            a linear progression (see comments in aten/src/ATen/native/cpu/HistogramKernel.cpp).
-            However, we end up constructing the bin edge tensors twice because
-            _histogramdd_from_bin_cts cannot pass back (Tensor, Tensor[]).
-            """
-            bin_edges = _VF._histogramdd_bin_edges(input, bins, range=range, weight=weight, density=density)
-            hist = _VF._histogramdd_from_bin_cts(input, bins, range=range, weight=weight, density=density)
-        else:
-            """
-            If bins is Tensor[] we simply return it back.
-            """
-            bin_edges = bins
-            hist = _VF._histogramdd_from_bin_tensors(input, bin_edges, weight=weight, density=density)
-
-        return torch.return_types.histogramdd((hist, bin_edges))
 
 # This wrapper exists to support variadic args.
 if TYPE_CHECKING:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75796
* #75792

Merge once the forward compatibility period is expired for the histogramdd
operator.

Approved by: https://github.com/ezyang
