### PR TITLE
[FSDP] Change default auto wrap policy name 

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -458,13 +458,17 @@ class FullyShardedDataParallel(nn.Module):
             Note that this policy currently will only apply to child modules of
             the passed in module. The remainder modules are always wrapped in
             the returned FSDP root instance.
-            ``default_auto_wrap_policy`` written in ``torch.distributed.fsdp.wrap`` is
+            ``size_based_auto_wrap_policy`` written in ``torch.distributed.fsdp.wrap`` is
             an example of ``auto_wrap_policy`` callable, this policy wraps layers
-            with parameter sizes larger than 100M. Users can supply the customized
+            with the number of parameters larger than 100M. ``transformer_auto_wrap_policy``
+            written in ``torch.distributed.fsdp.wrap`` is an example of ``auto_wrap_policy``
+            callable for tranformer-like model architectures. Users can supply the customized
             ``auto_wrap_policy`` callable that should accept following arguments:
             ``module: nn.Module``, ``recurse: bool``, ``unwrapped_params: int``,
             extra customized arguments could be added to the customized
-            ``auto_wrap_policy`` callable as well.
+            ``auto_wrap_policy`` callable as well. It is a good practice to print out
+            the sharded model and check whether the sharded model is what
+            the application wants and then adjust accordingly.
 
             Example::
 
@@ -523,12 +527,12 @@ class FullyShardedDataParallel(nn.Module):
                 >>> module = MyModule(device="meta")
                 >>> def my_init_fn(module):
                 >>>     # responsible for initializing a module, such as with reset_parameters
-                >>> fsdp_model = FSDP(module, param_init_fn=my_init_fn, auto_wrap_policy=default_auto_wrap_policy)
+                >>> fsdp_model = FSDP(module, param_init_fn=my_init_fn, auto_wrap_policy=size_based_auto_wrap_policy)
                 >>> print(next(fsdp_model.parameters()).device) # current CUDA device
                 >>> # With torchdistX
                 >>> module = deferred_init.deferred_init(MyModule, device="cuda")
                 >>> # Will initialize via deferred_init.materialize_module().
-                >>> fsdp_model = FSDP(module, auto_wrap_policy=default_auto_wrap_policy)
+                >>> fsdp_model = FSDP(module, auto_wrap_policy=size_based_auto_wrap_policy)
 
     """
 

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -36,12 +36,34 @@ def transformer_auto_wrap_policy(
     transformer_layer_cls: Set[Type[nn.Module]],
 ) -> bool:
     """
-    A convenient auto wrap policy for transformer models. If the submodule is an instance of
-    transformer_layer_cls, the submodule will be wrapped as a FSDP unit. Otherwise, all the other
-    remainder submodules are wrapped by the outermost FSDP unit. Right now, FSDP requires submodules
-    that share weights to be wrapped in the same FSDP unit, this auto wrap policy can conviniently
-    wrap the shared embeddings into the same FSDP unit for transformer models. In the near future,
-    FSDP will support submodules that share weights to be wrapped in the separated FSDP units.
+    A convenient auto wrap policy for transformer models. If the submodule
+    is an instance of transformer_layer_cls, the submodule will be wrapped
+    as a FSDP unit. Otherwise, all the other remainder submodules are wrapped
+    by the outermost FSDP unit. Right now, FSDP requires submodules that share
+    weights to be wrapped in the same FSDP unit, this auto wrap policy can
+    conviniently wrap the shared embeddings into the same FSDP unit for transformer
+    models. In the near future, FSDP will support submodules that share weights
+    to be wrapped in the separated FSDP units.
+
+    Return if a module should be wrapped during FSDP auto wrapping.
+
+    The first three parameters are required by :func:`_recursive_wrap`.
+
+
+    Args:
+       module (nn.Module):
+           The module to be considered in this decision.
+       recurse (bool):
+           Indicate if this is called to make a decision on whether we
+           should recurse down a subgraph of the module structure.
+           If False, it means this function is called to make a decision
+           on whether we should wrap the said module.
+       unwrapped_params (int):
+           The number of parameters yet to be wrapped in this module.
+
+       transformer_layer_cls (int):
+           Submodules with one of the `transformer_layer_cls` names
+           will be wrapped as seperated FSDP units
     """
     if recurse:
         # always recurse
@@ -51,20 +73,20 @@ def transformer_auto_wrap_policy(
         return isinstance(module, tuple(transformer_layer_cls))
 
 
-def default_auto_wrap_policy(
+def size_based_auto_wrap_policy(
     module: nn.Module,
     recurse: bool,
     unwrapped_params: int,
-    # These are customizable for this default policy function.
+    # These are customizable for this policy function.
     min_num_params: int = int(1e8),
     force_leaf_modules: Optional[Set[Type[nn.Module]]] = None,
     exclude_wrap_modules: Optional[Set[Type[nn.Module]]] = None,
 ) -> bool:
-    """Default policy function for :func:`auto_wrap`.
+    """A size based auto_wrap_policy function for FSDP API.
 
-       Return if a module should be wrapped during :func:`auto_wrap`.
+       Return if a module should be wrapped during FSDP auto wrapping.
 
-       The first three parameters are used by :func:`auto_wrap`. If
+       The first three parameters are used by :func:`_recursive_wrap`. If
        you write a custom version of this policy function, your version
        needs to at least accept the first three parameters and free
        to do whatever you want in the function.
@@ -89,12 +111,12 @@ def default_auto_wrap_policy(
            Customizable set of module types to be excluded in wrapping.
     """
     force_leaf_modules = (
-        default_auto_wrap_policy.FORCE_LEAF_MODULES  # type: ignore[attr-defined]
+        size_based_auto_wrap_policy.FORCE_LEAF_MODULES  # type: ignore[attr-defined]
         if force_leaf_modules is None
         else force_leaf_modules
     )
     exclude_wrap_modules = (
-        default_auto_wrap_policy.EXCLUDE_WRAP_MODULES  # type: ignore[attr-defined]
+        size_based_auto_wrap_policy.EXCLUDE_WRAP_MODULES  # type: ignore[attr-defined]
         if exclude_wrap_modules is None
         else exclude_wrap_modules
     )
@@ -108,9 +130,9 @@ def default_auto_wrap_policy(
         return is_large and not isinstance(module, tuple(exclude_wrap_modules))
 
 
-# Set those defaults to the default_auto_wrap_policy function. Make them easy to be imported.
-default_auto_wrap_policy.EXCLUDE_WRAP_MODULES = {nn.ModuleList, nn.ModuleDict}  # type: ignore[attr-defined]
-default_auto_wrap_policy.FORCE_LEAF_MODULES = {nn.MultiheadAttention}  # type: ignore[attr-defined]
+# Set those defaults to the size_based_auto_wrap_policy function. Make them easy to be imported.
+size_based_auto_wrap_policy.EXCLUDE_WRAP_MODULES = {nn.ModuleList, nn.ModuleDict}  # type: ignore[attr-defined]
+size_based_auto_wrap_policy.FORCE_LEAF_MODULES = {nn.MultiheadAttention}  # type: ignore[attr-defined]
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
current default_auto_wrap_policy is not really a recommended default auto wrap policy, change the name to avoid confusion, updated the doc as well
