### PR TITLE
Fix bug where __getstate__ of DDP looks for self._replicated_tensor_module

### DIFF
--- a/test/distributed/_shard/test_replicated_tensor.py
+++ b/test/distributed/_shard/test_replicated_tensor.py
@@ -287,13 +287,22 @@ class TestReplicatedTensor(ShardedTensorTestBase):
                     out = ddp(replica_tensor)
                 self.assertIsInstance(out, ReplicatedTensor)
 
-        # Test save.
+        # Test save and load.
         with _ddp_replicated_tensor(False):
             ddp = DDP(model)
+            expected_state_dict = ddp.state_dict()
             buffer = io.BytesIO()
             torch.save(ddp, buffer)
+
+            buffer.seek(0)
+            obj = torch.load(buffer)
+            self.assertEqual(expected_state_dict, obj.state_dict())
 
         with _ddp_replicated_tensor(True):
             ddp = DDP(model)
             buffer = io.BytesIO()
             torch.save(ddp, buffer)
+
+            buffer.seek(0)
+            obj = torch.load(buffer)
+            self.assertEqual(expected_state_dict, obj.state_dict())

--- a/test/distributed/_shard/test_replicated_tensor.py
+++ b/test/distributed/_shard/test_replicated_tensor.py
@@ -1,4 +1,5 @@
 # Owner(s): ["oncall: distributed"]
+import io
 
 import torch
 import torch.distributed._shard.sharded_tensor as sharded_tensor
@@ -285,3 +286,14 @@ class TestReplicatedTensor(ShardedTensorTestBase):
                     ddp = DDP(model)
                     out = ddp(replica_tensor)
                 self.assertIsInstance(out, ReplicatedTensor)
+
+        # Test save.
+        with _ddp_replicated_tensor(False):
+            ddp = DDP(model)
+            buffer = io.BytesIO()
+            torch.save(ddp, buffer)
+
+        with _ddp_replicated_tensor(True):
+            ddp = DDP(model)
+            buffer = io.BytesIO()
+            torch.save(ddp, buffer)

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -776,7 +776,8 @@ class DistributedDataParallel(Module, Joinable):
         del attrs["process_group"]
         del attrs["reducer"]
         del attrs["logger"]
-        del attrs["_replicated_tensor_module"]
+        if self._use_replicated_tensor_module:
+            del attrs["_replicated_tensor_module"]
         return attrs
 
     def __setstate__(self, state):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #76349

When we are not using ReplicatedTensor in DDP and try to save a DDP
module it will error out since it tries to delete the _replicated_tensor_module
attribute.

Fixing this by checking if this mode is enabled before triggering the delete.

Differential Revision: [D35875167](https://our.internmc.facebook.com/intern/diff/D35875167/)