### PR TITLE
[torch package] show where broken dependency comes from in packaging error message

### DIFF
--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -140,7 +140,10 @@ class PackagingError(Exception):
         for reason, module_names in broken.items():
             message.write(f"* {reason.value}\n")
             for module_name in module_names:
-                message.write(f"    {module_name}\n")
+                first_path = dependency_graph.first_path(module_name)
+                message.write(
+                    f"    {module_name} (first_path: {'->'.join(first_path)})\n"
+                )
 
                 # Print additional context if it's provided.
                 error_context = dependency_graph.nodes[module_name].get("error_context")


### PR DESCRIPTION
Summary: as titled, make the error more developer friendenly

Test Plan:
sample error output before:
{P494891331}
sample output after
{P494894321}

Differential Revision: D35659332

