### PR TITLE
[wip][pytorch profiler] expose kineto event metadata in pytorch

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -336,6 +336,7 @@ class profile(object):
                 device_type=kineto_event.device_type(),
                 device_index=kineto_event.device_index(),
                 flops=kineto_event.flops(),
+                metadata=kineto_event.metadataJson(),
             )
             max_evt_id = fe.id if fe.id > max_evt_id else max_evt_id
             if fe.device_type == DeviceType.CPU and not fe.is_async:

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -375,10 +375,11 @@ class FunctionEvent(FormattedTimesMixin):
             self, id, name, thread, start_us, end_us, fwd_thread=None, input_shapes=None,
             stack=None, scope=0, cpu_memory_usage=0, cuda_memory_usage=0, is_async=False,
             is_remote=False, sequence_nr=-1, node_id=-1, device_type=DeviceType.CPU, device_index=0,
-            is_legacy=False, flops=None, trace_name=None):
+            is_legacy=False, flops=None, trace_name=None, metadata=""):
         self.id: int = id
         self.node_id: int = node_id
         self.name: str = name
+        self.metadata: str = metadata
         self.trace_name: str = trace_name
         self.time_range: Interval = Interval(start_us, end_us)
         self.thread: int = thread

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -265,6 +265,10 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject *unused) {
       .def("is_async", [](const KinetoEvent& e) {
         return e.isAsync();
       })
+      // metadata json
+      .def("metadataJson", [](const KinetoEvent& e) {
+        return e.metadataJson();
+      })
       .def("cuda_elapsed_us", &KinetoEvent::cudaElapsedUs)
       .def("nbytes", [](const KinetoEvent& e) {
         return e.nBytes();

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -575,7 +575,8 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
             .deviceResourceId(activity.resourceId())
             .startUs(activity.timestamp())
             .durationUs(activity.duration())
-            .activityType((uint8_t)activity.type());
+            .activityType((uint8_t)activity.type())
+            .metadataJson(activity.metadataJson());
         if (activity.linkedActivity()) {
           kineto_event.linkedCorrelationId(
               activity.linkedActivity()->correlationId());

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -235,6 +235,14 @@ struct TORCH_API KinetoEvent {
     return *this;
   }
 
+  std::string metadataJson() const {
+    return metadataJson_;
+  }
+
+  KinetoEvent& metadataJson(const std::string& metadata) {
+    metadataJson_ = metadata;
+    return *this;
+  }
   int64_t cudaElapsedUs() const;
 
   uint64_t start_thread_id_ = 0;
@@ -262,6 +270,7 @@ struct TORCH_API KinetoEvent {
   bool is_async_{false};
   int64_t debug_handle_{-1};
   std::string backend_;
+  std::string metadataJson_;
 
   torch::profiler::impl::CUDAEventStub cuda_event_start_ = nullptr;
   torch::profiler::impl::CUDAEventStub cuda_event_end_ = nullptr;


### PR DESCRIPTION
Summary:
Exposes kineto event metadata json as a property in profiler FunctionEvent class.
The metadata can be useful for profiler metrics.
Please comment on trade offs / memory etc

Test Plan: Tested in following diff

Reviewed By: chaekit

Differential Revision: D35516226

