### PR TITLE
Enable multi-dimensional lengths in segment_reduce to support pytorch_scatter.segment_* functionalities (CPU-only)

### DIFF
--- a/aten/src/ATen/native/SegmentReduce.cpp
+++ b/aten/src/ATen/native/SegmentReduce.cpp
@@ -22,8 +22,10 @@ SegmentReductionType get_reduction_enum(const c10::string_view& reduce) {
     return SegmentReductionType::MIN;
   } else if (reduce == "sum") {
     return SegmentReductionType::SUM;
+  } else if (reduce == "prod") {
+    return SegmentReductionType::PROD;
   } else {
-    TORCH_CHECK(false, "unsopported reduction given! ", reduce);
+    TORCH_CHECK(false, "unsupported reduction given! ", reduce);
   }
 }
 
@@ -56,6 +58,8 @@ void _segment_reduce_cpu_kernel1(
               initial_value = 0;
             } else if (reduction == SegmentReductionType::MIN) {
               initial_value = std::numeric_limits<scalar_t>::infinity();
+            } else if (reduction == SegmentReductionType::PROD) {
+              initial_value = 1;
             }
 
             // ===== step2: apply reduction
@@ -76,6 +80,8 @@ void _segment_reduce_cpu_kernel1(
                 initial_value = at::_isnan(data)
                     ? data
                     : std::min<scalar_t>(initial_value, data);
+              } else if (reduction == SegmentReductionType::PROD) {
+                initial_value = initial_value * data;
               }
             }
 
@@ -97,21 +103,114 @@ void _segment_reduce_cpu_kernel1(
         }
       });
 }
