### PR TITLE
Fix string repr for nested tensors & run nested tensor tests

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -9,7 +9,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     skipMeta,
 )
-from torch.testing._internal.common_utils import TestCase, IS_FBCODE
+from torch.testing._internal.common_utils import TestCase, IS_FBCODE, run_tests
 from torch import nested_tensor
 
 # Tests are ported from pytorch/nestedtensor.
@@ -336,3 +336,6 @@ class TestNestedTensorDeviceType(TestCase):
         self.assertEqual(nt.is_cuda, is_cuda)
 
 instantiate_device_type_tests(TestNestedTensorDeviceType, globals())
+
+if __name__ == '__main__':
+    run_tests()

--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -299,10 +299,10 @@ def get_summarized_data(self):
 
 def _str_intern(inp, *, tensor_contents=None):
     is_plain_tensor = type(inp) is torch.Tensor or type(inp) is torch.nn.Parameter
-    if is_plain_tensor:
-        prefix = 'tensor('
-    elif inp.is_nested:
+    if inp.is_nested:
         prefix = "nested_tensor("
+    elif is_plain_tensor:
+        prefix = 'tensor('
     else:
         prefix = f"{type(inp).__name__}("
     indent = len(prefix)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #76541

Fixes #76540

Test already exists for the correct repr, but tests in `test/test_nestedtensor.py` weren't being run. This PR enables these as well.