### PR TITLE
Back out "[easy][PTE] Remove GetMutableSizePrefixed* functions"

### DIFF
--- a/torch/csrc/jit/serialization/mobile_bytecode_generated.h
+++ b/torch/csrc/jit/serialization/mobile_bytecode_generated.h
@@ -2521,8 +2521,16 @@ inline const torch::jit::mobile::serialization::Module *GetModule(const void *bu
   return flatbuffers::GetRoot<torch::jit::mobile::serialization::Module>(buf);
 }
 
-inline Module* GetMutableModule(void* buf) {
+inline const torch::jit::mobile::serialization::Module *GetSizePrefixedModule(const void *buf) {
+  return flatbuffers::GetSizePrefixedRoot<torch::jit::mobile::serialization::Module>(buf);
+}
+
+inline Module *GetMutableModule(void *buf) {
   return flatbuffers::GetMutableRoot<Module>(buf);
+}
+
+inline torch::jit::mobile::serialization::Module *GetMutableSizePrefixedModule(void *buf) {
+  return flatbuffers::GetMutableSizePrefixedRoot<torch::jit::mobile::serialization::Module>(buf);
 }
 
 inline const char *ModuleIdentifier() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #76187

The file `torch/csrc/jit/serialization/mobile_bytecode_generated.h` should be a generated file not edited by hand anymore. For OSS, until it is generated on thee fly, this checked in file will be used.

Differential Revision: [D35822915](https://our.internmc.facebook.com/intern/diff/D35822915/)