### PR TITLE
[flaky test reporting] print stack trace for flaky reruns

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1848,19 +1848,21 @@ class TestCase(expecttest.TestCase):
         if not RETRY_TEST_CASES or not using_unittest:
             return
 
-        err = sys.exc_info()
+        (typ, val, _) = sys.exc_info()
         num_retries_left = num_runs_left - 1
         if failures_before < len(result.failures):
             print(f"    {self._testMethodName} failed - num_retries_left: {num_retries_left}")
             if (report_only and num_retries_left < MAX_NUM_RETRIES) or (not report_only and num_retries_left > 0):
-                result.failures.pop(-1)
-                result.addExpectedFailure(self, err)
+                _, exc_info = result.failures.pop(-1)
+                print(exc_info)
+                result.addExpectedFailure(self, (typ, val, exc_info))
             self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only)
         elif errors_before < len(result.errors):
             print(f"    {self._testMethodName} errored - num_retries_left: {num_retries_left}")
             if (report_only and num_retries_left < MAX_NUM_RETRIES) or (not report_only and num_retries_left > 0):
-                result.errors.pop(-1)
-                result.addExpectedFailure(self, err)
+                _, exc_info = result.errors.pop(-1)
+                print(exc_info)
+                result.addExpectedFailure(self, (typ, val, exc_info))
             self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only)
         elif report_only and num_retries_left < MAX_NUM_RETRIES:
             print(f"    {self._testMethodName} succeeded - num_retries_left: {num_retries_left}")

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1848,21 +1848,21 @@ class TestCase(expecttest.TestCase):
         if not RETRY_TEST_CASES or not using_unittest:
             return
 
-        (typ, val, _) = sys.exc_info()
+        err = sys.exc_info()
         num_retries_left = num_runs_left - 1
         if failures_before < len(result.failures):
             print(f"    {self._testMethodName} failed - num_retries_left: {num_retries_left}")
             if (report_only and num_retries_left < MAX_NUM_RETRIES) or (not report_only and num_retries_left > 0):
-                _, exc_info = result.failures.pop(-1)
-                print(exc_info)
-                result.addExpectedFailure(self, (typ, val, exc_info))
+                _, traceback_str = result.failures.pop(-1)
+                print(traceback_str)
+                result.addExpectedFailure(self, err)
             self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only)
         elif errors_before < len(result.errors):
             print(f"    {self._testMethodName} errored - num_retries_left: {num_retries_left}")
             if (report_only and num_retries_left < MAX_NUM_RETRIES) or (not report_only and num_retries_left > 0):
-                _, exc_info = result.errors.pop(-1)
-                print(exc_info)
-                result.addExpectedFailure(self, (typ, val, exc_info))
+                _, traceback_str = result.errors.pop(-1)
+                print(traceback_str)
+                result.addExpectedFailure(self, err)
             self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only)
         elif report_only and num_retries_left < MAX_NUM_RETRIES:
             print(f"    {self._testMethodName} succeeded - num_retries_left: {num_retries_left}")


### PR DESCRIPTION
Give context about failures ~and include it in the test report~! Unfortunately I cannot include it easily in the test report through the addExpectedFailures :c as tracebacks are not something I can instantiate. (see revert comment)

Current way doesn't print the stack traces, which has been fine because we don't hide the signal and it shows up at the end:
<img width="545" alt="image" src="https://user-images.githubusercontent.com/31798555/168878182-914edc39-369f-40bc-8b35-9d5cd47a6b1c.png">

However, when we want to hide the signal, we'd like to print the stack traces for each failed attempt, as it won't be shown at the end.