### PR TITLE
[torchelastic] Mvoe get_host_addr into separate module

### DIFF
--- a/test/distributed/elastic/agent/server/test/api_test.py
+++ b/test/distributed/elastic/agent/server/test/api_test.py
@@ -21,12 +21,12 @@ from torch.distributed.elastic.agent.server.api import (
     WorkerGroup,
     WorkerSpec,
     WorkerState,
-    _get_fq_hostname,
     _RoleInstanceInfo,
 )
 from torch.distributed.elastic.multiprocessing import SignalException
 from torch.distributed.elastic.multiprocessing.errors import ProcessFailure
 from torch.distributed.elastic.rendezvous import RendezvousHandler, RendezvousParameters
+from torch.distributed.elastic.utils.common import _get_host_address
 from torch.distributed.elastic.utils.distributed import get_free_port
 from torch.testing._internal.common_utils import run_tests
 
@@ -300,7 +300,7 @@ class SimpleElasticAgentTest(unittest.TestCase):
 
         master_addr, master_port = agent._get_master_addr_port(worker_group.store)
 
-        self.assertEqual(_get_fq_hostname(), master_addr)
+        self.assertEqual(_get_host_address(), master_addr)
         self.assertTrue(master_port > 0)
 
         rank_set = {w.global_rank for w in worker_group.workers}

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -30,8 +30,8 @@ from torch.distributed.elastic.multiprocessing import (
     SignalException,
     Std,
 )
+from torch.distributed.elastic.utils.common import _get_host_address
 from torch.distributed.elastic.utils.logging import get_logger
-
 
 _TERMINAL_STATE_SYNC_ID = "torchelastic/agent/terminal_state"
 
@@ -381,10 +381,6 @@ def _get_socket_with_port() -> socket.socket:
     raise RuntimeError("Failed to create a socket")
 
 
-def _get_fq_hostname() -> str:
-    return socket.getfqdn(socket.gethostname())
-
-
 class ElasticAgent(abc.ABC):
     """
     Agent process responsible for managing one or more worker processes.
@@ -512,7 +508,7 @@ class SimpleElasticAgent(ElasticAgent):
                 master_port = sock.getsockname()[1]
 
         if master_addr is None:
-            master_addr = _get_fq_hostname()
+            master_addr = _get_host_address()
 
         store.set("MASTER_ADDR", master_addr.encode(encoding="UTF-8"))
         store.set("MASTER_PORT", str(master_port).encode(encoding="UTF-8"))
@@ -781,7 +777,7 @@ class SimpleElasticAgent(ElasticAgent):
             "group_rank": wg.group_rank,
             "worker_id": worker_id,
             "role": spec.role,
-            "hostname": _get_fq_hostname(),
+            "hostname": _get_host_address(),
             "state": state,
             "total_run_time": self._total_execution_time,
             "rdzv_backend": spec.rdzv_handler.get_backend(),

--- a/torch/distributed/elastic/utils/common.py
+++ b/torch/distributed/elastic/utils/common.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import socket
+
+
+def _get_host_address() -> str:
+    """
+    Returns address of the host. This can be either hostname or IP address
+    """
+    return socket.getfqdn(socket.gethostname())


### PR DESCRIPTION
Summary:
Move `get_host_addr` to separate module, and implement meta-internal `get_host_addr` that uses meta networking lib.

More info:   https://docs.google.com/document/d/1paDoXWOy1ws2i1riFypJ3hpP6rO7cPwzTAHnH8OkPKY

Test Plan:
[https://www.internalfb.com/mast/job/torchx-compute_world_size_main-gfkjf6xfvlfqdc](https://www.internalfb.com/mast/job/torchx-compute_world_size_main-gfkjf6xfvlfqdc)

Flow: https://www.internalfb.com/intern/fblearner/details/337178123

Reviewed By: kiukchung, Babar

Differential Revision: D35288985

