### PR TITLE
remove math.h from generate_proposals_op_util_boxes.h

### DIFF
--- a/caffe2/operators/generate_proposals_op_util_boxes.h
+++ b/caffe2/operators/generate_proposals_op_util_boxes.h
@@ -2,7 +2,6 @@
 #define CAFFE2_OPERATORS_UTILS_BOXES_H_
 
 #include "caffe2/utils/eigen_utils.h"
-#include "caffe2/utils/math.h"
 
 #include <c10/util/irange.h>
 


### PR DESCRIPTION
generate_proposals_op_util_boxes.h is used by pytorch and math.h depends on profobuf which is not needed for pytorch.
