### PR TITLE
ci: Add single concurrency to merge / revert

### DIFF
--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -37,3 +37,5 @@ jobs:
           else
             python3 .github/scripts/trymerge.py --revert "${PR_NUM}"
           fi
+
+concurrency: try-revert

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -40,4 +40,4 @@ jobs:
             python3 .github/scripts/trymerge.py "${PR_NUM}"
           fi
 
-concurrency: try-merge
+concurrency: try-merge-${{ github.event.client_payload.on_green }}

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -40,4 +40,6 @@ jobs:
             python3 .github/scripts/trymerge.py "${PR_NUM}"
           fi
 
-concurrency: try-merge-${{ github.event.client_payload.on_green }}
+# TODO: Separate merge on green merges from regular merges to not hold up try-merge workflows overall concurrency
+# NOTE: force pushes are also put in their concurrency group to put them higher than regular merges
+concurrency: try-merge-${{ github.event.client_payload.force}}-${{ github.event.client_payload.on_green }}

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -39,3 +39,5 @@ jobs:
           else
             python3 .github/scripts/trymerge.py "${PR_NUM}"
           fi
+
+concurrency: try-merge


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77424

Changes the merge / revert workflows to only run one job at a time

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>