### PR TITLE
[GH1] Add FFT related changes to merge rules

### DIFF
--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -58,6 +58,21 @@
          "test/test_linalg.py"
       ],
       "approved_by": ["nikitaved", "mruberry", "pearu", "Lezcano", "IvanYashchuk"],
+   },
+   {
+      "name": "FFT",
+      "patterns": [
+         "aten/src/ATen/native/cuda/*FFT*.h",
+         "docs/source/fft.rst",
+         "torch/fft/**",
+         "torch/include/**/*fft*.h",
+         "torch/include/ATen/native/cuda/*FFT*.h",
+         "torch/csrc/api/include/torch/fft.h",
+         "torch/**/python_fft_functions.*",
+         "tools/autograd/templates/python_fft_functions.cpp",
+         "test/cpp/api/fft.cpp"
+      ],
+      "approved_by": ["mruberry", "peterbell10"],
       "mandatory_checks_name": ["Facebook CLA Check", "Lint"]
    },
    {

--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -58,15 +58,17 @@
          "test/test_linalg.py"
       ],
       "approved_by": ["nikitaved", "mruberry", "pearu", "Lezcano", "IvanYashchuk"],
+      "mandatory_checks_name": ["Facebook CLA Check", "Lint"]
    },
    {
       "name": "FFT",
       "patterns": [
          "aten/src/ATen/native/cuda/*FFT*.h",
+         "aten/src/ATen/native/SpectralOps.cpp",
+         "aten/src/ATen/native/mkl/SpectralOps.cpp",
+         "aten/src/ATen/native/cuda/SpectralOps.*",
          "docs/source/fft.rst",
          "torch/fft/**",
-         "torch/include/**/*fft*.h",
-         "torch/include/ATen/native/cuda/*FFT*.h",
          "torch/csrc/api/include/torch/fft.h",
          "torch/**/python_fft_functions.*",
          "tools/autograd/templates/python_fft_functions.cpp",


### PR DESCRIPTION
This PR would allow Quansight FFT experts (in addition to metamates) to approve sparse related changes. As the fft module is not really internally used, we can start encouraging more GitHub 1st (GH1) landing for these.

This is DIFFERENT from the superuser rule because it allows non-metamates to be approvers.