### PR TITLE
Implement register_load_state_dict_post_hook

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1586,6 +1586,10 @@ class Module:
                 if child is not None:
                     load(child, prefix + name + '.')
 
+            incompatible_keys = _IncompatibleKeys(missing_keys, unexpected_keys)
+            for hook in module._load_state_dict_post_hooks.values():
+                hook(module, incompatible_keys)
+
         load(self)
         del load
 
@@ -1603,9 +1607,7 @@ class Module:
             raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
                                self.__class__.__name__, "\n\t".join(error_msgs)))
 
-        incompatible_keys = _IncompatibleKeys(missing_keys, unexpected_keys)
-        for hook in self._load_state_dict_post_hooks.values():
-            hook(self, incompatible_keys)
+        return _IncompatibleKeys(missing_keys, unexpected_keys)
 
         return incompatible_keys
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1586,6 +1586,7 @@ class Module:
                 if child is not None:
                     load(child, prefix + name + '.')
 
+            # Note that the hook can modify missing_keys and unexpected_keys.
             incompatible_keys = _IncompatibleKeys(missing_keys, unexpected_keys)
             for hook in module._load_state_dict_post_hooks.values():
                 hook(module, incompatible_keys)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1610,8 +1610,6 @@ class Module:
 
         return _IncompatibleKeys(missing_keys, unexpected_keys)
 
-        return incompatible_keys
-
     def _named_members(self, get_members_fn, prefix='', recurse=True):
         r"""Helper method for yielding various names + members of modules."""
         memo = set()


### PR DESCRIPTION
Implements `register_load_state_dict_post_hook` API as discussed in https://github.com/pytorch/pytorch/issues/75287.

Unittests cover:
- Ensuring hooks are called with the correct module
- Hook is called with `IncompatibleKeys` field
- If hook modifies this, load_state_dict returns the modified result
