### PR TITLE
Make it possible to register decompositions to Meta key

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -109,7 +109,6 @@ meta_exclude_set = {
     torch.Tensor.nonzero,  # MISSING aten::nonzero
     torch.Tensor.orgqr,  # MISSING aten::linalg_householder_product
     torch.Tensor.ormqr,  # MISSING aten::ormqr
-    torch.Tensor.pinverse,  # MISSING aten::where.self
     torch.Tensor.prod,  # MISSING aten::prod
     torch.Tensor.qr,  # MISSING aten::_linalg_qr_helper
     torch.Tensor.quantile,  # MISSING aten::sort
@@ -135,7 +134,6 @@ meta_exclude_set = {
     torch.Tensor.unsqueeze,  # MISSING aten::_local_scalar_dense
     torch.Tensor.var,  # MISSING aten::var.correction
     torch.Tensor.vdot,  # MISSING aten::vdot
-    torch.Tensor.where,  # MISSING aten::where.self
     torch._add_relu,  # MISSING aten::_add_relu.Tensor
     torch._aminmax,  # MISSING aten::_aminmax
     torch._assert_async,  # MISSING aten::_assert_async
@@ -312,7 +310,6 @@ meta_exclude_set = {
     torch.linalg.matrix_power,  # MISSING aten::_local_scalar_dense
     torch.linalg.matrix_power,  # MISSING aten::eye.m_out
     torch.linalg.norm,  # MISSING aten::linalg_vector_norm
-    torch.linalg.pinv,  # MISSING aten::where.self
     torch.linalg.qr,  # MISSING aten::_linalg_qr_helper
     torch.linalg.slogdet,  # MISSING aten::linalg_slogdet
     torch.linalg.solve,  # MISSING aten::linalg_solve
@@ -350,7 +347,6 @@ meta_exclude_set = {
     torch.nn.functional.batch_norm,  # MISSING aten::native_batch_norm
     torch.nn.functional.binary_cross_entropy,  # MISSING aten::binary_cross_entropy
     torch.nn.functional.channel_shuffle,  # MISSING aten::channel_shuffle
-    torch.nn.functional.cosine_embedding_loss,  # MISSING aten::clamp_min.out
     torch.nn.functional.cross_entropy,  # MISSING aten::_local_scalar_dense
     torch.nn.functional.cross_entropy,  # MISSING aten::nll_loss2d_forward
     torch.nn.functional.ctc_loss,  # MISSING aten::_ctc_loss
@@ -361,10 +357,7 @@ meta_exclude_set = {
     torch.nn.functional.group_norm,  # MISSING aten::native_batch_norm
     torch.nn.functional.hardswish,  # MISSING aten::hardswish
     torch.nn.functional.hardtanh,  # MISSING aten::hardtanh
-    torch.nn.functional.hinge_embedding_loss,  # MISSING aten::clamp_min.out
-    torch.nn.functional.huber_loss,  # MISSING aten::huber_loss
     torch.nn.functional.instance_norm,  # MISSING aten::native_batch_norm
-    torch.nn.functional.kl_div,  # MISSING aten::where.self
     torch.nn.functional.layer_norm,  # MISSING aten::native_batch_norm
     torch.nn.functional.logsigmoid,  # MISSING aten::log_sigmoid_forward
     torch.nn.functional.max_pool3d,  # MISSING aten::max_pool3d_with_indices
@@ -388,7 +381,6 @@ meta_exclude_set = {
     torch.normal,  # MISSING aten::_local_scalar_dense
     torch.orgqr,  # MISSING aten::linalg_householder_product
     torch.ormqr,  # MISSING aten::ormqr
-    torch.pinverse,  # MISSING aten::where.self
     torch.poisson,  # MISSING aten::poisson
     torch.polar,  # MISSING aten::polar.out
     torch.prod,  # MISSING aten::prod
@@ -419,7 +411,6 @@ meta_exclude_set = {
     torch.var,  # MISSING aten::var.correction
     torch.var_mean,  # MISSING aten::var_mean.correction
     torch.vdot,  # MISSING aten::vdot
-    torch.where,  # MISSING aten::where.self
     torch.quantile,  # MISSING aten::isnan
     torch.nanquantile,  # MISSING aten::isnan
 }
@@ -434,6 +425,7 @@ overload_exclude_set = {
     torch.remainder,  # MISSING aten::remainder.Scalar_Tensor
     torch.linalg.matrix_rank,  # MISSING aten::linalg_eigh
     torch.diff,  # MISSING aten::logical_xor.out
+    torch.linalg.pinv,  # CompositeExplicitAutograd but mH fails
 }
 
 # These are fine in OpInfo tests, but triggered errors in full test suite

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -1,5 +1,6 @@
 import torch
 import torch._ops
+import torch.library
 from typing import Callable, Union, Dict, Sequence
 from torch.utils._pytree import tree_map
 from collections import defaultdict
@@ -11,7 +12,10 @@ __all__ = ["decomposition_table", "register_decomposition", "get_decompositions"
 decomposition_table: Dict[torch._ops.OpOverload, Callable] = {}
 
 
-def register_decomposition(aten_op, registry=None):
+meta_lib = torch.library.Library("aten", "IMPL", "Meta")
+
+
+def register_decomposition(aten_op, registry=None, *, register_meta: bool = False):
     """
     A decorator to register a function as a decomposition to the Python
     decomposition table.  Use it like this::
@@ -27,6 +31,10 @@ def register_decomposition(aten_op, registry=None):
     the API when we make decompositions eligible for use in transforms (e.g.,
     autograd) and not just backend tracing, where we then need to know if a
     decomposition can be used to simulate a transform.
+
+    If `register_meta` is True, we will also register this function to the
+    Meta key in the dispatcher, so that it will be used to compute meta
+    tensors.
     """
     def decomposition_decorator(f):
         nonlocal registry
@@ -45,6 +53,8 @@ def register_decomposition(aten_op, registry=None):
                 if op_overload in registry:
                     raise RuntimeError(f"duplicate registrations for {op_overload}")
                 registry[op_overload] = f
+                if register_meta:
+                    meta_lib.impl(op_overload, f)
 
         # To handle allowing multiple aten_ops at once
         tree_map(add_op_to_table, aten_op)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -391,7 +391,7 @@ def mse_loss_backward(
     return norm * (input - target) * grad_output
 
 
-@register_decomposition(aten.huber_loss)
+@register_decomposition(aten.huber_loss, register_meta=True)
 @pw_cast_for_opmath
 def huber_loss(
     self: Tensor,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -2,6 +2,14 @@ import torch
 
 meta_lib = torch.library.Library("aten", "IMPL", "Meta")
 
+def toRealValueType(dtype):
+    from_complex = {
+        torch.complex32: torch.half,
+        torch.cfloat: torch.float,
+        torch.cdouble: torch.double
+    }
+    return from_complex.get(dtype, dtype)
+
 # Implementations below are taken from https://github.com/albanD/subclass_zoo/blob/main/python_meta_tensor.py
 @torch.library.impl(meta_lib, "index_select")
 def meta_index_select(self, dim, index):
@@ -18,8 +26,7 @@ def meta_index_select_out(self, dim, index, out):
 @torch.library.impl(meta_lib, "abs")
 def meta_abs(self):
     if self.is_complex():
-        from_complex = {torch.complex32: torch.half, torch.cfloat: torch.float, torch.cdouble: torch.double}
-        float_type = from_complex[self.dtype]
+        float_type = toRealValueType(self.dtype)
         return self.new_empty(self.size(), dtype=float_type)
     else:
         return self.new_empty(self.size())
@@ -36,3 +43,26 @@ def meta_max(self):
 @torch.library.impl(meta_lib, "min")
 def meta_min(self):
     return self.new_empty(())
+
+def squareCheckInputs(self, f_name):
+    assert self.dim() >= 2, f"{f_name}: The input tensor must have at least 2 dimensions."
+    # TODO: I think the error message has the -2 and -1 swapped.  If you fix
+    # it fix the C++ squareCheckInputs too
+    assert self.size(-1) == self.size(-2), \
+        f"{f_name}: A must be batches of square matrices, but they are {self.size(-1)} by {self.size(-2)} matrices"
+
+def checkUplo(uplo: str):
+    uplo_uppercase = uplo.upper()
+    assert len(uplo) == 1 and uplo_uppercase == 'U' or uplo_uppercase == 'L', \
+        f"Expected UPLO argument to be 'L' or 'U', but got {uplo}"
+
+@torch.library.impl(meta_lib, "linalg_eigh")
+def meta_linalg_eigh(self, uplo="L"):
+    squareCheckInputs(self, "linalg_eigh")
+    checkUplo(uplo)
+    real_dtype = toRealValueType(self.dtype)
+    assert self.dim() >= 2
+    values = self.new_empty(self.shape, dtype=real_dtype)
+    values.transpose_(-2, -1)
+    vectors = self.new_empty(self.shape[:-1])
+    return (values, vectors)

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -169,7 +169,9 @@ def _wrap_tensor_meta(f):
     def unwrap(t):
         # TODO: doesn't setup aliasing relation on views correctly
         if isinstance(t, TensorMeta):
-            return torch.empty_strided(t.shape, t.stride(), dtype=t.dtype, device='meta')
+            return torch.empty_strided(
+                t.shape, t.stride(), dtype=t.dtype, device="meta"
+            )
         else:
             return t
 

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -16,6 +16,7 @@ from torch._prims.utils import (
 )
 from torch.overrides import has_torch_function, handle_torch_function
 import torch.library
+from torch.utils._pytree import tree_map
 
 from typing import Sequence, Optional, Union, Callable, List, Tuple, Any
 from functools import reduce, partial
@@ -25,6 +26,7 @@ import math
 
 prim = torch.library.Library("prims", "DEF")
 prim_impl = torch.library.Library("prims", "IMPL", "CompositeExplicitAutograd")
+prim_meta_impl = torch.library.Library("prims", "IMPL", "Meta")
 
 # Experimental module containing prototype "primitive" operations.
 
@@ -157,6 +159,28 @@ class RETURN_TYPE(Enum):
     INPLACE = (2,)
 
 
+def _wrap_tensor_meta(f):
+    def wrap(t):
+        if isinstance(t, torch.Tensor):
+            return TensorMeta(t)
+        else:
+            return t
+
+    def unwrap(t):
+        # TODO: doesn't setup aliasing relation on views correctly
+        if isinstance(t, TensorMeta):
+            return torch.empty_strided(t.shape, t.stride(), dtype=t.dtype, device='meta')
+        else:
+            return t
+
+    def wrapper(*args, **kwargs):
+        wrapped_args = tree_map(wrap, args)
+        wrapped_kwargs = tree_map(wrap, kwargs)
+        return tree_map(unwrap, f(*wrapped_args, **wrapped_kwargs))
+
+    return wrapper
+
+
 def _make_prim(
     *,
     schema: str,
@@ -182,7 +206,7 @@ def _make_prim(
 
     name = schema.split("(")[0]
     prim_impl.impl(name, _prim_impl)
-    # TODO: register meta
+    prim_meta_impl.impl(name, _wrap_tensor_meta(meta))
 
     _prim = getattr(torch.ops.prims, name).default
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -701,7 +701,7 @@ true_divide = _make_elementwise_binary_reference(
 
 # https://pytorch.org/docs/stable/generated/torch.where.html
 # TODO: implement alternate where
-@register_decomposition(torch.ops.aten.where)
+@register_decomposition(torch.ops.aten.where, register_meta=True)
 @out_wrapper
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("a", "b"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #77386
* #77362
* __->__ #77353

Decompositions can be used to fill in meta support where necessary,
assuming the operations they decompose to support meta key.
This PR adds register_meta kwarg to register_decomposition that
optionally lets you register the meta to the C++ dispatch table
for meta tensors.  I use this to then get the meta function for
where and huber_loss for free.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>