### PR TITLE
Removed direct doc formatting

### DIFF
--- a/test/test_stateless.py
+++ b/test/test_stateless.py
@@ -178,5 +178,20 @@ exit(len(w))
         else:
             self.assertTrue(False, "No warning was raised.")
 
+class TestPythonOptimizeMode(TestCase):
+    def test_runs_with_optimize_flag(self):
+        script = """
+import torch
+"""
+        try:
+            subprocess.check_output(
+                [sys.executable, '-OO', '-c', script],
+                stderr=subprocess.STDOUT,
+                # On Windows, opening the subprocess with the default CWD makes `import torch`
+                # fail, so just set CWD to this script's directory
+                cwd=os.path.dirname(os.path.realpath(__file__)),)
+        except subprocess.CalledProcessError as e:
+            self.assertFalse(e.returncode, "Import failed while running python in optimized mode")
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -470,7 +470,8 @@ def method_factory(method_name, docstring):
     def method(self, *args, **kwargs):
         return getattr(super(RRef, self), method_name)(*args, **kwargs)
 
-    method.__doc__ = docstring
+    if method.__doc__:
+        method.__doc__ = docstring
     return method
 
 

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -33,7 +33,9 @@ _backend_type_doc = """
 BackendType = enum.Enum(value="BackendType", names=dict())  # type: ignore[misc]
 # Unable to assign a function a method (mypy bug #2427)
 BackendType.__repr__ = _backend_type_repr  # type: ignore[assignment]
-BackendType.__doc__ = _backend_type_doc
+
+if BackendType.__doc__:
+    BackendType.__doc__ = _backend_type_doc
 
 def backend_registered(backend_name):
     """
@@ -80,7 +82,8 @@ def register_backend(
     BackendType = enum.Enum(value="BackendType", names=extended_enum_dict)  # type: ignore[misc]
     # Unable to assign a function a method (mypy bug #2427)
     BackendType.__repr__ = _backend_type_repr  # type: ignore[assignment]
-    BackendType.__doc__ = _backend_type_doc
+    if BackendType.__doc__:
+        BackendType.__doc__ = _backend_type_doc
     return BackendType[backend_name]
 
 def construct_rpc_backend_options(

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -822,4 +822,5 @@ def _add_kl_info():
         rows.append("* :class:`~torch.distributions.{}` and :class:`~torch.distributions.{}`"
                     .format(p.__name__, q.__name__))
     kl_info = '\n\t'.join(rows)
-    kl_divergence.__doc__ += kl_info  # type: ignore[operator]
+    if kl_divergence.__doc__:
+        kl_divergence.__doc__ += kl_info  # type: ignore[operator]

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2332,7 +2332,8 @@ def embedding_bag(
     return ret
 
 
-embedding_bag.__doc__ = embedding_bag.__doc__.format(**reproducibility_notes)
+if embedding_bag.__doc__:
+    embedding_bag.__doc__ = embedding_bag.__doc__.format(**reproducibility_notes)
 
 
 def _verify_batch_size(size: List[int]) -> None:
@@ -2566,7 +2567,8 @@ def ctc_loss(
     )
 
 
-ctc_loss.__doc__ = ctc_loss.__doc__.format(**reproducibility_notes)
+if ctc_loss.__doc__:
+    ctc_loss.__doc__ = ctc_loss.__doc__.format(**reproducibility_notes)
 
 
 def nll_loss(
@@ -3670,7 +3672,8 @@ def upsample(input, size=None, scale_factor=None, mode="nearest", align_corners=
     return interpolate(input, size, scale_factor, mode, align_corners)
 
 
-upsample.__doc__ = upsample.__doc__.format(**reproducibility_notes)
+if upsample.__doc__:
+    upsample.__doc__ = upsample.__doc__.format(**reproducibility_notes)
 
 
 @_overload  # noqa: F811
@@ -3911,7 +3914,8 @@ def interpolate(input: Tensor, size: Optional[int] = None, scale_factor: Optiona
     )
 
 
-interpolate.__doc__ = interpolate.__doc__.format(**reproducibility_notes)
+if interpolate.__doc__:
+    interpolate.__doc__ = interpolate.__doc__.format(**reproducibility_notes)
 
 
 @_overload  # noqa: F811
@@ -3948,7 +3952,8 @@ def upsample_nearest(input, size=None, scale_factor=None):  # noqa: F811
     return interpolate(input, size, scale_factor, mode="nearest")
 
 
-upsample_nearest.__doc__ = upsample_nearest.__doc__.format(**reproducibility_notes)
+if upsample_nearest.__doc__:
+    upsample_nearest.__doc__ = upsample_nearest.__doc__.format(**reproducibility_notes)
 
 
 @_overload  # noqa: F811
@@ -4003,7 +4008,8 @@ def upsample_bilinear(input, size=None, scale_factor=None):  # noqa: F811
     return interpolate(input, size, scale_factor, mode="bilinear", align_corners=True)
 
 
-upsample_bilinear.__doc__ = upsample_bilinear.__doc__.format(**reproducibility_notes)
+if upsample_bilinear.__doc__:
+    upsample_bilinear.__doc__ = upsample_bilinear.__doc__.format(**reproducibility_notes)
 
 GRID_SAMPLE_INTERPOLATION_MODES = {
     "bilinear": 0,


### PR DESCRIPTION
Fixes #76034

This does not make python remove all `__doc__` because in some places `__doc__` is assigned to a string.

Example:
https://github.com/pytorch/pytorch/blob/04b3313379712098183dfe5bea002a5e43b5af48/torch/nn/modules/conv.py#L174-L233

Since there are quite a few of these, I will add all of them together in this PR later. (Basically still a lot of docstring will persist even with `-OO` enabled.)