### PR TITLE
Cleanup ATen-core forward declarations

### DIFF
--- a/aten/src/ATen/core/ATen_fwd.h
+++ b/aten/src/ATen/core/ATen_fwd.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <c10/core/QScheme.h>
+
+// Forward declarations of core ATen types used in dispatch functions
+namespace c10 {
+
+template<typename T>
+class optional;
+template<typename T>
+class List;
+class ITensorListRef;
+class Stream;
+class Scalar;
+class SymInt;
+class SymIntList;
+struct Storage;
+struct TensorOptions;
+template <typename T>
+class ArrayRef;
+template <typename T>
+class OptionalArrayRef;
+
+}  // namespace c10
+
+namespace at {
+
+class Tensor;
+struct Dimname;
+struct Generator;
+using TensorList = c10::ArrayRef<Tensor>;
+using ITensorListRef = c10::ITensorListRef;
+using DimnameList = c10::ArrayRef<Dimname>;
+using IntArrayRef = c10::ArrayRef<int64_t>;
+using OptionalIntArrayRef = c10::OptionalArrayRef<int64_t>;
+
+using c10::Stream;
+using c10::Storage;
+using c10::QScheme;
+using c10::Scalar;
+using c10::SymInt;
+using c10::SymIntList;
+using c10::TensorOptions;
+
+}  // namespace at

--- a/aten/src/ATen/core/ATen_pch.h
+++ b/aten/src/ATen/core/ATen_pch.h
@@ -105,6 +105,7 @@
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/core/impl/InlineDeviceGuard.h>
 #include <c10/core/impl/LocalDispatchKeySet.h>
+#include <c10/core/impl/PyInterpreter.h>
 #include <c10/core/impl/SizesAndStrides.h>
 #include <c10/core/impl/VirtualGuardImpl.h>
 
@@ -153,17 +154,20 @@
 #include <c10/util/quint4x2.h>
 #include <c10/util/quint8.h>
 #include <c10/util/reverse_iterator.h>
+#include <c10/util/safe_numerics.h>
 #include <c10/util/string_utils.h>
 #include <c10/util/string_view.h>
 #include <c10/util/typeid.h>
 
-#include <ATen/Dispatch.h>
 #include <ATen/core/DeprecatedTypeProperties.h>
 #include <ATen/core/DeprecatedTypePropertiesRegistry.h>
+#include <ATen/core/DimVector.h>
 #include <ATen/core/Dimname.h>
 #include <ATen/core/Generator.h>
 #include <ATen/core/NamedTensor.h>
 #include <ATen/core/QuantizerBase.h>
+#include <ATen/core/SymInt.h>
+#include <ATen/core/SymIntArrayRef.h>
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/core/TensorBase.h>
 #include <ATen/core/symbol.h>

--- a/aten/src/ATen/core/SymIntArrayRef.h
+++ b/aten/src/ATen/core/SymIntArrayRef.h
@@ -11,10 +11,7 @@
 
 #include <ATen/core/SymInt.h>
 #include <c10/util/ArrayRef.h>
-#include <c10/util/C++17.h>
-#include <c10/util/Deprecated.h>
 #include <c10/util/Exception.h>
-#include <c10/util/SmallVector.h>
 
 #include <array>
 #include <initializer_list>

--- a/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
+++ b/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/ivalue.h>
 #include <ATen/core/stack.h>
+#include <c10/util/TypeList.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/Metaprogramming.h>
 

--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -14,6 +14,7 @@
 // See https://github.com/pytorch/pytorch/issues/37577 for an instance
 // of this bug in the past.
 
+#include <cassert>
 #include <cstring>
 #include <functional>
 #include <cmath>

--- a/aten/src/ATen/templates/DispatchKeyFunction.h
+++ b/aten/src/ATen/templates/DispatchKeyFunction.h
@@ -11,31 +11,9 @@
 // Forward declarations of any types needed in the operator signatures.
 // We can't directly include these classes because it will cause circular include dependencies.
 // This file is included by TensorBody.h, which defines the Tensor class.
