### PR TITLE
fix anon-struct usage that's a warning/error -Wnon-c-typedef-for-linkage (#137)

### DIFF
--- a/caffe2/contrib/shm_mutex/shm_mutex.h
+++ b/caffe2/contrib/shm_mutex/shm_mutex.h
@@ -58,7 +58,7 @@ class ShmProcessMutexCheck {
 template <class Derived>
 struct shm_traits;
 
-using ShmBaseHeader = struct {
+struct ShmBaseHeader {
   std::atomic<bool> isInitialized;
   std::atomic<int> countMapped;
   std::atomic<pid_t> owner;

--- a/caffe2/image/image_input_op.h
+++ b/caffe2/image/image_input_op.h
@@ -62,7 +62,7 @@ class ImageInputOp final : public PrefetchOperator<Context> {
   bool CopyPrefetched() override;
 
  private:
-  using BoundingBox = struct {
+  struct BoundingBox {
     bool valid;
     int ymin;
     int xmin;
@@ -73,7 +73,7 @@ class ImageInputOp final : public PrefetchOperator<Context> {
   // Structure to store per-image information
   // This can be modified by the DecodeAnd* so needs
   // to be privatized per launch.
-  using PerImageArg = struct { BoundingBox bounding_params; };
+  struct PerImageArg { BoundingBox bounding_params; };
 
   bool GetImageAndLabelAndInfoFromDBValue(
       const string& value,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/CacheLib/pull/137

Fix
  error: anonymous non-C-compatible type given name for linkage purposes by alias declaration; add a tag name here [-Werror,-Wnon-c-typedef-for-linkage]

Test Plan:
```name=before
buck-out/v2/gen/fbcode/d839c731f5505c62/datasec/messaging/auth/utils/__MessagingAuthUtils__/headers/datasec/messaging/auth/utils/MessagingAuthLogger.h:83:25: error: anonymous non-C-compatible type given name for linkage purposes by alias declaration; add a tag name here [-Werror,-Wnon-c-typedef-for-linkage]
  using LogInfo = struct {
```

CI

Reviewed By: philippv

Differential Revision: D36043476

