### PR TITLE
Fix to support no-batch-dim inputs in ConvTransposeNd._output_padding

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13831,7 +13831,7 @@ class TestNNDeviceType(NNTestCase):
         inp = torch.randn((1, 15, 13) if N == 2 else (1, 15, 13, 13), device=device)
         output_size = (1, 240, 200) if N == 2 else (1, 240, 200, 200)
         ConvTransposeNd = getattr(nn, 'ConvTranspose{}d'.format(N))
-        m = ConvTransposeNd(1, 1, kernel_size=16, stride=16, padding=7, bias=False)
+        m = ConvTransposeNd(1, 1, kernel_size=16, stride=16, padding=7, bias=False, device=device)
         output = m(inp, output_size=output_size)
         self.assertEqual(output.shape, output_size)
 

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -610,22 +610,24 @@ class _ConvTransposeNd(_ConvNd):
     # compatibility
     def _output_padding(self, input: Tensor, output_size: Optional[List[int]],
                         stride: List[int], padding: List[int], kernel_size: List[int],
-                        dilation: Optional[List[int]] = None) -> List[int]:
+                        num_spatial_dims: int, dilation: Optional[List[int]] = None) -> List[int]:
         if output_size is None:
             ret = _single(self.output_padding)  # converting to list if was not already
         else:
-            k = input.dim() - 2
-            if len(output_size) == k + 2:
-                output_size = output_size[2:]
+            has_batch_dim = input.dim() == num_spatial_dims + 2
+            num_non_spatial_dims = 2 if has_batch_dim else 1
+            k = num_spatial_dims
+            if len(output_size) == k + num_non_spatial_dims:
+                output_size = output_size[num_non_spatial_dims:]
             if len(output_size) != k:
                 raise ValueError(
-                    "output_size must have {} or {} elements (got {})"
-                    .format(k, k + 2, len(output_size)))
+                    "ConvTranspose{}D: for {}D input, output_size must have {} or {} elements (got {})"
+                    .format(num_spatial_dims, input.dim(), k, k + num_non_spatial_dims, len(output_size)))
 
             min_sizes = torch.jit.annotate(List[int], [])
             max_sizes = torch.jit.annotate(List[int], [])
             for d in range(k):
-                dim_size = ((input.size(d + 2) - 1) * stride[d] -
+                dim_size = ((input.size(d + num_non_spatial_dims) - 1) * stride[d] -
                             2 * padding[d] +
                             (dilation[d] if dilation is not None else 1) * (kernel_size[d] - 1) + 1)
                 min_sizes.append(dim_size)
@@ -769,8 +771,10 @@ class ConvTranspose1d(_ConvTransposeNd):
         assert isinstance(self.padding, tuple)
         # One cannot replace List by Tuple or Sequence in "_output_padding" because
         # TorchScript does not support `Sequence[T]` or `Tuple[T, ...]`.
+        num_spatial_dims = 1
         output_padding = self._output_padding(
-            input, output_size, self.stride, self.padding, self.kernel_size, self.dilation)  # type: ignore[arg-type]
+            input, output_size, self.stride, self.padding, self.kernel_size,
+            num_spatial_dims, self.dilation)  # type: ignore[arg-type]
         return F.conv_transpose1d(
             input, self.weight, self.bias, self.stride, self.padding,
             output_padding, self.groups, self.dilation)
@@ -919,8 +923,10 @@ class ConvTranspose2d(_ConvTransposeNd):
         assert isinstance(self.padding, tuple)
         # One cannot replace List by Tuple or Sequence in "_output_padding" because
         # TorchScript does not support `Sequence[T]` or `Tuple[T, ...]`.
