### PR TITLE
[quant][gpu][core][bug fix] Added memset to CacheKey for quantized cudnn add op

### DIFF
--- a/aten/src/ATen/native/quantized/cudnn/BinaryOps.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/BinaryOps.cpp
@@ -117,6 +117,11 @@ Tensor add(Tensor qa, Tensor qb, double output_scale, int64_t output_zero_point)
 
   cudnnHandle_t handle = at::native::getCudnnHandle();
   CacheKey key;
+  // memset is needed here because there is implicit packing added for CacheKey, and this can result in uninitialized padded values that are
+  // used for hashing (see how at::native::ParamsHash is defined). without memset, we can potentially come across a situation where two
+  // CacheKey objects have the same user defined parameters, but
+  // different padded values, resulting in different hash outputs.
+  memset(&key, 0, sizeof(key));
   bool deterministic{true};
   bool allow_tf32{false};
   setAddParams(&key.params, qa, qb, deterministic, allow_tf32);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #76446
* __->__ #76445

Summary:
See https://github.com/pytorch/pytorch/pull/76436. It is the same idea
here.

Test Plan:
python test/test_quantization.py -k test_qadd_relu_cudnn

Differential Revision: [D35970281](https://our.internmc.facebook.com/intern/diff/D35970281)