### PR TITLE
no submodules on tests

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -20,10 +20,10 @@ on:
         type: boolean
         default: false
         description: checks out viable/strict
-      needs-submodules:
+      checkout-pytorch-submodules:
         required: false
         default: false
-        type: boolean
+        type: string
         description: If this job needs to checkout the submodules
 
 env:
@@ -46,7 +46,7 @@ jobs:
         with:
           needs-viable-strict: ${{ inputs.needs-viable-strict }}
           needs-history-and-master: true
-          submodules: ${{ inputs.needs-submodules }}
+          submodules: ${{ inputs.checkout-pytorch-submodules }}
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           needs-viable-strict: ${{ inputs.needs-viable-strict }}
           needs-history-and-master: true
+          submodules: false
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -20,6 +20,11 @@ on:
         type: boolean
         default: false
         description: checks out viable/strict
+      needs-submodules:
+        required: false
+        default: false
+        type: boolean
+        description: If this job needs to checkout the submodules
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
@@ -41,7 +46,7 @@ jobs:
         with:
           needs-viable-strict: ${{ inputs.needs-viable-strict }}
           needs-history-and-master: true
-          submodules: false
+          submodules: ${{ inputs.needs-submodules }}
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -54,6 +54,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           needs-history-and-master: true
+          submodules: false
 
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           no-sudo: true
           needs-history-and-master: true
+          submodules: false
 
       - name: Setup ROCm
         uses: ./.github/actions/setup-rocm

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           no-sudo: true
           needs-history-and-master: true
+          submodules: false
 
       - name: Setup Windows
         uses: ./.github/actions/setup-win

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -114,7 +114,7 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-clang7-onnx
       docker-image: ${{ needs.linux-xenial-py3_7-clang7-onnx-build.outputs.docker-image }}
-      needs-submodules: true
+      checkout-pytorch-submodules: recursive
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 2, runner: "linux.2xlarge" },

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -114,6 +114,7 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-clang7-onnx
       docker-image: ${{ needs.linux-xenial-py3_7-clang7-onnx-build.outputs.docker-image }}
+      needs-submodules: true
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
@@ -299,8 +300,8 @@ jobs:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
       docker-image-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c
 
-  pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit:
-    name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
+  ? pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
+  : name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
     uses: ./.github/workflows/_android-build-test.yml
     with:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -300,8 +300,8 @@ jobs:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
       docker-image-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c
 
-  ? pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
-  : name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
+  pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit:
+    name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
     uses: ./.github/workflows/_android-build-test.yml
     with:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -143,7 +143,7 @@ jobs:
     with:
       build-environment: linux-bionic-py3.7-clang9-slow
       docker-image: ${{ needs.linux-bionic-py3_7-clang9-slow-build.outputs.docker-image }}
-      needs-submodules: true
+      checkout-pytorch-submodules: recursive
       test-matrix: |
         { include: [
           { config: "slow", shard: 1, num_shards: 1, runner: "linux.2xlarge" },

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -143,6 +143,7 @@ jobs:
     with:
       build-environment: linux-bionic-py3.7-clang9-slow
       docker-image: ${{ needs.linux-bionic-py3_7-clang9-slow-build.outputs.docker-image }}
+      needs-submodules: true
       test-matrix: |
         { include: [
           { config: "slow", shard: 1, num_shards: 1, runner: "linux.2xlarge" },

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -143,7 +143,6 @@ jobs:
     with:
       build-environment: linux-bionic-py3.7-clang9-slow
       docker-image: ${{ needs.linux-bionic-py3_7-clang9-slow-build.outputs.docker-image }}
-      checkout-pytorch-submodules: recursive
       test-matrix: |
         { include: [
           { config: "slow", shard: 1, num_shards: 1, runner: "linux.2xlarge" },


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

Don't checkout submodules for tests, with the exception of `linux-xenial-py3.7-clang7-onnx`, which seems to break if submodules aren't checked out

Should reduce checkout time by 30-60s