### PR TITLE
[RF][scuba] add pytorch_operator_stats column for Static Runtime out variant

### DIFF
--- a/aten/src/ATen/record_function.cpp
+++ b/aten/src/ATen/record_function.cpp
@@ -692,4 +692,16 @@ bool RecordFunction::isAsync() const {
   return false;
 }
 
+void RecordFunction::_setStaticRuntimeOutVariant() {
+  if (isActive()) {
+    state_->is_static_runtime_out_variant_ = true;
+  }
+}
+
+bool RecordFunction::isStaticRuntimeOutVariant() const {
+  if (isActive()) {
+    return state_->is_static_runtime_out_variant_;
+  }
+  return false;
+}
 } // namespace at

--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -416,6 +416,10 @@ struct TORCH_API RecordFunction {
   // Returns whether this RecordFunction corresponds to an async event orn ot.
   bool isAsync() const;
 
+  // Internal-only, used to denote out variant used for Static Runtime execution
+  void _setStaticRuntimeOutVariant();
+  bool isStaticRuntimeOutVariant() const;
+
   RecordFunctionHandle handle() const {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(state_, "Called handle() on inactive RecordFunction");
     return state_->handle_;
@@ -499,6 +503,10 @@ struct TORCH_API RecordFunction {
     // This is specifically is useful for mobile runtime, where generated
     // debug handles can be lazily symbolicated using debug information
     int64_t debug_handle_{-1};
+
+    // Whether this RecordFunction is used for an out variant run with
+    // Static Runtime
+    bool is_static_runtime_out_variant_{false};
   };
 
   c10::optional<State> state_;

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1845,6 +1845,9 @@ void ProcessedNode::run() {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(guard.isActive());
     guard.needsInputs() ? guard.before(get_op_name(), inputs_ivalue_vec())
                         : guard.before(get_op_name());
+    if (has_out_variant()) {
+      guard._setStaticRuntimeOutVariant();
+    }
 
     fn_->run(this);
   } else {


### PR DESCRIPTION
Summary:
Add static_runtime_out_variant field to pytorch_operator_stats scuba.

Add field for static_runtime_out_variant to RecordFunction.

Test Plan:
`ptail perfpipe_pytorch_operator_stats_dev | grep devbig371`
No out variant, SR on: P498206546
Out variant: P498206634

Check column shows up in scuba: https://fburl.com/scuba/pytorch_operator_stats_dev/tfgmth1t

CMF 4M test https://www.internalfb.com/intern/servicelab/802987274/
ICVR 4M https://www.internalfb.com/intern/servicelab/802987272/

AF prod canary
https://our.intern.facebook.com/intern/ads/canary/443234131523314631

Differential Revision: D36016857

