### PR TITLE
Sparse CSR CUDA: add batched support for torch.sparse.sampled_addmm

### DIFF
--- a/aten/src/ATen/cuda/CUDASparseDescriptors.cpp
+++ b/aten/src/ATen/cuda/CUDASparseDescriptors.cpp
@@ -53,12 +53,12 @@ cusparseIndexType_t getCuSparseIndexType(const c10::ScalarType& scalar_type) {
   }
 }
 
-CuSparseDnMatDescriptor::CuSparseDnMatDescriptor(const Tensor& input) {
+CuSparseDnMatDescriptor::CuSparseDnMatDescriptor(const Tensor& input, int64_t batch_offset) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(input.layout() == kStrided);
   IntArrayRef input_strides = input.strides();
   IntArrayRef input_sizes = input.sizes();
   auto ndim = input.dim();
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(ndim == 2 || ndim == 3);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(ndim >= 2);
   auto rows = input_sizes[ndim - 2];
   auto cols = input_sizes[ndim - 1];
 
@@ -79,7 +79,9 @@ CuSparseDnMatDescriptor::CuSparseDnMatDescriptor(const Tensor& input) {
   auto order = CUSPARSE_ORDER_COL;
 #endif
 
-  void* values_ptr = input.data_ptr();
+  auto batch_stride = ndim > 2 && batch_offset >= 0 ? input_strides[ndim - 3] : 0;
+  void* values_ptr = static_cast<char*>(input.data_ptr()) +
+      batch_offset * batch_stride * input.itemsize();
 
   cudaDataType value_type = ScalarTypeToCudaDataType(input.scalar_type());
   check_supported_cuda_type(value_type);
@@ -94,7 +96,7 @@ CuSparseDnMatDescriptor::CuSparseDnMatDescriptor(const Tensor& input) {
       value_type,
       order));
 
-  if (ndim == 3) {
+  if (ndim >= 3 && batch_offset == -1) {
     int batch_count =
         at::native::cuda_int_cast(at::native::batchCount(input), "batch_count");
     TORCH_CUDASPARSE_CHECK(cusparseDnMatSetStridedBatch(
@@ -121,9 +123,9 @@ CuSparseDnVecDescriptor::CuSparseDnVecDescriptor(const Tensor& input) {
   descriptor_.reset(raw_descriptor);
 }
 
-CuSparseSpMatCsrDescriptor::CuSparseSpMatCsrDescriptor(const Tensor& input) {
+CuSparseSpMatCsrDescriptor::CuSparseSpMatCsrDescriptor(const Tensor& input, int64_t batch_offset) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(input.is_sparse_csr());
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(input.dim() == 2 || input.dim() == 3);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(input.dim() >= 2);
 
   IntArrayRef input_sizes = input.sizes();
   auto ndim = input.dim();
@@ -144,16 +146,29 @@ CuSparseSpMatCsrDescriptor::CuSparseSpMatCsrDescriptor(const Tensor& input) {
   cudaDataType value_type = ScalarTypeToCudaDataType(input.scalar_type());
   check_supported_cuda_type(value_type);
 
+  auto crow_indices_batch_stride = crow_indices.dim() >= 2 && batch_offset >= 0
+      ? crow_indices.stride(-2)
+      : 0;
+  auto col_indices_batch_stride =
+      col_indices.dim() >= 2 && batch_offset >= 0 ? col_indices.stride(-2) : 0;
+  auto values_batch_stride =
+      values.dim() >= 2 && batch_offset >= 0 ? values.stride(-2) : 0;
+
   cusparseSpMatDescr_t raw_descriptor;
   TORCH_CUDASPARSE_CHECK(cusparseCreateCsr(
       &raw_descriptor, // output descriptor
       rows,
       cols,
       nnz,
-      crow_indices
-          .data_ptr(), // row offsets of the sparse matrix, size = rows + 1
-      col_indices.data_ptr(), // column indices of the sparse matrix, size = nnz
-      values.data_ptr(), // values of the sparse matrix, size = nnz
+      // row offsets of the sparse matrix, size = rows + 1
+      static_cast<char*>(crow_indices.data_ptr()) +
+          batch_offset * crow_indices_batch_stride * crow_indices.itemsize(),
+      // column indices of the sparse matrix, size = nnz
+      static_cast<char*>(col_indices.data_ptr()) +
+          batch_offset * col_indices_batch_stride * col_indices.itemsize(),
+      // values of the sparse matrix, size = nnz
+      static_cast<char*>(values.data_ptr()) +
+          batch_offset * values_batch_stride * values.itemsize(),
       index_type, // data type of row offsets index
       index_type, // data type of col indices
       CUSPARSE_INDEX_BASE_ZERO, // base index of row offset and col indes
@@ -161,7 +176,7 @@ CuSparseSpMatCsrDescriptor::CuSparseSpMatCsrDescriptor(const Tensor& input) {
       ));
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
-  if (ndim == 3) {
+  if (ndim == 3 && batch_offset == -1) {
     int batch_count =
         at::native::cuda_int_cast(at::native::batchCount(input), "batch_count");
     if (crow_indices.dim() >= 2 || values.dim() >= 2 ||

--- a/aten/src/ATen/cuda/CUDASparseDescriptors.h
+++ b/aten/src/ATen/cuda/CUDASparseDescriptors.h
@@ -99,7 +99,7 @@ cusparseIndexType_t getCuSparseIndexType(const c10::ScalarType& scalar_type);
 class TORCH_CUDA_CPP_API CuSparseDnMatDescriptor
     : public CuSparseDescriptor<cusparseDnMatDescr, &cusparseDestroyDnMat> {
  public:
-  explicit CuSparseDnMatDescriptor(const Tensor& input);
+  explicit CuSparseDnMatDescriptor(const Tensor& input, int64_t batch_offset = -1);
 };
 
 class TORCH_CUDA_CPP_API CuSparseDnVecDescriptor
@@ -114,7 +114,7 @@ class TORCH_CUDA_CPP_API CuSparseSpMatDescriptor
 class TORCH_CUDA_CPP_API CuSparseSpMatCsrDescriptor
     : public CuSparseSpMatDescriptor {
  public:
-  explicit CuSparseSpMatCsrDescriptor(const Tensor& input);
+  explicit CuSparseSpMatCsrDescriptor(const Tensor& input, int64_t batch_offset = -1);
 
 #if defined(CUDA_VERSION) && CUDA_VERSION >= 11000
   std::tuple<int64_t, int64_t, int64_t> get_size() {

--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -623,7 +623,10 @@ static inline bool is_blas_compatible_column_major_order(const Tensor& input) {
   IntArrayRef input_strides = input.strides();
   IntArrayRef input_sizes = input.sizes();
   auto ndim = input.dim();
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(ndim == 2 || ndim == 3);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(ndim >= 2);
+  if (ndim > 3) {
+    return input.transpose(-2, -1).is_contiguous();
+  }
   auto leading_dimension = input_strides[ndim - 1];
   auto rows = input_sizes[ndim - 2];
   bool batch_stride_compatible = true;
@@ -641,7 +644,10 @@ static inline bool is_blas_compatible_row_major_order(const Tensor& input) {
   IntArrayRef input_strides = input.strides();
   IntArrayRef input_sizes = input.sizes();
   auto ndim = input.dim();
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(ndim == 2 || ndim == 3);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(ndim >= 2);
+  if (ndim > 3) {
+    return input.is_contiguous();
+  }
   auto leading_dimension = input_strides[ndim - 2];
   auto cols = input_sizes[ndim - 1];
   bool batch_stride_compatible = true;

--- a/aten/src/ATen/native/sparse/SparseBlas.cpp
+++ b/aten/src/ATen/native/sparse/SparseBlas.cpp
@@ -1,7 +1,9 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Tensor.h>
 #include <ATen/ExpandUtils.h>
+#include <ATen/SparseCsrTensorUtils.h>
 #include <ATen/native/Resize.h>
+#include <ATen/native/sparse/SparseBlas.h>
 #include <ATen/native/sparse/SparseBlasImpl.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -109,49 +111,15 @@ Tensor& sparse_sampled_addmm_out_sparse_csr_cpu(
     const Scalar& beta,
     const Scalar& alpha,
     Tensor& result) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(self.is_sparse_csr());
-
-  TORCH_CHECK(mat1.layout() == kStrided, "sampled_addmm: Expected mat1 to have strided layout, but got ", mat1.layout());
-  TORCH_CHECK(mat2.layout() == kStrided, "sampled_addmm: Expected mat2 to have strided layout, but got ", mat2.layout());
-
-  TORCH_CHECK(result.layout() == kSparseCsr, "sampled_addmm: Expected result to have sparse csr layout, but got ", result.layout());
-
-  TORCH_CHECK(mat1.scalar_type() == mat2.scalar_type(), "sampled_addmm: Expected mat1 and mat2 to have the same dtype, but got ", mat1.scalar_type(), " and ", mat2.scalar_type());
-  TORCH_CHECK(mat1.scalar_type() == self.scalar_type(), "sampled_addmm: Expected mat1 and self to have the same dtype, but got ", mat1.scalar_type(), " and ", self.scalar_type());
-  TORCH_CHECK(result.scalar_type() == self.scalar_type(), "sampled_addmm: Expected result and self to have the same dtype, but got ", result.scalar_type(), " and ", self.scalar_type());
-
-  TORCH_CHECK(
-      mat1.dim() == 2, "sampled_addmm: Expected mat1 to be a matrix, got ", mat1.dim(), "-D tensor");
-  TORCH_CHECK(
-      mat2.dim() == 2, "sampled_addmm: Expected mat2 to be a matrix, got ", mat2.dim(), "-D tensor");
-  TORCH_CHECK(
-    result.dim() == 2, "sampled_addmm: Expected result to be a matrix, got ", result.dim(), "-D tensor");
-
-  IntArrayRef mat1_sizes = mat1.sizes();
-  IntArrayRef mat2_sizes = mat2.sizes();
-  TORCH_CHECK(
-      mat1_sizes[1] == mat2_sizes[0],
-      "sampled_addmm: mat1 and mat2 shapes cannot be multiplied (",
-      mat1_sizes[0],
-      "x",
-      mat1_sizes[1],
-      " and ",
-      mat2_sizes[0],
-      "x",
-      mat2_sizes[1],
-      ")");
-
-  IntArrayRef self_sizes = self.sizes();
-  TORCH_CHECK(
-      self_sizes[0] == mat1_sizes[0], "sampled_addmm: self dim 0 must match mat1 dim 0");
-  TORCH_CHECK(
-      self_sizes[1] == mat2_sizes[1], "sampled_addmm: self dim 1 must match mat2 dim 1");
-
+  at::native::sparse::sparse_sampled_addmm_check_inputs(self, mat1, mat2, beta, alpha, result);
   if (&result != &self) {
-    at::native::resize_as_sparse_csr_(result, self);
+    // We allow self to be a single matrix when mat1 and mat2 are batched
+    auto result_sizes = DimVector(mat1.sizes().slice(0, mat1.dim() - 2));
+    result_sizes.push_back(self.size(-2));
+    result_sizes.push_back(self.size(-1));
+    at::sparse_csr::get_sparse_csr_impl(result)->resize_(self._nnz(), result_sizes);
   }
-
-  result.copy_(at::addmm(self.to_dense(), mat1, mat2, beta, alpha).sparse_mask(self));
+  result.copy_((self.to_dense().mul(beta).add(mat1.matmul(mat2), alpha)).sparse_mask(self));
   return result;
 }
 
@@ -165,6 +133,105 @@ Tensor sparse_sampled_addmm_sparse_csr_cpu(
   at::native::sparse_sampled_addmm_out_sparse_csr_cpu(self, mat1, mat2, beta, alpha, result);
   return result;
 }
+
+namespace sparse {
+
+void sparse_sampled_addmm_check_inputs(
+    const Tensor& self,
+    const Tensor& mat1,
+    const Tensor& mat2,
+    const Scalar& beta,
+    const Scalar& alpha,
+    const Tensor& result) {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(self.is_sparse_csr());
+
+  TORCH_CHECK(
+      mat1.layout() == kStrided,
+      "sampled_addmm: Expected mat1 to have strided layout, but got ",
+      mat1.layout());
+  TORCH_CHECK(
+      mat2.layout() == kStrided,
+      "sampled_addmm: Expected mat2 to have strided layout, but got ",
+      mat2.layout());
+
+  TORCH_CHECK(
+      result.layout() == kSparseCsr,
+      "sampled_addmm: Expected result to have sparse csr layout, but got ",
+      result.layout());
+
+  TORCH_CHECK(
+      mat1.scalar_type() == mat2.scalar_type(),
+      "sampled_addmm: Expected mat1 and mat2 to have the same dtype, but got ",
+      mat1.scalar_type(),
+      " and ",
+      mat2.scalar_type());
+  TORCH_CHECK(
+      mat1.scalar_type() == self.scalar_type(),
+      "sampled_addmm: Expected mat1 and self to have the same dtype, but got ",
+      mat1.scalar_type(),
+      " and ",
+      self.scalar_type());
+  TORCH_CHECK(
+      result.scalar_type() == self.scalar_type(),
+      "sampled_addmm: Expected result and self to have the same dtype, but got ",
+      result.scalar_type(),
+      " and ",
+      self.scalar_type());
+
+  TORCH_CHECK(
+      mat1.dim() >= 2,
+      "sampled_addmm: Expected mat1 to be a matrix, got ",
+      mat1.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      mat2.dim() >= 2,
+      "sampled_addmm: Expected mat2 to be a matrix, got ",
+      mat2.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      result.dim() >= 2,
+      "sampled_addmm: Expected result to be a matrix, got ",
+      result.dim(),
+      "-D tensor");
+
+  TORCH_CHECK(
+    mat1.sizes().slice(0, mat1.dim() - 2) == mat2.sizes().slice(0, mat2.dim() - 2),
+    "sampled_addmm: Expected mat1 and mat2 to have the same batch size, but got ",
+    mat1.sizes().slice(0, mat1.dim() - 2),
+    " and ",
+    mat2.sizes().slice(0, mat2.dim() - 2));
+
+  TORCH_CHECK(
+    !(self.dim() > 2 && self.sizes().slice(0, self.dim() - 2) != mat1.sizes().slice(0, mat1.dim() - 2)),
+    "sampled_addmm: Expected self and mat1 to have the same batch size, but got ",
+    self.sizes().slice(0, self.dim() - 2),
+    " and ",
+    mat1.sizes().slice(0, mat1.dim() - 2));
+
+  IntArrayRef mat1_sizes = mat1.sizes();
+  IntArrayRef mat2_sizes = mat2.sizes();
+  TORCH_CHECK(
+      mat1_sizes[mat1.dim() - 1] == mat2_sizes[mat2.dim() - 2],
+      "sampled_addmm: mat1 and mat2 shapes cannot be multiplied (",
+      mat1_sizes[mat1.dim() - 2],
+      "x",
+      mat1_sizes[mat1.dim() - 1],
+      " and ",
+      mat2_sizes[mat2.dim() - 2],
+      "x",
+      mat2_sizes[mat2.dim() - 1],
+      ")");
+
+  IntArrayRef self_sizes = self.sizes();
+  TORCH_CHECK(
+      self_sizes[self.dim() - 2] == mat1_sizes[mat1.dim() - 2],
+      "sampled_addmm: self dim -2 must match mat1 dim -2");
+  TORCH_CHECK(
+      self_sizes[self.dim() - 1] == mat2_sizes[mat2.dim() - 1],
+      "sampled_addmm: self dim -1 must match mat2 dim -1");
+}
+
+} // namespace sparse
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/sparse/SparseBlas.h
+++ b/aten/src/ATen/native/sparse/SparseBlas.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <c10/macros/Export.h>
+
+#include <ATen/Tensor.h>
+#include <ATen/core/Scalar.h>
+
+namespace at {
+namespace native {
+namespace sparse {
+
+TORCH_API void sparse_sampled_addmm_check_inputs(
+    const Tensor& self,
+    const Tensor& mat1,
+    const Tensor& mat2,
+    const Scalar& beta,
+    const Scalar& alpha,
+    const Tensor& result);
+
+} // namespace sparse
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseCsrTensor.cpp
@@ -511,9 +511,6 @@ const Tensor& resize_sparse_csr_(
 
 Tensor& copy_sparse_csr_(Tensor& self, const Tensor& src, bool non_blocking) {
   TORCH_CHECK(
-      self.sizes() == src.sizes(),
-      "copy_sparse_csr_: only same size tensors are supported.");
-  TORCH_CHECK(
       self.is_sparse_csr() && src.is_sparse_csr(),
       "copy_sparse_csr_: copy between different layouts is not supported. Found self type = ",
       self.toString(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77243
* #76591

This PR adds a forloop around cuSPARSE calls to support batched inputs.
cuSPARSE function itself doesn't support batched inputs yet.
`mat1` and `mat2` must have the same batch shape. It's allowed to pass
`self` as a single matrix when `mat1` and `mat2` are batched.