### PR TITLE
Monkey patch Variable module to fix FX codegen

### DIFF
--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -319,3 +319,6 @@ def _register_py_tensor_class_for_device(device, cls):
     if not isinstance(cls, type):
         raise RuntimeError("cls isn't a typeinfo object")
     torch._C._register_py_class_for_device(device, cls)
+
+# Fix for FX codgen
+Variable.__module__ = "torch.autograd"


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/torchdynamo/issues/82

There is a `torch.auotgrad.variable` function which conflicts with the module class `torch.autograd.variable.Variable`.

@jansel 
