### PR TITLE
[ci] don't run cpu tests on win-cuda builds

### DIFF
--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -50,6 +50,13 @@ if [[ "$TEST_CONFIG" = "force_on_cpu" ]]; then
   export USE_CUDA=0
 fi
 
+if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
+  # Used so that only cuda/rocm specific versions of tests are generated
+  # mainly used so that we're not spending extra cycles testing cpu
+  # devices on expensive gpu machines
+  export PYTORCH_TESTING_DEVICE_ONLY_FOR="cuda"
+fi
+
 run_tests() {
     # Run nvidia-smi if available
     for path in '/c/Program Files/NVIDIA Corporation/NVSMI/nvidia-smi.exe' /c/Windows/System32/nvidia-smi.exe; do


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77240

Ugh, this accounts for a MASSIVE amount of extra time spent doing
windows gpu testing...like, it doubles the number of tests we run for all the generated tests.