### PR TITLE
[CI] Make `install_user.sh` compatible with Focal

### DIFF
--- a/.circleci/docker/common/install_user.sh
+++ b/.circleci/docker/common/install_user.sh
@@ -6,6 +6,8 @@ set -ex
 # jenkins user as ec2-user should have the same user-id
 echo "jenkins:x:1000:1000::/var/lib/jenkins:" >> /etc/passwd
 echo "jenkins:x:1000:" >> /etc/group
+# Needed on focal or newer
+echo "jenkins:*:19110:0:99999:7:::" >>/etc/shadow
 
 # Create $HOME
 mkdir -p /var/lib/jenkins
@@ -19,3 +21,6 @@ chown jenkins:jenkins /usr/local
 # Allow sudo
 # TODO: Maybe we shouldn't
 echo 'jenkins ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/jenkins
+
+# Test that sudo works
+sudo -u jenkins sudo -v

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -38,6 +38,7 @@ jobs:
           - docker-image-name: pytorch-linux-xenial-py3-clang7-onnx
           - docker-image-name: pytorch-linux-xenial-py3.7-gcc5.4
           - docker-image-name: pytorch-linux-xenial-py3.7-gcc7
+          - docker-image-name: pytorch-linux-focal-py3.7-gcc7
     env:
       DOCKER_IMAGE_BASE: 308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${{ matrix.docker-image-name }}
     steps:


### PR DESCRIPTION
By adding explicit `/etc/shadow` entry

Also, add test that it works, by running `sudo -v` as user `jenkins`

