### PR TITLE
[shard] add more tensor creation ops

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -617,7 +617,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_with_rand(self):
-        """ Test sharded_tensor.rand(...) """
+        """ Test sharded_tensor.rand(...)/randn(...) """
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -635,6 +635,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         expected_device = torch.device(f"cuda:{self.rank}")
         dtype = torch.double
         torch.manual_seed(seed)
+        # Test sharded_tensor.rand creation
         expected = torch.rand(expected_h, w, device=expected_device, dtype=dtype)
         # reset seed to ensure the same random numbers are generated
         torch.manual_seed(seed)
@@ -648,6 +649,20 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.assertEqual((expected_h, w), local_shard.size())
         self.assertEqual(expected, local_shard)
 
+        # Test sharded_tensor.randn creation
+        torch.manual_seed(seed)
+        expected_randn = torch.randn(expected_h, w, device=expected_device, dtype=dtype)
+        # reset seed to ensure the same random numbers are generated
+        torch.manual_seed(seed)
+        st_randn = sharded_tensor.randn(spec, h, w, dtype=dtype)
+
+        # Validate local shard is initialized with torch.randn
+        local_shards = st_randn.local_shards()
+        self.assertEqual(1, len(local_shards))
+        local_shard = local_shards[0].tensor
+        self.assertEqual(expected_device, local_shard.device)
+        self.assertEqual((expected_h, w), local_shard.size())
+        self.assertEqual(expected_randn, local_shard)
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -679,6 +694,52 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.assertEqual(local_shard,
                          torch.full(size=(expected_h, w), fill_value=fill_value, dtype=torch.int32))
 
+    @with_comms
+    @skip_if_lt_x_gpu(4)
+    @requires_nccl()
+    def test_create_sharded_tensor_like(self):
+        """ Test tensor like methods, i.e. torch.zeros_like(...), torch.full_like, etc. """
+
+        spec = ChunkShardingSpec(
+            dim=0,
+            placements=[
+                "rank:0/cuda:0",
+                "rank:1/cuda:1",
+                "rank:2/cuda:2",
+                "rank:3/cuda:3",
+            ],
+        )
+        h, w = 8, 8
+        expected_h = 2
+        seed = 1234
+        dtype = torch.double
+        expected_device = torch.device(f"cuda:{self.rank}")
+        st = sharded_tensor.rand(spec, (h, w), dtype=dtype)
+        tensor_like_ops = {
+            torch.zeros_like: torch.zeros,
+            torch.ones_like: torch.ones,
+            torch.rand_like: torch.rand,
+            torch.randn_like: torch.randn,
+            torch.empty_like: torch.empty,
+            torch.full_like: torch.full
+        }
+        for op, expect_local_op in tensor_like_ops.items():
+            if op == torch.full_like:
+                # special handle full/full_like as it needs to have additional fill_value arg
+                expect_tensor = expect_local_op((expected_h, w), 8.8, device=expected_device, dtype=dtype)
+                new_op_st = op(st, 8.8, dtype=dtype)
+                self.assertEqual(new_op_st.local_tensor(), expect_tensor)
+            elif op == torch.empty_like:
+                # empty/empty_like we only compare the shape
+                expect_tensor = expect_local_op(expected_h, w, device=expected_device, dtype=dtype)
+                new_op_st = op(st, dtype=dtype)
+                self.assertEqual(new_op_st.local_tensor().shape, expect_tensor.shape)
+            else:
+                torch.manual_seed(seed)
+                expect_tensor = expect_local_op(expected_h, w, device=expected_device, dtype=dtype)
+                torch.manual_seed(seed)
+                new_op_st = op(st, dtype=dtype)
+                self.assertEqual(new_op_st.local_tensor(), expect_tensor)
 
     @with_comms
     @skip_if_lt_x_gpu(4)

