### PR TITLE
add a new at::lift operator, fix torch.tensor for functionalization

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -3328,5 +3328,12 @@ at::Tensor diagonal_scatter(const at::Tensor& self, const at::Tensor& src, int64
     return output;
 }
 
+// The default implementation of lift is a no-op.
+// If TLS is set appropriately (for wrapper-tensor keys like Functionalize or functorch transforms),
+// then we'll dispatch to one of their implementations, which will properly lift the tensor into a wrapper.
+at::Tensor lift(const at::Tensor& self) {
+    return self;
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6026,6 +6026,9 @@
     CUDA: set_cuda_
     Meta: set_meta_
 
+- func: lift(Tensor self) -> Tensor
+  variants: method
+
 - func: is_set_to(Tensor self, Tensor tensor) -> bool
   variants: method
   device_check: NoCheck

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -146,6 +146,16 @@ $3 = torch._ops.aten.mul.Tensor($2, $2)""")
 $0 = input('input')
 $1, $2 = torch._ops.aten.aminmax.default($0, dim=0)""")
 
+    def test_tensor_ctr(self):
+        def f(x):
+            y = torch.tensor((1, 2, 3))
+            z = y.view(-1)
+            z.add_(1)
+            return y
+        self.assert_functionalization(f, torch.arange(3, dtype=torch.float32))
+        logs = self.get_logs(f, torch.arange(3, dtype=torch.float32))
+        self.assertExpectedInline('\n'.join(logs), """$0 = input('input')""")
+
     def test_inplace_on_non_view(self):
         def f(x):
             # test for the case where we functionalize an inplace op on the other tensor - not a view.

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -153,6 +153,7 @@ _SKIP_PYTHON_BINDINGS = [
     "copy",  # only used by the functionalization pass
     "fill.Tensor",  # only used by the functionalization pass
     "fill.Scalar",  # only used by the functionalization pass
+    "lift",
 ]
 
 SKIP_PYTHON_BINDINGS = list(

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -268,62 +268,69 @@ Tensor internal_new_from_data(
   // This exists to prevent us from tracing the call to empty().  The actual
   // autograd code doesn't really matter, because requires_grad is always false
   // here.
+  // What are the semantics of tensor_new()?
+  // We manually construct a tensor and place on it on the correct device with empty() and to().
+  // We then have to "lift" the newly constructed tensor in some cases, like when we're performing
+  // a functorch transform or running functionalization.
+  // The exclude guards are all to ensure that extra logic doesn't run when we're constructing the raw tensor.
   Tensor tensor;
   {
-    at::AutoDispatchBelowADInplaceOrView guard;  // TODO: remove
-    at::tracer::impl::NoTracerDispatchMode tracer_guard;
+    at::AutoDispatchBelowADInplaceOrView guard;
     c10::impl::ExcludeDispatchKeyGuard torchdispatchmode_guard(c10::DispatchKey::Python);
     c10::impl::ExcludeDispatchKeyGuard torchdispatchmode_snapshot_guard(c10::DispatchKey::PythonTLSSnapshot);
     // functorch uses FuncTorchDynamicLayerBackMode as a mode key to wrap all
     // tensors returned from operators in special TensorWrapper tensor extension
-    // The problem with this is that TensorWrapper does not have storage so
-    // accessing the data_ptr (for recursive_store) internal asserts.
-    // As a quick hack, the guard here prevents functorch from wrapping the empty
-    // tensor in a TensorWrapper and instead when `tensor.to` is called later,
-    // the tensor gets wrapped. A more long-term solution is to think about
-    // what the extensibility mechanism for this function (internal_new_from_data)
-    // looks like for mode-based dispatch keys and C++ tensor extensions.
     c10::impl::ExcludeDispatchKeyGuard functorch_guard(c10::DispatchKey::FuncTorchDynamicLayerBackMode);
     // We disable DeferredInit handler for similar reasons as functorch.
     c10::impl::ExcludeDispatchKeyGuard deferred_init_guard(c10::DispatchKey::DeferredInit);
+    // Note [Functionalization <> torch.Tensor constructor]
+    // Functionalization "lifts" the newly constructed tensor into a wrapper using aten::lift().
+    c10::impl::ExcludeDispatchKeyGuard functionalize_guard(c10::DispatchKey::Functionalize);
+    {
+      // Tracing should probably also use the "lift" operator to add the tensor to a trace,
+      // but it's technically BC-breaking to do that, since we currently trace .to() calls.
+      at::tracer::impl::NoTracerDispatchMode tracer_guard;
 
-    if (isStorage(data)) {
-      ScalarType storage_scalar_type;
-      bool is_typed_storage = false;
-      Storage storage = createStorageGetType(data, storage_scalar_type, is_typed_storage);
-      TORCH_CHECK(!is_typed_storage || storage_scalar_type == scalar_type,
-          "Expected a Storage of type ", scalar_type,
-          " or an _UntypedStorage, but got ", storage_scalar_type);
-      tensor = at::empty(sizes, at::initialTensorOptions().dtype(is_typed_storage ? storage_scalar_type : inferred_scalar_type).pinned_memory(pin_memory).device(storage.device()));
-      tensor.set_(storage);
+      if (isStorage(data)) {
+        ScalarType storage_scalar_type;
+        bool is_typed_storage = false;
+        Storage storage = createStorageGetType(data, storage_scalar_type, is_typed_storage);
+        TORCH_CHECK(!is_typed_storage || storage_scalar_type == scalar_type,
+            "Expected a Storage of type ", scalar_type,
+            " or an _UntypedStorage, but got ", storage_scalar_type);
+        tensor = at::empty(sizes, at::initialTensorOptions().dtype(is_typed_storage ? storage_scalar_type : inferred_scalar_type).pinned_memory(pin_memory).device(storage.device()));
+        tensor.set_(storage);
 
-    } else {
-      TensorOptions opts = at::initialTensorOptions().dtype(inferred_scalar_type);
+      } else {
+        TensorOptions opts = at::initialTensorOptions().dtype(inferred_scalar_type);
 
-      // If the device is Meta, take the shortcut. We don't want to allocate an
-      // empty CPU tensor which would break our contract for meta tensors.
-      if (device == at::kMeta) {
-        return at::empty(sizes, opts.device(device));
-      }
-      tensor = at::empty(sizes, opts.pinned_memory(pin_memory));
-      if (c10::multiply_integers(tensor.sizes()) != 0) {
-        recursive_store(
-            (char*)tensor.data_ptr(), tensor.sizes(), tensor.strides(), 0,
-            inferred_scalar_type, tensor.dtype().itemsize(), data);
+        // If the device is Meta, take the shortcut. We don't want to allocate an
+        // empty CPU tensor which would break our contract for meta tensors.
+        if (device == at::kMeta) {
+          return at::empty(sizes, opts.device(device));
+        }
+        tensor = at::empty(sizes, opts.pinned_memory(pin_memory));
+        if (c10::multiply_integers(tensor.sizes()) != 0) {
+          recursive_store(
+              (char*)tensor.data_ptr(), tensor.sizes(), tensor.strides(), 0,
+              inferred_scalar_type, tensor.dtype().itemsize(), data);
+        }
       }
     }
+    pybind11::gil_scoped_release no_gil;
+    maybe_initialize_cuda(device);
+    // However, it is VERY important that we trace the to() call here (even
+    // though the reason this is important is a hack).  Without *some* factory
+    // function call that is traced at construction time, we will consider
+    // a tensor constant as originating from "outside" the trace, and if you
+    // try to return it directly we will fail with the error saying no
+    // "no observable data dependence".  In an ideal world, we wouldn't trace
+    // a to() call but I need to think harder about what exactly we should trace
+    // in this case.
+    tensor = tensor.to(device, inferred_scalar_type, /*non_blocking=*/false, /*copy=*/false);
   }
-  pybind11::gil_scoped_release no_gil;
-  maybe_initialize_cuda(device);
-  // However, it is VERY important that we trace the to() call here (even
-  // though the reason this is important is a hack).  Without *some* factory
-  // function call that is traced at construction time, we will consider
-  // a tensor constant as originating from "outside" the trace, and if you
-  // try to return it directly we will fail with the error saying no
-  // "no observable data dependence".  In an ideal world, we wouldn't trace
-  // a to() call but I need to think harder about what exactly we should trace
-  // in this case.
-  return tensor.to(device, inferred_scalar_type, /*non_blocking=*/false, /*copy=*/false);
+
+  return tensor.lift();
 }
 
 Tensor new_from_data_copy(

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -3927,9 +3927,11 @@ def linspace(g, start, end, steps, dtype, layout, device, pin_memory):
     )
     return add(g, mul(g, range_tensor, step), start)
 
+
 def lift(g, self):
     # at::lift() is a no-op from the perspective of tracing for onnx
     return self
+
 
 def masked_fill(g, self, mask, value):
     mask = _cast_Bool(g, mask, False)  # type: ignore[name-defined]

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -3927,6 +3927,9 @@ def linspace(g, start, end, steps, dtype, layout, device, pin_memory):
     )
     return add(g, mul(g, range_tensor, step), start)
 
+def lift(g, self):
+    # at::lift() is a no-op from the perspective of tracing for onnx
+    return self
 
 def masked_fill(g, self, mask, value):
     mask = _cast_Bool(g, mask, False)  # type: ignore[name-defined]

--- a/torchgen/gen_functionalization_type.py
+++ b/torchgen/gen_functionalization_type.py
@@ -536,6 +536,9 @@ def gen_functionalization_registration(
         return view_str
     else:
         f = g
+        if str(f.func.name) == "lift":
+            # See Note [Functionalization <> torch.Tensor constructor]
+            return []
         assert not f.is_view_op
         # functionalization needs to generate and register kernals for inplace ops.
         # We *also* need to directly register CompositeImplicitAUtograd kernels


### PR DESCRIPTION
Re-land of https://github.com/pytorch/pytorch/pull/76319 - I needed to tell `onnx` what the new `at::lift` op is, since it technically gets traced by `torch.jit.trace()` into torchscript. I think it should be a no-op though.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77285

This reverts commit 85bd65a880ddd7a1f4b1ea4288423d75d45a56b3.