### PR TITLE
[quant][fx][bc-breaking] Add required example_args argument to prepare_fx and prepare_qat_fx (#249)

### DIFF
--- a/test/quantization/bc/test_backward_compatibility.py
+++ b/test/quantization/bc/test_backward_compatibility.py
@@ -171,9 +171,10 @@ class TestSerialization(TestCase):
             m: torch.nn.Module,
             input_tensor: torch.Tensor,
         ) -> torch.nn.Module:
+            example_inputs = (input_tensor,)
             # do the quantizaton transforms and save result
             qconfig = torch.quantization.get_default_qconfig('fbgemm')
-            mp = quantize_fx.prepare_fx(m, {'': qconfig})
+            mp = quantize_fx.prepare_fx(m, {'': qconfig}, example_inputs=example_inputs)
             mp(input_tensor)
             mq = quantize_fx.convert_fx(mp)
             return mq

--- a/test/quantization/fx/test_numeric_suite_fx.py
+++ b/test/quantization/fx/test_numeric_suite_fx.py
@@ -295,7 +295,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
     @skipIfNoFBGEMM
     def test_simple_mod(self):
         m = nn.Sequential(nn.Conv2d(1, 1, 1)).eval()
-        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig}, example_inputs=(torch.randn(1, 1, 1, 1),))
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -322,7 +322,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
                 return F.linear(x, self.w, self.b)
 
         m = M().eval()
-        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig}, example_inputs=(torch.randn(1, 1, 1, 1),))
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -340,7 +340,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
     @skipIfNoFBGEMM
     def test_simple_fusion(self):
         m = LinearReluFunctional().eval()
-        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig}, example_inputs=(torch.randn(4, 4),))
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -363,7 +363,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
             ),
             nn.Conv2d(1, 1, 1),
         ).eval()
-        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig}, example_inputs=(torch.randn(1, 1, 1, 1),))
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         # assume success if no exceptions
@@ -380,7 +380,8 @@ class TestFXGraphMatcher(QuantizationTestCase):
                 return z
 
         m = M().eval()
-        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
+        example_inputs = (torch.randn(1), torch.randn(1))
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig}, example_inputs=example_inputs)
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         # assume success if no exceptions
@@ -392,8 +393,9 @@ class TestFXGraphMatcher(QuantizationTestCase):
         # different counts of matchable nodes fails
         m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).eval()
         m2 = nn.Sequential(nn.Conv2d(1, 1, 1), nn.Conv2d(1, 1, 1)).eval()
-        mp1 = prepare_fx(m1, {'': torch.ao.quantization.default_qconfig})
-        mp2 = prepare_fx(m2, {'': torch.ao.quantization.default_qconfig})
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp1 = prepare_fx(m1, {'': torch.ao.quantization.default_qconfig}, example_inputs=example_inputs)
+        mp2 = prepare_fx(m2, {'': torch.ao.quantization.default_qconfig}, example_inputs=example_inputs)
         with self.assertRaises(GraphMatchingException) as ex:
             results = get_matching_subgraph_pairs(mp1, mp2)
 
@@ -402,8 +404,10 @@ class TestFXGraphMatcher(QuantizationTestCase):
         # verify that matching graphs with non-matching node types fails
         m1 = nn.Sequential(nn.Conv2d(1, 1, 1)).eval()
         m2 = nn.Sequential(nn.Linear(1, 1)).eval()
-        mp1 = prepare_fx(m1, {'': torch.ao.quantization.default_qconfig})
-        mp2 = prepare_fx(m2, {'': torch.ao.quantization.default_qconfig})
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp1 = prepare_fx(m1, {'': torch.ao.quantization.default_qconfig}, example_inputs=example_inputs)
+        example_inputs = (torch.randn(1, 1),)
+        mp2 = prepare_fx(m2, {'': torch.ao.quantization.default_qconfig}, example_inputs=example_inputs)
         with self.assertRaises(GraphMatchingException) as ex:
             results = get_matching_subgraph_pairs(mp1, mp2)
 
@@ -421,7 +425,8 @@ class TestFXGraphMatcher(QuantizationTestCase):
                 return x2
 
         m = M().eval()
-        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
+        example_inputs = (torch.randn(1),)
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig}, example_inputs=example_inputs)
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -456,7 +461,8 @@ class TestFXGraphMatcher(QuantizationTestCase):
                 return a1
 
         m = M().eval()
-        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
+        example_inputs = (torch.randn(1),)
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig}, example_inputs=example_inputs)
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -499,7 +505,8 @@ class TestFXGraphMatcher(QuantizationTestCase):
             '': torch.ao.quantization.default_qconfig,
             'module_name': [('conv2', None)],
         }
-        mp = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -541,8 +548,9 @@ class TestFXGraphMatcher(QuantizationTestCase):
         m1 = M().eval()
         m2 = M().eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        m1p = prepare_fx(m1, qconfig_dict)
-        m2p = prepare_fx(m2, qconfig_dict)
+        example_inputs = (torch.randn(1),)
+        m1p = prepare_fx(m1, qconfig_dict, example_inputs=example_inputs)
+        m2p = prepare_fx(m2, qconfig_dict, example_inputs=example_inputs)
         results = get_matching_subgraph_pairs(m1p, m2p)
         base_name_to_sets_of_related_ops = get_base_name_to_sets_of_related_ops()
         sigmoid_name_0 = 'base_op_' + get_base_name_for_op(
@@ -733,8 +741,9 @@ class TestFXGraphMatcher(QuantizationTestCase):
                 return x
 
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        m1 = prepare_fx(M1().eval(), qconfig_dict)
-        m2 = prepare_fx(M2().eval(), qconfig_dict)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        m1 = prepare_fx(M1().eval(), qconfig_dict, example_inputs=example_inputs)
+        m2 = prepare_fx(M2().eval(), qconfig_dict, example_inputs=example_inputs)
 
         base_name_to_sets_of_related_ops = get_base_name_to_sets_of_related_ops()
         add_op_to_sets_of_related_ops(
@@ -760,7 +769,8 @@ class TestFXGraphMatcher(QuantizationTestCase):
             nn.Conv2d(1, 1, 1),
             nn.Linear(1, 1),
         ).eval()
-        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig})
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp = prepare_fx(m, {'': torch.ao.quantization.default_qconfig}, example_inputs=example_inputs)
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
@@ -782,7 +792,8 @@ class TestFXGraphMatcherModels(QuantizationTestCase):
         # verify that mobilenetv2 graph is able to be matched
         import torchvision
         m = torchvision.models.__dict__['mobilenet_v2'](pretrained=False).eval().float()
-        mp = prepare_fx(copy.deepcopy(m), {'': torch.ao.quantization.default_qconfig})
+        example_inputs = (torch.randn(1, 3, 224, 224),)
+        mp = prepare_fx(copy.deepcopy(m), {'': torch.ao.quantization.default_qconfig}, example_inputs=example_inputs)
         # assume success if no exceptions
         results_m_mp = get_matching_subgraph_pairs(torch.fx.symbolic_trace(m), mp)
         mp_copy = copy.deepcopy(mp)
@@ -796,9 +807,11 @@ class TestFXGraphMatcherModels(QuantizationTestCase):
         # verify that mobilenetv2 graph is able to be matched
         import torchvision
         m = torchvision.models.__dict__['mobilenet_v2'](pretrained=False).float()
+        example_inputs = (torch.randn(1, 3, 224, 224),)
         mp = prepare_qat_fx(
             copy.deepcopy(m),
-            {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')})
+            {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')},
+            example_inputs=example_inputs)
         # assume success if no exceptions
         results_m_mp = get_matching_subgraph_pairs(torch.fx.symbolic_trace(m), mp)
         mp_copy = copy.deepcopy(mp)
@@ -809,12 +822,12 @@ class TestFXGraphMatcherModels(QuantizationTestCase):
 
 class FXNumericSuiteQuantizationTestCase(QuantizationTestCase):
     def _test_extract_weights(
-        self, m, results_len=0, qconfig_dict=None, prepare_fn=prepare_fx
+        self, m, example_inputs, results_len=0, qconfig_dict=None, prepare_fn=prepare_fx
     ):
         m = torch.fx.symbolic_trace(m)
         if qconfig_dict is None:
             qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = prepare_fn(copy.deepcopy(m), qconfig_dict)
+        mp = prepare_fn(copy.deepcopy(m), qconfig_dict, example_inputs=example_inputs)
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
 
@@ -848,7 +861,7 @@ class FXNumericSuiteQuantizationTestCase(QuantizationTestCase):
             m.eval()
         else:
             m.train()
-        mp = prepare_fn(copy.deepcopy(m), qconfig_dict)
+        mp = prepare_fn(copy.deepcopy(m), qconfig_dict, example_inputs=data)
         mp(*data)
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
@@ -911,7 +924,7 @@ class FXNumericSuiteQuantizationTestCase(QuantizationTestCase):
             m.eval()
         else:
             m.train()
-        mp = prepare_fn(copy.deepcopy(m), qconfig_dict)
+        mp = prepare_fn(copy.deepcopy(m), qconfig_dict, example_inputs=data)
         mp(*data)
         mp_copy = copy.deepcopy(mp)
         mq = convert_fx(mp_copy)
@@ -969,26 +982,30 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     @skipIfNoFBGEMM
     def test_extract_weights_mod_ptq(self):
         m = AllConvAndLinearFusionModules().eval()
-        self._test_extract_weights(m, results_len=14)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        self._test_extract_weights(m, example_inputs, results_len=14)
 
     @skipIfNoFBGEMM
     def test_extract_weights_mod_qat(self):
         m = AllConvAndLinearFusionModules().train()
         qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
+        example_inputs = (torch.randn(1, 1, 1, 1),)
         self._test_extract_weights(
-            m, results_len=14, qconfig_dict=qconfig_dict, prepare_fn=prepare_qat_fx)
+            m, example_inputs, results_len=14, qconfig_dict=qconfig_dict, prepare_fn=prepare_qat_fx)
 
     @skipIfNoFBGEMM
     def test_extract_weights_linear_fun_ptq(self):
         m = LinearReluLinearFunctional().eval()
-        self._test_extract_weights(m, results_len=2)
+        example_inputs = (torch.randn(1, 4),)
+        self._test_extract_weights(m, example_inputs, results_len=2)
 
     @skipIfNoFBGEMM
     def test_extract_weights_linear_fun_qat(self):
         m = LinearReluLinearFunctional().train()
         qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
+        example_inputs = (torch.randn(1, 4),)
         self._test_extract_weights(
-            m, results_len=2, qconfig_dict=qconfig_dict, prepare_fn=prepare_qat_fx)
+            m, example_inputs, results_len=2, qconfig_dict=qconfig_dict, prepare_fn=prepare_qat_fx)
 
     @skipIfNoFBGEMM
     def test_extract_weights_conv_fun_ptq(self):
@@ -999,7 +1016,8 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         b2d = torch.randn(1)
         b3d = torch.randn(1)
         m = AllConvFunctional(w1d, w2d, w3d, b1d, b2d, b3d).eval()
-        self._test_extract_weights(m, results_len=6)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        self._test_extract_weights(m, example_inputs, results_len=6)
 
     @skipIfNoFBGEMM
     def test_extract_weights_conv_fun_qat(self):
@@ -1011,8 +1029,9 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         b3d = torch.randn(1)
         m = AllConvFunctional(w1d, w2d, w3d, b1d, b2d, b3d).train()
         qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
+        example_inputs = (torch.randn(1, 1, 1, 1),)
         self._test_extract_weights(
-            m, results_len=6, qconfig_dict=qconfig_dict, prepare_fn=prepare_qat_fx)
+            m, example_inputs, results_len=6, qconfig_dict=qconfig_dict, prepare_fn=prepare_qat_fx)
 
     @skipIfNoFBGEMM
     def test_extract_weights_dynamic(self):
@@ -1023,7 +1042,8 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
                 (nn.Linear, default_dynamic_qconfig),
             ],
         }
-        self._test_extract_weights(m, results_len=1, qconfig_dict=qconfig_dict)
+        example_inputs = (torch.randn(1, 1),)
+        self._test_extract_weights(m, example_inputs, results_len=1, qconfig_dict=qconfig_dict)
 
     @skipIfNoFBGEMM
     def test_extract_weights_fqn(self):
