### PR TITLE
Mixed precision batchnorm fix

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -2,12 +2,14 @@
 
 import sys
 import contextlib
+import copy
 from functools import partial
 from itertools import product
 
 import torch
 import torch.cuda.nccl as nccl
 import torch.nn as nn
+import torch.nn.functional as F
 from torch import distributed as dist
 from torch.distributed.fsdp import (
     FullyShardedDataParallel as FSDP,
@@ -16,6 +18,8 @@ from torch.distributed.fsdp import (
     BackwardPrefetch,
     ShardingStrategy,
 )
+from torch.distributed.fsdp.wrap import default_auto_wrap_policy
+from torch.nn.modules.batchnorm import _BatchNorm
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     FSDPTest,
@@ -26,8 +30,18 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
+    sandcastle_skip_if,
 )
 from torch.testing._internal.common_cuda import CUDA11OrLater
+
+try:
+    import torchvision
+
+    HAS_TORCHVISION = True
+except ImportError:
+    HAS_TORCHVISION = False
+
+skipIfNoTorchVision = sandcastle_skip_if(not HAS_TORCHVISION, "no torchvision")
 
 
 if not dist.is_available():
@@ -387,6 +401,100 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
             self.assertEqual(loss.dtype, mp_config.param_dtype)
             model.module.run_backward(loss)
             optim.step()
