### PR TITLE
BUG: Evade segfault by throwing a RuntimeError for `nn.ChannelShuffle` and empty input tensors

### DIFF
--- a/aten/src/ATen/native/ChanelShuffle.cpp
+++ b/aten/src/ATen/native/ChanelShuffle.cpp
@@ -28,7 +28,7 @@ Tensor channel_shuffle(const Tensor& self, int64_t groups) {
               "channel_shuffle expects input with > 2 dims, but got input with sizes ",
               self.sizes());
   int64_t c = self.size(1);
-  TORCH_CHECK(self.numel() != 0, "channel_shuffle: Input tensor must not be empty");
+  TORCH_CHECK(self.numel() != 0, "nn.ChannelShuffle: Input tensor must not be empty");
   TORCH_CHECK(groups > 0,
               "Number of groups to divide channels in must be positive.",
               " Value of groups:", groups);

--- a/aten/src/ATen/native/ChanelShuffle.cpp
+++ b/aten/src/ATen/native/ChanelShuffle.cpp
@@ -17,7 +17,6 @@ Tensor channel_shuffle_cpu(const Tensor& self, int64_t groups) {
   auto output = at::empty({0}, self.options());
   output.resize_(self.sizes(), memory_format);
   auto input = self.contiguous(memory_format);
-  TORCH_CHECK(input.numel() != 0, "Input tensor should have no zeros");
   channel_shuffle_kernel(kCPU, output, input, groups);
   return namedinference::propagate_names_if_nonempty(
       output,
@@ -29,7 +28,7 @@ Tensor channel_shuffle(const Tensor& self, int64_t groups) {
               "channel_shuffle expects input with > 2 dims, but got input with sizes ",
               self.sizes());
   int64_t c = self.size(1);
-  TORCH_CHECK(self.numel() != 0, "Input Tensor should have no zeros");
+  TORCH_CHECK(self.numel() != 0, "channel_shuffle: Input tensor must not be empty");
   TORCH_CHECK(groups > 0,
               "Number of groups to divide channels in must be positive.",
               " Value of groups:", groups);

--- a/aten/src/ATen/native/ChanelShuffle.cpp
+++ b/aten/src/ATen/native/ChanelShuffle.cpp
@@ -17,6 +17,7 @@ Tensor channel_shuffle_cpu(const Tensor& self, int64_t groups) {
   auto output = at::empty({0}, self.options());
   output.resize_(self.sizes(), memory_format);
   auto input = self.contiguous(memory_format);
+  TORCH_CHECK(input.numel() != 0, "Input tensor should have no zeros");
   channel_shuffle_kernel(kCPU, output, input, groups);
   return namedinference::propagate_names_if_nonempty(
       output,
@@ -28,6 +29,7 @@ Tensor channel_shuffle(const Tensor& self, int64_t groups) {
               "channel_shuffle expects input with > 2 dims, but got input with sizes ",
               self.sizes());
   int64_t c = self.size(1);
+  TORCH_CHECK(self.numel() != 0, "Input Tensor should have no zeros");
   TORCH_CHECK(groups > 0,
               "Number of groups to divide channels in must be positive.",
               " Value of groups:", groups);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11090,13 +11090,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         y = y.contiguous(memory_format=torch.contiguous_format)
         self.assertEqual(y, y_ref)
 
-    def test_channel_shuffle_runtime_errors(self):
-        # gh-76616: nn.ChannelShuffle will crash with empty input tensor
-        groups = 3
-        input_tensor = torch.rand([0, 9, 4, 4])
-        with self.assertRaisesRegex(RuntimeError, "nn.ChannelShuffle: Input tensor must not be empty"):
-            torch.nn.ChannelShuffle(groups)(input_tensor)
-
     def test_upsamplingLinear1d(self):
         for align_corners in [True, False]:
             for recompute_scale_factor in [True, False]:
@@ -14362,6 +14355,14 @@ class TestNNDeviceType(NNTestCase):
         if bias is not None:
             bias.requires_grad_(False)
         self.assertTrue(gradgradcheck(convolution, inputs, nondet_tol=gradcheck_nondet_tol))
+
+
+    def test_channel_shuffle_runtime_errors(self, device):
+        # gh-76616: nn.ChannelShuffle will crash with empty input tensor
+        groups = 3
+        input_tensor = torch.rand([0, 9, 4, 4], device=device)
+        with self.assertRaisesRegex(RuntimeError, "nn.ChannelShuffle: Input tensor must not be empty"):
+            torch.nn.ChannelShuffle(groups)(input_tensor)
 
     def test_Dropout(self, device):
         input = torch.empty(1000)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11090,6 +11090,14 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         y = y.contiguous(memory_format=torch.contiguous_format)
         self.assertEqual(y, y_ref)
 
+
+    def test_channel_shuffle_return_self(self):
+        # gh-76616: nn.ChannelShuffle will return self with an  empty input tensor
+        groups = 3
+        input_tensor = torch.rand([0, 9, 4, 4])
+        output = torch.nn.ChannelShuffle(groups)(input_tensor)
+        torch.testing.assert_close(output, input_tensor)
+
     def test_upsamplingLinear1d(self):
         for align_corners in [True, False]:
             for recompute_scale_factor in [True, False]:
@@ -14356,13 +14364,6 @@ class TestNNDeviceType(NNTestCase):
             bias.requires_grad_(False)
         self.assertTrue(gradgradcheck(convolution, inputs, nondet_tol=gradcheck_nondet_tol))
 
-
-    def test_channel_shuffle_return_self(self, device):
-        # gh-76616: nn.ChannelShuffle will return self with an  empty input tensor
-        groups = 3
-        input_tensor = torch.rand([0, 9, 4, 4], device=device)
-        output = torch.nn.ChannelShuffle(groups)(input_tensor)
-        torch.testing.assert_close(output, input_tensor)
 
     def test_Dropout(self, device):
         input = torch.empty(1000)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14357,12 +14357,12 @@ class TestNNDeviceType(NNTestCase):
         self.assertTrue(gradgradcheck(convolution, inputs, nondet_tol=gradcheck_nondet_tol))
 
 
-    def test_channel_shuffle_runtime_errors(self, device):
+    def test_channel_shuffle_return_self(self, device):
         # gh-76616: nn.ChannelShuffle will return self with an  empty input tensor
         groups = 3
         input_tensor = torch.rand([0, 9, 4, 4], device=device)
         output = torch.nn.ChannelShuffle(groups)(input_tensor)
-        torch.tensting.assert_close(output, input_tensor)
+        torch.testing.assert_close(output, input_tensor)
 
     def test_Dropout(self, device):
         input = torch.empty(1000)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11090,6 +11090,13 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         y = y.contiguous(memory_format=torch.contiguous_format)
         self.assertEqual(y, y_ref)
 
+    def test_channel_shuffle_warnings(self):
+        # gh-76616: nn.ChannelShuffle will crash with empty input tensor
+        groups = 3
+        input_tensor = torch.rand([0, 9, 4, 4])
+        with self.assertRaisesRegex(RuntimeError, "channel_shuffle: Input tensor must not be empty"):
+            torch.nn.ChannelShuffle(groups)(input_tensor)
+
     def test_upsamplingLinear1d(self):
         for align_corners in [True, False]:
             for recompute_scale_factor in [True, False]:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11090,11 +11090,11 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         y = y.contiguous(memory_format=torch.contiguous_format)
         self.assertEqual(y, y_ref)
 
-    def test_channel_shuffle_warnings(self):
+    def test_channel_shuffle_runtime_errors(self):
         # gh-76616: nn.ChannelShuffle will crash with empty input tensor
         groups = 3
         input_tensor = torch.rand([0, 9, 4, 4])
-        with self.assertRaisesRegex(RuntimeError, "channel_shuffle: Input tensor must not be empty"):
+        with self.assertRaisesRegex(RuntimeError, "nn.ChannelShuffle: Input tensor must not be empty"):
             torch.nn.ChannelShuffle(groups)(input_tensor)
 
     def test_upsamplingLinear1d(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14358,11 +14358,11 @@ class TestNNDeviceType(NNTestCase):
 
 
     def test_channel_shuffle_runtime_errors(self, device):
-        # gh-76616: nn.ChannelShuffle will crash with empty input tensor
+        # gh-76616: nn.ChannelShuffle will return self with an  empty input tensor
         groups = 3
         input_tensor = torch.rand([0, 9, 4, 4], device=device)
-        with self.assertRaisesRegex(RuntimeError, "nn.ChannelShuffle: Input tensor must not be empty"):
-            torch.nn.ChannelShuffle(groups)(input_tensor)
+        output = torch.nn.ChannelShuffle(groups)(input_tensor)
+        torch.tensting.assert_close(output, input_tensor)
 
     def test_Dropout(self, device):
         input = torch.empty(1000)

--- a/torch/nn/modules/channelshuffle.py
+++ b/torch/nn/modules/channelshuffle.py
@@ -46,6 +46,8 @@ class ChannelShuffle(Module):
         self.groups = groups
 
     def forward(self, input: Tensor) -> Tensor:
+        if input.numel() == 0:
+            return input
         return F.channel_shuffle(input, self.groups)
 
     def extra_repr(self) -> str:

--- a/torch/nn/modules/channelshuffle.py
+++ b/torch/nn/modules/channelshuffle.py
@@ -46,8 +46,6 @@ class ChannelShuffle(Module):
         self.groups = groups
 
     def forward(self, input: Tensor) -> Tensor:
-        if input.numel() == 0:
-            return input
         return F.channel_shuffle(input, self.groups)
 
     def extra_repr(self) -> str:


### PR DESCRIPTION
Fixes #76616.