+
+template <typename T>
+void _segment_reduce_cpu_kernel2(
+    SegmentReductionType reduction,
+    const Tensor& data,
+    const T* lengths_data,
+    int64_t axis,
+    const c10::optional<Scalar>& initial,
+    Tensor& output,
+    int64_t segment_count,
+    int64_t lengths_stride_axis) {
+  // outer_offset is the size of the outer dimensions of output (before axis)
+  // inner_offset is the size of the inner dimensions of output (after axis)
+  int64_t outer_offset = 1, inner_offset = 1;
+  for (int64_t d = 0; d < axis; d++)
+      outer_offset *= output.size(d);
+  for (int64_t d = axis + 1; d < output.dim(); d++)
+      inner_offset *= output.size(d);
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      kBFloat16, kHalf, data.scalar_type(), "_segment_reduce_cpu", [&]() {
+        auto* output_data = output.data_ptr<scalar_t>();
+        const auto* values_data = data.data_ptr<scalar_t>();
+        for (const auto outer_idx : c10::irange(outer_offset)) {
+          int64_t lengths_cum_sum = 0;
+          for (const auto dim_idx : c10::irange(segment_count)) {
+            // FIXME: pass lengths
+            int64_t segment_length = lengths_data[outer_idx * lengths_stride_axis * segment_count + dim_idx];
+            for (const auto inner_idx : c10::irange(inner_offset)) {
+              // ===== step1: initialize starting value
+              // FIXME: could we just fill out with the inits beforehand?
+              scalar_t initial_value;
+              if (initial.has_value()) {
+                initial_value = initial.value().to<scalar_t>();
+              } else if (reduction == SegmentReductionType::MAX) {
+                initial_value = -std::numeric_limits<scalar_t>::infinity();
+              } else if (
+                  reduction == SegmentReductionType::MEAN ||
+                  reduction == SegmentReductionType::SUM) {
+                initial_value = 0;
+              } else if (reduction == SegmentReductionType::MIN) {
+                initial_value = std::numeric_limits<scalar_t>::infinity();
+              } else if (reduction == SegmentReductionType::PROD) {
+                initial_value = 1;
+              }
+
+              // ===== step2: apply reduction
+              for (const auto j : c10::irange(segment_length)) {
+                int64_t data_index = outer_idx * data.stride(axis) * data.size(axis)
+                                     + (lengths_cum_sum + j) * data.stride(axis) + inner_idx;
+                const auto val = values_data[data_index];
+                if (reduction == SegmentReductionType::MAX) {
+                  initial_value = at::_isnan(val)
+                      ? val
+                      : std::max<scalar_t>(initial_value, val);
+                } else if (
+                    reduction == SegmentReductionType::MEAN ||
+                    reduction == SegmentReductionType::SUM) {
+                  initial_value = initial_value + val;
+                } else if (reduction == SegmentReductionType::MIN) {
+                  initial_value = at::_isnan(val)
+                      ? val
+                      : std::min<scalar_t>(initial_value, val);
+                } else if (reduction == SegmentReductionType::PROD) {
+                  initial_value = initial_value * val;
+                }
+              }
+
+              // ===== step3: finalize reduction
+              TORCH_CHECK(segment_length >= 0);
+
+              if (segment_length == 0 && !initial.has_value() &&
+                  reduction == SegmentReductionType::MEAN) {
+                initial_value = static_cast<scalar_t>(NAN);
+              } else if (
+                  reduction == SegmentReductionType::MEAN &&
+                  segment_length > 0 && !at::_isnan(initial_value)) {
+                initial_value = initial_value / segment_length;
+              }
+              int64_t output_index = outer_idx * output.stride(axis) * output.size(axis)
+                                     + dim_idx * output.stride(axis) + inner_idx;
+              output_data[output_index] = initial_value;
+            }
+            lengths_cum_sum += segment_length;
+          }
+        }
+      });
+}
+
 Tensor _segment_reduce_cpu_kernel(
     SegmentReductionType reduction,
     const Tensor& data,
     const Tensor& lengths,
     int64_t axis,
     const c10::optional<Scalar>& initial) {
-  int64_t segment_count = lengths.numel();
+  // data and lengths should be contiguous from the call to .contiguous in segment_reduce_kernel
+  TORCH_CHECK(data.is_contiguous(), "Expected data to be contiguous.");
+  TORCH_CHECK(lengths.is_contiguous(), "Expected lengths to be contiguous.");
+  axis = lengths.dim() - 1;
+  int64_t segment_count = lengths.size(axis);
+  int64_t lengths_stride_axis = lengths.stride(axis);
   auto output_shape = data.sizes().vec();
   output_shape[axis] = segment_count;
   auto output = at::empty(output_shape, data.options());
 
   AT_DISPATCH_INDEX_TYPES(lengths.scalar_type(), "_segment_reduce_cpu_kernel1", [&]() {
     const auto* lengths_data = lengths.data_ptr<index_t>();
-    _segment_reduce_cpu_kernel1(
-        reduction, data, lengths_data, axis, initial, output, segment_count);
+    _segment_reduce_cpu_kernel2(
+        reduction, data, lengths_data, axis, initial, output, segment_count, lengths_stride_axis);
   });
 
   return output;
@@ -125,6 +224,7 @@ void _segment_reduce_cpu_backward_kernel1(
     SegmentReductionType reduction,
     const T* lengths_data,
     int64_t axis,
+    const c10::optional<Scalar>& initial,
     Tensor& grad_input,
     int64_t segment_count) {
   int64_t stride_count = data_contig.numel() / data_contig.size(axis);
@@ -140,6 +240,15 @@ void _segment_reduce_cpu_backward_kernel1(
         auto* grad_data = grad_contig.data_ptr<scalar_t>();
         auto* grad_input_data = grad_input.data_ptr<scalar_t>();
         const auto* values_data = data_contig.data_ptr<scalar_t>();
+        // Used to calculate exclusive prod
+        scalar_t initial_prod_value;
+        if (reduction == SegmentReductionType::PROD) {
+          if (initial.has_value()) {
+            initial_prod_value = initial.value().to<scalar_t>();
+          } else {
+            initial_prod_value = 1;
+          }
+        }
 
         int64_t lengths_cum_sum = 0;
         for (const auto i : c10::irange(segment_count)) {
@@ -189,10 +298,151 @@ void _segment_reduce_cpu_backward_kernel1(
                     ((lengths_cum_sum + j) * stride_count) + l;
                 grad_input_data[starting_index] = grad_val;
               }
+            } else if (reduction == SegmentReductionType::PROD) {
+              const auto& grad_val = grad_data[output_index] * output_data[output_index];
+              for (const auto j : c10::irange(lengths_data[i])) {
+                int64_t starting_index =
+                    ((lengths_cum_sum + j) * stride_count) + l;
+                if (at::_isnan(values_data[starting_index]) ||
+                    values_data[starting_index] == 0) {
+                  // explicitly compute exclusive prod
+                  scalar_t exclusive_prod = initial_prod_value;
+                  int64_t idx;
+                  for (const auto k : c10::irange(lengths_data[i])) {
+                    if (k != j) {
+                      idx = ((lengths_cum_sum + k) * stride_count) + l;
+                      exclusive_prod *= values_data[idx];
+                    }
+                  }
+                  grad_input_data[starting_index] = grad_data[output_index] * exclusive_prod;
+                } else {
+                  grad_input_data[starting_index] = grad_val / values_data[starting_index];
+                }
+              }
             }
           }
 
           lengths_cum_sum += lengths_data[i];
+        }
+      });
+}
+
+template <typename T>
+void _segment_reduce_cpu_backward_kernel2(
+    const Tensor& grad_contig,
+    const Tensor& output_contig,
+    const Tensor& data_contig,
+    SegmentReductionType reduction,
+    const T* lengths_data,
+    int64_t axis,
+    const c10::optional<Scalar>& initial,
+    Tensor& grad_input,
+    int64_t segment_count,
+    int64_t lengths_stride_axis) {
+  // outer_offset is the size of the outer dimensions of output (before axis)
+  // inner_offset is the size of the inner dimensions of output (after axis)
+  int64_t outer_offset = 1, inner_offset = 1;
+  for (int64_t d = 0; d < axis; d++)
+      outer_offset *= output_contig.size(d);
+  for (int64_t d = axis + 1; d < output_contig.dim(); d++)
+      inner_offset *= output_contig.size(d);
+  // TODO: Swtich to TensorIterator for better maintainablility and
+  // readability
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      kBFloat16,
+      kHalf,
+      data_contig.scalar_type(),
+      "_segment_reduce_cpu",
+      [&]() {
+        auto* output_data = output_contig.data_ptr<scalar_t>();
+        auto* grad_data = grad_contig.data_ptr<scalar_t>();
+        auto* grad_input_data = grad_input.data_ptr<scalar_t>();
+        const auto* values_data = data_contig.data_ptr<scalar_t>();
+        // Used to calculate exclusive prod
+        scalar_t initial_prod_value;
+        if (reduction == SegmentReductionType::PROD) {
+          if (initial.has_value()) {
+            initial_prod_value = initial.value().to<scalar_t>();
+          } else {
+            initial_prod_value = 1;
+          }
+        }
+
+        for (const auto outer_idx : c10::irange(outer_offset)) {
+          int64_t lengths_cum_sum = 0;
+          for (const auto dim_idx : c10::irange(segment_count)) {
+            int64_t segment_length = lengths_data[outer_idx * lengths_stride_axis * segment_count + dim_idx];
+            if (segment_length == 0) {
+              continue;
+            }
+            for (const auto inner_idx : c10::irange(inner_offset)) {
+              int64_t output_index = outer_idx * output_contig.stride(axis) * output_contig.size(axis)
+                                     + dim_idx * output_contig.stride(axis) + inner_idx;
+              if (reduction == SegmentReductionType::MAX ||
+                  reduction == SegmentReductionType::MIN) {
+                int64_t counter = 0;
+                for (const auto j : c10::irange(segment_length)) {
+                  int64_t data_index = outer_idx * data_contig.stride(axis) * data_contig.size(axis)
+                                       + (lengths_cum_sum + j) * data_contig.stride(axis) + inner_idx;
+                  if (at::_isnan(values_data[data_index]) ||
+                      values_data[data_index] == output_data[output_index]) {
+                    grad_input_data[data_index] = grad_data[output_index];
+                    counter++;
+                  }
+                }
+                // Average gradient based on number of maximum elements in
+                // the segment
+                if (counter < 2) {
+                  continue;
+                }
+                for (const auto j : c10::irange(segment_length)) {
+                  int64_t data_index = outer_idx * data_contig.stride(axis) * data_contig.size(axis)
+                                       + (lengths_cum_sum + j) * data_contig.stride(axis) + inner_idx;
+                  if (grad_input_data[data_index] > 0) {
+                    grad_input_data[data_index] =
+                        grad_input_data[data_index] / counter;
+                  }
+                }
+              } else if (reduction == SegmentReductionType::MEAN) {
+                auto grad_val = grad_data[output_index] / segment_length;
+                for (const auto j : c10::irange(segment_length)) {
+                  int64_t data_index = outer_idx * data_contig.stride(axis) * data_contig.size(axis)
+                                       + (lengths_cum_sum + j) * data_contig.stride(axis) + inner_idx;
+                  grad_input_data[data_index] = grad_val;
+                }
+              } else if (reduction == SegmentReductionType::SUM) {
+                const auto& grad_val = grad_data[output_index];
+                for (const auto j : c10::irange(segment_length)) {
+                  int64_t data_index = outer_idx * data_contig.stride(axis) * data_contig.size(axis)
+                                       + (lengths_cum_sum + j) * data_contig.stride(axis) + inner_idx;
+                  grad_input_data[data_index] = grad_val;
+                }
+              } else if (reduction == SegmentReductionType::PROD) {
+                const auto& grad_val = grad_data[output_index] * output_data[output_index];
+                for (const auto j : c10::irange(segment_length)) {
+                  int64_t data_index = outer_idx * data_contig.stride(axis) * data_contig.size(axis)
+                                       + (lengths_cum_sum + j) * data_contig.stride(axis) + inner_idx;
+                  if (at::_isnan(values_data[data_index]) ||
+                      values_data[data_index] == 0) {
+                    // explicitly compute exclusive prod
+                    scalar_t exclusive_prod = initial_prod_value;
+                    int64_t idx;
+                    for (const auto k : c10::irange(segment_length)) {
+                      if (k != j) {
+                        idx = outer_idx * data_contig.stride(axis) * data_contig.size(axis)
+                              + (lengths_cum_sum + k) * data_contig.stride(axis) + inner_idx;
+                        exclusive_prod *= values_data[idx];
+                      }
+                    }
+                    grad_input_data[data_index] = grad_data[output_index] * exclusive_prod;
+                  } else {
+                    grad_input_data[data_index] = grad_val / values_data[data_index];
+                  }
+                }
+              }
+            }
+            lengths_cum_sum += segment_length;
+          }
         }
       });
 }
