### PR TITLE
[lint] fix spurious annotations on formatting linters

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1,3 +1,6 @@
+[init_config]
+last_hash = "7d8b366223b22aaab788b0a7efec064dfef38b24"
+
 [[linter]]
 code = 'FLAKE8'
 include_patterns = ['**/*.py']

--- a/tools/linter/adapters/circleci_linter.py
+++ b/tools/linter/adapters/circleci_linter.py
@@ -100,8 +100,8 @@ def run_check(
     return [
         LintMessage(
             path=config_file,
-            line=1,
-            char=1,
+            line=None,
+            char=None,
             code="CIRCLECI",
             severity=LintSeverity.ERROR,
             name="config inconsistency",

--- a/tools/linter/adapters/clangformat_linter.py
+++ b/tools/linter/adapters/clangformat_linter.py
@@ -153,8 +153,8 @@ def check_file(
     return [
         LintMessage(
             path=filename,
-            line=1,
-            char=1,
+            line=None,
+            char=None,
             code="CLANGFORMAT",
             severity=LintSeverity.WARNING,
             name="format",

--- a/tools/linter/adapters/nativefunctions_linter.py
+++ b/tools/linter/adapters/nativefunctions_linter.py
@@ -89,8 +89,8 @@ if __name__ == "__main__":
     if contents != new_contents:
         msg = LintMessage(
             path=args.native_functions_yml,
-            line=1,
-            char=1,
+            line=None,
+            char=None,
             code="NATIVEFUNCTIONS",
             severity=LintSeverity.ERROR,
             name="roundtrip inconsistency",

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -6,6 +6,12 @@
 #include <c10/util/StringUtil.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/api/function_impl.h>
+
+
+
+
+
+
 #include <torch/csrc/jit/frontend/error_report.h>
 #include <torch/csrc/jit/frontend/schema_matching.h>
 #include <torch/csrc/jit/ir/constants.h>

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -6,12 +6,6 @@
 #include <c10/util/StringUtil.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/api/function_impl.h>
-
-
-
-
-
-
 #include <torch/csrc/jit/frontend/error_report.h>
 #include <torch/csrc/jit/frontend/schema_matching.h>
 #include <torch/csrc/jit/ir/constants.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #75928

We would for some reason report formatting-based lints as showing up at
line 1 column 1. This removes them for now. Maybe eventually we can
recover better line numbers from the formatting diff and post messages
for each diff cluster, but that requires actual changes to the linting
engine.