@@ -1032,7 +1052,8 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             nn.Conv2d(1, 1, 1),
         ).eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         mq = convert_fx(copy.deepcopy(mp))
         results = extract_weights('a', mp, 'b', mq)
         fqn_a_0 = results['_0_0']['weight']['a'][0]['fqn']
@@ -1110,7 +1131,8 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             nn.Conv2d(1, 1, 1),
         ).eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         mq = convert_fx(copy.deepcopy(mp))
         mp_ns, mq_ns = add_loggers('a', mp, 'b', mq, OutputLogger)
         datum = torch.randn(1, 1, 1, 1)
@@ -1187,7 +1209,8 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             nn.Conv2d(1, 1, 1),
         ).eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         mq = convert_fx(copy.deepcopy(mp))
         mp_shadows_mq = add_shadow_loggers('a', mp, 'b', mq, OutputLogger)
         datum = torch.randn(1, 1, 1, 1)
@@ -1254,7 +1277,8 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     def test_linear_fp16_weights(self):
         qconfig_dict = {'': torch.ao.quantization.float16_static_qconfig}
         m = LinearReluFunctional().eval()
-        self._test_extract_weights(m, results_len=1, qconfig_dict=qconfig_dict)
+        example_inputs = (torch.randn(1, 4),)
+        self._test_extract_weights(m, example_inputs, results_len=1, qconfig_dict=qconfig_dict)
 
     @skipIfNoFBGEMM
     def test_linear_fp16_activations(self):
@@ -1292,7 +1316,8 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     def test_linear_fp16_vs_linear_fp16_shadow_activations(self):
         m = LinearFunctional().eval()
         qconfig_dict = {'': torch.ao.quantization.float16_static_qconfig}
-        mp = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 4),)
+        mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         mq1 = convert_fx(copy.deepcopy(mp))
         mq2 = convert_fx(copy.deepcopy(mp))
         mq1_shadows_mq2 = _add_shadow_loggers_impl(
@@ -1332,8 +1357,9 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         Verify that shadowing works where both modules are int8
         """
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = prepare_fx(m, qconfig_dict)
-        mp(torch.randn(4, 1, 4, 4))
+        example_inputs = (torch.randn(4, 1, 4, 4),)
+        mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        mp(*example_inputs)
         mq1 = convert_fx(copy.deepcopy(mp))
         mq2 = convert_fx(mp)
         mq1_shadows_mq2 = add_shadow_loggers('a', mq1, 'b', mq2, OutputLogger)
@@ -1377,7 +1403,12 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         prepare_custom_config_dict = {
             'non_traceable_module_class': [M1],
         }
-        mp1 = prepare_fx(m, qconfig_dict, prepare_custom_config_dict)
+        example_inputs = (torch.randn(1),)
+        mp1 = prepare_fx(
+            m,
+            qconfig_dict,
+            example_inputs=example_inputs,
+            prepare_custom_config_dict=prepare_custom_config_dict)
         mp2 = copy.deepcopy(mp1)
         unmatchable_types_map = get_unmatchable_types_map()
         unmatchable_types_map['mods_unmatchable'].add(M1)
@@ -1419,8 +1450,13 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         # quantize without tracing through UserModule
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
         prepare_custom_config_dict = {'non_traceable_module_name': ['user_module']}
-        mp = prepare_fx(m, qconfig_dict, prepare_custom_config_dict)
-        mp(torch.randn(1, 1, 1))
+        example_inputs = (torch.randn(1, 1, 1),)
+        mp = prepare_fx(
+            m,
+            qconfig_dict,
+            example_inputs=example_inputs,
+            prepare_custom_config_dict=prepare_custom_config_dict)
+        mp(*example_inputs)
         mq = convert_fx(copy.deepcopy(mp))
 
         # weight extraction should not crash
@@ -1661,8 +1697,9 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
                 return x
 
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        m1 = prepare_fx(M1().eval(), qconfig_dict)
-        m2 = prepare_fx(M2().eval(), qconfig_dict)
+        example_inputs = (torch.randn(1, 1),)
+        m1 = prepare_fx(M1().eval(), qconfig_dict, example_inputs=example_inputs)
+        m2 = prepare_fx(M2().eval(), qconfig_dict, example_inputs=example_inputs)
         data = torch.randn(1, 1)
 
         base_name_to_sets_of_related_ops = get_base_name_to_sets_of_related_ops()
@@ -1731,7 +1768,8 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             nn.Sigmoid(),
         ).eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         mq = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
 
         # extract weights
@@ -1767,7 +1805,9 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     def test_extend_logger_results_with_comparison(self):
         m = nn.Sequential(nn.Conv2d(1, 1, 1), nn.Conv2d(1, 1, 1)).eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp = torch.ao.quantization.quantize_fx.prepare_fx(
+            m, qconfig_dict, example_inputs=example_inputs)
         mq = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
 
         # extract weights
@@ -1792,7 +1832,9 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     def test_int8_shadows_fp32_simple(self):
         m = nn.Sequential(nn.Conv2d(1, 1, 1), nn.Conv2d(1, 1, 1), nn.ReLU()).eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp = torch.ao.quantization.quantize_fx.prepare_fx(
+            m, qconfig_dict, example_inputs=example_inputs)
         mp(torch.randn(1, 1, 1, 1))
         mq = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
         mq_ref = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
@@ -1846,8 +1888,9 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
 
         m = M().eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
-        mp(torch.randn(1, 1, 1, 1))
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        mp(*example_inputs)
         mq = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
         mq_ref = torch.ao.quantization.quantize_fx.convert_fx(copy.deepcopy(mp))
         mp_shadows_mq = add_shadow_loggers(
@@ -1862,18 +1905,18 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     def test_loggers_preserve_qat_numerics(self):
         m = nn.Sequential(nn.Conv2d(1, 1, 1), nn.Conv2d(1, 1, 1))
         qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
-        mp = prepare_qat_fx(m, qconfig_dict)
-        mp(torch.randn(1, 1, 1, 1))
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp = prepare_qat_fx(m, qconfig_dict, example_inputs=example_inputs)
+        mp(*example_inputs)
         mc = convert_fx(copy.deepcopy(mp))
         mp.apply(torch.ao.quantization.disable_observer)
 
-        datum = torch.randn(1, 1, 1, 1)
-        ref_fp32 = mp(datum)
-        ref_int8 = mc(datum)
+        ref_fp32 = mp(*example_inputs)
+        ref_int8 = mc(*example_inputs)
 
         mp_ns, mc_ns = add_loggers('fp32', mp, 'int8', mc, OutputLogger)
-        ref_fp32_ns = mp_ns(datum)
-        ref_int8_ns = mc_ns(datum)
+        ref_fp32_ns = mp_ns(*example_inputs)
+        ref_int8_ns = mc_ns(*example_inputs)
         self.assertEqual(ref_fp32, ref_fp32_ns)
         self.assertEqual(ref_int8, ref_int8_ns)
 
@@ -1881,17 +1924,17 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
     def test_shadow_loggers_preserve_qat_numerics(self):
         m = nn.Sequential(nn.Conv2d(1, 1, 1), nn.Conv2d(1, 1, 1))
         qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
-        mp = prepare_qat_fx(m, qconfig_dict)
-        mp(torch.randn(1, 1, 1, 1))
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        mp = prepare_qat_fx(m, qconfig_dict, example_inputs=example_inputs)
+        mp(*example_inputs)
         mc = convert_fx(copy.deepcopy(mp))
         mp.apply(torch.ao.quantization.disable_observer)
 
-        datum = torch.randn(1, 1, 1, 1)
-        ref_fp32 = mp(datum)
-        ref_int8 = mc(datum)
+        ref_fp32 = mp(*example_inputs)
+        ref_int8 = mc(*example_inputs)
 
         mc_shadows_mp = add_shadow_loggers('int8', mc, 'fp32', mp, OutputLogger)
-        ref_shadow = mc_shadows_mp(datum)
+        ref_shadow = mc_shadows_mp(*example_inputs)
         self.assertEqual(ref_fp32, ref_shadow)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
@@ -1940,8 +1983,9 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
 
     def test_fp16_shadows_fp32(self):
         m = LinearReluFunctional().eval()
+        example_inputs = (torch.randn(1, 4),)
         qconfig_dict = {"": torch.ao.quantization.float16_static_qconfig}
-        mp = prepare_fx(copy.deepcopy(m), qconfig_dict)
+        mp = prepare_fx(copy.deepcopy(m), qconfig_dict, example_inputs=example_inputs)
         mq = convert_fx(mp, is_reference=True)
         mq_shadows_m = add_shadow_loggers('a', mq, 'b', m, OutputLogger)
 
@@ -2005,7 +2049,8 @@ class TestFXNumericSuiteCoreAPIsModels(FXNumericSuiteQuantizationTestCase):
         )
         for m, in test_cases:
             m.eval()
-            self._test_extract_weights(m, results_len=1)
+            example_inputs = (torch.randn(1, 3, 5, 5),)
+            self._test_extract_weights(m, example_inputs, results_len=1)
 
     @skipIfNoFBGEMM
     def test_compare_weights_linear(self):
@@ -2018,15 +2063,19 @@ class TestFXNumericSuiteCoreAPIsModels(FXNumericSuiteQuantizationTestCase):
         )
         for m, qconfig_dict in test_cases:
             m.eval()
+            example_inputs = (torch.randn(1, 3, 5, 5),)
             res = self._test_extract_weights(
-                m, results_len=1, qconfig_dict=qconfig_dict)
+                m, example_inputs, results_len=1, qconfig_dict=qconfig_dict)
 
     @skipIfNoFBGEMM
     def test_compare_weights_lstm_dynamic(self):
         qconfig_dict = {"object_type": [(nn.LSTM, default_dynamic_qconfig)]}
+        lstm_input = torch.rand((1, 1, 2))
+        lstm_hidden = (torch.rand(1, 1, 2), torch.rand(1, 1, 2))
+        example_inputs = (lstm_input, lstm_hidden)
         m = LSTMwithHiddenDynamicModel().eval()
         res = self._test_extract_weights(
-            m, results_len=1, qconfig_dict=qconfig_dict)
+            m, example_inputs, results_len=1, qconfig_dict=qconfig_dict)
 
     @skipIfNoFBGEMM
     def test_compare_activations_conv(self):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -248,7 +248,7 @@ class TestFuseFx(QuantizationTestCase):
         # TODO: if we decide to do that in the future, this test needs to
         # be updated
         # train mode fuse_fx is called in prepare_qat_fx
-        m = prepare_qat_fx(m, {})
+        m = prepare_qat_fx(m, {}, example_inputs=(torch.randn(1, 1, 1, 1),))
         expected_nodes = [
             ns.call_module(nni.ConvBn1d),
             ns.call_module(nni.ConvBn2d),
@@ -401,8 +401,10 @@ class TestFuseFx(QuantizationTestCase):
 
         for M, node_list in tests:
             m = M().eval()
-            prepared = prepare_fx(m, qconfig_dict)
-            prepared(torch.rand(5, 5))
+            example_inputs = (torch.rand(5, 5),)
+            prepared = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+
+            prepared(*example_inputs)
             quantized = convert_fx(prepared)
 
             self.checkGraphModuleNodes(quantized, expected_node_list=node_list)
@@ -435,7 +437,7 @@ class TestFuseFx(QuantizationTestCase):
                 (torch.nn.ReLU, get_default_qconfig('fbgemm')),
             ],
         }
-        m = prepare_fx(model, qconfig_dict)
+        m = prepare_fx(model, qconfig_dict, example_inputs=(torch.randn(1, 5),))
 
         self.checkGraphModuleNodes(m, expected_node=ns.call_module(torch.nn.intrinsic.modules.fused.LinearReLU))
 
@@ -732,7 +734,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 (torch.nn.ReLU, default_qat_qconfig),
             ],
         }
-        prepared = prepare_qat_fx(model, qconfig_dict)
+        prepared = prepare_qat_fx(model, qconfig_dict, example_inputs=(torch.randn(1, 5),))
         self.assertTrue(isinstance(getattr(prepared.mods1, "0").tmp, torch.nn.intrinsic.qat.LinearReLU))
 
     def _get_conv_linear_test_cases(self, is_reference):
@@ -1020,7 +1022,8 @@ class TestQuantizeFx(QuantizationTestCase):
         m = M(torch.rand(1, 1)).eval()
         qconfig = default_dynamic_qconfig
         qconfig_dict = {'': qconfig}
-        prepared = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.rand(1, 1),)
+        prepared = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         quantized = convert_fx(prepared, is_reference=True)
         qparams = (quantized._scale_0, quantized._zero_point_0)
         weight_obs = qconfig.weight()
@@ -1199,7 +1202,7 @@ class TestQuantizeFx(QuantizationTestCase):
                     node_occurrence[weight_prepack_node] = 0
                 m = ModuleClass(*module_constructor_inputs).eval()
                 qconfig_dict = {"": float16_dynamic_qconfig}
-                m = prepare_fx(m, qconfig_dict)
+                m = prepare_fx(m, qconfig_dict, example_inputs=inputs)
                 m = convert_fx(m, is_reference=is_reference)
                 self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
 
@@ -1232,12 +1235,12 @@ class TestQuantizeFx(QuantizationTestCase):
         device = torch.device('cuda:0')
         model.to(device)
 
+        example_inputs = (torch.randn(4, 1, 4, 4, device=device),)
         # QAT prepare
-        model = prepare_qat_fx(model, qconfig_dict)
+        model = prepare_qat_fx(model, qconfig_dict, example_inputs=example_inputs)
 
         # ensure that running an input on CUDA works without any needed changes
-        input = torch.randn(4, 1, 4, 4, device=device)
-        model(input)
+        model(*example_inputs)
 
         # ensure all buffers and parameters are on the device we expect
         model_devices = {p.device for p in model.parameters()} | \
@@ -1258,13 +1261,13 @@ class TestQuantizeFx(QuantizationTestCase):
             def forward(self, x):
                 return {"output": self.conv(x["input"])}
 
-        dict_input = {"input": torch.randn(1, 1, 1, 1)}
+        example_inputs = ({"input": torch.randn(1, 1, 1, 1)},)
         m = M().eval()
         qconfig_dict = {"": default_qconfig}
-        m = prepare_fx(m, qconfig_dict)
-        m(dict_input)
+        m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
-        m(dict_input)
+        m(*example_inputs)
 
     @override_qengines
     def test_attention(self):
@@ -1287,7 +1290,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 r = torch.mm(k, v)
                 return q * k + r
 
-        tensor_input = torch.randn(3, 1, 1, 1)
+        example_inputs = (torch.randn(3, 1, 1, 1),)
         m = M().eval()
         qconfig_dict = {
             "": None,
@@ -1296,10 +1299,10 @@ class TestQuantizeFx(QuantizationTestCase):
             ]
         }
         # make sure it runs
-        m = prepare_fx(m, qconfig_dict)
-        m(tensor_input)
+        m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
-        m(tensor_input)
+        m(*example_inputs)
 
     def _test_standalone_module(
             self,
@@ -1341,7 +1344,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 x = self.conv2(x)
                 return x
 
-        data = torch.randn(1, 1, 1, 1)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
         # instantiate M and RefM and align the parameters
         original_m = M().eval()
         original_ref_m = RefM().eval()
@@ -1351,13 +1354,14 @@ class TestQuantizeFx(QuantizationTestCase):
         original_ref_m.conv2.bias = torch.nn.Parameter(original_m.standalone.conv.bias.detach())
 
         for is_name in [True, False]:
+            sm_example_inputs = example_inputs
             if is_name:
                 prepare_config = {
-                    "standalone_module_name": [("standalone", None, interface_config, None)]
+                    "standalone_module_name": [("standalone", None, sm_example_inputs, interface_config, None)]
                 }
             else:
                 prepare_config = {
-                    "standalone_module_class": [(StandaloneModule, None, interface_config, None)]
+                    "standalone_module_class": [(StandaloneModule, None, sm_example_inputs, interface_config, None)]
                 }
 
             original_m_copy = copy.deepcopy(original_m)
@@ -1366,9 +1370,12 @@ class TestQuantizeFx(QuantizationTestCase):
             qconfig_dict = {"": default_qconfig}
             # check prepared model
             m = prepare_fx(
-                original_m_copy, qconfig_dict, prepare_custom_config_dict=prepare_config)
+                original_m_copy,
+                qconfig_dict,
+                example_inputs=example_inputs,
+                prepare_custom_config_dict=prepare_config)
             # calibration
-            m(data)
+            m(*example_inputs)
             self.checkGraphModuleNodes(m, expected_node_occurrence=prepare_count_check)
             self.checkGraphModuleNodes(m.standalone, expected_node_occurrence=standalone_prepare_count_check)
 
@@ -1376,13 +1383,17 @@ class TestQuantizeFx(QuantizationTestCase):
             m = convert_fx(m)
             self.checkGraphModuleNodes(m, expected_node_occurrence=convert_count_check)
             self.checkGraphModuleNodes(m.standalone, expected_node_occurrence=standalone_convert_count_check)
-            res = m(data)
+            res = m(*example_inputs)
 
             # quantize the reference model
-            ref_m = prepare_fx(original_ref_m_copy, qconfig_dict)
-            ref_m(data)
+            ref_m = prepare_fx(
+                original_ref_m_copy,
+                qconfig_dict,
+                example_inputs=example_inputs,
+            )
+            ref_m(*example_inputs)
             ref_m = convert_fx(ref_m)
-            ref_res = ref_m(data)
+            ref_res = ref_m(*example_inputs)
             self.assertEqual(res, ref_res)
 
     def test_standalone_module_float_interface(self):
@@ -1471,11 +1482,11 @@ class TestQuantizeFx(QuantizationTestCase):
         m = M().eval()
         qconfig_dict = {"": default_qconfig,
                         "module_name": [("conv2", None)]}
-        m = prepare_fx(m, qconfig_dict)
-        data = torch.randn(1, 1, 1, 1)
-        m(data)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
-        m(data)
+        m(*example_inputs)
         # first conv is quantized, second conv is not quantized
         node_list = [
             ns.call_function(torch.quantize_per_tensor),
@@ -1499,11 +1510,11 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M().eval()
         qconfig_dict = {"object_type": [(torch.nn.Conv2d, default_qconfig)]}
-        m = prepare_fx(m, qconfig_dict)
-        data = torch.randn(1, 1, 1, 1)
-        m(data)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
-        m(data)
+        m(*example_inputs)
         # first conv is quantized, second conv is not quantized
         node_list = [
             ns.call_function(torch.quantize_per_tensor),
@@ -1541,10 +1552,11 @@ class TestQuantizeFx(QuantizationTestCase):
                 (torch.nn.ReLU, default_qat_qconfig),
             ],
         }
-        m = prepare_qat_fx(model, qconfig_dict)
-        m(torch.rand(5, 5))
+        example_inputs = (torch.rand(5, 5),)
+        m = prepare_qat_fx(model, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
-        m(torch.rand(5, 5))
+        m(*example_inputs)
         node_list = [
             ns.call_function(torch.quantize_per_tensor),
             ns.call_module(nniq.LinearReLU),
@@ -1563,11 +1575,12 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M().eval()
         qconfig_dict = {"object_type": [(operator.add, default_qconfig)]}
-        m = prepare_fx(m, qconfig_dict)
         data = torch.randn(1, 1, 1, 1)
-        m(data, data)
+        example_inputs = (data, data)
+        m = prepare_fx(m, qconfig_dict, example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
-        m(data, data)
+        m(*example_inputs)
         # first conv is quantized, second conv is not quantized
         node_list = [
             ns.call_function(torch.quantize_per_tensor),
@@ -1590,11 +1603,11 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M().eval()
         qconfig_dict = {"module_name_regex": [("conv*", default_qconfig)]}
-        m = prepare_fx(m, qconfig_dict)
-        data = torch.randn(1, 1, 1, 1)
-        m(data)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
-        m(data)
+        m(*example_inputs)
         # first conv is quantized, second conv is not quantized
         node_list = [
             ns.call_function(torch.quantize_per_tensor),
@@ -1636,7 +1649,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 "object_type": [(nn.Conv2d, object_type_qconfig)],
                 "module_name_regex": [("module_conv*", module_name_regex_qconfig)],
                 "module_name": [("module_conv2", module_name_qconfig)]}
-            m_prep = prepare_fx(m, qconfig_dict)
+            m_prep = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 1),))
             self.assertEqual(m_prep.linear.qconfig.activation.p.func, global_qconfig.activation.p.func)
             self.assertEqual(m_prep.linear.qconfig.weight.p.func, global_qconfig.weight.p.func)
             self.assertEqual(m_prep.conv.qconfig.activation.p.func, object_type_qconfig.activation.p.func)
@@ -1702,11 +1715,11 @@ class TestQuantizeFx(QuantizationTestCase):
                 ("m2.m1", torch.add, 0, torch.ao.quantization.default_qconfig),
             ],
         }
-        m = prepare_fx(m, qconfig_dict)
-        data = torch.randn(1, 1, 1, 1)
-        m(data)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
-        m(data)
+        m(*example_inputs)
 
         node_list = [
             # m3
@@ -1759,11 +1772,11 @@ class TestQuantizeFx(QuantizationTestCase):
                 ("", torch.add, 1, None),
             ],
         }
-        m = prepare_fx(m, qconfig_dict)
-        data = torch.randn(1, 1, 1, 1)
-        m(data)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
-        m(data)
+        m(*example_inputs)
 
         node_list = [
             ns.call_function(torch.quantize_per_tensor),
@@ -1819,7 +1832,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 m = model(relu).eval()
                 qconfig_dict = torch.ao.quantization.get_default_qconfig_dict("fbgemm")
                 # should not crash as in https://github.com/pytorch/pytorch/issues/75825
-                prepare_fx(m, qconfig_dict)
+                prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 3, 3, 3),))
 
     def test_qconfig_dict_validity(self):
         r"""
@@ -1831,7 +1844,7 @@ class TestQuantizeFx(QuantizationTestCase):
         qconfig_dict = {"object_typo": [(torch.nn.Conv2d, default_qconfig)]}
 
         with self.assertRaises(ValueError) as context:
-            m = prepare_fx(m, qconfig_dict)
+            m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 3, 3, 3),))
         self.assertTrue(
             'Expected qconfig_dict to have the following keys:' in str(context.exception)
         )
