### PR TITLE
Fix seed in distributions test for deterministic results

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2288,6 +2288,7 @@ class TestDistributions(TestCase):
 
     @unittest.skipIf(not TEST_NUMPY, "Numpy not found")
     def test_wishart_log_prob(self):
+        set_rng_seed(0)
         ndim = 3
         df = torch.rand([], requires_grad=True) + ndim - 1
         # SciPy allowed ndim -1 < df < ndim for Wishar distribution after version 1.7.0


### PR DESCRIPTION
Summary:
Fix for https://github.com/pytorch/pytorch/issues/76160

This fixes the random seed for the `test_wishart_log_prob` (like all random tests in `test_distributions`) to prevent non-determinism.

Test Plan: Tested locally.

Differential Revision: D35914795

