### PR TITLE
Add test_imports

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1780,7 +1780,7 @@ class TestImports(TestCase):
         if not sys.version_info >= (3, 8):
             ignored_modules.append("torch.utils.benchmark")
         if IS_WINDOWS:
-            ignored_modules.append("torch.distributed.rpc.")
+            ignored_modules.append("torch.distributed.")
 
         torch_dir = os.path.dirname(torch.__file__)
         for base, folders, files in os.walk(torch_dir):
@@ -1794,8 +1794,10 @@ class TestImports(TestCase):
                     continue
                 if any(mod_name.startswith(x) for x in ignored_modules):
                     continue
-                print(mod_name)
-                mod = importlib.import_module(mod_name)
+                try:
+                    mod = importlib.import_module(mod_name)
+                except Exception as e:
+                    raise RuntimeError(f"Failed to import {mod_name}: {e}") from e
                 self.assertTrue(inspect.ismodule(mod))
 
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1780,7 +1780,9 @@ class TestImports(TestCase):
         if not sys.version_info >= (3, 8):
             ignored_modules.append("torch.utils.benchmark")
         if IS_WINDOWS:
+            # Distributed does not work on Windows
             ignored_modules.append("torch.distributed.")
+            ignored_modules.append("torch.testing._internal.dist_utils")
 
         torch_dir = os.path.dirname(torch.__file__)
         for base, folders, files in os.walk(torch_dir):

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1777,7 +1777,7 @@ class TestImports(TestCase):
                            "torch.testing._internal.distributed.",  # just fails
                            ]
         # See https://github.com/pytorch/pytorch/issues/77801
-        if not sys.version_info >= (3, 8):
+        if not sys.version_info >= (3, 9):
             ignored_modules.append("torch.utils.benchmark")
         if IS_WINDOWS:
             # Distributed does not work on Windows

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -9,6 +9,7 @@ import itertools
 import math
 import os
 import re
+import sys
 import unittest.mock
 from typing import Any, Callable, Iterator, List, Tuple
 
@@ -1777,7 +1778,7 @@ class TestImports(TestCase):
                            ]
         # See https://github.com/pytorch/pytorch/issues/77801
         if not sys.version_info >= (3, 8):
-            ignored_modules.append("torch.utils.benchmark.examples.")
+            ignored_modules.append("torch.utils.benchmark")
         if IS_WINDOWS:
             ignored_modules.append("torch.distributed.rpc.")
 
@@ -1791,16 +1792,9 @@ class TestImports(TestCase):
                 # Do not attempt to import executable modules
                 if f == "__main__.py":
                     continue
-                ignored_modules = ["torch.utils.tensorboard",  # deps on tensorboard
-                                   "torch.distributed.elastic.rendezvous",  # depps on etcd
-                                   "torch.backends._coreml",  # depends on pycoreml
-                                   "torch.contrib.",  # something weird
-                                   "torch.testing._internal.common_fx2trt",  # needs fx
-                                   "torch.testing._internal.distributed.",  # just fails
-                                   ]
-
                 if any(mod_name.startswith(x) for x in ignored_modules):
                     continue
+                print(mod_name)
                 mod = importlib.import_module(mod_name)
                 self.assertTrue(inspect.ismodule(mod))
 


### PR DESCRIPTION
That validates that every PyTorch submodule can be imported

Prevents regressions like the one described in https://github.com/pytorch/pytorch/issues/77441 from happening in the future

