### PR TITLE
[lint] don't run differently on PR vs. master

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run lintrunner on all files
         run: |
           set +e
-          if ! lintrunner --force-color --paths-cmd='git grep -Il .' ; then
+          if ! lintrunner --verbose --force-color --paths-cmd='git grep -Il .' ; then
               echo ""
               echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`.\e[0m"
               echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions.\e[0m"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,16 +40,9 @@ jobs:
             --deprecated-functions-path "tools/autograd/deprecated.yaml"
 
       - name: Run lintrunner on all files
-        if: github.event_name == 'push'
-        run: lintrunner -vv --paths-cmd='git grep -Il .' --force-color
-
-      - name: Run lintrunner on PR files
-        if: github.event_name == 'pull_request'
-        env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set +e
-          if ! lintrunner -vv --force-color --merge-base-with "${PR_BASE_SHA}" ; then
+          if ! lintrunner --force-color --paths-cmd='git grep -Il .' ; then
               echo ""
               echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`.\e[0m"
               echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions.\e[0m"
@@ -60,13 +53,11 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         # Don't show this as an error; the above step will have already failed.
         continue-on-error: true
-        env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           # The easiest way to get annotations is to just run lintrunner again
           # in JSON mode and use jq to massage the output into GitHub Actions
           # workflow commands.
-          lintrunner --merge-base-with "${PR_BASE_SHA}" --output=json | \
+          lintrunner --paths-cmd='git grep -Il .' --output=json | \
             jq --raw-output '"::\(if .severity == "advice" or .severity == "disabled" then "warning" else .severity end) file=\(.path),line=\(.line),col=\(.char),title=\(.code) \(.name)::" + (.description | gsub("\\n"; "%0A"))'
 
   quick-checks:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77211

I originally thought it might be nice for the CI workflow to only run
lint on files your PR changed, which is marginally faster. But this
doesn't work that well in cases where your change may have affected a
file you *didn't* change, like in the case of
https://github.com/pytorch/pytorch/commit/3a68155ce0973c005457593375801a2cc19de54f.

Since we block/revert on lint, it's better to be safe and just run the
exact same thing on PR and master.