### PR TITLE
ProcessGroupNCCL check tensor is_contiguous->is_non_overlapping_and_dense

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -2582,8 +2582,8 @@ at::Tensor& checkSingleTensor(std::vector<at::Tensor>& tensors) {
     TORCH_CHECK(false, "ProcessGroupGloo::send takes a single tensor");
   }
   auto& tensor = tensors[0];
-  if (!tensor.is_contiguous()) {
-    TORCH_CHECK(false, "input tensor has to be contiguous");
+  if (!tensor.is_non_overlapping_and_dense()) {
+    TORCH_CHECK(false, "input tensor has to be non-overlapping and dense");
   }
   if (tensor.is_sparse()) {
     TORCH_CHECK(false, "input tensor has to be dense");

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -63,8 +63,8 @@ bool cudaAwareMpiCheck() {
 
 // Checking the input tensor's validity
 void checkSingleTensorHelper(const at::Tensor& tensor) {
-  if (!tensor.is_contiguous()) {
-    TORCH_CHECK(false, "input tensor has to be contiguous");
+  if (!tensor.is_non_overlapping_and_dense()) {
+    TORCH_CHECK(false, "input tensor has to be non-overlapping and dense");
   }
   if (tensor.is_sparse()) {
     TORCH_CHECK(false, "input tensor has to be dense");

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1221,8 +1221,8 @@ void check_gpu_single_tensor(const at::Tensor& tensor) {
   if (!tensor.is_cuda() || tensor.is_sparse()) {
     TORCH_CHECK(false, "Tensors must be CUDA and dense");
   }
-  if (!tensor.is_contiguous()) {
-    TORCH_CHECK(false, "Tensors must be contiguous");
+  if (!tensor.is_non_overlapping_and_dense()) {
+    TORCH_CHECK(false, "Tensors must be non-overlapping and dense");
   }
 }
 

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -442,6 +442,7 @@ def _build_multidim_tensor(dim, dim_size, value=None, dtype=torch.float):
         tensor.view(-1).copy_(torch.arange(dim, dim_size ** dim + dim))
     else:
         tensor.fill_(value)
+    return tensor
 
 
 def _create_autograd_profiler():


### PR DESCRIPTION
I don't see any reason why we are asserting contiguous here. In my opinion, `is_non_overlapping_and_dense` makes more sense because this allows tasks like NHWC training.

Currently `check_gpu_tensors_same_device` and `check_gpu_tensors_different_devices` are both checking `is_non_overlapping_and_dense` instead of `is_contiguous`, so I think it makes more sense to modify `check_gpu_single_tensor` to have the same behavior

https://github.com/pytorch/pytorch/blob/f6c275f55ddfd22f8c0558efad3068b0e91f1560/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1290-L1292
https://github.com/pytorch/pytorch/blob/f6c275f55ddfd22f8c0558efad3068b0e91f1560/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1260-L1262