### PR TITLE
[Vulkan] VK Timestamp Queries for op profiling

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Adapter.cpp
+++ b/aten/src/ATen/native/vulkan/api/Adapter.cpp
@@ -105,7 +105,9 @@ Adapter::Adapter(const VkPhysicalDevice handle, const uint32_t num_queues)
     handle_(VK_NULL_HANDLE),
     queues_{},
     num_compute_queues_{},
-    has_unified_memory_{false} {
+    has_unified_memory_{false},
+    timestamp_compute_and_graphics_{false},
+    timestamp_period_{0.f} {
   // This should never happen, but double check to be safe
   TORCH_CHECK(
       VK_NULL_HANDLE != physical_handle_,
@@ -113,6 +115,9 @@ Adapter::Adapter(const VkPhysicalDevice handle, const uint32_t num_queues)
 
   vkGetPhysicalDeviceProperties(physical_handle_, &properties_);
   vkGetPhysicalDeviceMemoryProperties(physical_handle_, &memory_properties_);
+
+  timestamp_compute_and_graphics_ = properties_.limits.timestampComputeAndGraphics;
+  timestamp_period_ = properties_.limits.timestampPeriod;
 
   // Check if there are any memory types have both the HOST_VISIBLE and the
   // DEVICE_LOCAL property flags
@@ -156,7 +161,9 @@ Adapter::Adapter(Adapter&& other) noexcept
     handle_(other.handle_),
     queues_(std::move(other.queues_)),
     num_compute_queues_(other.num_compute_queues_),
-    has_unified_memory_(other.has_unified_memory_) {
+    has_unified_memory_(other.has_unified_memory_),
+    timestamp_compute_and_graphics_(other.timestamp_compute_and_graphics_),
+    timestamp_period_(other.timestamp_period_) {
   other.physical_handle_ = VK_NULL_HANDLE;
   other.handle_ = VK_NULL_HANDLE;
 }

--- a/aten/src/ATen/native/vulkan/api/Adapter.h
+++ b/aten/src/ATen/native/vulkan/api/Adapter.h
@@ -73,6 +73,8 @@ class Adapter final {
   // Metadata
   uint32_t num_compute_queues_;
   bool has_unified_memory_;
+  bool timestamp_compute_and_graphics_;
+  float timestamp_period_;
 
  public:
   inline VkPhysicalDevice physical_handle() const {
@@ -89,6 +91,14 @@ class Adapter final {
 
   inline uint32_t num_compute_queues() const {
     return num_compute_queues_;
+  }
+
+  inline bool timestamp_compute_and_graphics() const {
+    return timestamp_compute_and_graphics_;
+  }
+
+  inline float timestamp_period() const {
+    return timestamp_period_;
   }
 
   void init_device();

--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -1,6 +1,7 @@
 #include <ATen/native/vulkan/api/Context.h>
-#include <ATen/vulkan/Context.h>
+#include <ATen/native/vulkan/api/OpProfiler.h>
 #include <ATen/native/vulkan/ops/Copy.h>
+#include <ATen/vulkan/Context.h>
 
 #include <sstream>
 

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -40,6 +40,7 @@ class Context final {
   GPU gpu();
   Command& command();
   Shader& shader();
+  QueryPool& querypool();
   Pipeline& pipeline();
   Descriptor& descriptor();
   Resource& resource();
@@ -119,6 +120,10 @@ inline Descriptor& Context::descriptor() {
 
 inline Resource& Context::resource() {
   return threadcontext_.resource();
+}
+
+inline QueryPool& Context::querypool() {
+  return threadcontext_.querypool();
 }
 
 inline VkDevice Context::device() {

--- a/aten/src/ATen/native/vulkan/api/OpProfiler.h
+++ b/aten/src/ATen/native/vulkan/api/OpProfiler.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/QueryPool.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+class OpProfiler final {
+ public:
+  explicit OpProfiler(Command::Buffer& buffer, QueryPool& querypool, const std::string& query_name)
+    : buffer_(buffer),
+      querypool_(querypool) {
+    query_index_ = querypool.begin(buffer_.handle(), query_name);
+  }
+  OpProfiler(const OpProfiler&) = delete;
+  OpProfiler(OpProfiler&&) = delete;
+  OpProfiler& operator=(const OpProfiler&) = delete;
+  OpProfiler& operator=(OpProfiler&&) = delete;
+  ~OpProfiler() {
+    querypool_.end(buffer_.handle(), query_index_);
+  }
+
+private:
+  Command::Buffer& buffer_;
+  QueryPool& querypool_;
+  int query_index_;
+};
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/api/QueryPool.cpp
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.cpp
@@ -1,0 +1,120 @@
+#include <ATen/native/vulkan/api/QueryPool.h>
+#include <ATen/native/vulkan/ops/Tensor.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+namespace {
+
+VkQueryPool create_query_pool(const VkDevice& device, const uint32_t queryCount) {
+  VkQueryPool queryPool{};
+  VkQueryPoolCreateInfo info{};
+  info.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+  info.queryType = VK_QUERY_TYPE_TIMESTAMP;
+  info.queryCount = queryCount;
+  VK_CHECK(vkCreateQueryPool(device, &info, nullptr, &queryPool));
+  return queryPool;
+};
+
+void destroy_query_pool(const VkDevice& device, const VkQueryPool& querypool) {
+  if (VK_NULL_HANDLE != device && VK_NULL_HANDLE != querypool) {
+    vkDestroyQueryPool(device, querypool, nullptr);
+  }
+}
+
+} // namespace
+
+QueryPool::QueryPool(const VkDevice& device, const bool is_timestamps_supported, const float timestamp_period_us)
+  : device_(device),
+    is_timestamps_supported_(is_timestamps_supported),
+    timestamp_period_us_(timestamp_period_us),
+    querypool_(VK_NULL_HANDLE) {
+}
+
+QueryPool::~QueryPool() {
+  destroy_query_pool(device_, querypool_);
+  querypool_ = VK_NULL_HANDLE;
+  query_names_.clear();
+}
+
+bool QueryPool::is_enabled() const {
+  return VK_NULL_HANDLE != querypool_;
+}
+
+bool QueryPool::enable() {
+  TORCH_CHECK(VK_NULL_HANDLE == querypool_, "The query pool already exists.");
+  TORCH_CHECK(is_timestamps_supported_, "The device doesn't support for timestamps on all graphics and compute queues.");
+  querypool_ = create_query_pool(device_, Configuration::kMaxQueryCount);
+  return is_enabled();
+}
+
+std::vector<QueryPool::PerfInfo> QueryPool::disable(const bool waitfor_allqueries/* = true*/) {
+  auto out = result(waitfor_allqueries);
+  destroy_query_pool(device_, querypool_);
+  querypool_ = VK_NULL_HANDLE;
+  query_names_.clear();
+  return out;
+}
+
+int QueryPool::begin(const VkCommandBuffer& commandBuffer, const std::string& query_name) {
+  if (VK_NULL_HANDLE == querypool_ || VK_NULL_HANDLE == commandBuffer) {
+    return -1;
+  }
+  auto newQueryIndex = static_cast<uint32_t>(query_names_.size());
+  TORCH_CHECK(newQueryIndex < Configuration::kMaxQueryCount, "The query index cannot exceed Configuration::kMaxQueryCount.");
+  query_names_.push_back(query_name);
+
+  vkCmdWriteTimestamp(
+        commandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, querypool_, newQueryIndex * Configuration::kTimestampsPerQuery);
+  return static_cast<int>(newQueryIndex);
+}
+
+void QueryPool::end(const VkCommandBuffer& commandBuffer, const int queryIndex) {
+  if (VK_NULL_HANDLE == querypool_ || VK_NULL_HANDLE == commandBuffer) {
+    return;
+  }
+  vkCmdWriteTimestamp(
+        commandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, querypool_, static_cast<uint32_t>(queryIndex) * Configuration::kTimestampsPerQuery + 1u);
+}
+
+std::vector<QueryPool::PerfInfo> QueryPool::result(const bool waitfor_allqueries) const {
+  if (VK_NULL_HANDLE == querypool_) {
+    return std::vector<QueryPool::PerfInfo> {};
+  }
+
+  std::vector<QueryPool::PerfInfo> perfInfo;
+  const VkQueryResultFlags flags = waitfor_allqueries ? (VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT) : VK_QUERY_RESULT_64_BIT;
+  std::array<uint64_t, 2> counter_data{};
+  for (uint32_t queryIndex = 0u; queryIndex < query_names_.size(); ++queryIndex) {
+    const auto& query_name = query_names_[queryIndex];
+
+    // Grab the gpu timings (nanoseconds)
+    auto ret = vkGetQueryPoolResults(device_, querypool_, queryIndex * Configuration::kTimestampsPerQuery, Configuration::kTimestampsPerQuery,
+        sizeof(uint64_t) * counter_data.size(), counter_data.data(), sizeof(uint64_t),
+        flags);
+    if (ret != VK_SUCCESS) {
+      std::stringstream msg;
+      msg << "vkGetQueryPoolResults() for \"" << query_name << "\"" << " returned an error code " << ret << ".";
+      TORCH_WARN(msg.str());
+      continue;
+    }
+
+    // Tally up GPU time
+    int64_t gpu_time_us = static_cast<int64_t>(
+        (static_cast<double>(counter_data[1] - counter_data[0]) *
+            timestamp_period_us_) / 1'000.f);    // convert ns to us
+
+    perfInfo.emplace_back(QueryPool::PerfInfo {
+        query_name,
+        static_cast<int64_t>(static_cast<double>(counter_data[0]) * timestamp_period_us_ / 1'000.f),
+        static_cast<int64_t>(static_cast<double>(counter_data[1]) * timestamp_period_us_ / 1'000.f),
+        gpu_time_us });
+ }
+  return perfInfo;
+}
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/api/QueryPool.h
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/api/Adapter.h>
+#include <ATen/native/vulkan/api/Command.h>
+#include <ATen/native/vulkan/api/Common.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace api {
+
+class QueryPool final {
+ public:
+  explicit QueryPool(const VkDevice& device, const bool is_timestamps_supported, const float timestamp_period_us);
+  QueryPool(const QueryPool&) = delete;
+  QueryPool(QueryPool&&) = default;
+  QueryPool& operator=(const QueryPool&) = delete;
+  QueryPool& operator=(QueryPool&&) = default;
+  ~QueryPool();
+
+public:
+  struct PerfInfo final {
+    std::string query_name;
+    int64_t start_time_us;
+    int64_t end_time_us;
+    int64_t execution_time_us;
+  };
+
+  struct Configuration final {
+    static constexpr uint32_t kTimestampsPerQuery = 2u;
+    static constexpr uint32_t kMaxQueryCount = 65536u;
+  };
+
+public:
+  bool is_enabled() const;
+  bool enable();
+  std::vector<QueryPool::PerfInfo> disable(const bool waitfor_allqueries = true);
+  int begin(const VkCommandBuffer& commandBuffer, const std::string& query_name);
+  void end(const VkCommandBuffer& commandBuffer, const int queryIndex);
+  std::vector<PerfInfo> result(const bool waitfor_allqueries) const;
+
+private:
+  VkDevice device_;
+  bool is_timestamps_supported_;
+  float timestamp_period_us_;
+  VkQueryPool querypool_;
+  std::vector<std::string> query_names_;
+};
+
+} // namespace api
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/api/ThreadContext.cpp
+++ b/aten/src/ATen/native/vulkan/api/ThreadContext.cpp
@@ -35,6 +35,13 @@ ThreadContext::SingletonThreadLocalObject<Resource>::SingletonThreadLocalObject(
   : object_(gpu) {
 }
 
+template<>
+ThreadContext::SingletonThreadLocalObject<QueryPool>::SingletonThreadLocalObject(const GPU& gpu)
+  : object_(gpu.device,
+      gpu.adapter->timestamp_compute_and_graphics(),
+      gpu.adapter->timestamp_period()) {
+}
+
 } // namespace api
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/native/vulkan/api/ThreadContext.h
+++ b/aten/src/ATen/native/vulkan/api/ThreadContext.h
@@ -5,6 +5,7 @@
 #include <ATen/native/vulkan/api/Common.h>
 #include <ATen/native/vulkan/api/Command.h>
 #include <ATen/native/vulkan/api/Descriptor.h>
+#include <ATen/native/vulkan/api/QueryPool.h>
 #include <ATen/native/vulkan/api/Resource.h>
 
 namespace at {
@@ -29,6 +30,7 @@ class ThreadContext final {
   Command& command();
   Descriptor& descriptor();
   Resource& resource();
+  QueryPool& querypool();
 
  private:
   GPU gpu_;
@@ -65,6 +67,10 @@ inline Descriptor& ThreadContext::descriptor() {
 
 inline Resource& ThreadContext::resource() {
   return SingletonThreadLocalObject<Resource>::get(gpu_);
+}
+
+inline QueryPool& ThreadContext::querypool() {
+  return SingletonThreadLocalObject<QueryPool>::get(gpu_);
 }
 
 } // namespace api

--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -1,3 +1,4 @@
+#include <ATen/native/vulkan/api/OpProfiler.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <torch/library.h>
 
@@ -54,7 +55,8 @@ Tensor arithmetic_scalar(
     const Tensor& self_arg,
     const Scalar& other,
     const c10::optional<Scalar>& alpha_arg,
-    const api::Shader::Descriptor& shader_descriptor) {
+    const api::Shader::Descriptor& shader_descriptor,
+    const std::string& op_name) {
   api::Context* const context = api::context();
 
   const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
@@ -69,6 +71,8 @@ Tensor arithmetic_scalar(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), op_name);
+
     if C10_LIKELY (v_output.has_image() && v_self.has_image()) {
       const float other_val = alpha_arg
           ? other.to<float>() * alpha_arg->to<float>()
@@ -114,7 +118,8 @@ Tensor& arithmetic_scalar_(
     Tensor& self,
     const Scalar& other,
     const c10::optional<Scalar>& alpha_arg,
-    const api::Shader::Descriptor& shader_descriptor) {
+    const api::Shader::Descriptor& shader_descriptor,
+    const std::string& op_name) {
   api::Context* const context = api::context();
 
   TORCH_CHECK(
@@ -126,6 +131,8 @@ Tensor& arithmetic_scalar_(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), op_name);
+
     if C10_LIKELY (v_self.has_image()) {
       const float other_val = alpha_arg
           ? other.to<float>() * alpha_arg->to<float>()
@@ -169,7 +176,8 @@ Tensor arithmetic_tensor(
     const Tensor& self_arg,
     const Tensor& other_arg,
     const c10::optional<Scalar>& alpha_arg,
-    const api::Shader::Descriptor& shader_descriptor) {
+    const api::Shader::Descriptor& shader_descriptor,
+    const std::string& op_name) {
   check_inputs(self_arg, other_arg);
   api::Context* const context = api::context();
 
@@ -188,6 +196,8 @@ Tensor arithmetic_tensor(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), op_name);
+
     if C10_LIKELY (v_self.has_image() && v_other.has_image()) {
       const float alpha = alpha_arg ? alpha_arg->to<float>() : 1.0;
       const struct Block final {
@@ -243,7 +253,8 @@ Tensor& arithmetic_tensor_(
     Tensor& self,
     const Tensor& other_arg,
     const c10::optional<Scalar>& alpha_arg,
-    const api::Shader::Descriptor& shader_descriptor) {
+    const api::Shader::Descriptor& shader_descriptor,
+    const std::string& op_name) {
   check_inputs(self, other_arg);
   api::Context* const context = api::context();
 
@@ -259,6 +270,8 @@ Tensor& arithmetic_tensor_(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), op_name);
+
     if C10_LIKELY (
         v_self.has_image() && v_other.has_image() && !self.is_same(other)) {
       const float alpha = alpha_arg ? alpha_arg->to<float>() : 1.0;
@@ -310,12 +323,12 @@ Tensor add_scalar(
     const Scalar& other,
     const Scalar& alpha) {
   return arithmetic_scalar(
-      self_arg, other, c10::optional<Scalar>(alpha), VK_KERNEL(add_scalar));
+      self_arg, other, c10::optional<Scalar>(alpha), VK_KERNEL(add_scalar), "aten::add.Scalar");
 }
 
 Tensor& add_scalar_(Tensor& self, const Scalar& other, const Scalar& alpha) {
   return arithmetic_scalar_(
-      self, other, c10::optional<Scalar>(alpha), VK_KERNEL(add_scalar_));
+      self, other, c10::optional<Scalar>(alpha), VK_KERNEL(add_scalar_), "aten::add_.Scalar");
 }
 
 Tensor add_tensor(
@@ -327,15 +340,16 @@ Tensor add_tensor(
         self_arg,
         other_arg.item<float>(),
         c10::optional<Scalar>(alpha.to<float>()),
-        VK_KERNEL(add_scalar));
+        VK_KERNEL(add_scalar),
+        "aten::add.Tensor");
   }
   return arithmetic_tensor(
-      self_arg, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(add));
+      self_arg, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(add), "aten::add.Tensor");
 }
 
 Tensor& add_tensor_(Tensor& self, const Tensor& other_arg, const Scalar& alpha) {
   return arithmetic_tensor_(
-      self, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(add_));
+      self, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(add_), "aten::add_.Tensor");
 }
 
 Tensor sub_scalar(
@@ -346,7 +360,8 @@ Tensor sub_scalar(
       self_arg,
       other,
       c10::optional<Scalar>(-1 * alpha.to<float>()),
-      VK_KERNEL(add_scalar));
+      VK_KERNEL(add_scalar),
+      "aten::sub.Scalar");
 }
 
 Tensor& sub_scalar_(Tensor& self, const Scalar& other, const Scalar& alpha) {
@@ -354,7 +369,8 @@ Tensor& sub_scalar_(Tensor& self, const Scalar& other, const Scalar& alpha) {
       self,
       other,
       c10::optional<Scalar>(-1 * alpha.to<float>()),
-      VK_KERNEL(add_scalar_));
+      VK_KERNEL(add_scalar_),
+      "aten::sub_.Scalar");
 }
 
 Tensor sub_tensor(
@@ -366,25 +382,26 @@ Tensor sub_tensor(
         self_arg,
         other_arg.item<float>(),
         c10::optional<Scalar>(-1 * alpha.to<float>()),
-        VK_KERNEL(add_scalar));
+        VK_KERNEL(add_scalar),
+        "aten::sub.Tensor");
   }
   return arithmetic_tensor(
-      self_arg, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(sub));
+      self_arg, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(sub), "aten::sub.Tensor");
 }
 
 Tensor& sub_tensor_(Tensor& self, const Tensor& other_arg, const Scalar& alpha) {
   return arithmetic_tensor_(
-      self, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(sub_));
+      self, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(sub_), "aten::sub_.Tensor");
 }
 
 Tensor mul_scalar(const Tensor& self_arg, const Scalar& other) {
   return arithmetic_scalar(
-      self_arg, other, c10::optional<Scalar>(), VK_KERNEL(mul_scalar));
+      self_arg, other, c10::optional<Scalar>(), VK_KERNEL(mul_scalar), "aten::mul.Scalar");
 }
 
 Tensor& mul_scalar_(Tensor& self, const Scalar& other) {
   return arithmetic_scalar_(
-      self, other, c10::optional<Scalar>(), VK_KERNEL(mul_scalar_));
+      self, other, c10::optional<Scalar>(), VK_KERNEL(mul_scalar_), "aten::mul_.Scalar");
 }
 
 Tensor mul_tensor(const Tensor& self_arg, const Tensor& other_arg) {
@@ -393,15 +410,16 @@ Tensor mul_tensor(const Tensor& self_arg, const Tensor& other_arg) {
         self_arg,
         other_arg.item<float>(),
         c10::optional<Scalar>(),
-        VK_KERNEL(mul_scalar));
+        VK_KERNEL(mul_scalar),
+        "aten::mul.Tensor");
   }
   return arithmetic_tensor(
-      self_arg, other_arg, c10::optional<Scalar>(), VK_KERNEL(mul));
+      self_arg, other_arg, c10::optional<Scalar>(), VK_KERNEL(mul), "aten::mul.Tensor");
 }
 
 Tensor& mul_tensor_(Tensor& self, const Tensor& other_arg) {
   return arithmetic_tensor_(
-      self, other_arg, c10::optional<Scalar>(), VK_KERNEL(mul_));
+      self, other_arg, c10::optional<Scalar>(), VK_KERNEL(mul_), "aten::mul_.Tensor");
 }
 
 Tensor div_scalar(const Tensor& self_arg, const Scalar& other) {
@@ -409,7 +427,8 @@ Tensor div_scalar(const Tensor& self_arg, const Scalar& other) {
       self_arg,
       1.0 / other.to<float>(),
       c10::optional<Scalar>(),
-      VK_KERNEL(mul_scalar));
+      VK_KERNEL(mul_scalar),
+      "aten::div.Scalar");
 }
 
 Tensor& div_scalar_(Tensor& self, const Scalar& other) {
@@ -417,7 +436,8 @@ Tensor& div_scalar_(Tensor& self, const Scalar& other) {
       self,
       1.0 / other.to<float>(),
       c10::optional<Scalar>(),
-      VK_KERNEL(mul_scalar_));
+      VK_KERNEL(mul_scalar_),
+      "aten::div_.Scalar");
 }
 
 Tensor div_tensor(const Tensor& self_arg, const Tensor& other_arg) {
@@ -426,15 +446,16 @@ Tensor div_tensor(const Tensor& self_arg, const Tensor& other_arg) {
         self_arg,
         1.0 / other_arg.item<float>(),
         c10::optional<Scalar>(),
-        VK_KERNEL(mul_scalar));
+        VK_KERNEL(mul_scalar),
+        "aten::div.Tensor");
   }
   return arithmetic_tensor(
-      self_arg, other_arg, c10::optional<Scalar>(), VK_KERNEL(div));
+      self_arg, other_arg, c10::optional<Scalar>(), VK_KERNEL(div), "aten::div.Tensor");
 }
 
 Tensor& div_tensor_(Tensor& self, const Tensor& other_arg) {
   return arithmetic_tensor_(
-      self, other_arg, c10::optional<Scalar>(), VK_KERNEL(div_));
+      self, other_arg, c10::optional<Scalar>(), VK_KERNEL(div_), "aten::div_.Tensor");
 }
 
 #ifdef USE_VULKAN_API

