### PR TITLE
faster batch sampler

### DIFF
--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -232,6 +232,7 @@ class BatchSampler(Sampler[List[int]]):
         self.drop_last = drop_last
 
     def __iter__(self) -> Iterator[List[int]]:
+        # Implemented based on the benchmarking in https://github.com/pytorch/pytorch/pull/76951
         if self.drop_last:
             sampler_iter = iter(self.sampler)
             while True:

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -232,14 +232,26 @@ class BatchSampler(Sampler[List[int]]):
         self.drop_last = drop_last
 
     def __iter__(self) -> Iterator[List[int]]:
-        batch = []
-        for idx in self.sampler:
-            batch.append(idx)
-            if len(batch) == self.batch_size:
-                yield batch
-                batch = []
-        if len(batch) > 0 and not self.drop_last:
-            yield batch
+        if self.drop_last:
+            sampler_iter = iter(self.sampler)
+            while True:
+                try:
+                    batch = [next(sampler_iter) for _ in range(self.batch_size)]
+                    yield batch
+                except StopIteration:
+                    break
+        else:
+            batch = [0] * self.batch_size
+            idx_in_batch = 0
+            for idx in self.sampler:
+                batch[idx_in_batch] = idx
+                idx_in_batch += 1
+                if idx_in_batch == self.batch_size:
+                    yield batch
+                    idx_in_batch = 0
+                    batch = [0] * self.batch_size
+            if idx_in_batch > 0:
+                yield batch[:idx_in_batch]
 
     def __len__(self) -> int:
         # Can only be called if self.sampler has __len__ implemented


### PR DESCRIPTION
Fixes #76950

Improve the performance of iteration on `BatchSampler` , especially when `batch_size` is big.

Python 3.6.8:
```
  batch_size  drop_last      origin(avg)    origin(std)   new(avg)   new(std)  speedup
------------  -----------  -------------  -------------  ---------  ---------  -------
           4  True                 0.026      0.0001183      0.032  0.0004839  -18.07%
           4  False                0.026      2.326e-05      0.022  3.317e-05  15.92% 
           8  True                 0.025      0.0001441      0.023  0.0001204  9.43%
           8  False                0.025      4.457e-05      0.019  3.951e-05  30.90% 
          64  True                 0.024      0.0005505      0.015  0.0002987  54.99%
          64  False                0.023      8.014e-05      0.016  1.999e-05  49.64% 
         640  True                 0.024      0.0005598      0.015  2.327e-05  66.26%
         640  False                0.024      2.229e-05      0.016  2.358e-05  48.32% 
        6400  True                 0.025      0.0005789      0.015  2.935e-05  69.06%
        6400  False                0.025      2.529e-05      0.017  6.737e-05  45.17% 
```

Python 3.8.12:
```
  batch_size  drop_last      origin(avg)    origin(std)   new(avg)   new(std)  speedup
------------  -----------  -------------  -------------  ---------  ---------  -------
           4  True                 0.017      0.0001389      0.019  3.026e-05  -10.50%
           4  False                0.017      9.909e-06      0.017  2.37e-05   -0.78% 
           8  True                 0.016      1.251e-05      0.013  2.748e-05  24.40%
           8  False                0.016      5.523e-05      0.015  1.156e-05  10.20% 
          64  True                 0.015      2.483e-05      0.008  1.859e-05  90.96%
          64  False                0.015      2.622e-05      0.012  3.227e-05  26.09% 
         640  True                 0.016      6.405e-05      0.007  1.836e-05  112.88%
         640  False                0.016      1.284e-05      0.013  0.0004079  20.09% 
        6400  True                 0.016      8.298e-05      0.008  1.507e-05  111.80%
        6400  False                0.016      1.716e-05      0.014  0.0004602  18.37% 

```

Check the issue page for more details of the tests.