### PR TITLE
[FSDP] Do not check fwd order in eval mode

### DIFF
--- a/test/distributed/fsdp/test_fsdp_exec_order.py
+++ b/test/distributed/fsdp/test_fsdp_exec_order.py
@@ -183,7 +183,7 @@ class TestFSDPExecOrder(FSDPTest):
         warning_prefix = "Forward order differs"
         for warning in w:
             if str(warning.message).startswith(warning_prefix):
-                raise AssertionError("Warning was incorrectly issued")
+                raise AssertionError(f"Warning was incorrectly issued: {warning.message}")
         # If we still validate the forward execution order in eval mode, then
         # an `AssertionError` will be raised above for both sharding strategies
 

--- a/test/distributed/fsdp/test_fsdp_exec_order.py
+++ b/test/distributed/fsdp/test_fsdp_exec_order.py
@@ -1,6 +1,7 @@
 # Owner(s): ["oncall: distributed"]
 
 import sys
+import warnings
 from contextlib import suppress
 
 import torch
@@ -109,7 +110,7 @@ class TestFSDPExecOrder(FSDPTest):
             fsdp_model.flip_path()
         inp = fsdp_model.module.get_input(self.device)
         # Match the error message with the following prefix
-        error_regex = "^(All-gather order differs across ranks)"
+        error_regex = "^(Forward order differs across ranks)"
         with self.assertRaisesRegex(RuntimeError, error_regex):
             fsdp_model(*inp)
 
@@ -135,7 +136,7 @@ class TestFSDPExecOrder(FSDPTest):
             loss = fsdp_model.module.get_loss(inp, output).to(self.device)
             fsdp_model.module.run_backward(loss)
         # Match the warning message with the following prefix
-        regex = "^(All-gather order differs from that of the first iteration " \
+        regex = "^(Forward order differs from that of the first iteration " \
             f"on rank {self.rank} -- collectives are unchecked and may give " \
             "incorrect results or hang)"
         context = self.assertWarnsRegex(
@@ -154,6 +155,37 @@ class TestFSDPExecOrder(FSDPTest):
         output = fsdp_model(*inp)
         loss = fsdp_model.module.get_loss(inp, output).to(self.device)
         fsdp_model.module.run_backward(loss)
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize(
+        "sharding_strategy",
+        [ShardingStrategy.FULL_SHARD, ShardingStrategy.SHARD_GRAD_OP],
+    )
+    def test_train_eval(self, sharding_strategy: ShardingStrategy):
+        fsdp_model = Model.wrap(sharding_strategy, self.device)
+        NUM_ITERS = 3
+        NUM_EPOCHS = 2
+        with warnings.catch_warnings(record=True) as w:  # records warnings to `w`
+            for _ in range(NUM_EPOCHS):
+                fsdp_model.train()
+                for _ in range(NUM_ITERS):
+                    inp = fsdp_model.module.get_input(self.device)
+                    output = fsdp_model(*inp)
+                    loss = fsdp_model.module.get_loss(inp, output).to(self.device)
+                    fsdp_model.module.run_backward(loss)
+                fsdp_model.eval()
+                for _ in range(NUM_ITERS):
+                    inp = fsdp_model.module.get_input(self.device)
+                    output = fsdp_model(*inp)
+                    fsdp_model.module.get_loss(inp, output).to(self.device)
+        # Check that the order validation warning was not issued (errors do not
+        # need to be checked since they will be directly reported)
+        warning_prefix = "Forward order differs"
+        for warning in w:
+            if str(warning.message).startswith(warning_prefix):
+                raise AssertionError("Warning was incorrectly issued")
+        # If we still validate the forward execution order in eval mode, then
+        # an `AssertionError` will be raised above for both sharding strategies
 
 
 instantiate_parametrized_tests(TestFSDPExecOrder)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -321,9 +321,9 @@ class _ExecOrderData():
         _all_flat_params (List[FlatParameter]): A :class:`list` of all
             flattened parameters contained in the FSDP module hierarchy with
             the list index implicitly giving a unique parameter index.
-        param_to_unflat_param_names (Dict[FlatParameter, List[str]]): A mapping
-            from flattened parameter to the comprising unflattened parameters'
-            names.
+        _param_to_unflat_param_names (Dict[FlatParameter, List[str]]): A
+            mapping from flattened parameter to the comprising unflattened
+            parameters' names.
         is_first_iter (bool): Whether executing in the first iteration or not.
         param_order (List[int]): Order that parameters participate in the
             forward pass; constructed on the first iteration and validated

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -2762,11 +2762,11 @@ class FullyShardedDataParallel(nn.Module):
         Executing in ``no_sync()`` does not affect this check for
         ``FULL_SHARD`` and ``SHARD_GRAD_OP``: (1) Being in ``no_sync()`` in the
         first iteration does not yield a different forward
-        `_rebuild_full_params()` sequence, and (2) being in ``no_sync()`` in a
-        later iteration does not give false positive warnings since the forward
-        `_rebuild_full_params()` sequence still matches the first iteration
-        sequence (for ``FULL_SHARD``) or the first iteration sequence's prefix
-        (for ``SHARD_GRAD_OP``).
+        :meth:`_rebuild_full_params()` sequence, and (2) being in ``no_sync()``
+        in a later iteration does not give false positive warnings since the
+        forward :meth:`_rebuild_full_params()` sequence still matches the first
+        iteration sequence (for ``FULL_SHARD``) or the first iteration
+        sequence's prefix (for ``SHARD_GRAD_OP``).
         """
         # Only check all-gathers when rebuilding the full parameters in the
         # forward pass and in train mode


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#77195 [FSDP] Do not check fwd order in eval mode**

Fixes https://github.com/pytorch/pytorch/issues/76949.

**Overview**
If we check the forward execution order in eval mode, where there is no backward pass (namely, no post-backward), the execution order data will not be reset to mark the end of the iteration. This results in false positive warnings of deviating execution order.

This PR removes any checking during eval mode.
- I believe this to be the most reasonable solution since without a backward pass, there is no reliable way to know the end of an iteration.
- In training, the reset point is in `_wait_for_post_backward()`.

**Additional Minor Changes**
In addition, this PR
- removes the unnecessary `reset()` call in `_post_backward_hook()` when in `no_sync()` since `reset()` will still be called in `_wait_for_post_backward()`;
- moves the order check to be called even if the forward `_rebuild_full_params()` will not call all-gather (i.e. if the parameter is not sharded or if it is already rebuilt) since more broadly, the forward order is being validated, not just the all-gather order; and
    - Note: This is useful if this iteration is in train mode and the last iteration was in eval mode. In that case, the root does not free its full parameters and will not all-gather them in this iteration, which would give a false positive warning of the order deviating if we only tracked actual all-gathers.
- improves the warning/error messaging.

Differential Revision: [D36293454](https://our.internmc.facebook.com/intern/diff/D36293454)