### PR TITLE
Fix memory use after free: buffer need to be attached to the module.

### DIFF
--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -555,6 +555,7 @@ mobile::Module _load_for_mobile(
           mobile::serialization::GetMutableModule(data.get());
       mobile::Module m = initialize_mobile_module(flatbuffer_module);
       parseExtraFiles(flatbuffer_module, extra_files);
+      m.set_delete_memory(data);
       return m;
     }
 #else
@@ -604,6 +605,7 @@ mobile::Module _load_for_mobile(
           mobile::serialization::GetMutableModule(data.get());
       mobile::Module m = initialize_mobile_module(flatbuffer_module);
       parseExtraFiles(flatbuffer_module, extra_files);
+      m.set_delete_memory(data);
       return m;
     }
 #else


### PR DESCRIPTION
Summary: fix memory issue

Test Plan:
User reported ASAN errors when running `//xplat/langtech/mobile:giga5_bin`

Verified with the user that rebasing to this diff it is gone.

Reviewed By: pavithranrao

Differential Revision: D35911894

