### PR TITLE
[Reland] load_state_dict post hook

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -45,7 +45,7 @@ from torch.testing._internal.common_utils import freeze_rng_state, run_tests, Te
     skipIfRocmVersionLessThan, skipIfNotMiopenSuggestNHWC, TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, \
     download_file, get_function_arglist, load_tests, skipIfMps,\
     suppress_warnings, TemporaryFileName, TEST_WITH_UBSAN, IS_PPC, \
-    parametrize as parametrize_test, subtest, instantiate_parametrized_tests, set_default_dtype
+    parametrize as parametrize_test, subtest, instantiate_parametrized_tests, set_default_dtype, IS_WINDOWS
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
 from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
     module_tests, criterion_tests, loss_reference_fns, \
@@ -21623,6 +21623,7 @@ class TestStateDictHooks(TestCase):
         self.assertEqual([], ret.missing_keys)
         self.assertEqual([], ret.unexpected_keys)
 
+    @unittest.skipIf(IS_WINDOWS, "Tempfile permission issue on windows")
     def test_load_state_dict_post_hook_backward_compatibility(self):
         def my_post_load_hook(mod, _):
             nonlocal called

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -21609,6 +21609,19 @@ class TestStateDictHooks(TestCase):
         # hook_called should not have been incremented
         self.assertEqual(hook_called, 2)
 
+        def load_hook_clear_incompatible(module, incompatible_keys):
+            incompatible_keys.missing_keys.clear()
+            incompatible_keys.unexpected_keys.clear()
+
+        nested.register_load_state_dict_post_hook(load_hook_clear_incompatible)
+        state_dict = wrapped.state_dict()
+        state_dict["extra"] = torch.ones(1)
+        # load state_dict with strict=True should not throw.
+        ret = wrapped.load_state_dict(state_dict, strict=True)
+        # explicitly ensure that the post hook clearned out incompatible_keys
+        self.assertEqual([], ret.missing_keys)
+        self.assertEqual([], ret.unexpected_keys)
+
 
 instantiate_device_type_tests(TestNNDeviceType, globals())
 instantiate_parametrized_tests(TestNN)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -21566,6 +21566,40 @@ class TestStateDictHooks(TestCase):
             m.load_state_dict(state_dict)
             self.assertEqual(2, hook_called)
 
