### PR TITLE
disable xla test job

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -229,6 +229,7 @@ jobs:
       docker-image-name: xla_base
 
   pytorch-xla-linux-bionic-py3_7-clang8-test:
+    if: ${{ false }}
     name: pytorch-xla-linux-bionic-py3.7-clang8
     uses: ./.github/workflows/_linux-test.yml
     needs: pytorch-xla-linux-bionic-py3_7-clang8-build


### PR DESCRIPTION
This disables XLA test for now cause it's consistently failing on HUD and we're waiting on XLA to update. 

https://hud.pytorch.org/minihud 