### PR TITLE
move win cuda tests from pr to trunk

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -263,6 +263,7 @@ jobs:
           { config: "default", shard: 2, num_shards: 2, runner: "windows.4xlarge" },
         ]}
 
+  # please ensure that this and its corresponding job in trunk.yml are the same
   win-vs2019-cuda11_3-py3-build:
     name: win-vs2019-cuda11.3-py3
     uses: ./.github/workflows/_win-build.yml

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -270,20 +270,6 @@ jobs:
       build-environment: win-vs2019-cuda11.3-py3
       cuda-version: "11.3"
 
-  win-vs2019-cuda11_3-py3-test:
-    name: win-vs2019-cuda11.3-py3
-    uses: ./.github/workflows/_win-test.yml
-    needs: win-vs2019-cuda11_3-py3-build
-    with:
-      build-environment: win-vs2019-cuda11.3-py3
-      cuda-version: "11.3"
-      test-matrix: |
-        { include: [
-          { config: "default", shard: 1, num_shards: 2, runner: "windows.8xlarge.nvidia.gpu" },
-          { config: "default", shard: 2, num_shards: 2, runner: "windows.8xlarge.nvidia.gpu" },
-          { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge" },
-        ]}
-
   linux-xenial-cuda11_3-py3_7-gcc7-bazel-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7-bazel-test
     uses: ./.github/workflows/_bazel-build-test.yml

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -263,8 +263,10 @@ jobs:
           { config: "default", shard: 2, num_shards: 2, runner: "windows.4xlarge" },
         ]}
 
-  # please ensure that this and its corresponding job in trunk.yml are the same
+  # please ensure that this and its corresponding job in trunk.yml are in sync
   win-vs2019-cuda11_3-py3-build:
+    # don't run build twice on master
+    if: github.event_name == 'pull_request'
     name: win-vs2019-cuda11.3-py3
     uses: ./.github/workflows/_win-build.yml
     with:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -225,6 +225,7 @@ jobs:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
+  # please ensure that this and its corresponding job in pull.yml are the same
   win-vs2019-cuda11_3-py3-build:
     name: win-vs2019-cuda11.3-py3
     uses: ./.github/workflows/_win-build.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -224,3 +224,24 @@ jobs:
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
+
+  win-vs2019-cuda11_3-py3-build:
+    name: win-vs2019-cuda11.3-py3
+    uses: ./.github/workflows/_win-build.yml
+    with:
+      build-environment: win-vs2019-cuda11.3-py3
+      cuda-version: "11.3"
+
+  win-vs2019-cuda11_3-py3-test:
+    name: win-vs2019-cuda11.3-py3
+    uses: ./.github/workflows/_win-test.yml
+    needs: win-vs2019-cuda11_3-py3-build
+    with:
+      build-environment: win-vs2019-cuda11.3-py3
+      cuda-version: "11.3"
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 2, runner: "windows.8xlarge.nvidia.gpu" },
+          { config: "default", shard: 2, num_shards: 2, runner: "windows.8xlarge.nvidia.gpu" },
+          { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge" },
+        ]}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -225,7 +225,7 @@ jobs:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
-  # please ensure that this and its corresponding job in pull.yml are the same
+  # please ensure that this and its corresponding job in pull.yml are in sync
   win-vs2019-cuda11_3-py3-build:
     name: win-vs2019-cuda11.3-py3
     uses: ./.github/workflows/_win-build.yml


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

helps w/ #76838
as in title

they take a long time theres a lot of queuing for the windows.8xlarge.nvidia.gpu machines, hopefully this will bring the queue time down + decrease tts

avg tts for the past week for `pull / win-vs2019-cuda11.3-py3 / test` is 4.7 and 4.4 hours 

