### PR TITLE
Fixed type promotion semantics for native_batch_norm and native_layer_norm

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -162,6 +162,7 @@ def op_assert_ref(test_case, op, orig, decomp, ref, args, kwargs):
             raise RuntimeError(
                 f"Difference from float64 is larger with decomposition {op.__name__}"
                 f" than original. Original max diff: {orig_diff}, Decomp max diff: {decomp_diff}\n"
+                f"atol = {atol}\n"
                 f"args = {args}\n"
                 f"kwargs = {kwargs}"
             )

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -152,6 +152,7 @@ def op_assert_ref(test_case, op, orig, decomp, ref, args, kwargs):
     assert orig.shape == decomp.shape, f"Operation:  {op}"
     tol_table = {
         (torch.bfloat16, torch.ops.aten.native_layer_norm.default): 1e-5,
+        (torch.float16, torch.ops.aten.native_layer_norm.default): 1e-5,
     }
     if ref.is_floating_point():
         orig_diff = (orig - ref).abs().max()

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -145,7 +145,6 @@ def _getDefaultRtolAndAtol(dtype0, dtype1):
 
 
 def op_assert_ref(test_case, op, orig, decomp, ref, args, kwargs):
-    print(orig.dtype, decomp.dtype)
     assert orig.dtype == decomp.dtype, f"Operation:  {op}"
     if orig.numel() == 0 or decomp.numel() == 0:
         assert orig.numel() == decomp.numel()
