### PR TITLE
Change no_torch_function_mode to StashTorchFunctionModeGuard

### DIFF
--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -257,7 +257,7 @@ auto handle_torch_function_no_python_arg_parser(
     TORCH_INTERNAL_ASSERT(args != nullptr);
     // Disable mode on the inside; this makes for a more user-friendly
     // experience if you try to, e.g., print your tensors.
-    at::optional<torch::overrides::no_torch_function_mode> tf_g;
+    at::optional<torch::overrides::StashTorchFunctionModeGuard> tf_g;
     at::optional<torch_dispatch_mode::StashTorchDispatchModeGuard> td_g;
     if (is_torch_function) {
       tf_g.emplace();

--- a/torch/csrc/utils/python_torch_function_mode.h
+++ b/torch/csrc/utils/python_torch_function_mode.h
@@ -10,9 +10,9 @@ namespace overrides {
 // mode waiting to go after you, and you shouldn't just blindly disable it.
 // From C++ side, there is no such thing as compositional modes, there is one
 // mode and of course you should be able to clear it.
-struct no_torch_function_mode {
-  no_torch_function_mode() { at::impl::PythonTorchFunctionTLS::swap_mode(old_mode_); }
-  ~no_torch_function_mode() { at::impl::PythonTorchFunctionTLS::set_mode(std::move(old_mode_)); }
+struct StashTorchFunctionModeGuard {
+  StashTorchFunctionModeGuard() { at::impl::PythonTorchFunctionTLS::swap_mode(old_mode_); }
+  ~StashTorchFunctionModeGuard() { at::impl::PythonTorchFunctionTLS::set_mode(std::move(old_mode_)); }
 private:
   std::shared_ptr<c10::SafePyObject> old_mode_ = nullptr;
 };


### PR DESCRIPTION
As discussed [here](https://github.com/pytorch/pytorch/pull/75965#discussion_r863097966), changes the torch dispatch and torch function RAII guards to have unified names (StashXModeGuard). This also match the [TLS guard](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/core/PythonFallbackKernel.cpp#L30-L44), called StashTLSOnEntryGuard, that has a similar RAII pattern