### PR TITLE
ci: Move lint to be run on linux.20_04.16x runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 self-hosted-runner:
   labels:
+    - linux.20_04.16x
     - linux.large
     - linux.2xlarge
     - linux.4xlarge

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,7 @@ jobs:
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
+          no-sudo: true
 
       - name: Install lintrunner
         run: pip install lintrunner==0.8.*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,21 +9,14 @@ on:
       - release/*
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: bash -e -l {0}
-
 jobs:
   lintrunner:
     runs-on: linux.2xlarge
-    steps:
-      - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          python-version: 3.8
-          activate-environment: build
+    # NOTE: I'm curious if we'll get rate limited by this
+    container:
+      image: python:3.8
 
+    steps:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,17 +11,18 @@ on:
 
 jobs:
   lintrunner:
-    runs-on: linux.2xlarge
-    # NOTE: I'm curious if we'll get rate limited by this
-    container:
-      image: python:3.8
-
+    runs-on: linux.20_04.16x
     steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
         with:
           submodules: false
-          no-sudo: true
 
       - name: Install lintrunner
         run: pip install lintrunner==0.8.*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,15 +9,20 @@ on:
       - release/*
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash -e -l {0}
+
 jobs:
   lintrunner:
     runs-on: linux.2xlarge
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v2
+      - name: Setup miniconda
+        uses: conda-incubator/setup-miniconda@v2
         with:
+          auto-update-conda: true
           python-version: 3.8
-          architecture: x64
+          activate-environment: build
 
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lintrunner:
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77290

We noticed that lint was taking a long time to run on github default
runners so we should utilize our own infra to run these jobs

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>