### PR TITLE
Enhance exporting torch.minimum() function to ONNX so it can handle parameters with different dtype.

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -226,6 +226,7 @@ namespace c10 {
   _(onnx, Gemm)                      \
   _(onnx, LSTM)                      \
   _(onnx, MatMul)                    \
+  _(onnx, Min)                       \
   _(onnx, Mul)                       \
   _(onnx, Pow)                       \
   _(onnx, RNN)                       \

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -7866,6 +7866,28 @@ class _TestONNXRuntime:
         y = torch.rand(1, 3)
         self.run_test(ModelWithNan(), (x, y))
 
+    @skipIfUnsupportedMinOpsetVersion(12)
+    def test_minimum_dtypes(self):
+        class MinimumModel(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.minimum(x, y)
+
+        x = torch.randn((5, 5), dtype=torch.float16)
+        y = torch.randn((5, 5), dtype=torch.float)
+        self.run_test(MinimumModel(), (x, y))
+
+        x = torch.randn((5, 5), dtype=torch.float16)
+        y = torch.randint(10, (5, 5), dtype=torch.int16)
+        self.run_test(MinimumModel(), (x, y))
+
+        x = torch.randint(10, (5, 5), dtype=torch.int8)
+        y = torch.randint(10, (5, 5), dtype=torch.int16)
+        self.run_test(MinimumModel(), (x, y))
+
+        x = torch.randint(10, (5, 5), dtype=torch.int)
+        y = torch.full_like(x, True)
+        self.run_test(MinimumModel(), (x, y))
+
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_any(self):
         class M(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -7880,8 +7880,8 @@ class _TestONNXRuntime:
         y = torch.randint(10, (5, 5), dtype=torch.int16)
         self.run_test(MinimumModel(), (x, y))
 
-        x = torch.randint(10, (5, 5), dtype=torch.int8)
-        y = torch.randint(10, (5, 5), dtype=torch.int16)
+        x = torch.randint(10, (5, 5), dtype=torch.int16)
+        y = torch.randint(10, (5, 5), dtype=torch.int32)
         self.run_test(MinimumModel(), (x, y))
 
         x = torch.randint(10, (5, 5), dtype=torch.int)

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -44,13 +44,14 @@ static int64_t ScalarTypeToONNXType(const c10::ScalarType& st) {
 // There is no operator-wise special case handling needed.
 static const std::unordered_set<NodeKind> standardOps = {
     onnx::Add,
-    onnx::Sub,
-    onnx::Mul,
+    onnx::Concat,
     onnx::Div,
     onnx::Gemm,
-    onnx::Pow,
+    onnx::Min,
     onnx::Mod,
-    onnx::Concat,
+    onnx::Mul,
+    onnx::Pow,
+    onnx::Sub,
 };
 
 // For these operators, all inputs share the same scalar type.


### PR DESCRIPTION
Handle the case that the parameters of torch.minimum() have different dtypes. Add tests as well.

Fixes #76022