### PR TITLE
fix torch.jit.tracing for at::lift

### DIFF
--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -330,6 +330,9 @@ Tensor internal_new_from_data(
     tensor = tensor.to(device, inferred_scalar_type, /*non_blocking=*/false, /*copy=*/false);
   }
 
+  // torch.jit.trace will continue to trace out `.to()` instead of `.lift()`, since
+  // changing it is BC-breaking.
+  at::tracer::impl::NoTracerDispatchMode tracer_guard;
   return tensor.lift();
 }
 


### PR DESCRIPTION
After adding the `at::lift` op, it started getting traced during `torch.jit.trace`. We don't want that to happen for BC reasons