### PR TITLE
Disallow calling tolist on tensors with nullptr storage

### DIFF
--- a/torch/csrc/utils/tensor_list.cpp
+++ b/torch/csrc/utils/tensor_list.cpp
@@ -19,7 +19,6 @@ static PyObject* recursive_to_list(
   }
   auto n = sizes[dim];
   auto list = THPObjectPtr(PyList_New(n));
-  TORCH_CHECK(data, "tolist() shouldn't be called on a tensor with unallocated storage");
   if (!list) throw python_error();
   for(const auto i : c10::irange(n)) {
     PyObject* obj = recursive_to_list(data, sizes, strides, dim + 1, scalarType, elementSize);
@@ -37,6 +36,7 @@ PyObject* tensor_to_list(const Tensor& tensor) {
     pybind11::gil_scoped_release no_gil;
     data = data.toBackend(Backend::CPU);
   }
+  TORCH_CHECK(tensor.numel() == 0 || data.data_ptr(), "tolist() shouldn't be called on a tensor with unallocated storage");
   return recursive_to_list(
       (char*)data.data_ptr(), data.sizes(), data.strides(), 0,
       data.scalar_type(), data.dtype().itemsize());

--- a/torch/csrc/utils/tensor_list.cpp
+++ b/torch/csrc/utils/tensor_list.cpp
@@ -19,6 +19,7 @@ static PyObject* recursive_to_list(
   }
   auto n = sizes[dim];
   auto list = THPObjectPtr(PyList_New(n));
+  TORCH_CHECK(data, "tolist() shouldn't be called on a tensor with unallocated storage");
   if (!list) throw python_error();
   for(const auto i : c10::irange(n)) {
     PyObject* obj = recursive_to_list(data, sizes, strides, dim + 1, scalarType, elementSize);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #75990

In response to [D35571561](https://l.workplace.com/l.php?u=https%3A%2F%2Fwww.internalfb.com%2Fdiff%2FD35571561%3Fentry_point%3D20&h=AT0fUr10R18qDZCM0JNBDjvu4bPW4NDrbG-YPL40LgC73o2Ti9zUogTs_ATLf5h1ZwD9RNxO4Zlx7OSD7XqUl9aD_NNbDdAjHJaON5sWpOQmXWXhFUYZ20J_Acd-2wqhsKIIPFhYmvaINdnSH-tLEvvT-7w5Xdj1Obn8jpfUZw1tFPbQp1fMUA&__tn__=-UK-R&c[0]=AT2_w0m9Tyt1GS5CPv5FM8x_lItxqpKxqgy0-nSaEEmerYZD_WDPUGrW7J4aAREupRcNW1S-hAAqRo-xCh5YherOpo_zaAUaFiTjpzrmzCyaxnL_JVFRr-IU0T94apwL3CRvTAYftYYMmPbqtRAs6s7ZzY8FBQYKIC3SZruVzhjpYr0l1CfhMm5jFMxi5xnZM5SX)
```
>>> torch._efficientzerotensor(2).tolist()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: tolist() shouldn't be called on a tensor with unallocated storage
```
This code used to segfault before. Not adding this as a test because we should just return a list of zeros in this case. will fix it in a follow up PR. 