### PR TITLE
missing header include in SortImpl.cu

### DIFF
--- a/aten/src/ATen/native/cuda/SortImpl.cu
+++ b/aten/src/ATen/native/cuda/SortImpl.cu
@@ -1,5 +1,6 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
+#include <thrust/execution_policy.h>
 #include <thrust/sort.h>
 
 namespace at { namespace native {


### PR DESCRIPTION
SortImpl.cu needs to include <thrust/execution_policy.h> for
thrust::host.  Depending on the nvidia/thrust or rocThrust version,
transitive inclusion of this header is not guaranteed.