### PR TITLE
Make tracer be able to trace different forward functions

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -474,6 +474,40 @@ class TestFX(JitTestCase):
         x = torch.randn(5)
         torch.testing.assert_close(traced(x), f(x))
 
+    def test_trace_multiple_funcs(self):
+        class Foo(torch.nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+            def minus_forward(self, x, y):
+                return x - y
+
+            def multiply_forward(self, x, y):
+                return x * y
+
+        f = Foo()
+        x, y = torch.randn(5), torch.randn(5)
+
+        tracer = Tracer()
+        torch.testing.assert_close(GraphModule(f, tracer.trace(f))(x, y), f(x, y))
+
+        tracer.traced_func_name = "minus_forward"
+        torch.testing.assert_close(
+            GraphModule(f, tracer.trace(f))(x, y),
+            f.minus_forward(x, y),
+        )
+
+        tracer.traced_func_name = "multiply_forward"
+        torch.testing.assert_close(
+            GraphModule(f, tracer.trace(f))(x, y),
+            f.multiply_forward(x, y),
+        )
+
+        tracer.traced_func_name = "add_forward"
+        with self.assertRaisesRegex(AssertionError, "doesn't exist in"):
+            tracer.trace(f)
+
+
     def test_graph_unique_names(self):
         class M(torch.nn.Module):
             def forward(self, a, b):

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -523,7 +523,12 @@ class Tracer(TracerBase):
         """
         if isinstance(root, torch.nn.Module):
             self.root = root
-            fn = type(root).forward
+
+            assert hasattr(
+                type(root), self.traced_func_name
+            ), f"traced_func_name={self.traced_func_name} doesn't exist in {type(root).__name__}"
+
+            fn = getattr(type(root), self.traced_func_name)
             self.submodule_paths = {mod: name for name, mod in root.named_modules()}
         else:
             self.root = torch.nn.Module()

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -22,6 +22,10 @@ class TracerBase:
     # Feature flag for proxying accesses to buffer values
     proxy_buffer_attributes : bool = False
 
+    # Name of the function to be traced. It will only be used when
+    # ``root`` is an instance of ``nn.Module``
+    traced_func_name: str = "forward"
+
     @compatibility(is_backward_compatible=True)
     def create_node(self, kind : str, target : Target,
                     args : Tuple[Argument, ...], kwargs : Dict[str, Argument], name : Optional[str] = None,


### PR DESCRIPTION
Summary: The root module may have different forward functions. The current implementation assumes only the func `forward` can be traced. In this diff, we add an argument of forward func name to enable users trace different forward functions

Test Plan: N1903198

Differential Revision: D36157032

