### PR TITLE
Bugfix gradient formula for index_reduce('prod') + separate out sample_inputs for index_reduce

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7066,20 +7066,33 @@ class TestAutogradDeviceType(TestCase):
                 self.assertEqual(x.grad.sum(), 1.)
                 self.assertEqual((x.grad == 1 / 3).sum(), 3)
 
-    def test_scatter_reduce_prod_gradgrad_error(self, device):
+    def test_scatter_index_reduce_amin_amax_backprops_to_all_values(self, device):
+        # tests that gradients are evenly distributed when there are multiple max/min values
+        # tested here instead of adding a SampleInput as the backward for this case is non-differentiable for gradgrad
+        # as is the case for test_min_max_median_backprops_to_all_values above
+        fns = (torch.scatter_reduce, torch.index_reduce)
+        reduces = ('amin', 'amax')
+        for fn, reduction in product(fns, reduces):
+            input = torch.randn((2, 3), device=device, dtype=torch.float64, requires_grad=True)
+            src = input.clone().detach_().requires_grad_(True)
+            idx = torch.arange(2).to(dtype=torch.long, device=device)
+            if fn == torch.scatter_reduce:
+                idx = idx.unsqueeze(-1).expand((2, 3))
+
+            gradcheck(fn, (input, 0, idx, src, reduction), check_batched_grad=False)
+
+    def test_scatter_index_reduce_prod_gradgrad_error(self, device):
         # test that double backward raises an error for the case where 2 zeros in src
         # are scattered to the same position in self
         input = torch.tensor([1.], device=device, dtype=torch.float64, requires_grad=True)
         src = torch.tensor([0., 0.], device=device, dtype=torch.float64, requires_grad=True)
         idx = torch.tensor([0, 0], device=device, dtype=torch.long)
 
-        def fn(input, src):
-            return input.scatter_reduce(0, idx, src, 'prod')
-
-        # check that this case passes on gradcheck
-        gradcheck(fn, [input, src], check_batched_grad=False)
-        with self.assertRaisesRegex(RuntimeError, "Double backward is unsupported for src when"):
-            gradgradcheck(fn, [input, src])
+        for fn in (torch.scatter_reduce, torch.index_reduce):
+            # check that this case passes on gradcheck
+            gradcheck(fn, (input, 0, idx, src, 'prod'), check_batched_grad=False)
+            with self.assertRaisesRegex(RuntimeError, "Double backward is unsupported for"):
+                gradgradcheck(fn, (input, 0, idx, src, 'prod'))
 
     def test_parameter_resize(self, device):
         asd = torch.nn.Parameter(torch.ones(16, dtype=torch.double, device=device))

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -5545,10 +5545,28 @@ std::tuple<Tensor, Tensor> index_reduce_backward(
   }
 
   if (reduce == "prod") {
-    grad_self = (grad * result) / self;
-    grad_self.masked_fill_(self == 0, 0);
-    grad_src = (grad * result).index_select(dim, index) / source;
-    grad_src.masked_fill_(source == 0, 0);
+    Tensor masked_self = self.masked_fill(self == 0, 1);
+    Tensor masked_self_result = masked_self.index_reduce(dim, index, source, reduce, include_self);
+    grad_self = grad * masked_self_result / masked_self;
+    Tensor src_zero = source == 0;
+    Tensor src_num_zeros = zeros_like(self).index_add(dim, index, src_zero.to(self.dtype())).index_select(dim, index);
+    Tensor src_single_zero = bitwise_and(src_zero, src_num_zeros == 1);
+    // For src positions with src_single_zero, (grad * result).index_select(dim,index) / source.masked_fill(src_zero, 1)
+    // would incorrectly propagate zeros as the gradient
+    Tensor masked_src = source.masked_fill(src_single_zero, 1);
+    Tensor masked_src_result = self.index_reduce(dim, index, masked_src, reduce, include_self);
+    Tensor grad_src1 = where(src_single_zero,
+                             (grad * masked_src_result).index_select(dim, index),
+                             (grad * result).index_select(dim, index) / source.masked_fill(src_zero, 1));
+    if ((src_num_zeros > 1).any().item<bool>()) {
+      auto node = std::make_shared<DelayedError>(
+        "index_reduce(): Double backward is unsupported for source when >1 zeros in source are scattered to the same position in self",
+        /* num inputs */ 1);
+      auto result = node->apply({ grad_src1 });
+      grad_src = result[0];
+    } else {
+      grad_src = grad_src1;
+    }
   } else if (reduce == "mean") {
     Tensor N = include_self ? ones_like(grad) : zeros_like(grad);
     N = N.index_add(dim, index, ones_like(source));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #76996
* __->__ #77382
* #76997
* #76296

- Applies the same backward fix for `index_reduce(prod)` as was applied to `scatter_reduce(prod)` in #76523 (gradients of 0s in self/source should not be zeroed out)
- Adds a separate test for even propagation of gradients for min/max for scatter/index_reduce as this case will fail on gradgradcheck
- Separates out sample_inputs_function for index_reduce [as per this comment](https://github.com/pytorch/pytorch/pull/75981#discussion_r860578084)
