### PR TITLE
Fix `mean` bug for integral tensors.

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -212,11 +212,16 @@ TORCH_META_FUNC2(mean, dim)
 (const Tensor& self, IntArrayRef dim, bool keepdim, optional<ScalarType> opt_dtype) {
   auto in_dtype = at::native::get_dtype_from_self(self, opt_dtype, true);
 
+  std::string opt_dtype_str("None");
+  if (opt_dtype.has_value()) {
+    opt_dtype_str = toString(opt_dtype.value());
+  }
+
   TORCH_CHECK(
       at::isFloatingType(in_dtype) || at::isComplexType(in_dtype),
       "mean(): at least one of (i) the input dtype and (ii) the desired output dtype should be "
       "either floating point or complex. "
-      "Got (i) ", self.scalar_type(), " and (ii) ", opt_dtype, " instead.");
+      "Got (i) ", self.scalar_type(), " and (ii) ", opt_dtype_str, " instead.");
 
   auto out_dtype = infer_dtype_from_optional(self, dim, keepdim, opt_dtype, maybe_get_output());
   resize_reduction(*this, self, dim, keepdim, out_dtype);

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -201,27 +201,22 @@ TORCH_META_FUNC2(prod, dim_int)
   resize_reduction(*this, self, dim, keepdim, out_dtype);
 }
 
-void check_floating_or_complex_dtype(const char* name, ScalarType dtype) {
-  TORCH_CHECK(
-      at::isFloatingType(dtype) || at::isComplexType(dtype),
-      name, "(): input dtype should be either floating point or complex dtypes. "
-      "Got ", toString(dtype), " instead.");
-}
-
 TORCH_META_FUNC2(mean, dim)
 (const Tensor& self, IntArrayRef dim, bool keepdim, optional<ScalarType> opt_dtype) {
   auto in_dtype = at::native::get_dtype_from_self(self, opt_dtype, true);
 
-  std::string opt_dtype_str("None");
-  if (opt_dtype.has_value()) {
-    opt_dtype_str = toString(opt_dtype.value());
-  }
+  if (!at::isFloatingType(in_dtype) && !at::isComplexType(in_dtype)) {
+    std::string opt_dtype_str("None");
+    if (opt_dtype.has_value()) {
+      opt_dtype_str = toString(opt_dtype.value());
+    }
 
-  TORCH_CHECK(
-      at::isFloatingType(in_dtype) || at::isComplexType(in_dtype),
-      "mean(): at least one of (i) the input dtype and (ii) the desired output dtype should be "
-      "either floating point or complex. "
-      "Got (i) ", self.scalar_type(), " and (ii) ", opt_dtype_str, " instead.");
+    TORCH_CHECK(
+        false,
+        "mean(): at least one of (i) the input dtype and (ii) the desired output dtype should be "
+        "either floating point or complex. "
+        "Got (i) ", self.scalar_type(), " and (ii) ", opt_dtype_str, " instead.");
+  }
 
   auto out_dtype = infer_dtype_from_optional(self, dim, keepdim, opt_dtype, maybe_get_output());
   resize_reduction(*this, self, dim, keepdim, out_dtype);

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -206,16 +206,19 @@ TORCH_META_FUNC2(mean, dim)
   auto in_dtype = at::native::get_dtype_from_self(self, opt_dtype, true);
 
   if (!at::isFloatingType(in_dtype) && !at::isComplexType(in_dtype)) {
-    std::string opt_dtype_str("None");
+    std::string what = "Input";
+    std::string dtype = toString(self.scalar_type());
+
     if (opt_dtype.has_value()) {
-      opt_dtype_str = toString(opt_dtype.value());
+      what = "Optional";
+      dtype = toString(opt_dtype.value());
     }
 
     TORCH_CHECK(
         false,
-        "mean(): at least one of (i) the input dtype and (ii) the desired output dtype should be "
-        "either floating point or complex. "
-        "Got (i) ", self.scalar_type(), " and (ii) ", opt_dtype_str, " instead.");
+        "mean(): could not infer output dtype. ",
+        what, " dtype must be either a floating point or complex dtype. ",
+        "Got: ", dtype);
   }
 
   auto out_dtype = infer_dtype_from_optional(self, dim, keepdim, opt_dtype, maybe_get_output());

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -749,7 +749,7 @@ class TestReductions(TestCase):
         a = make_tensor((3, 4, 5), dtype=torch.int64, device=device)
 
         # Can't compute mean of integral tensors.
