### PR TITLE
[GHF] Skip b3aa2de

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -215,7 +215,9 @@ class GitRepo:
         # Another HACK: Patch-id is not stable for commits with binary files or for big changes across commits
         # I.e. cherry-picking those from one branch into another will change patchid
         if "pytorch/pytorch" in self.remote_url():
-            for excluded_commit in ["8e09e20c1dafcdbdb45c2d1574da68a32e54a3a5", "5f37e5c2a39c3acb776756a17730b865f0953432"]:
+            for excluded_commit in {"8e09e20c1dafcdbdb45c2d1574da68a32e54a3a5",
+                                    "5f37e5c2a39c3acb776756a17730b865f0953432",
+                                    "b5222584e6d6990c6585981a936defd1af14c0ba"}:
                 if excluded_commit in from_commits:
                     from_commits.remove(excluded_commit)
 


### PR DESCRIPTION
Difference between were https://github.com/pytorch/pytorch/commit/b5222584e6d6990c6585981a936defd1af14c0ba and https://github.com/pytorch/pytorch/commit/69e048b090ab06103e5be0e6c0774126bcff4b9b are reconciled in https://github.com/pytorch/pytorch/commit/b3aa2de5becd749d11ae6d2918c980db0228a0f8, so the commit must be manually skipped

