### PR TITLE
[pytorch/tensorexpr] Update use of LLJIT::lookup for LLVM 15

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -171,7 +171,16 @@ class TORCH_API PytorchLLVMJITImpl {
   }
 
   JITSymbol findSymbol(const std::string Name) {
+#if LLVM_VERSION_MAJOR >= 15
+    // Starting with llvm-15, LLJIT::lookup returns an address rather than a
+    // symbol. Even though an address is what we ultimately we want, we also
+    // want to avoid churning our internal APIs, so we wrap the returned address
+    // in a fake JITSymbol.
+    auto result = assertSuccess(LLJ->lookup(Name));
+    return JITSymbol(result.getValue(), JITSymbolFlags());
+#else
     return assertSuccess(LLJ->lookup(Name));
+#endif
   }
 
   bool hasSymbol(const std::string& Name) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #77169

`lookup` will return an address, rather than a symbol, in LLVM 15.
For consistency with the old APIs we can just wrap the address in a fake symbol
and return that, since we only care about the address anyways.

Differential Revision: [D36282406](https://our.internmc.facebook.com/intern/diff/D36282406/)