+
+    @skip_if_lt_x_gpu(2)
+    @skipIfNoTorchVision
+    def test_mixed_precision_resnet(self):
+        resnet_model = torchvision.models.resnet50().cuda()
+        resnet_model = nn.SyncBatchNorm.convert_sync_batchnorm(
+            copy.deepcopy(resnet_model),
+            process_group=dist.distributed_c10d._get_default_group()
+        )
+        n_bn = len(
+            [x for x in resnet_model.modules() if isinstance(x, _BatchNorm)]
+        )
+        inp = torch.ones(1, 3, 1000, 1000, device='cuda')
+        mp_config = MixedPrecision(
+            param_dtype=torch.float16,
+            reduce_dtype=torch.float16,
+            buffer_dtype=torch.float16,
+        )
+        fsdp = FSDP(
+            resnet_model,
+            auto_wrap_policy=default_auto_wrap_policy,
+            mixed_precision=mp_config
+        )
+        # Batchnorm units should be wrapped individually. Validate this by
+        # ensuring there are equal no. of FSDP units that are BN as BN units
+        # in original resnet model.
+        fsdp_bn = 0
+        for module in fsdp.fsdp_modules(fsdp):
+            wrapped_module = module.module.module
+            if isinstance(wrapped_module, _BatchNorm):
+                fsdp_bn += 1
+
+        self.assertEqual(fsdp_bn, n_bn)
+        # Would throw type mismatch issue without mixed precision autowrapping.
+        loss = fsdp(inp).sum()
+        loss.backward()
+
+    @skip_if_lt_x_gpu(2)
+    def test_mp_batchnorm(self):
+        class BatchNormNet(nn.Module):
+            def __init__(self, affine=True):
+                super(BatchNormNet, self).__init__()
+                self.fc1 = nn.Linear(2, 40, bias=False)
+                self.bn = nn.BatchNorm1d(4, affine=affine)
+                self.fc2 = nn.Linear(40, 4, bias=False)
+
+            def forward(self, x):
+                x = torch.reshape(self.fc1(x), (-1, 4, 10))
+                x = self.bn(x)
+                x = torch.reshape(x, (-1, 40))
+                x = self.fc2(x)
+                return F.softmax(x, dim=1)
+
+        def never_wrap_policy(*args, **kwargs):
+            return False
+
+        for convert in [True, False]:
+            net = BatchNormNet().cuda()
+            if convert:
+                net = nn.SyncBatchNorm.convert_sync_batchnorm(
+                    copy.deepcopy(net)
+                )
+            # FSDP detects that mixed precision + batchnorm will cause issues
+            # and thus wrap batchnorm in a distinct FSDP unit that does not
+            # use mixed precision.
+            mp_config = MixedPrecision(
+                param_dtype=torch.float16,
+                reduce_dtype=torch.float16,
+                buffer_dtype=torch.float16,
+            )
+            with self.assertWarnsRegex(
+                expected_warning=UserWarning,
+                expected_regex="BatchNorm units will be wrapped as a separate"
+            ):
+                model = FSDP(
+                    net,
+                    mixed_precision=mp_config,
+                    auto_wrap_policy=never_wrap_policy,
+                )
+
+            bn = model.bn
+            self.assertTrue(isinstance(bn, FSDP))
+            # policy should not have wrapped any other submodules
+            self.assertFalse(isinstance(model.fc1, FSDP))
+            self.assertFalse(isinstance(model.fc2, FSDP))
+            self.assertEqual(None, bn.mixed_precision)
+            self.assertNotEqual(None, model.mixed_precision)
+
+            inp = torch.randn((1, 2), device='cuda')
+            # Without FSDP BN mixed precision fix, this would result in
+            # RuntimeError: Expected counts to have type Half but got Float
+            # for syncBN
+            model(inp).sum().backward()
+
 
 class TestFSDPMixedPrecisionUnsharded(TestFSDPMixedPrecision):
     """

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -18,6 +18,8 @@ from torch.distributed.fsdp.wrap import (
     default_auto_wrap_policy,
     enable_wrap,
     wrap,
+    wrap_batchnorm_individually,
+    or_policy,
 )
 from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
@@ -36,6 +38,15 @@ from torch.testing._internal.common_utils import (
     parametrize,
     instantiate_parametrized_tests,
 )
+
+class BatchNormNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = nn.Linear(10, 10, bias=False)
+        self.bn1 = nn.BatchNorm1d(10)
+        self.bn2 = nn.BatchNorm2d(10)
+        self.bn3 = nn.BatchNorm3d(10)
+        self.sync_bn = nn.SyncBatchNorm(10)
 
 class WrapMethod(Enum):
     FSDP_CTOR = auto()
@@ -133,6 +144,62 @@ class TestFSDPWrap(FSDPTest):
 
         with self.assertRaisesRegex(ValueError, "to NOT be FullyShardedDataParallel"):
             mod = FSDP(wrapped_fsdp, auto_wrap_policy=default_auto_wrap_policy)
+
+    @skip_if_lt_x_gpu(2)
+    def test_wrap_batchnorm_individually(self):
+        def never_wrap_policy(*args, **kwargs):
+            return False
+
+        for policy in [
+            wrap_batchnorm_individually,
+            functools.partial(
+                or_policy,
+                policies=[never_wrap_policy, wrap_batchnorm_individually]
+            )
+        ]:
+            model = BatchNormNet()
+            fsdp = FSDP(model, auto_wrap_policy=policy)
+            # Batchnorms should be wrapped
+            for layer in [fsdp.bn1, fsdp.bn2, fsdp.bn3, fsdp.sync_bn]:
+                self.assertTrue(isinstance(layer, FSDP))
+
+            self.assertFalse(isinstance(fsdp.lin, FSDP))
+
+    @skip_if_lt_x_gpu(2)
+    def test_bn_always_wrapped_individually(self):
+        """
+        Ensures that by using or_policy with wrap_batchnorm_individually, even
+        if the other policy results in a module containing a BN unit being
+        wrapped, the contained BN unit will still be individually wrapped.
+        """
+        class MyModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.bn_container = BatchNormNet()
+
+        def wrap_bn_container(module, recurse, *args, **kwargs):
+            if recurse:
+                return True
+            return isinstance(module, BatchNormNet)
+
+        my_policy = functools.partial(
+            or_policy,
+            policies=[wrap_bn_container, wrap_batchnorm_individually]
+        )
+        mod = MyModule()
+        fsdp = FSDP(mod, auto_wrap_policy=my_policy)
+
+        # Wrapping should be FSDP(FSDP(BatchNormNet(FSDP(BN))))
+        # and not FSDP(FSDP(BatchNormNet(BN))) (in the latter the inner
+        # BN is not individually wrapped.)
+
+        for bn in [
+            fsdp.bn_container.bn1,
+            fsdp.bn_container.bn2,
+            fsdp.bn_container.bn3,
+            fsdp.bn_container.sync_bn
+        ]:
+            self.assertTrue(isinstance(bn, FSDP))
 
     @skip_if_lt_x_gpu(2)
     @parametrize(

--- a/torch/distributed/fsdp/_utils.py
+++ b/torch/distributed/fsdp/_utils.py
@@ -2,11 +2,21 @@ from typing import Dict, List, Tuple, Union, Any, Callable, Set
 from torch.nn.utils.rnn import PackedSequence
 
 import torch
+from torch.nn.modules.batchnorm import _BatchNorm
 
 from collections import OrderedDict
 
 """Useful functions to deal with tensor types with other python container types."""
 
+def _contains_batchnorm(module):
+    return any(
+        isinstance(mod, _BatchNorm) for mod in module.modules()
+    )
+
+def _override_batchnorm_mixed_precision(module):
+    for mod in module.modules():
+        if isinstance(mod, _BatchNorm):
+            mod._wrap_overrides = {"mixed_precision": None}
 
 def _apply_to_tensors(
     fn: Callable, container: Union[torch.Tensor, Dict, List, Tuple, Set, OrderedDict, PackedSequence]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #76642

Currently, if BN such as SyncBN is used in model with FSDP mixed precision enabled, auto wrapping will produce the following error:

```
RuntimeError: Expected counts to have type Half but got Float
```

the root cause being in this case that SyncBN kernels seems to assume fp32 somewhere and crashes for fp16 inputs.

Long term solution might be to make all BN kernels support fp16 / reduced precision types, but FSDP also supports other precision such as bloat16.

As a result, this PR fixes the issue by disabling mixed precision for BN units. To do this, we:

1. Add a policy that always wraps batchnorm layers in their own FSDP unit
2. Add a notion of "or policy" which returns True if either policy A or policy B fires
3. Use this in FSDP, where if mixed precision is enabled and model has BN, we `or` the given auto_wrap_policy with the policy that always wraps BN in its own unit. This works because children modules are always wrapped first, so recursive wrapping will go to leaf BN units and always wrap those.
4. Add an attribute to module `_wrap_override` that turns mixed precision off in FSDP config.

Differential Revision: [D36032761](https://our.internmc.facebook.com/intern/diff/D36032761/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D36032761/)!