### PR TITLE
[ROCm][GHA] keep docker images for at most 1 day

### DIFF
--- a/.github/actions/teardown-rocm/action.yml
+++ b/.github/actions/teardown-rocm/action.yml
@@ -1,0 +1,17 @@
+name: Teardown ROCm host
+
+description: Teardown ROCm host for CI
+
+runs:
+  using: composite
+  steps:
+    - name: Kill containers, clean up images
+      if: always()
+      run: |
+        # ignore expansion of "docker ps -q" since it could be empty
+        # shellcheck disable=SC2046
+        docker stop $(docker ps -q) || true
+        # Prune all of the docker containers
+        docker container prune -f
+        # Prune all of the docker images older than 1 day
+        docker system prune -af --filter "until=24h"

--- a/.github/actions/teardown-rocm/action.yml
+++ b/.github/actions/teardown-rocm/action.yml
@@ -7,6 +7,7 @@ runs:
   steps:
     - name: Kill containers, clean up images
       if: always()
+      shell: bash
       run: |
         # ignore expansion of "docker ps -q" since it could be empty
         # shellcheck disable=SC2046

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -181,8 +181,6 @@ jobs:
           python3 -m pip install boto3==1.19.12
           python3 -m tools.stats.print_test_stats --upload-to-s3 --compare-with-s3 test
 
-      - name: Teardown Linux
-        uses: ./.github/actions/teardown-linux
+      - name: Teardown ROCm
+        uses: ./.github/actions/teardown-rocm
         if: always()
-        with:
-          skip-wait-ssh: true


### PR DESCRIPTION
Fixes #76413.  ROCm runners take longer to pull docker images than other runners.  Try to cache images for at most 1 day to improve workflow throughput.