### PR TITLE
Provide a default implementation of NVFuser callback

### DIFF
--- a/torch/csrc/jit/codegen/cuda/manager.cpp
+++ b/torch/csrc/jit/codegen/cuda/manager.cpp
@@ -368,8 +368,8 @@ void runCudaFusionGroup(const Node* fusion_node, Stack& stack) {
           stack_copy->end() - output_count,
           stack_copy->end());
     }
-    auto graph_str = fusion_node->g(attr::Subgraph)->toString();
-    compare_callback.callback(fused_outputs, fallback_outputs, graph_str);
+    auto& graph = fusion_node->g(attr::Subgraph);
+    compare_callback.callback(fused_outputs, fallback_outputs, graph);
   }
 }
 

--- a/torch/csrc/jit/passes/cuda_graph_fuser.h
+++ b/torch/csrc/jit/passes/cuda_graph_fuser.h
@@ -30,7 +30,7 @@ struct TORCH_API RegisterCudaFuseGraph
 
 struct CudaFuserComparisonCallback {
   using callback_type =
-      std::function<void(const Stack&, const Stack&, const std::string&)>;
+      std::function<void(const Stack&, const Stack&, const std::shared_ptr<Graph>&)>;
   bool run_fallback;
   callback_type callback;
 };

--- a/torch/csrc/jit/passes/cuda_graph_fuser.h
+++ b/torch/csrc/jit/passes/cuda_graph_fuser.h
@@ -29,8 +29,8 @@ struct TORCH_API RegisterCudaFuseGraph
 };
 
 struct CudaFuserComparisonCallback {
-  using callback_type =
-      std::function<void(const Stack&, const Stack&, const std::shared_ptr<Graph>&)>;
+  using callback_type = std::function<
+      void(const Stack&, const Stack&, const std::shared_ptr<Graph>&)>;
   bool run_fallback;
   callback_type callback;
 };

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -720,9 +720,9 @@ void initJITBindings(PyObject* module) {
             auto callback_lambda = [fn_ptr](
                                        const Stack& fused_outputs,
                                        const Stack& unfused_outputs,
-                                       const std::string& graph_ir) {
+                                       const std::shared_ptr<Graph>& graph) {
               py::gil_scoped_acquire acquire{};
-              (*fn_ptr)(fused_outputs, unfused_outputs, graph_ir);
+              (*fn_ptr)(fused_outputs, unfused_outputs, graph);
             };
             setCudaFuserComparisonCallback({run_fallback, callback_lambda});
           })

--- a/torch/utils/jit/nvfuser_compare.py
+++ b/torch/utils/jit/nvfuser_compare.py
@@ -1,0 +1,12 @@
+import torch
+
+class CompareLog():
+    def __init__(self):
+        pass
+
+    def callback(self, arg1, arg, arg3):
+        pass
+
+def register_compare_log(options):
+    logger = CompareLog()
+    torch._C._jit_set_nvfuser_comparison_callback(logger, True)

--- a/torch/utils/jit/nvfuser_compare.py
+++ b/torch/utils/jit/nvfuser_compare.py
@@ -1,13 +1,30 @@
 import torch
+
+import csv
+import json
+import sys
+
 from dataclasses import dataclass
+from typing import List, Dict
 
 class ComparisonResult():
     graph: str
+    output_idx: int
     rel_diff: float
     abs_diff: float
-    expected_dtype = torch.int
-    actual_dtype = torch.int
+    unfused_dtype: str
+    fused_dtype: str
     ops_count: float
+
+    def asdict(self):
+        return {
+            "graph": self.graph,
+            "output_idx": self.output_idx,
+            "rel_diff": self.rel_diff,
+            "unfused_dtype": self.unfused_dtype,
+            "fused_dtype": self.fused_dtype,
+            "ops_count": self.ops_count,
+        }
 
 def count_nonconstant_ops(graph):
     count = 0
@@ -22,9 +39,12 @@ class CompareLogger():
         self.results = []
 
     def callback(self, fused_outputs, unfused_outputs, graph):
-        for fused, unfused in zip(fused_outputs, unfused_outputs):
+        for i in range(len(fused_outputs)):
+            fused = fused_outputs[i]
+            unfused = unfused_outputs[i]
             result = ComparisonResult()
             result.graph = str(graph)
+            result.output_idx = i
             result.ops_count = count_nonconstant_ops(graph)
             result.abs_diff = torch.max(torch.abs(fused - unfused)).item()
             matches = (fused == unfused)
@@ -32,15 +52,44 @@ class CompareLogger():
             rel_diff_tensor[matches] = 0
             result.rel_diff = torch.max(rel_diff_tensor).item()
 
-            result.unfused_dtype = unfused.dtype
-            result.fused_dtype = fused.dtype
+            result.unfused_dtype = str(unfused.dtype)
+            result.fused_dtype = str(fused.dtype)
             self.results.append(result)
 
-    def dump(self):
-        for result in self.results:
-            print(result.graph, result.rel_diff, result.abs_diff, result.expected_dtype, result.actual_dtype, result.ops_count)
+    def dedup_graphs(self, graphs: List[str]) -> Dict[str, int]:
+        counter = 1
+        result = {}
+        for g in graphs:
+            if g not in result:
+                result[g] = counter
+                counter += 1
 
