### PR TITLE
Add reshaping for distributions.

### DIFF
--- a/torch/distributions/bernoulli.py
+++ b/torch/distributions/bernoulli.py
@@ -3,7 +3,7 @@ from numbers import Number
 import torch
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
-from torch.distributions.utils import broadcast_all, probs_to_logits, logits_to_probs, lazy_property
+from torch.distributions.utils import broadcast_all, probs_to_logits, logits_to_probs, lazy_property, first_attribute
 from torch.nn.functional import binary_cross_entropy_with_logits
 
 
@@ -62,6 +62,10 @@ class Bernoulli(ExponentialFamily):
 
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
+
+    @property
+    def _reshape_args(self):
+        yield first_attribute(self, 'probs', 'logits')
 
     @property
     def mean(self):

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -1,7 +1,7 @@
 import torch
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all, probs_to_logits, lazy_property, logits_to_probs
+from torch.distributions.utils import broadcast_all, probs_to_logits, lazy_property, logits_to_probs, first_attribute
 
 
 def _clamp_by_zero(x):
@@ -49,6 +49,11 @@ class Binomial(Distribution):
         self._param = self.probs if probs is not None else self.logits
         batch_shape = self._param.size()
         super(Binomial, self).__init__(batch_shape, validate_args=validate_args)
+
+    @property
+    def _reshape_args(self):
+        yield 'total_count'
+        yield first_attribute(self, 'probs', 'logits')
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Binomial, _instance)

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -2,7 +2,7 @@ import torch
 from torch._six import nan
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import probs_to_logits, logits_to_probs, lazy_property
+from torch.distributions.utils import probs_to_logits, logits_to_probs, lazy_property, first_attribute
 
 
 class Categorical(Distribution):
@@ -62,6 +62,10 @@ class Categorical(Distribution):
         self._num_events = self._param.size()[-1]
         batch_shape = self._param.size()[:-1] if self._param.ndimension() > 1 else torch.Size()
         super(Categorical, self).__init__(batch_shape, validate_args=validate_args)
+
+    @property
+    def _reshape_args(self):
+        yield first_attribute(self, 'logits', 'probs')
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Categorical, _instance)

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -4,7 +4,8 @@ import math
 import torch
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
-from torch.distributions.utils import broadcast_all, probs_to_logits, logits_to_probs, lazy_property, clamp_probs
+from torch.distributions.utils import broadcast_all, probs_to_logits, logits_to_probs, lazy_property, clamp_probs, \
+    first_attribute
 from torch.nn.functional import binary_cross_entropy_with_logits
 
 
@@ -61,6 +62,10 @@ class ContinuousBernoulli(ExponentialFamily):
             batch_shape = self._param.size()
         self._lims = lims
         super(ContinuousBernoulli, self).__init__(batch_shape, validate_args=validate_args)
+
+    @property
+    def _reshape_args(self):
+        yield first_attribute(self, 'logits', 'probs')
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(ContinuousBernoulli, _instance)

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -3,7 +3,7 @@ from numbers import Number
 import torch
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all, probs_to_logits, logits_to_probs, lazy_property
+from torch.distributions.utils import broadcast_all, probs_to_logits, logits_to_probs, lazy_property, first_attribute
 from torch.nn.functional import binary_cross_entropy_with_logits
 
 
@@ -55,6 +55,10 @@ class Geometric(Distribution):
                     f"of distribution {repr(self)} "
                     f"to be positive but found invalid values:\n{invalid_value}"
                 )
+
+    @property
+    def _reshape_args(self):
+        yield first_attribute(self, 'logits', 'probs')
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Geometric, _instance)

--- a/torch/distributions/lkj_cholesky.py
+++ b/torch/distributions/lkj_cholesky.py
@@ -68,6 +68,11 @@ class LKJCholesky(Distribution):
         self._beta = Beta(beta_conc1, beta_conc0)
         super(LKJCholesky, self).__init__(batch_shape, event_shape, validate_args)
 
+    @property
+    def _reshape_args(self):
+        yield 'dim', False
+        yield 'concentration'
+
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(LKJCholesky, _instance)
         batch_shape = torch.Size(batch_shape)

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -48,6 +48,11 @@ class Multinomial(Distribution):
     total_count: int
 
     @property
+    def _reshape_args(self):
+        yield 'total_count', False
+        yield from self._categorical._reshape_args
+
+    @property
     def mean(self):
         return self.probs * self.total_count
 

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -3,7 +3,7 @@ import math
 import torch
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import _standard_normal, lazy_property
+from torch.distributions.utils import _standard_normal, lazy_property, first_attribute
 
 
 def _batch_mv(bmat, bvec):
