### PR TITLE
[GHF] Exclude 5f37e5c2a39c3acb776756a17730b865f0953432 from sync

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -210,10 +210,10 @@ class GitRepo:
                 from_commits.remove(commit)
             for commit in to_values:
                 to_commits.remove(commit)
-        # Another HACK: Patch-id is not stable for commits with binary files
+        # Another HACK: Patch-id is not stable for commits with binary files or for big changes across commits
         # I.e. cherry-picking those from one branch into another will change patchid
         if "pytorch/pytorch" in self.remote_url():
-            for excluded_commit in ["8e09e20c1dafcdbdb45c2d1574da68a32e54a3a5"]:
+            for excluded_commit in ["8e09e20c1dafcdbdb45c2d1574da68a32e54a3a5", "5f37e5c2a39c3acb776756a17730b865f0953432"]:
                 if excluded_commit in from_commits:
                     from_commits.remove(excluded_commit)
 


### PR DESCRIPTION
Corresponding trunk commit generate different patch-id, as history
diverged between `master` and `fbsync`

Fixes #ISSUE_NUMBER
