### PR TITLE
switch DimensionNode's base from TsNode to Node

### DIFF
--- a/torch/csrc/lazy/core/dynamic_ir.cpp
+++ b/torch/csrc/lazy/core/dynamic_ir.cpp
@@ -4,7 +4,7 @@ namespace torch {
 namespace lazy {
 
 DimensionNode::DimensionNode(OpKind op, OpList operands, hash_t hash_seed):
-  TsNode(op, operands, /*num_outputs=*/1,
+  Node(op, operands, /*num_outputs=*/1,
   /* node_hash */ HashCombine(op.hash(), hash_seed)){}
 
 std::string DimensionNode::ToString() const {

--- a/torch/csrc/lazy/core/dynamic_ir.h
+++ b/torch/csrc/lazy/core/dynamic_ir.h
@@ -43,16 +43,9 @@ namespace lazy {
  * burned into the Graph.
  */
 
-class TORCH_API DimensionNode : public lazy::TsNode {
+class TORCH_API DimensionNode : public lazy::Node {
  public:
   DimensionNode(OpKind op, OpList operands, hash_t hash_seed = kHashSeed);
-
-  // N.B. Node doesn't have sizes() so we don't need to override it to
-  // throw an error
-
-  // TODO: Fix this when John lands input shape API. Change
-  // DimensionNode's `isDynamic` to a virtual method and implement the
-  // actual `isDynamic` in all DimensionNode subclasses
   bool isDynamic() {
       return false;
   }


### PR DESCRIPTION
Switching the base of DimensionNode to TsNode so it can be reused by XLA and other backends.