### PR TITLE
torch/distributed: move quantization ops to libtorch instead of libtorch_python

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -482,6 +482,7 @@ libtorch_distributed_base_sources = [
     "torch/csrc/distributed/c10d/exception.cpp",
     "torch/csrc/distributed/c10d/logger.cpp",
     "torch/csrc/distributed/c10d/logging.cpp",
+    "torch/csrc/distributed/c10d/quantization/quantization.cpp",
     "torch/csrc/distributed/c10d/reducer.cpp",
     "torch/csrc/distributed/c10d/sequence_num.cpp",
     "torch/csrc/distributed/c10d/socket.cpp",
@@ -944,7 +945,6 @@ libtorch_python_core_sources = [
 libtorch_python_distributed_core_sources = [
     "torch/csrc/distributed/c10d/init.cpp",
     "torch/csrc/distributed/c10d/python_comm_hook.cpp",
-    "torch/csrc/distributed/c10d/quantization/quantization.cpp",
 ]
 
 libtorch_python_distributed_sources = libtorch_python_distributed_core_sources + [


### PR DESCRIPTION
Summary: This moves the distributed/c10d/quantization ops to libtorch instead of libtorch_python. Since they don't depend on Python this avoids the duplicate registration error from TORCH_LIBRARY when used in torch::deploy.

Test Plan:
Build

https://www.internalfb.com/intern/testinfra/testconsole/testrun/8162774414164820/

Differential Revision: D36384244

