### PR TITLE
stirde_properties fix

### DIFF
--- a/aten/src/ATen/core/tensor_type.cpp
+++ b/aten/src/ATen/core/tensor_type.cpp
@@ -193,7 +193,7 @@ VaryingShape<Stride> TensorType::computeStrideProps(
       } else if (strides[a] > strides[b]) {
         return 1;
       } else { // strides[a] == strides[b]
-        if (sizes[a] < sizes[b] || a > b ) {
+        if (sizes[a] > sizes[b]) {
           return 1;
         }
       }

--- a/aten/src/ATen/test/stride_properties_test.cpp
+++ b/aten/src/ATen/test/stride_properties_test.cpp
@@ -69,10 +69,25 @@ TEST(StridePropertiesTest, ZeroStrideIndicesEagerConsistencyTest) {
 }
 
 TEST(StridePropertiesTest, ExpandedStrideIndicesTest) {
-  // NOLINTNEXTLINE(performance-for-range-copy)
   Tensor t = at::rand({1});
   // note: expand with dimension of size 1 is tricky as stride is different
   // depending on the order of the unsqueezed dimension.
   t = t.expand({4, 4, 4});
   EXPECT_TRUE(CheckStrideIndices(t, at::MemoryFormat::Contiguous));
+}
+
+TEST(StridePropertiesTest, SlicedStrideIndicesTest) {
+  // Sliced tensor shouldn't have changed stride order
+  Tensor t = at::rand({16, 4}).slice(1, 0, 4, 4);
+
+  auto temp = TensorType::create(c10::nullopt, c10::nullopt, t.sizes(), t.strides(), c10::nullopt);
+  TORCH_INTERNAL_ASSERT(temp->stride_properties().isComplete() &&
+      temp->stride_properties().isComplete(), "complete stride properties is needed for the test");
+  std::vector<size_t> stride_indices(2);
+  std::iota(stride_indices.rbegin(), stride_indices.rend(), 0);
+
+  auto index_iter = stride_indices.begin();
+  for (const auto& opt_stride : *temp->stride_properties().sizes()) {
+    EXPECT_TRUE(*index_iter++ != opt_stride->stride_index_.value());
+  }
 }

--- a/aten/src/ATen/test/stride_properties_test.cpp
+++ b/aten/src/ATen/test/stride_properties_test.cpp
@@ -88,6 +88,6 @@ TEST(StridePropertiesTest, SlicedStrideIndicesTest) {
 
   auto index_iter = stride_indices.begin();
   for (const auto& opt_stride : *temp->stride_properties().sizes()) {
-    EXPECT_TRUE(*index_iter++ != opt_stride->stride_index_.value());
+    EXPECT_TRUE(*index_iter++ == opt_stride->stride_index_.value());
   }
 }


### PR DESCRIPTION
Fixes part of #6015

profiled permutation order is wrong and nvfuser generates output in wrong memory format. Though this problem doesn't seem to cause any issue with the test (except a graceful fallback path taken by CudaFusionGuard).