### PR TITLE
Migrate x86 trunk build/test to macos12

### DIFF
--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -69,6 +69,7 @@ jobs:
           auto-update-conda: true
           python-version: 3.8
           activate-environment: build
+          miniconda-version: latest
 
       - name: Install macOS homebrew dependencies
         run: |

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -69,7 +69,7 @@ jobs:
           auto-update-conda: true
           python-version: 3.8
           activate-environment: build
-          miniconda-version: latest
+          miniconda-version: 4.7.12
 
       - name: Install macOS homebrew dependencies
         run: |

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -65,7 +65,7 @@ jobs:
           auto-update-conda: true
           python-version: 3.8
           activate-environment: build
-          miniconda-version: latest
+          miniconda-version: 4.7.12
 
       - name: Install macOS homebrew dependencies
         run: |

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -65,6 +65,7 @@ jobs:
           auto-update-conda: true
           python-version: 3.8
           activate-environment: build
+          miniconda-version: latest
 
       - name: Install macOS homebrew dependencies
         run: |

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -159,8 +159,7 @@ jobs:
     uses: ./.github/workflows/_mac-build.yml
     with:
       build-environment: macos-11-py3-x86-64
-      xcode-version: "12.4"
-      runner-type: macos-11
+      runner-type: macos-12
       build-generates-artifacts: true
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
@@ -174,8 +173,8 @@ jobs:
       build-environment: macos-11-py3-x86-64
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 2, runner: "macos-11" },
-          { config: "default", shard: 2, num_shards: 2, runner: "macos-11" },
+          { config: "default", shard: 1, num_shards: 2, runner: "macos-12" },
+          { config: "default", shard: 2, num_shards: 2, runner: "macos-12" },
         ]}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -159,6 +159,7 @@ jobs:
     uses: ./.github/workflows/_mac-build.yml
     with:
       build-environment: macos-11-py3-x86-64
+      xcode-version: "13.3.1"
       runner-type: macos-12
       build-generates-artifacts: true
     secrets:
@@ -173,8 +174,8 @@ jobs:
       build-environment: macos-11-py3-x86-64
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 2, runner: "macos-12" },
-          { config: "default", shard: 2, num_shards: 2, runner: "macos-12" },
+          { config: "default", shard: 1, num_shards: 2, runner: "macos-12", xcode-version: "13.3.1" },
+          { config: "default", shard: 2, num_shards: 2, runner: "macos-12", xcode-version: "13.3.1" },
         ]}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -37,7 +37,7 @@ cross_compile_arm64() {
 }
 
 compile_x86_64() {
-  USE_DISTRIBUTED=1 python setup.py bdist_wheel
+  USE_DISTRIBUTED=1 USE_NNPACK=OFF python setup.py bdist_wheel
 }
 
 build_lite_interpreter() {

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -36,7 +36,8 @@ from torch.utils.data.datapipes.map import SequenceWrapper
 from torch._utils import ExceptionWrapper
 from torch.testing._internal.common_utils import (TestCase, run_tests, TEST_NUMPY, IS_WINDOWS,
                                                   IS_IN_CI, NO_MULTIPROCESSING_SPAWN, skipIfRocm, slowTest,
-                                                  load_tests, TEST_WITH_ASAN, TEST_WITH_TSAN, IS_SANDCASTLE)
+                                                  load_tests, TEST_WITH_ASAN, TEST_WITH_TSAN, IS_SANDCASTLE,
+                                                  IS_MACOS)
 
 
 try:
@@ -1375,6 +1376,7 @@ except RuntimeError as e:
         with self.assertRaisesRegex(AssertionError, "ChainDataset only supports IterableDataset"):
             list(iter(ChainDataset([dataset1, self.dataset])))
 
+    @unittest.skipIf(IS_MACOS, "Not working on macos")
     def test_multiprocessing_contexts(self):
         reference = [
             torch.arange(3),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77662
* #77647
* __->__ #77645
* #77644

This will enable MPS building but will NOT test mps
as the runner do not have AMD gpus

Note that we disable nnpack for now due to https://github.com/pytorch/pytorch/issues/76094