### PR TITLE
[CUBLAS][TF32] Add environment variable to allow override of `allow_tf32_cublas`

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -4,6 +4,7 @@
 
 #include <c10/core/TensorOptions.h>
 #include <c10/core/CPUAllocator.h>
+#include <c10/util/env.h>
 
 #include <algorithm>
 #include <cctype>
@@ -140,7 +141,8 @@ void Context::setBenchmarkCuDNN(bool b) {
 }
 
 bool Context::allowTF32CuBLAS() const {
-  return float32_matmul_precision != at::Float32MatmulPrecision::HIGHEST;
+  static bool allow_tf32_cublas_override = c10::utils::check_env("TORCH_ALLOW_TF32_CUBLAS_OVERRIDE") == true;
+  return allow_tf32_cublas_override || float32_matmul_precision != at::Float32MatmulPrecision::HIGHEST;
 }
 
 void Context::setAllowTF32CuBLAS(bool b) {


### PR DESCRIPTION
update: the env var is `TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=1`, the originally committed git message below might be inaccurate 
---

#76509 changes the default behavior of matmuls to avoid using TF32. However, TF32 use cases still exist including CI/deployment environments that are often managed via environment variables. This PR just adds an environment variable check, currently called `TORCH_ALLOW_TF32_OVERRIDE` to support enabling TF32 via an environment variable rather than the C++/Python API.

CC @xwang233 @ptrblck @syed-ahmed @csarofeen @ngimel @mruberry 