### PR TITLE
[NVFuser] Add environment variable to force disable NVFuser

### DIFF
--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -99,7 +99,7 @@ class NVFuserEnabler {
       }
     });
     // 0. opportunity to force disable NVFuser
-    if (getCachedNNCNotNVFuser() {
+    if (getCachedNNCNotNVFuser()) {
       return false;
     }
     // 1. if user has explicitly assigned fuser value, that value takes

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -72,6 +72,24 @@ class NVFuserEnabler {
     return default_enabled;
   }
 
+  static bool getNNCNotNVFuser() {
+    static const char* env_c_str =
+        std::getenv("PYTORCH_JIT_USE_NNC_NOT_NVFUSER");
+    if (!env_c_str) {
+      return false;
+    }
+    std::string env(env_c_str);
+    if (env == "1" || env == "ON") {
+      return true;
+    }
+    return false;
+  }
+
+  static bool getCachedNNCNotNVFuser() {
+    static bool force_disable = getNNCNotNVFuser();
+    return force_disable;
+  }
+
   bool isEnabledImpl() {
     std::call_once(enabled_check_flag_, [&]() {
       // if environment variable is setting the value, we must
@@ -80,7 +98,10 @@ class NVFuserEnabler {
         assertFuserCanBeEnabled(*getCachedFuserEnabledEnvVar());
       }
     });
-
+    // 0. opportunity to force disable NVFuser
+    if (getCachedNNCNotNVFuser() {
+      return false;
+    }
     // 1. if user has explicitly assigned fuser value, that value takes
     // precedence.
     if (runtime_assigned_fuser_enabled_.has_value()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77168

PYTORCH_JIT_USE_NNC_NOT_NVFUSER=1 will force NVFuser to be disabled,
regardless of other environment variables or values set at runtime. It
will be used for guarding certain parts of the internal rollout.

Demo: use fuser.py:
```
import torch

def f(x, y):
    return torch.relu(torch.add(x, y))

s = torch.jit.script(f)
x = torch.rand((4, 4), dtype=torch.float).cuda()
y = torch.rand((4, 4), dtype=torch.float).cuda()

with torch.jit.fuser("fuser2"):
    s(x, y)
    s(x, y)
```

Run the following:
```
$ PYTORCH_JIT_LOG_LEVEL=">>graph_fuser" python fuser.py
... logs show NVFuser is being used ...
$ PYTORCH_JIT_USE_NNC_NOT_NVFUSER=1 PYTORCH_JIT_LOG_LEVEL=">>graph_fuser" python fuser.py
... no logs
```

Differential Revision: [D36302592](https://our.internmc.facebook.com/intern/diff/D36302592)