### PR TITLE
Remove deprecated string torch::lazy::BackendDevice constructor

### DIFF
--- a/torch/csrc/lazy/backend/backend_device.cpp
+++ b/torch/csrc/lazy/backend/backend_device.cpp
@@ -17,9 +17,6 @@ BackendDevice::BackendDevice()
 BackendDevice::BackendDevice(std::shared_ptr<BackendDeviceType>&& type, int64_t ordinal)
   : type_(std::move(type)), ordinal_(ordinal) {}
 
-BackendDevice::BackendDevice(const std::string& device_spec)
-  : BackendDevice::BackendDevice() {}
-
 int8_t BackendDevice::type() const {
   TORCH_INTERNAL_ASSERT(type_);
   return type_->type;

--- a/torch/csrc/lazy/backend/backend_device.h
+++ b/torch/csrc/lazy/backend/backend_device.h
@@ -36,16 +36,13 @@ class TORCH_API BackendDevice {
   BackendDevice(std::shared_ptr<BackendDeviceType>&& type, int64_t ordinal);
 
   int8_t type() const;
-  int64_t ordinal() const { return ordinal_;  }
+  int64_t ordinal() const { return ordinal_; }
 
   bool operator==(const BackendDevice& other) const { return compare(other) == 0; }
   bool operator!=(const BackendDevice& other) const { return compare(other) != 0; }
   bool operator<(const BackendDevice& rhs) const { return compare(rhs) < 0; }
 
   std::string toString() const;
-
-  // The string -> Device conversion should be handled by the backend interface.
-  C10_DEPRECATED explicit BackendDevice(const std::string& device_spec);
 
  private:
   int compare(const BackendDevice& rhs) const;


### PR DESCRIPTION
Remove deprecated string torch::lazy::BackendDevice constructor, re-landing part of https://github.com/pytorch/pytorch/pull/76264. 