### PR TITLE
ci: Move rocm distributed tests to periodic

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -84,6 +84,29 @@ jobs:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
 
+  linux-bionic-rocm5_1-py3_7-distributed-build:
+    name: linux-bionic-rocm5.1-py3.7-distributed
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-bionic-rocm5.1-py3.7
+      docker-image-name: pytorch-linux-bionic-rocm5.1-py3.7
+
+  linux-bionic-rocm5_1-py3_7-distributed-test:
+    name: linux-bionic-rocm5.1-py3.7-distributed
+    uses: ./.github/workflows/_rocm-test.yml
+    needs: linux-bionic-rocm5_1-py3_7-distributed-build
+    with:
+      build-environment: linux-bionic-rocm5.1-py3.7
+      docker-image: ${{ needs.linux-bionic-rocm5_1-py3_7-distributed-build.outputs.docker-image }}
+      test-matrix: |
+        { include: [
+          { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
+          { config: "distributed", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
+        ]}
+    secrets:
+      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
+      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
+
   linux-xenial-cuda11_3-py3_7-gcc7-debug-build:
     name: linux-xenial-cuda11.3-py3.7-gcc7-debug
     uses: ./.github/workflows/_linux-build.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -94,29 +94,6 @@ jobs:
       build-environment: linux-xenial-cuda11.3-py3.7-gcc7-no-ops
       docker-image-name: pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7
 
-  linux-bionic-rocm5_1-py3_7-distributed-build:
-    name: linux-bionic-rocm5.1-py3.7-distributed
-    uses: ./.github/workflows/_linux-build.yml
-    with:
-      build-environment: linux-bionic-rocm5.1-py3.7
-      docker-image-name: pytorch-linux-bionic-rocm5.1-py3.7
-
-  linux-bionic-rocm5_1-py3_7-distributed-test:
-    name: linux-bionic-rocm5.1-py3.7-distributed
-    uses: ./.github/workflows/_rocm-test.yml
-    needs: linux-bionic-rocm5_1-py3_7-distributed-build
-    with:
-      build-environment: linux-bionic-rocm5.1-py3.7
-      docker-image: ${{ needs.linux-bionic-rocm5_1-py3_7-distributed-build.outputs.docker-image }}
-      test-matrix: |
-        { include: [
-          { config: "distributed", shard: 1, num_shards: 2, runner: "linux.rocm.gpu" },
-          { config: "distributed", shard: 2, num_shards: 2, runner: "linux.rocm.gpu" },
-        ]}
-    secrets:
-      AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
-      AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
-
   pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build:
     name: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-build
     uses: ./.github/workflows/_android-full-build-test.yml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77205

These jobs have a high TTS and a capacity crunch so moving these to
periodic should resolve both of these issues.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>