### PR TITLE
[metal] fix op registration for cat

### DIFF
--- a/aten/src/ATen/native/metal/ops/MetalConcat.mm
+++ b/aten/src/ATen/native/metal/ops/MetalConcat.mm
@@ -203,7 +203,7 @@ Tensor cat(const TensorList tensors, int64_t dim) {
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl(TORCH_SELECTIVE_NAME("aten::_cat"), TORCH_FN(cat));
+  m.impl(TORCH_SELECTIVE_NAME("aten::cat"), TORCH_FN(cat));
 }
 
 }


### PR DESCRIPTION
Summary: Registration for the concatenation op has seemingly changed from `aten::_cat` to `aten::cat`. This diff resolves the "op not found" error caused by the mismatched registration.

Test Plan:
Test in pytorch playground:

```
arc focus2 -b pp-ios -a ModelRunner -a //xplat/caffe2/c10:c10Apple -a //xplat/caffe2:torch_mobile_coreApple  -a //xplat/caffe2/fb/dynamic_pytorch:dynamic_pytorch_implApple -a //xplat/caffe2:coreml_delegateApple  -a ModelRunnerDevOps -a //xplat/caffe2:torch_mobile_all_opsApple -fd --force-with-wrong-xcode
```

Differential Revision: D36387105

