### PR TITLE
Re-enable ios-12-5 builds

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -128,7 +128,6 @@ jobs:
         ]}
 
   ios-12-5-1-x86-64:
-    if: ${{ false }}
     name: ios-12-5-1-x86-64
     uses: ./.github/workflows/_ios-build-test.yml
     with:


### PR DESCRIPTION
In essence, this is a revert of https://github.com/pytorch/pytorch/pull/77162
Test plan: https://github.com/pytorch/pytorch/runs/6461856319?check_suite_focus=true

Fixes #77163