@@ -1848,7 +1861,11 @@ class TestQuantizeFx(QuantizationTestCase):
         prepare_custom_config_dict = {"typo": None}
 
         with self.assertRaises(ValueError) as context:
-            m = prepare_fx(m, qconfig_dict, prepare_custom_config_dict)
+            m = prepare_fx(
+                m,
+                qconfig_dict,
+                example_inputs=(torch.randn(1, 3, 3, 3),),
+                prepare_custom_config_dict=prepare_custom_config_dict)
         self.assertTrue(
             'Expected prepare_custom_config_dict to have the following keys:'
             in str(context.exception)
@@ -1863,7 +1880,7 @@ class TestQuantizeFx(QuantizationTestCase):
         """
         m = ConvModel().eval()
         qconfig_dict = {"module_name_regex": [("conv*", default_qconfig)]}
-        m = prepare_fx(m, qconfig_dict)
+        m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 3, 3, 3),))
         convert_custom_config_dict = {"typo": None}
 
         with self.assertRaises(ValueError) as context:
@@ -1885,11 +1902,11 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M().eval()
         qconfig_dict = {'': default_qconfig}
-        m = prepare_fx(m, qconfig_dict)
-        data = torch.randn(1, 1, 1, 1)
-        m(data)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
-        m(data)
+        m(*example_inputs)
         for name, module in m.named_modules():
             self.assertFalse(hasattr(module, 'qconfig'),
                              'qconfig is not removed for ' + name)
@@ -1901,7 +1918,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M().eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        m = prepare_fx(m, qconfig_dict)
+        m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1),))
         m = convert_fx(m)
 
     def test_default_quant_after_none_qconfig(self):
@@ -1924,7 +1941,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 ("conv1", None)
             ]
         }
-        m = prepare_fx(m, qconfig_dict)
+        m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 1, 1, 1),))
         m = convert_fx(m)
 
     def test_qconfig_for_call_method(self):
@@ -1988,13 +2005,14 @@ class TestQuantizeFx(QuantizationTestCase):
                 (qconfig_dict1, node_list1),
                 (qconfig_dict2, node_list2)
         ]:
+            example_inputs = (torch.randn(2, 1, 3, 3),)
             m = M().eval()
-            m = prepare_fx(m, qconfig_dict)
+            m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
             m(torch.randn(2, 1, 3, 3))
             m = convert_fx(m)
             self.checkGraphModuleNodes(m, expected_node_list=node_list)
             # make sure it runs
-            m(torch.randn(2, 1, 3, 3))
+            m(*example_inputs)
 
     def test_qconfig_for_call_func(self):
         class Linear(torch.nn.Module):
@@ -2021,9 +2039,10 @@ class TestQuantizeFx(QuantizationTestCase):
                 return x
 
         model = M().eval()
+        example_inputs = (torch.rand(5, 5),)
         qconfig_dict = {"": default_qconfig, "module_name": [("mods2", None)]}
-        m = prepare_fx(model, qconfig_dict)
-        m(torch.rand(5, 5))
+        m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
 
         m = convert_fx(m)
         node_list = [
@@ -2051,7 +2070,12 @@ class TestQuantizeFx(QuantizationTestCase):
         prepare_custom_config_dict = {
             "preserved_attributes": ["preserved_attr"]
         }
-        m = prepare_fx(m, {"": default_qconfig}, prepare_custom_config_dict)
+        example_inputs = (torch.randn(1, 1, 1, 1),)
+        m = prepare_fx(
+            m,
+            {"": default_qconfig},
+            example_inputs=example_inputs,
+            prepare_custom_config_dict=prepare_custom_config_dict)
 
         def assertAttrPreserved(m):
             self.assertTrue(hasattr(m, "preserved_attr"))
@@ -2069,12 +2093,13 @@ class TestQuantizeFx(QuantizationTestCase):
         model = LinearModelWithSubmodule().train()
         qengine = torch.backends.quantized.engine
         qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig(qengine)}
-        model = prepare_qat_fx(model, qconfig_dict)
+        x = torch.randn(5, 5)
+        example_inputs = (x,)
+        model = prepare_qat_fx(model, qconfig_dict, example_inputs=example_inputs)
 
         # ensure scripting works
         scripted = torch.jit.script(model)
         # run one round to make sure model runs
-        x = torch.randn(5, 5)
         scripted(x)
         FileCheck().check_count('FakeQuantize = prim::GetAttr[name="', 4, exactly=True) \
                    .run(scripted.graph)
@@ -2104,10 +2129,10 @@ class TestQuantizeFx(QuantizationTestCase):
         orig = LinearModelWithSubmodule().eval()
         model = orig
         qconfig_dict = {'': torch.ao.quantization.get_default_qconfig('fbgemm')}
-        model = prepare_fx(model, qconfig_dict)
+        x = torch.randn(5, 5)
+        model = prepare_fx(model, qconfig_dict, example_inputs=(x,))
 
         # run it through input
-        x = torch.randn(5, 5)
         model(x)
 
         quant = convert_fx(model)
@@ -2120,7 +2145,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         # Load the stats into new model
         model_2 = orig
-        model_2 = prepare_fx(model_2, qconfig_dict)
+        model_2 = prepare_fx(model_2, qconfig_dict, example_inputs=(x,))
 
         loaded_dict = torch.load(b)
         torch.ao.quantization.load_observer_state_dict(model_2, loaded_dict)
@@ -2208,7 +2233,6 @@ class TestQuantizeFx(QuantizationTestCase):
                 x = self.linear2(x)
                 return x
 
-        data = torch.randn(3, 3)
         # instantiate M and RefM and align the parameters
         original_m = M().eval()
         original_ref_m = RefM().eval()
@@ -2255,13 +2279,15 @@ class TestQuantizeFx(QuantizationTestCase):
                     }
                 }
 
+            example_inputs = (torch.randn(3, 3),)
             # check prepared model
             m = prepare_fx(
                 original_m,
                 qconfig_dict,
+                example_inputs=example_inputs,
                 prepare_custom_config_dict=prepare_custom_config_dict)
             # calibration
-            m(data)
+            m(*example_inputs)
             # all activation observers are inserted in the top level module
             count_check = {
                 ns.call_module(torch.ao.quantization.MinMaxObserver): num_observers
@@ -2280,13 +2306,13 @@ class TestQuantizeFx(QuantizationTestCase):
                 }
                 self.checkGraphModuleNodes(m, expected_node_occurrence=count_check)
             self.assertEqual(type(m.custom), quantized_module_class)
-            res = m(data)
+            res = m(*example_inputs)
 
             # quantize the reference model
-            ref_m = prepare_fx(original_ref_m, qconfig_dict)
-            ref_m(data)
+            ref_m = prepare_fx(original_ref_m, qconfig_dict, example_inputs=example_inputs)
+            ref_m(*example_inputs)
             ref_m = convert_fx(ref_m)
-            ref_res = ref_m(data)
+            ref_res = ref_m(*example_inputs)
             self.assertEqual(res, ref_res)
 
     @skipIfNoFBGEMM
@@ -2360,16 +2386,18 @@ class TestQuantizeFx(QuantizationTestCase):
             }
         }
         m = M().eval()
+        example_inputs = (torch.randn(3, 3),)
         m = prepare_fx(
             m,
             {"": default_qconfig},
+            example_inputs=example_inputs,
             prepare_custom_config_dict=prepare_custom_config_dict)
         # make sure it works
         m = convert_fx(
             m,
             convert_custom_config_dict=convert_custom_config_dict)
         # make sure it runs
-        m(torch.randn(3, 3))
+        m(*example_inputs)
 
     @skipIfNoFBGEMM
     def test_non_traceable_module(self):
@@ -2415,6 +2443,7 @@ class TestQuantizeFx(QuantizationTestCase):
         }
         m = prepare_fx(
             m, qconfig_dict,
+            example_inputs=({"key": torch.randn(1)},),
             prepare_custom_config_dict=prepare_custom_config_dict)
 
         node_occurrence = {
@@ -2441,9 +2470,10 @@ class TestQuantizeFx(QuantizationTestCase):
         m = M()
         m.eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        prepared = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(4, 1, 4, 4),)
+        prepared = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         # calibrate
-        prepared(torch.randn(4, 1, 4, 4))
+        prepared(*example_inputs)
         # copy
         prepared_copy = copy.deepcopy(prepared)
         # quantize, should run with no errors
@@ -2460,21 +2490,21 @@ class TestQuantizeFx(QuantizationTestCase):
             def forward(self, x):
                 return self.linear(x)
 
-        data = torch.rand(8, 5)
+        example_inputs = (torch.rand(8, 5),)
         m = M().eval()
-        m = prepare_fx(m, {"": default_qconfig})
+        m = prepare_fx(m, {"": default_qconfig}, example_inputs=example_inputs)
         m = convert_fx(m)
         # test deepcopy
         m_copy = copy.deepcopy(m)
-        self.assertEqual(m_copy(data), m(data))
+        self.assertEqual(m_copy(*example_inputs), m(*example_inputs))
 
         # test state_dict
         state_dict = m.state_dict()
         m_new = M().eval()
-        m_new = prepare_fx(m_new, {"": default_qconfig})
+        m_new = prepare_fx(m_new, {"": default_qconfig}, example_inputs=example_inputs)
         m_new = convert_fx(m_new)
         m_new.load_state_dict(state_dict)
-        self.assertEqual(m_new(data), m(data))
+        self.assertEqual(m_new(*example_inputs), m(*example_inputs))
 
     def test_dequantize(self):
         r""" Test to make sure dequantize node are placed before
@@ -2542,12 +2572,14 @@ class TestQuantizeFx(QuantizationTestCase):
         # quantized input, quantized output
         m = M()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
+        example_inputs = (torch.randn(1, 1, 4, 4),)
         m.eval()
         mp = torch.ao.quantization.quantize_fx.prepare_fx(
             m, qconfig_dict,
+            example_inputs=example_inputs,
             prepare_custom_config_dict=prepare_custom_config_dict)
         self.checkGraphModuleNodes(mp, expected_node_occurrence=prepare_count_check)
-        mp(torch.randn(1, 1, 4, 4))
+        mp(*example_inputs)
         mq = torch.ao.quantization.quantize_fx.convert_fx(mp)
         self.checkGraphModuleNodes(mq, expected_node_occurrence=convert_count_check)
 
@@ -2612,7 +2644,7 @@ class TestQuantizeFx(QuantizationTestCase):
         m.eval()
         qconfig_dict = {'': torch.ao.quantization.get_default_qconfig('fbgemm')}
         with self.assertRaises(AssertionError) as context:
-            mp = prepare_fx(m, qconfig_dict)
+            mp = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 1, 1, 1),))
         self.assertTrue(
             str(context.exception) ==
             'Per channel weight observer is not supported yet for ConvTranspose{n}d.')
