### PR TITLE
check that flip doesn't accept repeating dimensions

### DIFF
--- a/torch/_prims/utils.py
+++ b/torch/_prims/utils.py
@@ -929,8 +929,9 @@ def compute_reduction_output_shape(
 
     return tuple(new_shape)
 
-def validate_no_repeating_dims(dims: Sequence) -> bool:
-    if (len(dims) != len(set(dims))):
+
+def validate_no_repeating_dims(dims: Sequence):
+    if len(dims) != len(set(dims)):
         raise RuntimeError("duplicate value in the list of dims")
 
 
@@ -938,7 +939,7 @@ def reduction_dims(shape: ShapeType, dims: Optional[Sequence]) -> Tuple[int, ...
     if dims is None:
         return tuple(range(len(shape)))
     dims = tuple(canonicalize_dim(len(shape), idx) for idx in dims)
-    validate_no_repeating_dims()
+    validate_no_repeating_dims(dims)
     return dims
 
 

--- a/torch/_prims/utils.py
+++ b/torch/_prims/utils.py
@@ -929,13 +929,16 @@ def compute_reduction_output_shape(
 
     return tuple(new_shape)
 
+def validate_no_repeating_dims(dims: Sequence) -> bool:
+    if (len(dims) != len(set(dims))):
+        raise RuntimeError("duplicate value in the list of dims")
+
 
 def reduction_dims(shape: ShapeType, dims: Optional[Sequence]) -> Tuple[int, ...]:
     if dims is None:
         return tuple(range(len(shape)))
     dims = tuple(canonicalize_dim(len(shape), idx) for idx in dims)
-    if len(dims) != len(set(dims)):
-        raise RuntimeError("duplicate value in the list of dims")
+    validate_no_repeating_dims()
     return dims
 
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -951,7 +951,10 @@ def flatten(a: TensorLikeType, start_dim: int = 0, end_dim: int = -1) -> TensorL
 
 @register_decomposition(torch.ops.aten.flip, register_meta=True)
 def flip(a: TensorLikeType, dims: DimsSequenceType) -> TensorLikeType:
+    if not isinstance(dims, tuple) and not isinstance(dims, list):
+        raise ValueError("dims has to be a sequence of ints")
     dims = utils.canonicalize_dims(a.ndim, dims)  # type: ignore[assignment]
+    utils.validate_no_repeating_dims(dims)
     return prims.rev(a, dims)
 
 


### PR DESCRIPTION
Per title.
Before this PR `flip` throws errors on invalid inputs from ATen implementation itself, and not from error checks happening in prims/refs. 
We should make sure that prims/refs do all the necessary error checking (@mruberry is going to test that by moving reference error inputs testing to call meta implementations instead of real ones).  
In general, most error checking should live in refs, prims meta functions should propagate the necessary properties, but they should assume that they are getting valid inputs. The checks on the inputs should happen in refs, where they can be traced to the necessary guards, or lead to RuntimeErrors during tracing. 