### PR TITLE
torch/deploy,package: log usage for InterpreterManager, PackageExporter, PackageImporter

### DIFF
--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -94,6 +94,8 @@ InterpreterManager::InterpreterManager(
     size_t nInterp,
     std::shared_ptr<Environment> env)
     : resources_(nInterp) {
+  C10_LOG_API_USAGE_ONCE("torch.deploy.InterpreterManager");
+
   TORCH_DEPLOY_TRY
   for (const auto i : c10::irange(nInterp)) {
     instances_.emplace_back(this, env);

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -197,6 +197,8 @@ class PackageExporter:
             importer: If a single Importer is passed, use that to search for modules.
                 If a sequence of importers are passsed, an ``OrderedImporter`` will be constructed out of them.
         """
+        torch._C._log_api_usage_once("torch.package.PackageExporter")
+
         if isinstance(f, (Path, str)):
             f = str(f)
             self.buffer: Optional[BinaryIO] = None

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -45,6 +45,8 @@ class PackageImporter(Importer):
     """The dictionary of already loaded modules from this package, equivalent to ``sys.modules`` but
     local to this importer.
     """
+    torch._C._log_api_usage_once("torch.package.PackageImporter")
+
     modules: Dict[str, types.ModuleType]
 
     def __init__(


### PR DESCRIPTION
Summary: This adds logs for usage of deploy and package. These can be used to track where it's being used in production so we can support it better.

Test Plan: no functional changes - existing tests

Reviewed By: PaliC

Differential Revision: D36258876

