### PR TITLE
Remove c10::getClassConverter

### DIFF
--- a/aten/src/ATen/core/custom_class.cpp
+++ b/aten/src/ATen/core/custom_class.cpp
@@ -16,13 +16,6 @@ static ska::flat_hash_map<std::type_index, c10::ClassTypePtr>& getCustomClassTyp
   return tmap;
 }
 
-std::unordered_map<std::string, std::function<PyObject*(void*)>>&
-getClassConverter() {
-  static std::unordered_map<std::string, std::function<PyObject*(void*)>>
-      classConverter;
-  return classConverter;
-}
-
 c10::ClassTypePtr getCustomClassTypeImpl(const std::type_index &tindex) {
   auto& tmap = c10::getCustomClassTypeMap();
   auto res = tmap.find(tindex);

--- a/aten/src/ATen/core/custom_class.h
+++ b/aten/src/ATen/core/custom_class.h
@@ -2,12 +2,10 @@
 
 #include <typeindex>
 #include <memory>
-#include <unordered_map>
 
 #include <c10/macros/Export.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
-#include <c10/util/python_stub.h>
 
 namespace c10 {
 
@@ -27,6 +25,4 @@ const c10::ClassTypePtr& getCustomClassType() {
   return cache;
 }
 
-TORCH_API std::unordered_map<std::string, std::function<PyObject*(void*)>>&
-getClassConverter();
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #76550
* #76549

As far as I can tell, this function is not unused anywhere.