--- a/torch/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/distributed/_shard/sharded_tensor/__init__.py
@@ -174,7 +174,8 @@ def zeros(sharding_spec: shard_spec.ShardingSpec,
 
 def full(sharding_spec: shard_spec.ShardingSpec,
          size,
-         fill_value=torch.types.Number,
+         fill_value,
+         *,
          dtype=None,
          layout=torch.strided,
          requires_grad=False,
@@ -234,16 +235,15 @@ def rand(sharding_spec: shard_spec.ShardingSpec,
          process_group=None,
          init_rrefs=False) -> ShardedTensor:
     """
-    Creates a :class:`ShardedTensor` filled with fill_value. The tensor’s dtype
-        is inferred from fill_value. If dtype is specified, it will override the
-        inferred type from fill_value. Needs to be called on all ranks in an SPMD fashion.
+    Creates a :class:`ShardedTensor` filled with random numbers from a uniform distribution
+        on the interval :math:`[0, 1)`. The shape of the tensor is defined by the
+        variable argument `size`. Needs to be called on all ranks in an SPMD fashion.
 
     Args:
         sharding_spec (:class:`torch.distributed._shard.sharding_spec.ShardingSpec`): The specification
             describing how to shard the Tensor.
         size (int...):  a list, tuple, or `torch.Size` of integers defining the shape of the
             output tensor.
-        fill_value (Scalar) – the value to fill the output tensor with.
 
     Keyword args:
         dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
@@ -276,6 +276,60 @@ def rand(sharding_spec: shard_spec.ShardingSpec,
         init_rrefs=init_rrefs,
     )
     torch.nn.init.uniform_(sharded_tensor, 0, 1)  # type: ignore[arg-type]
+    return sharded_tensor
+
+def randn(sharding_spec: shard_spec.ShardingSpec,
+          *size,
+          dtype=None,
+          layout=torch.strided,
+          requires_grad=False,
+          pin_memory=False,
+          memory_format=torch.contiguous_format,
+          process_group=None,
+          init_rrefs=False) -> ShardedTensor:
+    """
+    Creates a :class:`ShardedTensor` filled with random numbers from a uniform distribution
+        with mean `0` and variance `1` (also called standard normal distribution). The shape
+        of the tensor is defined by the variable argument `size`. Needs to be called on all ranks
+        in an SPMD fashion.
+
+    Args:
+        sharding_spec (:class:`torch.distributed._shard.sharding_spec.ShardingSpec`): The specification
+            describing how to shard the Tensor.
+        size (int...):  a list, tuple, or `torch.Size` of integers defining the shape of the
+            output tensor.
+
+    Keyword args:
+        dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
+            Default: if ``None``, uses a global default (see :func:`torch.set_default_tensor_type`).
+        layout (:class:`torch.layout`, optional): the desired layout of returned Tensor.
+            Default: ``torch.strided``.
+        requires_grad (bool, optional): If autograd should record operations on the
+            returned tensor. Default: ``False``.
+        pin_memory (bool, optional): If set, returned tensor would be allocated in
+            the pinned memory. Works only for CPU tensors. Default: ``False``.
+        process_group (ProcessGroup, optional): The process group to work on. If None,
+            the default process group will be used.
+        init_rrefs (bool, optional): Whether or not to initialize
+            :class:`torch.distributed.rpc.RRef`s pointing to remote shards.
+            Need to initialize the RPC Framework if specified as ``True``.
+            Default: ``False``.
+
+    Returns:
+        A :class:`ShardedTensor` object on each rank
+    """
+    sharded_tensor = ShardedTensor(
+        sharding_spec,
+        *size,
+        dtype=dtype,
+        layout=layout,
+        requires_grad=requires_grad,
+        pin_memory=pin_memory,
+        memory_format=memory_format,
+        process_group=process_group,
+        init_rrefs=init_rrefs,
+    )
+    torch.nn.init.normal_(sharded_tensor, 0, 1)  # type: ignore[arg-type]
     return sharded_tensor
 
 def init_from_local_shards(

--- a/torch/distributed/_shard/sharded_tensor/_ops/init.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/init.py
@@ -1,4 +1,5 @@
 import torch
+import torch.distributed._shard.sharded_tensor as sharded_tensor
 from torch.distributed._shard.sharded_tensor import (
     sharded_op_impl,
 )
@@ -103,3 +104,40 @@ def constant_(types, args=(), kwargs=None, pg=None):
     for shard in sharded_tensor.local_shards():
         torch.nn.init.constant_(shard.tensor, val=val)
     return sharded_tensor
+
+tensor_like_creation_op_map = {
+    torch.full_like: sharded_tensor.full,
+    torch.empty_like: sharded_tensor.empty,
+    torch.zeros_like: sharded_tensor.zeros,
+    torch.ones_like: sharded_tensor.ones,
+    torch.rand_like: sharded_tensor.rand,
+    torch.randn_like: sharded_tensor.randn,
+}
+
+# tensor ops that behave the same as the default tensor
+def register_tensor_creation_op(op):
+    @sharded_op_impl(op)
+    def tensor_creation_op(types, args=(), kwargs=None, pg=None):
+        """
+        Handles ``__torch_function__`` dispatch for tensor creation ops that
+        takes a ShardedTensor as argument, such as ``torch.zeros_like`` or
+        ``torch.full_like``.
+        """
+        creation_op = tensor_like_creation_op_map.get(op, None)
+        if creation_op is None:
+            raise RuntimeError(f"Tensor creation {op} not supported!")
+        if kwargs is None:
+            kwargs = {}
+
+        st = args[0]
+
+        new_st = creation_op(st.sharding_spec(), st.size(), *args[1:], **kwargs)  # type: ignore[operator]
+        return new_st
+
+
+register_tensor_creation_op(torch.full_like)
+register_tensor_creation_op(torch.empty_like)
+register_tensor_creation_op(torch.zeros_like)
+register_tensor_creation_op(torch.ones_like)
+register_tensor_creation_op(torch.rand_like)
+register_tensor_creation_op(torch.randn_like)


### PR DESCRIPTION
Summary: This PR fix some existing tensor constructors (i.e. full), add sharded_tensor.randn, and add more tensor-like creation ops (i.e. full_like, rand_like, etc.)

Test Plan:
test_create_sharded_tensor_with_rand
test_create_sharded_tensor_like

Differential Revision: D36274148

