### PR TITLE
ci: Cleanup create_release.yml workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -40,7 +40,7 @@ jobs:
             cp -r "$PWD" "/tmp/$PT_RELEASE_NAME"
             mv "/tmp/$PT_RELEASE_NAME" .
             # Cleanup
-            rm -r "$PT_RELEASE_NAME"/{.azure_pipelines,.circleci,.jenkins}
+            rm -rf "$PT_RELEASE_NAME"/{.circleci,.jenkins}
             find "$PT_RELEASE_NAME" -name '.git*' -exec rm -rv {} \; || true
             # Create archive
             tar -czf "$PT_RELEASE_FILE" "$PT_RELEASE_NAME"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77370
* __->__ #77369

Removes azure_pipelines removal from create_release.yml

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>