### PR TITLE
New generated conv_bn folding should use same weight and bias dtype as original conv module

### DIFF
--- a/torch/csrc/jit/passes/fold_conv_bn.cpp
+++ b/torch/csrc/jit/passes/fold_conv_bn.cpp
@@ -27,9 +27,13 @@ std::tuple<at::Tensor, at::Tensor> computeUpdatedConvWeightAndBias(
   const int64_t ndim = p.conv_w.dim();
   at::DimVector sizes(ndim, 1);
   sizes.at(0) = -1;
+
+  auto conv_w_dtype = p.conv_w.dtype();
+  auto conv_b_dtype = p.conv_b.dtype();
+
   at::Tensor new_w = p.conv_w * (p.bn_w * bn_var_rsqrt).reshape(sizes);
   at::Tensor new_b = (p.conv_b - p.bn_rm) * bn_var_rsqrt * p.bn_w + p.bn_b;
-  return std::make_tuple(new_w, new_b);
+  return std::make_tuple(new_w.to(conv_w_dtype), new_b.to(conv_b_dtype));
 }
 
 namespace {


### PR DESCRIPTION
When doing the conv_bn folding in `torch.jit.freeze`, the new calculated `weight` and `bias` for the new conv will be promoted to high precision such as `float32` even the original `weight` and `bias` for the conv is low precision such as `bfloat16`. 
In this PR, we will record the original dtype for the conv's `weight` and `bias` and convert the data type back after `conv_bn` folding.
