### PR TITLE
[metal] Fix error reporting on failure to flush command buffer

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
@@ -37,7 +37,12 @@ using namespace at::native::metal;
       _imageWrapper->release();
     }
     // throw exceptions if we failed to flush the command buffer
-    TORCH_CHECK(error);
+    TORCH_CHECK(false,
+        "Command buffer execution failed!",
+        " Localized_description: ", error.localizedDescription.UTF8String,
+        " Domain: ", error.domain.UTF8String,
+        " Code: ", error.code,
+        " User Info: ", error.userInfo.description.UTF8String);
   }
 }
 


### PR DESCRIPTION
Summary: Because the check is written `TORCH_CHECK(error)` instead of `TORCH_CHECK(false, error)` the check passes (since error will evaluate to true) and the real error message is lost. This causes a `TORCH_CHECK` failure down the line that is impossible to diagnose.

Test Plan:

Differential Revision: D35858173

