### PR TITLE
[LT] Implement lazy allreduce

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -214,14 +214,9 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
       std::vector<at::Tensor>& tensors,
       const BroadcastOptions& opts = {});
 
-  virtual c10::intrusive_ptr<ProcessGroup::Work> allreduce(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceOptions& /* opts */ = AllreduceOptions()) {
-    TORCH_CHECK(
-        false,
-        c10::str(
-            "ProcessGroup ", getBackendName(), "does not support allreduce"));
-  }
+  c10::intrusive_ptr<ProcessGroup::Work> allreduce(
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = {});
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> allreduce_coalesced(
       std::vector<at::Tensor>& /* tensors */,
@@ -435,6 +430,15 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
         false,
         c10::str(
             "ProcessGroup ", getBackendName(), "does not support broadcast"));
+  }
+
+    virtual c10::intrusive_ptr<ProcessGroup::Work> allreduce_impl(
+      std::vector<at::Tensor>& /* tensors */,
+      const AllreduceOptions& /* opts */ = AllreduceOptions()) {
+    TORCH_CHECK(
+        false,
+        c10::str(
+            "ProcessGroup ", getBackendName(), "does not support allreduce"));
   }
 
  protected:

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.cpp
@@ -1414,7 +1414,7 @@ class AsyncSparseAllreduceCUDAWork : public AsyncSparseAllreduceWork {
 
 } // namespace
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupGloo::allreduce(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupGloo::allreduce_impl(
     std::vector<at::Tensor>& inputs,
     const AllreduceOptions& opts) {
   static auto invalidArgument = [](const std::string& msg) {

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -227,7 +227,7 @@ class TORCH_API ProcessGroupGloo : public ProcessGroup {
       std::vector<at::Tensor>& tensors,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allreduce(
+  c10::intrusive_ptr<ProcessGroup::Work> allreduce_impl(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -399,7 +399,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::broadcast_impl(
       c10::optional<std::vector<at::Tensor>>(tensors));
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::allreduce(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::allreduce_impl(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts) {
   checkSingleTensor(tensors);

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
@@ -150,7 +150,7 @@ class TORCH_API ProcessGroupMPI : public ProcessGroup {
       std::vector<at::Tensor>& data,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allreduce(
+  c10::intrusive_ptr<ProcessGroup::Work> allreduce_impl(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1659,7 +1659,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::pointToPoint(
       profilingTitle);
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce_impl(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce_intern(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts) {
   return collective(
@@ -1682,7 +1682,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce_impl(
       "nccl:all_reduce");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce_impl(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts) {
   check_gpu_tensors_different_devices(tensors);
@@ -1698,7 +1698,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce(
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>()); // outSplitSizes
 
-  return allreduce_impl(tensors, opts);
+  return allreduce_intern(tensors, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce_coalesced(
@@ -1717,7 +1717,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::allreduce_coalesced(
       std::vector<int64_t>(), // inSplitSizes
       std::vector<int64_t>()); // outSplitSizes
 
-  return allreduce_impl(tensors, opts);
+  return allreduce_intern(tensors, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::broadcast_impl(

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -273,7 +273,7 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
       std::vector<at::Tensor>& tensors,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allreduce(
+  c10::intrusive_ptr<ProcessGroup::Work> allreduce_impl(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
@@ -436,7 +436,7 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
       PostProcess post,
       const char* profilingTitle);
 
-  c10::intrusive_ptr<ProcessGroup::Work> allreduce_impl(
+  c10::intrusive_ptr<ProcessGroup::Work> allreduce_intern(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions());
 

--- a/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.cpp
@@ -23,7 +23,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::broadcast_impl(
   return next()->broadcast(tensors, opts);
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::allreduce(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::allreduce_impl(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts) {
   return next()->allreduce(tensors, opts);

--- a/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.hpp
@@ -35,7 +35,7 @@ class TORCH_API ProcessGroupRoundRobin final : public ProcessGroup {
       std::vector<at::Tensor>& tensors,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allreduce(
+  c10::intrusive_ptr<ProcessGroup::Work> allreduce_impl(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -192,7 +192,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::broadcast_impl(
   return pg_->broadcast(data, opts);
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::allreduce(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::allreduce_impl(
     std::vector<at::Tensor>& data,
     const AllreduceOptions& opts) {
   runCollectiveChecks(OpType::ALLREDUCE, data);

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -21,7 +21,7 @@ class TORCH_API ProcessGroupWrapper : public ProcessGroup {
       std::vector<at::Tensor>& data,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allreduce(
+  c10::intrusive_ptr<ProcessGroup::Work> allreduce_impl(
       std::vector<at::Tensor>& data,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 

--- a/torch/csrc/distributed/c10d/PyProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/PyProcessGroup.hpp
@@ -47,13 +47,13 @@ class PyProcessGroup : public ProcessGroup {
         opts);
   }
 
-  c10::intrusive_ptr<ProcessGroup::Work> allreduce(
+  c10::intrusive_ptr<ProcessGroup::Work> allreduce_impl(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override {
     PYBIND11_OVERRIDE(
         c10::intrusive_ptr<ProcessGroup::Work>, /* Return type */
         ProcessGroup, /* Parent class */
-        allreduce, /* Name of function in C++ */
+        allreduce_impl, /* Name of function in C++ */
         tensors,
         opts);
   }

--- a/torch/csrc/lazy/ts_backend/ops/allreduce.h
+++ b/torch/csrc/lazy/ts_backend/ops/allreduce.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <c10d/ProcessGroup.hpp>
+#include <torch/csrc/lazy/ts_backend/ts_node.h>
+
+namespace torch {
+namespace lazy {
+
+struct Allreduce : public TsNode {
+  Allreduce(const Value& input, const c10::intrusive_ptr<c10d::ProcessGroup>& process_group,
+      int64_t reduce_op, int64_t timeout, std::vector<Shape>&& shapes)
+    : TsNode(OpKind(c10::Symbol::fromQualString("c10d::allreduce_")),
+          {input}, std::move(shapes), /* num_outputs */ 1,
+          MHash(reduce_op, timeout)),
+      process_group(process_group),
+      reduce_op(reduce_op),
+      timeout(timeout) {}
+
+  std::string ToString() const override {
+    std::stringstream ss;
+    ss << TsNode::ToString();
+    ss << ", process_group=" << process_group->getBackendName() << ", reduce_op=" << reduce_op
+        << ", timeout=" << timeout;
+    return ss.str();
+  }
+
+  TSOpVector Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+      TSLoweringContext* loctx) const override {
+    std::vector<torch::jit::NamedValue> arguments;
+    arguments.reserve(4);
+    arguments.emplace_back(loctx->GetOutputOp(operand(0)));
+    arguments.emplace_back("process_group", process_group);
+    arguments.emplace_back("reduce_op", reduce_op);
+    arguments.emplace_back("timeout", timeout);
+
+    auto out = torch::lazy::LowerTSBuiltin(function, op().op, arguments);
+    TORCH_INTERNAL_ASSERT(out.size(), 1);
+
+    return out;
+  }
+
+  c10::intrusive_ptr<c10d::ProcessGroup> process_group;
+  int64_t reduce_op;
+  int64_t timeout;
+};
+
+}  // namespace lazy
+}  // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #77940
* #77813
* #77806
* __->__ #77686
* #77670
* #77443
* #77408
* #76946
* #76722

Summary:
This is a WIP patch to implement c10d::allreduce for LazyTensor such that
we can trace it properly in the graph.

Test Plan:
python test/lazy/test_c10d.py