### PR TITLE
[complex32] mul

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -56,6 +56,12 @@ void atan2_kernel(TensorIteratorBase& iter) {
 void mul_kernel(TensorIteratorBase& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     cpu_kernel(iter, [=](bool a, bool b) -> bool { return a && b; });
+  } else if (iter.dtype() == kComplexHalf) {
+    using scalar_t = c10::complex<at::Half>;
+    cpu_kernel(iter, [=](scalar_t a, scalar_t b) -> scalar_t {
+      using comp_t = c10::complex<float>;
+      return static_cast<scalar_t>(comp_t{a} * comp_t{b});
+    });
   } else {
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kBFloat16, kHalf, iter.dtype(), "mul_cpu", [&]() {
       cpu_kernel_vec(iter,

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -57,11 +57,13 @@ void mul_kernel(TensorIteratorBase& iter) {
   if (iter.dtype() == ScalarType::Bool) {
     cpu_kernel(iter, [=](bool a, bool b) -> bool { return a && b; });
   } else if (iter.dtype() == kComplexHalf) {
-    using scalar_t = c10::complex<at::Half>;
-    cpu_kernel(iter, [=](scalar_t a, scalar_t b) -> scalar_t {
-      using comp_t = c10::complex<float>;
-      return static_cast<scalar_t>(comp_t{a} * comp_t{b});
-    });
+    cpu_kernel(
+        iter,
+        [=](c10::complex<at::Half> a,
+            c10::complex<at::Half> b) -> c10::complex<at::Half> {
+          using comp_t = c10::complex<float>;
+          return comp_t{a} * comp_t{b};
+        });
   } else {
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kBFloat16, kHalf, iter.dtype(), "mul_cpu", [&]() {
       cpu_kernel_vec(iter,

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -5,6 +5,7 @@
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/cuda/JitLoops.cuh>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAMathCompat.h>
 #include <c10/util/TypeSafeSignMath.h>
@@ -171,11 +172,29 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
   }
 }
 
+const char mul_name[] = "mul_kernel";
 void mul_kernel_cuda(TensorIteratorBase& iter) {
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "mul_cuda", [&]() {
-    using opmath_t = at::opmath_type<scalar_t>;
-    opmath_gpu_kernel_with_scalars<scalar_t>(iter, MulFunctor<opmath_t>());
-  });
+  auto common_dtype = iter.common_dtype();
+  if (common_dtype == kComplexHalf) {
+    using scalar_t = c10::complex<at::Half>;
+    #if AT_USE_JITERATOR()
+      static const auto mul_string = jiterator_stringify(
+        template <typename T>
+        T mul_kernel(T a, T b) {
+          return a * b;
+        }
+      );
+      jitted_gpu_kernel<mul_name, scalar_t, scalar_t, 2>(iter, mul_string);
+    #else
+      using opmath_t = at::opmath_type<scalar_t>;
+      opmath_gpu_kernel_with_scalars<scalar_t>(iter, MulFunctor<opmath_t>());
+    #endif
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "mul_cuda", [&]() {
+      using opmath_t = at::opmath_type<scalar_t>;
+      opmath_gpu_kernel_with_scalars<scalar_t>(iter, MulFunctor<opmath_t>());
+    });
+  }
 }
 
 REGISTER_DISPATCH(div_true_stub, &div_true_kernel_cuda);

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -110,7 +110,7 @@ struct AUnaryFunctor {
   using traits = function_traits<func_t>;
   using opmath_arg1_t = typename traits::template arg<0>::type;
   __device__ return_t operator()(arg2_t b) const {
-    return f(a, b);
+    return static_cast<return_t>(f(a, b));
   }
   // NB: scalar is stored in higher precision!
   AUnaryFunctor(func_t f_, opmath_arg1_t a_): f(f_), a(a_) {}
@@ -124,7 +124,7 @@ struct BUnaryFunctor {
   using traits = function_traits<func_t>;
   using opmath_arg2_t = typename traits::template arg<1>::type;
   __device__ return_t operator()(arg1_t a) const {
-    return f(a, b);
+    return static_cast<return_t>(f(a, b));
   }
   // NB: scalar is stored in higher precision!
   BUnaryFunctor(func_t f_, opmath_arg2_t b_): f(f_), b(b_) {}
@@ -138,7 +138,7 @@ struct BUnaryFunctor {
 template <typename arg1_t, typename arg2_t, typename return_t, typename func_t>
 struct BinaryFunctor {
   __device__ return_t operator()(arg1_t a, arg2_t b) const {
-    return f(a, b);
+    return static_cast<return_t>(f(a, b));
   }
   BinaryFunctor(func_t f_): f(f_) {}
   private:

--- a/aten/src/ATen/native/cuda/Loops.cuh
+++ b/aten/src/ATen/native/cuda/Loops.cuh
@@ -110,7 +110,7 @@ struct AUnaryFunctor {
   using traits = function_traits<func_t>;
   using opmath_arg1_t = typename traits::template arg<0>::type;
   __device__ return_t operator()(arg2_t b) const {
-    return static_cast<return_t>(f(a, b));
+    return f(a, b);
   }
   // NB: scalar is stored in higher precision!
   AUnaryFunctor(func_t f_, opmath_arg1_t a_): f(f_), a(a_) {}
@@ -124,7 +124,7 @@ struct BUnaryFunctor {
   using traits = function_traits<func_t>;
   using opmath_arg2_t = typename traits::template arg<1>::type;
   __device__ return_t operator()(arg1_t a) const {
-    return static_cast<return_t>(f(a, b));
+    return f(a, b);
   }
   // NB: scalar is stored in higher precision!
   BUnaryFunctor(func_t f_, opmath_arg2_t b_): f(f_), b(b_) {}
@@ -138,7 +138,7 @@ struct BUnaryFunctor {
 template <typename arg1_t, typename arg2_t, typename return_t, typename func_t>
 struct BinaryFunctor {
   __device__ return_t operator()(arg1_t a, arg2_t b) const {
-    return static_cast<return_t>(f(a, b));
+    return f(a, b);
   }
   BinaryFunctor(func_t f_): f(f_) {}
   private:

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -404,7 +404,7 @@ struct alignas(4) complex<Half> {
   // be constexpr
   C10_HOST_DEVICE explicit inline complex(const Half& real, const Half& imag)
       : real_(real), imag_(imag) {}
-  C10_HOST_DEVICE explicit inline complex(const c10::complex<float>& value)
+  C10_HOST_DEVICE inline complex(const c10::complex<float>& value)
       : real_(value.real()), imag_(value.imag()) {}
 
   // Conversion operator

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8867,7 +8867,7 @@ op_db: List[OpInfo] = [
                     )),
     BinaryUfuncInfo('mul',
                     aliases=('multiply',),
-                    dtypes=all_types_and_complex_and(torch.float16, torch.bfloat16, torch.bool),
+                    dtypes=all_types_and_complex_and(torch.chalf, torch.float16, torch.bfloat16, torch.bool),
                     assert_autodiffed=True,
                     supports_forward_ad=True,
                     supports_fwgrad_bwgrad=True,


### PR DESCRIPTION
Reference: https://github.com/pytorch/pytorch/issues/74537

Required for complex32 support by `fft` module.

Tested with `test_dtypes` and `test_complex_half_reference_testing` in test_ops.py