### PR TITLE
Disable XLA test workflow

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -231,6 +231,7 @@ jobs:
       docker-image-name: xla_base
 
   pytorch-xla-linux-bionic-py3_7-clang8-test:
+    if: ${{ false }}
     name: pytorch-xla-linux-bionic-py3.7-clang8
     uses: ./.github/workflows/_linux-test.yml
     needs: pytorch-xla-linux-bionic-py3_7-clang8-build


### PR DESCRIPTION
Our trunk is hosed rn https://hud.pytorch.org/minihud?name_filter=pull%20/%20pytorch-xla-linux-bionic-py3.7-clang8%20/%20test%20(xla,%201,%201,%20linux.2xlarge)

This mitigates by disabling the workflow