### PR TITLE
[lint] use python to run flake8 and mypy in linter

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -20,7 +20,6 @@ exclude_patterns = [
 command = [
     'python3',
     'tools/linter/adapters/flake8_linter.py',
-    '--binary=flake8',
     '--',
     '@{{PATHSFILE}}'
 ]
@@ -110,7 +109,6 @@ exclude_patterns = [
 command = [
     'python3',
     'tools/linter/adapters/mypy_linter.py',
-    '--binary=mypy',
     '--config=mypy.ini',
     '--',
     '@{{PATHSFILE}}'
@@ -141,7 +139,6 @@ include_patterns = [
 command = [
     'python3',
     'tools/linter/adapters/mypy_linter.py',
-    '--binary=mypy',
     '--config=mypy-strict.ini',
     '--',
     '@{{PATHSFILE}}'

--- a/tools/linter/adapters/flake8_linter.py
+++ b/tools/linter/adapters/flake8_linter.py
@@ -245,14 +245,13 @@ def get_issue_documentation_url(code: str) -> str:
 
 def check_files(
     filenames: List[str],
-    binary: str,
     flake8_plugins_path: Optional[str],
     severities: Dict[str, LintSeverity],
     retries: int,
 ) -> List[LintMessage]:
     try:
         proc = run_command(
-            [binary, "--exit-zero"] + filenames,
+            ["python3", "-mflake8", "--exit-zero"] + filenames,
             extra_env={"FLAKE8_PLUGINS_PATH": flake8_plugins_path}
             if flake8_plugins_path
             else None,
@@ -314,11 +313,6 @@ def main() -> None:
         fromfile_prefix_chars="@",
     )
     parser.add_argument(
-        "--binary",
-        required=True,
-        help="flake8 binary path",
-    )
-    parser.add_argument(
         "--flake8-plugins-path",
         help="FLAKE8_PLUGINS_PATH env value",
     )
@@ -368,7 +362,7 @@ def main() -> None:
             assert len(parts) == 2, f"invalid severity `{severity}`"
             severities[parts[0]] = LintSeverity(parts[1])
 
-    lint_messages = check_files(args.filenames, args.binary, flake8_plugins_path, severities, args.retries)
+    lint_messages = check_files(args.filenames, flake8_plugins_path, severities, args.retries)
     for lint_message in lint_messages:
         print(json.dumps(lint_message._asdict()), flush=True)
 

--- a/tools/linter/adapters/flake8_linter.py
+++ b/tools/linter/adapters/flake8_linter.py
@@ -251,7 +251,7 @@ def check_files(
 ) -> List[LintMessage]:
     try:
         proc = run_command(
-            ["python3", "-mflake8", "--exit-zero"] + filenames,
+            [sys.executable, "-mflake8", "--exit-zero"] + filenames,
             extra_env={"FLAKE8_PLUGINS_PATH": flake8_plugins_path}
             if flake8_plugins_path
             else None,

--- a/tools/linter/adapters/mypy_linter.py
+++ b/tools/linter/adapters/mypy_linter.py
@@ -89,7 +89,7 @@ def check_files(
 ) -> List[LintMessage]:
     try:
         proc = run_command(
-            ["python3", "-mmypy", f"--config={config}"] + filenames,
+            [sys.executable, "-mmypy", f"--config={config}"] + filenames,
             extra_env={},
             retries=retries,
         )

--- a/tools/linter/adapters/mypy_linter.py
+++ b/tools/linter/adapters/mypy_linter.py
@@ -85,12 +85,11 @@ severities = {
 def check_files(
     filenames: List[str],
     config: str,
-    binary: str,
     retries: int,
 ) -> List[LintMessage]:
     try:
         proc = run_command(
-            [binary, f"--config={config}"] + filenames,
+            ["python3", "-mmypy", f"--config={config}"] + filenames,
             extra_env={},
             retries=retries,
         )
@@ -131,11 +130,6 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="mypy wrapper linter.",
         fromfile_prefix_chars="@",
-    )
-    parser.add_argument(
-        "--binary",
-        required=True,
-        help="mypy binary path",
     )
     parser.add_argument(
         "--retries",
@@ -187,7 +181,7 @@ def main() -> None:
         else:
             filenames[filename] = True
 
-    lint_messages = check_files(list(filenames), args.config, args.binary, args.retries)
+    lint_messages = check_files(list(filenames), args.config, args.retries)
     for lint_message in lint_messages:
         print(json.dumps(lint_message._asdict()), flush=True)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #75858

Previously we were just using whatever version the shell picked up, but
@malfet reported that this can (and is) overridden on some machines.