+        num_spatial_dims = 2
         output_padding = self._output_padding(
-            input, output_size, self.stride, self.padding, self.kernel_size, self.dilation)  # type: ignore[arg-type]
+            input, output_size, self.stride, self.padding, self.kernel_size,
+            num_spatial_dims, self.dilation)  # type: ignore[arg-type]
 
         return F.conv_transpose2d(
             input, self.weight, self.bias, self.stride, self.padding,
@@ -1067,8 +1073,10 @@ class ConvTranspose3d(_ConvTransposeNd):
         assert isinstance(self.padding, tuple)
         # One cannot replace List by Tuple or Sequence in "_output_padding" because
         # TorchScript does not support `Sequence[T]` or `Tuple[T, ...]`.
+        num_spatial_dims = 3
         output_padding = self._output_padding(
-            input, output_size, self.stride, self.padding, self.kernel_size, self.dilation)  # type: ignore[arg-type]
+            input, output_size, self.stride, self.padding, self.kernel_size,
+            num_spatial_dims, self.dilation)  # type: ignore[arg-type]
 
         return F.conv_transpose3d(
             input, self.weight, self.bias, self.stride, self.padding,

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -616,17 +616,17 @@ class _ConvTransposeNd(_ConvNd):
         else:
             has_batch_dim = input.dim() == num_spatial_dims + 2
             num_non_spatial_dims = 2 if has_batch_dim else 1
-            k = num_spatial_dims
-            if len(output_size) == k + num_non_spatial_dims:
+            if len(output_size) == num_non_spatial_dims + num_spatial_dims:
                 output_size = output_size[num_non_spatial_dims:]
-            if len(output_size) != k:
+            if len(output_size) != num_spatial_dims:
                 raise ValueError(
                     "ConvTranspose{}D: for {}D input, output_size must have {} or {} elements (got {})"
-                    .format(num_spatial_dims, input.dim(), k, k + num_non_spatial_dims, len(output_size)))
+                    .format(num_spatial_dims, input.dim(), num_spatial_dims,
+                            num_non_spatial_dims + num_spatial_dims, len(output_size)))
 
             min_sizes = torch.jit.annotate(List[int], [])
             max_sizes = torch.jit.annotate(List[int], [])
-            for d in range(k):
+            for d in range(num_spatial_dims):
                 dim_size = ((input.size(d + num_non_spatial_dims) - 1) * stride[d] -
                             2 * padding[d] +
                             (dilation[d] if dilation is not None else 1) * (kernel_size[d] - 1) + 1)
@@ -644,7 +644,7 @@ class _ConvTransposeNd(_ConvNd):
                             output_size, min_sizes, max_sizes, input.size()[2:]))
 
             res = torch.jit.annotate(List[int], [])
-            for d in range(k):
+            for d in range(num_spatial_dims):
                 res.append(output_size[d] - min_sizes[d])
 
             ret = res

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -773,7 +773,7 @@ class ConvTranspose1d(_ConvTransposeNd):
         # TorchScript does not support `Sequence[T]` or `Tuple[T, ...]`.
         num_spatial_dims = 1
         output_padding = self._output_padding(
-            input, output_size, self.stride, self.padding, self.kernel_size,
+            input, output_size, self.stride, self.padding, self.kernel_size,  # type: ignore[arg-type]
             num_spatial_dims, self.dilation)  # type: ignore[arg-type]
         return F.conv_transpose1d(
             input, self.weight, self.bias, self.stride, self.padding,
@@ -925,7 +925,7 @@ class ConvTranspose2d(_ConvTransposeNd):
         # TorchScript does not support `Sequence[T]` or `Tuple[T, ...]`.
         num_spatial_dims = 2
         output_padding = self._output_padding(
-            input, output_size, self.stride, self.padding, self.kernel_size,
+            input, output_size, self.stride, self.padding, self.kernel_size,  # type: ignore[arg-type]
             num_spatial_dims, self.dilation)  # type: ignore[arg-type]
 
         return F.conv_transpose2d(
@@ -1075,7 +1075,7 @@ class ConvTranspose3d(_ConvTransposeNd):
         # TorchScript does not support `Sequence[T]` or `Tuple[T, ...]`.
         num_spatial_dims = 3
         output_padding = self._output_padding(
-            input, output_size, self.stride, self.padding, self.kernel_size,
+            input, output_size, self.stride, self.padding, self.kernel_size,  # type: ignore[arg-type]
             num_spatial_dims, self.dilation)  # type: ignore[arg-type]
 
         return F.conv_transpose3d(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #76151

Fixes #75889