-        with self.assertRaisesRegex(RuntimeError, fr"mean\(\): at least one of .* Got \(i\) Long and \(ii\) None"):
+        with self.assertRaisesRegex(RuntimeError, r"mean\(\): at least one of .* Got \(i\) Long and \(ii\) None"):
             a.mean()
 
 
@@ -763,7 +763,7 @@ class TestReductions(TestCase):
         self.assertEqual(a_float.mean(), a.mean(dtype=torch.float32))
 
         # Error if desired output dtype mismatches
-        with self.assertRaisesRegex(RuntimeError, fr".* out tensor to have dtype double, but got float instead"):
+        with self.assertRaisesRegex(RuntimeError, r".* out tensor to have dtype double, but got float instead"):
             torch.mean(a, [], dtype=torch.float64, out=a_float)
 
     # TODO: update this and tests that use it to handle device properly

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -744,6 +744,19 @@ class TestReductions(TestCase):
             lambda n, d: logsumexp(n, d),
             use_integral=False)
 
+    @onlyCPU
+    def test_mean_int_with_optdtype(self, device):
+        a = make_tensor((3, 4, 5), dtype=torch.int64, device=device)
+
+        # Can't compute mean of integral tensors.
+        with self.assertRaisesRegex(RuntimeError, f"mean(): at least one of .* Got (i) Long and (ii) None"):
+            a.mean()
+
+        # If the optional desired output type is given, the input
+        # is internally cast.
+        a_float = a.to(torch.float32)
+        self.assertEqual(a_float.mean(), a.mean(dtype=torch.float32))
+
     # TODO: update this and tests that use it to handle device properly
     def _test_reduce_integer_upcast(self, fn, has_out=True, test_complex=True):
         shape = (3, 4, 5)

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -745,15 +745,6 @@ class TestReductions(TestCase):
             use_integral=False)
 
     @onlyCPU
-    def test_mean_int(self, device):
-        a = make_tensor((3, 4, 5), dtype=torch.int64, device=device)
-
-        # Can't compute mean of integral tensors.
-        with self.assertRaisesRegex(RuntimeError, r"mean\(\): at least one of .* Got \(i\) Long and \(ii\) None"):
-            a.mean()
-
-
-    @onlyCPU
     def test_mean_int_with_optdtype(self, device):
         a = make_tensor((3, 4, 5), dtype=torch.int64, device=device)
 
@@ -761,10 +752,6 @@ class TestReductions(TestCase):
         # is internally cast.
         a_float = a.to(torch.float32)
         self.assertEqual(a_float.mean(), a.mean(dtype=torch.float32))
-
-        # Error if desired output dtype mismatches
-        with self.assertRaisesRegex(RuntimeError, r".* out tensor to have dtype double, but got float instead"):
-            torch.mean(a, [], dtype=torch.float64, out=a_float)
 
     # TODO: update this and tests that use it to handle device properly
     def _test_reduce_integer_upcast(self, fn, has_out=True, test_complex=True):

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -745,17 +745,26 @@ class TestReductions(TestCase):
             use_integral=False)
 
     @onlyCPU
-    def test_mean_int_with_optdtype(self, device):
+    def test_mean_int(self, device):
         a = make_tensor((3, 4, 5), dtype=torch.int64, device=device)
 
         # Can't compute mean of integral tensors.
-        with self.assertRaisesRegex(RuntimeError, f"mean(): at least one of .* Got (i) Long and (ii) None"):
+        with self.assertRaisesRegex(RuntimeError, fr"mean\(\): at least one of .* Got \(i\) Long and \(ii\) None"):
             a.mean()
+
+
+    @onlyCPU
+    def test_mean_int_with_optdtype(self, device):
+        a = make_tensor((3, 4, 5), dtype=torch.int64, device=device)
 
         # If the optional desired output type is given, the input
         # is internally cast.
         a_float = a.to(torch.float32)
         self.assertEqual(a_float.mean(), a.mean(dtype=torch.float32))
