### PR TITLE
[Pytorch] Disable use of qnnpack with ceil_mode avgpool

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
+++ b/aten/src/ATen/native/quantized/cpu/q_avgpool.cpp
@@ -361,7 +361,7 @@ Tensor avg_pool2d_quantized_cpu(
   Tensor output;
 #ifdef USE_PYTORCH_QNNPACK
   if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
-      input.scalar_type() == kQUInt8) {
+      input.scalar_type() == kQUInt8 && !ceil_mode) {
     return at::native::qnnp_avgpool_helper::qnnpack_avg_pool2d(
         input,
         kernel_size,


### PR DESCRIPTION
Summary:
In pooling ops qnnpack does not handle ceil_mode. This is protected in maxpool
but not in avgpool. This diff adds that.

Test Plan: CI

Differential Revision: D36492927

