### PR TITLE
Adding `broadcast_in_dim` and non-contiguous Tensor support NVFuser Python Frontend

### DIFF
--- a/torch/csrc/jit/codegen/cuda/python_frontend/examples/python_example_broadcast_in_dim.py
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/examples/python_example_broadcast_in_dim.py
@@ -1,0 +1,31 @@
+import torch
+
+from torch._C._nvfuser import Fusion, FusionDefinition
+
+# Construct and Define Fusion
+fusion = Fusion()
+
+with FusionDefinition(fusion) as fd :
+    t0 = fd.define_tensor(1)
+    t1 = fd.define_tensor(3)
+
+    fd.add_input(t0)
+    fd.add_input(t1)
+
+    t0_b = fd.Ops.broadcast_in_dim(t0, [2, 3, 4], [1])
+    t2 = fd.Ops.add(t0_b, t1)
+
+    fd.add_output(t2)
+
+fusion.print_ir()
+
+# Execute Fusion
+input1 = torch.ones(3, device='cuda')
+input2 = torch.ones(2, 3, 4, device='cuda')
+
+# Kernel compilation should be cached for the 2nd iteration
+# with input tensors of the same shape
+for _ in range(5) :
+    outputs = fusion.execute([input1, input2])
+
+print(outputs[0])

--- a/torch/csrc/jit/codegen/cuda/python_frontend/examples/python_example_noncontiguous_tensor.py
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/examples/python_example_noncontiguous_tensor.py
@@ -1,0 +1,31 @@
+import torch
+
+from torch._C._nvfuser import Fusion, FusionDefinition
+
+# Construct and Define Fusion
+fusion = Fusion()
+
+with FusionDefinition(fusion) as fd :
+    t0 = fd.define_tensor(3, [True, False, False])
+    t1 = fd.define_tensor(3, [True, True, True])
+
+    fd.add_input(t0)
+    fd.add_input(t1)
+
+    t2 = fd.Ops.add(t0, t1)
+
+    fd.add_output(t2)
+
+fusion.print_ir()
+
+# Execute Fusion
+input1 = torch.ones(2, 4, 8, device='cuda').transpose(1, 2)
+input2 = torch.ones(2, 8, 4, device='cuda')
+
+# Kernel compilation should be cached for the 2nd iteration
+# with input tensors of the same shape
+for _ in range(5) :
+    outputs = fusion.execute([input1, input2])
+
+print(outputs[0])
+print(outputs[0].size(), outputs[0].stride())

--- a/torch/csrc/jit/codegen/cuda/python_frontend/examples/python_example_noncontiguous_tensor.py
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/examples/python_example_noncontiguous_tensor.py
@@ -24,7 +24,7 @@ fusion.print_kernel()
 
 # Execute Fusion
 input1 = torch.Tensor([4, 3, 2, 1]).cuda().unsqueeze(0).unsqueeze(-1)
-input1 = (input1 + torch.zeros(2, 4, 3, device='cuda')).transpose(1,2)
+input1 = (input1 + torch.zeros(2, 4, 3, device='cuda')).transpose(1, 2)
 input2 = torch.Tensor([1, 2, 3, 4]).cuda().unsqueeze(0).unsqueeze(0)
 input2 = input2 + torch.zeros(2, 3, 4, device='cuda')
 

--- a/torch/csrc/jit/codegen/cuda/python_frontend/examples/python_example_noncontiguous_tensor.py
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/examples/python_example_noncontiguous_tensor.py
@@ -6,26 +6,38 @@ from torch._C._nvfuser import Fusion, FusionDefinition
 fusion = Fusion()
 
 with FusionDefinition(fusion) as fd :
-    t0 = fd.define_tensor(3, [True, False, False])
+    t0 = fd.define_tensor(3, [False, False, False])
     t1 = fd.define_tensor(3, [True, True, True])
 
     fd.add_input(t0)
     fd.add_input(t1)
+    print("Input1 Contiguity:", t0)
+    print("Input2 Contiguity:", t1)
 
     t2 = fd.Ops.add(t0, t1)
 
