### PR TITLE
[FSDP] Relax exec order valid. to only fwd

### DIFF
--- a/test/distributed/fsdp/test_fsdp_comm.py
+++ b/test/distributed/fsdp/test_fsdp_comm.py
@@ -135,9 +135,10 @@ class TestCommunication(FSDPTest):
                 f"is_first_iter={is_first_iter} " \
                 f"is_last_iter_no_sync={is_last_iter_no_sync} " \
                 f"sharding_strategy={sharding_strategy}"
-        if is_first_iter:
+        if is_first_iter and pass_type == PassType.FWD:
             # With execution order validation, on the first iteration, we have
-            # an additional all-gather before every actual all-gather
+            # an additional all-gather before every actual all-gather in the
+            # forward pass
             num_all_gathers *= 2
         return num_all_gathers
 

--- a/test/distributed/fsdp/test_fsdp_exec_order.py
+++ b/test/distributed/fsdp/test_fsdp_exec_order.py
@@ -148,11 +148,7 @@ class TestFSDPExecOrder(FSDPTest):
         with context:  # warning for forward pass all-gather
             output = fsdp_model(*inp)
         loss = fsdp_model.module.get_loss(inp, output).to(self.device)
-        # Expect a warning for the pre-backward pass all-gather for `FULL_SHARD`
-        if sharding_strategy != ShardingStrategy.FULL_SHARD:
-            context = suppress()
-        with context:
-            fsdp_model.module.run_backward(loss)
+        fsdp_model.module.run_backward(loss)
         # Run an additional iteration to check that there are no more warnings
         inp = fsdp_model.module.get_input(self.device)
         output = fsdp_model(*inp)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#76556 [FSDP] Relax exec order valid. to only fwd**

This relaxes the execution order validation to only check all-gathers in the forward pass. See https://github.com/pytorch/pytorch/issues/76553.

Differential Revision: [D36018401](https://our.internmc.facebook.com/intern/diff/D36018401)