### PR TITLE
Add code for more error message

### DIFF
--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -307,41 +307,74 @@ class TestPublicBindings(TestCase):
                     return
 
             # verifies that each public API has the correct module name and naming semantics
-            def check_one_element(elem, modname, mod, *, is_public):
+            def check_one_element(elem, modname, mod, *, is_public, is_all):
                 obj = getattr(mod, elem)
                 if not (isinstance(obj, Callable) or inspect.isclass(obj)):
                     return
                 elem_module = getattr(obj, '__module__', None)
+                # Only used for nice error message below
+                why_not_looks_public = ""
+                if elem_module is None:
+                    why_not_looks_public = "because it does not have a `__module__` attribute"
                 elem_modname_starts_with_mod = elem_module is not None and \
                     elem_module.startswith(modname) and '._' not in elem_module
+                if not why_not_looks_public and not elem_modname_starts_with_mod:
+                    why_not_looks_public = f"because its `__module__` attribute (`{elem_module}`) does not " \
+                        f"start with the submodule where it is defined (`{modname}`)"
                 # elem's name must NOT begin with an `_` and it's module name
                 # SHOULD start with it's current module since it's a public API
                 looks_public = not elem.startswith('_') and elem_modname_starts_with_mod
+                if not why_not_looks_public and not looks_public:
+                    why_not_looks_public = f"because it starts with `_` ({elem})"
+
                 if is_public != looks_public:
                     if modname in allow_dict and elem in allow_dict[modname]:
                         return
-                    failure_list.append((modname, elem, elem_module))
+
+                    if is_public:
+                        why_is_public = f"it is inside the module's ({modname}) `__all__`" if is_all else \
+                            "it is an attribute that does not start with `_` on a module that " \
+                            "does not have `__all__` defined"
+                    else:
+                        assert is_all
+                        why_is_public = f"it is not inside the module's ({modname}) `__all__`"
+
+                    if looks_public:
+                        why_looks_public = "it does look public because it follows the rules from the doc above " \
+                            "(does not start with `_` and has a proper `__module__`)."
+                    else:
+                        why_looks_public = why_not_looks_public
+
+                    failure_list.append(f"# {modname}.{elem}:")
+                    is_public_str = "" if is_public else " NOT"
+                    failure_list.append(f"  - Is{is_public_str} public: {why_is_public}")
+                    looks_public_str = "" if looks_public else " NOT"
+                    failure_list.append(f"  - Does{looks_public_str} look public: {why_looks_public}")
 
             if hasattr(mod, '__all__'):
                 public_api = mod.__all__
                 all_api = dir(mod)
                 for elem in all_api:
-                    check_one_element(elem, modname, mod, is_public=elem in public_api)
+                    check_one_element(elem, modname, mod, is_public=elem in public_api, is_all=True)
 
             else:
                 all_api = dir(mod)
                 for elem in all_api:
                     if not elem.startswith('_'):
-                        check_one_element(elem, modname, mod, is_public=True)
+                        check_one_element(elem, modname, mod, is_public=True, is_all=False)
 
         for _, modname, ispkg in pkgutil.walk_packages(path=torch.__path__, prefix=torch.__name__ + '.'):
             test_module(modname)
 
         test_module('torch')
-        msg = "Following new APIs ( displayed in the form (module, element, element module) )" \
-              " were added that do not meet our guidelines for public API" \
-              " Please review  https://github.com/pytorch/pytorch/wiki/Public-API-definition-and-documentation" \
-              " for more information:\n" + "\n".join(map(str, failure_list))
+
+        msg = "All the APIs below do not meet our guidelines for public API from " \
+              "https://github.com/pytorch/pytorch/wiki/Public-API-definition-and-documentation.\n"
+        msg += "Make sure that everything that is public is expected (in particular that the module " \
+            "has a properly populated `__all__` attribute) and that everything that is supposed to be public " \
+            "does look public (it does not start with `_` and has a `__module__` that is properly populated)."
+        msg += "\n\nFull list:\n"
+        msg += "\n".join(map(str, failure_list))
 
         # empty lists are considered false in python
         self.assertTrue(not failure_list, msg)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #76147
* #76146

This is what it looks like when I add a bunch of errors:
```
AssertionError: False is not true : All the APIs below do not meet our guidelines for public API from https://github.com/pytorch/pytorch/wiki/Public-API-definition-and-documentation.
Make sure that everything that is public is expected (in particular that the module has a properly populated `__all__` attribute) and that everything that is supposed to be public does look public (it does not start with `_` and has a `__module__` that is properly populated).

Full list:
# torch.amp.autocast_mode.Any:
  - Is public: it is an attribute that does not start with `_` on a module that does not have `__all__` defined
  - Does NOT look public: because its `__module__` attribute (`typing`) does not start with the submodule where it is defined (`torch.amp.autocast_mode`)
# torch.ao.nn.sparse.quantized.dynamic.linear.LinearBlockSparsePattern:
  - Is public: it is an attribute that does not start with `_` on a module that does not have `__all__` defined
  - Does NOT look public: because its `__module__` attribute (`torch.ao.nn.sparse.quantized.utils`) does not start with the submodule where it is defined (`torch.ao.nn.sparse.quantized.dynamic.linear`)
# torch.utils.data._DatasetKind:
  - Is public: it is inside the module's (torch.utils.data) `__all__`
  - Does NOT look public: because it starts with `_` (_DatasetKind)
# torch.is_tensor:
  - Is NOT public: it is not inside the module's (torch) `__all__`
  - Does look public: it does look public because it follows the rules from the doc above (does not start with `_` and has a proper `__module__`).

```