### PR TITLE
Add support for return_all_layers with nested tensor in torchtext

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4697,6 +4697,10 @@
     CPU, NestedTensorCPU: transform_bias_rescale_qkv_cpu
     CUDA, NestedTensorCUDA: transform_bias_rescale_qkv_cuda
 
+- func: _nested_tensor_from_mask(Tensor t, Tensor mask) -> Tensor
+  dispatch:
+    CPU, CUDA: NestedTensor_nested_tensor_from_mask
+
 - func: _nested_from_padded(Tensor padded, Tensor cpu_nested_shape_example, bool fuse_transform_0213=False) -> Tensor
   device_check: NoCheck # cpu_nested_shape_example will always be on CPU
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11694,7 +11694,7 @@
     CompositeExplicitAutograd: alias_copy
   tags: view_copy
 
-- func: to_padded_tensor(Tensor self, float padding, int[]? output_size=None) -> Tensor
+- func: to_padded_tensor(Tensor self, float padding=0, int[]? output_size=None) -> Tensor
   variants: method
   dispatch:
     NestedTensorCPU: NestedTensor_to_padded_tensor_generic

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -197,9 +197,19 @@ class TransformerEncoder(Module):
             see the docs in Transformer class.
         """
         output = src
+        convert_to_nested = False
+        if hasattr(self.layers[0], "is_fastpath"):
+            if self.layers[0].is_fastpath() and src.dim() == 3:
+                if src_key_padding_mask is not None and not output.is_nested:
+                    convert_to_nested = True
+                    output = torch._nested_tensor_from_mask(output,
+                            src_key_padding_mask.logical_not())
 
         for mod in self.layers:
             output = mod(output, src_mask=mask, src_key_padding_mask=src_key_padding_mask)
+
+        if convert_to_nested:
+            output = output.to_padded_tensor(0.)
 
         if self.norm is not None:
             output = self.norm(output)
@@ -353,6 +363,14 @@ class TransformerEncoderLayer(Module):
             state['activation'] = F.relu
         super(TransformerEncoderLayer, self).__setstate__(state)
 
+    def is_fastpath(self):
+        if (not self.norm_first and not self.training and
+            self.self_attn.batch_first and
+            self.self_attn._qkv_same_embed_dim and self.activation_relu_or_gelu and
+            self.norm1.eps == self.norm2.eps):
+            return True
+        return False
+
     def forward(self, src: Tensor, src_mask: Optional[Tensor] = None,
                 src_key_padding_mask: Optional[Tensor] = None) -> Tensor:
         r"""Pass the input through the encoder layer.
@@ -368,9 +386,7 @@ class TransformerEncoderLayer(Module):
 
         # see Fig. 1 of https://arxiv.org/pdf/2002.04745v1.pdf
 
-        if (not self.norm_first and not self.training and
-            self.self_attn.batch_first and src.dim() == 3 and self.self_attn._qkv_same_embed_dim and
-            self.activation_relu_or_gelu and self.norm1.eps == self.norm2.eps and
+        if (self.is_fastpath() and src.dim() == 3 and
             ((src_mask is None and src_key_padding_mask is None)
              if src.is_nested
              else (src_mask is None or src_key_padding_mask is None))):


### PR DESCRIPTION
Summary:
As we may automatically switch to use nested tensor, we need further support of this in torchtext,
especially for return_all_layers

Test Plan: CI

Reviewed By: mikekgfb, parmeet

Differential Revision: D36213184

