### PR TITLE
Fix failing test when SciPy is not available for test_ldl_factor 

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -7845,7 +7845,6 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
     @dtypes(*floating_and_complex_types())
     def test_ldl_factor(self, device, dtype):
         from torch.testing._internal.common_utils import random_hermitian_pd_matrix
-        from scipy.linalg import ldl as scipy_ldl
 
         def run_test(shape, batch, hermitian):
             A = random_hermitian_pd_matrix(shape, *batch, dtype=dtype, device=device)
@@ -7873,6 +7872,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
 
             # Now test against SciPy implementation
             if TEST_SCIPY:
+                from scipy.linalg import ldl as scipy_ldl
                 A_np = A.cpu().numpy()
                 np_dtype = A_np.dtype
                 scipy_ldl_batched = np.vectorize(


### PR DESCRIPTION
This PR moves the SciPy function import under the `if TEST_SCIPY` block.
