### PR TITLE
back to fetch depth 0

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -10,12 +10,10 @@ inputs:
     description: Works as stated in actions/checkout, but the default value is recursive
     required: false
     default: recursive
-  needs-history-and-master:
-    description: If history of this commit and master should be checked out.  Usually used because the job calls git merge-base
+  fetch-depth:
+    description: Works as stated in actions/checkout, but the default value is 0
     required: false
-  needs-viable-strict:
-    description: If viable/strict should be checked out.  Usually used because the job queries for test stats
-    required: false
+    default: "0"
 
 runs:
   using: composite
@@ -38,17 +36,5 @@ runs:
       with:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         # --depth=1 for speed, manually fetch history and other refs as necessary
-        fetch-depth: 1
+        fetch-depth: ${{ inputs.fetch-depth }}
         submodules: ${{ inputs.submodules }}
-
-    - name: Checkout the rest of history and master
-      shell: bash
-      if: ${{ inputs.needs-history-and-master == 'true' }}
-      env:
-        HASH: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
-      run: git fetch --no-tags --prune --no-recurse-submodules origin --unshallow "${HASH}" master
-
-    - name: Checkout viable/strict
-      shell: bash
-      if: ${{ inputs.needs-viable-strict == 'true' }}
-      run: git fetch --no-tags --prune --no-recurse-submodules origin viable/strict

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -26,8 +26,6 @@ jobs:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-        with:
-          needs-history-and-master: true
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -21,11 +21,6 @@ on:
         type: boolean
         default: false
         description: If set, build in debug mode.
-      needs-viable-strict:
-        required: false
-        type: boolean
-        default: false
-        description: checks out viable/strict
 
     outputs:
       docker-image:
@@ -51,8 +46,6 @@ jobs:
       # checkout. In other cases you should prefer a local checkout.
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-        with:
-          needs-viable-strict: ${{ inputs.needs-viable-strict }}
 
       - name: Check for new workflows
         run: |

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -15,11 +15,6 @@ on:
         required: true
         type: string
         description: Docker image to run in.
-      needs-viable-strict:
-        required: false
-        type: boolean
-        default: false
-        description: checks out viable/strict
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
@@ -38,9 +33,6 @@ jobs:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-        with:
-          needs-viable-strict: ${{ inputs.needs-viable-strict }}
-          needs-history-and-master: true
 
       - name: Setup Linux
         uses: ./.github/actions/setup-linux

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -52,8 +52,6 @@ jobs:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
-        with:
-          needs-history-and-master: true
 
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -48,7 +48,6 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           no-sudo: true
-          needs-history-and-master: true
 
       - name: Setup ROCm
         uses: ./.github/actions/setup-rocm

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -36,7 +36,6 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           no-sudo: true
-          needs-history-and-master: true
 
       - name: Setup Windows
         uses: ./.github/actions/setup-win

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,6 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
-          needs-history-and-master: true
 
       - name: Install lintrunner
         run: pip install lintrunner==0.6.*
@@ -80,6 +79,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
+          fetch-depth: 1
       - name: Clean PyTorch checkout
         run: |
           # Remove any artifacts from the previous checkouts
@@ -122,6 +122,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
+          fetch-depth: 1
       - name: Install requirements
         id: requirements
         run: |
@@ -165,6 +166,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
+          fetch-depth: 1
       - name: Install markdown-toc
         run: npm install -g markdown-toc
       - name: Regenerate ToCs and check that they didn't change
@@ -207,7 +209,6 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
-          needs-history-and-master: true
       - name: Install dependencies
         # mypy and boto3 versions copied from
         # .circleci/docker/common/install_conda.sh
@@ -244,6 +245,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
+          fetch-depth: 1
       - name: Install torch
         if: matrix.with_torch == 'with_torch'
         run: |

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -76,7 +76,6 @@ jobs:
     with:
       build-environment: linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck
       docker-image-name: pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7
-      needs-viable-strict: true
 
   linux-xenial-cuda10_2-py3-gcc7-slow-gradcheck-test:
     name: linux-xenial-cuda10.2-py3-gcc7-slow-gradcheck
@@ -98,7 +97,6 @@ jobs:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7-debug
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
       build-with-debug: true
