### PR TITLE
Implement sym_sizes to create proper IR for sym ints representing tensor sizes

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -221,7 +221,7 @@ class TORCH_API TensorBase {
     return impl_->sizes();
   }
   c10::SymIntArrayRef sym_sizes() const {
-    return c10::SymIntArrayRef(reinterpret_cast<const SymInt*>(sizes().data()), sizes().size());
+    return impl_->sym_sizes();
   }
   IntArrayRef strides() const {
     return impl_->strides();

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -6,6 +6,7 @@
 #include <c10/core/impl/LocalDispatchKeySet.h>
 #include <c10/util/Optional.h>
 #include <c10/util/irange.h>
+#include "c10/core/SymIntArrayRef.h"
 
 C10_DEFINE_bool(
     caffe2_keep_on_shrink,
@@ -360,6 +361,10 @@ bool TensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
 IntArrayRef TensorImpl::sizes_custom() const {
   TORCH_CHECK(
       false, "Tensors of type ", tensorimpl_type_name(), " do not have sizes");
+}
+c10::SymIntArrayRef TensorImpl::sym_sizes_custom() const {
+  TORCH_CHECK(
+      false, "Tensors of type ", tensorimpl_type_name(), " do not have sym sizes");
 }
 IntArrayRef TensorImpl::strides_custom() const {
   TORCH_CHECK(

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -2,11 +2,11 @@
 
 #include <c10/core/Backend.h>
 #include <c10/core/InferenceMode.h>
+#include <c10/core/SymIntArrayRef.h>
 #include <c10/core/WrapDimMinimal.h>
 #include <c10/core/impl/LocalDispatchKeySet.h>
 #include <c10/util/Optional.h>
 #include <c10/util/irange.h>
-#include "c10/core/SymIntArrayRef.h"
 
 C10_DEFINE_bool(
     caffe2_keep_on_shrink,
@@ -364,7 +364,10 @@ IntArrayRef TensorImpl::sizes_custom() const {
 }
 c10::SymIntArrayRef TensorImpl::sym_sizes_custom() const {
   TORCH_CHECK(
-      false, "Tensors of type ", tensorimpl_type_name(), " do not have sym sizes");
+      false,
+      "Tensors of type ",
+      tensorimpl_type_name(),
+      " do not have sym sizes");
 }
 IntArrayRef TensorImpl::strides_custom() const {
   TORCH_CHECK(

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -686,7 +686,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return sizes_and_strides_.sizes_arrayref();
   }
   inline c10::SymIntArrayRef sym_sizes_default() const {
-    return c10::SymIntArrayRef(reinterpret_cast<const c10::SymInt*>(sizes_and_strides_.sizes_data()), sizes_and_strides_.size());
+    return c10::SymIntArrayRef(
+        reinterpret_cast<const c10::SymInt*>(sizes_and_strides_.sizes_data()),
+        sizes_and_strides_.size());
   }
   inline int64_t dim_default() const {
     return sizes_and_strides_.size();

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -548,6 +548,15 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return sizes_default();
   }
 
+  c10::SymIntArrayRef sym_sizes() const {
+    if (C10_UNLIKELY(
+            sizes_strides_policy_ >=
+            static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
+      return sym_sizes_custom();
+    }
+    return sym_sizes_default();
+  }
+
   /**
    * Return a reference to the strides of this tensor.  This reference remains
    * valid as long as the tensor is live and not restrided.
@@ -655,6 +664,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   virtual bool is_contiguous_custom(at::MemoryFormat memory_format) const;
   // sizes_strides_policy_ >= CustomSizes
   virtual IntArrayRef sizes_custom() const;
+  virtual c10::SymIntArrayRef sym_sizes_custom() const;
   virtual int64_t dim_custom() const;
   virtual int64_t numel_custom() const;
 
@@ -674,6 +684,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
   inline IntArrayRef sizes_default() const {
     return sizes_and_strides_.sizes_arrayref();
+  }
+  inline c10::SymIntArrayRef sym_sizes_default() const {
+    return c10::SymIntArrayRef(reinterpret_cast<const c10::SymInt*>(sizes_and_strides_.sizes_data()), sizes_and_strides_.size());
   }
   inline int64_t dim_default() const {
     return sizes_and_strides_.size();

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -430,8 +430,7 @@ class TORCH_API Tensor final {
   }
 
   inline c10::SymIntArrayRef sym_sizes() const {
-    auto sizes = impl_.get()->sizes();
-    return c10::SymIntArrayRef(reinterpret_cast<const c10::SymInt*>(sizes.data()), sizes.size());
+    return impl_->sym_sizes();
   }
 
   inline int64_t size_from_dim(int k) const {

--- a/test/cpp/lazy/test_lazy_ops.cpp
+++ b/test/cpp/lazy/test_lazy_ops.cpp
@@ -94,6 +94,19 @@ TEST(LazyDynamicOpsTest, NarrowCopy) {
   AllClose(z.cpu(), x.cpu().narrow_copy(X_DIM_INDEX, 0, Y_DIM));
 }
 
+TEST(LazyDynamicOpsTest, NarrowCopyViaSymSizes) {
+  auto xc = torch::rand({10});
+  auto x = xc.to(kLazy);
+  const size_t Y_DIM = 3;
+  const size_t X_DIM_INDEX = 0;
+  auto y = torch::rand({Y_DIM}).to(kLazy);
+  auto z = x.narrow_copy(X_DIM_INDEX, 0, y.sym_sizes()[0]);
+  auto zc = xc.narrow_copy(X_DIM_INDEX, 0, Y_DIM);
+  ASSERT_EQ(z.sizes()[0], xc.sizes()[0]); // note, xc not zc
+  // shape inference assumes narrow_copy can copy the whole tensor
+  AllClose(z.cpu(), zc);
+}
+
 TEST_F(LazyOpsTest, TestScalarTensor) {
   torch::Tensor scalar_tensor = torch::scalar_tensor(
       1., torch::TensorOptions(torch::kFloat).device(DefaultDevice()));

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -140,7 +140,7 @@ void LTCTensorImpl::shallow_copy_from(
   generation_ = 0;
 }
 
-c10::SymIntArrayRef LTCTensorImpl::sym_sizes() const {
+c10::SymIntArrayRef LTCTensorImpl::sym_sizes_custom() const {
   return c10::SymIntArrayRef(sym_sizes_.data(), sym_sizes_.size());
 }
 

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -9,8 +9,6 @@
 #include <torch/csrc/lazy/core/ir_builder.h>
 // I guess we will need to use one of IRBuilder methods here
 #include <torch/csrc/lazy/ts_backend/dynamic_ir.h>
-#include "ATen/core/SymIntArrayRef.h"
-
 
 namespace torch {
 namespace lazy {

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -7,8 +7,6 @@
 #include <c10/util/irange.h>
 #include <torch/csrc/lazy/core/tensor_util.h>
 #include <torch/csrc/lazy/core/ir_builder.h>
-// I guess we will need to use one of IRBuilder methods here
-#include <torch/csrc/lazy/ts_backend/dynamic_ir.h>
 
 namespace torch {
 namespace lazy {
@@ -90,7 +88,7 @@ LTCTensorImpl::LTCTensorImpl(LazyTensor&& tensor)
   auto rank = tensor_->shape().Get().sizes().size();
   sym_sizes_.reserve(rank);
   for (auto i: c10::irange(rank)) {
-    auto dim_node = MakeNode<SizeNode>(this->tensor_->GetIrValue(), i);
+    auto dim_node = MakeSizeNode(this->tensor_->GetIrValue(), i);
     auto sn = std::make_shared<torch::lazy::SymbolicIntNode>(dim_node);
     sym_sizes_.push_back(sn->toSymInt());
   }

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -6,6 +6,11 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/lazy/core/tensor_util.h>
+#include <torch/csrc/lazy/core/ir_builder.h>
+// I guess we will need to use one of IRBuilder methods here
+#include <torch/csrc/lazy/ts_backend/dynamic_ir.h>
+#include "ATen/core/SymIntArrayRef.h"
+
 
 namespace torch {
 namespace lazy {
@@ -83,6 +88,14 @@ LTCTensorImpl::LTCTensorImpl(LazyTensor&& tensor)
   // according to https://github.com/pytorch/xla/pull/2682.
   is_non_overlapping_and_dense_ = false;
   set_sizes_strides_policy(SizesStridesPolicy::CustomSizes);
+
+  auto rank = tensor_->shape().Get().sizes().size();
+  sym_sizes_.reserve(rank);
+  for (auto i: c10::irange(rank)) {
+    auto dim_node = MakeNode<SizeNode>(this->tensor_->GetIrValue(), i);
+    auto sn = std::make_shared<torch::lazy::SymbolicIntNode>(dim_node);
+    sym_sizes_.push_back(sn->toSymInt());
+  }
 }
 
 void LTCTensorImpl::set_tensor(const LazyTensorPtr& lazy_tensor) {
@@ -125,6 +138,10 @@ void LTCTensorImpl::shallow_copy_from(
       /*allow_tensor_metadata_change=*/allow_tensor_metadata_change());
   ltc_impl->tensor_->ShallowCopyTo(tensor_);
   generation_ = 0;
+}
+
+c10::SymIntArrayRef LTCTensorImpl::sym_sizes() const {
+  return c10::SymIntArrayRef(sym_sizes_.data(), sym_sizes_.size());
 }
 
 void LTCTensorImpl::setup_size_properties() {

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -88,7 +88,7 @@ LTCTensorImpl::LTCTensorImpl(LazyTensor&& tensor)
   auto rank = tensor_->shape().Get().sizes().size();
   sym_sizes_.reserve(rank);
   for (auto i: c10::irange(rank)) {
-    auto dim_node = MakeSizeNode(this->tensor_->GetIrValue(), i);
+    auto dim_node = getBackend()->GetIrBuilder()->MakeSizeNode(this->tensor_->GetIrValue(), i);
     auto sn = std::make_shared<torch::lazy::SymbolicIntNode>(dim_node);
     sym_sizes_.push_back(sn->toSymInt());
   }

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -39,7 +39,7 @@ class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
   int64_t numel_custom() const override;
   bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
 
-  virtual c10::SymIntArrayRef sym_sizes() const;
+  virtual c10::SymIntArrayRef sym_sizes_custom() const override;
 
 #ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
   const at::Storage& storage() const override { return tensor_->Storage(); }

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <ATen/Tensor.h>
+#include <c10/core/SymIntArrayRef.h>
 #include <c10/core/TensorImpl.h>
 
 #include <torch/csrc/lazy/core/tensor.h>
-#include "ATen/core/SymIntArrayRef.h"
 
 namespace torch {
 namespace lazy {

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -4,6 +4,7 @@
 #include <c10/core/TensorImpl.h>
 
 #include <torch/csrc/lazy/core/tensor.h>
+#include "ATen/core/SymIntArrayRef.h"
 
 namespace torch {
 namespace lazy {
@@ -38,6 +39,8 @@ class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
   int64_t numel_custom() const override;
   bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
 
+  virtual c10::SymIntArrayRef sym_sizes() const;
+
 #ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
   const at::Storage& storage() const override { return tensor_->Storage(); }
   bool has_storage() const override { return tensor_->Storage(); }
@@ -47,6 +50,7 @@ class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
   void setup_size_properties();
 
   LazyTensorPtr tensor_;
+  std::vector<c10::SymInt> sym_sizes_;
   size_t generation_ {0};
 };
 


### PR DESCRIPTION
LTC Tensors now create real IR (SizeNode) for sym_sizes() in LTCTensorImpl.cpp. 