### PR TITLE
[primTorch] log2, isinf, zeros_like

### DIFF
--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -47,6 +47,7 @@ __all__ = [
     "cosh",
     "bessel_i0e",
     "bessel_i1e",
+    "bitwise_not",
     "cbrt",
     "ceil",
     "digamma",
@@ -57,9 +58,11 @@ __all__ = [
     "expm1",
     "floor",
     "is_finite",
+    "is_infinite",
     "lgamma",
     "log",
     "log1p",
+    "log2",
     "neg",
     "reciprocal",
     "round",
@@ -75,7 +78,6 @@ __all__ = [
     "add",
     "atan2",
     "bitwise_and",
-    "bitwise_not",
     "bitwise_or",
     "bitwise_xor",
     # 'complex',  # needs custom meta
@@ -393,6 +395,13 @@ bessel_i1e = _make_elementwise_unary_prim(
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
+bitwise_not = _make_elementwise_unary_prim(
+    "bitwise_not",
+    impl_aten=torch.bitwise_not,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
 
 def _cbrt_aten(a: torch.Tensor):
     return pow(a, (1 / 3))
@@ -468,6 +477,13 @@ is_finite = _make_elementwise_unary_prim(
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
 )
 
+is_infinite = _make_elementwise_unary_prim(
+    "is_infinite",
+    impl_aten=torch.isinf,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
+)
+
 lgamma = _make_elementwise_unary_prim(
     "lgamma",
     impl_aten=torch.lgamma,
@@ -485,6 +501,13 @@ log = _make_elementwise_unary_prim(
 log1p = _make_elementwise_unary_prim(
     "log1p",
     impl_aten=torch.log1p,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
+log2 = _make_elementwise_unary_prim(
+    "log2",
+    impl_aten=torch.log2,
     doc="",
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
@@ -578,13 +601,6 @@ atan2 = _make_elementwise_binary_prim(
 bitwise_and = _make_elementwise_binary_prim(
     "bitwise_and",
     impl_aten=torch.bitwise_and,
-    doc="",
-    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
-)
-
-bitwise_not = _make_elementwise_binary_prim(
-    "bitwise_not",
-    impl_aten=torch.bitwise_not,
     doc="",
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -42,6 +42,7 @@ __all__ = [
     "atan",
     # "bessel_i0e",  # special.i0e
     # "bessel_i1e",  # special.i1e
+    "bitwise_not",
     # "cbrt",  # No corresponding torch operation
     "ceil",
     "cos",
@@ -54,10 +55,12 @@ __all__ = [
     "expm1",
     "floor",
     "isfinite",
+    "isinf",
     "isnan",
     "lgamma",
     "log",
     "log1p",
+    "log2",
     "neg",
     "reciprocal",
     "round",  # TODO: model kwargs
@@ -157,6 +160,7 @@ __all__ = [
     "full",
     "full_like",
     "ones_like",
+    "zeros_like",
 ]
 
 Tensor = torch.Tensor
@@ -299,6 +303,11 @@ atan = _make_elementwise_unary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
 )
 
+bitwise_not = _make_elementwise_unary_reference(
+    prims.bitwise_not,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
 ceil = _make_elementwise_unary_reference(
     prims.ceil,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
@@ -365,6 +374,25 @@ isfinite = _make_elementwise_unary_reference(
 )
 
 
+def _isinf(a: TensorLikeType) -> TensorLikeType:
+    # TODO Add complex tensor support to remove is_infinite prim
+    # if utils.is_complex_dtype(a):
+    #     return bitwise_or(_isinf(real(a), _isinf(imag(a))
+    # else:
+    #     return bitwise_not(bitwise_or(isnan(a), isfinite(a)))
+    if utils.is_float_dtype(a.dtype) or utils.is_complex_dtype(a.dtype):
+        return prims.is_infinite(a)
+
+    return zeros_like(a, dtype=torch.bool)
+
+
+isinf = _make_elementwise_unary_reference(
+    _isinf,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
+    aten_op=torch.ops.aten.isinf,  # prim/aten name mismatch
+)
+
+
 def _isnan(a: TensorLikeType) -> TensorLikeType:
     return prims.ne(a, a)
 
@@ -388,6 +416,11 @@ log = _make_elementwise_unary_reference(
 
 log1p = _make_elementwise_unary_reference(
     prims.log1p,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+)
+
+log2 = _make_elementwise_unary_reference(
+    prims.log2,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
 )
 
@@ -1449,3 +1482,13 @@ def ones_like(
     requires_grad: bool = False,
 ) -> TensorLikeType:
     return full_like(a, 1, dtype=dtype, device=device, requires_grad=requires_grad)
+
+
+def zeros_like(
+    a: TensorLikeType,
+    *,
+    dtype: Optional[torch.dtype] = None,
+    device: Optional[torch.device] = None,
+    requires_grad: bool = False,
+) -> TensorLikeType:
+    return full_like(a, 0, dtype=dtype, device=device, requires_grad=requires_grad)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -18611,6 +18611,10 @@ python_ref_db = [
         torch_opinfo_name="atan",
     ),
     ElementwiseUnaryPythonRefInfo(
+        "_refs.bitwise_not",
+        torch_opinfo_name="bitwise_not",
+    ),
+    ElementwiseUnaryPythonRefInfo(
         "_refs.ceil",
         torch_opinfo_name="ceil",
     ),
@@ -18673,6 +18677,20 @@ python_ref_db = [
         )
     ),
     ElementwiseUnaryPythonRefInfo(
+        "_refs.isinf",
+        torch_opinfo_name="isinf",
+        supports_out=True,
+        skips=(
+            # RuntimeError: "index_select" not implemented for 'ComplexHalf'
+            # RuntimeError: "index_select_cuda" not implemented for 'ComplexHalf'
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_reference_consistency',
+                         dtypes=(torch.chalf,)),
+            # Same reason as `test_python_reference_consistency`
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_reference_meta_functions',
+                         dtypes=(torch.chalf,)),
+        )
+    ),
+    ElementwiseUnaryPythonRefInfo(
         "_refs.isnan",
         torch_opinfo_name="isnan",
         supports_out=True,
@@ -18696,6 +18714,10 @@ python_ref_db = [
     ElementwiseUnaryPythonRefInfo(
         "_refs.log1p",
         torch_opinfo_name="log1p",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.log2",
+        torch_opinfo_name="log2",
     ),
     ElementwiseUnaryPythonRefInfo(
         "_refs.neg",


### PR DESCRIPTION
 * Add support for `log2, isinf, zeros_like`
 * Add primitives for `log2` and `is_infinite`

I left a TODO to remove the `is_infinite` prim and to implement `isinf` reference using `isfinite` and `isnan`.
We're missing `real` and `imag` ops to handle complex tensors.