### PR TITLE
Support no sharding config

### DIFF
--- a/test/distributed/fsdp/test_fsdp_core.py
+++ b/test/distributed/fsdp/test_fsdp_core.py
@@ -46,7 +46,7 @@ if TEST_WITH_DEV_DBG_ASAN:
 params = "cpu_offload,backward_prefetch,sharding_strategy"
 cpu_offload_config = [CPUOffload(offload_params=True), CPUOffload(offload_params=False)]
 backward_prefetch_config = [BackwardPrefetch.BACKWARD_PRE, BackwardPrefetch.BACKWARD_POST, None]
-sharding_strategy_config = [ShardingStrategy.SHARD_GRAD_OP, None]
+sharding_strategy_config = [ShardingStrategy.SHARD_GRAD_OP, None, ShardingStrategy.NO_SHARD]
 configs = list(itertools.product(cpu_offload_config,
                                  backward_prefetch_config,
                                  sharding_strategy_config))
@@ -56,6 +56,7 @@ test_name_mapping = {
     str(BackwardPrefetch.BACKWARD_PRE): "prefetch_pre",
     str(BackwardPrefetch.BACKWARD_POST): "prefetch_post",
     str(ShardingStrategy.SHARD_GRAD_OP): "shard_grad_op",
+    str(ShardingStrategy.NO_SHARD): "no_shard",
 }
 
 subtest_name = functools.partial(subtest_name, test_name_mapping)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -103,25 +103,18 @@ class ShardingStrategy(Enum):
                    GPU memory until backward computation is done. It inserts reduce_scater
                    after backward computation for synchronizing and sharding gradients.
                    Sharded optimizer states are updated locally.
