### PR TITLE
[ONNX] Fix type comparison in utils._need_symbolic_context

### DIFF
--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1485,7 +1485,7 @@ def _should_aten_fallback(ns, op_name, opset_version, operator_export_type):
 def _need_symbolic_context(symbolic_fn) -> bool:
     """Checks if the first argument to symbolic_fn is annotated as type `torch.onnx.SymbolicContext`."""
     params = tuple(inspect.signature(symbolic_fn).parameters.values())
-    # When the annotation is postponed evaluated, the annotation is a string
+    # When the annotation is postpone-evaluated, the annotation is a string
     # and not a type. We need to use get_type_hints to get the real type.
     if not params:
         return False

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -10,6 +10,7 @@ import numbers
 import os
 import re
 import textwrap
+import typing
 import warnings
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 


### PR DESCRIPTION
In `_need_symbolic_context`, when the annotation is postponed evaluated, the annotation is a string and not a type. We need to use get_type_hints to get the real type.

For example,

```python
def g(a: int) -> int: return a

def f(a: "int") -> "int": return a
```

we will get the correct type `int` for both g and f with `typing.get_type_hints`. Otherwise, the type for `a` in `f` will be a string and is not comparable to the type `int` - `issubclass` will complain.

This is necessary as we will use postponed typing evaluation to break circular dependencies.