### PR TITLE
Upstream `argmax` shape function.

### DIFF
--- a/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
+++ b/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
@@ -4,7 +4,7 @@
  * This is an auto-generated file. Please do not modify it by hand.
  * To re-generate, please run:
  * cd ~/pytorch && python
- * tools/codegen/shape_functions/gen_jit_shape_functions.py
+ * torchgen/shape_functions/gen_jit_shape_functions.py
  */
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/inliner.h>
@@ -2332,6 +2332,47 @@ def transpose(self: List[int],
   return expandedSizes
 
 )=====")
++ std::string(R"=====(def argmax(self: List[int],
+    dim: Optional[int]=None,
+    keepdim: bool=False) -> List[int]:
+  if torch.__is__(dim, None):
+    _0 = annotate(List[int], [])
+  else:
+    dim0 = unchecked_cast(int, dim)
+    _1 = torch.len(self)
+    if torch.le(_1, 0):
+      dim_post_expr = 1
+    else:
+      dim_post_expr = _1
+    min = torch.neg(dim_post_expr)
+    max = torch.sub(dim_post_expr, 1)
+    if torch.lt(dim0, min):
+      _2 = True
+    else:
+      _2 = torch.gt(dim0, max)
+    if torch.__not__(_2):
+      pass
+    else:
+      ops.prim.RaiseException("AssertionError: ")
+    if torch.lt(dim0, 0):
+      dim1 = torch.add(dim0, dim_post_expr)
+    else:
+      dim1 = dim0
+    out = annotate(List[int], [])
+    _3 = [9223372036854775807, torch.len(self)]
+    for i in range(ops.prim.min(_3)):
+      self_dim = self[i]
+      if torch.eq(i, dim1):
+        if keepdim:
+          _4 = torch.append(out, 1)
+        else:
+          pass
+      else:
+        _5 = torch.append(out, self_dim)
+    _0 = out
+  return _0
+
+)=====")
 + std::string(R"=====(def broadcast_three(a: List[int],
     b: List[int],
     c: List[int]) -> List[int]:
@@ -2544,6 +2585,7 @@ const OperatorMap<std::string>& GetShapeFunctionMappings() {
     {"aten::quantize_per_tensor.tensor_qparams(Tensor self, Tensor scale, Tensor zero_point, ScalarType dtype) -> Tensor", "unary"},
     {"aten::dequantize(Tensor self) -> Tensor", "unary"},
     {"quantized::add(Tensor qa, Tensor qb, float scale, int zero_point) -> Tensor qc", "broadcast"},
+    {"aten::argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor", "argmax"},
     {"aten::lerp.Tensor(Tensor self, Tensor end, Tensor weight) -> Tensor", "broadcast_three"},
     {"aten::where.ScalarSelf(Tensor condition, Scalar self, Tensor other) -> Tensor", "broadcast_one_three"},
     {"aten::add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)", "broadcast_inplace"},

--- a/torch/jit/_shape_functions.py
+++ b/torch/jit/_shape_functions.py
@@ -837,6 +837,22 @@ def flatten(input: List[int], start_dim: int, end_dim: int):
         shape.append(input[i])
     return shape
 
+def _reduce_along_dim(self: List[int], dim: int, keepdim: bool):
+    dim = maybe_wrap_dim(dim, len(self))
+    out: List[int] = []
+    for i, self_dim in enumerate(self):
+        if i == dim:
+            if keepdim:
+                out.append(1)
+        else:
+            out.append(self_dim)
+    return out
+
+def argmax(self: List[int], dim: Optional[int] = None, keepdim: bool = False) -> List[int]:
+    if dim is None:
+        return []
+    return _reduce_along_dim(self, dim, keepdim)
+
 shape_compute_graph_mapping : Dict[str, torch._C.ScriptFunction] = {}
 script_func_map: Dict[Callable, torch._C.ScriptFunction] = {}
 
@@ -912,6 +928,7 @@ add_shape_compute_mapping("aten::quantize_per_tensor(Tensor self, float scale, i
 add_shape_compute_mapping("aten::quantize_per_tensor.tensor_qparams(Tensor self, Tensor scale, Tensor zero_point, ScalarType dtype) -> Tensor", unary)
 add_shape_compute_mapping("aten::dequantize(Tensor self) -> Tensor", unary)
 add_shape_compute_mapping("quantized::add(Tensor qa, Tensor qb, float scale, int zero_point) -> Tensor qc", broadcast)
+add_shape_compute_mapping("aten::argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor", argmax)
 
 # TODO: migrate over all of symbolic_shape_registry_util.cpp
 # These are duplicated here so that the functions will be serialiazed

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -16576,6 +16576,7 @@ op_db: List[OpInfo] = [
         'argmax',
         supports_multiple_dims=False,
         supports_autograd=False,
+        assert_jit_shape_analysis=True,
         result_dtype=torch.int64,
         dtypes=all_types_and(torch.float16, torch.bfloat16),
         ref=reference_reduction_numpy(np.argmax, supports_keepdims=False),


### PR DESCRIPTION
Keeping this first commit simple to test out the flow. Will bulk-add the
rest once this one goes through.

Shape function taken from:
https://github.com/llvm/torch-mlir/blob/5192a4e9f3e4cbc77838b70153cd4632aa43dd7f/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/shape_lib_gen.py#L488

