### PR TITLE
[ONNX] Fix repeat_interleave-9 ONNX symbolic for detectron2 models

### DIFF
--- a/test/onnx/test_onnx_export.py
+++ b/test/onnx/test_onnx_export.py
@@ -3,29 +3,71 @@
 import io
 import os
 import sys
-from unittest.mock import patch
+import unittest
+from contextlib import ExitStack
+from typing import Callable, List, Optional, Tuple, Union
 
 import onnx
-import torch
-from typing import Callable
-
 from test_pytorch_common import TestCase
-from torch.onnx.symbolic_helper import _onnx_unsupported
-from torch.onnx import (OperatorExportTypes,
-                        symbolic_registry)
-from torch.testing._internal.common_utils import (skipIfCaffe2,
-                                                  custom_op)
 
+import torch
+from torch.onnx import OperatorExportTypes, symbolic_registry
+from torch.onnx.symbolic_helper import _onnx_unsupported
+from torch.testing._internal.common_utils import custom_op, skipIfCaffe2
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
 
+
+def export_to_onnx(
+    model: Union[torch.nn.Module, torch.jit.ScriptFunction],
+    input: Tuple[torch.Tensor],
+    custom_ops: Optional[List[Tuple[str, Callable, int]]] = [],
+    mocks: Optional[List[unittest.mock.patch]] = [],
+    operator_export_type: OperatorExportTypes = OperatorExportTypes.ONNX,
+    opset_version=torch.onnx.symbolic_helper._export_onnx_opset_version
+):
+    """Exports `model(input)` to ONNX and return it.
+
+    Custom operators and/or unittest patches can be used help reproducing specific behaviors.
+
+    Args:
+        model: model to export
+        input: model input with same format as `torch.onnx.export(..,args,...)`
+        custom_ops: list of custom operators to use during export
+        mocks: list of unittests mocks to use during export
+        operator_export_type: export type as described by `torch.onnx.export(...operator_export_type,...)`
+        opset_version: ONNX opset version as described by `torch.onnx.export(...opset_version,...)`
+    Returns:
+        A valid ONNX model (`onnx.ModelProto`)
+    """
+    print(f"model={model}")
+    print(f"custom_ops={custom_ops}")
+    print(f"mocks={mocks}")
+
+    with ExitStack() as stack:
+        for mgr in [*custom_ops, *mocks]:
+            stack.enter_context(mgr)
+
+        f = io.BytesIO()
+        torch.onnx.export(
+            model,
+            input,
+            f,
+            operator_export_type=operator_export_type,
+            opset_version=opset_version
+        )
+
+    # Validate ONNX graph before returning it
+    onnx_model = onnx.load_from_string(f.getvalue())
+    onnx.checker.check_model(onnx_model)
+    return onnx_model
+
+
 class TestONNXExport(TestCase):
     @skipIfCaffe2
     def test_clip_aten_fallback_due_exception(self):
-        x = torch.randn(3, 4, requires_grad=True)
-
         def bad_clamp(g, self, min, max):
             return _onnx_unsupported("Bad boy!")
 
@@ -33,11 +75,12 @@ class TestONNXExport(TestCase):
             def forward(self, x):
                 return torch.clamp(x, min=-0.5, max=0.5)
 
-        f = io.BytesIO()
-        with custom_op("aten::clamp", bad_clamp, 9):
-            torch.onnx.export(MyClip(), x, f,
-                              operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK)
-        onnx_model = onnx.load_from_string(f.getvalue())
+        onnx_model = export_to_onnx(
+            MyClip(),
+            torch.randn(3, 4, requires_grad=True),
+            custom_ops=[custom_op("aten::clamp", bad_clamp, 9)],
+            operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK,
+        )
         self.assertAtenOp(onnx_model, "clamp", "Tensor")
 
     @skipIfCaffe2
@@ -47,24 +90,30 @@ class TestONNXExport(TestCase):
                 return torch.clamp(x, min=-0.5, max=0.5)
 
         def break_is_registered_op_api(opname, domain, version):
-            fake_missing_symbolics = ('clamp',)
+            fake_missing_symbolics = ("clamp",)
             if opname in fake_missing_symbolics:
                 return False
-            return (domain, version) in symbolic_registry._registry \
+            return (
+                (domain, version) in symbolic_registry._registry
                 and opname in symbolic_registry._registry[(domain, version)]
+            )
 