@@ -203,8 +453,11 @@ Tensor _segment_reduce_cpu_backward_kernel(
     const Tensor& data_contig,
     SegmentReductionType reduction,
     const Tensor& lengths_contig,
-    int64_t axis) {
-  int64_t segment_count = lengths_contig.numel();
+    int64_t axis,
+    const c10::optional<Scalar>& initial) {
+  axis = lengths_contig.dim() - 1;
+  int64_t segment_count = lengths_contig.size(axis);
+  int64_t lengths_stride_axis = lengths_contig.stride(axis);
   auto output_shape = data_contig.sizes().vec();
   output_shape[axis] = segment_count;
   auto grad_input = at::zeros({data_contig.sizes()}, grad_contig.options());
@@ -212,15 +465,17 @@ Tensor _segment_reduce_cpu_backward_kernel(
   AT_DISPATCH_INDEX_TYPES(
       lengths_contig.scalar_type(), "_segment_reduce_cpu_backward_kernel1", [&] {
         const auto* lengths_data = lengths_contig.data_ptr<index_t>();
-        _segment_reduce_cpu_backward_kernel1(
+        _segment_reduce_cpu_backward_kernel2(
             grad_contig,
             output_contig,
             data_contig,
             reduction,
             lengths_data,
             axis,
+            initial,
             grad_input,
-            segment_count);
+            segment_count,
+            lengths_stride_axis);
       });
 
   return grad_input;
@@ -237,7 +492,7 @@ Tensor segment_reduce_kernel(
     bool unsafe,
     const c10::optional<Scalar>& initial) {
   axis = maybe_wrap_dim(axis, data.ndimension());
-  TORCH_CHECK(axis == 0, "Currently only dim=0 is supported! ", axis);
+  // TORCH_CHECK(axis == 0, "Currently only dim=0 is supported! ", axis);
   TORCH_CHECK(data.numel() > 0);
 
   // length related checks
@@ -245,7 +500,7 @@ Tensor segment_reduce_kernel(
       lengths.has_value() && !indices.has_value(),
       "Currently only lengths based reduction is supported!")
   const auto& lengths_value = lengths.value();
-  TORCH_CHECK(lengths_value.dim() == 1);
+  // TORCH_CHECK(lengths_value.dim() == 1);
   TORCH_CHECK(data.get_device() == lengths_value.get_device());
   TORCH_CHECK(data.dim() >= lengths_value.dim());
 
@@ -285,9 +540,10 @@ Tensor _segment_reduce_backward_kernel(
     const Tensor& data,
     c10::string_view reduce,
     const c10::optional<Tensor>& lengths,
-    int64_t axis) {
+    int64_t axis,
+    const c10::optional<Scalar>& initial) {
   axis = maybe_wrap_dim(axis, data.ndimension());
-  TORCH_CHECK(axis == 0, "Currently only dim=0 is supported! ", axis);
+  // TORCH_CHECK(axis == 0, "Currently only dim=0 is supported! ", axis);
   TORCH_CHECK(
       lengths.has_value(),
       "Currently only lengths based reduction is supported!")
@@ -306,7 +562,8 @@ Tensor _segment_reduce_backward_kernel(
       data_contig,
       reduction,
       lengths_contig,
-      axis);
+      axis,
+      initial);
 }
 
 REGISTER_ARCH_DISPATCH(

--- a/aten/src/ATen/native/SegmentReduce.h
+++ b/aten/src/ATen/native/SegmentReduce.h
@@ -9,7 +9,7 @@ class Tensor;
 
 namespace native {
 
-enum SegmentReductionType { MAX, MEAN, MIN, SUM };
+enum SegmentReductionType { MAX, MEAN, MIN, SUM, PROD};
 
 using segment_reduce_fn = Tensor (*)(
     SegmentReductionType,
@@ -25,7 +25,8 @@ using segment_reduce_backward_fn = Tensor (*)(
     const Tensor&,
     SegmentReductionType,
     const Tensor&,
-    int64_t);
+    int64_t,
+    const c10::optional<Scalar>&);
 DECLARE_DISPATCH(segment_reduce_backward_fn, _segment_reduce_backward_stub);
 
 } // namespace native

--- a/aten/src/ATen/native/cuda/SegmentReduce.cu
+++ b/aten/src/ATen/native/cuda/SegmentReduce.cu
@@ -40,6 +40,14 @@ struct CustomSum {
   }
 };
 
+struct CustomProd {
+  template <typename OutputT>
+  __host__ __device__ __forceinline__ OutputT
+  operator()(const OutputT& a, const OutputT& b) const {
+    return a * b;
+  }
+};
+
 struct CustomMin {
   template <typename OutputT>
   __host__ __device__ __forceinline__ OutputT
@@ -127,6 +135,9 @@ __global__ void segment_reduce_forward_kernel(
     } else if (reduction == SegmentReductionType::MIN) {
       initial_value =
           at::_isnan(data) ? data : std::min<scalar_t>(initial_value, data);
+    } else if (
+      reduction == SegmentReductionType::PROD) {
+      initial_value = initial_value * data;
     }
   }
 
@@ -154,7 +165,8 @@ __global__ void segment_reduce_backward_kernel(
     const index_t* lengths_data,
     const index_t* lengths_cumsum_data,
     const int64_t segment_count,
-    const int64_t stride_count) {
+    const int64_t stride_count,
+    scalar_t initial_prod_value) {
   int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   int64_t row_id = idx / stride_count;
   int64_t lane_id = idx % stride_count;
@@ -206,6 +218,26 @@ __global__ void segment_reduce_backward_kernel(
       int64_t starting_index = (j * stride_count) + lane_id;
       grad_input_data[starting_index] = grad_val;
     }
+  } else if (reduction == SegmentReductionType::PROD) {
+    const auto& grad_val = grad_data[output_index] * output_data[output_index];
+    for (int64_t j = offset_start; j < offset_end; ++j) {
+      int64_t starting_index = (j * stride_count) + lane_id;
+      if (at::_isnan(values_data[starting_index]) ||
+          values_data[starting_index] == 0) {
+        // explicitly compute exclusive prod
+        scalar_t exclusive_prod = initial_prod_value;
+        int64_t idx;
+        for (int64_t k = offset_start; k < offset_end; ++k) {
+          if (k != j) {
+            idx = (k * stride_count) + lane_id;
+            exclusive_prod *= values_data[idx];
+          }
+        }
+        grad_input_data[starting_index] = grad_data[output_index] * exclusive_prod;
+      } else {
+        grad_input_data[starting_index] = grad_val / values_data[starting_index];
+      }
+    }
   }
 }
 
@@ -217,7 +249,8 @@ Tensor _segment_reduce_cuda_backward_kernel(
     const Tensor& data_contig,
     SegmentReductionType reduction,
     const Tensor& lengths_contig,
-    int64_t axis) {
+    int64_t axis,
+    const c10::optional<Scalar>& initial) {
   int64_t segment_count = lengths_contig.numel();
   auto output_shape = data_contig.sizes().vec();
   output_shape[axis] = segment_count;
@@ -252,6 +285,13 @@ Tensor _segment_reduce_cuda_backward_kernel(
               auto* grad_input_data = grad_input.data_ptr<scalar_t>();
               const auto* values_data = data_contig.data_ptr<scalar_t>();
 
+              scalar_t initial_prod_value;
+              if (initial.has_value()) {
+                initial_prod_value = initial.value().to<scalar_t>();
+              } else {
+                initial_prod_value = 1;
+              }
+
               segment_reduce_backward_kernel<scalar_t>
                   <<<num_blocks,
                      threads_per_block,
@@ -265,7 +305,8 @@ Tensor _segment_reduce_cuda_backward_kernel(
                       lengths_data,
                       offsets_data,
                       segment_count,
-                      stride_count);
+                      stride_count,
+                      initial_prod_value);
               C10_CUDA_KERNEL_LAUNCH_CHECK();
             }));
       }));
