### PR TITLE
TorchScript to support capability to rethrow the original python exception

### DIFF
--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -146,10 +146,34 @@ void initJITBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
   auto jit = m.def_submodule("_jit");
 
-  py::register_exception<JITException>(m, "JITException");
+  static py::exception<JITException> exc(m, "JITException");
+
+  py::register_exception_translator([](std::exception_ptr p) {
+    try {
+      if (p) {
+        std::rethrow_exception(p);
+      }
+    } catch (const JITException& e) {
+      // special handling of JITException, to set its python class name and msg
+      py::gil_scoped_acquire acquire;
+      const auto& className = e.getPythonClassName();
+      const auto& originalMsg = e.getOriginalMsg();
+      JITException::setCaughtOriginalMsg(originalMsg.value_or(""));
+      JITException::setCaughtPythonClassName(className.value_or(""));
+      exc(e.what());
+    }
+  });
+
+  m.def(
+      "_get_caught_jit_exception_class_name",
+      JITException::getCaughtPythonClassName);
+  m.def(
+      "_get_caught_jit_exception_original_msg",
+      JITException::getCaughtOriginalMsg);
 
   py::class_<python::IODescriptor> iodescriptor(
-      m, "IODescriptor"); // NOLINT(bugprone-unused-raii)
+      m,
+      "IODescriptor"); // NOLINT(bugprone-unused-raii)
 
   m.def("_jit_init", loadPythonClasses)
       .def(

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -828,7 +828,8 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
     if (future_) {
       future_->setError(std::make_exception_ptr(Future::FutureError(ss.str())));
     } else if (is_jit_exception) {
-      throw JITException(ss.str(), python_class_name);
+      // save the original exception's message when creating a new JITException
+      throw JITException(ss.str(), python_class_name, e.what());
     } else if (not_implemented_error) {
       throw c10::NotImplementedError(
           ss.str(),

--- a/torch/csrc/jit/runtime/jit_exception.cpp
+++ b/torch/csrc/jit/runtime/jit_exception.cpp
@@ -3,11 +3,30 @@
 namespace torch {
 namespace jit {
 
+static thread_local std::string caughtOriginalMsg = "";
+static thread_local std::string caughtPythonClassName = "";
+
 JITException::JITException(
     const std::string& msg,
-    c10::optional<std::string> python_class_name)
+    c10::optional<std::string> python_class_name,
+    c10::optional<std::string> original_msg)
     : std::runtime_error(msg),
-      python_class_name_(std::move(python_class_name)) {}
+      python_class_name_(std::move(python_class_name)),
+      original_msg_(std::move(original_msg)) {}
+
+  const std::string& JITException::getCaughtOriginalMsg() {
+    return caughtOriginalMsg;
+  }
+  const std::string& JITException::getCaughtPythonClassName() {
+    return caughtPythonClassName;
+  }
+  void JITException::setCaughtOriginalMsg(const std::string& msg) {
+    caughtOriginalMsg = msg;
+  }
+  void JITException::setCaughtPythonClassName(
+      const std::string& pythonClassName) {
+    caughtPythonClassName = pythonClassName;
+  }
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/jit_exception.h
+++ b/torch/csrc/jit/runtime/jit_exception.h
@@ -12,14 +12,28 @@ namespace jit {
 struct TORCH_API JITException : public std::runtime_error {
   explicit JITException(
       const std::string& msg,
-      c10::optional<std::string> python_class_name = c10::nullopt);
+      c10::optional<std::string> python_class_name = c10::nullopt,
+      c10::optional<std::string> original_msg = c10::nullopt);
 
   c10::optional<std::string> getPythonClassName() const {
     return python_class_name_;
   }
 
+  // the original msg if this is from a python exception. The interpretor has
+  // changed the original message by adding "The following operation failed in
+  // the TorchScript interpreter." in front of it in the handleError function.
+  c10::optional<std::string> getOriginalMsg() const {
+    return original_msg_;
+  }
+
+  static const std::string& getCaughtOriginalMsg();
+  static const std::string& getCaughtPythonClassName();
+  static void setCaughtOriginalMsg(const std::string& msg);
+  static void setCaughtPythonClassName(const std::string& pythonClassName);
+
  private:
   c10::optional<std::string> python_class_name_;
+  c10::optional<std::string> original_msg_;
 };
 
 } // namespace jit


### PR DESCRIPTION
Summary:
In order to categorize exceptions/errors, the observability /migration team faced a problem that currently the exception is shown as RuntimeError, and hard to categorize.

The solution to this problem is to be able to get the original python exception's class name and msg, and hopefully to recreate a python exception from that.
TO support this approach, we did the following in this diff:

(1) TorchScript to translate JITException so that it does not show as RuntimeError
(2) record python exception class name, original message during translation.

Then, later, the python exception can be reconstructed.

(3) Added a new decorator to reconstruct the python exception and then rethrow it.

Test Plan:
buck test //caffe2/torch/fb/translate_exception/tests:test_rethrow mode/dev-tsan
```
More details at https://www.internalfb.com/intern/buck/build/1180a788-3767-48e5-a64d-06d284b91a17
BUILD SUCCEEDED
Tpx test run coordinator for Facebook. See https://fburl.com/tpx for details.
Running with tpx session id: 24ae6c7c-a647-404e-8f12-d12c762bf728
Trace available for this run at /tmp/tpx-20220507-195320.698499-24ae6c7c-a647-404e-8f12-d12c762bf728/trace.log
RemoteExecution session id: reSessionID-24ae6c7c-a647-404e-8f12-d12c762bf728-tpx
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/8162774413147962
    ✓ ListingSuccess: caffe2/torch/fb/translate_exception/tests:test_rethrow : 3 tests discovered (27.233)
    ✓ Pass: caffe2/torch/fb/translate_exception/tests:test_rethrow - test_one_parameter (test_rethrow.TestTranslateRethrowPythonException) (28.467)
    ✓ Pass: caffe2/torch/fb/translate_exception/tests:test_rethrow - test_no_parameter (test_rethrow.TestTranslateRethrowPythonException) (28.495)
    ✓ Pass: caffe2/torch/fb/translate_exception/tests:test_rethrow - test_2_parameter_with_torch_script_only (test_rethrow.TestTranslateRethrowPythonException) (28.708)
Summary
  Pass: 3
  ListingSuccess: 1
If you need help understanding your runs, please follow the wiki: https://fburl.com/posting_in_tpx_users
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/8162774413147962

```

Differential Revision: D36166520

