### PR TITLE
Add new PrivateUse1 DeviceType for non-public devices

### DIFF
--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -53,6 +53,7 @@ enum class Backend {
   MPS,
   HPU,
   Lazy,
+  PrivateUse1,
   NumOptions
 };
 
@@ -107,6 +108,8 @@ static inline Backend dispatchKeyToBackend(DispatchKey t) {
     return Backend::QuantizedXPU;
   } else if (t == DispatchKey::HPU || t == DispatchKey::AutogradHPU) {
     return Backend::HPU;
+  } else if (t == DispatchKey::PrivateUse1) {
+    return Backend::PrivateUse1;
   } else if (t == DispatchKey::Undefined) {
     return Backend::Undefined;
   } else {
@@ -166,6 +169,8 @@ static inline DispatchKey backendToDispatchKey(Backend b) {
       return DispatchKey::MPS;
     case Backend::HPU:
       return DispatchKey::HPU;
+    case Backend::PrivateUse1:
+      return DispatchKey::PrivateUse1;
     default:
       throw std::runtime_error("Unknown backend");
   }
@@ -220,6 +225,8 @@ static inline DeviceType backendToDeviceType(Backend b) {
       return DeviceType::MPS;
     case Backend::HPU:
       return DeviceType::HPU;
+    case Backend::PrivateUse1:
+      return DeviceType::PrivateUse1;
     case Backend::Undefined:
       TORCH_CHECK(false, "Undefined backend is not a valid device type");
     default:
@@ -280,6 +287,8 @@ static inline const char* toString(Backend b) {
       return "QuantizedXPU";
     case Backend::HPU:
       return "HPU";
+    case Backend::PrivateUse1:
+      return "PrivateUseOne";
     default:
       return "UNKNOWN_BACKEND";
   }

--- a/c10/core/Device.cpp
+++ b/c10/core/Device.cpp
@@ -36,6 +36,7 @@ DeviceType parse_type(const std::string& device_string) {
           {"mps", DeviceType::MPS},
           {"meta", DeviceType::Meta},
           {"hpu", DeviceType::HPU},
+          {"privateuseone", DeviceType::PrivateUse1},
       }};
   auto device = std::find_if(
       types.begin(),
@@ -48,7 +49,7 @@ DeviceType parse_type(const std::string& device_string) {
   }
   TORCH_CHECK(
       false,
-      "Expected one of cpu, cuda, ipu, xpu, mkldnn, opengl, opencl, ideep, hip, ve, ort, mps, xla, lazy, vulkan, meta, hpu device type at start of device string: ",
+      "Expected one of cpu, cuda, ipu, xpu, mkldnn, opengl, opencl, ideep, hip, ve, ort, mps, xla, lazy, vulkan, meta, hpu, privateuseone device type at start of device string: ",
       device_string);
 }
 enum DeviceStringParsingState { START, INDEX_START, INDEX_REST, ERROR };

--- a/c10/core/DeviceType.cpp
+++ b/c10/core/DeviceType.cpp
@@ -45,6 +45,8 @@ std::string DeviceTypeName(DeviceType d, bool lower_case) {
       return lower_case ? "hpu" : "HPU";
     case DeviceType::IPU:
       return lower_case ? "ipu" : "IPU";
+    case DeviceType::PrivateUse1:
+      return lower_case ? "privateuseone" : "PRIVATEUSEONE";
     default:
       TORCH_CHECK(
           false,
@@ -87,6 +89,7 @@ bool isValidDeviceType(DeviceType d) {
     case DeviceType::Meta:
     case DeviceType::HPU:
     case DeviceType::IPU:
+    case DeviceType::PrivateUse1:
       return true;
     default:
       return false;

--- a/c10/core/DeviceType.h
+++ b/c10/core/DeviceType.h
@@ -32,11 +32,12 @@ enum class DeviceType : int8_t {
   VE = 16, // SX-Aurora / NEC
   Lazy = 17, // Lazy Tensors
   IPU = 18, // Graphcore IPU
+  PrivateUse1 = 19, // PrivateUse1 device
   // NB: If you add more devices:
   //  - Change the implementations of DeviceTypeName and isValidDeviceType
   //    in DeviceType.cpp
   //  - Change the number below
-  COMPILE_TIME_MAX_DEVICE_TYPES = 19,
+  COMPILE_TIME_MAX_DEVICE_TYPES = 20,
 };
 
 constexpr DeviceType kCPU = DeviceType::CPU;
@@ -54,18 +55,19 @@ constexpr DeviceType kHPU = DeviceType::HPU;
 constexpr DeviceType kVE = DeviceType::VE;
 constexpr DeviceType kLazy = DeviceType::Lazy;
 constexpr DeviceType kIPU = DeviceType::IPU;
+constexpr DeviceType kPrivateUse1 = DeviceType::PrivateUse1;
 
 // define explicit int constant
 constexpr int COMPILE_TIME_MAX_DEVICE_TYPES =
     static_cast<int>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES);
 
 static_assert(
-    COMPILE_TIME_MAX_DEVICE_TYPES <= 19,
+    COMPILE_TIME_MAX_DEVICE_TYPES <= 20,
     "Hey!  You seem to be adding a lot of new DeviceTypes.  The intent was "
     "for this constant to reflect the actual number of DeviceTypes we support "
     "in PyTorch; it's important that this number is not too large as we "
     "use this to allocate stack arrays in some places in our code.  If you "
-    "are indeed just adding the 19th device type, feel free to change "
+    "are indeed just adding the 20th device type, feel free to change "
     "the check to 32; but if you are adding some sort of extensible device "
     "types registration, please be aware that you are affecting code that "
     "this number is small.  Try auditing uses of this constant.");

--- a/c10/core/TensorOptions.h
+++ b/c10/core/TensorOptions.h
@@ -683,6 +683,9 @@ inline DispatchKey computeDispatchKey(
           return DispatchKey::Meta;
         case DeviceType::HPU:
           return DispatchKey::HPU;
+        case DeviceType::PrivateUse1: {
+          return DispatchKey::PrivateUse1;
+        }
         default:
           TORCH_CHECK_NOT_IMPLEMENTED(
               false,
@@ -809,6 +812,8 @@ inline DeviceType dispatchKeyToDeviceType(DispatchKey dispatch_key) {
       return DeviceType::HPU;
     case DispatchKey::ORT:
       return DeviceType::ORT;
+    case DispatchKey::PrivateUse1:
+      return DeviceType::PrivateUse1;
     default:
       TORCH_CHECK(
           false,

--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -28,6 +28,7 @@ static const char* backend_to_string(const at::Backend& backend) {
     case at::Backend::QuantizedCPU: return "torch.quantized";
     case at::Backend::HPU: return "torch.hpu";
     case at::Backend::MPS: return "torch.mps";
+    case at::Backend::PrivateUse1: return "torch.privateuseone";
     default: AT_ERROR("Unimplemented backend ", backend);
   }
 }

--- a/torch/library.h
+++ b/torch/library.h
@@ -371,6 +371,8 @@ inline CppFunction dispatch(c10::DeviceType type, Func&& raw_f) {
         return c10::DispatchKey::ORT;
       case c10::DeviceType::HPU:
         return c10::DispatchKey::HPU;
+      case c10::DeviceType::PrivateUse1:
+        return c10::DispatchKey::PrivateUse1;
       default:
         TORCH_CHECK(
             false,


### PR DESCRIPTION
Summary: The new PrivateUse1 DeviceType is associated with the PrivateUse1 DispatchKey, which can be used for non-public devices without introducing a new device type. Note that the stringified name of the PrivateUse1 device is "privateuseone".

Test Plan: All CI should pass.

Differential Revision: D35859437

