### PR TITLE
Try not to invoke std::string constructor in dispatcher

### DIFF
--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -7,7 +7,7 @@ namespace torch {
 namespace {
   // TODO: Consider representing debug info as a struct instead so you
   // don't have to allocate strings all the time
-  std::string debugString(const std::string& file, uint32_t line) {
+  std::string debugString(const char* file, uint32_t line) {
 #ifdef STRIP_ERROR_MESSAGES
     return std::string();
 #else
@@ -15,7 +15,7 @@ namespace {
 #endif
   }
 
-  std::string debugString(std::string debug, const std::string& file, uint32_t line) {
+  std::string debugString(std::string debug, const char* file, uint32_t line) {
 #ifdef STRIP_ERROR_MESSAGES
     return std::string();
 #else
@@ -52,11 +52,12 @@ CppFunction::~CppFunction() = default;
 
 #define ERROR_CONTEXT "(Error occurred while processing ", toString(kind_), " block at ", file_, ":", line_, ")"
 
-Library::Library(Kind kind, std::string ns, c10::optional<c10::DispatchKey> k, const char* file, uint32_t line)
+Library::Library(Kind kind, std::string ns, c10::optional<c10::DispatchKey> k, const char* file, std::unique_ptr<std::string> owned_file, uint32_t line)
   : kind_(kind)
   , ns_(ns == "_" ? c10::nullopt : c10::make_optional(std::move(ns)))
   , dispatch_key_((!k.has_value() || *k == c10::DispatchKey::CatchAll) ? c10::nullopt : k)
   , file_(file)
+  , owned_file_(std::move(owned_file))
   , line_(line)
   {
     switch (kind_) {

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -162,11 +162,14 @@ void initDispatchBindings(PyObject* module) {
 
   m.def("_dispatch_library", [](const char* kind, std::string name, const char* dispatch, const char* file, uint32_t linenum) {
     HANDLE_TH_ERRORS
+    auto file_ptr = std::make_unique<std::string>(file);
+    auto* safe_file = file_ptr->c_str();
     return std::make_unique<torch::Library>(
       parseKind(kind),
       std::move(name),
       std::string(dispatch) == "" ? c10::nullopt : c10::make_optional(c10::parseDispatchKey(dispatch)),
-      file,
+      safe_file,
+      std::move(file_ptr),
       linenum);
     END_HANDLE_TH_ERRORS_PYBIND
   }, "", py::arg("kind"), py::arg("name"), py::arg("dispatch"), py::arg("file")="/dev/null", py::arg("linenum")=0)

--- a/torch/library.h
+++ b/torch/library.h
@@ -549,6 +549,7 @@ class TORCH_API Library final {
       std::string ns,
       c10::optional<c10::DispatchKey> k,
       const char* file,
+      std::unique_ptr<std::string> owned_file,
       uint32_t line);
 
   Library(const Library&) = delete;
@@ -800,7 +801,8 @@ class TORCH_API Library final {
   Kind kind_;
   c10::optional<std::string> ns_;
   c10::optional<c10::DispatchKey> dispatch_key_;
-  std::string file_;
+  const char* file_;
+  std::unique_ptr<std::string> owned_file_;
   uint32_t line_;
 
   std::vector<c10::RegistrationHandleRAII> registrars_;
@@ -834,7 +836,7 @@ class TorchLibraryInit final {
       c10::optional<c10::DispatchKey> k,
       const char* file,
       uint32_t line)
-      : lib_(kind, ns, k, file, line) {
+      : lib_(kind, ns, k, file, nullptr, line) {
     fn(lib_);
   }
 };
@@ -985,14 +987,14 @@ class TorchLibraryInit final {
 
 /// \private
 #define MAKE_TORCH_LIBRARY(ns) \
-  torch::Library(torch::Library::DEF, #ns, c10::nullopt, __FILE__, __LINE__)
+  torch::Library(torch::Library::DEF, #ns, c10::nullopt, __FILE__, nullptr, __LINE__)
 /// \private
 #define MAKE_TORCH_LIBRARY_IMPL(ns, k)         \
   torch::Library(                              \
       torch::Library::IMPL,                    \
       #ns,                                     \
       c10::make_optional(c10::DispatchKey::k), \
-      __FILE__,                                \
+      __FILE__, nullptr,                       \
       __LINE__)
 
 // Make the custom class API visible, so it is available from


### PR DESCRIPTION
Summary:
Apparently on M1 iOS builds somehow the std::string constructor
results in an AVX instruction that Rosetta can't deal with.
We only need this for Python anyway, so work hard not to
have a std::string constructor.

Test Plan: show that D36334484 fixes crash; oss tests

Differential Revision: D36335369

