### PR TITLE
Enable LTC Input/Output Mapping

### DIFF
--- a/torch/csrc/lazy/backend/lowering_context.h
+++ b/torch/csrc/lazy/backend/lowering_context.h
@@ -54,8 +54,22 @@ class TORCH_API LoweringContext {
   const std::vector<BackendDataPtr>&
   GetParametersData() const;
 
-  // Get the shape of the result tuple component, given by index.
-  virtual Shape GetResultShape(size_t index) const = 0;
+  // Adds a new input/output alias.
+  virtual void SetUpAlias(
+      const std::vector<int64_t>& output_index,
+      int64_t param_number,
+      const std::vector<int64_t>& param_index,
+      bool must_alias = false) {
+    // Dummy default implementation to do nothing.
+  }
+
+  // Check if parameter shape matches result at index.
+  virtual bool CheckResultShape(
+      const BackendDataPtr& parameter_data,
+      size_t result_idx) {
+    // Dummy default implementation to do nothing.
+    return false;
+  }
 
   // Adds the given output as a component of the result tuple and returns its
   // assigned position within the tuple.

--- a/torch/csrc/lazy/core/config.cpp
+++ b/torch/csrc/lazy/core/config.cpp
@@ -4,7 +4,7 @@ C10_DEFINE_bool(torch_lazy_ir_debug, false, "Enable lazy tensor IR debugging");
 
 C10_DEFINE_bool(
     torch_lazy_param_aliasing,
-    false,
+    true,
     "Enable parameter aliasing support");
 
 C10_DEFINE_bool(

--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -872,12 +872,9 @@ void LazyGraphExecutor::BuildInputOutputAliases(
       auto it = output_tensor_id_map.find(data_info->tensor_id);
       if (it != output_tensor_id_map.end()) {
         size_t output_index = it->second;
-        const Shape& root_shape = lowering_ctx->GetResultShape(output_index);
-        if (Shape(parameters_data[i]->shape()) == root_shape &&
+        if (lowering_ctx->CheckResultShape(parameters_data[i], output_index) &&
             alias_map[output_index] < 0) {
-          // TODO(whc) deleted this interface until we see a need (no TS impl)
-          // lowering_ctx->SetUpAlias({static_cast<int64_t>(output_index)}, i,
-          // {});
+          lowering_ctx->SetUpAlias({static_cast<int64_t>(output_index)}, i, {});
           alias_map[output_index] = i;
 
           VLOG(6) << "Aliased parameter " << i << " with output "

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.h
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.h
@@ -81,13 +81,6 @@ class TORCH_API TSLoweringContext : public LoweringContext {
       c10::ArrayRef<Node*> post_order,
       Util::EmissionMap emit_status);
 
-  // TODO(whc) replace these when real impl lands;
-  // I am just landing the interface in this diff, but MSVC won't allow
-  // undefined virtual funcs
-  Shape GetResultShape(size_t index) const override {
-    TORCH_INTERNAL_ASSERT(false, "not implemented");
-  }
-
   size_t AddResult(const Output& output) override {
     return AddResult(GetOutputOp(output));
   }


### PR DESCRIPTION
This PR enables Input/Output aliasing for Lazy Tensor Core. `SetUpAlias` is a virtual function that can be overridden in a vendor's custom `LoweringContext` implementation.

`GetResultShape`  has been replaced with `CheckResultShape` to ensure compatible with vendor backends that use different shape types (e.g. XLA).

The changes here mirror the interface used by `torch_xla`: https://github.com/pytorch/xla/blob/master/torch_xla/csrc/tensor.cpp#L1548-L1549

cc: @antoniojkim @ke1337 @wconstab @silvasean 