### PR TITLE
Use cuda instead of cudatoolkit for cuda 11.6

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -53,9 +53,9 @@ if [[ "\$python_nodot" = *39*  ]]; then
   NUMPY_PIN=">=1.20"
 fi
 
-if [[ "$DESIRED_CUDA" == "cu116" ]]; then
-  EXTRA_CONDA_FLAGS="-c=conda-forge"
-fi
+#if [[ "$DESIRED_CUDA" == "cu116" ]]; then
+#  EXTRA_CONDA_FLAGS="-c=conda-forge"
+#fi
 
 # Move debug wheels out of the the package dir so they don't get installed
 mkdir -p /tmp/debug_final_pkgs
@@ -94,7 +94,7 @@ if [[ "$PACKAGE_TYPE" == conda ]]; then
       else
         cu_ver="${DESIRED_CUDA:2:2}.${DESIRED_CUDA:4}"
       fi
-      retry conda install \${EXTRA_CONDA_FLAGS} -yq -c nvidia -c pytorch "cudatoolkit=\${cu_ver}"
+      retry conda install \${EXTRA_CONDA_FLAGS} -yq -c nvidia -c pytorch "cuda=\${cu_ver}"
     fi
     conda install \${EXTRA_CONDA_FLAGS} -y "\$pkg" --offline
   )

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -88,7 +88,7 @@ if [[ "$PACKAGE_TYPE" == conda ]]; then
     else
 
       cu_ver="${DESIRED_CUDA:2:2}.${DESIRED_CUDA:4}"
-      CUDA_PACKAGE = "cudatoolkit"
+      CUDA_PACKAGE="cudatoolkit"
       if [[ "$DESIRED_CUDA" == "cu116" ]]; then
         CUDA_PACKAGE="cuda"
       fi

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -53,9 +53,7 @@ if [[ "\$python_nodot" = *39*  ]]; then
   NUMPY_PIN=">=1.20"
 fi
 
-#if [[ "$DESIRED_CUDA" == "cu116" ]]; then
-#  EXTRA_CONDA_FLAGS="-c=conda-forge"
-#fi
+
 
 # Move debug wheels out of the the package dir so they don't get installed
 mkdir -p /tmp/debug_final_pkgs
@@ -88,13 +86,14 @@ if [[ "$PACKAGE_TYPE" == conda ]]; then
     if [[ "$DESIRED_CUDA" == 'cpu' ]]; then
       retry conda install -c pytorch -y cpuonly
     else
-      # DESIRED_CUDA is in format cu90 or cu102
-      if [[ "${#DESIRED_CUDA}" == 4 ]]; then
-        cu_ver="${DESIRED_CUDA:2:1}.${DESIRED_CUDA:3}"
-      else
-        cu_ver="${DESIRED_CUDA:2:2}.${DESIRED_CUDA:4}"
+
+      cu_ver="${DESIRED_CUDA:2:2}.${DESIRED_CUDA:4}"
+      CUDA_PACKAGE = "cudatoolkit"
+      if [[ "$DESIRED_CUDA" == "cu116" ]]; then
+        CUDA_PACKAGE="cuda"
       fi
-      retry conda install \${EXTRA_CONDA_FLAGS} -yq -c nvidia -c pytorch "cuda=\${cu_ver}"
+
+      retry conda install \${EXTRA_CONDA_FLAGS} -yq -c nvidia -c pytorch "\${CUDA_PACKAGE}=\${cu_ver}"
     fi
     conda install \${EXTRA_CONDA_FLAGS} -y "\$pkg" --offline
   )


### PR DESCRIPTION
Remove cudatoolkit dependency and as a resuld remove conda-forge depencency

Please refer to following job for cuda 11.6 workflow:
https://pipelines.actions.githubusercontent.com/serviceHosts/7d146c05-69c3-4c20-a0e7-818111670117/_apis/pipelines/1/runs/1996311/signedlogcontent/624?urlExpires=2022-05-11T15%3A20%3A49.2066302Z&urlSigningMethod=HMACV1&urlSignature=%2FxavsXyw5%2F0DCx%2FTGXrsP2kIM15TUELebxUOxRnE7%2B8%3D

Test PR: https://github.com/pytorch/pytorch/pull/79706