### PR TITLE
ldl_factor fix magma version check

### DIFF
--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -60,6 +60,11 @@ struct MagmaInitializer {
 
 #define AT_MAGMA_VERSION MAGMA_VERSION_MAJOR*100 + MAGMA_VERSION_MINOR*10 + MAGMA_VERSION_PATCH
 
+// Check that MAGMA never releases MAGMA_VERSION_MINOR >= 10 or MAGMA_VERSION_PATCH >= 10
+#if MAGMA_VERSION_MINOR >= 10 || MAGMA_VERSION_PATCH >= 10
+#error "MAGMA release minor or patch version >= 10, please correct AT_MAGMA_VERSION"
+#endif
+
 #else
 const bool use_magma_ = false;
 

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -58,11 +58,11 @@ struct MagmaInitializer {
 } initializer;
 }  // namespace (anonymous)
 
-#define AT_MAGMA_VERSION MAGMA_VERSION_MAJOR*100 + MAGMA_VERSION_MINOR*10 + MAGMA_VERSION_PATCH
+#define AT_MAGMA_VERSION MAGMA_VERSION_MAJOR*100 + MAGMA_VERSION_MINOR*10 + MAGMA_VERSION_MICRO
 
-// Check that MAGMA never releases MAGMA_VERSION_MINOR >= 10 or MAGMA_VERSION_PATCH >= 10
-#if MAGMA_VERSION_MINOR >= 10 || MAGMA_VERSION_PATCH >= 10
-#error "MAGMA release minor or patch version >= 10, please correct AT_MAGMA_VERSION"
+// Check that MAGMA never releases MAGMA_VERSION_MINOR >= 10 or MAGMA_VERSION_MICRO >= 10
+#if MAGMA_VERSION_MINOR >= 10 || MAGMA_VERSION_MICRO >= 10
+#error "MAGMA release minor or micro version >= 10, please correct AT_MAGMA_VERSION"
 #endif
 
 #else

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -1413,7 +1413,10 @@ void ldl_factor_magma(
   if (LD.is_complex()) {
     TORCH_CHECK(
         hermitian,
-        "torch.linalg.ldl_factor: complex tensors with hermitian=False flag are not supported.");
+        "torch.linalg.ldl_factor: complex tensors with hermitian=False flag are not supported with MAGMA backend. ",
+        "Currently preferred backend is ",
+        at::globalContext().linalgPreferredBackend(),
+        ", please set 'default' or 'cusolver' backend with torch.backends.cuda.preferred_linalg_library");
   }
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
       LD.scalar_type(), "ldl_factor_magma", [&] {

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebra.cpp
@@ -58,6 +58,8 @@ struct MagmaInitializer {
 } initializer;
 }  // namespace (anonymous)
 
+#define AT_MAGMA_VERSION MAGMA_VERSION_MAJOR*100 + MAGMA_VERSION_MINOR*10 + MAGMA_VERSION_PATCH
+
 #else
 const bool use_magma_ = false;
 
@@ -291,8 +293,7 @@ void magmaSolveBatched<c10::complex<float>>(
   AT_CUDA_CHECK(cudaGetLastError());
 }
 
-#if MAGMA_VERSION_MAJOR >= 2 && MAGMA_VERSION_MINOR >= 5 && \
-    MAGMA_VERSION_MICRO >= 4
+#if AT_MAGMA_VERSION >= 254
 
 template <>
 void magmaLdlHermitian<double>(
@@ -348,8 +349,7 @@ void magmaLdlHermitian<c10::complex<float>>(
   AT_CUDA_CHECK(cudaGetLastError());
 }
 
-#endif // MAGMA_VERSION_MAJOR >= 2 && MAGMA_VERSION_MINOR >= 5 &&
-       // MAGMA_VERSION_MICRO >= 4
+#endif // AT_MAGMA_VERSION >= 254
 
 template<>
 void magmaLu<double>(
@@ -1439,7 +1439,7 @@ void ldl_factor_kernel(
     // If cusolver and magma 2.5.4+ are both available and hermitian=true,
     // call magma for complex inputs
 #ifdef USE_CUSOLVER
-#if AT_MAGMA_ENABLED() && (MAGMA_VERSION_MAJOR >= 2 && MAGMA_VERSION_MINOR >= 5 && MAGMA_VERSION_MICRO >= 4)
+#if AT_MAGMA_ENABLED() && (AT_MAGMA_VERSION >= 254)
       if (LD.is_complex() && hermitian) {
         return ldl_factor_magma(
             LD, pivots, info, upper, hermitian);

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -276,12 +276,11 @@ void ldl_factor_cusolver(
     bool upper,
     bool hermitian) {
   if (LD.is_complex()) {
-    auto preferred_backend = at::globalContext().linalgPreferredBackend();
     TORCH_CHECK(
         !hermitian,
         "torch.linalg.ldl_factor: complex tensors with hermitian=True flag are not supported with cuSOLVER backend. ",
         "Currently preferred backend is ",
-        preferred_backend,
+        at::globalContext().linalgPreferredBackend(),
         ", please set 'default' or 'magma' backend with torch.backends.cuda.preferred_linalg_library");
   }
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -276,9 +276,13 @@ void ldl_factor_cusolver(
     bool upper,
     bool hermitian) {
   if (LD.is_complex()) {
+    auto preferred_backend = at::globalContext().linalgPreferredBackend();
     TORCH_CHECK(
         !hermitian,
-        "torch.linalg.ldl_factor: complex tensors with hermitian=True flag are not supported.");
+        "torch.linalg.ldl_factor: complex tensors with hermitian=True flag are not supported with cuSOLVER backend. ",
+        "Currently preferred backend is ",
+        preferred_backend,
+        ", please set 'default' or 'magma' backend with torch.backends.cuda.preferred_linalg_library");
   }
   AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(
       LD.scalar_type(), "ldl_factor_looped_cusolver", [&] {

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6101,6 +6101,7 @@ def sample_inputs_linalg_ldl_factor(op_info, device, dtype, requires_grad=False,
 
     # Hermitian inputs
     # hermitian=True for complex inputs on CUDA is supported only with MAGMA 2.5.4+
+    torch.backends.cuda.preferred_linalg_library(backend="default")
     magma_254_available = device.type == 'cuda' and _get_magma_version() >= (2, 5, 4)
     if dtype.is_complex and (device.type == 'cpu' or magma_254_available):
         yield SampleInput(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6101,7 +6101,6 @@ def sample_inputs_linalg_ldl_factor(op_info, device, dtype, requires_grad=False,
 
     # Hermitian inputs
     # hermitian=True for complex inputs on CUDA is supported only with MAGMA 2.5.4+
-    torch.backends.cuda.preferred_linalg_library(backend="default")
     magma_254_available = device.type == 'cuda' and _get_magma_version() >= (2, 5, 4)
     if dtype.is_complex and (device.type == 'cpu' or magma_254_available):
         yield SampleInput(


### PR DESCRIPTION
The tests were failing for CUDA 11.6 environment because it is using MAGMA 2.6.1 and preprocessor macros were incorrectly checking the version.

Fixes #76961
