### PR TITLE
enable NVFuser by default

### DIFF
--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -90,9 +90,12 @@ class NVFuserEnabler {
     if (getCachedFuserEnabledEnvVar().has_value()) {
       return *getCachedFuserEnabledEnvVar();
     }
-    // 3. default value (if you switch this to true, make sure
-    //    to check nvfuserCanBeEnabled())
+    // 3. default value
+#ifdef FBCODE_CAFFE2
     return false;
+#else
+    return nvfuserCanBeEnabled();
+#endif
   }
 
  public:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77213

Enable NVFuser in OSS.

Tests are passing, and we've also run tests in [torchvision](https://github.com/pytorch/vision/pull/5959) and [torchaudio](https://github.com/pytorch/audio/pull/2372)

Retry of #76006, because that PR had GH1/ghstack issues.

Differential Revision: [D36302686](https://our.internmc.facebook.com/intern/diff/D36302686)