+    def test_load_state_dict_post_hook(self):
+        hook_called = 0
+
+        class MyModule(nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+                self.foo = torch.nn.Parameter(torch.rand(10))
+
+            def my_post_load_hook(self, module, incompatible_keys):
+                assert module is self
+                nonlocal hook_called
+                incompatible_keys.missing_keys.append("foo")
+                incompatible_keys.unexpected_keys.append("bar")
+                hook_called += 1
+
+        class MyModuleContainer(nn.Module):
+            def __init__(self, mod):
+                super().__init__()
+                self.mod = mod
+
+        nested = MyModule()
+        wrapped = MyModuleContainer(nested)
+        nested.register_load_state_dict_post_hook(
+            nested.my_post_load_hook,
+        )
+        # Hook must be called even if it is wrapped
+        ret = wrapped.load_state_dict(wrapped.state_dict(), strict=False)
+        self.assertEqual(hook_called, 1)
+        # Ensure that the hook modified missing_keys and unexpected_keys
+        missing = ret.missing_keys
+        unexpected = ret.unexpected_keys
+        self.assertEqual(missing, ["foo"])
+        self.assertEqual(unexpected, ["bar"])
+
 
 instantiate_device_type_tests(TestNNDeviceType, globals())
 instantiate_parametrized_tests(TestNN)

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -65,6 +65,7 @@ _REMOTE_MODULE_ATTRIBUTES_IGNORE_FOR_PICKLING = (
     "_forward_pre_hooks",
     "_state_dict_hooks",
     "_load_state_dict_pre_hooks",
+    "_load_state_dict_post_hooks",
     "_modules",
     # The two attributes below are generated methods, not available at pickling time.
     "forward_async",

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1312,10 +1312,9 @@ class Softmin(Module):
         self.dim = dim
 
     def __setstate__(self, state):
+        super().__setstate__(state)
         if not hasattr(self, 'dim'):
             self.dim = None
-
-        super().__setstate__(state)
 
     def forward(self, input: Tensor) -> Tensor:
         return F.softmin(input, self.dim, _stacklevel=5)
@@ -1369,10 +1368,9 @@ class Softmax(Module):
         self.dim = dim
 
     def __setstate__(self, state):
+        super().__setstate__(state)
         if not hasattr(self, 'dim'):
             self.dim = None
-
-        super().__setstate__(state)
 
     def forward(self, input: Tensor) -> Tensor:
         return F.softmax(input, self.dim, _stacklevel=5)
@@ -1441,10 +1439,9 @@ class LogSoftmax(Module):
         self.dim = dim
 
     def __setstate__(self, state):
+        super().__setstate__(state)
         if not hasattr(self, 'dim'):
             self.dim = None
-
-        super().__setstate__(state)
 
     def forward(self, input: Tensor) -> Tensor:
         return F.log_softmax(input, self.dim, _stacklevel=5)

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1312,9 +1312,10 @@ class Softmin(Module):
         self.dim = dim
 
     def __setstate__(self, state):
-        self.__dict__.update(state)
         if not hasattr(self, 'dim'):
             self.dim = None
+
+        super().__setstate__(state)
 
     def forward(self, input: Tensor) -> Tensor:
         return F.softmin(input, self.dim, _stacklevel=5)
@@ -1368,9 +1369,10 @@ class Softmax(Module):
         self.dim = dim
 
     def __setstate__(self, state):
-        self.__dict__.update(state)
         if not hasattr(self, 'dim'):
             self.dim = None
+
+        super().__setstate__(state)
 
     def forward(self, input: Tensor) -> Tensor:
         return F.softmax(input, self.dim, _stacklevel=5)
@@ -1439,9 +1441,10 @@ class LogSoftmax(Module):
         self.dim = dim
 
     def __setstate__(self, state):
-        self.__dict__.update(state)
         if not hasattr(self, 'dim'):
             self.dim = None
+
+        super().__setstate__(state)
 
     def forward(self, input: Tensor) -> Tensor:
         return F.log_softmax(input, self.dim, _stacklevel=5)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -282,6 +282,7 @@ class Module:
         self._forward_pre_hooks: Dict[int, Callable] = OrderedDict()
         self._state_dict_hooks: Dict[int, Callable] = OrderedDict()
         self._load_state_dict_pre_hooks: Dict[int, Callable] = OrderedDict()
+        self._load_state_dict_post_hooks: Dict[int, Callable] = OrderedDict()
         self._modules: Dict[str, Optional['Module']] = OrderedDict()
 
     forward: Callable[..., Any] = _forward_unimplemented
@@ -1197,6 +1198,8 @@ class Module:
             self._state_dict_hooks = OrderedDict()
         if '_load_state_dict_pre_hooks' not in self.__dict__:
             self._load_state_dict_pre_hooks = OrderedDict()
+        if '_load_state_dict_post_hooks' not in self.__dict__:
+            self._load_state_dict_post_hooks = OrderedDict()
         if '_non_persistent_buffers_set' not in self.__dict__:
             self._non_persistent_buffers_set = set()
         if '_is_full_backward_hook' not in self.__dict__:
@@ -1417,6 +1420,26 @@ class Module:
         self._load_state_dict_pre_hooks[handle.id] = hook
         return handle
 
+    def register_load_state_dict_post_hook(self, hook):
+        r"""
+        These hooks will be called with the following arguments:
+            1. The current module this hook is registered on
+            2. A ``NamedTuple`` consisting of attributes ``missing_keys``
+                and ``unexpected_keys``. ``missing_keys`` is a ``list`` of
+                ``str`` containing the missing keys and ``unexpected_keys``
+                is a ``list`` of ``str`` containing the unexpected keys.
+        If the hook wishes to modify the ``NamedTuple`` ``missing_keys``
+        or ``unexpected_keys`` returned by ``load_state_dict``, the hook
+        can simply modify the ``NamedTuple`` argument it is invoked with.
+        Arguments:
+            hook (Callable): Callable hook that will be invoked after
+                loading the state dict.
+        """
+        handle = hooks.RemovableHandle(self._load_state_dict_post_hooks)
+        self._load_state_dict_post_hooks[handle.id] = hook
+        return handle
+
+
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
         r"""Copies parameters and buffers from :attr:`state_dict` into only
@@ -1557,6 +1580,11 @@ class Module:
                 if child is not None:
                     load(child, prefix + name + '.')
 
+            # Note that the hook can modify missing_keys and unexpected_keys.
+            incompatible_keys = _IncompatibleKeys(missing_keys, unexpected_keys)
+            for hook in module._load_state_dict_post_hooks.values():
+                hook(module, incompatible_keys)
+
         load(self)
         del load
 
@@ -1573,6 +1601,7 @@ class Module:
         if len(error_msgs) > 0:
             raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
                                self.__class__.__name__, "\n\t".join(error_msgs)))
+
         return _IncompatibleKeys(missing_keys, unexpected_keys)
 
     def _named_members(self, get_members_fn, prefix='', recurse=True):

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1440,6 +1440,7 @@ class Module:
         ``missing_keys`` or ``unexpected_keys``, as expected. Additions to either
         set of keys will result in an error being thrown when ``strict=True``, and
         clearning out both missing and unexpected keys will avoid an error.
+
         Returns:
             :class:`torch.utils.hooks.RemovableHandle`:
                 a handle that can be used to remove the added hook by calling


### PR DESCRIPTION
Reland of https://github.com/pytorch/pytorch/pull/76823 with fixes to call `__setstate__` for softmax/softmin/logsoftmax as per discussion with @albanD and @jbschlosser. Original description:

Implements `register_load_state_dict_post_hook` API as discussed in https://github.com/pytorch/pytorch/issues/75287.

Unittests cover:
- Ensuring hooks are called with the correct module
- Hook is called with `IncompatibleKeys` field
- If hook modifies this, load_state_dict returns the modified result
