### PR TITLE
[quant] Fix tensorrt config after the backend_config_dict refactor

### DIFF
--- a/torch/ao/quantization/backend_config/native.py
+++ b/torch/ao/quantization/backend_config/native.py
@@ -563,7 +563,7 @@ def _get_bn_configs():
         })
     return bn_configs
 
-def _get_share_qparams_op_configs():
+def _get_share_qparams_op_configs(dtype_configs):
     """ Get the operator config for the operators that works for both float and quantized input
     if input is quantized, the output Tensor shares the same quantization parameter
     with input.
@@ -576,7 +576,7 @@ def _get_share_qparams_op_configs():
         return {
             "pattern": op,
             "observation_type": ObservationType.OUTPUT_SHARE_OBSERVER_WITH_INPUT,
-            "dtype_configs": [default_op_quint8_dtype_config, default_op_fp16_dtype_config],
+            "dtype_configs": dtype_configs,
         }
 
     share_qparams_ops = [
@@ -696,6 +696,10 @@ def get_native_backend_config_dict():
         weighted_op_int8_dtype_config,
         default_op_fp16_dtype_config,
     ]
+    share_qparams_op_dtype_configs = [
+        default_op_quint8_dtype_config,
+        default_op_fp16_dtype_config
+    ]
     return {
         # optional
         "name": "native",
@@ -707,7 +711,7 @@ def get_native_backend_config_dict():
             *_get_fixed_qparams_op_configs(),
             _CAT_CONFIG,
             *_get_bn_configs(),
-            *_get_share_qparams_op_configs(),
+            *_get_share_qparams_op_configs(share_qparams_op_dtype_configs),
             *_get_rnn_op_configs(),
             *_get_embedding_op_configs(),
         ],

--- a/torch/ao/quantization/backend_config/tensorrt.py
+++ b/torch/ao/quantization/backend_config/tensorrt.py
@@ -5,6 +5,7 @@ import torch.nn.intrinsic as nni
 import torch.nn.intrinsic.qat as nniqat
 # TODO: maybe refactor this to a separate util function
 from .native import _get_binary_op_configs
+from .native import _get_share_qparams_op_configs
 
 from ..fuser_method_mappings import reverse_sequential_wrapper2
 
@@ -192,15 +193,11 @@ def get_tensorrt_backend_config_dict():
             non_weighted_op_qint8_dtype_config,
         ]
     }
-    identity_config = {
-        "pattern": torch.nn.Identity,
-        "observation_type": ObservationType.OUTPUT_SHARE_OBSERVER_WITH_INPUT,
-        "dtype_configs": [
-            non_weighted_op_qint8_dtype_config,
-        ]
-    }
     binary_op_dtype_configs = [
         weighted_op_qint8_dtype_config,
+    ]
+    share_qparams_op_dtype_configs = [
+        non_weighted_op_qint8_dtype_config,
     ]
     return {
         # optional
@@ -224,8 +221,8 @@ def get_tensorrt_backend_config_dict():
             # conv3d_relu_fused_config,
             addmm_config,
             cat_config,
-            identity_config,
             *_get_binary_op_configs(binary_op_dtype_configs),
+            *_get_share_qparams_op_configs(share_qparams_op_dtype_configs),
         ]
     }
 


### PR DESCRIPTION
Summary:
Previously we refactored FX Graph Mode Quantization code base to use a native backend config dict for fbgemmq/qnnpack,
because of this, we need to defien the backend config dict for tensorrt properly as well (previously it was relying on
fbgemm/qnnpack configs), this PR added some configs to enable uru10x10 again

Test Plan: buck run mode/dev-nosan -c fbcode.split-dwarf=true -c fbcode.platform=platform009 accelerators/workloads/models/uru10x10:uru_10x10_to_trt_eval -- --int8

Differential Revision: D35939944

