### PR TITLE
[lint] register formatter linters

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -74,6 +74,7 @@ command = [
     '--',
     '@{{PATHSFILE}}'
 ]
+is_formatter = true
 
 [[linter]]
 code = 'MYPY'
@@ -263,6 +264,7 @@ init_command = [
     '--dry-run={{DRYRUN}}',
     'ruamel.yaml==0.17.4',
 ]
+is_formatter = true
 
 [[linter]]
 code = 'NEWLINE'
@@ -283,6 +285,7 @@ command = [
     '--',
     '@{{PATHSFILE}}',
 ]
+is_formatter = true
 
 [[linter]]
 code = 'SPACES'
@@ -560,3 +563,4 @@ init_command = [
     '--dry-run={{DRYRUN}}',
     'black==22.3.0',
 ]
+is_formatter = true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #76761

Register clang format, newlines, black, and nativefunctions_linter as
formatters, which can be run with `lintrunner f`