### PR TITLE
Fix forward-mode AD formula for binary_cross_entropy_with_logits

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1613,8 +1613,8 @@ Tensor binary_cross_entropy_with_logits_jvp(const Tensor& input_t, const Tensor&
   }
 
   if (weight.defined()) {
-    grad_input.mul_(weight);
-    grad_target.mul_(weight);
+    grad_input = grad_input.mul(weight);
+    grad_target = grad_target.mul(weight);
   }
   return apply_loss_reduction(grad_target + grad_input, reduction);
 }

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11582,7 +11582,6 @@ op_db: List[OpInfo] = [
                 dtypes=(torch.float32,)
             ),
             DecorateInfo(unittest.skip("Skipped!"), 'TestGradients', "test_fn_gradgrad", dtypes=(torch.float64,)),
-            DecorateInfo(unittest.skip("Skipped!"), 'TestGradients', "test_forward_mode_AD", dtypes=(torch.float64,)),
             DecorateInfo(unittest.skip("Skipped!"), 'TestGradients', "test_fn_fwgrad_bwgrad", dtypes=(torch.float64,)),
         ),
     ),


### PR DESCRIPTION
The problem was that `grad_input` and `grad_target` may be ZeroTensors,
which are immutable. This PR changes it so that operations on grad_input
and grad_target in `binary_cross_entropy_with_logits_jvp` are no longer
in-place.

Test Plan:
- run existing tests

Fixes #ISSUE_NUMBER
