### PR TITLE
Added support for `expand` in LazyTensor shape inference

### DIFF
--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -450,7 +450,7 @@ std::vector<Shape> compute_shape_expand(const at::Tensor & self, c10::SymIntArra
     std::shared_ptr<c10::SymbolicIntNode> symbolicIntNode = _sizes[idx].toSymbolicIntNode();
     auto lazySymIntNode = std::dynamic_pointer_cast<torch::lazy::SymbolicIntNode>(symbolicIntNode);
     auto size_node = lazySymIntNode->node_;
-    auto static_value = std::dynamic_pointer_cast<DimensionNode>(size_node)->getStaticValue();
+    auto static_value = std::dynamic_pointer_cast<DimensionNode>(size_node)->getStaticValue(); //TODO: blocked on landing torch::lazy::DimensionNode
     target_size[idx] = static_value == -1 ? padded_self[idx] : static_value;
   }
   return {Shape(self.scalar_type(), target_size)};

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -49,6 +49,9 @@
 
 #include <torch/csrc/lazy/core/shape_inference.h>
 
+#include <torch/csrc/lazy/core/shape.h>
+#include <torch/csrc/lazy/ts_backend/dynamic_ir.h>
+#include <ATen/native/ConvUtils.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/CompositeExplicitAutogradFunctions.h>
 #include <ATen/Dispatch.h>
@@ -419,6 +422,33 @@ std::vector<Shape> compute_shape_embedding_dense_backward(
   return {
       Shape(grad_output.scalar_type(), {num_weights, grad_output.size(-1)})};
 }
+
+std::vector<Shape> compute_shape_expand(const at::Tensor & self, at::IntArrayRef size, bool implicit) {
+  CHECK_GE(size.size(), self.dim());
+  int64_t num_new_dimensions = size.size() - self.dim();
+  std::vector<int64_t> padded_self(num_new_dimensions, 0);
+  padded_self.insert(padded_self.end(), self.sizes().begin(),
+                     self.sizes().end());
+  std::vector<int64_t> target_size(size.size());
+  for (const auto idx : c10::irange(size.size())) {
+    target_size[idx] = size[idx] == -1 ? padded_self[idx] : size[idx];
+  }
+  return {Shape(self.scalar_type(), target_size)};
+}
+
+// std::vector<Shape> compute_shape_expand(const at::Tensor & self, c10::SymIntArrayRef size, bool implicit) {
+//   CHECK_GE(size.size(), self.dim());
+//   // NOTE: hm... how can we allow size dimensions to hold -1?
+//   // NOTE: should move this block somewhere better - ref: https://github.com/pytorch/xla/pull/3558/files
+//   std::vector<int64_t> target_size;
+//   for (auto& _size : size) {
+//     const std::shared_ptr<c10::SymbolicIntNode> symbolicIntNode = _size.toSymbolicIntNode();
+//     auto lazySymIntNode = std::dynamic_pointer_cast<torch::lazy::SymbolicIntNode>(symbolicIntNode);
+//     auto size_node = lazySymIntNode->node_;
+//     target_size.push_back(std::dynamic_pointer_cast<DimensionNode>(size_node)->getStaticValue());
+//   }
+//   return {Shape(self.scalar_type(), target_size)};
+// }
 
 std::vector<Shape> compute_shape_index_select(
     const at::Tensor& self,

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -49,10 +49,6 @@
 
 #include <torch/csrc/lazy/core/shape_inference.h>
 
-#include <torch/csrc/lazy/ts_backend/dynamic_ir.h>
-#include <torch/csrc/lazy/core/shape.h>
-#include <torch/csrc/lazy/core/util.h>
-#include <ATen/native/ConvUtils.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/CompositeExplicitAutogradFunctions.h>
 #include <ATen/Dispatch.h>
@@ -68,6 +64,8 @@
 #include <torch/csrc/api/include/torch/enum.h>
 #include <torch/csrc/lazy/core/ops/utils.h>
 #include <torch/csrc/lazy/core/shape.h>
+#include <torch/csrc/lazy/core/util.h>
+#include <torch/csrc/lazy/ts_backend/dynamic_ir.h>
 #include <ostream>
 #include <vector>
 
@@ -424,12 +422,15 @@ std::vector<Shape> compute_shape_embedding_dense_backward(
       Shape(grad_output.scalar_type(), {num_weights, grad_output.size(-1)})};
 }
 
