### PR TITLE
Avoid unnecessary copy of Tensor in softmax

### DIFF
--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -430,7 +430,7 @@ Tensor softmax(const Tensor& input_, const int64_t dim_, c10::optional<ScalarTyp
     if (input_.is_cuda() && input_.scalar_type() == ScalarType::Half && dtype == ScalarType::Float){
         return at::_softmax(input_, dim_, true);
     } else {
-        Tensor converted = dtype.has_value() ? input_.toType(dtype.value()) : input_;
+        const Tensor& converted = dtype.has_value() ? input_.toType(dtype.value()) : input_;
         return at::_softmax(converted, dim_, false);
     }
   }();


### PR DESCRIPTION
Summary:
This opportunity was found with the combination of [Infer's PULSE_UNNECESSARY_COPY analysis and Strobelight cycle counts](https://fb.workplace.com/groups/infer.eng/permalink/970566283876913/).

This shows up as one of the top issues ordered by inclusive cycle counts across the whole fleet (D33790780) with cycles **226,757,691,000**

Differential Revision: D35814997

