### PR TITLE
[primTorch] Prototype tracer and elementwise unary reference opinfo class

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -95,9 +95,9 @@ class TestBinaryUfuncs(TestCase):
             l = sample.input
             r = sample.args[0]
 
-            np_input, np_args, np_kwargs = sample.numpy()
-            l_numpy = np_input
-            r_numpy = np_args[0]
+            numpy_sample = sample.numpy()
+            l_numpy = numpy_sample.input
+            r_numpy = numpy_sample.args[0]
 
             actual = op(l, r)
             expected = op.ref(l_numpy, r_numpy)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -226,8 +226,7 @@ class TestCommon(TestCase):
             # Sets the default dtype to NumPy's default dtype of double
             cur_default = torch.get_default_dtype()
             torch.set_default_dtype(torch.double)
-            reference_inputs = op.reference_inputs(device, dtype)
-            for sample_input in reference_inputs:
+            for sample_input in op.reference_inputs(device, dtype):
                 self.compare_with_reference(op, op.ref, sample_input, exact_dtype=(dtype is not torch.long))
         finally:
             torch.set_default_dtype(cur_default)
@@ -247,7 +246,7 @@ class TestCommon(TestCase):
             result = op(sample.input, *sample.args, **sample.kwargs)
 
             meta_sample = sample.transform(_to_tensormeta)
-            meta_result = op(meta_sample[0], *meta_sample[1], **meta_sample[2])
+            meta_result = op(meta_sample.input, *meta_sample.args, **meta_sample.kwargs)
 
             prims.utils.compare_tensor_meta(result, meta_result)
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -274,7 +274,8 @@ class TestCommon(TestCase):
         sample_inputs = op.sample_inputs(device, dtype, requires_grad=test_grad)
         for sample_input in sample_inputs:
             t_inp, t_args, t_kwargs = sample_input.input, sample_input.args, sample_input.kwargs
-            n_inp, n_args, n_kwargs = sample_input.noncontiguous()
+            noncontig_sample = sample_input.noncontiguous()
+            n_inp, n_args, n_kwargs = noncontig_sample.input, noncontig_sample.args, noncontig_sample.kwargs
 
             # Verifies sample input tensors should have no grad or history
             sample_tensor = t_inp if isinstance(t_inp, torch.Tensor) else t_inp[0]

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -732,8 +732,8 @@ class TestCommon(TestCase):
 
         for sample in op.sample_inputs(device, dtype):
             actual = op(sample.input, *sample.args, **sample.kwargs)
-            (inp, args, kwargs) = sample.transform(lambda x: x.to(torch.complex64))
-            expected = op(inp, *args, **kwargs)
+            transformed_sample = sample.transform(lambda x: x.to(torch.complex64))
+            expected = op(transformed_sample.input, *transformed_sample.args, **transformed_sample.kwargs)
             self.assertEqual(actual, expected, exact_dtype=False)
 
 class TestCompositeCompliance(TestCase):

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -106,6 +106,15 @@ __all__ = [
     #
     "copy_to",
     "resize",
+    #
+    # Reduction prims
+    #
+    "all",
+    "amax",
+    "amin",
+    "any",
+    "prod",
+    "sum",
 ]
 
 #
