### PR TITLE
Migrate cross compilation trunk test to use macos12 to build MPS

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -197,7 +197,7 @@ jobs:
     uses: ./.github/workflows/_mac-build.yml
     with:
       build-environment: macos-10-15-py3-arm64
-      runner-type: macos-10.15
+      runner-type: macos-12
       build-generates-artifacts: false
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77662
* __->__ #77647
* #77645
* #77644

Note that the generated binaries are not tested yet