### PR TITLE
Lint rule that would fail for PRs containing subdmodule updates #74326

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -97,6 +97,12 @@ jobs:
         if: always()
         run: |
           (! git --no-pager grep -In '#!.*python$' -- . || (echo "The above lines have versionless Python shebangs; please specify either python2 or python3"; false))
+      - name: Ensure submodules are up to date
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_BASE: ${{ github.event.pull_request.base.sha }}
+        if: always()
+        run: if git diff --name-only "$GH_BASE" HEAD | grep -q third_party  && ! echo "$PR_BODY" | grep -q submodule-update; then echo "PR contains a submodule update, did you forget to run \`git submodule update\`? If this was on purpose, please specify \"submodule-update\" in the PR description."; false; fi
       - name: C++ docs check
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,9 +100,22 @@ jobs:
       - name: Ensure submodules are up to date
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-          GH_BASE: ${{ github.event.pull_request.base.sha }}
-        if: always()
-        run: if git diff --name-only "$GH_BASE" HEAD | grep -q third_party  && ! echo "$PR_BODY" | grep -q submodule-update; then echo "PR contains a submodule update, did you forget to run \`git submodule update\`? If this was on purpose, please specify \"submodule-update\" in the PR description."; false; fi
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          changed_files=$(git diff --name-only $GH_REF HEAD)
+          status=$(echo $?)
+          if [ $status -eq 0 ]; then 
+              echo $changed_files | grep -q "third_party"
+              if [ $(echo $?) -eq 0 ]; then
+                  echo "$PR_BODY" | grep -q "submodule-update"
+                  status=$(echo $?)
+                  if [ $status -ne 0 ]; then
+                      echo "PR contains a submodule update, did you forget to run \`git submodule update\`? If this was on purpose, please specify \"submodule-update\" in the PR description."
+                  fi
+              fi
+          fi
+          exit $status
       - name: C++ docs check
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
@@ -265,3 +278,4 @@ jobs:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
+


### PR DESCRIPTION
### The feature and motivation

When submodules gets updated after checkout, devs often forget to run git submodule update command and propose PR that effectively reverts the update.

Prevent those accidental updates by requiring one to add "submodule-update" keyword to PR description before change can be merged. This allows intentional submodule updates to still make it through the linter.

Fixes #74326

### Testing

1. Create branch `behind` in personal repo (identical to this branch)
2. on `behind` branch, revert cudnn_frontend submodule to an earlier commit
3. Create PR where HEAD=`behind`, base=this branch, description="ignorance is bliss"
4. See that lint workflow fails on the new "Ensure submodules are up to date" step of quick-checks (output below):
```
Run if git diff --name-only $GH_BASE HEAD | grep -q third_party  && ! echo $PR_BODY | grep -q submodule-update; then echo "PR contains a submodule update, did you forget to run \`git submodule update\`? If this was on purpose, please specify \"submodule-update\" in the PR description."; false; fi
  if git diff --name-only $GH_BASE HEAD | grep -q third_party  && ! echo $PR_BODY | grep -q submodule-update; then echo "PR contains a submodule update, did you forget to run \`git submodule update\`? If this was on purpose, please specify \"submodule-update\" in the PR description."; false; fi
  shell: /bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.10.4/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.4/x64/lib
    PR_BODY: ignorance is bliss
    GH_BASE: 728943d6a516e7665ee1b18d162542e2b135a954
PR contains a submodule update, did you forget to run `git submodule update`? If this was on purpose, please specify "submodule-update" in the PR description.
Error: Process completed with exit code 1.
```
6. edit PR description to be "i swear I ran submodule-update"
7. Rerun workflow, see that new step now passes (output below):
```
Run if git diff --name-only $GH_BASE HEAD | grep -q third_party  && ! echo $PR_BODY | grep -q submodule-update; then echo "PR contains a submodule update, did you forget to run \`git submodule update\`? If this was on purpose, please specify \"submodule-update\" in the PR description."; false; fi
  if git diff --name-only $GH_BASE HEAD | grep -q third_party  && ! echo $PR_BODY | grep -q submodule-update; then echo "PR contains a submodule update, did you forget to run \`git submodule update\`? If this was on purpose, please specify \"submodule-update\" in the PR description."; false; fi
  shell: /bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.10.4/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.4/x64/lib
    PR_BODY: i swear i ran submodule-update
    GH_BASE: 728943d6a516e7665ee1b18d162542e2b135a954
```