@@ -2644,8 +2676,9 @@ class TestQuantizeFx(QuantizationTestCase):
 
         model = M().eval()
         qconfig_dict = {"": default_qconfig}
-        m = prepare_fx(model, qconfig_dict)
-        m(torch.rand(5, 5))
+        example_inputs = (torch.rand(5, 5),)
+        m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
         keys = m.state_dict().keys()
         quant_scale_count = quant_zero_point = scale_count = zero_point_count = 0
@@ -2663,7 +2696,7 @@ class TestQuantizeFx(QuantizationTestCase):
         self.assertTrue(scale_count == 3, "Expect each quantized linear op to have a scale in state_dict")
         self.assertTrue(zero_point_count == 3, "Expect each quantized linear op to have a zero_point in state_dict")
         # ensure it runs
-        m(torch.rand(5, 5))
+        m(*example_inputs)
         # ensure it is scriptable
         scripted = torch.jit.script(m)
         scripted_keys = scripted.state_dict().keys()
@@ -2708,9 +2741,10 @@ class TestQuantizeFx(QuantizationTestCase):
                 return x
 
         model = M().eval()
+        example_inputs = (torch.rand(5, 5),)
         qconfig_dict = {"": default_qconfig}
-        m = prepare_fx(model, qconfig_dict)
-        m(torch.rand(5, 5))
+        m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
         assert hasattr(m, "mods1_0_packed_weight_0")
         assert hasattr(m, "mods1_1_packed_weight_0")
@@ -2743,10 +2777,11 @@ class TestQuantizeFx(QuantizationTestCase):
                 return x
         model = M().eval()
         qconfig_dict = {"": float16_dynamic_qconfig}
-        m = prepare_fx(model, qconfig_dict)
+        example_inputs = (torch.rand(5, 5),)
+        m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
         m = convert_fx(m)
         # make sure it runs
-        m(torch.randn(5, 5))
+        m(*example_inputs)
 
     def test_getattr_with_nontensor_result(self):
         """
@@ -2785,9 +2820,10 @@ class TestQuantizeFx(QuantizationTestCase):
 
         for cls in (M1, M2, M3):
             m = cls().eval()
-            m(torch.rand(4, 4, 4, 4))
+            example_inputs = (torch.rand(4, 4, 4, 4),)
+            m(*example_inputs)
             qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-            mp = prepare_fx(m, qconfig_dict)
+            mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
             mp(torch.rand(4, 4, 4, 4))
             mc = convert_fx(mp)
 
@@ -2841,7 +2877,7 @@ class TestQuantizeFx(QuantizationTestCase):
     def _test_dtype_propagation(self, model, node_info_to_non_tensor_args, *args):
         model.eval()
         qconfig_dict = {"": torch.ao.quantization.get_default_qconfig("fbgemm")}
-        prepared_model = prepare_fx(model, qconfig_dict)
+        prepared_model = prepare_fx(model, qconfig_dict, example_inputs=tuple(args))
         self._check_not_observed(prepared_model, node_info_to_non_tensor_args)
         prepared_model(*args)
 
@@ -3035,12 +3071,13 @@ class TestQuantizeFx(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        m(torch.rand(4, 1, 4, 4))
+        example_inputs = (torch.rand(4, 1, 4, 4),)
+        m(*example_inputs)
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = prepare_fx(m, qconfig_dict)
-        mp(torch.rand(4, 1, 4, 4))
+        mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        mp(*example_inputs)
         mc = convert_fx(mp)
-        mc(torch.rand(4, 1, 4, 4))
+        mc(*example_inputs)
 
     def test_fp32_sum(self):
         """
