### PR TITLE
Consolidate customization contiguous/sizes policy into unified policy

### DIFF
--- a/aten/src/ATen/BatchedTensorImpl.cpp
+++ b/aten/src/ATen/BatchedTensorImpl.cpp
@@ -17,7 +17,7 @@ BatchedTensorImpl::BatchedTensorImpl(Tensor value, BatchDims bdims)
 {
   TORCH_INTERNAL_ASSERT(value_.defined());
   set_storage_access_should_throw();
-  set_has_contiguity_policy(HasContiguityPolicy::CustomBehavior);
+  set_sizes_strides_policy(SizesStridesPolicy::CustomStrides);
   checkInvariants();
 
   const auto public_dims = value_.dim() - bdims_.size();
@@ -77,6 +77,13 @@ void BatchedTensorImpl::checkInvariants() const {
 }
 
 // The following are publically exposed as methods of Tensor
+
+IntArrayRef BatchedTensorImpl::strides_custom() const {
+  return strides_default();
+}
+
+// TODO: implement proper contiguity on batched tensor, then put
+// sizes_strides_policy back to Default
 bool BatchedTensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
   TORCH_CHECK(memory_format == MemoryFormat::Contiguous,
       "NYI: querying is_contiguous inside of vmap for memory_format ",

--- a/aten/src/ATen/BatchedTensorImpl.h
+++ b/aten/src/ATen/BatchedTensorImpl.h
@@ -72,6 +72,8 @@ struct TORCH_API BatchedTensorImpl : public c10::TensorImpl {
   // bt.actualDim(2) -> Error
   int64_t actualDim(int64_t dim, bool wrap_dim = true) const;
 
+  // We have to override this because we opted into CustomStrides
+  IntArrayRef strides_custom() const override;
   // Override a bunch of methods inherited from TensorImpl to return error messages.
   bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
   void set_size(int64_t dim, int64_t new_size) override;

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -67,6 +67,9 @@ void NestedTensorImpl::refresh_dim() {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(dim() == my_dim);
 }
 
+int64_t NestedTensorImpl::dim_custom() const {
+  return dim_default();
+}
 int64_t NestedTensorImpl::numel_custom() const {
   TORCH_CHECK(false, "numel is disabled.");
 }

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -67,6 +67,20 @@ void NestedTensorImpl::refresh_dim() {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(dim() == my_dim);
 }
 
+int64_t NestedTensorImpl::numel_custom() const {
+  TORCH_CHECK(false, "numel is disabled.");
+}
+bool NestedTensorImpl::is_contiguous_custom(MemoryFormat) const {
+  TORCH_CHECK(false, "is_contiguous is disabled.");
+}
+IntArrayRef NestedTensorImpl::sizes_custom() const {
+  TORCH_CHECK(false, "Internal error: NestedTensorImpl doesn't support sizes. Please file an issue on https://github.com/pytorch/nestedtensor");
+}
+
+IntArrayRef NestedTensorImpl::strides_custom() const {
+  TORCH_CHECK(false, "Internal error: NestedTensorImpl doesn't support strides. Please file an issue on https://github.com/pytorch/nestedtensor");
+}
+
 const char* NestedTensorImpl::tensorimpl_type_name() const {
   return "NestedTensorImpl";
 }

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -58,7 +58,7 @@ NestedTensorImpl::NestedTensorImpl(
   key_set_ =
       key_set_ - c10::DispatchKeySet({c10::DispatchKey::ADInplaceOrView});
   refresh_dim();
-  set_sizes_customization_policy(CustomizableMethodPolicy::NotSupported);
+  set_sizes_strides_policy(c10::TensorImpl::SizesStridesPolicy::CustomStrides);
 }
 
 void NestedTensorImpl::refresh_dim() {

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -58,7 +58,7 @@ NestedTensorImpl::NestedTensorImpl(
   key_set_ =
       key_set_ - c10::DispatchKeySet({c10::DispatchKey::ADInplaceOrView});
   refresh_dim();
-  set_sizes_strides_policy(c10::TensorImpl::SizesStridesPolicy::CustomStrides);
+  set_sizes_strides_policy(c10::TensorImpl::SizesStridesPolicy::CustomSizes);
 }
 
 void NestedTensorImpl::refresh_dim() {

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -38,6 +38,11 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   const char* tensorimpl_type_name() const override;
 
   // TODO: numel_custom and is_contiguous_custom can be profitably overridden
+  // with real implementations
+  int64_t numel_custom() const override;
+  bool is_contiguous_custom(MemoryFormat) const override;
+  IntArrayRef sizes_custom() const override;
+  IntArrayRef strides_custom() const override;
 
  private:
   // Must be called after any changes to our dim() to sync the state

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -13,19 +13,6 @@ namespace native {
 struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   explicit NestedTensorImpl(at::Tensor buffer, at::Tensor nested_size_tensor);
 
-#ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
-  int64_t numel() const override {
-    TORCH_CHECK(
-        false, "numel is disabled. These methods are not virtual in fbcode.");
-  }
-#endif
-#ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
-  bool is_contiguous(at::MemoryFormat memory_format) const override {
-    TORCH_CHECK(
-        false,
-        "is_contiguous is disabled. These methods are not virtual in fbcode.");
-  }
-#endif
   // TODO: don't expose private implementation details like this; in
   // particular, resizing this tensor will mess up our dim() and
   // callers cannot fix it.
@@ -42,22 +29,6 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
     }
     return opt_sizes_[d];
   }
-#ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
-  IntArrayRef sizes() const override {
-    TORCH_CHECK(
-        false,
-        "Internal error: NestedTensorImpl doesn't support sizes. Please file an issue on https://github.com/pytorch/nestedtensor");
-    return IntArrayRef();
-  }
-#endif
-#ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
-  IntArrayRef strides() const override {
-    TORCH_CHECK(
-        false,
-        "Internal error: NestedTensorImpl doesn't support strides. Please file an issue on https://github.com/pytorch/nestedtensor");
-    return IntArrayRef();
-  }
-#endif
 
   const at::Tensor& get_buffer() const {
     return buffer_;
@@ -65,6 +36,8 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
 
  protected:
   const char* tensorimpl_type_name() const override;
+
+  // TODO: numel_custom and is_contiguous_custom can be profitably overridden
 
  private:
   // Must be called after any changes to our dim() to sync the state

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -44,6 +44,9 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   IntArrayRef sizes_custom() const override;
   IntArrayRef strides_custom() const override;
 
+  // this one is real
+  int64_t dim_custom() const override;
+
  private:
   // Must be called after any changes to our dim() to sync the state
   // to TensorImpl.

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -29,7 +29,7 @@ struct TORCH_API OpaqueTensorImpl : public TensorImpl {
       : TensorImpl(key_set, data_type, device),
         opaque_handle_(std::move(opaque_handle)) {
     set_storage_access_should_throw();
-    set_has_contiguity_policy(HasContiguityPolicy::ContiguityNotSupported);
+    set_sizes_strides_policy(SizesStridesPolicy::CustomStrides);
     sizes_and_strides_.set_sizes(sizes);
     refresh_numel();
     is_non_overlapping_and_dense_ = is_non_overlapping_and_dense;
@@ -38,14 +38,6 @@ struct TORCH_API OpaqueTensorImpl : public TensorImpl {
   void release_resources() override {
     TensorImpl::release_resources();
     opaque_handle_ = {};
-  }
-
-  IntArrayRef strides() const override {
-    AT_ERROR("opaque tensors do not have strides");
-  }
-
-  int64_t stride(int64_t d) const override {
-    AT_ERROR("opaque tensors do not have strides");
   }
 
   void set_size(int64_t dim, int64_t new_size) override {

--- a/aten/src/ATen/SparseCsrTensorImpl.cpp
+++ b/aten/src/ATen/SparseCsrTensorImpl.cpp
@@ -148,6 +148,9 @@ void SparseCsrTensorImpl::set_member_tensors(
   TORCH_CHECK(values_.device() == col_indices_.device(), "Values and col_indices need to be on the same device.");
 }
 
+IntArrayRef SparseCsrTensorImpl::strides_custom() const {
+  TORCH_CHECK(false, "Sparse ", at::sparse_csr::layoutToString(layout_, /*upper=*/true), " tensors do not have stride");
+}
 void SparseCsrTensorImpl::set_size(int64_t dim, int64_t new_size) {
   TORCH_CHECK(false, "Sparse ", at::sparse_csr::layoutToString(layout_, /*upper=*/true), " tensors do not have set_size.");
 }

--- a/aten/src/ATen/SparseCsrTensorImpl.cpp
+++ b/aten/src/ATen/SparseCsrTensorImpl.cpp
@@ -68,7 +68,7 @@ SparseCsrTensorImpl::SparseCsrTensorImpl(
                   "to https://github.com/pytorch/pytorch/issues.");
   set_storage_access_should_throw();
   is_non_overlapping_and_dense_ = false;
-  set_has_contiguity_policy(HasContiguityPolicy::ContiguityNotSupported);
+  set_sizes_strides_policy(SizesStridesPolicy::CustomStrides);
   // TODO: If this check ever shows up as a bottleneck, which is unlikely given that
   // comparing devices only involves comparing the type and index (two integers), we
   // can move this to a DEBUG only assert. Until then this confirms and maintains a
@@ -148,12 +148,6 @@ void SparseCsrTensorImpl::set_member_tensors(
   TORCH_CHECK(values_.device() == col_indices_.device(), "Values and col_indices need to be on the same device.");
 }
 
-IntArrayRef SparseCsrTensorImpl::strides() const {
-  TORCH_CHECK(false, "Sparse ", at::sparse_csr::layoutToString(layout_, /*upper=*/true), " tensors do not have strides.");
-}
-int64_t SparseCsrTensorImpl::stride(int64_t d) const {
-  TORCH_CHECK(false, "Sparse ", at::sparse_csr::layoutToString(layout_, /*upper=*/true), " tensors do not have strides.");
-}
 void SparseCsrTensorImpl::set_size(int64_t dim, int64_t new_size) {
   TORCH_CHECK(false, "Sparse ", at::sparse_csr::layoutToString(layout_, /*upper=*/true), " tensors do not have set_size.");
 }

--- a/aten/src/ATen/SparseCsrTensorImpl.cpp
+++ b/aten/src/ATen/SparseCsrTensorImpl.cpp
@@ -149,7 +149,7 @@ void SparseCsrTensorImpl::set_member_tensors(
 }
 
 IntArrayRef SparseCsrTensorImpl::strides_custom() const {
-  TORCH_CHECK(false, "Sparse ", at::sparse_csr::layoutToString(layout_, /*upper=*/true), " tensors do not have stride");
+  TORCH_CHECK(false, "Sparse ", at::sparse_csr::layoutToString(layout_, /*upper=*/true), " tensors do not have strides");
 }
 void SparseCsrTensorImpl::set_size(int64_t dim, int64_t new_size) {
   TORCH_CHECK(false, "Sparse ", at::sparse_csr::layoutToString(layout_, /*upper=*/true), " tensors do not have set_size.");

--- a/aten/src/ATen/SparseCsrTensorImpl.h
+++ b/aten/src/ATen/SparseCsrTensorImpl.h
@@ -46,6 +46,10 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
   const Tensor& values() const { return values_; }
   int nnz() { return col_indices_.size(-1); }
 
+ protected:
+  IntArrayRef strides_custom() const override;
+
+ public:
   void set_size(int64_t dim, int64_t new_size) override;
   void set_stride(int64_t dim, int64_t new_stride) override;
   void set_storage_offset(int64_t storage_offset) override;

--- a/aten/src/ATen/SparseCsrTensorImpl.h
+++ b/aten/src/ATen/SparseCsrTensorImpl.h
@@ -46,8 +46,6 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
   const Tensor& values() const { return values_; }
   int nnz() { return col_indices_.size(-1); }
 
-  IntArrayRef strides() const override;
-  int64_t stride(int64_t d) const override;
   void set_size(int64_t dim, int64_t new_size) override;
   void set_stride(int64_t dim, int64_t new_stride) override;
   void set_storage_offset(int64_t storage_offset) override;

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -51,7 +51,7 @@ SparseTensorImpl::SparseTensorImpl(at::DispatchKeySet key_set, const caffe2::Typ
 
   is_non_overlapping_and_dense_ = false;
   set_storage_access_should_throw();
-  set_has_contiguity_policy(HasContiguityPolicy::ContiguityNotSupported);
+  set_sizes_strides_policy(SizesStridesPolicy::CustomStrides);
 }
 
 void SparseTensorImpl::release_resources() {
@@ -60,12 +60,6 @@ void SparseTensorImpl::release_resources() {
   indices_.reset();
 }
 
-IntArrayRef SparseTensorImpl::strides() const {
-  AT_ERROR("sparse tensors do not have strides");
-}
-int64_t SparseTensorImpl::stride(int64_t d) const {
-  AT_ERROR("sparse tensors do not have strides");
-}
 void SparseTensorImpl::set_size(int64_t dim, int64_t new_size) {
   AT_ERROR("sparse tensors do not have set_size");
 }

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -54,8 +54,6 @@ public:
   Tensor indices() const { return indices_; }
   Tensor values() const { return values_; }
 
-  IntArrayRef strides() const override;
-  int64_t stride(int64_t d) const override;
   void set_size(int64_t dim, int64_t new_size) override;
   void set_stride(int64_t dim, int64_t new_stride) override;
   void set_storage_offset(int64_t storage_offset) override;

--- a/aten/src/ATen/native/vulkan/VulkanOpaqueTensorImpl.h
+++ b/aten/src/ATen/native/vulkan/VulkanOpaqueTensorImpl.h
@@ -24,10 +24,9 @@ struct VulkanOpaqueTensorImpl : public OpaqueTensorImpl<OpaqueHandle> {
             sizes,
             false),
         strides_(strides.vec()) {
-    TensorImpl::set_has_contiguity_policy(TensorImpl::HasContiguityPolicy::CustomBehavior);
   }
 
-  IntArrayRef strides() const override {
+  IntArrayRef strides_custom() const override {
     return strides_;
   }
 
@@ -35,16 +34,13 @@ struct VulkanOpaqueTensorImpl : public OpaqueTensorImpl<OpaqueHandle> {
     return true;
   }
 
-  int64_t stride(int64_t d) const override {
-    d = at::maybe_wrap_dim(d, this->dim(), false);
-    return strides_[d];
-  }
-
  private:
   const char* tensorimpl_type_name() const override {
     return "VulkanOpaqueTensorImpl";
   }
 
+  // TODO: storing strides separately is unnecessary, the base TensorImpl
+  // has space for them
   SmallVector<int64_t, 5> strides_;
 };
 

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -352,22 +352,30 @@ void TensorImpl::throw_storage_access_error() const {
 bool TensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
   TORCH_CHECK(
       false,
-      "Tensors of type ", tensorimpl_type_name(), " do not have is_contiguous");
+      "Tensors of type ",
+      tensorimpl_type_name(),
+      " do not have is_contiguous");
 }
 
 IntArrayRef TensorImpl::sizes_custom() const {
-  TORCH_CHECK(false, "Tensors of type ", tensorimpl_type_name(), " do not have sizes");
+  TORCH_CHECK(
+      false, "Tensors of type ", tensorimpl_type_name(), " do not have sizes");
 }
 IntArrayRef TensorImpl::strides_custom() const {
-  TORCH_CHECK(false, "Tensors of type ", tensorimpl_type_name(), " do not have strides");
+  TORCH_CHECK(
+      false,
+      "Tensors of type ",
+      tensorimpl_type_name(),
+      " do not have strides");
 }
 int64_t TensorImpl::dim_custom() const {
-  TORCH_CHECK(false, "Tensors of type ", tensorimpl_type_name(), " do not have dim");
+  TORCH_CHECK(
+      false, "Tensors of type ", tensorimpl_type_name(), " do not have dim");
 }
 int64_t TensorImpl::numel_custom() const {
-  TORCH_CHECK(false, "Tensors of type ", tensorimpl_type_name(), " do not have numel");
+  TORCH_CHECK(
+      false, "Tensors of type ", tensorimpl_type_name(), " do not have numel");
 }
-
 
 static void deletePlacementDeleteContext(void* ptr) {
   delete static_cast<PlacementDeleteContext*>(ptr);
@@ -503,8 +511,7 @@ void TensorImpl::copy_tensor_metadata_except_version_counter(
   dest_impl->is_wrapped_number_ = src_impl->is_wrapped_number_;
   dest_impl->reserved_ = src_impl->reserved_;
   dest_impl->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
-  dest_impl->sizes_strides_policy_ =
-      src_impl->sizes_strides_policy_;
+  dest_impl->sizes_strides_policy_ = src_impl->sizes_strides_policy_;
   dest_impl->storage_access_should_throw_ =
       src_impl->storage_access_should_throw_;
   if (src_impl->named_tensor_meta_ != nullptr) {

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -181,16 +181,6 @@ TensorImpl::TensorImpl(
   // Caffe2 operators create Storages with default devices.
 }
 
-#ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
-IntArrayRef TensorImpl::sizes() const {
-  return sizes_and_strides_.sizes_arrayref();
-}
-#endif
-
-IntArrayRef TensorImpl::strides() const {
-  return sizes_and_strides_.strides_arrayref();
-}
-
 void TensorImpl::HandleResize() {
   // If needed, we will free the data. the next mutable_data() call
   // will create the data storage.
@@ -349,22 +339,6 @@ void TensorImpl::release_resources() {
 }
 
 #ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
-int64_t TensorImpl::dim() const {
-  return sizes_and_strides_.size();
-}
-#endif
-
-int64_t TensorImpl::size(int64_t d) const {
-  d = at::maybe_wrap_dim(d, dim(), false);
-  return sizes_and_strides_.size_at_unchecked(d);
-}
-
-int64_t TensorImpl::stride(int64_t d) const {
-  d = at::maybe_wrap_dim(d, dim(), false);
-  return sizes_and_strides_.stride_at_unchecked(d);
-}
-
-#ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
 bool TensorImpl::has_storage() const {
   return storage_;
 }
@@ -375,45 +349,25 @@ void TensorImpl::throw_storage_access_error() const {
       false, "Cannot access storage of ", tensorimpl_type_name());
 }
 
-bool TensorImpl::is_contiguous_nondefault_policy_impl(
-    at::MemoryFormat memory_format) const {
-  if (has_contiguity_ ==
-      static_cast<uint8_t>(CustomizableMethodPolicy::ContiguityNotSupported)) {
-    TORCH_CHECK_NOT_IMPLEMENTED(
-        false,
-        "Tensors of type ",
-        tensorimpl_type_name(),
-        " do not have is_contiguous");
-  } else {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-        has_contiguity_ ==
-        static_cast<uint8_t>(CustomizableMethodPolicy::CustomBehavior));
-    return is_contiguous_custom(memory_format);
-  }
-}
-
 bool TensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
-  TORCH_INTERNAL_ASSERT(
+  TORCH_CHECK(
       false,
-      "TensorImpl::is_contiguous_custom should never be called; did you "
-      "set_has_contiguity_policy and forget to override is_contiguous_custom?");
+      "tensors of type ", tensorimpl_type_name(), " do not have is_contiguous");
 }
 
-IntArrayRef TensorImpl::sizes_nondefault_policy_impl() const {
-  if (sizes_customization_policy_ ==
-      static_cast<uint8_t>(CustomizableMethodPolicy::NotSupported)) {
-    TORCH_CHECK_NOT_IMPLEMENTED(
-        false,
-        "Tensors of type ",
-        tensorimpl_type_name(),
-        " do not have sizes");
-  } else {
-    TORCH_CHECK_NOT_IMPLEMENTED(
-        false,
-        "custom behavior for sizes() is not supported; please add it or file "
-        "an issue.")
-  }
+IntArrayRef TensorImpl::sizes_custom() const {
+  TORCH_CHECK(false, "tensors of type ", tensorimpl_type_name(), " do not have sizes");
 }
+IntArrayRef TensorImpl::strides_custom() const {
+  TORCH_CHECK(false, "tensors of type ", tensorimpl_type_name(), " do not have strides");
+}
+int64_t TensorImpl::dim_custom() const {
+  TORCH_CHECK(false, "tensors of type ", tensorimpl_type_name(), " do not have dim");
+}
+int64_t TensorImpl::numel_custom() const {
+  TORCH_CHECK(false, "tensors of type ", tensorimpl_type_name(), " do not have numel");
+}
+
 
 static void deletePlacementDeleteContext(void* ptr) {
   delete static_cast<PlacementDeleteContext*>(ptr);
@@ -538,7 +492,6 @@ void TensorImpl::copy_tensor_metadata_except_version_counter(
   dest_impl->key_set_ = (src_impl->key_set_ - c10::python_ks) |
       (dest_impl->key_set_ & c10::python_ks);
   dest_impl->is_contiguous_ = src_impl->is_contiguous_;
-  dest_impl->has_contiguity_ = src_impl->has_contiguity_;
   dest_impl->is_channels_last_contiguous_ =
       src_impl->is_channels_last_contiguous_;
   dest_impl->is_channels_last_3d_contiguous_ =
@@ -550,8 +503,8 @@ void TensorImpl::copy_tensor_metadata_except_version_counter(
   dest_impl->is_wrapped_number_ = src_impl->is_wrapped_number_;
   dest_impl->reserved_ = src_impl->reserved_;
   dest_impl->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
-  dest_impl->sizes_customization_policy_ =
-      src_impl->sizes_customization_policy_;
+  dest_impl->sizes_strides_policy_ =
+      src_impl->sizes_strides_policy_;
   dest_impl->storage_access_should_throw_ =
       src_impl->storage_access_should_throw_;
   if (src_impl->named_tensor_meta_ != nullptr) {

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -352,20 +352,20 @@ void TensorImpl::throw_storage_access_error() const {
 bool TensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
   TORCH_CHECK(
       false,
-      "tensors of type ", tensorimpl_type_name(), " do not have is_contiguous");
+      "Tensors of type ", tensorimpl_type_name(), " do not have is_contiguous");
 }
 
 IntArrayRef TensorImpl::sizes_custom() const {
-  TORCH_CHECK(false, "tensors of type ", tensorimpl_type_name(), " do not have sizes");
+  TORCH_CHECK(false, "Tensors of type ", tensorimpl_type_name(), " do not have sizes");
 }
 IntArrayRef TensorImpl::strides_custom() const {
-  TORCH_CHECK(false, "tensors of type ", tensorimpl_type_name(), " do not have strides");
+  TORCH_CHECK(false, "Tensors of type ", tensorimpl_type_name(), " do not have strides");
 }
 int64_t TensorImpl::dim_custom() const {
-  TORCH_CHECK(false, "tensors of type ", tensorimpl_type_name(), " do not have dim");
+  TORCH_CHECK(false, "Tensors of type ", tensorimpl_type_name(), " do not have dim");
 }
 int64_t TensorImpl::numel_custom() const {
-  TORCH_CHECK(false, "tensors of type ", tensorimpl_type_name(), " do not have numel");
+  TORCH_CHECK(false, "Tensors of type ", tensorimpl_type_name(), " do not have numel");
 }
 
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -538,9 +538,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * Return a reference to the sizes of this tensor.  This reference remains
    * valid as long as the tensor is live and not resized.
    */
-  IntArrayRef sizes() const
-  {
-    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
+  IntArrayRef sizes() const {
+    if (C10_UNLIKELY(
+            sizes_strides_policy_ >=
+            static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
       return sizes_custom();
     }
     return sizes_default();
@@ -550,9 +551,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * Return a reference to the strides of this tensor.  This reference remains
    * valid as long as the tensor is live and not restrided.
    */
-  IntArrayRef strides() const
-  {
-    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomStrides))) {
+  IntArrayRef strides() const {
+    if (C10_UNLIKELY(
+            sizes_strides_policy_ >=
+            static_cast<uint8_t>(SizesStridesPolicy::CustomStrides))) {
       return strides_custom();
     }
     return strides_default();
@@ -567,7 +569,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    */
   int64_t size(int64_t d) const {
     d = maybe_wrap_dim(d, dim(), false);
-    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
+    if (C10_UNLIKELY(
+            sizes_strides_policy_ >=
+            static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
       return sizes_custom()[d]; // unchecked (maybe_wrap_dim enforces bounds)
     }
     return sizes_and_strides_.size_at_unchecked(d);
@@ -582,7 +586,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    */
   int64_t stride(int64_t d) const {
     d = maybe_wrap_dim(d, dim(), false);
-    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomStrides))) {
+    if (C10_UNLIKELY(
+            sizes_strides_policy_ >=
+            static_cast<uint8_t>(SizesStridesPolicy::CustomStrides))) {
       return strides_custom()[d]; // unchecked (maybe_wrap_dim enforces bounds)
     }
     return sizes_and_strides_.stride_at_unchecked(d);
@@ -592,9 +598,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * Return the number of dimensions of this tensor.  Note that 0-dimension
    * represents a Tensor that is a Scalar, e.g., one that has a single element.
    */
-  int64_t dim() const
-  {
-    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
+  int64_t dim() const {
+    if (C10_UNLIKELY(
+            sizes_strides_policy_ >=
+            static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
       return dim_custom();
     }
     return dim_default();
@@ -609,7 +616,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * of sizes of a tensor.
    */
   int64_t numel() const {
-    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
+    if (C10_UNLIKELY(
+            sizes_strides_policy_ >=
+            static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
       return numel_custom();
     }
     return numel_default();
@@ -624,7 +633,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    */
   bool is_contiguous(
       at::MemoryFormat memory_format = at::MemoryFormat::Contiguous) const {
-    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomStrides))) {
+    if (C10_UNLIKELY(
+            sizes_strides_policy_ >=
+            static_cast<uint8_t>(SizesStridesPolicy::CustomStrides))) {
       return is_contiguous_custom(memory_format);
     }
     return is_contiguous_default(memory_format);
@@ -674,7 +685,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
  public:
-
   /**
    * True if this tensor has storage. See storage() for details.
    */
@@ -2379,7 +2389,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // then subsequent Resize()s will not free up Storage.
   bool reserved_ : 1;
 
-  // Call _custom() virtual methods for strides()/is_contiguous()/sizes()/dim()/numel()
+  // Call _custom() virtual methods for
+  // strides()/is_contiguous()/sizes()/dim()/numel()
   bool sizes_strides_policy_ : 2;
 
   // The set of DispatchKeys which describe this tensor.  NB: this

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -7,6 +7,7 @@
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/Storage.h>
 #include <c10/core/TensorOptions.h>
+#include <c10/core/WrapDimMinimal.h>
 #include <c10/core/impl/LocalDispatchKeySet.h>
 #include <c10/core/impl/PyInterpreter.h>
 #include <c10/core/impl/SizesAndStrides.h>
@@ -536,50 +537,143 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   /**
    * Return a reference to the sizes of this tensor.  This reference remains
    * valid as long as the tensor is live and not resized.
-   *
-   * NOTE: sizes() is only `TENSORIMPL_MAYBE_VIRTUAL` for backward
-   * compatibility. See `set_sizes_customization_policy` for the
-   * encouraged customization point.
-   *
-   * NOTE: Currently, CustomizableMethodPolicy::CustomBehavior is not
-   * supported due to a lack of use case, but it can easily be added.
    */
-  TENSORIMPL_MAYBE_VIRTUAL IntArrayRef sizes() const
-#ifdef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
+  IntArrayRef sizes() const
   {
-    if (C10_UNLIKELY(
-            sizes_customization_policy_ !=
-            static_cast<uint8_t>(CustomizableMethodPolicy::Default))) {
-      return sizes_nondefault_policy_impl();
+    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
+      return sizes_custom();
     }
-    return sizes_and_strides_.sizes_arrayref();
+    return sizes_default();
   }
-#else
-      ;
-#endif
 
- private:
-  IntArrayRef sizes_nondefault_policy_impl() const;
-
- public:
   /**
    * Return a reference to the strides of this tensor.  This reference remains
    * valid as long as the tensor is live and not restrided.
    */
-  virtual IntArrayRef strides() const;
+  IntArrayRef strides() const
+  {
+    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomStrides))) {
+      return strides_custom();
+    }
+    return strides_default();
+  }
+
+  /**
+   * Return the size of a tensor at some dimension, wrapping the dimension if
+   * necessary.
+   *
+   * NOTE: if you know wrapping is unnecessary, do sizes()[d] instead; it will
+   * be faster
+   */
+  int64_t size(int64_t d) const {
+    d = maybe_wrap_dim(d, dim(), false);
+    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
+      return sizes_custom()[d]; // unchecked (maybe_wrap_dim enforces bounds)
+    }
+    return sizes_and_strides_.size_at_unchecked(d);
+  }
+
+  /**
+   * Return the stride of a tensor at some dimension, wrapping the dimension
+   * if necessary.
+   *
+   * NOTE: if you know wrapping is unnecessary, do sizes()[d] instead; it will
+   * be faster
+   */
+  int64_t stride(int64_t d) const {
+    d = maybe_wrap_dim(d, dim(), false);
+    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomStrides))) {
+      return strides_custom()[d]; // unchecked (maybe_wrap_dim enforces bounds)
+    }
+    return sizes_and_strides_.stride_at_unchecked(d);
+  }
 
   /**
    * Return the number of dimensions of this tensor.  Note that 0-dimension
    * represents a Tensor that is a Scalar, e.g., one that has a single element.
    */
-  TENSORIMPL_MAYBE_VIRTUAL int64_t dim() const
-#ifdef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
+  int64_t dim() const
   {
+    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
+      return dim_custom();
+    }
+    return dim_default();
+  }
+
+  /**
+   * The number of elements in a tensor.
+   *
+   * WARNING: Previously, if you were using the Caffe2 API, you could
+   * test numel() == -1 to see if a tensor was uninitialized.  This
+   * is no longer true; numel always accurately reports the product
+   * of sizes of a tensor.
+   */
+  int64_t numel() const {
+    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
+      return numel_custom();
+    }
+    return numel_default();
+  }
+
+  /**
+   * Whether or not a tensor is laid out in contiguous memory.
+   *
+   * Tensors with non-trivial strides are not contiguous.  See
+   * compute_contiguous() for the exact definition of whether or not
+   * a tensor is contiguous or not.
+   */
+  bool is_contiguous(
+      at::MemoryFormat memory_format = at::MemoryFormat::Contiguous) const {
+    if (C10_UNLIKELY(sizes_strides_policy_ >= static_cast<uint8_t>(SizesStridesPolicy::CustomStrides))) {
+      return is_contiguous_custom(memory_format);
+    }
+    return is_contiguous_default(memory_format);
+  }
+
+ protected:
+  /**
+   * Customization points for the functions above.  sizes_strides_policy_
+   * must be set to enable these.
+   *
+   * NB: dim is overrideable separately from sizes because it is possible
+   * for a tensor to have rank, but not well defined sizes.
+   */
+  // sizes_strides_policy_ >= CustomStrides
+  virtual IntArrayRef strides_custom() const;
+  virtual bool is_contiguous_custom(at::MemoryFormat memory_format) const;
+  // sizes_strides_policy_ >= CustomSizes
+  virtual IntArrayRef sizes_custom() const;
+  virtual int64_t dim_custom() const;
+  virtual int64_t numel_custom() const;
+
+  // These are factored into separate functions in case subclasses
+  // want to use them
+  inline IntArrayRef strides_default() const {
+    return sizes_and_strides_.strides_arrayref();
+  }
+  inline bool is_contiguous_default(at::MemoryFormat memory_format) const {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(compute_contiguous() == is_contiguous_);
+    if (memory_format == at::MemoryFormat::ChannelsLast) {
+      return is_channels_last_contiguous_;
+    } else if (memory_format == at::MemoryFormat::ChannelsLast3d) {
+      return is_channels_last_3d_contiguous_;
+    }
+    return is_contiguous_;
+  }
+  inline IntArrayRef sizes_default() const {
+    return sizes_and_strides_.sizes_arrayref();
+  }
+  inline int64_t dim_default() const {
     return sizes_and_strides_.size();
   }
-#else
-      ;
+  inline int64_t numel_default() const {
+#ifdef DEBUG
+    TORCH_INTERNAL_ASSERT(compute_numel() == numel_);
 #endif
+    return numel_;
+  }
+
+ public:
 
   /**
    * True if this tensor has storage. See storage() for details.
@@ -630,63 +724,11 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return storage_;
   }
 
-  /**
-   * The number of elements in a tensor.
-   *
-   * WARNING: Previously, if you were using the Caffe2 API, you could
-   * test numel() == -1 to see if a tensor was uninitialized.  This
-   * is no longer true; numel always accurately reports the product
-   * of sizes of a tensor.
-   */
-  TENSORIMPL_MAYBE_VIRTUAL int64_t numel() const {
-#ifdef DEBUG
-    TORCH_INTERNAL_ASSERT(compute_numel() == numel_);
-#endif
-    return numel_;
-  }
-
   bool unique_version() const {
     return version_counter_.unique();
   }
 
-  /**
-   * Whether or not a tensor is laid out in contiguous memory.
-   *
-   * Tensors with non-trivial strides are not contiguous.  See
-   * compute_contiguous() for the exact definition of whether or not
-   * a tensor is contiguous or not.
-   *
-   * NOTE: is_contiguous is only `TENSORIMPL_MAYBE_VIRTUAL` for
-   * backward compatibility. See `set_has_contiguity_policy` and
-   * `is_contiguous_custom` for the encouraged customization point.
-   */
-  TENSORIMPL_MAYBE_VIRTUAL bool is_contiguous(
-      at::MemoryFormat memory_format = at::MemoryFormat::Contiguous) const {
-    if (C10_UNLIKELY(
-            has_contiguity_ !=
-            static_cast<uint8_t>(HasContiguityPolicy::Default))) {
-      return is_contiguous_nondefault_policy_impl(memory_format);
-    }
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(compute_contiguous() == is_contiguous_);
-    if (memory_format == at::MemoryFormat::ChannelsLast) {
-      return is_channels_last_contiguous_;
-    } else if (memory_format == at::MemoryFormat::ChannelsLast3d) {
-      return is_channels_last_3d_contiguous_;
-    }
-    return is_contiguous_;
-  }
-
- private:
-  bool is_contiguous_nondefault_policy_impl(at::MemoryFormat) const;
-
  protected:
-  /**
-   * Customization point for is_contiguous; must also
-   * set_has_contiguity_policy(HasContiguityPolicy::Custom) for this
-   * to be called.
-   */
-  virtual bool is_contiguous_custom(at::MemoryFormat memory_format) const;
-
   virtual Layout layout_impl() const {
     TORCH_CHECK(
         false, "layout_impl is only implemented for TensorImpl subclasses.");
@@ -1298,16 +1340,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     refresh_numel();
     refresh_contiguous();
   }
-
-  /**
-   * Return the size of a tensor at some dimension.
-   */
-  virtual int64_t size(int64_t d) const;
-
-  /**
-   * Return the stride of a tensor at some dimension.
-   */
-  virtual int64_t stride(int64_t d) const;
 
   /**
    * Set whether a tensor allows changes to its metadata (e.g. sizes / strides /
@@ -2150,31 +2182,24 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
  protected:
-  // Policy for adjusting the behavior of customizable methods like
-  // is_contiguous() and sizes(). Allows subclass customization while
-  // still being able to inline the methods in the common case.
-  enum class CustomizableMethodPolicy : uint8_t {
-    // Default behavior.
-    Default,
-    // Throw a generic error message that this tensor type does not
-    // support the method in question.
-    NotSupported,
-    // For backward compatibility.
-    ContiguityNotSupported = NotSupported,
-    // Call virtual foo_custom method to implement custom foo
-    // behavior.
-    CustomBehavior,
+  enum class SizesStridesPolicy : uint8_t {
+    // Default behavior, e.g., dense tensor.
+    //
+    // Can override: nothing
+    Default = 0,
+    // Customizable strides behavior, e.g., sparse tensor,
+    // mkldnn tensor.
+    //
+    // Can override: strides(), is_contiguous()
+    CustomStrides = 1,
+    // Customizable sizes behavior, e.g., nested tensor
+    //
+    // Can override: strides(), is_contiguous(), sizes(), dim(), numel()
+    CustomSizes = 2,
   };
 
-  // For backward compatibility.
-  using HasContiguityPolicy = CustomizableMethodPolicy;
-
-  void set_has_contiguity_policy(CustomizableMethodPolicy p) {
-    has_contiguity_ = static_cast<uint8_t>(p);
-  }
-
-  void set_sizes_customization_policy(CustomizableMethodPolicy p) {
-    sizes_customization_policy_ = static_cast<uint8_t>(p);
+  void set_sizes_strides_policy(SizesStridesPolicy policy) {
+    sizes_strides_policy_ = static_cast<uint8_t>(policy);
   }
 
   Storage storage_;
@@ -2283,9 +2308,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
 
   // Tensor is contiguous
   bool is_contiguous_ : 1;
-  // gcc doesn't like enum class bitfields; see
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61414
-  /* HasContiguityPolicy */ uint8_t has_contiguity_ : 2;
 
   // Tensor is a subclass that does not permit storage access.
   bool storage_access_should_throw_ : 1;
@@ -2294,7 +2316,6 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // or -std=gnu++2a
   inline void init_bitfields() {
     is_contiguous_ = true;
-    has_contiguity_ = static_cast<uint8_t>(CustomizableMethodPolicy::Default);
 
     is_channels_last_ = false;
     is_channels_last_contiguous_ = false;
@@ -2304,8 +2325,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     is_wrapped_number_ = false;
     allow_tensor_metadata_change_ = true;
     reserved_ = false;
-    sizes_customization_policy_ =
-        static_cast<uint8_t>(CustomizableMethodPolicy::Default);
+    sizes_strides_policy_ = static_cast<uint8_t>(SizesStridesPolicy::Default);
     storage_access_should_throw_ = false;
   }
 
@@ -2359,8 +2379,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // then subsequent Resize()s will not free up Storage.
   bool reserved_ : 1;
 
-  // Customization policy for the sizes() virtual method.
-  /* CustomizableMethodPolicy */ uint8_t sizes_customization_policy_ : 2;
+  // Call _custom() virtual methods for strides()/is_contiguous()/sizes()/dim()/numel()
+  bool sizes_strides_policy_ : 2;
 
   // The set of DispatchKeys which describe this tensor.  NB: this
   // does NOT include Autograd (historically, it did, but

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2391,7 +2391,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
 
   // Call _custom() virtual methods for
   // strides()/is_contiguous()/sizes()/dim()/numel()
-  bool sizes_strides_policy_ : 2;
+  uint8_t sizes_strides_policy_ : 2;
 
   // The set of DispatchKeys which describe this tensor.  NB: this
   // does NOT include Autograd (historically, it did, but

--- a/c10/core/UndefinedTensorImpl.cpp
+++ b/c10/core/UndefinedTensorImpl.cpp
@@ -9,14 +9,6 @@ UndefinedTensorImpl::UndefinedTensorImpl()
   set_storage_access_should_throw();
 }
 
-int64_t UndefinedTensorImpl::size(int64_t d) const {
-  TORCH_CHECK(false, "size(dim) called on an undefined Tensor");
-}
-
-int64_t UndefinedTensorImpl::stride(int64_t d) const {
-  TORCH_CHECK(false, "stride(dim) called on an undefined Tensor");
-}
-
 #ifdef DEBUG
 bool UndefinedTensorImpl::has_storage() const {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
@@ -27,10 +19,6 @@ bool UndefinedTensorImpl::has_storage() const {
 
 void UndefinedTensorImpl::set_storage_offset(int64_t) {
   TORCH_CHECK(false, "set_storage_offset() called on an undefined Tensor");
-}
-
-IntArrayRef UndefinedTensorImpl::strides() const {
-  TORCH_CHECK(false, "strides() called on undefined Tensor");
 }
 
 const char* UndefinedTensorImpl::tensorimpl_type_name() const {

--- a/c10/core/UndefinedTensorImpl.cpp
+++ b/c10/core/UndefinedTensorImpl.cpp
@@ -7,6 +7,7 @@ namespace c10 {
 UndefinedTensorImpl::UndefinedTensorImpl()
     : TensorImpl(DispatchKey::Undefined, caffe2::TypeMeta(), c10::nullopt) {
   set_storage_access_should_throw();
+  set_sizes_strides_policy(SizesStridesPolicy::CustomSizes);
 }
 
 #ifdef DEBUG

--- a/c10/core/UndefinedTensorImpl.cpp
+++ b/c10/core/UndefinedTensorImpl.cpp
@@ -7,7 +7,13 @@ namespace c10 {
 UndefinedTensorImpl::UndefinedTensorImpl()
     : TensorImpl(DispatchKey::Undefined, caffe2::TypeMeta(), c10::nullopt) {
   set_storage_access_should_throw();
-  set_sizes_strides_policy(SizesStridesPolicy::CustomSizes);
+  // TODO: accessing the sizes on an undefined tensor is not meaningful
+  // and should error too, but empirically it does not!
+  set_sizes_strides_policy(SizesStridesPolicy::CustomStrides);
+}
+
+bool UndefinedTensorImpl::is_contiguous_custom(MemoryFormat format) const {
+  return is_contiguous_default(format);
 }
 
 #ifdef DEBUG

--- a/c10/core/UndefinedTensorImpl.h
+++ b/c10/core/UndefinedTensorImpl.h
@@ -18,9 +18,6 @@ struct C10_API UndefinedTensorImpl final : public TensorImpl {
 #endif
     return &_singleton;
   }
-  IntArrayRef strides() const override;
-  int64_t size(int64_t d) const override;
-  int64_t stride(int64_t d) const override;
 #ifdef DEBUG
   bool has_storage() const override;
 #endif

--- a/c10/core/UndefinedTensorImpl.h
+++ b/c10/core/UndefinedTensorImpl.h
@@ -23,6 +23,9 @@ struct C10_API UndefinedTensorImpl final : public TensorImpl {
 #endif
   void set_storage_offset(int64_t offset) override;
 
+ protected:
+  bool is_contiguous_custom(MemoryFormat format) const override;
+
  private:
   UndefinedTensorImpl();
   static UndefinedTensorImpl _singleton;

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -82,6 +82,7 @@ LTCTensorImpl::LTCTensorImpl(LazyTensor&& tensor)
   // This is a temporary fix for a PyTorch core issue,
   // according to https://github.com/pytorch/xla/pull/2682.
   is_non_overlapping_and_dense_ = false;
+  set_sizes_strides_policy(SizesStridesPolicy::CustomSizes);
 }
 
 void LTCTensorImpl::set_tensor(const LazyTensorPtr& lazy_tensor) {
@@ -126,18 +127,6 @@ void LTCTensorImpl::shallow_copy_from(
   generation_ = 0;
 }
 
-int64_t LTCTensorImpl::size(int64_t d) const {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-  const_cast<LTCTensorImpl*>(this)->setup_size_properties();
-  return c10::TensorImpl::size(d);
-}
-
-int64_t LTCTensorImpl::stride(int64_t d) const {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-  const_cast<LTCTensorImpl*>(this)->setup_size_properties();
-  return c10::TensorImpl::stride(d);
-}
-
 void LTCTensorImpl::setup_size_properties() {
   size_t generation = tensor_->generation();
   if (generation != generation_) {
@@ -159,31 +148,31 @@ void LTCTensorImpl::setup_size_properties() {
 
 #ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
 
-at::IntArrayRef LTCTensorImpl::sizes() const {
+at::IntArrayRef LTCTensorImpl::sizes_custom() const {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
-  return c10::TensorImpl::sizes();
+  return sizes_default();
 }
 
-at::IntArrayRef LTCTensorImpl::strides() const {
+at::IntArrayRef LTCTensorImpl::strides_custom() const {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
-  return c10::TensorImpl::strides();
+  return strides_default();
 }
 
-int64_t LTCTensorImpl::dim() const {
+int64_t LTCTensorImpl::dim_custom() const {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
-  return c10::TensorImpl::dim();
+  return dim_default();
 }
 
-int64_t LTCTensorImpl::numel() const {
+int64_t LTCTensorImpl::numel_custom() const {
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   const_cast<LTCTensorImpl*>(this)->setup_size_properties();
-  return c10::TensorImpl::numel();
+  return numel_default();
 }
 
-bool LTCTensorImpl::is_contiguous(c10::MemoryFormat _unused) const {
+bool LTCTensorImpl::is_contiguous_custom(c10::MemoryFormat _unused) const {
   if (tensor_->CurrentTensorData()) {
     return tensor_->CurrentTensorData()->is_contiguous();
   }

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -32,17 +32,13 @@ class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
 
   void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override;
 
-  int64_t size(int64_t d) const override;
-
-  int64_t stride(int64_t d) const override;
+  at::IntArrayRef sizes_custom() const override;
+  at::IntArrayRef strides_custom() const override;
+  int64_t dim_custom() const override;
+  int64_t numel_custom() const override;
+  bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
 
 #ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
-  at::IntArrayRef sizes() const override;
-  at::IntArrayRef strides() const override;
-  int64_t dim() const override;
-  int64_t numel() const override;
-
-  bool is_contiguous(at::MemoryFormat memory_format) const override;
   const at::Storage& storage() const override { return tensor_->Storage(); }
   bool has_storage() const override { return tensor_->Storage(); }
 #endif  // C10_DISABLE_TENSORIMPL_EXTENSIBILITY


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #77059
* __->__ #77036
* #77028

Prior to this PR, we had a mish-mash of ways of getting unconventional
sizes/strides behavior:

- In OSS (but not in fbcode), some methods are virtual and you
  can override them directly

- There is a is_contiguous policy which is a bitfield tag that lets
  you toggle is_contiguous to error or hit a virtual method
  is_contiguous_custom if it is set.  Ordinarily is_contiguous()
  is virtual and you can just override it, but this works EVEN IF
  is_contiguous() is non-virtual (e.g., in fbcode)

- There is also a sizes policy which is the same idea but for sizes

This PR unifies these mechanisms, and in doing so, eliminates the
maybe virtual/not-virtualness of the methods in question.  The primary
downside of this change is that it is BC-breaking (but the BC break is
very easy to fix!)

The new scheme works like this: we have three levels of policy for
sizes/strides (order matters).

- The Default policy is a conventional dense tensor, where we use
  all of the built-in fields to directly represent the
  sizes/strides/numel/contiguity of the tensor, and it is possible
  to bypass virtual call entirely.

- The CustomStrides policy represent tensors which have a custom
  notion of strides (most typically, that they don't support them),
  shunting strides() and is_contiguous() to virtual methods
  strides_custom() and is_contiguous_custom().  This INCLUDES handling
  for contiguity, since they typically go hand-in-hand (although
  the situation is murky with batched tensors).  The default
  implementations of these functions raise errors saying the tensor
  doesn't support them.

- The CustomSizes policy represent tensors which have a custom
  notion of sizes (the two notable examples are nested tensor, which
  doesn't have a representation of sizes in the conventional form, and
  XLA/LTC tensor, which synchronizes its sizes with an underlying
  compiler backend).  This shunts sizes(), numel() and dim() (along
  with everything from strides) to _custom() variants.

There is no special policy for erroring; instead, we just do a vcall
and expect the virtual method to raise an exception (the performance
hit from the vcall doesn't matter because you're about to raise a C++
exception anyway).  The default implementations of all overridable
functions are available at _default() which is helpful in some
situations when you just want to do a "sync" and then run the
conventional semantics.

This PR could be extended further in two ways but I did not do them
due to time constraints:

- Ideally, all TENSORIMPL_MAYBE_VIRTUAL would be eliminated from
  TensorImpl, by using the same policy trick.

- set_size and set_stride are still virtual; it's not entirely clear
  the same trick should be used here though as these methods are
  deprecated.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>