### PR TITLE
[Nvfuser] Add cast support between double and half types

### DIFF
--- a/torch/csrc/jit/codegen/cuda/python_frontend/examples/double_half_cast.py
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/examples/double_half_cast.py
@@ -1,0 +1,33 @@
+import torch
+
+from torch._C._nvfuser import Fusion, FusionDefinition, DataType
+
+# Construct and Define Fusion
+fusion = Fusion()
+
+with FusionDefinition(fusion) as fd :
+    t0 = fd.define_tensor(2, DataType.Double)
+    t1 = fd.define_tensor(2, DataType.Double)
+
+    fd.add_input(t0)
+    fd.add_input(t1)
+
+    t0h = fd.Ops.cast(DataType.Half, t0)
+    t1h = fd.Ops.cast(DataType.Half, t1)
+    t2 = fd.Ops.add(t0h, t1h)
+    t3 = fd.Ops.relu(t2)
+
+    fd.add_output(t3)
+
+fusion.print_ir()
+
+# Execute Fusion
+input1 = torch.ones(2, 4, device='cuda', dtype=torch.float64)
+input2 = torch.ones(2, 4, device='cuda', dtype=torch.float64)
+
+# Kernel compilation should be cached for the 2nd iteration
+# with input tensors of the same shape
+for _ in range(5) :
+    outputs = fusion.execute([input1, input2])
+
+print(outputs[0])

--- a/torch/csrc/jit/codegen/cuda/python_frontend/examples/half_double_cast.py
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/examples/half_double_cast.py
@@ -1,0 +1,31 @@
+import torch
+
+from torch._C._nvfuser import Fusion, FusionDefinition, DataType
+
+# Construct and Define Fusion
+fusion = Fusion()
+
+with FusionDefinition(fusion) as fd :
+    t0 = fd.define_tensor(2, DataType.Half)
+    t1 = fd.define_tensor(2, DataType.Double)
+
+    fd.add_input(t0)
+    fd.add_input(t1)
+
+    t2 = fd.Ops.add(t0, t1)
+    t5 = fd.Ops.relu(t2)
+
+    fd.add_output(t5)
+
+fusion.print_ir()
+
+# Execute Fusion
+input1 = torch.ones(2, 4, device='cuda', dtype=torch.float16)
+input2 = torch.ones(2, 4, device='cuda', dtype=torch.float64)
+
+# Kernel compilation should be cached for the 2nd iteration
+# with input tensors of the same shape
+for _ in range(5) :
+    outputs = fusion.execute([input1, input2])
+
+print(outputs[0])

--- a/torch/csrc/jit/codegen/cuda/runtime/fp16_support.cu
+++ b/torch/csrc/jit/codegen/cuda/runtime/fp16_support.cu
@@ -30,3 +30,18 @@ __device__ float __half2float(const __half h) {
   asm("{  cvt.f32.f16 %0, %1;}\n" : "=f"(val) : "h"(__NVFUSER_HALF_TO_CUS(h)));
   return val;
 }
+
+__device__ __half __double2half(const double x)
+{
+  __half val;
+  asm("{  cvt.rn.f16.f64 %0, %1;}\n"
+      : "=h"(__NVFUSER_HALF_TO_US(val))
+      : "d"(x));
+  return val;
+}
+
+__device__ double __half2double(const __half h) {
+  double val;
+  asm("{  cvt.f64.f16 %0, %1;}\n" : "=d"(val) : "h"(__NVFUSER_HALF_TO_CUS(h)));
+  return val;
+}

--- a/torch/csrc/jit/codegen/cuda/runtime/fp16_support.cu
+++ b/torch/csrc/jit/codegen/cuda/runtime/fp16_support.cu
@@ -27,7 +27,9 @@ __device__ __half __float2half(const float f) {
 
 __device__ float __half2float(const __half h) {
   float val;
-  asm("{  cvt.f32.f16 %0, %1;}\n" : "=f"(val) : "h"(__NVFUSER_HALF_TO_CUS(h)));
+  asm("{  cvt.f32.f16 %0, %1;}\n"
+      : "=f"(val)
+      : "h"(__NVFUSER_HALF_TO_CUS(h)));
   return val;
 }
 
@@ -47,7 +49,9 @@ __device__ __half __double2half(const double d)
 __device__ double __half2double(const __half h) {
 #if __CUDA_ARCH__ >= 700
   double val;
-  asm("{  cvt.f64.f16 %0, %1;}\n" : "=d"(val) : "h"(__NVFUSER_HALF_TO_CUS(h)));
+  asm("{  cvt.f64.f16 %0, %1;}\n"
+      : "=d"(val)
+      : "h"(__NVFUSER_HALF_TO_CUS(h)));
   return val;
 #else
   return static_cast<double>(__half2float(h));

--- a/torch/csrc/jit/codegen/cuda/runtime/fp16_support.cu
+++ b/torch/csrc/jit/codegen/cuda/runtime/fp16_support.cu
@@ -31,17 +31,25 @@ __device__ float __half2float(const __half h) {
   return val;
 }
 
-__device__ __half __double2half(const double x)
+__device__ __half __double2half(const double d)
 {
+#if __CUDA_ARCH__ >= 700
   __half val;
   asm("{  cvt.rn.f16.f64 %0, %1;}\n"
       : "=h"(__NVFUSER_HALF_TO_US(val))
-      : "d"(x));
+      : "d"(d));
   return val;
+#else
+  return __float2half(static_cast<float>(d));
+#endif
 }
 
 __device__ double __half2double(const __half h) {
+#if __CUDA_ARCH__ >= 700
   double val;
   asm("{  cvt.f64.f16 %0, %1;}\n" : "=d"(val) : "h"(__NVFUSER_HALF_TO_CUS(h)));
   return val;
+#else
+  return static_cast<double>(__half2float(h));
+#endif
 }

--- a/torch/csrc/jit/codegen/cuda/type.cpp
+++ b/torch/csrc/jit/codegen/cuda/type.cpp
@@ -676,10 +676,14 @@ static const char* supported_casts2string(
       return "(std::complex<float>)";
     case supported_switch_pair(DataType::Float, DataType::Half):
       return "__float2half";
+    case supported_switch_pair(DataType::Double, DataType::Half):
+      return "__double2half";
     case supported_switch_pair(DataType::Float, DataType::BFloat16):
       return "__float2bfloat";
     case supported_switch_pair(DataType::Half, DataType::Float):
       return "__half2float";
+    case supported_switch_pair(DataType::Half, DataType::Double):
+      return "__half2double";
     case supported_switch_pair(DataType::BFloat16, DataType::Float):
       return "__bfloat2float";
     default:


### PR DESCRIPTION
Fixes `RuntimeError: Illegal Cast value from  DataType: __half to DataType: double`

Example:
```
with FusionDefinition(fusion) as fd :
    t0 = fd.define_tensor(2, DataType.Half)
    t1 = fd.define_tensor(2, DataType.Double)

    fd.add_input(t0)
    fd.add_input(t1)

    t2 = fd.Ops.add(t0, t1)
    t5 = fd.Ops.relu(t2)

    fd.add_output(t5)
```