### PR TITLE
Switch to use nested tensor by-default in TransformerEncoder

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -170,6 +170,9 @@ class TransformerEncoder(Module):
         encoder_layer: an instance of the TransformerEncoderLayer() class (required).
         num_layers: the number of sub-encoder-layers in the encoder (required).
         norm: the layer normalization component (optional).
+        enable_nested_tensor: if True, input will automatically convert to nested tensor
+            (and convert back on output). This will improve the overall performance of
+            TransformerEncoder when padding rate is high. Default: ``True`` (enabled).
 
     Examples::
         >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
@@ -179,11 +182,12 @@ class TransformerEncoder(Module):
     """
     __constants__ = ['norm']
 
-    def __init__(self, encoder_layer, num_layers, norm=None):
+    def __init__(self, encoder_layer, num_layers, norm=None, enable_nested_tensor=True):
         super(TransformerEncoder, self).__init__()
         self.layers = _get_clones(encoder_layer, num_layers)
         self.num_layers = num_layers
         self.norm = norm
+        self.enable_nested_tensor = enable_nested_tensor
 
     def forward(self, src: Tensor, mask: Optional[Tensor] = None, src_key_padding_mask: Optional[Tensor] = None) -> Tensor:
         r"""Pass the input through the encoder layers in turn.
@@ -197,9 +201,18 @@ class TransformerEncoder(Module):
             see the docs in Transformer class.
         """
         output = src
+        convert_to_nested = False
+        if hasattr(self.layers[0], "is_fastpath"):
+            if self.layers[0].is_fastpath() and src.dim() == 3 and self.enable_nested_tensor:
+                if src_key_padding_mask is not None and not output.is_nested:
+                    convert_to_nested = True
+                    output = torch._nested_tensor_from_mask(output, src_key_padding_mask.logical_not())
 
         for mod in self.layers:
             output = mod(output, src_mask=mask, src_key_padding_mask=src_key_padding_mask)
+
+        if convert_to_nested:
+            output = output.to_padded_tensor(0.)
 
         if self.norm is not None:
             output = self.norm(output)
@@ -353,6 +366,14 @@ class TransformerEncoderLayer(Module):
             state['activation'] = F.relu
         super(TransformerEncoderLayer, self).__setstate__(state)
 
+    def is_fastpath(self):
+        if (not self.norm_first and not self.training and
+                self.self_attn.batch_first and
+                self.self_attn._qkv_same_embed_dim and self.activation_relu_or_gelu and
+                self.norm1.eps == self.norm2.eps):
+            return True
+        return False
+
     def forward(self, src: Tensor, src_mask: Optional[Tensor] = None,
                 src_key_padding_mask: Optional[Tensor] = None) -> Tensor:
         r"""Pass the input through the encoder layer.
@@ -368,9 +389,7 @@ class TransformerEncoderLayer(Module):
 
         # see Fig. 1 of https://arxiv.org/pdf/2002.04745v1.pdf
 
-        if (not self.norm_first and not self.training and
-            self.self_attn.batch_first and src.dim() == 3 and self.self_attn._qkv_same_embed_dim and
-            self.activation_relu_or_gelu and self.norm1.eps == self.norm2.eps and
+        if (self.is_fastpath() and src.dim() == 3 and
             ((src_mask is None and src_key_padding_mask is None)
              if src.is_nested
              else (src_mask is None or src_key_padding_mask is None))):


### PR DESCRIPTION
Summary: Switch to use nested tensor as by default setting in TransformerEncoderLayer.

Test Plan:
CI

Torchtext
buck test mode/opt pytorch/text/test:integration_tests_test_models -- test_xlmr_base_model

Reviewed By: frank-wei

Differential Revision: D36153335

