### PR TITLE
[caffe2] drop XROS ports

### DIFF
--- a/aten/src/ATen/nnapi/nnapi_wrapper.cpp
+++ b/aten/src/ATen/nnapi/nnapi_wrapper.cpp
@@ -336,8 +336,6 @@ int check_Execution_getOutputOperandDimensions(ANeuralNetworksExecution* executi
 void nnapi_wrapper_load(struct nnapi_wrapper** nnapi, struct nnapi_wrapper** check_nnapi) {
 #ifdef _WIN32
   TORCH_CHECK(false, "Running NNAPI models is not supported on Windows.");
-#elif __XROS__
-  TORCH_CHECK(false, "Running NNAPI models is not supported on XROS.");
 #else
   if (!loaded) {
     // Clear error flag.

--- a/c10/core/GeneratorImpl.cpp
+++ b/c10/core/GeneratorImpl.cpp
@@ -43,7 +43,7 @@ namespace detail {
  * Note this is a legacy method (from THRandom.cpp)
  * FIXME: use std::random_device with entropy information
  */
-#if !defined(_WIN32) && !defined(__XROS__)
+#if !defined(_WIN32)
 static uint64_t readURandomLong() {
   int randDev = open("/dev/urandom", O_RDONLY);
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
@@ -56,7 +56,7 @@ static uint64_t readURandomLong() {
   close(randDev);
   return randValue;
 }
-#endif // _WIN32 && __XROS__
+#endif // _WIN32
 
 /**
  * Gets a non deterministic random number number from either the
@@ -82,9 +82,6 @@ uint64_t getNonDeterministicRandom(bool is_cuda) {
     s = (uint64_t)std::chrono::high_resolution_clock::now()
             .time_since_epoch()
             .count();
-#elif defined(__XROS__)
-    std::random_device rd;
-    s = ((((uint64_t)rd()) << 32) + rd()) & 0x1FFFFFFFFFFFFF;
 #elif defined(__SGX_ENABLED__)
     TORCH_CHECK(
         sgx_read_rand(reinterpret_cast<uint8_t*>(&s), sizeof(s)) == SGX_SUCCESS,

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -331,8 +331,7 @@ constexpr uint32_t CUDA_THREADS_PER_BLOCK_FALLBACK = 256;
 // CUDA_KERNEL_ASSERT checks the assertion
 // even when NDEBUG is defined. This is useful for important assertions in CUDA
 // code that would otherwise be suppressed when building Release.
-#if defined(__ANDROID__) || defined(__APPLE__) || defined(__XROS__) || \
-    defined(USE_ROCM)
+#if defined(__ANDROID__) || defined(__APPLE__) || defined(USE_ROCM)
 // Those platforms do not support assert()
 #define CUDA_KERNEL_ASSERT(cond)
 #elif defined(_MSC_VER)
@@ -481,8 +480,7 @@ __host__ __device__
 #endif
 
 #ifndef HAS_DEMANGLE
-#if defined(__ANDROID__) || defined(_WIN32) || defined(__EMSCRIPTEN__) || \
-    defined(__XROS__)
+#if defined(__ANDROID__) || defined(_WIN32) || defined(__EMSCRIPTEN__)
 #define HAS_DEMANGLE 0
 #elif defined(__APPLE__) && \
     (TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR || TARGET_OS_IPHONE)

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -214,9 +214,7 @@ void initGoogleLogging(char const* name) {
     ::google::InitGoogleLogging(name);
 #if !defined(_MSC_VER)
     // This is never defined on Windows
-#if !defined(__XROS__)
     ::google::InstallFailureSignalHandler();
-#endif
 #endif
   }
 }

--- a/caffe2/utils/threadpool/pthreadpool-cpp.cc
+++ b/caffe2/utils/threadpool/pthreadpool-cpp.cc
@@ -83,7 +83,7 @@ size_t getDefaultNumThreads();
 PThreadPool* pthreadpool() {
   static auto threadpool =
     std::make_unique<PThreadPool>(getDefaultNumThreads());
-#if !(defined(WIN32)) && !(defined(__XROS__))
+#if !(defined(WIN32))
   static std::once_flag flag;
   std::call_once(flag, []() {
     pthread_atfork(nullptr, nullptr, child_atfork);

--- a/caffe2/utils/threadpool/pthreadpool.h
+++ b/caffe2/utils/threadpool/pthreadpool.h
@@ -8,7 +8,7 @@
 #include <stddef.h> // for size_t
 #include <stdint.h> // for uint32_t
 
-#if defined(USE_PTHREADPOOL) && !(defined(__XROS__))
+#if defined(USE_PTHREADPOOL)
 // This is a hack.
 // Mainly introduced here because
 // 1. NNPACK can be compiled to use internal legacy threadpool implementation because much of C2 depends on that.

--- a/caffe2/utils/threadpool/pthreadpool_impl.cc
+++ b/caffe2/utils/threadpool/pthreadpool_impl.cc
@@ -2,7 +2,7 @@
 #include "caffe2/utils/threadpool/pthreadpool-cpp.h"
 #include "caffe2/utils/threadpool/ThreadPool.h"
 
-#if defined(USE_PTHREADPOOL) && !(defined(__XROS__))
+#if defined(USE_PTHREADPOOL)
 namespace caffe2 {
 namespace {
 static thread_local bool using_new_threadpool{false};
@@ -34,7 +34,7 @@ void legacy_pthreadpool_compute_1d(
     }
     return;
   }
-#if defined(USE_PTHREADPOOL) && !(defined(__XROS__))
+#if defined(USE_PTHREADPOOL)
   if (caffe2::using_new_threadpool) {
     pthreadpool_parallelize_1d(threadpool, function, argument, range, 0u);
   } else {

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -50,7 +50,7 @@ static void forked_autograd_child() { in_bad_autograd_fork = true; }
 
 // Should be called before unsafe for forks (thread pool) calls
 static void track_bad_autograd_forks() {
-#if !defined(WIN32) && !defined(__XROS__)
+#if !defined(WIN32)
   static std::once_flag flag;
   std::call_once(
       flag, [&] { pthread_atfork(nullptr, nullptr, forked_autograd_child); });


### PR DESCRIPTION
Summary: caffe2 is not currently being built for XROS.

Test Plan: CI

Differential Revision: D35923922

