### PR TITLE
[PyTorch] Add TupleElements(Iterator, Iterator) constructor

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -324,6 +324,19 @@ struct TORCH_API TupleElements {
     new (&elementsInline_[2]) IValue(std::move(e3));
   }
 
+  template <typename Iterator,
+            typename = std::enable_if_t<std::is_base_of<std::input_iterator_tag, typename std::iterator_traits<Iterator>::iterator_category>::value>>
+  explicit TupleElements(Iterator begin, Iterator end)
+  : inlineSize_((end - begin <= 3) ? (end - begin) : 0) {
+    if (inlineSize_) {
+      for (int ii = 0; begin != end; ++begin, ++ii) {
+        new (&elementsInline_[ii]) IValue(*begin);
+      }
+    } else {
+      new (&elementsVector_) std::vector<IValue>(begin, end);
+    }
+  }
+
   ~TupleElements() {
     if (inlineSize_) {
       destroyInline();

--- a/aten/src/ATen/test/ivalue_test.cpp
+++ b/aten/src/ATen/test/ivalue_test.cpp
@@ -843,11 +843,33 @@ TEST(TupleElementsTest, Basic) {
   validateTupleElements(large, sampleIValuesArray);
 }
 
+TEST(TupleElementsTest, ConstructFromIterator) {
+  std::array<IValue, 0> x;
+  TupleElements empty(x.begin(), x.end());
+  validateTupleElements(empty, {});
+
+  std::array<IValue, 1> arr1 = {1};
+  TupleElements size1(arr1.begin(), arr1.end());
+  validateTupleElements(size1, {1});
+
+  std::array<IValue, 2> arr2 = {1, 2};
+  TupleElements size2(arr2.begin(), arr2.end());
+  validateTupleElements(size2, {1, 2});
+
+  std::array<IValue, 3> arr3 = {1, 2, 3};
+  TupleElements size3(arr3.begin(), arr3.end());
+  validateTupleElements(size3, {1, 2, 3});
+
+  auto sampleIValuesArray = makeSampleIValues();
+  TupleElements large(sampleIValuesArray.begin(), sampleIValuesArray.end());
+  validateTupleElements(large, sampleIValuesArray);
+}
+
 namespace {
 
 std::array<TupleElements(*)(), 3> factories = {
   []() { return TupleElements();},
-  []() { return  TupleElements(1, 2, 3);},
+  []() { return TupleElements(1, 2, 3);},
   []() { return TupleElements(std::vector<IValue>({1, 2, 3, "hello"})); }
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This makes it possible to use inline storage for a tuple of unknown size without constructing an intermediate container from which to get a c10::ArrayRef.

Differential Revision: [D35758295](https://our.internmc.facebook.com/intern/diff/D35758295/)