### PR TITLE
[shard] make init_rpc be False by default in tests

### DIFF
--- a/test/distributed/_shard/checkpoint/test_checkpoint.py
+++ b/test/distributed/_shard/checkpoint/test_checkpoint.py
@@ -70,7 +70,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
     def world_size(self) -> int:
         return 2
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     def test_validate_metadata(self) -> None:
@@ -117,7 +117,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
 
         return metadata[0]
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     def test_checkpoint_has_shard_too_small(self) -> None:
@@ -141,7 +141,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
         with self.assertRaisesRegex(ValueError, "only has 1 available"):
             validate_metadata(module.state_dict(), metadata)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     def test_checkpoint_has_shard_overlap(self) -> None:
@@ -166,7 +166,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
             validate_metadata(module.state_dict(), metadata)
 
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     def test_checkpoint_has_storage_type_mismatch(self) -> None:
@@ -185,7 +185,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
             validate_metadata(module.state_dict(), metadata)
 
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     def test_tensor_metadata_with_missing_rank_spec(self) -> None:
@@ -206,7 +206,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
         self.assertEqual(1, len(mapping))
 
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     def test_storage_key_mapping(self) -> None:

--- a/test/distributed/_shard/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/_shard/checkpoint/test_file_system_checkpoint.py
@@ -207,7 +207,7 @@ class TestDistributedStateDictSaveLoadWithSharedTensor(ShardedTensorTestBase):
     def world_size(self) -> int:
         return 2
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     def test_read_write_shard_tensor(self) -> None:
@@ -271,7 +271,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
         _sharded_tensor_gather(tensor, out=res)
         return cast(Tensor, res)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     def test_load_with_different_shard_plan(self) -> None:
@@ -385,7 +385,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
                         torch.allclose(store_tensor, load_tensor), msg=f"{s0} vs {s1}"
                     )
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     def test_load_rowwise_to_colwise(self) -> None:
@@ -437,7 +437,7 @@ class TestDistributedReshardOnLoad(ShardedTensorTestBase):
             self.assertTrue(torch.allclose(store_tensor, load_tensor))
 
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     def test_save_load_bytes(self) -> None:

--- a/test/distributed/_shard/sharded_optim/test_sharded_optim.py
+++ b/test/distributed/_shard/sharded_optim/test_sharded_optim.py
@@ -89,7 +89,7 @@ class MyShardedLinear(torch.nn.Module):
 
 class TestShardedOptimizer(ShardedTensorTestBase):
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_sharded_optim(self):
@@ -149,7 +149,7 @@ class TestShardedOptimizer(ShardedTensorTestBase):
                 self.assertNotEqual(val, new_val)
                 self.assertEqual(new_val, local_model.param)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_named_params_with_sharded_tensor(self):

--- a/test/distributed/_shard/sharded_tensor/ops/test_chunk.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_chunk.py
@@ -52,7 +52,7 @@ class TestShardedTensorChunkOps(ShardedTensorTestBase):
         chunked_st = st_tensor.chunk(chunk_num, dim=-1)
         self._compare_chunk_result(local_tensor_chunked, chunked_st)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_chunk(self):
@@ -68,7 +68,7 @@ class TestShardedTensorChunkOps(ShardedTensorTestBase):
             self._run_sharded_chunk_test([128, 512], spec, 8)
             self._run_sharded_chunk_test([1024, 2048], spec, 4)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_chunk_error(self):

--- a/test/distributed/_shard/sharded_tensor/ops/test_elementwise_ops.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_elementwise_ops.py
@@ -45,7 +45,7 @@ class TestShardedTensorElementWiseOps(ShardedTensorTestBase):
             new_st_local_shard,
         )
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_gelu(self):
@@ -58,7 +58,7 @@ class TestShardedTensorElementWiseOps(ShardedTensorTestBase):
             self._run_sharded_elementwise_ops(spec, [17, 23], torch.nn.functional.gelu)
             self._run_sharded_elementwise_ops(spec, [14, 15], torch.nn.functional.gelu)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_relu(self):
@@ -71,7 +71,7 @@ class TestShardedTensorElementWiseOps(ShardedTensorTestBase):
             self._run_sharded_elementwise_ops(spec, [17, 23], torch.nn.functional.relu)
             self._run_sharded_elementwise_ops(spec, [14, 15], torch.nn.functional.relu)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_dropout(self):

--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding.py
@@ -121,7 +121,7 @@ class TestShardedEmbedding(ShardedTensorTestBase):
 
         self.assertEqual(local_output, sharded_output)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_embedding_colwise(self):
