### PR TITLE
retry - enable NVFuser by default

### DIFF
--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -111,9 +111,12 @@ class NVFuserEnabler {
     if (getCachedFuserEnabledEnvVar().has_value()) {
       return *getCachedFuserEnabledEnvVar();
     }
-    // 3. default value (if you switch this to true, make sure
-    //    to check nvfuserCanBeEnabled())
+    // 3. default value
+#ifdef FBCODE_CAFFE2
     return false;
+#else
+    return nvfuserCanBeEnabled();
+#endif
   }
 
  public:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77579

Enable NVFuser in OSS.

Retry of #77213, because it was breaking torchvision tests.

Fix in #77471 is being verified by @jjsjann123

Summary on on-by-default testing: https://github.com/csarofeen/pytorch/wiki/on-by-default-testing-for-PyTorch-1.12-release