### PR TITLE
Validate that tensors are contiguous in ProcessGroupNCCL

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1267,8 +1267,8 @@ void check_gpu_tensors_different_devices(const std::vector<at::Tensor>& tensors)
     if (t.strides() != first.strides()) {
       TORCH_CHECK(false, "Tensors must have identical strides");
     }
-    if (!t.is_non_overlapping_and_dense()) {
-      TORCH_CHECK(false, "Tensors must be non-overlapping and dense");
+    if (!t.is_contiguous()) {
+      TORCH_CHECK(false, "Tensors must be contiguous");
     }
     const auto inserted = usedDevices.insert(t.get_device()).second;
     if (!inserted) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #77809

Fixes https://github.com/pytorch/pytorch/issues/77554 by ensuring we
require contiguous tensors for send/recv in ProcessGroupNCCL.

Differential Revision: [D36500769](https://our.internmc.facebook.com/intern/diff/D36500769/)