-      needs-viable-strict: true
 
   linux-xenial-cuda11_3-py3_7-gcc7-debug-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7-debug

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -295,8 +295,8 @@ jobs:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
       docker-image-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c
 
-  ? pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
-  : name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
+  pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit:
+    name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
     uses: ./.github/workflows/_android-build-test.yml
     with:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -20,7 +20,6 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-gcc5.4
       docker-image-name: pytorch-linux-xenial-py3.7-gcc5.4
-      needs-viable-strict: true
 
   linux-xenial-py3_7-gcc5_4-test:
     name: linux-xenial-py3.7-gcc5.4
@@ -53,7 +52,6 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-py3.7-gcc7
-      needs-viable-strict: true
 
   linux-xenial-py3_7-gcc7-test:
     name: linux-xenial-py3.7-gcc7
@@ -74,7 +72,6 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-clang7-asan
       docker-image-name: pytorch-linux-xenial-py3-clang7-asan
-      needs-viable-strict: true
 
   linux-xenial-py3_7-clang7-asan-test:
     name: linux-xenial-py3.7-clang7-asan
@@ -83,7 +80,6 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-clang7-asan
       docker-image: ${{ needs.linux-xenial-py3_7-clang7-asan-build.outputs.docker-image }}
-      needs-viable-strict: true
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 3, runner: "linux.2xlarge" },
@@ -97,7 +93,6 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-gcc7-no-ops
       docker-image-name: pytorch-linux-xenial-py3.7-gcc7
-      needs-viable-strict: true
 
   linux-xenial-py3_7-clang7-onnx-build:
     name: linux-xenial-py3.7-clang7-onnx
@@ -105,7 +100,6 @@ jobs:
     with:
       build-environment: linux-xenial-py3.7-clang7-onnx
       docker-image-name: pytorch-linux-xenial-py3-clang7-onnx
-      needs-viable-strict: true
 
   linux-xenial-py3_7-clang7-onnx-test:
     name: linux-xenial-py3.7-clang7-onnx
@@ -173,7 +167,6 @@ jobs:
     with:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
-      needs-viable-strict: true
 
   linux-xenial-cuda11_3-py3_7-gcc7-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7
@@ -302,8 +295,8 @@ jobs:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single
       docker-image-name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c
 
-  pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit:
-    name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
+  ? pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
+  : name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
     uses: ./.github/workflows/_android-build-test.yml
     with:
       build-environment: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-custom-build-single-full-jit
@@ -323,7 +316,6 @@ jobs:
     with:
       build-environment: deploy-linux-xenial-cuda11.3-py3.7-gcc7
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
-      needs-viable-strict: true
 
   deploy-linux-xenial-cuda11_3-py3_7-gcc7-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -22,7 +22,6 @@ jobs:
     with:
       build-environment: parallelnative-linux-xenial-py3.7-gcc5.4
       docker-image-name: pytorch-linux-xenial-py3.7-gcc5.4
-      needs-viable-strict: true
 
   parallelnative-linux-xenial-py3_7-gcc5_4-test:
     name: parallelnative-linux-xenial-py3.7-gcc5.4
@@ -44,7 +43,6 @@ jobs:
     with:
       build-environment: caffe2-linux-xenial-py3.7-gcc5.4
       docker-image-name: pytorch-linux-xenial-py3.7-gcc5.4
-      needs-viable-strict: true
 
   linux-bionic-cuda10_2-py3_9-gcc7-build:
     name: linux-bionic-cuda10.2-py3.9-gcc7
@@ -95,7 +93,6 @@ jobs:
     with:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7-no-ops
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
-      needs-viable-strict: true
 
   linux-bionic-rocm4_5-py3_7-distributed-build:
     name: linux-bionic-rocm5.0-py3.7-distributed


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
undo #75783 b/c setting fetch depth 1 doesn't really help reduce time b/c most of the jobs need either master or viable/strict

also, more branches need viable/strict than i thought, so sharding isn't picking up test times (although default sharding seems to do pretty well) (regarding the jobs i didn't realize needed viable/strict: it looks like the linux-bionic jobs don't fail when `git rev-parse viable/strict` is run but viable/strict doesn't exist but the linux-xenial ones do)

pretty sure jobs are broken only b/c its using the master version of `checkout-pytorch/action.yml`
tested via #76077