### PR TITLE
Adding max_padded_size to to_padded_tensor

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11674,7 +11674,7 @@
     CompositeExplicitAutograd: alias_copy
   tags: view_copy
 
-- func: to_padded_tensor(Tensor self, float padding) -> Tensor
+- func: to_padded_tensor(Tensor self, float padding, int[]? output_size=None) -> Tensor
   variants: method
   dispatch:
     NestedTensorCPU: NestedTensor_to_padded_tensor_generic

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -452,6 +452,7 @@
     SparseCsrCPU, SparseCsrCUDA: add_sparse_csr
     MkldnnCPU: mkldnn_add
     ZeroTensor: add_zerotensor
+    NestedTensorCPU, NestedTensorCUDA: NestedTensor_add_Tensor
 
 - func: add_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -461,6 +462,7 @@
     SparseCPU, SparseCUDA: add_sparse_
     SparseCsrCPU, SparseCsrCUDA: add_sparse_csr_
     MkldnnCPU: mkldnn_add_
+    NestedTensorCPU, NestedTensorCUDA: NestedTensor_add__Tensor
 
 - func: add.out(Tensor self, Tensor other, *, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -3219,6 +3221,7 @@
     SparseCsrCPU, SparseCsrCUDA: mul_sparse_csr
     MkldnnCPU: mkldnn_mul
     ZeroTensor: mul_zerotensor
+    NestedTensorCPU, NestedTensorCUDA: NestedTensor_mul_Tensor
 
 - func: mul_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -3228,6 +3231,7 @@
     SparseCPU, SparseCUDA: mul_sparse_
     SparseCsrCPU, SparseCsrCUDA: mul_sparse_csr_
     MkldnnCPU: mkldnn_mul_
+    NestedTensorCPU, NestedTensorCUDA: NestedTensor_mul__Tensor
 
 - func: mul.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -303,7 +303,10 @@ Tensor nested_from_padded_generic(
       std::move(new_buffer), sizes);
 }
 
