### PR TITLE
[PyTorch] Fix bulleted lists in transformer fast path docstrings

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -898,6 +898,7 @@ class MultiheadAttention(Module):
 
     ``forward()`` will use a special optimized implementation if all of the following
     conditions are met:
+
     - self attention is being computed (i.e., ``query``, ``key``, and ``value`` are the same tensor. This restriction will be loosened in the future.)
     - Either autograd is disabled (using ``torch.inference_mode`` or ``torch.no_grad``) or no tensor argument ``requires_grad``
     - training is disabled (using ``.eval()``)

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -293,6 +293,7 @@ class TransformerEncoderLayer(Module):
     Fast path:
         forward() will use a special optimized implementation if all of the following
         conditions are met:
+
         - Either autograd is disabled (using ``torch.inference_mode`` or ``torch.no_grad``) or no tensor argument ``requires_grad``
         - training is disabled (using ``.eval()``)
         - batch_first is ``True`` and the input is batched (i.e., ``src.dim() == 3``)
@@ -301,6 +302,7 @@ class TransformerEncoderLayer(Module):
         - at most one of ``src_mask`` and ``src_key_padding_mask`` is passed
         - if src is a `NestedTensor <https://pytorch.org/docs/stable/nested.html>`_, neither ``src_mask`` nor ``src_key_padding_mask`` is passed
         - the two ``LayerNorm`` instances have a consistent ``eps`` value (this will naturally be the case unless the caller has manually modified one without modifying the other)
+
         If the optimized implementation is in use, a
         `NestedTensor <https://pytorch.org/docs/stable/nested.html>`_ can be
         passed for ``src`` to represent padding more efficiently than using a padding


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #76154
* #75809

The formatting was off.

Differential Revision: [D35797735](https://our.internmc.facebook.com/intern/diff/D35797735/)