-std::vector<Shape> compute_shape_expand(const at::Tensor & self, at::IntArrayRef size, bool implicit) {
+std::vector<Shape> compute_shape_expand(
+    const at::Tensor& self,
+    at::IntArrayRef size,
+    bool implicit) {
   CHECK_GE(size.size(), self.dim());
   int64_t num_new_dimensions = size.size() - self.dim();
   std::vector<int64_t> padded_self(num_new_dimensions, 0);
-  padded_self.insert(padded_self.end(), self.sizes().begin(),
-                     self.sizes().end());
+  padded_self.insert(
+      padded_self.end(), self.sizes().begin(), self.sizes().end());
   std::vector<int64_t> target_size(size.size());
   for (const auto idx : c10::irange(size.size())) {
     target_size[idx] = size[idx] == -1 ? padded_self[idx] : size[idx];
@@ -437,20 +438,28 @@ std::vector<Shape> compute_shape_expand(const at::Tensor & self, at::IntArrayRef
   return {Shape(self.scalar_type(), target_size)};
 }
 
-std::vector<Shape> compute_shape_expand(const at::Tensor & self, c10::SymIntArrayRef size, bool implicit) {
+std::vector<Shape> compute_shape_expand(
+    const at::Tensor& self,
+    c10::SymIntArrayRef size,
+    bool implicit) {
   CHECK_GE(size.size(), self.dim());
   std::vector<c10::SymInt> _sizes = ToVector<c10::SymInt>(size);
   int64_t num_new_dimensions = _sizes.size() - self.dim();
   std::vector<int64_t> padded_self(num_new_dimensions, 0);
-  padded_self.insert(padded_self.end(), self.sizes().begin(),
-                     self.sizes().end());
+  padded_self.insert(
+      padded_self.end(), self.sizes().begin(), self.sizes().end());
   std::vector<int64_t> target_size(_sizes.size());
   for (const auto idx : c10::irange(_sizes.size())) {
     if (_sizes[idx].is_symbolic()) {
-      std::shared_ptr<c10::SymbolicIntNode> symbolicIntNode = _sizes[idx].toSymbolicIntNode();
-      auto lazySymIntNode = std::dynamic_pointer_cast<torch::lazy::SymbolicIntNode>(symbolicIntNode);
+      std::shared_ptr<c10::SymbolicIntNode> symbolicIntNode =
+          _sizes[idx].toSymbolicIntNode();
+      auto lazySymIntNode =
+          std::dynamic_pointer_cast<torch::lazy::SymbolicIntNode>(
+              symbolicIntNode);
       auto size_node = lazySymIntNode->node_;
-      auto static_value = std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node)->getStaticValue();
+      auto static_value =
+          std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node)
+              ->getStaticValue();
       target_size[idx] = static_value;
     } else {
       target_size[idx] = _sizes[idx].data();

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -464,11 +464,11 @@ std::vector<Shape> compute_shape_expand(
     } else {
       target_size[idx] = _sizes[idx].data();
       if (_sizes[idx].data() == -1) {
-          // -1 can't be specified for non-existing dimensions
-          TORCH_CHECK(idx >= num_new_dimensions);
-          target_size[idx] = padded_self[idx];
+        // -1 can't be specified for non-existing dimensions
+        TORCH_CHECK(idx >= num_new_dimensions);
+        target_size[idx] = padded_self[idx];
       } else {
-          target_size[idx] = _sizes[idx].data();
+        target_size[idx] = _sizes[idx].data();
       }
     }
   }

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -446,11 +446,10 @@ std::vector<Shape> compute_shape_expand(const at::Tensor & self, c10::SymIntArra
                      self.sizes().end());
   std::vector<int64_t> target_size(_sizes.size());
   for (const auto idx : c10::irange(_sizes.size())) {
-    // NOTE: should move this block somewhere better - ref: https://github.com/pytorch/xla/pull/3558/files
     std::shared_ptr<c10::SymbolicIntNode> symbolicIntNode = _sizes[idx].toSymbolicIntNode();
     auto lazySymIntNode = std::dynamic_pointer_cast<torch::lazy::SymbolicIntNode>(symbolicIntNode);
     auto size_node = lazySymIntNode->node_;
-    auto static_value = std::dynamic_pointer_cast<DimensionNode>(size_node)->getStaticValue(); //TODO: blocked on landing torch::lazy::DimensionNode
+    auto static_value = std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node)->getStaticValue();
     target_size[idx] = static_value == -1 ? padded_self[idx] : static_value;
   }
   return {Shape(self.scalar_type(), target_size)};

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -463,6 +463,13 @@ std::vector<Shape> compute_shape_expand(
       target_size[idx] = static_value;
     } else {
       target_size[idx] = _sizes[idx].data();
+      if (_sizes[idx].data() == -1) {
+          // -1 can't be specified for non-existing dimensions
+          TORCH_CHECK(idx >= num_new_dimensions);
+          target_size[idx] = padded_self[idx];
+      } else {
+          target_size[idx] = _sizes[idx].data();
+      }
     }
   }
   return {Shape(self.scalar_type(), target_size)};

--- a/torch/csrc/lazy/core/shape_inference.h
+++ b/torch/csrc/lazy/core/shape_inference.h
@@ -30,6 +30,8 @@ TORCH_API std::vector<torch::lazy::Shape> compute_shape_convolution(const at::Te
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_convolution_backward(const at::Tensor & grad_output, const at::Tensor & input, const at::Tensor & weight, at::OptionalIntArrayRef bias_sizes, at::IntArrayRef stride, at::IntArrayRef padding, at::IntArrayRef dilation, bool transposed, at::IntArrayRef output_padding, int64_t groups, ::std::array<bool,3> output_mask);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_embedding(const at::Tensor & weight, const at::Tensor & indices, int64_t padding_idx, bool scale_grad_by_freq, bool sparse);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_embedding_dense_backward(const at::Tensor & grad_output, const at::Tensor & indices, int64_t num_weights, int64_t padding_idx, bool scale_grad_by_freq);
+TORCH_API std::vector<torch::lazy::Shape> compute_shape_expand(const at::Tensor & self, at::IntArrayRef size, bool implicit);
+// TORCH_API std::vector<torch::lazy::Shape> compute_shape_expand(const at::Tensor & self, c10::SymIntArrayRef size, bool implicit);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_flip(const at::Tensor & self, at::IntArrayRef dims);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_glu_backward(const at::Tensor & grad_output, const at::Tensor & self, int64_t dim);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_glu_jvp(const at::Tensor & glu, const at::Tensor & x, const at::Tensor & dx, int64_t dim);

--- a/torch/csrc/lazy/core/shape_inference.h
+++ b/torch/csrc/lazy/core/shape_inference.h
@@ -2,11 +2,15 @@
 
 #include <ATen/Tensor.h>
 #include <c10/core/ScalarType.h>
+#include <c10/core/SymInt.h>
+#include <c10/core/SymIntArrayRef.h>
+#include <c10/core/SymbolicIntNode.h>
 #include <c10/macros/Export.h>
 #include <c10/util/Optional.h>
 #include <torch/csrc/lazy/backend/backend_data.h>
 #include <torch/csrc/lazy/core/ir.h>
 #include <torch/csrc/lazy/core/shape.h>
+#include <torch/csrc/lazy/core/tensor.h>
 #include <vector>
 
 namespace torch {
@@ -31,7 +35,7 @@ TORCH_API std::vector<torch::lazy::Shape> compute_shape_convolution_backward(con
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_embedding(const at::Tensor & weight, const at::Tensor & indices, int64_t padding_idx, bool scale_grad_by_freq, bool sparse);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_embedding_dense_backward(const at::Tensor & grad_output, const at::Tensor & indices, int64_t num_weights, int64_t padding_idx, bool scale_grad_by_freq);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_expand(const at::Tensor & self, at::IntArrayRef size, bool implicit);
-// TORCH_API std::vector<torch::lazy::Shape> compute_shape_expand(const at::Tensor & self, c10::SymIntArrayRef size, bool implicit);
+TORCH_API std::vector<torch::lazy::Shape> compute_shape_expand(const at::Tensor & self, c10::SymIntArrayRef size, bool implicit);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_flip(const at::Tensor & self, at::IntArrayRef dims);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_glu_backward(const at::Tensor & grad_output, const at::Tensor & self, int64_t dim);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_glu_jvp(const at::Tensor & glu, const at::Tensor & x, const at::Tensor & dx, int64_t dim);


### PR DESCRIPTION
Added support for `expand` in LazyTensor shape inference
Fixes #77831

---

**Blockers:**

- [x] https://github.com/pytorch/pytorch/issues/77880
- [x] https://github.com/pytorch/pytorch/issues/77882