### PR TITLE
fix grad(torch.tensor()) using lift() operator

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6208,6 +6208,10 @@
 
 - func: lift(Tensor self) -> Tensor
   variants: method
+  dispatch:
+    # Not making it CompositeImplicitAutograd because lift
+    # should be a primitive w.r.t. functorch
+    CompositeExplicitAutograd: lift
 
 - func: is_set_to(Tensor self, Tensor tensor) -> bool
   variants: method

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1653,6 +1653,9 @@
   self: grad.reshape(self.sizes())
   result: auto_linear
 
+- name: lift(Tensor self) -> Tensor
+  self: not_implemented("lift")
+
 - name: unsqueeze(Tensor(a) self, int dim) -> Tensor(a)
   self: grad.squeeze(dim)
   result: auto_linear

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -495,6 +495,8 @@ DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     # just in case
     "_cudnn_rnn",
     "dequantize_self",
+    # lift() should never actually be called with a requires_grad=True tensor,
+    "lift",
 }
 
 DONT_ENFORCE_STORAGE_IMPL_USE_COUNT = {
@@ -502,6 +504,8 @@ DONT_ENFORCE_STORAGE_IMPL_USE_COUNT = {
     "_slow_conv2d_forward",
     "slow_conv3d_forward",
     "channel_shuffle",
+    # lift() should never actually be called with a requires_grad=True tensor,
+    "lift",
     # If an input is returned as-is in output, we cannot guarantee its storage_impl
     # use count to be 1 either.
     *DONT_ENFORCE_TENSOR_IMPL_USE_COUNT,

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -280,7 +280,8 @@ Tensor internal_new_from_data(
     c10::impl::ExcludeDispatchKeyGuard torchdispatchmode_snapshot_guard(c10::DispatchKey::PythonTLSSnapshot);
     // functorch uses FuncTorchDynamicLayerBackMode as a mode key to wrap all
     // tensors returned from operators in special TensorWrapper tensor extension
-    c10::impl::ExcludeDispatchKeyGuard functorch_guard(c10::DispatchKey::FuncTorchDynamicLayerBackMode);
+    c10::impl::ExcludeDispatchKeyGuard functorch_front_guard(c10::DispatchKey::FuncTorchDynamicLayerFrontMode);
+    c10::impl::ExcludeDispatchKeyGuard functorch_back_guard(c10::DispatchKey::FuncTorchDynamicLayerBackMode);
     // We disable DeferredInit handler for similar reasons as functorch.
     c10::impl::ExcludeDispatchKeyGuard deferred_init_guard(c10::DispatchKey::DeferredInit);
     // Note [Functionalization <> torch.Tensor constructor]


### PR DESCRIPTION
Confirmed that this fixes https://github.com/pytorch/functorch/issues/806 locally.

The problem was that in the `torch.tensor()` constructor we needed to exclude both the functorch FrontMode + BackMode keys until we call `at::lift`, since both keys can potentially wrap their outputs into `TensorWrappers`.

Separately, Richard also pointed out that we want `at::lift()` to be a primitive op w.r.t. functorch. Otherwise, if we have multiple layers of transforms like `grad(grad(...))`, the first layer will decompose `at::lift()` into a no-op, and the second layer won't see `at::lift()` at all (and won't perform a second level of wrapping.

I made `at::lift()` a CompositeExplicitAutograd op, but also needed to explicitly op it out of autograd's view tracking / error checking logic.

The idea is that technically `lift` has incorrect alias info, because the no-op kernel for `lift` just returns the input tensor instead of creating a fresh one. But we don't actually want autograd to care about `lift` - `lift` should never be called with a `requires_grad=True` tensor.

Unfortunately that still doesn't fix this extra test though. Gonna take a deeper look at why later:
```
      def test_tensor_ctor_inside_grad_nested(self, device):
          def foo(x):
              z = torch.tensor(0.)
              z.copy_(x)
              return z.sum()

          x = torch.tensor(3.14, device=device)
          functorch.grad(functorch.grad(foo))(x)

# fails with:
  File "/raid/hirsheybar/pytorch/functorch/functorch/_src/eager_transforms.py", line 1086, in wrapper
    flat_grad_input = _autograd_grad(flat_outputs, flat_diff_args, create_graph=True)
  File "/raid/hirsheybar/pytorch/functorch/functorch/_src/eager_transforms.py", line 104, in _autograd_grad
    grad_inputs = torch.autograd.grad(diff_outputs, inputs, grad_outputs,
  File "/raid/hirsheybar/pytorch/torch/autograd/__init__.py", line 276, in grad
    return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
NotImplementedError: Cannot access storage of TensorWrapper
```

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77650

