### PR TITLE
Enable MKLDNN OP fusion for convolution

### DIFF
--- a/aten/src/ATen/native/mkldnn/Common.h
+++ b/aten/src/ATen/native/mkldnn/Common.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ideep/tensor.hpp>
+
+namespace at {
+namespace native {
+namespace mkldnn {
+
+struct ContextConv2D final {
+  ideep::tensor weight_packed_;
+  c10::optional<at::Tensor> at_bias_;
+  std::array<int64_t, 2> padding_;
+  std::array<int64_t, 2> stride_;
+  std::array<int64_t, 2> dilation_;
+  int64_t groups_;
+  ideep::attr_t attr_;
+
+  ContextConv2D() = delete;
+
+  ContextConv2D(
+      ideep::tensor&& weight_packed,
+      c10::optional<at::Tensor> at_bias,
+      std::array<int64_t, 2> padding,
+      std::array<int64_t, 2> stride,
+      std::array<int64_t, 2> dilation,
+      int64_t groups,
+      ideep::attr_t attr)
+      : weight_packed_(std::move(weight_packed)),
+        at_bias_(std::move(at_bias)),
+        padding_(padding),
+        stride_(stride),
+        dilation_(dilation),
+        groups_(groups),
+        attr_(attr) {}
+};
+
+} // namespace mkldnn
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/mkldnn/Common.h
+++ b/aten/src/ATen/native/mkldnn/Common.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <ATen/Config.h>
+
+#if AT_MKLDNN_ENABLED()
+
 #include <ideep/tensor.hpp>
 
 namespace at {
@@ -38,3 +42,5 @@ struct ContextConv2D final {
 } // namespace mkldnn
 } // namespace native
 } // namespace at
+
+#endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/ConvPrepack.cpp
+++ b/aten/src/ATen/native/mkldnn/ConvPrepack.cpp
@@ -8,6 +8,8 @@
 #include <ATen/native/utils/ParamUtils.h>
 #include <c10/util/irange.h>
 
+#if AT_MKLDNN_ENABLED()
+
 namespace at {
 namespace native {
 namespace mkldnn {
@@ -200,3 +202,5 @@ Tensor conv2d_run(
 } // namespace mkldnn
 } // namespace native
 } // namespace at
+
+#endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/ConvPrepack.cpp
+++ b/aten/src/ATen/native/mkldnn/ConvPrepack.cpp
@@ -1,0 +1,199 @@
+#include <vector>
+
+#include <ATen/native/ConvUtils.h>
+#include <ATen/native/mkldnn/Common.h>
+#include <ATen/native/mkldnn/ConvPrepack.h>
+#include <ATen/native/mkldnn/MKLDNNCommon.h>
+#include <ATen/native/utils/Factory.h>
+#include <ATen/native/utils/ParamUtils.h>
+#include <c10/util/irange.h>
+
+namespace at {
+namespace native {
+namespace mkldnn {
+namespace internal {
+namespace convolution2d {
+
+std::map<AttrType, ideep::attr_t> FusionAttrMap{
+    {AttrType::None, ideep::attr_t()},
+    {AttrType::ReLU, ideep::attr_t::fuse_relu()},
+};
+
+c10::intrusive_ptr<mkldnn::Conv2dOpContext> createConv2dPrePackOpContext(
+    Tensor weight,
+    c10::optional<Tensor> bias,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> dilation,
+    int64_t groups,
+    std::vector<int64_t> input_size,
+    c10::string_view attr) {
+  auto attr_type = get_attrtype_enum(attr);
+  auto it = FusionAttrMap.find(attr_type);
+  TORCH_CHECK(it != FusionAttrMap.end(), "Fusion behavior undefined.");
+  ideep::attr_t op_attr = FusionAttrMap[attr_type];
+
+  return mkldnn::MkldnnConv2dOpContext::create_context(
+      std::move(weight),
+      std::move(bias),
+      std::move(padding),
+      std::move(stride),
+      std::move(dilation),
+      groups,
+      std::move(input_size),
+      op_attr);
+}
+
+ContextConv2D create(
+    const Tensor& weight,
+    const c10::optional<Tensor>& bias,
+    const IntArrayRef padding,
+    const IntArrayRef stride,
+    const IntArrayRef dilation,
+    const int64_t groups,
+    const IntArrayRef input_size,
+    const ideep::attr_t& attr) {
+  const auto padding_expanded = expand_param_if_needed(padding, "padding", 2);
+  const auto stride_expanded = expand_param_if_needed(stride, "stride", 2);
+  const auto dilation_expanded =
+      expand_param_if_needed(dilation, "dilation", 2);
+  const auto input_size_expanded =
+      expand_param_if_needed(input_size, "input_size", 4);
+
+  auto w = itensor_view_from_dense(weight);
+  ideep::tensor::desc expected_weight_desc =
+      ideep::convolution_forward::expected_weights_desc(
+          w.get_dims(),
+          w.get_data_type(),
+          {stride_expanded.begin(), stride_expanded.end()},
+          {padding_expanded.begin(), padding_expanded.end()},
+          {padding_expanded.begin(), padding_expanded.end()},
+          {dilation_expanded.begin(), dilation_expanded.end()},
+          groups,
+          ideep::algorithm::convolution_direct,
+          ideep::prop_kind::forward,
+          /*x_dtype*/ w.get_data_type(),
+          {input_size_expanded.begin(), input_size_expanded.end()});
+
+  ideep::tensor packed_weight;
+  packed_weight.init(expected_weight_desc);
+  packed_weight.feed_from(w);
+
+  return ContextConv2D{
+      std::move(packed_weight),
+      bias.has_value() ? c10::make_optional(*bias) : c10::nullopt,
+      {padding_expanded[0], padding_expanded[1]},
+      {stride_expanded[0], stride_expanded[1]},
+      {dilation_expanded[0], dilation_expanded[1]},
+      groups,
+      std::move(attr)};
+}
+
+ideep::tensor _mkldnn_convolution(
+    const ideep::tensor& x,
+    const ideep::tensor& w,
+    const c10::optional<ideep::tensor>& b,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    const ideep::attr_t& attr = ideep::attr_t()) {
+  auto kernel_size = w.get_dims();
+
+  std::vector<int64_t> input_size = x.get_dims();
+  std::vector<int64_t> output_sizes =
+      conv_output_size(input_size, kernel_size, padding, stride, dilation);
+
+  ideep::tensor y;
+  if (b.has_value()) {
+    ideep::convolution_forward::compute(
+        x,
+        w,
+        b.value(),
+        {output_sizes.cbegin(), output_sizes.cend()},
+        y,
+        {stride.begin(), stride.end()},
+        {dilation.begin(), dilation.end()},
+        {padding.begin(), padding.end()},
+        {padding.begin(), padding.end()},
+        groups,
+        ideep::scale_t(),
+        ideep::scale_t(),
+        ideep::scale_t(),
+        attr);
+  } else {
+    ideep::convolution_forward::compute(
+        x,
+        w,
+        {output_sizes.cbegin(), output_sizes.cend()},
+        y,
+        {stride.begin(), stride.end()},
+        {dilation.begin(), dilation.end()},
+        {padding.begin(), padding.end()},
+        {padding.begin(), padding.end()},
+        groups,
+        ideep::scale_t(),
+        ideep::scale_t(),
+        ideep::scale_t(),
+        attr);
+  }
+  return y;
+}
+
+Tensor mkldnn_convolution(
+    const Tensor& input,
+    const ideep::tensor& mkldnn_weight,
+    const c10::optional<Tensor>& bias_opt,
+    IntArrayRef padding,
+    IntArrayRef stride,
+    IntArrayRef dilation,
+    int64_t groups,
+    const ideep::attr_t& attr = ideep::attr_t()) {
+  c10::MaybeOwned<Tensor> bias_maybe_owned =
+      at::borrow_from_optional_tensor(bias_opt);
+  const Tensor& bias = *bias_maybe_owned;
+  const ideep::tensor mkldnn_input = itensor_from_tensor(input);
+  c10::optional<ideep::tensor> mkldnn_bias{c10::nullopt};
+  if (bias.defined()) {
+    mkldnn_bias = itensor_from_tensor(bias);
+  }
+
+  ideep::tensor mkldnn_output = _mkldnn_convolution(
+      mkldnn_input,
+      mkldnn_weight,
+      mkldnn_bias,
+      padding,
+      stride,
+      dilation,
+      groups,
+      attr);
+
+  return mkldnn_to_dense(new_with_itensor_mkldnn(
+      std::move(mkldnn_output),
+      optTypeMetaToScalarType(input.options().dtype_opt()),
+      input.options().device_opt()));
+}
+
+Tensor run(ContextConv2D& context, const Tensor& input) {
+  return mkldnn_convolution(
+      input,
+      context.weight_packed_,
+      context.at_bias_,
+      context.padding_,
+      context.stride_,
+      context.dilation_,
+      context.groups_,
+      context.attr_);
+}
+
+Tensor conv2d_run(
+    const Tensor& input,
+    const c10::intrusive_ptr<mkldnn::Conv2dOpContext>& op_context) {
+  return op_context->run(input);
+}
+
+} // namespace convolution2d
+} // namespace internal
+} // namespace mkldnn
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/mkldnn/ConvPrepack.cpp
+++ b/aten/src/ATen/native/mkldnn/ConvPrepack.cpp
@@ -60,6 +60,7 @@ ContextConv2D create(
   const auto input_size_expanded =
       expand_param_if_needed(input_size, "input_size", 4);
 
+  c10::impl::ExcludeDispatchKeyGuard edkg(c10::autograd_dispatch_keyset);
   auto w = itensor_view_from_dense(weight);
   ideep::tensor::desc expected_weight_desc =
       ideep::convolution_forward::expected_weights_desc(
@@ -152,6 +153,8 @@ Tensor mkldnn_convolution(
   c10::MaybeOwned<Tensor> bias_maybe_owned =
       at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
+
+  c10::impl::ExcludeDispatchKeyGuard edkg(c10::autograd_dispatch_keyset);
   const ideep::tensor mkldnn_input = itensor_from_tensor(input);
   c10::optional<ideep::tensor> mkldnn_bias{c10::nullopt};
   if (bias.defined()) {

--- a/aten/src/ATen/native/mkldnn/ConvPrepack.h
+++ b/aten/src/ATen/native/mkldnn/ConvPrepack.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+#include <ATen/native/mkldnn/Common.h>
+#include <ATen/native/mkldnn/OpContext.h>
+#include <c10/util/string_view.h>
+
+namespace at {
+namespace native {
+namespace mkldnn {
+namespace internal {
+namespace convolution2d {
+
+// These constants control the fusion behavior of convolution.
+enum AttrType {
+  None, // No fusion
+  ReLU, // ReLU fusion
+  END
+};
+
+static AttrType get_attrtype_enum(const c10::string_view attr) {
+  if (attr == "none") {
+    return AttrType::None;
+  } else if (attr == "relu") {
+    return AttrType::ReLU;
+  } else {
+    TORCH_CHECK(false, "unknown attr argument: ", attr);
+  }
+}
+
+c10::intrusive_ptr<mkldnn::Conv2dOpContext> createConv2dPrePackOpContext(
+    Tensor weight,
+    c10::optional<Tensor> bias,
+    std::vector<int64_t> stride,
+    std::vector<int64_t> padding,
+    std::vector<int64_t> dilation,
+    int64_t groups,
+    std::vector<int64_t> input_size,
+    c10::string_view attr);
+
+Tensor conv2d_run(
+    const Tensor& input,
+    const c10::intrusive_ptr<mkldnn::Conv2dOpContext>& op_context);
+
+ContextConv2D create(
+    const Tensor& weight,
+    const c10::optional<Tensor>& bias,
+    const IntArrayRef padding,
+    const IntArrayRef stride,
+    const IntArrayRef dilation,
+    const int64_t groups,
+    const IntArrayRef input_size,
+    const ideep::attr_t& attr);
+
+Tensor run(ContextConv2D& context, const Tensor& input);
+
+} // namespace convolution2d
+} // namespace internal
+} // namespace mkldnn
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/mkldnn/ConvPrepack.h
+++ b/aten/src/ATen/native/mkldnn/ConvPrepack.h
@@ -5,6 +5,8 @@
 #include <ATen/native/mkldnn/OpContext.h>
 #include <c10/util/string_view.h>
 
+#if AT_MKLDNN_ENABLED()
+
 namespace at {
 namespace native {
 namespace mkldnn {
@@ -59,3 +61,5 @@ Tensor run(ContextConv2D& context, const Tensor& input);
 } // namespace mkldnn
 } // namespace native
 } // namespace at
+
+#endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/OpContext.cpp
+++ b/aten/src/ATen/native/mkldnn/OpContext.cpp
@@ -1,6 +1,8 @@
 #include <ATen/native/mkldnn/ConvPrepack.h>
 #include <ATen/native/mkldnn/OpContext.h>
 
+#if AT_MKLDNN_ENABLED()
+
 namespace at {
 namespace native {
 namespace mkldnn {
@@ -37,3 +39,5 @@ Tensor MkldnnConv2dOpContext::run(const Tensor& input) {
 } // namespace mkldnn
 } // namespace native
 } // namespace at
+
+#endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/OpContext.cpp
+++ b/aten/src/ATen/native/mkldnn/OpContext.cpp
@@ -1,0 +1,39 @@
+#include <ATen/native/mkldnn/ConvPrepack.h>
+#include <ATen/native/mkldnn/OpContext.h>
+
+namespace at {
+namespace native {
+namespace mkldnn {
+
+c10::intrusive_ptr<Conv2dOpContext> MkldnnConv2dOpContext::create_context(
+    at::Tensor&& weight,
+    c10::optional<at::Tensor>&& bias,
+    std::vector<int64_t>&& padding,
+    std::vector<int64_t>&& stride,
+    std::vector<int64_t>&& dilation,
+    int64_t groups,
+    std::vector<int64_t>&& input_size,
+    const ideep::attr_t& attr) {
+  auto op_context = mkldnn::internal::convolution2d::create(
+      weight, bias, padding, stride, dilation, groups, input_size, attr);
+
+  auto conv2d_op_context = c10::make_intrusive<MkldnnConv2dOpContext>(
+      std::move(weight),
+      std::move(bias),
+      std::move(padding),
+      std::move(stride),
+      std::move(dilation),
+      groups,
+      std::move(input_size),
+      std::move(op_context));
+
+  return conv2d_op_context;
+}
+
+Tensor MkldnnConv2dOpContext::run(const Tensor& input) {
+  return mkldnn::internal::convolution2d::run(op_context_, input);
+}
+
+} // namespace mkldnn
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/mkldnn/OpContext.h
+++ b/aten/src/ATen/native/mkldnn/OpContext.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+#include <ATen/core/ivalue.h>
+#include <ATen/native/mkldnn/Common.h>
+
+namespace at {
+namespace native {
+namespace mkldnn {
+
+using SerializationTypeConv2dPrePack = std::tuple<
+    Tensor,
+    c10::optional<Tensor>,
+    std::vector<int64_t>,
+    std::vector<int64_t>,
+    std::vector<int64_t>,
+    int64_t,
+    std::vector<int64_t>,
+    c10::string_view>;
+
+class Conv2dOpContext : public torch::jit::CustomClassHolder {
+ protected:
+  Tensor orig_weight_;
+  c10::optional<Tensor> orig_bias_;
+  std::vector<int64_t> stride_;
+  std::vector<int64_t> padding_;
+  std::vector<int64_t> dilation_;
+  int64_t groups_;
+  std::vector<int64_t> input_size_;
+  c10::string_view attr_;
+
+ public:
+  SerializationTypeConv2dPrePack unpack() {
+    return std::make_tuple(
+        orig_weight_,
+        orig_bias_,
+        stride_,
+        padding_,
+        dilation_,
+        groups_,
+        input_size_,
+        attr_);
+  }
+
+  virtual Tensor run(const Tensor& input) = 0;
+};
+
+class MkldnnConv2dOpContext final : public Conv2dOpContext {
+ private:
+  ContextConv2D op_context_;
+
+ public:
+  MkldnnConv2dOpContext(
+      Tensor&& weight,
+      c10::optional<Tensor>&& bias,
+      std::vector<int64_t>&& padding,
+      std::vector<int64_t>&& stride,
+      std::vector<int64_t>&& dilation,
+      uint64_t groups,
+      std::vector<int64_t>&& input_size,
+      ContextConv2D&& op_context)
+      : op_context_(std::move(op_context)) {
+    orig_weight_ = std::move(weight);
+    orig_bias_ = std::move(bias);
+    padding_ = std::move(padding);
+    stride_ = std::move(stride);
+    dilation_ = std::move(dilation);
+    groups_ = groups;
+    input_size_ = std::move(input_size);
+  }
+
+  Tensor run(const Tensor& input) override;
+
+  static c10::intrusive_ptr<Conv2dOpContext> create_context(
+      Tensor&& weight,
+      c10::optional<Tensor>&& bias,
+      std::vector<int64_t>&& padding,
+      std::vector<int64_t>&& stride,
+      std::vector<int64_t>&& dilation,
+      int64_t groups,
+      std::vector<int64_t>&& input_size,
+      const ideep::attr_t& attr);
+};
+
+} // namespace mkldnn
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/mkldnn/OpContext.h
+++ b/aten/src/ATen/native/mkldnn/OpContext.h
@@ -4,6 +4,8 @@
 #include <ATen/core/ivalue.h>
 #include <ATen/native/mkldnn/Common.h>
 
+#if AT_MKLDNN_ENABLED()
+
 namespace at {
 namespace native {
 namespace mkldnn {
@@ -85,3 +87,5 @@ class MkldnnConv2dOpContext final : public Conv2dOpContext {
 } // namespace mkldnn
 } // namespace native
 } // namespace at
+
+#endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
+++ b/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
@@ -4,6 +4,8 @@
 #include <torch/custom_class.h>
 #include <torch/library.h>
 
+#if AT_MKLDNN_ENABLED()
+
 namespace at {
 namespace native {
 namespace mkldnn {
@@ -55,3 +57,5 @@ TORCH_LIBRARY_IMPL(mkldnn_prepacked, CPU, m) {
 } // namespace mkldnn
 } // namespace native
 } // namespace at
+
+#endif // AT_MKLDNN_ENABLED()

--- a/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
+++ b/aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
@@ -1,0 +1,57 @@
+#include <ATen/Tensor.h>
+#include <ATen/native/mkldnn/ConvPrepack.h>
+#include <ATen/native/mkldnn/OpContext.h>
+#include <torch/custom_class.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace mkldnn {
+
+using namespace internal::convolution2d;
+
+TORCH_LIBRARY(mkldnn, m) {
+  m.class_<Conv2dOpContext>(TORCH_SELECTIVE_CLASS("Conv2dOpContext"))
+      .def_pickle(
+          [](const c10::intrusive_ptr<Conv2dOpContext>& op_context)
+              -> SerializationTypeConv2dPrePack { // __getstate__
+            return op_context->unpack();
+          },
+          [](SerializationTypeConv2dPrePack state)
+              -> c10::intrusive_ptr<Conv2dOpContext> { // __setstate__
+            return createConv2dPrePackOpContext(
+                std::move(std::get<0>(state)),
+                std::move(std::get<1>(state)),
+                std::move(std::get<2>(state)),
+                std::move(std::get<3>(state)),
+                std::move(std::get<4>(state)),
+                // NOLINTNEXTLINE(performance-move-const-arg,cppcoreguidelines-avoid-magic-numbers)
+                std::move(std::get<5>(state)),
+                // NOLINTNEXTLINE(performance-move-const-arg,cppcoreguidelines-avoid-magic-numbers)
+                std::move(std::get<6>(state)),
+                // NOLINTNEXTLINE(performance-move-const-arg,cppcoreguidelines-avoid-magic-numbers)
+                std::move(std::get<7>(state)));
+          });
+}
+
+TORCH_LIBRARY(mkldnn_prepacked, m) {
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "mkldnn_prepacked::conv2d_prepack(Tensor W, Tensor? B, int[2] stride, int[2] padding, int[2] dilation, int groups, int[4] input_size, str attr) -> __torch__.torch.classes.mkldnn.Conv2dOpContext"));
+
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "mkldnn_prepacked::conv2d_run(Tensor X, __torch__.torch.classes.mkldnn.Conv2dOpContext W_prepack) -> Tensor Y"));
+}
+
+TORCH_LIBRARY_IMPL(mkldnn_prepacked, CPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("mkldnn_prepacked::conv2d_prepack"),
+      TORCH_FN(createConv2dPrePackOpContext));
+
+  m.impl(
+      TORCH_SELECTIVE_NAME("mkldnn_prepacked::conv2d_run"),
+      TORCH_FN(conv2d_run));
+}
+
+} // namespace mkldnn
+} // namespace native
+} // namespace at

--- a/test/test_mkldnn_fusion.py
+++ b/test/test_mkldnn_fusion.py
@@ -1,0 +1,83 @@
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch import nn
+import unittest
+
+from torch.testing._internal.common_utils import run_tests
+
+from torch.testing._internal.jit_utils import JitTestCase, TensorExprTestOptions
+
+from test_tensorexpr import warmup_and_run_forward
+
+
+def get_eltwise_fn(name):
+    if hasattr(torch, name):
+        return getattr(torch, name)
+    elif hasattr(F, name):
+        return getattr(F, name)
+    else:
+        raise NameError("Eltwise function %s not found" % name)
+
+
+@unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
+class TestMkldnnFusion(JitTestCase):
+    def _check_model(self, m, x):
+        old = torch._C._debug_get_fusion_group_inlining()
+        torch._C._debug_set_fusion_group_inlining(False)
+        m.eval()
+        with torch.no_grad():
+            script = torch.jit.script(m)
+        script = torch.jit.freeze(script)
+
+        with torch.no_grad():
+            y = warmup_and_run_forward(script, x)
+            y = script(x)
+            y_ref = m(x)
+
+            graph = script.graph_for(*x)
+            self.assertEqual(y, y_ref)
+        torch._C._debug_set_fusion_group_inlining(old)
+        return graph
+
+    def test_conv(self):
+        class M(nn.Module):
+            def __init__(self, in_channels, out_channels, **kwargs):
+                super(M, self).__init__()
+                self.conv = torch.nn.Conv2d(in_channels, out_channels, bias=False, **kwargs)
+
+            def forward(self, x):
+                res = self.conv(x)
+                return res
+
+        m = M(3, 10, kernel_size=(3, 3))
+        x = torch.randn(1, 3, 224, 224)
+        graph = self._check_model(m, x)
+        self.assertAllFused(graph)
+
+    def test_conv_eltwise(self):
+        class M(nn.Module):
+            def __init__(self, eltwise_fn, in_channels, out_channels, **kwargs):
+                super(M, self).__init__()
+                self.conv = torch.nn.Conv2d(in_channels, out_channels, bias=False, **kwargs)
+                self.eltwise = eltwise_fn
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = self.eltwise(x)
+                return x
+
+        for eltwise in ["relu"]:
+            for inplace in [False]:
+                eltwise_fn_name = eltwise + "_" if inplace else eltwise
+                eltwise_fn = get_eltwise_fn(eltwise_fn_name)
+
+                m = M(eltwise_fn, 3, 10, kernel_size=(3, 3))
+                x = torch.randn(1, 3, 224, 224)
+
+                graph = self._check_model(m, x)
+                self.assertAllFused(graph)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -316,6 +316,7 @@ core_sources_full_mobile_no_backend_interface = [
     "torch/csrc/jit/passes/utils/subgraph_utils.cpp",
     "torch/csrc/jit/passes/utils/optimization_utils.cpp",
     "torch/csrc/jit/passes/utils/op_registry.cpp",
+    "torch/csrc/jit/passes/mkldnn_rewrite.cpp",
     "torch/csrc/jit/passes/xnnpack_rewrite.cpp",
     "torch/csrc/jit/passes/vulkan_rewrite.cpp",
     "torch/csrc/jit/passes/metal_rewrite.cpp",

--- a/torch/csrc/jit/passes/mkldnn_rewrite.cpp
+++ b/torch/csrc/jit/passes/mkldnn_rewrite.cpp
@@ -1,0 +1,216 @@
+#include <ATen/core/jit_type.h>
+
+#include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/ir/subgraph_matcher.h>
+#include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/constant_pooling.h>
+#include <torch/csrc/jit/passes/constant_propagation.h>
+#include <torch/csrc/jit/passes/dead_code_elimination.h>
+#include <torch/csrc/jit/passes/fold_conv_bn.h>
+#include <torch/csrc/jit/passes/freeze_module.h>
+#include <torch/csrc/jit/passes/graph_rewrite_helper.h>
+#include <torch/csrc/jit/passes/inliner.h>
+#include <torch/csrc/jit/passes/mkldnn_rewrite.h>
+#include <torch/csrc/jit/passes/remove_dropout.h>
+#include <torch/csrc/jit/passes/subgraph_rewrite.h>
+#include <torch/csrc/jit/runtime/graph_executor_impl.h>
+
+namespace torch {
+namespace jit {
+
+c10::VaryingShape<int64_t> getSizesOf(Node* n, size_t idx) {
+  auto tt = n->input(idx)->type()->cast<TensorType>();
+  return tt->sizes();
+}
+
+bool ndimEquals(c10::VaryingShape<int64_t> sizes, size_t value) {
+  if (!sizes.concrete_sizes()) {
+    return false;
+  }
+  auto concrete_sizes = *sizes.concrete_sizes();
+  if (concrete_sizes.size() != value) {
+    return false;
+  }
+  return true;
+}
+
+void insertPrePackedConvOpForNode(Node* n) {
+  // Need to know all the shapes of input and weight
+  auto input_sizes = getSizesOf(n, /*idx*/ 0);
+  if (!ndimEquals(input_sizes, 4)) {
+    return;
+  }
+
+  auto weight_sizes = getSizesOf(n, /*idx*/ 1);
+  if (!ndimEquals(weight_sizes, 4)) {
+    return;
+  }
+
+  WithInsertPoint guard(n);
+  auto graph = n->owningGraph();
+
+  IValue input_size_value(*input_sizes.concrete_sizes());
+  auto input_size = graph->insertConstant(input_size_value);
+
+  auto prepack_node = graph->create(
+      Symbol::fromQualString("mkldnn_prepacked::conv2d_prepack"), 1);
+
+  // skip input value
+  for (auto i = 1; i < n->inputs().size(); i++) {
+    Value* v = n->input(i);
+    prepack_node->addInput(v);
+  }
+  prepack_node->addInput(input_size);
+  auto attr = graph->insertConstant(IValue("none"));
+  prepack_node->addInput(attr);
+  prepack_node->output()->setType(
+      getCustomClass("__torch__.torch.classes.mkldnn.Conv2dOpContext"));
+  graph->insertNode(prepack_node);
+
+  auto prepack_conv = graph->insertNode(
+      graph->create(Symbol::fromQualString("mkldnn_prepacked::conv2d_run"), 1));
+  prepack_conv->addInput(n->input(0));
+  prepack_conv->addInput(prepack_node->output());
+  prepack_conv->output()->setType(n->output()->type()->cast<TensorType>());
+
+  n->output()->replaceAllUsesWith(prepack_conv->output());
+}
+
+bool canFuseOnDevice(Value* v) {
+  auto type = v->type()->cast<TensorType>();
+  if (!type) {
+    return true;
+  }
+  auto device = type->device();
+  if (!device) {
+    return false;
+  }
+  return device->is_cpu();
+}
+
+bool isFusableOnDevice(Node* node) {
+  for (const auto& input : node->inputs()) {
+    if (!canFuseOnDevice(input)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void insertPrePackedConvOp(Block* b) {
+  for (Node* n : b->nodes()) {
+    for (Block* b : n->blocks()) {
+      insertPrePackedConvOp(b);
+    }
+
+    if (n->kind() == aten::conv2d) {
+      if (isFusableOnDevice(n)) {
+        insertPrePackedConvOpForNode(n);
+      }
+    }
+  }
+  EliminateDeadCode(b);
+}
+
+void insertMkldnnPrePackedConv2dOp(std::shared_ptr<Graph>& graph) {
+  // Replace _convolution with conv2d
+  graph_rewrite_helper::replaceConvolutionWithAtenConv(graph);
+
+  insertPrePackedConvOp(graph->block());
+}
+
+void insertMkldnnPrePackedOps(std::shared_ptr<Graph>& graph) {
+  insertMkldnnPrePackedConv2dOp(graph);
+}
+
+void insertMkldnnPrePackedOps(script::Module& module) {
+  for (auto& method : module.get_methods()) {
+    auto graph = method.graph();
+    insertMkldnnPrePackedOps(graph);
+  }
+  for (script::Module m : module.children()) {
+    insertMkldnnPrePackedOps(m);
+  }
+}
+
+void FuseReluWithPackedOps(std::shared_ptr<Graph>& graph) {
+  SubgraphRewriter rewriter;
+
+  std::string conv2d_prepack_run_relu_fused = R"(
+    graph(%input, %weight, %bias, %stride:int[], %padding:int[],
+          %dilation:int[], %groups:int, %input_size:int[], %dummy_attr:str):
+        %attr: str = prim::Constant[value="relu"]()
+        %packed_weight_bias : __torch__.torch.classes.mkldnn.Conv2dOpContext = mkldnn_prepacked::conv2d_prepack(
+            %weight, %bias, %stride, %padding, %dilation, %groups,
+            %input_size, %attr)
+        %res = mkldnn_prepacked::conv2d_run(%input, %packed_weight_bias)
+        return (%res) )";
+
+  std::string conv2d_prepack_run_relu = R"(
+    graph(%input, %weight, %bias, %stride:int[], %padding:int[],
+          %dilation:int[], %groups:int, %input_size:int[], %dummy_attr:str):
+        %packed_weight_bias = mkldnn_prepacked::conv2d_prepack(
+            %weight, %bias, %stride, %padding, %dilation, %groups,
+            %input_size, %dummy_attr)
+        %conv2d_res = mkldnn_prepacked::conv2d_run(%input, %packed_weight_bias)
+        %res = aten::relu(%conv2d_res)
+        return (%res) )";
+
+  rewriter.RegisterRewritePattern(
+      conv2d_prepack_run_relu, conv2d_prepack_run_relu_fused);
+  rewriter.runOnGraph(graph);
+}
+
+void PrePackingOpsFolder(Block* b) {
+  auto is_foldable_op = [](const Node* n) -> bool {
+    return (
+        n->kind() ==
+        Symbol::fromQualString("mkldnn_prepacked::conv2d_prepack"));
+  };
+
+  std::unordered_set<Node*> nodes_to_delete;
+  for (Node* n : b->nodes()) {
+    for (Block* block : n->blocks()) {
+      PrePackingOpsFolder(block);
+    }
+    if (is_foldable_op(n)) {
+      auto optional_outputs = torch::jit::runNodeIfInputsAreConstant(n);
+      if (optional_outputs) {
+        auto outputs = optional_outputs.value();
+        TORCH_CHECK(outputs.size() == 1, "Prepack ops have single output");
+        Value* prepack_op_value = n->output(0);
+        auto graph = n->owningGraph();
+        WithInsertPoint ins(prepack_op_value->node());
+        auto weak_class_obj =
+            outputs[0].toObject()->copy_to_weak_compilation_ref();
+        Value* packed_weight = graph->insertConstant(weak_class_obj)
+                                   ->setType(n->output(0)->type());
+        prepack_op_value->replaceAllUsesWith(packed_weight);
+        nodes_to_delete.insert(n);
+      }
+    }
+  }
+  for (auto n : nodes_to_delete) {
+    n->removeAllInputs();
+  }
+  for (auto n : nodes_to_delete) {
+    n->destroy();
+  }
+}
+
+void FoldPrePackingOps(std::shared_ptr<Graph>& graph) {
+  PrePackingOpsFolder(graph->block());
+}
+
+void FuseMkldnn(std::shared_ptr<Graph>& graph) {
+  insertMkldnnPrePackedOps(graph);
+  GRAPH_DEBUG(
+      "After insertMkldnnPrePackedOps, before FuseReluWithPackedOps\n", *graph);
+  FuseReluWithPackedOps(graph);
+  GRAPH_DEBUG(
+      "After FuseReluWithPackedOps, before FoldPrePackingOps\n", *graph);
+  FoldPrePackingOps(graph);
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/mkldnn_rewrite.h
+++ b/torch/csrc/jit/passes/mkldnn_rewrite.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <torch/csrc/jit/api/module.h>
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch {
+namespace jit {
+
+TORCH_API void FuseMkldnn(std::shared_ptr<Graph>& graph);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/mkldnn_rewrite.h
+++ b/torch/csrc/jit/passes/mkldnn_rewrite.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/Config.h>
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/ir/ir.h>
 

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 
+#include <ATen/Config.h>
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/symbol.h>
 #include <ATen/record_function.h>
@@ -70,9 +71,13 @@ Value* broadcastSizes(at::ArrayRef<Value*> sizes, AliasDb* db) {
 namespace tensorexpr {
 
 OperatorSet& getCustomOperatorSet() {
-  static OperatorSet _g_custom_operator_set{
-      "mkldnn_prepacked::conv2d_run(Tensor X, __torch__.torch.classes.mkldnn.Conv2dOpContext W_prepack) -> (Tensor Y)",
-  };
+  static OperatorSet _g_custom_operator_set{};
+
+#if AT_MKLDNN_ENABLED()
+  _g_custom_operator_set.insert(
+      {"mkldnn_prepacked::conv2d_run(Tensor X, __torch__.torch.classes.mkldnn.Conv2dOpContext W_prepack) -> (Tensor Y)"});
+#endif // AT_MKLDNN_ENABLED()
+
   return _g_custom_operator_set;
 }
 

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -70,7 +70,9 @@ Value* broadcastSizes(at::ArrayRef<Value*> sizes, AliasDb* db) {
 namespace tensorexpr {
 
 OperatorSet& getCustomOperatorSet() {
-  static OperatorSet _g_custom_operator_set{};
+  static OperatorSet _g_custom_operator_set{
+      "mkldnn_prepacked::conv2d_run(Tensor X, __torch__.torch.classes.mkldnn.Conv2dOpContext W_prepack) -> (Tensor Y)",
+  };
   return _g_custom_operator_set;
 }
 

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -25,6 +25,7 @@
 #include <torch/csrc/jit/passes/loop_unrolling.h>
 #include <torch/csrc/jit/passes/lower_grad_of.h>
 #include <torch/csrc/jit/passes/lower_tuples.h>
+#include <torch/csrc/jit/passes/mkldnn_rewrite.h>
 #include <torch/csrc/jit/passes/pass_manager.h>
 #include <torch/csrc/jit/passes/peephole.h>
 #include <torch/csrc/jit/passes/remove_expands.h>
@@ -428,8 +429,10 @@ void ProfilingGraphExecutorImpl::runNoGradOptimizations(
       // accidentally used by any other pass.
       RemoveProfileNodesAndSpecializeTypes(graph);
       GRAPH_DEBUG(
-          "After RemoveProfileNodesAndSpecializeTypes, before BatchMM\n",
+          "After RemoveProfileNodesAndSpecializeTypes, before FuseMkldnn\n",
           *graph);
+      FuseMkldnn(graph);
+      GRAPH_DEBUG("After FuseMkldnn, before BatchMM\n", *graph);
       // Rewrite subgraphs with many MMs into expressions that batch them.
       BatchMM(graph);
       GRAPH_DEBUG("After BatchMM, before Fusion\n", *graph);

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -1412,6 +1412,8 @@ void nnc_aten_triangular_solve(
   }
 }
 
+#if AT_MKLDNN_ENABLED()
+
 void nnc_mkldnn_prepacked_conv2d_run(
     int64_t bufs_num,
     void** buf_data,
@@ -1432,6 +1434,8 @@ void nnc_mkldnn_prepacked_conv2d_run(
   memcpy(
       buf_data[0], output.data_ptr(), output.element_size() * output.numel());
 }
+
+#endif // AT_MKLDNN_ENABLED()
 
 #ifdef USE_XNNPACK
 
@@ -1611,9 +1615,11 @@ const static RegisterNNCExternalFunction nnc_embedding(
     "nnc_aten_embedding",
     nnc_aten_embedding);
 
+#if AT_MKLDNN_ENABLED()
 const static RegisterNNCExternalFunction reg_nnc_mkldnn_prepacked_conv2d_run(
     "nnc_mkldnn_prepacked_conv2d_run",
     nnc_mkldnn_prepacked_conv2d_run);
+#endif // AT_MKLDNN_ENABLED()
 
 #ifdef USE_XNNPACK
 const static RegisterNNCExternalFunction reg_nnc_prepacked_linear_clamp_run(

--- a/torch/csrc/jit/tensorexpr/lowerings.cpp
+++ b/torch/csrc/jit/tensorexpr/lowerings.cpp
@@ -44,6 +44,10 @@ int nnc_lowerings_lazy_registration() {
       computePrepackedLinearClampRun);
 #endif
 
+  RegisterNNCLoweringsFunction mkldnn_prepacked_conv2d_run(
+      {"mkldnn_prepacked::conv2d_run(Tensor X, __torch__.torch.classes.mkldnn.Conv2dOpContext W_prepack) -> (Tensor Y)"},
+      computeMkldnnPrepackedConv2dRun);
+
   RegisterNNCLoweringsFunction aten_sub(
       {"aten::sub.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> (Tensor)",
        "aten::sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> (Tensor)"},

--- a/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/conv2d.cpp
@@ -421,6 +421,24 @@ Tensor computePrepackedLinearClampRun(
   return Tensor(ResultBuf.node(), s);
 }
 
+Tensor computeMkldnnPrepackedConv2dRun(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device) {
+  Dtype dtype = kFloat;
+  if (outputType) {
+    dtype = Dtype(*outputType);
+  }
+
+  BufHandle ResultBuf("mkldnn_prepacked_conv2d_run", outputShape, dtype);
+  const BufHandle& inp = c10::get<BufHandle>(inputs[0]);
+  const BufHandle& prepacked = c10::get<BufHandle>(inputs[1]);
+  StmtPtr s = ExternalCall::make(
+      ResultBuf, "nnc_mkldnn_prepacked_conv2d_run", {inp, prepacked}, {});
+  return Tensor(ResultBuf.node(), s);
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/operators/conv2d.h
+++ b/torch/csrc/jit/tensorexpr/operators/conv2d.h
@@ -83,7 +83,11 @@ Tensor computePrepackedLinearClampRun(
     const std::vector<ExprHandle>& outputShape,
     const c10::optional<ScalarType>& outputType,
     at::Device device);
-
+Tensor computeMkldnnPrepackedConv2dRun(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const c10::optional<ScalarType>& outputType,
+    at::Device device);
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
## Pitch
Enable MKLDNN OP fusion for convolution

## Description
1. Rewrite the graph to insert MKLDNN prepack and run OPs for conv2d when the below conditions are met:

- the device is CPU
- inference mode
- MKLDNN is enabled
- the concrete shapes of input and weight are known

2. Fuse elementwise OPs (ReLU currently) with the MKLDNN prepack and run convolution OPs.

3. Enable tensorexpr fuser to support fused MKLDNN conv2d run OPs via external call.

## Code structure
Graph rewrite pass related code is placed in:
```
torch/csrc/jit/passes/mkldnn_rewrite.h
torch/csrc/jit/passes/mkldnn_rewrite.cpp
```

MKLDNN prepack OP context is in:
```
aten/src/ATen/native/mkldnn/Common.h
aten/src/ATen/native/mkldnn/RegisterMkldnnOpContextClass.cpp
aten/src/ATen/native/mkldnn/OpContext.h
aten/src/ATen/native/mkldnn/OpContext.cpp
```

MKLDNN prepack OP implementation is done in:
```
aten/src/ATen/native/mkldnn/ConvPrepack.h
aten/src/ATen/native/mkldnn/ConvPrepack.cpp
```

NNC integration of MKLDNN prepack OP via external call is located in:
```
torch/csrc/jit/tensorexpr/operators/conv2d.h
torch/csrc/jit/tensorexpr/operators/conv2d.cpp

torch/csrc/jit/tensorexpr/lowerings.cpp
torch/csrc/jit/tensorexpr/external_functions.cpp
```

## UT
```
test/test_mkldnn_fusion.py
```