### PR TITLE
[PyTorch] Replace IValue::intrusive_ptr with IValue::isIntrusivePtr()

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -273,8 +273,8 @@ bool operator==(const IValue& lhs, const IValue& rhs) {
 }
 
 bool IValue::ptrEqual(const IValue& lhs, const IValue& rhs) {
-  TORCH_INTERNAL_ASSERT(lhs.is_intrusive_ptr);
-  TORCH_INTERNAL_ASSERT(rhs.is_intrusive_ptr);
+  TORCH_INTERNAL_ASSERT(lhs.isIntrusivePtr());
+  TORCH_INTERNAL_ASSERT(rhs.isIntrusivePtr());
   return lhs.tag == rhs.tag &&
       lhs.payload.u.as_intrusive_ptr == rhs.payload.u.as_intrusive_ptr;
 }
@@ -404,8 +404,8 @@ bool IValue::is(const IValue& rhs) const {
     return rhs.isTensor() && lhs.toTensor().is_same(rhs.toTensor());
   }
 
-  if (lhs.is_intrusive_ptr) {
-    return rhs.is_intrusive_ptr && ptrEqual(lhs, rhs);
+  if (lhs.isIntrusivePtr()) {
+    return rhs.isIntrusivePtr() && ptrEqual(lhs, rhs);
   }
   return lhs == rhs;
 }

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -144,7 +144,7 @@ struct Capsule {
   _(Double)                  \
   _(ComplexDouble)           \
   _(Int)                     \
-  _(SymInt)   \
+  _(SymInt)                  \
   _(Bool)                    \
   _(Tuple)                   \
   _(String)                  \
@@ -201,13 +201,13 @@ struct Capsule {
 /// \endrst
 struct TORCH_API IValue final {
   IValue(const IValue& rhs)
-      : IValue(rhs.payload, rhs.tag, rhs.is_intrusive_ptr) {
-    if (is_intrusive_ptr && payload.u.as_intrusive_ptr != c10::UndefinedTensorImpl::singleton()) {
+      : IValue(rhs.payload, rhs.tag) {
+    if (isIntrusivePtr() && payload.u.as_intrusive_ptr != c10::UndefinedTensorImpl::singleton()) {
       c10::raw::intrusive_ptr::incref(payload.u.as_intrusive_ptr);
     }
   }
 
-  IValue(IValue&& rhs) noexcept : tag(rhs.tag), is_intrusive_ptr(rhs.is_intrusive_ptr) {
+  IValue(IValue&& rhs) noexcept : tag(rhs.tag) {
     moveFrom(std::move(rhs));
   }
 
@@ -348,12 +348,12 @@ public:
       return isAliasOf(this->toTensor(), rhs.toTensor());
     }
 
-    if (!this->is_intrusive_ptr) {
+    if (!isIntrusivePtr()) {
       // Primitive types don't alias anything
       return false;
     }
 
-    AT_ASSERT(rhs.is_intrusive_ptr);
+    AT_ASSERT(rhs.isIntrusivePtr());
 
     // Other types can be compared by their ptr value
     return this->payload.u.as_intrusive_ptr == rhs.payload.u.as_intrusive_ptr;
@@ -365,11 +365,14 @@ public:
       return payload.as_tensor.use_count();
     }
 
-    if (!is_intrusive_ptr) {
+    if (!isIntrusivePtr()) {
       return 1;
     }
 
     if (payload.u.as_intrusive_ptr == c10::UndefinedTensorImpl::singleton()) {
+      if (isStorage() || isGenerator()) {
+        return 1;
+      }
       return 0;
     }
     return c10::raw::intrusive_ptr::use_count(payload.u.as_intrusive_ptr);
@@ -398,7 +401,6 @@ public:
     } else {
       std::swap(payload.u, rhs.payload.u);
     }
-    std::swap(is_intrusive_ptr, rhs.is_intrusive_ptr);
     std::swap(tag, rhs.tag);
   }
 
@@ -406,7 +408,7 @@ public:
   // While some of these accessors could be generated through templates,
   // we prefer to write them manually for clarity
 
-  IValue(at::TensorBase t) : tag(Tag::Tensor), is_intrusive_ptr(false) {
+  IValue(at::TensorBase t) : tag(Tag::Tensor) {
     new (&payload.as_tensor) at::Tensor(std::move(t));
   }
   bool isTensor() const {
@@ -425,12 +427,7 @@ public:
     return payload.as_tensor.unsafeGetTensorImpl();
   }
 
-  IValue(at::Storage s) : tag(Tag::Storage), is_intrusive_ptr(static_cast<bool>(s)) {
-    // Note: the undefined tensor is not refcounted, so while it
-    // is tagged as a tensor, is_intrusive_ptr is set to false.
-    // This is not an optional optimization: our incref call
-    // *will not* do the right thing when called on an
-    // undefined tensor.
+  IValue(at::Storage s) : tag(Tag::Storage) {
     payload.u.as_intrusive_ptr = null_to_undefined_tensor(s.unsafeReleaseStorageImpl());
   }
   bool isStorage() const {
@@ -448,7 +445,7 @@ public:
 
   /// @private [doxygen private]
   IValue(intrusive_ptr<caffe2::Blob> blob)
-      : tag(Tag::Blob), is_intrusive_ptr(true) {
+      : tag(Tag::Blob) {
     // TODO (after Tensor merge) If we pass in a Blob holding a Tensor, extract
     // and store it as a Tensor instead.
     payload.u.as_intrusive_ptr = null_to_undefined_tensor(blob.release());
@@ -515,7 +512,7 @@ public:
   C10_NODISCARD ivalue::Tuple& toTupleRef() const;
 
   // Double
-  IValue(double d) : tag(Tag::Double), is_intrusive_ptr(false) {
+  IValue(double d) : tag(Tag::Double) {
     payload.u.as_double = d;
   }
   bool isDouble() const {
@@ -557,11 +554,11 @@ public:
   c10::intrusive_ptr<at::Quantizer> toQuantizer() const&;
 
   // Int
-  IValue(int64_t i) : tag(Tag::Int), is_intrusive_ptr(false) {
+  IValue(int64_t i) : tag(Tag::Int) {
     payload.u.as_int = i;
   }
 
-  IValue(c10::SymInt i) : tag(Tag::SymInt), is_intrusive_ptr(false) {
+  IValue(c10::SymInt i) : tag(Tag::SymInt) {
     payload.u.as_int = i.data();
   }
 
@@ -588,7 +585,7 @@ public:
   }
 
   // Bool
-  IValue(bool b) : tag(Tag::Bool), is_intrusive_ptr(false) {
+  IValue(bool b) : tag(Tag::Bool) {
 #if defined(__clang__) && defined(__x86_64__)
     // Initializing entire payload stops valgrind's from reporting
     // "jump or move depends on uninitialised value" in IValue copy constructor
@@ -738,7 +735,7 @@ public:
   c10::intrusive_ptr<ivalue::EnumHolder> toEnumHolder() const&;
 
   // None
-  IValue() : tag(Tag::None), is_intrusive_ptr(false) {}
+  IValue() : tag(Tag::None) {}
   bool isNone() const {
     return Tag::None == tag;
   }
@@ -785,7 +782,7 @@ public:
   }
 
   // Device
-  IValue(c10::Device d) : tag(Tag::Device), is_intrusive_ptr(false) {
+  IValue(c10::Device d) : tag(Tag::Device) {
     payload.u.as_device.type = d.type();
     payload.u.as_device.index = d.index();
   }
@@ -799,7 +796,7 @@ public:
 
   //Stream
   IValue(c10::Stream stream)
-    : tag(Tag::Stream), is_intrusive_ptr(false) {
+    : tag(Tag::Stream) {
     payload.u.as_int = stream.pack();
   }
   c10::Stream toStream() &&;
@@ -828,7 +825,7 @@ public:
   }
 
   // QScheme
-  IValue(at::QScheme qscheme) : tag(Tag::Int), is_intrusive_ptr(false) {
+  IValue(at::QScheme qscheme) : tag(Tag::Int) {
     payload.u.as_int = static_cast<int64_t>(qscheme);
   }
 
@@ -844,12 +841,7 @@ public:
   }
 
   // Generator
-  IValue(at::Generator g) : tag(Tag::Generator), is_intrusive_ptr(g.defined()) {
-    // Note: the undefined generator is not refcounted, so while it
-    // is tagged as a generator, is_intrusive_ptr is set to false.
-    // This is not an optional optimization: our incref call
-    // *will not* do the right thing when called on an
-    // undefined generator.
+  IValue(at::Generator g) : tag(Tag::Generator) {
     payload.u.as_intrusive_ptr = null_to_undefined_tensor(g.unsafeReleaseGeneratorImpl());
   }
   bool isGenerator() const {
@@ -921,7 +913,13 @@ public:
       const IValue& v);
 
   bool isPtrType() const {
-    return (isTensor() && payload.as_tensor.defined()) || is_intrusive_ptr;
+    if (isTensor()) {
+      return payload.as_tensor.defined();
+    }
+    if (isStorage() || isGenerator()) {
+      return payload.u.as_intrusive_ptr != c10::UndefinedTensorImpl::singleton();
+    }
+    return isIntrusivePtr();
   }
 
   /// @private [doxygen private]
@@ -1029,7 +1027,7 @@ public:
     // the "wrong" one of as_tensor and as_intrusive_ptr and 2) enable
     // the compiler to generate the same code for each case. It is
     // surprisingly difficult to get this right.
-    if (isTensor() || is_intrusive_ptr) {
+    if (isTensor() || isIntrusivePtr()) {
       c10::intrusive_ptr_target* p = isTensor() ? payload.as_tensor.unsafeGetTensorImpl() : payload.u.as_intrusive_ptr;
       c10::intrusive_ptr<intrusive_ptr_target, c10::UndefinedTensorImpl>::reclaim(p);
       // No need to make this destructor call!
@@ -1053,14 +1051,76 @@ public:
       payload.u = rhs.payload.u;
     }
     tag = rhs.tag;
-    is_intrusive_ptr = rhs.is_intrusive_ptr;
     rhs.clearToNone();
   }
 
   void clearToNone() noexcept {
     payload.u.as_int = 0;
     tag = Tag::None;
-    is_intrusive_ptr = false;
+  }
+
+  bool isIntrusivePtr() const {
+    switch (tag) {
+      case Tag::None:
+        return false;
+      case Tag::Tensor:
+        return false;
+      case Tag::Storage:
+        return true;
+      case Tag::Generator:
+        return true;
+      case Tag::Double:
+        return false;
+      case Tag::ComplexDouble:
+        return true;
+      case Tag::Int:
+        return false;
+      case Tag::SymInt:
+        return false;
+      case Tag::Bool:
+        return false;
+      case Tag::Tuple:
+        return true;
+      case Tag::String:
+        return true;
+      case Tag::Blob:
+        return true;
+      case Tag::GenericList:
+        return true;
+      case Tag::GenericDict:
+        return true;
+      case Tag::Future:
+        return true;
+      case Tag::Device:
+        return false;
+      case Tag::Stream:
+        return false;
+      case Tag::Object:
+        return true;
+      case Tag::PyObject:
+        return true;
+      case Tag::Uninitialized:
+        return false;
+      case Tag::Capsule:
+        return true;
+      case Tag::RRef:
+        return true;
+      case Tag::Quantizer:
+        return true;
+      case Tag::Enum:
+        return true;
+    }
+  }
+
+  // Storage and Generator were treated specially when
+  // is_intrusive_ptr was stored as explicit state. This getter
+  // preserves the old behavior for use with WeakIValue for now.
+  bool isIntrusivePtrLegacyBehavior() const {
+    if (tag == Tag::Storage || tag == Tag::Generator) {
+      return payload.u.as_intrusive_ptr != c10::UndefinedTensorImpl::singleton();
+    } else {
+      return isIntrusivePtr();
+    }
   }
 
   union Payload {
@@ -1088,7 +1148,7 @@ public:
     ~Payload() {}
   };
 
-  IValue(const Payload& p, Tag t, bool i) : tag(t), is_intrusive_ptr(i) {
+  IValue(const Payload& p, Tag t) : tag(t) {
     if (isTensor()) {
       new (&payload.as_tensor) at::Tensor(p.as_tensor);
     } else {
@@ -1103,7 +1163,6 @@ public:
 
   Payload payload;
   Tag tag;
-  bool is_intrusive_ptr;
   friend struct WeakIValue;
 };
 
@@ -1120,7 +1179,7 @@ struct TORCH_API WeakIValue final {
   }
   WeakIValue(const IValue& rhs)
       : tag(rhs.tag),
-        is_intrusive_ptr(rhs.is_intrusive_ptr) {
+    is_intrusive_ptr(rhs.isIntrusivePtrLegacyBehavior()) {
     if (rhs.isTensor()) {
       payload.as_intrusive_ptr = rhs.unsafeToTensorImpl();
       is_intrusive_ptr = true;
@@ -1164,7 +1223,7 @@ struct TORCH_API WeakIValue final {
     if (!is_intrusive_ptr) {
       IValue::Payload newPayload;
       newPayload.u = payload;
-      return IValue(newPayload, tag, false);
+      return IValue(newPayload, tag);
     }
     if (IValue::Tag::Tensor == tag) {
       auto temp = c10::weak_intrusive_ptr<at::TensorImpl, c10::UndefinedTensorImpl>::reclaim(
@@ -1187,7 +1246,7 @@ struct TORCH_API WeakIValue final {
       if (!pl.u.as_intrusive_ptr) {
         return IValue();
       } else {
-        return IValue(pl, tag, true);
+        return IValue(pl, tag);
       }
     }
   }

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1939,7 +1939,7 @@ inline ivalue::Tuple& IValue::toTupleRef() const {
 }
 
 inline IValue::IValue(c10::intrusive_ptr<ivalue::Tuple> v)
-    : tag(Tag::Tuple), is_intrusive_ptr(true) {
+    : tag(Tag::Tuple) {
   payload.u.as_intrusive_ptr = null_to_undefined_tensor(v.release());
 }
 template <
@@ -1967,14 +1967,14 @@ inline IValue::IValue(std::tuple<Args...>&& t)
 }
 
 inline IValue::IValue(c10::intrusive_ptr<ivalue::ConstantString> v)
-    : tag(Tag::String), is_intrusive_ptr(true) {
+    : tag(Tag::String) {
   payload.u.as_intrusive_ptr = null_to_undefined_tensor(v.release());
 }
 inline IValue::IValue(std::string v)
     : IValue(ivalue::ConstantString::create(std::move(v))) {}
 
 inline IValue::IValue(c10::impl::GenericList v)
-    : tag(Tag::GenericList), is_intrusive_ptr(true) {
+    : tag(Tag::GenericList) {
   payload.u.as_intrusive_ptr = null_to_undefined_tensor(v.impl_.release());
 }
 
@@ -2016,7 +2016,7 @@ inline IValue::IValue(std::array<T, N> v) : IValue(c10::List<T>()) {
 }
 
 inline IValue::IValue(c10::impl::GenericDict v)
-    : tag(Tag::GenericDict), is_intrusive_ptr(true) {
+    : tag(Tag::GenericDict) {
   payload.u.as_intrusive_ptr = null_to_undefined_tensor(v.impl_.release());
 }
 template <class Key, class Value>
@@ -2043,17 +2043,17 @@ inline IValue::IValue(c10::optional<T> v) : IValue() {
 inline IValue::IValue(c10::nullopt_t) : IValue() {}
 
 inline IValue::IValue(c10::intrusive_ptr<ivalue::Object> v)
-    : tag(Tag::Object), is_intrusive_ptr(true) {
+    : tag(Tag::Object) {
   payload.u.as_intrusive_ptr = null_to_undefined_tensor(v.release());
 }
 
 inline IValue::IValue(c10::intrusive_ptr<ivalue::PyObjectHolder> v)
-    : tag(Tag::PyObject), is_intrusive_ptr(true) {
+    : tag(Tag::PyObject) {
   payload.u.as_intrusive_ptr = null_to_undefined_tensor(v.release());
 }
 
 inline IValue::IValue(c10::intrusive_ptr<ivalue::EnumHolder> v)
-    : tag(Tag::Enum), is_intrusive_ptr(true) {
+    : tag(Tag::Enum) {
   payload.u.as_intrusive_ptr = null_to_undefined_tensor(v.release());
 }
 
@@ -2061,7 +2061,6 @@ inline IValue IValue::make_capsule(
     intrusive_ptr<torch::CustomClassHolder> blob) {
   IValue iv;
   iv.tag = Tag::Capsule;
-  iv.is_intrusive_ptr = true;
   iv.payload.u.as_intrusive_ptr = null_to_undefined_tensor(blob.release());
   return iv;
 }
@@ -2084,27 +2083,26 @@ IValue::IValue(c10::intrusive_ptr<T> custom_class) {
   ivalue_obj->setSlot(0, IValue::make_capsule(std::move(custom_class)));
   payload.u.as_intrusive_ptr = null_to_undefined_tensor(ivalue_obj.release());
   tag = Tag::Object;
-  is_intrusive_ptr = true;
 }
 
 inline IValue::IValue(c10::intrusive_ptr<ivalue::Future> v)
-    : tag(Tag::Future), is_intrusive_ptr(true) {
+    : tag(Tag::Future) {
   payload.u.as_intrusive_ptr = null_to_undefined_tensor(v.release());
 }
 
 inline IValue::IValue(c10::intrusive_ptr<c10::RRefInterface> v)
-    : tag(Tag::RRef), is_intrusive_ptr(true) {
+    : tag(Tag::RRef) {
   payload.u.as_intrusive_ptr = null_to_undefined_tensor(v.release());
 }
 
 inline IValue::IValue(c10::intrusive_ptr<at::Quantizer> v)
-    : tag(Tag::Quantizer), is_intrusive_ptr(true) {
+    : tag(Tag::Quantizer) {
   payload.u.as_intrusive_ptr = null_to_undefined_tensor(v.release());
 }
 
 template <typename T>
 inline IValue::IValue(c10::complex<T> c)
-    : tag(Tag::ComplexDouble), is_intrusive_ptr(true) {
+    : tag(Tag::ComplexDouble) {
   auto v = c10::make_intrusive<ivalue::ComplexHolder>(c);
   payload.u.as_intrusive_ptr = v.release();
 }
@@ -2175,7 +2173,7 @@ inline bool IValue::isSameIdentity(const IValue& rhs) const {
   // Str) return value equality
   // 2. If it is a tensor type, we need to take undefined tensor into account
   // 3. Undefined_tensor is None and vice versa should be true
-  // 4. If it is a reference type (i.e. is_intrusive_ptr), then is True when
+  // 4. If it is a reference type (i.e. isIntrusivePtr()), then is True when
   // the pointed-to object is the same.
   // 5. False for all other comparisons.
   if (this->isNone() && rhs.isNone()) {
@@ -2200,7 +2198,7 @@ inline bool IValue::isSameIdentity(const IValue& rhs) const {
   } else {
     // for objects holding in IValue, do shallow compare on pointer address to
     // testify the identity
-    return this->is_intrusive_ptr && rhs.is_intrusive_ptr &&
+    return this->isIntrusivePtr() && rhs.isIntrusivePtr() &&
         this->payload.u.as_intrusive_ptr == rhs.payload.u.as_intrusive_ptr;
   }
 }
@@ -2246,7 +2244,7 @@ struct MaybeOwnedTraits<IValue> {
     if (from.isTensor()) {
       return IValue(MaybeOwnedTraits<at::Tensor>::createBorrow(from.toTensor()));
     } else {
-      return IValue(from.payload, from.tag, from.is_intrusive_ptr);
+      return IValue(from.payload, from.tag);
     }
   }
 
@@ -2257,7 +2255,7 @@ struct MaybeOwnedTraits<IValue> {
     } else if (rhs.isTensor()) {
       lhs = IValue(MaybeOwnedTraits<at::Tensor>::createBorrow(rhs.toTensor()));
     } else {
-      lhs = IValue(rhs.payload, rhs.tag, rhs.is_intrusive_ptr);
+      lhs = IValue(rhs.payload, rhs.tag);
     }
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #76421
* #76418

This tidies up an extra piece of state that was computable from the other state in IValue.

Differential Revision: [D31290017](https://our.internmc.facebook.com/intern/diff/D31290017/)