### PR TITLE
Make binary_cross_entropy_with_logits composite compliant

### DIFF
--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -332,7 +332,7 @@ Tensor binary_cross_entropy_with_logits(
   auto max_val = (-input).clamp_min_(0);
   auto hasSubclassTensors = at::areAnyTensorSubclassLike({target, input});
   if (pos_weight.defined()) {
-    // pos_weight need to be broadcasted, thus mul(target) is not inplace.
+    // pos_weight might need to be broadcasted, thus mul(target) is not inplace.
     auto log_weight = (pos_weight - 1).mul(target).add_(1);
     loss = hasSubclassTensors
         ? (1 - target)
@@ -360,7 +360,7 @@ Tensor binary_cross_entropy_with_logits(
   }
   if (weight.defined()) {
     if (at::areAnyTensorSubclassLike({loss, weight})) {
-      loss.mul(weight);
+      loss = loss.mul(weight);
     } else {
       loss.mul_(weight);
     }
@@ -388,7 +388,7 @@ Tensor binary_cross_entropy_with_logits_backward(
 
   // If there are subclassed tensors use the out of place version
   if (pos_weight.defined()) {
-    // pos_weight need to be broadcasted, thus mul(target) is not inplace.
+    // pos_weight might need to be broadcasted, thus mul(target) is not inplace.
     auto t = pos_weight.mul(target);
     grad_input = hasSubclassTensors
         ? t.add(1).sub(target).mul(input.sigmoid()).sub(t).mul(grad)
@@ -399,7 +399,7 @@ Tensor binary_cross_entropy_with_logits_backward(
   }
   if (weight.defined()) {
     if (at::areAnyTensorSubclassLike({grad_input, weight})) {
-      grad_input.mul(weight);
+      grad_input = grad_input.mul(weight);
     } else {
       grad_input.mul_(weight);
     }

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -8,6 +8,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
 #include <c10/util/Exception.h>
+#include <ATen/TensorSubclassLikeUtils.h>
 
 constexpr float EPSILON = 1e-12;
 
@@ -314,53 +315,101 @@ Tensor& binary_cross_entropy_backward_out_cpu(const Tensor& grad, const Tensor& 
     return grad_input;
 }
 
-Tensor binary_cross_entropy_with_logits(const Tensor& input, const Tensor& target, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& pos_weight_opt, int64_t reduction) {
+Tensor binary_cross_entropy_with_logits(
+    const Tensor& input,
+    const Tensor& target,
+    const c10::optional<Tensor>& weight_opt,
+    const c10::optional<Tensor>& pos_weight_opt,
+    int64_t reduction) {
   // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
+  c10::MaybeOwned<Tensor> weight_maybe_owned =
+      at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
-  const Tensor& pos_weight = c10::value_or_else(pos_weight_opt, [] {return Tensor();});
+  const Tensor& pos_weight =
+      c10::value_or_else(pos_weight_opt, [] { return Tensor(); });
 
-    Tensor loss;
-    auto max_val = (-input).clamp_min_(0);
-    if (pos_weight.defined()) {
-        // pos_weight need to be broadcasted, thus mul(target) is not inplace.
-        auto log_weight = (pos_weight - 1).mul(target).add_(1);
-        loss = (1 - target).mul_(input).add_(log_weight.mul_(((-max_val).exp_().add_((-input - max_val).exp_())).log_().add_(max_val)));
+  Tensor loss;
+  auto max_val = (-input).clamp_min_(0);
+  auto hasSubclassTensors = at::areAnyTensorSubclassLike({target, input});
+  if (pos_weight.defined()) {
+    // pos_weight need to be broadcasted, thus mul(target) is not inplace.
+    auto log_weight = (pos_weight - 1).mul(target).add_(1);
+    loss = hasSubclassTensors
+        ? (1 - target)
+              .mul(input)
+              .add(log_weight.mul(
+                  ((-max_val).exp().add((-input - max_val).exp()))
+                      .log()
+                      .add(max_val)))
+        : (1 - target)
+              .mul_(input)
+              .add_(log_weight.mul_(
+                  ((-max_val).exp_().add_((-input - max_val).exp_()))
+                      .log_()
+                      .add_(max_val)));
+  } else {
+    loss = hasSubclassTensors
+        ? (1 - target)
+              .mul(input)
+              .add(max_val)
+              .add((-max_val).exp().add((-input - max_val).exp()).log())
+        : (1 - target)
+              .mul_(input)
+              .add_(max_val)
+              .add_((-max_val).exp_().add_((-input - max_val).exp_()).log_());
+  }
+  if (weight.defined()) {
+    if (at::areAnyTensorSubclassLike({loss, weight})) {
+      loss.mul(weight);
     } else {
-        loss = (1 - target).mul_(input).add_(max_val).add_((-max_val).exp_().add_((-input -max_val).exp_()).log_());
+      loss.mul_(weight);
     }
+  }
 
-    if (weight.defined()) {
-        loss.mul_(weight);
-    }
-
-    return apply_loss_reduction(loss, reduction);
+  return apply_loss_reduction(loss, reduction);
 }
 
-Tensor binary_cross_entropy_with_logits_backward(const Tensor& grad, const Tensor& input, const Tensor& target, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& pos_weight_opt, int64_t reduction) {
+Tensor binary_cross_entropy_with_logits_backward(
+    const Tensor& grad,
+    const Tensor& input,
+    const Tensor& target,
+    const c10::optional<Tensor>& weight_opt,
+    const c10::optional<Tensor>& pos_weight_opt,
+    int64_t reduction) {
   // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
+  c10::MaybeOwned<Tensor> weight_maybe_owned =
+      at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
-  const Tensor& pos_weight = c10::value_or_else(pos_weight_opt, [] {return Tensor();});
+  const Tensor& pos_weight =
+      c10::value_or_else(pos_weight_opt, [] { return Tensor(); });
 
-    Tensor grad_input;
-    if (pos_weight.defined()) {
-        // pos_weight need to be broadcasted, thus mul(target) is not inplace.
-        auto t = pos_weight.mul(target);
-        grad_input = t.add(1).sub_(target).mul_(input.sigmoid()).sub_(t).mul_(grad);
+  Tensor grad_input;
+  auto hasSubclassTensors = at::areAnyTensorSubclassLike({grad, input, target});
+
+  // If there are subclassed tensors use the out of place version
+  if (pos_weight.defined()) {
+    // pos_weight need to be broadcasted, thus mul(target) is not inplace.
+    auto t = pos_weight.mul(target);
+    grad_input = hasSubclassTensors
+        ? t.add(1).sub(target).mul(input.sigmoid()).sub(t).mul(grad)
+        : t.add(1).sub_(target).mul_(input.sigmoid()).sub_(t).mul_(grad);
+  } else {
+    grad_input = hasSubclassTensors ? (input.sigmoid() - target).mul(grad)
+                                    : (input.sigmoid() - target).mul_(grad);
+  }
+  if (weight.defined()) {
+    if (at::areAnyTensorSubclassLike({grad_input, weight})) {
+      grad_input.mul(weight);
     } else {
-        grad_input = (input.sigmoid() - target).mul_(grad);
+      grad_input.mul_(weight);
     }
+  }
 
-    if (weight.defined()) {
-        grad_input.mul_(weight);
-    }
+  if (reduction == at::Reduction::Mean) {
+    return grad_input / input.numel();
+  }
 
-    if (reduction == at::Reduction::Mean) {
-        return grad_input / input.numel();
-    }
-
-    return grad_input;
+  return grad_input;
 }
 
 Tensor poisson_nll_loss(const Tensor& input, const Tensor& target, const bool log_input, const bool full, const double eps, const int64_t reduction)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11587,6 +11587,12 @@ op_db: List[OpInfo] = [
                 'test_variant_consistency_jit',
                 dtypes=(torch.float32,)
             ),
+            DecorateInfo(
+                unittest.expectedFailure,
+                'TestCompositeCompliance',
+                'test_forward_ad',
+                dtypes=(torch.float32,)
+            ),
             DecorateInfo(unittest.skip("Skipped!"), 'TestGradients', "test_fn_gradgrad", dtypes=(torch.float64,)),
             DecorateInfo(unittest.skip("Skipped!"), 'TestGradients', "test_forward_mode_AD", dtypes=(torch.float64,)),
             DecorateInfo(unittest.skip("Skipped!"), 'TestGradients', "test_fn_fwgrad_bwgrad", dtypes=(torch.float64,)),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11577,13 +11577,13 @@ op_db: List[OpInfo] = [
             DecorateInfo(
                 unittest.skip("Skipped!"),
                 "TestNNCOpInfo",
-                "test_nnc_correctness",
+                "test_nc_correctness",
             ),
-            # Adding OpInfo to existing operator
+            # The Weight tensor requires_grad = False
             DecorateInfo(
                 unittest.skip("Skipped!"),
-                "TestCompositeCompliance",
-                "test_backward",
+                "TestCommon",
+                "test_floating_inputs_are_differentiable",
                 dtypes=(torch.float32,)
             ),
             DecorateInfo(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7816,16 +7816,24 @@ def sample_inputs_nll_loss(op_info, device, dtype, requires_grad, **kwargs):
 def sample_inputs_binary_cross_entropy_with_logits(
     op_info, device, dtype, requires_grad, **kwargs
 ):
-    _make_tensor = partial(make_tensor, device=device, dtype=dtype, requires_grad=False)
-    for input, target, base_dict in _generate_sample_inputs_nn_loss(
-        op_info, device, dtype, requires_grad, **kwargs
-    ):
-        weight_lst = [None, random.uniform(-9, 9)]
-        pos_weight_lst = [None, random.uniform(-9, 9)]
-        for weight, pos_weight in product(weight_lst, pos_weight_lst):
-            base_dict["weight"] = _make_tensor(input.shape)
-            base_dict["pos_weight"] = _make_tensor(1, low=0)
-            yield SampleInput(input, args=(target,), kwargs=base_dict)
+    make = partial(make_tensor, device=device, dtype=dtype)
+    make_prob = partial(make, low=0, high=1)
+
+    reductions = ("mean", "sum", "none")
+
+    shapes_and_kwargs = [
+        *[(shape, None) for shape in ((), (1,), (S,), (S, S), (S, S, S))],
+        *[((S, S), dict(reduction=reduction)) for reduction in reductions],
+        *[((S, S), dict(reduction=reduction, weight=make((S, S)))) for reduction in reductions],
+        *[((S, S), dict(reduction=reduction, pos_weight=make((S,), low=0))) for reduction in reductions]
+    ]
+
+    for shape, kwargs in shapes_and_kwargs:
+        yield SampleInput(
+            make(shape, requires_grad=requires_grad),
+            args=(make_prob(shape, requires_grad=requires_grad),),
+            kwargs=kwargs,
+        )
 
 def sample_inputs_argwhere(op_info, device, dtype, requires_grad, **kwargs):
     yield SampleInput(torch.tensor([1, 0, 2, 0], dtype=dtype, device=device, requires_grad=requires_grad))
@@ -11567,43 +11575,6 @@ op_db: List[OpInfo] = [
         gradcheck_nondet_tol=GRADCHECK_NONDET_TOL,
         sample_inputs_func=sample_inputs_binary_cross_entropy_with_logits,
         skips=(
-            # RuntimeError: expected int at position 0, but got: Tensor
-            DecorateInfo(
-                unittest.skip("Skipped!"),
-                "TestCudaFuserOpInfo",
-                "test_nvfuser_correctness",
-            ),
-            # RuntimeError: expected int at position 0, but got: Tensor
-            DecorateInfo(
-                unittest.skip("Skipped!"),
-                "TestNNCOpInfo",
-                "test_nc_correctness",
-            ),
-            # The Weight tensor requires_grad = False
-            DecorateInfo(
-                unittest.skip("Skipped!"),
-                "TestCommon",
-                "test_floating_inputs_are_differentiable",
-                dtypes=(torch.float32,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                'TestCompositeCompliance',
-                'test_forward_ad'),
-            # Pos Weight is required to be positve
-            DecorateInfo(
-                unittest.skip("Skipped!"),
-                "TestMathBits",
-                "test_neg_view",
-                dtypes=(torch.float64,)
-            ),
-            # Test Gradient failures CI
-            DecorateInfo(
-                unittest.skip("Skipped!"),
-                "TestGradients",
-                "test_neg_view",
-                dtypes=(torch.float64,)
-            ),
             DecorateInfo(
                 unittest.skip("Skipped!"),
                 'TestJit',

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7831,7 +7831,7 @@ def sample_inputs_binary_cross_entropy_with_logits(
         *[((S, S), dict(reduction=reduction)) for reduction in reductions],
         *make_weight_shape_kwargs(),
         *[((S, S), dict(reduction=reduction, pos_weight=make((S,), low=0))) for reduction in reductions],
-        *[((S, S), dict(reduction=reduction,  weight=make((S, S)), pos_weight=make((S,), low=0))) for reduction in reductions],
+        *[((S, S), dict(reduction=reduction, weight=make((S, S)), pos_weight=make((S,), low=0))) for reduction in reductions],
     ]
 
     for shape, kwargs in shapes_and_kwargs:


### PR DESCRIPTION
Fixes one of the tests related to this issue #75680
Removes the skip for the composite compliance test_backward and updates implementation of binary_cross_entropy_with_logits so that the correct inplace and out of place operators are used depending on tensor subclasses being present