### PR TITLE
[DataPipe] Update `mux` data pipe

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -890,7 +890,7 @@ class TestFunctionalIterDataPipe(TestCase):
         input_dp2 = dp.iter.IterableWrapper([10])
         input_dp3 = dp.iter.IterableWrapper([100, 200, 300])
         output_dp = input_dp1.mux(input_dp2, input_dp3)
-        expected_output = [1, 10, 100, 2, 200, 3, 300, 4]
+        expected_output = [1, 10, 100]
         self.assertEqual(len(expected_output), len(output_dp))
         self.assertEqual(expected_output, list(output_dp))
 
@@ -898,8 +898,8 @@ class TestFunctionalIterDataPipe(TestCase):
         input_dp1 = dp.iter.IterableWrapper([0, 1, 2, 3])
         input_dp2 = dp.iter.IterableWrapper([])
         output_dp = input_dp1.mux(input_dp2)
-        self.assertEqual(len(input_dp1), len(output_dp))
-        self.assertEqual(list(input_dp1), list(output_dp))
+        self.assertEqual(len(input_dp2), len(output_dp))
+        self.assertEqual(list(input_dp2), list(output_dp))
 
         # __len__ Test: raises TypeError when __len__ is called and an input doesn't have __len__
         input_dp1 = dp.iter.IterableWrapper(range(10))

--- a/torch/utils/data/datapipes/iter/combining.py
+++ b/torch/utils/data/datapipes/iter/combining.py
@@ -1,7 +1,7 @@
 import warnings
 
 from collections import deque
-from typing import Any, Callable, Iterator, List, Optional, Set, Sized, Tuple, TypeVar, Deque
+from typing import Any, Callable, Iterator, List, Optional, Sized, Tuple, TypeVar, Deque
 
 from torch.utils.data.datapipes._decorator import functional_datapipe
 from torch.utils.data.datapipes.datapipe import IterDataPipe
@@ -392,16 +392,16 @@ class MultiplexerIterDataPipe(IterDataPipe):
     r"""
     Yields one element at a time from each of the input Iterable DataPipes (functional name: ``mux``). As in,
     one element from the 1st input DataPipe, then one element from the 2nd DataPipe in the next iteration,
-    and so on. It skips over DataPipes that are exhausted, and ends when all input DataPipes are exhausted.
+    and so on. It ends when the shortest input DataPipe is exhausted.
 
     Args:
-        datapipes: Iterable DataPipes that will take turn to yield their elements, until they are all exhausted
+        datapipes: Iterable DataPipes that will take turn to yield their elements, until the shortest DataPipe is exhausted
 
     Example:
         >>> from torchdata.datapipes.iter import IterableWrapper
-        >>> dp1, dp2, dp3 = IterableWrapper(range(5)), IterableWrapper(range(10, 15)), IterableWrapper(range(20, 25))
+        >>> dp1, dp2, dp3 = IterableWrapper(range(3)), IterableWrapper(range(10, 15)), IterableWrapper(range(20, 25))
         >>> list(dp1.mux(dp2, dp3))
-        [0, 10, 20, 1, 11, 21, 2, 12, 22, 3, 13, 23, 4, 14, 24]
+        [0, 10, 20, 1, 11, 21, 2, 12, 22]
     """
     def __init__(self, *datapipes):
         self.datapipes = datapipes
@@ -409,15 +409,16 @@ class MultiplexerIterDataPipe(IterDataPipe):
 
     def __iter__(self):
         iterators = [iter(x) for x in self.datapipes]
-        finished: Set[int] = set()
-        while len(finished) < len(iterators):
-            for i in range(len(iterators)):
-                if i not in finished:
-                    try:
-                        value = next(iterators[i])
-                        yield value
-                    except StopIteration:
-                        finished.add(i)
+        while len(iterators):
+            values: List[Any] = []
+            for it in iterators:
+                try:
+                    value = next(it)
+                    values.append(value)
+                except StopIteration:
+                    return
+            for value in values:
+                yield value
 
     def __len__(self):
         if self.length is not None:
@@ -425,7 +426,7 @@ class MultiplexerIterDataPipe(IterDataPipe):
                 raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))
             return self.length
         if all(isinstance(dp, Sized) for dp in self.datapipes):
-            self.length = sum(len(dp) for dp in self.datapipes)
+            self.length = min(len(dp) for dp in self.datapipes) * len(self.datapipes)
         else:
             self.length = -1
         return len(self)


### PR DESCRIPTION
Summary:
OSS issue discussion: https://github.com/pytorch/data/issues/346
This diff updates `mux` and `mux_longest` data pipe.
`mux`: Yields one element at a time from each of the input Iterable DataPipes (functional name: ``mux``). As in, one element from the 1st input DataPipe, then one element from the 2nd DataPipe in the next iteration, and so on. It ends when the shortest input DataPipe is exhausted.

`mux` example:

```
>>> from torchdata.datapipes.iter import IterableWrapper
>>> dp1, dp2, dp3 = IterableWrapper(range(3)), IterableWrapper(range(10, 15)), IterableWrapper(range(20, 25))
>>> list(dp1.mux(dp2, dp3))
[0, 10, 20, 1, 11, 21, 2, 12, 22]
```

Test Plan:
buck test mode/dev //pytorch/data/test:tests -- --exact 'pytorch/data/test:tests - test_mux_longest_iterdatapipe (test_datapipe.TestDataPipe)'

https://www.internalfb.com/intern/testinfra/testrun/3096224791148107

Reviewed By: ejguan

Differential Revision: D35799965

