### PR TITLE
[FSDP] Support initialization of modules on meta device

### DIFF
--- a/test/distributed/fsdp/test_fsdp_meta.py
+++ b/test/distributed/fsdp/test_fsdp_meta.py
@@ -23,6 +23,12 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
 )
 
+_TORCHDISTX_AVAIL = True
+try:
+    from torchdistx import fake, deferred_init
+except ImportError:
+    _TORCHDISTX_AVAIL = False
+
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
@@ -34,23 +40,30 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
+
+class MyLinear(nn.Linear):
+    """
+    Linear layer with deterministic reset_parameters for testing.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def reset_parameters(self, *args, **kwargs):
+        with torch.no_grad():
+            self.weight.fill_(1)
+
 class MyModel(nn.Module):
     def __init__(self, device):
         super().__init__()
-        torch.manual_seed(0)
-        torch.cuda.manual_seed(0)
-        self.lin1 = nn.Linear(2, 2, bias=False, device=device)
-        self.lin2 = nn.Linear(2, 2, bias=False, device=device)
+        self.lin1 = MyLinear(2, 2, bias=False, device=device)
+        self.lin2 = MyLinear(2, 2, bias=False, device=device)
 
     def forward(self, x):
         return self.lin2(self.lin1(x))
 
     def reset_parameters(self, *args, **kwargs):
-        # Reset any parameters that are not FSDP
         for m in [self.lin1, self.lin2]:
             if not isinstance(m, FSDP):
-                torch.manual_seed(0)
-                torch.cuda.manual_seed(0)
                 m.reset_parameters()
 
 
@@ -59,9 +72,9 @@ class NestedModel(nn.Module):
         super().__init__()
         torch.manual_seed(0)
         torch.cuda.manual_seed(0)
-        self.lin1 = nn.Linear(2, 2, bias=False, device=device)
+        self.lin1 = MyLinear(2, 2, bias=False, device=device)
         self.lin1 = wrap(self.lin1)
-        self.lin2 = nn.Linear(2, 2, bias=False, device=device)
+        self.lin2 = MyLinear(2, 2, bias=False, device=device)
         self.l3 = MyModel(device=device)
         self.l3 = wrap(self.l3)
 
@@ -71,18 +84,27 @@ class NestedModel(nn.Module):
     def reset_parameters(self):
         for m in [self.lin1, self.lin2, self.l3]:
             if not isinstance(m, FSDP):
-                torch.manual_seed(0)
-                torch.cuda.manual_seed(0)
                 m.reset_parameters()
 
 def _init_with_reset_params(module):
+    """
+    to_empty + reset_parameters() init function example for modules
+    initailized with device="meta"
+    """
     is_meta = any(t.is_meta for t in module.parameters())
     if is_meta:
         module.to_empty(device=torch.cuda.current_device())
     with torch.no_grad():
-        torch.manual_seed(0)
-        torch.cuda.manual_seed(0)
         module.reset_parameters()
+
+def _init_with_torchdistx(module):
+    """
+    torchdistx-based deferred module initialization function example
+    using ``materialize_module``.
+    """
+    assert _TORCHDISTX_AVAIL
+    check_fn = lambda k: not isinstance(k, FSDP)
+    deferred_init.materialize_module(module, check_fn=check_fn)
 
 class TestFSDPWithMetaDevice(FSDPTest):
     @property
@@ -97,26 +119,33 @@ class TestFSDPWithMetaDevice(FSDPTest):
         with fsdp1.summon_full_params(fsdp1):
             with fsdp2.summon_full_params(fsdp2):
                 for p1, p2 in zip(fsdp1.parameters(), fsdp2.parameters()):
-                    self.assertTrue(torch.allclose(p1, p2), f"{p1} vs {p2}")
-    
-    def _test_simple_model_with_meta_device(self, meta_module_fn, init_fn):
+                    if self.rank ==0: self.assertTrue(torch.allclose(p1, p2), f"{p1} vs {p2}")
+
+    def _test_simple_model_with_meta_device(self, meta_module_fn, init_fn=None):
+        # Create model on meta device and wrap with FSDP.
         model = meta_module_fn()
-        
+        is_meta = next(model.parameters()).is_meta
         fsdp_meta = FSDP(
             model,
             auto_wrap_policy=always_wrap,
             param_init_fn=init_fn,
         )
-        
+
         meta_opt = torch.optim.SGD(fsdp_meta.parameters(), lr=1e-3)
 
         # Test to make sure it is the same model parameters as regular FSDP
         # approach.
         regular = MyModel(device="cuda")
-        regular.reset_parameters()
+        # For torchdistx init, we don't need to call reset_params, as
+        # deferred_init(model).materialize() is equivalent to model().
+        if is_meta:
+            regular.reset_parameters()
         fsdp_regular = FSDP(regular, auto_wrap_policy=always_wrap)
         regular_opt = torch.optim.SGD(fsdp_regular.parameters(), lr=1e-3)
 
+        self._compare_fsdp(fsdp_meta, fsdp_regular)
+        torch.manual_seed(0)
+        torch.cuda.manual_seed(0)
         inp = torch.randn(10, 2).cuda()
         fsdp_meta(inp).sum().backward()
         fsdp_regular(inp).sum().backward()
@@ -130,7 +159,10 @@ class TestFSDPWithMetaDevice(FSDPTest):
         fsdp_meta = FSDP(model, param_init_fn=init_fn)
         meta_opt = torch.optim.SGD(fsdp_meta.parameters(), lr=1e-3)
         regular = MyModel(device="cuda")
-        regular.reset_parameters()
+        # For torchdistx init, we don't need to call reset_params, as
+        # deferred_init(model).materialize() is equivalent to model().
+        if is_meta:
+            regular.reset_parameters()
         fsdp_regular = FSDP(regular, auto_wrap_policy=always_wrap)
         regular_opt = torch.optim.SGD(fsdp_regular.parameters(), lr=1e-3)
 
@@ -140,27 +172,44 @@ class TestFSDPWithMetaDevice(FSDPTest):
         meta_opt.step()
         regular_opt.step()
         self._compare_fsdp(fsdp_meta, fsdp_regular)
-    
+
     @skip_if_lt_x_gpu(2)
     def test_simple_model_with_meta_device_reset_params(self):
         meta_module_fn = lambda: MyModel(device="meta")
         self._test_simple_model_with_meta_device(
             meta_module_fn, _init_with_reset_params
         )
-    
+
     @skip_if_lt_x_gpu(2)
-    @parametrize("auto_wrap", [True, False])
-    def test_nested_model_with_meta_device(self, auto_wrap):
+    def test_simple_model_with_meta_device_default_init(self):
+        meta_module_fn = lambda: MyModel(device="meta")
+        self._test_simple_model_with_meta_device(meta_module_fn)
+
+    @skip_if_lt_x_gpu(2)
+    def test_simple_model_with_torchdistx_default_init(self):
+        meta_module_fn = lambda: deferred_init.deferred_init(MyModel, device="cuda")
+        self._test_simple_model_with_meta_device(meta_module_fn)
+
+    @skip_if_lt_x_gpu(2)
+    def test_simple_model_with_torchdistx_init_fn(self):
+        meta_module_fn = lambda: deferred_init.deferred_init(MyModel, device="cuda")
+        self._test_simple_model_with_meta_device(meta_module_fn, init_fn=_init_with_torchdistx)
+
+    def _test_nested_model_with_meta_device(self, auto_wrap, meta_module_fn, init_fn=None):
         if auto_wrap:
-            module = NestedModel(device="meta")
+            module = meta_module_fn()
+            is_meta = next(module.parameters()).is_meta
             fsdp_meta = FSDP(
                 module,
                 auto_wrap_policy=always_wrap,
-                param_init_fn=_init_with_reset_params,
+                param_init_fn=init_fn,
             )
             meta_opt = torch.optim.SGD(fsdp_meta.parameters(), lr=1e-3)
             module_regular = NestedModel(device="cuda")
-            module_regular.reset_parameters()
+            # For torchdistx init, we don't need to call reset_params, as
+            # deferred_init(model).materialize() is equivalent to model().
+            if is_meta:
+                module_regular.reset_parameters()
             fsdp_regular = FSDP(
                 module_regular,
                 auto_wrap_policy=always_wrap,
@@ -168,36 +217,69 @@ class TestFSDPWithMetaDevice(FSDPTest):
             regular_opt = torch.optim.SGD(fsdp_regular.parameters(), lr=1e-3)
         else:
             with enable_wrap(
-                wrapper_cls=FSDP, param_init_fn=_init_with_reset_params
+                wrapper_cls=FSDP, param_init_fn=init_fn,
             ):
-                module = NestedModel(device="meta")
-                # Users need to explicitly initialize non FSDP modules.
-                module.lin2.to_empty(device=torch.cuda.current_device())
-                module.lin2.reset_parameters()
+                module = meta_module_fn()
+                is_meta = next(module.parameters()).is_meta
+                # Non FSDP modules will still be initialized because they bubble up
+                # to be part of a larger FSDP unit.
                 fsdp_meta = wrap(module)
                 meta_opt = torch.optim.SGD(fsdp_meta.parameters(), lr=1e-3)
 
             # Init and reset parameters before wrapping so that reset_params
             # matches up with meta device's initialization.
             module_regular = NestedModel(device="cuda")
-            module_regular.reset_parameters()
+            # For torchdistx init, we don't need to call reset_params, as
+            # deferred_init(model).materialize() is equivalent to model().
+            if is_meta:
+                module_regular.reset_parameters()
             with enable_wrap(wrapper_cls=FSDP):
                 module_regular.lin1 = wrap(module_regular.lin1)
                 module_regular.l3 = wrap(module_regular.l3)
                 fsdp_regular = wrap(module_regular)
                 regular_opt = torch.optim.SGD(fsdp_regular.parameters(), lr=1e-3)
 
+        # Compare it before training
+        self._compare_fsdp(fsdp_meta, fsdp_regular)
         inp = torch.randn(10, 2, device='cuda')
         fsdp_meta(inp).sum().backward()
         fsdp_regular(inp).sum().backward()
         meta_opt.step()
         regular_opt.step()
         self._compare_fsdp(fsdp_meta, fsdp_regular)
-    
+
     @skip_if_lt_x_gpu(2)
     @parametrize("auto_wrap", [True, False])
     def test_nested_model_with_meta_device_reset_params(self, auto_wrap):
-        self._test_nested_model_with_meta_device(auto_wrap=auto_wrap)
+        meta_module_fn = lambda: NestedModel(device="meta")
+
+        self._test_nested_model_with_meta_device(
+            auto_wrap=auto_wrap, meta_module_fn=meta_module_fn, init_fn=_init_with_reset_params
+        )
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("auto_wrap", [True, False])
+    def test_nested_model_with_meta_device_default_init(self, auto_wrap):
+        meta_module_fn = lambda: NestedModel(device="meta")
+        self._test_nested_model_with_meta_device(
+            auto_wrap=auto_wrap, meta_module_fn=meta_module_fn,
+        )
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("auto_wrap", [True, False])
+    def test_nested_model_with_torchdistx_default_init(self, auto_wrap):
+        meta_module_fn = lambda: deferred_init.deferred_init(NestedModel, device="cuda")
+        self._test_nested_model_with_meta_device(
+            auto_wrap=auto_wrap, meta_module_fn=meta_module_fn
+        )
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("auto_wrap", [True, False])
+    def test_nested_model_with_torchdistx_init_fn(self, auto_wrap):
+        meta_module_fn = lambda: deferred_init.deferred_init(NestedModel, device="cuda")
+        self._test_nested_model_with_meta_device(
+            auto_wrap=auto_wrap, meta_module_fn=meta_module_fn, init_fn=_init_with_torchdistx,
+        )
 
 
 instantiate_parametrized_tests(TestFSDPWithMetaDevice)

--- a/test/distributed/fsdp/test_fsdp_meta.py
+++ b/test/distributed/fsdp/test_fsdp_meta.py
@@ -1,0 +1,194 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import sys
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.flatten_params_wrapper import FlattenParamsWrapper
+from torch.distributed.fsdp.wrap import always_wrap_policy as always_wrap
+from torch.distributed.fsdp.wrap import wrap, enable_wrap
+from torch.testing._internal.common_fsdp import (
+    FSDPTest,
+)
+from torch.testing._internal.common_utils import (
+    TEST_WITH_DEV_DBG_ASAN,
+    run_tests,
+    parametrize,
+    instantiate_parametrized_tests,
+    sandcastle_skip_if,
+)
+
+_TORCHDISTX_AVAIL = True
+
+try:
+    from torchdistx import fake, deferred_init  # noqa: F401
+except ImportError:
+    _TORCHDISTX_AVAIL = False
+
+if not dist.is_available():
+    print("Distributed not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+if TEST_WITH_DEV_DBG_ASAN:
+    print(
+        "Skip dev-asan as torch + multiprocessing spawn have known issues",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+class MyModel(nn.Module):
+    def __init__(self, device):
+        super().__init__()
+        torch.manual_seed(0)
+        torch.cuda.manual_seed(0)
+        self.lin1 = nn.Linear(2, 2, bias=False, device=device)
+        self.lin2 = nn.Linear(2, 2, bias=False, device=device)
+
+    def forward(self, x):
+        return self.lin2(self.lin1(x))
+
+    def reset_parameters(self, *args, **kwargs):
+        # Reset any parameters that are not FSDP
+        for m in [self.lin1, self.lin2]:
+            if not isinstance(m, FSDP):
+                torch.manual_seed(0)
+                torch.cuda.manual_seed(0)
+                m.reset_parameters()
+
+
+class NestedModel(nn.Module):
+    def __init__(self, device):
+        super().__init__()
+        torch.manual_seed(0)
+        torch.cuda.manual_seed(0)
+        self.lin1 = nn.Linear(2, 2, bias=False, device=device)
+        self.lin1 = wrap(self.lin1)
+        self.lin2 = nn.Linear(2, 2, bias=False, device=device)
+        self.l3 = MyModel(device=device)
+        self.l3 = wrap(self.l3)
+
+    def forward(self, x):
+        return self.l3(self.lin2(self.lin1(x)))
+
+    def reset_parameters(self):
+        for m in [self.lin1, self.lin2, self.l3]:
+            if not isinstance(m, FSDP):
+                torch.manual_seed(0)
+                torch.cuda.manual_seed(0)
+                m.reset_parameters()
+
+def _init_with_reset_params(module):
+    is_meta = any(t.is_meta for t in module.parameters())
+    if is_meta:
+        module.to_empty(device=torch.cuda.current_device())
+    with torch.no_grad():
+        torch.manual_seed(0)
+        torch.cuda.manual_seed(0)
+        module.reset_parameters()
+
+def _torchdistx_init(module):
+    if not _TORCHDISTX_AVAIL:
+        raise ValueError(
+            "Should not call _torchdistx_init if torchdistx is not available."
+        )
+
+    def check_fn(k):
+        return not isinstance(k, FSDP)
+    deferred_init.materialize_module(module, check_fn=check_fn)
+
+
+class TestFSDPWithMetaDevice(FSDPTest):
+    @property
+    def world_size(self):
+        return 2
+
+    @property
+    def process_group(self):
+        return dist.distributed_c10d._get_default_group()
+
+    def _compare_fsdp(self, fsdp1, fsdp2):
+        with fsdp1.summon_full_params(fsdp1):
+            with fsdp2.summon_full_params(fsdp2):
+                for p1, p2 in zip(fsdp1.parameters(), fsdp2.parameters()):
+                    self.assertTrue(torch.allclose(p1, p1), f"{p1} vs {p2}")
+
+    def test_simple_model_with_meta_device_reset_params(self):
+        model = MyModel(device="meta")
+        assert next(model.lin1.parameters()).is_meta
+        assert next(model.lin2.parameters()).is_meta
+
+        fsdp_meta = FSDP(
+            model,
+            auto_wrap_policy=always_wrap,
+            param_init_fns=_init_with_reset_params,
+        )
+
+        # Test to make sure it is the same model parameters as regular FSDP
+        # approach.
+        regular = MyModel(device="cuda")
+        regular.reset_parameters()
+        fsdp_regular = FSDP(regular, auto_wrap_policy=always_wrap)
+
+        self._compare_fsdp(fsdp_meta, fsdp_regular)
+
+        # Test that meta init works if all submodules are contained in only a
+        # single FSDP unit.
+        fsdp_meta = FSDP(model, param_init_fns=_init_with_reset_params)
+        regular = MyModel(device="cuda")
+        regular.reset_parameters()
+        fsdp_regular = FSDP(regular, auto_wrap_policy=always_wrap)
+
+        inp = torch.randn(10, 2).cuda()
+        # Run a forward + backward pass to ensure things work
+        fsdp_meta(inp).sum().backward()
+        fsdp_regular(inp).sum().backward()
+        self._compare_fsdp(fsdp_meta, fsdp_regular)
+
+
+    @parametrize("auto_wrap", [True, False])
+    def test_nested_model_with_meta_device_reset_params(self, auto_wrap):
+        if auto_wrap:
+            module = NestedModel(device="meta")
+            fsdp_meta = FSDP(
+                module,
+                auto_wrap_policy=always_wrap,
+                param_init_fns=_init_with_reset_params,
+            )
+            module_regular = NestedModel(device="cuda")
+            module_regular.reset_parameters()
+            fsdp_regular = FSDP(
+                module_regular,
+                auto_wrap_policy=always_wrap,
+            )
+        else:
+            with enable_wrap(
+                wrapper_cls=FSDP, param_init_fns=_init_with_reset_params
+            ):
+                module = NestedModel(device="meta")
+                # Users need to explicitly initialize non FSDP modules.
+                module.lin2.to_empty(device=torch.cuda.current_device())
+                module.lin2.reset_parameters()
+                fsdp_meta = wrap(module)
+
+            # Init and reset parameters before wrapping so that reset_params
+            # matches up with meta device's initialization.
+            module_regular = NestedModel(device="cuda")  # note: not wrapped now
+            module_regular.reset_parameters()
+            with enable_wrap(wrapper_cls=FSDP):
+                module_regular = NestedModel(device="cuda")
+                module_regular.lin1 = wrap(module_regular.lin1)
+                module_regular.l3 = wrap(module_regular.l3)
+                fsdp_regular = wrap(module_regular)
+
+        inp = torch.randn(10, 2, device='cuda')
+        fsdp_meta(inp).sum().backward()
+        fsdp_regular(inp).sum().backward()
+        self._compare_fsdp(fsdp_meta, fsdp_regular)
+
+
+instantiate_parametrized_tests(TestFSDPWithMetaDevice)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/fsdp/test_fsdp_meta.py
+++ b/test/distributed/fsdp/test_fsdp_meta.py
@@ -19,13 +19,9 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     sandcastle_skip_if,
 )
-
-_TORCHDISTX_AVAIL = True
-
-try:
-    from torchdistx import fake, deferred_init  # noqa: F401
-except ImportError:
-    _TORCHDISTX_AVAIL = False
+from torch.testing._internal.common_distributed import (
+    skip_if_lt_x_gpu,
+)
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -88,17 +84,6 @@ def _init_with_reset_params(module):
         torch.cuda.manual_seed(0)
         module.reset_parameters()
 
-def _torchdistx_init(module):
-    if not _TORCHDISTX_AVAIL:
-        raise ValueError(
-            "Should not call _torchdistx_init if torchdistx is not available."
-        )
-
-    def check_fn(k):
-        return not isinstance(k, FSDP)
-    deferred_init.materialize_module(module, check_fn=check_fn)
-
-
 class TestFSDPWithMetaDevice(FSDPTest):
     @property
     def world_size(self):
@@ -112,80 +97,107 @@ class TestFSDPWithMetaDevice(FSDPTest):
         with fsdp1.summon_full_params(fsdp1):
             with fsdp2.summon_full_params(fsdp2):
                 for p1, p2 in zip(fsdp1.parameters(), fsdp2.parameters()):
-                    self.assertTrue(torch.allclose(p1, p1), f"{p1} vs {p2}")
-
-    def test_simple_model_with_meta_device_reset_params(self):
-        model = MyModel(device="meta")
-        assert next(model.lin1.parameters()).is_meta
-        assert next(model.lin2.parameters()).is_meta
-
+                    self.assertTrue(torch.allclose(p1, p2), f"{p1} vs {p2}")
+    
+    def _test_simple_model_with_meta_device(self, meta_module_fn, init_fn):
+        model = meta_module_fn()
+        
         fsdp_meta = FSDP(
             model,
             auto_wrap_policy=always_wrap,
-            param_init_fns=_init_with_reset_params,
+            param_init_fn=init_fn,
         )
+        
+        meta_opt = torch.optim.SGD(fsdp_meta.parameters(), lr=1e-3)
 
         # Test to make sure it is the same model parameters as regular FSDP
         # approach.
         regular = MyModel(device="cuda")
         regular.reset_parameters()
         fsdp_regular = FSDP(regular, auto_wrap_policy=always_wrap)
+        regular_opt = torch.optim.SGD(fsdp_regular.parameters(), lr=1e-3)
 
+        inp = torch.randn(10, 2).cuda()
+        fsdp_meta(inp).sum().backward()
+        fsdp_regular(inp).sum().backward()
+        meta_opt.step()
+        regular_opt.step()
         self._compare_fsdp(fsdp_meta, fsdp_regular)
 
         # Test that meta init works if all submodules are contained in only a
         # single FSDP unit.
-        fsdp_meta = FSDP(model, param_init_fns=_init_with_reset_params)
+        model = meta_module_fn()
+        fsdp_meta = FSDP(model, param_init_fn=init_fn)
+        meta_opt = torch.optim.SGD(fsdp_meta.parameters(), lr=1e-3)
         regular = MyModel(device="cuda")
         regular.reset_parameters()
         fsdp_regular = FSDP(regular, auto_wrap_policy=always_wrap)
+        regular_opt = torch.optim.SGD(fsdp_regular.parameters(), lr=1e-3)
 
-        inp = torch.randn(10, 2).cuda()
-        # Run a forward + backward pass to ensure things work
+        # Run a forward + backward pass + optimizer step
         fsdp_meta(inp).sum().backward()
         fsdp_regular(inp).sum().backward()
+        meta_opt.step()
+        regular_opt.step()
         self._compare_fsdp(fsdp_meta, fsdp_regular)
-
-
+    
+    @skip_if_lt_x_gpu(2)
+    def test_simple_model_with_meta_device_reset_params(self):
+        meta_module_fn = lambda: MyModel(device="meta")
+        self._test_simple_model_with_meta_device(
+            meta_module_fn, _init_with_reset_params
+        )
+    
+    @skip_if_lt_x_gpu(2)
     @parametrize("auto_wrap", [True, False])
-    def test_nested_model_with_meta_device_reset_params(self, auto_wrap):
+    def test_nested_model_with_meta_device(self, auto_wrap):
         if auto_wrap:
             module = NestedModel(device="meta")
             fsdp_meta = FSDP(
                 module,
                 auto_wrap_policy=always_wrap,
-                param_init_fns=_init_with_reset_params,
+                param_init_fn=_init_with_reset_params,
             )
+            meta_opt = torch.optim.SGD(fsdp_meta.parameters(), lr=1e-3)
             module_regular = NestedModel(device="cuda")
             module_regular.reset_parameters()
             fsdp_regular = FSDP(
                 module_regular,
                 auto_wrap_policy=always_wrap,
             )
+            regular_opt = torch.optim.SGD(fsdp_regular.parameters(), lr=1e-3)
         else:
             with enable_wrap(
-                wrapper_cls=FSDP, param_init_fns=_init_with_reset_params
+                wrapper_cls=FSDP, param_init_fn=_init_with_reset_params
             ):
                 module = NestedModel(device="meta")
                 # Users need to explicitly initialize non FSDP modules.
                 module.lin2.to_empty(device=torch.cuda.current_device())
                 module.lin2.reset_parameters()
                 fsdp_meta = wrap(module)
+                meta_opt = torch.optim.SGD(fsdp_meta.parameters(), lr=1e-3)
 
             # Init and reset parameters before wrapping so that reset_params
             # matches up with meta device's initialization.
-            module_regular = NestedModel(device="cuda")  # note: not wrapped now
+            module_regular = NestedModel(device="cuda")
             module_regular.reset_parameters()
             with enable_wrap(wrapper_cls=FSDP):
-                module_regular = NestedModel(device="cuda")
                 module_regular.lin1 = wrap(module_regular.lin1)
                 module_regular.l3 = wrap(module_regular.l3)
                 fsdp_regular = wrap(module_regular)
+                regular_opt = torch.optim.SGD(fsdp_regular.parameters(), lr=1e-3)
 
         inp = torch.randn(10, 2, device='cuda')
         fsdp_meta(inp).sum().backward()
         fsdp_regular(inp).sum().backward()
+        meta_opt.step()
+        regular_opt.step()
         self._compare_fsdp(fsdp_meta, fsdp_regular)
+    
+    @skip_if_lt_x_gpu(2)
+    @parametrize("auto_wrap", [True, False])
+    def test_nested_model_with_meta_device_reset_params(self, auto_wrap):
+        self._test_nested_model_with_meta_device(auto_wrap=auto_wrap)
 
 
 instantiate_parametrized_tests(TestFSDPWithMetaDevice)

--- a/test/distributed/fsdp/test_fsdp_meta.py
+++ b/test/distributed/fsdp/test_fsdp_meta.py
@@ -1,4 +1,4 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Owner(s): ["oncall: distributed"]
 
 import sys
 
@@ -42,8 +42,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 def _reset_params_if_meta(is_meta, model):
-# For torchdistX init, we don't need to call reset_params, as
-# deferred_init(model).materialize() is equivalent to model().
+    # For torchdistX init, we don't need to call reset_params, as
+    # deferred_init(model).materialize() is equivalent to model().
     if is_meta:
         model.reset_parameters()
 

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -479,7 +479,7 @@ class FullyShardedDataParallel(nn.Module):
                 >>> def my_init_fn(module):
                 >>>     # responsible for initializing a module, such as with reset_parameters
                 >>> fsdp_model = FSDP(module, param_init_fn=my_init_fn, auto_wrap_policy=default_auto_wrap_policy)
-                >>> print(next(fsdp_model.parameters()).device) # current CUDA devic
+                >>> print(next(fsdp_model.parameters()).device) # current CUDA device
     """
 
     def __init__(

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -5,6 +5,7 @@ import itertools
 import traceback
 import warnings
 from contextlib import contextmanager
+import warnings
 from dataclasses import dataclass
 from enum import Enum, auto
 from math import inf
@@ -464,6 +465,21 @@ class FullyShardedDataParallel(nn.Module):
             avoid sharding specific parameters when using an
             ``auto_wrap_policy`` or if parameters' sharding is not managed by
             FSDP. (Default: ``None``)
+        param_init_fns: (Optional[Union[Callable, Dict[torch.nn.Module, Callable]]]):
+            A ``Callable[torch.nn.Module]`` or a ``Dict[torch.nn.Module, Callable]`` that
+            specifies how modules that are currently on the meta device should be initialized
+            onto a actual device. Note that if this argument is passed in, it is assumed that
+            the corresponding module is currently on the meta device. If this argument is a
+            ``Callable``, the same ``Callable`` is applied to initialize all meta modules, and
+            different initialization functions are supported via passing in a ``Dict`` mapping
+            the module to the respective initialization function. Note that this
+            initialization function is applied before doing any FSDP sharding
+            logic, so if a module is not going to be wrapped with FSDP, FSDP
+            will not initialize this module onto a compute device. For example,
+            if wrapping with ``auto_wrap_policy``, if a particular module ends
+            up not contained in any FSDP instance, it will not be initialized
+            with this function by FSDP, and the user is responsible for this
+            initialization.
     """
 
     def __init__(
@@ -476,6 +492,7 @@ class FullyShardedDataParallel(nn.Module):
         backward_prefetch: Optional[BackwardPrefetch] = None,
         mixed_precision: Optional[MixedPrecision] = None,
         ignored_modules: Optional[Iterable[torch.nn.Module]] = None,
+        param_init_fns: Optional[Union[Callable, Dict[torch.nn.Module, Callable]]]=None,
     ):
         torch._C._log_api_usage_once("torch.distributed.fsdp")
         super().__init__()
@@ -517,11 +534,35 @@ class FullyShardedDataParallel(nn.Module):
                 cpu_offload=cpu_offload,
                 backward_prefetch=backward_prefetch,
                 mixed_precision=mixed_precision,
+                param_init_fns=param_init_fns,
             )
 
         self.process_group = process_group or _get_default_group()
         self.rank = self.process_group.rank()
         self.world_size = self.process_group.size()
+
+        # We assume that the module is initialized on the meta device
+        # if the user has specified param_init_fns. TODO: investigate
+        # a way to more robustly determine if the module is on the meta
+        # device or not.
+        is_meta_module = param_init_fns is not None
+        if is_meta_module:
+            # Initialize parameters according to the user lambda.
+            if isinstance(param_init_fns, dict):
+                # As an example, this will call something like
+                # module.reset_parameters() to initialize the parameters
+                # on CPU / GPU.
+                module_fn = param_init_fns[module]
+                assert callable(module_fn), (
+                    f"Expected {module_fn} to be callable, but got type {type(param_init_fns)}"
+                )
+                param_init_fns[module](module)
+            else:
+                assert callable(param_init_fns), (
+                    f"Expected {param_init_fns} to be callable, but got {type(param_init_fns)}"
+                )
+                param_init_fns(module)
+
         # device for computation, if module is on GPU, use module.device;
         # if module is on CPU, use current device;
         self.compute_device = _get_default_cuda_device(module)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
 
 _TORCHDISTX_AVAIL = True
 try:
-    from torchdistX import fake, deferred_init
+    from torchdistx import fake, deferred_init
 except ImportError:
     _TORCHDISTX_AVAIL = False
 

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -83,7 +83,8 @@ def _default_meta_device_init_fn(module):
             module.reset_parameters()
     except BaseException as e:
         warnings.warn(
-                f"Unable to call reset_parameters() for module on meta device with error {str(e)}. Please ensure your module implements a ``reset_parameters`` function."
+            f"Unable to call reset_parameters() for module on meta device with error {str(e)}. "
+            "Please ensure your module implements a ``reset_parameters`` function."
         )
         raise e
 
@@ -583,7 +584,7 @@ class FullyShardedDataParallel(nn.Module):
         is_torchdistx_deferred_init = (
             _TORCHDISTX_AVAIL and not is_meta_module
             and any(fake.is_fake(p) for p in module.parameters())
-            )
+        )
 
         if is_meta_module:
             if param_init_fn is not None:
@@ -592,7 +593,7 @@ class FullyShardedDataParallel(nn.Module):
                     f"Expected {param_init_fn} to be callable, but got {type(param_init_fn)}"
                 )
                 param_init_fn(module)
-                else:
+            else:
                 # Call default initialization function that is dependent on
                 # reset_parameters.
                 _default_meta_device_init_fn(module)
@@ -607,7 +608,7 @@ class FullyShardedDataParallel(nn.Module):
             else:
                 # Call default torchdistx initialization function. Omit re-initialization of FSDP submodules
                 # which is unnecessary.
-                check_fn = lambda k: not isinstance(k, FullyShardedDataParallel)
+                check_fn = lambda k: not isinstance(k, FullyShardedDataParallel)  # noqa: E731
                 deferred_init.materialize_module(module, check_fn=check_fn)
 
         # device for computation, if module is on GPU, use module.device;

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -5,7 +5,6 @@ import itertools
 import traceback
 import warnings
 from contextlib import contextmanager
-import warnings
 from dataclasses import dataclass
 from enum import Enum, auto
 from math import inf
@@ -472,12 +471,15 @@ class FullyShardedDataParallel(nn.Module):
             the corresponding module is currently on the meta device.
             The same ``Callable`` is applied to initialize all meta modules. Note that this
             initialization function is applied before doing any FSDP sharding
-            logic, so if a module is not going to be wrapped with FSDP, FSDP
-            will not initialize this module onto a compute device. For example,
-            if wrapping with ``auto_wrap_policy``, if a particular module ends
-            up not contained in any FSDP instance, it will not be initialized
-            with this function by FSDP, and the user is responsible for this
-            initialization. Please see example below for details on how this can be done.
+            logic.
+
+            Example::
+
+                >>> module = MyModule(device="meta")
+                >>> def my_init_fn(module):
+                >>>     # responsible for initializing a module, such as with reset_parameters
+                >>> fsdp_model = FSDP(module, param_init_fn=my_init_fn, auto_wrap_policy=default_auto_wrap_policy)
+                >>> print(next(fsdp_model.parameters()).device) # current CUDA devic
     """
 
     def __init__(

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -502,9 +502,8 @@ class FullyShardedDataParallel(nn.Module):
             ``deferred_init`` API. In this case, deferred modules would be initialized
             by a default initialization function that calls torchdistX's
             ``materialize_module``, or the passed in ``param_init_fn``, if it is not
-            ``None``.
-            The same ``Callable`` is applied to initialize all meta modules. Note that this
-            initialization function is applied before doing any FSDP sharding
+            ``None``. The same ``Callable`` is applied to initialize all meta modules.
+            Note that this initialization function is applied before doing any FSDP sharding
             logic.
 
             Example::
@@ -518,6 +517,7 @@ class FullyShardedDataParallel(nn.Module):
                 >>> module = deferred_init.deferred_init(MyModule, device="cuda")
                 >>> # Will initialize via deferred_init.materialize_module().
                 >>> fsdp_model = FSDP(module, auto_wrap_policy=default_auto_wrap_policy)
+
     """
 
     def __init__(

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -502,7 +502,7 @@ class FullyShardedDataParallel(nn.Module):
             ``deferred_init`` API. In this case, deferred modules would be initialized
             by a default initialization function that calls torchdistX's
             ``materialize_module``, or the passed in ``param_init_fn``, if it is not
-                ``None``.
+            ``None``.
             The same ``Callable`` is applied to initialize all meta modules. Note that this
             initialization function is applied before doing any FSDP sharding
             logic.


### PR DESCRIPTION
Adds support for FSDP to initialize modules on a "meta" device, either through the in-tree device="meta" + reset_parameters approach or [torchdistx](https://github.com/cbalioglu/torchdistx)'s deferred_init + materialize_module APIs.

Current constraints:

1. Argument added is `param_init_fn` which is a single lambda that specifies how a module should be initialized. If needed to initialize different modules in different ways, user can do this in the function they specify, or we can enhance FSDP to take a Dict[str, Callable] to support this more natively.
2. Does not cleanly support `ignored_modules` at the moment. Concretely, if a module is not sharded at all, it may remain unitialized, and user will have to initialize it on their own. Will dig into this as follow up work.

Currently, unittests only contain device="meta" + reset_parameters approach because torchdistx is not available in CI. Will work with CI team in order to allow unittesting with torchdistx.
