### PR TITLE
Back out Dispatcher change that makes Messenger Desktop crash on M1 devices

### DIFF
--- a/aten/src/ATen/core/library.cpp
+++ b/aten/src/ATen/core/library.cpp
@@ -7,7 +7,7 @@ namespace torch {
 namespace {
   // TODO: Consider representing debug info as a struct instead so you
   // don't have to allocate strings all the time
-  std::string debugString(const std::string& file, uint32_t line) {
+  std::string debugString(const char* file, uint32_t line) {
 #ifdef STRIP_ERROR_MESSAGES
     return std::string();
 #else
@@ -15,7 +15,7 @@ namespace {
 #endif
   }
 
-  std::string debugString(std::string debug, const std::string& file, uint32_t line) {
+  std::string debugString(std::string debug, const char* file, uint32_t line) {
 #ifdef STRIP_ERROR_MESSAGES
     return std::string();
 #else

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -166,7 +166,7 @@ void initDispatchBindings(PyObject* module) {
       parseKind(kind),
       std::move(name),
       std::string(dispatch) == "" ? c10::nullopt : c10::make_optional(c10::parseDispatchKey(dispatch)),
-      file,
+      "<unknown>", // temporary workaround
       linenum);
     END_HANDLE_TH_ERRORS_PYBIND
   }, "", py::arg("kind"), py::arg("name"), py::arg("dispatch"), py::arg("file")="/dev/null", py::arg("linenum")=0)

--- a/torch/library.h
+++ b/torch/library.h
@@ -555,7 +555,7 @@ class TORCH_API Library final {
   Library& operator=(const Library&) = delete;
   Library(Library&&) = default;
   Library& operator=(Library&&) = default;
-  // TODO: add gen_python_error boolean flag
+
   // Some notes about the API design here.  We had the following constraints:
   //
   //  - We need to support multiple "types" of arguments for schema and
@@ -800,7 +800,7 @@ class TORCH_API Library final {
   Kind kind_;
   c10::optional<std::string> ns_;
   c10::optional<c10::DispatchKey> dispatch_key_;
-  std::string file_;
+  const char* file_;
   uint32_t line_;
 
   std::vector<c10::RegistrationHandleRAII> registrars_;


### PR DESCRIPTION
Summary:
This change causes Messenger Dekstop to crash on M1 devices when the user enables background during the call. The change apparently causes the compiler to emit AVX instructions that are not supported by Rosetta.

This is a surgical backout that only backs out the changes in C++ side,
and not Python bindings which I believe are not shipped with Workplace Chat.

Test Plan:
Run the application and make sure that it doesn't crash when the background is enabled
https://pxl.cl/23VSH

Reviewed By: ezyang

Differential Revision: D36358832

