### PR TITLE
tools: Only return tag if valid

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -22,13 +22,18 @@ def get_sha(pytorch_root: Union[str, Path]) -> str:
 
 def get_tag(pytorch_root: Union[str, Path]) -> str:
     try:
-        return (
+        tag = (
             subprocess.check_output(
                 ["git", "describe", "--tags", "--exact"], cwd=pytorch_root
             )
             .decode("ascii")
             .strip()
         )
+        # Valid version tags should always start with "v"
+        if not tag.startswith("v"):
+            return tag
+        else:
+            return UNKNOWN
     except Exception:
         return UNKNOWN
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77435

We were running into bugs related to ciflow tags and we should only set
torch version if the tag is a valid version tag (which is denoted by
starting with v)

Relates to https://github.com/pytorch/pytorch/pull/77279

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>