### PR TITLE
[kineto] implement kineto client interface

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -163,6 +163,7 @@ libtorch_profiler_sources = [
     "torch/csrc/profiler/collection.cpp",
     "torch/csrc/profiler/kineto_shim.cpp",
     "torch/csrc/profiler/nvtx_observer.cpp",
+    "torch/csrc/profiler/kineto_client_interface.cpp",
     "torch/csrc/monitor/counters.cpp",
     "torch/csrc/monitor/events.cpp",
 ]

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -6,6 +6,7 @@
 #include <c10/util/irange.h>
 #include <c10/util/overloaded.h>
 #include <c10/util/variant.h>
+#include <c10/util/C++17.h>
 
 #include <torch/csrc/profiler/api.h>
 #include <torch/csrc/profiler/collection.h>
@@ -194,7 +195,8 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
     event_post_process_cb_ = std::move(cb);
   }
 
-  torch::profiler::impl::kineto::ActivityTraceWrapper finalizeTrace() {
+  torch::profiler::impl::kineto::ActivityTraceWrapper finalizeTrace(
+    const torch::profiler::impl::ProfilerConfig& config) {
     auto end_time = getTimeUs();
     materializeOpEvents();
 
@@ -210,10 +212,14 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
       cpu_trace_.transferCpuTrace(end_time);
     }
 
-    auto trace = torch::profiler::impl::kineto::stopTrace();
-    TORCH_CHECK(trace || !torch::profiler::kKinetoAvailable);
-    addTraceEvents(trace);
-    return trace;
+    if (config.state != ProfilerState::KINETO_ONDEMAND) {
+      auto trace = torch::profiler::impl::kineto::stopTrace();
+      TORCH_CHECK(trace || !torch::profiler::kKinetoAvailable);
+      addTraceEvents(trace);
+      return trace; 
+    } else {
+      return torch::profiler::impl::kineto::ActivityTraceWrapper();
+    }
   }
 
   void materializeOpEvents() {
@@ -592,48 +598,84 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
   std::function<void(std::vector<KinetoEvent>&)> event_post_process_cb_;
 };
 
