### PR TITLE
ci: Change with-ssh to be on by default

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -14,3 +14,4 @@ runs:
       uses: seemethere/add-github-ssh-key@v1
       with:
         GITHUB_TOKEN: ${{ inputs.github-secret }}
+        activate-with-label: false


### PR DESCRIPTION
Changes the behavior of with-ssh to no longer require a label in order to activate

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
