### PR TITLE
Add option to disable autocast pass

### DIFF
--- a/aten/src/ATen/core/function.h
+++ b/aten/src/ATen/core/function.h
@@ -29,7 +29,7 @@ using Kwargs = std::unordered_map<std::string, at::IValue>;
 struct RecursiveMethodCallError : public std::exception {};
 using TaskLauncher = std::function<void(std::function<void()>)>;
 
-TORCH_API void preoptimizeGraph(std::shared_ptr<Graph>& graph);
+TORCH_API void preoptimizeGraph(std::shared_ptr<Graph>& graph, bool disable_autocast=false);
 
 // A Function is a pure Graph with no implicit `self` object bound.
 // It contains schema information and the executor that manages the

--- a/torch/csrc/jit/api/function_impl.cpp
+++ b/torch/csrc/jit/api/function_impl.cpp
@@ -88,6 +88,9 @@ const c10::FunctionSchema& GraphFunction::getSchema() const {
 }
 
 GraphFunction::SpecializationKey GraphFunction::currentSpecialization() const {
+  if (force_no_amp_) {
+    return SpecializationKey::AutocastOff;
+  }
 #ifdef C10_MOBILE
   // disabling autodiff pass for mobile build since autocast APIs don't exist
   return SpecializationKey::AutocastOff;
@@ -105,7 +108,7 @@ GraphFunction::SpecializationKey GraphFunction::currentSpecialization() const {
 #endif
 }
 
-void preoptimizeGraph(std::shared_ptr<Graph>& graph) {
+void preoptimizeGraph(std::shared_ptr<Graph>& graph, bool disable_autocast) {
   Inline(*graph);
 
   // Peephole Optimize cleans up many "is None" checks and creates constant prop
@@ -125,7 +128,9 @@ void preoptimizeGraph(std::shared_ptr<Graph>& graph) {
   //     of the any optimizations
   //  2. AMP transformations would benefit from followup passes's cleanup
   //
-  Autocast(graph);
+  if (!disable_autocast) {
+    Autocast(graph);
+  }
 #endif
 
   ConstantPooling(graph);

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1502,6 +1502,14 @@ void initJitScriptBindings(PyObject* module) {
       .def_property_readonly(
           "name",
           [](const StrongFunctionPtr& self) { return self.function_->name(); })
+      .def(
+          "_set_ignore_amp",
+          [](StrongFunctionPtr& self, bool ignore) {
+            auto fn = self.function_;
+            TORCH_INTERNAL_ASSERT(fn->isGraphFunction());
+            GraphFunction& g_fn = toGraphFunction(*fn);
+            g_fn._set_ignore_amp(ignore);
+          })
       .def_property_readonly(
           "qualified_name",
           [](const StrongFunctionPtr& self) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #77566

Fix for AOT autograd, where amp has already been traced out and you don't want to re-invoke the amp pass. 

cc @anijain2305, @Chillee 