### PR TITLE
fix pyre type checking issues

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -734,6 +734,7 @@ del manager_path
 # is not a good way to fix this problem.  Perhaps, try to redesign VariableFunctions
 # so that this import is good enough
 if TYPE_CHECKING:
+    from torch._C import *  # type: ignore[misc] # noqa: F403 F811
     # Some type signatures pulled in from _VariableFunctions here clash with
     # signatures already imported. For now these clashes are ignored; see
     # PR #43339 for details.

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -1,6 +1,5 @@
-import os
 import sys
-from enum import Enum
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -73,3 +72,7 @@ if is_available():
     from .remote_device import _remote_device
 
     set_debug_level_from_env()
+
+if TYPE_CHECKING:
+    from torch._C._distributed_c10d import *  # noqa: F403
+    from .distributed_c10d import *  # noqa: F403 F811


### PR DESCRIPTION
Fixes #76465

To test:

create a file test.py:

```
import torch

# these are valid function calls
torch.device('cpu')
torch.distributed.all_gather([], torch.Tensor([1]),)

# these are expected to raise a type error:
torch.distributed.all_gather(None)
torch.device()
... other methods
```

run `pyre`

**output:**

_before_

```
ƛ Found 4 type errors!
test_pytorch.py:2:0 Undefined attribute [16]: Module `torch` has no attribute `device`.
test_pytorch.py:3:0 Undefined attribute [16]: Module `torch.distributed` has no attribute `all_gather`.
test_pytorch.py:4:0 Undefined attribute [16]: Module `torch.distributed` has no attribute `all_gather`.
test_pytorch.py:5:0 Undefined attribute [16]: Module `torch` has no attribute `device`.
```
_after_

(note these errors are correctly identified)

```
ƛ Found 2 type errors!
test_pytorch.py:4:0 Missing argument [20]: Call `torch.distributed.distributed_c10d.all_gather` expects argument `tensor`.
test_pytorch.py:5:0 Missing argument [20]: Call `torch._C.device.__init__` expects argument `device`.
```
