### PR TITLE
[NNC] channels last propagation within NNC fusion group

### DIFF
--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import torch
-from torch._C import memory_format
 import torch.nn.functional as F
 from torch import nn
 import unittest

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1609,7 +1609,7 @@ class TestTensorExprFuser(BaseTestClass):
             a = torch.rand(2, 3, 4, 5, dtype=torch.float32)
             b = torch.rand(2, 3, 4, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
             c = torch.rand(2, 3, 4, 5, dtype=torch.float32)
-            # The memory layouts of the imperative mode outputs are
+            # The memory layout of the imperative mode output is
             #     (contiguous)
             # propagation memory layout is contiguous
             run_foo_case(foo, a, b, c)
@@ -1623,7 +1623,7 @@ class TestTensorExprFuser(BaseTestClass):
             a = torch.rand(2, 3, 4, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
             b = torch.rand(2, 3, 4, 5, dtype=torch.float32)
             c = torch.rand(2, 3, 4, 5, dtype=torch.float32)
-            # The memory layouts of the imperative mode outputs are
+            # The memory layout of the imperative mode output is
             #     (channels-last)
             # propagation memory layout is contiguous
             run_foo_case(foo, a, b, c)
@@ -1637,7 +1637,7 @@ class TestTensorExprFuser(BaseTestClass):
             a = torch.rand(2, 3, 4, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
             b = torch.rand(2, 3, 4, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
             c = torch.rand(2, 3, 4, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
-            # The memory layouts of the imperative mode outputs are
+            # The memory layout of the imperative mode output is
             #     (channels-last)
             # propagation memory layout is channels-last
             run_foo_case(foo, a, b, c)

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -1560,5 +1560,121 @@ class TestTensorExprFuser(BaseTestClass):
             exp = traced(a, b, c)
             self.assertEqual(ref, exp)
 
+    def test_propagated_mem_layout(self):
+        def foo(a, b, c):
+            t_next = c + 1
+            t5 = t_next * b
+            t7 = a * t5
+            return t7
+
+        def foo_multi_outputs(a, b, c):
+            t_next = c + 1
+            t5 = b * t_next
+            t7 = a * t5
+            return (t7, t5, t_next)
+
+        def foo_multi_outputs_i_nhwc_o_nchw(a, b, c):
+            t_next = c + 1
+            t5 = b * t_next
+            t7 = a * t5
+            t8 = t7.to(memory_format=torch.contiguous_format)
+            return (t8, t7, t5, t_next)
+
+        def run_foo_case(foo, a, b, c):
+            traced_contiguous = torch.jit.trace(foo, (a, b, c))
+            ref = foo(a, b, c)
+            exp = traced_contiguous(a, b, c)
+            exp = traced_contiguous(a, b, c)
+            self.assertEqual(ref, exp)
+
+        for strategy in ["STATIC", "DYNAMIC"]:
+            old_strategy = torch.jit.set_fusion_strategy([(strategy, 10)])
+
+            # The memory layouts of the inputs are
+            #     (contiguous, contiguous, contiguous)
+            a = torch.rand(2, 3, 4, 5, dtype=torch.float32)
+            b = torch.rand(2, 3, 4, 5, dtype=torch.float32)
+            c = torch.rand(2, 3, 4, 5, dtype=torch.float32)
+            # The memory layout of the imperative mode output is
+            #     (contiguous)
+            # propagation memory layout is contiguous
+            run_foo_case(foo, a, b, c)
+            # The memory layouts of the imperative mode outputs are
+            #     (contiguous, contiguous, contiguous)
+            # propagation memory layout is contiguous
+            run_foo_case(foo_multi_outputs, a, b, c)
+
+            # The memory layouts of the inputs are
+            #     (contiguous, channels-last, contiguous)
+            a = torch.rand(2, 3, 4, 5, dtype=torch.float32)
+            b = torch.rand(2, 3, 4, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
+            c = torch.rand(2, 3, 4, 5, dtype=torch.float32)
+            # The memory layouts of the imperative mode outputs are
+            #     (contiguous)
+            # propagation memory layout is contiguous
+            run_foo_case(foo, a, b, c)
+            # The memory layouts of the imperative mode outputs are
+            #     (contiguous, channels-last, contiguous)
+            # propagation memory layout is contiguous
+            run_foo_case(foo_multi_outputs, a, b, c)
+
+            # The memory layouts of the inputs are
+            #     (channels-last, contiguous, contiguous)
+            a = torch.rand(2, 3, 4, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
+            b = torch.rand(2, 3, 4, 5, dtype=torch.float32)
+            c = torch.rand(2, 3, 4, 5, dtype=torch.float32)
+            # The memory layouts of the imperative mode outputs are
+            #     (channels-last)
+            # propagation memory layout is contiguous
+            run_foo_case(foo, a, b, c)
+            # The memory layout of the imperative mode outputs are
+            #     (channels-last, contiguous, contiguous)
+            # propagation memory layout is contiguous
+            run_foo_case(foo_multi_outputs_i_nhwc_o_nchw, a, b, c)
+
+            # The memory layouts of the inputs are
+            #     (channels-last, channels-last, channels-last)
+            a = torch.rand(2, 3, 4, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
+            b = torch.rand(2, 3, 4, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
+            c = torch.rand(2, 3, 4, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
+            # The memory layouts of the imperative mode outputs are
+            #     (channels-last)
+            # propagation memory layout is channels-last
+            run_foo_case(foo, a, b, c)
+            # The memory layout of the imperative mode outputs are
+            #     (channels-last, channels-last, channels-last)
+            # propagation memory layout is channels-last
+            run_foo_case(foo_multi_outputs, a, b, c)
+            # The memory layout of the imperative mode outputs are
+            #     (contiguous, channels-last, channels-last, channels-last)
+            # propagation memory layout is contiguous
+            run_foo_case(foo_multi_outputs_i_nhwc_o_nchw, a, b, c)
+
+            # Test special dimension - 1
+            a = torch.rand(2, 1, 1, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
+            b = torch.rand(2, 1, 1, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
+            c = torch.rand(2, 1, 1, 5, dtype=torch.float32).to(memory_format=torch.channels_last)
+            run_foo_case(foo, a, b, c)
+            run_foo_case(foo_multi_outputs, a, b, c)
+            run_foo_case(foo_multi_outputs_i_nhwc_o_nchw, a, b, c)
+
+            # Test permute and special dimension
+            a = torch.rand(2, 1, 1, 5, dtype=torch.float32).permute(dims=[0, 3, 2, 1])
+            b = torch.rand(2, 1, 1, 5, dtype=torch.float32).permute(dims=[0, 3, 2, 1])
+            c = torch.rand(2, 1, 1, 5, dtype=torch.float32).permute(dims=[0, 3, 1, 2])
+            run_foo_case(foo, a, b, c)
+            run_foo_case(foo_multi_outputs, a, b, c)
+            run_foo_case(foo_multi_outputs_i_nhwc_o_nchw, a, b, c)
+
+            # Test permute - Non-contiguous tensor
+            a = torch.rand(2, 3, 4, 5, dtype=torch.float32).permute(dims=[0, 3, 2, 1])
+            b = torch.rand(2, 3, 4, 5, dtype=torch.float32).permute(dims=[0, 3, 2, 1])
+            c = torch.rand(2, 4, 3, 5, dtype=torch.float32).permute(dims=[0, 3, 1, 2])
+            run_foo_case(foo, a, b, c)
+            run_foo_case(foo_multi_outputs, a, b, c)
+            run_foo_case(foo_multi_outputs_i_nhwc_o_nchw, a, b, c)
+
+            torch.jit.set_fusion_strategy(old_strategy)
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
@@ -163,9 +163,7 @@ StrideInput summarizeOutputStrides(const TensorType& tt) {
   // We only try to maintain output striding for channels last tensors,
   // otherwise we defer to contiguous
   // TODO: channels last 3d
-  // NNC Channels last permutation for outputs causes slowdown, disable
-  if (c10::is_channels_last_strides_2d(sizes, strides) &&
-      !tt.device()->is_cpu()) {
+  if (c10::is_channels_last_strides_2d(sizes, strides)) {
     return StrideInput::TENSOR_CONT_CHANNELS_LAST;
   }
   return StrideInput::TENSOR_CONT;

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1585,7 +1585,8 @@ void TensorExprKernel::deduceMemoryLayoutPolicy() {
                     if (has_symbolic_strides) {
                       output_strides.push_back(getSymbolicOutputStrideDesc(el));
                     } else {
-                      // It is a concrete tensor but does not have stride information
+                      // It is a concrete tensor but does not have stride
+                      // information
                       if (!(el->isCompleteTensor()))
                         return true;
                     }

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -963,7 +963,7 @@ std::vector<torch::jit::StrideInput>& TensorExprKernel::
   TORCH_INTERNAL_ASSERT(false);
 }
 
-torch::jit::StrideInput& TensorExprKernel::getSymbolicOutputStrideDesc(
+torch::jit::StrideInput TensorExprKernel::getSymbolicOutputStrideDesc(
     const torch::jit::Value* value) {
   for (size_t i : c10::irange(graph_->outputs().size())) {
     if (value == graph_->outputs().at(i)) {
@@ -1542,7 +1542,9 @@ void TensorExprKernel::deduceMemoryLayoutPolicy() {
 
   std::vector<torch::jit::StrideInput> empty_strides = {};
   auto inputs_all_channels_last = std::all_of(
-      graph_->inputs().begin(), graph_->inputs().end(), [&](const auto& el) {
+      graph_->inputs().begin(),
+      graph_->inputs().end(),
+      [&](const jit::Value* el) {
         if (el->type()->kind() != TypeKind::TensorType) {
           return true;
         }
@@ -1554,7 +1556,9 @@ void TensorExprKernel::deduceMemoryLayoutPolicy() {
       });
 
   auto outputs_all_channels_last = std::all_of(
-      graph_->outputs().begin(), graph_->outputs().end(), [&](const auto& el) {
+      graph_->outputs().begin(),
+      graph_->outputs().end(),
+      [&](const jit::Value* el) {
         if (el->type()->kind() != TypeKind::TensorType) {
           return true;
         }

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -295,6 +295,9 @@ class TORCH_API TensorExprKernel {
   std::vector<torch::jit::StrideInput>& getSymbolicStrideDesc(
       const torch::jit::Value* value);
 
+  // Abstract graph optimizations as a single function.
+  void optimizeOwningGraph();
+
   int64_t nInputs_ = 0;
   int64_t nOutputs_ = 0;
   std::vector<CodeGen::BufferArg> bufferArgs_;
@@ -342,9 +345,6 @@ class TORCH_API TensorExprKernel {
   // map from <input index, tensor dimension> to stride as arg VarHandle
   std::unordered_map<std::pair<size_t, size_t>, VarHandle, SmallSizeTPairHash>
       strideArgToVar_;
-  std::unordered_map<size_t, std::vector<torch::jit::StrideInput>>
-      sym_stride_inputs_;
-  std::unordered_map<size_t, torch::jit::StrideInput> sym_stride_outputs_;
   std::unordered_map<
       const torch::jit::Value*,
       std::vector<torch::jit::StrideInput>>

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -194,6 +194,11 @@ class TORCH_API TensorExprKernel {
     kBlockCodeGen,
   };
 
+  enum MemoryLayoutPolicy {
+    kContiguous,
+    kChannelsLastNdContiguous,
+  };
+
   void compile();
   void genInputDebugNames();
   void runKernel(Stack& stack) const;
@@ -230,6 +235,19 @@ class TORCH_API TensorExprKernel {
 
   Tensor bindInput(const torch::jit::Value* input);
   BlockPtr bindAllInputs();
+
+  // Deduce the memory layout policy to be propagated within
+  // NNC fusion group. The memory layout policy could be `kContiguous`
+  // or `kChannelsLastNdContiguous`.
+  //    `kContiguous`: Always convert the non-contiguous input tensors and
+  //        internal buffers to contiguous.
+  //    `kChannelsLastNdContiguous`: Always convert the input tensors and
+  //        internal buffers to channels-last contiguous.
+  // Currently, the rule is simple.
+  //    If all the input and out tensors of NNC fusion group are channels-last
+  //    contiguous, the policy is `kChannelsLastNdContiguous`. Otherwise, it
+  //    is always `kContiguous`.
+  void deduceMemoryLayoutPolicy();
 
   Tensor convertSymbolicOutputToCorrectStrides(torch::jit::Value* v);
   Tensor convertStaticShapeOutputToCorrectStrides(torch::jit::Value* v);
@@ -275,6 +293,8 @@ class TORCH_API TensorExprKernel {
       const torch::jit::Value* input,
       const std::vector<ExprHandle>& inputTensorDims);
   std::vector<torch::jit::StrideInput>& getSymbolicInputStrideDesc(
+      const torch::jit::Value* value);
+  torch::jit::StrideInput& getSymbolicOutputStrideDesc(
       const torch::jit::Value* value);
 
   int64_t nInputs_ = 0;
@@ -327,6 +347,9 @@ class TORCH_API TensorExprKernel {
   std::unordered_map<size_t, std::vector<torch::jit::StrideInput>>
       sym_stride_inputs_;
   std::unordered_map<size_t, torch::jit::StrideInput> sym_stride_outputs_;
+
+  // Memory layout to be propagated with fusion group
+  MemoryLayoutPolicy memory_layout_policy_ = MemoryLayoutPolicy::kContiguous;
 };
 
 TORCH_API int& getTECudaPointwiseLoopLevels();

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -295,7 +295,9 @@ class TORCH_API TensorExprKernel {
   std::vector<torch::jit::StrideInput>& getSymbolicStrideDesc(
       const torch::jit::Value* value);
 
-  // Abstract graph optimizations as a single function.
+  // Apply the optimizations to the graph owned by the current fusion group,
+  // like concatenation optimization, post-op fusion, and some other graph-level
+  // optimizations.
   void optimizeOwningGraph();
 
   int64_t nInputs_ = 0;

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -292,9 +292,7 @@ class TORCH_API TensorExprKernel {
   std::vector<ExprHandle> getInputStrides(
       const torch::jit::Value* input,
       const std::vector<ExprHandle>& inputTensorDims);
-  std::vector<torch::jit::StrideInput>& getSymbolicInputStrideDesc(
-      const torch::jit::Value* value);
-  torch::jit::StrideInput getSymbolicOutputStrideDesc(
+  std::vector<torch::jit::StrideInput>& getSymbolicStrideDesc(
       const torch::jit::Value* value);
 
   int64_t nInputs_ = 0;
@@ -347,6 +345,10 @@ class TORCH_API TensorExprKernel {
   std::unordered_map<size_t, std::vector<torch::jit::StrideInput>>
       sym_stride_inputs_;
   std::unordered_map<size_t, torch::jit::StrideInput> sym_stride_outputs_;
+  std::unordered_map<
+      const torch::jit::Value*,
+      std::vector<torch::jit::StrideInput>>
+      symbolic_strides_;
 
   // Memory layout to be propagated with fusion group
   MemoryLayoutPolicy memory_layout_policy_ = MemoryLayoutPolicy::kContiguous;

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -294,7 +294,7 @@ class TORCH_API TensorExprKernel {
       const std::vector<ExprHandle>& inputTensorDims);
   std::vector<torch::jit::StrideInput>& getSymbolicInputStrideDesc(
       const torch::jit::Value* value);
-  torch::jit::StrideInput& getSymbolicOutputStrideDesc(
+  torch::jit::StrideInput getSymbolicOutputStrideDesc(
       const torch::jit::Value* value);
 
   int64_t nInputs_ = 0;


### PR DESCRIPTION
Decide the memory layout propagation policy and propagate it within the NNC fusion group. The memory layout propagation policy could be `Contiguous` and `Channels-last contiguous`.
 - `Contiguous`: Convert the non-contiguous including channels-last contiguous input tensors to contiguous and generate the contiguous output `Buf` for lowering function.
 - `Channels-last contiguous`: Convert the input tensors to channels-last contiguous and generate the channels-last contiguous output `Buf` for lowering function.

Currently, the rule is simple. If all the input and out tensors of the NNC fusion group are channels-last contiguous, then the propagated memory layout is `Channels-last contiguous`. Otherwise, it is always `Contiguous` which is as same as current situation. It means that this PR provides a fast path to channels-last and the optimization is conservative since its trigger conditions are strict.