### PR TITLE
functionalization: fix nested grad + functionalize transforms

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -22,13 +22,20 @@ void FunctionalTensorWrapper::set_constructor_metadata() {
   shallow_copy_from(value_.getIntrusivePtr());
   storage_ = functional_storage;
   storage_access_should_throw_ = false;
-  key_set_ = c10::DispatchKeySet(c10::DispatchKey::Functionalize) | value_.key_set();
+  // The final keyset should include whatever backend keys were on the inner tensor,
+  // because we need that to properly set e.g. autocast / autograd keys
+  // (for LTC/XLA, autocast / autograd will run *directly* on the FunctionalTensorWrapper).
+  // However, we don't want to copy over *all* of the keys.
+  // FuncTorch keys are the main example of this. If you run grad(functionalize(f)),
+  // we don't want the lower transform (grad)'s keys to propagate to the outer wrapper.
+  key_set_ = c10::DispatchKeySet(c10::DispatchKey::Functionalize)
+    | c10::DispatchKeySet(c10::highestPriorityBackendTypeId(value_.key_set()));
 }
 
 FunctionalTensorWrapper::FunctionalTensorWrapper(const Tensor& value)
   : c10::TensorImpl(
       c10::Storage(c10::make_intrusive<functionalization::FunctionalStorageImpl>(value)),
-      c10::DispatchKeySet(DispatchKey::Functionalize) | value.key_set(),
+      c10::DispatchKeySet(DispatchKey::Functionalize),
       value.dtype()
     ),
     value_(value)


### PR DESCRIPTION
This should fix the segfault with `jacfwd(functionalize(f))` described in https://github.com/pytorch/functorch/issues/715#issuecomment-1104457800.

Planning to add some more tests in functorch to make sure that basic functionality with functionalize <> other transforms also works soon.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #75527 [prototype] integrate functionalization <> LTC torchscript backend
* #76126 add native view_copy.out ops, teach codegen about tensorlist out=
* #76125 functionalization bugfix: using owning type when unwrapping tensors
* #76085 [POC] fix static init issue with JIT container types
* #76190 remove _is_foreach_op codegen special cases, clean up mutable return type checks
* **#76189 functionalization: fix nested grad + functionalize transforms**
* #76084 functionalization: add native fill() op
* #76083 functionalization: add a copy() native function
* #75913 functionalization: introduce a "zero()" aten op

