### PR TITLE
[NVFuser] don't decompose conv2d if we don't have shape info

### DIFF
--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -2678,8 +2678,8 @@ class TestCudaFuser(JitTestCase):
             responses = []
             for i in range(2):
                 inp = torch.rand((3, 3, 32, 32)).cuda()
-                weight = torch.rand((x+i, 3, 7, 7)).cuda()
-                bias = torch.rand((x+i)).cuda()
+                weight = torch.rand((x + i, 3, 7, 7)).cuda()
+                bias = torch.rand((x + i)).cuda()
                 res = torch.nn.functional.conv2d(inp, weight, bias, padding=3)
                 responses.append(res)
             return responses

--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -2673,6 +2673,24 @@ class TestCudaFuser(JitTestCase):
     @unittest.skipIf(not RUN_NVFUSER, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
                      "Requires fusion optimization pass to be effective")
+    def test_conv2d_symbolic_shapes(self):
+        def fn(x: int):
+            responses = []
+            for i in range(2):
+                inp = torch.rand((3, 3, 32, 32)).cuda()
+                weight = torch.rand((x+i, 3, 7, 7)).cuda()
+                bias = torch.rand((x+i)).cuda()
+                res = torch.nn.functional.conv2d(inp, weight, bias, padding=3)
+                responses.append(res)
+            return responses
+
+        fn_s = torch.jit.script(fn)
+        fn_s(5)
+        fn_s(5)
+
+    @unittest.skipIf(not RUN_NVFUSER, "requires CUDA")
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
+                     "Requires fusion optimization pass to be effective")
     def test_backward_type(self):
         # not super useful to check gradient of integer/bool, so skipping here
         type_pairs = [

--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -2215,9 +2215,12 @@ void decomposeConvOps(Block* block) {
 
     auto bias_tensor_type = n->input(2)->type()->cast<c10::TensorType>();
     auto bias_size_opt = bias_tensor_type->sizes().concrete_sizes();
-    TORCH_INTERNAL_ASSERT(
-        bias_size_opt.has_value(),
-        "concrete shape for bias input to conv2d are required");
+    if (!bias_size_opt.has_value()) {
+      TORCH_WARN_ONCE(
+        "concrete shape for bias input is required to decompose into conv + bias"
+      );
+      continue;
+    }
     // bias shape (C)
     auto bias_size = bias_size_opt.value();
 

--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -2217,8 +2217,7 @@ void decomposeConvOps(Block* block) {
     auto bias_size_opt = bias_tensor_type->sizes().concrete_sizes();
     if (!bias_size_opt.has_value()) {
       TORCH_WARN_ONCE(
-        "concrete shape for bias input is required to decompose into conv + bias"
-      );
+          "concrete shape for bias input is required to decompose into conv + bias");
       continue;
     }
     // bias shape (C)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77440

Sometimes bias won't have shape info (e.g. in the added test, conv gets run two times in a loop, each with different shapes). In that case we should just skip decomposition instead of erroring out.