@@ -319,6 +360,8 @@ Tensor _segment_reduce_cuda_kernel(
                 initial_value = 0;
               } else if (reduction == SegmentReductionType::MIN) {
                 initial_value = std::numeric_limits<scalar_t>::infinity();
+              } else if (reduction == SegmentReductionType::PROD) {
+                initial_value = 1;
               }
 
               if (output_shape.size() > 1) {
@@ -396,6 +439,18 @@ Tensor _segment_reduce_cuda_kernel(
                       offsets_data_ptr,
                       offsets_data_ptr + 1,
                       sum_op,
+                      initial_value,
+                      at::cuda::getCurrentCUDAStream());
+                } else if (reduction == SegmentReductionType::PROD) {
+                  CustomProd prod_op{};
+                  CUB_WRAPPER(
+                      cub::DeviceSegmentedReduce::Reduce,
+                      data_data_ptr,
+                      output_data_ptr,
+                      segment_count,
+                      offsets_data_ptr,
+                      offsets_data_ptr + 1,
+                      prod_op,
                       initial_value,
                       at::cuda::getCurrentCUDAStream());
                 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11456,7 +11456,7 @@
   dispatch:
     CPU, CUDA: segment_reduce_kernel
 
-- func: _segment_reduce_backward(Tensor grad, Tensor output, Tensor data, str reduce, *, Tensor? lengths=None, int axis=0) -> Tensor
+- func: _segment_reduce_backward(Tensor grad, Tensor output, Tensor data, str reduce, *, Tensor? lengths=None, int axis=0, Scalar? initial=None) -> Tensor
   variants: function
   dispatch:
     CPU, CUDA: _segment_reduce_backward_kernel

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -7,15 +7,18 @@ import torch
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     dtypes,
+    onlyCPU
 )
 from torch.testing._internal.common_utils import (
     TestCase,
     run_tests,
     gradcheck,
+    parametrize
+
 )
 
 
