### PR TITLE
Fixes prim type promotion and updates type promotion testing

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -56,6 +56,7 @@ from torch.testing._internal.common_dtype import (
 )
 from torch.testing._internal.common_methods_invocations import (
     binary_ufuncs,
+    binary_ufuncs_and_refs,
     _NOTHING,
     generate_elementwise_binary_tensors,
     generate_elementwise_binary_small_value_tensors,
@@ -474,34 +475,36 @@ class TestBinaryUfuncs(TestCase):
     # NOTE: because the cross-product of all possible type promotion tests is huge, this
     #   just spot checks some handwritten cases.
     # NOTE: It may be possible to refactor this test into something simpler
-    @ops(binary_ufuncs, dtypes=OpDTypes.none)
+    @ops(binary_ufuncs_and_refs, dtypes=OpDTypes.none)
     def test_type_promotion(self, device, op):
         supported_dtypes = op.supported_dtypes(torch.device(device).type)
+
+        make_lhs = partial(
+            make_tensor, (5,), device=device, **op.lhs_make_tensor_kwargs
+        )
+        make_rhs = partial(
+            make_tensor, (5,), device=device, **op.rhs_make_tensor_kwargs
+        )
+
+        make_lhs_scalar_tensor = partial(
+            make_tensor, (), device=device, **op.lhs_make_tensor_kwargs
+        )
+        make_rhs_scalar_tensor = partial(
+            make_tensor, (), device=device, **op.rhs_make_tensor_kwargs
+        )
 
         def _supported(dtypes):
             return all(map(lambda x: x in supported_dtypes, dtypes))
 
         # int x int type promotion
         if _supported((torch.int16, torch.int32, torch.int64)):
-            lhs_i16 = make_tensor(
-                (5,), device=device, dtype=torch.int16, **op.lhs_make_tensor_kwargs
-            )
-            lhs_i32 = make_tensor(
-                (5,), device=device, dtype=torch.int32, **op.lhs_make_tensor_kwargs
-            )
-            lhs_i64 = make_tensor(
-                (5,), device=device, dtype=torch.int64, **op.lhs_make_tensor_kwargs
-            )
+            lhs_i16 = make_lhs(dtype=torch.int16)
+            lhs_i32 = make_lhs(dtype=torch.int32)
+            lhs_i64 = make_lhs(dtype=torch.int64)
 
-            rhs_i16 = make_tensor(
-                (5,), device=device, dtype=torch.int16, **op.rhs_make_tensor_kwargs
-            )
-            rhs_i32 = make_tensor(
-                (5,), device=device, dtype=torch.int32, **op.rhs_make_tensor_kwargs
-            )
-            rhs_i64 = make_tensor(
-                (5,), device=device, dtype=torch.int64, **op.rhs_make_tensor_kwargs
-            )
+            rhs_i16 = make_rhs(dtype=torch.int16)
+            rhs_i32 = make_rhs(dtype=torch.int32)
+            rhs_i64 = make_rhs(dtype=torch.int64)
 
             if op.promotes_int_to_float:
                 default_dtype = torch.get_default_dtype()
@@ -570,19 +573,11 @@ class TestBinaryUfuncs(TestCase):
 
         # float x float type promotion
         if _supported((torch.float32, torch.float64)):
-            lhs_f32 = make_tensor(
-                (5,), device=device, dtype=torch.float32, **op.lhs_make_tensor_kwargs
-            )
-            lhs_f64 = make_tensor(
-                (5,), device=device, dtype=torch.float64, **op.lhs_make_tensor_kwargs
-            )
+            lhs_f32 = make_lhs(dtype=torch.float32)
+            lhs_f64 = make_lhs(dtype=torch.float64)
 
-            rhs_f32 = make_tensor(
-                (5,), device=device, dtype=torch.float32, **op.rhs_make_tensor_kwargs
-            )
-            rhs_f64 = make_tensor(
-                (5,), device=device, dtype=torch.float64, **op.rhs_make_tensor_kwargs
-            )
+            rhs_f32 = make_rhs(dtype=torch.float32)
+            rhs_f64 = make_rhs(dtype=torch.float64)
 
             if op.always_returns_bool:
                 self.assertEqual(op(lhs_f32, rhs_f64).dtype, torch.bool)
@@ -625,19 +620,11 @@ class TestBinaryUfuncs(TestCase):
 
         # complex x complex type promotion
         if _supported((torch.complex64, torch.complex128)):
-            lhs_c64 = make_tensor(
-                (5,), device=device, dtype=torch.complex64, **op.lhs_make_tensor_kwargs
-            )
-            lhs_c128 = make_tensor(
-                (5,), device=device, dtype=torch.complex128, **op.lhs_make_tensor_kwargs
-            )
+            lhs_c64 = make_lhs(dtype=torch.complex64)
+            lhs_c128 = make_lhs(dtype=torch.complex128)
 
-            rhs_c64 = make_tensor(
-                (5,), device=device, dtype=torch.complex64, **op.rhs_make_tensor_kwargs
-            )
-            rhs_c128 = make_tensor(
-                (5,), device=device, dtype=torch.complex128, **op.rhs_make_tensor_kwargs
-            )
+            rhs_c64 = make_rhs(dtype=torch.complex64)
+            rhs_c128 = make_rhs(dtype=torch.complex128)
 
             if op.always_returns_bool:
                 self.assertEqual(op(lhs_c64, lhs_c128).dtype, torch.bool)
@@ -682,6 +669,124 @@ class TestBinaryUfuncs(TestCase):
                     out = torch.empty_like(lhs_f64, dtype=torch.int64)
                     self.assertEqual(op(lhs_f32, rhs_f64, out=out).dtype, torch.int64)
                     self.assertEqual(op(lhs_f32, rhs_f64), out, exact_dtype=False)
+
+        # int x float type promotion
+        # Note: float type is the result dtype
+        if _supported((torch.long, torch.float32)):
+            lhs_i64 = make_lhs(dtype=torch.int64)
+            rhs_f32 = make_rhs(dtype=torch.float32)
+
+            result = op(lhs_i64, rhs_f32)
+            expected_dtype = torch.float32 if not op.always_returns_bool else torch.bool
+            self.assertEqual(result.dtype, expected_dtype)
+
+        # float x complex type promotion
+        # Note: complex type with highest "value type" is the result dtype
+        if _supported((torch.float64, torch.complex64)):
+            lhs_f64 = make_lhs(dtype=torch.float64)
+            rhs_c64 = make_rhs(dtype=torch.complex64)
+
+            result = op(lhs_f64, rhs_c64)
+            expected_dtype = (
+                torch.complex128 if not op.always_returns_bool else torch.bool
+            )
+            self.assertEqual(result.dtype, expected_dtype)
+
+        # int x float scalar type promotion
+        # Note: default float dtype is the result dtype
+        if _supported((torch.int64, torch.float32)) and op.supports_rhs_python_scalar:
+            lhs_i64 = make_lhs(dtype=torch.int64)
+            rhs_f_scalar = 1.0
+
+            result = op(lhs_i64, rhs_f_scalar)
+            expected_dtype = (
+                torch.get_default_dtype() if not op.always_returns_bool else torch.bool
+            )
+            self.assertEqual(result.dtype, expected_dtype)
+
+            # repeats with a scalar float tensor, which should set the dtype
+            rhs_f32_scalar_tensor = make_rhs_scalar_tensor(dtype=torch.float32)
+            result = op(lhs_i64, rhs_f32_scalar_tensor)
+            expected_dtype = torch.float32 if not op.always_returns_bool else torch.bool
+            self.assertEqual(result.dtype, expected_dtype)
+
+            # Additional test with double
+            if _supported((torch.float64,)):
+                rhs_f64_scalar_tensor = make_rhs_scalar_tensor(dtype=torch.float64)
+                result = op(lhs_i64, rhs_f64_scalar_tensor)
+                expected_dtype = (
+                    torch.float64 if not op.always_returns_bool else torch.bool
+                )
+                self.assertEqual(result.dtype, expected_dtype)
+
+        # float x complex scalar type promotion
+        # Note: result dtype is complex with highest "value type" among all tensors
+        if (
+            _supported((torch.float32, torch.complex64))
+            and op.supports_rhs_python_scalar
+        ):
+            lhs_f32 = make_lhs(dtype=torch.float32)
+            rhs_c_scalar = complex(1, 1)
+
+            result = op(lhs_f32, rhs_c_scalar)
+            expected_dtype = (
+                torch.complex64 if not op.always_returns_bool else torch.bool
+            )
+            self.assertEqual(result.dtype, expected_dtype)
+
+            # repeats with a scalar complex tensor
+            rhs_c64_scalar_tensor = make_rhs_scalar_tensor(dtype=torch.complex64)
+            result = op(lhs_f32, rhs_c64_scalar_tensor)
+            expected_dtype = (
+                torch.complex64 if not op.always_returns_bool else torch.bool
+            )
+            self.assertEqual(result.dtype, expected_dtype)
+
+            # Additional test with complexdouble
+            if _supported((torch.complex128,)):
+                rhs_c128_scalar_tensor = make_rhs_scalar_tensor(dtype=torch.complex128)
+                result = op(lhs_f32, rhs_c128_scalar_tensor)
+                expected_dtype = (
+                    torch.complex128 if not op.always_returns_bool else torch.bool
+                )
+                self.assertEqual(result.dtype, expected_dtype)
+
+        # float x float scalar tensor
+        # Note: result dtype is the type of the float tensor
+        if _supported((torch.float32, torch.float64)) and op.supports_rhs_python_scalar:
+            lhs_f32 = make_lhs(dtype=torch.float32)
+            rhs_f64_scalar_tensor = make_rhs_scalar_tensor(dtype=torch.float64)
+
+            result = op(lhs_f32, rhs_f64_scalar_tensor)
+            expected_dtype = torch.float32 if not op.always_returns_bool else torch.bool
+            self.assertEqual(result.dtype, expected_dtype)
+
+        # complex x complex scalar tensor
+        # Note: result dtype is the type of the complex tensor
+        if (
+            _supported((torch.complex64, torch.complex128))
+            and op.supports_rhs_python_scalar
+        ):
+            lhs_c64 = make_lhs(dtype=torch.complex64)
+            rhs_c128_scalar_tensor = make_rhs_scalar_tensor(dtype=torch.complex128)
+
+            result = op(lhs_c64, rhs_c128_scalar_tensor)
+            expected_dtype = (
+                torch.complex64 if not op.always_returns_bool else torch.bool
+            )
+            self.assertEqual(result.dtype, expected_dtype)
+
+        # scalar int x scalar float
+        # Note: result dtype is default float type
+        # TODO: FIXME: re-enable this, scalar x scalar type promotion is currently broken
+        # https://github.com/pytorch/pytorch/issues/76801
+        # if op.supports_two_python_scalars and _supported((torch.long, torch.float32)):
+        #     lhs_i_scalar = 1
+        #     rhs_f_scalar = 2.
+
+        #     result = op(lhs_i_scalar, rhs_f_scalar)
+        #     expected_dtype = torch.get_default_dtype() if not op.always_returns_bool else torch.bool
+        #     self.assertEqual(result.dtype, expected_dtype)
 
     # TODO: move to error input test
     @ops(binary_ufuncs, allowed_dtypes=(torch.float32,))
@@ -4430,7 +4535,9 @@ class TestBinaryUfuncs(TestCase):
             test_helper(x, q)
 
     @onlyCUDA
-    @dtypes(torch.chalf,)
+    @dtypes(
+        torch.chalf,
+    )
     def test_mul_chalf_tensor_and_cpu_scalar(self, device, dtype):
         # Tests that Tensor and CPU Scalar work for `mul` for chalf.
         # Ideally, this should be covered by `test_complex_half_reference_testing`

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -157,17 +157,25 @@ _computation_dtype_map = {
 }
 
 
-def _get_computation_dtype(dtype: torch.dtype):
+def _get_computation_dtype(dtype: torch.dtype) -> torch.dtype:
     return _computation_dtype_map.get(dtype, dtype)
 
 
 # TODO: document type promotion kinds
-def _elementwise_dtypes(*_args, type_promotion: ELEMENTWISE_TYPE_PROMOTION_KIND):
+def _elementwise_dtypes(
+    *_args, type_promotion: ELEMENTWISE_TYPE_PROMOTION_KIND
+) -> Tuple[torch.dtype, torch.dtype]:
     """
     Computes the computation and result dtypes for elementwise type promotion
     on the given arguments and with the given elementwise type promotion kind.
 
-    Elementwise type promotion first decides which of four ordered types to use:
+    Note that not all inputs to an elementwise operation necessarily participate in type promotion.
+    For example, the "alpha" parameter of torch.add does not participate in type promotion,
+    although it is cast to the Python type corresponding to the computation dtype that
+    the type promotion algorithm determines.
+
+    Default elementwise type promotion, which all other type promotion kinds tweak (see below),
+    first decides which of four ordered types to use:
 
     bool -> integer -> floating point -> complex
 
@@ -183,102 +191,179 @@ def _elementwise_dtypes(*_args, type_promotion: ELEMENTWISE_TYPE_PROMOTION_KIND)
 
     The result dtype is selected by:
       - if no tensor's dtype has the same corresponding type as the one selected,
-          then the result dtype is the dtype corresponding to the selected type
-      - if no tensor with one or dimensions' dtype has the same corresponding type as the one
-          selected, then the result dtype is the highest dtype among all tensors
+          then the result dtype is the (default) dtype corresponding to the selected type
+          (for example, 1.5 + an integer tensor has a result dtype of the default floating point dtype)
+      - if the result type is complex then the dtype is:
+        -  the default complex dtype if there are no floating point or complex tensors
+        -  if there are floating point or complex tensors with one or more dimensions, then
+            the complex dtype corresponding to the highest corresponding complex dtype among those tensors
+            (for example, double + cfloat -> cdouble)
+        -  if there are only floating point or complex tensors with zero dimensions, then
+            the complex dtype corresponding to the highest corresponding complex dtype among those tensors
       - if the first two cases do not apply, the result dtype is the highest dtype among
-          all tensors with one or more dimensions
+          all tensors with one or more dimensions of the output type, and if there are no such
+          tensors then it's the highest dtype among all tensors with zero dimensions of the output type
+          (for example, long + half -> half, even if the half tensor has zero dimensions)
 
-    The computation dtype is usually the result dtype, except for float16 and bfloat16, where
-    the computation dtype is float32, and complex32, where the computation dtype is complex64.
+    The "corresponding complex dtypes" are:
+      float16    -> complex32
+      bfloat16   -> complex64
+      float32    -> complex64
+      float64    -> complex128
+      complex32  -> complex32
+      complex64  -> complex64
+      complex128 -> complex128
+
+    The DEFAULT type promotion option computes per above, and uses the result dtype as the computation dtype.
+
+    The OP_MATH, INT_TO_FLOAT, COMPLEX_TO_FLOAT and BOOL_TO_LONG type promotion options tweak the above slightly.
+    OP_MATH determines a "computation dtype" from the result dtype, and the mapping is simple:
+
+      float16   -> float32
+      bfloat16  -> float32
+      complex32 -> complex64
+
+    INT_TO_FLOAT, COMPLEX_TO_FLOAT, and BOOL_TO_LONG compute the computation type in the same way, but INT_TO_FLOAT
+    and BOOL_TO_LONG map the result dtype to another dtype first, and COMPLEX_TO_FLOAT maps its result dtype
+    after the compuation dtype is determined, as follows:
+
+      INT_TO_FLOAT  maps all boolean and integer result dtypes to the default floating point dtype
+      COMPLEX_TO_FLOAT  maps complex result dtypes to their corresponding floating point dtype
+      BOOL_TO_LONG maps the boolean result dtype to long
+
+    The "corresponding floating point dtypes" are:
+      complex32  -> float16
+      complex64  -> float32
+      complex128 -> float64
+
+    The ALWAYS_BOOL type promotion option always maps the result dtype to bool.
+
+    Example operators for each type promotion option:
+      DEFAULT          : nextafter
+      OP_MATH          : add
+      INT_TO_FLOAT     : sin
+      COMPLEX_TO_FLOAT : abs
+      BOOL_TO_LONG     : pow
+      ALWAYS_BOOL      : eq
+
     """
 
-    args = tuple(filter(lambda x: x is not None, _args))
+    args = tuple(x for x in _args if x is not None)
 
-    # Type checking
-    for arg in args:
-        assert isinstance(arg, (Number, TensorLike))
+    highest_type: type = bool
+    for x in args:
+        if not isinstance(x, (Number, TensorLike)):
+            msg = (
+                "Unexpected type {0} when computing elementwise type promotion!".format(
+                    str(type(x))
+                )
+            )
+            raise ValueError(msg)
 
-    # Determines datatypes for each category
-    scalar_args = filter(lambda x: isinstance(x, Number), args)
-    scalar_type = reduce(
-        lambda acc, x: utils.get_higher_type(acc, type(x)), scalar_args, bool  # type: ignore[arg-type, return-value]
-    )
-
-    scalar_tensors = filter(lambda t: isinstance(t, TensorLike) and t.ndim == 0, args)
-    scalar_tensor_dtype = reduce(
-        utils.get_higher_dtype, (t.dtype for t in scalar_tensors), torch.bool
-    )
-    scalar_tensor_type = utils.dtype_to_type(scalar_tensor_dtype)
-
-    nonscalar_tensors = filter(
-        lambda t: isinstance(t, TensorLike) and t.ndim != 0, args
-    )
-    nonscalar_tensor_dtype = reduce(
-        utils.get_higher_dtype, (t.dtype for t in nonscalar_tensors), torch.bool
-    )
-    nonscalar_tensor_type = utils.dtype_to_type(nonscalar_tensor_dtype)
-
-    typ = reduce(
-        utils.get_higher_type, (scalar_type, scalar_tensor_type, nonscalar_tensor_type)
-    )
-
-    if nonscalar_tensor_type is typ:
-        dtype = nonscalar_tensor_dtype
-    elif scalar_tensor_type is typ:
-        dtype = scalar_tensor_dtype
-    else:
-        # scalar type kind -> default torch dtype mapping
-        if typ is bool:
-            dtype = torch.bool
-        elif typ is int:
-            dtype = torch.int64
-        elif typ is float:
-            dtype = torch.get_default_dtype()
+        if isinstance(x, Number):
+            highest_type = utils.get_higher_type(highest_type, type(x))
         else:
-            # typ is complex
-            dtype = (
-                torch.complex128
-                if torch.get_default_dtype() is torch.float64
-                else torch.complex64
+            # x is a TensorLike
+            highest_type = utils.get_higher_type(
+                highest_type, utils.dtype_to_type(x.dtype)
             )
 
-    if type_promotion in (
-        ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
-        ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
-    ):
-        if type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL:
-            return dtype, torch.bool
+    result_dtype = None
 
-        return dtype, dtype
+    def _find_highest_dtype_filtered(
+        args, filter, *, float_as_complex=False, all_tensors_equal=False
+    ) -> Optional[torch.dtype]:
+        zero_dim_tensor_dtype = None
+        one_plus_dim_tensor_dtype = None
+        for x in args:
+            if isinstance(x, TensorLike) and filter(x.dtype):
+                _dtype = x.dtype
+                if float_as_complex and utils.is_float_dtype(_dtype):
+                    _dtype = utils.corresponding_complex_dtype(_dtype)
+                if x.ndim == 0 and not all_tensors_equal:
+                    zero_dim_tensor_dtype = utils.get_higher_dtype(
+                        zero_dim_tensor_dtype, _dtype
+                    )
+                else:
+                    # x.ndim > 0 or all_tensors_equal
+                    one_plus_dim_tensor_dtype = utils.get_higher_dtype(
+                        one_plus_dim_tensor_dtype, _dtype
+                    )
 
-    if type_promotion in (
-        ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
-        ELEMENTWISE_TYPE_PROMOTION_KIND.COMPLEX_TO_FLOAT,
-        ELEMENTWISE_TYPE_PROMOTION_KIND.BOOL_TO_LONG,
-        ELEMENTWISE_TYPE_PROMOTION_KIND.OP_MATH,
-    ):
+        # Prefers dtype of tensors with one or more dimensions
+        if one_plus_dim_tensor_dtype is not None:
+            return one_plus_dim_tensor_dtype
 
-        if type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT and (
-            utils.is_boolean_dtype(dtype) or utils.is_integer_dtype(dtype)
-        ):
-            return torch.get_default_dtype(), torch.get_default_dtype()
+        return zero_dim_tensor_dtype
 
-        if (
-            type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.COMPLEX_TO_FLOAT
-            and utils.is_complex_dtype(dtype)
-        ):
-            return _get_computation_dtype(dtype), utils.corresponding_real_dtype(dtype)
+    if highest_type is float:
+        result_dtype = _find_highest_dtype_filtered(args, utils.is_float_dtype)
+        result_dtype = (
+            torch.get_default_dtype() if result_dtype is None else result_dtype
+        )
+    elif highest_type is complex:
+        # NOTE: complex x float type promotion is incorrectly implemented in PyTorch today
+        # it will treat zero dim and non-zero-dim float and complex tensors equally
+        # unless there's a non-zero-dim complex tensor
+        # the following captures this oddity
+        has_one_plus_dim_complex_tensor = False
+        for x in args:
+            if (
+                isinstance(x, TensorLike)
+                and x.ndim > 0
+                and utils.is_complex_dtype(x.dtype)
+            ):
+                has_one_plus_dim_complex_tensor = True
+                break
 
-        if (
-            type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.BOOL_TO_LONG
-            and utils.is_boolean_dtype(dtype)
-        ):
+        if has_one_plus_dim_complex_tensor:
+            result_dtype = _find_highest_dtype_filtered(
+                args,
+                lambda x: utils.is_float_dtype(x) or utils.is_complex_dtype(x),
+                float_as_complex=True,
+            )
+        else:
+            # no complex tensors of rank 1+
+            # NOTE: bugged case where all tensors are equal
+            result_dtype = _find_highest_dtype_filtered(
+                args,
+                lambda x: utils.is_float_dtype(x) or utils.is_complex_dtype(x),
+                float_as_complex=True,
+                all_tensors_equal=True,
+            )
+
+        if result_dtype is None:
+            result_dtype = utils.corresponding_complex_dtype(torch.get_default_dtype())
+    elif highest_type is int:
+        result_dtype = _find_highest_dtype_filtered(args, utils.is_integer_dtype)
+        result_dtype = torch.long if result_dtype is None else result_dtype
+    else:
+        # highest_type is bool
+        result_dtype = torch.bool
+
+    if type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT:
+        return result_dtype, result_dtype
+    elif type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.OP_MATH:
+        return _get_computation_dtype(result_dtype), result_dtype
+    elif type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT:
+        if utils.is_integer_dtype(result_dtype) or utils.is_boolean_dtype(result_dtype):
+            result_dtype = torch.get_default_dtype()
+        return _get_computation_dtype(result_dtype), result_dtype
+    elif type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.COMPLEX_TO_FLOAT:
+        if utils.is_complex_dtype(result_dtype):
+            # Note: computation still occurs in complex
+            return _get_computation_dtype(result_dtype), utils.corresponding_real_dtype(
+                result_dtype
+            )
+        return _get_computation_dtype(result_dtype), result_dtype
+    elif type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.BOOL_TO_LONG:
+        if utils.is_boolean_dtype(result_dtype):
             return torch.long, torch.long
-
-        return _get_computation_dtype(dtype), dtype
-
-    raise ValueError("Unknown type promotion kind {0}".format(str(type_promotion)))
+        return result_dtype, result_dtype
+    elif type_promotion is ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL:
+        return result_dtype, torch.bool
+    else:
+        raise ValueError("Unknown type promotion kind {0}".format(str(type_promotion)))
 
 
 def _broadcast_shapes(*_shapes):
@@ -673,6 +758,7 @@ def float_power(
 
     # Handles type promotion
     dtype = utils.get_higher_dtype(a, b)
+    assert dtype is not None
     if utils.is_complex_dtype(dtype):
         dtype = torch.complex128
     else:
@@ -887,7 +973,9 @@ def _reduction(
         if dtype is not None:
             # TODO - this is true for eager mode currently, but it's wrong behavior for complex norms
             if dtype != out.dtype:
-                raise RuntimeError("dtype argument and out dtype must match in reduction")
+                raise RuntimeError(
+                    "dtype argument and out dtype must match in reduction"
+                )
     if not accepts_dim_tuple:
         assert dims is None or isinstance(dims, int)
     if isinstance(dims, int):
@@ -914,10 +1002,14 @@ def _reduction(
         if dtype is None:
             if output_dtype_kind == REDUCTION_OUTPUT_TYPE_KIND.SAME:
                 if out.dtype != a.dtype:
-                    raise RuntimeError("out dtype and output type of reduction must match")
+                    raise RuntimeError(
+                        "out dtype and output type of reduction must match"
+                    )
             elif output_dtype_kind == REDUCTION_OUTPUT_TYPE_KIND.ALWAYS_BOOL:
                 if out.dtype != torch.bool:
-                    raise RuntimeError("out dtype and output type of reduction must match")
+                    raise RuntimeError(
+                        "out dtype and output type of reduction must match"
+                    )
         out = _maybe_resize_out(out, result.shape)
         return copy_to(out, result, allow_cross_device=False)  # type: ignore[arg-type]
 


### PR DESCRIPTION
This PR fixes prim elementwise type promotion, tests elementwise binary references using `test_type_promotion` in the elementwise binary test suite, and updates that test with additional cases for float x complex and scalar type promotion. 

The following issues were discovered while working on this PR:

- https://github.com/pytorch/pytorch/issues/76806
- https://github.com/pytorch/pytorch/issues/76805
- https://github.com/pytorch/pytorch/issues/76804
- https://github.com/pytorch/pytorch/issues/76803
- https://github.com/pytorch/pytorch/issues/76801
