### PR TITLE
[GHA] Use silent checkout

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -32,9 +32,10 @@ runs:
         mkdir "${GITHUB_WORKSPACE}"
 
     - name: Checkout PyTorch
-      uses: zhouzhuojie/checkout@05b13c9a0d21f08f6d5e64a1d5042246d13619d9
+      uses: malfet/checkout@silent-checkout
       with:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         # --depth=1 for speed, manually fetch history and other refs as necessary
         fetch-depth: ${{ inputs.fetch-depth }}
         submodules: ${{ inputs.submodules }}
+        quiet-checkout: true


### PR DESCRIPTION
This switch changes the checkout action to https://github.com/malfet/checkout/tree/silent-checkout, that contains 2 commits on top of trunk:
- @zhouzhuojie's [Add retry](https://github.com/zhouzhuojie/checkout/commit/ffc6f93ad4b6e3cdcdd1a34e8c896765002f9b34)
- Mine [Add silent-checkout](https://github.com/malfet/checkout/commit/96ebf2582e6a298abb8d156b195838ff22be4bf8)

Testing by pushing temporary https://github.com/pytorch/pytorch/pull/77547/commits/10b11f99129ab7efe69e4dfdbb0a541d2813e93e, and here is a lintrun with silent checkouts: https://github.com/pytorch/pytorch/runs/6455157988?check_suite_focus=true#step:3:69


Potential downside of this change, is that checkout will be harder to debug if it hangs, but I don't think there were a single report of that

Fixes #77249