### PR TITLE
Back out "record_function: update to use custom_class API"

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2931,16 +2931,16 @@ class TestAutograd(TestCase):
         foo_event = [event for event in function_events if "foo" in event.name][0]
         self.assertEqual(foo_event.count, 1)
 
-    def test_record_function_legacy(self):
+    def test_record_function_new_signatures(self):
         # Test the new _record_function ops work
         # Note: Remove once record_function uses these directly
         x = torch.randn(10, 10)
         with profile(use_kineto=kineto_available()) as p:
-            handle = torch.ops.profiler._record_function_enter("bar", None)
+            record = torch.ops.profiler._record_function_enter_new("bar", None)
             try:
                 y = x * 2 + 4
             finally:
-                torch.ops.profiler._record_function_exit(handle)
+                torch.ops.profiler._record_function_exit(record)
 
         function_events = p.function_events
         foo_event = [event for event in function_events if "bar" in event.name][0]

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2715,7 +2715,7 @@ class TestFX(JitTestCase):
 
     def test_profiler_ranges_side_effect(self):
         g = torch.fx.Graph()
-        handle = g.call_function(torch.ops.profiler._record_function_enter_new, ('test_range',))
+        handle = g.call_function(torch.ops.profiler._record_function_enter, ('test_range',))
         g.call_function(torch.ops.profiler._record_function_exit, (handle,))
         g.output(None)
 
@@ -2725,7 +2725,7 @@ class TestFX(JitTestCase):
                 found_targets.setdefault(node.target)
         self.assertEqual(
             list(found_targets.keys()),
-            [torch.ops.profiler._record_function_enter_new, torch.ops.profiler._record_function_exit]
+            [torch.ops.profiler._record_function_enter, torch.ops.profiler._record_function_exit]
         )
 
         g.eliminate_dead_code()
@@ -2735,7 +2735,7 @@ class TestFX(JitTestCase):
                 found_targets.setdefault(node.target)
         self.assertEqual(
             list(found_targets.keys()),
-            [torch.ops.profiler._record_function_enter_new, torch.ops.profiler._record_function_exit]
+            [torch.ops.profiler._record_function_enter, torch.ops.profiler._record_function_exit]
         )
 
     def test_ast_rewriter_wrapped_via_decorator(self):

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -438,20 +438,17 @@ class record_function(ContextDecorator):
         self.args: Optional[str] = args
         # Whether or not we should run record function's end callbacks when exiting.
         self.run_callbacks_on_exit: bool = True
-        # TODO: TorchScript ignores standard type annotation here
-        # self.record: Optional["torch.classes.profiler._RecordFunction"] = None
-        self.record = torch.jit.annotate(Optional["torch.classes.profiler._RecordFunction"], None)
+        # Stores underlying RecordFunction as a tensor. TODO: move to custom
+        # class (https://github.com/pytorch/pytorch/issues/35026).
+        self.handle: torch.Tensor = torch.zeros(1)
 
     def __enter__(self):
-        self.record = torch.ops.profiler._record_function_enter_new(self.name, self.args)
+        self.handle = torch.ops.profiler._record_function_enter(self.name, self.args)
         return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any):
         if self.run_callbacks_on_exit:
-            # Local variable is needed by TorchScript to refine Optional[T] to T
-            record = self.record
-            assert record is not None
-            torch.ops.profiler._record_function_exit(record)
+            torch.ops.profiler._record_function_exit(self.handle)
 
     def _call_end_callbacks_on_future(self, fut: Future[Any]) -> Future[Any]:
         """
@@ -478,11 +475,7 @@ class record_function(ContextDecorator):
         # We are scheduling to run this RecordFunction's end callbacks when the
         # passed in future completes, so don't run end callbacks on exit.
         self.run_callbacks_on_exit = False
-
-        # Local variable is needed by TorchScript to refine Optional[T] to T
-        record = self.record
-        assert record is not None
-        profiled_future = torch.ops.profiler._call_end_callbacks_on_jit_fut(record, fut)
+        profiled_future = torch.ops.profiler._call_end_callbacks_on_jit_fut(self.handle, fut)
         return profiled_future
 
 

--- a/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/rpc_test.py
@@ -194,12 +194,12 @@ def script_fork_wait_throw(invalue):
 
 
 @torch.jit.script
-def call_rpc_with_profiling(record: torch.classes.profiler._RecordFunction, dst_worker_name: str) -> Tensor:
+def call_rpc_with_profiling(handle: Tensor, dst_worker_name: str) -> Tensor:
     # Call rpc_async from within ScriptFunction and ensure that we can attach
     # profiling callbacks. Note that handle here is a Tensor representation of
     # RecordFunction.
     fut = rpc.rpc_async(dst_worker_name, one_arg, (torch.tensor(1),))
-    torch.ops.profiler._call_end_callbacks_on_jit_fut(record, fut)
+    torch.ops.profiler._call_end_callbacks_on_jit_fut(handle, fut)
     ret = fut.wait()
     return ret
 
@@ -210,12 +210,12 @@ def call_rpc_torchscript_with_record_function(dst_worker_name: str, block: str) 
 
 
 @torch.jit.script
-def call_fork_with_profiling(record: torch.classes.profiler._RecordFunction) -> Tensor:
+def call_fork_with_profiling(handle: Tensor) -> Tensor:
     # Call fork from within ScriptFunction and ensure that we can attach profiling
     # callbacks to the resulting future. Note that handle here is a Tensor
     # representation of RecordFunction.
     fut = torch.jit._fork(one_arg, torch.tensor(1))
-    torch.ops.profiler._call_end_callbacks_on_jit_fut(record, fut)
+    torch.ops.profiler._call_end_callbacks_on_jit_fut(handle, fut)
     ret = fut.wait()
     return ret
 
@@ -1146,7 +1146,7 @@ class JitRpcTest(
                     "worker1",
                 )
                 with torch.autograd.profiler.record_function(prof_key) as rf:
-                    ret = call_rpc_with_profiling(rf.record, "worker1")
+                    ret = call_rpc_with_profiling(rf.handle, "worker1")
             # TODO: Can't get a reliable time for this profiling event since
             # it's hard to estimate the execution time on the remote end for non-UDFs.
             # This can be resolved by https://github.com/pytorch/pytorch/issues/36272.
@@ -1295,7 +1295,7 @@ class JitRpcTest(
         # future from within a script function with torch.jit.fork
         with _profile() as prof:
             with torch.autograd.profiler.record_function("foo") as rf:
-                ret = call_fork_with_profiling(rf.record)
+                ret = call_fork_with_profiling(rf.handle)
 
         events = prof.function_events
         function_event = get_function_event(events, "foo")


### PR DESCRIPTION
Summary:
We're observing large QPS regression on the original PR https://github.com/pytorch/pytorch/pull/72302. For the training job we had, it regressed from 720k QPS to 450k QPS (see the test plan in FB internal). We suspect this is because the api was changed from _record_function_enter to _record_function_enter_new, and we're running experiments to confirm that. Will add more details when the runs in the test plan has finished. For now, it's better to revert the diff to unblock internal usecases and we can think about how to reland this diff later.

Original commit changeset: dc9939f1fa6d

Original Phabricator Diff: D35257354

Test Plan:
on trunk: f338665947

with this diff: f338502850

Differential Revision: D35853300

