### PR TITLE
Remove unnecessary casts from _query_to_dict

### DIFF
--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -52,9 +52,9 @@ def register_rendezvous_handler(scheme, handler):
 
 # Query will have format "rank=0&world_size=1" and is
 # converted into {"rank": 0, "world_size": 1}
-def _query_to_dict(query):
+def _query_to_dict(query: str):
     query_dict: Dict[str, str] = dict(
-        cast(Tuple[str, str], pair.split("=")) for pair in cast(Iterable[str], filter(None, query.split("&")))
+        pair.split("=") for pair in filter(None, query.split("&"))
     )
     return query_dict
 


### PR DESCRIPTION
It is unnecessary and inefficient to perform `n + 1` casts (one cast for each parameter name-value pair and one cast for the `filter` generator itself) in a dictionary comprehension when only `1` type annotation is needed to avoid mypy warnings/errors.

Now, the helper function `_query_to_dict`, used in each of the 3 rendezvous handlers, store creation, as well as for the initial parsing of the URL string in `rendezvous()` itself, is cleaner and performs no extraneous function calls (i.e., the `n + 1` casts), instead using a single type annotation in the function definition, which is sufficient for mypy to infer the types of all internal variables.