--- a/aten/src/ATen/native/vulkan/ops/Clamp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clamp.cpp
@@ -1,3 +1,4 @@
+#include <ATen/native/vulkan/api/OpProfiler.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <torch/library.h>
 
@@ -9,10 +10,11 @@ namespace {
 
 using namespace api::utils;
 
-Tensor clamp(
+Tensor _clamp(
     const Tensor& self_arg,
     const c10::optional<Scalar>& min,
-    const c10::optional<Scalar>& max) {
+    const c10::optional<Scalar>& max,
+    const std::string& op_name) {
   TORCH_CHECK(
       min || max,
       "At least one of 'min' or 'max' must not be None");
@@ -31,6 +33,8 @@ Tensor clamp(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), op_name);
+
     if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
       const struct Block final {
         uvec3 extents;
@@ -79,10 +83,18 @@ Tensor clamp(
   return convert(v_output);
 }
 
-Tensor& clamp_(
-    Tensor& self,
+Tensor clamp(
+    const Tensor& self_arg,
     const c10::optional<Scalar>& min,
     const c10::optional<Scalar>& max) {
+  return _clamp(self_arg, min, max, "aten::clamp");
+}
+
+Tensor& _clamp_(
+    Tensor& self,
+    const c10::optional<Scalar>& min,
+    const c10::optional<Scalar>& max,
+    const std::string& op_name) {
   api::Context* const context = api::context();
 
   TORCH_CHECK(
@@ -98,6 +110,8 @@ Tensor& clamp_(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), op_name);
+
     if C10_LIKELY(v_self.has_image()) {
       const struct Block final {
         uvec3 extents;
@@ -140,9 +154,17 @@ Tensor& clamp_(
   return self;
 }
 
+Tensor& clamp_(
+    Tensor& self,
+    const c10::optional<Scalar>& min,
+    const c10::optional<Scalar>& max) {
+  return _clamp_(self, min, max, "aten::clamp_");
+}
+
 Tensor activation(
     const Tensor& self_arg,
-    const api::Shader::Descriptor& shader_descriptor) {
+    const api::Shader::Descriptor& shader_descriptor,
+    const std::string& op_name) {
   api::Context* const context = api::context();
 
   const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
@@ -157,6 +179,8 @@ Tensor activation(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), op_name);
+
     if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
       const struct Block final {
         uvec3 extents;
@@ -202,7 +226,8 @@ Tensor activation(
 
 Tensor& activation_(
     Tensor& self,
-    const api::Shader::Descriptor& shader_descriptor) {
+    const api::Shader::Descriptor& shader_descriptor,
+    const std::string& op_name) {
   api::Context* const context = api::context();
 
   TORCH_CHECK(
@@ -214,6 +239,8 @@ Tensor& activation_(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), op_name);
+
     if C10_LIKELY(v_self.has_image()) {
       const struct Block final {
         uvec3 extents;
@@ -255,44 +282,45 @@ Tensor hardtanh(
     const Tensor& self,
     const Scalar& min,
     const Scalar& max) {
-  return ops::clamp(self, min, max);
+  return ops::_clamp(self, min, max, "aten::hardtanh");
 }
 
 Tensor& hardtanh_(
     Tensor& self,
     const Scalar& min,
     const Scalar& max) {
-  return ops::clamp_(self, min, max);
+  return ops::_clamp_(self, min, max, "aten::hardtanh_");
 }
 
 Tensor relu(const Tensor& self) {
-  return ops::clamp(self, 0, c10::nullopt);
+  return ops::_clamp(self, 0, c10::nullopt, "aten::relu");
 }
 
 Tensor& relu_(Tensor& self) {
-  return ops::clamp_(self, 0, c10::nullopt);
+  return ops::_clamp_(self, 0, c10::nullopt, "aten::relu_");
 }
 
 Tensor hardswish(const Tensor& self) {
-  return ops::activation(self, VK_KERNEL(hardswish));
+  return ops::activation(self, VK_KERNEL(hardswish), "aten::hardswish");
 }
 
 Tensor& hardswish_(Tensor& self) {
-  return ops::activation_(self, VK_KERNEL(hardswish_));
+  return ops::activation_(self, VK_KERNEL(hardswish_), "aten::hardswish_");
 }
 
 Tensor hardsigmoid(const Tensor& self) {
-  return ops::activation(self, VK_KERNEL(hardsigmoid));
+  return ops::activation(self, VK_KERNEL(hardsigmoid), "aten::hardsigmoid");
 }
 
 Tensor& hardsigmoid_(Tensor& self) {
-  return ops::activation_(self, VK_KERNEL(hardsigmoid_));
+  return ops::activation_(self, VK_KERNEL(hardsigmoid_), "aten::hardsigmoid_");
 }
 
 Tensor activation_scalar(
     const Tensor& self_arg,
     const Scalar& scalar_arg,
-    const api::Shader::Descriptor& shader_descriptor) {
+    const api::Shader::Descriptor& shader_descriptor,
+    const std::string& op_name) {
   api::Context* const context = api::context();
 
   const Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
@@ -307,6 +335,8 @@ Tensor activation_scalar(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), op_name);
+
     if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
       const struct Block final {
         uvec3 extents;
@@ -355,7 +385,8 @@ Tensor activation_scalar(
 Tensor& activation_scalar_(
     Tensor& self,
     const Scalar& scalar_arg,
-    const api::Shader::Descriptor& shader_descriptor) {
+    const api::Shader::Descriptor& shader_descriptor,
+    const std::string& op_name) {
   api::Context* const context = api::context();
 
   TORCH_CHECK(
@@ -367,6 +398,8 @@ Tensor& activation_scalar_(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), op_name);
+
     if C10_LIKELY(v_self.has_image()) {
       const struct Block final {
         uvec3 extents;
@@ -409,41 +442,41 @@ Tensor& activation_scalar_(
 Tensor hardshrink(
     const Tensor& self_arg,
     const Scalar& lambd) {
-  return ops::activation_scalar(self_arg, lambd, VK_KERNEL(hardshrink));
+  return ops::activation_scalar(self_arg, lambd, VK_KERNEL(hardshrink), "aten::hardshrink");
 }
 
 Tensor& hardshrink_(
     Tensor& self,
     const Scalar& lambd) {
-  return ops::activation_scalar_(self, lambd, VK_KERNEL(hardshrink_));
+  return ops::activation_scalar_(self, lambd, VK_KERNEL(hardshrink_), "aten::hardshrink_");
 }
 
 Tensor leaky_relu(
     const Tensor& self_arg,
     const Scalar& negative_slope) {
-  return ops::activation_scalar(self_arg, negative_slope, VK_KERNEL(leaky_relu));
+  return ops::activation_scalar(self_arg, negative_slope, VK_KERNEL(leaky_relu), "aten::leaky_relu");
 }
 
 Tensor& leaky_relu_(
     Tensor& self,
     const Scalar& negative_slope) {
-  return ops::activation_scalar_(self, negative_slope, VK_KERNEL(leaky_relu_));
+  return ops::activation_scalar_(self, negative_slope, VK_KERNEL(leaky_relu_), "aten::leaky_relu_");
 }
 
 Tensor sigmoid(const Tensor& self) {
-  return ops::activation(self, VK_KERNEL(sigmoid));
+  return ops::activation(self, VK_KERNEL(sigmoid), "aten::sigmoid");
 }
 
 Tensor& sigmoid_(Tensor& self) {
-  return ops::activation_(self, VK_KERNEL(sigmoid_));
+  return ops::activation_(self, VK_KERNEL(sigmoid_), "aten::sigmoid_");
 }
 
 Tensor tanh(const Tensor& self) {
-  return ops::activation(self, VK_KERNEL(tanh));
+  return ops::activation(self, VK_KERNEL(tanh), "aten::tanh");
 }
 
 Tensor& tanh_(Tensor& self) {
-  return ops::activation_(self, VK_KERNEL(tanh_));
+  return ops::activation_(self, VK_KERNEL(tanh_), "aten::tanh_");
 }
 
 #ifdef USE_VULKAN_API

--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -1,4 +1,5 @@
 #include <ATen/native/vulkan/api/Helper.h>
+#include <ATen/native/vulkan/api/OpProfiler.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <c10/util/irange.h>
 #include <torch/library.h>
@@ -25,73 +26,75 @@ Tensor cat_feature(const TensorList tensors, vTensor& v_output) {
   api::Context* const context = api::context();
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
+  {
+    api::OpProfiler profiler(command_buffer, context->querypool(), "aten::_cat (cat_batch)");
 
-  int64_t ch_size_allprior = 0;
-  int64_t ch_interval = 0;
-  for (const auto& tensor : tensors) {
-    ch_interval += tensor.sizes()[1];
-  }
+    int64_t ch_size_allprior = 0;
+    int64_t ch_interval = 0;
+    for (const auto& tensor : tensors) {
+      ch_interval += tensor.sizes()[1];
+    }
 
-  auto dst_image = v_output.image(
-    command_buffer,
-    vTensor::Stage::Compute,
-    vTensor::Access::Read | vTensor::Access::Write);
+    auto dst_image = v_output.image(
+      command_buffer,
+      vTensor::Stage::Compute,
+      vTensor::Access::Read | vTensor::Access::Write);
 
-  for (const auto& tensor : tensors) {
-    const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
-    const vTensor& v_self = convert(self);
-    if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
-      auto src_image = v_self.image(
-              command_buffer,
-              vTensor::Stage::Compute);
+    for (const auto& tensor : tensors) {
+      const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
+      const vTensor& v_self = convert(self);
+      if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+        auto src_image = v_self.image(
+                command_buffer,
+                vTensor::Stage::Compute);
 
-      const struct Block final {
-        uvec3 size;                // output texture size
-        uint32_t fill_0;           // dummy
-        uvec3 isize;               // input texture size
-        uint32_t fill_1;           // dummy
-        uint32_t batch_size;       // input tensor's batch size
-        uint32_t ch_size;          // input tensor's channel size
-        uint32_t ch_interval;      // channel interval (total # of channels for all tensors)
-        uint32_t ch_size_allprior; // # of channels for tensor 0 to i-1 at ith tensor
-      } block {
-        v_output.extents(),
-        0u,
-        v_self.extents(),
-        0u,
-        safe_downcast<uint32_t>(v_self.sizes()[0]),
-        safe_downcast<uint32_t>(v_self.sizes()[1]),
-        safe_downcast<uint32_t>(ch_interval),
-        safe_downcast<uint32_t>(ch_size_allprior),
-      };
-
-      ch_size_allprior += v_self.sizes()[1];
-
-      context->dispatch(
-          command_buffer,
-          {
-            VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-            VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-            VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-          },
-          VK_KERNEL(cat_feature),
+        const struct Block final {
+          uvec3 size;                // output texture size
+          uint32_t fill_0;           // dummy
+          uvec3 isize;               // input texture size
+          uint32_t fill_1;           // dummy
+          uint32_t batch_size;       // input tensor's batch size
+          uint32_t ch_size;          // input tensor's channel size
+          uint32_t ch_interval;      // channel interval (total # of channels for all tensors)
+          uint32_t ch_size_allprior; // # of channels for tensor 0 to i-1 at ith tensor
+        } block {
+          v_output.extents(),
+          0u,
           v_self.extents(),
-          context->gpu().adapter->local_work_group_size(),
-          // Read/Write access bypasses synchronization but inserts appropriate
-          // barriers if necessary.
-          dst_image,
-          // Read-only access is implied on const tensors and triggers an async
-          // synchronization if necessary.
-          src_image,
-          // Object lifetime is managed by the resource pool.
-          // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
-    }
-    else {
-      TORCH_CHECK(false, "Not implemented!");
+          0u,
+          safe_downcast<uint32_t>(v_self.sizes()[0]),
+          safe_downcast<uint32_t>(v_self.sizes()[1]),
+          safe_downcast<uint32_t>(ch_interval),
+          safe_downcast<uint32_t>(ch_size_allprior),
+        };
+
+        ch_size_allprior += v_self.sizes()[1];
+
+        context->dispatch(
+            command_buffer,
+            {
+              VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+              VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+            },
+            VK_KERNEL(cat_feature),
+            v_self.extents(),
+            context->gpu().adapter->local_work_group_size(),
+            // Read/Write access bypasses synchronization but inserts appropriate
+            // barriers if necessary.
+            dst_image,
+            // Read-only access is implied on const tensors and triggers an async
+            // synchronization if necessary.
+            src_image,
+            // Object lifetime is managed by the resource pool.
+            // It is OK not to keep track of the handle.
+            context->resource().pool.uniform(block).object);
+      }
+      else {
+        TORCH_CHECK(false, "Not implemented!");
+      }
     }
   }
-
   command_pool.submit(context->gpu().queue, command_buffer);
 
   return convert(v_output);
@@ -101,52 +104,54 @@ Tensor cat_feature_mult4ch(const TensorList tensors, vTensor& v_output) {
   api::Context* const context = api::context();
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
+  {
+    api::OpProfiler profiler(command_buffer, context->querypool(), "aten::_cat (cat_feature_mult4ch)");
 
-  int64_t depth_size_allprior = 0;
-  int64_t ch_interval = 0;
-  for (const auto& tensor : tensors) {
-    ch_interval += tensor.sizes()[1];
-  }
-  const int64_t depth_interval = ch_interval / 4;
+    int64_t depth_size_allprior = 0;
+    int64_t ch_interval = 0;
+    for (const auto& tensor : tensors) {
+      ch_interval += tensor.sizes()[1];
+    }
+    const int64_t depth_interval = ch_interval / 4;
 
-  auto dst_image = v_output.image(
-    command_buffer,
-    vTensor::Stage::Transfer,
-    vTensor::Access::Write);
-  uvec3 src_offset{};
-  uvec3 dst_offset{};
+    auto dst_image = v_output.image(
+      command_buffer,
+      vTensor::Stage::Transfer,
+      vTensor::Access::Write);
+    uvec3 src_offset{};
+    uvec3 dst_offset{};
 
-  for (const auto& tensor : tensors) {
-    const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
-    const vTensor& v_self = convert(self);
-    if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
-      auto src_image = v_self.image(
-              command_buffer,
-              vTensor::Stage::Transfer);
+    for (const auto& tensor : tensors) {
+      const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
+      const vTensor& v_self = convert(self);
+      if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+        auto src_image = v_self.image(
+                command_buffer,
+                vTensor::Stage::Transfer);
 
-      const uint32_t depth_slice = safe_downcast<uint32_t>(tensor.sizes()[1] / 4);
-      uvec3 copy_extents {v_self.extents().data[0u],
-        v_self.extents().data[1u],
-        depth_slice};
+        const uint32_t depth_slice = safe_downcast<uint32_t>(tensor.sizes()[1] / 4);
+        uvec3 copy_extents {v_self.extents().data[0u],
+          v_self.extents().data[1u],
+          depth_slice};
 
-      for (const auto b : c10::irange(tensor.sizes()[0])) {
-        src_offset.data[2u] = safe_downcast<uint32_t>(depth_slice * b);
-        dst_offset.data[2u] = depth_size_allprior + safe_downcast<uint32_t>(depth_interval * b);
-        api::helper::copy_texture_to_texture(command_buffer,
-          src_image,
-          dst_image,
-          copy_extents,
-          src_offset,
-          dst_offset);
+        for (const auto b : c10::irange(tensor.sizes()[0])) {
+          src_offset.data[2u] = safe_downcast<uint32_t>(depth_slice * b);
+          dst_offset.data[2u] = depth_size_allprior + safe_downcast<uint32_t>(depth_interval * b);
+          api::helper::copy_texture_to_texture(command_buffer,
+            src_image,
+            dst_image,
+            copy_extents,
+            src_offset,
+            dst_offset);
+        }
+
+        depth_size_allprior += depth_slice;
       }
-
-      depth_size_allprior += depth_slice;
-    }
-    else {
-      TORCH_CHECK(false, "Not implemented!");
+      else {
+        TORCH_CHECK(false, "Not implemented!");
+      }
     }
   }
-
   command_pool.submit(context->gpu().queue, command_buffer);
 
   return convert(v_output);
@@ -160,37 +165,39 @@ Tensor cat_height(const TensorList tensors, vTensor& v_output) {
   api::Context* const context = api::context();
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
+  {
+    api::OpProfiler profiler(command_buffer, context->querypool(), "aten::_cat (cat_width)");
 
-  auto dst_image = v_output.image(
-    command_buffer,
-    vTensor::Stage::Transfer,
-    vTensor::Access::Write);
+    auto dst_image = v_output.image(
+      command_buffer,
+      vTensor::Stage::Transfer,
+      vTensor::Access::Write);
 
-  uvec3 src_offset{};
-  uvec3 dst_offset{};
-  for (const auto& tensor : tensors) {
-    const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
-    const vTensor& v_self = convert(self);
-    if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
-      auto src_image = v_self.image(
-              command_buffer,
-              vTensor::Stage::Transfer);
+    uvec3 src_offset{};
+    uvec3 dst_offset{};
+    for (const auto& tensor : tensors) {
+      const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
+      const vTensor& v_self = convert(self);
+      if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+        auto src_image = v_self.image(
+                command_buffer,
+                vTensor::Stage::Transfer);
 
-      api::helper::copy_texture_to_texture(command_buffer,
-        src_image,
-        dst_image,
-        v_self.extents(),
-        src_offset,
-        dst_offset);
+        api::helper::copy_texture_to_texture(command_buffer,
+          src_image,
+          dst_image,
+          v_self.extents(),
+          src_offset,
+          dst_offset);
 
-      // Increment by height
-      dst_offset.data[1u] += v_self.extents().data[1u];
-    }
-    else {
-      TORCH_CHECK(false, "Not implemented!");
+        // Increment by height
+        dst_offset.data[1u] += v_self.extents().data[1u];
+      }
+      else {
+        TORCH_CHECK(false, "Not implemented!");
+      }
     }
   }
-
   command_pool.submit(context->gpu().queue, command_buffer);
 
   return convert(v_output);

--- a/aten/src/ATen/native/vulkan/ops/Convolution.h
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.h
@@ -61,7 +61,8 @@ class Conv2dOpContext final : public torch::jit::CustomClassHolder {
   void conv2d_sliding_window(
       const api::Shader::Descriptor& shader,
       vTensor& v_output,
-      const vTensor& v_input) const;
+      const vTensor& v_input,
+      const std::string& op_name) const;
 
   void conv2d_winograd_2_3(
       vTensor& v_output,

--- a/aten/src/ATen/native/vulkan/ops/Gru.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Gru.cpp
@@ -196,9 +196,9 @@ std::tuple<Tensor, Tensor> GruOpContext::run(
     const auto&  cxt_in = packed_.linear_op_contexts[i * linear_op_contexts_per_layer + 4];
     const auto&  cxt_hn = packed_.linear_op_contexts[i * linear_op_contexts_per_layer + 5];
 
-    const auto&  r = at::sigmoid(cxt_ir.run(x, 1.0f, 1.0f) + cxt_hr.run(h, 1.0f, 1.0f));
-    const auto&  z = at::sigmoid(cxt_iz.run(x, 1.0f, 1.0f) + cxt_hz.run(h, 1.0f, 1.0f));
-    const auto&  n = at::tanh(cxt_in.run(x, 1.0f, 1.0f) + r * (cxt_hn.run(h, 1.0f, 1.0f)));
+    const auto&  r = at::sigmoid(cxt_ir.run(x, 1.0f, 1.0f, "aten::addmm") + cxt_hr.run(h, 1.0f, 1.0f, "aten::addmm"));
+    const auto&  z = at::sigmoid(cxt_iz.run(x, 1.0f, 1.0f, "aten::addmm") + cxt_hz.run(h, 1.0f, 1.0f, "aten::addmm"));
+    const auto&  n = at::tanh(cxt_in.run(x, 1.0f, 1.0f, "aten::addmm") + r * (cxt_hn.run(h, 1.0f, 1.0f, "aten::addmm")));
     h = (z * (-1) + 1) * n + z * h;
     x = h;  // next input
     h_n_list.emplace_back(h.reshape({1, 1, h.size(0), h.size(1)}));  // 2D to 4D for cat op

--- a/aten/src/ATen/native/vulkan/ops/Mean.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mean.cpp
@@ -1,3 +1,4 @@
+#include <ATen/native/vulkan/api/OpProfiler.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/Utils.h>
 #include <torch/library.h>
@@ -55,6 +56,8 @@ Tensor mean(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), "aten::mean.dim");
+
     if C10_LIKELY(v_input.has_image()) {
       const struct Block final {
         uvec3 extents;

--- a/aten/src/ATen/native/vulkan/ops/Mm.h
+++ b/aten/src/ATen/native/vulkan/ops/Mm.h
@@ -18,7 +18,7 @@ class LinearOpContext final : public torch::jit::CustomClassHolder {
 
   using State = std::tuple<Tensor, c10::optional<Tensor>>;
 
-  Tensor run(const Tensor& input, float beta, float alpha) const;
+  Tensor run(const Tensor& input, float beta, float alpha, const std::string& op_name) const;
   State unpack() const;
 
  private:

--- a/aten/src/ATen/native/vulkan/ops/Padding.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Padding.cpp
@@ -1,3 +1,4 @@
+#include <ATen/native/vulkan/api/OpProfiler.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <c10/util/irange.h>
 #include <torch/library.h>
@@ -55,6 +56,8 @@ Tensor reflection_pad2d(const Tensor& self_arg, IntArrayRef padding) {
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), "aten::reflection_pad2d");
+
     if C10_LIKELY (v_output.has_image() && v_self.has_image()) {
       const struct Block final {
         uvec3 extents;

--- a/aten/src/ATen/native/vulkan/ops/Permute.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Permute.cpp
@@ -1,3 +1,4 @@
+#include <ATen/native/vulkan/api/OpProfiler.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <torch/library.h>
 
@@ -13,63 +14,65 @@ Tensor permute_4d(const Tensor& input, const uvec4& in_size, const uvec4& out_si
   api::Context* const context = api::context();
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
+  {
+    api::OpProfiler profiler(command_buffer, context->querypool(), "aten::permute (permute_4d)");
 
-  auto dst_image = v_output.image(
-    command_buffer,
-    vTensor::Stage::Compute,
-    vTensor::Access::Read | vTensor::Access::Write);
+    auto dst_image = v_output.image(
+      command_buffer,
+      vTensor::Stage::Compute,
+      vTensor::Access::Read | vTensor::Access::Write);
 
-  const Tensor self = input.is_vulkan() ? input : input.vulkan();
-  const vTensor& v_self = convert(self);
-  if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
-    auto src_image = v_self.image(
-            command_buffer,
-            vTensor::Stage::Compute);
+    const Tensor self = input.is_vulkan() ? input : input.vulkan();
+    const vTensor& v_self = convert(self);
+    if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+      auto src_image = v_self.image(
+              command_buffer,
+              vTensor::Stage::Compute);
 
-    const struct Block final {
-      uvec3 size;                // output texture size
-      uint32_t fill_0;           // dummy
-      uvec3 isize;               // input texture size
-      uint32_t fill_1;           // dummy
-      uvec4 tensor_size;         // output tensor size
-      uvec4 itensor_size;        // input tensor size
-      uvec4 dims;                // output dims
-    } block {
-      v_output.extents(),
-      0u,
-      v_self.extents(),
-      0u,
-      out_size,
-      in_size,
-      out_dims,
-    };
-
-    context->dispatch(
-        command_buffer,
-        {
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-        },
-        VK_KERNEL(permute_4d),
-        // build up shader operations from the output texture point of view
-        // to avoid the nondeterministic order of GPU shader operations between texels
+      const struct Block final {
+        uvec3 size;                // output texture size
+        uint32_t fill_0;           // dummy
+        uvec3 isize;               // input texture size
+        uint32_t fill_1;           // dummy
+        uvec4 tensor_size;         // output tensor size
+        uvec4 itensor_size;        // input tensor size
+        uvec4 dims;                // output dims
+      } block {
         v_output.extents(),
-        context->gpu().adapter->local_work_group_size(),
-        // Read/Write access bypasses synchronization but inserts appropriate
-        // barriers if necessary.
-        dst_image,
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        src_image,
-        // Object lifetime is managed by the resource pool.
-        // It is OK not to keep track of the handle.
-        context->resource().pool.uniform(block).object);
-  }
-  else {
-    TORCH_CHECK(false, "Not implemented!");
-  }
+        0u,
+        v_self.extents(),
+        0u,
+        out_size,
+        in_size,
+        out_dims,
+      };
 
+      context->dispatch(
+          command_buffer,
+          {
+            VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+            VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+            VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          },
+          VK_KERNEL(permute_4d),
+          // build up shader operations from the output texture point of view
+          // to avoid the nondeterministic order of GPU shader operations between texels
+          v_output.extents(),
+          context->gpu().adapter->local_work_group_size(),
+          // Read/Write access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
+          dst_image,
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
+          src_image,
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
+    }
+    else {
+      TORCH_CHECK(false, "Not implemented!");
+    }
+  }
   command_pool.submit(context->gpu().queue, command_buffer);
 
   return convert(v_output);

--- a/aten/src/ATen/native/vulkan/ops/Slice.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Slice.cpp
@@ -1,4 +1,5 @@
 #include <ATen/NamedTensorUtils.h>
+#include <ATen/native/vulkan/api/OpProfiler.h>
 #include <ATen/native/vulkan/api/Helper.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <torch/library.h>
@@ -16,65 +17,67 @@ Tensor slice_4d(const Tensor& input, const int64_t dim, const int64_t start, con
   api::Context* const context = api::context();
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
+  {
+    api::OpProfiler profiler(command_buffer, context->querypool(), "aten::slice.Tensor (slice_4d)");
 
-  const Tensor self = input.is_vulkan() ? input : input.vulkan();
-  const vTensor& v_self = convert(self);
-  if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
-    auto src_image = v_self.image(
-            command_buffer,
-            vTensor::Stage::Compute);
-    auto dst_image = v_output.image(
-      command_buffer,
-      vTensor::Stage::Compute,
-      vTensor::Access::Write);
-
-    const struct Block final {
-      uvec3 size;                // output texture size
-      uint32_t fill_0;           // dummy
-      uvec3 isize;               // input texture size
-      uint32_t fill_1;           // dummy
-      uvec4 tensor_size;         // output tensor size
-      uvec4 itensor_size;        // input tensor size
-      uvec4 args;                // input arguments (dim, start, end, step)
-    } block {
-      v_output.extents(),
-      0u,
-      v_self.extents(),
-      0u,
-      out_tsize,
-      in_tsize,
-      { safe_downcast<uint32_t>(dim),
-        safe_downcast<uint32_t>(start),
-        safe_downcast<uint32_t>(end),
-        safe_downcast<uint32_t>(step) },
-    };
-
-    context->dispatch(
+    const Tensor self = input.is_vulkan() ? input : input.vulkan();
+    const vTensor& v_self = convert(self);
+    if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+      auto src_image = v_self.image(
+              command_buffer,
+              vTensor::Stage::Compute);
+      auto dst_image = v_output.image(
         command_buffer,
-        {
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-        },
-        VK_KERNEL(slice_4d),
-        // build up shader operations from the output texture point of view
-        // to avoid the nondeterministic order of GPU shader operations between texels
-        v_output.extents(),
-        context->gpu().adapter->local_work_group_size(),
-        // Write-only access bypasses synchronization but inserts appropriate
-        // barriers if necessary.
-        dst_image,
-        // Read-only access is implied on const tensors and triggers an async
-        // synchronization if necessary.
-        src_image,
-        // Object lifetime is managed by the resource pool.
-        // It is OK not to keep track of the handle.
-        context->resource().pool.uniform(block).object);
-  }
-  else {
-    TORCH_CHECK(false, "Not implemented!");
-  }
+        vTensor::Stage::Compute,
+        vTensor::Access::Write);
 
+      const struct Block final {
+        uvec3 size;                // output texture size
+        uint32_t fill_0;           // dummy
+        uvec3 isize;               // input texture size
+        uint32_t fill_1;           // dummy
+        uvec4 tensor_size;         // output tensor size
+        uvec4 itensor_size;        // input tensor size
+        uvec4 args;                // input arguments (dim, start, end, step)
+      } block {
+        v_output.extents(),
+        0u,
+        v_self.extents(),
+        0u,
+        out_tsize,
+        in_tsize,
+        { safe_downcast<uint32_t>(dim),
+          safe_downcast<uint32_t>(start),
+          safe_downcast<uint32_t>(end),
+          safe_downcast<uint32_t>(step) },
+      };
+
+      context->dispatch(
+          command_buffer,
+          {
+            VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+            VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+            VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          },
+          VK_KERNEL(slice_4d),
+          // build up shader operations from the output texture point of view
+          // to avoid the nondeterministic order of GPU shader operations between texels
+          v_output.extents(),
+          context->gpu().adapter->local_work_group_size(),
+          // Write-only access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
+          dst_image,
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
+          src_image,
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
+    }
+    else {
+      TORCH_CHECK(false, "Not implemented!");
+    }
+  }
   command_pool.submit(context->gpu().queue, command_buffer);
   return convert(v_output);
 }
@@ -83,56 +86,58 @@ Tensor slice_width(const Tensor& input, const int64_t start, const int64_t end, 
   api::Context* const context = api::context();
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
+  {
+    api::OpProfiler profiler(command_buffer, context->querypool(), "aten::slice.Tensor (slice_width)");
 
-  const Tensor self = input.is_vulkan() ? input : input.vulkan();
-  const vTensor& v_self = convert(self);
-  if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
-    auto src_image = v_self.image(
-            command_buffer,
-            vTensor::Stage::Transfer);
-    auto dst_image = v_output.image(
-      command_buffer,
-      vTensor::Stage::Transfer,
-      vTensor::Access::Write);
+    const Tensor self = input.is_vulkan() ? input : input.vulkan();
+    const vTensor& v_self = convert(self);
+    if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+      auto src_image = v_self.image(
+              command_buffer,
+              vTensor::Stage::Transfer);
+      auto dst_image = v_output.image(
+        command_buffer,
+        vTensor::Stage::Transfer,
+        vTensor::Access::Write);
 
-    uvec3 src_offset{};
-    uvec3 dst_offset{};
+      uvec3 src_offset{};
+      uvec3 dst_offset{};
 
-    if (step == 1) {
-      src_offset.data[0u] = start;
-      uvec3 copy_extents {safe_downcast<uint32_t>(end - start),
-        v_self.extents().data[1u],
-        v_self.extents().data[2u]};
-      api::helper::copy_texture_to_texture(command_buffer,
-        src_image,
-        dst_image,
-        copy_extents,
-        src_offset,
-        dst_offset);
-    } else {
-      uvec3 copy_extents {1u,
-        v_self.extents().data[1u],
-        v_self.extents().data[2u]};
-      const auto x_max = v_self.extents().data[0u];
-      for (int64_t x = start, x_new = 0; x < end; x += step, ++x_new) {
-        if (x >= x_max) { // out of range
-          continue;
-        }
-        src_offset.data[0u] = x;
-        dst_offset.data[0u] = x_new;
+      if (step == 1) {
+        src_offset.data[0u] = start;
+        uvec3 copy_extents {safe_downcast<uint32_t>(end - start),
+          v_self.extents().data[1u],
+          v_self.extents().data[2u]};
         api::helper::copy_texture_to_texture(command_buffer,
           src_image,
           dst_image,
           copy_extents,
           src_offset,
           dst_offset);
+      } else {
+        uvec3 copy_extents {1u,
+          v_self.extents().data[1u],
+          v_self.extents().data[2u]};
+        const auto x_max = v_self.extents().data[0u];
+        for (int64_t x = start, x_new = 0; x < end; x += step, ++x_new) {
+          if (x >= x_max) { // out of range
+            continue;
+          }
+          src_offset.data[0u] = x;
+          dst_offset.data[0u] = x_new;
+          api::helper::copy_texture_to_texture(command_buffer,
+            src_image,
+            dst_image,
+            copy_extents,
+            src_offset,
+            dst_offset);
+        }
       }
     }
+    else {
+      TORCH_CHECK(false, "Not implemented!");
+    }
   }
-  else {
-    TORCH_CHECK(false, "Not implemented!");
-  }
-
   command_pool.submit(context->gpu().queue, command_buffer);
   return convert(v_output);
 }
@@ -141,56 +146,58 @@ Tensor slice_height(const Tensor& input, const int64_t start, const int64_t end,
   api::Context* const context = api::context();
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
+  {
+    api::OpProfiler profiler(command_buffer, context->querypool(), "aten::slice.Tensor (slice_height)");
 
-  const Tensor self = input.is_vulkan() ? input : input.vulkan();
-  const vTensor& v_self = convert(self);
-  if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
-    auto src_image = v_self.image(
-            command_buffer,
-            vTensor::Stage::Transfer);
-    auto dst_image = v_output.image(
-      command_buffer,
-      vTensor::Stage::Transfer,
-      vTensor::Access::Write);
+    const Tensor self = input.is_vulkan() ? input : input.vulkan();
+    const vTensor& v_self = convert(self);
+    if C10_LIKELY(v_output.has_image() && v_self.has_image()) {
+      auto src_image = v_self.image(
+              command_buffer,
+              vTensor::Stage::Transfer);
+      auto dst_image = v_output.image(
+        command_buffer,
+        vTensor::Stage::Transfer,
+        vTensor::Access::Write);
 
-    uvec3 src_offset{};
-    uvec3 dst_offset{};
+      uvec3 src_offset{};
+      uvec3 dst_offset{};
 
-    if (step == 1) {
-      src_offset.data[1u] = start;
-      uvec3 copy_extents {v_self.extents().data[0u],
-        safe_downcast<uint32_t>(end - start),
-        v_self.extents().data[2u]};
-      api::helper::copy_texture_to_texture(command_buffer,
-        src_image,
-        dst_image,
-        copy_extents,
-        src_offset,
-        dst_offset);
-    } else {
-      uvec3 copy_extents {v_self.extents().data[0u],
-        1u,
-        v_self.extents().data[2u]};
-      const auto y_max = v_self.extents().data[1u];
-      for (int64_t y = start, y_new = 0; y < end; y += step, ++y_new) {
-        if (y >= y_max) { // out of range
-          continue;
-        }
-        src_offset.data[1u] = y;
-        dst_offset.data[1u] = y_new;
+      if (step == 1) {
+        src_offset.data[1u] = start;
+        uvec3 copy_extents {v_self.extents().data[0u],
+          safe_downcast<uint32_t>(end - start),
+          v_self.extents().data[2u]};
         api::helper::copy_texture_to_texture(command_buffer,
           src_image,
           dst_image,
           copy_extents,
           src_offset,
           dst_offset);
+      } else {
+        uvec3 copy_extents {v_self.extents().data[0u],
+          1u,
+          v_self.extents().data[2u]};
+        const auto y_max = v_self.extents().data[1u];
+        for (int64_t y = start, y_new = 0; y < end; y += step, ++y_new) {
+          if (y >= y_max) { // out of range
+            continue;
+          }
+          src_offset.data[1u] = y;
+          dst_offset.data[1u] = y_new;
+          api::helper::copy_texture_to_texture(command_buffer,
+            src_image,
+            dst_image,
+            copy_extents,
+            src_offset,
+            dst_offset);
+        }
       }
     }
+    else {
+      TORCH_CHECK(false, "Not implemented!");
+    }
   }
-  else {
-    TORCH_CHECK(false, "Not implemented!");
-  }
-
   command_pool.submit(context->gpu().queue, command_buffer);
   return convert(v_output);
 }

--- a/aten/src/ATen/native/vulkan/ops/Softmax.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Softmax.cpp
@@ -1,3 +1,4 @@
+#include <ATen/native/vulkan/api/OpProfiler.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/Utils.h>
 #include <torch/library.h>
@@ -14,7 +15,8 @@ Tensor softmax_internal(
     const at::Tensor& input_arg,
     const int64_t dim,
     const bool half_to_float,
-    const api::Shader::Descriptor& shader_descriptor) {
+    const api::Shader::Descriptor& shader_descriptor,
+    const std::string& op_name) {
   TORCH_CHECK(
       input_arg.dim() == 4,
       "Vulkan softmax expects 4-dimensional input!");
@@ -56,6 +58,8 @@ Tensor softmax_internal(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), op_name);
+
     if C10_LIKELY(v_input.has_image()) {
       const struct Block final {
         uvec3 iextents;
@@ -105,14 +109,14 @@ Tensor softmax(
     const at::Tensor& input_arg,
     const int64_t dim,
     const bool half_to_float) {
-  return softmax_internal(input_arg, dim, half_to_float, VK_KERNEL(softmax));
+  return softmax_internal(input_arg, dim, half_to_float, VK_KERNEL(softmax), "_softmax");
 }
 
 Tensor log_softmax(
     const at::Tensor& input_arg,
     const int64_t dim,
     const bool half_to_float) {
-  return softmax_internal(input_arg, dim, half_to_float, VK_KERNEL(log_softmax));
+  return softmax_internal(input_arg, dim, half_to_float, VK_KERNEL(log_softmax), "_log_softmax");
 }
 
 #ifdef USE_VULKAN_API

--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -1,3 +1,4 @@
+#include <ATen/native/vulkan/api/OpProfiler.h>
 #include <ATen/native/vulkan/ops/Tensor.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <c10/util/accumulate.h>
@@ -761,6 +762,8 @@ void vTensor::View::CMD::copy_buffer_to_image(
     return;
   }
 
+  api::OpProfiler profiler(command_buffer_, view_.context_->querypool(), "copy_buffer_to_image");
+
   barrier(
       state.transition({
           // Staging
@@ -818,6 +821,8 @@ void vTensor::View::CMD::copy_image_to_buffer(
   if (state.is_clean(Component::Buffer)) {
     return;
   }
+
+  api::OpProfiler profiler(command_buffer_, view_.context_->querypool(), "copy_image_to_buffer");
 
   barrier(
       state.transition({

--- a/aten/src/ATen/native/vulkan/ops/Upsample.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Upsample.cpp
@@ -1,5 +1,6 @@
-#include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/UpSample.h>
+#include <ATen/native/vulkan/api/OpProfiler.h>
+#include <ATen/native/vulkan/ops/Common.h>
 #include <torch/library.h>
 
 namespace at {
@@ -39,6 +40,8 @@ Tensor upsample_nearest2d(
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();
   {
+    api::OpProfiler profiler(command_buffer, context->querypool(), "aten::upsample_nearest2d");
+
     if C10_LIKELY(v_input.has_image()) {
       const struct Block final {
         uvec3 extents;

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3,6 +3,8 @@
 #include <gtest/gtest.h>
 #include <ATen/ATen.h>
 #include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/native/vulkan/api/api.h>
+#include <ATen/native/vulkan/api/OpProfiler.h>
 #include <c10/util/irange.h>
 
 // TODO: These functions should move to a common place.
@@ -167,7 +169,20 @@ inline std::vector<c10::IValue> callOpByName(
 
 namespace {
 
-TEST(VulkanAPITest, adaptive_avg_pool2d) {
+class VulkanAPITest : public ::testing::Test {
+public:
+#if defined (__ANDROID__)  // to avoid `Undefined symbols for architecture arm64` error
+    static void SetUpTestSuite() {
+      at::native::vulkan::api::context()->querypool().enable();
+    }
+
+    static void TearDownTestSuite() {
+      at::native::vulkan::api::context()->querypool().disable(false);
+    }
+#endif
+};
+
+TEST_F(VulkanAPITest, adaptive_avg_pool2d) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -185,7 +200,7 @@ TEST(VulkanAPITest, adaptive_avg_pool2d) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, add) {
+TEST_F(VulkanAPITest, add) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -207,7 +222,7 @@ TEST(VulkanAPITest, add) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, add_broadcast0) {
+TEST_F(VulkanAPITest, add_broadcast0) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -229,7 +244,7 @@ TEST(VulkanAPITest, add_broadcast0) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, add_broadcast1) {
+TEST_F(VulkanAPITest, add_broadcast1) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -251,7 +266,7 @@ TEST(VulkanAPITest, add_broadcast1) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, add_broadcast2) {
+TEST_F(VulkanAPITest, add_broadcast2) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -273,7 +288,7 @@ TEST(VulkanAPITest, add_broadcast2) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, add_) {
+TEST_F(VulkanAPITest, add_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -295,7 +310,7 @@ TEST(VulkanAPITest, add_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, add_broadcast0_) {
+TEST_F(VulkanAPITest, add_broadcast0_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -317,7 +332,7 @@ TEST(VulkanAPITest, add_broadcast0_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, add_broadcast1_) {
+TEST_F(VulkanAPITest, add_broadcast1_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -339,7 +354,7 @@ TEST(VulkanAPITest, add_broadcast1_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, add_scalar) {
+TEST_F(VulkanAPITest, add_scalar) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -360,7 +375,7 @@ TEST(VulkanAPITest, add_scalar) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, add_scalar_) {
+TEST_F(VulkanAPITest, add_scalar_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -381,7 +396,7 @@ TEST(VulkanAPITest, add_scalar_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, addmm) {
+TEST_F(VulkanAPITest, addmm) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -405,7 +420,7 @@ TEST(VulkanAPITest, addmm) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, addmm_expand) {
+TEST_F(VulkanAPITest, addmm_expand) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -429,7 +444,7 @@ TEST(VulkanAPITest, addmm_expand) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, avg_pool2d) {
+TEST_F(VulkanAPITest, avg_pool2d) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -446,7 +461,7 @@ TEST(VulkanAPITest, avg_pool2d) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, clamp) {
+TEST_F(VulkanAPITest, clamp) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -468,7 +483,7 @@ TEST(VulkanAPITest, clamp) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, clamp_) {
+TEST_F(VulkanAPITest, clamp_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -490,7 +505,7 @@ TEST(VulkanAPITest, clamp_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, conv2d) {
+TEST_F(VulkanAPITest, conv2d) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -563,7 +578,7 @@ TEST(VulkanAPITest, conv2d) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, conv2d_dw) {
+TEST_F(VulkanAPITest, conv2d_dw) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -635,7 +650,7 @@ TEST(VulkanAPITest, conv2d_dw) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, conv2d_pw) {
+TEST_F(VulkanAPITest, conv2d_pw) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -707,7 +722,7 @@ TEST(VulkanAPITest, conv2d_pw) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, conv2d_winograd) {
+TEST_F(VulkanAPITest, conv2d_winograd) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -779,7 +794,7 @@ TEST(VulkanAPITest, conv2d_winograd) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, copy) {
+TEST_F(VulkanAPITest, copy) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -795,7 +810,7 @@ TEST(VulkanAPITest, copy) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, div) {
+TEST_F(VulkanAPITest, div) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -817,7 +832,7 @@ TEST(VulkanAPITest, div) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, div_broadcast0) {
+TEST_F(VulkanAPITest, div_broadcast0) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -839,7 +854,7 @@ TEST(VulkanAPITest, div_broadcast0) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, div_broadcast1) {
+TEST_F(VulkanAPITest, div_broadcast1) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -861,7 +876,7 @@ TEST(VulkanAPITest, div_broadcast1) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, div_broadcast2) {
+TEST_F(VulkanAPITest, div_broadcast2) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -883,7 +898,7 @@ TEST(VulkanAPITest, div_broadcast2) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, div_) {
+TEST_F(VulkanAPITest, div_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -905,7 +920,7 @@ TEST(VulkanAPITest, div_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, div_broadcast0_) {
+TEST_F(VulkanAPITest, div_broadcast0_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -927,7 +942,7 @@ TEST(VulkanAPITest, div_broadcast0_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, div_broadcast1_) {
+TEST_F(VulkanAPITest, div_broadcast1_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -949,7 +964,7 @@ TEST(VulkanAPITest, div_broadcast1_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, div_scalar) {
+TEST_F(VulkanAPITest, div_scalar) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -970,7 +985,7 @@ TEST(VulkanAPITest, div_scalar) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, div_scalar_) {
+TEST_F(VulkanAPITest, div_scalar_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -991,7 +1006,7 @@ TEST(VulkanAPITest, div_scalar_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, empty) {
+TEST_F(VulkanAPITest, empty) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -999,7 +1014,7 @@ TEST(VulkanAPITest, empty) {
   ASSERT_NO_THROW(at::empty({1, 17, 41, 53}, at::device(at::kVulkan).dtype(at::kFloat)));
 }
 
-TEST(VulkanAPITest, hardsigmoid) {
+TEST_F(VulkanAPITest, hardsigmoid) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1018,7 +1033,7 @@ TEST(VulkanAPITest, hardsigmoid) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, hardsigmoid_) {
+TEST_F(VulkanAPITest, hardsigmoid_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1037,7 +1052,7 @@ TEST(VulkanAPITest, hardsigmoid_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, hardshrink) {
+TEST_F(VulkanAPITest, hardshrink) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1059,7 +1074,7 @@ TEST(VulkanAPITest, hardshrink) {
   }
 }
 
-TEST(VulkanAPITest, hardshrink_) {
+TEST_F(VulkanAPITest, hardshrink_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1080,7 +1095,7 @@ TEST(VulkanAPITest, hardshrink_) {
   }
 }
 
-TEST(VulkanAPITest, leaky_relu) {
+TEST_F(VulkanAPITest, leaky_relu) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1102,7 +1117,7 @@ TEST(VulkanAPITest, leaky_relu) {
   }
 }
 
-TEST(VulkanAPITest, leaky_relu_) {
+TEST_F(VulkanAPITest, leaky_relu_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1123,7 +1138,7 @@ TEST(VulkanAPITest, leaky_relu_) {
   }
 }
 
-TEST(VulkanAPITest, hardswish) {
+TEST_F(VulkanAPITest, hardswish) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1142,7 +1157,7 @@ TEST(VulkanAPITest, hardswish) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, hardswish_) {
+TEST_F(VulkanAPITest, hardswish_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1161,7 +1176,7 @@ TEST(VulkanAPITest, hardswish_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, max_pool2d) {
+TEST_F(VulkanAPITest, max_pool2d) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1179,7 +1194,7 @@ TEST(VulkanAPITest, max_pool2d) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mean) {
+TEST_F(VulkanAPITest, mean) {
   const auto in_cpu = at::rand({17, 3, 79, 53}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
   const auto out_cpu = at::mean(in_cpu, {-1, -2}, true);
 
@@ -1194,7 +1209,7 @@ TEST(VulkanAPITest, mean) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mean2d) {
+TEST_F(VulkanAPITest, mean2d) {
   const auto in_cpu = at::rand({11, 7, 173, 37}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
   const auto out_cpu = at::mean(in_cpu, {-1, -2}, false);
 
@@ -1209,7 +1224,7 @@ TEST(VulkanAPITest, mean2d) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mm) {
+TEST_F(VulkanAPITest, mm) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1229,7 +1244,7 @@ TEST(VulkanAPITest, mm) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mul) {
+TEST_F(VulkanAPITest, mul) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1251,7 +1266,7 @@ TEST(VulkanAPITest, mul) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mul_broadcast0) {
+TEST_F(VulkanAPITest, mul_broadcast0) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1273,7 +1288,7 @@ TEST(VulkanAPITest, mul_broadcast0) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mul_broadcast1) {
+TEST_F(VulkanAPITest, mul_broadcast1) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1295,7 +1310,7 @@ TEST(VulkanAPITest, mul_broadcast1) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mul_broadcast2) {
+TEST_F(VulkanAPITest, mul_broadcast2) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1317,7 +1332,7 @@ TEST(VulkanAPITest, mul_broadcast2) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mul_) {
+TEST_F(VulkanAPITest, mul_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1339,7 +1354,7 @@ TEST(VulkanAPITest, mul_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mul_broadcast0_) {
+TEST_F(VulkanAPITest, mul_broadcast0_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1361,7 +1376,7 @@ TEST(VulkanAPITest, mul_broadcast0_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mul_broadcast1_) {
+TEST_F(VulkanAPITest, mul_broadcast1_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1383,7 +1398,7 @@ TEST(VulkanAPITest, mul_broadcast1_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mul_scalar) {
+TEST_F(VulkanAPITest, mul_scalar) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1404,7 +1419,7 @@ TEST(VulkanAPITest, mul_scalar) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, mul_scalar_) {
+TEST_F(VulkanAPITest, mul_scalar_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1425,7 +1440,7 @@ TEST(VulkanAPITest, mul_scalar_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, reflection_pad2d) {
+TEST_F(VulkanAPITest, reflection_pad2d) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1444,7 +1459,7 @@ TEST(VulkanAPITest, reflection_pad2d) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, reshape) {
+TEST_F(VulkanAPITest, reshape) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1466,7 +1481,7 @@ TEST(VulkanAPITest, reshape) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, reshape_) {
+TEST_F(VulkanAPITest, reshape_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1488,7 +1503,7 @@ TEST(VulkanAPITest, reshape_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, sigmoid) {
+TEST_F(VulkanAPITest, sigmoid) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1507,7 +1522,7 @@ TEST(VulkanAPITest, sigmoid) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, sigmoid_) {
+TEST_F(VulkanAPITest, sigmoid_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1526,7 +1541,7 @@ TEST(VulkanAPITest, sigmoid_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, softmax) {
+TEST_F(VulkanAPITest, softmax) {
   at::Tensor test_in[] = {
     at::rand({1, 196, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
     at::rand({1, 197, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
@@ -1549,7 +1564,7 @@ TEST(VulkanAPITest, softmax) {
   }
 }
 
-TEST(VulkanAPITest, log_softmax) {
+TEST_F(VulkanAPITest, log_softmax) {
   at::Tensor test_in[] = {
     at::rand({1, 196, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
     at::rand({1, 197, 302, 5}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
@@ -1572,7 +1587,7 @@ TEST(VulkanAPITest, log_softmax) {
   }
 }
 
-TEST(VulkanAPITest, tanh) {
+TEST_F(VulkanAPITest, tanh) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1591,7 +1606,7 @@ TEST(VulkanAPITest, tanh) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, tanh_) {
+TEST_F(VulkanAPITest, tanh_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1610,7 +1625,7 @@ TEST(VulkanAPITest, tanh_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, sub) {
+TEST_F(VulkanAPITest, sub) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1632,7 +1647,7 @@ TEST(VulkanAPITest, sub) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, sub_broadcast0) {
+TEST_F(VulkanAPITest, sub_broadcast0) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1654,7 +1669,7 @@ TEST(VulkanAPITest, sub_broadcast0) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, sub_broadcast1) {
+TEST_F(VulkanAPITest, sub_broadcast1) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1676,7 +1691,7 @@ TEST(VulkanAPITest, sub_broadcast1) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, sub_broadcast2) {
+TEST_F(VulkanAPITest, sub_broadcast2) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1698,7 +1713,7 @@ TEST(VulkanAPITest, sub_broadcast2) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, sub_) {
+TEST_F(VulkanAPITest, sub_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1720,7 +1735,7 @@ TEST(VulkanAPITest, sub_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, sub_broadcast0_) {
+TEST_F(VulkanAPITest, sub_broadcast0_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1742,7 +1757,7 @@ TEST(VulkanAPITest, sub_broadcast0_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, sub_broadcast1_) {
+TEST_F(VulkanAPITest, sub_broadcast1_) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1764,7 +1779,7 @@ TEST(VulkanAPITest, sub_broadcast1_) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, transposed_conv2d) {
+TEST_F(VulkanAPITest, transposed_conv2d) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -1844,7 +1859,7 @@ TEST(VulkanAPITest, transposed_conv2d) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, upsample_nearest2d) {
+TEST_F(VulkanAPITest, upsample_nearest2d) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -1864,7 +1879,7 @@ TEST(VulkanAPITest, upsample_nearest2d) {
 }
 
 #if !defined(__APPLE__)
-TEST(VulkanAPITest, cat_dim1_samefeature_success) {
+TEST_F(VulkanAPITest, cat_dim1_samefeature_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -1888,7 +1903,7 @@ TEST(VulkanAPITest, cat_dim1_samefeature_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim1_difffeature_success) {
+TEST_F(VulkanAPITest, cat_dim1_difffeature_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -1912,7 +1927,7 @@ TEST(VulkanAPITest, cat_dim1_difffeature_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim1_texture2d_success) {
+TEST_F(VulkanAPITest, cat_dim1_texture2d_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -1937,7 +1952,7 @@ TEST(VulkanAPITest, cat_dim1_texture2d_success) {
 }
 #endif /* !defined(__APPLE__) */
 
-TEST(VulkanAPITest, cat_dim1_singledepth_success) {
+TEST_F(VulkanAPITest, cat_dim1_singledepth_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -1961,7 +1976,7 @@ TEST(VulkanAPITest, cat_dim1_singledepth_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim1_singletensor_success) {
+TEST_F(VulkanAPITest, cat_dim1_singletensor_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -1983,7 +1998,7 @@ TEST(VulkanAPITest, cat_dim1_singletensor_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim1_twotensors_success) {
+TEST_F(VulkanAPITest, cat_dim1_twotensors_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2006,7 +2021,7 @@ TEST(VulkanAPITest, cat_dim1_twotensors_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim1_bat1_mult4ch_success) {
+TEST_F(VulkanAPITest, cat_dim1_bat1_mult4ch_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2030,7 +2045,7 @@ TEST(VulkanAPITest, cat_dim1_bat1_mult4ch_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim1_bat2_mult4ch_success) {
+TEST_F(VulkanAPITest, cat_dim1_bat2_mult4ch_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2054,7 +2069,7 @@ TEST(VulkanAPITest, cat_dim1_bat2_mult4ch_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim1_mult4ch_mixed_success) {
+TEST_F(VulkanAPITest, cat_dim1_mult4ch_mixed_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2078,7 +2093,7 @@ TEST(VulkanAPITest, cat_dim1_mult4ch_mixed_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim1_mult4ch_nonmult4ch_success) {
+TEST_F(VulkanAPITest, cat_dim1_mult4ch_nonmult4ch_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2103,7 +2118,7 @@ TEST(VulkanAPITest, cat_dim1_mult4ch_nonmult4ch_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim2_sameheight_success) {
+TEST_F(VulkanAPITest, cat_dim2_sameheight_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2127,7 +2142,7 @@ TEST(VulkanAPITest, cat_dim2_sameheight_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim2_diffheight_success) {
+TEST_F(VulkanAPITest, cat_dim2_diffheight_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2151,7 +2166,7 @@ TEST(VulkanAPITest, cat_dim2_diffheight_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim2_singledepth_success) {
+TEST_F(VulkanAPITest, cat_dim2_singledepth_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2175,7 +2190,7 @@ TEST(VulkanAPITest, cat_dim2_singledepth_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, cat_dim2_invalidinputs_exceptions) {
+TEST_F(VulkanAPITest, cat_dim2_invalidinputs_exceptions) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2224,7 +2239,7 @@ TEST(VulkanAPITest, cat_dim2_invalidinputs_exceptions) {
   }
 }
 
-TEST(VulkanAPITest, permute_2d_success) {
+TEST_F(VulkanAPITest, permute_2d_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2246,7 +2261,7 @@ TEST(VulkanAPITest, permute_2d_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, permute_3d_success) {
+TEST_F(VulkanAPITest, permute_3d_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2273,7 +2288,7 @@ TEST(VulkanAPITest, permute_3d_success) {
   }
 }
 
-TEST(VulkanAPITest, permute_4d_success) {
+TEST_F(VulkanAPITest, permute_4d_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2300,7 +2315,7 @@ TEST(VulkanAPITest, permute_4d_success) {
   }
 }
 
-TEST(VulkanAPITest, permute_4dmclaren_success) {
+TEST_F(VulkanAPITest, permute_4dmclaren_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2322,7 +2337,7 @@ TEST(VulkanAPITest, permute_4dmclaren_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, permute_4dbig_success) {
+TEST_F(VulkanAPITest, permute_4dbig_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2349,7 +2364,7 @@ TEST(VulkanAPITest, permute_4dbig_success) {
   }
 }
 
-TEST(VulkanAPITest, permute_negativedims_success) {
+TEST_F(VulkanAPITest, permute_negativedims_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2371,7 +2386,7 @@ TEST(VulkanAPITest, permute_negativedims_success) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, permute_1d_nochange) {
+TEST_F(VulkanAPITest, permute_1d_nochange) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2393,7 +2408,7 @@ TEST(VulkanAPITest, permute_1d_nochange) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, permute_sameDims_nochange) {
+TEST_F(VulkanAPITest, permute_sameDims_nochange) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2415,7 +2430,7 @@ TEST(VulkanAPITest, permute_sameDims_nochange) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, permute_invalidinputs_exceptions) {
+TEST_F(VulkanAPITest, permute_invalidinputs_exceptions) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2475,7 +2490,7 @@ TEST(VulkanAPITest, permute_invalidinputs_exceptions) {
   }, ::c10::Error);
 }
 
-TEST(VulkanAPITest, slice_width_success) {
+TEST_F(VulkanAPITest, slice_width_success) {
   // Arrange
   std::unordered_map<int64_t, std::vector<int64_t>> dim2sizes {
     {3, {2, 3, 40, 50}},  // 4D tensors with dim=width
@@ -2488,7 +2503,7 @@ TEST(VulkanAPITest, slice_width_success) {
   slice_tests(dim2sizes);
 }
 
-TEST(VulkanAPITest, slice_height_success) {
+TEST_F(VulkanAPITest, slice_height_success) {
   // Arrange
   std::unordered_map<int64_t, std::vector<int64_t>> dim2sizes {
     {2, {2, 3, 40, 50}},  // 4D tensors with dim=height
@@ -2501,7 +2516,7 @@ TEST(VulkanAPITest, slice_height_success) {
   slice_tests(dim2sizes);
 }
 
-TEST(VulkanAPITest, slice_feature_success) {
+TEST_F(VulkanAPITest, slice_feature_success) {
   // Arrange
   std::unordered_map<int64_t, std::vector<int64_t>> dim2sizes {
     {1, {2, 40, 13, 14}}, // 4D tensors with dim=feature(channel)
@@ -2513,7 +2528,7 @@ TEST(VulkanAPITest, slice_feature_success) {
   slice_tests(dim2sizes);
 }
 
-TEST(VulkanAPITest, slice_batch_success) {
+TEST_F(VulkanAPITest, slice_batch_success) {
   // Arrange
   std::unordered_map<int64_t, std::vector<int64_t>> dim2sizes {
     {0, {40, 3, 13, 14}}, // 4D tensors with dim=batch
@@ -2524,7 +2539,7 @@ TEST(VulkanAPITest, slice_batch_success) {
   slice_tests(dim2sizes);
 }
 
-TEST(VulkanAPITest, slice_invalidinputs_exceptions) {
+TEST_F(VulkanAPITest, slice_invalidinputs_exceptions) {
   // Act: slice step must be positive
   EXPECT_THROW({
     slice_test({2, 3, 4, 5}, 3, 0, 3, 0);
@@ -2541,7 +2556,7 @@ TEST(VulkanAPITest, slice_invalidinputs_exceptions) {
   }, ::c10::Error);
 }
 
-TEST(VulkanAPITest, clone_success) {
+TEST_F(VulkanAPITest, clone_success) {
   // Arrange
   std::multimap<c10::optional<c10::MemoryFormat>, std::vector<int64_t>> mem2sizes {
     {c10::MemoryFormat::Preserve, {2, 3, 5, 161}},    // 4D tensors with MemoryFormat::Preserve
@@ -2564,7 +2579,7 @@ TEST(VulkanAPITest, clone_success) {
   }
 }
 
-TEST(VulkanAPITest, clone_invalidinputs_exceptions) {
+TEST_F(VulkanAPITest, clone_invalidinputs_exceptions) {
   // Act: Vulkan supports Preserve and Contiguous memory foramts
   EXPECT_THROW({
     clone_test({2, 3, 5, 161}, c10::MemoryFormat::ChannelsLast);
@@ -2812,7 +2827,7 @@ class MobileNetV2 final : public OpsList {
   }
 };
 
-TEST(VulkanAPITest, mobilenetv2) {
+TEST_F(VulkanAPITest, mobilenetv2) {
   if (!at::is_vulkan_available()) {
     return;
   }
@@ -2831,7 +2846,7 @@ TEST(VulkanAPITest, mobilenetv2) {
   ASSERT_TRUE(check);
 }
 
-TEST(VulkanAPITest, gru_mclareninputs_success) {
+TEST_F(VulkanAPITest, gru_mclareninputs_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2895,7 +2910,7 @@ TEST(VulkanAPITest, gru_mclareninputs_success) {
   ASSERT_TRUE(check_hidden);
 }
 
-TEST(VulkanAPITest, gru_invalidinputs_exceptions) {
+TEST_F(VulkanAPITest, gru_invalidinputs_exceptions) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2989,7 +3004,7 @@ TEST(VulkanAPITest, gru_invalidinputs_exceptions) {
   }, ::c10::Error);
 }
 
-TEST(VulkanAPITest, gru_prepack_success) {
+TEST_F(VulkanAPITest, gru_prepack_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -3059,7 +3074,7 @@ TEST(VulkanAPITest, gru_prepack_success) {
   ASSERT_TRUE(check_hidden);
 }
 
-TEST(VulkanAPITest, gru_prepack_invalidinputs_exceptions) {
+TEST_F(VulkanAPITest, gru_prepack_invalidinputs_exceptions) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -3184,6 +3199,99 @@ TEST(VulkanAPITest, gru_prepack_invalidinputs_exceptions) {
         has_biases, num_layers, 1.0, train, bidirectional, batch_first);
   }, ::c10::Error);
 }
+
+#if defined (__ANDROID__)  // to avoid `Undefined symbols for architecture arm64` error
+TEST_F(VulkanAPITest, profiling_invalideinputs_exceptions) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Act: The device doesn't support for timestamps on all graphics and compute queues.
+  EXPECT_THROW({
+    const bool is_timestamps_supported_ = false;
+    const float timestamp_period = 1.f;
+    at::native::vulkan::api::QueryPool querypool(at::native::vulkan::api::context()->gpu().device, is_timestamps_supported_, timestamp_period);
+    querypool.enable();
+  }, ::c10::Error);
+
+  // Act: The query pool already exists.
+  EXPECT_THROW({
+    auto context = at::native::vulkan::api::context();
+    at::native::vulkan::api::QueryPool querypool(
+        context->gpu().device,
+        context->gpu().adapter->timestamp_compute_and_graphics(),
+        context->gpu().adapter->timestamp_period());
+    querypool.enable();
+    querypool.enable(); // already enabled
+  }, ::c10::Error);
+
+  // Act: The query index cannot exceed Configuration::kMaxQueryCount.
+  EXPECT_THROW({
+    auto context = at::native::vulkan::api::context();
+    at::native::vulkan::api::QueryPool querypool(
+        context->gpu().device,
+        context->gpu().adapter->timestamp_compute_and_graphics(),
+        context->gpu().adapter->timestamp_period());
+    querypool.enable();
+    for (uint32_t i = 0u; i < at::native::vulkan::api::QueryPool::Configuration::kMaxQueryCount + 1u; ++i) {
+      at::native::vulkan::api::Command::Buffer& command_buffer = context->command().pool.stream();
+      {
+        at::native::vulkan::api::OpProfiler profiler(command_buffer, querypool, "test");
+      }
+      context->command().pool.submit(context->gpu().queue, command_buffer);
+    }
+  }, ::c10::Error);
+}
+
+// NOTE: Keep the following test at the end of file
+//       so that it can print out the op execution time for all prior tests
+TEST_F(VulkanAPITest, profiling_result_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  auto is_enabled = at::native::vulkan::api::context()->querypool().is_enabled();
+  if (is_enabled) {
+    auto perf_info = at::native::vulkan::api::context()->querypool().disable(false);
+    std::cout
+        << "-----------------------------------------------------------------------------------------" << std::endl
+        << "Query Name                                  Execution             Start               End" << std::endl
+        << "-----------------------------------------------------------------------------------------" << std::endl;
+    for (size_t i = 0; i < perf_info.size(); i++) {
+      std::cout << std::left << std::setw(35) << perf_info[i].query_name.c_str()
+        << std::right << std::setw(15) << perf_info[i].execution_time_us << " us"
+        << std::setw(15) << perf_info[i].start_time_us << " us"
+        << std::setw(15) << perf_info[i].end_time_us << " us" << std::left << std::endl;
+    }
+  }
+  at::native::vulkan::api::context()->querypool().enable();
+  const auto in_cpu1 = at::rand({2, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({2, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({2, 4, 221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto out_vulkan = at::cat({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 1);
+  out_vulkan.cpu();  // to make sure all GPU operations are done
+
+  // Act
+  auto perf_info = at::native::vulkan::api::context()->querypool().disable(true);
+  for (size_t i = 0; i < perf_info.size(); i++) {
+    std::cout << std::left << std::setw(35) << perf_info[i].query_name.c_str()
+      << std::right << std::setw(15) << perf_info[i].execution_time_us << " us"
+      << std::setw(15) << perf_info[i].start_time_us << " us"
+      << std::setw(15) << perf_info[i].end_time_us << " us" << std::left << std::endl;
+  }
+
+  // Assert
+  ASSERT_TRUE(perf_info.size() == 5u);
+  ASSERT_TRUE(perf_info[0].query_name == "aten::_cat (cat_feature_mult4ch)");
+
+  if (is_enabled) {
+    at::native::vulkan::api::context()->querypool().enable();
+  }
+}
+#endif
 
 } // namespace
 


### PR DESCRIPTION
Summary:
Added ability for measuring the pure GPU execution time by using [Vulkan Timestamp Queries](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#queries-timestamps).
* Two key limitations for Vulkan Timestamp Queries:
  * `timestampComputeAndGraphics` specifies support for timestamps on all graphics and compute queues.
  * `timestampPeriod` is the number of nanoseconds required for a timestamp query to be incremented by 1.
  * See [VkPhysicalDeviceProperties.VkPhysicalDeviceLimits](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceLimits.html)
  * These can be extracted from `Adapter::properties::limits`.
* The pure GPU execution time includes shaders and recorded command buffers + butter to texture conversion. However, it doesn't include the overhead of tensor conversion between CPU and Vulkan.
* A new class `QueryPool` was introduced to manage Vulkan timestamp queries:
  * Per-thread (TLS) instance
  * Thread-safe: Verified by `cat_op_channel_perf_gpu_only` test with 3 threads in `vulkan_perf_test.cpp`
  * This records the pure GPU execution time (shader execution and Vulkan API calls) for each operator. In other words, it doesn't include some setup code and tensor conversion between CPU and GPU for the operator. Note that `copy_` query will be recorded only when converting Vulkan to Vulkan tensor. Waiting for all GPU operations and `memcpy()` calls are involved for other copy operations (CPU <-> Vulkan) .
  * `QueryPool::Configuration::kMaxQueryCount` defines the max # of queries. 65,536 for now but can be increased as needed in the future.
  * `PerfInfo` struct contains query name, start/end/execution time in microseconds.
  * `QueryPool::Configuration::kTimestampsPerQuery` defines the number of timestamps per query. 2 for start and end timestamps
  * `is_enabled()` returns whether or not the timestamp query feature is enabled.
  * `enable()` enables the timestamp query. To isolate the queries from the previous run, it submits the pending command buffer first by calling `submit_anypending()` if exists.
  * `disable()` stops the timestamp query and returns a collection of `PerfInfo`. To wait for any pending execution, it also submits the pending command buffer first by calling `submit_anypending()` if exists.
  * `begin()` starts a query with command buffer and query name. This should be called before starting operation recording for the command buffer. It returns the query index assigned to the command buffer.
  * `end()` finishes the query by query index for the command buffer. This should be called before calling `vkEndCommandBuffer()` or `vkQueueSubmit` API, and after recording all desired shader or Vulkan API calls.
  * `result()` returns a collection of `PerfInfo` for the queries so far. It leaves a warning message if `waitfor_allqueries` argument is false and `vkGetQueryPoolResults()` call returns `VK_NOT_READY(1)` because the command buffer was not executed yet.
  * `submit_anypending()` submits if there is a pending command buffer (`Command::Pool::stream_.buffer`). The pending one is waiting for more calls prior to submission. If we don't submit the pending one, `vkGetQueryPoolResults()` won't return at all which results in hanging.
  * Expected exceptions if:
    * the `timestampComputeAndGraphics` flag of the device is false which means it doesn't support the timestamp query feature.
    * the query pool already exists when the QueryPool instance is already enabled.
    * the query index exceeds `Configuration::kMaxQueryCount`.
* Manual time based Vuikan performance tests:
  * With google benchmark, each iteration time can be manually set by `benchmark::State::SetIterationTime()` after setting `Benchmark::UseManualTime()`.
  * See [UseManualTime API](https://github.com/google/benchmark/blob/365670e4328beb694d0a3adaf40a5974a616bb17/include/benchmark/benchmark.h#L1013)
  * Ignore `CPU` column. `Time` column is the average execution time for each operator.
  * Added gtest `SetUpTestSuite` and `TearDownTestSuite` impl. to enable/disable profiling
  <img width="975" alt="image" src="https://user-images.githubusercontent.com/88354936/164074022-0911f3ff-7ace-4991-961c-7cb26204fda8.png">
* The desired order of API calls:
```
vkBeginCommandBuffer
vkCmdResetQueryPool (optional, this is not needed since we are not reusing the same query)
vkCmdWriteTimestamp for start
...
vkCmdDispatch for shader (or vkCmdXXX API calls. i.e., vkCmdCopyImage)
vkCmdWriteTimestamp for end
vkEndCommandBuffer or vkQueueSubmit
vkGetQueryPoolResults
```
* Limitation:
  * Vulkan Timestamp Queries doesn't work on MacOS due to the limitations of MoltenVk (which is running on top of the Apple Metal framework to support Vulkan APIs). The begin/end timestamp counters return the same number.
* How it works:
  * Call `Command::Pool::stream(QueryPool* query_pool, , const std::string& query_name)` when getting a command buffer before recording. This internally calls `Command::Buffer:::begin_query()` which begins adding the start timestamp (`QueryPool::begin()`). `begin_query()` stores the QueryPool pointer so that it calls `QueryPool::end()` when `Command::Buffer::end()` gets hit if there is a fence or `Command::Pool::stream_.counter` is greater than `Command::Pool::Configuration::kSubmit`.
  * Call `Command::Pool::submit()` after recording all command buffers. This internally calls  `Command::Buffer::end()` which result in calling `QueryPool::end()`.
* Usage - Recording timestamps:
  * The reason why we need to pass an instance of `QueryPool` here instead of retrieving by `api::context()->querypool()` is for injecting a test instance of `QueryPool` in unit tests.
```
// Case 1. No query recording for scenarios where we don't execute any shader nor Vulkan API call
api::Command::Buffer& command_buffer = command_pool.stream();

// Case 2. Simply passing the pointer of QueryPool instance with query name enables the timestamp recording
api::Command::Buffer& command_buffer = command_pool.stream(&context->querypool(), "aten::hardtanh");
```

* Usage - Getting the result for the `cat` operator with google benchmark:
```
for (auto _ : state) {
  at::native::vulkan::api::context()->querypool().enable();
  at::cat({in_vulkan1, in_vulkan2, in_vulkan3}, 1);
  auto perf_info = at::native::vulkan::api::context()->querypool().disable(true);
  state.SetIterationTime(perf_info[0].execution_time_us / 1'000'000.); // us to sec
}
```
* Test result of `vulkan_perf_test` for `cat` operator with 4x channels (shader vs `vkCmdCopyImage`):
  * GPU only for `cat` operator; the pure GPU execution time of shaders, recorded command buffers and buffer-to-texture conversion: 86.91% improved in average 
<img width="690" alt="image" src="https://user-images.githubusercontent.com/88354936/163472900-8cce69e5-7c28-47d7-acf8-2f181da0997b.png">

* Reflected code review feedback:
  * Decoupling `QueryPool` from `Command Buffer`
    - Added a new class `OpProfiler` as a RAII object
    - Backed out the changes on `Command.h/cpp`
    - Replaced all `stream()` calls with `OpProfiler` RAII instances
  * Removed `submit_pending()` API. Now we use `.cpu()` call to make sure all GPU operations are done in the test cases
  * Added new `copy_image_to_buffer` and `copy_buffer_to_image` op names for copy operations between CPU and GPU
  * Reflected some minor feedback such as `TORCH_CHECK`, `emplace_back` and `timestamp_period_us_`

* References:
  * [Benchmarking GPU execution by manual timing](https://chromium.googlesource.com/external/github.com/google/benchmark/#manual-timing)
  * [A micro Vulkan compute pipeline and a collection of benchmarking compute shaders](https://github.com/google/uVkCompute)
  * [Improving Vulkan Breakout](http://kylehalladay.com/blog/tutorial/vulkan/2017/08/30/Vulkan-Uniform-Buffers-pt2.html)
  * [Sample code with VK Timestamp Queries](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/src/graphics/lib/compute/hotsort/platforms/vk/tests/hotsort_vk_bench/main.c)
  * [[mlir][vulkan-runner] Add basic timing for compute pipeline](https://reviews.llvm.org/D75531)

* Next Steps:
  * Publish all Vulkan timestamp queries via `KinetoEdgeCPUPorfiler` for op level benchmarking

Test Plan:
**Test build on Android (vulkan_perf_test)**
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_perf_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_perf_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_perf_test
adb shell "/data/local/tmp/vulkan_perf_test"
```

**Test build on Android (vulkan_api_test)**
```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
```

**Test result on Google Pixel 5 (vulkan_perf_test)**
```
Without optimization for 4x channels:
---------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                       Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------------------------------
cat_op_channel_perf_gpu_only/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:1       30.1 ms         6.78 ms          100
cat_op_channel_perf_gpu_only/N:3/C:20/H:221/W:193/iterations:100/manual_time/threads:1       21.7 ms         3.17 ms          100
cat_op_channel_perf_gpu_only/N:3/C:39/H:221/W:193/iterations:100/manual_time/threads:1       30.0 ms         5.47 ms          100
cat_op_channel_perf_gpu_only/N:3/C:4/H:221/W:193/iterations:100/manual_time/threads:1        6.75 ms         1.05 ms          100
cat_op_channel_perf_gpu_only/N:3/C:3/H:221/W:193/iterations:100/manual_time/threads:1        5.54 ms         1.02 ms          100
cat_op_channel_perf_gpu_only/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:3       10.0 ms         15.4 ms          300
gru_op_perf/N:384/C:384/H:2/iterations:100/threads:1                                         18.0 ms         15.9 ms          100

With optimization for 4x channels:
---------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                       Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------------------------------
cat_op_channel_perf_gpu_only/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:1       5.47 ms         3.79 ms          100
cat_op_channel_perf_gpu_only/N:3/C:20/H:221/W:193/iterations:100/manual_time/threads:1       2.77 ms         1.41 ms          100
cat_op_channel_perf_gpu_only/N:3/C:39/H:221/W:193/iterations:100/manual_time/threads:1       30.0 ms         6.02 ms          100
cat_op_channel_perf_gpu_only/N:3/C:4/H:221/W:193/iterations:100/manual_time/threads:1       0.562 ms        0.557 ms          100
cat_op_channel_perf_gpu_only/N:3/C:3/H:221/W:193/iterations:100/manual_time/threads:1        5.39 ms        0.738 ms          100
cat_op_channel_perf_gpu_only/N:3/C:40/H:221/W:193/iterations:100/manual_time/threads:3       1.89 ms         8.03 ms          300
gru_op_perf/N:384/C:384/H:2/iterations:100/threads:1                                         18.2 ms         16.2 ms          100
```

**Test result on Google Pixel 5 (vulkan_api_test)**
```
Building... 15.9 sec (99%) 429/431 jobs, 1/431 updated
     - //xplat/caffe2:pt_vulkan_api_test_binAndroid#android-arm64,binary... 8.0 sec (running computing_output_hashes[4.1 sec])
//xplat/caffe2:pt_vulkan_api_test_binAndroid#android-arm64 buck-out/gen/fe3a39b8/xplat/caffe2/pt_vulkan_api_test_binAndroid#android-arm64
buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid#android-arm64: 1 file pushed, 0 skipped. 149.9 MB/s (881568472 bytes in 5.609s)
Running main() from xplat/third-party/gmock/googletest-1.10.0/googletest/src/gtest_main.cc
[==========] Running 106 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 106 tests from VulkanAPITest
[ RUN      ] VulkanAPITest.adaptive_avg_pool2d
[       OK ] VulkanAPITest.adaptive_avg_pool2d (23 ms)
[ RUN      ] VulkanAPITest.add
[       OK ] VulkanAPITest.add (63 ms)
[ RUN      ] VulkanAPITest.add_broadcast0
[       OK ] VulkanAPITest.add_broadcast0 (31 ms)
[ RUN      ] VulkanAPITest.add_broadcast1
[       OK ] VulkanAPITest.add_broadcast1 (23 ms)
[ RUN      ] VulkanAPITest.add_broadcast2
[       OK ] VulkanAPITest.add_broadcast2 (23 ms)
[ RUN      ] VulkanAPITest.add_
[       OK ] VulkanAPITest.add_ (144 ms)
[ RUN      ] VulkanAPITest.add_broadcast0_
[       OK ] VulkanAPITest.add_broadcast0_ (23 ms)
[ RUN      ] VulkanAPITest.add_broadcast1_
[       OK ] VulkanAPITest.add_broadcast1_ (14 ms)
[ RUN      ] VulkanAPITest.add_scalar
[       OK ] VulkanAPITest.add_scalar (53 ms)
[ RUN      ] VulkanAPITest.add_scalar_
[       OK ] VulkanAPITest.add_scalar_ (12 ms)
[ RUN      ] VulkanAPITest.addmm
[       OK ] VulkanAPITest.addmm (21 ms)
[ RUN      ] VulkanAPITest.addmm_expand
[       OK ] VulkanAPITest.addmm_expand (30 ms)
[ RUN      ] VulkanAPITest.avg_pool2d
[       OK ] VulkanAPITest.avg_pool2d (18 ms)
[ RUN      ] VulkanAPITest.clamp
[       OK ] VulkanAPITest.clamp (211 ms)
[ RUN      ] VulkanAPITest.clamp_
[       OK ] VulkanAPITest.clamp_ (194 ms)
[ RUN      ] VulkanAPITest.conv2d
[       OK ] VulkanAPITest.conv2d (22 ms)
[ RUN      ] VulkanAPITest.conv2d_dw
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0412 19:30:29.990865 3098789112 TensorImpl.h:1336] Warning: Named tensors and all their associated APIs are an experimental feature and subject to change. Please do not use them for anything important until they are released as stable. (function operator())
[       OK ] VulkanAPITest.conv2d_dw (22 ms)
[ RUN      ] VulkanAPITest.conv2d_pw
[       OK ] VulkanAPITest.conv2d_pw (79 ms)
[ RUN      ] VulkanAPITest.conv2d_winograd
[       OK ] VulkanAPITest.conv2d_winograd (55 ms)
[ RUN      ] VulkanAPITest.copy
[       OK ] VulkanAPITest.copy (5 ms)
[ RUN      ] VulkanAPITest.div
[       OK ] VulkanAPITest.div (74 ms)
[ RUN      ] VulkanAPITest.div_broadcast0
[       OK ] VulkanAPITest.div_broadcast0 (25 ms)
[ RUN      ] VulkanAPITest.div_broadcast1
[       OK ] VulkanAPITest.div_broadcast1 (26 ms)
[ RUN      ] VulkanAPITest.div_broadcast2
[       OK ] VulkanAPITest.div_broadcast2 (20 ms)
[ RUN      ] VulkanAPITest.div_
[       OK ] VulkanAPITest.div_ (151 ms)
[ RUN      ] VulkanAPITest.div_broadcast0_
[       OK ] VulkanAPITest.div_broadcast0_ (31 ms)
[ RUN      ] VulkanAPITest.div_broadcast1_
[       OK ] VulkanAPITest.div_broadcast1_ (3 ms)
[ RUN      ] VulkanAPITest.div_scalar
[       OK ] VulkanAPITest.div_scalar (190 ms)
[ RUN      ] VulkanAPITest.div_scalar_
[       OK ] VulkanAPITest.div_scalar_ (63 ms)
[ RUN      ] VulkanAPITest.empty
[       OK ] VulkanAPITest.empty (0 ms)
[ RUN      ] VulkanAPITest.hardsigmoid
[       OK ] VulkanAPITest.hardsigmoid (217 ms)
[ RUN      ] VulkanAPITest.hardsigmoid_
[       OK ] VulkanAPITest.hardsigmoid_ (212 ms)
[ RUN      ] VulkanAPITest.hardshrink
Max Diff allowed: 0.1
xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp:1070: Failure
Value of: check
  Actual: false
Expected: true
[  FAILED  ] VulkanAPITest.hardshrink (1154 ms)
[ RUN      ] VulkanAPITest.hardshrink_
[       OK ] VulkanAPITest.hardshrink_ (1488 ms)
[ RUN      ] VulkanAPITest.leaky_relu
[       OK ] VulkanAPITest.leaky_relu (758 ms)
[ RUN      ] VulkanAPITest.leaky_relu_
[       OK ] VulkanAPITest.leaky_relu_ (752 ms)
[ RUN      ] VulkanAPITest.hardswish
[       OK ] VulkanAPITest.hardswish (217 ms)
[ RUN      ] VulkanAPITest.hardswish_
[       OK ] VulkanAPITest.hardswish_ (214 ms)
[ RUN      ] VulkanAPITest.max_pool2d
[       OK ] VulkanAPITest.max_pool2d (26 ms)
[ RUN      ] VulkanAPITest.mean
[       OK ] VulkanAPITest.mean (24 ms)
[ RUN      ] VulkanAPITest.mean2d
[       OK ] VulkanAPITest.mean2d (60 ms)
[ RUN      ] VulkanAPITest.mm
[       OK ] VulkanAPITest.mm (15 ms)
[ RUN      ] VulkanAPITest.mul
[       OK ] VulkanAPITest.mul (71 ms)
[ RUN      ] VulkanAPITest.mul_broadcast0
[       OK ] VulkanAPITest.mul_broadcast0 (25 ms)
[ RUN      ] VulkanAPITest.mul_broadcast1
[       OK ] VulkanAPITest.mul_broadcast1 (23 ms)
[ RUN      ] VulkanAPITest.mul_broadcast2
[       OK ] VulkanAPITest.mul_broadcast2 (19 ms)
[ RUN      ] VulkanAPITest.mul_
[       OK ] VulkanAPITest.mul_ (144 ms)
[ RUN      ] VulkanAPITest.mul_broadcast0_
[       OK ] VulkanAPITest.mul_broadcast0_ (29 ms)
[ RUN      ] VulkanAPITest.mul_broadcast1_
[       OK ] VulkanAPITest.mul_broadcast1_ (4 ms)
[ RUN      ] VulkanAPITest.mul_scalar
[       OK ] VulkanAPITest.mul_scalar (190 ms)
[ RUN      ] VulkanAPITest.mul_scalar_
[       OK ] VulkanAPITest.mul_scalar_ (55 ms)
[ RUN      ] VulkanAPITest.reflection_pad2d
[       OK ] VulkanAPITest.reflection_pad2d (8 ms)
[ RUN      ] VulkanAPITest.reshape
[       OK ] VulkanAPITest.reshape (127 ms)
[ RUN      ] VulkanAPITest.reshape_
[       OK ] VulkanAPITest.reshape_ (99 ms)
[ RUN      ] VulkanAPITest.sigmoid
[       OK ] VulkanAPITest.sigmoid (239 ms)
[ RUN      ] VulkanAPITest.sigmoid_
[       OK ] VulkanAPITest.sigmoid_ (234 ms)
[ RUN      ] VulkanAPITest.softmax
[       OK ] VulkanAPITest.softmax (89 ms)
[ RUN      ] VulkanAPITest.log_softmax
Max Diff allowed: 0.05875
xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp:1583: Failure
Value of: check
  Actual: false
Expected: true
[  FAILED  ] VulkanAPITest.log_softmax (41 ms)
[ RUN      ] VulkanAPITest.tanh
[       OK ] VulkanAPITest.tanh (271 ms)
[ RUN      ] VulkanAPITest.tanh_
[       OK ] VulkanAPITest.tanh_ (263 ms)
[ RUN      ] VulkanAPITest.sub
[       OK ] VulkanAPITest.sub (72 ms)
[ RUN      ] VulkanAPITest.sub_broadcast0
[       OK ] VulkanAPITest.sub_broadcast0 (22 ms)
[ RUN      ] VulkanAPITest.sub_broadcast1
[       OK ] VulkanAPITest.sub_broadcast1 (23 ms)
[ RUN      ] VulkanAPITest.sub_broadcast2
[       OK ] VulkanAPITest.sub_broadcast2 (17 ms)
[ RUN      ] VulkanAPITest.sub_
[       OK ] VulkanAPITest.sub_ (129 ms)
[ RUN      ] VulkanAPITest.sub_broadcast0_
[       OK ] VulkanAPITest.sub_broadcast0_ (23 ms)
[ RUN      ] VulkanAPITest.sub_broadcast1_
[       OK ] VulkanAPITest.sub_broadcast1_ (4 ms)
[ RUN      ] VulkanAPITest.transposed_conv2d
[       OK ] VulkanAPITest.transposed_conv2d (16 ms)
[ RUN      ] VulkanAPITest.upsample_nearest2d
[       OK ] VulkanAPITest.upsample_nearest2d (6 ms)
[ RUN      ] VulkanAPITest.cat_dim1_samefeature_success
[       OK ] VulkanAPITest.cat_dim1_samefeature_success (140 ms)
[ RUN      ] VulkanAPITest.cat_dim1_difffeature_success
[       OK ] VulkanAPITest.cat_dim1_difffeature_success (127 ms)
[ RUN      ] VulkanAPITest.cat_dim1_texture2d_success
[       OK ] VulkanAPITest.cat_dim1_texture2d_success (4 ms)
[ RUN      ] VulkanAPITest.cat_dim1_singledepth_success
[       OK ] VulkanAPITest.cat_dim1_singledepth_success (8 ms)
[ RUN      ] VulkanAPITest.cat_dim1_singletensor_success
[       OK ] VulkanAPITest.cat_dim1_singletensor_success (23 ms)
[ RUN      ] VulkanAPITest.cat_dim1_twotensors_success
[       OK ] VulkanAPITest.cat_dim1_twotensors_success (71 ms)
[ RUN      ] VulkanAPITest.cat_dim1_bat1_mult4ch_success
[       OK ] VulkanAPITest.cat_dim1_bat1_mult4ch_success (18 ms)
[ RUN      ] VulkanAPITest.cat_dim1_bat2_mult4ch_success
[       OK ] VulkanAPITest.cat_dim1_bat2_mult4ch_success (36 ms)
[ RUN      ] VulkanAPITest.cat_dim1_mult4ch_mixed_success
[       OK ] VulkanAPITest.cat_dim1_mult4ch_mixed_success (105 ms)
[ RUN      ] VulkanAPITest.cat_dim1_mult4ch_nonmult4ch_success
[       OK ] VulkanAPITest.cat_dim1_mult4ch_nonmult4ch_success (124 ms)
[ RUN      ] VulkanAPITest.cat_dim2_sameheight_success
[       OK ] VulkanAPITest.cat_dim2_sameheight_success (124 ms)
[ RUN      ] VulkanAPITest.cat_dim2_diffheight_success
[       OK ] VulkanAPITest.cat_dim2_diffheight_success (125 ms)
[ RUN      ] VulkanAPITest.cat_dim2_singledepth_success
[       OK ] VulkanAPITest.cat_dim2_singledepth_success (10 ms)
[ RUN      ] VulkanAPITest.cat_dim2_invalidinputs_exceptions
[       OK ] VulkanAPITest.cat_dim2_invalidinputs_exceptions (125 ms)
[ RUN      ] VulkanAPITest.permute_2d_success
[       OK ] VulkanAPITest.permute_2d_success (28 ms)
[ RUN      ] VulkanAPITest.permute_3d_success
[       OK ] VulkanAPITest.permute_3d_success (7 ms)
[ RUN      ] VulkanAPITest.permute_4d_success
[       OK ] VulkanAPITest.permute_4d_success (13 ms)
[ RUN      ] VulkanAPITest.permute_4dmclaren_success
[       OK ] VulkanAPITest.permute_4dmclaren_success (1 ms)
[ RUN      ] VulkanAPITest.permute_4dbig_success
[       OK ] VulkanAPITest.permute_4dbig_success (211 ms)
[ RUN      ] VulkanAPITest.permute_negativedims_success
[       OK ] VulkanAPITest.permute_negativedims_success (0 ms)
[ RUN      ] VulkanAPITest.permute_1d_nochange
[       OK ] VulkanAPITest.permute_1d_nochange (1 ms)
[ RUN      ] VulkanAPITest.permute_sameDims_nochange
[       OK ] VulkanAPITest.permute_sameDims_nochange (0 ms)
[ RUN      ] VulkanAPITest.permute_invalidinputs_exceptions
[       OK ] VulkanAPITest.permute_invalidinputs_exceptions (1 ms)
[ RUN      ] VulkanAPITest.slice_width_success
[       OK ] VulkanAPITest.slice_width_success (17 ms)
[ RUN      ] VulkanAPITest.slice_height_success
[       OK ] VulkanAPITest.slice_height_success (14 ms)
[ RUN      ] VulkanAPITest.slice_feature_success
[       OK ] VulkanAPITest.slice_feature_success (20 ms)
[ RUN      ] VulkanAPITest.slice_batch_success
[       OK ] VulkanAPITest.slice_batch_success (8 ms)
[ RUN      ] VulkanAPITest.slice_invalidinputs_exceptions
[       OK ] VulkanAPITest.slice_invalidinputs_exceptions (0 ms)
[ RUN      ] VulkanAPITest.clone_success
[       OK ] VulkanAPITest.clone_success (4 ms)
[ RUN      ] VulkanAPITest.clone_invalidinputs_exceptions
[       OK ] VulkanAPITest.clone_invalidinputs_exceptions (1 ms)
[ RUN      ] VulkanAPITest.mobilenetv2
[       OK ] VulkanAPITest.mobilenetv2 (153 ms)
[ RUN      ] VulkanAPITest.gru_mclareninputs_success
[       OK ] VulkanAPITest.gru_mclareninputs_success (64 ms)
[ RUN      ] VulkanAPITest.gru_invalidinputs_exceptions
[       OK ] VulkanAPITest.gru_invalidinputs_exceptions (17 ms)
[ RUN      ] VulkanAPITest.gru_prepack_success
[       OK ] VulkanAPITest.gru_prepack_success (48 ms)
[ RUN      ] VulkanAPITest.gru_prepack_invalidinputs_exceptions
[       OK ] VulkanAPITest.gru_prepack_invalidinputs_exceptions (106 ms)
[ RUN      ] VulkanAPITest.profiling_invalideinputs_exceptions
[       OK ] VulkanAPITest.profiling_invalideinputs_exceptions (433 ms)
[ RUN      ] VulkanAPITest.profiling_result_success
[       OK ] VulkanAPITest.profiling_result_success (86 ms)
[----------] 106 tests from VulkanAPITest (11317 ms total)

[----------] Global test environment tear-down
[==========] 106 tests from 1 test suite ran. (11345 ms total)
[  PASSED  ] 104 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] VulkanAPITest.hardshrink
[  FAILED  ] VulkanAPITest.log_softmax

 2 FAILED TESTS
```

**Test result on Google Pixel 5 (vulkan op profiling)**
```
-----------------------------------------------------------------------------------------
Query Name                                  Execution             Start               End
-----------------------------------------------------------------------------------------
aten::_adaptive_avg_pool2d                     206 us          26020 us          26227 us
copy_buffer_to_image                            78 us          26020 us          26099 us
copy_image_to_buffer                             6 us          26227 us          26234 us
aten::add.Tensor                              4352 us          59917 us          64270 us
copy_buffer_to_image                          1546 us          59918 us          61464 us
copy_buffer_to_image                          1541 us          61464 us          63006 us
copy_image_to_buffer                          2758 us          64270 us          67029 us
aten::add.Tensor                              1447 us          99504 us         100952 us
...
aten::add.Tensor                                11 us         526147 us         526159 us
aten::sigmoid                                   14 us         526160 us         526174 us
aten::addmm                                    435 us         526175 us         526610 us
copy_buffer_to_image                           143 us         526175 us         526319 us
copy_buffer_to_image                             6 us         526319 us         526326 us
aten::addmm                                    446 us         526611 us         527057 us
copy_buffer_to_image                           144 us         526611 us         526755 us
copy_buffer_to_image                             6 us         526755 us         526762 us
aten::add.Tensor                                12 us         527057 us         527070 us
aten::sigmoid                                   15 us         527070 us         527085 us
aten::addmm                                    435 us         527573 us         528009 us
copy_buffer_to_image                           144 us         527574 us         527718 us
copy_buffer_to_image                             6 us         527718 us         527725 us
aten::addmm                                    434 us         528009 us         528444 us
copy_buffer_to_image                           141 us         528009 us         528151 us
copy_buffer_to_image                             7 us         528152 us         528159 us
aten::mul.Tensor                                12 us         528444 us         528457 us
aten::add.Tensor                                12 us         528457 us         528470 us
aten::tanh                                      16 us         528470 us         528486 us
aten::mul.Scalar                                 7 us         528487 us         528494 us
aten::add.Scalar                                 7 us         528495 us         528502 us
aten::mul.Tensor                                11 us         528503 us         528515 us
aten::mul.Tensor                                10 us         528515 us         528525 us
aten::add.Tensor                                12 us         528526 us         528538 us
aten::_reshape_alias                            26 us         528538 us         528564 us
copy_image_to_buffer                             9 us         528539 us         528548 us
aten::_cat (cat_batch)                          53 us         528565 us         528618 us
copy_buffer_to_image                             8 us         528565 us         528573 us
copy_buffer_to_image                             7 us         528592 us         528600 us
aten::_reshape_alias                            25 us         528619 us         528644 us
copy_image_to_buffer                             9 us         528619 us         528628 us
aten::_reshape_alias                            14 us         579597 us         579612 us
aten::slice.Tensor (slice_4d)                   33 us         579612 us         579646 us
copy_buffer_to_image                            12 us         579613 us         579625 us
aten::_reshape_alias                            25 us         579646 us         579672 us
copy_image_to_buffer                             9 us         579647 us         579656 us
aten::addmm                                    443 us         579673 us         580116 us
copy_buffer_to_image                             7 us         579673 us         579681 us
copy_buffer_to_image                           144 us         579681 us         579826 us
copy_buffer_to_image                             6 us         579827 us         579833 us
aten::addmm                                    439 us         580117 us         580556 us
copy_buffer_to_image                             7 us         580117 us         580125 us
copy_buffer_to_image                           142 us         580125 us         580267 us
copy_buffer_to_image                             6 us         580268 us         580275 us
aten::add.Tensor                                12 us         580556 us         580569 us
aten::sigmoid                                   14 us         580569 us         580584 us
aten::addmm                                    432 us         580584 us         581016 us
copy_buffer_to_image                           140 us         580584 us         580725 us
copy_buffer_to_image                             6 us         580725 us         580732 us
aten::addmm                                    436 us         581017 us         581453 us
copy_buffer_to_image                           142 us         581017 us         581160 us
copy_buffer_to_image                             6 us         581160 us         581167 us
aten::add.Tensor                                13 us         581454 us         581467 us
aten::sigmoid                                   14 us         581468 us         581483 us
aten::addmm                                    438 us         581483 us         581921 us
copy_buffer_to_image                           141 us         581483 us         581625 us
copy_buffer_to_image                             6 us         581625 us         581632 us
aten::addmm                                    430 us         581935 us         582365 us
copy_buffer_to_image                           143 us         581935 us         582078 us
copy_buffer_to_image                             6 us         582079 us         582085 us
aten::mul.Tensor                                12 us         582365 us         582377 us
aten::add.Tensor                                11 us         582378 us         582390 us
aten::tanh                                      15 us         582390 us         582406 us
aten::mul.Scalar                                 7 us         582407 us         582414 us
aten::add.Scalar                                 7 us         582415 us         582423 us
aten::mul.Tensor                                11 us         582423 us         582435 us
aten::mul.Tensor                                10 us         582435 us         582446 us
aten::add.Tensor                                11 us         582446 us         582458 us
aten::_reshape_alias                            24 us         582458 us         582483 us
copy_image_to_buffer                             9 us         582458 us         582468 us
aten::slice.Tensor (slice_4d)                   20 us         582483 us         582504 us
aten::_reshape_alias                            24 us         582504 us         582529 us
copy_image_to_buffer                             9 us         582505 us         582514 us
aten::addmm                                    435 us         582530 us         582965 us
copy_buffer_to_image                           140 us         582530 us         582671 us
copy_buffer_to_image                             7 us         582671 us         582678 us
aten::addmm                                    446 us         582966 us         583413 us
copy_buffer_to_image                             8 us         582966 us         582974 us
copy_buffer_to_image                           142 us         582975 us         583117 us
copy_buffer_to_image                             6 us         583118 us         583125 us
aten::add.Tensor                                12 us         583413 us         583426 us
aten::sigmoid                                   14 us         583426 us         583441 us
aten::addmm                                    437 us         583441 us         583879 us
copy_buffer_to_image                           140 us         583441 us         583582 us
copy_buffer_to_image                             6 us         583583 us         583589 us
aten::addmm                                    432 us         583879 us         584312 us
copy_buffer_to_image                           139 us         583880 us         584019 us
copy_buffer_to_image                             6 us         584020 us         584026 us
aten::add.Tensor                                12 us         584324 us         584337 us
aten::sigmoid                                   14 us         584337 us         584352 us
aten::addmm                                    432 us         584352 us         584784 us
copy_buffer_to_image                           138 us         584353 us         584492 us
copy_buffer_to_image                             6 us         584492 us         584498 us
aten::addmm                                    425 us         584786 us         585211 us
copy_buffer_to_image                           139 us         584786 us         584925 us
copy_buffer_to_image                             6 us         584926 us         584932 us
aten::mul.Tensor                                12 us         585212 us         585224 us
aten::add.Tensor                                12 us         585224 us         585236 us
aten::tanh                                      16 us         585237 us         585253 us
aten::mul.Scalar                                 7 us         585253 us         585261 us
aten::add.Scalar                                 7 us         585261 us         585268 us
aten::mul.Tensor                                11 us         585269 us         585280 us
aten::mul.Tensor                                10 us         585281 us         585291 us
aten::add.Tensor                                11 us         585291 us         585303 us
aten::_reshape_alias                            24 us         585303 us         585328 us
copy_image_to_buffer                             9 us         585304 us         585313 us
aten::_cat (cat_batch)                          51 us         585329 us         585380 us
copy_buffer_to_image                             7 us         585329 us         585337 us
copy_buffer_to_image                             7 us         585355 us         585363 us
aten::_reshape_alias                            24 us         585380 us         585405 us
copy_image_to_buffer                             8 us         585381 us         585390 us
aten::_cat (cat_feature_mult4ch)              1564 us        1009857 us        1011422 us
copy_buffer_to_image                           414 us        1009858 us        1010272 us
copy_buffer_to_image                           407 us        1010386 us        1010793 us
copy_buffer_to_image                           408 us        1010904 us        1011312 us
copy_image_to_buffer                          2321 us        1011422 us        1013744 us
```

Differential Revision: D33151286

