### PR TITLE
Pad: don't error when unused fill value is zero

### DIFF
--- a/aten/src/ATen/native/PadNd.cpp
+++ b/aten/src/ATen/native/PadNd.cpp
@@ -163,10 +163,13 @@ Tensor _pad_enum(const Tensor &self, IntArrayRef pad, int64_t mode_int, c10::opt
   if (mode == at::padding_mode::constant) {
     return at::constant_pad_nd(self, pad, value.value_or(0.0));
   }
-  TORCH_CHECK(
-      !value.has_value(), "Padding mode \"",
-      padding_mode_string(mode),
-      "\" doesn't take in value argument");
+  if (value.has_value()) {
+    auto err_msg = c10::str("Padding mode \"", padding_mode_string(mode),
+                            "\" doesn't take in value argument");
+    // Emit error if value != 0, otherwise just warn
+    TORCH_CHECK(*value == 0, err_msg);
+    TORCH_WARN(err_msg);
+  }
 
   if (pad.size() == 2 && (input_dim == 2 || input_dim == 3)) {
     switch (mode) {

--- a/aten/src/ATen/native/PadNd.cpp
+++ b/aten/src/ATen/native/PadNd.cpp
@@ -163,13 +163,9 @@ Tensor _pad_enum(const Tensor &self, IntArrayRef pad, int64_t mode_int, c10::opt
   if (mode == at::padding_mode::constant) {
     return at::constant_pad_nd(self, pad, value.value_or(0.0));
   }
-  if (value.has_value()) {
-    auto err_msg = c10::str("Padding mode \"", padding_mode_string(mode),
-                            "\" doesn't take in value argument");
-    // Emit error if value != 0, otherwise just warn
-    TORCH_CHECK(*value == 0, err_msg);
-    TORCH_WARN(err_msg);
-  }
+  TORCH_CHECK(!value.has_value() || *value == 0,
+              "Padding mode \"", padding_mode_string(mode),
+              "\" doesn't take in value argument");
 
   if (pad.size() == 2 && (input_dim == 2 || input_dim == 3)) {
     switch (mode) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #73434
* __->__ #76307

Fixes pytorch/vision#5873

In the python version of `F.pad`, checking that the fill value was
left as default was done by comparing against zero:
https://github.com/pytorch/pytorch/blob/bc2c6edaf163b1a1330e37a6e34caf8c553e4755/torch/nn/functional.py#L4366

So if someone does explicitly pass in a zero-value, then this
`TORCH_CHECK` was an accidental BC-break.