-def register_compare_log(options):
-    logger = CompareLogger()
-    torch._C._jit_nvfuser_set_comparison_callback(True, logger)
-    return logger
+        return result
+
+    def dump_without_graphs(self, dump_to=None, export_format='csv'):
+        if dump_to is None:
+            dump_to = sys.stdout
+        graph_idx = self.dedup_graphs([x.graph for x in self.results])
+        data = []
+        for result in self.results:
+            data_dict = result.asdict()
+            data_dict["graph_idx"] = graph_idx[data_dict["graph"]]
+            del data_dict["graph"]
+            data.append(data_dict)
+        if export_format == 'csv':
+            cols = ["graph_idx", "output_idx", "rel_diff", "abs_diff", "unfused_dtype", "fused_dtype", "ops_count"]
+            writer = csv.DictWriter(dump_to, fieldnames=cols)
+            writer.writeheader()
+            for d in data:
+                writer.writerow(d)
+        elif export_format == 'json':
+            json.dump(data, dump_to, indent=4)
+
+    def dump_graphs(self, dump_to=None):
+        if dump_to is None:
+            dump_to = sys.stdout
+
+        graph_idx = self.dedup_graphs([x.graph for x in self.results])
+        reverse = {v: k for k, v in graph_idx.items()}
+
+        json.dump(reverse, dump_to, indent=4)

--- a/torch/utils/jit/nvfuser_compare.py
+++ b/torch/utils/jit/nvfuser_compare.py
@@ -4,7 +4,6 @@ import csv
 import json
 import sys
 
-from dataclasses import dataclass
 from typing import List, Dict
 
 class ComparisonResult():

--- a/torch/utils/jit/nvfuser_compare.py
+++ b/torch/utils/jit/nvfuser_compare.py
@@ -1,12 +1,35 @@
 import torch
 
-class CompareLog():
-    def __init__(self):
-        pass
+@dataclass
+class ComparisonResult():
+    graph: str
+    rel_diff: float
+    abs_diff: float
+    ops_count: float
 
-    def callback(self, arg1, arg, arg3):
-        pass
+def count_nonconstant_ops(graph):
+    count = 0
+    for n in graph.nodes():
+        if n.kind() != 'prim::Constant':
+            count += 1
+    return count
+
+class CompareLogger():
+    def __init__(self, print_all=True):
+        self.print_all = print_all
+
+    def callback(self, fused_outputs, unfused_outputs, graph):
+        result = ComparisonResult()
+        result.graph = str(graph)
+        result.ops_count = count_nonconstant_ops(graph)
+
+        abs_diff = torch.max(torch.abs(fused_outputs - unfused_outputs)).item()
+        matches = (fused_outputs == unfused_outputs)
+        rel_diff_tensor = torch.abs(fused_outputs - unfused_outputs) / torch.abs(unfused_outputs)
+        rel_diff_tensor[matches] = 0
+        rel_diff = torch.max(rel_diff_tensor).item()
 
 def register_compare_log(options):
-    logger = CompareLog()
-    torch._C._jit_set_nvfuser_comparison_callback(logger, True)
+    logger = CompareLogger()
+    torch._C._jit_nvfuser_set_comparison_callback(True, logger)
+    return logger

--- a/torch/utils/jit/nvfuser_compare.py
+++ b/torch/utils/jit/nvfuser_compare.py
@@ -1,10 +1,12 @@
 import torch
+from dataclasses import dataclass
 
-@dataclass
 class ComparisonResult():
     graph: str
     rel_diff: float
     abs_diff: float
+    expected_dtype = torch.int
+    actual_dtype = torch.int
     ops_count: float
 
 def count_nonconstant_ops(graph):
@@ -17,17 +19,26 @@ def count_nonconstant_ops(graph):
 class CompareLogger():
     def __init__(self, print_all=True):
         self.print_all = print_all
+        self.results = []
 
     def callback(self, fused_outputs, unfused_outputs, graph):
-        result = ComparisonResult()
-        result.graph = str(graph)
-        result.ops_count = count_nonconstant_ops(graph)
+        for fused, unfused in zip(fused_outputs, unfused_outputs):
+            result = ComparisonResult()
+            result.graph = str(graph)
+            result.ops_count = count_nonconstant_ops(graph)
+            result.abs_diff = torch.max(torch.abs(fused - unfused)).item()
+            matches = (fused == unfused)
+            rel_diff_tensor = torch.abs(fused - unfused) / torch.abs(unfused)
+            rel_diff_tensor[matches] = 0
+            result.rel_diff = torch.max(rel_diff_tensor).item()
 
-        abs_diff = torch.max(torch.abs(fused_outputs - unfused_outputs)).item()
-        matches = (fused_outputs == unfused_outputs)
-        rel_diff_tensor = torch.abs(fused_outputs - unfused_outputs) / torch.abs(unfused_outputs)
-        rel_diff_tensor[matches] = 0
-        rel_diff = torch.max(rel_diff_tensor).item()
+            result.unfused_dtype = unfused.dtype
+            result.fused_dtype = fused.dtype
+            self.results.append(result)
+
+    def dump(self):
+        for result in self.results:
+            print(result.graph, result.rel_diff, result.abs_diff, result.expected_dtype, result.actual_dtype, result.ops_count)
 
 def register_compare_log(options):
     logger = CompareLogger()


### PR DESCRIPTION
Fixes #76007

This provides an implementation of an NVFuser callback which records:
* Graphs
* Relative and absolute difference
* Dtypes
* Number of ops (e.g. accuracy may be expected to decrease for fusions with many ops)

Usage:
```python
import sys
import torch
from torch.utils.jit.nvfuser_compare import CompareLogger

logger = CompareLogger()
torch._C._jit_nvfuser_set_comparison_callback(True, logger.callback)

# do things that use NVFuser

torch._C._jit_nvfuser_clear_comparison_callback()
data=io.BytesIO()
logger.dump_without_graphs(dump_to=data, export_format='json')
graphs=io.BytesIO()
logger.dump_graphs(dump_to=graphs)
# do something with `data` and `graphs`
```