### PR TITLE
deploy: add dummy metadata for builtin packages

### DIFF
--- a/torch/csrc/deploy/interpreter/builtin_registry.h
+++ b/torch/csrc/deploy/interpreter/builtin_registry.h
@@ -22,7 +22,7 @@
  * BuiltinRegisterer object. The constructor of BuiltinRegisterer does the real
  * registration work.
  */
-#include <gtest/gtest.h>
+#include <gtest/gtest_prod.h>
 #include <cstdarg>
 #include <memory>
 #include <unordered_map>

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -451,6 +451,18 @@ result = torch.Tensor([1,2,3])
   EXPECT_TRUE(w_grad0.equal(w_grad1));
 }
 
+TEST(TorchpyTest, ImportlibMetadata) {
+  torch::deploy::InterpreterManager m(1);
+  m.registerModuleSource("importlib_test", R"PYTHON(
+from importlib.metadata import version
+
+result = version("torch")
+)PYTHON");
+  auto I = m.allInstances()[0].acquireSession();
+  auto ver = I.global("importlib_test", "result").toIValue().toString();
+  ASSERT_EQ(ver->string(), "0.0.1+fake_multipy");
+}
+
 // OSS build does not have bultin numpy support yet. Use this flag to guard the
 // test case.
 #if HAS_NUMPY


### PR DESCRIPTION
This adds dummy metadata for frozen builtin packages when using `torch::deploy`. This is a bit hacky but unblocks allows Huggingface transformers library to be used within `torch::deploy` which depends on `importlib.metadata.version` to detect whether torch is installed or not.

https://github.com/huggingface/transformers/blob/main/src/transformers/utils/import_utils.py#L49

Test plan:

Added `importlib.metadata.version("torch")` unit test