### PR TITLE
delete ${GEN_VULKAN_FLAGS}

### DIFF
--- a/cmake/Codegen.cmake
+++ b/cmake/Codegen.cmake
@@ -153,7 +153,6 @@ if(INTERN_BUILD_ATEN_OPS)
       ${GEN_PER_OPERATOR_FLAG}
       ${GEN_ROCM_FLAG}
       ${CUSTOM_BUILD_FLAGS}
-      ${GEN_VULKAN_FLAGS}
   )
 
   file(GLOB_RECURSE headers_templates "${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/templates/*\.h")


### PR DESCRIPTION
'--vulkan' no longer exists in 'tools/codegen/gen.py', was deleted in #46938.
