### PR TITLE
Properly capitalize PyTorch

### DIFF
--- a/docs/source/notes/numerical_accuracy.rst
+++ b/docs/source/notes/numerical_accuracy.rst
@@ -10,7 +10,7 @@ In particular, note that floating point provides limited accuracy (about 7 decim
 for single precision floating point numbers, about 16 decimal digits for double precision
 floating point numbers) and that floating point addition and multiplication are not
 associative, so the order of the operations affects the results.
-Because of this, pytorch is not guaranteed
+Because of this, PyTorch is not guaranteed
 to produce bitwise identical results for floating point computations that are
 mathematically identical. Similarly, bitwise identical results are not guaranteed across
 PyTorch releases, individual commits, or different platforms. In particular, CPU and GPU
@@ -20,12 +20,12 @@ the sources of randomness.
 Batched computations or slice computations
 ------------------------------------------
 
-Many operations in pytorch support batched computation, where the same operation is performed
+Many operations in PyTorch support batched computation, where the same operation is performed
 for the elements of the batches of inputs. An example of this is :meth:`torch.mm` and
 :meth:`torch.bmm`. It is possible to implement batched computation as a loop over batch elements,
 and apply the necessary math operations to the individual batch elements, for efficiency reasons
 we are not doing that, and typically perform computation for the whole batch. The mathematical
-libraries that we are calling, and pytorch internal implementations of operations can produces
+libraries that we are calling, and PyTorch internal implementations of operations can produces
 slightly different results in this case, compared to non-batched computations. In particular,
 let ``A`` and ``B`` be 3D tensors with the dimensions suitable for batched matrix multiplication.
 Then ``(A@B)[0]`` (the first element of the batched result) is not guaranteed to be bitwise
@@ -54,7 +54,7 @@ datatype. E.g.:
 TensorFloat-32(TF32) on Nvidia Ampere devices
 ---------------------------------------------
 
-On Ampere Nvidia GPUs, pytorch by default uses TensorFloat32 (TF32) to speed up mathematically
+On Ampere Nvidia GPUs, PyTorch by default uses TensorFloat32 (TF32) to speed up mathematically
 intensive operations, in particular matrix multiplications and convolutions. When operation is performed
 using TF32 tensor cores, only the first 10 bits of the input mantissa are read. This leads to less accurate
 results, and surprising results such as multiplying a matrix by identity matrix produces


### PR DESCRIPTION
pytorch -> PyTorch