### PR TITLE
Move //xplat/caffe2:caffe2_serialize to shared build structure

### DIFF
--- a/build.bzl
+++ b/build.bzl
@@ -1,0 +1,25 @@
+def define_targets(rules):
+    rules.cc_library(
+        name = "caffe2_serialize",
+        srcs = [
+            "caffe2/serialize/file_adapter.cc",
+            "caffe2/serialize/inline_container.cc",
+            "caffe2/serialize/istream_adapter.cc",
+            "caffe2/serialize/read_adapter_interface.cc",
+        ],
+        # Flags that end with '()' are converted to a list of strings
+        # by calling the function when translating in to buck/bazel.
+        # TODO: find a better way to do this.
+        copts = ["get_c2_fbandroid_xplat_compiler_flags()", "-frtti"],
+        tags = [
+            "supermodule:android/default/pytorch",
+            "supermodule:ios/default/public.pytorch",
+        ],
+        visibility = ["//visibility:public"],
+        deps = [
+            ":caffe2_headers",
+            ":miniz",
+            "//third-party/glog:glog",
+            "//xplat/caffe2/c10:c10",
+        ],
+    )


### PR DESCRIPTION
Summary: This is a first step to migrate xplat targets to shared build structure. Eventually both xplat buck and open source bazel targets will be generated from shared build.bzl.

Test Plan: Should be no-op, rely on CI.

Reviewed By: malfet

Differential Revision: D35270004

