### PR TITLE
Exclude mobile TorchScript models from linter checks

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -304,6 +304,7 @@ command = [
 code = 'TABS'
 include_patterns = ['**']
 exclude_patterns = [
+    '**/*.ptl',
     '**/*.svg',
     '**/*Makefile',
     '**/contrib/**',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -269,6 +269,7 @@ exclude_patterns=[
     'third_party/**',
     '**/*.expect',
     '**/*.ipynb',
+    '**/*.ptl',
     'tools/clang_format_hash/**',
 ]
 command = [
@@ -304,7 +305,6 @@ command = [
 code = 'TABS'
 include_patterns = ['**']
 exclude_patterns = [
-    '**/*.ptl',
     '**/*.svg',
     '**/*Makefile',
     '**/contrib/**',

--- a/tools/linter/adapters/grep_linter.py
+++ b/tools/linter/adapters/grep_linter.py
@@ -160,7 +160,7 @@ def main() -> None:
     )
 
     try:
-        proc = run_command(["grep", "-nPH", args.pattern, *args.filenames])
+        proc = run_command(["grep", "-nPHI", args.pattern, *args.filenames])
     except Exception as err:
         err_msg = LintMessage(
             path=None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #73434
* #73433
* #75896
* __->__ #75906

When `lintrunner` is run on the whole repository, files are found using `grep` with the `-I` flag to exclude binary files. However, when it's run on a diff, it doesn't filter out binary files and runs into unexpected errors such as this CI run:
https://github.com/pytorch/pytorch/runs/6041884681