### PR TITLE
ci: bump linux.4xlarge.nvidia.gpu to 175

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -48,7 +48,7 @@ runner_types:
   linux.4xlarge.nvidia.gpu:
     instance_type: g3.4xlarge
     os: linux
-    max_available: 125
+    max_available: 175
     disk_size: 150
     is_ephemeral: false
   linux.16xlarge.nvidia.gpu:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77275

We're seeing long queuing times for these types of machines so bump to
resolve

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>