### PR TITLE
improve package error message

### DIFF
--- a/.github/generated-ciflow-ruleset.json
+++ b/.github/generated-ciflow-ruleset.json
@@ -1,0 +1,303 @@
+{
+  "__comment": "@generated DO NOT EDIT MANUALLY, Generation script: .github/scripts/generate_ci_workflows.py",
+  "label_rules": {
+    "ciflow/all": [
+      "caffe2-linux-xenial-py3.7-gcc5.4",
+      "deploy-linux-xenial-cuda11.3-py3.7-gcc7",
+      "docker-builds",
+      "ios-12-5-1-arm64",
+      "ios-12-5-1-arm64-coreml",
+      "ios-12-5-1-arm64-custom-ops",
+      "ios-12-5-1-arm64-metal",
+      "ios-12-5-1-x86-64",
+      "ios-12-5-1-x86-64-coreml",
+      "libtorch-linux-xenial-cuda10.2-py3.7-gcc7",
+      "libtorch-linux-xenial-cuda11.3-py3.7-gcc7",
+      "linux-bionic-cuda10.2-py3.9-gcc7",
+      "linux-bionic-py3.7-clang9",
+      "linux-bionic-rocm4.5-py3.7",
+      "linux-docs",
+      "linux-docs-push",
+      "linux-vulkan-bionic-py3.7-clang9",
+      "linux-xenial-cuda11.3-py3.7-gcc7",
+      "linux-xenial-cuda11.3-py3.7-gcc7-bazel-test",
+      "linux-xenial-cuda11.3-py3.7-gcc7-no-ops",
+      "linux-xenial-py3-clang5-mobile-build",
+      "linux-xenial-py3-clang5-mobile-custom-build-static",
+      "linux-xenial-py3.7-clang7-asan",
+      "linux-xenial-py3.7-clang7-onnx",
+      "linux-xenial-py3.7-gcc5.4",
+      "linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build",
+      "linux-xenial-py3.7-gcc7",
+      "linux-xenial-py3.7-gcc7-no-ops",
+      "macos-10-15-py3-arm64",
+      "macos-10-15-py3-lite-interpreter-x86-64",
+      "macos-11-py3-x86-64",
+      "parallelnative-linux-xenial-py3.7-gcc5.4",
+      "periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7",
+      "periodic-linux-bionic-cuda11.5-py3.7-gcc7",
+      "periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck",
+      "periodic-linux-xenial-cuda11.3-py3.7-gcc7-debug",
+      "periodic-win-vs2019-cuda11.5-py3",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
+      "pytorch-xla-linux-bionic-py3.7-clang8",
+      "win-vs2019-cpu-py3",
+      "win-vs2019-cuda11.3-py3"
+    ],
+    "ciflow/android": [
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit"
+    ],
+    "ciflow/bazel": [
+      "linux-xenial-cuda11.3-py3.7-gcc7-bazel-test"
+    ],
+    "ciflow/binaries": [
+      "linux-binary-conda",
+      "linux-binary-libtorch-cxx11-abi",
+      "linux-binary-libtorch-pre-cxx11",
+      "linux-binary-manywheel",
+      "macos-arm64-binary-conda",
+      "macos-arm64-binary-wheel",
+      "macos-binary-conda",
+      "macos-binary-libtorch-cxx11-abi",
+      "macos-binary-libtorch-pre-cxx11",
+      "macos-binary-wheel",
+      "windows-binary-libtorch-cxx11-abi",
+      "windows-binary-libtorch-pre-cxx11",
+      "windows-binary-wheel"
+    ],
+    "ciflow/binaries_conda": [
+      "linux-binary-conda",
+      "macos-arm64-binary-conda",
+      "macos-binary-conda"
+    ],
+    "ciflow/binaries_libtorch": [
+      "linux-binary-libtorch-cxx11-abi",
+      "linux-binary-libtorch-pre-cxx11",
+      "macos-binary-libtorch-cxx11-abi",
+      "macos-binary-libtorch-pre-cxx11",
+      "windows-binary-libtorch-cxx11-abi",
+      "windows-binary-libtorch-pre-cxx11"
+    ],
+    "ciflow/binaries_wheel": [
+      "linux-binary-manywheel",
+      "macos-arm64-binary-wheel",
+      "macos-binary-wheel",
+      "windows-binary-wheel"
+    ],
+    "ciflow/cpu": [
+      "caffe2-linux-xenial-py3.7-gcc5.4",
+      "linux-bionic-py3.7-clang9",
+      "linux-docs",
+      "linux-docs-push",
+      "linux-vulkan-bionic-py3.7-clang9",
+      "linux-xenial-cuda11.3-py3.7-gcc7-bazel-test",
+      "linux-xenial-py3.7-clang7-asan",
+      "linux-xenial-py3.7-clang7-onnx",
+      "linux-xenial-py3.7-gcc5.4",
+      "linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build",
+      "linux-xenial-py3.7-gcc7",
+      "linux-xenial-py3.7-gcc7-no-ops",
+      "parallelnative-linux-xenial-py3.7-gcc5.4",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
+      "pytorch-xla-linux-bionic-py3.7-clang8",
+      "win-vs2019-cpu-py3"
+    ],
+    "ciflow/cuda": [
+      "deploy-linux-xenial-cuda11.3-py3.7-gcc7",
+      "libtorch-linux-xenial-cuda10.2-py3.7-gcc7",
+      "libtorch-linux-xenial-cuda11.3-py3.7-gcc7",
+      "linux-bionic-cuda10.2-py3.9-gcc7",
+      "linux-xenial-cuda11.3-py3.7-gcc7",
+      "linux-xenial-cuda11.3-py3.7-gcc7-no-ops",
+      "periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7",
+      "periodic-linux-bionic-cuda11.5-py3.7-gcc7",
+      "periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck",
+      "periodic-linux-xenial-cuda11.3-py3.7-gcc7-debug",
+      "periodic-win-vs2019-cuda11.5-py3",
+      "win-vs2019-cuda11.3-py3"
+    ],
+    "ciflow/default": [
+      "deploy-linux-xenial-cuda11.3-py3.7-gcc7",
+      "linux-binary-conda",
+      "linux-binary-libtorch-cxx11-abi",
+      "linux-binary-libtorch-pre-cxx11",
+      "linux-binary-manywheel",
+      "linux-bionic-py3.7-clang9",
+      "linux-bionic-rocm4.5-py3.7",
+      "linux-docs",
+      "linux-vulkan-bionic-py3.7-clang9",
+      "linux-xenial-cuda11.3-py3.7-gcc7",
+      "linux-xenial-cuda11.3-py3.7-gcc7-bazel-test",
+      "linux-xenial-py3-clang5-mobile-build",
+      "linux-xenial-py3-clang5-mobile-custom-build-static",
+      "linux-xenial-py3.7-clang7-asan",
+      "linux-xenial-py3.7-clang7-onnx",
+      "linux-xenial-py3.7-gcc5.4",
+      "linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build",
+      "linux-xenial-py3.7-gcc7",
+      "linux-xenial-py3.7-gcc7-no-ops",
+      "macos-arm64-binary-conda",
+      "macos-arm64-binary-wheel",
+      "macos-binary-conda",
+      "macos-binary-libtorch-cxx11-abi",
+      "macos-binary-libtorch-pre-cxx11",
+      "macos-binary-wheel",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
+      "win-vs2019-cpu-py3",
+      "win-vs2019-cuda11.3-py3",
+      "windows-binary-libtorch-cxx11-abi",
+      "windows-binary-libtorch-pre-cxx11",
+      "windows-binary-wheel"
+    ],
+    "ciflow/docs": [
+      "linux-docs"
+    ],
+    "ciflow/ios": [
+      "ios-12-5-1-arm64",
+      "ios-12-5-1-arm64-coreml",
+      "ios-12-5-1-arm64-custom-ops",
+      "ios-12-5-1-arm64-metal",
+      "ios-12-5-1-x86-64",
+      "ios-12-5-1-x86-64-coreml"
+    ],
+    "ciflow/libtorch": [
+      "libtorch-linux-xenial-cuda10.2-py3.7-gcc7",
+      "libtorch-linux-xenial-cuda11.3-py3.7-gcc7",
+      "linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build",
+      "periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7"
+    ],
+    "ciflow/linux": [
+      "caffe2-linux-xenial-py3.7-gcc5.4",
+      "deploy-linux-xenial-cuda11.3-py3.7-gcc7",
+      "libtorch-linux-xenial-cuda10.2-py3.7-gcc7",
+      "libtorch-linux-xenial-cuda11.3-py3.7-gcc7",
+      "linux-bionic-cuda10.2-py3.9-gcc7",
+      "linux-bionic-py3.7-clang9",
+      "linux-bionic-rocm4.5-py3.7",
+      "linux-docs",
+      "linux-docs-push",
+      "linux-vulkan-bionic-py3.7-clang9",
+      "linux-xenial-cuda11.3-py3.7-gcc7",
+      "linux-xenial-cuda11.3-py3.7-gcc7-bazel-test",
+      "linux-xenial-cuda11.3-py3.7-gcc7-no-ops",
+      "linux-xenial-py3-clang5-mobile-build",
+      "linux-xenial-py3-clang5-mobile-custom-build-static",
+      "linux-xenial-py3.7-clang7-asan",
+      "linux-xenial-py3.7-clang7-onnx",
+      "linux-xenial-py3.7-gcc5.4",
+      "linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build",
+      "linux-xenial-py3.7-gcc7",
+      "linux-xenial-py3.7-gcc7-no-ops",
+      "parallelnative-linux-xenial-py3.7-gcc5.4",
+      "periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7",
+      "periodic-linux-bionic-cuda11.5-py3.7-gcc7",
+      "periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck",
+      "periodic-linux-xenial-cuda11.3-py3.7-gcc7-debug",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
+      "pytorch-xla-linux-bionic-py3.7-clang8"
+    ],
+    "ciflow/macos": [
+      "ios-12-5-1-arm64",
+      "ios-12-5-1-arm64-coreml",
+      "ios-12-5-1-arm64-custom-ops",
+      "ios-12-5-1-arm64-metal",
+      "ios-12-5-1-x86-64",
+      "ios-12-5-1-x86-64-coreml",
+      "macos-10-15-py3-arm64",
+      "macos-10-15-py3-lite-interpreter-x86-64",
+      "macos-11-py3-x86-64"
+    ],
+    "ciflow/mobile": [
+      "linux-xenial-py3-clang5-mobile-build",
+      "linux-xenial-py3-clang5-mobile-custom-build-static",
+      "linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build"
+    ],
+    "ciflow/noarch": [
+      "linux-bionic-py3.7-clang9"
+    ],
+    "ciflow/onnx": [
+      "linux-xenial-py3.7-clang7-onnx"
+    ],
+    "ciflow/rocm": [
+      "linux-bionic-rocm4.5-py3.7"
+    ],
+    "ciflow/sanitizers": [
+      "linux-xenial-py3.7-clang7-asan"
+    ],
+    "ciflow/scheduled": [
+      "ios-12-5-1-arm64",
+      "ios-12-5-1-arm64-coreml",
+      "ios-12-5-1-arm64-custom-ops",
+      "ios-12-5-1-arm64-metal",
+      "linux-docs-push",
+      "periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7",
+      "periodic-linux-bionic-cuda11.5-py3.7-gcc7",
+      "periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck",
+      "periodic-linux-xenial-cuda11.3-py3.7-gcc7-debug",
+      "periodic-win-vs2019-cuda11.5-py3"
+    ],
+    "ciflow/slow": [
+      "linux-bionic-cuda10.2-py3.9-gcc7",
+      "periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck"
+    ],
+    "ciflow/slow-gradcheck": [
+      "periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck"
+    ],
+    "ciflow/trunk": [
+      "caffe2-linux-xenial-py3.7-gcc5.4",
+      "deploy-linux-xenial-cuda11.3-py3.7-gcc7",
+      "docker-builds",
+      "ios-12-5-1-x86-64",
+      "ios-12-5-1-x86-64-coreml",
+      "libtorch-linux-xenial-cuda10.2-py3.7-gcc7",
+      "libtorch-linux-xenial-cuda11.3-py3.7-gcc7",
+      "linux-bionic-cuda10.2-py3.9-gcc7",
+      "linux-bionic-py3.7-clang9",
+      "linux-bionic-rocm4.5-py3.7",
+      "linux-docs",
+      "linux-vulkan-bionic-py3.7-clang9",
+      "linux-xenial-cuda11.3-py3.7-gcc7",
+      "linux-xenial-cuda11.3-py3.7-gcc7-bazel-test",
+      "linux-xenial-cuda11.3-py3.7-gcc7-no-ops",
+      "linux-xenial-py3-clang5-mobile-build",
+      "linux-xenial-py3-clang5-mobile-custom-build-static",
+      "linux-xenial-py3.7-clang7-asan",
+      "linux-xenial-py3.7-clang7-onnx",
+      "linux-xenial-py3.7-gcc5.4",
+      "linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build",
+      "linux-xenial-py3.7-gcc7",
+      "linux-xenial-py3.7-gcc7-no-ops",
+      "macos-10-15-py3-arm64",
+      "macos-10-15-py3-lite-interpreter-x86-64",
+      "macos-11-py3-x86-64",
+      "parallelnative-linux-xenial-py3.7-gcc5.4",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+      "pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
+      "pytorch-xla-linux-bionic-py3.7-clang8",
+      "win-vs2019-cpu-py3",
+      "win-vs2019-cuda11.3-py3"
+    ],
+    "ciflow/vulkan": [
+      "linux-vulkan-bionic-py3.7-clang9"
+    ],
+    "ciflow/win": [
+      "periodic-win-vs2019-cuda11.5-py3",
+      "win-vs2019-cpu-py3",
+      "win-vs2019-cuda11.3-py3"
+    ],
+    "ciflow/xla": [
+      "pytorch-xla-linux-bionic-py3.7-clang8"
+    ]
+  },
+  "version": "v1"
+}

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -42,6 +42,211 @@ class Config(TypedDict):
     num_shards: int
     runner: str
 
