### PR TITLE
[GH1] Add linalg related changes to merge rules

### DIFF
--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -42,6 +42,23 @@
       "mandatory_checks_name": ["Facebook CLA Check", "Lint"]
    },
    {
+      "name": "Linear Algebra",
+      "patterns": [
+         "aten/src/ATen/native/cuda/linalg/**",
+         "aten/src/ATen/LinalgBackend.h",
+         "aten/src/ATen/native/**/*LinearAlgebra*",
+         "docs/source/linalg.rst",
+         "torch/linalg/**",
+         "torch/_linalg_utils.py",
+         "torch/**/python_linalg_functions.*",
+         "torch/**/linalg.h",
+         "tools/autograd/templates/python_linalg_functions.cpp",
+         "test/test_linalg.py"
+      ],
+      "approved_by": ["nikitaved", "mruberry", "pearu", "Lezcano", "IvanYashchuk"],
+      "mandatory_checks_name": ["Facebook CLA Check", "Lint"]
+   },
+   {
       "name": "superuser",
       "patterns": ["*"],
       "approved_by": ["pytorch/metamates"],


### PR DESCRIPTION
This PR would allow Quansight linear algebra experts (in addition to metamates) to approve sparse related changes. Linear algebra would be a great place to start encouraging more GitHub 1st (GH1) landing to test our external contributor GH1 experience. 

This is DIFFERENT from the superuser rule because it allows non-metamates to be approvers.