### PR TITLE
[coreml] Use special throw macro when encountering CoreML API errors

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNUtils.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNUtils.h
@@ -2,6 +2,24 @@
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 #include <string>
 
+// This is a utility macro that can be used to throw an exception when a Metal
+// API function produces a NSError. The exception will contain a message with
+// useful info extracted from the NSError.
+#define METAL_THROW_IF_ERROR(error, preamble)                                    \
+  do {                                                                           \
+    if C10_LIKELY(error) {                                                       \
+      throw c10::Error(                                                          \
+          {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},                 \
+          c10::str(                                                              \
+              preamble,                                                          \
+              " Error details: ",                                                \
+              " Localized_description: ", error.localizedDescription.UTF8String, \
+              " Domain: ", error.domain.UTF8String,                              \
+              " Code: ", error.code,                                             \
+              " User Info: ", error.userInfo.description.UTF8String));           \
+    }                                                                            \
+  } while (false)
+
 namespace at {
 namespace native {
 namespace metal {

--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
@@ -32,17 +32,13 @@ using namespace at::native::metal;
 }
 
 - (void)endSynchronization:(NSError*)error {
+  // if something went wrong during command buffer execution
   if (error) {
     if (_imageWrapper) {
       _imageWrapper->release();
     }
-    // throw exceptions if we failed to flush the command buffer
-    TORCH_CHECK(false,
-        "Command buffer execution failed!",
-        " Localized_description: ", error.localizedDescription.UTF8String,
-        " Domain: ", error.domain.UTF8String,
-        " Code: ", error.code,
-        " User Info: ", error.userInfo.description.UTF8String);
+    // throw an exception with error details
+    METAL_THROW_IF_ERROR(error, "Command buffer execution failed!");
   }
 }
 


### PR DESCRIPTION
Summary: Error messages from `TORCH_CHECK` are stripped during production builds via  `-DSTRIP_ERROR_MESSAGES`. This diff introduces a new macro `COREML_CHECK` which will always preserve the error message. This macro is used when encountering errors produced by CoreML API calls so that we can heve enough context to debug.

Test Plan:
Test in pytorch playground:

```
arc focus2 -b pp-ios -a ModelRunner -a //xplat/caffe2/c10:c10Apple -a //xplat/caffe2:torch_mobile_coreApple  -a //xplat/caffe2/fb/dynamic_pytorch:dynamic_pytorch_implApple -a //xplat/caffe2:coreml_delegateApple  -a ModelRunnerDevOps -a //xplat/caffe2:torch_mobile_all_opsApple -fd --force-with-wrong-xcode
```

Differential Revision: D36378286

