### PR TITLE
Make ShufflerDataPipe deterministic for SP & MP DataLoader

### DIFF
--- a/torch/utils/data/__init__.py
+++ b/torch/utils/data/__init__.py
@@ -19,9 +19,9 @@ from torch.utils.data.dataset import (
 )
 from torch.utils.data.datapipes.datapipe import (
     DFIterDataPipe,
+    DataChunk,
     IterDataPipe,
     MapDataPipe,
-    DataChunk,
 )
 from torch.utils.data.dataloader import (
     DataLoader,

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -526,7 +526,6 @@ class _BaseDataLoaderIter(object):
     def __init__(self, loader: DataLoader) -> None:
         self._dataset = loader.dataset
         if isinstance(self._dataset, IterDataPipe):
-            shuffle_seed = torch.empty((), dtype=torch.int64).random_(generator=loader.generator).item()
             self._dataset = torch.utils.data.graph_settings.apply_shuffle_seed(self._dataset, loader.generator)
         self._dataset_kind = loader._dataset_kind
         self._IterableDataset_len_called = loader._IterableDataset_len_called

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -525,6 +525,9 @@ class DataLoader(Generic[T_co]):
 class _BaseDataLoaderIter(object):
     def __init__(self, loader: DataLoader) -> None:
         self._dataset = loader.dataset
+        if isinstance(self._dataset, IterDataPipe):
+            shuffle_seed = torch.empty((), dtype=torch.int64).random_(generator=loader.generator).item()
+            self._dataset = torch.utils.data.graph_settings.apply_shuffle_seed(self._dataset, loader.generator)
         self._dataset_kind = loader._dataset_kind
         self._IterableDataset_len_called = loader._IterableDataset_len_called
         self._auto_collation = loader._auto_collation

--- a/torch/utils/data/datapipes/iter/combinatorics.py
+++ b/torch/utils/data/datapipes/iter/combinatorics.py
@@ -1,4 +1,5 @@
 import random
+import torch
 
 from torch.utils.data import Sampler, SequentialSampler
 from torch.utils.data.datapipes._decorator import functional_datapipe
@@ -84,8 +85,11 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
     """
     datapipe: IterDataPipe[T_co]
     buffer_size: int
-    _shuffle_enabled: bool
-    buffer: List[T_co]
+    _buffer: List[T_co]
+    _enabled: bool
+    _running: bool
+    _seed: Optional[int]
+    _rng: random.Random
 
     def __init__(self,
                  datapipe: IterDataPipe[T_co],
@@ -94,7 +98,9 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
                  unbatch_level: int = 0
                  ) -> None:
         super().__init__()
-        self.buffer: List[T_co] = []
+        # TODO: Performance optimization
+        #       buffer can be a fixed size and remove expensive `append()` and `len()` operations
+        self._buffer: List[T_co] = []
         assert buffer_size > 0, "buffer_size should be larger than 0"
         if unbatch_level == 0:
             self.datapipe = datapipe
@@ -102,17 +108,16 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
             self.datapipe = datapipe.unbatch(unbatch_level=unbatch_level)
         self.buffer_size = buffer_size
         self._enabled = True
-
-    @staticmethod
-    def buffer_replace(buffer, x):
-        idx = random.randint(0, len(buffer) - 1)
-        val = buffer[idx]
-        buffer[idx] = x
-        return val
+        self._running = False
+        self._seed = None
+        self._rng = random.Random()
 
     def set_shuffle(self, shuffle=True):
         self._enabled = shuffle
         return self
+
+    def set_seed(self, seed: int):
+        self._seed = seed
 
     def __iter__(self) -> Iterator[T_co]:
         if not self._enabled:
@@ -120,13 +125,16 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
                 yield x
         else:
             for x in self.datapipe:
-                if len(self.buffer) == self.buffer_size:
-                    yield ShufflerIterDataPipe.buffer_replace(self.buffer, x)
+                if len(self._buffer) == self.buffer_size:
+                    idx = self._rng.randint(0, len(self._buffer) - 1)
+                    val, self._buffer[idx] = self._buffer[idx], x
+                    yield val
                 else:
-                    self.buffer.append(x)
-            random.shuffle(self.buffer)
-            while self.buffer:
-                yield self.buffer.pop()
+                    self._buffer.append(x)
+            self._rng.shuffle(self._buffer)
+            while self._buffer:
+                yield self._buffer.pop()
+            self._running = False
 
     def __len__(self) -> int:
         if isinstance(self.datapipe, Sized):
@@ -134,7 +142,13 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))
 
     def reset(self) -> None:
-        self.buffer = []
+        if not self._running:
+            self._buffer = []
+            if self._enabled and self._seed is None:
+                self._seed = torch.empty((), dtype=torch.int64).random_().item()
+            self._rng.seed(self._seed)
+            self._seed = None
+        self._running = True
 
     def __getstate__(self):
         if IterDataPipe.getstate_hook is not None:
@@ -142,7 +156,10 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         state = (
             self.datapipe,
             self.buffer_size,
-            self._enabled
+            self._enabled,
+            self._running,
+            self._seed,
+            self._rng.getstate(),
         )
         return state
 
@@ -150,9 +167,14 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         (
             self.datapipe,
             self.buffer_size,
-            self._enabled
+            self._enabled,
+            self._running,
+            self._seed,
+            rng_state,
         ) = state
-        self.buffer = []
+        self._rng = random.Random()
+        self._rng.setstate(rng_state)
+        self._buffer = []
 
     def __del__(self):
-        self.buffer.clear()
+        self._buffer.clear()

--- a/torch/utils/data/datapipes/iter/combinatorics.py
+++ b/torch/utils/data/datapipes/iter/combinatorics.py
@@ -145,7 +145,7 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         if not self._running:
             self._buffer = []
             if self._enabled and self._seed is None:
-                self._seed = torch.empty((), dtype=torch.int64).random_().item()
+                self._seed = int(torch.empty((), dtype=torch.int64).random_().item())
             self._rng.seed(self._seed)
             self._seed = None
         self._running = True

--- a/torch/utils/data/datapipes/iter/combinatorics.py
+++ b/torch/utils/data/datapipes/iter/combinatorics.py
@@ -124,6 +124,8 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
             for x in self.datapipe:
                 yield x
         else:
+            self._rng.seed(self._seed)
+            self._seed = None
             for x in self.datapipe:
                 if len(self._buffer) == self.buffer_size:
                     idx = self._rng.randint(0, len(self._buffer) - 1)
@@ -145,8 +147,6 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
             self._buffer = []
             if self._enabled and self._seed is None:
                 self._seed = int(torch.empty((), dtype=torch.int64).random_().item())
-            self._rng.seed(self._seed)
-            self._seed = None
         else:
             self._restored = False
 

--- a/torch/utils/data/datapipes/iter/combinatorics.py
+++ b/torch/utils/data/datapipes/iter/combinatorics.py
@@ -89,7 +89,6 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
     _enabled: bool
     _seed: Optional[int]
     _rng: random.Random
-    _restored: bool
 
     def __init__(self,
                  datapipe: IterDataPipe[T_co],
@@ -110,7 +109,6 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         self._enabled = True
         self._seed = None
         self._rng = random.Random()
-        self._restored = False
 
     def set_shuffle(self, shuffle=True):
         self._enabled = shuffle
@@ -143,12 +141,9 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))
 
     def reset(self) -> None:
-        if not self._restored:
-            self._buffer = []
-            if self._enabled and self._seed is None:
-                self._seed = int(torch.empty((), dtype=torch.int64).random_().item())
-        else:
-            self._restored = False
+        self._buffer = []
+        if self._enabled and self._seed is None:
+            self._seed = int(torch.empty((), dtype=torch.int64).random_().item())
 
     def __getstate__(self):
         if IterDataPipe.getstate_hook is not None:
@@ -173,7 +168,6 @@ class ShufflerIterDataPipe(IterDataPipe[T_co]):
         self._rng = random.Random()
         self._rng.setstate(rng_state)
         self._buffer = []
-        self._restored = True
 
     def __del__(self):
         self._buffer.clear()

--- a/torch/utils/data/datapipes/map/combinatorics.py
+++ b/torch/utils/data/datapipes/map/combinatorics.py
@@ -45,7 +45,6 @@ class ShufflerMapDataPipe(MapDataPipe[T_co]):
         self.datapipe = datapipe
         self.indices = list(range(len(datapipe))) if indices is None else indices
         self.index_map = {index_name: num_index for num_index, index_name in enumerate(self.indices)}
-        self._seed = None
         # We do not lazily shuffle because this way is significantly faster in terms of total time
         random.shuffle(self.indices)
 

--- a/torch/utils/data/datapipes/map/combinatorics.py
+++ b/torch/utils/data/datapipes/map/combinatorics.py
@@ -45,6 +45,7 @@ class ShufflerMapDataPipe(MapDataPipe[T_co]):
         self.datapipe = datapipe
         self.indices = list(range(len(datapipe))) if indices is None else indices
         self.index_map = {index_name: num_index for num_index, index_name in enumerate(self.indices)}
+        self._seed = None
         # We do not lazily shuffle because this way is significantly faster in terms of total time
         random.shuffle(self.indices)
 

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -62,7 +62,7 @@ def apply_shuffle_seed(datapipe, rng):
     shufflers = {pipe for pipe in all_pipes if isinstance(pipe, Shuffler)}
 
     for shuffler in shufflers:
-        shuffle_seed = torch.empty((), dtype=torch.int64).random_(generator=rng).item()
+        shuffle_seed = int(torch.empty((), dtype=torch.int64).random_(generator=rng).item())
         shuffler.set_seed(shuffle_seed)
 
     return datapipe

--- a/torch/utils/data/graph_settings.py
+++ b/torch/utils/data/graph_settings.py
@@ -3,9 +3,10 @@ from torch.utils.data.datapipes.iter import Shuffler
 import warnings
 
 __all__ = [
-    "get_all_graph_pipes",
     "apply_sharding",
+    "apply_shuffle_seed",
     "apply_shuffle_settings",
+    "get_all_graph_pipes",
 ]
 
 
@@ -51,5 +52,17 @@ def apply_shuffle_settings(datapipe, shuffle):
 
     for shuffler in shufflers:
         shuffler.set_shuffle(shuffle)
+
+    return datapipe
+
+
+def apply_shuffle_seed(datapipe, rng):
+    graph = torch.utils.data.graph.traverse(datapipe, only_datapipe=True)
+    all_pipes = get_all_graph_pipes(graph)
+    shufflers = {pipe for pipe in all_pipes if isinstance(pipe, Shuffler)}
+
+    for shuffler in shufflers:
+        shuffle_seed = torch.empty((), dtype=torch.int64).random_(generator=rng).item()
+        shuffler.set_seed(shuffle_seed)
 
     return datapipe


### PR DESCRIPTION
This is the first PR to make DataPipe deterministic. See: https://github.com/pytorch/data/issues/302

Users should be able to use `torch.manual_seed(seed)` to control the shuffle order for the following cases:
- Directly over `DataPipe`
- For single-process DataLoader
- Multiprocessing DataLoader

Unfortunately, for distributed training, users have to run `apply_shuffle_seed` manually to make sure all distributed processes having the same order of shuffle.