### PR TITLE
ci: Unblock syncbranches, add a58c6ae and 7106d21 to block list

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -202,7 +202,9 @@ class GitRepo:
                             "pytorch/pytorch" not in self.remote_url() or
                             frc.commit_hash not in {"0a6a1b27a464ba5be5f587cce2ee12ab8c504dbf",
                                                     "6d0f4a1d545a8f161df459e8d4ccafd4b9017dbe",
-                                                    "edf909e58f06150f7be41da2f98a3b9de3167bca"}
+                                                    "edf909e58f06150f7be41da2f98a3b9de3167bca",
+                                                    "a58c6aea5a0c9f8759a4154e46f544c8b03b8db1",
+                                                    "7106d216c29ca16a3504aa2bedad948ebcf4abc2"}
                         ):
                             raise RuntimeError(f"Unexpected differences between {frc} and {toc}")
                     from_commits.remove(frc.commit_hash)


### PR DESCRIPTION
Adds a58c6aea5a0c9f8759a4154e46f544c8b03b8db1 and 7106d216c29ca16a3504aa2bedad948ebcf4abc2 to the list of excluded
commits since this was landed through phab and cherry picked to master
directly

Similar to https://github.com/pytorch/pytorch/pull/76231

In both cases the original `syncbranches.yml` run came up with `Nothing to do`:
* Back out "record_function: update to use custom_class API" (a58c6aea5a0c9f8759a4154e46f544c8b03b8db1)
  * https://github.com/pytorch/pytorch/runs/6153245247
  * Originally landed through GHF, landed internally, reverted using GHF, re-landed using GHF, reverted in Phab, cherry picked onto master
* [PyTorch] Add native fast path for transformer encoder inference (7106d216c29ca16a3504aa2bedad948ebcf4abc2)
  * https://github.com/pytorch/pytorch/actions/runs/2223597371
  * Originally landed through GHF, reverted using GHF, re-landed using Phab

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>
