### PR TITLE
Shard rocm distributed tests

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -110,7 +110,8 @@ jobs:
       docker-image: ${{ needs.linux-bionic-rocm5_1-py3_7-distributed-build.outputs.docker-image }}
       test-matrix: |
         { include: [
-          { config: "distributed", shard: 1, num_shards: 1, runner: "linux.rocm.gpu" },
+          { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
+          { config: "distributed", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
         ]}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}


### PR DESCRIPTION
As ROCm enabled more distributed tests on trunk, the test time has increased dramatically and is now past the 5hr timeout threshold.

This is a mitigation! Note that distributed tests take 2.5 hrs ish on a linux machine, but they take over 5 hours now on ROCm. 
One can observe by going through the pages in https://hud.pytorch.org/hud/pytorch/pytorch/master/3?name_filter=rocm and seeing that after fdsp tests were enabled + some other changes, ROCm dist test time increased by 1hr+. 