### PR TITLE
adds elementwise opinfos and unary references, extends to out testing

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -336,6 +336,7 @@ class TestCommon(TestCase):
 
     # Tests that experimental Python References perform the same computation
     # as the operators they reference.
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @ops(python_ref_db)
     def test_python_reference_consistency(self, device, dtype, op):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -101,6 +101,7 @@ class TestCommon(TestCase):
 
     # Validates that each OpInfo specifies its forward and backward dtypes
     #   correctly for CPU and CUDA devices
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @skipMeta
     @onlyNativeDeviceTypes
     @ops(ops_and_refs, dtypes=OpDTypes.none)
@@ -318,6 +319,7 @@ class TestCommon(TestCase):
     # Tests that experimental Python References can propagate shape, dtype,
     # and device metadata properly.
     # TODO: include stride propagation.
+    @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @onlyNativeDeviceTypes
     @ops(python_ref_db)
     def test_python_reference_meta_functions(self, device, dtype, op):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -74,6 +74,7 @@ _ref_test_ops = tuple(
         op_db,
     )
 )
+_ops_and_refs = op_db + python_ref_db
 
 # Tests that apply to all operators and aren't related to any particular
 #   system
@@ -229,6 +230,14 @@ class TestCommon(TestCase):
         ) == 0:
             return
 
