### PR TITLE
[GHF] Fix sync-branches

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -210,6 +210,13 @@ class GitRepo:
                 from_commits.remove(commit)
             for commit in to_values:
                 to_commits.remove(commit)
+        # Another HACK: Patch-id is not stable for commits with binary files
+        # I.e. cherry-picking those from one branch into another will change patchid
+        if "pytorch/pytorch" in self.remote_url():
+            for excluded_commit in ["8e09e20c1dafcdbdb45c2d1574da68a32e54a3a5"]:
+                if excluded_commit in from_commits:
+                    from_commits.remove(excluded_commit)
+
         return (from_commits, to_commits)
 
     def cherry_pick_commits(self, from_branch: str, to_branch: str) -> None:


### PR DESCRIPTION
Manually skip 8e09e20c1dafcdbdb45c2d1574da68a32e54a3a5 which introduces
unstable patch-ids
