### PR TITLE
Back out "Export NamedTuple when it's nested in first type layer Dict"

### DIFF
--- a/test/mobile/test_lite_script_type.py
+++ b/test/mobile/test_lite_script_type.py
@@ -3,7 +3,7 @@
 import torch
 import torch.utils.bundled_inputs
 import io
-from typing import Dict, List, NamedTuple
+from typing import List, NamedTuple
 
 from torch.jit.mobile import _load_for_lite_interpreter
 from torch.testing._internal.common_utils import TestCase, run_tests
@@ -28,69 +28,6 @@ class TestLiteScriptModule(TestCase):
         buffer.seek(0)
         mobile_module = _load_for_lite_interpreter(buffer)  # Error here
         mobile_module_result = mobile_module(sample_input).a
-        torch.testing.assert_allclose(
-            script_module_result,
-            mobile_module_result
-        )
-
-
-    def test_typing_dict_with_namedtuple(self):
-        class Foo(NamedTuple):
-            id: torch.Tensor
-
-        class Bar(torch.nn.Module):
-            def __init__(self):
-                super(Bar, self).__init__()
-                self.foo = Foo(torch.tensor(1))
-
-            def forward(self, a: torch.Tensor):
-                self.foo = Foo(a)
-                re: Dict[str, Foo] = dict()
-                re["test"] = Foo(a)
-                return self.foo, re["test"]
-
-        # The corresponding bytecode is
-        # (8,
-        #  ('__torch__.___torch_mangle_2.Bar.forward',
-        #   (('instructions',
-        #     (('STOREN', 1, 2),
-        #      ('DROPR', 1, 0),
-        #      ('DICT_CONSTRUCT', 0, 0),
-        #      ('STORE', 3, 0),
-        #      ('LOAD', 3, 0),
-        #      ('LOADC', 1, 0),
-        #      ('MOVE', 2, 0),
-        #      ('NAMED_TUPLE_CONSTRUCT', 1, 1),
-        #      ('OP', 0, 0),
-        #      ('MOVE', 3, 0),
-        #      ('LOADC', 1, 0),
-        #      ('DICT_INDEX', 0, 0),
-        #      ('LOADC', 0, 0),
-        #      ('TUPLE_INDEX', 0, 0),
-        #      ('RET', 0, 0))),
-        #    ('operators', (('aten::_set_item', 'str', 3),)),
-        #    ('constants', (0, 'test')),
-        #    ('types',
-        #     ('Dict[str,__torch__.Foo[NamedTuple, [[id, Tensor]]]]',
-        #      '__torch__.Foo[NamedTuple, [[id, Tensor]]]')),
-        #    ('register_size', 3)),
-        #   (('arguments',
-        #     ((('name', 'self'),
-        #       ('type', '__torch__.___torch_mangle_2.Bar'),
-        #       ('default_value', None)),
-        #      (('name', 'a'), ('type', 'Tensor'), ('default_value', None)))),
-        #    ('returns',
-        #     ((('name', ''), ('type', 'Tensor'), ('default_value', None)),)))))
-
-        sample_input = torch.tensor(5)
-        script_module = torch.jit.script(Bar())
-
-        script_module_result = script_module(sample_input)
-
-        buffer_mobile = io.BytesIO(script_module._save_to_buffer_for_lite_interpreter())
-        buffer_mobile.seek(0)
-        mobile_module = _load_for_lite_interpreter(buffer_mobile)
-        mobile_module_result = mobile_module(sample_input)
         torch.testing.assert_allclose(
             script_module_result,
             mobile_module_result

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -80,88 +80,6 @@ ExportModuleExtraFilesHook& GetExtraFilesHook() {
   return func;
 }
 
-/**
- * If the type is not NamedTuple, it will return default_type_str. If the type
- * is a NamedTuple, it will return a string with following structure to describe
- * the content in the NamedTuple: "qualified_named[ NamedTuple, [ [filed_name_1,
- * field_type_1], [filed_name_2, field_type_2]
- *   ]
- * ]"
- *  Example NamedTuple type:
- *  "__torch__.base_models.sparse_nn.pytorch_preproc_types.PreprocOutputType[
- *     NamedTuple, [
- *         [float_features, Tensor],
- *         [id_list_features, List[Tensor]],
- *         [label,  Tensor],
- *         [weight, Tensor],
- *         ]
- *     ]"
- *
- * @param compilation_unit Jit compilcation unit to look up function schema.
- * @param type_ptr A type pointer and it can be possibly any type.
- * @param default_type_str The default string representation. The string can
- * either from type_ptr->str(), type_ptr->annotation_str(), or
- * type_ptr->repr_str(). In some cases, they could be different in different
- * scenario. For example, Tensor type can be "Tensor", "Tensor (inferred)" and
- * "Tensor[]", and we only want "Tensor". Leave it as part of arguments as the
- * default return, when type_ptr is not a NamedTuple.
- * @return string representation.
- */
-std::string get_named_tuple_str_or_default(
-    const CompilationUnit& compilation_unit,
-    const TypePtr& type_ptr,
-    std::string default_type_str) {
-  if (type_ptr->kind() == TypeKind::TupleType) {
-    TORCH_CHECK(
-        compilation_unit.get_named_tuple(type_ptr->str()),
-        "Can't find definition for the qualified name: ",
-        type_ptr->str(),
-        "(TypeKind::TupleType)  in compilation unit.",
-        "Please report a bug to PyTorch.");
-    auto named_tuple_ptr = compilation_unit.get_named_tuple(type_ptr->str());
-    if (named_tuple_ptr != nullptr) {
-      std::string named_tuple_str = type_ptr->str();
-      named_tuple_str.append("[NamedTuple, [");
-      std::vector<IValue> name_type_pairs;
-
-      // Get the field name and field type for the NamedTuple
-      for (auto it = named_tuple_ptr->schema()->arguments().begin();
-           it != named_tuple_ptr->schema()->arguments().end();
-           it++) {
-        const std::string named_tuple_name = it->name();
-        const c10::TypePtr& named_tuple_type = it->type();
-        // When it->type() is Tensor type, in Python, if it's inferred type,
-        // str() return "Tensor" and repr_str() return "Tensor (inferred)". If
-        // it's not inferred type, str() return "Tensor[]" and repr_str()
-        // return "Tensor". In cpp, repr_str() will always return "Tensor"
-        // regardless inferred type. When exporing custom type in bytecode,
-        // "Tensor" is the preferred way to deserialize Tensor type
-        std::string named_tuple_type_str = it->is_inferred_type()
-            ? named_tuple_type->str()
-            : named_tuple_type->repr_str();
-        // The type can also be NamedTuple. Will parse it recursively and get
-        // it's string representation.
-        named_tuple_type_str = get_named_tuple_str_or_default(
-            compilation_unit, named_tuple_type, named_tuple_type->repr_str());
-        name_type_pairs.emplace_back(
-            c10::ivalue::Tuple::create({it->name(), named_tuple_type_str}));
-
-        named_tuple_str.append("[")
-            .append(named_tuple_name)
-            .append(", ")
-            .append(named_tuple_type_str)
-            .append("]");
-        if (it != named_tuple_ptr->schema()->arguments().end() - 1) {
-          named_tuple_str.append(",");
-        }
-      }
-      named_tuple_str.append("]]");
-      return named_tuple_str;
-    }
-  }
-  return default_type_str;
-}
-
 std::pair<IValue, IValue> getFunctionTuple(
     const CompilationUnit& compilation_unit,
     const mobile::Function& func,
@@ -202,36 +120,59 @@ std::pair<IValue, IValue> getFunctionTuple(
       t = dyn->fallback();
     }
     std::string type_str = t->annotation_str();
-    if (t->kind() == TypeKind::DictType) {
-      // For DictType, there are two items in t->containedTypes(), the first one
-      // is key and the second one is value. Both of them could be NamedTuple
-      // type.
-      const TypePtr& key_type = t->containedTypes()[0];
-      const TypePtr& value_type = t->containedTypes()[1];
-      std::string key_type_str = get_named_tuple_str_or_default(
-          compilation_unit, key_type, key_type->annotation_str());
-      std::string value_type_str = get_named_tuple_str_or_default(
-          compilation_unit, value_type, value_type->annotation_str());
+    if (t->kind() == TypeKind::TupleType) {
+      TORCH_CHECK(
+          compilation_unit.get_named_tuple(t->str()),
+          "Can't find definition for the qualified name: ",
+          t->str(),
+          "(TypeKind::TupleType)  in compilation unit.",
+          "Please report a bug to PyTorch.");
+      auto named_tuple_type = compilation_unit.get_named_tuple(t->str());
+      if (named_tuple_type != nullptr) {
+        std::string named_tuple_str = t->str();
+        named_tuple_str.append("[NamedTuple, [");
+        std::vector<IValue> name_type_pairs;
 
-      // Construct the dict representation after achieving correct string
-      // representation for both key and value, like
-      // "Dict[str,__torch__.dper3.core.pytorch_schema_utils.IdScoreListFeatureTuple[NamedTuple,
-      // [[lengths, Tensor],[values,
-      // __torch__.dper3.core.pytorch_schema_utils.IdScoreTuple[NamedTuple,
-      // [[ids, Tensor],[scores, Tensor]]]],[offsets, Optional[Tensor]]]]]"
-      std::string dict_str;
-      dict_str.append("Dict[")
-          .append(key_type_str)
-          .append(",")
-          .append(value_type_str)
-          .append("]");
-      types.emplace_back(dict_str);
-      continue;
-    } else if (t->kind() == TypeKind::TupleType) {
-      std::string named_tuple_str =
-          get_named_tuple_str_or_default(compilation_unit, t, type_str);
-      types.emplace_back(named_tuple_str);
-      continue;
+        // Get the field name and field type for the NamedTuple
+        for (auto it = named_tuple_type->schema()->arguments().begin();
+             it != named_tuple_type->schema()->arguments().end();
+             it++) {
+          name_type_pairs.emplace_back(
+              c10::ivalue::Tuple::create({it->name(), it->type()->repr_str()}));
+
+          // When it->type() is Tensor type, in Python, if it's inferred type,
+          // str() return "Tensor" and repr_str() return "Tensor (inferred)". If
+          // it's not inferred type, str() return "Tensor[]" and repr_str()
+          // return "Tensor". In cpp, repr_str() will always return "Tensor"
+          // regardless inferred type. When exporing custom type in bytecode,
+          // "Tensor" is the preferred way to deserialize Tensor type
+          type_str = it->is_inferred_type() ? it->type()->str()
+                                            : it->type()->repr_str();
+          named_tuple_str.append("[" + it->name() + ", " + type_str + "]");
+          if (it != named_tuple_type->schema()->arguments().end() - 1) {
+            named_tuple_str.append(",");
+          }
+        }
+        named_tuple_str.append("]]");
+        // Create a named_tuple type with following structure
+        // "qualified_named[
+        //   NamedTuple, [
+        //       [filed_name_1, field_type_1],
+        //       [filed_name_2, field_type_2]
+        //   ]
+        // ]"
+        //  Example NamedTuple type:
+        //  "__torch__.base_models.sparse_nn.pytorch_preproc_types.PreprocOutputType[
+        //     NamedTuple, [
+        //         [float_features, Tensor],
+        //         [id_list_features, List[Tensor]],
+        //         [label,  Tensor],
+        //         [weight, Tensor],
+        //         ]
+        //     ]"
+        types.emplace_back(named_tuple_str);
+        continue;
+      }
     } else if (type_str.find(torch_prefix) == 0) {
       TORCH_CHECK(
           type_str.find(class_prefix) == 0,


### PR DESCRIPTION
Summary:
Original commit changeset: b8da2e720b8c

Original Phabricator Diff: D35705480 (https://github.com/pytorch/pytorch/commit/d938867f9181905320f81c690214e00e8b3aab58)

This change breaks the backport_service and no new build/fbpkg can pushed to Prod.

{F724622934}

NOTE: It seems like the Conveyor canary doesn't catch the bad build B1336 and push it to Prod anyway, as a result, the one running is prod is failing as well. But this is a separate issue to be reported to Conveyor users group

Test Plan:
```
buck test //smart/pytorch_mobile/backport_service:handler_test
```
```
BUILD SUCCEEDED
Tpx test run coordinator for Facebook. See https://fburl.com/tpx for details.
Running with tpx session id: f309f176-1516-427e-816e-3eac07faa44f
Trace available for this run at /tmp/tpx-20220420-192427.590549-f309f176-1516-427e-816e-3eac07faa44f/trace.log
RemoteExecution session id: reSessionID-f309f176-1516-427e-816e-3eac07faa44f-tpx
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/5910974609808215
    ✓ ListingSuccess: smart/pytorch_mobile/backport_service:handler_test : 2 tests discovered (47.220)
    ✓ Pass: smart/pytorch_mobile/backport_service:handler_test - test_illegal_version_exception (smart.pytorch_mobile.backport_service.handler_test.BackportServiceTest) (0.380)
    ✓ Pass: smart/pytorch_mobile/backport_service:handler_test - test_backport (smart.pytorch_mobile.backport_service.handler_test.BackportServiceTest) (16.252)
Summary
  Pass: 2
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/5910974609808215
```

Reviewed By: cccclai

Differential Revision: D35804035

