### PR TITLE
ci: Add ability to manually skip commits

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -212,7 +212,7 @@ class GitRepo:
                 to_commits.remove(commit)
         return (from_commits, to_commits)
 
-    def cherry_pick_commits(self, from_branch: str, to_branch: str) -> None:
+    def cherry_pick_commits(self, from_branch: str, to_branch: str, skip_commits: List[str]) -> None:
         orig_branch = self.current_branch()
         self.checkout(to_branch)
         from_commits, to_commits = self.compute_branch_diffs(from_branch, to_branch)
@@ -221,7 +221,10 @@ class GitRepo:
             self.checkout(orig_branch)
             return
         for commit in reversed(from_commits):
-            print(f"Cherry picking commit {commit}")
+            if commit in skip_commits:
+                print(f"- Manually skipping commit {commit}")
+                continue
+            print(f"+ Cherry picking commit {commit}")
             self.cherry_pick(commit)
         self.checkout(orig_branch)
 

--- a/.github/scripts/syncbranches.py
+++ b/.github/scripts/syncbranches.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import os
+
 from gitutils import get_git_repo_dir, get_git_remote_name, GitRepo
 from typing import Any
 
@@ -11,13 +13,18 @@ def parse_args() -> Any:
     parser.add_argument("--default-branch", type=str, default="main")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--debug", action="store_true")
+    parser.add_argument(
+        "--skip-commits",
+        type=str,
+        default=os.environ.get("PYTORCH_SYNC_SKIP_COMMITS", "")
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name(), debug=args.debug)
-    repo.cherry_pick_commits(args.sync_branch, args.default_branch)
+    repo.cherry_pick_commits(args.sync_branch, args.default_branch, args.skip_commits.split(","))
     repo.push(args.default_branch, args.dry_run)
 
 


### PR DESCRIPTION
Adds the ability to manually skip commits in syncbranches.py

This is useful for when commits are blocking syncbranches from running
and we need to manually skip commits to unblock syncbranches.

Usage:
```
python3 .github/scripts/syncbranches.py --sync-branch=fbsync --default-branch=master --dry-run --debug --skip-commits "ed262b15487557720bb0d498f9f2e8fcdba772d9"
```

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Fixes #ISSUE_NUMBER