-        f = io.BytesIO()
-        with patch("torch.onnx.symbolic_registry.is_registered_op", side_effect=break_is_registered_op_api):
-            # Force missing symbolic for well-known op
-            x = torch.randn(3, 4, requires_grad=True)
-            torch.onnx.export(MyClip(), x, f,
-                              operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK)
-        onnx_model = onnx.load_from_string(f.getvalue())
+        # Force missing symbolic for well-known op using a mock
+        onnx_model = export_to_onnx(
+            MyClip(),
+            torch.randn(3, 4, requires_grad=True),
+            mocks=[
+                unittest.mock.patch(
+                    "torch.onnx.symbolic_registry.is_registered_op",
+                    side_effect=break_is_registered_op_api,
+                )
+            ],
+            operator_export_type=OperatorExportTypes.ONNX_ATEN_FALLBACK,
+        )
         self.assertAtenOp(onnx_model, "clamp", "Tensor")
 
-
     def _helper_test_to_(self, cast_fn: Callable[[torch.Tensor], torch.Tensor]):
-        """Helper to test aten::to(device) variants
+        """Helper to test aten::to(device) variants.
 
         `cast_fn` is converted into a `torch.jit.script`. It wraps `aten::to`
         during export to preventing the devices to be hard-coded.
@@ -72,11 +121,7 @@ class TestONNXExport(TestCase):
         Needed by detectron2 after https://github.com/facebookresearch/detectron2/pull/4132/
         """
         cast_fn = torch.jit.script(cast_fn)
-
-        f = io.BytesIO()
-        x = torch.zeros([1, 3, 32, 32])
-        torch.onnx.export(cast_fn, (x,), f)
-        onnx_model = onnx.load_from_string(f.getvalue())
+        onnx_model = export_to_onnx(cast_fn, torch.zeros([1, 3, 32, 32]))
         for n in onnx_model.graph.node:
             self.assertNotEqual(n.op_type, "To")
             self.assertNotEqual(n.op_type, "Cast")
@@ -84,9 +129,29 @@ class TestONNXExport(TestCase):
     def test_to__cpu_string(self):
         def cast_cpu_string(src: torch.Tensor) -> torch.Tensor:
             return src.to("cpu")
+
         self._helper_test_to_(cast_cpu_string)
 
     def test_to__device_cpu_string(self):
         def cast_device_cpu_string(src: torch.Tensor) -> torch.Tensor:
             return src.to(device="cpu")
+
         self._helper_test_to_(cast_device_cpu_string)
+
+    def test_repeat_interleave_repeats_dim1_repeats_size1(self):
+        class MyModel(torch.nn.Module):
+            def forward(self, x, repeats):
+                return torch.repeat_interleave(x, repeats)
+
+        onnx_model = export_to_onnx(
+            MyModel(),
+            (
+                torch.zeros((1,), dtype=torch.float32),
+                torch.ones((1,), dtype=torch.long),
+            ),
+            opset_version=9
+        )
+
+        print(onnx_model.graph)
+
+        self.assertTrue(isinstance(onnx_model, onnx.ModelProto))

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -3852,7 +3852,10 @@ class Prim:
             for i, b_in in enumerate(b.inputs()):
                 if i == 0 and i < len(inputs):
                     b_in.setType(inputs[i].type())
-                if i > 0 and (i + 1) < len(inputs):
+                # For optional block inputs, they may switch between None not-None inside
+                # the loop body, so if the loop input is not optional, the block input may
+                # still need to be optional.
+                if i > 0 and (i + 1) < len(inputs) and not isinstance(b_in.type(), OptionalType):
                     b_in.setType(inputs[i + 1].type())
             torch._C._jit_pass_onnx_block(b, new_block, operator_export_type, env, False)  # type:ignore[arg-type]
         new_op_outputs = torch._C._jit_pass_fixup_onnx_controlflow_node(new_node, opset_version)


### PR DESCRIPTION
[Fixes detectron2](https://github.com/facebookresearch/detectron2/pull/4120)

Several models at detectron2 hit an ONNX export issue when `r_splits` and `i_splits` are `torch._C.Value` as opposed to a list of it.

This PR makes sure they are lists, even if they are a single element