### PR TITLE
[RecordFunction] Don't lazily construct the guts of RecordFunction.

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -498,7 +498,6 @@ inline Return Dispatcher::callWithDispatchKeySlowPath(const TypedOperatorHandle<
   // If callbacks need inputs, we box the arguments and pass them to the guard.
   // Note: For perf reasons we wouldn't want to prematurely box the arguments.
   at::RecordFunction guard(std::move(stepCallbacks));
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(guard.isActive());
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(op.operatorDef_->op.isObserved());
   auto dispatchKey = dispatchKeySet.highestPriorityTypeId();
   auto& schema = op.schema();
@@ -555,7 +554,6 @@ inline void Dispatcher::callBoxed(const OperatorHandle& op, Stack* stack) const 
   auto step_callbacks = at::getStepCallbacks(at::RecordScope::FUNCTION);
   if (C10_UNLIKELY(!step_callbacks.empty() && entry.isObserved())) {
     at::RecordFunction guard(std::move(step_callbacks));
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(guard.isActive());
     auto dispatchKey = dispatchKeySet.highestPriorityTypeId();
     auto& schema = op.schema();
     auto schema_ref = std::reference_wrapper<const FunctionSchema>(schema);

--- a/aten/src/ATen/record_function.cpp
+++ b/aten/src/ATen/record_function.cpp
@@ -500,73 +500,63 @@ C10_ALWAYS_INLINE bool tryRunCallback(
 RecordFunction::RecordFunction(RecordScope scope)
     : RecordFunction(getStepCallbacks(scope)) {}
 
-RecordFunction::RecordFunction(StepCallbacks&& step_callbacks) {
-  if (!step_callbacks.empty()) {
-    state_.emplace(std::move(step_callbacks));
-    state_->ctx_.resize(state_->step_callbacks_.callbacks_.size());
-    if (state_->step_callbacks_.needs_ids_) {
-      setHandle(next_unique_record_function_handle());
-    }
+RecordFunction::RecordFunction(StepCallbacks&& step_callbacks)
+    : step_callbacks_{std::move(step_callbacks)} {
+  ctx_.resize(step_callbacks_.callbacks_.size());
+  if (step_callbacks_.needs_ids_) {
+    setHandle(next_unique_record_function_handle());
   }
 }
 
 void RecordFunction::runStartCallbacks() {
-  for (const auto i : c10::irange(state_->step_callbacks_.callbacks_.size())) {
+  for (const auto i : c10::irange(step_callbacks_.callbacks_.size())) {
     tryRunCallback</*is_start=*/true>(
-        state_->step_callbacks_.callbacks_[i], *this, state_->ctx_[i]);
+        step_callbacks_.callbacks_[i], *this, ctx_[i]);
   }
-  state_->called_start_callbacks_ = true;
+  called_start_callbacks_ = true;
 }
 
 void RecordFunction::end() {
-  if (isActive() && state_->called_start_callbacks_) {
-    for (const auto i : c10::irange(state_->step_callbacks_.callbacks_.size())) {
+  if (called_start_callbacks_) {
+    for (const auto i : c10::irange(step_callbacks_.callbacks_.size())) {
       tryRunCallback</*is_start=*/false>(
-        state_->step_callbacks_.callbacks_[i], *this, state_->ctx_[i]);
+        step_callbacks_.callbacks_[i], *this, ctx_[i]);
     }
-    state_.reset();
+    step_callbacks_.callbacks_.clear();
   }
 }
 
 const char* RecordFunction::name() const {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      state_, "Called name() on inactive RecordFunction");
   return c10::visit(
       c10::overloaded(
           [](const std::string& name) { return name.c_str(); },
           [](const schema_ref_t schema) {
             return schema.get().name().c_str();
           }),
-      state_->fn_);
+      fn_);
 }
 
 size_t RecordFunction::num_inputs() const {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      state_, "Called num_inputs() on inactive RecordFunction");
   return c10::visit(
       c10::overloaded(
-          [&](const std::string&) { return state_->inputs_.size(); },
+          [&](const std::string&) { return inputs_.size(); },
           [](const schema_ref_t schema) {
             return schema.get().arguments().size();
           }),
-      state_->fn_);
+      fn_);
 }
 
 size_t RecordFunction::num_outputs() const {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      state_, "Called num_outputs() on inactive RecordFunction");
   return c10::visit(
       c10::overloaded(
-          [&](const std::string&) { return state_->outputs_.size(); },
+          [&](const std::string&) { return outputs_.size(); },
           [](const schema_ref_t schema) {
             return schema.get().returns().size();
           }),
-      state_->fn_);
+      fn_);
 }
 
 c10::optional<OperatorName> RecordFunction::operator_name() const {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      state_, "Called operator_name() on inactive RecordFunction");
   return c10::visit(
       c10::overloaded(
           [&](const std::string&) -> c10::optional<OperatorName> {
@@ -575,7 +565,7 @@ c10::optional<OperatorName> RecordFunction::operator_name() const {
           [](const schema_ref_t schema) -> c10::optional<OperatorName> {
             return schema.get().operator_name();
           }),
-      state_->fn_);
+      fn_);
 }
 
 StepCallbacks getStepCallbacks(RecordScope scope) {
@@ -679,22 +669,16 @@ uint64_t RecordFunction::currentThreadId() {
 }
 
 void RecordFunction::before(const char* name, int64_t sequence_nr) {
-  if (!isActive()) {
-    return;
-  }
-  state_->fn_ = name;
-  state_->sequence_nr_ = sequence_nr;
+  fn_ = name;
+  sequence_nr_ = sequence_nr;
 
   runStartCallbacks();
   invalidateInputs();
 }
 
 void RecordFunction::before(std::string name, int64_t sequence_nr) {
-  if (!isActive()) {
-    return;
-  }
-  state_->fn_ = std::move(name);
-  state_->sequence_nr_ = sequence_nr;
+  fn_ = std::move(name);
+  sequence_nr_ = sequence_nr;
 
   runStartCallbacks();
   invalidateInputs();
@@ -703,11 +687,8 @@ void RecordFunction::before(std::string name, int64_t sequence_nr) {
 void RecordFunction::before(
     RecordFunction::schema_ref_t schema,
     int64_t sequence_nr) {
-  if (!isActive()) {
-    return;
-  }
-  state_->sequence_nr_ = sequence_nr;
-  state_->fn_ = schema;
+  sequence_nr_ = sequence_nr;
+  fn_ = schema;
 
   runStartCallbacks();
   invalidateInputs();
@@ -727,27 +708,22 @@ RecordFunction::~RecordFunction() {
 }
 
 void RecordFunction::_setAsync() {
-  if (isActive()) {
-    state_->is_async_ = true;
-  }
+  is_async_ = true;
 }
 
 bool RecordFunction::isAsync() const {
-  if (isActive()) {
-    return state_->is_async_;
-  }
-  return false;
+  return is_async_;
 }
 
 void RecordFunction::_setStaticRuntimeOutVariant() {
   if (isActive()) {
-    state_->is_static_runtime_out_variant_ = true;
+    is_static_runtime_out_variant_ = true;
   }
 }
 
 bool RecordFunction::isStaticRuntimeOutVariant() const {
   if (isActive()) {
-    return state_->is_static_runtime_out_variant_;
+    return is_static_runtime_out_variant_;
   }
   return false;
 }

--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -224,7 +224,7 @@ class TORCH_API RecordFunctionCallback {
 //    not picked to run, the corresponding end callback won't be called
 //  - a typical use case for the global callbacks is passive monitoring
 //    in the background (e.g. fleet-wide monitoring), without focusing on
-//    the specific peice of code
+//    the specific piece of code
 //  - in contrast, thread local callbacks are enabled locally, on demand,
 //    for the specific piece of code (range) and are not sampled
 //  - a typical use case for thread local callbacks is profiler and code
@@ -290,9 +290,9 @@ struct TORCH_API RecordFunction {
     if (!isActive()) {
       return;
     }
-    state_->inputs_ = args;
+    inputs_ = args;
 #ifndef NDEBUG
-    state_->inputs_valid_ = true;
+    inputs_valid_ = true;
 #endif
     before(fn, current_sequence_nr);
   }
@@ -314,31 +314,26 @@ struct TORCH_API RecordFunction {
   const char* name() const;
 
   int64_t seqNr() const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called seqNr() on inactive RecordFunction");
-    return state_->sequence_nr_;
+    return sequence_nr_;
   }
 
   c10::ArrayRef<const IValue> inputs() const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called inputs() on inactive RecordFunction");
 #ifndef NDEBUG
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_->inputs_valid_, "Called inputs() outside RecordFunction start callback");
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(inputs_valid_, "Called inputs() outside RecordFunction start callback");
 #endif
-    return state_->inputs_;
+    return inputs_;
   }
 
   const std::vector<c10::IValue>& outputs() const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called outputs() on inactive RecordFunction");
-    return state_->outputs_;
+    return outputs_;
   }
 
   void setOutputs(std::vector<c10::IValue>&& outputs) {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called setOutputs() on inactive RecordFunction");
-    state_->outputs_ = std::move(outputs);
+    outputs_ = std::move(outputs);
   }
 
   void setOutputs(c10::ArrayRef<c10::IValue> outputs) {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called setOutputs() on inactive RecordFunction");
-    state_->outputs_ = outputs.vec();
+    outputs_ = outputs.vec();
   }
 
   size_t num_inputs() const;
@@ -348,8 +343,7 @@ struct TORCH_API RecordFunction {
   // Useful for writing thread safe end callbacks that may be potentially
   // executed in a different thread (async ops)
   uint64_t threadId() const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called threadId() on inactive RecordFunction");
-    return state_->step_callbacks_.thread_id_;
+    return step_callbacks_.thread_id_;
   }
 
   // For backward functions - thread id of the corresponding forward function,
@@ -357,18 +351,15 @@ struct TORCH_API RecordFunction {
   // used alongside with sequence number to correlate backward functions with
   // the forward ones
   uint64_t forwardThreadId() const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called forwardThreadId() on inactive RecordFunction");
-    return state_->fwd_thread_id_;
+    return fwd_thread_id_;
   }
 
   void setForwardThreadId(uint64_t thread_id) {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called setForwardThreadId() on inactive RecordFunction");
-    state_->fwd_thread_id_ = thread_id;
+    fwd_thread_id_ = thread_id;
   }
 
   RecordScope scope() const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called scope() on inactive RecordFunction");
-    return state_->step_callbacks_.scope_;
+    return step_callbacks_.scope_;
   }
 
   // Returns logical thread_id for the current thread
@@ -403,100 +394,86 @@ struct TORCH_API RecordFunction {
   bool isStaticRuntimeOutVariant() const;
 
   RecordFunctionHandle handle() const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called handle() on inactive RecordFunction");
-    return state_->handle_;
+    return handle_;
   }
 
   c10::optional<OperatorName> operator_name() const;
 
   void setHandle(RecordFunctionHandle handle) {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called setHandle() on inactive RecordFunction");
-    state_->handle_ = handle;
+    handle_ = handle;
   }
 
   // Whether this RecordFunction runs any callbacks.
   bool isActive() const {
-    return state_.has_value();
+    return !step_callbacks_.empty();
   }
 
   bool needsInputs() const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called needsInputs() on inactive RecordFunction");
-    return state_->step_callbacks_.needs_inputs_;
+    return step_callbacks_.needs_inputs_;
   }
 
   bool needsOutputs() const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called needsOutputs() on inactive RecordFunction");
