### PR TITLE
ROCM: Increase timeout for flaky test_with_kwargs

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -335,6 +335,9 @@ else:
     TIMEOUT_DEFAULT = 100
 TIMEOUT_OVERRIDE = {"test_ddp_uneven_inputs": 400}
 
+# https://github.com/pytorch/pytorch/issues/75665
+if TEST_WITH_ROCM:
+    TIMEOUT_OVERRIDE["test_join_kwargs"] = 200
 
 def create_device(interface=None):
     if sys.platform == "win32" or interface is None:


### PR DESCRIPTION
Fixes #75665.

Very rarely the test is failing on ROCM at boundary
of the current timeout set to 100 seconds.
Setting the timeout to 200 as default for ROCM,
for only this test, to be on the safe side.

Signed-off-by: Arindam Roy <rarindam@gmail.com>


