### PR TITLE
[CUBLAS][TF32] Skip `test_cublas_allow_tf32_get_set` if `TORCH_ALLOW_TF32_CUBLAS_OVERRIDE` is set

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -7,6 +7,7 @@ import contextlib
 import ctypes
 import gc
 import io
+import os
 import pickle
 import queue
 import sys
@@ -573,6 +574,9 @@ class TestCuda(TestCase):
         q_copy[1].fill_(10)
         self.assertEqual(q_copy[3], torch.cuda.IntStorage(10).fill_(10))
 
+    @unittest.skipIf('TORCH_ALLOW_TF32_CUBLAS_OVERRIDE' in os.environ and
+                        int(os.environ['TORCH_ALLOW_TF32_CUBLAS_OVERRIDE']) == True,
+                     'skipping allow_tf32 test as TORCH_ALLOW_TF32_CUBLAS_OVERRIDE is set')
     def test_cublas_allow_tf32_get_set(self):
         orig = torch.backends.cuda.matmul.allow_tf32
         self.assertEqual(torch._C._get_cublas_allow_tf32(), orig)
@@ -582,14 +586,20 @@ class TestCuda(TestCase):
 
     def test_float32_matmul_precision_get_set(self):
         self.assertEqual(torch.get_float32_matmul_precision(), 'highest')
-        self.assertFalse(torch.backends.cuda.matmul.allow_tf32, False)
+        skip_tf32_cublas = 'TORCH_ALLOW_TF32_CUBLAS_OVERRIDE' in os.environ and\
+            int(os.environ['TORCH_ALLOW_TF32_CUBLAS_OVERRIDE']) == True
+        print(skip_tf32_cublas) 
+        if not skip_tf32_cublas:
+            self.assertFalse(torch.backends.cuda.matmul.allow_tf32)
         for p in ('medium', 'high'):
             torch.set_float32_matmul_precision(p)
             self.assertEqual(torch.get_float32_matmul_precision(), p)
-            self.assertTrue(torch.backends.cuda.matmul.allow_tf32, True)
+            if not skip_tf32_cublas:
+                self.assertTrue(torch.backends.cuda.matmul.allow_tf32)
         torch.set_float32_matmul_precision('highest')
         self.assertEqual(torch.get_float32_matmul_precision(), 'highest')
-        self.assertFalse(torch.backends.cuda.matmul.allow_tf32, False)
+        if not skip_tf32_cublas:
+            self.assertFalse(torch.backends.cuda.matmul.allow_tf32)
 
     def test_cublas_allow_fp16_reduced_precision_reduction_get_set(self):
         orig = torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -588,7 +588,6 @@ class TestCuda(TestCase):
         self.assertEqual(torch.get_float32_matmul_precision(), 'highest')
         skip_tf32_cublas = 'TORCH_ALLOW_TF32_CUBLAS_OVERRIDE' in os.environ and\
             int(os.environ['TORCH_ALLOW_TF32_CUBLAS_OVERRIDE']) == True
-        print(skip_tf32_cublas) 
         if not skip_tf32_cublas:
             self.assertFalse(torch.backends.cuda.matmul.allow_tf32)
         for p in ('medium', 'high'):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -576,7 +576,7 @@ class TestCuda(TestCase):
 
     def test_cublas_allow_tf32_get_set(self):
         skip_tf32_cublas = 'TORCH_ALLOW_TF32_CUBLAS_OVERRIDE' in os.environ and\
-            int(os.environ['TORCH_ALLOW_TF32_CUBLAS_OVERRIDE']) == True
+            int(os.environ['TORCH_ALLOW_TF32_CUBLAS_OVERRIDE'])
         if skip_tf32_cublas:
             self.assertTrue(torch.backends.cuda.matmul.allow_tf32)
             return
@@ -590,7 +590,7 @@ class TestCuda(TestCase):
     def test_float32_matmul_precision_get_set(self):
         self.assertEqual(torch.get_float32_matmul_precision(), 'highest')
         skip_tf32_cublas = 'TORCH_ALLOW_TF32_CUBLAS_OVERRIDE' in os.environ and\
-            int(os.environ['TORCH_ALLOW_TF32_CUBLAS_OVERRIDE']) == True
+            int(os.environ['TORCH_ALLOW_TF32_CUBLAS_OVERRIDE'])
         if not skip_tf32_cublas:
             self.assertFalse(torch.backends.cuda.matmul.allow_tf32)
         for p in ('medium', 'high'):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -574,10 +574,13 @@ class TestCuda(TestCase):
         q_copy[1].fill_(10)
         self.assertEqual(q_copy[3], torch.cuda.IntStorage(10).fill_(10))
 
-    @unittest.skipIf('TORCH_ALLOW_TF32_CUBLAS_OVERRIDE' in os.environ and
-                        int(os.environ['TORCH_ALLOW_TF32_CUBLAS_OVERRIDE']) == True,
-                     'skipping allow_tf32 test as TORCH_ALLOW_TF32_CUBLAS_OVERRIDE is set')
     def test_cublas_allow_tf32_get_set(self):
+        skip_tf32_cublas = 'TORCH_ALLOW_TF32_CUBLAS_OVERRIDE' in os.environ and\
+            int(os.environ['TORCH_ALLOW_TF32_CUBLAS_OVERRIDE']) == True
+        if skip_tf32_cublas:
+            self.assertTrue(torch.backends.cuda.matmul.allow_tf32)
+            return
+
         orig = torch.backends.cuda.matmul.allow_tf32
         self.assertEqual(torch._C._get_cublas_allow_tf32(), orig)
         torch.backends.cuda.matmul.allow_tf32 = not orig


### PR DESCRIPTION
Follow-up to #77114 to prevent test breakages when the environment variable is set.

CC @xwang233 @ngimel @ptrblck 