### PR TITLE
Add mode property to distributions.

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2947,6 +2947,13 @@ class TestDistributions(TestCase):
                     'icdf(cdf(x)) = {}'.format(actual),
                 ]))
 
+    def test_gamma_log_prob_at_boundary(self):
+        for concentration, log_prob in [(.5, inf), (1, 0), (2, -inf)]:
+            dist = Gamma(concentration, 1)
+            scipy_dist = scipy.stats.gamma(concentration)
+            np.testing.assert_allclose(dist.log_prob(0), log_prob)
+            np.testing.assert_allclose(dist.log_prob(0), scipy_dist.logpdf(0))
+
     def test_cdf_log_prob(self):
         # Tests if the differentiation of the CDF gives the PDF at a given value
         for Dist, params in EXAMPLES:

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2752,6 +2752,18 @@ class TestDistributions(TestCase):
                                     'Dirichlet(alpha={})'.format(list(alpha)),
                                     multivariate=True)
 
+    def test_dirichlet_mode(self):
+        # Test a few edge cases for the Dirichlet distribution mode. This also covers beta distributions.
+        concentrations_and_modes = [
+            ([2, 2, 1], [.5, .5, 0.]),
+            ([3, 2, 1], [2 / 3, 1 / 3, 0]),
+            ([.5, .2, .2], [1., 0., 0.]),
+            ([1, 1, 1], [nan, nan, nan]),
+        ]
+        for concentration, mode in concentrations_and_modes:
+            dist = Dirichlet(torch.tensor(concentration))
+            self.assertEqual(dist.mode, torch.tensor(mode))
+
     def test_beta_shape(self):
         con1 = torch.randn(2, 3).exp().requires_grad_()
         con0 = torch.randn(2, 3).exp().requires_grad_()

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -68,6 +68,10 @@ class Bernoulli(ExponentialFamily):
         return self.probs
 
     @property
+    def mode(self):
+        return (self.probs >= 0.5).to(self.probs)
+
+    @property
     def variance(self):
         return self.probs * (1 - self.probs)
 

--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -1,6 +1,7 @@
 from numbers import Number
 
 import torch
+from torch._six import nan
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import broadcast_all, probs_to_logits, logits_to_probs, lazy_property
@@ -69,7 +70,9 @@ class Bernoulli(ExponentialFamily):
 
     @property
     def mode(self):
-        return (self.probs >= 0.5).to(self.probs)
+        mode = (self.probs >= 0.5).to(self.probs)
+        mode[self.probs == 0.5] = nan
+        return mode
 
     @property
     def variance(self):

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -50,10 +50,7 @@ class Beta(ExponentialFamily):
 
     @property
     def mode(self):
-        mode = (self.concentration1 - 1) / (self.concentration0 + self.concentration1 - 2)
-        f = (self.concentration0 < 1) | (self.concentration1 < 1)
-        mode[f] = (self.concentration0[f] < self.concentration1[f]).to(self.concentration0)
-        return mode.clamp(min=0, max=1)
+        return self._dirichlet.mode[..., 0]
 
     @property
     def variance(self):

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -1,6 +1,7 @@
 from numbers import Real, Number
 
 import torch
+from torch._six import nan
 from torch.distributions import constraints
 from torch.distributions.dirichlet import Dirichlet
 from torch.distributions.exp_family import ExponentialFamily
@@ -47,6 +48,12 @@ class Beta(ExponentialFamily):
     @property
     def mean(self):
         return self.concentration1 / (self.concentration1 + self.concentration0)
+
+    @property
+    def mode(self):
+        mode = (self.concentration1 - 1) / (self.concentration0 + self.concentration1 - 2)
+        mode[(self.concentration0 <= 1) & (self.concentration1 <= 1)] = nan
+        return mode.clamp(0, 1)
 
     @property
     def variance(self):

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -53,7 +53,7 @@ class Beta(ExponentialFamily):
     def mode(self):
         mode = (self.concentration1 - 1) / (self.concentration0 + self.concentration1 - 2)
         mode[(self.concentration0 <= 1) & (self.concentration1 <= 1)] = nan
-        return mode.clamp(0, 1)
+        return mode.clamp(min=0, max=1)
 
     @property
     def variance(self):

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -1,7 +1,6 @@
 from numbers import Real, Number
 
 import torch
-from torch._six import nan
 from torch.distributions import constraints
 from torch.distributions.dirichlet import Dirichlet
 from torch.distributions.exp_family import ExponentialFamily
