### PR TITLE
[ONNX] Relax node constraint for onnx shape inference

### DIFF
--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -201,6 +201,15 @@ class TestONNXShapeInference(unittest.TestCase):
         expand = g.op("Expand", constant, shape)
         self.run_test(g, expand.node(), expect_tensor("Float", shape=(None, None)))
 
+    def test_pad(self):
+        g = self.create_empty_graph()
+        input = g.addInput()
+        input.setType(input.type().with_dtype(torch.float).with_sizes([3, 320, 100]))
+        constant = self.insert_tensor_constant(g, torch.ones(6, dtype=torch.long))
+        none = g.op("prim::Constant").setType(torch.NoneType.get())
+        pad = g.op("Pad", input, constant, none, mode_s="constant")
+        self.run_test(g, pad.node(), expect_tensor("Float", shape=(None, None, None)))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -226,12 +226,6 @@ bool IsValidONNXNode(const Node* n) {
     }
   }
 
-  for (auto inp : n->inputs()) {
-    if (inp->type() == NoneType::get()) {
-      return false;
-    }
-  }
-
   return true;
 }
 


### PR DESCRIPTION
None as input is legal per ONNX spec for representing
optional inputs. For [example](https://github.com/onnx/onnx/blob/main/docs/Operators.md#inputs-2---3-7) `constant_value` for `ONNX::Pad`.
This PR removes such constraint check that was set prior 
to calling onnx shape inference. For the issue below, such 
constraint prevents the onnx shape inference of `ONNX::Pad`,
which leads to falling back on an incorrect constant traced 
shape.
For the unit test in this PR, prior to this PR, the ONNX shape inference
for `ONNX::Pad` would be skipped, and would return `None` instead.

Fixes https://github.com/pytorch/vision/issues/5971
