### PR TITLE
added a warning in default_collate when encountering a non cpu tensor

### DIFF
--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -132,12 +132,13 @@ def default_collate(batch):
     elem_type = type(elem)
     if isinstance(elem, torch.Tensor):
         if elem.device != torch.device('cpu'):
-            warn((f'default_collate: Spotted a non-cpu tensor in default_collate (device={elem.device}). '
-            'In typical usage scenarios this is not recommended as it will significantly limit multiprocessing performance, '
-            'resulting in low GPU utilization. '
-            'The recommended approach is to modify your Dataset instances to return either numpy array or cpu tensors in '
-            'their __getitem__ method implementation.'
-            ))
+            warn(
+                f'default_collate: Spotted a non-cpu tensor in default_collate (device={elem.device}). '
+                'In typical usage scenarios this is not recommended as it will significantly limit multiprocessing performance, '
+                'resulting in low GPU utilization. '
+                'The recommended approach is to modify your Dataset instances to return either numpy array or cpu tensors in '
+                'their __getitem__ method implementation.'
+            )
         out = None
         if torch.utils.data.get_worker_info() is not None:
             # If we're in a background process, concatenate directly into a

--- a/torch/utils/data/_utils/collate.py
+++ b/torch/utils/data/_utils/collate.py
@@ -11,7 +11,7 @@ import torch
 import re
 import collections
 from torch._six import string_classes
-
+from warnings import warn
 np_str_obj_array_pattern = re.compile(r'[SaUO]')
 
 
@@ -131,6 +131,13 @@ def default_collate(batch):
     elem = batch[0]
     elem_type = type(elem)
     if isinstance(elem, torch.Tensor):
+        if elem.device != torch.device('cpu'):
+            warn((f'default_collate: Spotted a non-cpu tensor in default_collate (device={elem.device}). '
+            'In typical usage scenarios this is not recommended as it will significantly limit multiprocessing performance, '
+            'resulting in low GPU utilization. '
+            'The recommended approach is to modify your Dataset instances to return either numpy array or cpu tensors in '
+            'their __getitem__ method implementation.'
+            ))
         out = None
         if torch.utils.data.get_worker_info() is not None:
             # If we're in a background process, concatenate directly into a


### PR DESCRIPTION
Fixes #77159

As described in the mentioned [issue](https://github.com/pytorch/pytorch/issues/77159),
it's too easy for a user without pytorch internals knowledge to have very low gpu utilziation due to returning a non-cpu tensor in Dataset __getitem__. The current errors output by pytorch lead the user down a path which doesn't solve the core issue and has bad side effects.

