### PR TITLE
remove unused math.h from generate_proposals_op_util_nms.h

### DIFF
--- a/caffe2/operators/generate_proposals_op_util_nms.h
+++ b/caffe2/operators/generate_proposals_op_util_nms.h
@@ -6,7 +6,6 @@
 #include "caffe2/core/logging.h"
 #include "caffe2/core/macros.h"
 #include "caffe2/utils/eigen_utils.h"
-#include "caffe2/utils/math.h"
 
 #include <c10/util/irange.h>
 


### PR DESCRIPTION
generate_proposals_op_util_nms.h is needed by pytorch and math.h introduced protobuf dependency so we want to remove it.

Fixes #ISSUE_NUMBER
