### PR TITLE
Retry - [NVFuser] always use fallback if fusion fails

### DIFF
--- a/torch/csrc/jit/codegen/cuda/manager.cpp
+++ b/torch/csrc/jit/codegen/cuda/manager.cpp
@@ -52,6 +52,30 @@ namespace cuda {
 
 namespace {
 
+// TODO remove this (75983):
+//   we don't need this any more. I think we can use revertAliasCopyOps.
+//   Similar refactor should be done infallback graph used by fusion guard.
+//   implementation of xxxx_copy ops should be removed.
+//
+// Mark string attribute in alias-copy nodes to enable its implementation
+// in the fallback path.
+void enableAliasCopyNodes(const std::shared_ptr<Graph>& graph, Block* block) {
+  static std::unordered_set<Symbol> alias_copy_op(
+      {prim::view_copy,
+       prim::reshape_copy,
+       prim::squeeze_copy,
+       prim::unsqueeze_copy});
+
+  for (Node* n : block->nodes()) {
+    for (Block* b : n->blocks()) {
+      enableAliasCopyNodes(graph, b);
+    }
+    if (alias_copy_op.find(n->kind()) != alias_copy_op.end()) {
+      n->s_(attr::name, "CudaFusionGroup");
+    }
+  }
+}
+
 // CudaFusionManager is not thread safe!
 // TODO: we should make the tradeoff here to use thread_local instead of global
 // singleton;
@@ -110,6 +134,30 @@ class CudaFusionManager {
     return graph_cache_[kernel_id]->runGraphWithInputs(inputs);
   }
 
+  bool hasFallbackCode(int32_t kernel_id) {
+    std::lock_guard<std::mutex> guard(mutex_);
+    return fallback_cache_.count(kernel_id);
+  }
+
+  Code* getFallbackCode(int32_t kernel_id, const Node* fusion_node) {
+    {
+      std::lock_guard<std::mutex> guard(mutex_);
+      auto it = fallback_cache_.find(kernel_id);
+      if (it != fallback_cache_.end()) {
+        return it->second.get();
+      }
+    }
+
+    auto copied_graph = fusion_node->g(attr::Subgraph)->copy();
+    EraseShapeInformation(copied_graph);
+    enableAliasCopyNodes(copied_graph, copied_graph->block());
+    auto code = std::make_unique<Code>(copied_graph, "fallback_cuda_fuser");
+
+    std::lock_guard<std::mutex> guard(mutex_);
+    auto it = fallback_cache_.insert({kernel_id, std::move(code)}).first;
+    return it->second.get();
+  }
+
  private:
   // TODO: Dimension collapsing should be abstracted out and integrated into
   // graph caching.
@@ -138,28 +186,10 @@ class CudaFusionManager {
 
   std::unordered_map<std::string, int32_t> graph_cache_ids_;
   std::unordered_map<int64_t, std::unique_ptr<GraphCache>> graph_cache_;
+  std::unordered_map<int64_t, std::unique_ptr<Code>> fallback_cache_;
 
   int32_t next_unique_id_ = 0;
 };
-
-// Mark string attribute in alias-copy nodes to enable its implementation
-// in the fallback path.
-void enableAliasCopyNodes(const std::shared_ptr<Graph>& graph, Block* block) {
-  static std::unordered_set<Symbol> alias_copy_op(
-      {prim::view_copy,
-       prim::reshape_copy,
-       prim::squeeze_copy,
-       prim::unsqueeze_copy});
-
-  for (Node* n : block->nodes()) {
-    for (Block* b : n->blocks()) {
-      enableAliasCopyNodes(graph, b);
-    }
-    if (alias_copy_op.find(n->kind()) != alias_copy_op.end()) {
-      n->s_(attr::name, "CudaFusionGroup");
-    }
-  }
-}
 
 } // namespace
 
@@ -210,11 +240,10 @@ void runCudaFusionGroup(const Node* fusion_node, Stack& stack) {
 
   // Fallback to use if anything goes wrong
   auto take_fallback = [&](Stack& stack) {
-    // copying graph here since we are eliminating shape information;
-    auto copied_graph = fusion_node->g(attr::Subgraph)->copy();
-    EraseShapeInformation(copied_graph);
-    enableAliasCopyNodes(copied_graph, copied_graph->block());
-    InterpreterState{Code(copied_graph, "fallback_cuda_fuser")}.run(stack);
+    int32_t kernel_id = fusion_node->i(attr::cache_id);
+    auto fallback_code =
+        CudaFusionManager::getManager().getFallbackCode(kernel_id, fusion_node);
+    InterpreterState{*fallback_code}.run(stack);
   };
 
   c10::optional<Stack> stack_copy;
@@ -264,7 +293,17 @@ void runCudaFusionGroup(const Node* fusion_node, Stack& stack) {
 
   if (useFallback()) {
     try {
-      run_fusion();
+      // if fusion failed once, it's likely to fail again; and failures are
+      // slow. So if the fusion fails, then record the failure and always use
+      // the fallback instead
+      int32_t kernel_id = fusion_node->i(attr::cache_id);
+      bool force_fallback =
+          CudaFusionManager::getManager().hasFallbackCode(kernel_id);
+      if (force_fallback) {
+        take_fallback(stack);
+      } else {
+        run_fusion();
+      }
     } catch (...) {
       TORCH_WARN(
           "FALLBACK path has been taken. This is an indication that codegen"


### PR DESCRIPTION
Retry of #75983. The change is to handle cases where attr::cache_id is
not set. This can happen if compilation fails.

Original message:

1) remember when fusions fail; and on subsequent runs, always take the fallback.
2) during the first fallback, cache the Code object.

On autogen-69 from the nvfuser microbenchmarks (https://github.com/pytorch/benchmark/pull/801) this improved performanance as follows:
* Original (always attempt fusion): 25ms
* Always take fallback after first failure: 0.79ms
* Always take fallback + cache Code object: 0.62ms
* Eager: 0.58ms
