### PR TITLE
shard `linux-bionic-rocm5.1-py3.7 / test (default` from 2 to 3

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -201,8 +201,9 @@ jobs:
       docker-image: ${{ needs.linux-bionic-rocm5_1-py3_7-build.outputs.docker-image }}
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
-          { config: "default", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 1, num_shards: 3, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 2, num_shards: 3, runner: "linux.rocm.gpu" },
+          { config: "default", shard: 3, num_shards: 3, runner: "linux.rocm.gpu" },
         ]}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}


### PR DESCRIPTION
Notes
- surprisingly minimal overhead when the docker image doesn't need to be pulled (but when it does need to be pulled it adds a ton of time)
- seems like diminishing returns after 3
- tts on master is 3.6, 3.4 hr on master, 3.0, 3.0 hr on all branches
- pray queue time doesnt explode

sharding spreadsheet: https://docs.google.com/spreadsheets/d/1BdtVsjRr0Is9LXMNilR02FEdPXNq7zEWl8AmR3ArsLQ/edit#gid=1242752407