### PR TITLE
c10/SymInt.h: Fix "integer conversion resulted in a change of sign"

### DIFF
--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -39,7 +39,8 @@ class C10_API SymInt {
   }
 
   bool is_symbolic() const {
-    return SYM_TAG_MASK & static_cast<uint64_t>(this->data_);
+    return static_cast<uint64_t>(SYM_TAG_MASK) &
+        static_cast<uint64_t>(this->data_);
   }
 
   bool operator==(const SymInt& p2) const {


### PR DESCRIPTION
Summary:
By casting both operands to uint64_t as bitwise operations on signed types might be architecture dependent, but for x86_64 it doesn't matter:
https://godbolt.org/z/n81EncGz9

Test Plan: CI

Differential Revision: D36365405

