### PR TITLE
[torch deploy] Re-define D_GLIBCXX_USE_CXX11_ABI in deploy CMakeLists.txt

### DIFF
--- a/torch/csrc/deploy/CMakeLists.txt
+++ b/torch/csrc/deploy/CMakeLists.txt
@@ -1,6 +1,13 @@
 set(DEPLOY_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 add_subdirectory(interpreter)
 
+if(DEFINED GLIBCXX_USE_CXX11_ABI)
+  if(${GLIBCXX_USE_CXX11_ABI} EQUAL 1)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
+    set(TORCH_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=1")
+  endif()
+endif()
+
 # we do not want to have torch_deployinterpreter linked against libstdc++ or libc because
 # when loading it with RTLD_DEEPBIND it will resolve std::cout/stdout to the copy in libc++/libc instead of the
 # ones in the main process (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42679).


### PR DESCRIPTION
Summary:
**context**
GLIBCXX_USE_CXX11_ABI dictates whether the compiler uses the new (1) or old (0) ABI.
The new abi defines strings as: `std::__cxx11::string`
The old abi defines strings as: `std::string`
Usually GLIBCXX_USE_CXX11_ABI defaults to 1 on most systems.

Differential Revision: D35694220