@@ -3073,12 +3110,13 @@ class TestQuantizeFx(QuantizationTestCase):
 
         for cls in (M1, M2):
             m = cls().eval()
-            m(torch.rand(4, 1, 4, 4))
+            example_inputs = (torch.rand(4, 1, 4, 4),)
+            m(*example_inputs)
             qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-            mp = prepare_fx(m, qconfig_dict)
-            mp(torch.rand(4, 1, 4, 4))
+            mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+            mp(*example_inputs)
             mc = convert_fx(mp)
-            mc(torch.rand(4, 1, 4, 4))
+            mc(*example_inputs)
 
     def test_fusion_pattern_unquantized(self):
         """
@@ -3113,8 +3151,9 @@ class TestQuantizeFx(QuantizationTestCase):
                 ('child', None),
             ],
         }
-        mp = prepare_fx(m, qconfig_dict)
-        mp(torch.rand(1, 1, 1, 1))
+        example_inputs = (torch.rand(1, 1, 1, 1),)
+        mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        mp(*example_inputs)
         mc = convert_fx(mp)
 
     def test_state_dict(self):
@@ -3133,7 +3172,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M1().eval()
         qconfig_dict = {"": default_qconfig}
-        m = prepare_fx(m, qconfig_dict)
+        m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 30),))
         m = convert_fx(m)
         state_dict = m.state_dict()
         self.assertTrue("_packed_weight_0" in state_dict)
@@ -3154,7 +3193,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M2().eval()
         qconfig_dict = {"": default_qconfig}
-        m = prepare_fx(m, qconfig_dict)
+        m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 3, 3, 3),))
         m = convert_fx(m)
         state_dict = m.state_dict()
         self.assertTrue("_packed_weight_0" in state_dict)
@@ -3164,7 +3203,7 @@ class TestQuantizeFx(QuantizationTestCase):
         data = torch.rand(1, 3, 5, 5)
         ref_res = m(data)
         m = M2().eval()
-        m = prepare_fx(m, qconfig_dict)
+        m = prepare_fx(m, qconfig_dict, (data,))
         m = convert_fx(m)
         res = m(data)
         weight, bias = m._packed_weight_0.unpack()
@@ -3186,7 +3225,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         # Test save to disk and load back
         m = M2().eval()
-        m = prepare_fx(m, qconfig_dict)
+        m = prepare_fx(m, qconfig_dict, example_inputs=(data,))
         m = convert_fx(m)
         m.load_state_dict(state_dict)
         with TemporaryFileName() as fname:
@@ -3229,8 +3268,9 @@ class TestQuantizeFx(QuantizationTestCase):
                 (torch.nn.functional.linear, float16_dynamic_qconfig),
             ],
         }
-        m = prepare_fx(model, qconfig_dict)
-        m(torch.rand(5, 5))
+        example_inputs = (torch.rand(5, 5),)
+        m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m, _remove_qconfig=False)
 
         self.assertTrue(hasattr(m.mods2, 'qconfig'))
@@ -3250,7 +3290,7 @@ class TestQuantizeFx(QuantizationTestCase):
         m = M().eval()
         qconfig_dict = {"": float16_static_qconfig}
         # make sure quantization runs
-        m = prepare_fx(m, qconfig_dict)
+        m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1),))
         m = convert_fx(m)
 
     def test_qparams_fqn(self):
@@ -3288,8 +3328,9 @@ class TestQuantizeFx(QuantizationTestCase):
                 (torch.nn.functional.relu, default_qconfig),
             ],
         }
-        m = prepare_fx(model, qconfig_dict)
-        m(torch.rand(5, 5))
+        example_inputs = (torch.rand(5, 5),)
+        m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
         keys = m.state_dict().keys()
         m(torch.randn(5, 5))
@@ -3321,12 +3362,13 @@ class TestQuantizeFx(QuantizationTestCase):
         m = M().eval()
 
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(4, 4, 4, 4),)
+        mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         # if an observer is inserted after _user_func_with_complex_return_type,
         # the following call will fail
-        mp(torch.randn(4, 4, 4, 4))
+        mp(*example_inputs)
         mc = convert_fx(mp)
-        mc(torch.randn(4, 4, 4, 4))
+        mc(*example_inputs)
 
     def test_fold_quant_dequant(self):
         """ Test that the sequence of quant-dequant nodes in the
@@ -3352,11 +3394,12 @@ class TestQuantizeFx(QuantizationTestCase):
                 (torch.nn.functional.linear, default_qconfig),
             ],
         }
-        m = prepare_fx(model, qconfig_dict)
-        m(torch.rand(5, 5))
+        example_inputs = (torch.rand(5, 5),)
+        m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
         keys = m.state_dict().keys()
-        m(torch.randn(5, 5))
+        m(*example_inputs)
         dequant = 0
         quant = 0
         for n in m.graph.nodes:
@@ -3375,7 +3418,7 @@ class TestQuantizeFx(QuantizationTestCase):
         """
         qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
         prepare_custom_config_dict = {'output_quantized_idxs': [0]}
-        data = (torch.randn(4, 1, 4, 4),)
+        example_inputs = (torch.randn(4, 1, 4, 4),)
 
         # non-quantizeable node, quantized output
         class M1(torch.nn.Module):
@@ -3389,7 +3432,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m1 = M1()
         self.checkGraphModeFxOp(
-            m1, data, QuantType.QAT,
+            m1, example_inputs, QuantType.QAT,
             prepare_expected_node_occurrence={
                 ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 2,
             },
@@ -3410,7 +3453,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m2 = M2()
         self.checkGraphModeFxOp(
-            m2, data, QuantType.QAT,
+            m2, example_inputs, QuantType.QAT,
             prepare_expected_node_occurrence={
                 # one for weights, one for activations
                 ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 2,
@@ -3432,7 +3475,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m3 = M3()
         self.checkGraphModeFxOp(
-            m3, data, QuantType.QAT,
+            m3, example_inputs, QuantType.QAT,
             prepare_expected_node_occurrence={
                 # one for weights, one for activations
                 ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 2,
@@ -3452,7 +3495,11 @@ class TestQuantizeFx(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        m = prepare_fx(m, {"": default_qconfig}, prepare_custom_config_dict={"preserved_attributes": ["attr"]})
+        m = prepare_fx(
+            m,
+            {"": default_qconfig},
+            example_inputs=(torch.randn(1),),
+            prepare_custom_config_dict={"preserved_attributes": ["attr"]})
         self.assertTrue(hasattr(m, "attr"))
         m2 = copy.deepcopy(m)
         self.assertTrue(hasattr(m2, "attr"))
@@ -3475,7 +3522,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         m = M().eval()
         qconfig_dict = {'': torch.ao.quantization.default_qconfig}
-        mp = prepare_fx(m, qconfig_dict)
+        mp = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 1, 1, 1),))
         mc = convert_fx(mp)
 
     def test_shape_followed_by_quantized_op(self):
@@ -3497,9 +3544,10 @@ class TestQuantizeFx(QuantizationTestCase):
 
         # make sure quantization runs
         m = M().eval()
-        m = prepare_fx(m, {"": default_qconfig})
+        example_inputs = (torch.randn(2, 2, 4, 4),)
+        m = prepare_fx(m, {"": default_qconfig}, example_inputs=example_inputs)
         m = convert_fx(m)
-        m(torch.randn(2, 2, 4, 4))
+        m(*example_inputs)
         node_occurrence = {
             ns.call_function(torch.quantize_per_tensor): 1,
             ns.call_method("dequantize"): 1
@@ -3517,7 +3565,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        m = prepare_fx(m, {"": default_qconfig})
+        m = prepare_fx(m, {"": default_qconfig}, example_inputs=(torch.randn(1, 1, 3, 3),))
         m = convert_fx(m)
         # Make sure this runs without error
         m = torch.fx.Transformer(m).transform()
@@ -3558,7 +3606,8 @@ class TestQuantizeFx(QuantizationTestCase):
                 qconfig = default_qconfig
                 actpp_module_class = torch.ao.quantization.MinMaxObserver
 
-            m = prepare(m, {"": qconfig})
+            example_inputs = (torch.randn(1, 3, 3, 3),)
+            m = prepare(m, {"": qconfig}, example_inputs=example_inputs)
             # check that there is a duplicated observer instance
             actpp_module_count = 0
             for name, module in m.named_modules(remove_duplicate=False):
@@ -3620,12 +3669,16 @@ class TestQuantizeFx(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        m = prepare_fx(m, {"": torch.ao.quantization.QConfig(
-            activation=torch.ao.quantization.HistogramObserver.with_args(
-                qscheme=torch.per_tensor_symmetric, dtype=torch.qint8
-            ), weight=torch.ao.quantization.default_per_channel_weight_observer)})
+        example_inputs = (torch.rand(2, 1, 5, 5),)
+        m = prepare_fx(
+            m,
+            {"": torch.ao.quantization.QConfig(
+                activation=torch.ao.quantization.HistogramObserver.with_args(
+                    qscheme=torch.per_tensor_symmetric, dtype=torch.qint8
+                ), weight=torch.ao.quantization.default_per_channel_weight_observer)},
+            example_inputs=example_inputs)
         m = convert_fx(m, is_reference=True)
-        m(torch.rand(2, 1, 5, 5))
+        m(*example_inputs)
 
     def test_preserve_tuple(self):
         """ Test tuple input type is preserved
@@ -3642,7 +3695,8 @@ class TestQuantizeFx(QuantizationTestCase):
                 return self.lstm(inputs, (h, c))
 
         m = LSTM().eval()
-        m = prepare_fx(m, {"": default_qconfig})
+        example_inputs = (torch.randn(5, 3, 50), torch.randn(2, 3, 50), torch.randn(2, 3, 50))
+        m = prepare_fx(m, {"": default_qconfig}, example_inputs=example_inputs)
         # make sure the arg[1] of lstm module is a tuple
         for n in m.graph.nodes:
             if n.target == "lstm":
@@ -3654,7 +3708,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 return torch.nn.functional.relu(x)
 
         m = M().eval()
-        m = prepare_fx(m, {"": default_qconfig})
+        m = prepare_fx(m, {"": default_qconfig}, example_inputs=(torch.randn(1),))
         m_copy = copy.deepcopy(m)
         m = convert_fx(m)
         m_ref = convert_fx(m_copy, is_reference=True)
@@ -3716,9 +3770,10 @@ class TestQuantizeFx(QuantizationTestCase):
             qconfig_dict = {
                 "": qconfig
             }
-            m = prepare_fx(model, qconfig_dict)
+            example_inputs = (torch.rand(5, 5),)
+            m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
             m = convert_fx(m)
