### PR TITLE
DOC fix momentum equation for nesterov

### DIFF
--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -25,7 +25,7 @@ class SGD(Optimizer):
             &\hspace{10mm}\textbf{else}                                                          \\
             &\hspace{15mm} \textbf{b}_t \leftarrow g_t                                           \\
             &\hspace{10mm}\textbf{if} \: \textit{nesterov}                                       \\
-            &\hspace{15mm} g_t \leftarrow g_{t-1} + \mu \textbf{b}_t                             \\
+            &\hspace{15mm} g_t \leftarrow g_{t} + \mu \textbf{b}_t                             \\
             &\hspace{10mm}\textbf{else}                                                   \\[-1.ex]
             &\hspace{15mm} g_t  \leftarrow  \textbf{b}_t                                         \\
             &\hspace{5mm}\textbf{if} \: \textit{maximize}                                          \\


### PR DESCRIPTION
Fix https://github.com/pytorch/pytorch/issues/72395

This is a small fix in the doc for an indice in this equation:

![image](https://user-images.githubusercontent.com/3321081/166165461-140855b5-96b5-4417-85fc-2a170f95700a.png)


I think teh indice should not be `t-1` but `t`. This is coherent with [the implementation)[https://github.com/pytorch/pytorch/blob/master/torch/optim/sgd.py#L236] and with what is done for instance in [keras](https://www.tensorflow.org/api_docs/python/tf/keras/optimizers/SGD).