@@ -144,7 +144,7 @@ class TestShardedEmbedding(ShardedTensorTestBase):
             )
             self._run_sharded_embedding(spec, [30], 15, 14, max_norm=2.0, sharded_dim=1)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_embedding_rowwise(self):

--- a/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_embedding_bag.py
@@ -165,14 +165,14 @@ class TestShardedEmbeddingBag(ShardedTensorTestBase):
 
         self.assertEqual(local_output, sharded_output)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_embedding_bag_colwise(self):
         for spec in generate_chunk_sharding_specs_for_test(1):
             self._test_sharded_embedding_bag_with_test_cases(spec, 1)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_embedding_bag_rowwise(self):

--- a/test/distributed/_shard/sharded_tensor/ops/test_linear.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_linear.py
@@ -142,7 +142,7 @@ class TestShardedTensorOpsLinear(ShardedTensorTestBase):
         self.assertNotEqual(previous_sharded_bias, sharded_linear.bias)
         self.assertEqual(sharded_linear.bias, local_linear.bias)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_linear_colwise(self):
@@ -164,7 +164,7 @@ class TestShardedTensorOpsLinear(ShardedTensorTestBase):
             self._run_sharded_linear(spec, [23], [23, 13], 0)
             self._run_sharded_linear(spec, [15], [15, 14], 0)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_linear_rowwise(self):
@@ -186,7 +186,7 @@ class TestShardedTensorOpsLinear(ShardedTensorTestBase):
             self._run_sharded_linear(spec, [19], [19, 11], 1)
             self._run_sharded_linear(spec, [21], [21, 11], 1)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_linear_errors(self):

--- a/test/distributed/_shard/sharded_tensor/ops/test_math_ops.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_math_ops.py
@@ -27,7 +27,7 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_ops_common 
 )
 
 class TestMathOps(ShardedTensorTestBase):
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_basic_math_ops(self):
@@ -87,7 +87,7 @@ class TestMathOps(ShardedTensorTestBase):
 
 
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_math_ops_errors(self):
@@ -135,7 +135,7 @@ class TestMathOps(ShardedTensorTestBase):
             torch.add(st, sharded_rhs)
 
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_bmm(self):
@@ -150,7 +150,7 @@ class TestMathOps(ShardedTensorTestBase):
             self.assertTrue(torch.allclose(st_lhs.bmm(st_rhs), st_expected))
 
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_bmm_errors(self):

--- a/test/distributed/_shard/sharded_tensor/ops/test_matrix_ops.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_matrix_ops.py
@@ -35,7 +35,7 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestShardedTensorMatrixOps(ShardedTensorTestBase):
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_tensor_contiguous(self):
@@ -47,7 +47,7 @@ class TestShardedTensorMatrixOps(ShardedTensorTestBase):
             self.assertTrue(st.is_contiguous())
             self.assertTrue(st.local_tensor().is_contiguous())
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_tensor_type_as(self):
@@ -66,7 +66,7 @@ class TestShardedTensorMatrixOps(ShardedTensorTestBase):
             self.assertEqual(torch.bool, st_3.dtype)
             self.assertEqual(torch.bool, st_3.local_tensor().dtype)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_tensor_transpose(self):
@@ -92,7 +92,7 @@ class TestShardedTensorMatrixOps(ShardedTensorTestBase):
                 torch.allclose(_shard_tensor(tensor, spec).transpose(1, 2), st_expected)
             )
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_tensor_transpose_error(self):
@@ -106,7 +106,7 @@ class TestShardedTensorMatrixOps(ShardedTensorTestBase):
         ):
             st.transpose(1, 0)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_tensor_softmax(self):
@@ -140,7 +140,7 @@ class TestShardedTensorMatrixOps(ShardedTensorTestBase):
                 )
             )
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_tensor_masked_fill(self):
@@ -149,7 +149,7 @@ class TestShardedTensorMatrixOps(ShardedTensorTestBase):
         self._test_masked_fill_with_sizes((35, 26), broadcast_style=True)
         self._test_masked_fill_with_sizes((26,))
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_tensor_masked_fill_error(self):
@@ -176,7 +176,7 @@ class TestShardedTensorMatrixOps(ShardedTensorTestBase):
             ):
                 st.masked_fill(mask, 25.0)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_tensor_view(self):
@@ -202,7 +202,7 @@ class TestShardedTensorMatrixOps(ShardedTensorTestBase):
                 )
             )
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_tensor_view_error(self):
@@ -227,7 +227,7 @@ class TestShardedTensorMatrixOps(ShardedTensorTestBase):
             ):
                 st.view(5, 7, -1, -1)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_tensor_layer_norm(self):