@@ -126,7 +135,12 @@ class RETURN_TYPE(Enum):
 
 
 def _make_prim(
-    *, meta: Callable, impl_aten: Callable, return_type: RETURN_TYPE, doc: str
+    *,
+    name: str,
+    meta: Callable,
+    impl_aten: Callable,
+    return_type: RETURN_TYPE,
+    doc: str
 ):
     """
     Creates a primitive operation.
@@ -144,6 +158,7 @@ def _make_prim(
         meta(*args, **kwargs)
         return impl_aten(*args, **kwargs)
 
+    _prim.__name__ = name
     _prim.__doc__ = doc
     _prim.meta = meta  # type: ignore[attr-defined]
     _prim.return_type = return_type  # type: ignore[attr-defined]
@@ -196,12 +211,13 @@ def _elementwise_meta(*args):
     return TensorMeta(number)
 
 
-def _make_elementwise_unary_prim(impl_aten: Callable, doc: str):
+def _make_elementwise_unary_prim(name: str, impl_aten: Callable, doc: str):
     """
     Creates an elementwise unary prim.
     """
 
     return _make_prim(
+        name=name,
         meta=_elementwise_meta,
         impl_aten=impl_aten,
         return_type=RETURN_TYPE.NEW,
@@ -209,12 +225,13 @@ def _make_elementwise_unary_prim(impl_aten: Callable, doc: str):
     )
 
 
-def _make_elementwise_binary_prim(impl_aten: Callable, doc: str):
+def _make_elementwise_binary_prim(name: str, impl_aten: Callable, doc: str):
     """
     Creates an elementwise binary prim.
     """
 
     return _make_prim(
+        name=name,
         meta=_elementwise_meta,
         impl_aten=impl_aten,
         return_type=RETURN_TYPE.NEW,
@@ -231,46 +248,55 @@ def _not_impl(*args, **kwargs):
 #
 
 abs = _make_elementwise_unary_prim(
+    "abs",
     impl_aten=torch.abs,
     doc="",
 )
 
 acos = _make_elementwise_unary_prim(
+    "acos",
     impl_aten=torch.acos,
     doc="",
 )
 
 acosh = _make_elementwise_unary_prim(
+    "acosh",
     impl_aten=torch.acosh,
     doc="",
 )
 
 asin = _make_elementwise_unary_prim(
+    "asin",
     impl_aten=torch.asin,
     doc="",
 )
 
 atan = _make_elementwise_unary_prim(
+    "atan",
     impl_aten=torch.atan,
     doc="",
 )
 
 cos = _make_elementwise_unary_prim(
+    "cos",
     impl_aten=torch.cos,
     doc="",
 )
 
 cosh = _make_elementwise_unary_prim(
+    "cosh",
     impl_aten=torch.cosh,
     doc="",
 )
 
 bessel_i0e = _make_elementwise_unary_prim(
+    "bessel_i0e",
     impl_aten=torch.special.i0e,
     doc="",
 )
 
 bessel_i1e = _make_elementwise_unary_prim(
+    "bessel_i1e",
     impl_aten=torch.special.i1e,
     doc="",
 )
@@ -281,121 +307,145 @@ def _cbrt_aten(a: torch.Tensor):
 
 
 cbrt = _make_elementwise_unary_prim(
+    "cbrt",
     impl_aten=_cbrt_aten,
     doc="",
 )
 
 ceil = _make_elementwise_unary_prim(
+    "ceil",
     impl_aten=torch.ceil,
     doc="",
 )
 
 digamma = _make_elementwise_unary_prim(
+    "digamma",
     impl_aten=torch.digamma,
     doc="",
 )
 
 erf = _make_elementwise_unary_prim(
+    "erf",
     impl_aten=torch.erf,
     doc="",
 )
 
 erf_inv = _make_elementwise_unary_prim(
+    "erf_inv",
     impl_aten=torch.special.erfinv,
     doc="",
 )
 
 erfc = _make_elementwise_unary_prim(
+    "erfc",
     impl_aten=torch.special.erfc,
     doc="",
 )
 
 exp = _make_elementwise_unary_prim(
+    "exp",
     impl_aten=torch.exp,
     doc="",
 )
 
 expm1 = _make_elementwise_unary_prim(
+    "expm1",
     impl_aten=torch.special.expm1,
     doc="",
 )
 
 floor = _make_elementwise_unary_prim(
+    "floor",
     impl_aten=torch.floor,
     doc="",
 )
 
 igamma = _make_elementwise_unary_prim(
+    "igamma",
     impl_aten=torch.special.gammainc,
     doc="",
 )
 
 igammac = _make_elementwise_unary_prim(
+    "igammac",
     impl_aten=torch.special.gammaincc,
     doc="",
 )
 
 is_finite = _make_elementwise_unary_prim(
+    "is_finite",
     impl_aten=torch.isfinite,
     doc="",
 )
 
 lgamma = _make_elementwise_unary_prim(
+    "lgamma",
     impl_aten=torch.lgamma,
     doc="",
 )
 
 log = _make_elementwise_unary_prim(
+    "log",
     impl_aten=torch.log,
     doc="",
 )
 
 log1p = _make_elementwise_unary_prim(
+    "log1p",
     impl_aten=torch.log1p,
     doc="",
 )
 
 reciprocal = _make_elementwise_unary_prim(
+    "reciprocal",
     impl_aten=torch.reciprocal,
     doc="",
 )
 
 neg = _make_elementwise_unary_prim(
+    "neg",
     impl_aten=torch.neg,
     doc="",
 )
 
 round = _make_elementwise_unary_prim(
+    "round",
     impl_aten=torch.round,
     doc="",
 )
 
 sign = _make_elementwise_unary_prim(
+    "sign",
     impl_aten=torch.sign,
     doc="",
 )
 
 sin = _make_elementwise_unary_prim(
+    "sin",
     impl_aten=torch.sin,
     doc="",
 )
 
 sinh = _make_elementwise_unary_prim(
+    "sinh",
     impl_aten=torch.sinh,
     doc="",
 )
 
 sqrt = _make_elementwise_unary_prim(
+    "sqrt",
     impl_aten=torch.sqrt,
     doc="",
 )
 
 square = _make_elementwise_unary_prim(
+    "square",
     impl_aten=torch.square,
     doc="",
 )
 
 tan = _make_elementwise_unary_prim(
+    "tan",
     impl_aten=torch.tan,
     doc="",
 )
@@ -405,31 +455,37 @@ tan = _make_elementwise_unary_prim(
 #
 
 add = _make_elementwise_binary_prim(
+    name="add",
     impl_aten=torch.add,
     doc="",
 )
 
 atan2 = _make_elementwise_binary_prim(
+    name="atan2",
     impl_aten=torch.atan2,
     doc="",
 )
 
 bitwise_and = _make_elementwise_binary_prim(
+    "bitwise_and",
     impl_aten=torch.bitwise_and,
     doc="",
 )
 
 bitwise_not = _make_elementwise_binary_prim(
+    "bitwise_not",
     impl_aten=torch.bitwise_not,
     doc="",
 )
 
 bitwise_or = _make_elementwise_binary_prim(
+    "bitwise_or",
     impl_aten=torch.bitwise_or,
     doc="",
 )
 
 bitwise_xor = _make_elementwise_binary_prim(
+    "bitwise_xor",
     impl_aten=torch.bitwise_xor,
     doc="",
 )
@@ -449,76 +505,91 @@ def _div(a, b):
 
 
 div = _make_elementwise_binary_prim(
+    "div",
     impl_aten=_div,
     doc="",
 )
 
 eq = _make_elementwise_binary_prim(
+    "eq",
     impl_aten=torch.eq,
     doc="",
 )
 
 ge = _make_elementwise_binary_prim(
+    "ge",
     impl_aten=torch.ge,
     doc="",
 )
 
 gt = _make_elementwise_binary_prim(
+    "gt",
     impl_aten=torch.gt,
     doc="",
 )
 
 le = _make_elementwise_binary_prim(
+    "le",
     impl_aten=torch.le,
     doc="",
 )
 
 lt = _make_elementwise_binary_prim(
+    "lt",
     impl_aten=torch.lt,
     doc="",
 )
 
 max = _make_elementwise_binary_prim(
+    "max",
     impl_aten=torch.maximum,
     doc="",
 )
 
 min = _make_elementwise_binary_prim(
+    "min",
     impl_aten=torch.minimum,
     doc="",
 )
 
 mul = _make_elementwise_binary_prim(
+    "mul",
     impl_aten=torch.mul,
     doc="",
 )
 
 ne = _make_elementwise_binary_prim(
+    "ne",
     impl_aten=torch.ne,
     doc="",
 )
 
 nextafter = _make_elementwise_binary_prim(
+    "nextafter",
     impl_aten=torch.nextafter,
     doc="",
 )
 
 pow = _make_elementwise_binary_prim(
+    "pow",
     impl_aten=torch.pow,
     doc="",
 )
 
 rsqrt = _make_elementwise_binary_prim(
+    "rsqrt",
     impl_aten=torch.rsqrt,
     doc="",
 )
 
 shift_left = _make_elementwise_binary_prim(
+    "shift_left",
     impl_aten=torch.bitwise_left_shift,
     doc="",
 )
 
 shift_right_arithmetic = _make_elementwise_binary_prim(
+    "shift_right_arithmetic",
     impl_aten=torch.bitwise_right_shift,
     doc="",
 )
@@ -526,6 +597,7 @@ shift_right_arithmetic = _make_elementwise_binary_prim(
 shift_right_logical = _not_impl
 
 sub = _make_elementwise_binary_prim(
+    "sub",
     impl_aten=torch.sub,
     doc="",
 )
@@ -600,6 +672,7 @@ _broadcast_in_dim_doc = """
   """
 
 broadcast_in_dim = _make_prim(
+    name="broadcast_in_dim",
     meta=_broadcast_in_dim_meta,
     impl_aten=_broadcast_in_dim_aten,
     return_type=RETURN_TYPE.VIEW,
@@ -666,6 +739,7 @@ _collapse_view_doc = """
   """
 
 collapse_view = _make_prim(
+    name="collapse_view",
     meta=_collapse_view_meta,
     impl_aten=_collapse_view_aten,
     return_type=RETURN_TYPE.VIEW,
@@ -712,6 +786,7 @@ _split_dim_doc = """
 
 # TODO: consider renaming split_dim_view
 split_dim = _make_prim(
+    name="split_dim",
     meta=_split_dim_meta,
     impl_aten=_split_dim_aten,
     return_type=RETURN_TYPE.VIEW,
@@ -752,6 +827,7 @@ _squeeze_doc = """
   """
 
 squeeze = _make_prim(
+    name="squeeze",
     meta=_squeeze_meta,
     impl_aten=_squeeze_aten,
     return_type=RETURN_TYPE.VIEW,
@@ -820,6 +896,7 @@ _concatenate_doc = """
   """
 
 concatenate = _make_prim(
+    name="concatenate",
     meta=_concatenate_meta,
     impl_aten=_concatenate_aten,
     return_type=RETURN_TYPE.NEW,
@@ -849,6 +926,7 @@ _reshape_doc = """
   containing a copy of the data in a.
   """
 reshape = _make_prim(
+    name="reshape",
     meta=_reshape_meta,
     impl_aten=_reshape_aten,
     return_type=RETURN_TYPE.NEW,
@@ -882,6 +960,7 @@ _select_doc = """
   """
 
 select = _make_prim(
+    name="select",
     meta=_select_meta,
     impl_aten=_select_aten,
     return_type=RETURN_TYPE.NEW,
@@ -910,6 +989,7 @@ _convert_element_type_doc = """
   """
 
 convert_element_type = _make_prim(
+    name="convert_element_type",
     meta=_convert_element_type_meta,
     impl_aten=_convert_element_type_aten,
     return_type=RETURN_TYPE.NEW,
@@ -935,6 +1015,7 @@ _device_put_doc = """
   """
 
 device_put = _make_prim(
+    name="device_put",
     meta=_device_put_meta,
     impl_aten=_device_put_aten,
     return_type=RETURN_TYPE.NEW,
@@ -976,6 +1057,7 @@ _copy_to_doc = """
 
 # TODO: Remove safe casting and implement on reference instead
 copy_to = _make_prim(
+    name="copy_to",
     meta=_copy_to_meta,
     impl_aten=_copy_to_aten,
     return_type=RETURN_TYPE.INPLACE,
@@ -1002,6 +1084,7 @@ _resize_doc = """
 
 # TODO: review support arbitrary resizes
 resize = _make_prim(
+    name="resize",
     meta=_resize_meta,
     impl_aten=_resize_aten,
     return_type=RETURN_TYPE.INPLACE,
@@ -1040,10 +1123,15 @@ _amin_doc = """
 
 
 sum = _make_prim(
-    meta=_reduction_meta, impl_aten=torch.sum, return_type=RETURN_TYPE.NEW, doc=_sum_doc
+    name="sum",
+    meta=_reduction_meta,
+    impl_aten=torch.sum,
+    return_type=RETURN_TYPE.NEW,
+    doc=_sum_doc,
 )
 
 prod = _make_prim(
+    name="prod",
     meta=_reduction_meta,
     impl_aten=torch.prod,
     return_type=RETURN_TYPE.NEW,
@@ -1051,6 +1139,7 @@ prod = _make_prim(
 )
 
 amax = _make_prim(
+    name="amax",
     meta=_reduction_meta,
     impl_aten=torch.amax,
     return_type=RETURN_TYPE.NEW,
@@ -1058,6 +1147,7 @@ amax = _make_prim(
 )
 
 amin = _make_prim(
+    name="amin",
     meta=_reduction_meta,
     impl_aten=torch.amin,
     return_type=RETURN_TYPE.NEW,
@@ -1065,6 +1155,7 @@ amin = _make_prim(
 )
 
 all = _make_prim(
+    name="all",
     meta=_bool_return_reduction_meta,
     impl_aten=torch.all,
     return_type=RETURN_TYPE.NEW,
@@ -1072,6 +1163,7 @@ all = _make_prim(
 )
 
 any = _make_prim(
+    name="any",
     meta=_bool_return_reduction_meta,
     impl_aten=torch.any,
     return_type=RETURN_TYPE.NEW,

--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -1,0 +1,152 @@
+import string
+from typing import Callable, Sequence, Any, Dict
+from itertools import chain
+
+import torch
+from torch.fx.graph import Graph, Node
+
+from torch._prims.utils import TensorMeta
+import torch._refs as refs
+
+
+_torch_to_reference_map = {
+    torch.add: refs.add,
+}
+
+
+class PrimContext(object):
+    """
+    The prototype prim tracing context.
+
+    Example usage:
+
+    import torch._prims.utils as utils
+    from torch._prims.context import PrimContext
+    from torch._prims.executor import execute
+
+    a = torch.randn((2, 2))
+    b = torch.randn((2, 2))
+
+    ctx = PrimContext()
+    with ctx as tracing_ctx:
+      meta_a = ctx.placeholder(utils.TensorMeta(a))
+      meta_b = ctx.placeholder(utils.TensorMeta(b))
+      result = torch.add(meta_a, meta_b)
+      ctx.output(result)
+
+    exc_result = execute(ctx, a, b)
+
+    Currently this only acquires a trace of prims, and
+    it does not account for control flow. As such,
+    execute must be called with tensors that have the
+    same metadata (dtype, device, shape...) as
+    the tensors used to trace the operations.
+
+    The tracing context's FX graph can be acquired
+    using its graph attribute.
+    """
+
+    def __init__(self):
+        self.graph = Graph()
+
+        # Private attributes for generating names
+        self._tensor_name_counter = 0
+        self._dim_name_counter = 0
+        self._shape_name_counter = 0
+        self._lowercase = tuple(string.ascii_lowercase)
+        self._uppercase = tuple(string.ascii_uppercase)
+
+    def __enter__(self):
+        self.old_ctx = TensorMeta.ctx
+        TensorMeta.ctx = self
+
+    def __exit__(self, type, value, traceback):
+        TensorMeta.ctx = self.old_ctx
+
+    @staticmethod
+    def _create_name(idx, chars):
+        name = ""
+        while idx >= len(chars):
+            name = chars[idx % len(chars)] + name
+            idx = idx - len(chars)
+        name = chars[idx] + name
+
+        return name
+
+    def _tensor_name(self):
+        idx = self._tensor_name_counter
+        self._tensor_name_counter = self._tensor_name_counter + 1
+
+        return self._create_name(idx, self._lowercase)
+
+    def _add_user(self, tm: TensorMeta, node: Node) -> None:
+        assert tm.node is not None
+        tm.node.users[node] = None
+
+    def placeholder(self, tm: TensorMeta):
+        # TODO: allow other input types
+        assert isinstance(tm, TensorMeta)
+
+        if tm.node is not None:
+            raise ValueError("Attempting to reuse a TensorMeta in a new trace!")
+
+        name = self._tensor_name()
+        node = self.graph.placeholder(name)
+        tm.name = name
+        tm.node = node
+        return tm
+
+    def output(self, tm: TensorMeta):
+        # TODO: allow other output types
+        assert isinstance(tm, TensorMeta)
+
+        node = self.graph.output(tm)
+        self._add_user(tm, node)
+
+    def handle_torch_function(
+        self,
+        func: Callable,
+        types: Sequence,
+        args: Sequence[Any],
+        kwargs: Dict,
+    ):
+        """
+        Determines which function to call. The order of which
+        function is called is determined by:
+
+        - func's "meta" attribute, if it exists
+        - if func is a torch operation, its corresponding reference
+        - func
+        """
+
+        if hasattr(func, "meta"):
+            # TODO: add check that all args/kwargs are 'registered' properly
+            # to this trace
+
+            output = func.meta(*args, **kwargs)  # type: ignore[attr-defined]
+
+            # Updates graph
+            # TODO: handle outputs with multiple tensors
+            # TODO: handle non-tensor outputs
+            assert isinstance(output, TensorMeta)
+            output_name = self._tensor_name()
+            node = self.graph.create_node(
+                "call_function", func, name=output_name, args=args, kwargs=kwargs
+            )
+            output.name = output_name
+            output.node = node
+
+            # Marks uses
+            for x in (
+                x for x in chain(args, kwargs.values()) if isinstance(x, TensorMeta)
+            ):
+                self._add_user(x, node)
+
+            return output
+
+        # Remaps torch operations to their references
+        if func in _torch_to_reference_map:
+            fn = _torch_to_reference_map[func]
+            return fn(*args, **kwargs)
+
+        return func(*args, **kwargs)

--- a/torch/_prims/executor.py
+++ b/torch/_prims/executor.py
@@ -1,0 +1,13 @@
+from torch.fx import GraphModule
+from torch._prims.context import PrimContext
+
+
+def execute(ctx: PrimContext, *args, **kwargs):
+    """
+    Prototype ATen executor.
+
+    Just executes the context's graph.
+    """
+
+    gm = GraphModule({}, ctx.graph)
+    return gm.forward(*args, **kwargs)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -16,6 +16,10 @@ from typing import Sequence, Optional, Union, Callable, List
 
 all = [
     #
+    # Elementwise Unary References
+    #
+    "floor",
+    #
     # Elementwise Binary References
     #
     "add",
@@ -285,9 +289,38 @@ def _maybe_resize_out(out: Tensor, shape):
     return out
 
 
+#
+# Elementwise unary references
+#
+
+# TODO: add type promotion support
+def _make_elementwise_unary_reference(prim: Callable) -> Callable:
+    def _ref(a: Tensor, *, out: Optional[Tensor] = None) -> Tensor:
+
+        assert isinstance(a, TensorLike)
+        assert out is None or isinstance(out, TensorLike)
+
+        result = prim(a)
+
+        # TODO: refactor out handling to a generic wrapper
+        if out is not None:
+            out = _maybe_resize_out(out, result.shape)
+            return copy_to(out, result, allow_cross_device=False)  # type: ignore[arg-type]
+
+        return result
+
+    return _ref
+
+
+floor = _make_elementwise_unary_reference(prims.floor)
+
+
 def _make_elementwise_binary_reference(prim: Callable, *, type_promotion) -> Callable:
     def _ref(
-        a: Union[Tensor, Number], b: Union[Tensor, Number], out: Optional[Tensor] = None
+        a: Union[Tensor, Number],
+        b: Union[Tensor, Number],
+        *,
+        out: Optional[Tensor] = None
     ) -> Tensor:
         assert isinstance(a, (TensorLike, Number))
         assert isinstance(b, (TensorLike, Number))

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -95,7 +95,6 @@ class DecorateInfo(object):
             (self.dtypes is None or dtype in self.dtypes)
         )
 
-
 # FIXME
 # Note: historically the 'input' kwarg had to be a Tensor or TensorList, but we are trying
 #   to support scalar inputs, too. Some tests still depend on 'input' being a Tensor
@@ -186,8 +185,15 @@ class SampleInput(object):
                 return t
 
         sample_tt_input, tt_args, tt_kwargs = tt(self.input), tt(self.args), tt(self.kwargs)
-        # TODO update this return to be a named tuple consistent with SampleInput
-        return (sample_tt_input, tt_args, tt_kwargs)
+
+        # Note the transformed SampleInput assumes metadata like output_process_fn_grad is still valid!
+        return SampleInput(
+            sample_tt_input,
+            args=tt_args,
+            kwargs=tt_kwargs,
+            output_process_fn_grad=self.output_process_fn_grad,
+            broadcasts_input=self.broadcasts_input,
+            name=self.name + "_transformed")
 
     # Returns the NumPy version of the sample input object in the form of a tuple: (input, args, kwargs)
     # Converts tensors to ndarrays by calling .detach().cpu().numpy() on them
@@ -1332,6 +1338,8 @@ class UnaryUfuncInfo(OpInfo):
                  supports_sparse=False,
                  reference_numerics_filter=None,  # Filter for singular input values for test_reference_numerics_normal
                  **kwargs):
+        self._original_unary_ufunc_args = locals().copy()
+
         super(UnaryUfuncInfo, self).__init__(name,
                                              dtypes=dtypes,
                                              dtypesIfCUDA=dtypesIfCUDA,
@@ -2270,10 +2278,8 @@ def sample_inputs_elementwise_binary(op, device, dtype, requires_grad, **kwargs)
 
         yield SampleInput(lhs, args=(rhs,), kwargs=sample_kwargs, broadcasts_input=broadcasts_input)
 
-
-# Note that these references inputs use scalars for the SampleInput.input value,
-#   and many tests require SampleInput.input be a tensor or a list of tensors
-def reference_inputs_elementwise_binary(op, device, dtype, requires_grad, **kwargs):
+# The base reference input generation for elementwise binary operations
+def _reference_inputs_elementwise_binary(op, device, dtype, requires_grad, **kwargs):
     yield from op.sample_inputs_func(op, device, dtype, requires_grad, **kwargs)
     yield from generate_elementwise_binary_tensors(op, device=device, dtype=dtype, requires_grad=requires_grad)
     if dtype is not torch.bool:
@@ -2286,6 +2292,18 @@ def reference_inputs_elementwise_binary(op, device, dtype, requires_grad, **kwar
 
     if dtype.is_floating_point or dtype.is_complex:
         yield from generate_elementwise_binary_extremal_value_tensors(op, device=device, dtype=dtype, requires_grad=requires_grad)
+
+# Note that these references inputs use scalars for the SampleInput.input value,
+#   and many tests require SampleInput.input be a tensor or a list of tensors
+def reference_inputs_elementwise_binary(op, device, dtype, requires_grad, **kwargs):
+    gen = partial(_reference_inputs_elementwise_binary, op, device, dtype, requires_grad, **kwargs)
+
+    # yields "normal" samples
+    yield from gen()
+
+    # yields noncontiguous samples
+    for sample in gen():
+        yield sample.noncontiguous()
 
 # A functional that extends an elementwise binary operator's bespoke error inputs
 #   with generic error inputs for the class of elementwise binary operations
@@ -16886,19 +16904,54 @@ op_db: List[OpInfo] = [
 # Python Reference OpInfos should be added to the python_ref_db list below.
 #   Tests can opt-into running on these references by including
 #   that list in the Sequence they pass to the @ops decorator.
+#
+# When a Python Reference OpInfo is constructed a pointer to an
+#   existing OpInfo must be provided using the torch_opinfo_name kwarg.
+#   The existing OpInfo with that name and no variant will be found
+#   to inherit from.
+#
+# Instead of just inheriting the existing OpInfo's metadata, the
+#   Python Reference OpInfos inherit the existing OpInfo's
+#   construction arguments. These arguments can be overridden
+#   by adding kwargs to the constructor.
 
-class ElementwiseBinaryPythonRefInfo(BinaryUfuncInfo):
+def _find_referenced_opinfo(referenced_name):
     '''
-    An OpInfo for a Python reference to an elementwise binary operation.
+    Finds the OpInfo with the given name that has no variant name.
+    '''
+    for opinfo in op_db:
+        if opinfo.name == referenced_name and opinfo.variant_test_name == '':
+            return opinfo
 
-    When constructing this OpInfo a pointer to an existing OpInfo must be
-    provided using the torch_opinfo_name kwarg. An OpInfo with the same
-    name as that string (and no variant) will be found to inherit from.
+def _inherit_constructor_args(name, op, inherited, overrides):
+    # inherits metadata
+    common_kwargs = {
+        'name': name,
+        'op': op,
+        'aliases': None,  # TODO add a check for alias coverage
+        'method_variant': None,
+        'inplace_variant': None,  # TODO: add a check for inplace coverage
+        'supports_scripting': False,
+    }
 
-    Instead of just inheriting the existing OpInfo's metadata, this
-    will actually reconstruct the appropriate OpInfo metadata by
-    inheriting the existing OpInfo's initialization arguments. These
-    arguments can be overridden by adding kwargs to the constructor.
+    # Acquires inherited kwargs
+    kwargs = inherited.copy()
+
+    # Fixes metadata
+    kwargs.update(kwargs['kwargs'])
+    del kwargs['kwargs']
+    del kwargs['self']
+    del kwargs['__class__']
+
+    # Overrides metadata
+    kwargs.update(common_kwargs)
+    kwargs.update(overrides)
+
+    return kwargs
+
+class ElementwiseUnaryPythonRefInfo(UnaryUfuncInfo):
+    '''
+    An OpInfo for a Python reference of an elementwise unary operation.
     '''
     def __init__(
             self,
@@ -16910,44 +16963,49 @@ class ElementwiseBinaryPythonRefInfo(BinaryUfuncInfo):
 
         # TODO: extract this into a common helper
         self.torch_opinfo_name = torch_opinfo_name
+        self.torch_opinfo = _find_referenced_opinfo(torch_opinfo_name)
+        assert isinstance(self.torch_opinfo, UnaryUfuncInfo)
 
-        # finds the corresponding opinfo
-        self.torch_opinfo = None
-        for opinfo in op_db:
-            if opinfo.name == torch_opinfo_name and opinfo.variant_test_name == '':
-                assert self.torch_opinfo is None
-                self.torch_opinfo = opinfo
+        inherited = self.torch_opinfo._original_unary_ufunc_args
+        ukwargs = _inherit_constructor_args(name, op, inherited, {})
 
+        super(ElementwiseUnaryPythonRefInfo, self).__init__(**ukwargs)
+
+class ElementwiseBinaryPythonRefInfo(BinaryUfuncInfo):
+    '''
+    An OpInfo for a Python reference of an elementwise binary operation.
+    '''
+    def __init__(
+            self,
+            name,  # the stringname of the callable Python reference
+            *,
+            op=None,  # the function variant of the operation, populated as torch.<name> if None
+            torch_opinfo_name,  # the string name of the corresponding torch opinfo
+            **kwargs):  # additional kwargs override kwargs inherited from the torch opinfo
+
+        # TODO: extract this into a common helper
+        self.torch_opinfo_name = torch_opinfo_name
+        self.torch_opinfo = _find_referenced_opinfo(torch_opinfo_name)
         assert isinstance(self.torch_opinfo, BinaryUfuncInfo)
 
-        # inherits metadata
-        common_kwargs = {
-            'name': name,
-            'op': op,
-            'aliases': None,  # TODO add a check for alias coverage
-            'method_variant': None,
-            'inplace_variant': None,  # TODO: add a check for inplace coverage
-            'supports_scripting': False,
-        }
-
-        ukwargs = self.torch_opinfo._original_binary_ufunc_args.copy()
-
-        # Fixes metadata
-        original_kwargs = ukwargs['kwargs']
-        del ukwargs['kwargs']
-        del ukwargs['self']
-        del ukwargs['__class__']
-        ukwargs.update(original_kwargs)
-
-        # Overrides metadata
-        ukwargs.update(common_kwargs)
-        ukwargs.update(kwargs)
+        inherited = self.torch_opinfo._original_binary_ufunc_args
+        ukwargs = _inherit_constructor_args(name, op, inherited, {})
 
         super(ElementwiseBinaryPythonRefInfo, self).__init__(**ukwargs)
 
 
 # Separate registry for experimental Python Reference OpInfos.
 python_ref_db = [
+    #
+    # Elementwise unary OpInfos
+    #
+    ElementwiseUnaryPythonRefInfo(
+        '_refs.floor',
+        torch_opinfo_name='floor',
+    ),
+    #
+    # Elementwise binary OpInfos
+    #
     ElementwiseBinaryPythonRefInfo(
         '_refs.add',
         torch_opinfo_name='add',

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16961,7 +16961,6 @@ class ElementwiseUnaryPythonRefInfo(UnaryUfuncInfo):
             torch_opinfo_name,  # the string name of the corresponding torch opinfo
             **kwargs):  # additional kwargs override kwargs inherited from the torch opinfo
 
-        # TODO: extract this into a common helper
         self.torch_opinfo_name = torch_opinfo_name
         self.torch_opinfo = _find_referenced_opinfo(torch_opinfo_name)
         assert isinstance(self.torch_opinfo, UnaryUfuncInfo)
@@ -16983,7 +16982,6 @@ class ElementwiseBinaryPythonRefInfo(BinaryUfuncInfo):
             torch_opinfo_name,  # the string name of the corresponding torch opinfo
             **kwargs):  # additional kwargs override kwargs inherited from the torch opinfo
 
-        # TODO: extract this into a common helper
         self.torch_opinfo_name = torch_opinfo_name
         self.torch_opinfo = _find_referenced_opinfo(torch_opinfo_name)
         assert isinstance(self.torch_opinfo, BinaryUfuncInfo)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2085,7 +2085,8 @@ class TestCase(expecttest.TestCase):
     # Compares a torch function with a reference function for a given sample input (object of SampleInput)
     # Note: only values are compared, type comparison is not done here
     def compare_with_reference(self, torch_fn, ref_fn, sample_input, **kwargs):
-        n_inp, n_args, n_kwargs = sample_input.numpy()
+        numpy_sample = sample_input.numpy()
+        n_inp, n_args, n_kwargs = numpy_sample.input, numpy_sample.args, numpy_sample.kwargs
         t_inp, t_args, t_kwargs = sample_input.input, sample_input.args, sample_input.kwargs
 
         actual = torch_fn(t_inp, *t_args, **t_kwargs)


### PR DESCRIPTION
Adds a prototype tracer with no caching support and the `ElementwiseUnaryPythonRefInfo` class. A reference for `floor` is added to test the latter, and the elementwise binary reference inputs are extended to also return noncontiguous inputs. The SampleInput transform operation has been updated to return an actual SampleInput instead of a tuple to facilitate uniform handling of (transformed) SampleInputs.