### PR TITLE
Add a transform for positive-definite matrices.

### DIFF
--- a/test/distributions/test_constraints.py
+++ b/test/distributions/test_constraints.py
@@ -53,6 +53,7 @@ CONSTRAINTS = [
     (constraints.simplex,),
     (constraints.corr_cholesky,),
     (constraints.lower_cholesky,),
+    (constraints.positive_definite,),
 ]
 
 

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3188,8 +3188,6 @@ class TestDistributions(DistributionsTestCase):
             self.assertTrue((-1e-12 < delta[mask].detach()).all())  # Allow up to 1e-12 rounding error.
 
     def _test_continuous_distribution_mode(self, dist, sanitized_mode, batch_isfinite):
-        if isinstance(dist, Wishart):
-            return
         # We perturb the mode in the unconstrained space and expect the log probability to decrease.
         num_points = 10
         transform = transform_to(dist.support)

--- a/test/distributions/test_transforms.py
+++ b/test/distributions/test_transforms.py
@@ -118,10 +118,11 @@ def generate_data(transform):
         domain = domain.base_constraint
     codomain = transform.codomain
     x = torch.empty(4, 5)
-    if domain is constraints.lower_cholesky or codomain is constraints.lower_cholesky:
-        x = torch.empty(6, 6)
-        x = x.normal_()
-        return x
+    if domain is constraints.lower_cholesky:
+        x = torch.randn(6, 6)
+        return x.tril(-1) + x.diag().exp().diag_embed()
+    elif codomain is constraints.lower_cholesky:
+        return torch.randn(6, 6)
     elif domain is constraints.real:
         return x.normal_()
     elif domain is constraints.real_vector:
@@ -189,6 +190,7 @@ def test_with_cache(transform):
 @pytest.mark.parametrize('test_cached', [True, False])
 def test_forward_inverse(transform, test_cached):
     x = generate_data(transform).requires_grad_()
+    assert transform.domain.check(x).all()  # verify that the input data are valid
     try:
         y = transform(x)
     except NotImplementedError:

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -229,6 +229,12 @@ def _transform_to_lower_cholesky(constraint):
     return transforms.LowerCholeskyTransform()
 
 
+@transform_to.register(constraints.positive_definite)
+@transform_to.register(constraints.positive_semidefinite)
+def _transform_to_positive_definite(constraint):
+    return transforms.PositiveDefiniteTransform()
+
+
 @biject_to.register(constraints.corr_cholesky)
 @transform_to.register(constraints.corr_cholesky)
 def _transform_to_corr_cholesky(constraint):

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -977,7 +977,7 @@ class PositiveDefiniteTransform(LowerCholeskyTransform):
     """
     Transform from unconstrained matrices to positive-definite matrices.
     """
-    codomain = constraints.positive_definite
+    codomain = constraints.positive_definite  # type: ignore
 
     def __eq__(self, other):
         return isinstance(other, PositiveDefiniteTransform)

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -24,6 +24,7 @@ __all__ = [
     'ExpTransform',
     'IndependentTransform',
     'LowerCholeskyTransform',
+    'PositiveDefiniteTransform',
     'PowerTransform',
     'ReshapeTransform',
     'SigmoidTransform',
@@ -971,6 +972,23 @@ class LowerCholeskyTransform(Transform):
     def _inverse(self, y):
         return y.tril(-1) + y.diagonal(dim1=-2, dim2=-1).log().diag_embed()
 
+
+class PositiveDefiniteTransform(LowerCholeskyTransform):
+    """
+    Transform from unconstrained matrices to positive-definite matrices.
+    """
+    codomain = constraints.positive_definite
+
+    def __eq__(self, other):
+        return isinstance(other, PositiveDefiniteTransform)
+
+    def _call(self, x):
+        x = super()._call(x)
+        return x @ x.transpose(-1, -2)
+
+    def _inverse(self, y):
+        y = torch.linalg.cholesky(y)
+        return super()._inverse(y)
 
 class CatTransform(Transform):
     """

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -977,7 +977,7 @@ class PositiveDefiniteTransform(LowerCholeskyTransform):
     """
     Transform from unconstrained matrices to positive-definite matrices.
     """
-    codomain = constraints.positive_definite  # type: ignore
+    codomain = constraints.positive_definite  # type: ignore[assignment]
 
     def __eq__(self, other):
         return isinstance(other, PositiveDefiniteTransform)

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -973,22 +973,24 @@ class LowerCholeskyTransform(Transform):
         return y.tril(-1) + y.diagonal(dim1=-2, dim2=-1).log().diag_embed()
 
 
-class PositiveDefiniteTransform(LowerCholeskyTransform):
+class PositiveDefiniteTransform(Transform):
     """
     Transform from unconstrained matrices to positive-definite matrices.
     """
+    domain = constraints.independent(constraints.real, 2)
     codomain = constraints.positive_definite  # type: ignore[assignment]
 
     def __eq__(self, other):
         return isinstance(other, PositiveDefiniteTransform)
 
     def _call(self, x):
-        x = super()._call(x)
+        x = LowerCholeskyTransform()(x)
         return x @ x.mT
 
     def _inverse(self, y):
         y = torch.linalg.cholesky(y)
-        return super()._inverse(y)
+        return LowerCholeskyTransform().inv(y)
+
 
 class CatTransform(Transform):
     """

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -984,7 +984,7 @@ class PositiveDefiniteTransform(LowerCholeskyTransform):
 
     def _call(self, x):
         x = super()._call(x)
-        return x @ x.transpose(-1, -2)
+        return x @ x.mT
 
     def _inverse(self, y):
         y = torch.linalg.cholesky(y)


### PR DESCRIPTION
The `PositiveDefiniteTransform` is required to transform from an unconstrained space to positive definite matrices, e.g. to support testing the Wishart mode in #76690. It is a simple extension of the `LowerCholeskyTransform`.

I've also added a small test that ensures the generated data belong to the domain of the associated transform. Previously, the data generated for the inverse transform of the `LowerCholeskyTransform` wasn't part of the domain, and the test only passed because the comparison uses `equal_nan=True`.

cc @fritzo, @neerajprad 