### PR TITLE
[pytorch][PR] [Profiler] Add EventFieldsVisitor

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -344,10 +344,14 @@ TORCH_API void enableProfiler(
  * callback, via enableProfilerWithEventPostProcess, that takes these debug handles
  * and generates stack trace and module hierarchy information, once profiling is done.
  */
+using post_process_t = std::function<void(
+    /*debug_handle */ int64_t,
+    /*jit_stack    */ std::vector<std::string>&,
+    /*jit_modules  */ std::vector<std::string>&)>;
 TORCH_API void enableProfilerWithEventPostProcess(
     const torch::profiler::impl::ProfilerConfig& config,
     const std::set<torch::profiler::impl::ActivityType>& activities,
-    std::function<void(std::vector<KinetoEvent>&)>&& cb,
+    post_process_t&& cb,
     const std::unordered_set<at::RecordScope>& scopes = {});
 
 TORCH_API std::unique_ptr<ProfilerResult> disableProfiler();

--- a/torch/csrc/jit/mobile/profiler_edge.cpp
+++ b/torch/csrc/jit/mobile/profiler_edge.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/Exception.h>
+#include <c10/util/overloaded.h>
 #include <torch/csrc/jit/mobile/profiler_edge.h>
 #include <string>
 #include <vector>
@@ -28,33 +29,26 @@ KinetoEdgeCPUProfiler::KinetoEdgeCPUProfiler(
   torch::autograd::profiler::prepareProfiler(
       config, {torch::autograd::profiler::ActivityType::CPU});
   if (with_modules || with_stack) {
-    auto post_processing =
-        [this, with_stack, with_modules](
-            std::vector<torch::autograd::profiler::KinetoEvent>& events) {
-          std::string no_debug_info(
-              "Model was not saved with debug information");
-          for (auto& e : events) {
-            if (with_modules) {
-              // Since KinetoEvents's module hierarchy takes vector of strings
-              // we just construct a temporary vector using one string element
-              if (this->m_.hasDebugHandles()) {
-                e.moduleHierarchy(std::vector<std::string>(
-                    {this->m_.getModuleHierarchy(e.debugHandle())}));
-              } else {
-                e.moduleHierarchy(std::vector<std::string>({no_debug_info}));
-              }
-            } else if (with_stack) {
-              // Since KinetoEvents's stack trace takes vector of strings we
-              // just construct a temporary vector using one string element
-              if (this->m_.hasDebugHandles()) {
-                e.stack(std::vector<std::string>(
-                    {this->m_.getCallStack(e.debugHandle())}));
-              } else {
-                e.stack(std::vector<std::string>({no_debug_info}));
-              }
-            }
-          }
-        };
+    auto post_processing = [this, with_stack, with_modules](
+                               int64_t debug_handle,
+                               std::vector<std::string>& jit_stack,
+                               std::vector<std::string>& jit_modules) {
+      std::string no_debug_info("Model was not saved with debug information");
+      if (with_modules) {
+        // Since KinetoEvents's module hierarchy takes vector of strings
+        // we just construct a temporary vector using one string element
+        jit_modules = std::vector<std::string>(
+            {this->m_.hasDebugHandles()
+                 ? this->m_.getModuleHierarchy(debug_handle)
+                 : no_debug_info});
+      } else if (with_stack) {
+        // Since KinetoEvents's stack trace takes vector of strings we
+        // just construct a temporary vector using one string element
+        jit_stack = std::vector<std::string>(
+            {this->m_.hasDebugHandles() ? this->m_.getCallStack(debug_handle)
+                                        : no_debug_info});
+      }
+    };
     torch::autograd::profiler::enableProfilerWithEventPostProcess(
         config,
         {torch::autograd::profiler::ActivityType::CPU},


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #77699
* #77698
* #77697
* #77696
* #77695
* #77694
* #77693
* #77692
* __->__ #77691

One source of complexity in profiler_kineto is that we do most things twice: once to set a field in `kineto_events_.back()`, and once for the metadata json. These have historically been chained, with the KinetoEvent used to populate the metadata fields. However this is hard to read and error prone, as we have one giant block of assignments followed by another giant block. It also means that logic about whether a field is present or not is duplicated.

This PR replaces this logic with a visitor that writes both together. E.g.
```
    auto& dtypes = result_.get().inputs_.dtypes_;
    if (!dtypes.empty()) {
      kineto_event_.get().dtypes(dtypes);
      out.emplace_back("Input type", dtypesToStr(dtypes));
    }
```

Differential Revision: [D36070202](https://our.internmc.facebook.com/intern/diff/D36070202/)