### PR TITLE
shard `win-vs2019-cuda11.3-py3 / test` from 2 shards to 5 shards

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -242,7 +242,10 @@ jobs:
       cuda-version: "11.3"
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 2, runner: "windows.8xlarge.nvidia.gpu" },
-          { config: "default", shard: 2, num_shards: 2, runner: "windows.8xlarge.nvidia.gpu" },
+          { config: "default", shard: 1, num_shards: 5, runner: "windows.8xlarge.nvidia.gpu" },
+          { config: "default", shard: 2, num_shards: 5, runner: "windows.8xlarge.nvidia.gpu" },
+          { config: "default", shard: 3, num_shards: 5, runner: "windows.8xlarge.nvidia.gpu" },
+          { config: "default", shard: 4, num_shards: 5, runner: "windows.8xlarge.nvidia.gpu" },
+          { config: "default", shard: 5, num_shards: 5, runner: "windows.8xlarge.nvidia.gpu" },
           { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge" },
         ]}


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
shard `win-vs2019-cuda11.3-py3 / test` from 2 shards to 5 shards
helps w/ #76838


Notes:
- avg tts for the past week as of May 5 is 4.7 and 4.5 hours for 1st and 2nd shard on master, around 4 hours for all branches (but I don't think the changes from removing distributed tests + moving testing off of pull have come into effect yet)
- high overhead
- hope that tts doesn't explode

Sharding spreadsheet: https://docs.google.com/spreadsheets/d/1BdtVsjRr0Is9LXMNilR02FEdPXNq7zEWl8AmR3ArsLQ/edit#gid=1153012347