-    SHARD_OP(future support): Shard optimizer states only, this algorithm inserts all_gather
-                              or broadcast before forward computation and keeps the full
-                              parameters in GPU memory until backward computation is done. It
-                              inserts all_reduce after backward computation for synchronizing
-                              gradients. Sharded optimizer states are updated locally.
-    NO_SHARD(future support): This is similar to PyTorch `DistributedDataParallel` API.
-                              Parameters, gradients and optimizer states are replicated
-                              among ranks, all_reduce is inserted after backward computation
-                              is done for synchronizing gradients. Full optimizer states
-                              are updated in each rank.
+    NO_SHARD: This is similar to PyTorch ``DistributedDataParallel`` API. Parameters, gradients
+              and optimizer states are replicated among ranks, all_reduce is inserted after
+              backward computation is done for synchronizing gradients. Full optimizer states
+              are updated in each rank.
     HYBRID_SHARD(future support): apply FULL_SHARD algorithm in the intra node and
                                   apply NO_SHARD algorithm in the inter nodes.
 
     """
     FULL_SHARD = auto()
     SHARD_GRAD_OP = auto()
+    NO_SHARD = auto()
     # TODO
-    # SHARD_OP = auto()
-    # NO_SHARD = auto()
     # HYBRID_SHARD = auto()
 
 
@@ -680,7 +673,7 @@ class FullyShardedDataParallel(nn.Module):
         for n, p in self.named_parameters():
             if p not in ignored_params and not isinstance(p, FlatParameter):
                 raise RuntimeError(
-                    f"found unsharded parameter: {n} ; {p.size()} {p.__class__}"
+                    f"found unflattened parameter: {n} ; {p.size()} {p.__class__}"
                 )
         self._reset_lazy_init()
 
@@ -733,9 +726,13 @@ class FullyShardedDataParallel(nn.Module):
             # Keep full params in the GPU memory until backward
             # computation is done
             self.reshard_after_forward = False
+        elif self.sharding_strategy == ShardingStrategy.NO_SHARD:
+            # self.reshard_after_forward is not used when NO_SHARD
+            # is set, just setting it as False here
+            self.reshard_after_forward = False
         else:
             raise RuntimeError(
-                "sharding_strategy only supports FULL_SHARD and SHARD_GRAD_OP right now."
+                "sharding_strategy only supports FULL_SHARD, SHARD_GRAD_OP and NO_SHARD right now."
             )
 
     def _get_ignored_modules(
@@ -1060,8 +1057,12 @@ class FullyShardedDataParallel(nn.Module):
                 p.is_floating_point()
             ), "Autograd does not support operations for integer type."
 
-            # Sharding is done only when world_size is larger than 1.
-            p._is_sharded = self.world_size > 1  # type: ignore[attr-defined]
+            # Sharding is done only when world_size is larger than 1 and
+            # sharding_strategy!=NO_SHARD.
+            p._is_sharded = (  # type: ignore[attr-defined]
+                self.world_size > 1
+                and self.sharding_strategy != ShardingStrategy.NO_SHARD
+            )
             p._orig_size = p.size()  # type: ignore[attr-defined]
 
             if not p._is_sharded:  # type: ignore[attr-defined]
@@ -1217,8 +1218,9 @@ class FullyShardedDataParallel(nn.Module):
         are set by :func:`_shard_parameters`:
             ``_is_sharded``: ``True`` if the Parameter is sharded or ``False``
                 if the Parameter is intentionally not sharded (in which case we
-                will all-reduce grads for this param). Currently the only way
-                `_is_sharded = False` is if world_size = 1.
+                will all-reduce grads for this param). Currently the way
+                `_is_sharded = False` is if world_size = 1 or sharding strategy 
+                is NO_SHARD.
             ``_orig_size``: the size of the original Parameter (before sharding)
         A few attributes are set here:
             ``_local_shard``: a single shard of the parameter. This is needed to
@@ -2412,14 +2414,17 @@ class FullyShardedDataParallel(nn.Module):
                     param._saved_grad_shard = output  # type: ignore[attr-defined]
                 grad = param._saved_grad_shard  # type: ignore[attr-defined]
             else:
-                # Currently the only way for _is_sharded to be False is if
-                # world_size == 1. This could be relaxed in the future, e.g,
-                # no sharding like PyTorch DDP, in which case grads should be
-                # all-reduced here.
+                # Currently the way for _is_sharded to be False is if
+                # world_size == 1 or sharding_strategy is NO_SHARD.
                 assert (
-                    self.world_size == 1
-                ), "Currently the only way for _is_sharded to be False is \
-                    world_size == 1"
+                    self.world_size == 1 or self.sharding_strategy == ShardingStrategy.NO_SHARD
+                ), "Currently the way for _is_sharded to be False is \
+                    world_size == 1 or sharding_stratagy is set to be NO_SHARD"
+                if self.sharding_strategy == ShardingStrategy.NO_SHARD:
+                    dist.all_reduce(param.grad, group=self.process_group)
+                    if self.gradient_postdivide_factor > 1:
+                        # Average grad by world_size for consistency with PyTorch DDP.
+                        param.grad.div_(self.gradient_postdivide_factor)
                 # Note that we need to cast grads back to the full precision if
                 # 1) parameters were in reduced precision during fwd, as grads
                 # would thus be in this reduced precision, or
@@ -2835,7 +2840,7 @@ class FullyShardedDataParallel(nn.Module):
             params = self.params
         current_stream = torch.cuda.current_stream()
         for p in params:
-            # e.g., world_size == 1
+            # e.g., world_size == 1 or self.sharding_strategy = NO_SHARD
             if not p._is_sharded:  # type: ignore[attr-defined]
                 if (
                     self._mixed_precision_enabled_for_params()


### PR DESCRIPTION
supporting no sharding config to make it similar to DDP algorithm

Benchmarked this version of ddp vs PyTorch C++ ddp, the perf gap is small and depends on the wrapping strategy. For 1GB bert model on 32 gpus with slow network connected.

if the bucket size is small like 25MB for PT DDP and wrapping min size is like 28MB for this version of ddp, this version of ddp has around 6% perf regression. The difference is because this version of ddp wrapping needs one more all reduce, not due to the python context switch;
if the bucket size is large like 40MB for PT DDP and wrapping min size is like 40MB for this version of ddp, this version of ddp has around 17% perf regression. because the last FSDP unit in this version of DDP wrapping has large delay to kick off the first all reduce; The difference is not due to the python context switch
if the bucket size larger than the model size, both PT DDP and this version of DDP will have single all reduce, they have the similar performance. That means python context switch is not a big concern again.
Overall, I think if the wrapping can be done well in this version of DDP and aligned with PT DDP bucketing orders, then the performance will be comparable. As you can see, we still need to improve our auto wrapping policy for both no_shard and fsdp strategy.

Once the auto wrapping issues is resolved for this API overall, it is promising to make this API back compatible with PT C++ DDP and merge them in the long run.

Also this API provides flexibility to mix DDP with other data parallelisms for a module, e.g FSDP(FSDP(submodule1, sharding_strategy=FULL_SHARDED), FSDP(submodule2, sharding_strategy=NO_SHARD), FSDP(submodule3, sharding_strategy=HSDP), submodule4, sharding_strategy=NO_SHARD)