-void pushProfilingCallbacks(const std::unordered_set<at::RecordScope>& scopes) {
-  auto registration_state_ptr = KinetoThreadLocalState::getTLS();
-  TORCH_INTERNAL_ASSERT(registration_state_ptr, "Expected profiler state set");
-  auto handle = at::addThreadLocalCallback(
-      at::RecordFunctionCallback(
-          [](const at::RecordFunction& fn)
-              -> std::unique_ptr<at::ObserverContext> {
-            auto state_ptr = KinetoThreadLocalState::getTLS();
-            if (!state_ptr) {
-              return nullptr;
-            }
-            const auto& config = state_ptr->config();
-            auto corr_id = next_correlation_id();
-            torch::profiler::impl::kineto::pushCorrelationId(corr_id);
-            return state_ptr->record_queue_.getSubqueue()->begin_op(fn, corr_id);
-          },
-          [](const at::RecordFunction& fn, at::ObserverContext* ctx_ptr) {
-            auto state_ptr = KinetoThreadLocalState::getTLS();
-            if (!state_ptr) {
-              return;
-            }
-            const auto& config = state_ptr->config();
-            auto* kineto_ctx_ptr =
-                static_cast<torch::profiler::impl::KinetoObserverContext*>(ctx_ptr);
-            TORCH_INTERNAL_ASSERT(kineto_ctx_ptr != nullptr);
-            kineto_ctx_ptr->event_->end_time_ = torch::profiler::impl::getApproximateTime();
-            kineto_ctx_ptr->event_->end_thread_id_ = at::RecordFunction::currentThreadId();
-            if (config.state == ProfilerState::KINETO_GPU_FALLBACK) {
-              try {
-                auto fallback = kineto_ctx_ptr->fallback_;
-                TORCH_INTERNAL_ASSERT(fallback != nullptr);
-                torch::profiler::impl::cudaStubs()->record(
-                    nullptr, &fallback->cuda_event_end_, nullptr);
-              } catch (const std::exception& e) {
-                LOG(WARNING) << "Failed to record CUDA event. " << e.what();
-              }
-            }
+static std::unique_ptr<KinetoThreadLocalState> globalStatePtr;
 
-            torch::profiler::impl::kineto::popCorrelationId();
-          })
-          .needsInputs(registration_state_ptr->config().report_input_shapes)
-          .scopes(scopes));
+template<typename... Args>
+static void initGlobalState(Args... args) {
+  if (globalStatePtr) {
+    LOG(WARNING) << "GlobalStatePtr already exists!";
+  } else {
+    globalStatePtr = std::make_unique<KinetoThreadLocalState>(std::forward<Args>(args)...);
+  }
+}
+
+static void resetGlobalState() {
+  TORCH_INTERNAL_ASSERT(globalStatePtr != nullptr, "Global state ptr cannot be null before resetting");
+  globalStatePtr.reset();
+}
+
+template<bool use_global>
+static KinetoThreadLocalState* getStatePtr() {
+  return c10::guts::if_constexpr<use_global>(
+      [] { return globalStatePtr.get(); },
+      [] { return KinetoThreadLocalState::getTLS(); });
+}
+
+template<bool use_global_state_ptr = false>
+std::unique_ptr<at::ObserverContext> onFunctionEnter(const at::RecordFunction& fn) {
+  auto state_ptr = getStatePtr<use_global_state_ptr>();
+  if (!state_ptr) {
+    return nullptr;
+  }
+  const auto& config = state_ptr->config();
+  auto corr_id = next_correlation_id();
+  torch::profiler::impl::kineto::pushCorrelationId(corr_id);
+  return state_ptr->record_queue_.getSubqueue()->begin_op(fn, corr_id);
+}
+
+// @lint-ignore CLANGTIDY clang-diagnostic-unused-parameter
+template<bool use_global_state_ptr = false>
+void onFunctionExit(const at::RecordFunction& fn, at::ObserverContext* ctx_ptr) {
+  auto state_ptr = getStatePtr<use_global_state_ptr>();
+  if (!state_ptr) {
+    return;
+  }
+  const auto& config = state_ptr->config();
+  auto* kineto_ctx_ptr =
+    static_cast<torch::profiler::impl::KinetoObserverContext*>(ctx_ptr);
+  TORCH_INTERNAL_ASSERT(kineto_ctx_ptr != nullptr);
+  kineto_ctx_ptr->event_->end_time_ = torch::profiler::impl::getApproximateTime();
+  kineto_ctx_ptr->event_->end_thread_id_ = at::RecordFunction::currentThreadId();
+  if (config.state == ProfilerState::KINETO_GPU_FALLBACK) {
+    try {
+      auto fallback = kineto_ctx_ptr->fallback_;
+      TORCH_INTERNAL_ASSERT(fallback != nullptr);
+      torch::profiler::impl::cudaStubs()->record(
+          nullptr, &fallback->cuda_event_end_, nullptr);
+    } catch (const std::exception& e) {
+      LOG(WARNING) << "Failed to record CUDA event. " << e.what();
+    }
+  }
+
+  torch::profiler::impl::kineto::popCorrelationId();
+}
+
+template <bool use_global_callback = false>
+void pushProfilingCallbacks(const std::unordered_set<at::RecordScope>& scopes) {
+  auto registration_state_ptr = getStatePtr<use_global_callback>();
+
+  TORCH_INTERNAL_ASSERT(registration_state_ptr, "Expected profiler state set");
+
+  auto recordFunctionCallback = 
+    at::RecordFunctionCallback(
+        onFunctionEnter<use_global_callback>, onFunctionExit<use_global_callback>)
+    .needsInputs(registration_state_ptr->config().report_input_shapes)
+    .scopes(scopes);
+
+  auto handle = c10::guts::if_constexpr<use_global_callback>(
+      [&] { return at::addGlobalCallback(recordFunctionCallback); },
+      [&] { return at::addThreadLocalCallback(recordFunctionCallback);
+      });
   registration_state_ptr->setCallbackHandle(handle);
 }
 
@@ -646,6 +688,8 @@ void reportBackendEventToActiveKinetoProfiler(
     const at::RecordScope scope,
     const std::string& event_name,
     const std::string& backend_name) {
+  TORCH_INTERNAL_ASSERT(globalStatePtr == nullptr, "On-demand profiling does not support post processing callback");
+
   auto state_ptr = KinetoThreadLocalState::getTLS();
   if (!state_ptr) {
     return;
@@ -690,6 +734,8 @@ void enableProfilerWithEventPostProcess(
   TORCH_CHECK(
       config.state != ProfilerState::NVTX,
       "NVTX does not support post processing callback.");
+  TORCH_INTERNAL_ASSERT(globalStatePtr == nullptr, "On-demand profiling does not support post processing callback");
+
   enableProfiler(config, activities, scopes);
   auto state_ptr = KinetoThreadLocalState::getTLS();
   state_ptr->setEventPostProcessingCallback(std::move(cb));
@@ -707,36 +753,44 @@ void enableProfiler(
 
   TORCH_CHECK(
       config.state == ProfilerState::KINETO ||
-      config.state == ProfilerState::KINETO_GPU_FALLBACK);
+      config.state == ProfilerState::KINETO_GPU_FALLBACK ||
+      config.state == ProfilerState::KINETO_ONDEMAND);
   TORCH_CHECK(
       !activities.empty(), "No activities specified for Kineto profiler");
 
-  auto state = std::make_shared<KinetoThreadLocalState>(config, activities);
-  c10::ThreadLocalDebugInfo::_push(c10::DebugInfoKind::PROFILER_STATE, state);
+  if (config.state == ProfilerState::KINETO ||
+      config.state == ProfilerState::KINETO_GPU_FALLBACK) {
+    auto state = std::make_shared<KinetoThreadLocalState>(config, activities);
+    c10::ThreadLocalDebugInfo::_push(c10::DebugInfoKind::PROFILER_STATE, state);
 
-  if (state->tracePython()) {
-    python_tracer::call(python_tracer::Command::kStartOne);
+    if (state->tracePython()) {
+      python_tracer::call(python_tracer::Command::kStartOne);
+    }
+
+    if (activities.count(ActivityType::CPU)) {
+      pushProfilingCallbacks<false>(scopes);
+    }
+    torch::profiler::impl::kineto::startTrace();
+  } 
+  
+  if (config.state == ProfilerState::KINETO_ONDEMAND) {
+    initGlobalState(config, activities);
+
+    TORCH_INTERNAL_ASSERT(activities.count(ActivityType::CPU), "Ondemand profiling must enable CPU tracing");
+    pushProfilingCallbacks<true>(scopes);
   }
-
-  if (activities.count(ActivityType::CPU)) {
-    pushProfilingCallbacks(scopes);
-  }
-
-  torch::profiler::impl::kineto::startTrace();
 }
 
 std::unique_ptr<ProfilerResult> disableProfiler() {
-  // all the DebugInfoBase objects are scope based and supposed to use
-  // DebugInfoGuard
-  auto state =
-      c10::ThreadLocalDebugInfo::_pop(c10::DebugInfoKind::PROFILER_STATE);
+  auto state_ptr = 
+    static_cast<ProfilerThreadLocalStateBase*>((globalStatePtr == nullptr) ? getStatePtr<false>() : getStatePtr<true>());
 
-  auto state_ptr = static_cast<ProfilerThreadLocalStateBase*>(state.get());
   const auto& config = state_ptr->config();
   TORCH_CHECK(
       state_ptr &&
           (config.state == ProfilerState::KINETO ||
            config.state == ProfilerState::KINETO_GPU_FALLBACK ||
+           config.state == ProfilerState::KINETO_ONDEMAND ||
            config.state == ProfilerState::NVTX),
       "Can't disable Kineto profiler when it's not running");
 
@@ -744,24 +798,42 @@ std::unique_ptr<ProfilerResult> disableProfiler() {
     at::removeCallback(state_ptr->callbackHandle());
   }
 
-  if (state_ptr->config().state == ProfilerState::NVTX) {
+  // Traces are converged via libkineto automatically for ondemand flow
+  if (state_ptr->config().state == ProfilerState::KINETO_ONDEMAND) {
+    auto kineto_state_ptr = static_cast<KinetoThreadLocalState*>(state_ptr);
+    auto trace = kineto_state_ptr->finalizeTrace(state_ptr->config());
+    resetGlobalState();
     return std::make_unique<ProfilerResult>();
   }
 
-  auto kineto_state_ptr = static_cast<KinetoThreadLocalState*>(state_ptr);
-  if (kineto_state_ptr->tracePython()) {
-    python_tracer::call(python_tracer::Command::kStop);
+  // Shared among NVTX, KINETO, KINETO_GPU_FALLBACK
+  std::unique_ptr<ProfilerResult> result;
+  if (state_ptr->config().state == ProfilerState::NVTX) {
+    result = std::make_unique<ProfilerResult>();
   }
 
-  auto trace = kineto_state_ptr->finalizeTrace();
-  if (kineto_state_ptr->tracePython()) {
-    python_tracer::call(python_tracer::Command::kClear);
+  if (config.state == ProfilerState::KINETO ||
+      config.state == ProfilerState::KINETO_GPU_FALLBACK) {
+    auto kineto_state_ptr = static_cast<KinetoThreadLocalState*>(state_ptr);
+    if (kineto_state_ptr->tracePython()) {
+      python_tracer::call(python_tracer::Command::kStop);
+    }
+
+    auto trace = kineto_state_ptr->finalizeTrace(state_ptr->config());
+    if (kineto_state_ptr->tracePython()) {
+      python_tracer::call(python_tracer::Command::kClear);
+    }
+
+    result = std::make_unique<ProfilerResult>(
+        kineto_state_ptr->start_time_,
+        std::move(kineto_state_ptr->kineto_events_),
+        std::move(trace));
   }
 
-  return std::make_unique<ProfilerResult>(
-      kineto_state_ptr->start_time_,
-      std::move(kineto_state_ptr->kineto_events_),
-      std::move(trace));
+  // Disable thread-local profiler. We can't pop until the very end as it would invalidate
+  // the `state_ptr` reference which we need to process the traces.
+  (void)c10::ThreadLocalDebugInfo::_pop(c10::DebugInfoKind::PROFILER_STATE);
+  return result;
 }
 
 int64_t KinetoEvent::cudaElapsedUs() const {

--- a/torch/csrc/profiler/api.h
+++ b/torch/csrc/profiler/api.h
@@ -25,6 +25,7 @@ enum class C10_API_ENUM ProfilerState {
   NVTX, // only emit NVTX markers
   KINETO, // use libkineto
   KINETO_GPU_FALLBACK, // use CUDA events when CUPTI is not available
+  KINETO_ONDEMAND, // run the profiler in on-demand mode
   NUM_PROFILER_STATES, // must be the last one
 };
 

--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -1,5 +1,6 @@
 #ifdef USE_KINETO
 #include <libkineto.h>
+#include <caffe2/torch/csrc/api/include/torch/torch.h>
 
 namespace torch {
 namespace profiler {
@@ -7,23 +8,34 @@ namespace impl {
 
 namespace {
 
+using namespace torch::autograd::profiler; 
+
 class LibKinetoClient : public libkineto::ClientInterface {
  public:
-  void init() override {
-    // TODO: implement
-  }
+  void init() override {}
 
   void warmup(bool setupOpInputsCollection) override {
-    // TODO: implement
+    reportInputShapes_ = setupOpInputsCollection;
   }
 
   void start() override {
-    // TODO: implement
+    ProfilerConfig cfg{
+      ProfilerState::KINETO_ONDEMAND,
+        reportInputShapes_,
+        false,
+        false,
+        false,
+        false};
+    std::set<ActivityType> activities{ActivityType::CPU};
+    auto scopes = {RecordScope::FUNCTION, RecordScope::USER_SCOPE};
+    enableProfiler(cfg, activities, scopes);
   }
 
   void stop() override {
-    // TODO: implement
+    (void)disableProfiler();
   }
+ private:
+  bool reportInputShapes_{true};
 };
 
 } // namespace

--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -1,0 +1,45 @@
+#ifdef USE_KINETO
+#include <libkineto.h>
+
+namespace torch {
+namespace profiler {
+namespace impl {
+
+namespace {
+
+class LibKinetoClient : public libkineto::ClientInterface {
+ public:
+  void init() override {
+    // TODO: implement
+  }
+
+  void warmup(bool setupOpInputsCollection) override {
+    // TODO: implement
+  }
+
+  void start() override {
+    // TODO: implement
+  }
+
+  void stop() override {
+    // TODO: implement
+  }
+};
+
+} // namespace
+
+
+} // namespace impl
+} // namespace profiler
+
+#ifdef ENABLE_LIBKINETO_CLIENT
+struct RegisterLibKinetoClient {
+  RegisterLibKinetoClient() {
+    static profiler::impl::LibKinetoClient client;
+    libkineto::api().registerClient(&client);
+  }
+} register_libkineto_client;
+#endif // ENABLE_LIBKINETO_CLIENT
+
+} // namespace torch
+#endif // USE_KINETO


### PR DESCRIPTION
Summary: The last missing puzzle that enables ProfilerKineto in the ondemand flow

Test Plan:
Sample trace taken with the e2e trace_tester(diff above)

`sh kineto/libkineto/fb/integration_tests/dyno_trace_tester.sh`

https://fburl.com/perfdoctor/tzgtw2ln

Reviewed By: robieta

Differential Revision: D35572928