+    print("Output Contiguity:", t2, "\n")
     fd.add_output(t2)
 
 fusion.print_ir()
+fusion.print_kernel()
 
 # Execute Fusion
-input1 = torch.ones(2, 4, 8, device='cuda').transpose(1, 2)
-input2 = torch.ones(2, 8, 4, device='cuda')
+input1 = torch.Tensor([4, 3, 2, 1]).cuda().unsqueeze(0).unsqueeze(-1)
+input1 = (input1 + torch.zeros(2, 4, 3, device='cuda')).transpose(1,2)
+input2 = torch.Tensor([1, 2, 3, 4]).cuda().unsqueeze(0).unsqueeze(0)
+input2 = input2 + torch.zeros(2, 3, 4, device='cuda')
 
 # Kernel compilation should be cached for the 2nd iteration
 # with input tensors of the same shape
 for _ in range(5) :
     outputs = fusion.execute([input1, input2])
 
-print(outputs[0])
-print(outputs[0].size(), outputs[0].stride())
+print("\nInput1 Size and Stride:", input1.size(), input1.stride())
+print(input1)
+print("Input2 Size and Stride:", input2.size(), input2.stride())
+print(input2)
+print("Output Size and Stride:", outputs[0].size(), outputs[0].stride())
+print("Output Tensor is expected to have all 5's when contiguity is correctly specified.\n", outputs[0])
+
+assert outputs[0].equal(torch.full((2, 3, 4), 5.0, device='cuda')), "Contiguity is not properly specified!"

--- a/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
@@ -118,10 +118,26 @@ void initNvFuserPythonBindings(PyObject* module) {
       .def("print_kernel", [](PythonFusionOwner& self) { self.printKernel(); });
 
   // Bindings to Types required for Tensor/Scalar Creation
-  // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<TensorView>(nvfuser, "TensorView");
-  // NOLINTNEXTLINE(bugprone-unused-raii)
-  py::class_<torch::jit::fuser::cuda::Val>(nvfuser, "Val");
+  py::class_<TensorView>(nvfuser, "TensorView")
+      .def(
+          "__str__",
+          [](TensorView& self) -> std::string {
+            std::stringstream ss;
+            TORCH_CHECK(
+                self.getDataType().has_value(),
+                "TensorView does not have DataType?");
+            ss << self.getDataType().value();
+            return self.toString() + " DataType: " + ss.str() +
+                " Contiguity: " + self.domain()->getContiguityString();
+          },
+          py::return_value_policy::reference);
+  py::class_<torch::jit::fuser::cuda::Val>(nvfuser, "Val")
+      .def(
+          "__str__",
+          [](torch::jit::fuser::cuda::Val& self) -> std::string {
+            return self.toString();
+          },
+          py::return_value_policy::reference);
 
   // C++ Side of Context Manager used to mimic the FusionGuard as a way
   // to programatically distinguish code used to define the Fusion instead


### PR DESCRIPTION
Adding new features.

1. `broadcast_in_dim` support and example.
2. Adding non-contiguous `TensorView` support and example.

`broadcast_in_dim` example:
```
with FusionDefinition(fusion) as fd :
    t0 = fd.define_tensor(1)
    t1 = fd.define_tensor(3)

    fd.add_input(t0)
    fd.add_input(t1)

    t0_b = fd.Ops.broadcast_in_dim(t0, [2, 3, 4], [1])
    t2 = fd.Ops.add(t0_b, t1)

    fd.add_output(t2)
```

Non-contiguous tensor support example:

```
with FusionDefinition(fusion) as fd :
    t0 = fd.define_tensor(3, [False, False, False])
    t1 = fd.define_tensor(3, [True, True, True])

    fd.add_input(t0)
    fd.add_input(t1)
    print("Input1 Contiguity:", t0)
    print("Input2 Contiguity:", t1)

    t2 = fd.Ops.add(t0, t1)

    print("Output Contiguity:", t2, "\n")
    fd.add_output(t2)
```