### PR TITLE
Throw a nice error when SubTensor.__torch_dispatch__() returns the wrong type for detach()

### DIFF
--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -39,11 +39,11 @@ class Parameter(torch.Tensor, metaclass=_ParameterMeta):
         # Path for custom tensors: set a flag on the instance to indicate parameter-ness.
         t = data.detach().requires_grad_(requires_grad)
         if type(t) is not type(data):
-            raise RuntimeError("Creating a Parameter from an instance of type {} requires that detach() "
-                               "returns an instance of the same type, but return type {} was found instead. "
-                               "To use the type as a Parameter, please correct the detach() semantics defined by "
-                               "its __torch_dispatch__() implementation.".format(
-                                   type(data).__name__, type(t).__name__))
+            raise RuntimeError(f"Creating a Parameter from an instance of type {type(data).__name__} "
+                               "requires that detach() returns an instance of the same type, but return "
+                               f"type {type(t).__name__} was found instead. To use the type as a "
+                               "Parameter, please correct the detach() semantics defined by "
+                               "its __torch_dispatch__() implementation.")
         t._is_param = True
         return t
 

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -31,7 +31,7 @@ class Parameter(torch.Tensor, metaclass=_ParameterMeta):
     def __new__(cls, data=None, requires_grad=True):
         if data is None:
             data = torch.empty(0)
-        if type(data) is torch.Tensor:
+        if type(data) is torch.Tensor or type(data) is Parameter:
             # For ease of BC maintenance, keep this path for standard Tensor.
             # Eventually (tm), we should change the behavior for standard Tensor to match.
             return torch.Tensor._make_subclass(cls, data, requires_grad)

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -38,6 +38,12 @@ class Parameter(torch.Tensor, metaclass=_ParameterMeta):
 
         # Path for custom tensors: set a flag on the instance to indicate parameter-ness.
         t = data.detach().requires_grad_(requires_grad)
+        if type(t) is not type(data):
+            raise RuntimeError("Creating a Parameter from an instance of type {} requires that detach() "
+                               "returns an instance of the same type, but return type {} was found instead. "
+                               "To use the type as a Parameter, please correct the detach() semantics defined by "
+                               "its __torch_dispatch__() implementation.".format(
+                                   type(data).__name__, type(t).__name__))
         t._is_param = True
         return t
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77655

Addresses part of #77265: raise a nice error if a `SubTensor.__torch_dispatch__()` impl breaks the expected semantics of `detach()` by returning an instance of a different type. This should make it easier to fix a naive, non-rewrapping `__torch_dispatch__()` impl by pointing out the problem explicitly.