### PR TITLE
Experimental MetaTensorTracer

### DIFF
--- a/torch/fx/experimental/meta_tracer.py
+++ b/torch/fx/experimental/meta_tracer.py
@@ -4,7 +4,7 @@ import warnings
 import functools
 import builtins
 
-from typing import Dict
+from typing import Callable, Dict
 
 def embedding_override(self, input):
     return torch.empty(*input.shape, self.weight.shape[-1], device='meta')
@@ -37,7 +37,7 @@ def torch_abs_override(input, *, out=None):
     assert out is None, 'Dont support in-place abs for MetaTensor analysis'
     return input
 
-manual_meta_overrides = {
+manual_meta_overrides : Dict[Callable, Callable] = {
     torch.nn.Embedding: embedding_override,
     torch.nn.LayerNorm: nn_layernorm_override,
     torch.relu: torch_relu_override,

--- a/torch/fx/experimental/meta_tracer.py
+++ b/torch/fx/experimental/meta_tracer.py
@@ -18,6 +18,10 @@ def torch_relu_override(x):
     return x
 
 
+def torch_nn_relu_override(self, x):
+    return x
+
+
 def functional_relu_override(x, inplace=False):
     assert not inplace, 'dont support inplace functional.relu for metatensor analysis'
     return x
@@ -38,6 +42,7 @@ manual_meta_overrides = {
     torch.nn.LayerNorm: nn_layernorm_override,
     torch.relu: torch_relu_override,
     torch.nn.functional.relu: functional_relu_override,
+    torch.nn.ReLU: torch_nn_relu_override,
     torch.where: torch_where_override,
     torch.abs: torch_abs_override,
 }
@@ -190,7 +195,7 @@ class MetaTracer(torch.fx.Tracer):
             assert isinstance(rv, torch.fx.Proxy), 'Dont support composite output yet'
             rv.install_tensor_meta(meta_out)
         except Exception as e:
-            warnings.warn(f'Could not compute metadata for target {target}: {e}')
+            warnings.warn(f'Could not compute metadata for {kind} target {target}: {e}')
 
         return rv
 

--- a/torch/fx/experimental/meta_tracer.py
+++ b/torch/fx/experimental/meta_tracer.py
@@ -1,0 +1,205 @@
+import torch
+import torch.fx
+import warnings
+import functools
+
+from typing import Dict
+
+def embedding_override(self, input):
+    return torch.empty(*input.shape, self.weight.shape[-1], device='meta')
+
+
+def nn_layernorm_override(self, input):
+    return input
+
+
+def torch_relu_override(x):
+    return x
+
+
+manual_meta_overrides = {
+    torch.nn.Embedding: embedding_override,
+    torch.nn.LayerNorm: nn_layernorm_override,
+    torch.relu: torch_relu_override,
+}
+
+def gen_constructor_wrapper(target):
+    @functools.wraps(target)
+    def wrapper(*args, **kwargs):
+        proxy = None
+
+        def check_has_proxy(v):
+            if isinstance(v, torch.fx.Proxy):
+                nonlocal proxy
+                proxy = v
+        torch.fx.node.map_aggregate(args, check_has_proxy)
+        torch.fx.node.map_aggregate(kwargs, check_has_proxy)
+
+        if proxy is not None:
+            return proxy.tracer.create_proxy('call_function', target, args, kwargs)
+        else:
+            return target(*args, **kwargs)
+    return wrapper, target
+
+class MetaProxy(torch.fx.Proxy):
+    def install_tensor_meta(self, tensor_meta):
+        self._tensor_meta = tensor_meta
+
+    def size(self, dim=None):
+        if hasattr(self, '_tensor_meta') and self._tensor_meta is not None:
+            return self._tensor_meta.size(*[dim] if dim else [])
+        return self.tracer.create_proxy('call_method', 'size', (self, dim) if dim else (self,), {})
+
+    def dim(self):
+        if hasattr(self, '_tensor_meta') and self._tensor_meta is not None:
+            return self._tensor_meta.dim()
+        return self.tracer.create_proxy('call_method', 'dim', (self,), {})
+
+    @property
+    def shape(self):
+        if hasattr(self, '_tensor_meta') and self._tensor_meta is not None:
+            return self._tensor_meta.shape
+        return self.tracer.create_proxy('call_method', 'size', (self,), {})
+
+    def __getattr__(self, k):
+        if k == '_tensor_meta':
+            return self.__getattribute__(k)
+        # note: not added to the graph yet, if this is a method call
+        # we peephole optimize to the method invocation
+        return MetaAttribute(self, k)
+
+class MetaAttribute(MetaProxy):
+    def __init__(self, root, attr: str):
+
+        self.root = root
+        self.attr = attr
+        self.tracer = root.tracer
+        self._node = None
+
+    @property
+    def node(self):
+        # the node for attributes is added lazily, since most will just be method calls
+        # which do not rely on the getitem call
+        if self._node is None:
+            self._node = self.tracer.create_proxy('call_function', getattr, (self.root, self.attr), {}).node
+        return self._node
+
+    def __call__(self, *args, **kwargs):
+        return self.tracer.create_proxy('call_method', self.attr, (self.root,) + args, kwargs)
+
+def proxys_to_metas(v):
+    if isinstance(v, torch.fx.Proxy):
+        assert isinstance(v, MetaProxy), f'Expected MetaProxy but got {type(v)}'
+        assert hasattr(v, '_tensor_meta'), 'MetaProxy does not have an associated meta'
+        return v._tensor_meta
+    return v
+
+class MetaTracer(torch.fx.Tracer):
+    allow_insert_stateless_mods : bool = True
+
+    _TORCH_METHODS_TO_PATCH = ['arange', 'zeros', 'ones', 'full_like', 'eye']
+
+    def create_proxy(self, kind, target, args, kwargs, name=None, type_expr=None, proxy_factory_fn=None):
+        rv = super().create_proxy(kind, target, args, kwargs, name, type_expr, proxy_factory_fn)
+
+        if kind == 'placeholder' and target in self.meta_args:
+            rv.install_tensor_meta(self.meta_args[target])
+            return rv
+
+        if target in self.orig_fns:
+            # NOTE: tensor constructors in PyTorch define the `device` argument as
+            # *kwargs-only*. That is why this works. If you add methods to
+            # _TORCH_METHODS_TO_PATCH that do not define `device` as kwarg-only,
+            # this will break and you will likely see issues where we cannot infer
+            # the size of the output.
+            if 'device' in kwargs:
+                kwargs['device'] = 'meta'
+
+        try:
+            args_metas = torch.fx.node.map_aggregate(args, proxys_to_metas)
+            kwargs_metas = torch.fx.node.map_aggregate(kwargs, proxys_to_metas)
+
+            if kind == 'call_function':
+                meta_target = manual_meta_overrides.get(target, target)
+                meta_out = meta_target(*args_metas, **kwargs_metas)
+            elif kind == 'call_method':
+                meta_out = getattr(args_metas[0], target)(*args_metas[1:], **kwargs_metas)
+            elif kind == 'call_module':
+                assert hasattr(self, 'orig_forward')
+                self._disable_module_getattr = True
+                try:
+                    mod = self.root.get_submodule(target)
+                    mod_type = type(mod)
+                    if mod_type in manual_meta_overrides:
+                        meta_out = manual_meta_overrides[mod_type](mod, *args_metas, **kwargs_metas)
+                    else:
+                        meta_out = self.orig_forward(*args_metas, **kwargs_metas)
+                finally:
+                    self._disable_module_getattr = False
+            else:
+                assert kind in ['placeholder'], f'Unsupported node kind {kind}'
+                return rv
+
+            # TODO
+            assert isinstance(rv, torch.fx.Proxy), 'Dont support composite output yet'
+            rv.install_tensor_meta(meta_out)
+        except Exception as e:
+            warnings.warn(f'Could not compute metadata for target {target}: {e}')
+
+        return rv
+
+    def _module_getattr(self, attr, attr_val, parameter_proxy_cache):
+        if getattr(self, '_disable_module_getattr', False):
+            return attr_val
+        else:
+            return super()._module_getattr(attr, attr_val, parameter_proxy_cache)
+
+    def call_module(self, m, forward, args, kwargs):
+        self.orig_forward = forward
+        return super().call_module(m, forward, args, kwargs)
+
+    def _insert_module_as_submodule(self, mod: torch.nn.Module) -> str:
+        """
+        Helper method which tries to insert a module that was not declared as submodule.
+        """
+        idx = 0
+        mod_name = mod.__class__.__name__.lower()
+        path = f"{mod_name}_{idx}"
+        while hasattr(self.root, path):
+            path = f"{mod_name}_{idx}"
+            idx += 1
+
+        self.root.add_module(path, mod)
+        return path
+
+    def path_of_module(self, mod: torch.nn.Module) -> str:
+        try:
+            return super().path_of_module(mod)
+        except NameError as e:
+            if self.allow_insert_stateless_mods and len(list(mod.parameters())) == 0 and len(list(mod.buffers())) == 0:
+                path = self._insert_module_as_submodule(mod)
+                self.prev_module = path
+                return path
+            raise
+
+    def proxy(self, node):
+        return MetaProxy(node, self)
+
+    def trace(self, root, meta_args : Dict[str, torch.Tensor], concrete_args=None):
+        assert isinstance(meta_args, dict)
+        self.meta_args = meta_args
+
+        self.patched_torch_methods = {
+            target: gen_constructor_wrapper(getattr(torch, target)) for target in self._TORCH_METHODS_TO_PATCH
+        }
+        self.orig_fns = set()
+
+        for name, (wrapper, orig) in self.patched_torch_methods.items():
+            setattr(torch, name, wrapper)
+            self.orig_fns.add(orig)
+
+        try:
+            return super().trace(root, concrete_args)
+        finally:
+            for name, (_, orig) in self.patched_torch_methods.items():
+                setattr(torch, name, orig)

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -222,56 +222,6 @@ def _assign_attr(from_obj: Any, to_module: torch.nn.Module, target: str):
     else:
         setattr(to_module, field, from_obj)
 
-class _WrappedCall:
-    def __init__(self, cls, cls_call):
-        self.cls = cls
-        self.cls_call = cls_call
-
-    # Previously, if an error occurred when valid
-    # symbolically-traced code was run with an invalid input, the
-    # user would see the source of the error as coming from
-    # `File "<eval_with_key_N">`, where N is some number. We use
-    # this function to generate a more informative error message. We
-    # return the traceback itself, a message explaining that the
-    # error occurred in a traced Module's generated forward
-    # function, and five lines of context surrounding the faulty
-    # line
-    @staticmethod
-    def _generate_error_message(frame_summary: traceback.FrameSummary) -> str:
-        # auxiliary variables (for readability)
-        err_lineno = frame_summary.lineno
-        err_line_len = len(frame_summary.line)
-        all_src_lines = linecache.getlines(frame_summary.filename)
-
-        # constituent substrings of the error message
-        tb_repr = traceback.format_exc()
-        custom_msg = ("Call using an FX-traced Module, "
-                        f"line {err_lineno} of the traced Module's "
-                        "generated forward function:")
-        before_err = "".join(all_src_lines[err_lineno - 2 : err_lineno])
-        marker = "~" * err_line_len + "~~~ <--- HERE"
-        err_and_after_err = "\n".join(all_src_lines[err_lineno : err_lineno + 2])
-
-        # joined message
-        return "\n".join([tb_repr, custom_msg, before_err, marker, err_and_after_err])
-
-    def __call__(self, obj, *args, **kwargs):
-        try:
-            if self.cls_call is not None:
-                return self.cls_call(obj, *args, **kwargs)
-            else:
-                return super(self.cls, obj).__call__(*args, **kwargs)
-        except Exception as e:
-            assert e.__traceback__
-            topmost_framesummary: traceback.FrameSummary = \
-                traceback.StackSummary.extract(traceback.walk_tb(e.__traceback__))[-1]  # type: ignore[arg-type]
-            if "eval_with_key" in topmost_framesummary.filename:
-                print(_WrappedCall._generate_error_message(topmost_framesummary),
-                        file=sys.stderr)
-                raise e.with_traceback(None)
-            else:
-                raise e
-
 @compatibility(is_backward_compatible=True)
 class GraphModule(torch.nn.Module):
     """
@@ -637,13 +587,51 @@ class {module_name}(torch.nn.Module):
         # bypass patching of torch.nn.Module.__call__ done while symbolic tracing.
         cls_call = cls.__call__ if "__call__" in vars(cls) else None
 
-        if '_wrapped_call' not in vars(cls):
-            cls._wrapped_call = _WrappedCall(cls, cls_call)
+        # Previously, if an error occurred when valid
+        # symbolically-traced code was run with an invalid input, the
+        # user would see the source of the error as coming from
+        # `File "<eval_with_key_N">`, where N is some number. We use
+        # this function to generate a more informative error message. We
+        # return the traceback itself, a message explaining that the
+        # error occurred in a traced Module's generated forward
+        # function, and five lines of context surrounding the faulty
+        # line
+        def generate_error_message(frame_summary: traceback.FrameSummary) -> str:
+            # auxiliary variables (for readability)
+            err_lineno = frame_summary.lineno
+            err_line_len = len(frame_summary.line)
+            all_src_lines = linecache.getlines(frame_summary.filename)
 
-        def call_wrapped(self, *args, **kwargs):
-            return self._wrapped_call(self, *args, **kwargs)
-        
-        cls.__call__ = call_wrapped
+            # constituent substrings of the error message
+            tb_repr = traceback.format_exc()
+            custom_msg = ("Call using an FX-traced Module, "
+                          f"line {err_lineno} of the traced Module's "
+                          "generated forward function:")
+            before_err = "".join(all_src_lines[err_lineno - 2 : err_lineno])
+            marker = "~" * err_line_len + "~~~ <--- HERE"
+            err_and_after_err = "\n".join(all_src_lines[err_lineno : err_lineno + 2])
+
+            # joined message
+            return "\n".join([tb_repr, custom_msg, before_err, marker, err_and_after_err])
+
+        def wrapped_call(self, *args, **kwargs):
+            try:
+                if cls_call is not None:
+                    return cls_call(self, *args, **kwargs)
+                else:
+                    return super(cls, self).__call__(*args, **kwargs)
+            except Exception as e:
+                assert e.__traceback__
+                topmost_framesummary: traceback.FrameSummary = \
+                    traceback.StackSummary.extract(traceback.walk_tb(e.__traceback__))[-1]  # type: ignore[arg-type]
+                if "eval_with_key" in topmost_framesummary.filename:
+                    print(generate_error_message(topmost_framesummary),
+                          file=sys.stderr)
+                    raise e.with_traceback(None)
+                else:
+                    raise e
+
+        cls.__call__ = wrapped_call
 
         return python_code
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -222,6 +222,56 @@ def _assign_attr(from_obj: Any, to_module: torch.nn.Module, target: str):
     else:
         setattr(to_module, field, from_obj)
 
+class _WrappedCall:
+    def __init__(self, cls, cls_call):
+        self.cls = cls
+        self.cls_call = cls_call
+
+    # Previously, if an error occurred when valid
+    # symbolically-traced code was run with an invalid input, the
+    # user would see the source of the error as coming from
+    # `File "<eval_with_key_N">`, where N is some number. We use
+    # this function to generate a more informative error message. We
+    # return the traceback itself, a message explaining that the
+    # error occurred in a traced Module's generated forward
+    # function, and five lines of context surrounding the faulty
+    # line
+    @staticmethod
+    def _generate_error_message(frame_summary: traceback.FrameSummary) -> str:
+        # auxiliary variables (for readability)
+        err_lineno = frame_summary.lineno
+        err_line_len = len(frame_summary.line)
+        all_src_lines = linecache.getlines(frame_summary.filename)
+
+        # constituent substrings of the error message
+        tb_repr = traceback.format_exc()
+        custom_msg = ("Call using an FX-traced Module, "
+                        f"line {err_lineno} of the traced Module's "
+                        "generated forward function:")
+        before_err = "".join(all_src_lines[err_lineno - 2 : err_lineno])
+        marker = "~" * err_line_len + "~~~ <--- HERE"
+        err_and_after_err = "\n".join(all_src_lines[err_lineno : err_lineno + 2])
+
+        # joined message
+        return "\n".join([tb_repr, custom_msg, before_err, marker, err_and_after_err])
+
+    def __call__(self, obj, *args, **kwargs):
+        try:
+            if self.cls_call is not None:
+                return self.cls_call(obj, *args, **kwargs)
+            else:
+                return super(self.cls, obj).__call__(*args, **kwargs)
+        except Exception as e:
+            assert e.__traceback__
+            topmost_framesummary: traceback.FrameSummary = \
+                traceback.StackSummary.extract(traceback.walk_tb(e.__traceback__))[-1]  # type: ignore[arg-type]
+            if "eval_with_key" in topmost_framesummary.filename:
+                print(_WrappedCall._generate_error_message(topmost_framesummary),
+                        file=sys.stderr)
+                raise e.with_traceback(None)
+            else:
+                raise e
+
 @compatibility(is_backward_compatible=True)
 class GraphModule(torch.nn.Module):
     """
@@ -587,51 +637,13 @@ class {module_name}(torch.nn.Module):
         # bypass patching of torch.nn.Module.__call__ done while symbolic tracing.
         cls_call = cls.__call__ if "__call__" in vars(cls) else None
 
-        # Previously, if an error occurred when valid
-        # symbolically-traced code was run with an invalid input, the
-        # user would see the source of the error as coming from
-        # `File "<eval_with_key_N">`, where N is some number. We use
-        # this function to generate a more informative error message. We
-        # return the traceback itself, a message explaining that the
-        # error occurred in a traced Module's generated forward
-        # function, and five lines of context surrounding the faulty
-        # line
-        def generate_error_message(frame_summary: traceback.FrameSummary) -> str:
-            # auxiliary variables (for readability)
-            err_lineno = frame_summary.lineno
-            err_line_len = len(frame_summary.line)
-            all_src_lines = linecache.getlines(frame_summary.filename)
+        if '_wrapped_call' not in vars(cls):
+            cls._wrapped_call = _WrappedCall(cls, cls_call)
 
-            # constituent substrings of the error message
-            tb_repr = traceback.format_exc()
-            custom_msg = ("Call using an FX-traced Module, "
-                          f"line {err_lineno} of the traced Module's "
-                          "generated forward function:")
-            before_err = "".join(all_src_lines[err_lineno - 2 : err_lineno])
-            marker = "~" * err_line_len + "~~~ <--- HERE"
-            err_and_after_err = "\n".join(all_src_lines[err_lineno : err_lineno + 2])
-
-            # joined message
-            return "\n".join([tb_repr, custom_msg, before_err, marker, err_and_after_err])
-
-        def wrapped_call(self, *args, **kwargs):
-            try:
-                if cls_call is not None:
-                    return cls_call(self, *args, **kwargs)
-                else:
-                    return super(cls, self).__call__(*args, **kwargs)
-            except Exception as e:
-                assert e.__traceback__
-                topmost_framesummary: traceback.FrameSummary = \
-                    traceback.StackSummary.extract(traceback.walk_tb(e.__traceback__))[-1]  # type: ignore[arg-type]
-                if "eval_with_key" in topmost_framesummary.filename:
-                    print(generate_error_message(topmost_framesummary),
-                          file=sys.stderr)
-                    raise e.with_traceback(None)
-                else:
-                    raise e
-
-        cls.__call__ = wrapped_call
+        def call_wrapped(self, *args, **kwargs):
+            return self._wrapped_call(self, *args, **kwargs)
+        
+        cls.__call__ = call_wrapped
 
         return python_code
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #76068
* __->__ #76003


Experimental `Tracer` implementation that carries a meta tensor for each value and allows access to the concrete shape/dtype/etc values.

Confirmed to work with HF models (except for `*ForQuestionAnswering`). See https://github.com/pytorch/PiPPy/pull/138

Example:

```
import inspect

import torch
import transformers.utils.fx as fx
from transformers import *

device = torch.device('meta')

config = BertConfig()
model = BertModel(config)
model.to(device)

# hf_tracer = HFBertTracer()

input_names = model.dummy_inputs.keys()
sig = inspect.signature(model.forward)
concrete_args = {p.name: p.default for p in sig.parameters.values() if p.name not in input_names}

from torch.fx.experimental.meta_tracer import MetaTracer

tracer = MetaTracer()
T, B = 50, 50
concrete_metas = [None, torch.zeros(T, B, dtype=torch.long, device='meta')]
graph = tracer.trace(model, concrete_metas, concrete_args)
gm = torch.fx.GraphModule(model, graph)

print(gm.code)
"""
def forward(self, input_ids : typing_Union[torch.Tensor,NoneType] = None, attention_mask_1 = None, token_type_ids_1 = None, position_ids_1 = None, head_mask_1 = None, inputs_embeds_1 = None, encoder_hidden_states_1 = None, encoder_attention_mask_1 = None, past_key_values_1 = None, use_cache_1 = None, output_attentions_1 = None, output_hidden_states_1 = None, return_dict_1 = None) -> typing_Union[typing_Tuple[torch.Tensor],transformers_modeling_outputs_BaseModelOutputWithPoolingAndCrossAttentions]:
    _assert_is_none = torch.fx._symbolic_trace._assert_is_none(attention_mask_1, 'attention_mask has been specialized to have value None but got another value');  attention_mask_1 = None
    _assert_is_none_1 = torch.fx._symbolic_trace._assert_is_none(token_type_ids_1, 'token_type_ids has been specialized to have value None but got another value');  token_type_ids_1 = None
    _assert_is_none_2 = torch.fx._symbolic_trace._assert_is_none(position_ids_1, 'position_ids has been specialized to have value None but got another value');  position_ids_1 = None
    _assert_is_none_3 = torch.fx._symbolic_trace._assert_is_none(head_mask_1, 'head_mask has been specialized to have value None but got another value');  head_mask_1 = None
    _assert_is_none_4 = torch.fx._symbolic_trace._assert_is_none(inputs_embeds_1, 'inputs_embeds has been specialized to have value None but got another value');  inputs_embeds_1 = None
    _assert_is_none_5 = torch.fx._symbolic_trace._assert_is_none(encoder_hidden_states_1, 'encoder_hidden_states has been specialized to have value None but got another value');  encoder_hidden_states_1 = None
    _assert_is_none_6 = torch.fx._symbolic_trace._assert_is_none(encoder_attention_mask_1, 'encoder_attention_mask has been specialized to have value None but got another value');  encoder_attention_mask_1 = None
    _assert_is_none_7 = torch.fx._symbolic_trace._assert_is_none(past_key_values_1, 'past_key_values has been specialized to have value None but got another value');  past_key_values_1 = None
    _assert_is_none_8 = torch.fx._symbolic_trace._assert_is_none(use_cache_1, 'use_cache has been specialized to have value None but got another value');  use_cache_1 = None
    _assert_is_none_9 = torch.fx._symbolic_trace._assert_is_none(output_attentions_1, 'output_attentions has been specialized to have value None but got another value');  output_attentions_1 = None
    _assert_is_none_10 = torch.fx._symbolic_trace._assert_is_none(output_hidden_states_1, 'output_hidden_states has been specialized to have value None but got another value');  output_hidden_states_1 = None
    _assert_is_none_11 = torch.fx._symbolic_trace._assert_is_none(return_dict_1, 'return_dict has been specialized to have value None but got another value');  return_dict_1 = None
    getattr_1 = input_ids.device
    ones = torch.ones((50, 50), device = getattr_1);  getattr_1 = None
    getitem = ones[(slice(None, None, None), None, None, slice(None, None, None))];  ones = None
    to = getitem.to(dtype = torch.float32);  getitem = None
    sub = 1.0 - to;  to = None
    mul = sub * -10000.0;  sub = None
    embeddings_word_embeddings = self.embeddings.word_embeddings(input_ids);  input_ids = None
    _tensor_constant0 = self._tensor_constant0
    embeddings_token_type_embeddings = self.embeddings.token_type_embeddings(_tensor_constant0);  _tensor_constant0 = None
    add = embeddings_word_embeddings + embeddings_token_type_embeddings;  embeddings_word_embeddings = embeddings_token_type_embeddings = None
    _tensor_constant1 = self._tensor_constant1
    embeddings_position_embeddings = self.embeddings.position_embeddings(_tensor_constant1);  _tensor_constant1 = None
    add_1 = add + embeddings_position_embeddings;  add = embeddings_position_embeddings = None
    embeddings_layer_norm = self.embeddings.LayerNorm(add_1);  add_1 = None
    embeddings_dropout = self.embeddings.dropout(embeddings_layer_norm);  embeddings_layer_norm = None
<...>
"""
```