### PR TITLE
[checkpoint] Synchronize error handling across all ranks

### DIFF
--- a/test/distributed/_shard/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/_shard/checkpoint/test_file_system_checkpoint.py
@@ -188,7 +188,7 @@ class TestDistributedStateDictSaveLoad(TestCase):
             state_dict_to_save = MyTestModule().state_dict()
 
             fs_writer = FileSystemWriter(path=path)
-            save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer)
+            save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer, no_dist=True)
 
             state_dict_to_load_to = MyTestModule().state_dict()
 
@@ -197,7 +197,7 @@ class TestDistributedStateDictSaveLoad(TestCase):
 
             # Load from file without any resharding
             fs_reader = FileSystemReader(path=path)
-            load_state_dict(state_dict=state_dict_to_load_to, storage_reader=fs_reader)
+            load_state_dict(state_dict=state_dict_to_load_to, storage_reader=fs_reader, no_dist=True)
 
             assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
 

--- a/torch/distributed/_shard/checkpoint/__init__.py
+++ b/torch/distributed/_shard/checkpoint/__init__.py
@@ -12,3 +12,4 @@ from .state_dict_loader import load_state_dict
 from .state_dict_saver import save_state_dict
 from .storage import StorageReader, StorageWriter
 from .filesystem import FileSystemReader, FileSystemWriter
+from .api import CheckpointException

--- a/torch/distributed/_shard/checkpoint/api.py
+++ b/torch/distributed/_shard/checkpoint/api.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+class CheckpointException(BaseException):
+    """
+    Exception raised if failure was detected as part of a checkpoint load or save.
+    """
+    def __init__(self, msg: str, failures: Dict[int, BaseException]):
+        super().__init__(msg, failures)
+        self._failures = failures
+
+    @property
+    def failures(self) -> Dict[int, BaseException]:
+        """
+        Returns:
+            Dict of failed nodes and their associated exception.
+              Keys are node ranks and values are exceptions
+        """
+        return self._failures

--- a/torch/distributed/_shard/checkpoint/state_dict_loader.py
+++ b/torch/distributed/_shard/checkpoint/state_dict_loader.py
@@ -116,7 +116,7 @@ def load_state_dict(
 
     This function can be used for local inference and load a checkpoint
     produced by ``save_state_dict`` without having a process group initialized
-    by passing `no_dist=True` and by using Tensors instead of ShardedTensors.
+    by passing ``no_dist=True`` and by using Tensors instead of ShardedTensors.
 
     Args:
         state_dict (Dict[str, Any]) : The state_dict to load. Note that this
@@ -124,7 +124,7 @@ def load_state_dict(
         storage_reader (StorageReader): StorageReader used to load data from.
         process_group (ProcessGroup): ProcessGroup to be used for cross-rank synchronization
         coordinator_rank (int): Rank to use to coordinate the checkpoint, rank0 is used by default
-        no_dist (bool): Don't attempt to load in SPMD style. Default to false
+        no_dist (bool): Don't attempt to load in SPMD style. Default to False
 
     Returns:
         None.
@@ -179,7 +179,6 @@ def load_state_dict(
 
     global_result: Optional[CheckpointException] = None
     if not no_dist:
-        # FIXME we could do an all_to_all_object if once existed
         all_errors = [None] * dist.get_world_size(process_group)
 
         dist.all_gather_object(

--- a/torch/distributed/_shard/checkpoint/state_dict_saver.py
+++ b/torch/distributed/_shard/checkpoint/state_dict_saver.py
@@ -111,7 +111,7 @@ def save_state_dict(
     call `save_state_dict` and that all data in state_dict belong to it.
 
     This function can be used to save a state_dict with an intialized process
-    group by passing `no_dist=True`. This can be used to produce a checkpoint
+    group by passing ``no_dist=True``. This can be used to produce a checkpoint
     that can consumed by load_state_dict is a SPMD fashion.
 
     Args:
@@ -119,7 +119,7 @@ def save_state_dict(
         storage_writer (StorageWriter): Instance of StorageWrite use to perform writes.
         process_group (ProcessGroup): ProcessGroup to be used for cross-rank synchronization
         coordinator_rank (int): Rank to use to coordinate the checkpoint, rank0 is used by default
-        no_dist (bool): Don't attempt to save in SPMD style. Default to false
+        no_dist (bool): Don't attempt to save in SPMD style. Default to False
 
     Example:
         >>> my_model = MyModule()

--- a/torch/distributed/_shard/checkpoint/storage.py
+++ b/torch/distributed/_shard/checkpoint/storage.py
@@ -1,5 +1,5 @@
 import abc
-from typing import List, Union, Dict
+from typing import List, Union
 
 from torch.futures import Future
 
@@ -22,12 +22,13 @@ class StorageWriter(abc.ABC):
     3) write_bytes
     4) write_tensors.
     5) Wait for (2) and (3) futures. If either fail, abort checkpoint.
-    6) (called once globally) write_metadata().
-    7) (called once globally) finish().
+    6) (called once globally) finish().
 
     There's a single process that executes methods that are called once globally.
