### PR TITLE
Fix docs "quantization" instead of "quantiztion"

### DIFF
--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -604,7 +604,7 @@ The following table compares the differences between Eager Mode Quantization and
 |                 |Static, Dynamic,   |Static, Dynamic,   |
 |                 |Weight Only        |Weight Only        |
 |                 |                   |                   |
-|                 |Quantiztion Aware  |Quantiztion Aware  |
+|                 |Quantization Aware |Quantization Aware |
 |                 |Training:          |Training:          |
 |                 |Static             |Static             |
 +-----------------+-------------------+-------------------+


### PR DESCRIPTION
There seems to be a typo in the main quantization docs.

In the table comparing "Eager Mode Quantization" against "FX Graph Mode Quantization", in the row named "Quantization Mode Support" both modes say they are "Quantiztion aware" instead of "Quantization aware"