-reductions = ["max", "mean", "min", "sum"]
+reductions = ["max", "mean", "min", "sum", "prod"]
 
 
 def get_default_value(initial_value, reduction):
@@ -29,6 +32,8 @@ def get_default_value(initial_value, reduction):
         return float("Inf")
     elif reduction == "sum":
         return 0.0
+    elif reduction == "prod":
+        return 1.0
 
 
 class TestSegmentReductions(TestCase):
@@ -134,6 +139,15 @@ class TestSegmentReductions(TestCase):
                 elif reduction == "sum":
                     expected_result = [1, float("nan"), 14, default_value]
                     expected_grad = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+                elif reduction == "prod":
+                    if initial is not None:
+                        initial_value = 2  # 0 initial_value will zero out everything for prod
+                        default_value = get_default_value(initial_value, reduction)
+                        expected_result = [2, float("nan"), 200, default_value]
+                        expected_grad = [2.0, 6.0, float("nan"), 50.0, 40.0, 40.0]
+                    else:
+                        expected_result = [1, float("nan"), 100, default_value]
+                        expected_grad = [1.0, 3.0, float("nan"), 25.0, 20.0, 20.0]
                 for axis in [0, -1]:
                     for unsafe in [True, False]:
                         self._test_common(
@@ -231,6 +245,39 @@ class TestSegmentReductions(TestCase):
                         [1.0, 1.0],
                         [1.0, 1.0],
                     ]
