### PR TITLE
[FX qconfig] add weighted_op_qint8_dtype_config for int8 TRT and import linear config to get_tensorrt_backend_config_dict

### DIFF
--- a/torch/ao/quantization/backend_config/native.py
+++ b/torch/ao/quantization/backend_config/native.py
@@ -145,18 +145,11 @@ _DEFAULT_OP_INT8_CONFIGS = [
         torch.nn.functional.layer_norm,
     ]]
 
-def _get_linear_configs():
+def _get_linear_configs(dtype_configs):
     """
     Return all configs related to linear modules and ops.
     """
     observation_type = ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT
-    dtype_configs = [
-        weighted_op_int8_dtype_config,
-        default_dynamic_int8_dtype_config,
-        default_dynamic_float16_dtype_config,
-        # TODO: maybe remove this since fbgemm/qnnpack doesn't have kernels for it
-        default_op_fp16_dtype_config,
-    ]
     linear_configs = []
 
     # (1) Single linear modules/functions
@@ -692,6 +685,13 @@ def _get_embedding_op_configs():
 
 def get_native_backend_config_dict():
     """ Get backend_config_dict for PyTorch Native backend (fbgemm/qnnpack). """
+    linear_dtype_configs = [
+        weighted_op_int8_dtype_config,
+        default_dynamic_int8_dtype_config,
+        default_dynamic_float16_dtype_config,
+        # TODO: maybe remove this since fbgemm/qnnpack doesn't have kernels for it
+        default_op_fp16_dtype_config,
+    ]
     binary_op_dtype_configs = [
         weighted_op_int8_dtype_config,
         default_op_fp16_dtype_config,
@@ -705,7 +705,7 @@ def get_native_backend_config_dict():
         "name": "native",
         "configs": [
             *_DEFAULT_OP_INT8_CONFIGS,
-            *_get_linear_configs(),
+            *_get_linear_configs(linear_dtype_configs),
             *_get_conv_configs(),
             *_get_binary_op_configs(binary_op_dtype_configs),
             *_get_fixed_qparams_op_configs(),

--- a/torch/ao/quantization/backend_config/tensorrt.py
+++ b/torch/ao/quantization/backend_config/tensorrt.py
@@ -5,6 +5,7 @@ import torch.nn.intrinsic as nni
 import torch.nn.intrinsic.qat as nniqat
 # TODO: maybe refactor this to a separate util function
 from .native import _get_binary_op_configs
+from .native import _get_linear_configs
 from .native import _get_share_qparams_op_configs
 
 from ..fuser_method_mappings import reverse_sequential_wrapper2
@@ -34,20 +35,6 @@ def get_tensorrt_backend_config_dict():
     }
 
     # operator (module/functional/torch ops) configs
-    linear_module_config = {
-        # Please see README under this folder for pattern format
-        "pattern": torch.nn.Linear,
-        "observation_type": ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT,
-        "dtype_configs": [
-            weighted_op_qint8_dtype_config,
-        ],
-        # the root module for the pattern, used to query the reference quantized module
-        # e.g. for a (torch.nn.ReLU, torch.nn.Linear) pattern, the root will be torch.nn.Linear
-        "root_module": torch.nn.Linear,
-        # the corresponding reference quantized module for the root module
-        "reference_quantized_module_for_root": torch.nn.quantized._reference.Linear,
-        "qat_module": nnqat.Linear,
-    }
     linear_qat_config = {
         "pattern": nnqat.Linear,
         "observation_type": ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT,
@@ -193,6 +180,9 @@ def get_tensorrt_backend_config_dict():
             non_weighted_op_qint8_dtype_config,
         ]
     }
+    linear_dtype_configs = [
+        weighted_op_qint8_dtype_config,
+    ]
     binary_op_dtype_configs = [
         weighted_op_qint8_dtype_config,
     ]
@@ -203,7 +193,6 @@ def get_tensorrt_backend_config_dict():
         # optional
         "name": "tensorrt",
         "configs": [
-            linear_module_config,
             linear_qat_config,
             linear_relu_fused_config,
             linear_relu_qat_config,
@@ -221,6 +210,7 @@ def get_tensorrt_backend_config_dict():
             # conv3d_relu_fused_config,
             addmm_config,
             cat_config,
+            *_get_linear_configs(linear_dtype_configs),
             *_get_binary_op_configs(binary_op_dtype_configs),
             *_get_share_qparams_op_configs(share_qparams_op_dtype_configs),
         ]


### PR DESCRIPTION
Summary:
- Add weighted_op_qint8_dtype_config
- import import linear config to get_tensorrt_backend_config_dict()
- Add qconfig for _get_linear_configs()

Test Plan: CI

Differential Revision: D36152319

