### PR TITLE
Mark torch.utils.data.Dataset as iterable

### DIFF
--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -9,6 +9,7 @@ from typing import (
     Sequence,
     Tuple,
     TypeVar,
+    TYPE_CHECKING,
 )
 
 # No 'default_generator' in torch/__init__.pyi
@@ -52,6 +53,10 @@ class Dataset(Generic[T_co]):
 
     def __add__(self, other: 'Dataset[T_co]') -> 'ConcatDataset[T_co]':
         return ConcatDataset([self, other])
+
+    if TYPE_CHECKING:
+        # Convince type checkers that Dataset objects are iterable
+        def __iter__(self) -> Iterator[T_co]: ...
 
     # No `def __len__(self)` default?
     # See NOTE [ Lack of Default `__len__` in Python Abstract Base Classes ]

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -56,7 +56,8 @@ class Dataset(Generic[T_co]):
 
     if TYPE_CHECKING:
         # Convince type checkers that Dataset objects are iterable
-        def __iter__(self) -> Iterator[T_co]: ...
+        def __iter__(self) -> Iterator[T_co]:
+            ...
 
     # No `def __len__(self)` default?
     # See NOTE [ Lack of Default `__len__` in Python Abstract Base Classes ]


### PR DESCRIPTION
Python supports iterating over things in two ways. The familiar way is
call iter on an iterable and then call next on the resulting iterator,
until StopIteration. This was introduced in PEP 234, implemented in
Python 2.1

The other way iteration can work is if Python sees a `__getitem__`,
it'll throw integers at it until IndexError is raised. This is sometimes
referred to as "old-style" iteration.

The problem with this is that type checkers typically don't recognise
old-style iteration (this applies to at least pyright and mypy). The
code here helps type checkers out, at little cost.

Alternatively, it looks like it may make sense for
torch.utils.data.Dataset to inherit from collections.abc.Sequence? But
the comments suggest this might not be feasible, since e.g. we don't
want to implement `__len__`

For some recent discussion, see https://github.com/python/typeshed/issues/7813
(I help maintain mypy and typeshed)