### PR TITLE
check if docker image exists before pulling

### DIFF
--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -16,4 +16,4 @@ runs:
         DOCKER_IMAGE: ${{ inputs.docker-image }}
       run: |
         retry () { "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@") }
-        retry docker pull "${DOCKER_IMAGE}"
+        docker image inspect "${DOCKER_IMAGE}" > /dev/null || retry docker pull "${DOCKER_IMAGE}"


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
rocm still takes 20m to pull docker image, so check if docker image exists before pulling, followup for #76413