@@ -267,7 +267,7 @@ class TestShardedTensorMatrixOps(ShardedTensorTestBase):
                 )
             )
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_tensor_layer_norm_error(self):

--- a/test/distributed/_shard/sharded_tensor/ops/test_softmax.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_softmax.py
@@ -39,14 +39,14 @@ class TestShardedSoftmax(ShardedTensorTestBase):
 
         self.assertEqual(local_softmax.chunk(self.world_size, dim=sharding_dim)[self.rank], sharded_softmax.local_tensor())
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_softmax_basic(self):
         self._test_sharded_softmax(0, 1)
         self._test_sharded_softmax(-2, 1)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_softmax_on_sharding_dim(self):

--- a/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
@@ -22,7 +22,7 @@ from torch.testing._internal.common_utils import (
 )
 
 class TestTensorOps(ShardedTensorTestBase):
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_deep_copy(self):
@@ -41,7 +41,7 @@ class TestTensorOps(ShardedTensorTestBase):
         self.assertEqual(copied_st.local_tensor(), st.local_tensor())
         self.assertFalse(copied_st is st)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_clone(self):
@@ -60,7 +60,7 @@ class TestTensorOps(ShardedTensorTestBase):
         self.assertEqual(copied_st.local_tensor(), st.local_tensor())
         self.assertFalse(copied_st is st)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_detach(self):
@@ -85,7 +85,7 @@ class TestTensorOps(ShardedTensorTestBase):
         for local_shard in detached_st.local_shards():
             self.assertFalse(local_shard.tensor.requires_grad)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_set_requires_grad(self):

--- a/test/distributed/_shard/sharded_tensor/test_megatron_prototype.py
+++ b/test/distributed/_shard/sharded_tensor/test_megatron_prototype.py
@@ -175,7 +175,7 @@ class TestShardedTensorMegatronLinear(ShardedTensorTestBase):
         self.assertNotEqual(previous_bias_fc2, bias_fc2)
         self.assertEqual(bias_fc2, local_bias_fc2)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_megatron_two_layer_prototype(self):

--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -128,7 +128,7 @@ class TestCreateTensorFromParams(TestCase):
 
 
 class TestShardParameter(ShardedTensorTestBase):
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_shard_parameter(self):
@@ -155,7 +155,7 @@ class TestShardParameter(ShardedTensorTestBase):
         self.assertEqual(12, local_shards[0].tensor.size(1))
         self.assertEqual(torch.narrow(weight_og, 0, 3 * self.rank, 3), local_shards[0].tensor)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_shard_parameter_errors(self):
@@ -214,7 +214,7 @@ class TestShardParameter(ShardedTensorTestBase):
 
 
 class TestShardTensor(ShardedTensorTestBase):
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_shard_tensor(self):
@@ -237,7 +237,7 @@ class TestShardTensor(ShardedTensorTestBase):
         self.assertEqual(torch.Size([3, 12]), local_shard.size())
         self.assertEqual(torch.narrow(tensor, 0, 3 * self.rank, 3), local_shard)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_shard_tensor_errors(self):
@@ -298,7 +298,7 @@ class TestModuleHookApi(ShardedTensorTestBase):
         def forward(self):
             return self.st
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_reshard_output(self):
@@ -323,7 +323,7 @@ class TestModuleHookApi(ShardedTensorTestBase):
         self.assertEqual(local_shard.size(0), 24)
         self.assertEqual(local_shard.size(1), 3)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_collect_local_shard(self):
@@ -339,7 +339,7 @@ class TestModuleHookApi(ShardedTensorTestBase):
 
 
 class TestLocalTensor(ShardedTensorTestBase):
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_local_tensor(self):
@@ -357,7 +357,7 @@ class TestLocalTensor(ShardedTensorTestBase):
         self.assertEqual(torch.Size([6, 12]), local_shard.size())
         self.assertEqual(st.local_tensor(), local_shard)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_local_tensor_error(self):
@@ -433,7 +433,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         with self.assertRaisesRegex(AttributeError, "can't set attribute"):
             st.requires_grad = True
 
-    @with_comms
+    @with_comms(init_rpc=True)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_complete_world_size(self):
@@ -741,7 +741,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                 new_op_st = op(st, dtype=dtype)
                 self.assertEqual(new_op_st.local_tensor(), expect_tensor)
 
