### PR TITLE
[BE] remove unused RDS pipeline from print_test_stats.py

### DIFF
--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -892,6 +892,7 @@ def write_flaky_test_stats_to_rockset(
                     )
     if len(flaky_tests) > 0:
         import uuid
+
         for flaky_test in flaky_tests:
             flaky_test["job_id"] = os.environ["GHA_WORKFLOW_JOB_ID"]
             flaky_test["workflow_id"] = workflow_id

--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -41,12 +41,7 @@ from tools.stats.s3_stat_parser import (
     Version2Report,
     ReportMetaMeta,
 )
-from tools.stats.scribe import (
-    send_to_scribe,
-    rds_write,
-    register_rds_schema,
-    schema_from_sample,
-)
+from tools.stats.scribe import send_to_scribe
 
 
 SimplerSuite = Dict[str, Version2Case]
@@ -872,7 +867,7 @@ def process_intentional_test_runs(runs: List[TestCase]) -> Tuple[int, int]:
     )
 
 
-def assemble_flaky_test_stats(
+def write_flaky_test_stats_to_rockset(
     duplicated_tests_by_file: Dict[str, DuplicatedDict]
 ) -> Any:
     flaky_tests = []
@@ -896,13 +891,7 @@ def assemble_flaky_test_stats(
                         }
                     )
     if len(flaky_tests) > 0:
-        # write to RDS
-        register_rds_schema("flaky_tests", schema_from_sample(flaky_tests[0]))
-        rds_write("flaky_tests", flaky_tests, only_on_master=False)
-
-        # write to S3 to go to Rockset as well
         import uuid
-
         for flaky_test in flaky_tests:
             flaky_test["job_id"] = os.environ["GHA_WORKFLOW_JOB_ID"]
             flaky_test["workflow_id"] = workflow_id
@@ -1031,32 +1020,6 @@ def send_report_to_s3(head_report: Version2Report) -> None:
     # because for some reason zlib doesn't seem to play nice with the
     # gunzip command whereas Python's bz2 does work with bzip2
     obj.put(Body=bz2.compress(json.dumps(head_report).encode()))
-
-
-def upload_failures_to_rds(reports: Dict[str, TestFile]) -> None:
-    """
-    We have 40k+ tests, so saving every test for every commit is not very
-    feasible for PyTorch. Most of these are things we don't care about anyways,
-    so this code filters out failures and saves only those to the DB.
-    """
-    # Gather all failures across the entire report
-    failures = []
-    for file in reports.values():
-        for suite in file.test_suites.values():
-            for case in suite.test_cases.values():
-                if case.errored or case.failed:
-                    failures.append(
-                        {
-                            "name": case.name,
-                            "suite": suite.name,
-                            "file": file.name,
-                            "status": "failure" if case.failed else "error",
-                        }
-                    )
-
-    if len(failures) > 0:
-        register_rds_schema("test_failures", schema_from_sample(failures[0]))
-        rds_write("test_failures", failures, only_on_master=False)
 
 
 def print_regressions(head_report: Report, *, num_prev_commits: int) -> None:
@@ -1195,9 +1158,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     reports_by_file, duplicated_tests_by_file = parse_reports(args.folder)
-    assemble_flaky_test_stats(duplicated_tests_by_file)
+    write_flaky_test_stats_to_rockset(duplicated_tests_by_file)
 
-    upload_failures_to_rds(reports_by_file)
     if reports_has_no_tests(reports_by_file):
         print(f"No tests in reports found in {args.folder}")
         sys.exit(0)


### PR DESCRIPTION
Now that Grafana is deprecated and we report test status + flaky tests to Rockset, we should remove the need to write to RDS at all. 

Some runners (like ROCm) don't have permissions to write to RDS on pull requests anyway so this was causing a split in stats. 

Next steps:
- Remove RDS in binary_size and sccache stats.