+                elif reduction == "prod":
+                    if initial is not None:
+                        initial_value = 2  # 0 initial_value will zero out everything for prod
+                        default_value = get_default_value(initial_value, reduction)
+                        expected_result = [
+                            [2, 2],
+                            [float("nan"), float("nan")],
+                            [48, 12],
+                            [default_value, default_value],
+                        ]
+                        expected_grad = [
+                            [2.0, 2.0],
+                            [6.0, float("nan")],
+                            [float("nan"), 2.0],
+                            [12.0, 12.0],
+                            [16.0, 6.0],
+                            [24.0, 4.0],
+                        ]
+                    else:
+                        expected_result = [
+                            [1, 1],
+                            [float("nan"), float("nan")],
+                            [24, 6],
+                            [default_value, default_value],
+                        ]
+                        expected_grad = [
+                            [1.0, 1.0],
+                            [3.0, float("nan")],
+                            [float("nan"), 1.0],
+                            [6.0, 6.0],
+                            [8.0, 3.0],
+                            [12.0, 2.0],
+                        ]
                 for unsafe in [True, False]:
                     self._test_common(
                         reduction,
@@ -252,11 +299,117 @@ class TestSegmentReductions(TestCase):
             (torch.int, torch.int64),
         )
     )
+    @parametrize("reduce", ['sum', 'prod', 'min', 'max', 'mean'])
+    @onlyCPU  # will be removed in next PR where CUDA implementation of segment_reduce is adjusted
+    def test_pytorch_scatter_test_cases(self, device, dtypes, reduce):
+        val_dtype, length_dtype = dtypes
+        # zero-length segments are filled with reduction inits contrary to pytorch_scatter.
+        tests = [
+            {
+                'src': [1, 2, 3, 4, 5, 6],
+                'index': [0, 0, 1, 1, 1, 3],
+                'indptr': [0, 2, 5, 5, 6],
+                'sum': [3, 12, 0, 6],
+                'prod': [2, 60, 1, 6],
+                'mean': [1.5, 4, float('nan'), 6],
+                'min': [1, 3, float('inf'), 6],
+                'max': [2, 5, -float('inf'), 6],
+            },
+            {
+                'src': [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]],
+                'index': [0, 0, 1, 1, 1, 3],
+                'indptr': [0, 2, 5, 5, 6],
+                'sum': [[4, 6], [21, 24], [0, 0], [11, 12]],
+                'prod': [[3, 8], [315, 480], [1, 1], [11, 12]],
+                'mean': [[2, 3], [7, 8], [float('nan'), float('nan')], [11, 12]],
+                'min': [[1, 2], [5, 6], [float('inf'), float('inf')], [11, 12]],
+                'max': [[3, 4], [9, 10], [-float('inf'), -float('inf')], [11, 12]],
+            },
+            {
+                'src': [[1, 3, 5, 7, 9, 11], [2, 4, 6, 8, 10, 12]],
+                'index': [[0, 0, 1, 1, 1, 3], [0, 0, 0, 1, 1, 2]],
+                'indptr': [[0, 2, 5, 5, 6], [0, 3, 5, 6, 6]],
+                'sum': [[4, 21, 0, 11], [12, 18, 12, 0]],
+                'prod': [[3, 315, 1, 11], [48, 80, 12, 1]],
+                'mean': [[2, 7, float('nan'), 11], [4, 9, 12, float('nan')]],
+                'min': [[1, 5, float('inf'), 11], [2, 8, 12, float('inf')]],
+                'max': [[3, 9, -float('inf'), 11], [6, 10, 12, -float('inf')]],
+            },
+            {
+                'src': [[[1, 2], [3, 4], [5, 6]], [[7, 9], [10, 11], [12, 13]]],
+                'index': [[0, 0, 1], [0, 2, 2]],
+                'indptr': [[0, 2, 3, 3], [0, 1, 1, 3]],
+                'sum': [[[4, 6], [5, 6], [0, 0]], [[7, 9], [0, 0], [22, 24]]],
+                'prod': [[[3, 8], [5, 6], [1, 1]], [[7, 9], [1, 1], [120, 143]]],
+                'mean': [[[2, 3], [5, 6], [float('nan'), float('nan')]],
+                         [[7, 9], [float('nan'), float('nan')], [11, 12]]],
+                'min': [[[1, 2], [5, 6], [float('inf'), float('inf')]],
+                        [[7, 9], [float('inf'), float('inf')], [10, 11]]],
+                'max': [[[3, 4], [5, 6], [-float('inf'), -float('inf')]],
+                        [[7, 9], [-float('inf'), -float('inf')], [12, 13]]],
+            },
+            {
+                'src': [[1, 3], [2, 4]],
+                'index': [[0, 0], [0, 0]],
+                'indptr': [[0, 2], [0, 2]],
+                'sum': [[4], [6]],
+                'prod': [[3], [8]],
+                'mean': [[2], [3]],
+                'min': [[1], [2]],
+                'max': [[3], [4]],
+            },
+            {
+                'src': [[[1, 1], [3, 3]], [[2, 2], [4, 4]]],
+                'index': [[0, 0], [0, 0]],
+                'indptr': [[0, 2], [0, 2]],
+                'sum': [[[4, 4]], [[6, 6]]],
+                'prod': [[[3, 3]], [[8, 8]]],
+                'mean': [[[2, 2]], [[3, 3]]],
+                'min': [[[1, 1]], [[2, 2]]],
+                'max': [[[3, 3]], [[4, 4]]],
+            },
+        ]
+        for test in tests:
+            data = torch.tensor(test['src'], dtype=val_dtype, device=device, requires_grad=True)
+            indptr = torch.tensor(test['indptr'], dtype=length_dtype, device=device)
+            dim = indptr.ndim - 1
+            # calculate lengths from indptr
+            lengths = torch.diff(indptr, dim=dim)
+            expected = torch.tensor(test[reduce], dtype=val_dtype, device=device)
+
+            actual_result = torch.segment_reduce(
+                data=data,
+                reduce=reduce,
+                lengths=lengths,
+                axis=dim,
+                unsafe=True,
+            )
+
+            self.assertEqual(actual_result, expected)
+
+            if val_dtype == torch.float64:
+                def fn(x):
+                    initial = 1
+                    # supply initial values to prevent gradcheck from failing for 0 length segments
+                    # where nan/inf are reduction identities that produce nans when calculating the numerical jacobian
+                    if reduce == 'min':
+                        initial = 1000
+                    elif reduce == 'max':
+                        initial = -1000
+                    return torch.segment_reduce(x, reduce, lengths=lengths, axis=dim, unsafe=True, initial=initial)
+                self.assertTrue(gradcheck(fn, (data.clone().detach().requires_grad_(True))))
+
+    @dtypes(
+        *product(
+            (torch.half, torch.bfloat16, torch.float, torch.double),
+            (torch.int, torch.int64),
+        )
+    )
     def test_multi_d(self, device, dtypes):
         val_dtype, length_type = dtypes
         axis = 0
