### PR TITLE
Make s3_init linter adapter work in abscense of git

### DIFF
--- a/tools/linter/adapters/s3_init.py
+++ b/tools/linter/adapters/s3_init.py
@@ -16,12 +16,19 @@ from pathlib import Path
 HOST_PLATFORM = platform.system()
 
 # PyTorch directory root
-result = subprocess.run(
-    ["git", "rev-parse", "--show-toplevel"],
-    stdout=subprocess.PIPE,
-    check=True,
-)
-PYTORCH_ROOT = result.stdout.decode("utf-8").strip()
+try:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    PYTORCH_ROOT = result.stdout.decode("utf-8").strip()
+except subprocess.CalledProcessError:
+    # If git is not installed, compute repo root as 3 folders up from this file
+    path_ = os.path.abspath(__file__)
+    for _ in range(4):
+        path_ = os.path.dirname(path_)
+    PYTORCH_ROOT = path_
 
 DRY_RUN = False
 


### PR DESCRIPTION
Summary: PYTORCH_ROOT is just 3 folders above `s3_init.__file__`

Test Plan: CI

Differential Revision: D36389775

