### PR TITLE
[quant][gpu][core] Removed TORCH_API from quantized cudnn linear and conv packed param classes

### DIFF
--- a/aten/src/ATen/native/quantized/cudnn/utils.h
+++ b/aten/src/ATen/native/quantized/cudnn/utils.h
@@ -19,7 +19,7 @@ This file contains some of the auxiliary functions used by both Conv.cpp & Linea
 #include <c10/util/ArrayRef.h>
 #include <cudnn_frontend.h>
 
-struct TORCH_API PackedLinearWeightCudnn : public LinearPackedParamsBase {
+struct PackedLinearWeightCudnn : public LinearPackedParamsBase {
   PackedLinearWeightCudnn(
       at::Tensor orig_weight,
       c10::optional<at::Tensor> bias,
@@ -77,7 +77,7 @@ struct TORCH_API PackedLinearWeightCudnn : public LinearPackedParamsBase {
 };
 
 template <int kSpatialDim = 2>
-struct TORCH_API PackedConvWeightCudnn : public ConvPackedParamsBase<kSpatialDim> {
+struct PackedConvWeightCudnn : public ConvPackedParamsBase<kSpatialDim> {
   PackedConvWeightCudnn(
       at::Tensor orig_weight,
       c10::optional<at::Tensor> bias,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #75934

Summary:
The TORCH_API may be the culprit for CI failures when compiling with
visual C++ (definition of dllimport function not allowed).
This is currently a test PR to see if this fixes the issue.