-    return state_->step_callbacks_.needs_outputs_;
+    return step_callbacks_.needs_outputs_;
   }
 
   int64_t debugHandle() const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called debugHandle() on inactive RecordFunction");
-    return state_->debug_handle_;
+    return debug_handle_;
   }
 
   void setDebugHandle(int64_t debug_handle) {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called setDebugHandle() on inactive RecordFunction");
-    state_->debug_handle_ = debug_handle;
+    debug_handle_ = debug_handle;
   }
 
   void invalidateInputs() {
 #ifndef NDEBUG
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called invalidateInputs() on inactive RecordFunction");
-    state_->inputs_valid_ = false;
+    inputs_valid_ = false;
 #endif
   }
 
  private:
   void runStartCallbacks();
 
-  struct State {
-    explicit State(StepCallbacks&& step_callbacks)
-        : step_callbacks_{std::move(step_callbacks)} {}
+  StepCallbacks step_callbacks_;
 
-    StepCallbacks step_callbacks_;
-
-    // In cases when RecordFunction might be active but we chose not to
-    // use the observers (e.g. operator is not observed), this boolean
-    // flag is used to check whether the start callbacks were called
-    bool called_start_callbacks_ = false;
+  // In cases when RecordFunction might be active but we chose not to
+  // use the observers (e.g. operator is not observed), this boolean
+  // flag is used to check whether the start callbacks were called
+  bool called_start_callbacks_ = false;
 
 #ifndef NDEBUG
-    bool inputs_valid_ = false;
+  bool inputs_valid_ = false;
 #endif
 
-    // Stores various ObserverContext objects with event metadata for callbacks.
-    ObserverContextList ctx_;
+  // Stores various ObserverContext objects with event metadata for callbacks.
+  ObserverContextList ctx_;
 
-    c10::variant<std::string, schema_ref_t> fn_;
+  c10::variant<std::string, schema_ref_t> fn_;
 
-    int64_t sequence_nr_ = -1;
-    c10::ArrayRef<const IValue> inputs_;
-    std::vector<c10::IValue> outputs_;
+  int64_t sequence_nr_ = -1;
+  c10::ArrayRef<const IValue> inputs_;
+  std::vector<c10::IValue> outputs_;
 
-    // For backward functions - thread id of the the forward function
-    uint64_t fwd_thread_id_ = 0;
+  // For backward functions - thread id of the the forward function
+  uint64_t fwd_thread_id_ = 0;
 
-    // Unique id for this RecordFunction, used in callbacks to track start
-    // and end of ranges
-    RecordFunctionHandle handle_ {0};
+  // Unique id for this RecordFunction, used in callbacks to track start
+  // and end of ranges
+  RecordFunctionHandle handle_ {0};
 
-    // Whether this record_function corresponds to an async event or not. Async
-    // events can complete in different threads or follow a future-like pattern
-    // of use.
-    bool is_async_{false};
+  // Whether this record_function corresponds to an async event or not. Async
+  // events can complete in different threads or follow a future-like pattern
+  // of use.
+  bool is_async_{false};
 
-    // Debug handles are used for lazy annotation of module hierarchy
-    // and callstack.
-    // This is specifically is useful for mobile runtime, where generated
-    // debug handles can be lazily symbolicated using debug information
-    int64_t debug_handle_{-1};
+  // Debug handles are used for lazy annotation of module hierarchy
+  // and callstack.
+  // This is specifically is useful for mobile runtime, where generated
+  // debug handles can be lazily symbolicated using debug information
+  int64_t debug_handle_{-1};
 
-    // Whether this RecordFunction is used for an out variant run with
-    // Static Runtime
-    bool is_static_runtime_out_variant_{false};
-  };
-
-  c10::optional<State> state_;
+  // Whether this RecordFunction is used for an out variant run with
+  // Static Runtime
+  bool is_static_runtime_out_variant_{false};
 };
 
 TORCH_API StepCallbacks getStepCallbacks(RecordScope scope);

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -154,7 +154,6 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
     auto step_callbacks = at::getStepCallbacks(at::RecordScope::BACKWARD_FUNCTION);
     if (!step_callbacks.empty()) {
       at::RecordFunction guard(std::move(step_callbacks));
-      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(guard.isActive());
       // Using sequence number and thread id to correlate with
       // the forward pass function
       guard.setForwardThreadId(thread_id_);


### PR DESCRIPTION
Summary:
When we were pre-sampling this was a pretty important optimizaton. However now when we make a record function we can be sure that it will be called.

For the RECORD_FUNCTION macros I preserved the old behavior by making a `c10::optional<RecordFunction>` since we can't force callers to have separate paths the way Dispatcher does.

Maybe it makes sense to have a guard that handles the optional logic? If we can move enough out of the internals (e.g. replace `std::string`s with `char*`s) we might not even need the optional to get good perf.

Test Plan: The no-op observer overhead benchmark got a bit better, but even with lots of replicates it's hard to tell if that's just noise. This is primarily a change to simplify the semantics of RecordFunction.

Reviewed By: chaekit

Differential Revision: D35276157

