### PR TITLE
[PyTorch][AMD] fix hipify_python

### DIFF
--- a/tools/amd_build/build_amd.py
+++ b/tools/amd_build/build_amd.py
@@ -104,8 +104,8 @@ includes = [os.path.join(proj_dir, include) for include in includes]
 for new_dir in args.extra_include_dir:
     abs_new_dir = os.path.join(proj_dir, new_dir)
     if os.path.exists(abs_new_dir):
-        new_dir = os.path.join(new_dir, "**/*")
-        includes.append(new_dir)
+        abs_new_dir = os.path.join(abs_new_dir, "**/*")
+        includes.append(abs_new_dir)
 
 ignores = [
     "caffe2/operators/depthwise_3x3_conv_op_cudnn.cu",


### PR DESCRIPTION
Summary:
This PR fixes an issue in hipify_python introduced by https://github.com/pytorch/pytorch/pull/76141.

https://github.com/pytorch/pytorch/pull/76141 made all the `includes` paths "absolute", but this was not done for `args.extra_include_dir`; `new_dir`, which is a relative path, is directly added to `includes`. This PR fixes it by passing the absolute path (`abs_new_dir`).

Test Plan: CI

Differential Revision: D36089556

