### PR TITLE
[StaticRuntime] Replace Permute with copy version only when it's followed by reshape or flatten

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -2015,7 +2015,7 @@ TEST(StaticRuntime, Transpose) {
 }
 
 TEST(StaticRuntime, Permute) {
-  const auto permute_script = R"JIT(
+  auto permute_script = R"JIT(
     def forward(self, a: Tensor, dims: List[int]):
         return torch.permute(a, dims).clone()
   )JIT";
@@ -2030,6 +2030,16 @@ TEST(StaticRuntime, Permute) {
 
   testStaticRuntime(permute_script, args_a);
   testStaticRuntime(permute_script, args_a, args_b);
+
+  permute_script = R"JIT(
+    def forward(self, a: Tensor, dims: List[int], shape: List[int]):
+        return torch.permute(a, dims).reshape(shape).clone()
+  )JIT";
+
+  a = at::randn({8, 16, 4});
+  dims_a = {0, 2, 1};
+  dims_b = {-1, 16};
+  testStaticRuntime(permute_script, {a, dims_a, dims_b});
 }
 
 TEST(StaticRuntime, Slice) {

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -161,6 +161,8 @@ void OptimizeGraph(
 #ifdef FBCODE_CAFFE2
     if (opts.use_copy_variants && !opts.enable_tensorexpr_fusion) {
       ReplaceWithCopy(graph);
+    } else {
+      ReplacePermuteWithCopy(graph);
     }
     if (opts.use_maybe_copy_variants && !opts.enable_tensorexpr_fusion) {
       ReplaceWithMaybeCopy(graph);

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -666,25 +666,17 @@ void ReplaceWithMaybeCopy(
 #endif
 }
 
-void ReplaceWithCopy(
+void ReplaceWithCopyImpl(
     std::shared_ptr<Graph>& graph,
+    const FastMap<c10::Symbol, c10::Symbol>& supported,
+    const std::vector<std::pair<c10::FunctionSchema, c10::Symbol>>&
+        supported_schema,
+    const std::function<bool(Node*)>& f_extra_checks,
     bool outputs_are_immutable) {
   AliasDb db(graph);
-  const FastMap<c10::Symbol, c10::Symbol> supported = {
-#ifdef FBCODE_CAFFE2
-      OP_PAIR("aten::permute", "static_runtime::permute_copy"),
-      OP_PAIR("fb::expand_dims", "static_runtime::expand_dims_copy"),
-#endif
-      OP_PAIR("aten::narrow", "aten::narrow_copy"),
-      OP_PAIR("aten::reshape", "static_runtime::reshape_copy"),
-      OP_PAIR("aten::flatten", "static_runtime::flatten_copy")};
 
-  static const std::array<std::pair<c10::FunctionSchema, c10::Symbol>, 1>
-      supported_schema = {
-          {{torch::schema("aten::dequantize.self(Tensor self) -> Tensor"),
-            fromQualString("static_runtime::dequantize_copy")}}};
-
-  auto match_schema = [](const Node* node, c10::Symbol& out_matched_symbol) {
+  auto match_schema = [&supported_schema](
+                          const Node* node, c10::Symbol& out_matched_symbol) {
     for (auto& schema : supported_schema) {
       if (node->matches(schema.first)) {
         out_matched_symbol = schema.second;
@@ -732,11 +724,14 @@ void ReplaceWithCopy(
     if (!outputs_are_immutable && db.mayContainAlias(out, graph->outputs())) {
       continue;
     }
+    if (!f_extra_checks(n)) {
+      continue;
+    }
     auto* new_node = graph->create(new_symbol, n->outputs().size());
     for (auto* input : n->inputs()) {
       new_node->addInput(input);
     }
-    replacement.emplace_back(std::make_pair(n, new_node));
+    replacement.emplace_back(n, new_node);
   }
 
   for (const auto& p : replacement) {
@@ -752,6 +747,56 @@ void ReplaceWithCopy(
   AliasDb db2(graph);
   torch::jit::Lint(&db2);
 #endif
+}
+
+// replace aten::permute with copy version only when it's followed by
+// reshape/flatten. It's only enabled when ReplaceWithCopy is off.
+void ReplacePermuteWithCopy(
+    std::shared_ptr<Graph>& graph,
+    bool outputs_are_immutable) {
+  AliasDb db(graph);
+  const FastMap<c10::Symbol, c10::Symbol> supported = {
+#ifdef FBCODE_CAFFE2
+      OP_PAIR("aten::permute", "static_runtime::permute_copy"),
+#endif
+  };
+  auto f_extra_checks = [](Node* n) {
+    Value* out = n->output();
+    Node* next_node = out->uses()[0].user;
+    if (next_node->kind() != aten::reshape ||
+        next_node->kind() != aten::flatten) {
+      return true;
+    }
+    return false;
+  };
+  ReplaceWithCopyImpl(
+      graph, supported, {}, f_extra_checks, outputs_are_immutable);
+}
+
+void ReplaceWithCopy(
+    std::shared_ptr<Graph>& graph,
+    bool outputs_are_immutable) {
+  AliasDb db(graph);
+  const FastMap<c10::Symbol, c10::Symbol> supported = {
+#ifdef FBCODE_CAFFE2
+      OP_PAIR("aten::permute", "static_runtime::permute_copy"),
+      OP_PAIR("fb::expand_dims", "static_runtime::expand_dims_copy"),
+#endif
+      OP_PAIR("aten::narrow", "aten::narrow_copy"),
+      OP_PAIR("aten::reshape", "static_runtime::reshape_copy"),
+      OP_PAIR("aten::flatten", "static_runtime::flatten_copy")};
+
+  static const std::vector<std::pair<c10::FunctionSchema, c10::Symbol>>
+      supported_schema = {
+          {{torch::schema("aten::dequantize.self(Tensor self) -> Tensor"),
+            fromQualString("static_runtime::dequantize_copy")}}};
+
+  ReplaceWithCopyImpl(
+      graph,
+      supported,
+      supported_schema,
+      [](Node* n) { return true; },
+      outputs_are_immutable);
 }
 
 void EliminateTrivialEquallySplit(std::shared_ptr<torch::jit::Graph>& graph) {

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -17,6 +17,10 @@ TORCH_API void ReplaceWithCopy(
     std::shared_ptr<torch::jit::Graph>& graph,
     bool outputs_are_immutable = true);
 
+TORCH_API void ReplacePermuteWithCopy(
+    std::shared_ptr<torch::jit::Graph>& graph,
+    bool outputs_are_immutable = true);
+
 void ReplaceWithMaybeCopy(
     std::shared_ptr<torch::jit::Graph>& graph,
     bool outputs_are_immutable = true);


### PR DESCRIPTION
Reviewed By: mikeiovine

Differential Revision: D36466622