+
+@dataclass
+class CIWorkflow:
+    # Required fields
+    arch: Arch
+    build_environment: str
+
+    # Optional fields
+    test_runner_type: str = ''
+    multigpu_runner_type: str = ''
+    distributed_gpu_runner_type: str = ''
+    ciflow_config: CIFlowConfig = field(default_factory=CIFlowConfig)
+    cuda_version: str = ''
+    docker_image_base: str = ''
+    enable_doc_jobs: bool = False
+    exclude_test: bool = False
+    build_generates_artifacts: bool = True
+    build_with_debug: bool = False
+    is_scheduled: str = ''
+    is_default: bool = False
+    on_pull_request: bool = False
+    num_test_shards: int = 1
+    timeout_after: int = 240
+    xcode_version: str = ''
+    ios_arch: str = ''
+    ios_platform: str = ''
+    test_jobs: Any = field(default_factory=list)
+
+    enable_default_test: bool = True
+    enable_jit_legacy_test: bool = False
+    enable_distributed_test: bool = True
+    enable_multigpu_test: bool = False
+    enable_nogpu_no_avx_test: bool = False
+    enable_nogpu_no_avx2_test: bool = False
+    enable_slow_test: bool = False
+    enable_docs_test: bool = False
+    enable_backwards_compat_test: bool = False
+    enable_xla_test: bool = False
+    enable_noarch_test: bool = False
+    enable_force_on_cpu_test: bool = False
+    enable_deploy_test: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.build_generates_artifacts:
+            self.exclude_test = True
+
+        self.multigpu_runner_type = LINUX_MULTIGPU_RUNNERS.get(self.test_runner_type, "linux.16xlarge.nvidia.gpu")
+        self.distributed_gpu_runner_type = LINUX_DISTRIBUTED_GPU_RUNNERS.get(self.test_runner_type, "linux.8xlarge.nvidia.gpu")
+
+        if LABEL_CIFLOW_DEFAULT in self.ciflow_config.labels:
+            self.is_default = True
+
+        if self.is_default:
+            self.on_pull_request = True
+
+        self.test_jobs = self._gen_test_jobs()
+        self.assert_valid()
+
+    def assert_valid(self) -> None:
+        err_message = f"invalid test_runner_type for {self.arch}: {self.test_runner_type}"
+        if self.arch == 'linux':
+            assert self.test_runner_type in LINUX_RUNNERS, err_message
+        if self.arch == 'windows':
+            assert self.test_runner_type in WINDOWS_RUNNERS, err_message
+
+        if not self.ciflow_config.isolated_workflow:
+            assert LABEL_CIFLOW_ALL in self.ciflow_config.labels
+        if self.arch == 'linux':
+            assert LABEL_CIFLOW_LINUX in self.ciflow_config.labels
+        if self.arch == 'windows':
+            assert LABEL_CIFLOW_WIN in self.ciflow_config.labels
+        if self.arch == 'macos':
+            assert LABEL_CIFLOW_MACOS in self.ciflow_config.labels
+        # Make sure that jobs with tests have a test_runner_type
+        if not self.exclude_test:
+            assert self.test_runner_type != ''
+        if self.test_runner_type in CUDA_RUNNERS:
+            assert LABEL_CIFLOW_CUDA in self.ciflow_config.labels
+        if self.test_runner_type in ROCM_RUNNERS:
+            assert LABEL_CIFLOW_ROCM in self.ciflow_config.labels
+        if self.test_runner_type in CPU_RUNNERS and not self.exclude_test:
+            assert LABEL_CIFLOW_CPU in self.ciflow_config.labels
+        if self.is_scheduled:
+            assert LABEL_CIFLOW_DEFAULT not in self.ciflow_config.labels
+            assert LABEL_CIFLOW_TRUNK not in self.ciflow_config.labels
+            assert LABEL_CIFLOW_SCHEDULED in self.ciflow_config.labels
+        if self.build_with_debug:
+            assert self.build_environment.endswith("-debug")
+
+    def generate_workflow_file(self, workflow_template: jinja2.Template) -> None:
+        output_file_path = GITHUB_DIR / f"workflows/generated-{self.build_environment}.yml"
+        with open(output_file_path, "w") as output_file:
+            GENERATED = "generated"  # Note that please keep the variable GENERATED otherwise phabricator will hide the whole file
+            output_file.writelines([f"# @{GENERATED} DO NOT EDIT MANUALLY\n"])
+            try:
+                content = workflow_template.render(asdict(self))
+            except Exception as e:
+                print(f"Failed on template: {workflow_template}", file=sys.stderr)
+                raise e
+            output_file.write(content)
+            if content[-1] != "\n":
+                output_file.write("\n")
+        print(output_file_path)
+
+    def normalized_build_environment(self, suffix: str) -> str:
+        return self.build_environment.replace(".", "_") + suffix
+
+    def _gen_test_jobs(self) -> Any:
+        if self.arch == "linux":
+            MULTIGPU_RUNNER_TYPE = "linux.16xlarge.nvidia.gpu"
+            DISTRIBUTED_GPU_RUNNER_TYPE = "linux.8xlarge.nvidia.gpu"
+            NOGPU_RUNNER_TYPE = "linux.2xlarge"
+        elif self.arch == "windows":
+            DISTRIBUTED_GPU_RUNNER_TYPE = self.test_runner_type
+            NOGPU_RUNNER_TYPE = "windows.4xlarge"
+
+        test_jobs = []
+
+        configs: Dict[str, Config] = {}
+        if self.enable_jit_legacy_test:
+            configs["jit_legacy"] = {"num_shards": 1, "runner": self.test_runner_type}
+        if self.enable_multigpu_test:
+            configs["multigpu"] = {"num_shards": 1, "runner": MULTIGPU_RUNNER_TYPE}
+
+        if self.enable_nogpu_no_avx_test:
+            configs["nogpu_NO_AVX"] = {"num_shards": 1, "runner": NOGPU_RUNNER_TYPE}
+        if self.enable_nogpu_no_avx2_test:
+            configs["nogpu_NO_AVX2"] = {"num_shards": 1, "runner": NOGPU_RUNNER_TYPE}
+        if self.enable_force_on_cpu_test:
+            configs["force_on_cpu"] = {"num_shards": 1, "runner": NOGPU_RUNNER_TYPE}
+        if self.enable_distributed_test:
+            configs["distributed"] = {
+                "num_shards": 1,
+                "runner": DISTRIBUTED_GPU_RUNNER_TYPE
+                if "cuda" in str(self.build_environment)
+                else self.test_runner_type,
+            }
+        if self.enable_slow_test:
+            configs["slow"] = {"num_shards": 1, "runner": self.test_runner_type}
+        if self.enable_docs_test:
+            configs["docs_test"] = {"num_shards": 1, "runner": self.test_runner_type}
+        if self.enable_backwards_compat_test:
+            configs["backwards_compat"] = {
+                "num_shards": 1,
+                "runner": self.test_runner_type,
+            }
+        if self.enable_xla_test:
+            configs["xla"] = {"num_shards": 1, "runner": self.test_runner_type}
+        if self.enable_noarch_test:
+            configs["noarch"] = {"num_shards": 1, "runner": self.test_runner_type}
+        if self.enable_deploy_test:
+            configs["deploy"] = {"num_shards": 1, "runner": self.test_runner_type}
+
+        for name, config in configs.items():
+            for shard in range(1, config["num_shards"] + 1):
+                test_jobs.append(
+                    {
+                        "id": f"test_{name}_{shard}_{config['num_shards']}",
+                        "name": f"test ({name}, {shard}, {config['num_shards']}, {config['runner']})",
+                        "config": name,
+                        "shard": shard,
+                        "num_shards": config["num_shards"],
+                        "runner": config["runner"],
+                    }
+                )
+
+        if self.enable_default_test:
+            for shard in range(1, self.num_test_shards + 1):
+                test_jobs.append(
+                    {
+                        "id": f"test_default_{shard}_{self.num_test_shards}",
+                        "name": f"test (default, {shard}, {self.num_test_shards}, {self.test_runner_type})",
+                        "config": "default",
+                        "shard": shard,
+                        "num_shards": self.num_test_shards,
+                        "runner": self.test_runner_type,
+                    }
+                )
+        return test_jobs
+
+@dataclass
+class DockerWorkflow:
+    build_environment: str
+    docker_images: List[str]
+
+    # Optional fields
+    ciflow_config: CIFlowConfig = field(default_factory=CIFlowConfig)
+    cuda_version: str = ''
+    is_scheduled: str = ''
+
+    def generate_workflow_file(self, workflow_template: jinja2.Template) -> None:
+        output_file_path = GITHUB_DIR / "workflows/generated-docker-builds.yml"
+        with open(output_file_path, "w") as output_file:
+            GENERATED = "generated"  # Note that please keep the variable GENERATED otherwise phabricator will hide the whole file
+            output_file.writelines([f"# @{GENERATED} DO NOT EDIT MANUALLY\n"])
+            try:
+                content = workflow_template.render(asdict(self))
+            except Exception as e:
+                print(f"Failed on template: {workflow_template}", file=sys.stderr)
+                raise e
+            output_file.write(content)
+            if content[-1] != "\n":
+                output_file.write("\n")
+        print(output_file_path)
+
 @dataclass
 class BinaryBuildWorkflow:
     os: str
