### PR TITLE
increase sleep for TestCuda.test_caching_pinned_memory_multi_gpu

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1363,7 +1363,7 @@ class TestCuda(TestCase):
 
         # check that the allocation is not re-used if it's in-use by a copy
         gpu_tensor = torch.cuda.FloatTensor([0])
-        torch.cuda._sleep(int(50 * cycles_per_ms))  # delay the copy
+        torch.cuda._sleep(int(1000 * cycles_per_ms))  # delay the copy by 1s
         gpu_tensor.copy_(t, non_blocking=True)
         del t
         t = torch.FloatTensor([1]).pin_memory()
@@ -1382,7 +1382,7 @@ class TestCuda(TestCase):
         gpu_tensor1 = torch.cuda.FloatTensor([0], device=1)
 
         with torch.cuda.device(1):
-            torch.cuda._sleep(int(50 * cycles_per_ms))  # delay the copy
+            torch.cuda._sleep(int(1000 * cycles_per_ms))  # delay the copy by 1s
             gpu_tensor1.copy_(t, non_blocking=True)
 
         del t


### PR DESCRIPTION
Fixes #68299.  Fixes #70875.

Test is flaky on ROCm because the HIP runtime occasionally copies asynchronously too quickly for the current sleep value of 50ms.  This is not a bug.  Increasing the sleep value to 1s to avoid flakiness.