### PR TITLE
[FSDP][Easy] Remove extraneous print

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3126,8 +3126,6 @@ class FullyShardedDataParallel(nn.Module):
                 curr_iter_param_names = [
                     eod.get_unflat_param_names(index) for index in curr_param_order
                 ]
-                print(first_iter_param_names, type(first_iter_param_names))
-                print(curr_iter_param_names, type(curr_iter_param_names))
                 warnings.warn(
                     "Forward order differs from that of the first iteration "
                     f"on rank {self.rank} -- collectives are unchecked and may "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#77705 [FSDP][Easy] Remove extraneous print**

This removes two `print()`s that I let slip through.