### PR TITLE
[easy][PTE] Remove GetMutableSizePrefixed* functions

### DIFF
--- a/torch/csrc/jit/serialization/mobile_bytecode_generated.h
+++ b/torch/csrc/jit/serialization/mobile_bytecode_generated.h
@@ -2521,16 +2521,8 @@ inline const torch::jit::mobile::serialization::Module *GetModule(const void *bu
   return flatbuffers::GetRoot<torch::jit::mobile::serialization::Module>(buf);
 }
 
-inline const torch::jit::mobile::serialization::Module *GetSizePrefixedModule(const void *buf) {
-  return flatbuffers::GetSizePrefixedRoot<torch::jit::mobile::serialization::Module>(buf);
-}
-
-inline Module *GetMutableModule(void *buf) {
+inline Module* GetMutableModule(void* buf) {
   return flatbuffers::GetMutableRoot<Module>(buf);
-}
-
-inline torch::jit::mobile::serialization::Module *GetMutableSizePrefixedModule(void *buf) {
-  return flatbuffers::GetMutableSizePrefixedRoot<torch::jit::mobile::serialization::Module>(buf);
 }
 
 inline const char *ModuleIdentifier() {


### PR DESCRIPTION
Summary: fb: Fix the error: https://www.internalfb.com/intern/sandcastle/job/9007199888273681/insights

Test Plan:
CI

```
 ~/fbsource/fbcode] eval $(fbpkg info --json smart.pytorch_mobile.backport_service.persistent | jq -r .build.config.build_command)

Downloaded 26538/30277 artifacts, 1.00 Gbytes, 4.9% cache miss (for updated rules)
Building: finished in 10:22.3 min (100%) 48817/48817 jobs, 48817/48817 updated
  Total time: 11:13.5 min
More details at https://www.internalfb.com/intern/buck/build/f7743351-c166-4263-9140-bc59cbb39a37
BUILD SUCCEEDED

Reviewed By: qihqi, guangy10

Differential Revision: D35734987

