### PR TITLE
Adjust the stubs for PyCharm autocompletion of the Tensor methods.

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -2,7 +2,6 @@
 
 import torch
 from torch.package import PackageExporter
-from torch import Tensor
 from enum import Enum
 from pathlib import Path
 from typing import (

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -836,9 +836,6 @@ class ThroughputBenchmark(object):
 # Defined in torch/csrc/generic/Storage.cpp
 ${legacy_storage_base_hints}
 
-# TODO: where
-${legacy_class_hints}
-
 # Defined in torch/csrc/autograd/python_engine.cpp
 class _ImperativeEngine:
     ...
@@ -872,6 +869,11 @@ class _TensorBase(metaclass=_TensorMeta):
     _grad: Optional[Tensor]
     _backward_hooks: Optional[Dict[_int, Callable[[Tensor], Optional[Tensor]]]]
     ${tensor_method_hints}
+
+class Tensor(_TensorBase): ...
+
+# TODO: where
+${legacy_class_hints}
 
 # Defined in torch/csrc/multiprocessing/init.cpp
 def _multiprocessing_init() -> None: ...


### PR DESCRIPTION
With current stub information, PyCharm (maybe other tools too) is not able to offer a correct method auto-completion of `Tensor` object or type inference involving `Tensor`s in a method chain. It is the same for sub-classes such as `FloatTensor`.   
For a workaround, I added `class Tensor` in the stub file and moved sub-class declarations. This allows much richer type inference results from PyCharm.