@@ -78,6 +283,544 @@ class BinaryBuildWorkflow:
             if content[-1] != "\n":
                 output_file.write("\n")
         print(output_file_path)
+
+WINDOWS_WORKFLOWS = [
+    CIWorkflow(
+        arch="windows",
+        build_environment="win-vs2019-cpu-py3",
+        cuda_version="cpu",
+        enable_distributed_test=False,
+        test_runner_type=WINDOWS_CPU_TEST_RUNNER,
+        num_test_shards=2,
+        ciflow_config=CIFlowConfig(
+            run_on_canary=True,
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_CPU, LABEL_CIFLOW_WIN}
+        ),
+    ),
+    CIWorkflow(
+        arch="windows",
+        build_environment="win-vs2019-cuda11.3-py3",
+        cuda_version="11.3",
+        enable_distributed_test=False,
+        test_runner_type=WINDOWS_CUDA_TEST_RUNNER,
+        num_test_shards=2,
+        enable_force_on_cpu_test=True,
+        # TODO: Revert back to default value after https://github.com/pytorch/pytorch/issues/73489 is closed
+        timeout_after=270,
+        ciflow_config=CIFlowConfig(
+            run_on_canary=True,
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_CUDA, LABEL_CIFLOW_WIN}
+        ),
+    ),
+    CIWorkflow(
+        arch="windows",
+        build_environment="periodic-win-vs2019-cuda11.5-py3",
+        cuda_version="11.5",
+        enable_distributed_test=False,
+        test_runner_type=WINDOWS_CUDA_TEST_RUNNER,
+        num_test_shards=2,
+        enable_force_on_cpu_test=True,
+        is_scheduled="45 4,10,16,22 * * *",
+        ciflow_config=CIFlowConfig(
+            run_on_canary=True,
+            labels={LABEL_CIFLOW_SCHEDULED, LABEL_CIFLOW_CUDA, LABEL_CIFLOW_WIN}
+        ),
+    ),
+]
+
+LINUX_WORKFLOWS = [
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-xenial-py3.7-gcc5.4",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.7-gcc5.4",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        enable_jit_legacy_test=True,
+        enable_backwards_compat_test=True,
+        enable_docs_test=True,
+        num_test_shards=2,
+        ciflow_config=CIFlowConfig(
+            run_on_canary=True,
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU}
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-docs",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.7-gcc5.4",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        enable_doc_jobs=True,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_DOCS, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU}
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-docs-push",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.7-gcc5.4",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        enable_doc_jobs=True,
+        exclude_test=True,
+        is_scheduled="0 0 * * *",  # run pushes only on a nightly schedule
+        # NOTE: This is purposefully left without LABEL_CIFLOW_DOCS so that you can run
+        #       docs builds on your PR without the fear of anything pushing
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_SCHEDULED, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU}
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-xenial-py3.7-gcc7",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.7-gcc7",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        num_test_shards=2,
+        ciflow_config=CIFlowConfig(
+            run_on_canary=True,
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU}
+        ),
+    ),
+    # ParallelTBB does not have a maintainer and is currently flaky
+    # CIWorkflow(
+    #    arch="linux",
+    #    build_environment="paralleltbb-linux-xenial-py3.6-gcc5.4",
+    #    docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.6-gcc5.4",
+    #    test_runner_type=LINUX_CPU_TEST_RUNNER,
+    #    ciflow_config=CIFlowConfig(
+    #        labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU},
+    #    ),
+    # ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="parallelnative-linux-xenial-py3.7-gcc5.4",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.7-gcc5.4",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU},
+        ),
+    ),
+    # Build PyTorch with BUILD_CAFFE2=ON
+    CIWorkflow(
+        arch="linux",
+        build_environment="caffe2-linux-xenial-py3.7-gcc5.4",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.7-gcc5.4",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU},
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-xenial-py3-clang5-mobile-build",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-asan",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        build_generates_artifacts=False,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_MOBILE, LABEL_CIFLOW_DEFAULT},
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="deploy-linux-xenial-cuda11.3-py3.7-gcc7",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7",
+        test_runner_type=LINUX_CUDA_TEST_RUNNER,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CUDA, LABEL_CIFLOW_DEFAULT},
+        ),
+        enable_default_test=False,
+        enable_distributed_test=False,
+        enable_deploy_test=True,
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-xenial-py3-clang5-mobile-custom-build-static",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        build_generates_artifacts=False,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_MOBILE, LABEL_CIFLOW_DEFAULT},
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-xenial-py3.7-gcc5.4-mobile-lightweight-dispatch-build",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.7-gcc5.4",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        build_generates_artifacts=False,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_MOBILE, LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_LIBTORCH, LABEL_CIFLOW_CPU},
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-xenial-py3.7-clang7-asan",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang7-asan",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        num_test_shards=3,
+        enable_distributed_test=False,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_SANITIZERS, LABEL_CIFLOW_CPU},
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-xenial-py3.7-clang7-onnx",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang7-onnx",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        num_test_shards=2,
+        enable_distributed_test=False,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_ONNX, LABEL_CIFLOW_CPU},
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-bionic-cuda10.2-py3.9-gcc7",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7",
+        test_runner_type=LINUX_CUDA_TEST_RUNNER,
+        enable_jit_legacy_test=True,
+        enable_multigpu_test=True,
+        enable_nogpu_no_avx_test=True,
+        enable_nogpu_no_avx2_test=True,
+        enable_slow_test=True,
+        num_test_shards=2,
+        ciflow_config=CIFlowConfig(
+            run_on_canary=True,
+            labels={LABEL_CIFLOW_SLOW, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CUDA}
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="libtorch-linux-xenial-cuda10.2-py3.7-gcc7",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7",
+        test_runner_type=LINUX_CUDA_TEST_RUNNER,
+        build_generates_artifacts=False,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels=set([LABEL_CIFLOW_LIBTORCH, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CUDA]),
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="periodic-linux-bionic-cuda11.5-py3.7-gcc7",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-cuda11.5-cudnn8-py3-gcc7",
+        test_runner_type=LINUX_CUDA_TEST_RUNNER,
+        num_test_shards=2,
+        is_scheduled="45 4,10,16,22 * * *",
+        ciflow_config=CIFlowConfig(
+            labels=set([LABEL_CIFLOW_SCHEDULED, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CUDA]),
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="periodic-libtorch-linux-bionic-cuda11.5-py3.7-gcc7",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-cuda11.5-cudnn8-py3-gcc7",
+        test_runner_type=LINUX_CUDA_TEST_RUNNER,
+        build_generates_artifacts=False,
+        is_scheduled="45 4,10,16,22 * * *",
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels=set([LABEL_CIFLOW_SCHEDULED, LABEL_CIFLOW_LIBTORCH, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CUDA]),
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-xenial-cuda11.3-py3.7-gcc7",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7",
+        test_runner_type=LINUX_CUDA_TEST_RUNNER,
+        num_test_shards=2,
+        ciflow_config=CIFlowConfig(
+            labels=set([LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CUDA]),
+        ),
+    ),
+    # no-ops builds test USE_PER_OPERATOR_HEADERS=0 where ATen/ops is not generated
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-xenial-cuda11.3-py3.7-gcc7-no-ops",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7",
+        test_runner_type=LINUX_CUDA_TEST_RUNNER,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels=set([LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CUDA]),
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-xenial-py3.7-gcc7-no-ops",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.7-gcc7",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels=set([LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU]),
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-bionic-rocm4.5-py3.7",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-rocm4.5-py3.7",
+        test_runner_type=LINUX_ROCM_TEST_RUNNER,
+        num_test_shards=2,
+        ciflow_config=CIFlowConfig(
+            labels=set([LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_ROCM]),
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="libtorch-linux-xenial-cuda11.3-py3.7-gcc7",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7",
+        test_runner_type=LINUX_CUDA_TEST_RUNNER,
+        build_generates_artifacts=False,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels=set([LABEL_CIFLOW_LIBTORCH, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CUDA]),
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="periodic-linux-xenial-cuda11.3-py3.7-gcc7-debug",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7",
+        test_runner_type=LINUX_CUDA_TEST_RUNNER,
+        num_test_shards=2,
+        build_with_debug=True,
+        is_scheduled="45 0,4,8,12,16,20 * * *",
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_SCHEDULED, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CUDA}
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-bionic-py3.7-clang9",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-py3.7-clang9",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        num_test_shards=2,
+        enable_distributed_test=False,
+        enable_noarch_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU, LABEL_CIFLOW_NOARCH},
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-vulkan-bionic-py3.7-clang9",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-py3.7-clang9",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        num_test_shards=1,
+        enable_distributed_test=False,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU, LABEL_CIFLOW_VULKAN},
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="periodic-linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7",
+        test_runner_type=LINUX_CUDA_TEST_RUNNER,
+        num_test_shards=2,
+        enable_distributed_test=False,
+        timeout_after=360,
+        # Only run this on master 4 times per day since it does take a while
+        is_scheduled="0 */4 * * *",
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CUDA, LABEL_CIFLOW_SLOW_GRADCHECK, LABEL_CIFLOW_SLOW, LABEL_CIFLOW_SCHEDULED},
+        ),
+    ),
+]
+
+XLA_WORKFLOWS = [
+    CIWorkflow(
+        arch="linux",
+        build_environment="pytorch-xla-linux-bionic-py3.7-clang8",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/xla_base",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        enable_distributed_test=False,
+        enable_xla_test=True,
+        enable_default_test=False,
+        on_pull_request=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU, LABEL_CIFLOW_XLA},
+        ),
+    ),
+
+]
+
+ANDROID_SHORT_WORKFLOWS = [
+    CIWorkflow(
+        arch="linux",
+        build_environment="pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU, LABEL_CIFLOW_ANDROID, LABEL_CIFLOW_DEFAULT},
+        ),
+    ),
+    CIWorkflow(
+        arch="linux",
+        build_environment="pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU, LABEL_CIFLOW_ANDROID, LABEL_CIFLOW_DEFAULT},
+        ),
+    ),
+]
+
+ANDROID_WORKFLOWS = [
+    CIWorkflow(
+        arch="linux",
+        build_environment="pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_LINUX, LABEL_CIFLOW_CPU, LABEL_CIFLOW_ANDROID},
+        ),
+    ),
+]
+
+BAZEL_WORKFLOWS = [
+    CIWorkflow(
+        arch="linux",
+        build_environment="linux-xenial-cuda11.3-py3.7-gcc7-bazel-test",
+        docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_DEFAULT, LABEL_CIFLOW_BAZEL, LABEL_CIFLOW_CPU, LABEL_CIFLOW_LINUX},
+        ),
+    ),
+]
+
+IOS_WORKFLOWS = [
+    CIWorkflow(
+        arch="macos",
+        build_environment="ios-12-5-1-arm64",
+        ios_arch="arm64",
+        ios_platform="OS",
+        test_runner_type=MACOS_TEST_RUNNER_10_15,
+        is_scheduled="45 4,10,16,22 * * *",
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_SCHEDULED, LABEL_CIFLOW_IOS, LABEL_CIFLOW_MACOS},
+        ),
+    ),
+    CIWorkflow(
+        arch="macos",
+        build_environment="ios-12-5-1-arm64-coreml",
+        ios_arch="arm64",
+        ios_platform="OS",
+        test_runner_type=MACOS_TEST_RUNNER_10_15,
+        is_scheduled="45 4,10,16,22 * * *",
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_SCHEDULED, LABEL_CIFLOW_IOS, LABEL_CIFLOW_MACOS},
+        ),
+    ),
+    CIWorkflow(
+        arch="macos",
+        build_environment="ios-12-5-1-arm64-custom-ops",
+        ios_arch="arm64",
+        ios_platform="OS",
+        test_runner_type=MACOS_TEST_RUNNER_10_15,
+        is_scheduled="45 4,10,16,22 * * *",
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_SCHEDULED, LABEL_CIFLOW_IOS, LABEL_CIFLOW_MACOS},
+        ),
+    ),
+    CIWorkflow(
+        arch="macos",
+        build_environment="ios-12-5-1-arm64-metal",
+        ios_arch="arm64",
+        ios_platform="OS",
+        test_runner_type=MACOS_TEST_RUNNER_10_15,
+        is_scheduled="45 4,10,16,22 * * *",
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_SCHEDULED, LABEL_CIFLOW_IOS, LABEL_CIFLOW_MACOS},
+        ),
+    ),
+    CIWorkflow(
+        arch="macos",
+        build_environment="ios-12-5-1-x86-64",
+        ios_arch="x86_64",
+        ios_platform="SIMULATOR",
+        test_runner_type=MACOS_TEST_RUNNER_10_15,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_IOS, LABEL_CIFLOW_MACOS},
+        ),
+    ),
+    CIWorkflow(
+        arch="macos",
+        build_environment="ios-12-5-1-x86-64-coreml",
+        ios_arch="x86_64",
+        ios_platform="SIMULATOR",
+        test_runner_type=MACOS_TEST_RUNNER_10_15,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_IOS, LABEL_CIFLOW_MACOS},
+        ),
+    ),
+]
+
+MACOS_WORKFLOWS = [
+    # Distributed tests are still run on MacOS, but part of regular shards
+    CIWorkflow(
+        arch="macos",
+        build_environment="macos-11-py3-x86-64",
+        xcode_version="12.4",
+        test_runner_type=MACOS_TEST_RUNNER_11,
+        num_test_shards=2,
+        enable_distributed_test=False,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_MACOS},
+        ),
+    ),
+    CIWorkflow(
+        arch="macos",
+        build_environment="macos-10-15-py3-lite-interpreter-x86-64",
+        xcode_version="12",
+        test_runner_type=MACOS_TEST_RUNNER_10_15,
+        exclude_test=True,
+        build_generates_artifacts=False,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_MACOS},
+        ),
+    ),
+    CIWorkflow(
+        arch="macos",
+        build_environment="macos-10-15-py3-arm64",
+        test_runner_type=MACOS_TEST_RUNNER_10_15,
+        exclude_test=True,
+        ciflow_config=CIFlowConfig(
+            labels={LABEL_CIFLOW_MACOS},
+        ),
+    ),
+]
+
+DOCKER_IMAGES = {
+    f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-rocm4.3.1-py3.7",               # for rocm
+    f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-rocm4.5-py3.7",                 # for rocm
+}
+
+DOCKER_IMAGES.update({
+    workflow.docker_image_base
+    for workflow in [*LINUX_WORKFLOWS, *BAZEL_WORKFLOWS, *ANDROID_WORKFLOWS]
+    if workflow.docker_image_base
+})
+
+DOCKER_WORKFLOWS = [
+    DockerWorkflow(
+        build_environment="docker-builds",
+        docker_images=sorted(DOCKER_IMAGES),
+        # Run every Wednesday at 3:01am to ensure they can build
+        is_scheduled="1 3 * * 3",
+    ),
+]
 
 class OperatingSystem:
     LINUX = "linux"