@@ -52,7 +51,8 @@ class Beta(ExponentialFamily):
     @property
     def mode(self):
         mode = (self.concentration1 - 1) / (self.concentration0 + self.concentration1 - 2)
-        mode[(self.concentration0 <= 1) & (self.concentration1 <= 1)] = nan
+        f = (self.concentration0 < 1) | (self.concentration1 < 1)
+        mode[f] = (self.concentration0[f] < self.concentration1[f]).to(self.concentration0)
         return mode.clamp(min=0, max=1)
 
     @property

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -76,6 +76,10 @@ class Binomial(Distribution):
         return self.total_count * self.probs
 
     @property
+    def mode(self):
+        return ((self.total_count + 1) * self.probs).floor()
+
+    @property
     def variance(self):
         return self.total_count * self.probs * (1 - self.probs)
 

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -77,7 +77,7 @@ class Binomial(Distribution):
 
     @property
     def mode(self):
-        return ((self.total_count + 1) * self.probs).floor()
+        return ((self.total_count + 1) * self.probs).floor().clamp(max=self.total_count)
 
     @property
     def variance(self):

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -102,6 +102,10 @@ class Categorical(Distribution):
         return torch.full(self._extended_shape(), nan, dtype=self.probs.dtype, device=self.probs.device)
 
     @property
+    def mode(self):
+        return self.probs.argmax(axis=-1)
+
+    @property
     def variance(self):
         return torch.full(self._extended_shape(), nan, dtype=self.probs.dtype, device=self.probs.device)
 

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -50,6 +50,10 @@ class Cauchy(Distribution):
         return torch.full(self._extended_shape(), nan, dtype=self.loc.dtype, device=self.loc.device)
 
     @property
+    def mode(self):
+        return self.loc
+
+    @property
     def variance(self):
         return torch.full(self._extended_shape(), inf, dtype=self.loc.dtype, device=self.loc.device)
 

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -79,7 +79,7 @@ class Dirichlet(ExponentialFamily):
     @property
     def mode(self):
         concentrationm1 = self.concentration - 1
-        mode = (concentrationm1 / concentrationm1.sum(-1, True)).clamp(0)
+        mode = (concentrationm1 / concentrationm1.sum(-1, True)).clamp(min=0)
         mode = mode * torch.where((self.concentration <= 1).any(-1, True), nan, 1.)
         return mode
 

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -1,4 +1,5 @@
 import torch
+from torch._six import nan
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 from torch.distributions import constraints
@@ -74,6 +75,13 @@ class Dirichlet(ExponentialFamily):
     @property
     def mean(self):
         return self.concentration / self.concentration.sum(-1, True)
+
+    @property
+    def mode(self):
+        concentrationm1 = self.concentration - 1
+        mode = (concentrationm1 / concentrationm1.sum(-1, True)).clamp(0)
+        mode = mode * torch.where((self.concentration <= 1).any(-1, True), nan, 1.)
+        return mode
 
     @property
     def variance(self):

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -122,6 +122,13 @@ class Distribution(object):
         raise NotImplementedError
 
     @property
+    def mode(self):
+        """
+        Returns the mode of the distribution.
+        """
+        raise NotImplementedError(self)
+
+    @property
     def variance(self):
         """
         Returns the variance of the distribution.

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -126,7 +126,7 @@ class Distribution(object):
         """
         Returns the mode of the distribution.
         """
-        raise NotImplementedError(self)
+        raise NotImplementedError(f"{self.__class__} does not implement mode")
 
     @property
     def variance(self):

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -29,6 +29,10 @@ class Exponential(ExponentialFamily):
         return self.rate.reciprocal()
 
     @property
+    def mode(self):
+        return torch.zeros_like(self.rate)
+
+    @property
     def stddev(self):
         return self.rate.reciprocal()
 

--- a/torch/distributions/fishersnedecor.py
+++ b/torch/distributions/fishersnedecor.py
@@ -54,6 +54,12 @@ class FisherSnedecor(Distribution):
         return df2 / (df2 - 2)
 
     @property
+    def mode(self):
+        mode = (self.df1 - 2) / self.df1 * self.df2 / (self.df2 + 2)
+        mode[self.df1 <= 2] = nan
+        return mode
+
+    @property
     def variance(self):
         df2 = self.df2.clone(memory_format=torch.contiguous_format)
         df2[df2 <= 4] = nan

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -70,8 +70,8 @@ class Gamma(ExponentialFamily):
         value = torch.as_tensor(value, dtype=self.rate.dtype, device=self.rate.device)
         if self._validate_args:
             self._validate_sample(value)
-        return (self.concentration * torch.log(self.rate) +
-                (self.concentration - 1) * torch.log(value) -
+        return (torch.xlogy(self.concentration, self.rate) +
+                torch.xlogy(self.concentration - 1, value) -
                 self.rate * value - torch.lgamma(self.concentration))
 
     def entropy(self):

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -27,7 +27,7 @@ class Gamma(ExponentialFamily):
             (often referred to as beta)
     """
     arg_constraints = {'concentration': constraints.positive, 'rate': constraints.positive}
