### PR TITLE
Improve more the error message with explicit recommendation

### DIFF
--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -360,7 +360,7 @@ class TestPublicBindings(TestCase):
                     looks_public_str = "" if looks_public else " NOT"
                     failure_list.append(f"  - Does{looks_public_str} look public: {why_looks_public}")
                     # Swap the str below to avoid having to create the NOT again
-                    failure_list.append(f"  - You can do either of these two things to fix this problem:")
+                    failure_list.append("  - You can do either of these two things to fix this problem:")
                     failure_list.append(f"    - To make it{looks_public_str} public: {fix_is_public}")
                     failure_list.append(f"    - To make it{is_public_str} look public: {fix_looks_public}")
 

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -319,37 +319,51 @@ class TestPublicBindings(TestCase):
                 elem_modname_starts_with_mod = elem_module is not None and \
                     elem_module.startswith(modname) and '._' not in elem_module
                 if not why_not_looks_public and not elem_modname_starts_with_mod:
-                    why_not_looks_public = f"because its `__module__` attribute (`{elem_module}`) does not " \
-                        f"start with the submodule where it is defined (`{modname}`)"
+                    why_not_looks_public = f"because its `__module__` attribute (`{elem_module}`) is not within the " \
+                        f"torch library or does not start with the submodule where it is defined (`{modname}`)"
                 # elem's name must NOT begin with an `_` and it's module name
                 # SHOULD start with it's current module since it's a public API
                 looks_public = not elem.startswith('_') and elem_modname_starts_with_mod
                 if not why_not_looks_public and not looks_public:
-                    why_not_looks_public = f"because it starts with `_` ({elem})"
+                    why_not_looks_public = f"because it starts with `_` (`{elem}`)"
 
                 if is_public != looks_public:
                     if modname in allow_dict and elem in allow_dict[modname]:
                         return
 
                     if is_public:
-                        why_is_public = f"it is inside the module's ({modname}) `__all__`" if is_all else \
+                        why_is_public = f"it is inside the module's (`{modname}`) `__all__`" if is_all else \
                             "it is an attribute that does not start with `_` on a module that " \
                             "does not have `__all__` defined"
+                        fix_is_public = f"remove it from the modules's (`{modname}`) `__all__`" if is_all else \
+                            f"either define a `__all__` for `{modname}` or add a `_` at the beginning of the name"
                     else:
                         assert is_all
-                        why_is_public = f"it is not inside the module's ({modname}) `__all__`"
+                        why_is_public = f"it is not inside the module's (`{modname}`) `__all__`"
+                        fix_is_public = f"add it from the modules's (`{modname}`) `__all__`"
 
                     if looks_public:
                         why_looks_public = "it does look public because it follows the rules from the doc above " \
                             "(does not start with `_` and has a proper `__module__`)."
+                        fix_looks_public = "make its name start with `_`"
                     else:
                         why_looks_public = why_not_looks_public
+                        if not elem_modname_starts_with_mod:
+                            fix_looks_public = "make sure the `__module__` is properly set and points to a submodule "\
+                                f"of `{modname}`"
+                        else:
+                            fix_looks_public = "remove the `_` at the beginning of the name"
 
                     failure_list.append(f"# {modname}.{elem}:")
                     is_public_str = "" if is_public else " NOT"
                     failure_list.append(f"  - Is{is_public_str} public: {why_is_public}")
                     looks_public_str = "" if looks_public else " NOT"
                     failure_list.append(f"  - Does{looks_public_str} look public: {why_looks_public}")
+                    # Swap the str below to avoid having to create the NOT again
+                    failure_list.append(f"  - You can do either of these two things to fix this problem:")
+                    failure_list.append(f"    - To make it{looks_public_str} public: {fix_is_public}")
+                    failure_list.append(f"    - To make it{is_public_str} look public: {fix_looks_public}")
+
 
             if hasattr(mod, '__all__'):
                 public_api = mod.__all__


### PR DESCRIPTION
Following feedback.
The new message looks like:
```
# torch.nn.intrinsic.modules._FusedModule:
  - Is public: it is inside the module's (`torch.nn.intrinsic.modules`) `__all__`
  - Does NOT look public: because it starts with `_` (`_FusedModule`)
  - You can do either of these two things to fix this problem:
    - To make it NOT public: remove it from the modules's (`torch.nn.intrinsic.modules`) `__all__`
    - To make it look public: remove the `_` at the beginning of the name
# torch.ao.nn.sparse.quantized.dynamic.linear.LinearBlockSparsePattern:
  - Is public: it is an attribute that does not start with `_` on a module that does not have `__all__` defined
  - Does NOT look public: because its `__module__` attribute (`torch.ao.nn.sparse.quantized.utils`) is not within the torch library or does not start with the submodule where it is defined (`torch.ao.nn.sparse.quantized.dynamic.linear`)
  - You can do either of these two things to fix this problem:
    - To make it NOT public: either define a `__all__` for `torch.ao.nn.sparse.quantized.dynamic.linear` or add a `_` at the beginning of the name
    - To make it look public: make sure the `__module__` is properly set and points to a submodule of `torch.ao.nn.sparse.quantized.dynamic.linear`

```