### PR TITLE
aten::_validate_sparse_compressed_tensor_args ops added to the ALLOW_LISST

### DIFF
--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -121,6 +121,7 @@ ALLOW_LIST = [
     ("aten::_cat", datetime.date(2022, 5, 15)),
     ("aten::nansum", datetime.date(2022, 5, 15)),
     ("aten::zero", datetime.date(2022, 5, 15)),
+    ("aten::_validate_sparse_compressed_tensor_args", datetime.date(2022, 5, 15)),
 ]
 
 ALLOW_LIST_COMPILED = [


### PR DESCRIPTION
aten::_validate_sparse_compressed_tensor_args ops added to the ALLOW_LISST of the ops can be backwards incompatible (till May 15 2022).

Fixes build problems, introduced by https://github.com/pytorch/pytorch/pull/76635