-    support = constraints.positive
+    support = constraints.nonnegative
     has_rsample = True
     _mean_carrier_measure = 0
 

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -37,7 +37,7 @@ class Gamma(ExponentialFamily):
 
     @property
     def mode(self):
-        return ((self.concentration - 1) / self.rate).clamp(0)
+        return ((self.concentration - 1) / self.rate).clamp(min=0)
 
     @property
     def variance(self):

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -36,6 +36,10 @@ class Gamma(ExponentialFamily):
         return self.concentration / self.rate
 
     @property
+    def mode(self):
+        return ((self.concentration - 1) / self.rate).clamp(0)
+
+    @property
     def variance(self):
         return self.concentration / self.rate.pow(2)
 

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -72,6 +72,10 @@ class Geometric(Distribution):
         return 1. / self.probs - 1.
 
     @property
+    def mode(self):
+        return torch.zeros_like(self.probs)
+
+    @property
     def variance(self):
         return (1. / self.probs - 1.) / self.probs
 

--- a/torch/distributions/gumbel.py
+++ b/torch/distributions/gumbel.py
@@ -55,6 +55,10 @@ class Gumbel(TransformedDistribution):
         return self.loc + self.scale * euler_constant
 
     @property
+    def mode(self):
+        return self.loc
+
+    @property
     def stddev(self):
         return (math.pi / math.sqrt(6)) * self.scale
 

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -25,7 +25,7 @@ class HalfCauchy(TransformedDistribution):
         scale (float or Tensor): scale of the full Cauchy distribution
     """
     arg_constraints = {'scale': constraints.positive}
-    support = constraints.positive
+    support = constraints.nonnegative
     has_rsample = True
 
     def __init__(self, scale, validate_args=None):

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -46,6 +46,10 @@ class HalfCauchy(TransformedDistribution):
         return torch.full(self._extended_shape(), math.inf, dtype=self.scale.dtype, device=self.scale.device)
 
     @property
+    def mode(self):
+        return torch.zeros_like(self.scale)
+
+    @property
     def variance(self):
         return self.base_dist.variance
 

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -24,7 +24,7 @@ class HalfNormal(TransformedDistribution):
         scale (float or Tensor): scale of the full Normal distribution
     """
     arg_constraints = {'scale': constraints.positive}
-    support = constraints.positive
+    support = constraints.nonnegative
     has_rsample = True
 
     def __init__(self, scale, validate_args=None):

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -1,5 +1,6 @@
 import math
 
+import torch
 from torch._six import inf
 from torch.distributions import constraints
 from torch.distributions.transforms import AbsTransform
@@ -43,6 +44,10 @@ class HalfNormal(TransformedDistribution):
     @property
     def mean(self):
         return self.scale * math.sqrt(2 / math.pi)
+
+    @property
+    def mode(self):
+        return torch.zeros_like(self.scale)
 
     @property
     def variance(self):

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -78,6 +78,10 @@ class Independent(Distribution):
         return self.base_dist.mean
 
     @property
+    def mode(self):
+        return self.base_dist.mode
+
+    @property
     def variance(self):
         return self.base_dist.variance
 

--- a/torch/distributions/kumaraswamy.py
+++ b/torch/distributions/kumaraswamy.py
@@ -60,8 +60,8 @@ class Kumaraswamy(TransformedDistribution):
     @property
     def mode(self):
         # Evaluate in log-space for numerical stability.
-        log_mode = self.concentration0.recpriocal() * \
-            (-self.concentration0).log1p - (-self.concentration0 * self.concentration1).log1p()
+        log_mode = self.concentration0.reciprocal() * \
+            (-self.concentration0).log1p() - (-self.concentration0 * self.concentration1).log1p()
         log_mode[(self.concentration0 < 1) | (self.concentration1 < 1)] = nan
         return log_mode.exp()
 

