### PR TITLE
Fix 'Code below assumes there is at least one tensor arg' assumption

### DIFF
--- a/torch/csrc/lazy/backend/backend_device.cpp
+++ b/torch/csrc/lazy/backend/backend_device.cpp
@@ -46,12 +46,6 @@ BackendDevice atenDeviceToBackendDevice(const c10::Device& device) {
   int64_t ordinal = device.has_index() ? device.index() : 0;
   return BackendDevice(getBackend()->GetDefaultDeviceType(), ordinal);
 }
-c10::optional<BackendDevice> atenDeviceToBackendDevice(const c10::optional<c10::Device> device) {
-  if (device) {
-    return c10::make_optional(atenDeviceToBackendDevice(*device));
-  }
-  return c10::nullopt;
-}
 
 // TODO(whc) refactor this: we need to support non 1 on 1 mapping for torch/XLA.
 c10::Device backendDeviceToAtenDevice(const BackendDevice& device) {
@@ -70,6 +64,13 @@ c10::optional<BackendDevice> GetBackendDevice(const at::TensorList tensors) {
 c10::optional<BackendDevice> GetBackendDevice(const at::Tensor& tensor) {
   if (auto lt = TryGetLtcTensor(tensor)) {
     return lt->GetDevice();
+  }
+  return c10::nullopt;
+}
+
+c10::optional<BackendDevice> GetBackendDevice(const c10::optional<c10::Device> device) {
+  if (device) {
+    return c10::make_optional(atenDeviceToBackendDevice(*device));
   }
   return c10::nullopt;
 }

--- a/torch/csrc/lazy/backend/backend_device.cpp
+++ b/torch/csrc/lazy/backend/backend_device.cpp
@@ -5,6 +5,7 @@
 #include <c10/util/StringUtil.h>
 #include <torch/csrc/lazy/core/tensor.h>
 #include <torch/csrc/lazy/backend/backend_interface.h>
+#include <c10/util/Optional.h>
 
 namespace torch {
 namespace lazy {
@@ -44,6 +45,12 @@ BackendDevice atenDeviceToBackendDevice(const c10::Device& device) {
   TORCH_CHECK(device.type() == at::kLazy, device);
   int64_t ordinal = device.has_index() ? device.index() : 0;
   return BackendDevice(getBackend()->GetDefaultDeviceType(), ordinal);
+}
+c10::optional<BackendDevice> atenDeviceToBackendDevice(const c10::optional<c10::Device> device) {
+  if (device) {
+    return c10::make_optional(atenDeviceToBackendDevice(*device));
+  }
+  return c10::nullopt;
 }
 
 // TODO(whc) refactor this: we need to support non 1 on 1 mapping for torch/XLA.

--- a/torch/csrc/lazy/backend/backend_device.h
+++ b/torch/csrc/lazy/backend/backend_device.h
@@ -56,6 +56,7 @@ TORCH_API std::ostream& operator<<(std::ostream& os, const BackendDevice& device
 
 // Helpers for converting a c10::Device to BackendDevice and vice versa.
 TORCH_API BackendDevice atenDeviceToBackendDevice(const c10::Device& device);
+TORCH_API c10::optional<BackendDevice> atenDeviceToBackendDevice(const c10::optional<c10::Device> device);
 TORCH_API c10::Device backendDeviceToAtenDevice(const BackendDevice& device);
 
 // Tries to extract the backend device out of the lazy tensor. Returns nullopt if the

--- a/torch/csrc/lazy/backend/backend_device.h
+++ b/torch/csrc/lazy/backend/backend_device.h
@@ -56,13 +56,13 @@ TORCH_API std::ostream& operator<<(std::ostream& os, const BackendDevice& device
 
 // Helpers for converting a c10::Device to BackendDevice and vice versa.
 TORCH_API BackendDevice atenDeviceToBackendDevice(const c10::Device& device);
-TORCH_API c10::optional<BackendDevice> atenDeviceToBackendDevice(const c10::optional<c10::Device> device);
 TORCH_API c10::Device backendDeviceToAtenDevice(const BackendDevice& device);
 
 // Tries to extract the backend device out of the lazy tensor. Returns nullopt if the
 // input is not a lazy tensor.
 TORCH_API c10::optional<BackendDevice> GetBackendDevice(const at::TensorList tensors);
 TORCH_API c10::optional<BackendDevice> GetBackendDevice(const at::Tensor& tensor);
+TORCH_API c10::optional<BackendDevice> GetBackendDevice(const c10::optional<c10::Device> device);
 
 // For variadic template.
 TORCH_API c10::optional<BackendDevice> GetBackendDevice();

--- a/torchgen/api/lazy.py
+++ b/torchgen/api/lazy.py
@@ -170,10 +170,11 @@ class LazyArgument:
     def __init__(self, arg: Argument):
         self.name = arg.name
         self.orig_type = arg.type
+        self.is_optional = isinstance(arg.type, OptionalType)
         self.is_generator = isGeneratorType(arg.type)
         if self.is_generator:
-            assert isinstance(
-                arg.type, OptionalType
+            assert (
+                self.is_optional
             ), "We expect all generators are optional since currently they are"
             # there is no handling for generators in TorchScript IR (or XLA)
             # so we fall back to eager if the (optional)generator has value, and otherwise

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -1,5 +1,6 @@
 from abc import ABC
-from typing import List, Union
+import re
+from typing import List, Optional, Union
 from dataclasses import dataclass
 from torchgen.context import method_with_native_function
 from torchgen.model import BackendIndex, NativeFunction, NativeFunctionsGroup
@@ -350,11 +351,22 @@ class GenLazyNativeFuncDefinition:
 
     def get_device(self, func: NativeFunction, schema: LazyIrSchema) -> str:
         value_args = schema.filtered_args(values=True, scalars=False)
+        scalar_args = schema.filtered_args(values=False, scalars=True)
         value_types_names = [f"{a.name}" for a in value_args if not a.is_wrapped_scalar]
-        assert (
-            len(value_types_names) > 0
-        ), "Code below assumes there is at least one tensor arg"
-        return f"""auto common_device = {self.get_device_fn}({', '.join(value_types_names)});
+        if len(value_types_names) > 0:
+            get_device_str = (
+                f"{self.get_device_fn}({', '.join(value_types_names)})"
+            )
+        else:
+            optional_device_re = re.compile("(.*::)?optional<(.*::)?Device>")
+            for a in scalar_args:
+                if optional_device_re.search(a.lazy_type.cpp_type()):
+                    get_device_str = f"atenDeviceToBackendDevice({a.name})"
+                    break
+            else:
+                raise ValueError("Expected at least one Value or Device type")
+
+        return f"""auto common_device = {get_device_str};
         TORCH_INTERNAL_ASSERT(common_device);
         """
 
@@ -406,10 +418,13 @@ class GenLazyNativeFuncDefinition:
         }}
         """
 
-    def create_lazy_tensor(self, first_tensor_name: str) -> str:
+    def create_lazy_tensor(self, first_tensor_name: Optional[str] = None) -> str:
         # xla uses an instance method for tensor creation, for the time being
         if self.create_from_first_tensor:
             # TODO(whc) remove this if XLA switches to using static method for creation
+            assert (
+                first_tensor_name is not None
+            ), "Requires first tensor to create lazy tensor"
             return f"{first_tensor_name}.{self.create_tensor}"
         return f"{self.backend_namespace}::{self.create_tensor}"
 
@@ -417,15 +432,15 @@ class GenLazyNativeFuncDefinition:
         returns_length = len(schema.returns)
         value_args = schema.filtered_args(values=True, scalars=False)
         value_types_names = [f"{a.name}" for a in value_args if not a.is_wrapped_scalar]
-        assert (
-            len(value_types_names) > 0
-        ), "Code below assumes there is at least one tensor arg"
-        first_tensor_name = value_types_names[0]
+        first_tensor_name = value_types_names[0] if len(value_types_names) > 0 else None
         bridge_str = f"""auto result = {self.create_aten_from_ltc_tensor}(
                 {self.create_lazy_tensor(first_tensor_name)}(std::move(node), *common_device));"""
 
         if returns_length > 1:
-            bridge_str = f"""std::vector<{self.lazy_tensor_ptr}> lazy_tensors;
+            assert (
+                len(value_types_names) > 0
+            ), "Code below assumes there is at least one tensor arg"
+            bridge_str = f"""std::vector<{self.tensor_class}Ptr> lazy_tensors;
         for (int i = 0; i < {returns_length}; i++) {{
             lazy_tensors.push_back({self.create_lazy_tensor(first_tensor_name)}({getValueT()}(node, i), *common_device));
         }}

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -437,7 +437,7 @@ class GenLazyNativeFuncDefinition:
             assert (
                 len(value_types_names) > 0
             ), "Code below assumes there is at least one tensor arg"
-            bridge_str = f"""std::vector<{self.tensor_class}Ptr> lazy_tensors;
+            bridge_str = f"""std::vector<{self.lazy_tensor_ptr}> lazy_tensors;
         for (int i = 0; i < {returns_length}; i++) {{
             lazy_tensors.push_back({self.create_lazy_tensor(first_tensor_name)}({getValueT()}(node, i), *common_device));
         }}

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -1,5 +1,4 @@
 from abc import ABC
-import re
 from typing import List, Optional, Union
 from dataclasses import dataclass
 from torchgen.context import method_with_native_function
@@ -9,6 +8,7 @@ from torchgen.api.types import (
     OptionalCType,
     VectorCType,
     kernel_signature,
+    deviceT,
 )
 import torchgen.api.dispatcher as dispatcher
 from torchgen.api.lazy import (
@@ -358,9 +358,9 @@ class GenLazyNativeFuncDefinition:
                 f"{self.get_device_fn}({', '.join(value_types_names)})"
             )
         else:
-            optional_device_re = re.compile("(.*::)?optional<(.*::)?Device>")
+            optional_device = OptionalCType(BaseCType(deviceT))
             for a in scalar_args:
-                if optional_device_re.search(a.lazy_type.cpp_type()):
+                if a.lazy_type == optional_device:
                     get_device_str = f"atenDeviceToBackendDevice({a.name})"
                     break
             else:


### PR DESCRIPTION
Previously when codegening ops like `zeros_` or `ones_` we'd hit a `Code below assumes there is at least one tensor arg error`. This check is not entirely correct which is what is causing the error to be thrown. There are ops like the ones mentioned that pass in a `device` parameter that can be used in place of the "first tensor".

CC: @wconstab @desertfire @henrytwo @ke1337