### PR TITLE
don't treat -1 as symbolic ints

### DIFF
--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -6,13 +6,17 @@ namespace c10 {
 
 std::shared_ptr<SymbolicIntNode> SymInt::toSymbolicIntNode() {
   auto& st = getSymIntTable();
-  TORCH_CHECK(is_symbolic());
+  TORCH_CHECK(is_symbolic(), "SymInt isn't symbolic");
   return st.getNode(SymInt::SYM_TAG_MASK ^ static_cast<uint64_t>(data_));
 }
 
 c10::SymInt SymInt::toSymInt(std::shared_ptr<SymbolicIntNode> sin_sp) {
   auto& sit = getSymIntTable();
-  auto data = sit.addNode(sin_sp) | SYM_TAG_MASK;
+  auto index = sit.addNode(sin_sp);
+  TORCH_CHECK(
+      index != -1,
+      "PyTorch doesn't support more than std::numeric_limits<uint64_t>::max() symints");
+  auto data = index | SYM_TAG_MASK;
   return c10::SymInt(data);
 }
 } // namespace c10

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -39,8 +39,9 @@ class C10_API SymInt {
   }
 
   bool is_symbolic() const {
-    return static_cast<uint64_t>(SYM_TAG_MASK) &
-        static_cast<uint64_t>(this->data_);
+    return data_ != -1 &&
+        (static_cast<uint64_t>(SYM_TAG_MASK) &
+         static_cast<uint64_t>(this->data_));
   }
 
   bool operator==(const SymInt& p2) const {

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -1416,6 +1416,18 @@ TEST(TestSymInt, AddSymbolicInt) {
   ASSERT_TRUE((a + b).expect_int() == 8);
 }
 
+TEST(TestSymInt, MinusOne) {
+  c10::SymInt a(-1);
+  ASSERT_FALSE(a.is_symbolic());
+  try {
+    (void)a.toSymbolicIntNode();
+    ASSERT_TRUE(false); // Supposed to throw.
+  } catch (const std::exception& e) {
+    std::cerr << e.what() << std::endl;
+    ASSERT_TRUE(strstr(e.what(), "SymInt isn't symbolic") != nullptr);
+  }
+}
+
 TEST(FallbackGraphsTest, Basic) {
   static const auto nestGraphIntoFallbackGraph =
       [](const std::shared_ptr<Graph>& graph) {


### PR DESCRIPTION
I think we would like to treat `-1` as a concrete value that backends will need to handle specially possibly constructing a symbolic size expression equivalent to what -1 means for a given op.

This PR changes encoding of SymInts to account for -1 being a concrete value.
Another option I have in mind is to add a dummy int to the SymInt table so we skip -1. Then we can change `is_symbolic` check to `data_ < -1` This seems to be a bit less intuitive @ezyang @suo albeit a bit faster