### PR TITLE
[lint] update lintrunner, don't run lint twice

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           submodules: false
 
       - name: Install lintrunner
-        run: pip install lintrunner==0.8.*
+        run: pip install lintrunner==0.9.*
 
       - name: Initialize lint dependencies
         run: lintrunner init
@@ -42,7 +42,7 @@ jobs:
       - name: Run lintrunner on all files
         run: |
           set +e
-          if ! lintrunner --verbose --force-color --paths-cmd='git grep -Il .' ; then
+          if ! lintrunner --verbose --force-color --paths-cmd='git grep -Il .' --tee-json=lint.json; then
               echo ""
               echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`.\e[0m"
               echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions.\e[0m"
@@ -54,10 +54,8 @@ jobs:
         # Don't show this as an error; the above step will have already failed.
         continue-on-error: true
         run: |
-          # The easiest way to get annotations is to just run lintrunner again
-          # in JSON mode and use jq to massage the output into GitHub Actions
-          # workflow commands.
-          lintrunner --paths-cmd='git grep -Il .' --output=json | \
+          # Use jq to massage the JSON lint output into GitHub Actions workflow commands.
+          cat lint.json \
             jq --raw-output '"::\(if .severity == "advice" or .severity == "disabled" then "warning" else .severity end) file=\(.path),line=\(.line),col=\(.char),title=\(.code) \(.name)::" + (.description | gsub("\\n"; "%0A"))'
 
   quick-checks:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run lintrunner on all files
         run: |
           set +e
-          if ! lintrunner --verbose --force-color --paths-cmd='git grep -Il .' --tee-json=lint.json; then
+          if ! lintrunner --verbose --force-color --all-files --tee-json=lint.json; then
               echo ""
               echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner\`.\e[0m"
               echo -e "\e[1m\e[36mSee https://github.com/pytorch/pytorch/wiki/lintrunner for setup instructions.\e[0m"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,8 +55,9 @@ jobs:
         continue-on-error: true
         run: |
           # Use jq to massage the JSON lint output into GitHub Actions workflow commands.
-          cat lint.json | \
-            jq --raw-output '"::\(if .severity == "advice" or .severity == "disabled" then "warning" else .severity end) file=\(.path),line=\(.line),col=\(.char),title=\(.code) \(.name)::" + (.description | gsub("\\n"; "%0A"))'
+          jq --raw-output \
+            '"::\(if .severity == "advice" or .severity == "disabled" then "warning" else .severity end) file=\(.path),line=\(.line),col=\(.char),title=\(.code) \(.name)::" + (.description | gsub("\\n"; "%0A"))' \
+            lint.json
 
   quick-checks:
     name: quick-checks

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
         continue-on-error: true
         run: |
           # Use jq to massage the JSON lint output into GitHub Actions workflow commands.
-          cat lint.json \
+          cat lint.json | \
             jq --raw-output '"::\(if .severity == "advice" or .severity == "disabled" then "warning" else .severity end) file=\(.path),line=\(.line),col=\(.char),title=\(.code) \(.name)::" + (.description | gsub("\\n"; "%0A"))'
 
   quick-checks:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77229

Currently we run lintrunner twice, once for human-readable output and
once for json (to populate annotations on PRs.

Update lintrunner to 0.9.1
(https://github.com/suo/lintrunner/blob/main/CHANGELOG.md) which comes
with a `--tee-json` option which lets us output both in one run.