### PR TITLE
[ROCm] persist test results even on failure

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -137,10 +137,16 @@ jobs:
             -w /var/lib/jenkins/workspace \
             "${DOCKER_IMAGE}"
           )
+          # save container name for later step
+          echo "{container_name}={${container_name}}" >> $GITHUB_ENV
           # jenkins user does not have write permission to mounted workspace; work-around by copying within container to jenkins home
           docker exec -t "${container_name}" sh -c "cd .. && cp -R workspace pytorch && cd pytorch && pip install dist/*.whl && ${TEST_COMMAND}"
+
+      - name: Save test results
+        if: always()
+        run:
           # copy test results back to the mounted workspace, needed sudo, resulting permissions were correct
-          docker exec -t "${container_name}" sh -c "cd ../pytorch && sudo cp -R test/test-reports ../workspace/test"
+          docker exec -t "${{ env.container_name }}" sh -c "cd ../pytorch && sudo cp -R test/test-reports ../workspace/test"
 
       - name: Get workflow job id
         id: get-job-id

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -138,7 +138,7 @@ jobs:
             "${DOCKER_IMAGE}"
           )
           # save container name for later step
-          echo "CONTAINER_NAME=${container_name}" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=${container_name}" >> "$GITHUB_ENV"
           # jenkins user does not have write permission to mounted workspace; work-around by copying within container to jenkins home
           docker exec -t "${container_name}" sh -c "cd .. && cp -R workspace pytorch && cd pytorch && pip install dist/*.whl && ${TEST_COMMAND}"
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Save test results
         if: always()
-        run:
+        run: |
           # copy test results back to the mounted workspace, needed sudo, resulting permissions were correct
           docker exec -t "${{ env.CONTAINER_NAME }}" sh -c "cd ../pytorch && sudo cp -R test/test-reports ../workspace/test"
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -138,7 +138,7 @@ jobs:
             "${DOCKER_IMAGE}"
           )
           # save container name for later step
-          echo "{container_name}={${container_name}}" >> $GITHUB_ENV
+          echo "CONTAINER_NAME=${container_name}" >> $GITHUB_ENV
           # jenkins user does not have write permission to mounted workspace; work-around by copying within container to jenkins home
           docker exec -t "${container_name}" sh -c "cd .. && cp -R workspace pytorch && cd pytorch && pip install dist/*.whl && ${TEST_COMMAND}"
 
@@ -146,7 +146,7 @@ jobs:
         if: always()
         run:
           # copy test results back to the mounted workspace, needed sudo, resulting permissions were correct
-          docker exec -t "${{ env.container_name }}" sh -c "cd ../pytorch && sudo cp -R test/test-reports ../workspace/test"
+          docker exec -t "${{ env.CONTAINER_NAME }}" sh -c "cd ../pytorch && sudo cp -R test/test-reports ../workspace/test"
 
       - name: Get workflow job id
         id: get-job-id


### PR DESCRIPTION
Fixes #75169.  Default shell for workflow steps will fail fast.  Split ROCm test execution and test result copy into two steps so that test results are always persisted.