### PR TITLE
[NVFuser] fix force-disable flag

### DIFF
--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -91,6 +91,10 @@ class NVFuserEnabler {
   }
 
   bool isEnabledImpl() {
+    // 0. opportunity to force disable NVFuser
+    if (getCachedNNCNotNVFuser()) {
+      return false;
+    }
     std::call_once(enabled_check_flag_, [&]() {
       // if environment variable is setting the value, we must
       if (!runtime_assigned_fuser_enabled_.has_value() &&
@@ -98,10 +102,6 @@ class NVFuserEnabler {
         assertFuserCanBeEnabled(*getCachedFuserEnabledEnvVar());
       }
     });
-    // 0. opportunity to force disable NVFuser
-    if (getCachedNNCNotNVFuser()) {
-      return false;
-    }
     // 1. if user has explicitly assigned fuser value, that value takes
     // precedence.
     if (runtime_assigned_fuser_enabled_.has_value()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77395

This prevents the std::call_once() check from erroring if:

* PYTORCH_JIT_USE_NNC_NOT_NVFUSER=1
* PYTORCH_JIT_ENABLE_NVFUSER=1
* user has not set a flag.

Differential Revision: [D36364554](https://our.internmc.facebook.com/intern/diff/D36364554)