@@ -151,6 +151,11 @@ class MultivariateNormal(Distribution):
             self._unbroadcasted_scale_tril = torch.linalg.cholesky(covariance_matrix)
         else:  # precision_matrix is not None
             self._unbroadcasted_scale_tril = _precision_to_scale_tril(precision_matrix)
+
+    @property
+    def _reshape_args(self):
+        yield 'loc'
+        yield first_attribute(self, 'covariance_matrix', 'precision_matrix', 'scale_tril')
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(MultivariateNormal, _instance)

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.utils import broadcast_all, probs_to_logits, lazy_property, logits_to_probs
+from torch.distributions.utils import broadcast_all, probs_to_logits, lazy_property, logits_to_probs, first_attribute
 
 
 class NegativeBinomial(Distribution):
@@ -37,6 +37,11 @@ class NegativeBinomial(Distribution):
         self._param = self.probs if probs is not None else self.logits
         batch_shape = self._param.size()
         super(NegativeBinomial, self).__init__(batch_shape, validate_args=validate_args)
+
+    @property
+    def _reshape_args(self):
+        yield 'total_count'
+        yield first_attribute(self, 'probs', 'logits')
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(NegativeBinomial, _instance)

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -55,6 +55,10 @@ class OneHotCategorical(Distribution):
         return self._categorical._new(*args, **kwargs)
 
     @property
+    def _reshape_args(self):
+        yield from self._categorical._reshape_args
+
+    @property
     def _param(self):
         return self._categorical._param
 

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -54,6 +54,11 @@ class ExpRelaxedCategorical(Distribution):
         return self._categorical._new(*args, **kwargs)
 
     @property
+    def _reshape_args(self):
+        yield 'temperature', False
+        yield from self._categorical._reshape_args
+
+    @property
     def param_shape(self):
         return self._categorical.param_shape
 
@@ -117,6 +122,10 @@ class RelaxedOneHotCategorical(TransformedDistribution):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(RelaxedOneHotCategorical, _instance)
         return super(RelaxedOneHotCategorical, self).expand(batch_shape, _instance=new)
+
+    @property
+    def _reshape_args(self):
+        yield from self.base_dist._reshape_args
 
     @property
     def temperature(self):

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -153,3 +153,13 @@ def vec_to_tril_matrix(vec, diag=0):
     tril_mask = arange < arange.view(-1, 1) + (diag + 1)
     mat[..., tril_mask] = vec
     return mat
+
+
+def first_attribute(instance, *attrs):
+    """
+    Return the first attribute that exists or raise a ValueError if none of the attributes exist.
+    """
+    for attr in attrs:
+        if attr in instance.__dict__:
+            return attr
+    raise ValueError(f"{instance} has none of the attributes {', '.join(attrs)}")

--- a/torch/distributions/wishart.py
+++ b/torch/distributions/wishart.py
@@ -6,7 +6,7 @@ from typing import Union
 import torch
 from torch.distributions import constraints
 from torch.distributions.exp_family import ExponentialFamily
-from torch.distributions.utils import lazy_property
+from torch.distributions.utils import lazy_property, first_attribute
 from torch.distributions.multivariate_normal import _precision_to_scale_tril
 
 
@@ -120,6 +120,11 @@ class Wishart(ExponentialFamily):
                 ).expand(batch_shape + (-1,))
             )
         )
+
+    @property
+    def _reshape_args(self):
+        yield 'df'
+        yield first_attribute(self, 'covariance_matrix', 'precision_matrix', 'scale_tril')
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Wishart, _instance)


### PR DESCRIPTION
In light of #76709, I've been experimenting with reshaping for distributions. There seems to be a generic-ish way of handling reshaping. It comprises two parts:

1. A property `_reshape_args` (questionable name) that yields the names of arguments that need to be reshaped. It defaults to `arg_constraints` such that distributions like `Beta`, `Normal`, `Gamma` (and others with unambiguous arguments) can be handled in a generic way. For distributions with ambiguous arguments (such as `Bernoulli` which takes `probs` or `logits`), we yield the name of whichever argument was used to create the class.
2. An implementation in the `Distribution` base class that fetches all arguments that need to be reshaped, reshapes them, and creates a new instance with `validate_args=False` to skip the validation step.

This PR is very much a draft and requires further discussion.