### PR TITLE
[Profiler] Propagate metadata into `Engine::evaluate_function` event.

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -126,19 +126,6 @@ using torch::profiler::impl::shapesToStr;
 using torch::profiler::impl::dtypesToStr;
 using torch::profiler::impl::stacksToStr;
 
-struct MemoryEventData {
-  torch::profiler::impl::approx_time_t start_time;
-  void* ptr;
-  int64_t alloc_size;
-  int64_t total_allocated;
-  int64_t total_reserved;
-  uint64_t threadID;
-  torch::profiler::impl::kineto::DeviceAndResource kineto_info;
-  c10::DeviceType device_type;
-  c10::DeviceIndex device_index;
-};
-static_assert(std::is_pod<MemoryEventData>::value, "Non-POD member of MemoryEventData.");
-
 struct EventFieldsVisitor {
   EventFieldsVisitor(
       Result& result,
@@ -204,6 +191,25 @@ struct EventFieldsVisitor {
     }
   }
 
+  void operator()(const ExtraFields<EventType::Allocation>& alloc) {
+    kineto_event_.get()
+        .deviceIndex(alloc.device_index_)
+        .nBytes(alloc.alloc_size_);
+
+    annotations_ = {
+        {"Device Type", std::to_string((int8_t)alloc.device_type_)},
+        {"Device Id", std::to_string(alloc.device_index_)},
+        {"Addr", std::to_string(reinterpret_cast<intptr_t>(alloc.ptr_))},
+        {"Bytes", std::to_string(alloc.alloc_size_)}};
+    if (alloc.total_allocated_ >= 0) {
+      annotations_.emplace_back(
+          "Total Allocated", std::to_string(alloc.total_allocated_));
+    }
+    if (alloc.total_reserved_ >= 0) {
+      annotations_.emplace_back("Total Reserved", std::to_string(alloc.total_reserved_));
+    }
+  }
+
   template <typename T>
   void handleJIT(T& fields) {
     auto& jit_stack = fields.jit_stack_;
@@ -231,22 +237,6 @@ struct EventFieldsVisitor {
   std::reference_wrapper<const post_process_t> post_process_;
   annotation_t annotations_;
 };
-
-auto getAnnotations(const MemoryEventData& event) {
-  torch::profiler::impl::kineto::annotation_t out{
-      {"Device Type", std::to_string((int8_t)event.device_type)},
-      {"Device Id", std::to_string(event.device_index)},
-      {"Addr", std::to_string(reinterpret_cast<intptr_t>(event.ptr))},
-      {"Bytes", std::to_string(event.alloc_size)}};
-
-  if (event.total_allocated >= 0) {
-    out.emplace_back("Total Allocated", std::to_string(event.total_allocated));
-  }
-  if (event.total_reserved >= 0) {
-    out.emplace_back("Total Reserved", std::to_string(event.total_reserved));
-  }
-  return out;
-}
 
 // Assumption: Total threads number will not exceed 2^16-1, and total ops will
 // not exceed 2^48 -1.
@@ -287,15 +277,12 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
       int64_t total_reserved,
       c10::Device device) override {
     if (config_.profile_memory && config_.state != ProfilerState::Disabled) {
-      std::lock_guard<std::mutex> guard(state_mutex_);
-      memory_events_.emplace_back(
+      record_queue_.getSubqueue()->emplace_allocation_event(
           torch::profiler::impl::getApproximateTime(),
           ptr,
           alloc_size,
           total_allocated,
           total_reserved,
-          at::RecordFunction::currentThreadId(),
-          torch::profiler::impl::kineto::kineto_ids(),
           device.type(),
           device.index());
     }
@@ -333,28 +320,6 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
     std::lock_guard<std::mutex> guard(state_mutex_);
     auto converter = clock_converter_.makeConverter();
 
-    for (const auto& e : memory_events_) {
-      auto start_time_us = converter(e.start_time) / 1000;
-      cpu_trace_.addCPUActivity(
-          kMemoryEventName,
-          torch::profiler::impl::kineto::KinetoActivityType::CPU_INSTANT_EVENT,
-          e.kineto_info,
-          /*correlation_id=*/0,
-          start_time_us,
-          start_time_us,
-          getAnnotations(e));
-
-      kineto_events_.emplace_back();
-      auto& evt = kineto_events_.back();
-      evt.name(kMemoryEventName)
-          .startUs(start_time_us)
-          .deviceIndex(e.device_index)
-          .deviceType(e.device_type)
-          .nBytes(e.alloc_size)
-          .startThreadId(e.threadID);
-    }
-    memory_events_.clear();
-
     for (auto& e : record_queue_.getRecords(converter)) {
       // `take_data` handles time conversion.
       int64_t start_us = e.start_time_us_;
@@ -372,7 +337,7 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
           .startUs(start_us)
           .durationUs(end_us - start_us)
           .correlationId(e.correlationID())
-          .deviceType(c10::DeviceType::CPU)
+          .deviceType(e.deviceType())
           .startThreadId(e.start_tid_);
 
       // NB: also sets fields on `kineto_events_.back()`.
@@ -635,7 +600,6 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
   torch::profiler::impl::ApproximateClockToUnixTimeConverter clock_converter_;
   std::set<torch::profiler::impl::ActivityType> activities_;
   torch::profiler::impl::RecordQueue record_queue_;
-  torch::profiler::impl::AppendOnlyList<MemoryEventData, 1024> memory_events_;
   torch::profiler::impl::kineto::TraceWrapper cpu_trace_;
   std::vector<KinetoEvent> kineto_events_;
   // Optional, if event post-processing is enabled.

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -118,6 +118,8 @@ void _push_reverse_order(PyTraceEvent* e, std::vector<std::string>& names) {
 namespace {
 using torch::profiler::impl::ProfilerThreadLocalStateBase;
 using torch::profiler::impl::ActiveProfilerType;
+using torch::profiler::impl::EventType;
+using torch::profiler::impl::ExtraFields;
 using torch::profiler::impl::Result;
 using torch::profiler::impl::kineto::annotation_t;
 using torch::profiler::impl::shapesToStr;
@@ -138,57 +140,61 @@ struct MemoryEventData {
 static_assert(std::is_pod<MemoryEventData>::value, "Non-POD member of MemoryEventData.");
 
 struct EventFieldsVisitor {
-  EventFieldsVisitor(const Result& result, KinetoEvent& kineto_event)
-      : result_{result}, kineto_event_{kineto_event} {
-    handleJIT(result_.get().jit_stack_, result_.get().jit_modules_);
-    c10::visit(*this, result.event_);
+  EventFieldsVisitor(
+      Result& result,
+      KinetoEvent& kineto_event,
+      const post_process_t& post_process)
+      : kineto_event_{kineto_event}, post_process_{post_process} {
+    c10::visit(*this, result.extra_fields_);
   }
 
-  void operator()(const torch::profiler::impl::OpEvent& op_event) {
+  void operator()(ExtraFields<EventType::TorchOp>& op_event) {
+    handleJIT(op_event);
     kineto_event_.get()
-        .endThreadId(op_event.end_thread_id_)
-        .scope(op_event.record_function_scope_)
-        .setAsync(op_event.is_async_)
-        .debugHandle(op_event.debug_handle_);
+        .endThreadId(op_event.end_tid_)
+        .scope((int8_t)op_event.scope_)
+        .debugHandle(op_event.debug_handle_)
+        .setAsync(op_event.is_async_);
 
-    auto& shapes = result_.get().inputs_.shapes_;
+    auto& shapes = op_event.inputs_.shapes_;
     if (!shapes.empty()) {
       kineto_event_.get().shapes(shapes);
       annotations_.emplace_back("Input Dims", shapesToStr(shapes));
     }
 
-    auto& dtypes = result_.get().inputs_.dtypes_;
+    auto& dtypes = op_event.inputs_.dtypes_;
     if (!dtypes.empty()) {
       kineto_event_.get().dtypes(dtypes);
       annotations_.emplace_back("Input type", dtypesToStr(dtypes));
     }
 
-    if (!result_.get().extra_args_.empty()) {
+    if (!op_event.extra_args_.empty()) {
       kineto_event_.get().flops(
-          computeFlops(result_.get().name(), result_.get().extra_args_));
+          computeFlops(op_event.name_, op_event.extra_args_));
     }
     kineto_event_.get().cuda_event_start_ =
-        result_.get().gpu_fallback_.cuda_event_start_;
+        op_event.gpu_fallback_.cuda_event_start_;
     kineto_event_.get().cuda_event_end_ =
-        result_.get().gpu_fallback_.cuda_event_end_;
+        op_event.gpu_fallback_.cuda_event_end_;
 
     // add information about an associated forward op, if a sequence number
     // is available (e.g. during training)
     if (op_event.sequence_number_ >= 0) {
       kineto_event_.get()
           .sequenceNr(op_event.sequence_number_)
-          .fwdThreadId(op_event.forward_thread_id_);
+          .fwdThreadId(op_event.forward_tid_);
       annotations_.emplace_back(
-          "Fwd thread id", std::to_string(op_event.forward_thread_id_));
+          "Fwd thread id", std::to_string(op_event.forward_tid_));
       annotations_.emplace_back(
           "Sequence number", std::to_string(op_event.sequence_number_));
     }
   }
 
-  void operator()(const torch::profiler::impl::BackendEvent& backend_event) {
+  void operator()(ExtraFields<EventType::Backend>& backend_event) {
+    handleJIT(backend_event);
     kineto_event_.get()
-        .endThreadId(result_.get().start_tid_)
-        .scope(backend_event.record_function_scope_)
+        .endThreadId(kineto_event_.get().startThreadId())
+        .scope((int8_t)backend_event.scope_)
         .debugHandle(backend_event.debug_handle_)
         .backend(backend_event.backend_);
 
@@ -198,9 +204,13 @@ struct EventFieldsVisitor {
     }
   }
 
-  void handleJIT(
-      const std::vector<std::string>& jit_stack,
-      const std::vector<std::string>& jit_modules) {
+  template <typename T>
+  void handleJIT(T& fields) {
+    auto& jit_stack = fields.jit_stack_;
+    auto& jit_modules = fields.jit_modules_;
+    if (post_process_.get()) {
+      post_process_.get()(fields.debug_handle_, jit_stack, jit_modules);
+    }
     if (!jit_stack.empty()) {
       // NB: This is only for the JIT stack. The python stack (if applicable)
       //     is constructed later.
@@ -217,8 +227,8 @@ struct EventFieldsVisitor {
     }
   }
 
-  std::reference_wrapper<const Result> result_;
   std::reference_wrapper<KinetoEvent> kineto_event_;
+  std::reference_wrapper<const post_process_t> post_process_;
   annotation_t annotations_;
 };
 
@@ -348,7 +358,7 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
     for (auto& e : record_queue_.getRecords(converter)) {
       // `take_data` handles time conversion.
       int64_t start_us = e.start_time_us_;
-      int64_t end_us = e.end_time_us_;
+      int64_t end_us = e.endTimeUS();
 
       if (end_us < start_us) {
         // We initialize end_us_ to the smallest int64_t, so this means that
@@ -356,36 +366,27 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
         continue;
       }
 
-      // Call events post processing callback before finalizing trace, if there
-      // is one.
-      if (getEventPostProcessingCallback()) {
-        getEventPostProcessingCallback()(
-            c10::visit([](const auto& i) { return i.debug_handle_; }, e.event_),
-            e.jit_stack_,
-            e.jit_modules_);
-      }
-
       kineto_events_.emplace_back();
       kineto_events_.back()
           .name(e.name())
           .startUs(start_us)
           .durationUs(end_us - start_us)
-          .correlationId(e.correlation_id())
+          .correlationId(e.correlationID())
           .deviceType(c10::DeviceType::CPU)
           .startThreadId(e.start_tid_);
 
       // NB: also sets fields on `kineto_events_.back()`.
-      auto annotations =
-          EventFieldsVisitor(e, kineto_events_.back()).annotations_;
+      auto visitor = EventFieldsVisitor(
+          e, kineto_events_.back(), getEventPostProcessingCallback());
 
       cpu_trace_.addCPUActivity(
           e.name(),
           e.kinetoType(),
           e.kineto_info_,
-          e.correlation_id(),
+          e.correlationID(),
           start_us,
           end_us,
-          annotations);
+          visitor.annotations_);
     }
   }
 
@@ -691,7 +692,7 @@ void onFunctionExit(const at::RecordFunction& fn, at::ObserverContext* ctx_ptr) 
     static_cast<torch::profiler::impl::KinetoObserverContext*>(ctx_ptr);
   TORCH_INTERNAL_ASSERT(kineto_ctx_ptr != nullptr);
   kineto_ctx_ptr->event_->end_time_ = torch::profiler::impl::getApproximateTime();
-  kineto_ctx_ptr->event_->end_thread_id_ = at::RecordFunction::currentThreadId();
+  kineto_ctx_ptr->event_->basic_fields_.end_tid_ = at::RecordFunction::currentThreadId();
   if (config.state == ProfilerState::KINETO_GPU_FALLBACK) {
     try {
       auto fallback = kineto_ctx_ptr->fallback_;
@@ -745,13 +746,12 @@ void reportBackendEventToActiveKinetoProfiler(
   }
 
   state_ptr->record_queue_.getSubqueue()->emplace_backend_event(
-    torch::profiler::impl::BackendEvent {
       start_time_us,
       end_time_us,
-      (uint8_t)scope,
       debug_handle,
+      scope,
       event_name,
-      backend_name});
+      backend_name);
 
   /* no support for input shapes now?
   if (config.report_input_shapes) {

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -132,6 +132,22 @@ struct MemoryEventData {
 };
 static_assert(std::is_pod<MemoryEventData>::value, "Non-POD member of MemoryEventData.");
 
+auto getAnnotations(const MemoryEventData& event) {
+  torch::profiler::impl::kineto::annotation_t out{
+      {"Device Type", std::to_string((int8_t)event.device_type)},
+      {"Device Id", std::to_string(event.device_index)},
+      {"Addr", std::to_string(reinterpret_cast<intptr_t>(event.ptr))},
+      {"Bytes", std::to_string(event.alloc_size)}};
+
+  if (event.total_allocated >= 0) {
+    out.emplace_back("Total Allocated", std::to_string(event.total_allocated));
+  }
+  if (event.total_reserved >= 0) {
+    out.emplace_back("Total Reserved", std::to_string(event.total_reserved));
+  }
+  return out;
+}
+
 // Assumption: Total threads number will not exceed 2^16-1, and total ops will
 // not exceed 2^48 -1.
 static inline uint64_t getForwardThreadKey(uint64_t tid, uint64_t seqNr) {
@@ -227,15 +243,14 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
 
     for (const auto& e : memory_events_) {
       auto start_time_us = converter(e.start_time) / 1000;
-      cpu_trace_.addMemoryUsageActivity(
+      cpu_trace_.addCPUActivity(
           kMemoryEventName,
+          torch::profiler::impl::kineto::KinetoActivityType::CPU_INSTANT_EVENT,
           e.kineto_info,
+          /*correlation_id=*/0,
           start_time_us,
-          c10::Device(e.device_type, e.device_index),
-          e.ptr,
-          e.alloc_size,
-          e.total_allocated,
-          e.total_reserved);
+          start_time_us,
+          getAnnotations(e));
 
       kineto_events_.emplace_back();
       auto& evt = kineto_events_.back();
@@ -261,11 +276,12 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
 
       cpu_trace_.addCPUActivity(
           e.name(),
-          e.record_function_scope(),
+          e.kinetoType(),
           e.kineto_info_,
           e.correlation_id(),
           start_us,
-          end_us);
+          end_us,
+          /*annotations=*/{});
 
       kineto_events_.emplace_back();
       kineto_events_.back()

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -344,10 +344,14 @@ TORCH_API void enableProfiler(
  * callback, via enableProfilerWithEventPostProcess, that takes these debug handles
  * and generates stack trace and module hierarchy information, once profiling is done.
  */
+using post_process_t = std::function<void(
+    /*debug_handle */ int64_t,
+    /*jit_stack    */ std::vector<std::string>&,
+    /*jit_modules  */ std::vector<std::string>&)>;
 TORCH_API void enableProfilerWithEventPostProcess(
     const torch::profiler::impl::ProfilerConfig& config,
     const std::set<torch::profiler::impl::ActivityType>& activities,
-    std::function<void(std::vector<KinetoEvent>&)>&& cb,
+    post_process_t&& cb,
     const std::unordered_set<at::RecordScope>& scopes = {});
 
 TORCH_API std::unique_ptr<ProfilerResult> disableProfiler();

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -31,69 +31,69 @@ namespace {
 // It is passed as the second argument when enabling tracing via
 // `PyEval_SetProfile`.
 struct TraceContext {
-    PyObject_HEAD
+  PyObject_HEAD
 
-    // It is wasteful to store an entire PyThreadState* in RawEvent. So
-    // instead, we map thread ids down to a compact space that we can store in
-    // a single byte.
-    uint8_t thread_id_;
-    PyThreadState* thread_state_;
+  // It is wasteful to store an entire PyThreadState* in RawEvent. So
+  // instead, we map thread ids down to a compact space that we can store in
+  // a single byte.
+  uint8_t thread_id_;
+  PyThreadState* thread_state_;
 
-    // Likewise, int64_t is more precision than we need. By tracking when the
-    // profiler starts we can store "time since profile begin" which can fit
-    // into less space.
-    int64_t initial_us_;
+  // Likewise, int64_t is more precision than we need. By tracking when the
+  // profiler starts we can store "time since profile begin" which can fit
+  // into less space.
+  int64_t initial_us_;
 
-    // TODO:
-    //   Wall time is actually fairly expensive to compute. Empirically, it
-    //   takes ~600 ns to call `now()`. This puts a hard lower bound on the
-    //   overhead of the tracer. If we collected wall time less frequently, and
-    //   used TSC (e.g. through __rdtsc) to interpolate it should be possible
-    //   to reduce time spent on timestamps while retaining the same level of
-    //   accuracy.
+  // TODO:
+  //   Wall time is actually fairly expensive to compute. Empirically, it
+  //   takes ~600 ns to call `now()`. This puts a hard lower bound on the
+  //   overhead of the tracer. If we collected wall time less frequently, and
+  //   used TSC (e.g. through __rdtsc) to interpolate it should be possible
+  //   to reduce time spent on timestamps while retaining the same level of
+  //   accuracy.
 };
 
 // CPython boilerplate to define `TraceContext` as a proper python object.
 static PyTypeObject TraceContextType = {
-    PyVarObject_HEAD_INIT(nullptr, 0)
-    "TraceContext",             /* tp_name */
-    sizeof(TraceContext),       /* tp_basicsize */
-    0,                          /* tp_itemsize */
-    nullptr,                    /* tp_dealloc */
-    0,                          /* tp_vectorcall_offset */  // NOLINT: modernize-use-nullptr
-    nullptr,                    /* tp_getattr */
-    nullptr,                    /* tp_setattr */
-    nullptr,                    /* tp_reserved */
-    nullptr,                    /* tp_repr */
-    nullptr,                    /* tp_as_number */
-    nullptr,                    /* tp_as_sequence */
-    nullptr,                    /* tp_as_mapping */
-    nullptr,                    /* tp_hash  */
-    nullptr,                    /* tp_call */
-    nullptr,                    /* tp_str */
-    nullptr,                    /* tp_getattro */
-    nullptr,                    /* tp_setattro */
-    nullptr,                    /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,         /* tp_flags */
-    "Python tracer TLS",        /* tp_doc */
-    nullptr,                    /* tp_traverse */
-    nullptr,                    /* tp_clear */
-    nullptr,                    /* tp_richcompare */
-    0,                          /* tp_weaklistoffset */
-    nullptr,                    /* tp_iter */
-    nullptr,                    /* tp_iternext */
-    nullptr,                    /* tp_methods */
-    nullptr,                    /* tp_members */
-    nullptr,                    /* tp_getset */
-    nullptr,                    /* tp_base */
-    nullptr,                    /* tp_dict */
-    nullptr,                    /* tp_descr_get */
-    nullptr,                    /* tp_descr_set */
-    0,                          /* tp_dictoffset */
-    nullptr,                    /* tp_init */
-    nullptr,                    /* tp_alloc */
-    PyType_GenericNew,          /* tp_new */
-    nullptr                     /* tp_free */
+  PyVarObject_HEAD_INIT(nullptr, 0)
+  "TraceContext",             /* tp_name */
+  sizeof(TraceContext),       /* tp_basicsize */
+  0,                          /* tp_itemsize */
+  nullptr,                    /* tp_dealloc */
+  0,                          /* tp_vectorcall_offset */  // NOLINT: modernize-use-nullptr
+  nullptr,                    /* tp_getattr */
+  nullptr,                    /* tp_setattr */
+  nullptr,                    /* tp_reserved */
+  nullptr,                    /* tp_repr */
+  nullptr,                    /* tp_as_number */
+  nullptr,                    /* tp_as_sequence */
+  nullptr,                    /* tp_as_mapping */
+  nullptr,                    /* tp_hash  */
+  nullptr,                    /* tp_call */
+  nullptr,                    /* tp_str */
+  nullptr,                    /* tp_getattro */
+  nullptr,                    /* tp_setattro */
+  nullptr,                    /* tp_as_buffer */
+  Py_TPFLAGS_DEFAULT,         /* tp_flags */
+  "Python tracer TLS",        /* tp_doc */
+  nullptr,                    /* tp_traverse */
+  nullptr,                    /* tp_clear */
+  nullptr,                    /* tp_richcompare */
+  0,                          /* tp_weaklistoffset */
+  nullptr,                    /* tp_iter */
+  nullptr,                    /* tp_iternext */
+  nullptr,                    /* tp_methods */
+  nullptr,                    /* tp_members */
+  nullptr,                    /* tp_getset */
+  nullptr,                    /* tp_base */
+  nullptr,                    /* tp_dict */
+  nullptr,                    /* tp_descr_get */
+  nullptr,                    /* tp_descr_set */
+  0,                          /* tp_dictoffset */
+  nullptr,                    /* tp_init */
+  nullptr,                    /* tp_alloc */
+  PyType_GenericNew,          /* tp_new */
+  nullptr                     /* tp_free */
 };
 
 // CPython has a more expressive set of events for tracing / profiling:
@@ -105,12 +105,7 @@ static PyTypeObject TraceContextType = {
 // our replay stack), and we are not interested in `PyTrace_LINE` or
 // `PyTrace_OPCODE`. To simplify things we store our own enum when tracefunc is
 // called, and then use for all subsequent processing.
-enum TraceTag {
-    kPy_Call = 0,
-    kPy_Return,
-    kC_Call,
-    kC_Return
-};
+enum TraceTag { kPy_Call = 0, kPy_Return, kC_Call, kC_Return };
 
 //   When we are tracing a Python program, the general procedure is to record
 // every time we enter or exit a function and later replay these events during
@@ -156,77 +151,75 @@ enum TraceTag {
 // `RawEvent` would grow to three words. (Not just 50% bigger, but also less
 // cache friendly.)
 struct RawEvent {
-    RawEvent(TraceTag tag, int lasti, TraceContext* ctx)
-            : tag_(static_cast<uint8_t>(tag)),
-              thread_id_(ctx->thread_id_),
-              lasti_(static_cast<uint16_t>(lasti)),
-              misc_() {
-        int64_t t = now() - ctx->initial_us_;
-        t_ = static_cast<uint32_t>(t);
+  RawEvent(TraceTag tag, int lasti, TraceContext* ctx)
+      : tag_(static_cast<uint8_t>(tag)),
+        thread_id_(ctx->thread_id_),
+        lasti_(static_cast<uint16_t>(lasti)),
+        misc_() {
+    int64_t t = now() - ctx->initial_us_;
+    t_ = static_cast<uint32_t>(t);
 
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(lasti <= std::numeric_limits<uint16_t>::max());
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(t <= std::numeric_limits<uint32_t>::max());
-    }
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+        lasti <= std::numeric_limits<uint16_t>::max());
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(t <= std::numeric_limits<uint32_t>::max());
+  }
 
-    RawEvent(TraceTag tag, int lasti, TraceContext* ctx, PyCodeObject* f_code)
-            : RawEvent(tag, lasti, ctx) {
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(tag == TraceTag::kPy_Call);
-        misc_.f_code_ = f_code;
-    }
+  RawEvent(TraceTag tag, int lasti, TraceContext* ctx, PyCodeObject* f_code)
+      : RawEvent(tag, lasti, ctx) {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(tag == TraceTag::kPy_Call);
+    misc_.f_code_ = f_code;
+  }
 
-    RawEvent(TraceTag tag, int lasti, TraceContext* ctx, PyObject* arg)
-            : RawEvent(tag, lasti, ctx) {
-        TORCH_INTERNAL_ASSERT_DEBUG_ONLY(tag == TraceTag::kC_Call);
-        misc_.arg_ = arg;
-    }
+  RawEvent(TraceTag tag, int lasti, TraceContext* ctx, PyObject* arg)
+      : RawEvent(tag, lasti, ctx) {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(tag == TraceTag::kC_Call);
+    misc_.arg_ = arg;
+  }
 
-    uint8_t tag_;
-    uint8_t thread_id_;
-    uint16_t lasti_;
-    uint32_t t_;
-    union {
-        // TraceTag::kPy_Call
-        PyCodeObject* f_code_;
+  uint8_t tag_;
+  uint8_t thread_id_;
+  uint16_t lasti_;
+  uint32_t t_;
+  union {
+    // TraceTag::kPy_Call
+    PyCodeObject* f_code_;
 
-        // TraceTag::kC_Call
-        PyObject* arg_;
+    // TraceTag::kC_Call
+    PyObject* arg_;
 
-        // TraceTag::kPy_Return
-        // TraceTag::kC_Return
-        // ** Unused (placeholder) **
-        void* null_;
-    } misc_;
+    // TraceTag::kPy_Return
+    // TraceTag::kC_Return
+    // ** Unused (placeholder) **
+    void* null_;
+  } misc_;
 
-    C10_NODISCARD TraceTag tag() const {
-        return static_cast<TraceTag>(tag_);
-    }
+  C10_NODISCARD TraceTag tag() const {
+    return static_cast<TraceTag>(tag_);
+  }
 
-    C10_NODISCARD int lasti() const {
-        // f_lasti is positive, with one exception: CPython intializes frames
-        // with `f_lasti = -1`. We don't want to give up half of the range by
-        // switching to int16_t. So instead we do the fast (underflowing) cast
-        // in the ctor, and rectify the value in this accessor which should
-        // only be called during trace post processing.
-        return lasti_ == std::numeric_limits<uint16_t>::max()
-            ? (int)(-1)
-            : (int)lasti_;
-    }
+  C10_NODISCARD int lasti() const {
+    // f_lasti is positive, with one exception: CPython intializes frames
+    // with `f_lasti = -1`. We don't want to give up half of the range by
+    // switching to int16_t. So instead we do the fast (underflowing) cast
+    // in the ctor, and rectify the value in this accessor which should
+    // only be called during trace post processing.
+    return lasti_ == std::numeric_limits<uint16_t>::max() ? (int)(-1)
+                                                          : (int)lasti_;
+  }
 };
 
 // Make sure the bit packing that we do in RawEvent actually results in the
 // desired size reduction.
 static_assert(sizeof(RawEvent) <= 16, "RawEvent is too large");
 
-
 // std::hash doesn't have a specialization for pairs so we have to define one.
 // A simple XOR is good enough for our purposes.
 struct hash_pair {
-    template <class T1, class T2>
-    size_t operator() (const std::pair<T1, T2>& pair) const {
-        return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
-    }
+  template <class T1, class T2>
+  size_t operator()(const std::pair<T1, T2>& pair) const {
+    return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
+  }
 };
-
 
 // ============================================================================
 // == Tracing implementation ==================================================
@@ -235,211 +228,221 @@ constexpr size_t max_py_threads = std::numeric_limits<uint8_t>::max() + 1;
 
 class PythonTracer final {
  public:
-    // Static methods serve as external interfaces (which expect raw pointers)
-    // and handle forwarding to the singleton.
-    static void call(Command c);
+  // Static methods serve as external interfaces (which expect raw pointers)
+  // and handle forwarding to the singleton.
+  static void call(Command c);
 
-    static int pyProfileFn(
-        PyObject* obj,
-        PyFrameObject* frame,
-        int what,
-        PyObject* arg);
+  static int pyProfileFn(
+      PyObject* obj,
+      PyFrameObject* frame,
+      int what,
+      PyObject* arg);
 
  private:
-    PythonTracer();
-    static PythonTracer& singleton();
-    friend class PyTraceReplay;
+  PythonTracer();
+  static PythonTracer& singleton();
+  friend class PyTraceReplay;
 
-    void start(size_t max_threads = max_py_threads);
-    void stop();
-    void clear();
+  void start(size_t max_threads = max_py_threads);
+  void stop();
+  void clear();
 
-    void recordPyCall(TraceContext* ctx, PyFrameObject* frame);
-    void recordCCall(TraceContext* ctx, PyFrameObject* frame, PyObject* arg);
-    void recordReturn(TraceContext* ctx, PyFrameObject* frame, TraceTag tag);
+  void recordPyCall(TraceContext* ctx, PyFrameObject* frame);
+  void recordCCall(TraceContext* ctx, PyFrameObject* frame, PyObject* arg);
+  void recordReturn(TraceContext* ctx, PyFrameObject* frame, TraceTag tag);
 
-    void storeDescription(PyFrameObject* frame);
-    void trackModule(PyFrameObject* frame);
+  void storeDescription(PyFrameObject* frame);
+  void trackModule(PyFrameObject* frame);
 
-    // It is imperitive that we do not store strings for each python function,
-    // as that would do terrible things to our profiling overhead. So instead
-    // we store the much cheaper pair of `PyCodeObject*` and `int` which we can
-    // pack into `RawEvent`, and then store a mapping to the full strings the
-    // first time we see a function.
-    //
-    // TODO:
-    //   In theory we should be able to use a combination of Py_INCREF on
-    //   `f_code` and string interning to skip this step. (Effectively reusing
-    //   work that the CPython interpreter has already done.) However it tends
-    //   to segfault and simply caching the strings is inexpensive.
-    struct CodeDescription {
-        CodeDescription(int line_no, std::string filename, std::string funcname)
-            : line_no_(line_no),
-              filename_(std::move(filename)),
-              funcname_(std::move(funcname)) {}
-        int line_no_;
-        std::string filename_;
-        std::string funcname_;
-    };
+  // It is imperitive that we do not store strings for each python function,
+  // as that would do terrible things to our profiling overhead. So instead
+  // we store the much cheaper pair of `PyCodeObject*` and `int` which we can
+  // pack into `RawEvent`, and then store a mapping to the full strings the
+  // first time we see a function.
+  //
+  // TODO:
+  //   In theory we should be able to use a combination of Py_INCREF on
+  //   `f_code` and string interning to skip this step. (Effectively reusing
+  //   work that the CPython interpreter has already done.) However it tends
+  //   to segfault and simply caching the strings is inexpensive.
+  struct CodeDescription {
+    CodeDescription(int line_no, std::string filename, std::string funcname)
+        : line_no_(line_no),
+          filename_(std::move(filename)),
+          funcname_(std::move(funcname)) {}
+    int line_no_;
+    std::string filename_;
+    std::string funcname_;
+  };
 
-    struct ModuleForward {
-        ModuleForward(size_t event_index, PyObject* self)
-            : event_index_(event_index), self_(self) {}
-        size_t event_index_;
+  struct ModuleForward {
+    ModuleForward(size_t event_index, PyObject* self)
+        : event_index_(event_index), self_(self) {}
+    size_t event_index_;
 
-        // NB:
-        //  This is a non-owning reference to keep `ModuleForward` POD;
-        //  `PythonTracer` owns the contents instead. We  Py_INCREF in
-        //  `trackModule`, and `reset` is responsible for  calling Py_DECREF
-        //  when clearing `module_calls_`.
-        PyObject* self_;
-    };
+    // NB:
+    //  This is a non-owning reference to keep `ModuleForward` POD;
+    //  `PythonTracer` owns the contents instead. We  Py_INCREF in
+    //  `trackModule`, and `reset` is responsible for  calling Py_DECREF
+    //  when clearing `module_calls_`.
+    PyObject* self_;
+  };
 
-    bool active_;
-    PyObject* module_call_code_;
-    std::vector<std::string> path_prefixes_;
-    std::vector<TraceContext*> trace_contexts_;
+  bool active_;
+  PyObject* module_call_code_;
+  std::vector<std::string> path_prefixes_;
+  std::vector<TraceContext*> trace_contexts_;
 
-    std::vector<RawEvent> events_;
-    std::vector<ModuleForward> module_calls_;
+  std::vector<RawEvent> events_;
+  std::vector<ModuleForward> module_calls_;
 
-    using DescriptionKey = std::pair</*f_code=*/PyCodeObject*, /*f_lasti=*/int>;
-    ska::flat_hash_map<DescriptionKey, CodeDescription, hash_pair> code_descriptions_;
-    ska::flat_hash_map<PyObject*, std::string> c_function_reprs_;
+  using DescriptionKey = std::pair</*f_code=*/PyCodeObject*, /*f_lasti=*/int>;
+  ska::flat_hash_map<DescriptionKey, CodeDescription, hash_pair>
+      code_descriptions_;
+  ska::flat_hash_map<PyObject*, std::string> c_function_reprs_;
 };
 
 PythonTracer& PythonTracer::singleton() {
-    static PythonTracer singleton_;
-    return singleton_;
+  static PythonTracer singleton_;
+  return singleton_;
 }
 
 PythonTracer::PythonTracer() : active_(false) {
-    path_prefixes_ = py::module::import("torch.profiler.python_tracer")
-        .attr("_prefix_regex")().cast<std::vector<std::string>>();
+  path_prefixes_ = py::module::import("torch.profiler.python_tracer")
+    .attr("_prefix_regex")().cast<std::vector<std::string>>();
 
-    module_call_code_ = py::module::import("torch.nn")
-        .attr("Module")
-        .attr("__call__")
-        .attr("__code__")
-        .ptr();
+  module_call_code_ = py::module::import("torch.nn")
+    .attr("Module")
+    .attr("__call__")
+    .attr("__code__")
+    .ptr();
 }
 
 void PythonTracer::start(size_t max_threads) {
-    TORCH_CHECK(!active_, "PythonTracer is already active")
-    TORCH_CHECK(!trace_contexts_.size(), "PythonTracer should not have active contexts");
-    TORCH_CHECK(max_threads > 0, "max_threads must be positive, got ", max_threads);
-    TORCH_CHECK(
-        max_threads <= max_py_threads,
-        "max_threads must be less than or equal to ", max_py_threads);
+  TORCH_CHECK(!active_, "PythonTracer is already active")
+  TORCH_CHECK(
+      !trace_contexts_.size(), "PythonTracer should not have active contexts");
+  TORCH_CHECK(
+      max_threads > 0, "max_threads must be positive, got ", max_threads);
+  TORCH_CHECK(
+      max_threads <= max_py_threads,
+      "max_threads must be less than or equal to ",
+      max_py_threads);
 
-    pybind11::gil_scoped_acquire gil;
-    auto t0 = now();
+  pybind11::gil_scoped_acquire gil;
+  auto t0 = now();
 
-    // Loop over all threads within the current interpreter. We will need to
-    // register a trace function with each thread. We set the current thread to
-    // position zero to ensure that it is traced, and so we can restore the
-    // thread state after registration.
-    std::vector<PyThreadState*> thread_states { PyThreadState_Get() };
-    if (max_threads > 1) {
-        auto thread_state = thread_states[0];
-        while (thread_state != nullptr) {
-            if (thread_state != thread_states[0]) {
-                thread_states.push_back(thread_state);
-            }
-            thread_state = PyThreadState_Next(thread_state);
-        }
-
-        if (thread_states.size() > max_threads) {
-            std::cout << "Warning: can only trace " << max_threads << " threads. "
-                    << thread_states.size() << " are currently active." << std::endl;
-            thread_states.resize(max_threads);
-        }
+  // Loop over all threads within the current interpreter. We will need to
+  // register a trace function with each thread. We set the current thread to
+  // position zero to ensure that it is traced, and so we can restore the
+  // thread state after registration.
+  std::vector<PyThreadState*> thread_states{PyThreadState_Get()};
+  if (max_threads > 1) {
+    auto thread_state = thread_states[0];
+    while (thread_state != nullptr) {
+      if (thread_state != thread_states[0]) {
+        thread_states.push_back(thread_state);
+      }
+      thread_state = PyThreadState_Next(thread_state);
     }
 
-    // Register the tracer in each thread.
-    for (const auto i : c10::irange(thread_states.size())) {
-        PyThreadState* thread_state = thread_states[i];
-        PyThreadState_Swap(thread_state);
+    if (thread_states.size() > max_threads) {
+      std::cout << "Warning: can only trace " << max_threads << " threads. "
+                << thread_states.size() << " are currently active."
+                << std::endl;
+      thread_states.resize(max_threads);
+    }
+  }
 
-        auto ctx = (TraceContext*) TraceContextType.tp_alloc(&TraceContextType, 0);
-        ctx->thread_id_ = (uint8_t)i;
-        ctx->thread_state_ = thread_state;
-        ctx->initial_us_ = t0;
-        trace_contexts_.push_back(ctx);
+  // Register the tracer in each thread.
+  for (const auto i : c10::irange(thread_states.size())) {
+    PyThreadState* thread_state = thread_states[i];
+    PyThreadState_Swap(thread_state);
 
-        // When we begin profiling there are already frames on the Python
-        // interpreter stack. To ensure a complete trace, we must push calls
-        // to all the prior frames onto our event stack. (We stop at depth=128)
-        std::vector<PyFrameObject*> current_stack;
-        auto frame = PyEval_GetFrame();
-        size_t depth = 0;  // Make sure we can't infinite loop.
-        while (frame != nullptr && depth <= 128) {
-            current_stack.push_back(frame);
-            frame = frame->f_back;
-            depth++;
-        }
-        for (auto it = current_stack.rbegin(); it != current_stack.rend(); it++) {
-            recordPyCall(ctx, *it);
-        }
+    auto ctx = (TraceContext*)TraceContextType.tp_alloc(&TraceContextType, 0);
+    ctx->thread_id_ = (uint8_t)i;
+    ctx->thread_state_ = thread_state;
+    ctx->initial_us_ = t0;
+    trace_contexts_.push_back(ctx);
 
-        // Note:
-        //   This profile will not compose with other CPython profilers, and
-        //   cannot be round tripped via `sys.settrace(sys.gettrace())`
-        PyEval_SetProfile(PythonTracer::pyProfileFn, (PyObject*)ctx);
+    // When we begin profiling there are already frames on the Python
+    // interpreter stack. To ensure a complete trace, we must push calls
+    // to all the prior frames onto our event stack. (We stop at depth=128)
+    std::vector<PyFrameObject*> current_stack;
+    auto frame = PyEval_GetFrame();
+    size_t depth = 0; // Make sure we can't infinite loop.
+    while (frame != nullptr && depth <= 128) {
+      current_stack.push_back(frame);
+      frame = frame->f_back;
+      depth++;
+    }
+    for (auto it = current_stack.rbegin(); it != current_stack.rend(); it++) {
+      recordPyCall(ctx, *it);
     }
 
-    // Restore the thread state to its initial value.
-    PyThreadState_Swap(thread_states[0]);
+    // Note:
+    //   This profile will not compose with other CPython profilers, and
+    //   cannot be round tripped via `sys.settrace(sys.gettrace())`
+    PyEval_SetProfile(PythonTracer::pyProfileFn, (PyObject*)ctx);
+  }
 
-    active_ = true;
+  // Restore the thread state to its initial value.
+  PyThreadState_Swap(thread_states[0]);
+
+  active_ = true;
 };
 
 void PythonTracer::stop() {
-    TORCH_INTERNAL_ASSERT(active_, "PythonTracer is not running.")
+  TORCH_INTERNAL_ASSERT(active_, "PythonTracer is not running.")
 
-    pybind11::gil_scoped_acquire gil;
+  pybind11::gil_scoped_acquire gil;
 
-    PyThreadState* initial_thread_state = PyThreadState_Get();
-    for (const auto i : trace_contexts_) {
-        PyThreadState_Swap(i->thread_state_);
-        PyEval_SetProfile(nullptr, nullptr);
-    }
-    PyThreadState_Swap(initial_thread_state);
-    active_ = false;
+  PyThreadState* initial_thread_state = PyThreadState_Get();
+  for (const auto i : trace_contexts_) {
+    PyThreadState_Swap(i->thread_state_);
+    PyEval_SetProfile(nullptr, nullptr);
+  }
+  PyThreadState_Swap(initial_thread_state);
+  active_ = false;
 }
 
-
 void PythonTracer::clear() {
-    TORCH_CHECK(!active_, "Cannot clear state while PythonTracer is active.");
-    for (auto i : trace_contexts_) {
-        Py_DECREF((PyObject*) i);
-    }
-    trace_contexts_.clear();
-    events_.clear();
-    code_descriptions_.clear();
-    c_function_reprs_.clear();
-    for (auto& i : module_calls_) {
-        Py_DECREF(i.self_);
-    }
-    module_calls_.clear();
+  TORCH_CHECK(!active_, "Cannot clear state while PythonTracer is active.");
+  for (auto i : trace_contexts_) {
+    Py_DECREF((PyObject*)i);
+  }
+  trace_contexts_.clear();
+  events_.clear();
+  code_descriptions_.clear();
+  c_function_reprs_.clear();
+  for (auto& i : module_calls_) {
+    Py_DECREF(i.self_);
+  }
+  module_calls_.clear();
 }
 
 void PythonTracer::recordPyCall(TraceContext* ctx, PyFrameObject* frame) {
-    events_.emplace_back(TraceTag::kPy_Call, frame->f_lasti, ctx, frame->f_code);
-    storeDescription(frame);
-    trackModule(frame);
+  events_.emplace_back(TraceTag::kPy_Call, frame->f_lasti, ctx, frame->f_code);
+  storeDescription(frame);
+  trackModule(frame);
 }
 
-void PythonTracer::recordCCall(TraceContext* ctx, PyFrameObject* frame, PyObject* arg) {
-    events_.emplace_back(TraceTag::kC_Call, frame->f_lasti, ctx, arg);
-    const auto& it = c_function_reprs_.find(arg);
-    if C10_UNLIKELY(it == c_function_reprs_.end()) {
-        c_function_reprs_[arg] = py::repr(arg);
-    }
+void PythonTracer::recordCCall(
+    TraceContext* ctx,
+    PyFrameObject* frame,
+    PyObject* arg) {
+  events_.emplace_back(TraceTag::kC_Call, frame->f_lasti, ctx, arg);
+  const auto& it = c_function_reprs_.find(arg);
+  if C10_UNLIKELY (it == c_function_reprs_.end()) {
+    c_function_reprs_[arg] = py::repr(arg);
+  }
 }
 
-void PythonTracer::recordReturn(TraceContext* ctx, PyFrameObject* frame, TraceTag tag) {
-    events_.emplace_back(tag, frame->f_lasti, ctx);
+void PythonTracer::recordReturn(
+    TraceContext* ctx,
+    PyFrameObject* frame,
+    TraceTag tag) {
+  events_.emplace_back(tag, frame->f_lasti, ctx);
 }
 
 // NB:
@@ -448,41 +451,36 @@ void PythonTracer::recordReturn(TraceContext* ctx, PyFrameObject* frame, TraceTa
 //  call rather than the return. (Otherwise we would get the line with the
 //  return stmt.)
 void PythonTracer::storeDescription(PyFrameObject* frame) {
-    const auto& it = code_descriptions_.find({ frame->f_code, frame->f_lasti });
-    if C10_UNLIKELY(it == code_descriptions_.end()) {
-        code_descriptions_.insert({
-            { frame->f_code, frame->f_lasti },
-            {
-                /*line_no=*/ PyCode_Addr2Line(frame->f_code, frame->f_lasti),
-                /*filename=*/ THPUtils_unpackString(frame->f_code->co_filename),
-                /*funcname=*/ THPUtils_unpackString(frame->f_code->co_name)
-            }
-        });
-    }
+  const auto& it = code_descriptions_.find({frame->f_code, frame->f_lasti});
+  if C10_UNLIKELY (it == code_descriptions_.end()) {
+    code_descriptions_.insert(
+        {{frame->f_code, frame->f_lasti},
+         {/*line_no=*/PyCode_Addr2Line(frame->f_code, frame->f_lasti),
+          /*filename=*/THPUtils_unpackString(frame->f_code->co_filename),
+          /*funcname=*/THPUtils_unpackString(frame->f_code->co_name)}});
+  }
 }
 
 void PythonTracer::trackModule(PyFrameObject* frame) {
-    if ((PyObject*)(frame->f_code) == module_call_code_) {
-        // By default, CPython stores locals in a "fast" format, with an array
-        // of names and an array of values. Consequently, frame->f_locals is
-        // NULL since the interpreter has no need to populate it.
-        //
-        // If these arrays were part of the public API then we could very
-        // quickly access `self`. Unfortunately they are not, and moreover are
-        // not stable across versions. As a result, we are forced to call
-        // `PyFrame_FastToLocals` which forces the interpreter to materialize
-        // the full dict of locals.
-        PyFrame_FastToLocals(frame);
-        auto self = PyDict_GetItemString(frame->f_locals, "self");
-        Py_INCREF(self);
-        module_calls_.emplace_back(
-            /*event_index=*/events_.size() - 1,
-            /*self=*/self
-        );
-        PyFrame_LocalsToFast(frame, 0);
-    }
+  if ((PyObject*)(frame->f_code) == module_call_code_) {
+    // By default, CPython stores locals in a "fast" format, with an array
+    // of names and an array of values. Consequently, frame->f_locals is
+    // NULL since the interpreter has no need to populate it.
+    //
+    // If these arrays were part of the public API then we could very
+    // quickly access `self`. Unfortunately they are not, and moreover are
+    // not stable across versions. As a result, we are forced to call
+    // `PyFrame_FastToLocals` which forces the interpreter to materialize
+    // the full dict of locals.
+    PyFrame_FastToLocals(frame);
+    auto self = PyDict_GetItemString(frame->f_locals, "self");
+    Py_INCREF(self);
+    module_calls_.emplace_back(
+        /*event_index=*/events_.size() - 1,
+        /*self=*/self);
+    PyFrame_LocalsToFast(frame, 0);
+  }
 };
-
 
 // ============================================================================
 // == Post processing =========================================================
@@ -490,230 +488,228 @@ void PythonTracer::trackModule(PyFrameObject* frame) {
 
 class PyTraceReplay {
  public:
-    static std::vector<std::unique_ptr<PyTraceEvent>> getEvents() {
-        return PyTraceReplay().replayStack();
-    }
+  static std::vector<std::unique_ptr<PyTraceEvent>> getEvents() {
+    return PyTraceReplay().replayStack();
+  }
 
  private:
-    PyTraceReplay();
-    std::vector<std::unique_ptr<PyTraceEvent>> replayStack() const;
+  PyTraceReplay();
+  std::vector<std::unique_ptr<PyTraceEvent>> replayStack() const;
 
-    struct ReplayFrame {
-        std::unique_ptr<PyTraceEvent> event_;
-        size_t id_;
-        size_t parent_id_;
-    };
+  struct ReplayFrame {
+    std::unique_ptr<PyTraceEvent> event_;
+    size_t id_;
+    size_t parent_id_;
+  };
 
-    ska::flat_hash_map<size_t, PyObject*> module_self_map_;
-    ska::flat_hash_map<size_t, std::string> module_name_map_;
+  ska::flat_hash_map<size_t, PyObject*> module_self_map_;
+  ska::flat_hash_map<size_t, std::string> module_name_map_;
 };
 
 PyTraceReplay::PyTraceReplay() {
-    ska::flat_hash_map<PyObject*, std::string> module_names;
-    for (const auto& call : PythonTracer::singleton().module_calls_) {
-        if (module_names.find(call.self_) == module_names.end()) {
-            std::stringstream name_stream;
-            auto py_class_name = py::handle(call.self_)
-                .attr("__class__")
-                .attr("__name__");
-            name_stream << "nn.Module: " << py::str(py_class_name);
-            module_names.insert({ call.self_, name_stream.str() });
-        }
-
-        module_self_map_.insert({ call.event_index_, call.self_ });
-        module_name_map_.insert({ call.event_index_, module_names.at(call.self_) });
+  ska::flat_hash_map<PyObject*, std::string> module_names;
+  for (const auto& call : PythonTracer::singleton().module_calls_) {
+    if (module_names.find(call.self_) == module_names.end()) {
+      std::stringstream name_stream;
+      auto py_class_name =
+          py::handle(call.self_).attr("__class__").attr("__name__");
+      name_stream << "nn.Module: " << py::str(py_class_name);
+      module_names.insert({call.self_, name_stream.str()});
     }
-}
 
+    module_self_map_.insert({call.event_index_, call.self_});
+    module_name_map_.insert({call.event_index_, module_names.at(call.self_)});
+  }
+}
 
 // TODO: Use re2.
 void trimPrefix(std::string& s, const std::vector<std::string>& prefixes) {
-    for (const auto& p : prefixes) {
-        if (s.compare(0, p.size(), p) == 0) {
-            s.erase(0, p.size());
-            return;
-        }
+  for (const auto& p : prefixes) {
+    if (s.compare(0, p.size(), p) == 0) {
+      s.erase(0, p.size());
+      return;
     }
+  }
 }
-
 
 std::vector<std::unique_ptr<PyTraceEvent>> PyTraceReplay::replayStack() const {
-    const auto& tracer = PythonTracer::singleton();
+  const auto& tracer = PythonTracer::singleton();
 
-    // We want to prune paths to a sensible prefix. For example
-    //   `/foo/bar/baz/site-packages/torch/__init__.py` -> `torch/__init__.py`
-    // Pruning the path prefix is somewhat expensive, so we cache it.
-    ska::flat_hash_map<std::string, std::string> filename_map;
-    for (const auto& i : tracer.code_descriptions_) {
-        if (filename_map.find(i.second.filename_) == filename_map.end()) {
-            std::string s(i.second.filename_);
-            trimPrefix(s, tracer.path_prefixes_);
-            filename_map[i.second.filename_] = s;
-        }
+  // We want to prune paths to a sensible prefix. For example
+  //   `/foo/bar/baz/site-packages/torch/__init__.py` -> `torch/__init__.py`
+  // Pruning the path prefix is somewhat expensive, so we cache it.
+  ska::flat_hash_map<std::string, std::string> filename_map;
+  for (const auto& i : tracer.code_descriptions_) {
+    if (filename_map.find(i.second.filename_) == filename_map.end()) {
+      std::string s(i.second.filename_);
+      trimPrefix(s, tracer.path_prefixes_);
+      filename_map[i.second.filename_] = s;
     }
+  }
 
-    auto py_name = [&](const RawEvent& e) {
-        const auto& desc_it = tracer.code_descriptions_.find({e.misc_.f_code_, e.lasti()});
-        if (desc_it != tracer.code_descriptions_.end()) {
-            std::stringstream name_stream;
-            name_stream << filename_map.at(desc_it->second.filename_) << "("
-                        << desc_it->second.line_no_ << "): " << desc_it->second.funcname_;
-            return name_stream.str();
-        }
-        return std::string("Python: ???");
-    };
+  auto py_name = [&](const RawEvent& e) {
+    const auto& desc_it =
+        tracer.code_descriptions_.find({e.misc_.f_code_, e.lasti()});
+    if (desc_it != tracer.code_descriptions_.end()) {
+      std::stringstream name_stream;
+      name_stream << filename_map.at(desc_it->second.filename_) << "("
+                  << desc_it->second.line_no_
+                  << "): " << desc_it->second.funcname_;
+      return name_stream.str();
+    }
+    return std::string("Python: ???");
+  };
 
-    size_t id_counter = 0;
-    std::vector<std::vector<ReplayFrame>> stacks(tracer.trace_contexts_.size());
-    std::vector<ReplayFrame> results;
+  size_t id_counter = 0;
+  std::vector<std::vector<ReplayFrame>> stacks(tracer.trace_contexts_.size());
+  std::vector<ReplayFrame> results;
 
-    // Match calls and returns.
-    size_t event_idx = 0;
-    for (auto& raw_event : tracer.events_) {
-        auto& stack = stacks[raw_event.thread_id_];
-        auto ctx = tracer.trace_contexts_[raw_event.thread_id_];
-        auto t = static_cast<int64_t>(raw_event.t_) + ctx->initial_us_;
+  // Match calls and returns.
+  size_t event_idx = 0;
+  for (auto& raw_event : tracer.events_) {
+    auto& stack = stacks[raw_event.thread_id_];
+    auto ctx = tracer.trace_contexts_[raw_event.thread_id_];
+    auto t = static_cast<int64_t>(raw_event.t_) + ctx->initial_us_;
 
-        auto push_frame = [&](std::string name, CallType call_type, size_t module_id = 0) {
-            stack.push_back(ReplayFrame {
-                /*event_=*/ std::make_unique<PyTraceEvent>(PyTraceEvent{
-                    /*startTime_=*/ t,
-                    /*endTime_=*/ -1,  // Placeholder
-                    /*name_=*/ name,
-                    /*thread_id_=*/ raw_event.thread_id_,
-                    /*parent_=*/ nullptr,  // Placeholder
-                    /*call_type_=*/ call_type,
-                    /*module_id_=*/ module_id,
-                    /*call_idx_=*/ event_idx,
-                    /*return_idx_=*/ 0  // Placeholder
-                }),
-                /*id_=*/ id_counter++,
-                /*parent_id_=*/ stack.size() ? stack.back().id_ : 0,
-            });
+    auto push_frame =
+        [&](std::string name, CallType call_type, size_t module_id = 0) {
+          stack.push_back(ReplayFrame{
+              /*event_=*/std::make_unique<PyTraceEvent>(PyTraceEvent{
+                  /*startTime_=*/t,
+                  /*endTime_=*/-1, // Placeholder
+                  /*name_=*/name,
+                  /*thread_id_=*/raw_event.thread_id_,
+                  /*parent_=*/nullptr, // Placeholder
+                  /*call_type_=*/call_type,
+                  /*module_id_=*/module_id,
+                  /*call_idx_=*/event_idx,
+                  /*return_idx_=*/0 // Placeholder
+              }),
+              /*id_=*/id_counter++,
+              /*parent_id_=*/stack.size() ? stack.back().id_ : 0,
+          });
         };
 
-        switch (raw_event.tag()) {
-            case TraceTag::kPy_Call:
-                if (module_name_map_.find(event_idx) != module_name_map_.end()) {
-                    push_frame(
-                        module_name_map_.at(event_idx),
-                        CallType::kPyModuleCall,
-                        reinterpret_cast<size_t>(module_self_map_.at(event_idx)));
-                } else {
-                    push_frame(py_name(raw_event), CallType::kPyCall);
-                }
-                break;
-
-            case TraceTag::kC_Call:
-                push_frame(tracer.c_function_reprs_.at(raw_event.misc_.arg_), CallType::kCCall);
-                break;
-
-            case TraceTag::kPy_Return:
-            case TraceTag::kC_Return:
-                TORCH_INTERNAL_ASSERT(stack.size(), "Python replay stack is empty.")
-                stack.back().event_->endTime_ = t;
-                stack.back().event_->return_idx_ = event_idx;
-                results.push_back(std::move(stack.back()));
-                stack.pop_back();
-                break;
+    switch (raw_event.tag()) {
+      case TraceTag::kPy_Call:
+        if (module_name_map_.find(event_idx) != module_name_map_.end()) {
+          push_frame(
+              module_name_map_.at(event_idx),
+              CallType::kPyModuleCall,
+              reinterpret_cast<size_t>(module_self_map_.at(event_idx)));
+        } else {
+          push_frame(py_name(raw_event), CallType::kPyCall);
         }
-        event_idx++;
-    }
+        break;
 
-    // Cleanup by feining return to close out the stack. This is needed so
-    // frames above the one that called the profiler still appear in the trace.
-    const auto t_final = now();
-    for (auto& stack : stacks) {
-        while (stack.size()) {
-            stack.back().event_->endTime_ = t_final;
-            stack.back().event_->return_idx_ = event_idx;
-            results.push_back(std::move(stack.back()));
-            stack.pop_back();
-            event_idx++;
-        }
-    }
+      case TraceTag::kC_Call:
+        push_frame(
+            tracer.c_function_reprs_.at(raw_event.misc_.arg_),
+            CallType::kCCall);
+        break;
 
-    // Convert to `PyTraceEvent`, and map id to pointer.
-    ska::flat_hash_map<size_t, PyTraceEvent*> event_id_map {{0, nullptr}};
-    std::vector<std::unique_ptr<PyTraceEvent>> out;
-    for (auto& r : results) {
-        out.push_back(std::move(r.event_));
-        event_id_map.insert({r.id_, out.back().get()});
+      case TraceTag::kPy_Return:
+      case TraceTag::kC_Return:
+        TORCH_INTERNAL_ASSERT(stack.size(), "Python replay stack is empty.")
+        stack.back().event_->endTime_ = t;
+        stack.back().event_->return_idx_ = event_idx;
+        results.push_back(std::move(stack.back()));
+        stack.pop_back();
+        break;
     }
+    event_idx++;
+  }
 
-    // Link parents to children.
-    for (const auto i : c10::irange(results.size())) {
-        out[i]->parent_ = event_id_map.at(results[i].parent_id_);
+  // Cleanup by feining return to close out the stack. This is needed so
+  // frames above the one that called the profiler still appear in the trace.
+  const auto t_final = now();
+  for (auto& stack : stacks) {
+    while (stack.size()) {
+      stack.back().event_->endTime_ = t_final;
+      stack.back().event_->return_idx_ = event_idx;
+      results.push_back(std::move(stack.back()));
+      stack.pop_back();
+      event_idx++;
     }
-    return out;
+  }
+
+  // Convert to `PyTraceEvent`, and map id to pointer.
+  ska::flat_hash_map<size_t, PyTraceEvent*> event_id_map{{0, nullptr}};
+  std::vector<std::unique_ptr<PyTraceEvent>> out;
+  for (auto& r : results) {
+    out.push_back(std::move(r.event_));
+    event_id_map.insert({r.id_, out.back().get()});
+  }
+
+  // Link parents to children.
+  for (const auto i : c10::irange(results.size())) {
+    out[i]->parent_ = event_id_map.at(results[i].parent_id_);
+  }
+  return out;
 }
-
 
 // ============================================================================
 // == API =====================================================================
 // ============================================================================
-
 int PythonTracer::pyProfileFn(
-        PyObject* obj,
-        PyFrameObject* frame,
-        int what,
-        PyObject* arg) {
-    auto ctx = reinterpret_cast<TraceContext*>(obj);
-    switch (what) {
-        case PyTrace_CALL:
-            PythonTracer::singleton().recordPyCall(ctx, frame);
-            break;
+    PyObject* obj,
+    PyFrameObject* frame,
+    int what,
+    PyObject* arg) {
+  auto ctx = reinterpret_cast<TraceContext*>(obj);
+  switch (what) {
+    case PyTrace_CALL:
+      PythonTracer::singleton().recordPyCall(ctx, frame);
+      break;
 
-        case PyTrace_C_CALL:
-            PythonTracer::singleton().recordCCall(ctx, frame, arg);
-            break;
+    case PyTrace_C_CALL:
+      PythonTracer::singleton().recordCCall(ctx, frame, arg);
+      break;
 
-        case PyTrace_EXCEPTION:
-        case PyTrace_RETURN:
-            PythonTracer::singleton().recordReturn(ctx, frame, TraceTag::kPy_Return);
-            break;
+    case PyTrace_EXCEPTION:
+    case PyTrace_RETURN:
+      PythonTracer::singleton().recordReturn(ctx, frame, TraceTag::kPy_Return);
+      break;
 
-        case PyTrace_C_EXCEPTION:
-        case PyTrace_C_RETURN:
-            PythonTracer::singleton().recordReturn(ctx, frame, TraceTag::kC_Return);
-            break;
-    }
-    return 0;
+    case PyTrace_C_EXCEPTION:
+    case PyTrace_C_RETURN:
+      PythonTracer::singleton().recordReturn(ctx, frame, TraceTag::kC_Return);
+      break;
+  }
+  return 0;
 }
 
 void PythonTracer::call(Command c) {
-    switch (c) {
-        case Command::kStartOne:
-            PythonTracer::singleton().start(1);
-            break;
+  switch (c) {
+    case Command::kStartOne:
+      PythonTracer::singleton().start(1);
+      break;
 
-        case Command::kStartAll:
-            PythonTracer::singleton().start();
-            break;
+    case Command::kStartAll:
+      PythonTracer::singleton().start();
+      break;
 
-        case Command::kStop:
-            PythonTracer::singleton().stop();
-            break;
+    case Command::kStop:
+      PythonTracer::singleton().stop();
+      break;
 
-        case Command::kClear:
-            PythonTracer::singleton().clear();
-            break;
+    case Command::kClear:
+      PythonTracer::singleton().clear();
+      break;
 
-        default:
-            break;
-    }
+    default:
+      break;
+  }
 };
 
-}  // namespace
+} // namespace
 
 void init() {
-    pybind11::gil_scoped_acquire gil;
-    TORCH_CHECK(PyType_Ready(&TraceContextType) == 0);
+  pybind11::gil_scoped_acquire gil;
+  TORCH_CHECK(PyType_Ready(&TraceContextType) == 0);
 
-    registerFunctions(
-        /*call=*/&PythonTracer::call,
-        /*get_events=*/&PyTraceReplay::getEvents
-    );
+  registerFunctions(
+      /*call=*/&PythonTracer::call,
+      /*get_events=*/&PyTraceReplay::getEvents);
 }
-
 }}}} // namespace torch::autograd::profiler::python_tracer

--- a/torch/csrc/jit/mobile/profiler_edge.cpp
+++ b/torch/csrc/jit/mobile/profiler_edge.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/Exception.h>
+#include <c10/util/overloaded.h>
 #include <torch/csrc/jit/mobile/profiler_edge.h>
 #include <string>
 #include <vector>
@@ -28,33 +29,26 @@ KinetoEdgeCPUProfiler::KinetoEdgeCPUProfiler(
   torch::autograd::profiler::prepareProfiler(
       config, {torch::autograd::profiler::ActivityType::CPU});
   if (with_modules || with_stack) {
-    auto post_processing =
-        [this, with_stack, with_modules](
-            std::vector<torch::autograd::profiler::KinetoEvent>& events) {
-          std::string no_debug_info(
-              "Model was not saved with debug information");
-          for (auto& e : events) {
-            if (with_modules) {
-              // Since KinetoEvents's module hierarchy takes vector of strings
-              // we just construct a temporary vector using one string element
-              if (this->m_.hasDebugHandles()) {
-                e.moduleHierarchy(std::vector<std::string>(
-                    {this->m_.getModuleHierarchy(e.debugHandle())}));
-              } else {
-                e.moduleHierarchy(std::vector<std::string>({no_debug_info}));
-              }
-            } else if (with_stack) {
-              // Since KinetoEvents's stack trace takes vector of strings we
-              // just construct a temporary vector using one string element
-              if (this->m_.hasDebugHandles()) {
-                e.stack(std::vector<std::string>(
-                    {this->m_.getCallStack(e.debugHandle())}));
-              } else {
-                e.stack(std::vector<std::string>({no_debug_info}));
-              }
-            }
-          }
-        };
+    auto post_processing = [this, with_stack, with_modules](
+                               int64_t debug_handle,
+                               std::vector<std::string>& jit_stack,
+                               std::vector<std::string>& jit_modules) {
+      std::string no_debug_info("Model was not saved with debug information");
+      if (with_modules) {
+        // Since KinetoEvents's module hierarchy takes vector of strings
+        // we just construct a temporary vector using one string element
+        jit_modules = std::vector<std::string>(
+            {this->m_.hasDebugHandles()
+                 ? this->m_.getModuleHierarchy(debug_handle)
+                 : no_debug_info});
+      } else if (with_stack) {
+        // Since KinetoEvents's stack trace takes vector of strings we
+        // just construct a temporary vector using one string element
+        jit_stack = std::vector<std::string>(
+            {this->m_.hasDebugHandles() ? this->m_.getCallStack(debug_handle)
+                                        : no_debug_info});
+      }
+    };
     torch::autograd::profiler::enableProfilerWithEventPostProcess(
         config,
         {torch::autograd::profiler::ActivityType::CPU},

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -127,24 +127,39 @@ std::atomic<uint32_t> queue_id_{0};
 thread_local SubQueueThreadCache sub_queue_cache_{0, nullptr};
 } // namespace
 
-std::string Result::name() const {
-  return c10::visit([](auto& e){ return e.name_; }, event_);
-}
+#define OUT_T(method_name) decltype(std::declval<Result>().method_name())
+#define DEFINE_VISITOR(method_name, torch_op_field, backend_field)   \
+  OUT_T(method_name) Result::method_name() const {                   \
+    using out_t = OUT_T(method_name);                                \
+    return c10::visit(                                               \
+        c10::overloaded(                                             \
+            [&](const ExtraFields<EventType::TorchOp>& e) -> out_t { \
+              (void)e;                                               \
+              return torch_op_field;                                 \
+            },                                                       \
+            [&](const ExtraFields<EventType::Backend>& e) -> out_t { \
+              (void)e;                                               \
+              return backend_field;                                  \
+            }),                                                      \
+        extra_fields_);                                              \
+  }
 
-torch::profiler::impl::kineto::KinetoActivityType Result::kinetoType() const {
-  auto record_function_scope = static_cast<at::RecordScope>(
-      c10::visit([](auto& e) { return e.record_function_scope_; }, event_));
-  return record_function_scope == at::RecordScope::USER_SCOPE
-      ? torch::profiler::impl::kineto::KinetoActivityType::USER_ANNOTATION
-      : torch::profiler::impl::kineto::KinetoActivityType::CPU_OP;
+using torch::profiler::impl::kineto::KinetoActivityType;
+namespace {
+KinetoActivityType scopeToType(at::RecordScope scope) {
+  return scope == at::RecordScope::USER_SCOPE
+      ? KinetoActivityType::USER_ANNOTATION
+      : KinetoActivityType::CPU_OP;
 }
+} // namespace
 
-uint64_t Result::correlation_id() const {
-  return c10::visit(c10::overloaded(
-      [](const OpEvent& e){ return e.correlation_id_; },
-      [](const BackendEvent& e) { return std::numeric_limits<uint64_t>::max(); }
-  ), event_);
-}
+DEFINE_VISITOR(name, e.name_, e.name_);
+DEFINE_VISITOR(kinetoType, scopeToType(e.scope_), scopeToType(e.scope_));
+DEFINE_VISITOR(correlationID, e.correlation_id_, 0);
+DEFINE_VISITOR(endTimeUS, e.end_time_us_, e.end_time_us_);
+DEFINE_VISITOR(endTID, e.end_tid_, start_tid_);
+#undef DEFINE_VISITOR
+#undef OUT_T
 
 ThreadLocalSubqueue::ThreadLocalSubqueue(
     const uint64_t tid,
@@ -158,7 +173,6 @@ std::unique_ptr<KinetoObserverContext> ThreadLocalSubqueue::begin_op(
     uint64_t correlation_id) {
   auto event = op_events_.emplace_back(
       correlation_id,
-      fn.threadId(),
       fn.seqNr(),
       fn.forwardThreadId(),
       fn.scope(),
@@ -251,14 +265,14 @@ std::deque<Result> RecordQueue::getRecords(
   for (auto& subqueue_it : sub_queues_) {
     auto& queue = *subqueue_it.second;
     for (auto& i : queue.backend_events_) {
-      Result r;
-      r.start_time_us_ = i.start_time_us_;
-      r.end_time_us_ = i.end_time_us_;
-      r.start_tid_ = queue.tid();
-      r.kineto_info_ = queue.kineto_info();
-      r.event_ = std::move(i);
-      out.push_back(std::move(r));
+      auto start_time = i.start_time_us_;
+      out.emplace_back(
+          start_time,
+          /*start_tid_=*/queue.tid(),
+          /*kineto_info_=*/queue.kineto_info(),
+          /*extra_fields_=*/std::move(i));
     }
+    queue.backend_events_.clear();
 
     auto input_getter = queue.inputs_outputs_.getNextShapesAndDtypes();
     auto jit_stack_it = queue.jit_stack_.begin();
@@ -266,19 +280,20 @@ std::deque<Result> RecordQueue::getRecords(
     auto extra_args_it = queue.extra_args_.begin();
     auto gpu_fallback_it = queue.gpu_fallback_.begin();
     for (auto& i : queue.op_events_) {
-      Result r;
-      r.start_time_us_ = converter(i.start_time_);
-      r.end_time_us_ = converter(i.end_time_);
-      r.start_tid_ = queue.tid();
-      r.kineto_info_ = queue.kineto_info();
-      r.event_ = std::move(i);
-      r.inputs_ = input_getter();
-      r.jit_stack_ = steal_or_default(jit_stack_it);
-      r.jit_modules_ = steal_or_default(jit_module_it);
-      r.extra_args_ = steal_or_default(extra_args_it);
-      r.gpu_fallback_ = steal_or_default(gpu_fallback_it);
-
-      out.push_back(std::move(r));
+      auto start_time = converter(i.start_time_);
+      out.emplace_back(
+          start_time,
+          /*start_tid_=*/queue.tid(),
+          /*kineto_info_=*/queue.kineto_info(),
+          /*extra_fields_=*/
+          ExtraFields<EventType::TorchOp>(
+              std::move(i.basic_fields_),
+              converter(i.end_time_),
+              input_getter(),
+              steal_or_default(jit_stack_it),
+              steal_or_default(jit_module_it),
+              steal_or_default(extra_args_it),
+              steal_or_default(gpu_fallback_it)));
     }
     queue.op_events_.clear();
     queue.inputs_outputs_.clear();

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -131,8 +131,12 @@ std::string Result::name() const {
   return c10::visit([](auto& e){ return e.name_; }, event_);
 }
 
-uint8_t Result::record_function_scope() const {
-  return c10::visit([](auto& e){ return e.record_function_scope_; }, event_);
+torch::profiler::impl::kineto::KinetoActivityType Result::kinetoType() const {
+  auto record_function_scope = static_cast<at::RecordScope>(
+      c10::visit([](auto& e) { return e.record_function_scope_; }, event_));
+  return record_function_scope == at::RecordScope::USER_SCOPE
+      ? torch::profiler::impl::kineto::KinetoActivityType::USER_ANNOTATION
+      : torch::profiler::impl::kineto::KinetoActivityType::CPU_OP;
 }
 
 uint64_t Result::correlation_id() const {

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -71,7 +71,7 @@ struct BackendEvent {
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct Result {
   std::string name() const;
-  uint8_t record_function_scope() const;
+  torch::profiler::impl::kineto::KinetoActivityType kinetoType() const;
   uint64_t correlation_id() const;
 
   int64_t start_time_us_;

--- a/torch/csrc/profiler/kineto_shim.h
+++ b/torch/csrc/profiler/kineto_shim.h
@@ -58,31 +58,30 @@ using trace_t = DummyTraceBuffer;
 using interface_trace_t = DummyTraceBuffer;
 #endif // USE_KINETO
 
+// Subset of `libkineto::ActivityType` for `addCPUActivity`.
+enum class KinetoActivityType : uint8_t {
+  CPU_OP = 0,
+  CPU_INSTANT_EVENT,
+  USER_ANNOTATION
+};
+
+using annotation_t = std::vector<std::pair<std::string, std::string>>;
+
 // Wraps: libkineto::CpuTraceBuffer
 struct TraceWrapper {
   TraceWrapper(const int64_t start_time, const std::string& name);
   TraceWrapper(TraceWrapper&&) = default;
   TraceWrapper(const TraceWrapper&) = delete;
 
-  // The caller is expected to hold a mutex when calling `addCPUActivity` and
-  // addMemoryUsageActivity.
+  // The caller is expected to hold a mutex when calling `addCPUActivity`.
   void addCPUActivity(
       const std::string& name,
-      const uint8_t scope,
+      const KinetoActivityType kineto_type,
       const DeviceAndResource device_and_resource,
       const uint64_t correlation_id,
       const int64_t start_time,
-      const int64_t end_time);
-
-  void addMemoryUsageActivity(
-      const std::string& name,
-      const DeviceAndResource device_and_resource,
-      const int64_t time,
-      const c10::Device device,
-      const void* ptr,
-      const int64_t alloc_size,
-      const int64_t total_allocated,
-      const int64_t total_reserved);
+      const int64_t end_time,
+      const annotation_t& annotations);
 
   void transferCpuTrace(int64_t end_time);
 


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/pull/63619 added a RECORD_FUNCTION guard to make calls to `Engine::evaluate_function` visible regardless of the underlying op. While useful, this creates a call that looks like a forward call that somewhat complicates stitching forward and backward ops. I don't want to add complexity (and therefore work) on the hot path; instead it's fairly straightforward to stitch things back together in post. This PR simply propagates sequence number and forward tid info up to the `evaluate_function` event.

Test Plan: Updated `test_autograd.py` (And made it more robust overall)

Differential Revision: D36302562