-            m(torch.rand(5, 5))
+            m(*example_inputs)
             node_list = [
                 ns.call_module(nniqd.LinearReLU),
                 ns.call_module(nniqd.LinearReLU),
@@ -3756,9 +3811,10 @@ class TestQuantizeFx(QuantizationTestCase):
             qconfig_dict = {
                 "": qconfig
             }
-            m = prepare_fx(model, qconfig_dict)
+            example_inputs = (torch.randn(5, 5),)
+            m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
             m = convert_fx(m)
-            m(torch.rand(5, 5))
+            m(*example_inputs)
             node_list = [
                 ns.call_module(nniqd.LinearReLU),
                 ns.call_module(nniqd.LinearReLU),
@@ -3796,9 +3852,10 @@ class TestQuantizeFx(QuantizationTestCase):
             qconfig_dict = {
                 "": qconfig
             }
-            m = prepare_fx(model, qconfig_dict)
+            example_inputs = (torch.rand(5, 5, 5),)
+            m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
             m = convert_fx(m)
-            m(torch.rand(5, 5, 5))
+            m(*example_inputs)
             node_list = [
                 ns.call_module(nniqd.LinearReLU),
                 ns.call_module(nniqd.LinearReLU),
@@ -3828,13 +3885,13 @@ class TestQuantizeFx(QuantizationTestCase):
 
         for M in [M1, M2]:
             m = M().eval()
-            m = prepare_fx(m, {"": default_qconfig})
+            example_inputs = (torch.randn(5, 10),)
+            m = prepare_fx(m, {"": default_qconfig}, example_inputs=example_inputs)
             m_copy = copy.deepcopy(m)
             m = convert_fx(m, is_reference=False)
             m_ref = convert_fx(m_copy, is_reference=True)
-            data = torch.randn(5, 10)
-            result = m(data)
-            result_ref = m_ref(data)
+            result = m(*example_inputs)
+            result_ref = m_ref(*example_inputs)
             self.assertTrue(torch.equal(result, result_ref))
 
     def test_ref_conv_module(self):
@@ -3866,11 +3923,11 @@ class TestQuantizeFx(QuantizationTestCase):
 
         for dim, M in itertools.product([1, 2, 3], [M1, M2]):
             m = M(dim).eval()
-            m = prepare_fx(m, {"": default_qconfig})
+            data = self.img_data_dict[dim][0][0]
+            m = prepare_fx(m, {"": default_qconfig}, example_inputs=(data,))
             m_copy = copy.deepcopy(m)
             m = convert_fx(m, is_reference=False)
             m_ref = convert_fx(m_copy, is_reference=True)
-            data = self.img_data_dict[dim][0][0]
             result = m(data)
             result_ref = m_ref(data)
             self.assertTrue(torch.equal(result, result_ref))
@@ -3885,7 +3942,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        m = prepare_fx(m, {"": default_qconfig})
+        m = prepare_fx(m, {"": default_qconfig}, example_inputs=(torch.rand(3),))
         m = convert_fx(m)
         occurrence = {
             ns.call_function(torch.quantize_per_tensor): 2,
@@ -3930,7 +3987,7 @@ class TestQuantizeFx(QuantizationTestCase):
 
         model = M().eval()
 
-        prepared = prepare_fx(model, {"": default_qconfig})
+        prepared = prepare_fx(model, {"": default_qconfig}, example_inputs=(torch.randn(1, 5)))
         name_list = []
         for name, mod in prepared.named_modules():
             if isinstance(mod, torch.ao.quantization.observer.MinMaxObserver):
@@ -3959,11 +4016,11 @@ class TestQuantizeFx(QuantizationTestCase):
 
         for dim in range(1, len(convs) + 1):
             m = M(dim).eval()
-            m = prepare_fx(m, {"": default_qconfig})
+            data = self.img_data_dict[dim][0][0]
+            m = prepare_fx(m, {"": default_qconfig}, example_inputs=(data,))
             m_ref = copy.deepcopy(m)
             m_ref = convert_fx(m_ref, is_reference=True)
             m = convert_fx(m)
-            data = self.img_data_dict[dim][0][0]
             out_ref = m_ref(data)
             out = m(data)
             # check that reference pattern for quantized conv module is fused
@@ -4013,8 +4070,9 @@ class TestQuantizeFx(QuantizationTestCase):
                                 (nn.Linear, get_default_qat_qconfig("fbgemm")),
                             ],
                             }
-            prepared = prepare_qat_fx(model, qconfig_dict)
-            prepared(torch.rand(5, 5))
+            example_inputs = (torch.rand(5, 5),)
+            prepared = prepare_qat_fx(model, qconfig_dict, example_inputs=example_inputs)
+            prepared(*example_inputs)
             if check == "module_name":
                 convert_qconfig_dict = {"": None,
                                         "object_type": [
@@ -4133,7 +4191,8 @@ class TestQuantizeFx(QuantizationTestCase):
         options = itertools.product([M1, M2], [True, False])
         for M, is_qat in options:
             m = M1().eval()
-            m = prepare_fx(m, get_default_qconfig_dict())
+            example_inputs = (torch.randn(1, 3, 3, 3),)
+            m = prepare_fx(m, get_default_qconfig_dict(), example_inputs=example_inputs)
             m = convert_fx(m)
             node_list = [
                 ns.call_function(torch.quantize_per_tensor),
@@ -4146,7 +4205,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 expected_node_list=node_list)
 
             m = M2().eval()
-            m = prepare_fx(m, get_default_qconfig_dict())
+            m = prepare_fx(m, get_default_qconfig_dict(), example_inputs=example_inputs)
             m = convert_fx(m)
             node_occurrence = {
                 ns.call_function(torch.quantize_per_tensor): 0,
@@ -4171,7 +4230,7 @@ class TestQuantizeFx(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        mp = prepare_fx(m, get_default_qconfig_dict())
+        mp = prepare_fx(m, get_default_qconfig_dict(), example_inputs=(torch.randn(1, 1),))
 
         found_stack_trace = False
         for n in mp.graph.nodes:
@@ -4233,11 +4292,14 @@ class TestQuantizeFx(QuantizationTestCase):
             "non_traceable_module_class": [UnTraceableModuleClass],
             "non_traceable_module_name": ["untraceable_module_name"],
         }
+        example_inputs = (torch.randn(2, 2),)
         mod_prep = torch.ao.quantization.quantize_fx.prepare_qat_fx(
-            mod.train(), qconfig_dict, prepare_custom_config_dict
+            mod.train(), qconfig_dict, example_inputs=example_inputs,
+            prepare_custom_config_dict=prepare_custom_config_dict
         )
         mod_prep = torch.ao.quantization.quantize_fx.prepare_qat_fx(
-            mod.train(), qconfig_dict, prepare_custom_config_dict
+            mod.train(), qconfig_dict, example_inputs=example_inputs,
+            prepare_custom_config_dict=prepare_custom_config_dict
         )
         self.assertTrue(
             isinstance(mod_prep.untraceable_module_class.linear, torch.nn.Linear)
@@ -4287,7 +4349,7 @@ class TestQuantizeFx(QuantizationTestCase):
             for backend in backends:
                 m = M().eval()
                 qconfig_dict = func(backend)
-                m = prepare_fx(m, qconfig_dict)
+                m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 1, 1, 1)))
                 for name, mod in m.named_modules():
                     if is_activation_post_process(mod) and mod.dtype == torch.quint8:
                         if backend == "fbgemm":
@@ -4316,10 +4378,11 @@ class TestQuantizeFx(QuantizationTestCase):
             m = LinearModel()
             m1 = copy.deepcopy(m)
             m1.train()
-            prepare_fn(m1, qconfig_dict)
+            example_inputs = (torch.randn(1, 5),)
+            prepare_fn(m1, qconfig_dict, example_inputs=example_inputs)
             m2 = copy.deepcopy(m)
             m2.eval()
-            prepare_fn(m2, qconfig_dict)
+            prepare_fn(m2, qconfig_dict, example_inputs=example_inputs)
 
         # Ensure prepare_fx and prepare_qat_fx work in both training and eval modes
         _test(prepare_fx, get_default_qconfig_dict())
@@ -5016,7 +5079,8 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        m = prepare_fx(m, {"": default_qconfig})
+        example_inputs = (torch.randn(3), torch.randn(3))
+        m = prepare_fx(m, {"": default_qconfig}, example_inputs=example_inputs)
         m = convert_fx(m)
         node_occurrence = {
             ns.call_function(torch.quantize_per_tensor): 2,
@@ -5027,7 +5091,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
         # check the model is scriptable
         m = torch.jit.script(m)
         # check the model is runnable
-        m(torch.randn(3), torch.randn(3))
+        m(*example_inputs)
 
     @skipIfNoFBGEMM
     def test_mul_relu(self):
@@ -5037,9 +5101,9 @@ class TestQuantizeFxOps(QuantizationTestCase):
             operator.mul, operator.imul)
 
     # TODO(future PR): make more generic
-    def _test_quantized_add_mul_qat(self, model, expected_node_occurrence):
+    def _test_quantized_add_mul_qat(self, model, example_inputs, expected_node_occurrence):
         qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')}
-        mp = torch.ao.quantization.quantize_fx.prepare_qat_fx(model, qconfig_dict)
+        mp = prepare_qat_fx(model, qconfig_dict, example_inputs=example_inputs)
         self.checkGraphModuleNodes(
             mp, expected_node_occurrence=expected_node_occurrence)
 
@@ -5060,10 +5124,11 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 return x
 
         m = M()
+        example_inputs = (torch.randn(1, 1, 1, 1),)
         expected_node_occurrence = {
             ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 5,
         }
-        self._test_quantized_add_mul_qat(m, expected_node_occurrence)
+        self._test_quantized_add_mul_qat(m, example_inputs, expected_node_occurrence)
 
     @skipIfNoFBGEMM
     def test_quantized_mul_qat(self):
@@ -5082,10 +5147,11 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 return x
 
         m = M()
+        example_inputs = (torch.randn(1, 1, 1, 1),)
         expected_node_occurrence = {
             ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 5,
         }
-        self._test_quantized_add_mul_qat(m, expected_node_occurrence)
+        self._test_quantized_add_mul_qat(m, example_inputs, expected_node_occurrence)
 
     def test_int8_input_no_unnecessary_fq(self):
         """
@@ -5105,6 +5171,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
         m = M(0.5)
         mp = torch.ao.quantization.quantize_fx.prepare_qat_fx(
             m, {'': torch.ao.quantization.get_default_qat_qconfig('fbgemm')},
+            example_inputs=(torch.randn(1),),
             prepare_custom_config_dict={"input_quantized_idxs": [0]})
         expected_node_occurrence = {
             ns.call_module(torch.ao.quantization.FusedMovingAvgObsFakeQuantize): 1,
@@ -5128,8 +5195,8 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 y = self.conv2(y)
                 return torch.cat([x, y], 1)
 
-        data = (torch.randn(1, 2, 5, 5, dtype=torch.float),
-                torch.randn(1, 2, 5, 5, dtype=torch.float))
+        example_inputs = (torch.randn(1, 2, 5, 5, dtype=torch.float),
+                          torch.randn(1, 2, 5, 5, dtype=torch.float))
         quantized_node = ns.call_function(torch.cat)
         options = itertools.product(self.static_quant_types, [True, False])
         for quant_type, is_reference in options:
@@ -5158,7 +5225,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
 
             self.checkGraphModeFxOp(
                 M(),
-                data,
+                example_inputs,
                 quant_type,
                 quantized_node,
                 expected_node_list=converted_node_list,
@@ -5167,7 +5234,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
 
         # check cat is using the same observer for input and output
         m = M().eval()
-        m = prepare_fx(m, {"": default_qconfig})
+        m = prepare_fx(m, {"": default_qconfig}, example_inputs=example_inputs)
         # two inputs and one output of torch.cat are using same observer, so we have
         # 2 observers that's replicated
         all_observers = len(dict(m.named_modules(remove_duplicate=False)))
@@ -5175,7 +5242,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
         self.assertEqual(all_observers, distinct_observers + 2)
         # make sure the converted model runs
         m = convert_fx(m)
-        m(*data)
+        m(*example_inputs)
 
     @skipIfNoFBGEMM
     def test_qbatch_norm(self):
@@ -5630,6 +5697,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
 
         data_x = torch.randn((2, 2, 2,))
         data_y = torch.randn((2, 2, 2,))
+        example_inputs = (data_x, data_y)
         qconfig_dict = {"": torch.ao.quantization.get_default_qconfig("fbgemm")}
         is_reference = True
         node_list = [
@@ -5637,10 +5705,10 @@ class TestQuantizeFxOps(QuantizationTestCase):
         ]
 
         m = M().eval()
-        m_prep = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict)
-        m_prep(data_x, data_y)
+        m_prep = torch.ao.quantization.quantize_fx.prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        m_prep(*example_inputs)
         m_quant = torch.ao.quantization.quantize_fx.convert_fx(m_prep, is_reference=is_reference)
-        m_quant(data_x, data_y)
+        m_quant(*example_inputs)
 
         self.checkGraphModuleNodes(m_quant, expected_node_list=node_list)
 
@@ -5823,12 +5891,12 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 x = self.conv2(x)
                 return x
 
-        data = torch.rand(1, 3, 10, 10)
+        example_inputs = (torch.rand(1, 3, 10, 10),)
         # This model is not executable since we just put all ops
         # in the same forward
         m = M().eval()
         qconfig_dict = {'': default_qconfig}
-        prepared = prepare_fx(m, qconfig_dict)
+        prepared = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         # not runnable
         quantized = convert_fx(prepared)
 
@@ -5859,7 +5927,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
         # Checking the is_reference output
         m = M().eval()
         qconfig_dict = {'': default_qconfig}
-        prepared = prepare_fx(m, qconfig_dict)
+        prepared = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         # not runnable
         quantized = convert_fx(prepared, is_reference=True)
 
@@ -5884,7 +5952,10 @@ class TestQuantizeFxOps(QuantizationTestCase):
         m = M().eval()
         # nothing to fuse so skipping the fuse step
         qconfig_dict = {'': default_qconfig}
-        prepared = prepare_fx(m, qconfig_dict, prepare_custom_config_dict={"input_quantized_idxs": [0]})
+        example_inputs = (torch.randn(1, 3, 3, 3),)
+        prepared = prepare_fx(
+            m, qconfig_dict, example_inputs=example_inputs,
+            prepare_custom_config_dict={"input_quantized_idxs": [0]})
 
         # not runnable
         quantized = convert_fx(prepared)
@@ -5950,7 +6021,8 @@ class TestQuantizeFxOps(QuantizationTestCase):
         m = M().eval()
         # nothing to fuse so skipping the fuse step
         qconfig_dict = {'': default_qconfig}
-        prepared = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 3, 3, 3),)
+        prepared = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         # not runnable
         quantized = convert_fx(prepared)
 
@@ -5983,7 +6055,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        m = prepare_fx(m, {"": default_reuse_input_qconfig})
+        m = prepare_fx(m, {"": default_reuse_input_qconfig}, example_inputs=(torch.randn(1),))
         m = convert_fx(m)
         # make sure it runs
         m(torch.rand(1))
@@ -5998,12 +6070,13 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        m = prepare_fx(m, {"": default_qconfig})
+        example_inputs = (torch.rand(1, 2),)
+        m = prepare_fx(m, {"": default_qconfig}, example_inputs=example_inputs)
         self.checkGraphModuleNodes(m, expected_node_occurrence={
             ns.call_module(torch.ao.quantization.MinMaxObserver): 0
         })
         m = convert_fx(m)
-        m(torch.rand(1, 2))
+        m(*example_inputs)
 
         class M2(torch.nn.Module):
             def forward(self, xs):
@@ -6012,7 +6085,8 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 return x
 
         m2 = M2().eval()
-        m2 = prepare_fx(m2, {"": default_qconfig})
+        example_inputs = ([torch.rand(1, 2)],)
+        m2 = prepare_fx(m2, {"": default_qconfig}, example_inputs=example_inputs)
         self.checkGraphModuleNodes(m2, expected_node_occurrence={
             ns.call_module(torch.ao.quantization.MinMaxObserver): 1
         })
@@ -6021,7 +6095,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             ns.call_function(torch.quantize_per_tensor),
             ns.call_method("dequantize")
         ])
-        m2([torch.rand(1, 2)])
+        m2(*example_inputs)
 
         # testing prepare recognizes non-Tensor input for getitem
         class M3(torch.nn.Module):
@@ -6032,7 +6106,8 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 return x
 
         m3 = M3().eval()
-        m3 = prepare_fx(m3, {"": default_qconfig})
+        example_inputs = (torch.rand(1, 2, 3, 4),)
+        m3 = prepare_fx(m3, {"": default_qconfig}, example_inputs=example_inputs)
         self.checkGraphModuleNodes(m3, expected_node_occurrence={
             ns.call_module(torch.ao.quantization.MinMaxObserver): 1
         })
@@ -6041,7 +6116,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             ns.call_function(torch.quantize_per_tensor),
             ns.call_method("dequantize")
         ])
-        m3(torch.rand(1, 2, 3, 4))
+        m3(*example_inputs)
 
 
     @skipIfNoFBGEMM
@@ -6090,12 +6165,12 @@ class TestQuantizeFxOps(QuantizationTestCase):
             # nothing to fuse so skipping the fuse step
             m_copy = copy.deepcopy(m)
             qconfig_dict = {'': qconfig}
-            prepared = prepare(m, qconfig_dict)
+            example_inputs = (torch.rand(3, 3, 3, 3),)
+            prepared = prepare(m, qconfig_dict, example_inputs=example_inputs)
             prepared_copy = copy.deepcopy(prepared)
             # check that prepare does not change model result
             if eval_mode:
-                r = torch.rand(3, 3, 3, 3)
-                self.assertEqual(m_copy(r), prepared_copy(r))
+                self.assertEqual(m_copy(*example_inputs), prepared_copy(*example_inputs))
             # check the correct number of activation_post_process is inserted
             expected_activation_post_process = FixedQParamsObserver if eval_mode else FixedQParamsFakeQuantize
             count_check = {
@@ -6183,7 +6258,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 x = self.ff6.cat([x])
                 return x
 
-        data = torch.rand(3, 3)
+        example_inputs = (torch.rand(3, 3),)
         # Note: QAT test succeeded by chance, to make it actually work
         # we need to fix eager mode FloatFunctional by removing
         # activation_post_process in add_scalar and mul_scalar
@@ -6204,13 +6279,13 @@ class TestQuantizeFxOps(QuantizationTestCase):
 
             prepare_fx_function = prepare_qat_fx if is_qat else prepare_fx
             qconfig_dict = {"": qconfig}
-            m = prepare_fx_function(m, qconfig_dict)
+            m = prepare_fx_function(m, qconfig_dict, example_inputs=example_inputs)
             node_occurrence = {
                 ns.call_module(expected_act_post_process): 7,
                 ns.call_module(torch.nn.quantized.FloatFunctional): 0
             }
             self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
-            m(data)
+            m(*example_inputs)
             node_list = [
                 ns.call_function(torch.quantize_per_tensor),
                 ns.call_function(torch.ops.quantized.add),
@@ -6228,7 +6303,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             ref_m.qconfig = qconfig
             prepare_function = prepare_qat if is_qat else prepare
             ref_m = prepare_function(ref_m)
-            ref_m(data)
+            ref_m(*example_inputs)
             ref_m = convert(ref_m)
             # FX Graph Mode and Eager Mode now diverages in numerics of add_scalar and mul_scalar
             # self.assertEqual(m(data), ref_m(data))
@@ -6245,6 +6320,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
         for qconfig_type in [float_qparams_weight_only_qconfig, float_qparams_weight_only_qconfig_4bit]:
             model = M().eval()
             indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
+            example_inputs = (indices,)
             quantized_node = ns.call_module(nnq.Embedding)
             configs = [
                 (qconfig_type, ns.call_module(nnq.Embedding)),
@@ -6254,14 +6330,14 @@ class TestQuantizeFxOps(QuantizationTestCase):
 
             for qconfig, node in configs:
                 qconfig_dict = {"": qconfig}
-                m = prepare_fx(model, qconfig_dict)
+                m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
                 self.checkGraphModuleNodes(m, expected_node_occurrence={
                     ns.call_module(torch.ao.quantization.MinMaxObserver): 0
                 })
                 m = convert_fx(m)
                 self.checkGraphModuleNodes(m, expected_node=node)
                 # make sure it runs
-                m(indices)
+                m(*example_inputs)
 
     def test_embedding_bag(self):
         class M(torch.nn.Module):
@@ -6275,7 +6351,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
         indices = torch.tensor([9, 6, 5, 7, 8, 8, 9, 2, 8, 6, 6, 9, 1, 6, 8, 8, 3, 2, 3, 6, 3, 6, 5, 7, 0, 8, 4, 6, 5, 8, 2, 3])
         offsets = torch.tensor([0, 19, 20, 28, 28, 32])
         quantized_node = ns.call_module(nnq.EmbeddingBag)
-        inputs = (indices, offsets)
+        example_inputs = (indices, offsets)
 
         for dtype in [torch.quint8, torch.quint4x2]:
             model = M().eval()
@@ -6286,7 +6362,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
                                             weight=float_qparams_observer)
             self.checkGraphModeFxOp(
                 model,
-                inputs,
+                example_inputs,
                 QuantType.DYNAMIC,
                 quantized_node,
                 custom_qconfig_dict={"": float_qparams_qconfig}
@@ -6296,14 +6372,14 @@ class TestQuantizeFxOps(QuantizationTestCase):
         for qconfig in [None, default_qconfig]:
             qconfig_dict = {"": default_qconfig}
             m = M().eval()
-            m = prepare_fx(model, qconfig_dict)
+            m = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
             self.checkGraphModuleNodes(m, expected_node_occurrence={
                 ns.call_module(torch.ao.quantization.MinMaxObserver): 0
             })
             m = convert_fx(m)
             self.checkGraphModuleNodes(m, expected_node=ns.call_module(nn.EmbeddingBag))
             # make sure it runs
-            m(*inputs)
+            m(*example_inputs)
 
     def _test_rnn_impl(self, qconfigs, M, module_type_strs, module_types, sample_input):
         options = itertools.product(qconfigs, module_type_strs)
@@ -6323,7 +6399,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
                     (x, qconfig) for x in module_types
                 ]
             }
-            model_graph = prepare_fx(model_graph, graph_qconfig_dict)
+            model_graph = prepare_fx(model_graph, graph_qconfig_dict, example_inputs=(sample_input,))
             model_graph = convert_fx(model_graph)
             self.assertEqual(model_eager(sample_input), model_graph(sample_input))
             self.checkScriptable(model_graph, [[sample_input]], True)
@@ -6407,7 +6483,8 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 (torch.nn.functional.linear, default_qconfig)
             ]
         }
-        m = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 4),)
+        m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         expected_occurrence = {
             # input and weight of first and second linear, output of first and second linear
             ns.call_module(torch.ao.quantization.MinMaxObserver): 6,
@@ -6456,7 +6533,8 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 (torch.nn.functional.linear, default_qconfig)
             ]
         }
-        m = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 4),)
+        m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         expected_occurrence = {
             # input and weight of linear, output of linear
             ns.call_module(torch.ao.quantization.MinMaxObserver): 3,
@@ -6489,7 +6567,8 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 return x
 
         m = M().eval()
-        m = prepare_fx(m, {"": default_qconfig})
+        example_inputs = (torch.rand(1, 2, 3, 4), torch.rand(3, 4).bool())
+        m = prepare_fx(m, {"": default_qconfig}, example_inputs=example_inputs)
         expected_occurrence = {
             ns.call_module(torch.ao.quantization.MinMaxObserver): 0
         }
@@ -6497,8 +6576,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             m,
             expected_node_occurrence=expected_occurrence)
         m = convert_fx(m)
-        m(torch.rand(1, 2, 3, 4), torch.rand(3, 4).bool())
-        return m
+        m(*example_inputs)
 
     def test_chunk(self):
         class M(torch.nn.Module):
@@ -6507,11 +6585,11 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 x = x + y
                 return x
         m = M().eval()
-        m = prepare_fx(m, {"": default_qconfig})
-        data = torch.rand(2, 2, 2, 2)
-        m(data)
+        example_inputs = (torch.rand(2, 2, 2, 2),)
+        m = prepare_fx(m, {"": default_qconfig}, example_inputs=example_inputs)
+        m(*example_inputs)
         m = convert_fx(m)
-        m(data)
+        m(*example_inputs)
         # make sure everything runs
 
     def test_ref_pattern_multi_use(self):
@@ -6536,7 +6614,8 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 (torch.nn.ReLU, get_default_qconfig("fbgemm")),
             ],
         }
-        m = prepare_fx(m, qconfig_dict)
+        example_inputs = (torch.randn(1, 5),)
+        m = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
         m = convert_fx(m)
         expected_occurrence = {
             ns.call_function(torch.quantize_per_tensor): 1,
@@ -6557,9 +6636,10 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 return z
 
         m = M().eval()
+        example_inputs = (torch.randn(2, 2), torch.randn(2, 2))
         qconfig_dict = {"": torch.ao.quantization.default_qconfig}
-        mp = prepare_fx(m, qconfig_dict)
-        mp(torch.randn(2, 2), torch.randn(2, 2))
+        mp = prepare_fx(m, qconfig_dict, example_inputs=example_inputs)
+        mp(*example_inputs)
         mq = convert_fx(mp)
         expected_occurrence = {
             ns.call_function(torch.matmul): 0,
@@ -6569,7 +6649,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             mq,
             expected_node_occurrence=expected_occurrence)
         # verify no crash
-        res = mq(torch.randn(2, 2), torch.randn(2, 2))
+        res = mq(*example_inputs)
 
 class TestQuantizeFxModels(QuantizationTestCase):
     @skipIfNoFBGEMM
@@ -6589,12 +6669,13 @@ class TestQuantizeFxModels(QuantizationTestCase):
                 return y
 
         input = torch.randn((5, 1, 6, 6)).to('cuda')
+        example_inputs = (input,)
         model = Net().to('cuda').eval()
         qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
-        model_prepared = prepare_fx(model, qconfig_dict)
-        model_prepared(input)
+        model_prepared = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
+        model_prepared(*example_inputs)
         model_quantized = convert_fx(model_prepared, is_reference=True)
-        out = model_quantized(input)
+        out = model_quantized(*example_inputs)
         self.assertEqual(out.device.type, 'cuda')
 
     @skipIfNoFBGEMM
@@ -6618,7 +6699,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
             input = torch.randn((5, 1, 6, 6)).to(device)
             model = Net().to(device).eval()
             qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
-            model_prepared = prepare_fx(model, qconfig_dict)
+            model_prepared = prepare_fx(model, qconfig_dict, example_inputs=(input,))
             model_prepared(input)
             model_prepared.to(device_after)
             model_quantized = convert_fx(model_prepared, is_reference=True)
@@ -6644,8 +6725,8 @@ class TestQuantizeFxModels(QuantizationTestCase):
                 input = torch.randn((5, 1, 6, 6)).to(device)
                 model = Net().to(device).eval()
                 qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
-                model_prepared_first = prepare_fx(model, qconfig_dict)
-                model_prepared_second = prepare_fx(model, qconfig_dict)
+                model_prepared_first = prepare_fx(model, qconfig_dict, example_inputs=(input,))
+                model_prepared_second = prepare_fx(model, qconfig_dict, example_inputs=(input,))
                 model_prepared_first(input)
                 state_dict = model_prepared_first.state_dict()
                 del model_prepared_first
@@ -6660,10 +6741,11 @@ class TestQuantizeFxModels(QuantizationTestCase):
         from torchvision import models
         m = models.mobilenet_v3_small()
         qconfig_dict = {'': torch.quantization.get_default_qat_qconfig('fbgemm')}
-        mp = prepare_qat_fx(m, qconfig_dict)
-        mp(torch.randn(1, 3, 224, 224))
+        example_inputs = (torch.randn(1, 3, 224, 224),)
+        mp = prepare_qat_fx(m, qconfig_dict, example_inputs=example_inputs)
+        mp(*example_inputs)
         mq = convert_fx(mp)
-        res = mq(torch.randn(1, 3, 224, 224))
+        res = mq(*example_inputs)
 
     def _test_model_impl(
             self, mode, name, model, eager_quantizable_model,
@@ -6813,7 +6895,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
         eager = eager_prepare(eager)
 
         qconfig_dict = {"": qconfig}
-        graph = graph_prepare(graph, qconfig_dict)
+        graph = graph_prepare(graph, qconfig_dict, example_inputs=(data[0][0],))
 
         eager_out = eager(data[0][0])
         graph_out = graph(data[0][0])
@@ -6946,7 +7028,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
             eval_output = [[torch.randint(0, 10, (12, 1))]]
 
             model = EmbeddingBagLinear().train()
-            prepared_fx_model = prepare_qat_fx(model, qconfig_dict)
+            prepared_fx_model = prepare_qat_fx(model, qconfig_dict, example_inputs=(train_indices[0][0],))
             test_only_train_fn(prepared_fx_model, train_indices)
             quant_model = convert_fx(prepared_fx_model,
                                      qconfig_dict=qconfig_dict)
@@ -6986,7 +7068,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
             eval_output = [[torch.randint(0, 10, (12, 1))]]
 
             model = EmbeddingLinear().train()
-            prepared_fx_model = prepare_qat_fx(model, qconfig_dict)
+            prepared_fx_model = prepare_qat_fx(model, qconfig_dict, example_inputs=(train_indices[0][0],))
             test_only_train_fn(prepared_fx_model, train_indices)
             quant_model = convert_fx(prepared_fx_model,
                                      qconfig_dict=qconfig_dict)
@@ -7048,8 +7130,8 @@ class TestQuantizeFxModels(QuantizationTestCase):
             activation=ref_fake_quant, weight=ref_weight_fake_quant
         )
         qconfig_dict = {"": ref_qat_qconfig}
-
-        prepared_ref = prepare_qat_fx(model, qconfig_dict)
+        example_inputs = (torch.randn(1, 5),)
+        prepared_ref = prepare_qat_fx(model, qconfig_dict, example_inputs=example_inputs)
 
         custom_fake_quant = FusedMovingAvgObsFakeQuantize.with_args(
             observer=MovingAverageMinMaxObserver,
@@ -7069,7 +7151,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
             activation=custom_fake_quant, weight=custom_weight_fake_quant
         )
         custom_qconfig_dict = {"": custom_qconfig}
-        prepared = prepare_qat_fx(model, custom_qconfig_dict)
+        prepared = prepare_qat_fx(model, custom_qconfig_dict, example_inputs=example_inputs)
 
         prepared.to(device)
         prepared_ref.to(device)

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -34,7 +34,7 @@ from .quantization_patterns import (
 
 from torch.ao.quantization.quantization_types import (
     Pattern,
-    NodePattern
+    NodePattern,
 )
 
 from ._equalize import (
@@ -231,7 +231,7 @@ def prepare_get_standalone_module_configs(
     prepare_custom_config_dict: Dict[str, Any],
     parent_qconfig: QConfigAny,
     parent_backend_config_dict: Optional[Dict[str, Any]],
-) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]:
+) -> Tuple[Dict[str, Any], Tuple[Any], Dict[str, Any], Dict[str, Any]]:
     """
     Returns the standalone module qconfig_dict and prepare_config_dict
     for `node`, assuming that the module pointed to by `node` is
@@ -239,8 +239,11 @@ def prepare_get_standalone_module_configs(
     """
     standalone_module_name = str(node.target)
     standalone_module_type = type(modules[standalone_module_name])  # type: ignore[index]
-    sm_qconfig_dict, sm_prepare_config_dict, sm_backend_config_dict = \
-        get_standalone_module_configs(standalone_module_name, standalone_module_type, prepare_custom_config_dict)
+    sm_qconfig_dict, sm_example_inputs, sm_prepare_config_dict, \
+        sm_backend_config_dict = get_standalone_module_configs(
+            standalone_module_name,
+            standalone_module_type,
+            prepare_custom_config_dict)
     # fallback to use parent module's qconfig if user didn't specify qconfig dict
     if sm_qconfig_dict is None:
         sm_qconfig_dict = {"": parent_qconfig}
@@ -250,7 +253,7 @@ def prepare_get_standalone_module_configs(
     # as well, this can be added later
     if sm_backend_config_dict is None:
         sm_backend_config_dict = parent_backend_config_dict
-    return sm_qconfig_dict, sm_prepare_config_dict, sm_backend_config_dict
+    return sm_qconfig_dict, sm_example_inputs, sm_prepare_config_dict, sm_backend_config_dict
 
 def qat_swap_modules(
         root: torch.nn.Module,
@@ -529,7 +532,7 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
 
     else:
         # custom flow for standalone modules
-        _sm_qconfig_dict, sm_prepare_config_dict, _sm_backend_config_dict = \
+        _sm_qconfig_dict, _, sm_prepare_config_dict, _sm_backend_config_dict = \
             prepare_get_standalone_module_configs(
                 node, modules, prepare_custom_config_dict, qconfig, backend_config_dict)
 
@@ -1301,8 +1304,8 @@ def run_prepare_fx_on_standalone_modules(
         elif not qhandler.is_standalone_module():
             continue
 
-        sm_qconfig_dict, sm_prepare_config_dict, sm_backend_config_dict = \
-            prepare_get_standalone_module_configs(
+        sm_qconfig_dict, sm_example_inputs, sm_prepare_config_dict, \
+            sm_backend_config_dict = prepare_get_standalone_module_configs(
                 root_node, modules, prepare_custom_config_dict, qconfig, backend_config_dict)
 
         standalone_module = modules[root_node.target]
@@ -1313,7 +1316,8 @@ def run_prepare_fx_on_standalone_modules(
                 standalone_module,
                 sm_qconfig_dict,
                 is_qat,
-                sm_prepare_config_dict,
+                example_inputs=sm_example_inputs,
+                prepare_custom_config_dict=sm_prepare_config_dict,
                 backend_config_dict=sm_backend_config_dict)
         preserved_attributes = \
             set(sm_prepare_config_dict.get("preserved_attributes", []))
@@ -1349,6 +1353,7 @@ def prepare(
         qconfig_dict: Any,
         is_qat: bool,
         node_name_to_scope: Dict[str, Tuple[str, type]],
+        example_inputs: Tuple[Any, ...],
         prepare_custom_config_dict: Optional[Dict[str, Any]] = None,
         equalization_qconfig_dict: Optional[Dict[str, Any]] = None,
         backend_config_dict: Optional[Dict[str, Any]] = None,

--- a/torch/ao/quantization/fx/qconfig_utils.py
+++ b/torch/ao/quantization/fx/qconfig_utils.py
@@ -319,9 +319,9 @@ def get_standalone_module_configs(
         custom_config_dict.get("standalone_module_name", [])
     standalone_module_class_configs = \
         custom_config_dict.get("standalone_module_class", [])
-    class_config_map = {x[0]: (x[1], x[2], x[3]) for x in standalone_module_class_configs}
-    name_config_map = {x[0]: (x[1], x[2], x[3]) for x in standalone_module_name_configs}
-    config = class_config_map.get(module_type, (None, None, None))
+    class_config_map = {x[0]: (x[1], x[2], x[3], x[4]) for x in standalone_module_class_configs}
+    name_config_map = {x[0]: (x[1], x[2], x[3], x[4]) for x in standalone_module_name_configs}
+    config = class_config_map.get(module_type, (None, None, None, None))
     # name config has precedence over type config
     config = name_config_map.get(module_name, config)
     return config

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -864,6 +864,7 @@ class QuantizationTestCase(TestCase):
                 qconfig_dict = custom_qconfig_dict
             prepared = prepare(
                 model, qconfig_dict,
+                example_inputs=inputs,
                 prepare_custom_config_dict=prepare_custom_config_dict,
                 backend_config_dict=backend_config_dict)
             if not quant_type == QuantType.DYNAMIC:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/d2go/pull/249

X-link: https://github.com/fairinternal/ClassyVision/pull/104

X-link: https://github.com/pytorch/benchmark/pull/916

X-link: https://github.com/facebookresearch/ClassyVision/pull/791

X-link: https://github.com/facebookresearch/mobile-vision/pull/68

FX Graph Mode Quantization needs to know whether an fx node is a floating point Tensor before it can decide whether to
insert observer/fake_quantize module or not, since we only insert observer/fake_quantize module for floating point Tensors.
Currently we have some hacks to support this by defining some rules like NON_OBSERVABLE_ARG_DICT (https://github.com/pytorch/pytorch/blob/master/torch/ao/quantization/fx/utils.py#L496), but this approach is fragile and we do not plan to maintain it long term in the pytorch code base.

As we discussed in the design review, we'd need to ask users to provide sample args and sample keyword args
so that we can infer the type in a more robust way. This PR starts with changing the prepare_fx and prepare_qat_fx api to require user to either provide
example arguments thrugh example_inputs, Note this api doesn't support kwargs, kwargs can make https://github.com/pytorch/pytorch/pull/76496#discussion_r861230047 (comment) simpler, but
it will be rare, and even then we can still workaround with positional arguments, also torch.jit.trace(https://pytorch.org/docs/stable/generated/torch.jit.trace.html) and ShapeProp: https://github.com/pytorch/pytorch/blob/master/torch/fx/passes/shape_prop.py#L140 just have single positional args, we'll just use a single example_inputs argument for now.

If needed, we can extend the api with an optional example_kwargs. e.g. in case when there are a lot of arguments for forward and it makes more sense to
pass the arguments by keyword

BC-breaking Note:
Before:
```python
m = resnet18(...)
m = prepare_fx(m, qconfig_dict)
# or
m = prepare_qat_fx(m, qconfig_dict)
```
After:
```python
m = resnet18(...)
m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 3, 224, 224),))
# or
m = prepare_qat_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 3, 224, 224),))
```

Test Plan:
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps
python test/test_quantization.py TestQuantizeFxModels

Imported from OSS

**Static Docs Preview: classyvision**
|[Full Site](https://our.intern.facebook.com/intern/staticdocs/eph/D35984526/V30/classyvision/)|

|**Modified Pages**|

Reviewed By: vkuzo, andrewor14

Differential Revision: D35984526

