### PR TITLE
exclude slow tests from sharding calc for linux-bionic-py3.7-clang9-test

### DIFF
--- a/tools/stats/s3_stat_parser.py
+++ b/tools/stats/s3_stat_parser.py
@@ -1,13 +1,12 @@
 import bz2
 import json
 import logging
+import os
 import subprocess
 from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Union, Any, cast
 from typing_extensions import Literal, TypedDict
-
-from tools.testing.test_selections import _get_stripped_CI_job
 
 try:
     import boto3  # type: ignore[import]
@@ -144,6 +143,19 @@ def get_cases(
         else:
             raise RuntimeError(f'Unknown format version: {version}')
     return cases
+
+
+def _get_stripped_CI_job() -> str:
+    """E.g. convert 'pytorch_windows_vs2019_py36_cuda10.1_build' to 'pytorch_windows_vs2019_py36_cuda10.1'.
+    """
+    job = os.environ.get("JOB_BASE_NAME", "").rstrip('0123456789')
+    if job.endswith('_slow_test'):
+        job = job[:len(job) - len('_slow_test')]
+    elif job.endswith('_test') or job.endswith('-test'):
+        job = job[:len(job) - len('_test')]
+    elif job.endswith('_build') or job.endswith('-build'):
+        job = job[:len(job) - len('_build')]
+    return job
 
 
 def _parse_master_summaries(summaries: Any, jobs: List[str]) -> Dict[str, List[Report]]:

--- a/tools/stats/s3_stat_parser.py
+++ b/tools/stats/s3_stat_parser.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Union, Any, cast
 from typing_extensions import Literal, TypedDict
 
+from tools.testing.test_selections import _get_stripped_CI_job
+
 try:
     import boto3  # type: ignore[import]
     import botocore  # type: ignore[import]
@@ -210,9 +212,10 @@ def get_previous_reports_for_branch(branch: str, ci_job_prefix: str = "") -> Lis
         logger.info(f'Grabbing reports from commit: {commit}')
         summaries = get_test_stats_summaries_for_job(sha=commit, job_prefix=ci_job_prefix)
         for job_name, summary in summaries.items():
-            reports.append(summary[0])
-            if len(summary) > 1:
-                logger.warning(f'WARNING: Multiple summary objects found for {commit}/{job_name}')
+            if job_name[:len(job_name) - len('-test')] == _get_stripped_CI_job():
+                if len(summary) > 1:
+                    logger.warning(f'WARNING: Multiple summary objects found for {commit}/{job_name}')
+                reports.extend(summary)
         commit_index += 1
     return reports
 

--- a/tools/testing/test_selections.py
+++ b/tools/testing/test_selections.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 
 from tools.stats.s3_stat_parser import (
+    _get_stripped_CI_job,
     get_previous_reports_for_branch,
     get_previous_reports_for_pr,
     Report, Version2Report,
@@ -20,19 +21,6 @@ class JobTimeJSON(TypedDict):
     commit: str
     JOB_BASE_NAME: str
     job_times: Dict[str, float]
-
-
-def _get_stripped_CI_job() -> str:
-    """E.g. convert 'pytorch_windows_vs2019_py36_cuda10.1_build' to 'pytorch_windows_vs2019_py36_cuda10.1'.
-    """
-    job = os.environ.get("JOB_BASE_NAME", "").rstrip('0123456789')
-    if job.endswith('_slow_test'):
-        job = job[:len(job) - len('_slow_test')]
-    elif job.endswith('_test') or job.endswith('-test'):
-        job = job[:len(job) - len('_test')]
-    elif job.endswith('_build') or job.endswith('-build'):
-        job = job[:len(job) - len('_build')]
-    return job
 
 
 def _get_job_times_json(job_times: Dict[str, float]) -> JobTimeJSON:


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

Sharding for linux-bionic-py3.7-clang9 previously included slow test times in the calculation for how long a test takes, causing the sharding to be uneven:

| Duration      | Count | Name|
| ----------- | ----------- | ---|
| 11.2m      | 221       |linux-bionic-py3.7-clang9 / test (default, 1, 2, linux.2xlarge)|
| 1.1h   | 218        | linux-bionic-py3.7-clang9 / test (default, 2, 2, linux.2xlarge)|

Numbers taken from https://hud.pytorch.org/metrics from 04/10/2022 12:20 PM to 04/17/2022 12:20 PM.

The duration of these jobs on this PR are 39m and 38m.