### PR TITLE
[quant] Fix TensorRT tests (#60)

### DIFF
--- a/torch/ao/quantization/backend_config/native.py
+++ b/torch/ao/quantization/backend_config/native.py
@@ -446,7 +446,7 @@ def _get_conv_configs():
 
     return conv_configs
 
-def _get_binary_op_configs():
+def _get_binary_op_configs(dtype_configs):
     binary_op_configs: List[Dict[str, Any]] = []
     num_tensor_args_to_observation_type_mapping = {
         # TODO: this is not used right now since we have extra check in prepare
@@ -456,10 +456,6 @@ def _get_binary_op_configs():
         1: ObservationType.OUTPUT_SHARE_OBSERVER_WITH_INPUT,
         2: ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT,
     }
-    dtype_configs = [
-        weighted_op_int8_dtype_config,
-        default_op_fp16_dtype_config,
-    ]
     for op_with_quantized_bop_scalar_variant in [
             operator.add, torch.add, operator.mul, torch.mul]:
         binary_op_configs.append({
@@ -696,6 +692,10 @@ def _get_embedding_op_configs():
 
 def get_native_backend_config_dict():
     """ Get backend_config_dict for PyTorch Native backend (fbgemm/qnnpack). """
+    binary_op_dtype_configs = [
+        weighted_op_int8_dtype_config,
+        default_op_fp16_dtype_config,
+    ]
     return {
         # optional
         "name": "native",
@@ -703,7 +703,7 @@ def get_native_backend_config_dict():
             *_DEFAULT_OP_INT8_CONFIGS,
             *_get_linear_configs(),
             *_get_conv_configs(),
-            *_get_binary_op_configs(),
+            *_get_binary_op_configs(binary_op_dtype_configs),
             *_get_fixed_qparams_op_configs(),
             _CAT_CONFIG,
             *_get_bn_configs(),

--- a/torch/ao/quantization/backend_config/tensorrt.py
+++ b/torch/ao/quantization/backend_config/tensorrt.py
@@ -3,6 +3,8 @@ from .observation_type import ObservationType
 import torch.nn.qat as nnqat
 import torch.nn.intrinsic as nni
 import torch.nn.intrinsic.qat as nniqat
+# TODO: maybe refactor this to a separate util function
+from .native import _get_binary_op_configs
 
 from ..fuser_method_mappings import reverse_sequential_wrapper2
 
@@ -64,6 +66,7 @@ def get_tensorrt_backend_config_dict():
             weighted_op_qint8_dtype_config,
         ],
         "fuser_method": reverse_sequential_wrapper2(nni.LinearReLU),
+        "fused_module": nni.LinearReLU,
     }
     linear_relu_mf_config = {
         "pattern": (torch.nn.functional.relu, torch.nn.Linear),
@@ -72,6 +75,7 @@ def get_tensorrt_backend_config_dict():
             weighted_op_qint8_dtype_config,
         ],
         "fuser_method": reverse_sequential_wrapper2(nni.LinearReLU),
+        "fused_module": nni.LinearReLU,
     }
 
     linear_relu_fused_config = {
@@ -157,6 +161,7 @@ def get_tensorrt_backend_config_dict():
             weighted_op_qint8_dtype_config,
         ],
         "fuser_method": reverse_sequential_wrapper2(nni.ConvReLU2d),
+        "fused_module": nni.ConvReLU2d,
     }
     conv2d_relu_mm_config = {
         "pattern": (torch.nn.ReLU, torch.nn.Conv2d),
@@ -165,6 +170,7 @@ def get_tensorrt_backend_config_dict():
             weighted_op_qint8_dtype_config,
         ],
         "fuser_method": reverse_sequential_wrapper2(nni.ConvReLU2d),
+        "fused_module": nni.ConvReLU2d,
     }
     addmm_config = {
         "pattern": torch.addmm,
@@ -193,6 +199,9 @@ def get_tensorrt_backend_config_dict():
             non_weighted_op_qint8_dtype_config,
         ]
     }
+    binary_op_dtype_configs = [
+        weighted_op_qint8_dtype_config,
+    ]
     return {
         # optional
         "name": "tensorrt",
@@ -216,6 +225,7 @@ def get_tensorrt_backend_config_dict():
             addmm_config,
             cat_config,
             identity_config,
+            *_get_binary_op_configs(binary_op_dtype_configs),
         ]
     }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/fx2trt/pull/60

Recently, we landed some PRs to enable backend_config_dict by default in the quantization codebase, we also changes
the config to include "fused_module" for a pattern, but we didn't update tensorrt backend config dict,
this PR adds that configuration. Also adds the config for binary ops in TensorRT, since it was relying on fbgemm backend
config dict previously

Test Plan: Facebook internal tests

Differential Revision: D35789709

