### PR TITLE
[JIT][Autocast] Don't cast softmax on CPU

### DIFF
--- a/torch/csrc/jit/passes/autocast.cpp
+++ b/torch/csrc/jit/passes/autocast.cpp
@@ -418,8 +418,7 @@ void handleBlock(Block* block, AutocastContext initial_state) {
         if (!node->schema().is_mutable() && !hasExplicitDtypeArgument(node)) {
           auto context = current_state();
           context.cpu_enabled = false;
-          castTensorInputs(
-              node, aten::_autocast_to_full_precision, context);
+          castTensorInputs(node, aten::_autocast_to_full_precision, context);
         }
         break;
 

--- a/torch/csrc/jit/passes/autocast.cpp
+++ b/torch/csrc/jit/passes/autocast.cpp
@@ -403,7 +403,6 @@ void handleBlock(Block* block, AutocastContext initial_state) {
 
       // CastPolicy::fp32_set_opt_dtype
       case aten::prod:
-      case aten::softmax:
       case aten::log_softmax:
       case aten::cumprod:
       case aten::cumsum:
@@ -411,6 +410,16 @@ void handleBlock(Block* block, AutocastContext initial_state) {
         if (!node->schema().is_mutable() && !hasExplicitDtypeArgument(node)) {
           castTensorInputs(
               node, aten::_autocast_to_full_precision, current_state());
+        }
+        break;
+
+      // cast softmax to fp32 only on GPU
+      case aten::softmax:
+        if (!node->schema().is_mutable() && !hasExplicitDtypeArgument(node)) {
+          auto context = current_state();
+          context.cpu_enabled = false;
+          castTensorInputs(
+              node, aten::_autocast_to_full_precision, context);
         }
         break;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #76661

In eager autocasting, softmax is only up-casted on GPU (and not on CPU).
This fixes the JIT implementation to do the same.