### PR TITLE
[ROCm] unskip test_fmod_remainder_by_zero_integral

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -21,7 +21,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.common_device_type import (
     expectedFailureMeta, instantiate_device_type_tests, onlyCUDA, onlyCPU, dtypes, dtypesIfCUDA,
     dtypesIfCPU, deviceCountAtLeast, precisionOverride, onlyNativeDeviceTypes,
-    skipCUDAIfRocm, skipIf, ops, OpDTypes, skipMeta)
+    skipIf, ops, OpDTypes, skipMeta)
 from torch.testing import make_tensor
 from torch.testing._internal.common_dtype import (
     all_types_and_complex_and, all_types_and, integral_types, complex_types, integral_types_and,


### PR DESCRIPTION
The test is updated to check for ROCm-specific undefined behavior for
integral fmod division by zero.

Fixes #48130.
