### PR TITLE
re-enable kernel launch checks in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
           set -eux
-          python torch/testing/_internal/_check_kernel_launches.py |& tee "${GITHUB_WORKSPACE}"/cuda_kernel_launch_checks.txt
+          python torch/testing/_internal/check_kernel_launches.py |& tee "${GITHUB_WORKSPACE}"/cuda_kernel_launch_checks.txt
 
   workflow-checks:
     name: workflow-checks

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ always() && steps.requirements.outcome == 'success' }}
         run: |
           set -eux
-          python torch/testing/_check_kernel_launches.py |& tee "${GITHUB_WORKSPACE}"/cuda_kernel_launch_checks.txt
+          python torch/testing/_internal/_check_kernel_launches.py |& tee "${GITHUB_WORKSPACE}"/cuda_kernel_launch_checks.txt
 
   workflow-checks:
     name: workflow-checks


### PR DESCRIPTION
I just saw that I forgot to update the lint workflow in #60862. Unfortunately, [CI doesn't go red](https://github.com/pytorch/pytorch/runs/6503564764#step:9:11):

```
+ python torch/testing/_check_kernel_launches.py
+ tee /home/runner/actions-runner/_work/pytorch/pytorch/cuda_kernel_launch_checks.txt
python: can't open file '/home/runner/actions-runner/_work/pytorch/pytorch/torch/testing/_check_kernel_launches.py': [Errno 2] No such file or directory
```