-    @with_comms
+    @with_comms(init_rpc=True)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_partial_world_size(self):
@@ -790,7 +790,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                 self.assertEqual(f'rank:{rpc_rank}/cuda:{rpc_rank}', str(shard.metadata.placement))
                 self.assertEqual((5, 20), shard.tensor.size())
 
-    @with_comms
+    @with_comms(init_rpc=True)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_new_group(self):
@@ -1312,7 +1312,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         st = sharded_tensor.empty(spec, 10, 10, pin_memory=True, init_rrefs=True)
         self.assertTrue(st.is_pinned())
 
-    @with_comms
+    @with_comms(init_rpc=True)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_grid_sharding(self):
@@ -1664,7 +1664,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
             verify_size(rank, shard_metadata.shard_sizes)
             self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
 
-    @with_comms
+    @with_comms(init_rpc=True)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_partial_world_size(self):
@@ -1723,7 +1723,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
                 shard = remote_shard.to_here()
                 self.assertEqual((5, 5), shard.tensor.size())
 
-    @with_comms
+    @with_comms(init_rpc=True)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_new_group(self):
@@ -1780,7 +1780,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
                 shard = remote_shard.to_here()
                 self.assertEqual((5, 5), shard.tensor.size())
 
-    @with_comms
+    @with_comms(init_rpc=True)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_multiple_local_shards(self):
@@ -1849,7 +1849,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
                 shard = remote_shard.to_here()
                 self.assertEqual((5, 5), shard.tensor.size())
 
-    @with_comms
+    @with_comms(init_rpc=True)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_with_rpc_names(self):
@@ -1971,7 +1971,7 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
                         rank_to_metadata[rpc_rank].shard_sizes, shard.tensor.size()
                     )
 
-    @with_comms
+    @with_comms(init_rpc=True)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_init_from_local_tensor(self):
@@ -2023,7 +2023,7 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
 
 class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_local_shards(self):
@@ -2054,7 +2054,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                 metadata=wrong_local_shard_metadata,
             )
 
-    @with_comms
+    @with_comms(init_rpc=True)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_init_from_local_shards(self):
@@ -2100,7 +2100,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                 self.assertEqual((5, 5), shard.tensor.size())
 
 
-    @with_comms
+    @with_comms(init_rpc=True)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_init_from_local_shards_and_global_metadata(self):

--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor_reshard.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor_reshard.py
@@ -51,7 +51,7 @@ class TestReshard(ShardedTensorTestBase):
             st.local_shards()[0].metadata, st_compare.local_shards()[0].metadata
         )
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_sharded_tensor_reshard(self):
@@ -66,7 +66,7 @@ class TestReshard(ShardedTensorTestBase):
             self._run_sharded_tensor_reshard(spec, reshard_spec, [15, 26])
             self._run_sharded_tensor_reshard(spec, reshard_spec, [12, 24])
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_sharded_tensor_reshard_errors(self):

--- a/test/distributed/_shard/sharding_plan/test_sharding_plan.py
+++ b/test/distributed/_shard/sharding_plan/test_sharding_plan.py
@@ -60,7 +60,7 @@ class ChunkAllShardingPlanner(ShardingPlanner):
 
 class TestShardingPlan(ShardedTensorTestBase):
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharding_plan_simple_megatron(self):
@@ -196,7 +196,7 @@ class TestShardingPlan(ShardedTensorTestBase):
             self.assertNotEqual(previous_bias_fc2, bias_fc2)
             self.assertEqual(bias_fc2, local_bias_fc2)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_reshard_to_ddp_sharding_plan(self):
@@ -253,7 +253,7 @@ class TestShardingPlan(ShardedTensorTestBase):
         # verify and make sure local and sharded output matches
         self.assertEqual(local_output, sharded_output)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharding_plan_errors(self):
@@ -312,7 +312,7 @@ class TestShardingPlan(ShardedTensorTestBase):
             # shard the module with the provided sharding plan
             shard_module(megatron_lm, sharding_plan_wrong_param_path)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_custom_sharding_planner(self):

--- a/test/distributed/_shard/test_partial_tensor.py
+++ b/test/distributed/_shard/test_partial_tensor.py
@@ -70,7 +70,7 @@ class TestPartialTensorReshard(ShardedTensorTestBase):
         self.assertEqual(1, len(local_shards))
         self.assertEqual(local_shards[0].tensor, local_result_compare)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_partial_tensor_reshard(self):
@@ -81,7 +81,7 @@ class TestPartialTensorReshard(ShardedTensorTestBase):
         self._run_partial_tensor_n_reshard(spec, [13, 21], 3, dist.ReduceOp.SUM)
         self._run_partial_tensor_n_reshard(spec, [17, 21], 2, dist.ReduceOp.MAX)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_partial_tensor_reshard_errors(self):
