### PR TITLE
Reorganize Community Section v1

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,11 +28,17 @@ Features described in this documentation are classified by release status:
   binary distributions like PyPI or Conda, except sometimes behind run-time
   flags, and are at an early stage for feedback and testing.
 
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: Community
+
+   community/*
 
 .. toctree::
    :glob:
    :maxdepth: 1
-   :caption: Notes
+   :caption: Guides
 
    notes/*
 
@@ -113,13 +119,6 @@ Features described in this documentation are classified by release status:
    torchtext <https://pytorch.org/text/stable>
    torchvision <https://pytorch.org/vision/stable>
    PyTorch on XLA Devices <http://pytorch.org/xla/>
-
-.. toctree::
-   :glob:
-   :maxdepth: 1
-   :caption: Community
-
-   community/*
 
 Indices and tables
 ==================


### PR DESCRIPTION
- Change Notes to Guides
- Move the Community section to the top