### PR TITLE
Add torch dispatch mode to ProxyTensor tracing

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -714,8 +714,20 @@ class TestFXExperimental(JitTestCase):
         def f(x):
             return x + torch.randn(x.shape)
 
-        traced = make_fx(f)(torch.randn(3))
+        traced = make_fx(f, trace_factory_functions=True)(torch.randn(3))
         self.assertTrue(
+            any(
+                isinstance(node.target, torch._ops.OpOverloadPacket) and node.target._qualified_op_name == 'aten::randn'
+                for node in traced.graph.nodes
+            )
+        )
+
+    def test_mode_tracing_factory_function_default_behavior(self):
+        def f(x):
+            return x + torch.randn(x.shape)
+
+        traced = make_fx(f)(torch.randn(3))  # default behavior should not trace factory functions
+        self.assertFalse(
             any(
                 isinstance(node.target, torch._ops.OpOverloadPacket) and node.target._qualified_op_name == 'aten::randn'
                 for node in traced.graph.nodes

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -710,6 +710,18 @@ class TestFXExperimental(JitTestCase):
         inp = torch.randn(3, requires_grad=True)
         torch.testing.assert_close(traced_graph(inp), f(inp))
 
+    def test_mode_tracing_factory_function(self):
+        def f(x):
+            return x + torch.randn(x.shape)
+
+        traced = make_fx(f)(torch.randn(3))
+        self.assertTrue(
+            any(
+                isinstance(node.target, torch._ops.OpOverloadPacket) and node.target._qualified_op_name == 'aten::randn'
+                for node in traced.graph.nodes
+            )
+        )
+
     def test_call_to_assert_with_msg(self):
         class M(torch.nn.Module):
             def forward(self, a, b):

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -15,7 +15,6 @@ from contextlib import contextmanager
 
 from torch.utils._python_dispatch import push_torch_dispatch_mode, TorchDispatchMode
 
-
 __all__ = ["ProxyTensor", "PythonKeyTracer", "dispatch_trace", "make_fx"]
 aten = torch.ops.aten
 
@@ -121,7 +120,7 @@ class PythonKeyTracer(Tracer):
     # this tracer might want to override this in order to turn a couple specific
     # modules into leaves in the traced graph.
     def call_module(
-        self, m: torch.nn.Module, forward: Callable[..., Any], args: Tuple[Any, ...], kwargs: Dict[str, Any]
+            self, m: torch.nn.Module, forward: Callable[..., Any], args: Tuple[Any, ...], kwargs: Dict[str, Any]
     ) -> Any:
         return forward(*args, **kwargs)
 
@@ -150,7 +149,7 @@ class PythonKeyTracer(Tracer):
 
 
 def dispatch_trace(
-    root: Union[torch.nn.Module, Callable], concrete_args: Optional[Tuple[Any, ...]] = None
+        root: Union[torch.nn.Module, Callable], concrete_args: Optional[Tuple[Any, ...]] = None
 ) -> GraphModule:
     tracer = PythonKeyTracer()
     graph = tracer.trace(root, concrete_args)
@@ -164,7 +163,7 @@ def wrap_key(f, inps):
     @functools.wraps(f)
     def wrapped(*args):
         flat_args, args_spec = pytree.tree_flatten(args)
-        assert(len(flat_args) == len(flat_inps))
+        assert (len(flat_args) == len(flat_inps))
         for idx, arg in enumerate(flat_args):
             if isinstance(flat_inps[idx], torch.Tensor):
                 with no_dispatch():
@@ -193,7 +192,7 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
             return func(*args, **kwargs)  # mode is disabled, this redispatches to ProxyTensor's torch dispatch
         else:
             proxy_out = self.tracer.create_proxy('call_function', func, args, kwargs,
-                                     name=self.tracer.graph._target_to_str(func.__name__))
+                                                 name=self.tracer.graph._target_to_str(func.__name__))
 
             with no_dispatch():
                 real_out = func_overload(*args, **kwargs)


### PR DESCRIPTION
Uses a mode for ProxyTensor tracing so that it traces factory functions as well

cc @dhruvbird