-Tensor NestedTensor_to_padded_tensor_generic(const Tensor& t, double padding) {
+Tensor NestedTensor_to_padded_tensor_generic(
+    const Tensor& t,
+    double padding,
+    OptionalIntArrayRef output_size) {
   // TODO: skipped optimization for case of all 1x1 tensors
   auto& nt = *get_nested_tensor_impl(t);
   auto max_size = NestedTensor_get_max_size(nt);
@@ -356,7 +359,22 @@ Tensor NestedTensor_to_padded_tensor_generic(const Tensor& t, double padding) {
     buffers.push_back(pad_tensor_to_shape(to_pad, max_size, padding));
     sizes_ptr += sizes_num_columns;
   }
-  return at::stack(buffers);
+  auto ret_val = at::stack(buffers);
+
+  // Pad output tensor to output_size if provided
+  if (output_size.has_value()) {
+    auto output_size_ = output_size.value();
+    TORCH_CHECK(
+        (int64_t)output_size_.size() == ret_val.dim(),
+        "Length of output_size does not match NestedTensor dims. Broadcasting is not supported.");
+    for (int64_t i = 0; i < (int64_t)ret_val.dim(); i++) {
+      TORCH_CHECK(
+          output_size_[i] >= ret_val.size(i),
+          "Value in output_size is less than NestedTensor padded size. Truncation is not supported.");
+    }
+    return pad_tensor_to_shape(ret_val, output_size_, padding);
+  }
+  return ret_val;
 }
 
 Tensor NestedTensor_embedding(

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -385,5 +385,119 @@ Tensor NestedTensor_embedding(
   return at::detail::make_tensor<NestedTensorImpl>(
       result_buffer.reshape({-1}), std::move(new_sizes));
 }
+
+std::pair<NestedTensorImpl*, NestedTensorImpl*>
+get_elementwise_nested_tensor_impl(
+    const Tensor& self,
+    const Tensor& other,
+    const std::string& op_name) {
+  if (self.is_nested() && !(other.is_nested())) {
+    TORCH_CHECK(
+        false,
+        "Expected both self and other to be nested, but got a nested self and non-nested other");
+  } else if (!(self.is_nested()) && other.is_nested()) {
+    TORCH_CHECK(
+        false,
+        "Expected both self and other to be nested, but got a non-nested self and nested other");
+  } else if (!(self.is_nested()) || !(other.is_nested())) {
+    TORCH_CHECK(
+        false,
+        "Expected both self and other to be nested, but got a non-nested self and non-nested other");
+  }
+
+  auto self_ptr = get_nested_tensor_impl(self);
+  auto other_ptr = get_nested_tensor_impl(other);
+
+  TORCH_CHECK(
+      self.dim() == other.dim(),
+      op_name,
+      " does not support broadcasting when given a NestedTensor");
+  TORCH_CHECK(
+      at::equal(
+          self_ptr->get_nested_size_tensor(),
+          other_ptr->get_nested_size_tensor()),
+      op_name,
+      " does not support broadcasting when given a NestedTensor");
+  TORCH_CHECK(
+      nested_tensor_impl_is_contiguous(self_ptr) &&
+          nested_tensor_impl_is_contiguous(other_ptr),
+      op_name,
+      " does not support non-contiguous NestedTensor inputs");
+  return std::make_pair(self_ptr, other_ptr);
+}
+
+template <typename Func>
+Tensor NestedTensor_elementwise_Tensor(
+    const Tensor& self,
+    const Tensor& other,
+    const std::string& op_name,
+    Func f) {
+  NestedTensorImpl* self_impl = nullptr;
+  NestedTensorImpl* other_impl = nullptr;
+  std::tie(self_impl, other_impl) =
+      get_elementwise_nested_tensor_impl(self, other, op_name);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(self_impl);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(other_impl);
+  const auto& nt_self = *self_impl;
+  const auto& nt_other = *other_impl;
+  const auto& self_sizes = nt_self.get_nested_size_tensor();
+  return wrap_buffer(
+      f(nt_self.get_buffer().reshape({-1}),
+        nt_other.get_buffer().reshape({-1})),
+      self_sizes);
+}
+
+Tensor NestedTensor_add_Tensor(
+    const Tensor& self,
+    const Tensor& other,
+    const Scalar& alpha) {
+  return NestedTensor_elementwise_Tensor(
+      self, other, "add", [alpha](const Tensor& b1, const Tensor& b2) {
+        return at::add(b1, b2, alpha);
+      });
+}
+
+Tensor NestedTensor_mul_Tensor(const Tensor& self, const Tensor& other) {
+  return NestedTensor_elementwise_Tensor(
+      self, other, "mul", [](const Tensor& b1, const Tensor& b2) {
+        return at::mul(b1, b2);
+      });
+}
+
+template <typename Func>
+Tensor& NestedTensor_elementwise__Tensor(
+    Tensor& self,
+    const Tensor& other,
+    const std::string& op_name,
+    Func f) {
+  NestedTensorImpl* self_impl = nullptr;
+  NestedTensorImpl* other_impl = nullptr;
+  std::tie(self_impl, other_impl) =
+      get_elementwise_nested_tensor_impl(self, other, op_name);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(self_impl);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(other_impl);
+  const auto& nt_self = *self_impl;
+  const auto& nt_other = *other_impl;
+  f(nt_self.get_buffer().view({-1}), nt_other.get_buffer().view({-1}));
+  return self;
+}
+
+Tensor& NestedTensor_add__Tensor(
+    Tensor& self,
+    const Tensor& other,
+    const Scalar& alpha) {
+  return NestedTensor_elementwise__Tensor(
+      self, other, "add_", [alpha](const Tensor& b1, const Tensor& b2) {
+        return b1.add_(b2, alpha);
+      });
+}
+
+Tensor& NestedTensor_mul__Tensor(Tensor& self, const Tensor& other) {
+  return NestedTensor_elementwise__Tensor(
+      self, other, "mul_", [](const Tensor& b1, const Tensor& b2) {
+        return b1.mul_(b2);
+      });
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -14,7 +14,7 @@ int64_t get_consistent_last_dim_of_nested_tensor(const NestedTensorImpl& nt);
 
 TORCH_API std::vector<int64_t> NestedTensor_get_max_size(const NestedTensorImpl& nt);
 
-TORCH_API Tensor NestedTensor_to_padded_tensor_generic(const Tensor& t, double padding);
+TORCH_API Tensor NestedTensor_to_padded_tensor_generic(const Tensor& t, double padding, OptionalIntArrayRef output_size);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.h
+++ b/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.h
@@ -81,6 +81,7 @@ void add_padding_kernelLauncher(
     const int* input_sizes,
     int input_dim,
     const std::vector<int64_t>& output_sizes,
-    const int batch_size);
+    const int batch_size,
+    const int output_batch_size);
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cu
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cu
@@ -241,13 +241,13 @@ __global__ void add_padding_1(
   const int grid_id = blockIdx.y;
   const int tid = threadIdx.x + grid_id * 256;
   const int grainsize = 16 * 256;
-  const int batch_input_offset = offsets[batch_id];
   const int* sizes_i = input_sizes + batch_id * input_dim;
   const int batch_output_offset = batch_id * output_sizes_1;
   for (int ii = 0; ii < (output_sizes_1 / grainsize); ii++) {
     const int i = ii * grainsize + tid;
     const int output_offset = batch_output_offset + i;
-    if (i < sizes_i[0]) {
+    if (batch_id < batch_size && i < sizes_i[0]) {
+      const int batch_input_offset = offsets[batch_id];
       output[output_offset] = input[batch_input_offset + i];
     } else {
       output[output_offset] = padding_value;
@@ -256,7 +256,8 @@ __global__ void add_padding_1(
   const int i = (output_sizes_1 / grainsize) * grainsize + tid;
   if (i < output_sizes_1) {
     const int output_offset = batch_output_offset + i;
-    if (i < sizes_i[0]) {
+    if (batch_id < batch_size && (i < sizes_i[0])) {
+      const int batch_input_offset = offsets[batch_id];
       output[output_offset] = input[batch_input_offset + i];
     } else {
       output[output_offset] = padding_value;
@@ -279,7 +280,6 @@ __global__ void add_padding_2(
   const int grid_id = blockIdx.y;
   const int tid = threadIdx.x + grid_id * 256;
   const int grainsize = 16 * 256;
-  const int offset = offsets[batch_id];
   const int* sizes_i = input_sizes + batch_id * input_dim;
   const int output_offset = batch_id * output_sizes_1 * output_sizes_2;
   const int output_numel = output_sizes_1 * output_sizes_2;
@@ -287,7 +287,8 @@ __global__ void add_padding_2(
     const int i = ii * grainsize + tid;
     const int i0 = i / (output_sizes_2);
     const int i1 = i - i0 * output_sizes_2;
-    if (i0 < sizes_i[0] && i1 < sizes_i[1]) {
+    if (batch_id < batch_size && i0 < sizes_i[0] && i1 < sizes_i[1]) {
+      const int offset = offsets[batch_id];
       const int input_offset = offset + i0 * sizes_i[1] + i1;
       output[output_offset + i] = input[input_offset];
     } else {
@@ -298,7 +299,8 @@ __global__ void add_padding_2(
   if (i < output_numel) {
     const int i0 = i / (output_sizes_2);
     const int i1 = i - i0 * output_sizes_2;
-    if (i0 < sizes_i[0] && i1 < sizes_i[1]) {
+    if (batch_id < batch_size && i0 < sizes_i[0] && i1 < sizes_i[1]) {
+      const int offset = offsets[batch_id];
       const int input_offset = offset + i0 * sizes_i[1] + i1;
       output[output_offset + i] = input[input_offset];
     } else {
@@ -323,7 +325,6 @@ __global__ void add_padding_3(
   const int grid_id = blockIdx.y;
   const int tid = threadIdx.x + grid_id * 256;
   const int grainsize = 16 * 256;
-  const int offset = offsets[batch_id];
   const int* sizes_i = input_sizes + batch_id * input_dim;
   const int output_offset =
       batch_id * output_sizes_1 * output_sizes_2 * output_sizes_3;
@@ -333,7 +334,8 @@ __global__ void add_padding_3(
     const int i0 = i / (output_sizes_2 * output_sizes_3);
     const int i1 = (i % (output_sizes_2 * output_sizes_3)) / output_sizes_3;
     const int i2 = i % output_sizes_3;
-    if (i0 < sizes_i[0] && i1 < sizes_i[1] && i2 < sizes_i[2]) {
+    if (batch_id < batch_size && i0 < sizes_i[0] && i1 < sizes_i[1] && i2 < sizes_i[2]) {
+      const int offset = offsets[batch_id];
       const int input_offset =
           offset + i0 * (sizes_i[1] * sizes_i[2]) + i1 * sizes_i[2] + i2;
       output[output_offset + i] = input[input_offset];
@@ -346,7 +348,8 @@ __global__ void add_padding_3(
     const int i0 = i / (output_sizes_2 * output_sizes_3);
     const int i1 = (i % (output_sizes_2 * output_sizes_3)) / output_sizes_3;
     const int i2 = i % output_sizes_3;
-    if (i0 < sizes_i[0] && i1 < sizes_i[1] && i2 < sizes_i[2]) {
+    if (batch_id < batch_size && i0 < sizes_i[0] && i1 < sizes_i[1] && i2 < sizes_i[2]) {
+      const int offset = offsets[batch_id];
       const int input_offset =
           offset + i0 * (sizes_i[1] * sizes_i[2]) + i1 * sizes_i[2] + i2;
       output[output_offset + i] = input[input_offset];
@@ -365,10 +368,11 @@ void add_padding_kernelLauncher(
     const int* input_sizes,
     int input_dim,
     const std::vector<int64_t>& output_sizes,
-    const int batch_size) {
+    const int batch_size,
+    const int output_batch_size) {
   at::cuda::CUDAStream stream = at::cuda::getDefaultCUDAStream();
   dim3 grid;
-  grid.x = batch_size;
+  grid.x = output_batch_size;
   grid.y = 16;
   if (input_dim == 1) {
     add_padding_1<T><<<grid, 256, 0, stream>>>(
@@ -416,7 +420,8 @@ template void add_padding_kernelLauncher<double>(
     const int* input_sizes,
     int input_dim,
     const std::vector<int64_t>& output_sizes,
-    const int batch_size);
+    const int batch_size,
+    const int output_batch_size);
 
 template void add_padding_kernelLauncher<float>(
     float* input,
@@ -426,7 +431,8 @@ template void add_padding_kernelLauncher<float>(
     const int* input_sizes,
     int input_dim,
     const std::vector<int64_t>& output_sizes,
-    const int batch_size);
+    const int batch_size,
+    const int output_batch_size);
 
 template void add_padding_kernelLauncher<c10::Half>(
     c10::Half* input,
@@ -436,7 +442,8 @@ template void add_padding_kernelLauncher<c10::Half>(
     const int* input_sizes,
     int input_dim,
     const std::vector<int64_t>& output_sizes,
-    const int batch_size);
+    const int batch_size,
+    const int output_batch_size);
 
 } // namespace native
 } // namespace at

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -335,6 +335,65 @@ class TestNestedTensorDeviceType(TestCase):
         is_cuda = 'cuda' in str(device)
         self.assertEqual(nt.is_cuda, is_cuda)
 
+    # Helper functions for testing elementwise ops
+    def random_nt_pair(self, device, dtype, num_tensors, max_dims):
+        ts1 = []
+        ts2 = []
+        for _ in range(num_tensors):
+            tensor_dims = tuple([torch.randint(low=0, high=max_dim, size=(1,)).item() for max_dim in max_dims])
+            t1 = torch.randn(tensor_dims, device=device, dtype=dtype)
+            t2 = torch.randn(tensor_dims, device=device, dtype=dtype)
+            ts1.append(t1)
+            ts2.append(t2)
+        return (torch.nested_tensor(ts1, device=device, dtype=dtype),
+                torch.nested_tensor(ts2, device=device, dtype=dtype))
+
+    def nt_equal(self, nt1, nt2):
+        self.assertEqual(nt1.dtype, nt2.dtype)
+        self.assertEqual(nt1.device, nt2.device)
+        ub1 = nt1.unbind()
+        ub2 = nt2.unbind()
+        self.assertEqual(len(ub1), len(ub2))
+        n = len(ub1)
+        for i in range(n):
+            self.assertEqual(ub1[i], ub2[i])
+
+    @dtypes(torch.float, torch.float16)
+    @skipMeta
+    @torch.inference_mode()
+    def test_nested_tensor_add(self, device, dtype):
+        (nt1, nt2) = self.random_nt_pair(device, dtype, 4, (4, 4))
+        ref = torch.nested_tensor([t1 + t2 for (t1, t2) in zip(nt1.unbind(), nt2.unbind())])
+        out = nt1 + nt2
+        self.nt_equal(ref, out)
+
+    @dtypes(torch.float, torch.float16)
+    @skipMeta
+    @torch.inference_mode()
+    def test_nested_tensor_mul(self, device, dtype):
+        (nt1, nt2) = self.random_nt_pair(device, dtype, 4, (4, 4))
+        ref = torch.nested_tensor([t1 * t2 for (t1, t2) in zip(nt1.unbind(), nt2.unbind())])
+        out = nt1 * nt2
+        self.nt_equal(ref, out)
+
+    @dtypes(torch.float, torch.float16)
+    @skipMeta
+    @torch.inference_mode()
+    def test_nested_tensor_add_in_place(self, device, dtype):
+        (nt1, nt2) = self.random_nt_pair(device, dtype, 4, (4, 4))
+        ref = torch.nested_tensor([t1 + t2 for (t1, t2) in zip(nt1.unbind(), nt2.unbind())])
+        nt1 += nt2
+        self.nt_equal(ref, nt1)
+
+    @dtypes(torch.float, torch.float16)
+    @skipMeta
+    @torch.inference_mode()
+    def test_nested_tensor_mul_in_place(self, device, dtype):
+        (nt1, nt2) = self.random_nt_pair(device, dtype, 4, (4, 4))
+        ref = torch.nested_tensor([t1 * t2 for (t1, t2) in zip(nt1.unbind(), nt2.unbind())])
+        nt1 *= nt2
+        self.nt_equal(ref, nt1)
+
 instantiate_device_type_tests(TestNestedTensorDeviceType, globals())
 
 if __name__ == '__main__':


### PR DESCRIPTION
Summary:
- Adding max_padded_size argument to to_padded_tensor
- Modified add_padding_kernelLauncher and kernels to iterate over padded tensor batch size instead of nested tensor batch size
- No fast path for CPU version

Test Plan:
buck test mode/dev-nosan  //caffe2/test:nested

Performance test using N1763981:

{F728168808}

Differential Revision: D36056902

