### PR TITLE
Register torch.return_types.* as pytree nodes

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -5,6 +5,7 @@ from torch.testing._internal.common_utils import TestCase, run_tests
 from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten, TreeSpec, LeafSpec
 from torch.utils._pytree import _broadcast_to_and_flatten
 from collections import namedtuple
+from torch.testing._internal.common_utils import parametrize, subtest, instantiate_parametrized_tests
 
 class TestPytree(TestCase):
     def test_treespec_equality(self):
@@ -79,11 +80,18 @@ class TestPytree(TestCase):
         run_test(Point(1., 2))
         run_test(Point(torch.tensor(1.), 2))
 
-    def test_flatten_unflatten_torch_namedtuple_return_type(self):
+    @parametrize("op", [
+        subtest(torch.max, name='max'),
+        subtest(torch.min, name='min'),
+    ])
+    def test_flatten_unflatten_return_type(self, op):
         x = torch.randn(3, 3)
-        expected = torch.max(x, dim=0)
+        expected = op(x, dim=0)
 
         values, spec = tree_flatten(expected)
+        # Check that values is actually List[Tensor] and not (ReturnType(...),)
+        for value in values:
+            self.assertTrue(isinstance(value, torch.Tensor))
         result = tree_unflatten(values, spec)
 
         self.assertEqual(type(result), type(expected))
@@ -203,6 +211,8 @@ class TestPytree(TestCase):
             result = _broadcast_to_and_flatten(pytree, to_spec)
             self.assertEqual(result, expected, msg=str([pytree, to_spec, expected]))
 
+
+instantiate_parametrized_tests(TestPytree)
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/return_types.py
+++ b/torch/return_types.py
@@ -1,12 +1,31 @@
 import torch
+import inspect
 
 __all__ = []
 
 # error: Module has no attribute "_return_types"
 return_types = torch._C._return_types  # type: ignore[attr-defined]
 
+def pytree_register_structseq(cls):
+    def structseq_flatten(structseq):
+        return list(structseq), None
+
+    def structseq_unflatten(values, context):
+        return cls(values)
+
+    torch.utils._pytree._register_pytree_node(cls, structseq_flatten, structseq_unflatten)
+
 for name in dir(return_types):
     if name.startswith('__'):
         continue
     globals()[name] = getattr(return_types, name)
     __all__.append(name)
+
+    # Today everything in torch.return_types is a structseq, aka a "namedtuple"-like
+    # thing defined by the Python C-API. We're going to need to modify this when that
+    # is no longer the case.
+    # NB: I don't know how to check that something is a "structseq" so we do a fuzzy
+    # check for tuple
+    attr = globals()[name]
+    if inspect.isclass(attr) and issubclass(attr, tuple):
+        pytree_register_structseq(attr)


### PR DESCRIPTION
All of the torch.return_types.* are these special things "structseq"
that subclass tuple but have a different constructor from tuple :(.

This PR iterates through all of torch.return_types.* and adds a pytree
registration for them.

Test Plan:
- add tests for max and min which return torch.return_types.max, and
torch.return_types.min, respectively. There's not an easy way to
"get all torch ops that return a return_types object".

Fixes https://github.com/pytorch/pytorch/issues/75218