@@ -275,10 +274,6 @@ CROSS_REF_EXCLUDE_SET = {
     ("cuda", torch.float64, "nn.functional.dropout"),
     ("cuda", torch.float32, "nn.functional.dropout"),
     # decomp has problem even with opmath
-    # ("cuda", torch.bfloat16, "nn.functional.layer_norm"),
-    # ("cuda", torch.float16, "nn.functional.layer_norm"),
-    ("cuda", torch.bfloat16, "nn.functional.instance_norm"),
-    ("cuda", torch.float16, "nn.functional.instance_norm"),
     # doesn't work
     ("cuda", torch.bfloat16, "nn.functional.embedding"),
 

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -152,7 +152,7 @@ def op_assert_ref(test_case, op, orig, decomp, ref, args, kwargs):
     if ref.is_floating_point():
         orig_diff = (orig - ref).abs().max()
         decomp_diff = (decomp - ref).abs().max()
-        atol = 1e-10
+        atol = 1e-7
         if decomp_diff > orig_diff + atol:
             raise RuntimeError(
                 f"Difference from float64 is larger with decomposition {op.__name__}"
@@ -275,8 +275,6 @@ CROSS_REF_EXCLUDE_SET = {
     # decomp has problem even with opmath
     ("cuda", torch.bfloat16, "nn.functional.layer_norm"),
     ("cuda", torch.float16, "nn.functional.layer_norm"),
-    ("cuda", torch.bfloat16, "nn.functional.batch_norm"),
-    ("cuda", torch.float16, "nn.functional.batch_norm"),
     ("cuda", torch.bfloat16, "nn.functional.instance_norm"),
     ("cuda", torch.float16, "nn.functional.instance_norm"),
     # doesn't work

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -145,6 +145,7 @@ def _getDefaultRtolAndAtol(dtype0, dtype1):
 
 
 def op_assert_ref(test_case, op, orig, decomp, ref, args, kwargs):
+    print(orig.dtype, decomp.dtype)
     assert orig.dtype == decomp.dtype, f"Operation:  {op}"
     if orig.numel() == 0 or decomp.numel() == 0:
         assert orig.numel() == decomp.numel()
@@ -273,8 +274,8 @@ CROSS_REF_EXCLUDE_SET = {
     ("cuda", torch.float64, "nn.functional.dropout"),
     ("cuda", torch.float32, "nn.functional.dropout"),
     # decomp has problem even with opmath
-    ("cuda", torch.bfloat16, "nn.functional.layer_norm"),
-    ("cuda", torch.float16, "nn.functional.layer_norm"),
+    # ("cuda", torch.bfloat16, "nn.functional.layer_norm"),
+    # ("cuda", torch.float16, "nn.functional.layer_norm"),
     ("cuda", torch.bfloat16, "nn.functional.instance_norm"),
     ("cuda", torch.float16, "nn.functional.instance_norm"),
     # doesn't work

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -150,6 +150,7 @@ def op_assert_ref(test_case, op, orig, decomp, ref, args, kwargs):
     if orig.numel() == 0 or decomp.numel() == 0:
         assert orig.numel() == decomp.numel()
         return
+    assert orig.shape == decomp.shape, f"Operation:  {op}"
     if ref.is_floating_point():
         orig_diff = (orig - ref).abs().max()
         decomp_diff = (decomp - ref).abs().max()

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -150,10 +150,13 @@ def op_assert_ref(test_case, op, orig, decomp, ref, args, kwargs):
         assert orig.numel() == decomp.numel()
         return
     assert orig.shape == decomp.shape, f"Operation:  {op}"
+    tol_table = {
+        (torch.bfloat16, torch.ops.aten.native_layer_norm.default): 1e-5,
+    }
     if ref.is_floating_point():
         orig_diff = (orig - ref).abs().max()
         decomp_diff = (decomp - ref).abs().max()
-        atol = 1e-7
+        atol = tol_table.get((orig.dtype, op), 1e-7)
         if decomp_diff > orig_diff + atol:
             raise RuntimeError(
                 f"Difference from float64 is larger with decomposition {op.__name__}"

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1030,6 +1030,9 @@ def native_batch_norm(
     weight = _unsqueeze_to_dim(weight, input.dim() - 1)
     bias = _unsqueeze_to_dim(bias, input.dim() - 1)
     output = output * weight + bias
+    if not input.is_cuda:
+        save_mean = save_mean.to(dtype=input.dtype)
+        save_rstd = save_rstd.to(dtype=input.dtype)
     return output.to(dtype=input.dtype), save_mean, save_rstd
 
 

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -857,7 +857,8 @@ def addmm(self: Tensor, mat1: Tensor, mat2: Tensor, beta: int = 1, alpha: int = 
 def normalize(input, norm_dims, eps):
     computation_dtype = utils.get_computation_dtype(input.dtype)
     input_acc = input.to(dtype=computation_dtype)
-    biased_var, mean = torch.var_mean(input_acc, dim=norm_dims, unbiased=False, keepdim=True)
+    biased_var = torch.var(input_acc, dim=norm_dims, unbiased=False, keepdim=True)
+    mean = torch.mean(input_acc, dim=norm_dims, keepdim=True)
     rstd = torch.rsqrt(biased_var + eps)
 
     out = ((input - mean) * rstd)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -851,11 +851,10 @@ def addmm(self: Tensor, mat1: Tensor, mat2: Tensor, beta: int = 1, alpha: int = 
 
 # This computes the mean and variance along the specifized normalization dims,
 # then normalizes along those dims. Finally, it returns the mean and variance of
-# the normalized dims
+# the normalized dims. Note that it intentionally leaves outputs upcasted.
 # Example:
 # input: [2, 3, 4, 5], norm_dims: [1, 3]
-# (before squeezing) mean: [2, 1, 4, 1]
-# (after squeezing) mean: [2, 4]
+# mean: [2, 1, 4, 1]
 def normalize(input, norm_dims, eps):
     computation_dtype = utils.get_computation_dtype(input.dtype)
     input_acc = input.to(dtype=computation_dtype)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -39,7 +39,7 @@ def type_casts(f: Callable, type_promotion: utils.ELEMENTWISE_TYPE_PROMOTION_KIN
                 return x
 
         def decrease_prec(x):
-            if isinstance(x, Tensor):
+            if isinstance(x, Tensor) and x.dtype == computation_dtype:
                 return x.to(result_dtype)
             else:
                 return x

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -891,7 +891,7 @@ def native_layer_norm(
 
         out = out.to(dtype=input.dtype)
 
-    if not input.is_cuda:
+    if input.device.type == 'cpu':
         mean = mean.to(dtype=input.dtype)
         rstd = rstd.to(dtype=input.dtype)
     return (out, mean, rstd)
@@ -1030,7 +1030,7 @@ def native_batch_norm(
     weight = _unsqueeze_to_dim(weight, input.dim() - 1)
     bias = _unsqueeze_to_dim(bias, input.dim() - 1)
     output = output * weight + bias
-    if not input.is_cuda:
+    if input.device.type == 'cpu':
         save_mean = save_mean.to(dtype=input.dtype)
         save_rstd = save_rstd.to(dtype=input.dtype)
     return output.to(dtype=input.dtype), save_mean, save_rstd

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -857,8 +857,7 @@ def addmm(self: Tensor, mat1: Tensor, mat2: Tensor, beta: int = 1, alpha: int = 
 def normalize(input, norm_dims, eps):
     computation_dtype = utils.get_computation_dtype(input.dtype)
     input_acc = input.to(dtype=computation_dtype)
-    biased_var = torch.var(input_acc, dim=norm_dims, unbiased=False, keepdim=True)
-    mean = torch.mean(input_acc, dim=norm_dims, keepdim=True)
+    biased_var, mean = torch.var_mean(input_acc, dim=norm_dims, unbiased=False, keepdim=True)
     rstd = torch.rsqrt(biased_var + eps)
 
     out = ((input - mean) * rstd)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -39,7 +39,7 @@ def type_casts(f: Callable, type_promotion: utils.ELEMENTWISE_TYPE_PROMOTION_KIN
                 return x
 
         def decrease_prec(x):
-            if isinstance(x, Tensor) and x.dtype == computation_dtype:
+            if isinstance(x, Tensor):
                 return x.to(result_dtype)
             else:
                 return x
@@ -699,7 +699,6 @@ def logit_backward(
 
 
 @register_decomposition(aten.native_dropout)
-@pw_cast_for_opmath
 def native_dropout(input: Tensor, p: float, train: Optional[bool]):
     if train:
         bool_mask = torch.rand_like(input) < p
@@ -917,7 +916,10 @@ def native_layer_norm_backward(
     input_shape = input.shape
     input_ndim = input.dim()
     computation_dtype = utils.get_computation_dtype(input.dtype)
-    grad_out_cast, input_cast, weight_cast, bias_cast = [x.to(computation_dtype) if x is not None else x for x in (grad_out, input, weight, bias)]
+    grad_out_cast, input_cast, weight_cast, bias_cast = [
+        x.to(computation_dtype) if x is not None else x
+        for x in (grad_out, input, weight, bias)
+    ]
     assert grad_out_cast is not None
 
     axis = input_ndim - len(normalized_shape)

--- a/torch/_prims/utils.py
+++ b/torch/_prims/utils.py
@@ -799,7 +799,7 @@ _computation_dtype_map = {
 }
 
 
-def _get_computation_dtype(dtype: torch.dtype) -> torch.dtype:
+def get_computation_dtype(dtype: torch.dtype) -> torch.dtype:
     return _computation_dtype_map.get(dtype, dtype)
 
 
@@ -991,25 +991,25 @@ def elementwise_dtypes(
         result_dtype = torch.bool
 
     if type_promotion_kind is ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT:
-        return _get_computation_dtype(result_dtype), result_dtype
+        return get_computation_dtype(result_dtype), result_dtype
     elif type_promotion_kind is ELEMENTWISE_TYPE_PROMOTION_KIND.NO_OPMATH:
         return result_dtype, result_dtype
     elif type_promotion_kind is ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT:
         if is_integer_dtype(result_dtype) or is_boolean_dtype(result_dtype):
             result_dtype = torch.get_default_dtype()
-        return _get_computation_dtype(result_dtype), result_dtype
+        return get_computation_dtype(result_dtype), result_dtype
     elif type_promotion_kind is ELEMENTWISE_TYPE_PROMOTION_KIND.COMPLEX_TO_FLOAT:
         # NOTE: computation can still occur in a complex dtype
-        computation_dtype = _get_computation_dtype(result_dtype)
+        computation_dtype = get_computation_dtype(result_dtype)
         if is_complex_dtype(result_dtype):
             result_dtype = corresponding_real_dtype(result_dtype)
         return computation_dtype, result_dtype
     elif type_promotion_kind is ELEMENTWISE_TYPE_PROMOTION_KIND.BOOL_TO_LONG:
         if is_boolean_dtype(result_dtype):
             return torch.long, torch.long
-        return _get_computation_dtype(result_dtype), result_dtype
+        return get_computation_dtype(result_dtype), result_dtype
     elif type_promotion_kind is ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL:
-        return _get_computation_dtype(result_dtype), torch.bool
+        return get_computation_dtype(result_dtype), torch.bool
     else:
         raise ValueError(
             "Unknown type promotion kind {0}".format(str(type_promotion_kind))

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -918,7 +918,7 @@ def _reduction(
     # all the math ops (including comparisons) are still defined only for a computation type,
     # so promotion will still happen. We are doing it explicitly here
     inp_dtype = dtype if dtype is not None else a.dtype
-    computation_dtype = utils._get_computation_dtype(inp_dtype)
+    computation_dtype = utils.get_computation_dtype(inp_dtype)
     a_converted = prims.convert_element_type(a, computation_dtype)
     result = prim(a_converted, dims)
 


### PR DESCRIPTION
Originally, when these were written, they simply used the naive strategy of "upcast all inputs to floats, and downcast all inputs back". In addition to being... not quite what the kernels did, they also didn't capture some additional semantics. Namely, that the norms (except for layer norm on CPU! cc: @ngimel) return fp32 for the mean and rstd values.

Also, folks didn't like that I wrote `native_layer_norm` in terms of `native_batch_norm`. Which is fair - so I refactored the common logic into a `normalize` function.

cc: @jansel / @bertmaher , who've been looking at lowering layer norm/batch norm.