### PR TITLE
Add some shape decomps (t, transpose, rot90, stack)

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1181,7 +1181,7 @@ def rot90(self: Tensor, k: int = 1, dims: List[int] = [0, 1]) -> Tensor:
 
 @register_decomposition(aten.transpose.int)
 def transpose_int(self: Tensor, dim0: int, dim1: int) -> Tensor:
-    dim0, dim1 = utils.canonicalize_dims(self.ndim, (dim0, dim1))
+    dim0, dim1 = utils.canonicalize_dims(self.dim(), (dim0, dim1))
 
     if self.dim() <= 1:
         return self

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -623,11 +623,6 @@ def native_dropout_backward(grad_output: Tensor, mask: Tensor, scale: float):
     return grad_output * (mask.type_as(grad_output) * scale)
 
 
-@register_decomposition(aten.reciprocal)
-def reciprocal(self: Tensor) -> Tensor:
-    return 1 / self
-
-
 @register_decomposition(aten.logit)
 @pw_cast_for_int_to_real
 def logit(self: Tensor, eps: Optional[float] = None) -> Tensor:

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1165,7 +1165,8 @@ def rot90(self: Tensor, k: int = 1, dims: List[int] = [0, 1]) -> Tensor:  # noqa
     total_rot_dims = len(dims)
     assert total_rot_dims == 2, f"expected total rotation dims == 2, but got dims = {total_rot_dims}"
     assert total_dims >= 2, f"expected total dims >= 2, but got total dims = {total_dims}"
-    assert dims[0] != dims[1] and abs(dims[0] - dims[1]) != total_dims, f"expected rotation dims to be different, but got dim0 = {dims[0]} and dim1 = {dims[1]}"
+    assert dims[0] != dims[1] and abs(dims[0] - dims[1]) != total_dims,\
+           f"expected rotation dims to be different, but got dim0 = {dims[0]} and dim1 = {dims[1]}"
     assert dims[0] < total_dims and dims[0] >= -total_dims, f"Rotation dim0 out of range, dim0 = {dims[0]}"
     assert dims[1] < total_dims and dims[1] >= -total_dims, f"Rotation dim1 out of range, dim1 = {dims[1]}"
     k = k % 4

--- a/torch/_prims/utils.py
+++ b/torch/_prims/utils.py
@@ -228,7 +228,7 @@ def validate_exclusive_idx(shape: Sequence, ex_idx: int):
 
 # "Wraps" a dim (up to one time) for the given rank, allowing
 # dims to be specified using negative indices
-def canonicalize_idx(rank: int, idx: int) -> int:
+def canonicalize_dim(rank: int, idx: int) -> int:
     # TODO: add a comment for why this is
     _rank = rank if rank != 0 else 1
 
@@ -237,6 +237,8 @@ def canonicalize_idx(rank: int, idx: int) -> int:
 
     if idx < 0:
         _idx = idx + _rank
+    else:
+        _idx = idx
 
     if _idx < 0 or _idx > _rank:
         msg = "Received out of bounds index {0} for tensor of rank {1}!".format(
@@ -251,9 +253,9 @@ def canonicalize_idx(rank: int, idx: int) -> int:
 # mapping negative offsets to positive ones
 def canonicalize_dims(rank: int, indices: DimsType) -> DimsType:
     if isinstance(indices, int):
-        return canonicalize_idx(rank, indices)
+        return canonicalize_dim(rank, indices)
 
-    return tuple(canonicalize_idx(rank, x) for x in indices)
+    return tuple(canonicalize_dim(rank, x) for x in indices)
 
 
 def is_valid_permutation(rank: int, perm: DimsSequenceType) -> bool:
@@ -676,7 +678,7 @@ def compute_reduction_output_shape(
 def reduction_dims(shape: ShapeType, dims: Optional[Sequence]) -> Tuple[int, ...]:
     if dims is None:
         return tuple(range(len(shape)))
-    dims = tuple(canonicalize_idx(len(shape), idx) for idx in dims)
+    dims = tuple(canonicalize_dim(len(shape), idx) for idx in dims)
     if len(dims) != len(set(dims)):
         raise RuntimeError("duplicate value in the list of dims")
     return dims

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1123,7 +1123,7 @@ def tensor_split(
     indices_or_sections: Union[Tensor, DimsType],
     dim: int = 0,
 ) -> Tuple[TensorLikeType, ...]:
-    _dim = utils.canonicalize_idx(a.ndim, dim)
+    _dim = utils.canonicalize_dim(a.ndim, dim)
     if a.ndim == 0:
         msg = "tensor_split: received a rank zero tensor, but expected a tensor of rank one or greater!"
         raise ValueError(msg)


### PR DESCRIPTION
Also fixes xlogy (turns out the only thing it was missing was a type cast annotation! nice!)

I also renamed `canonicalize_idx` => `canonicalize_dim` (to align with `canonicalize_dims`) and fixed a bug in it (cc: @mruberry)