--- a/torch/distributions/kumaraswamy.py
+++ b/torch/distributions/kumaraswamy.py
@@ -1,4 +1,5 @@
 import torch
+from torch._six import nan
 from torch.distributions import constraints
 from torch.distributions.uniform import Uniform
 from torch.distributions.transformed_distribution import TransformedDistribution
@@ -55,6 +56,14 @@ class Kumaraswamy(TransformedDistribution):
     @property
     def mean(self):
         return _moments(self.concentration1, self.concentration0, 1)
+
+    @property
+    def mode(self):
+        # Evaluate in log-space for numerical stability.
+        log_mode = self.concentration0.recpriocal() * \
+            (-self.concentration0).log1p - (-self.concentration0 * self.concentration1).log1p()
+        log_mode[(self.concentration0 < 1) | (self.concentration1 < 1)] = nan
+        return log_mode.exp()
 
     @property
     def variance(self):

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -28,6 +28,10 @@ class Laplace(Distribution):
         return self.loc
 
     @property
+    def mode(self):
+        return self.loc
+
+    @property
     def variance(self):
         return 2 * self.scale.pow(2)
 

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -47,6 +47,10 @@ class LogNormal(TransformedDistribution):
         return (self.loc + self.scale.pow(2) / 2).exp()
 
     @property
+    def mode(self):
+        return (self.loc - self.scale.square()).exp()
+
+    @property
     def variance(self):
         return (self.scale.pow(2).exp() - 1) * (2 * self.loc + self.scale.pow(2)).exp()
 

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -129,6 +129,10 @@ class LowRankMultivariateNormal(Distribution):
     def mean(self):
         return self.loc
 
