### PR TITLE
[mergebot cli] add new revert regex

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -851,8 +851,6 @@ def try_revert(repo: GitRepo, pr: GitHubPR, *, dry_run: bool = False, comment_id
 def prefix_with_github_url(suffix_str: str) -> str:
     return f"https://github.com/{suffix_str}"
 
-def rebase_on_mergebot_branch() -> None:
-    print("hello")
 
 def merge_on_green(pr_num: int, repo: GitRepo, dry_run: bool = False) -> None:
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -852,13 +852,12 @@ def prefix_with_github_url(suffix_str: str) -> str:
     return f"https://github.com/{suffix_str}"
 
 
-def merge_on_green(pr_num: int, repo: GitRepo, dry_run: bool = False) -> None:
+def merge_on_green(pr_num: int, repo: GitRepo, dry_run: bool = False, timeout_minutes: int = 400) -> None:
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
     org, project = repo.gh_owner_and_name()
     start_time = time.time()
     last_exception = ''
     elapsed_time = 0.0
-    timeout_minutes = 400
     while elapsed_time < timeout_minutes * 60:
         current_time = time.time()
         elapsed_time = current_time - start_time

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -301,6 +301,7 @@ RE_PULL_REQUEST_RESOLVED = re.compile(
     re.MULTILINE
 )
 RE_REVERT_CMD = re.compile(r"@pytorch(merge|)bot\s+revert\s+this")
+RE_REVERT_CMD_CLI = re.compile(r"@pytorch(merge|)bot\s+revert\s+(-m.*|-c.*)(-m.*|-c.*)")
 RE_DIFF_REV = re.compile(r'^Differential Revision:.+?(D[0-9]+)', re.MULTILINE)
 
 
@@ -813,7 +814,7 @@ def try_revert(repo: GitRepo, pr: GitHubPR, *, dry_run: bool = False, comment_id
     if not pr.is_closed():
         return post_comment(f"Can't revert open PR #{pr.pr_num}")
     comment = pr.get_last_comment() if comment_id is None else pr.get_comment_by_id(comment_id)
-    if not RE_REVERT_CMD.match(comment.body_text):
+    if not RE_REVERT_CMD.match(comment.body_text) and not RE_REVERT_CMD_CLI.match(comment.body_text):
         raise RuntimeError(f"Comment {comment.body_text} does not seem to be a valid revert command")
     if comment.editor_login is not None:
         return post_comment("Don't want to revert based on edited command")
@@ -850,6 +851,8 @@ def try_revert(repo: GitRepo, pr: GitHubPR, *, dry_run: bool = False, comment_id
 def prefix_with_github_url(suffix_str: str) -> str:
     return f"https://github.com/{suffix_str}"
 
+def rebase_on_mergebot_branch() -> None:
+    print("hello")
 
 def merge_on_green(pr_num: int, repo: GitRepo, dry_run: bool = False) -> None:
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
@@ -870,7 +873,7 @@ def merge_on_green(pr_num: int, repo: GitRepo, dry_run: bool = False) -> None:
             print(f"Merged failed due to: {ex}. Retrying in 60 seconds.")
             time.sleep(60)
     # Finally report timeout back
-    msg = "Merged timed out after 6 hours. Please contact the pytorch_dev_infra team."
+    msg = "Merged timed out after 400 minutes. Please contact the pytorch_dev_infra team."
     msg += f"The last exception was: {last_exception}"
     if not dry_run:
         gh_add_labels(org, project, pr_num, ["land-failed"])

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -301,7 +301,7 @@ RE_PULL_REQUEST_RESOLVED = re.compile(
     re.MULTILINE
 )
 RE_REVERT_CMD = re.compile(r"@pytorch(merge|)bot\s+revert\s+this")
-RE_REVERT_CMD_CLI = re.compile(r"@pytorch(merge|)bot\s+revert\s+(-m.*|-c.*)(-m.*|-c.*)")
+RE_REVERT_CMD_CLI = re.compile(r"@pytorch(merge|)bot\s+revert\s+(-m.*-c.*|-c.*-m.*)")
 RE_DIFF_REV = re.compile(r'^Differential Revision:.+?(D[0-9]+)', re.MULTILINE)
 
 
@@ -858,7 +858,8 @@ def merge_on_green(pr_num: int, repo: GitRepo, dry_run: bool = False) -> None:
     start_time = time.time()
     last_exception = ''
     elapsed_time = 0.0
-    while elapsed_time < 400 * 60:
+    timeout_minutes = 400
+    while elapsed_time < timeout_minutes * 60:
         current_time = time.time()
         elapsed_time = current_time - start_time
 
@@ -871,7 +872,7 @@ def merge_on_green(pr_num: int, repo: GitRepo, dry_run: bool = False) -> None:
             print(f"Merged failed due to: {ex}. Retrying in 60 seconds.")
             time.sleep(60)
     # Finally report timeout back
-    msg = "Merged timed out after 400 minutes. Please contact the pytorch_dev_infra team."
+    msg = f"Merged timed out after {timeout_minutes} minutes. Please contact the pytorch_dev_infra team."
     msg += f"The last exception was: {last_exception}"
     if not dry_run:
         gh_add_labels(org, project, pr_num, ["land-failed"])


### PR DESCRIPTION
Since we added a new CLI, we have to update the regex validator for reverting. The same validation is not there for merging. 

The example command we want to validate:
`@pytorchbot merge -c="ghfirst" -m="this is breaking things internally"`