+        # Reference operators often support additional dtypes, and that's OK
+        if op in python_ref_db:
+            if (
+                len(claimed_but_unsupported_forward)
+                + len(claimed_but_unsupported_backward)
+            ) == 0:
+                return
+
         # Generates error msg
         msg = "The supported dtypes for {0} on device type {1} are incorrect!\n".format(
             op.name, device_type
@@ -317,12 +326,12 @@ class TestCommon(TestCase):
                 return prims.utils.TensorMeta(x)
 
         # TODO: iterate over requires_grad true/false
+        inps = tuple(op.reference_inputs(device, dtype, requires_grad=False))
         for sample in op.reference_inputs(device, dtype, requires_grad=False):
             result = op(sample.input, *sample.args, **sample.kwargs)
 
             meta_sample = sample.transform(_to_tensormeta)
             meta_result = op(meta_sample.input, *meta_sample.args, **meta_sample.kwargs)
-
             prims.utils.compare_tensor_meta(result, meta_result)
 
     # Tests that experimental Python References perform the same computation
@@ -455,7 +464,7 @@ class TestCommon(TestCase):
     #   incorrectly sized out parameter warning properly yet
     # Cases test here:
     #   - out= with the correct dtype and device, but the wrong shape
-    @ops(op_db, dtypes=OpDTypes.none)
+    @ops(_ops_and_refs, dtypes=OpDTypes.none)
     def test_out_warning(self, device, op):
         # Prefers running in float32 but has a fallback for the first listed supported dtype
         supported_dtypes = op.supported_dtypes(self.device_type)
@@ -579,7 +588,7 @@ class TestCommon(TestCase):
     #   - Case 3: out has the correct shape and dtype, but is on a different device type
     #   - Case 4: out has the with correct shape and device, but a dtype that cannot
     #       "safely" cast to
-    @ops(op_db, dtypes=OpDTypes.none)
+    @ops(_ops_and_refs, dtypes=OpDTypes.none)
     def test_out(self, device, op):
         # Prefers running in float32 but has a fallback for the first listed supported dtype
         supported_dtypes = op.supported_dtypes(self.device_type)

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -45,7 +45,6 @@ __all__ = [
     "expm1",
     "floor",
     "is_finite",
-    "isnan",
     "lgamma",
     "log",
     "log1p",

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -13,7 +13,7 @@ from torch.overrides import has_torch_function, handle_torch_function
 
 from typing import Sequence, Optional, Union, Callable, List, Tuple, Any
 from numbers import Number
-from functools import reduce
+from functools import reduce, partial
 from enum import Enum
 
 # Experimental module containing prototype "primitive" operations.
@@ -44,9 +44,8 @@ __all__ = [
     "exp",
     "expm1",
     "floor",
-    "igamma",
-    "igammac",
     "is_finite",
+    "isnan",
     "lgamma",
     "log",
     "log1p",
@@ -73,6 +72,8 @@ __all__ = [
     "eq",
     "ge",
     "gt",
+    "igamma",
+    "igammac",
     "le",
     "lt",
     "max",
@@ -174,7 +175,14 @@ def _make_prim(
     return _prim
 
 
-def _elementwise_meta(*args):
+class ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND(Enum):
+    DEFAULT = (0,)
+    ALWAYS_BOOL = (2,)
+    COMPLEX_TO_FLOAT = (3,)
+
+
+# TODO: implement and test type promotion and stride behavior
+def _elementwise_meta(*args, type_promotion):
     """
     Meta function for elementwise operations that produce outputs in the same dtype
     as their inputs.
@@ -219,23 +227,33 @@ def _elementwise_meta(*args):
     return TensorMeta(number)
 
 
-def _make_elementwise_unary_prim(name: str, **kwargs):
+def _make_elementwise_unary_prim(
+    name: str, *, type_promotion: ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND, **kwargs
+):
     """
     Creates an elementwise unary prim.
     """
 
     return _make_prim(
-        name=name, meta=_elementwise_meta, return_type=RETURN_TYPE.NEW, **kwargs
+        name=name,
+        meta=partial(_elementwise_meta, type_promotion=type_promotion),
+        return_type=RETURN_TYPE.NEW,
+        **kwargs
     )
 
 
-def _make_elementwise_binary_prim(name: str, **kwargs):
+def _make_elementwise_binary_prim(
+    name: str, *, type_promotion: ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND, **kwargs
+):
     """
     Creates an elementwise binary prim.
     """
 
     return _make_prim(
-        name=name, meta=_elementwise_meta, return_type=RETURN_TYPE.NEW, **kwargs
+        name=name,
+        meta=partial(_elementwise_meta, type_promotion=type_promotion),
+        return_type=RETURN_TYPE.NEW,
+        **kwargs
     )
 
 
@@ -251,54 +269,63 @@ abs = _make_elementwise_unary_prim(
     "abs",
     impl_aten=torch.abs,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.COMPLEX_TO_FLOAT,
 )
 
 acos = _make_elementwise_unary_prim(
     "acos",
     impl_aten=torch.acos,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 acosh = _make_elementwise_unary_prim(
     "acosh",
     impl_aten=torch.acosh,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 asin = _make_elementwise_unary_prim(
     "asin",
     impl_aten=torch.asin,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 atan = _make_elementwise_unary_prim(
     "atan",
     impl_aten=torch.atan,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 cos = _make_elementwise_unary_prim(
     "cos",
     impl_aten=torch.cos,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 cosh = _make_elementwise_unary_prim(
     "cosh",
     impl_aten=torch.cosh,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 bessel_i0e = _make_elementwise_unary_prim(
     "bessel_i0e",
     impl_aten=torch.special.i0e,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 bessel_i1e = _make_elementwise_unary_prim(
     "bessel_i1e",
     impl_aten=torch.special.i1e,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 
@@ -310,144 +337,154 @@ cbrt = _make_elementwise_unary_prim(
     "cbrt",
     impl_aten=_cbrt_aten,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 ceil = _make_elementwise_unary_prim(
     "ceil",
     impl_aten=torch.ceil,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 digamma = _make_elementwise_unary_prim(
     "digamma",
     impl_aten=torch.digamma,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 erf = _make_elementwise_unary_prim(
     "erf",
     impl_aten=torch.erf,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 erf_inv = _make_elementwise_unary_prim(
     "erf_inv",
     impl_aten=torch.special.erfinv,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 erfc = _make_elementwise_unary_prim(
     "erfc",
     impl_aten=torch.special.erfc,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 exp = _make_elementwise_unary_prim(
     "exp",
     impl_aten=torch.exp,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 expm1 = _make_elementwise_unary_prim(
     "expm1",
     impl_aten=torch.special.expm1,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 floor = _make_elementwise_unary_prim(
     "floor",
     impl_aten=torch.floor,
     doc="",
-)
-
-igamma = _make_elementwise_unary_prim(
-    "igamma",
-    impl_aten=torch.special.gammainc,
-    doc="",
-)
-
-igammac = _make_elementwise_unary_prim(
-    "igammac",
-    impl_aten=torch.special.gammaincc,
-    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 is_finite = _make_elementwise_unary_prim(
     "is_finite",
     impl_aten=torch.isfinite,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
 )
 
 lgamma = _make_elementwise_unary_prim(
     "lgamma",
     impl_aten=torch.lgamma,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 log = _make_elementwise_unary_prim(
     "log",
     impl_aten=torch.log,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 log1p = _make_elementwise_unary_prim(
     "log1p",
     impl_aten=torch.log1p,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 reciprocal = _make_elementwise_unary_prim(
     "reciprocal",
     impl_aten=torch.reciprocal,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 neg = _make_elementwise_unary_prim(
     "neg",
     impl_aten=torch.neg,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 round = _make_elementwise_unary_prim(
     "round",
     impl_aten=torch.round,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 sign = _make_elementwise_unary_prim(
     "sign",
     impl_aten=torch.sign,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 sin = _make_elementwise_unary_prim(
     "sin",
     impl_aten=torch.sin,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 sinh = _make_elementwise_unary_prim(
     "sinh",
     impl_aten=torch.sinh,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 sqrt = _make_elementwise_unary_prim(
     "sqrt",
     impl_aten=torch.sqrt,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 square = _make_elementwise_unary_prim(
     "square",
     impl_aten=torch.square,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 tan = _make_elementwise_unary_prim(
     "tan",
     impl_aten=torch.tan,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 #
@@ -463,36 +500,42 @@ add = _make_elementwise_binary_prim(
     impl_aten=torch.add,
     impl_nvfuser=_add_nvfuser,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 atan2 = _make_elementwise_binary_prim(
     name="atan2",
     impl_aten=torch.atan2,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 bitwise_and = _make_elementwise_binary_prim(
     "bitwise_and",
     impl_aten=torch.bitwise_and,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 bitwise_not = _make_elementwise_binary_prim(
     "bitwise_not",
     impl_aten=torch.bitwise_not,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 bitwise_or = _make_elementwise_binary_prim(
     "bitwise_or",
     impl_aten=torch.bitwise_or,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 bitwise_xor = _make_elementwise_binary_prim(
     "bitwise_xor",
     impl_aten=torch.bitwise_xor,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 # TODO: complex needs a special meta to account for its float -> complex behavior
@@ -518,12 +561,14 @@ div = _make_elementwise_binary_prim(
     impl_aten=_div_aten,
     impl_nvfuser=_div_nvfuser,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 eq = _make_elementwise_binary_prim(
     "eq",
     impl_aten=torch.eq,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
 )
 
 
@@ -536,6 +581,7 @@ ge = _make_elementwise_binary_prim(
     impl_aten=torch.ge,
     impl_nvfuser=_ge_nvfuser,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
 )
 
 
@@ -548,6 +594,21 @@ gt = _make_elementwise_binary_prim(
     impl_aten=torch.gt,
     impl_nvfuser=_gt_nvfuser,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
+)
+
+igamma = _make_elementwise_binary_prim(
+    "igamma",
+    impl_aten=torch.special.gammainc,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
+igammac = _make_elementwise_binary_prim(
+    "igammac",
+    impl_aten=torch.special.gammaincc,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 
@@ -560,6 +621,7 @@ le = _make_elementwise_binary_prim(
     impl_aten=torch.le,
     impl_nvfuser=_le_nvfuser,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
 )
 
 
@@ -572,18 +634,21 @@ lt = _make_elementwise_binary_prim(
     impl_aten=torch.lt,
     impl_nvfuser=_lt_nvfuser,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
 )
 
 max = _make_elementwise_binary_prim(
     "max",
     impl_aten=torch.maximum,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 min = _make_elementwise_binary_prim(
     "min",
     impl_aten=torch.minimum,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 
@@ -596,42 +661,49 @@ mul = _make_elementwise_binary_prim(
     impl_aten=torch.mul,
     impl_nvfuser=_mul_nvfuser,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 ne = _make_elementwise_binary_prim(
     "ne",
     impl_aten=torch.ne,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
 )
 
 nextafter = _make_elementwise_binary_prim(
     "nextafter",
     impl_aten=torch.nextafter,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 pow = _make_elementwise_binary_prim(
     "pow",
     impl_aten=torch.pow,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 rsqrt = _make_elementwise_binary_prim(
     "rsqrt",
     impl_aten=torch.rsqrt,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 shift_left = _make_elementwise_binary_prim(
     "shift_left",
     impl_aten=torch.bitwise_left_shift,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 shift_right_arithmetic = _make_elementwise_binary_prim(
     "shift_right_arithmetic",
     impl_aten=torch.bitwise_right_shift,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 shift_right_logical = _not_impl
@@ -640,6 +712,7 @@ sub = _make_elementwise_binary_prim(
     "sub",
     impl_aten=torch.sub,
     doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
 #
@@ -995,7 +1068,7 @@ def _select_meta(
     utils.check_same_shape(pred, a, b)
     assert pred.dtype is torch.bool
 
-    return _elementwise_meta(a, b)
+    return _elementwise_meta(a, b, type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT)
 
 
 def _select_aten(pred: Tensor, a: Tensor, b: Tensor) -> Tensor:
@@ -1124,7 +1197,6 @@ copy_to = _make_prim(
 def _resize_meta(
     a: TensorLikeType, shape: Union[torch.Size, List[int], Tuple[int, ...]]
 ):
-    assert a.numel() == 0
     return TensorMeta(a, shape=shape, strides=utils.make_contiguous_strides_for(shape))
 
 

--- a/torch/_prims/utils.py
+++ b/torch/_prims/utils.py
@@ -318,7 +318,7 @@ def check_same_shape(*args):
 
 _integer_dtypes = (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
 _float_dtypes = (torch.float16, torch.bfloat16, torch.float32, torch.float64)
-_complex_dtypes = (torch.complex64, torch.complex128)
+_complex_dtypes = (torch.complex32, torch.complex64, torch.complex128)
 
 
 def is_boolean_dtype(dtype: torch.dtype) -> bool:
@@ -335,6 +335,17 @@ def is_float_dtype(dtype: torch.dtype) -> bool:
 
 def is_complex_dtype(dtype: torch.dtype) -> bool:
     return dtype in _complex_dtypes
+
+
+_complex_to_real_dtype_map = {
+    torch.complex128: torch.float64,
+    torch.complex64: torch.float32,
+    torch.complex32: torch.float16,
+}
+
+
+def corresponding_real_dtype(dtype: torch.dtype) -> torch.dtype:
+    return _complex_to_real_dtype_map[dtype]
 
 
 def dtype_to_type(dtype: torch.dtype) -> type:
@@ -400,8 +411,8 @@ def get_higher_type(a: type, b: type) -> type:
 #   are not ordered relative to each other, the next
 #   higher datatype
 def get_higher_dtype(
-    a: Union[torch.dtype, torch.Tensor, Number],
-    b: Union[torch.dtype, torch.Tensor, Number],
+    a: Union[torch.dtype, TensorLikeType, Number],
+    b: Union[torch.dtype, TensorLikeType, Number],
 ) -> torch.dtype:
     """
     Computes the "lowest" datatype that is weakly
@@ -409,13 +420,13 @@ def get_higher_dtype(
     """
 
     # Type checking
-    assert isinstance(a, (torch.dtype, torch.Tensor, Number))
-    assert isinstance(b, (torch.dtype, torch.Tensor, Number))
+    assert isinstance(a, (torch.dtype, TensorLike, Number))
+    assert isinstance(b, (torch.dtype, TensorLike, Number))
 
-    def _extract_dtype(x: Union[torch.dtype, torch.Tensor, Number]) -> torch.dtype:
+    def _extract_dtype(x: Union[torch.dtype, TensorLikeType, Number]) -> torch.dtype:
         if isinstance(x, torch.dtype):
             return x
-        if isinstance(x, torch.Tensor):
+        if isinstance(x, TensorLike):
             return x.dtype
         if isinstance(x, Number):
             return type_to_dtype(type(x))

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -38,6 +38,7 @@ all = [
     "expm1",
     "floor",
     "isfinite",
+    "isnan",
     "lgamma",
     "log",
     "log1p",

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -3,12 +3,14 @@ import torch
 import torch._prims as prims
 import torch._prims.utils as utils
 from torch._prims import TensorLike as TensorLike
-from torch._prims.utils import DimsType
+from torch._prims.utils import DimsType, TensorLikeType
 
 from functools import reduce
 from enum import Enum
 from numbers import Number, Complex
 from typing import Sequence, Optional, Union, Callable, List
+import operator
+import warnings
 
 # Experimental module containing prototype Python references for existing
 #   PyTorch operations.
@@ -17,7 +19,37 @@ all = [
     #
     # Elementwise Unary References
     #
+    "abs",
+    "acos",
+    "acosh",
+    "asin",
+    "atan",
+    # "bessel_i0e",  # special.i0e
+    # "bessel_i1e",  # special.i1e
+    # "cbrt",  # No corresponding torch operation
+    "ceil",
+    "cos",
+    "cosh",
+    "digamma",
+    "erf",
+    "erfinv",
+    "erfc",
+    "exp",
+    "expm1",
     "floor",
+    "isfinite",
+    "lgamma",
+    "log",
+    "log1p",
+    "neg",
+    "reciprocal",
+    "round",  # TODO: model kwargs
+    "sign",
+    "sin",
+    "sinh",
+    "sqrt",
+    "square",
+    "tan",
     #
     # Elementwise Binary References
     #
@@ -41,8 +73,8 @@ all = [
     "gt",
     # 'heaviside',
     # 'hypot',
-    # 'igamma',
-    # 'igammac',
+    "igamma",
+    "igammac",
     # 'isclose', # abs, sub, le, add, mul
     # 'lcm',
     # 'ldexp',
@@ -70,15 +102,15 @@ all = [
     #
     # Conditional references
     #
-    "where",
+    "where",  # TODO: add opinfo
     #
     # Data conversion and movement references
     #
-    "copy_to",
+    "copy_to",  # TODO: add opinfo
     #
     # Reduction ops
     #
-    "sum",
+    "sum",  # TODO: add opinfo
 ]
 
 Tensor = torch.Tensor
@@ -88,7 +120,9 @@ class ELEMENTWISE_TYPE_PROMOTION_KIND(Enum):
     DEFAULT = (0,)
     INT_TO_FLOAT = (1,)
     ALWAYS_BOOL = (2,)
-    OP_MATH = 3
+    OP_MATH = (3,)
+    COMPLEX_TO_FLOAT = (4,)
+    BOOL_TO_LONG = (5,)
 
 
 class REDUCTION_OUTPUT_TYPE_KIND(Enum):
@@ -102,6 +136,7 @@ class REDUCTION_OUTPUT_TYPE_KIND(Enum):
 _computation_dtype_map = {
     torch.bfloat16: torch.float32,
     torch.float16: torch.float32,
+    torch.complex32: torch.complex64,
 }
 
 
@@ -191,19 +226,42 @@ def _elementwise_dtypes(*_args, type_promotion: ELEMENTWISE_TYPE_PROMOTION_KIND)
                 else torch.complex64
             )
 
-    if type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT and (
-        utils.is_boolean_dtype(dtype) or utils.is_integer_dtype(dtype)
+    if type_promotion in (
+        ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
+        ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     ):
-        return torch.get_default_dtype(), torch.get_default_dtype()
+        if type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL:
+            return dtype, torch.bool
 
-    if type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL:
-        return dtype, torch.bool
+        return dtype, dtype
 
-    if type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.OP_MATH:
+    if type_promotion in (
+        ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+        ELEMENTWISE_TYPE_PROMOTION_KIND.COMPLEX_TO_FLOAT,
+        ELEMENTWISE_TYPE_PROMOTION_KIND.BOOL_TO_LONG,
+        ELEMENTWISE_TYPE_PROMOTION_KIND.OP_MATH,
+    ):
+
+        if type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT and (
+            utils.is_boolean_dtype(dtype) or utils.is_integer_dtype(dtype)
+        ):
+            return torch.get_default_dtype(), torch.get_default_dtype()
+
+        if (
+            type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.COMPLEX_TO_FLOAT
+            and utils.is_complex_dtype(dtype)
+        ):
+            return _get_computation_dtype(dtype), utils.corresponding_real_dtype(dtype)
+
+        if (
+            type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.BOOL_TO_LONG
+            and utils.is_boolean_dtype(dtype)
+        ):
+            return torch.long, torch.long
+
         return _get_computation_dtype(dtype), dtype
 
-    # DEFAULT type promotion
-    return dtype, dtype
+    raise ValueError("Unknown type promotion kind {0}".format(str(type_promotion)))
 
 
 def _broadcast_shapes(*_shapes):
@@ -281,8 +339,21 @@ def _convert_dtype(*args, dtype: torch.dtype):
 
 
 # TODO: handle tuples of tensors
-def _maybe_resize_out(out: Tensor, shape):
+def _maybe_resize_out(out: TensorLikeType, shape):
     if out.numel() == 0:
+        return prims.resize(out, shape)
+
+    if out.numel() != reduce(operator.mul, shape, 1):
+        msg = (
+            "An output with one or more elements was resized since it had shape {0} "
+            "which does not match the required output shape {1}. "
+            "This behavior is deprecated, and in a future PyTorch release outputs will not "
+            "be resized unless they have zero elements. "
+            "You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0).".format(
+                str(out.shape), str(shape)
+            )
+        )
+        warnings.warn(msg)
         return prims.resize(out, shape)
 
     return out
@@ -293,13 +364,21 @@ def _maybe_resize_out(out: Tensor, shape):
 #
 
 # TODO: add type promotion support
-def _make_elementwise_unary_reference(prim: Callable) -> Callable:
+def _make_elementwise_unary_reference(prim: Callable, *, type_promotion) -> Callable:
     def _ref(a: Tensor, *, out: Optional[Tensor] = None) -> Tensor:
 
         assert isinstance(a, TensorLike)
         assert out is None or isinstance(out, TensorLike)
 
+        computation_dtype, result_dtype = _elementwise_dtypes(
+            a, type_promotion=type_promotion
+        )
+        (a,) = _convert_dtype(a, dtype=computation_dtype)
+
         result = prim(a)
+
+        if type_promotion is not ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT:
+            (result,) = _convert_dtype(result, dtype=result_dtype)
 
         # TODO: refactor out handling to a generic wrapper
         if out is not None:
@@ -311,7 +390,127 @@ def _make_elementwise_unary_reference(prim: Callable) -> Callable:
     return _ref
 
 
-floor = _make_elementwise_unary_reference(prims.floor)
+abs = _make_elementwise_unary_reference(
+    prims.abs, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.COMPLEX_TO_FLOAT
+)
+
+acos = _make_elementwise_unary_reference(
+    prims.acos, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+acosh = _make_elementwise_unary_reference(
+    prims.acosh, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+asin = _make_elementwise_unary_reference(
+    prims.asin, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+atan = _make_elementwise_unary_reference(
+    prims.atan, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+ceil = _make_elementwise_unary_reference(
+    prims.ceil, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
+)
+
+cos = _make_elementwise_unary_reference(
+    prims.cos, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+cosh = _make_elementwise_unary_reference(
+    prims.cosh, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+digamma = _make_elementwise_unary_reference(
+    prims.digamma, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+erf = _make_elementwise_unary_reference(
+    prims.erf, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+erfinv = _make_elementwise_unary_reference(
+    prims.erf_inv, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+erfc = _make_elementwise_unary_reference(
+    prims.erfc, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+exp = _make_elementwise_unary_reference(
+    prims.exp, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+expm1 = _make_elementwise_unary_reference(
+    prims.expm1, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+floor = _make_elementwise_unary_reference(
+    prims.floor, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
+)
+
+isfinite = _make_elementwise_unary_reference(
+    prims.is_finite, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL
+)
+
+
+def _isnan(a: Tensor) -> Tensor:
+    return prims.ne(a, a)
+
+
+isnan = _make_elementwise_unary_reference(
+    _isnan, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL
+)
+
+lgamma = _make_elementwise_unary_reference(
+    prims.lgamma, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+log = _make_elementwise_unary_reference(
+    prims.log, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+log1p = _make_elementwise_unary_reference(
+    prims.log1p, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+neg = _make_elementwise_unary_reference(
+    prims.neg, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
+)
+
+reciprocal = _make_elementwise_unary_reference(
+    prims.reciprocal, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+# TODO: round takes additional kwargs
+round = _make_elementwise_unary_reference(
+    prims.round, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
+)
+
+sign = _make_elementwise_unary_reference(
+    prims.sign, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT
+)
+
+sin = _make_elementwise_unary_reference(
+    prims.sin, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+sinh = _make_elementwise_unary_reference(
+    prims.sinh, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+sqrt = _make_elementwise_unary_reference(
+    prims.sqrt, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+square = _make_elementwise_unary_reference(
+    prims.square, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.BOOL_TO_LONG
+)
+
+tan = _make_elementwise_unary_reference(
+    prims.tan, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
 
 
 def _make_elementwise_binary_reference(prim: Callable, *, type_promotion) -> Callable:
@@ -441,11 +640,13 @@ eq = _make_elementwise_binary_reference(
 # TODO: add docstring
 # Float power has its own implementation because it has unique type promotion.
 def float_power(
-    a: Union[Tensor, Number], b: Union[Tensor, Number], out: Optional[Tensor] = None
+    a: Union[TensorLikeType, Number],
+    b: Union[TensorLikeType, Number],
+    out: Optional[TensorLikeType] = None,
 ) -> Tensor:
 
-    assert isinstance(a, (Tensor, Number))
-    assert isinstance(b, (Tensor, Number))
+    assert isinstance(a, (TensorLike, Number))
+    assert isinstance(b, (TensorLike, Number))
     assert out is None or isinstance(out, TensorLike)
 
     # Special-cases Number x Number case
@@ -483,9 +684,17 @@ gt = _make_elementwise_binary_reference(
     prims.gt, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL
 )
 
+igamma = _make_elementwise_binary_reference(
+    prims.igamma, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
+igammac = _make_elementwise_binary_reference(
+    prims.igammac, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT
+)
+
 # TODO: add docstring
 le = _make_elementwise_binary_reference(
-    prims.lt, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL
+    prims.le, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL
 )
 
 # TODO: add docstring
@@ -520,7 +729,7 @@ nextafter = _make_elementwise_binary_reference(
 
 # TODO: add docstring
 pow = _make_elementwise_binary_reference(
-    prims.pow, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.OP_MATH
+    prims.pow, type_promotion=ELEMENTWISE_TYPE_PROMOTION_KIND.BOOL_TO_LONG
 )
 
 # TODO: add docstring

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2304,9 +2304,11 @@ def _reference_inputs_elementwise_binary(op, device, dtype, requires_grad, **kwa
         yield from generate_elementwise_binary_large_value_tensors(
             op, device=device, dtype=dtype, requires_grad=requires_grad
         )
-    yield from generate_elementwise_binary_broadcasting_tensors(
-        op, device=device, dtype=dtype, requires_grad=requires_grad
-    )
+    # TODO: FIXME: RuntimeError: "index_select" not implemented for 'ComplexHalf'
+    if dtype not in (torch.chalf,):
+        yield from generate_elementwise_binary_broadcasting_tensors(
+            op, device=device, dtype=dtype, requires_grad=requires_grad
+        )
     yield from generate_elementwise_binary_with_scalar_samples(
         op, device=device, dtype=dtype, requires_grad=requires_grad
     )
@@ -2326,6 +2328,10 @@ def reference_inputs_elementwise_binary(op, device, dtype, requires_grad, **kwar
 
     # yields "normal" samples
     yield from gen()
+
+    # TODO: RuntimeError: "index_select" not implemented for 'ComplexHalf'
+    if dtype is torch.chalf:
+        return
 
     # yields noncontiguous samples
     for sample in gen():
@@ -2713,6 +2719,7 @@ class UnaryUfuncInfo(OpInfo):
         handles_large_floats=True,  # whether the op correctly handles large float values (like 1e20)
         supports_complex_to_float=False,  # op supports casting from complex input to real output safely eg. angle
         sample_inputs_func=sample_inputs_elementwise_unary,
+        reference_inputs_func=reference_inputs_elementwise_unary,
         sample_kwargs=lambda device, dtype, input: ({}, {}),
         supports_sparse=False,
         reference_numerics_filter=None,  # Filters values in the range of the domain specified above but that should not be tested
@@ -13532,7 +13539,7 @@ op_db: List[OpInfo] = [
                     supports_forward_ad=True,
                     supports_fwgrad_bwgrad=True,
                     assert_autodiffed=True,
-                    supports_two_python_scalars=True,
+                    supports_one_python_scalar=True,
                     # TODO: FIXME: pow needs a way of specifying that for integer
                     #   types only it does not support negative exponentes
                     rhs_make_tensor_kwargs=dict(low=1),
@@ -17504,8 +17511,117 @@ python_ref_db = [
     # Elementwise unary OpInfos
     #
     ElementwiseUnaryPythonRefInfo(
+        "_refs.abs",
+        torch_opinfo_name="abs",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.acos",
+        torch_opinfo_name="acos",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.acosh",
+        torch_opinfo_name="acosh",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.asin",
+        torch_opinfo_name="asin",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.atan",
+        torch_opinfo_name="atan",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.ceil",
+        torch_opinfo_name="ceil",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.cos",
+        torch_opinfo_name="cos",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.cosh",
+        torch_opinfo_name="cosh",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.digamma",
+        torch_opinfo_name="digamma",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.erf",
+        torch_opinfo_name="erf",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.erfinv",
+        torch_opinfo_name="erfinv",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.erfc",
+        torch_opinfo_name="erfc",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.exp",
+        torch_opinfo_name="exp",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.expm1",
+        torch_opinfo_name="expm1",
+    ),
+    ElementwiseUnaryPythonRefInfo(
         "_refs.floor",
         torch_opinfo_name="floor",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.isfinite",
+        torch_opinfo_name="isfinite",
+        supports_out=True,
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.lgamma",
+        torch_opinfo_name="lgamma",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.log",
+        torch_opinfo_name="log",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.log1p",
+        torch_opinfo_name="log1p",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.neg",
+        torch_opinfo_name="neg",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.reciprocal",
+        torch_opinfo_name="reciprocal",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.round",
+        torch_opinfo_name="round",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.sign",
+        torch_opinfo_name="sign",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.sin",
+        torch_opinfo_name="sin",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.sinh",
+        torch_opinfo_name="sinh",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.sqrt",
+        torch_opinfo_name="sqrt",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.square",
+        torch_opinfo_name="square",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.tan",
+        torch_opinfo_name="tan",
     ),
     #
     # Elementwise binary OpInfos
@@ -17523,8 +17639,110 @@ python_ref_db = [
                 ),
                 "TestCommon",
                 "test_python_reference_consistency",
+                device_type='cpu'
             ),
         ),
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.atan2",
+        torch_opinfo_name="atan2",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.bitwise_and",
+        torch_opinfo_name="bitwise_and",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.bitwise_left_shift",
+        torch_opinfo_name="bitwise_left_shift",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.bitwise_or",
+        torch_opinfo_name="bitwise_or",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.bitwise_xor",
+        torch_opinfo_name="bitwise_xor",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.eq",
+        torch_opinfo_name="eq",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.float_power",
+        torch_opinfo_name="float_power",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.ge",
+        torch_opinfo_name="ge",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.gt",
+        torch_opinfo_name="gt",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.igamma",
+        torch_opinfo_name="igamma",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.igammac",
+        torch_opinfo_name="igammac",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.le",
+        torch_opinfo_name="le",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.lt",
+        torch_opinfo_name="lt",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.maximum",
+        torch_opinfo_name="maximum",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.minimum",
+        torch_opinfo_name="minimum",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.mul",
+        torch_opinfo_name="mul",
+        skips=(
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_reference_consistency',
+                         dtypes=(torch.chalf,), device_type='cuda'),
+        )
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.ne",
+        torch_opinfo_name="ne",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.nextafter",
+        torch_opinfo_name="nextafter",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.pow",
+        torch_opinfo_name="pow",
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.sub",
+        torch_opinfo_name="sub",
+        decorators=(
+            DecorateInfo(
+                toleranceOverride(
+                    {
+                        torch.bfloat16: tol(atol=1, rtol=0),
+                        torch.float16: tol(atol=1e-2, rtol=0),
+                    }
+                ),
+                "TestCommon",
+                "test_python_reference_consistency",
+                device_type='cpu'
+            ),
+        ),
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.true_divide",
+        torch_opinfo_name="true_divide",
     ),
 ]
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17713,7 +17713,7 @@ python_ref_db = [
         torch_opinfo_name="mul",
         skips=(
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_reference_consistency',
-                         dtypes=(torch.chalf,), device_type='cuda'),
+                         dtypes=(torch.chalf,), device_type='cuda', active_if=(not TEST_WITH_ROCM)),
         )
     ),
     ElementwiseBinaryPythonRefInfo(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17576,6 +17576,11 @@ python_ref_db = [
         supports_out=True,
     ),
     ElementwiseUnaryPythonRefInfo(
+        "_refs.isnan",
+        torch_opinfo_name="isnan",
+        supports_out=True,
+    ),
+    ElementwiseUnaryPythonRefInfo(
         "_refs.lgamma",
         torch_opinfo_name="lgamma",
     ),


### PR DESCRIPTION
This PR makes the following changes:

Prims:
- igamma and igammac are now correctly listed as elementwise binary operations, not elementwise unary operations
- elementwise prims now must specify their type promotion kind (this is currently unused)

Refs:
- complexhalf is now handled by opmath-style type promotion
- adds references for: abs, acos, acosh, asin, atan, ceil, cos, cosh, digamma, erf, erfinv, erfc, exp, expm1, isfinite, isnan, lgamma, log, log1p, neg, reciprocal, sign, sin, sinh, sqrt, square, tan, igamma, igammac
- adds "complex to float" and "bool to long" type promotion kinds
- updates out behavior to warn when resizing a non-empty tensor, consistent with current ops
- updates the elementwise unary reference template with type promotion

Tests:
- fixes torch.pow's OpInfo to correctly specify it only supports one scalar input, not two
- fixes elementwise binary reference inputs to not attempt generating certain tensors in complex half (for now, cc @kshitij12345)
- adds OpInfos for the following Python references: abs, acos, acosh, asin, atan, ceil, cos, cosh, digamma, erf, erfinv, erfc, exp, expm1, isfinite, isnan, lgamma, log, log1p, neg, reciprocal, round, sign, sin, sinh, sqrt, square, tan, atan2, bitwise_and, bitwise_left_shift, bitwise_or, bitwise_xor, eq, float_power, ge, gt, igamma, igammac, le, lt, maximum, minimum, mul, ne, nextafter, pow, sub, true_divide

