### PR TITLE
[Quant][fx] Fix get_default_qconfig_dict for fused modules

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1818,6 +1818,7 @@ class TestQuantizeFx(QuantizationTestCase):
             for relu in [torch.nn.ReLU(), torch.nn.functional.relu, torch.relu]:
                 m = model(relu).eval()
                 qconfig_dict = torch.ao.quantization.get_default_qconfig_dict("fbgemm")
+                # should not crash as in https://github.com/pytorch/pytorch/issues/75825
                 prepare_fx(m, qconfig_dict)
 
     def test_qconfig_dict_validity(self):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1778,6 +1778,22 @@ class TestQuantizeFx(QuantizationTestCase):
         self.checkGraphModuleNodes(m, expected_node_list=node_list)
 
 
+    def test_qconfig_dict_with_fused_modules(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+                self.conv = torch.nn.Conv1d(3, 3, 3)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = self.relu(x)
+                return x
+
+        m = Model().eval()
+        qconfig_dict = torch.ao.quantization.get_default_qconfig_dict("fbgemm")
+        prepare_fx(m, qconfig_dict)
+
     def test_qconfig_dict_validity(self):
         r"""
         Verifies that if a user passes an invalid key or makes a typo when

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1779,20 +1779,46 @@ class TestQuantizeFx(QuantizationTestCase):
 
 
     def test_qconfig_dict_with_fused_modules(self):
-        class Model(torch.nn.Module):
-            def __init__(self):
-                super(Model, self).__init__()
+        class LinearReLUModel(torch.nn.Module):
+            def __init__(self, relu):
+                super(LinearReLUModel, self).__init__()
+                self.linear = torch.nn.Linear(3, 3)
+                self.relu = relu
+
+            def forward(self, x):
+                x = self.linear(x)
+                x = self.relu(x)
+                return x
+
+        class ConvReLUModel(torch.nn.Module):
+            def __init__(self, relu):
+                super(ConvReLUModel, self).__init__()
                 self.conv = torch.nn.Conv1d(3, 3, 3)
-                self.relu = torch.nn.ReLU()
+                self.relu = relu
 
             def forward(self, x):
                 x = self.conv(x)
                 x = self.relu(x)
                 return x
 
-        m = Model().eval()
-        qconfig_dict = torch.ao.quantization.get_default_qconfig_dict("fbgemm")
-        prepare_fx(m, qconfig_dict)
+        class ConvBnReLUModel(torch.nn.Module):
+            def __init__(self, relu):
+                super(ConvBnReLUModel, self).__init__()
+                self.conv = torch.nn.Conv1d(3, 3, 3)
+                self.bn = torch.nn.BatchNorm1d(3)
+                self.relu = relu
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = self.bn(x)
+                x = self.relu(x)
+                return x
+
+        for model in [LinearReLUModel, ConvReLUModel, ConvBnReLUModel]:
+            for relu in [torch.nn.ReLU(), torch.nn.functional.relu, torch.relu]:
+                m = model(relu).eval()
+                qconfig_dict = torch.ao.quantization.get_default_qconfig_dict("fbgemm")
+                prepare_fx(m, qconfig_dict)
 
     def test_qconfig_dict_validity(self):
         r"""

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -352,7 +352,11 @@ def _get_default_qconfig_dict_helper(qconfig, qconfig_transpose):
                         (torch.nn.functional.conv_transpose1d, qconfig_transpose),
                         (torch.nn.functional.conv_transpose2d, qconfig_transpose),
                         (torch.nn.functional.conv_transpose3d, qconfig_transpose),
-                        (torch.nn.functional.linear, qconfig)]}
+                        (torch.nn.functional.linear, qconfig),
+                        (torch.nn.ReLU, qconfig),
+                        (torch.nn.BatchNorm1d, qconfig),
+                        (torch.nn.BatchNorm2d, qconfig),
+                        (torch.nn.BatchNorm3d, qconfig)]}
 
 def get_default_qconfig_dict(backend='fbgemm', version=0):
     qconfig = get_default_qconfig(backend, version)

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -354,6 +354,8 @@ def _get_default_qconfig_dict_helper(qconfig, qconfig_transpose):
                         (torch.nn.functional.conv_transpose3d, qconfig_transpose),
                         (torch.nn.functional.linear, qconfig),
                         (torch.nn.ReLU, qconfig),
+                        (torch.nn.functional.relu, qconfig),
+                        (torch.relu, qconfig),
                         (torch.nn.BatchNorm1d, qconfig),
                         (torch.nn.BatchNorm2d, qconfig),
                         (torch.nn.BatchNorm3d, qconfig)]}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75838

Summary: Calling `prepare_fx` with `get_default_qconfig_dict`
failed for models with fused modules, such as `ConvReLU2d`.
This commit fixes this by adding qconfig entries for ReLU
and BatchNorm as well.

Test Plan:
python test/test_quantization.py TestQuantizeFx.test_qconfig_dict_with_fused_modules

Reviewers: jerryzh168

Subscribers: jerryzh168, vkuzo

Issue: https://github.com/pytorch/pytorch/issues/75825

Differential Revision: [D35668151](https://our.internmc.facebook.com/intern/diff/D35668151)