### PR TITLE
Turn on memory efficient format for jit pickle files.

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -4548,6 +4548,7 @@ def foo(xyz):
             debug_files = filter(lambda f: f.endswith('.debug_pkl'), files)
             debug_files = (archive.open(f) for f in debug_files)
             debug_files = (pickle.load(f) for f in debug_files)
+            debug_files = (f[2] for f in debug_files)
             return list(debug_files)
 
         debug_files = debug_records_from_mod(ft3)

--- a/torch/csrc/jit/serialization/source_range_serialization.cpp
+++ b/torch/csrc/jit/serialization/source_range_serialization.cpp
@@ -13,7 +13,7 @@ namespace jit {
 // "Whether to emit compact debug_pkl when saving a model to .pt file."
 // "Compact file is smaller but cannot be loaded by old torch binaries."
 // TODO(qihan) remove when all binaries are using string table.
-thread_local bool should_use_format_with_string_table_ = false;
+thread_local bool should_use_format_with_string_table_ = true;
 
 class SourceRangeSerializer {
  public:


### PR DESCRIPTION
Summary:
This enables previous change made at D35196883 (https://github.com/pytorch/pytorch/commit/b34b192d6b97325c9f78e5995c48c8498ede34bd)
Previous change is landed for 2 weeks to make sure that the format change introduced here will be handed in code.

Test Plan: existing tests

Differential Revision: D36074453