-
     The writes from (3) and (4) are initiated before any waiting is done.
+    The last call to finish() has the semantics of commiting the checkpoint.
+
+
     """
     @abc.abstractmethod
     def prepare(self) -> None:
@@ -78,12 +79,12 @@ class StorageWriter(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def write_metadata(self, metadata: Metadata) -> None:
+    def finish(self, metadata: Metadata) -> None:
         """
-        Write the global metadata and commit the checkpoint.
+        Writes the metadata and marks the current checkpoint as sucessfull.
 
         This method is called once globally after all data was writen
-        and is used to commit the checkpoint.
+        and is used to write its metadata and commit the checkpoint.
 
         The `metadata` object includes a global view of the checkpoint
         and, while writing it is optional, it must be recoverable by the
@@ -99,16 +100,6 @@ class StorageWriter(abc.ABC):
             None
         """
         pass
-
-    @abc.abstractmethod
-    def finish(self) -> None:
-        """
-        Mark the current checkpoint as sucessfully done.
-
-        This method is called once globally after metadata is writen.
-        """
-        pass
-
 
     def prepare_storage(self, storage_writes: List[Union[TensorWriteRequest, BytesWriteRequest]]) -> None:
         """
@@ -195,20 +186,3 @@ class StorageReader(abc.ABC):
 
         """
         pass
-
-class CheckpointException(BaseException):
-    """
-    Exception raised if failure was detected as part of a checkpoint load or save.
-    """
-    def __init__(self, msg: str, failures: Dict[int, BaseException]):
-        super().__init__(msg, failures)
-        self._failures = failures
-
-    @property
-    def failures(self) -> Dict[int, BaseException]:
-        """
-        Returns:
-            Dict of failed nodes and their associated exception.
-              Keys are node ranks and values are exceptions
-        """
-        return self._failures

--- a/torch/distributed/_shard/checkpoint/storage.py
+++ b/torch/distributed/_shard/checkpoint/storage.py
@@ -1,5 +1,5 @@
 import abc
-from typing import List, Union
+from typing import List, Union, Dict
 
 from torch.futures import Future
 
@@ -195,3 +195,20 @@ class StorageReader(abc.ABC):
 
         """
         pass
+
+class CheckpointException(BaseException):
+    """
+    Exception raised if failure was detected as part of a checkpoint load or save.
+    """
+    def __init__(self, msg: str, failures: Dict[int, BaseException]):
+        super().__init__(msg, failures)
+        self._failures = failures
+
+    @property
+    def failures(self) -> Dict[int, BaseException]:
+        """
+        Returns:
+            Dict of failed nodes and their associated exception.
+              Keys are node ranks and values are exceptions
+        """
+        return self._failures

--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -103,11 +103,11 @@ class ShardedTensor(object):
             Default: ``False``.
 
     .. note:: ShardedTensor uses collectives to do various operations, i.e. it
-        uses all_gather to do cross rank validations. For NCCL-based processed
+        uses all_gather to do cross rank validations. For NCCL-based process
         groups, internal tensor representations of objects must be moved to the
         GPU device before communication takes place. In this case, the device
         used is given by ``torch.cuda.current_device()`` and it is the user's
-        responsiblity to ensure that this is set so that each rank has an
+        responsibility to ensure that this is set so that each rank has an
         individual GPU, via ``torch.cuda.set_device()``
 
     """


### PR DESCRIPTION
Introduce error handling across all ranks when loading and saving checkpoints.

This makes it a lot simpler for users to handle failures and, as a positive side-effect, coordination of when it successfully finished.

This change requires 3 collectives when saving and 1 when loading.
All those collectives carry a small payload so they will be latency bound and write time should dominate it.

