### PR TITLE
[RPC small change] Improving logging for store.wait error

### DIFF
--- a/torch/distributed/rpc/_utils.py
+++ b/torch/distributed/rpc/_utils.py
@@ -1,12 +1,16 @@
 from contextlib import contextmanager
 from typing import cast
+import logging
 from . import api
 from . import TensorPipeAgent
+
+logger = logging.getLogger(__name__)
 
 @contextmanager
 def _group_membership_management(store, name, is_join):
     token_key = "RpcGroupManagementToken"
-    my_token = f"Token{name}-{int(is_join)}"
+    join_or_leave = "join" if is_join else "leave"
+    my_token = f"Token_for_{name}_{join_or_leave}"
     while True:
         # Retrieve token from store to signal start of rank join/leave critical section
         returned = store.compare_set(token_key, "", my_token).decode()
@@ -20,9 +24,12 @@ def _group_membership_management(store, name, is_join):
             store.set(my_token, "Done")
             break
         else:
-            # token_name = returned.split("-")[0]
             # Store will wait for the token to be released
-            store.wait([returned])
+            try:
+                store.wait([returned])
+            except RuntimeError:
+                logger.error(f"Group membership token {my_token} timed out waiting for {returned} to be released.")
+                raise
 
 def _update_group_membership(worker_info, my_devices, reverse_device_map, is_join):
     agent = cast(TensorPipeAgent, api._get_current_rpc_agent())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#76548 [RPC small change] Improving logging for store.wait error**
* #75811 [RPC small change] Improve logging from 'unknown destination worker'
* #74561 [Dynamic RPC] Add graceful shutdown for dynamic RPC members
* #74035 [Dynamic RPC] Allow existing ranks to communicate with newly joined ranks

Add logging message when the store times out waiting for `_group_membership_management` to let user know which worker/operation it was waiting on