### PR TITLE
Undo alternate target changes and test flatbuffer integration

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -636,7 +636,7 @@ void backportAllVersionCheck(
     std::vector<IValue>& expect_result_list,
     const uint64_t expect_from_version) {
   auto from_version = _get_model_bytecode_version(test_model_file_stream);
-  AT_ASSERT(from_version == expect_from_version);
+  ASSERT_EQ(from_version, expect_from_version);
   AT_ASSERT(from_version > 0);
 
   // Backport script_module_v5.ptl to an older version
@@ -749,7 +749,7 @@ TEST(LiteInterpreterTest, BackPortByteCodeModelAllVersions) {
       input_model_stream,
       input_data,
       expect_result_list,
-      caffe2::serialize::kProducedBytecodeVersion);
+      caffe2::serialize::kMaxSupportedBytecodeVersion);
 }
 #endif // !defined(FB_XPLAT_BUILD)
 

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -664,7 +664,8 @@ libtorch_extra_sources = libtorch_core_jit_sources + [
 ]
 
 def libtorch_sources(gencode_pattern = ":generate-code[{}]"):
-    enable_flatbuffer = bool(native.read_config("fbcode", "caffe2_enable_flatbuffer", None))
+    # enable_flatbuffer = bool(native.read_config("fbcode", "caffe2_enable_flatbuffer", None))
+    enable_flatbuffer = True
     flatbuffer_serializer_sources = [
         "torch/csrc/jit/serialization/flatbuffer_serializer.cpp",
         "torch/csrc/jit/serialization/flatbuffer_serializer_jit.cpp",

--- a/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/compatibility/model_compatibility.cpp
@@ -83,6 +83,7 @@ uint64_t _get_model_bytecode_version(std::istream& in) {
           false,
           "Flatbuffer input file but the build hasn't enabled flatbuffer");
 #else
+      std::cout << __FILE__ << " flatbuffer file" << std::endl;
       return get_bytecode_version(in);
 #endif
     }


### PR DESCRIPTION
Test Plan:
Code search for "_pickle_and_flatbuffer" should return NULL

```
buck build //xplat/caffe2:torch_mobile_coreAndroid
```

Differential Revision: D35656072

