### PR TITLE
make clamp_min/max use minimum/maximum kernels, make clamp* correctly propagate nans

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -5,6 +5,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/ReduceOpsUtils.h>
 #include <c10/util/Exception.h>
+#include <ATen/native/BinaryOps.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorCompare.h>
 #include <ATen/NamedTensorUtils.h>
@@ -207,8 +208,6 @@ DEFINE_DISPATCH(isposinf_stub); // NOLINT(cppcoreguidelines-avoid-non-const-glob
 DEFINE_DISPATCH(isneginf_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(mode_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(clamp_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(clamp_min_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-DEFINE_DISPATCH(clamp_max_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(clamp_scalar_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(clamp_min_scalar_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(clamp_max_scalar_stub); // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -573,9 +572,9 @@ TORCH_IMPL_FUNC(clamp_Tensor_out)
   if (min && max) {
     clamp_stub(device_type(), *this);
   } else if (min) {
-    clamp_min_stub(device_type(), *this);
+    maximum_stub(device_type(), *this);
   } else if (max) {
-    clamp_max_stub(device_type(), *this);
+    minimum_stub(device_type(), *this);
   }
 }
 
@@ -586,7 +585,7 @@ TORCH_IMPL_FUNC(clamp_max_out)
 
 TORCH_IMPL_FUNC(clamp_max_Tensor_out)
 (const Tensor& self, const Tensor& max, const Tensor& result) {
-  clamp_max_stub(device_type(), *this);
+  minimum_stub(device_type(), *this);
 }
 
 TORCH_IMPL_FUNC(clamp_min_out)
@@ -596,7 +595,7 @@ TORCH_IMPL_FUNC(clamp_min_out)
 
 TORCH_IMPL_FUNC(clamp_min_Tensor_out)
 (const Tensor& self, const Tensor& min, const Tensor& result) {
-  clamp_min_stub(device_type(), *this);
+  maximum_stub(device_type(), *this);
 }
 
 // Implements the "clip" alias for clamp

--- a/aten/src/ATen/native/TensorCompare.h
+++ b/aten/src/ATen/native/TensorCompare.h
@@ -34,8 +34,6 @@ DECLARE_DISPATCH(mode_fn, mode_stub);
 
 using clamp_tensor_fn = void (*)(TensorIteratorBase &);
 DECLARE_DISPATCH(clamp_tensor_fn, clamp_stub);
-DECLARE_DISPATCH(clamp_tensor_fn, clamp_min_stub);
-DECLARE_DISPATCH(clamp_tensor_fn, clamp_max_stub);
 
 namespace detail {
     enum class ClampLimits {Min, Max, MinMax};

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -335,10 +335,14 @@ static void clamp_kernel_impl(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.common_dtype(), "clamp_cpu", [&]() {
     cpu_kernel_vec(iter,
       [](scalar_t a, scalar_t min, scalar_t max) -> scalar_t {
-        return std::min(std::max(a, min), max);
+        if (min != min || max != max) {
+            return std::numeric_limits<scalar_t>::quiet_NaN();
+        } else {
+            return std::min(std::max(a, min), max);
+        }
       },
       [](Vectorized<scalar_t> a, Vectorized<scalar_t> min, Vectorized<scalar_t> max) {
-        return vec::clamp(a, min, max);
+        return vec::minimum(vec::maximum(a, min), max);
       });
   });
 }
@@ -359,18 +363,6 @@ static void clamp_scalar_kernel_impl(TensorIteratorBase& iter, const Scalar& min
   });
 }
 
-static void clamp_max_kernel_impl(TensorIteratorBase& iter) {
-  AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.common_dtype(), "clamp_max_cpu", [&]() {
-    cpu_kernel_vec(iter,
-      [](scalar_t a, scalar_t max) -> scalar_t {
-        return std::min(a, max);
-      },
-      [](Vectorized<scalar_t> a, Vectorized<scalar_t> max) {
-        return vec::clamp_max(a, max);
-      });
-  });
-}
-
 static void clamp_max_scalar_kernel_impl(TensorIteratorBase& iter, Scalar max_) {
   AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.common_dtype(), "clamp_max_scalar_cpu", [&]() {
     const auto max = max_.to<scalar_t>();
@@ -382,18 +374,6 @@ static void clamp_max_scalar_kernel_impl(TensorIteratorBase& iter, Scalar max_) 
       [=](Vectorized<scalar_t> a) {
         return vec::clamp_max(a, max_vec);
       });
-  });
-}
-
-static void clamp_min_kernel_impl(TensorIteratorBase& iter) {
-  AT_DISPATCH_ALL_TYPES_AND(kBFloat16, iter.common_dtype(), "clamp_min_cpu", [&]() {
-    cpu_kernel_vec(iter,
-        [](scalar_t a, scalar_t min) -> scalar_t {
-          return std::max(a, min);
-        },
-        [](Vectorized<scalar_t> a, Vectorized<scalar_t> min) {
-          return vec::clamp_min(a, min);
-        });
   });
 }
 
@@ -421,8 +401,6 @@ REGISTER_DISPATCH(isposinf_stub, &isposinf_kernel_impl);
 REGISTER_DISPATCH(isneginf_stub, &isneginf_kernel_impl);
 REGISTER_DISPATCH(mode_stub, &mode_kernel_impl);
 REGISTER_DISPATCH(clamp_stub, &clamp_kernel_impl);
-REGISTER_DISPATCH(clamp_min_stub, &clamp_min_kernel_impl);
-REGISTER_DISPATCH(clamp_max_stub, &clamp_max_kernel_impl);
 REGISTER_DISPATCH(clamp_scalar_stub, &clamp_scalar_kernel_impl);
 REGISTER_DISPATCH(clamp_min_scalar_stub, &clamp_min_scalar_kernel_impl);
 REGISTER_DISPATCH(clamp_max_scalar_stub, &clamp_max_scalar_kernel_impl);

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -43,7 +43,7 @@ void clamp_kernel_impl(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "clamp_cuda", [&] {
     gpu_kernel(iter, []GPU_LAMBDA(scalar_t v, scalar_t lower, scalar_t upper) -> scalar_t {
       // Propagate nan, which doesn't propagate automatically for ROCm
-      if (at::_isnan(v)) {
+      if (at::_isnan(v) || at::_isnan(lower) || at::_isnan(upper)) {
         return v;
       } else {
         return ::min(::max(v, lower), upper);
@@ -82,49 +82,9 @@ void clamp_min_scalar_kernel_impl(TensorIteratorBase& iter, Scalar min) {
   launch_clamp_scalar(iter, min, min, at::native::detail::ClampLimits::Min);
 }
 
-void clamp_min_kernel_impl(TensorIteratorBase& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "clamp_min_cuda", [&] {
-    if (iter.is_cpu_scalar(2)){
-      Scalar min = iter.scalar_value<scalar_t>(2);
-      iter.remove_operand(2);
-      clamp_min_scalar_kernel_impl(iter, min);
-    } else {
-      gpu_kernel(iter, []GPU_LAMBDA(scalar_t v, scalar_t lower) -> scalar_t {
-        // Propagate nan, which doesn't propagate automatically for ROCm
-        if (_isnan(v)) {
-          return v;
-        } else {
-          return ::max(v, lower);
-        }
-      });
-    }
-  });
-}
-
-
 void clamp_max_scalar_kernel_impl(TensorIteratorBase& iter, Scalar max) {
   launch_clamp_scalar(iter, max, max, at::native::detail::ClampLimits::Max);
 }
-
-void clamp_max_kernel_impl(TensorIteratorBase& iter) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "clamp_max_cuda", [&] {
-    if (iter.is_cpu_scalar(2)){
-      Scalar max = iter.scalar_value<scalar_t>(2);
-      iter.remove_operand(2);
-      clamp_max_scalar_kernel_impl(iter, max);
-    } else {
-      gpu_kernel(iter, []GPU_LAMBDA(scalar_t v, scalar_t upper) -> scalar_t {
-        // Propagate nan, which doesn't propagate automatically for ROCm
-        if (_isnan(v)) {
-          return v;
-        } else {
-          return ::min(v, upper);
-        }
-      });
-    }
-  });
-}
-
 
 } // anonymous namespace
 
@@ -133,8 +93,6 @@ REGISTER_DISPATCH(where_kernel, &where_kernel_impl);
 REGISTER_DISPATCH(isposinf_stub, &isposinf_kernel_impl);
 REGISTER_DISPATCH(isneginf_stub, &isneginf_kernel_impl);
 REGISTER_DISPATCH(clamp_stub, &clamp_kernel_impl);
-REGISTER_DISPATCH(clamp_min_stub, &clamp_min_kernel_impl);
-REGISTER_DISPATCH(clamp_max_stub, &clamp_max_kernel_impl);
 REGISTER_DISPATCH(clamp_scalar_stub, &clamp_scalar_kernel_impl);
 REGISTER_DISPATCH(clamp_min_scalar_stub, &clamp_min_scalar_kernel_impl);
 REGISTER_DISPATCH(clamp_max_scalar_stub, &clamp_max_scalar_kernel_impl);

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -43,8 +43,12 @@ void clamp_kernel_impl(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "clamp_cuda", [&] {
     gpu_kernel(iter, []GPU_LAMBDA(scalar_t v, scalar_t lower, scalar_t upper) -> scalar_t {
       // Propagate nan, which doesn't propagate automatically for ROCm
-      if (at::_isnan(v) || at::_isnan(lower) || at::_isnan(upper)) {
-        return NAN;
+      if (at::_isnan(v)) {
+        return v;
+      } if (at::_isnan(lower)) {
+        return lower;
+      } if (at::_isnan(upper)) {
+        return upper;
       } else {
         return ::min(::max(v, lower), upper);
       }

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -43,12 +43,8 @@ void clamp_kernel_impl(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "clamp_cuda", [&] {
     gpu_kernel(iter, []GPU_LAMBDA(scalar_t v, scalar_t lower, scalar_t upper) -> scalar_t {
       // Propagate nan, which doesn't propagate automatically for ROCm
-      if (at::_isnan(v)) {
-        return v;
-      } else if (at::_isnan(lower)) {
-        return lower;
-      } else if at::_isnan(upper)) {
-        return upper;
+      if (at::_isnan(v) || at::_isnan(lower) || at::_isnan(upper)) {
+        return NAN;
       } else {
         return ::min(::max(v, lower), upper);
       }

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -43,8 +43,12 @@ void clamp_kernel_impl(TensorIteratorBase& iter) {
   AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "clamp_cuda", [&] {
     gpu_kernel(iter, []GPU_LAMBDA(scalar_t v, scalar_t lower, scalar_t upper) -> scalar_t {
       // Propagate nan, which doesn't propagate automatically for ROCm
-      if (at::_isnan(v) || at::_isnan(lower) || at::_isnan(upper)) {
+      if (at::_isnan(v)) {
         return v;
+      } else if (at::_isnan(lower)) {
+        return lower;
+      } else if at::_isnan(upper)) {
+        return upper;
       } else {
         return ::min(::max(v, lower), upper);
       }

--- a/aten/src/ATen/native/cuda/TensorModeKernel.cu
+++ b/aten/src/ATen/native/cuda/TensorModeKernel.cu
@@ -3,7 +3,6 @@
 #include <ATen/native/cuda/TensorModeKernel.h>
 #include <ATen/Dispatch.h>
 #include <ATen/native/NonEmptyUtils.h>
-#include <ATen/native/TensorCompare.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/ThrustAllocator.h>
 #include <c10/core/DeviceArray.h>

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1100,6 +1100,8 @@ def sort_overloads(
         return (
             str(t1) == "Scalar"
             and str(t2) == "Tensor"
+            or str(t1) == "Scalar?"
+            and str(t2) == "Tensor?"
             or "Dimname" in str(t1)
             and "Dimname" not in str(t2)
             or


### PR DESCRIPTION
Since clamp_min and maximum is the same op, reuse the same kernel (it also correctly propagate nans from both input and boundary, clamp* propagated from input only). 
Also fixed codegen to make Tensor? overloads come before Scalar? overloads, cc @alband. 
Fixes #67428 and #76795 (scalar overloads for clamp* are still not fixed, will do in the next PR). 
