### PR TITLE
rename SymbolicIntNode to SymIntNode

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -1309,7 +1309,7 @@ struct TORCH_API SymIntType : public Type {
     return "SymInt";
   }
   std::string annotation_str_impl(TypePrinter printer = nullptr) const override {
-    // TODO: will become a Union[SymbolicIntNode|int] in the near future
+    // TODO: will become a Union[SymIntNode|int] in the near future
     return "int";
   }
   static const TypeKind Kind = TypeKind::SymIntType;

--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -1,16 +1,16 @@
 
 #include <c10/core/SymInt.h>
-#include <c10/core/SymbolicIntNode.h>
+#include <c10/core/SymIntNode.h>
 
 namespace c10 {
 
-std::shared_ptr<SymbolicIntNode> SymInt::toSymbolicIntNode() {
+std::shared_ptr<SymIntNode> SymInt::toSymIntNode() {
   auto& st = getSymIntTable();
   TORCH_CHECK(is_symbolic());
   return st.getNode(SymInt::SYM_TAG_MASK ^ static_cast<uint64_t>(data_));
 }
 
-c10::SymInt SymInt::toSymInt(std::shared_ptr<SymbolicIntNode> sin_sp) {
+c10::SymInt SymInt::toSymInt(std::shared_ptr<SymIntNode> sin_sp) {
   auto& sit = getSymIntTable();
   auto data = sit.addNode(sin_sp) | SYM_TAG_MASK;
   return c10::SymInt(data);

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -5,7 +5,7 @@
 
 namespace c10 {
 
-class SymbolicIntNode;
+class SymIntNode;
 
 // `SymInt` is a C++ wrapper class around int64_t data_ which  and is used to
 // represent concrete dimension values.
@@ -23,11 +23,11 @@ class SymbolicIntNode;
 // functions.
 //
 // SymInt will be extenteded to represent a union structure Union[int64_t,
-// SymbolicIntNode*] which will be implemented as a single packed int64_t field
+// SymIntNode*] which will be implemented as a single packed int64_t field
 // named data_.
 //
 // data_ can be either a plain int64_t or (1 << 63 | `index`). `index` points to
-// SymbolicIntNode* that will be responsible for constructing an IR node for
+// SymIntNode* that will be responsible for constructing an IR node for
 // a traced operation to represent it in LTC or Fx graphs.
 class C10_API SymInt {
  public:
@@ -53,8 +53,8 @@ class C10_API SymInt {
     return data_ + sci.data_;
   }
 
-  std::shared_ptr<SymbolicIntNode> toSymbolicIntNode();
-  static c10::SymInt toSymInt(std::shared_ptr<SymbolicIntNode> sin);
+  std::shared_ptr<SymIntNode> toSymIntNode();
+  static c10::SymInt toSymInt(std::shared_ptr<SymIntNode> sin);
 
   // This is needed for interoperability with IValue
   int64_t data() const {

--- a/c10/core/SymIntNode.h
+++ b/c10/core/SymIntNode.h
@@ -8,11 +8,10 @@
 
 namespace c10 {
 
-class C10_API SymbolicIntNode
-    : public std::enable_shared_from_this<SymbolicIntNode> {
+class C10_API SymIntNode : public std::enable_shared_from_this<SymIntNode> {
  public:
   c10::SymInt toSymInt();
-  virtual ~SymbolicIntNode(){};
+  virtual ~SymIntNode(){};
   virtual std::ostream& operator<<(std::ostream& os) {
     return os;
   };
@@ -20,11 +19,11 @@ class C10_API SymbolicIntNode
 
 class C10_API SymIntTable {
  public:
-  int64_t addNode(std::shared_ptr<SymbolicIntNode> sin);
-  std::shared_ptr<SymbolicIntNode> getNode(size_t index);
+  int64_t addNode(std::shared_ptr<SymIntNode> sin);
+  std::shared_ptr<SymIntNode> getNode(size_t index);
 
  private:
-  std::vector<std::shared_ptr<SymbolicIntNode>> nodes_;
+  std::vector<std::shared_ptr<SymIntNode>> nodes_;
   std::mutex mutex_;
 };
 

--- a/c10/core/SymIntTable.cpp
+++ b/c10/core/SymIntTable.cpp
@@ -1,20 +1,20 @@
-#include <c10/core/SymbolicIntNode.h>
+#include <c10/core/SymIntNode.h>
 
 namespace c10 {
 
-int64_t SymIntTable::addNode(std::shared_ptr<SymbolicIntNode> sin) {
+int64_t SymIntTable::addNode(std::shared_ptr<SymIntNode> sin) {
   std::lock_guard<std::mutex> lock(mutex_);
   auto index = nodes_.size();
   nodes_.push_back(sin);
   return index;
 }
-std::shared_ptr<SymbolicIntNode> SymIntTable::getNode(size_t index) {
+std::shared_ptr<SymIntNode> SymIntTable::getNode(size_t index) {
   std::lock_guard<std::mutex> lock(mutex_);
   TORCH_CHECK(index < nodes_.size());
   return nodes_[index];
 }
 
-c10::SymInt SymbolicIntNode::toSymInt() {
+c10::SymInt SymIntNode::toSymInt() {
   // We will need to figure out a way
   // to dedup nodes
   auto sit_sp = this->shared_from_this();

--- a/test/cpp/lazy/test_lazy_ops.cpp
+++ b/test/cpp/lazy/test_lazy_ops.cpp
@@ -89,7 +89,7 @@ TEST(LazyDynamicOpsTest, NarrowCopy) {
   auto y = torch::rand({Y_DIM}).to(kLazy);
   auto ly = torch::lazy::TryGetLtcTensor(y);
   auto dim_node = MakeNode<SizeNode>(ly->GetIrValue(), 0);
-  auto lmn = std::make_shared<torch::lazy::SymbolicIntNode>(dim_node);
+  auto lmn = std::make_shared<torch::lazy::SymIntNode>(dim_node);
   auto z = x.narrow_copy(X_DIM_INDEX, 0, lmn->toSymInt());
   AllClose(z.cpu(), x.cpu().narrow_copy(X_DIM_INDEX, 0, Y_DIM));
 }

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -6,15 +6,15 @@
 #include <torch/csrc/lazy/core/ir.h>
 #include <torch/csrc/lazy/core/lazy_view.h>
 #include <torch/csrc/lazy/core/util.h>
-#include <c10/core/SymbolicIntNode.h>
+#include <c10/core/SymIntNode.h>
 
 
 namespace torch {
 namespace lazy {
 
-class TORCH_API SymbolicIntNode: public c10::SymbolicIntNode {
+class TORCH_API SymIntNode: public c10::SymIntNode {
 public:
-  SymbolicIntNode(NodePtr ptr): node_(std::move(ptr)) {};
+  SymIntNode(NodePtr ptr): node_(std::move(ptr)) {};
   NodePtr node_;
 };
 

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -577,12 +577,12 @@ static bool is_int_or_symint(PyObject* obj) {
       return true;
   }
 
-  // TODO: test if it's the Python binding for SymbolicIntNode
+  // TODO: test if it's the Python binding for SymIntNode
   return false;
 }
 
 static bool is_int_or_symint_list(PyObject* obj, int broadcast_size) {
-  // TODO: add a check for SymbolicIntNode
+  // TODO: add a check for SymIntNode
   return is_int_list_(obj, broadcast_size);
 }
 

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -36,8 +36,8 @@ def node_ctor_arg_rvalue_string(arg: LazyArgument) -> str:
             elif arg.is_symint_or_list:
                 cpp_type = arg.lazy_type.cpp_type()
                 return (
-                    f"{cpp_type}(std::dynamic_pointer_cast<torch::lazy::SymbolicIntNode>"
-                    f"({arg.name}.toSymbolicIntNode())->node_, 0)"
+                    f"{cpp_type}(std::dynamic_pointer_cast<torch::lazy::SymIntNode>"
+                    f"({arg.name}.toSymIntNode())->node_, 0)"
                 )
             return f"lazy_{arg.name}->GetIrValue()"
         elif isinstance(arg.lazy_type, OptionalCType):


### PR DESCRIPTION
This makes naming consistent with the other Sym* classes such as SymInt and SymIntTable.