### PR TITLE
[PyTorch] Remove dead store in intrusive_ptr dtor

### DIFF
--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -293,7 +293,6 @@ class intrusive_ptr final {
         delete target_;
       }
     }
-    target_ = NullType::singleton();
   }
 
   // raw pointer constructors are not public because we shouldn't make
@@ -417,6 +416,7 @@ class intrusive_ptr final {
 
   void reset() noexcept {
     reset_();
+    target_ = NullType::singleton();
   }
 
   void swap(intrusive_ptr& rhs) noexcept {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #76701

There is no need to null out `target_` in the destructor.

Differential Revision: [D36083158](https://our.internmc.facebook.com/intern/diff/D36083158/)