### PR TITLE
Disable ios 12.5.1 job as its logs don't reveal why it's failing

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -150,6 +150,7 @@ jobs:
         ]}
 
   ios-12-5-1-x86-64:
+    if: ${{ false }}
     name: ios-12-5-1-x86-64
     uses: ./.github/workflows/_ios-build-test.yml
     with:


### PR DESCRIPTION
After the recent reverts (https://hud.pytorch.org/minihud?name_filter=trunk%20/%20ios-12-5-1-x86-64%20/%20build#2c5bf12584a8ec359cbce34fac73fb2bc3cd0af0), the iOS build is now failing. https://hud.pytorch.org/minihud?name_filter=trunk%20/%20ios-12-5-1-x86-64%20/%20build

However, the logs are unhelpful about how to debug this failure and is inactionable as far as I can tell. Thus, I think the best path forward is to disable this build until an expert can let us know what's wrong and how we can surface the error better next time.
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/31798555/167633477-7966dbad-20df-4649-92e9-4f44af77025c.png">
