### PR TITLE
[lint] make grep_linter.py portable

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -217,7 +217,7 @@ exclude_patterns = ['test/test_jit.py']
 command = [
     'python3',
     'tools/linter/adapters/grep_linter.py',
-    '--pattern=# type:\s*ignore(?!\[)',
+    '--pattern=# type:\s*ignore([^\[]|$)',
     '--linter-name=TYPEIGNORE',
     '--error-name=unqualified type: ignore',
     """--error-description=\
@@ -235,7 +235,7 @@ exclude_patterns = ['caffe2/**']
 command = [
     'python3',
     'tools/linter/adapters/grep_linter.py',
-    '--pattern=# noqa(?!: [A-Z]+\d{3})',
+    '--pattern=# noqa([^:]|$)',
     '--linter-name=NOQA',
     '--error-name=unqualified noqa',
     """--error-description=\
@@ -330,11 +330,12 @@ exclude_patterns = [
     '**/.gitmodules',
     'test/cpp/jit/upgrader_models/*.ptl',
     'test/cpp/jit/upgrader_models/*.ptl.ff',
+    '.lintrunner.toml',
 ]
 command = [
     'python3',
     'tools/linter/adapters/grep_linter.py',
-    '--pattern=\t',
+    '--pattern=	',
     '--linter-name=TABS',
     '--error-name=saw some tabs',
     '--replace-pattern=s/\t/    /',
@@ -384,7 +385,7 @@ command = [
     'tools/linter/adapters/grep_linter.py',
     """--pattern=\
     (pip|pip3|python -m pip|python3 -m pip|python3 -mpip|python -mpip) \
-    install ([a-z][\\.a-z-0-9]*+(?!(=|.*\\.whl))([[:blank:]]|))+\
+    install ([a-zA-Z0-9][A-Za-z0-9\\._\\-]+)([^/=<>~!]+)[A-Za-z0-9\\._\\-\\*\\+\\!]*$\
     """,
     '--linter-name=PYPIDEP',
     '--error-name=unpinned PyPI install',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1,6 +1,3 @@
-[init_config]
-last_hash = "7d8b366223b22aaab788b0a7efec064dfef38b24"
-
 [[linter]]
 code = 'FLAKE8'
 include_patterns = ['**/*.py']

--- a/tools/linter/adapters/grep_linter.py
+++ b/tools/linter/adapters/grep_linter.py
@@ -175,7 +175,7 @@ def main() -> None:
     )
 
     try:
-        proc = run_command(["grep", "-nPHI", args.pattern, *args.filenames])
+        proc = run_command(["grep", "-nEHI", args.pattern, *args.filenames])
     except Exception as err:
         err_msg = LintMessage(
             path=None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #76947

grep_linter.py was using the `-P` flag of `grep`, which is available in
GNU grep but notably *not* available in the BSD grep that is installed
on Macs.

Use `-E` instead, which uses ERE instead of PCRE. Sadly we were actually
using two PCRE features in our linters:
- Negative lookaheads. I changed these to less-accurate-but-still-good-enough
  versions that use `[^...]` expressions.
- Apparently ERE doesn't support the `\t` atom lol. So I used a literal tab
  character instead (and then had to disable the TAB linter for
  `.lintrunner.toml` lol.

closes https://github.com/pytorch/pytorch/issues/76827