+    @property
+    def mode(self):
+        return self.loc
+
     @lazy_property
     def variance(self):
         return (self._unbroadcasted_cov_factor.pow(2).sum(-1)

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -192,6 +192,10 @@ class MultivariateNormal(Distribution):
         return self.loc
 
     @property
+    def mode(self):
+        return self.loc
+
+    @property
     def variance(self):
         return self._unbroadcasted_scale_tril.pow(2).sum(-1).expand(
             self._batch_shape + self._event_shape)

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -60,6 +60,10 @@ class NegativeBinomial(Distribution):
         return self.total_count * torch.exp(self.logits)
 
     @property
+    def mode(self):
+        return ((self.total_count - 1) * self.logits.exp()).floor().clamp(min=0.)
+
+    @property
     def variance(self):
         return self.mean / torch.sigmoid(-self.logits)
 
@@ -96,5 +100,6 @@ class NegativeBinomial(Distribution):
 
         log_normalization = (-torch.lgamma(self.total_count + value) + torch.lgamma(1. + value) +
                              torch.lgamma(self.total_count))
+        log_normalization[self.total_count + value == 0.] = 0.
 
         return log_unnormalized_prob - log_normalization

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -34,6 +34,10 @@ class Normal(ExponentialFamily):
         return self.loc
 
     @property
+    def mode(self):
+        return self.loc
+
+    @property
     def stddev(self):
         return self.scale
 

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -72,8 +72,9 @@ class OneHotCategorical(Distribution):
 
     @property
     def mode(self):
-        max_prob, _ = self._categorical.probs.max(-1, True)
-        return (self._categorical.probs == max_prob).to(self._categorical.probs)
+        probs = self._categorical.probs
+        mode = probs.argmax(axis=-1)
+        return torch.nn.functional.one_hot(mode, num_classes=probs.shape[-1]).to(probs)
 
     @property
     def variance(self):

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -71,6 +71,11 @@ class OneHotCategorical(Distribution):
         return self._categorical.probs
 
     @property
+    def mode(self):
+        max_prob, _ = self._categorical.probs.max(-1, True)
+        return (self._categorical.probs == max_prob).to(self._categorical.probs)
+
+    @property
     def variance(self):
         return self._categorical.probs * (1 - self._categorical.probs)
 

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -40,6 +40,10 @@ class Pareto(TransformedDistribution):
         return a * self.scale / (a - 1)
 
     @property
+    def mode(self):
+        return self.scale
+
+    @property
     def variance(self):
         # var is inf for alpha <= 2
         a = self.alpha.clamp(min=2)
@@ -47,7 +51,7 @@ class Pareto(TransformedDistribution):
 
     @constraints.dependent_property(is_discrete=False, event_dim=0)
     def support(self):
-        return constraints.greater_than(self.scale)
+        return constraints.greater_than_eq(self.scale)
 
     def entropy(self):
         return ((self.scale / self.alpha).log() + (1 + self.alpha.reciprocal()))

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -32,6 +32,10 @@ class Poisson(ExponentialFamily):
         return self.rate
 
     @property
+    def mode(self):
+        return self.rate.floor()
+
+    @property
     def variance(self):
         return self.rate
 

--- a/torch/distributions/studentT.py
+++ b/torch/distributions/studentT.py
@@ -34,6 +34,10 @@ class StudentT(Distribution):
         return m
 
     @property
+    def mode(self):
+        return self.loc
+
+    @property
     def variance(self):
         m = self.df.clone(memory_format=torch.contiguous_format)
         m[self.df > 2] = self.scale[self.df > 2].pow(2) * self.df[self.df > 2] / (self.df[self.df > 2] - 2)

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -1,6 +1,7 @@
 from numbers import Number
 
 import torch
+from torch._six import nan
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
 from torch.distributions.utils import broadcast_all
@@ -29,6 +30,10 @@ class Uniform(Distribution):
     @property
     def mean(self):
         return (self.high + self.low) / 2
+
+    @property
+    def mode(self):
+        return nan * torch.empty_like(self.high)
 
     @property
     def stddev(self):

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -33,7 +33,7 @@ class Uniform(Distribution):
 
     @property
     def mode(self):
-        return nan * torch.empty_like(self.high)
+        return nan * self.high
 
     @property
     def stddev(self):

--- a/torch/distributions/von_mises.py
+++ b/torch/distributions/von_mises.py
@@ -131,6 +131,10 @@ class VonMises(Distribution):
         """
         return self.loc
 
+    @property
+    def mode(self):
+        return self.loc
+
     @lazy_property
     def variance(self):
         """

--- a/torch/distributions/weibull.py
+++ b/torch/distributions/weibull.py
@@ -53,6 +53,10 @@ class Weibull(TransformedDistribution):
         return self.scale * torch.exp(torch.lgamma(1 + self.concentration_reciprocal))
 
     @property
+    def mode(self):
+        return self.scale * ((self.concentration - 1) / self.concentration) ** self.concentration.reciprocal()
+
+    @property
     def variance(self):
         return self.scale.pow(2) * (torch.exp(torch.lgamma(1 + 2 * self.concentration_reciprocal)) -
                                     torch.exp(2 * torch.lgamma(1 + self.concentration_reciprocal)))

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -4,6 +4,7 @@ from numbers import Number
 from typing import Union
 
 import torch
+from torch._six import nan
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
 from torch.distributions.utils import lazy_property
@@ -178,6 +179,13 @@ class Wishart(ExponentialFamily):
     @property
     def mean(self):
         return self.df.view(self._batch_shape + (1, 1)) * self.covariance_matrix
+
+    @property
+    def mode(self):
+        factor = self.df - self.covariance_matrix.shape[-1] - 1
+        factor[factor <= 0] = nan
+        return factor.view(self._batch_shape + (1, 1)) * self.covariance_matrix
+
 
     @property
     def variance(self):


### PR DESCRIPTION
This PR fixes #69466 and introduces some other minor changes. Tests are somewhat more involved because a reference implementation in `scipy` is not available; tests proceed differently for discrete and continuous distributions.

For continuous distributions, we evaluate the gradient of the `log_prob` at the mode. Tests pass if the gradient is zero OR (the mode is at the boundary of the support of the distribution AND the `log_prob` decreases as we move away from the boundary to the interior of the support).

For discrete distributions, the notion of a gradient is not well defined. We thus "look" ahead and behind one step (e.g. if the mode of a Poisson distribution is 9, we consider 8 and 10). If the step ahead/behind is still within the support of the distribution, we assert that the `log_prob` is smaller than at the mode.

For one-hot encoded distributions (currently just `OneHotCategorical`), we evaluate the underlying mode (i.e. encoded as an integral tensor), "advance" by one label to get another sample that should have lower probability using `other = (mode + 1) % event_size` and re-encode as one-hot. The resultant `other` sample should have lower probability than the mode.

Furthermore, Gamma, half Cauchy, and half normal distributions have their support changed from positive to nonnegative. This change is necessary because the mode of the "half" distributions is zero, and the mode of the gamma distribution is zero for `concentration <= 1`.

cc @fritzo 