+
+        # Error if desired output dtype mismatches
+        with self.assertRaisesRegex(RuntimeError, fr".* out tensor to have dtype double, but got float instead"):
+            torch.mean(a, [], dtype=torch.float64, out=a_float)
 
     # TODO: update this and tests that use it to handle device properly
     def _test_reduce_integer_upcast(self, fn, has_out=True, test_complex=True):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17076,6 +17076,10 @@ op_db: List[OpInfo] = [
         nan_policy='propagate',
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
+        # FIXME: mean needs 'dim' parameter when using the 'out' overload.
+        # Adding it with 'generate_args_kwargs' does not work, since these also get passed
+        # onto the reference implementations.
+        supports_out=False,
         assert_autodiffed=True,
         assert_jit_shape_analysis=True,
         promotes_int_to_float=True,
@@ -17083,11 +17087,6 @@ op_db: List[OpInfo] = [
         ref=reference_reduction_numpy(np.mean),
         error_inputs_func=error_inputs_mean,
         skips=(
-            # FIXME: mean needs 'dim' parameter when using the 'out' overload.
-            # Adding it with 'generate_args_kwargs' does not work, since these also get passed
-            # onto the reference implementations.
-            DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_out'),
-            DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_out_warning'),
             # FIXME: mean does not support passing keepdim without passing dim
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_default_keepdim'),
             # FIXME: mean reduces all dimensions when dim=[]

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9466,15 +9466,23 @@ def generate_std_var_kwargs(t: torch.Tensor, **kwargs):
         yield ((), {'correction': numel // 2})
 
 def error_inputs_mean(op_info, device, **kwargs):
-    err_msg1 = (r"mean\(\): at least one of \(i\) the input dtype and "
-                r"\(ii\) the desired output dtype should be either floating point or complex. "
-                r"Got \(i\) Long and \(ii\) None instead.")
+    err_msg1 = (r"mean\(\): could not infer output dtype. "
+                r"Input dtype must be either a floating point or complex dtype. "
+                r"Got: Long")
     si1 = SampleInput(
         make_tensor((3, 4, 5), dtype=torch.int64, device=device),
         args=([],))
 
-    err_msg2 = "Expected out tensor to have dtype double, but got float instead"
+    err_msg2 = (r"mean\(\): could not infer output dtype. "
+                r"Optional dtype must be either a floating point or complex dtype. "
+                r"Got: Long")
     si2 = SampleInput(
+        make_tensor((3, 4, 5), dtype=torch.float32, device=device),
+        args=([],),
+        kwargs={"dtype": torch.int64})
+
+    err_msg3 = "Expected out tensor to have dtype double, but got float instead"
+    si3 = SampleInput(
         make_tensor((3, 4, 5), dtype=torch.int64, device=device),
         args=([],),
         kwargs={
@@ -9483,7 +9491,8 @@ def error_inputs_mean(op_info, device, **kwargs):
         })
 
     return (ErrorInput(si1, error_regex=err_msg1),
-            ErrorInput(si2, error_regex=err_msg2))
+            ErrorInput(si2, error_regex=err_msg2),
+            ErrorInput(si3, error_regex=err_msg3))
 
 # Operator database (sorted alphabetically)
 op_db: List[OpInfo] = [


### PR DESCRIPTION
Fixes #76430 

**The Problem:** `opt_dtype` wasn't being taken into consideration when checking whether the input dtype was either floating point or complex dtype.

**The Solution:** run those checks with the dtype returned by `get_dtype_from_self(self, opt_dtype, true)`.

This fix restores the original behavior, before #61643. It also improves the error message so that the user better comprehends what happened. Finally, I also added 2 tests for ensuring the issue was fixed

-----
#### Before

```python
>>> a = torch.randint(0, 5, (5, 5), dtype=torch.int64)
>>> b = torch.tensor([], dtype=torch.float32)

>>> a.mean() # no dtype
RuntimeError: mean(): input dtype should be either floating point or complex dtypes. Got Long instead.

>>> a.mean(dtype=torch.float32) # with dtype
RuntimeError: mean(): input dtype should be either floating point or complex dtypes. Got Long instead.

>>> torch.mean(a, [], dtype=torch.float64, out=b) # with mismatching dtype and out dtype
RuntimeError: mean(): input dtype should be either floating point or complex dtypes. Got Long instead.
```

#### After

```python
>>> a = torch.randint(0, 5, (5, 5), dtype=torch.int64)
>>> b = torch.tensor([], dtype=torch.float32)

>>> a.mean() # no dtype
RuntimeError: mean(): at least one of (i) the input dtype and (ii) the desired output dtype should be either floating point or complex. Got (i) Long and (ii) None instead.

>>> a.mean(dtype=torch.float32) # with dtype
tensor(1.6800)

>>> torch.mean(a, [], dtype=torch.float64, out=b) # with mismatching dtype and out dtype
RuntimeError: Expected out tensor to have dtype double, but got float instead
```