### PR TITLE
YOLO make save_mean/save_var on CPU match shape with CUDA

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -644,8 +644,8 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_cpu(const Tensor& self, const c10:
 
   return AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "batch_norm", [&] {
       if (!train) {
-        auto save_mean = at::empty({0}, self.options());
-        auto save_var = at::empty({0}, self.options());
+        auto save_mean = at::empty({self.size(1)}, self.options());
+        auto save_var = at::empty({self.size(1)}, self.options());
         return batch_norm_cpu_transform_input_template<scalar_t>(self, weight, bias, save_mean, save_var, running_mean, running_var, train, eps);
       } else {
         auto save_stats = batch_norm_cpu_update_stats_template<scalar_t, InvStd>(self, running_mean, running_var, momentum, eps);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #77506

Noticed in https://github.com/pytorch/pytorch/pull/77407
let's see how many tests break.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>