### PR TITLE
[torch deploy] remove torch deploy being added to "torch libraries" (doesnt work)

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -127,10 +127,6 @@ if(@USE_KINETO@)
   append_torchlib_if_found(kineto)
 endif()
 
-if(@USE_DEPLOY@)
-  append_torchlib_if_found(torch_deploy)
-endif()
-
 if(@USE_CUDA@)
   if(MSVC)
     if(NOT NVTOOLEXT_HOME)


### PR DESCRIPTION
Summary: This doesn't work because libtorch_deploy.so isn't a thing anymore.

Test Plan: tested in OSS, this does not break the build

Differential Revision: D35919131