--- a/.github/workflows/generated-deploy-linux-xenial-cuda11.3-py3.7-gcc7.yml
+++ b/.github/workflows/generated-deploy-linux-xenial-cuda11.3-py3.7-gcc7.yml
@@ -1,0 +1,509 @@
+# @generated DO NOT EDIT MANUALLY
+# Template is at:    .github/templates/linux_ci_workflow.yml.j2
+# Generation script: .github/scripts/generate_ci_workflows.py
+name: deploy-linux-xenial-cuda11.3-py3.7-gcc7
+
+on:
+  pull_request:
+  push:
+    tags:
+      - 'ciflow/all/*'
+      - 'ciflow/cuda/*'
+      - 'ciflow/linux/*'
+      - 'ciflow/trunk/*'
+    branches:
+      - master
+      - main
+      - release/*
+  workflow_dispatch:
+
+env:
+  BUILD_ENVIRONMENT: deploy-linux-xenial-cuda11.3-py3.7-gcc7
+  DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
+  SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
+  XLA_CLANG_CACHE_S3_BUCKET_NAME: ossci-compiler-clang-cache-circleci-xla
+  TORCH_CUDA_ARCH_LIST: 5.2
+  IN_CI: 1
+  IS_GHA: 1
+  # This is used for the phase of adding wheel tests only, will be removed once completed
+  IN_WHEEL_TEST: 1
+  # Used for custom_opertor, jit_hooks, custom_backend, see .jenkins/pytorch/build.sh
+  CUSTOM_TEST_ARTIFACT_BUILD_DIR: build/custom_test_artifacts
+  ALPINE_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/tool/alpine"
+  PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  AWS_DEFAULT_REGION: us-east-1
+  PR_NUMBER: ${{ github.event.pull_request.number }}
+  SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+  PYTORCH_RETRY_TEST_CASES: 1
+concurrency:
+  group: deploy-linux-xenial-cuda11.3-py3.7-gcc7-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    runs-on: linux.2xlarge
+    timeout-minutes: 240
+    env:
+      JOB_BASE_NAME: deploy-linux-xenial-cuda11.3-py3.7-gcc7-build
+    outputs:
+      docker_image: ${{ steps.calculate-tag.outputs.docker_image }}
+    steps:
+      - name: print labels
+        run: echo "${PR_LABELS}"
+      - name: Display EC2 information
+        shell: bash
+        run: |
+          set -euo pipefail
+          function get_ec2_metadata() {
+            # Pulled from instance metadata endpoint for EC2
+            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+            category=$1
+            curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+          }
+          echo "ami-id: $(get_ec2_metadata ami-id)"
+          echo "instance-id: $(get_ec2_metadata instance-id)"
+          echo "instance-type: $(get_ec2_metadata instance-type)"
+      - name: Log in to ECR
+        env:
+          AWS_RETRY_MODE: standard
+          AWS_MAX_ATTEMPTS: 5
+        run: |
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
+          retry () {
+              "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@")
+          }
+          retry aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS \
+              --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"
+      - name: Chown workspace
+        run: |
+          retry () {
+              "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@")
+          }
+          retry docker pull "${ALPINE_IMAGE}"
+          # Ensure the working directory gets chowned back to the current user
+          docker run --pull=never --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
+      - name: Clean workspace
+        run: |
+          rm -rf "${GITHUB_WORKSPACE}"
+          mkdir "${GITHUB_WORKSPACE}"
+      - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
+        uses: seemethere/add-github-ssh-key@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Preserve github env variables for use in docker
+        run: |
+          env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
+      - name: Checkout PyTorch
+        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
+          submodules: recursive
+      - name: Clean PyTorch checkout
+        run: |
+          # Remove any artifacts from the previous checkouts
+          git clean -fxd
+      - name: Calculate docker image tag
+        id: calculate-tag
+        run: |
+          DOCKER_TAG=$(git rev-parse HEAD:.circleci/docker)
+          echo "DOCKER_TAG=${DOCKER_TAG}" >> "${GITHUB_ENV}"
+          echo "DOCKER_IMAGE=${DOCKER_IMAGE_BASE}:${DOCKER_TAG}" >> "${GITHUB_ENV}"
+          echo "::set-output name=docker_tag::${DOCKER_TAG}"
+          echo "::set-output name=docker_image::${DOCKER_IMAGE_BASE}:${DOCKER_TAG}"
+      - name: Check if image should be built
+        id: check
+        env:
+          BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
+        run: |
+          set -x
+          # Check if image already exists, if it does then skip building it
+          if docker manifest inspect "${DOCKER_IMAGE_BASE}:${DOCKER_TAG}"; then
+            exit 0
+          fi
+          if [[ "$BASE_REVISION" = "$(git rev-parse HEAD)" ]]; then
+            # if we're on the base branch then use the parent commit
+            MERGE_BASE=$(git rev-parse HEAD~)
+          else
+            # otherwise we're on a PR, so use the most recent base commit
+            MERGE_BASE=$(git merge-base HEAD "$BASE_REVISION")
+          fi
+          # Covers the case where a previous tag doesn't exist for the tree
+          # this is only really applicable on trees that don't have `.circleci/docker` at its merge base, i.e. nightly
+          if ! git rev-parse "$MERGE_BASE:.circleci/docker"; then
+            echo "Directory '.circleci/docker' not found in commit $MERGE_BASE, you should probably rebase onto a more recent commit"
+            exit 1
+          fi
+          PREVIOUS_DOCKER_TAG=$(git rev-parse "$MERGE_BASE:.circleci/docker")
+          # If no image exists but the hash is the same as the previous hash then we should error out here
+          if [[ "${PREVIOUS_DOCKER_TAG}" = "${DOCKER_TAG}" ]]; then
+            echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+            echo "       contact the PyTorch team to restore the original images"
+            exit 1
+          fi
+          echo ::set-output name=rebuild::yes
+      - name: Build and push docker image
+        if: ${{ steps.check.outputs.rebuild }}
+        env:
+          DOCKER_SKIP_S3_UPLOAD: 1
+        working-directory: .circleci/docker
+        run: |
+          export IMAGE_NAME=${DOCKER_IMAGE_BASE#308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/}
+          ./build_docker.sh
+      - name: Pull Docker image
+        run: |
+          retry () {
+              "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@")
+          }
+          retry docker pull "${DOCKER_IMAGE}"
+      - name: Parse ref
+        shell: bash
+        id: parse-ref
+        run: ./.github/scripts/parse_ref.py
+      - name: Build
+        env:
+          BRANCH: ${{ steps.parse-ref.outputs.branch }}
+        run: |
+          # detached container should get cleaned up by teardown_ec2_linux
+          container_name=$(docker run \
+            -e BUILD_ENVIRONMENT \
+            -e JOB_BASE_NAME \
+            -e MAX_JOBS="$(nproc --ignore=2)" \
+            -e AWS_DEFAULT_REGION \
+            -e IS_GHA \
+            -e PR_NUMBER \
+            -e SHA1 \
+            -e BRANCH \
+            -e GITHUB_RUN_ID \
+            -e SCCACHE_BUCKET \
+            -e XLA_CLANG_CACHE_S3_BUCKET_NAME \
+            -e CUSTOM_TEST_ARTIFACT_BUILD_DIR \
+            -e SKIP_SCCACHE_INITIALIZATION=1 \
+            -e TORCH_CUDA_ARCH_LIST \
+            -e PR_LABELS \
+            -e http_proxy="http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128" -e https_proxy="http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128" -e no_proxy="localhost,127.0.0.1,github.com,amazonaws.com,s3.amazonaws.com,169.254.169.254,169.254.170.2,/var/run/docker.sock" \
+            --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
+            --security-opt seccomp=unconfined \
+            --cap-add=SYS_PTRACE \
+            --tty \
+            --detach \
+            --user jenkins \
+            -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -w /var/lib/jenkins/workspace \
+            "${DOCKER_IMAGE}"
+          )
+          docker exec -t "${container_name}" sh -c 'sudo chown -R jenkins . && .jenkins/pytorch/build.sh'
+      - name: Display and upload binary build size statistics (Click Me)
+        # temporary hack: set CIRCLE_* vars, until we update
+        # tools/stats/print_test_stats.py to natively support GitHub Actions
+        env:
+          SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
+          BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          TAG: ${{ steps.parse-ref.outputs.tag }}
+          WORKFLOW_ID: '${{ github.run_id }}'
+        run: |
+          COMMIT_TIME=$(git log --max-count=1 --format=%ct || echo 0)
+          export COMMIT_TIME
+          pip3 install requests==2.26 boto3==1.16.34
+          python3 -m tools.stats.upload_binary_size_to_scuba || exit 0
+      - name: Chown workspace
+        run: |
+          # Ensure the working directory gets chowned back to the current user
+          docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
+      - name: Archive artifacts into zip
+        run: |
+          zip -1 -r artifacts.zip dist/ build/custom_test_artifacts build/lib build/bin .pytorch-test-times.json
+      - uses: seemethere/upload-artifact-s3@v3
+        name: Store PyTorch Build Artifacts on S3
+        with:
+          name: ${{ env.BUILD_ENVIRONMENT }}
+          retention-days: 14
+          if-no-files-found: error
+          path:
+            artifacts.zip
+      - name: Hold runner for 2 hours or until ssh sessions have drained
+        # Always hold for active ssh sessions
+        if: always()
+        run: .github/scripts/wait_for_ssh_to_drain.sh
+      - name: Chown workspace
+        if: always()
+        run: |
+          # Ensure the working directory gets chowned back to the current user
+          docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
+      - name: Kill containers, clean up images
+        if: always()
+        run: |
+          # ignore expansion of "docker ps -q" since it could be empty
+          # shellcheck disable=SC2046
+          docker stop $(docker ps -q) || true
+          # Prune all of the docker images
+          docker system prune -af
+      - name: Hold runner for 2 hours or until ssh sessions have drained
+        # Always hold for active ssh sessions
+        if: always()
+        run: .github/scripts/wait_for_ssh_to_drain.sh
+      - name: Clean up docker images
+        if: always()
+        run: |
+          # Prune all of the docker images
+          docker system prune -af
+
+  test_deploy_1_1:
+    name: test (deploy, 1, 1, linux.4xlarge.nvidia.gpu)
+    needs: build
+    runs-on: linux.4xlarge.nvidia.gpu
+    timeout-minutes: 240
+    env:
+      DOCKER_IMAGE: ${{ needs.build.outputs.docker_image }}
+      JOB_BASE_NAME: deploy-linux-xenial-cuda11.3-py3.7-gcc7-test
+      TEST_CONFIG: deploy
+      SHARD_NUMBER: 1
+      NUM_TEST_SHARDS: 1
+      PR_BODY: ${{ github.event.pull_request.body }}
+    steps:
+      - name: Display EC2 information
+        shell: bash
+        run: |
+          set -euo pipefail
+          function get_ec2_metadata() {
+            # Pulled from instance metadata endpoint for EC2
+            # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+            category=$1
+            curl -fsSL "http://169.254.169.254/latest/meta-data/${category}"
+          }
+          echo "ami-id: $(get_ec2_metadata ami-id)"
+          echo "instance-id: $(get_ec2_metadata instance-id)"
+          echo "instance-type: $(get_ec2_metadata instance-type)"
+      - name: Log in to ECR
+        env:
+          AWS_RETRY_MODE: standard
+          AWS_MAX_ATTEMPTS: 5
+        run: |
+          AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
+          retry () {
+              "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@")
+          }
+          retry aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | docker login --username AWS \
+              --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com"
+      - name: Chown workspace
+        run: |
+          retry () {
+              "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@")
+          }
+          retry docker pull "${ALPINE_IMAGE}"
+          # Ensure the working directory gets chowned back to the current user
+          docker run --pull=never --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
+      - name: Clean workspace
+        run: |
+          rm -rf "${GITHUB_WORKSPACE}"
+          mkdir "${GITHUB_WORKSPACE}"
+      - name: "[FB EMPLOYEES] Enable SSH (Click me for login details)"
+        uses: seemethere/add-github-ssh-key@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Preserve github env variables for use in docker
+        run: |
+          env | grep '^GITHUB' > "/tmp/github_env_${GITHUB_RUN_ID}"
+      - name: Checkout PyTorch
+        uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # deep clone, to allow use of git merge-base
+          fetch-depth: 0
+          submodules: recursive
+      - name: Clean PyTorch checkout
+        run: |
+          # Remove any artifacts from the previous checkouts
+          git clean -fxd
+      - name: Pull Docker image
+        run: |
+          retry () {
+              "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@")
+          }
+          retry docker pull "${DOCKER_IMAGE}"
+      - uses: nick-fields/retry@71062288b76e2b6214ebde0e673ce0de1755740a
+        name: Install nvidia driver, nvidia-docker runtime, set GPU_FLAG
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: |
+            set -ex
+            bash .github/scripts/install_nvidia_utils_linux.sh
+            echo "GPU_FLAG=--gpus all" >> "${GITHUB_ENV}"
+      - name: Determine shm-size
+        run: |
+          shm_size="1g"
+          case "${BUILD_ENVIRONMENT}" in
+            *cuda*)
+              shm_size="2g"
+              ;;
+            *rocm*)
+              shm_size="8g"
+              ;;
+          esac
+          echo "SHM_SIZE=${shm_size}" >> "${GITHUB_ENV}"
+      - uses: seemethere/download-artifact-s3@0504774707cbc8603d7dca922e8026eb8bf3b47b
+        name: Download PyTorch Build Artifacts
+        with:
+          name: ${{ env.BUILD_ENVIRONMENT }}
+      - name: Unzip artifacts
+        run: |
+          unzip -o artifacts.zip
+      - name: Output disk space left
+        run: |
+          sudo df -H
+      - name: Parse ref
+        shell: bash
+        id: parse-ref
+        run: ./.github/scripts/parse_ref.py
+      - name: Test
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ steps.parse-ref.outputs.branch }}
+        # Time out the test phase after 240 minutes
+        timeout-minutes: 240
+        run: |
+          set -x
+
+          if [[ $TEST_CONFIG == 'multigpu' ]]; then
+            TEST_COMMAND=.jenkins/pytorch/multigpu-test.sh
+          elif [[ $BUILD_ENVIRONMENT == *onnx* ]]; then
+            TEST_COMMAND=.jenkins/caffe2/test.sh
+          else
+            TEST_COMMAND=.jenkins/pytorch/test.sh
+          fi
+          PROXY_ENV=
+          # NOTE: XLA multiprocessing tests appear to have issues with squid proxy, going to disable for now
+          #       We should investigate whether or not there's a list of hostnames we can add to no_proxy to
+          #       make it so that we shouldn't have to fully disable squid for XLA tests
+          if [[ $TEST_CONFIG != 'xla' ]]; then
+            # shellcheck disable=SC2089
+            PROXY_ENV="-e http_proxy=http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128 -e https_proxy=http://internal-tf-lb-20210727220640487900000002-835786077.us-east-1.elb.amazonaws.com:3128 -e no_proxy=localhost,127.0.0.1,github.com,amazonaws.com,s3.amazonaws.com,169.254.169.254,169.254.170.2,/var/run/docker.sock"
+          fi
+          # detached container should get cleaned up by teardown_ec2_linux
+          # TODO: Stop building test binaries as part of the build phase
+          # Used for GPU_FLAG since that doesn't play nice
+          # shellcheck disable=SC2086,SC2090
+          container_name=$(docker run \
+            ${GPU_FLAG:-} \
+            -e BUILD_ENVIRONMENT \
+            -e PR_NUMBER \
+            -e CUSTOM_TEST_ARTIFACT_BUILD_DIR \
+            -e GITHUB_ACTIONS \
+            -e IN_CI \
+            -e IS_GHA \
+            -e BRANCH \
+            -e SHA1 \
+            -e AWS_DEFAULT_REGION \
+            -e IN_WHEEL_TEST \
+            -e SHARD_NUMBER \
+            -e JOB_BASE_NAME \
+            -e TEST_CONFIG \
+            -e NUM_TEST_SHARDS \
+            -e PR_BODY \
+            -e PYTORCH_RETRY_TEST_CASES \
+            -e PR_LABELS \
+            -e MAX_JOBS="$(nproc --ignore=2)" \
+            -e SCCACHE_BUCKET \
+            -e XLA_CLANG_CACHE_S3_BUCKET_NAME \
+            ${PROXY_ENV} \
+            --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
+            --ulimit stack=10485760:83886080 \
+            --security-opt seccomp=unconfined \
+            --cap-add=SYS_PTRACE \
+            --ipc=host \
+            --shm-size="${SHM_SIZE}" \
+            --tty \
+            --detach \
+            --name="${container_name}" \
+            --user jenkins \
+            -v "${GITHUB_WORKSPACE}:/var/lib/jenkins/workspace" \
+            -w /var/lib/jenkins/workspace \
+            "${DOCKER_IMAGE}"
+          )
+          docker exec -t "${container_name}" sh -c "sudo chown -R jenkins . && pip install dist/*.whl && ${TEST_COMMAND}"
+      - name: Chown workspace
+        if: always()
+        run: |
+          # Ensure the working directory gets chowned back to the current user
+          docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
+      - name: Install render_test_results dependencies
+        if: always()
+        shell: bash
+        run: |
+          python3 -m pip install junitparser==2.1.1 rich==10.9.0
+      - name: "[[ Click me for rendered test results (useful for finding failing tests) ]]"
+        if: always()
+        shell: bash
+        # Encoding is weird on windows, just try to default to utf-8 if possible
+        env:
+          PYTHONIOENCODING: "utf-8"
+        run: |
+          python3 tools/render_junit.py test/
+      - name: Zip JSONs for upload
+        if: always()
+        env:
+          FILE_SUFFIX: '${{ github.job }}-deploy-1-1-linux.4xlarge.nvidia.gpu'
+        run: |
+          # Remove any previous test jsons if they exist
+          rm -f test-jsons-*.zip
+          zip -r "test-jsons-${FILE_SUFFIX}.zip" test -i '*.json'
+      - uses: seemethere/upload-artifact-s3@v3
+        name: Store Test Downloaded JSONs on S3
+        if: always()
+        with:
+          retention-days: 14
+          if-no-files-found: warn
+          path:
+            test-jsons-*.zip
+      - name: Zip test reports for upload
+        if: always()
+        env:
+          FILE_SUFFIX: '${{ github.job }}-deploy-1-1-linux.4xlarge.nvidia.gpu'
+        run: |
+          # Remove any previous test reports if they exist
+          rm -f test-reports-*.zip
+          zip -r "test-reports-${FILE_SUFFIX}.zip" test -i '*.xml'
+      - uses: seemethere/upload-artifact-s3@v3
+        name: Store Test Reports on S3
+        if: always()
+        with:
+          retention-days: 14
+          if-no-files-found: error
+          path:
+            test-reports-*.zip
+      - name: Upload test statistics
+        if: always()
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          BRANCH: ${{ steps.parse-ref.outputs.branch }}
+          JOB_BASE_NAME: deploy-linux-xenial-cuda11.3-py3.7-gcc7-test
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          TAG: ${{ steps.parse-ref.outputs.tag }}
+          WORKFLOW_ID: '${{ github.run_id }}'
+        shell: bash
+        run: |
+          python3 -m pip install -r requirements.txt
+          python3 -m pip install boto3==1.19.12
+          python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
+      - name: Hold runner for 2 hours or until ssh sessions have drained
+        # Always hold for active ssh sessions
+        if: always()
+        run: .github/scripts/wait_for_ssh_to_drain.sh
+      - name: Chown workspace
+        if: always()
+        run: |
+          # Ensure the working directory gets chowned back to the current user
+          docker run --rm -v "$(pwd)":/v -w /v "${ALPINE_IMAGE}" chown -R "$(id -u):$(id -g)" .
+      - name: Kill containers, clean up images
+        if: always()
+        run: |
+          # ignore expansion of "docker ps -q" since it could be empty
+          # shellcheck disable=SC2046
+          docker stop $(docker ps -q) || true
+          # Prune all of the docker images
+          docker system prune -af

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -540,7 +540,6 @@ test_torch_deploy() {
   ln -sf "$TORCH_LIB_DIR"/libshm* "$TORCH_BIN_DIR"
   ln -sf "$TORCH_LIB_DIR"/libc10* "$TORCH_BIN_DIR"
   "$TORCH_BIN_DIR"/test_deploy
-  "$TORCH_BIN_DIR"/test_deploy_gpu
   assert_git_not_dirty
 }
 

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -161,6 +161,8 @@ return a DOT-formatted graph showing all the dependency paths between ``src`` an
 
 If you would just like to see the whole dependency graph of your :class:`PackageExporter`, you can use :meth:`PackageExporter.dependency_graph_string`.
 
+If you would like to find a dependency path for each broken module in a packaging error you can use :meth:`package.analyze.find_first_use_of_broken_modules`
+
 
 Include arbitrary resources with my package and access them later?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -245,6 +245,9 @@ class TestDependencyAPI(PackageTestCase):
                 * Module did not match against any action pattern. Extern, mock, or intern it.
                     package_a
                     package_a.subpackage
+                We offer tools to help you figure out why modules were included as a dependency
+                to help you figure out if they are actually needed here:
+                https://pytorch.org/docs/stable/package.html#see-why-a-given-module-was-included-as-a-dependency.
                 """
             ),
         )
@@ -292,6 +295,9 @@ class TestDependencyAPI(PackageTestCase):
                 * Module is a C extension module. torch.package supports Python modules only.
                     foo
                     bar
+                We offer tools to help you figure out why modules were included as a dependency
+                to help you figure out if they are actually needed here:
+                https://pytorch.org/docs/stable/package.html#see-why-a-given-module-was-included-as-a-dependency.
                 """
             ),
         )
@@ -303,14 +309,18 @@ class TestDependencyAPI(PackageTestCase):
             with PackageExporter(buffer) as exporter:
                 # This import will fail to load.
                 exporter.save_source_string("foo", "from ........ import lol")
-
+        self.maxDiff = None
         self.assertEqual(
             str(e.exception),
+
             dedent(
                 """
                 * Dependency resolution failed.
                     foo
                       Context: attempted relative import beyond top-level package
+                We offer tools to help you figure out why modules were included as a dependency
+                to help you figure out if they are actually needed here:
+                https://pytorch.org/docs/stable/package.html#see-why-a-given-module-was-included-as-a-dependency.
                 """
             ),
         )

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -147,6 +147,12 @@ class PackagingError(Exception):
                 if error_context is not None:
                     message.write(f"      Context: {error_context}\n")
 
+        troubleshooting_str = (
+            "We offer tools to help you figure out why modules were included as a dependency\n"
+            "to help you figure out if they are actually needed here:\n"
+            "https://pytorch.org/docs/stable/package.html#see-why-a-given-module-was-included-as-a-dependency.\n"
+        )
+        message.write(troubleshooting_str)
         # Save the dependency graph so that tooling can get at it.
         self.dependency_graph = dependency_graph
         super().__init__(message.getvalue())


### PR DESCRIPTION
Adds a better error message for `PackageError` in order to point users to troubleshooting tools. This way in projects where package is used upstream with a set of `intern/extern/mock` rules it becomes more obvious what to do with the list of dependencies you get and how to get rid of them.

We also update documentation to add `package.analyze.find_first_use_of_broken_modules` as a troubleshooting tool