-        lengths = [0, 2]
-        data = np.arange(20).reshape(2, 2, 5).tolist()
+        lengths = [0, 2, 3, 0]
+        data = np.arange(50).reshape(5, 2, 5).tolist()
         expected_grad = []
 
         # TODO: calculate grad and check correctness
@@ -267,23 +420,39 @@ class TestSegmentReductions(TestCase):
             if reduction == "max":
                 expected_result = [
                     np.full((2, 5), initial_value).tolist(),
-                    np.max(data, axis=0).tolist(),
+                    np.max(data[:2], axis=0).tolist(),
+                    np.max(data[2:], axis=0).tolist(),
+                    np.full((2, 5), initial_value).tolist(),
                 ]
             elif reduction == "mean":
                 expected_result = [
                     np.full((2, 5), initial_value).tolist(),
-                    np.mean(data, axis=0).tolist(),
+                    np.mean(data[:2], axis=0).tolist(),
+                    np.mean(data[2:], axis=0).tolist(),
+                    np.full((2, 5), initial_value).tolist(),
                 ]
             elif reduction == "min":
                 initial_value = 1000  # some high number
                 expected_result = [
                     np.full((2, 5), initial_value).tolist(),
-                    np.min(data, axis=0).tolist(),
+                    np.min(data[:2], axis=0).tolist(),
+                    np.min(data[2:], axis=0).tolist(),
+                    np.full((2, 5), initial_value).tolist(),
                 ]
             elif reduction == "sum":
                 expected_result = [
                     np.full((2, 5), initial_value).tolist(),
-                    np.sum(data, axis=0).tolist(),
+                    np.sum(data[:2], axis=0).tolist(),
+                    np.sum(data[2:], axis=0).tolist(),
+                    np.full((2, 5), initial_value).tolist(),
+                ]
+            elif reduction == "prod":
+                initial_value = 1
+                expected_result = [
+                    np.full((2, 5), initial_value).tolist(),
+                    np.prod(data[:2], axis=0).tolist(),
+                    np.prod(data[2:], axis=0).tolist(),
+                    np.full((2, 5), initial_value).tolist(),
                 ]
             for unsafe in [True, False]:
                 self._test_common(

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2657,7 +2657,7 @@
   output_differentiability: [False]
 
 - name: segment_reduce(Tensor data, str reduce, *, Tensor? lengths=None, Tensor? indices=None, int axis=0, bool unsafe=False, Scalar? initial=None) -> Tensor
-  data: _segment_reduce_backward(grad, result, data, reduce, lengths)
+  data: _segment_reduce_backward(grad, result, data, reduce, lengths, axis, initial)
 
 - name: _pin_memory(Tensor self, Device? device=None) -> Tensor
   self: grad

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7600,6 +7600,30 @@ def sample_inputs_scatter_reduce(op_info, device, dtype, requires_grad, **kwargs
 
     return sample_inputs
 
+def sample_inputs_segment_reduce(op_info, device, dtype, requires_grad, **kwargs):
+    def _tensor(shape, dtype=dtype, low=None, high=None):
+        return make_tensor(shape, dtype=dtype, device=device, low=low, high=high, requires_grad=requires_grad)
+
+    zero = torch.tensor(0, dtype=torch.long, device=device)
+    test_cases = (
+        # inp_shape, dim, lengths, unsafe
+        ((S,), 0, [0, 1, 2, 2], False),
+        ((S,), 0, [0, 1, 2, 2], True),
+        ((S,), 0, [2, 0, 3, 0], False),
+        ((S, S), 0, [0, 1, 2, 2], False),
+        # test when lengths do not sum to dim size
+        ((M, S, S), 0, [1, 2, 0, 6, 0], True),
+    )
+
+    reductions = ["max", "mean", "min", "sum", "prod"]
+    for args, reduce, initial in product(test_cases, reductions, [1, 2]):
+        inp_shape, dim, lengths, unsafe = args
+        lengths_t = torch.tensor(lengths, dtype=torch.long, device=device)
+        yield SampleInput(_tensor(inp_shape),
+                          args=(reduce,),
+                          kwargs={'lengths': lengths_t, 'axis': dim, 'unsafe': unsafe, 'initial': initial})
+
+
 def sample_inputs_ravel(op_info, device, dtype, requires_grad, **kwargs):
     samples = (SampleInput(make_tensor((S, S, S), dtype=dtype, device=device,
                                        low=None, high=None,
@@ -17545,6 +17569,23 @@ op_db: List[OpInfo] = [
         dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
         dtypesIfCUDA=floating_types_and(torch.float16, torch.bfloat16),
         sample_inputs_func=sample_inputs_scatter_reduce,
+    ),
+    OpInfo(
+        'segment_reduce',
+        dtypes=floating_types_and(torch.float16, torch.bfloat16),
+        supports_out=False,
+        # RuntimeError: derivative for aten::_segment_reduce_backward is not implemented
+        supports_gradgrad=False,
+        sample_inputs_func=sample_inputs_segment_reduce,
+        skips=(
+            # FIXME: CUDA driver API confirmed a leak in __main__.TestJitCUDA.test_variant_consistency_jit_segment_reduce_cuda_float32
+            DecorateInfo(
+                unittest.skip("Skipped!"),
+                "TestJit",
+                "test_variant_consistency_jit",
+                device_type="cuda",
+            ),
+        ),
     ),
 ]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77057

