### PR TITLE
[lint] correctly display annotations for all severities

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
           echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`.\e[0m"
           echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions.\e[0m"
 
-      - name: Store annotatations
+      - name: Store annotations
         if: always() && github.event_name == 'pull_request'
         # Don't show this as an error; the above step will have already failed.
         continue-on-error: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,8 +63,14 @@ jobs:
 
           # Use jq to massage the output to look a little nicer in GitHub.
           lintrunner --merge-base-with "${PR_BASE_SHA}" --json \
-            | jq '{file: .path, line: .line, column: .char, severity: .severity, code: .code, message: ("["+.code+"] "+ .name + ": " +.description)}' -c
-
+            jq '{
+                  file: .path,
+                  line: .line,
+                  column: .char,
+                  severity: (if .severity == "advice" or .severity == "disabled" then "warning" else .severity end),
+                  code: .code,
+                  message: ("["+.code+"] "+ .name + ": " +.description)
+                }' -c
   quick-checks:
     name: quick-checks
     runs-on: ubuntu-18.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,7 @@ jobs:
           echo "::add-matcher::.github/lintrunner_problem_matcher.json"
 
           # Use jq to massage the output to look a little nicer in GitHub.
-          lintrunner --merge-base-with "${PR_BASE_SHA}" --json \
+          lintrunner --merge-base-with "${PR_BASE_SHA}" --json | \
             jq '{
                   file: .path,
                   line: .line,

--- a/tools/linter/adapters/clangformat_linter.py
+++ b/tools/linter/adapters/clangformat_linter.py
@@ -10,8 +10,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, List, NamedTuple, Optional
 
-import multiprocessing
-
 
 IS_WINDOWS: bool = os.name == "nt"
 

--- a/tools/linter/adapters/clangformat_linter.py
+++ b/tools/linter/adapters/clangformat_linter.py
@@ -10,6 +10,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, List, NamedTuple, Optional
 
+import multiprocessing
+
 
 IS_WINDOWS: bool = os.name == "nt"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #76348

GitHub's problem matchers only match against "warning" or "error" as
severities. So translate the "advice" and "disabled" severities into
warnings so they'll show up.