### PR TITLE
[PyTorch Edge] Using Qnnpack in Quantized Softmax Op

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qsoftmax.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qsoftmax.cpp
@@ -1,12 +1,119 @@
 #include <ATen/ATen.h>
 #include <torch/library.h>
 
+#ifdef USE_PYTORCH_QNNPACK
+#include <ATen/native/quantized/cpu/init_qnnpack.h>
+#include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <caffe2/utils/threadpool/pthreadpool-cpp.h>
+#include <pytorch_qnnpack.h>
+#endif // USE_PYTORCH_QNNPACK
+
 namespace at {
 namespace native {
 
 namespace {
 
-Tensor qsoftmax(
+#ifdef USE_PYTORCH_QNNPACK
+
+const static float qnnpack_softmax_output_scale = 0x1.0p-8f;
+const static int qnnpack_softmax_output_zero_point = 0;
+
+bool is_qnnpack_compatible(
+    const Tensor& qx,
+    const double output_scale,
+    const int64_t output_zero_point) {
+  return (
+      (qx.qscheme() == kPerTensorAffine ||
+       qx.qscheme() == kPerTensorSymmetric) &&
+      qx.scalar_type() == c10::kQUInt8 && qx.ndimension() > 0 &&
+      output_scale == qnnpack_softmax_output_scale &&
+      output_zero_point == qnnpack_softmax_output_zero_point);
+}
+
+Tensor qsoftmax_qnnpack(const Tensor& qx, const int64_t dim) {
+  /*
+    Cases for contiguity/dimensionality
+    1) stride along target dim is 1
+        requires no change to qx
+    2) dim is the last dimension (but qx is not contiguous)
+        requires using qx.contiguous()
+    3) other
+        requires permuting qx.contiguous()
+   */
+
+  const int64_t last_dim = qx.dim() - 1;
+  c10::optional<std::vector<int64_t>> permuted_dims = c10::nullopt;
+  c10::optional<at::Tensor> qx_contig = c10::nullopt;
+  const at::Tensor* qx_contig_ptr = nullptr;
+
+  if (qx.stride(dim) == 1) {
+    qx_contig_ptr = &qx;
+  } else if (dim == last_dim) {
+    qx_contig = qx.contiguous();
+    qx_contig_ptr = &qx_contig.value();
+  } else {
+    permuted_dims = std::vector<int64_t>(qx.dim());
+    std::iota(permuted_dims->begin(), permuted_dims->end(), 0);
+    permuted_dims->at(last_dim) = dim;
+    permuted_dims->at(dim) = last_dim;
+    qx_contig = qx.permute(permuted_dims.value()).contiguous();
+    qx_contig_ptr = &qx_contig.value();
+  }
+
+  at::Tensor qy = at::_empty_affine_quantized(
+      qx_contig_ptr->sizes(),
+      at::device(kCPU)
+          .dtype(qx.scalar_type())
+          .memory_format(qx_contig_ptr->suggest_memory_format()),
+      qnnpack_softmax_output_scale,
+      qnnpack_softmax_output_zero_point,
+      c10::nullopt);
+
+  const size_t channels = qx.size(dim);
+  const float input_scale = static_cast<float>(qx.q_scale());
+  const uint32_t flags = 0;
+  const size_t batch_size = qx.numel() / channels;
+  const uint8_t* input =
+      reinterpret_cast<const uint8_t*>(qx_contig_ptr->data_ptr<c10::quint8>());
+  const size_t input_stride = channels;
+  uint8_t* output = reinterpret_cast<uint8_t*>(qy.data_ptr<c10::quint8>());
+  const size_t output_stride = channels;
+
+  initQNNPACK();
+  pytorch_qnnp_operator_t softargmax = nullptr;
+  std::unique_ptr<pytorch_qnnp_operator, QnnpackOperatorDeleter> softmax_op(
+      softargmax);
+
+  pytorch_qnnp_status status = pytorch_qnnp_create_softargmax_nc_q8(
+      channels,
+      input_scale,
+      qnnpack_softmax_output_zero_point,
+      qnnpack_softmax_output_scale,
+      flags,
+      &softargmax);
+  TORCH_CHECK(
+      status == pytorch_qnnp_status_success,
+      "failed to create QNNPACK Softmax operator");
+  CHECK_NOTNULL(softargmax);
+
+  status = pytorch_qnnp_setup_softargmax_nc_q8(
+      softargmax, batch_size, input, input_stride, output, output_stride);
+  TORCH_CHECK(
+      status == pytorch_qnnp_status_success,
+      "failed to setup QNNPACK Softmax operator");
+
+  pthreadpool_t threadpool = caffe2::pthreadpool_();
+  status = pytorch_qnnp_run_operator(softargmax, threadpool);
+  TORCH_CHECK(
+      status == pytorch_qnnp_status_success,
+      "failed to run QNNPACK Softmax operator");
+
+  return permuted_dims.has_value() ? qy.permute(permuted_dims.value()) : qy;
+}
+
+#endif // USE_PYTORCH_QNNPACK
+
+Tensor qsoftmax_naive(
     const Tensor& qx,
     const int64_t dim,
     const double output_scale,
@@ -15,6 +122,20 @@ Tensor qsoftmax(
   Tensor ry = at::softmax(rx, dim);
   return at::quantize_per_tensor(
       ry, output_scale, output_zero_point, qx.scalar_type());
+}
+
+Tensor qsoftmax(
+    const Tensor& qx,
+    const int64_t dim,
+    const double output_scale,
+    const int64_t output_zero_point) {
+#ifdef USE_PYTORCH_QNNPACK
+  if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
+      is_qnnpack_compatible(qx, output_scale, output_zero_point)) {
+    return qsoftmax_qnnpack(qx, dim);
+  }
+#endif // USE_PYTORCH_QNNPACK
+  return qsoftmax_naive(qx, dim, output_scale, output_zero_point);
 }
 
 TORCH_LIBRARY_IMPL(quantized, QuantizedCPU, m) {


### PR DESCRIPTION
Summary: Use Qnnpack's quantized softmax in quantized::softmax op when available

Test Plan:
From fbcode
```buck test caffe2/test:quantization -- test_qsoftmax```

# Benchmarking

(Naive Quantized from D35469257 v1, rest D34996486 v14)

|Shape|Fp32|Naive Quantized|Qnnpack Quantized|Qnnpack Quantized with Permute|
|(1, 5, 49, 49)|[6.6757](https://www.internalfb.com/intern/aibench/details/916894241135767)|[7.5981](https://www.internalfb.com/intern/aibench/details/504937774229694)|[1.5579](https://www.internalfb.com/intern/aibench/details/197716001861453)|[2.8446](https://www.internalfb.com/intern/aibench/details/59311708375203)|
|(1, 9, 16, 128)|[7.8485](https://www.internalfb.com/intern/aibench/details/135980349949180)|[9.0499](https://www.internalfb.com/intern/aibench/details/10150813869685)|[1.8865](https://www.internalfb.com/intern/aibench/details/58396904565184)|[3.5282](https://www.internalfb.com/intern/aibench/details/24583753477273)|
|(1, 5, 49, 64)|[7.0626](https://www.internalfb.com/intern/aibench/details/232201930202347)|[8.1091](https://www.internalfb.com/intern/aibench/details/57639118425406)|[1.801](https://www.internalfb.com/intern/aibench/details/656994017385942)|[3.2989](https://www.internalfb.com/intern/aibench/details/518979104130992)|
|(1, 3, 196, 64)|[16.4717](https://www.internalfb.com/intern/aibench/details/895795134460898)|[18.1987](https://www.internalfb.com/intern/aibench/details/909875420196348)|[3.5657](https://www.internalfb.com/intern/aibench/details/206864227381228)|[8.4519](https://www.internalfb.com/intern/aibench/details/84462467166362)|
|(1, 6, 49, 128)|[15.9872](https://www.internalfb.com/intern/aibench/details/417436371026264)|[17.4556](https://www.internalfb.com/intern/aibench/details/183113464145486)|[3.3912](https://www.internalfb.com/intern/aibench/details/616978041358188)|[8.019](https://www.internalfb.com/intern/aibench/details/849820562672950)|
|(1, 3, 196, 196)|[47.3636](https://www.internalfb.com/intern/aibench/details/633568439089073)|[52.0079](https://www.internalfb.com/intern/aibench/details/742080402804069)|[8.5009](https://www.internalfb.com/intern/aibench/details/685773806433926)|[13.5807](https://www.internalfb.com/intern/aibench/details/871998384861927)|
|(1, 6, 16, 64)|[4.0205](https://www.internalfb.com/intern/aibench/details/380419433454222)|[4.5973](https://www.internalfb.com/intern/aibench/details/923432861470595)|[1.0569](https://www.internalfb.com/intern/aibench/details/176718883676884)|[2.0519](https://www.internalfb.com/intern/aibench/details/303780226597723)|
|(1, 6, 16, 16)|[1.8299](https://www.internalfb.com/intern/aibench/details/599824935422385)|[2.3109](https://www.internalfb.com/intern/aibench/details/669753943440643)|[0.808](https://www.internalfb.com/intern/aibench/details/956331973568963)|[1.6406](https://www.internalfb.com/intern/aibench/details/924887465284668)|
|(1, 9, 16, 49)|[4.5134](https://www.internalfb.com/intern/aibench/details/946070183169117)|[5.2282](https://www.internalfb.com/intern/aibench/details/623403709385332)|[2.8195](https://www.internalfb.com/intern/aibench/details/635876531473203)|[2.2251](https://www.internalfb.com/intern/aibench/details/507256033953952)|
|(1, 6, 49, 196)|[23.9811](https://www.internalfb.com/intern/aibench/details/605021113223196)|[26.2834](https://www.internalfb.com/intern/aibench/details/991778071254930)|[4.5338](https://www.internalfb.com/intern/aibench/details/626603993142478)|[9.3877](https://www.internalfb.com/intern/aibench/details/962263658487065)|

*table made with https://www.internalfb.com/intern/anp/view/?id=1714217&revision_id=686803042569716*

Reviewed By: kimishpatel

Differential Revision: D34953197

