### PR TITLE
[pytorch] Add return type for list of tensors

### DIFF
--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -1120,9 +1120,8 @@ class FunctionSchema:
                 "Did you forget to mark an out argument as keyword-only?"
             )
         if self.arguments.out:
-            assert len(self.arguments.out) == len(
-                self.returns
-            ), "Must return as many arguments as there are out arguments"
+            assert len(self.arguments.out) == len(self.returns) or len(self.returns) == 0, \
+                "Must return as many arguments as there are out arguments, or no return at all"
         if self.name.name.inplace:
             # TODO: fixme
             if not is_foreach_op(str(self.name)):


### PR DESCRIPTION
Summary:
Adding codegen logic to return `at::TensorList` as a return type.

Although we don't really have a return type of `-> Tensor(a)[]` in `native_functions.yaml`, there are use cases for a `TensorList` return type.

If the type is a list and the element type is tensor, return a `at::TensorList`. Since the copy cost of an `ArrayRef` is very small, we don't need to return a reference.

Test Plan: Rely on unit test.

Reviewed By: iseeyuan

Differential Revision: D35737310

