### PR TITLE
Fix issue in sparce_coo_tensor only supporting CUDA device.

### DIFF
--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -345,7 +345,7 @@ void _validate_sparse_coo_tensor_args(
     Tensor max_indices =
         std::get</* values */ 0>(indices.max(/* dim */ 1, /* keepdim */ false));
     Tensor cpu_min_indices, cpu_max_indices;
-    if (indices.is_cuda()) {
+    if (!indices.is_cpu()) {
       cpu_min_indices = min_indices.to(at::DeviceType::CPU);
       cpu_max_indices = max_indices.to(at::DeviceType::CPU);
     } else {


### PR DESCRIPTION
## Motivation
The at::native::_validate_sparse_coo_tensor_args only supports checking the indices on CUDA device and CPU device. To extend the function to support more device type.

## Solution
Copy  the indices to the CPU to validate the correctness.