-namespace c10 {
-
-template<typename T>
-class optional;
-template<typename T>
-class List;
-class Stream;
-class Scalar;
-struct Storage;
-struct TensorOptions;
-
-}
+#include <ATen/core/ATen_fwd.h>
 
 namespace at {
-
-class Tensor;
-struct Dimname;
-struct Generator;
-using TensorList = c10::ArrayRef<Tensor>;
-using DimnameList = c10::ArrayRef<Dimname>;
-using c10::Stream;
-using c10::Storage;
-using c10::QScheme;
-using c10::Scalar;
-using c10::TensorOptions;
 
 namespace ${dispatch_namespace} {
 

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -69,6 +69,7 @@
 #include <c10/core/TensorOptions.h>
 #include <c10/util/Deprecated.h>
 #include <c10/util/Optional.h>
+#include <c10/util/OptionalArrayRef.h>
 
 #include <ATen/ops/from_blob.h>
 #include <ATen/ops/tensor.h>

--- a/aten/src/ATen/templates/MethodOperators.h
+++ b/aten/src/ATen/templates/MethodOperators.h
@@ -13,33 +13,7 @@
 // Forward declarations of any types needed in the operator signatures.
 // We can't directly include these classes because it will cause circular include dependencies.
 // This file is included by TensorBody.h, which defines the Tensor class.
-namespace c10 {
-
-template<typename T>
-class optional;
-template<typename T>
-class List;
-class Stream;
-class Scalar;
-struct Storage;
-struct TensorOptions;
-
-}
-
-namespace at {
-
-class Tensor;
-struct Dimname;
-struct Generator;
-using TensorList = c10::ArrayRef<Tensor>;
-using DimnameList = c10::ArrayRef<Dimname>;
-using c10::Stream;
-using c10::Storage;
-using c10::QScheme;
-using c10::Scalar;
-using c10::TensorOptions;
-
-}
+#include <ATen/core/ATen_fwd.h>
 
 ${MethodOperators_includes}
 

--- a/aten/src/ATen/templates/Operator.h
+++ b/aten/src/ATen/templates/Operator.h
@@ -2,42 +2,15 @@
 
 // ${generated_comment}
 
-#include <c10/core/QScheme.h>
-#include <ATen/core/jit_type_base.h>
 #include <tuple>
 #include <vector>
 
 // Forward declarations of any types needed in the operator signatures.
 // We can't directly include these classes because it will cause circular include dependencies.
 // This file is included by TensorBody.h, which defines the Tensor class.
-namespace c10 {
-
-template<typename T>
-class optional;
-template<typename T>
-class List;
-class ITensorListRef;
-class Stream;
-class Scalar;
-struct Storage;
-struct TensorOptions;
-
-}
+#include <ATen/core/ATen_fwd.h>
 
 namespace at {
-
-class Tensor;
-struct Dimname;
-struct Generator;
-using TensorList = c10::ArrayRef<Tensor>;
-using ITensorListRef = c10::ITensorListRef;
-using DimnameList = c10::ArrayRef<Dimname>;
-using c10::Stream;
-using c10::Storage;
-using c10::QScheme;
-using c10::Scalar;
-using c10::TensorOptions;
-
 namespace _ops {
 
 ${declarations}

--- a/aten/src/ATen/templates/Operators.h
+++ b/aten/src/ATen/templates/Operators.h
@@ -22,6 +22,7 @@
 #include <c10/core/Scalar.h>
 #include <c10/core/TensorOptions.h>
 #include <c10/core/QScheme.h>
+#include <c10/util/OptionalArrayRef.h>
 #include <tuple>
 #include <vector>
 

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -17,7 +17,6 @@
 #include <c10/core/ScalarType.h>
 #include <c10/core/ScalarTypeToTypeMeta.h>
 #include <c10/core/Storage.h>
-#include <ATen/core/TensorAccessor.h>
 #include <c10/core/TensorImpl.h>
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/core/WrapDimMinimal.h>
@@ -25,6 +24,7 @@
 #include <c10/util/Deprecated.h>
 #include <c10/util/MaybeOwned.h>
 #include <c10/util/Optional.h>
+#include <c10/util/OptionalArrayRef.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/macros/Export.h>
 #include <ATen/core/CheckMemoryFormat.h>
@@ -33,6 +33,7 @@
 #include <ATen/core/NamedTensor.h>
 #include <ATen/core/QuantizerBase.h>
 #include <ATen/core/SymInt.h>
+#include <ATen/core/TensorAccessor.h>
 #include <ATen/core/TensorBase.h>
 
 

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <c10/util/ArrayRef.h>
 #include <c10/util/BFloat16.h>
+#include <c10/util/Exception.h>
 #include <c10/util/Half.h>
-#include <c10/util/Optional.h>
-#include <c10/util/OptionalArrayRef.h>
 #include <c10/util/complex.h>
 #include <c10/util/qint32.h>
 #include <c10/util/qint8.h>

--- a/c10/core/ScalarTypeToTypeMeta.h
+++ b/c10/core/ScalarTypeToTypeMeta.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/core/ScalarType.h>
+#include <c10/util/Optional.h>
 #include <c10/util/typeid.h>
 
 // these just expose TypeMeta/ScalarType bridge functions in c10

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -1,5 +1,6 @@
 #ifndef C10_MACROS_MACROS_H_
 #define C10_MACROS_MACROS_H_
+#include <cassert>
 
 /* Main entry for c10/macros.
  *

--- a/torch/csrc/jit/codegen/cuda/type.h
+++ b/torch/csrc/jit/codegen/cuda/type.h
@@ -2,6 +2,7 @@
 
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Optional.h>
 
 #include <c10/macros/Export.h>
 

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <c10/core/MemoryFormat.h>
+#include <c10/util/Optional.h>
 #include <torch/csrc/jit/tensorexpr/fwd_decls.h>
 #include <torch/csrc/jit/tensorexpr/ir_mutator.h>
 #include <torch/csrc/jit/tensorexpr/ir_visitor.h>


### PR DESCRIPTION
I noticed that when `SymInt` was introduced, `jit_type_base.h` was
added as an include to the `Operator.h` template which is supposed to
be kept extremely clean and only use forward declarations. Also,
that forward declarations for `OptionalArrayRef` were missing.

So, I've refactored the forward declarations into
`ATen/core/ATen_fwd.h` and cleaned up some of the `c10`
headers that were masking these missing declarations. I've also
re-generated the pre-compiled header so `SymInt` is included.