@@ -121,7 +121,7 @@ class TestPartialTensorReshard(ShardedTensorTestBase):
             )
 
 class TestPartialTensorOps(ShardedTensorTestBase):
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_transpose(self):
@@ -129,7 +129,7 @@ class TestPartialTensorOps(ShardedTensorTestBase):
         partial_tensor = partial_tensor.transpose(0, 1)
         self.assertEqual(partial_tensor.size(), torch.Size((10, 5)))
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_cat(self):
@@ -150,7 +150,7 @@ class TestPartialTensorOps(ShardedTensorTestBase):
         local_concat = torch.cat([t1, t2, t3], dim=1)
         self.assertEqual(local_concat.size(), partial_concat.size())
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_cat_errors(self):

--- a/test/distributed/_shard/test_replicated_tensor.py
+++ b/test/distributed/_shard/test_replicated_tensor.py
@@ -27,7 +27,7 @@ from torch.testing._internal.distributed._shard.sharded_tensor import TEST_GPU_N
 
 class TestReplicatedTensor(ShardedTensorTestBase):
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_replicated_tensor_basics(self):
@@ -48,7 +48,7 @@ class TestReplicatedTensor(ShardedTensorTestBase):
         with self.assertRaisesRegex(ValueError, 'have different values'):
             replica_tensor.validate()
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_replicated_tensor_inter_op_replicated_tensor(self):
@@ -68,7 +68,7 @@ class TestReplicatedTensor(ShardedTensorTestBase):
             replica_tensor_new_group * replica_tensor1
 
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_replicated_tensor_inter_op_tensor(self):
@@ -83,7 +83,7 @@ class TestReplicatedTensor(ShardedTensorTestBase):
 
         self.assertEqual(new_tensor, local_tensor + local_rand_tensor)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_replicated_tensor_inter_op_sharded_tensor(self):
@@ -131,7 +131,7 @@ class TestReplicatedTensor(ShardedTensorTestBase):
                 self.assertEqual(reflect_output, reflect_local_output)
 
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_replicated_tensor_implicit_broadcasting(self):
@@ -173,7 +173,7 @@ class TestReplicatedTensor(ShardedTensorTestBase):
                 self.assertEqual(output, local_output)
 
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_replicated_tensor_inter_op_sharded_tensor_errors(self):
@@ -200,7 +200,7 @@ class TestReplicatedTensor(ShardedTensorTestBase):
         with self.assertRaisesRegex(RuntimeError, 'not supported for ShardedTensor'):
             st1 % replica_tensor
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_with_ddp(self):
@@ -307,7 +307,7 @@ class TestReplicatedTensor(ShardedTensorTestBase):
             obj = torch.load(buffer)
             self.assertEqual(expected_state_dict, obj.state_dict())
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_unsqueeze(self):
@@ -322,7 +322,7 @@ class TestReplicatedTensor(ShardedTensorTestBase):
         self.assertEqual(unsqueezed_local_tensor, unsqueezed_replicated_tensor)
         self.assertEqual(torch.unsqueeze(replicated_tensor, 0), unsqueezed_replicated_tensor)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_getitem(self):

--- a/test/distributed/_shard/test_sharder.py
+++ b/test/distributed/_shard/test_sharder.py
@@ -85,7 +85,7 @@ class CustomSharder(Sharder):
 
 class TestCustomSharder(ShardedTensorTestBase):
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_custom_sharder(self):
@@ -128,7 +128,7 @@ class TestCustomSharder(ShardedTensorTestBase):
 
         self.assertEqual(local_output, sharded_output)
 
-    @with_comms(init_rpc=False)
+    @with_comms
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_custom_sharder_errors(self):

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -76,7 +76,7 @@ class ShardedTensorTestBase(MultiProcessTestCase):
         self.assertEqual(len(st1.remote_shards()), len(st2.remote_shards()))
 
 # wrapper to initialize comms (processgroup + rpc)
-def with_comms(func=None, init_rpc=True, backend="nccl"):
+def with_comms(func=None, init_rpc=False, backend="nccl"):
     if func is None:
         return partial(
             with_comms,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #77768

Make the with_comms to not initialize rpc by default
Only the tests involves with remote shards should have init_rpc=True
This helps with the case that most tests don't need rpc to be
initialized

Differential Revision: [D36564914](https://our.internmc.facebook.com/intern/diff/D36564914)