### PR TITLE
fix StridesPolicy logic for FunctionalTensorWrapper

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -17,10 +17,10 @@ void FunctionalTensorWrapper::set_constructor_metadata() {
   // For now I'm retroactively setting this in functorch,
   // but once Open Multiple Dispatch lands we should be able to calculate this in core.
   level_ = -1;
-  // shallow_copy_from overwrites the storage and dispatch keyset...
-  auto functional_storage = storage_;
-  shallow_copy_from(value_.getIntrusivePtr());
-  storage_ = functional_storage;
+  // mirror all of the generic tensor metadata onto the wrapper
+  copy_generic_tensor_metadata(value_.getIntrusivePtr().get(), this);
+  refresh_numel();
+  refresh_contiguous();
   storage_access_should_throw_ = false;
   key_set_ = c10::DispatchKeySet(c10::DispatchKey::Functionalize) | value_.key_set();
   // All of the keys corresponding to functorch transforms should not be copied over.

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -493,7 +493,8 @@ c10::intrusive_ptr<TensorImpl> TensorImpl::shallow_copy_and_detach(
 // - allow_tensor_metadata_change_
 // The idea is that if we have a "wrapper tensor" (like in functionalization),
 // all of the above are properties that the wrapper will want to customize,
-// while everything else should be mirrored between the wrapper and the inner tensor.
+// while everything else should be mirrored between the wrapper and the inner
+// tensor.
 void TensorImpl::copy_generic_tensor_metadata(
     const TensorImpl* src_impl,
     TensorImpl* dest_impl) {

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -484,21 +484,23 @@ c10::intrusive_ptr<TensorImpl> TensorImpl::shallow_copy_and_detach(
       std::move(version_counter), allow_tensor_metadata_change);
 }
 
-void TensorImpl::copy_tensor_metadata_except_version_counter(
+// This function copies all of the metadata from the src tensor except for:
+// - key_set_
+// - storage_
+// - storage_access_should_throw_
+// - sizes_strides_policy_
+// - version_counter_
+// - allow_tensor_metadata_change_
+// The idea is that if we have a "wrapper tensor" (like in functionalization),
+// all of the above are properties that the wrapper will want to customize,
+// while everything else should be mirrored between the wrapper and the inner tensor.
+void TensorImpl::copy_generic_tensor_metadata(
     const TensorImpl* src_impl,
-    TensorImpl* dest_impl,
-    bool allow_tensor_metadata_change) {
-  dest_impl->storage_ = src_impl->storage_;
+    TensorImpl* dest_impl) {
   dest_impl->sizes_and_strides_ = src_impl->sizes_and_strides_;
   dest_impl->storage_offset_ = src_impl->storage_offset_;
   dest_impl->data_type_ = src_impl->data_type_;
   dest_impl->device_opt_ = src_impl->device_opt_;
-  // Copying tensor metadata doesn't change the PyObject (maybe
-  // it should), which means that we have to preserve whatever the
-  // original Python keyset was (as it's associated with the PyObject
-  // being a tensor subclass or not)
-  dest_impl->key_set_ = (src_impl->key_set_ - c10::python_ks) |
-      (dest_impl->key_set_ & c10::python_ks);
   dest_impl->is_contiguous_ = src_impl->is_contiguous_;
   dest_impl->is_channels_last_contiguous_ =
       src_impl->is_channels_last_contiguous_;
@@ -510,13 +512,30 @@ void TensorImpl::copy_tensor_metadata_except_version_counter(
       src_impl->is_non_overlapping_and_dense_;
   dest_impl->is_wrapped_number_ = src_impl->is_wrapped_number_;
   dest_impl->reserved_ = src_impl->reserved_;
+  if (src_impl->named_tensor_meta_ != nullptr) {
+    dest_impl->named_tensor_meta_ = src_impl->named_tensor_meta_->clone();
+  }
+}
+
+void TensorImpl::copy_tensor_metadata_except_version_counter(
+    const TensorImpl* src_impl,
+    TensorImpl* dest_impl,
+    bool allow_tensor_metadata_change) {
+  // First call the generic copy function
+  copy_generic_tensor_metadata(src_impl, dest_impl);
+  // Then copy everything else (see the comment at copy_generic_tensor_metadata
+  // for the list of metadata that it does not directly copy).
+  dest_impl->storage_ = src_impl->storage_;
+  // Copying tensor metadata doesn't change the PyObject (maybe
+  // it should), which means that we have to preserve whatever the
+  // original Python keyset was (as it's associated with the PyObject
+  // being a tensor subclass or not)
+  dest_impl->key_set_ = (src_impl->key_set_ - c10::python_ks) |
+      (dest_impl->key_set_ & c10::python_ks);
   dest_impl->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
   dest_impl->sizes_strides_policy_ = src_impl->sizes_strides_policy_;
   dest_impl->storage_access_should_throw_ =
       src_impl->storage_access_should_throw_;
-  if (src_impl->named_tensor_meta_ != nullptr) {
-    dest_impl->named_tensor_meta_ = src_impl->named_tensor_meta_->clone();
-  }
 }
 
 void TensorImpl::copy_tensor_metadata(

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2178,6 +2178,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // See NOTE [ Metadata Change for a Detached Tensor ] for details.
   static const char* const err_msg_tensor_metadata_change_not_allowed;
 
+  static void copy_generic_tensor_metadata(
+      const TensorImpl* src_impl,
+      TensorImpl* dest_impl);
+
  public:
   void set_storage_access_should_throw() {
     storage_access_should_throw_ = true;


### PR DESCRIPTION
`FunctionalTensorWrapper` has been sneakily relying on `shallow_copy_from` to mirror metadata from the inner tensor onto the wrapper. The new changes from https://github.com/pytorch/pytorch/pull/77036 actually break this logic because we blindly mirror the contiguity policy from the inner tensor to the wrapper. But `FunctionalTensorWrapper` should always have the default policy - it has valid sizes and strides!

I originally wrote it this way to avoid having to alter `TensorImpl.h` just for functionalization, but now we have to; `shallow_copy_from()` copies the metadata and then immediately calls `refresh_sizes()`, which fails on `FunctionalTensorWrapper` if it was just given a non-default policy (because we don't have a `sizes_custom()` method override defined).

Instead, I tried to split out the copying methods in `TensorImpl.h` into a base method that copies all metadata relevant to wrappers. And I updated `shallow_copy_from` to use that, so the metadata copying isn't duplicated anywhere.

Companion functorch patch: https://github.com/pytorch/functorch/pull/800

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77358
* #77285

