### PR TITLE
Make SymInt constructor explicit

### DIFF
--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -31,7 +31,7 @@ class SymbolicIntNode;
 // a traced operation to represent it in LTC or Fx graphs.
 class C10_API SymInt {
  public:
-  SymInt(int64_t d) : data_(d){};
+  explicit SymInt(int64_t d) : data_(d){};
 
   int64_t expect_int() const {
     TORCH_CHECK(!is_symbolic());
@@ -51,7 +51,7 @@ class C10_API SymInt {
     TORCH_CHECK(
         !this->is_symbolic() && !sci.is_symbolic(),
         "Symbolic Add isn't supported yet");
-    return data_ + sci.data_;
+    return SymInt(data_ + sci.data_);
   }
 
   std::shared_ptr<SymbolicIntNode> toSymbolicIntNode();

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1386,7 +1386,7 @@ TEST(ThreadLocalDebugInfoTest, Basic) {
 TEST(TestSymIntArrayRef, BasicConversion) {
   const size_t X = 2, Y = 4, Z = 5;
   std::vector<int64_t> tgt_size_v{2, 4, 5};
-  std::vector<c10::SymInt> tgt_size({X, Y, Z});
+  std::vector<c10::SymInt> tgt_size({SymInt(X), SymInt(Y), SymInt(Z)});
   auto a = at::randn({1, 4, 1}, at::kCPU);
   auto b = a.expand(tgt_size);
   auto c = a.expand(tgt_size_v);

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -637,7 +637,9 @@ inline int64_t PythonArgs::toInt64(int i) {
 }
 
 inline c10::SymInt PythonArgs::toSymInt(int i) {
-  if (!args[i]) return signature.params[i].default_int;
+  if (!args[i]) {
+    return c10::SymInt(signature.params[i].default_int);
+  }
   if (traceable && jit::tracer::isTracing() && THPVariable_Check(args[i])) {
     auto & var = THPVariable_Unpack(args[i]);
     jit::tracer::ArgumentStash::stashValue(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #77666
* #77665

Since we plan to have a bunch of code that is sensitive to whether or
not a SymInt contains a symbolic shape or not, it seems like a bad idea
to have an implicit constructor.

For example, code like:
```
sizes_and_strides_.stride_at_unchecked(dim) = 0;
```

would sail through, and the `0` would get implicitly promoted to a
SymInt.

This is a tradeoff though: it makes code that handles `SymInt`s more
clunky as `int64_t`s and integer literals need to be explicitly wrapped
in `SymInt` before being used.