### PR TITLE
Fixed typo in documentation of `LazyModuleMixin`

### DIFF
--- a/torch/nn/modules/lazy.py
+++ b/torch/nn/modules/lazy.py
@@ -89,7 +89,7 @@ class LazyModuleMixin:
     >>> lazy_mlp = LazyMLP()
     >>> # transforms the network's device and dtype
     >>> # NOTE: these transforms can and should be applied after construction and before any 'dry runs'
-    >>> lazy_mlp = mlp.cuda().double()
+    >>> lazy_mlp = lazy_mlp.cuda().double()
     >>> lazy_mlp
     LazyMLP( (fc1): LazyLinear(in_features=0, out_features=10, bias=True)
       (relu1): ReLU()


### PR DESCRIPTION
- What changed? 
	- On line `#92` there was a typo (`mlp`). Changed it to `lazy_mlp`.

```diff
- >>> lazy_mlp = mlp.cuda().double()
+ >>> lazy_mlp = lazy_mlp.cuda().double()
```

- Docs: [`LazyModuleMixin`](https://pytorch.org/docs/1.11/_modules/torch/nn/modules/lazy.html#LazyModuleMixin)

Closes #76269.

https://github.com/pytorch/pytorch/blob/1a7e43be141ce01469d7605075cb1008bf19abd7/torch/nn/modules/lazy.py#L89-L93

:zap: The labels should be:

- [x] `release notes: lazy`
- [x] `topic: documentation`

> :fire: **NOTE**: Earlier another PR was opened and was given a go-ahead in the review, but the `@github-action` bot closed it, as the PR did not have the labels added to it. This time I have mentioned the relevant labels in this PR. The old PR is given below.

- https://github.com/pytorch/pytorch/pull/76269