### PR TITLE
Update _symbolic_trace.py

### DIFF
--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -831,7 +831,7 @@ def symbolic_trace(root : Union[torch.nn.Module, Callable], concrete_args: Optio
         f = fx.symbolic_trace(f, concrete_args={'b': False})
         assert f(3, False)  == 6
 
-    Note that although you can still pass in different values of `b`, they will be ignored.
+    Note that if you pass in different values of `b`, you will get an assertion error.
 
     We can also use `concrete_args` to eliminate data-structure handling from
     our function. This will use pytrees to flatten your input. To avoid


### PR DESCRIPTION
It seems that the up-to-date behavior has changed.  I got an assertion error instead.

```
>>> f = fx.symbolic_trace(f, concrete_args={"b":False}); assert f(3, False)==6
>>> f(3, True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/wkyi/Library/Python/3.7/lib/python/site-packages/torch/fx/graph_module.py", line 616, in wrapped_call
    raise e.with_traceback(None)
AssertionError: b has been specialized to have value False
```

Fixes #ISSUE_NUMBER
