### PR TITLE
Make `bias` a ReplicatedTensor in sharded linear.

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_megatron_prototype.py
+++ b/test/distributed/_shard/sharded_tensor/test_megatron_prototype.py
@@ -7,7 +7,6 @@ import torch
 import torch.distributed as dist
 from torch.distributed._shard.sharded_optim import (
     ShardedOptimizer,
-    named_params_with_sharded_tensor,
 )
 from torch.distributed._shard.api import (
     shard_parameter,
@@ -160,7 +159,10 @@ class TestShardedTensorMegatronLinear(ShardedTensorTestBase):
         # Need to adjust learning rate since DDP averages gradients.
         bias_optim = torch.optim.SGD([bias_fc1, bias_fc2], lr=0.1 * self.world_size)
         sharded_optim = ShardedOptimizer(
-            {'module.fc1.weight': sharded_megatron_lm.module.fc1.weight, 'module.fc2.weight': sharded_megatron_lm.module.fc2.weight},
+            {
+                'module.fc1.weight': sharded_megatron_lm.module.fc1.weight,
+                'module.fc2.weight': sharded_megatron_lm.module.fc2.weight
+            },
             torch.optim.SGD,
             lr=0.1,
         )

--- a/torch/distributed/_shard/partial_tensor.py
+++ b/torch/distributed/_shard/partial_tensor.py
@@ -244,15 +244,15 @@ def partial_add(types, args=(), kwargs=None):
             if lhs.dim() == 1 and rhs.dim() == 1:
                 if lhs.numel() % rhs.numel() != 0:
                     raise RuntimeError(
-                        f"torch function '{func.__name__}', with args: {args} and "
+                        f"torch function 'torch.add', with args: {args} and "
                         f"kwargs: {kwargs} not supported for PartialTensor!")
                 factor = lhs.numel() // rhs.numel()
-                rhs = rhs.reshape(1, -1).expand(factor, rhs.size(0)).reshape(lhs.size())
+                rhs = rhs.reshape(1, -1).expand(factor, rhs.size(0)).reshape(lhs.size())  # type: ignore[assignment]
             else:
-                rhs = rhs.expand(lhs.size())
+                rhs = rhs.expand(lhs.size())  # type: ignore[assignment]
             return _PartialTensor(torch.add(lhs, rhs / world_size))
     raise RuntimeError(
-        f"torch function '{func.__name__}', with args: {args} and "
+        f"torch function 'torch.add', with args: {args} and "
         f"kwargs: {kwargs} not supported for PartialTensor!")
 
 @_custom_partial_tensor_op(torch.Tensor.transpose)

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/linear.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/linear.py
@@ -295,7 +295,7 @@ def _handle_row_wise_sharding_tensor(
         )
 
     # Return the partial local result.
-    return torch.add(_PartialTensor(torch.cat(results), pg), bias)
+    return torch.add(_PartialTensor(torch.cat(results), pg), bias)  # type: ignore[call-overload]
 
 
 def _handle_row_wise_sharding_sharded_tensor(
@@ -331,4 +331,4 @@ def _handle_row_wise_sharding_sharded_tensor(
         )
 
     # Return the partial local result.
-    return torch.add(_PartialTensor(torch.cat(results), pg), bias)
+    return torch.add(_PartialTensor(torch.cat(results), pg), bias)  # type: ignore[call-overload]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #77307

`bias` was implicitly considered a ReplicatedTensor as part of the
sharded linear implementation.

Since, we now have ReplicatedTensor to express this and also support for DDP,
we can express this as ReplicatedTensor and have our ShardedTensor +
ReplicatedTensor inter-op deal with the associated ops in sharded linear.

Differential Revision: [D36329170](https://our.internmc.facebook.com/intern/diff/D36329170/)