### PR TITLE
[PyTorch Edge] Add Optimized QInt8 Quantize Tensor Arm

### DIFF
--- a/aten/src/ATen/native/quantized/affine_quantizer_base.cpp
+++ b/aten/src/ATen/native/quantized/affine_quantizer_base.cpp
@@ -115,12 +115,13 @@ T quantize_val(double scale, int64_t zero_point, float value) {
   return static_cast<T>(qvalue);
 }
 
-uint8_t quantize_val_arm(
+template <typename T>
+T quantize_val_arm(
     const float scale,
     const int32_t zero_point,
     const float value) {
-  constexpr int32_t qmin = std::numeric_limits<uint8_t>::min();
-  constexpr int32_t qmax = std::numeric_limits<uint8_t>::max();
+  constexpr int32_t qmin = std::numeric_limits<T>::min();
+  constexpr int32_t qmax = std::numeric_limits<T>::max();
   float inv_scale = 1.0f / scale;
 #ifndef _MSC_VER
   auto r = static_cast<int32_t>(Round(value * inv_scale));
@@ -135,7 +136,7 @@ uint8_t quantize_val_arm(
 #endif
   r = std::max(r, qmin);
   r = std::min(r, qmax);
-  return static_cast<uint8_t>(r);
+  return static_cast<T>(r);
 }
 
 template <typename T, int precision>
@@ -151,6 +152,14 @@ void quantize_vec(
   }
 }
 
+template uint8_t quantize_val_arm<uint8_t>(
+    const float scale,
+    const int32_t zero_point,
+    const float value);
+template int8_t quantize_val_arm<int8_t>(
+    const float scale,
+    const int32_t zero_point,
+    const float value);
 template <typename T>
 TORCH_API float dequantize_val(double scale, int64_t zero_point, T value) {
   return static_cast<float>(scale) * (value.val_ - static_cast<int32_t>(zero_point));

--- a/aten/src/ATen/native/quantized/affine_quantizer_base.h
+++ b/aten/src/ATen/native/quantized/affine_quantizer_base.h
@@ -10,7 +10,8 @@ template <typename T>
 TORCH_API T quantize_val(double scale, int64_t zero_point, float value);
 // TODO combine this with quantize_val once the numerics for ARM are aligned
 // with it
-uint8_t quantize_val_arm(
+template <typename T>
+T quantize_val_arm(
     const float scale,
     const int32_t zero_point,
     const float value);


### PR DESCRIPTION
Summary: The implementation is very similar to that of the QUInt8 version

Test Plan:
From Clone of Open Source PyTorch:
- BUILD_MOBILE_BENCHMARK=1 BUILD_MOBILE_TEST=1 ANDROID_DEBUG_SYMBOLS=1 BUILD_LITE_INTERPRETER=0  ANDROID_ABI=arm64-v8a ./scripts/build_android.sh  -DANDROID_CCACHE=$(which ccache) -DBUILD_BINARY=ON

Send binary to android device and run it
- Test with ```build_android/bin/quantized_test```
- Benchmark with ```build_android/bin/quantize_per_channel``` (after changes in D35616898)

___

Benchmark Results:

Benchmark on Body Keypoint Model (as in D35616898)

- Before: [21.0584 ms](https://www.internalfb.com/intern/aibench/details/14343432029716)
- After [11.8182 ms](https://www.internalfb.com/intern/aibench/details/697250961900934)

Benchmark in isolation over a variety of input shapes:
- Before: P495061553
- After: P495058591

Graphs generated by: https://www.internalfb.com/intern/anp/view/?id=1798160&revision_id=1018261229074723

Average speedup over all C and N: 3.27x

{F722742346}

{F722742351}

{F722742345}

{F722742353}

{F722742352}

{F722742350}

{F722742347}

___

Test Results:
```
quantized_test: 1 file pushed. 11.8 MB/s (1261058776 bytes in 102.295s)
Running main() from ../third_party/googletest/googletest/src/gtest_main.cc
[==========] Running 10 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 10 tests from TestQTensor
[ RUN      ] TestQTensor.QuantDequantAPIs
[       OK ] TestQTensor.QuantDequantAPIs (2 ms)
[ RUN      ] TestQTensor.RoundingMode
[       OK ] TestQTensor.RoundingMode (0 ms)
[ RUN      ] TestQTensor.Item
[       OK ] TestQTensor.Item (0 ms)
[ RUN      ] TestQTensor.EmptyQuantized
[       OK ] TestQTensor.EmptyQuantized (0 ms)
[ RUN      ] TestQTensor.EmptyPerchannelQuantized
[       OK ] TestQTensor.EmptyPerchannelQuantized (0 ms)
[ RUN      ] TestQTensor.QuantizePerChannel4d
[       OK ] TestQTensor.QuantizePerChannel4d (0 ms)
[ RUN      ] TestQTensor.QuantizePerChannel4dChannelsLast
[       OK ] TestQTensor.QuantizePerChannel4dChannelsLast (10 ms)
[ RUN      ] TestQTensor.FromBlobQuantizedPerTensor
[       OK ] TestQTensor.FromBlobQuantizedPerTensor (0 ms)
[ RUN      ] TestQTensor.FromBlobQuantizedPerChannel
[       OK ] TestQTensor.FromBlobQuantizedPerChannel (0 ms)
[ RUN      ] TestQTensor.TestArmVectorizedQuantizeDequantize
[       OK ] TestQTensor.TestArmVectorizedQuantizeDequantize (0 ms)
[----------] 10 tests from TestQTensor (15 ms total)

[----------] Global test environment tear-down
[==========] 10 tests from 1 test suite ran. (15 ms total)
[  PASSED  ] 10 tests.

```

Reviewed By: kimishpatel

Differential Revision: D35283670

