### PR TITLE
torch/deadlockdetection: add TORCH_DISABLE_DEADLOCK_DETECTION env for use with torch deploy

### DIFF
--- a/c10/test/util/DeadlockDetection_test.cpp
+++ b/c10/test/util/DeadlockDetection_test.cpp
@@ -1,0 +1,31 @@
+#include <c10/util/DeadlockDetection.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+using namespace ::testing;
+using namespace c10::impl;
+
+struct DummyPythonGILHooks : public PythonGILHooks {
+  bool check_python_gil() const override {
+    return true;
+  }
+};
+
+TEST(DeadlockDetection, basic) {
+  ASSERT_FALSE(check_python_gil());
+  DummyPythonGILHooks hooks;
+  SetPythonGILHooks(&hooks);
+  ASSERT_TRUE(check_python_gil());
+  SetPythonGILHooks(nullptr);
+}
+
+#ifndef _WIN32
+TEST(DeadlockDetection, disable) {
+  setenv("TORCH_DISABLE_DEADLOCK_DETECTION", "1", 1);
+  DummyPythonGILHooks hooks;
+  SetPythonGILHooks(&hooks);
+  SetPythonGILHooks(&hooks);
+}
+#endif

--- a/c10/util/DeadlockDetection.cpp
+++ b/c10/util/DeadlockDetection.cpp
@@ -1,11 +1,17 @@
 #include <c10/util/DeadlockDetection.h>
 
+#include <cstdlib>
+
 namespace c10 {
 namespace impl {
 
 namespace {
 PythonGILHooks* python_gil_hooks = nullptr;
+
+bool disable_detection() {
+  return std::getenv("TORCH_DISABLE_DEADLOCK_DETECTION") != nullptr;
 }
+} // namespace
 
 bool check_python_gil() {
   if (!python_gil_hooks) {
@@ -15,6 +21,9 @@ bool check_python_gil() {
 }
 
 void SetPythonGILHooks(PythonGILHooks* hooks) {
+  if (disable_detection()) {
+    return;
+  }
   TORCH_INTERNAL_ASSERT(!hooks || !python_gil_hooks);
   python_gil_hooks = hooks;
 }


### PR DESCRIPTION
Summary:
Currently there's an #ifdef USE_DEPLOY to disable deadlock detection in torch for torch deploy. We want to be able to link against binary distributions of PyTorch so we need to have a way to disable deadlock detection at runtime.

https://github.com/pytorch/pytorch/blob/55f55a4cf6cc50cde9e8e8369d92847ca85b23da/torch/csrc/autograd/python_variable.cpp#L1017

Test Plan: buck test //caffe2/c10/test:util_base_test

Differential Revision: D36303256

