### PR TITLE
Fix typing for load_state_dict_from_url()

### DIFF
--- a/torch/hub.py
+++ b/torch/hub.py
@@ -666,7 +666,7 @@ def load_state_dict_from_url(
     progress: bool = True,
     check_hash: bool = False,
     file_name: Optional[str] = None
-) -> nn.Module:
+) -> Dict[str, Any]:
     r"""Loads the Torch serialized object at the given URL.
 
     If downloaded file is a zip file, it will be automatically

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -10,12 +10,10 @@ import torch
 import warnings
 import zipfile
 from pathlib import Path
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, Optional, Union, Any
 from urllib.error import HTTPError
 from urllib.request import urlopen, Request
 from urllib.parse import urlparse  # noqa: F401
-
-import torch.nn as nn
 
 try:
     from tqdm.auto import tqdm  # automatically select proper tqdm submodule if available


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #76895

#74171 landed with an incorrect type for `load_state_dict_from_url()`. This PR fixes it. See the comment here: https://github.com/pytorch/pytorch/pull/74171/files/7f41d1ce0d0308258cfdd613477bb5e43068208d#r865982377