### PR TITLE
[ONNX] Modernize python syntax

### DIFF
--- a/test/onnx/export_onnx_tests_filter.py
+++ b/test/onnx/export_onnx_tests_filter.py
@@ -39,7 +39,7 @@ def collect_generated_testcases(
                         run_generated_test(model_file, data_dir, device)
                 if expect:
                     expect_file = os.path.join(
-                        _expect_dir, "PyTorch-generated-{}.expect".format(d)
+                        _expect_dir, f"PyTorch-generated-{d}.expect"
                     )
                     with open(expect_file, "w") as text_file:
                         model = onnx.load(model_file)
@@ -51,7 +51,7 @@ def collect_generated_testcases(
                 total_pass += 1
             except Exception as e:
                 if verbose:
-                    print("The test case in {} failed!".format(dir_name))
+                    print(f"The test case in {dir_name} failed!")
                     traceback.print_exc()
                 if fail_dir is None:
                     shutil.rmtree(dir_name)
@@ -61,12 +61,10 @@ def collect_generated_testcases(
                         shutil.rmtree(target_dir)
                     shutil.move(dir_name, target_dir)
                 total_fail += 1
-    print(
-        "Successfully generated/updated {} test cases from PyTorch.".format(total_pass)
-    )
+    print(f"Successfully generated/updated {total_pass} test cases from PyTorch.")
     if expect:
-        print("Expected pbtxt files are generated in {}.".format(_expect_dir))
-    print("Failed {} testcases are moved to {}.".format(total_fail, _fail_test_dir))
+        print(f"Expected pbtxt files are generated in {_expect_dir}.")
+    print(f"Failed {total_fail} testcases are moved to {_fail_test_dir}.")
 
 
 if __name__ == "__main__":

--- a/test/onnx/export_onnx_tests_generator.py
+++ b/test/onnx/export_onnx_tests_generator.py
@@ -53,7 +53,7 @@ def gen_module(testcase):
 
 
 def print_stats(FunctionalModule_nums, nn_module):
-    print("{} functional modules detected.".format(FunctionalModule_nums))
+    print(f"{FunctionalModule_nums} functional modules detected.")
     supported = []
     unsupported = []
     not_fully_supported = []
@@ -74,18 +74,18 @@ def print_stats(FunctionalModule_nums, nn_module):
     # Semi-Supported Ops: Part of related test cases of these ops have been exported
     # Unsupported Ops: None of related test cases of these ops have been exported
     for info, l in [
-        ["{} Fully Supported Operators:".format(len(supported)), supported],
+        [f"{len(supported)} Fully Supported Operators:", supported],
         [
-            "{} Semi-Supported Operators:".format(len(not_fully_supported)),
+            f"{len(not_fully_supported)} Semi-Supported Operators:",
             not_fully_supported,
         ],
-        ["{} Unsupported Operators:".format(len(unsupported)), unsupported],
+        [f"{len(unsupported)} Unsupported Operators:", unsupported],
     ]:
         fun(info, l)
 
 
 def convert_tests(testcases, sets=1):
-    print("Collect {} test cases from PyTorch.".format(len(testcases)))
+    print(f"Collect {len(testcases)} test cases from PyTorch.")
     failed = 0
     FunctionalModule_nums = 0
     nn_module = {}
@@ -120,19 +120,19 @@ def convert_tests(testcases, sets=1):
 
             for i in range(sets):
                 output = module(input)
-                data_dir = os.path.join(output_dir, "test_data_set_{}".format(i))
+                data_dir = os.path.join(output_dir, f"test_data_set_{i}")
                 os.makedirs(data_dir)
 
                 for index, var in enumerate([input]):
                     tensor = numpy_helper.from_array(var.data.numpy())
                     with open(
-                        os.path.join(data_dir, "input_{}.pb".format(index)), "wb"
+                        os.path.join(data_dir, f"input_{index}.pb"), "wb"
                     ) as file:
                         file.write(tensor.SerializeToString())
                 for index, var in enumerate([output]):
                     tensor = numpy_helper.from_array(var.data.numpy())
                     with open(
-                        os.path.join(data_dir, "output_{}.pb".format(index)), "wb"
+                        os.path.join(data_dir, f"output_{index}.pb"), "wb"
                     ) as file:
                         file.write(tensor.SerializeToString())
                 input = gen_input(t)

--- a/test/onnx/model_defs/dcgan.py
+++ b/test/onnx/model_defs/dcgan.py
@@ -22,7 +22,7 @@ def weights_init(m):
 
 class _netG(nn.Module):
     def __init__(self, ngpu):
-        super(_netG, self).__init__()
+        super().__init__()
         self.ngpu = ngpu
         self.main = nn.Sequential(
             # input is Z, going into a convolution
@@ -57,7 +57,7 @@ class _netG(nn.Module):
 
 class _netD(nn.Module):
     def __init__(self, ngpu):
-        super(_netD, self).__init__()
+        super().__init__()
         self.ngpu = ngpu
         self.main = nn.Sequential(
             # input is (nc) x 64 x 64

--- a/test/onnx/model_defs/emb_seq.py
+++ b/test/onnx/model_defs/emb_seq.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 
 class EmbeddingNetwork1(nn.Module):
     def __init__(self, dim=5):
-        super(EmbeddingNetwork1, self).__init__()
+        super().__init__()
         self.emb = nn.Embedding(10, dim)
         self.lin1 = nn.Linear(dim, 1)
         self.seq = nn.Sequential(
@@ -17,7 +17,7 @@ class EmbeddingNetwork1(nn.Module):
 
 class EmbeddingNetwork2(nn.Module):
     def __init__(self, in_space=10, dim=3):
-        super(EmbeddingNetwork2, self).__init__()
+        super().__init__()
         self.embedding = nn.Embedding(in_space, dim)
         self.seq = nn.Sequential(self.embedding, nn.Linear(dim, 1), nn.Sigmoid())
 

--- a/test/onnx/model_defs/lstm_flattening_result.py
+++ b/test/onnx/model_defs/lstm_flattening_result.py
@@ -10,7 +10,7 @@ class LstmFlatteningResult(nn.LSTM):
 
 class LstmFlatteningResultWithSeqLength(nn.Module):
     def __init__(self, input_size, hidden_size, layers, bidirect, dropout, batch_first):
-        super(LstmFlatteningResultWithSeqLength, self).__init__()
+        super().__init__()
 
         self.batch_first = batch_first
         self.inner_model = nn.LSTM(
@@ -29,7 +29,7 @@ class LstmFlatteningResultWithSeqLength(nn.Module):
 
 class LstmFlatteningResultWithoutSeqLength(nn.Module):
     def __init__(self, input_size, hidden_size, layers, bidirect, dropout, batch_first):
-        super(LstmFlatteningResultWithoutSeqLength, self).__init__()
+        super().__init__()
 
         self.batch_first = batch_first
         self.inner_model = nn.LSTM(

--- a/test/onnx/model_defs/mnist.py
+++ b/test/onnx/model_defs/mnist.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 
 class MNIST(nn.Module):
     def __init__(self):
-        super(MNIST, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
         self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
         self.conv2_drop = nn.Dropout2d()

--- a/test/onnx/model_defs/op_test.py
+++ b/test/onnx/model_defs/op_test.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 
 class DummyNet(nn.Module):
     def __init__(self, num_classes=1000):
-        super(DummyNet, self).__init__()
+        super().__init__()
         self.features = nn.Sequential(
             nn.LeakyReLU(0.02),
             nn.BatchNorm2d(3),
@@ -20,7 +20,7 @@ class DummyNet(nn.Module):
 
 class ConcatNet(nn.Module):
     def __init__(self):
-        super(ConcatNet, self).__init__()
+        super().__init__()
 
     def forward(self, inputs):
         return torch.cat(inputs, 1)
@@ -28,7 +28,7 @@ class ConcatNet(nn.Module):
 
 class PermuteNet(nn.Module):
     def __init__(self):
-        super(PermuteNet, self).__init__()
+        super().__init__()
 
     def forward(self, input):
         return input.permute(2, 3, 0, 1)
@@ -36,7 +36,7 @@ class PermuteNet(nn.Module):
 
 class PReluNet(nn.Module):
     def __init__(self):
-        super(PReluNet, self).__init__()
+        super().__init__()
         self.features = nn.Sequential(
             nn.PReLU(3),
         )
@@ -48,7 +48,7 @@ class PReluNet(nn.Module):
 
 class FakeQuantNet(nn.Module):
     def __init__(self):
-        super(FakeQuantNet, self).__init__()
+        super().__init__()
         self.fake_quant = torch.ao.quantization.FakeQuantize()
         self.fake_quant.disable_observer()
 

--- a/test/onnx/model_defs/rnn_model_with_packed_sequence.py
+++ b/test/onnx/model_defs/rnn_model_with_packed_sequence.py
@@ -4,7 +4,7 @@ from torch.nn.utils import rnn as rnn_utils
 
 class RnnModelWithPackedSequence(nn.Module):
     def __init__(self, model, batch_first):
-        super(RnnModelWithPackedSequence, self).__init__()
+        super().__init__()
         self.model = model
         self.batch_first = batch_first
 
@@ -19,7 +19,7 @@ class RnnModelWithPackedSequence(nn.Module):
 
 class RnnModelWithPackedSequenceWithoutState(nn.Module):
     def __init__(self, model, batch_first):
-        super(RnnModelWithPackedSequenceWithoutState, self).__init__()
+        super().__init__()
         self.model = model
         self.batch_first = batch_first
 
@@ -33,7 +33,7 @@ class RnnModelWithPackedSequenceWithoutState(nn.Module):
 
 class RnnModelWithPackedSequenceWithState(nn.Module):
     def __init__(self, model, batch_first):
-        super(RnnModelWithPackedSequenceWithState, self).__init__()
+        super().__init__()
         self.model = model
         self.batch_first = batch_first
 

--- a/test/onnx/model_defs/squeezenet.py
+++ b/test/onnx/model_defs/squeezenet.py
@@ -5,7 +5,7 @@ import torch.nn.init as init
 
 class Fire(nn.Module):
     def __init__(self, inplanes, squeeze_planes, expand1x1_planes, expand3x3_planes):
-        super(Fire, self).__init__()
+        super().__init__()
         self.inplanes = inplanes
         self.squeeze = nn.Conv2d(inplanes, squeeze_planes, kernel_size=1)
         self.squeeze_activation = nn.ReLU(inplace=True)
@@ -29,7 +29,7 @@ class Fire(nn.Module):
 
 class SqueezeNet(nn.Module):
     def __init__(self, version=1.0, num_classes=1000, ceil_mode=False):
-        super(SqueezeNet, self).__init__()
+        super().__init__()
         if version not in [1.0, 1.1]:
             raise ValueError(
                 "Unsupported SqueezeNet version {version}:"

--- a/test/onnx/model_defs/srresnet.py
+++ b/test/onnx/model_defs/srresnet.py
@@ -13,7 +13,7 @@ def _initialize_orthogonal(conv):
 
 class ResidualBlock(nn.Module):
     def __init__(self, n_filters):
-        super(ResidualBlock, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(
             n_filters, n_filters, kernel_size=3, padding=1, bias=False
         )
@@ -36,7 +36,7 @@ class ResidualBlock(nn.Module):
 
 class UpscaleBlock(nn.Module):
     def __init__(self, n_filters):
-        super(UpscaleBlock, self).__init__()
+        super().__init__()
         self.upscaling_conv = nn.Conv2d(
             n_filters, 4 * n_filters, kernel_size=3, padding=1
         )
@@ -50,7 +50,7 @@ class UpscaleBlock(nn.Module):
 
 class SRResNet(nn.Module):
     def __init__(self, rescale_factor, n_filters, n_blocks):
-        super(SRResNet, self).__init__()
+        super().__init__()
         self.rescale_levels = int(math.log(rescale_factor, 2))
         self.n_filters = n_filters
         self.n_blocks = n_blocks

--- a/test/onnx/model_defs/super_resolution.py
+++ b/test/onnx/model_defs/super_resolution.py
@@ -4,7 +4,7 @@ import torch.nn.init as init
 
 class SuperResolutionNet(nn.Module):
     def __init__(self, upscale_factor):
-        super(SuperResolutionNet, self).__init__()
+        super().__init__()
 
         self.relu = nn.ReLU()
         self.conv1 = nn.Conv2d(1, 64, (5, 5), (1, 1), (2, 2))

--- a/test/onnx/model_defs/word_language_model.py
+++ b/test/onnx/model_defs/word_language_model.py
@@ -22,7 +22,7 @@ class RNNModel(nn.Module):
         tie_weights=False,
         batchsize=2,
     ):
-        super(RNNModel, self).__init__()
+        super().__init__()
         self.drop = nn.Dropout(dropout)
         self.encoder = nn.Embedding(ntoken, ninp)
         if rnn_type in ["LSTM", "GRU"]:

--- a/test/onnx/pytorch_helper.py
+++ b/test/onnx/pytorch_helper.py
@@ -12,7 +12,7 @@ _next_idx = 0
 # We fake dict here
 
 
-class _FakeDict(object):
+class _FakeDict:
     def __init__(self, fn):
         self.fn = fn
 
@@ -59,7 +59,7 @@ def PyTorchModule(helper, model, sample_arguments, caffe2_inputs, prefix_name=No
     onnx_model = onnx.load(io.BytesIO(f.getvalue()))
     init_net, predict_net = Caffe2Backend.onnx_graph_to_caffe2_net(onnx_model)
 
-    initialized = set([x.name for x in onnx_model.graph.initializer])
+    initialized = {x.name for x in onnx_model.graph.initializer}
     uninitialized_inputs = {
         x.name: i
         for i, x in enumerate(onnx_model.graph.input)
@@ -86,9 +86,7 @@ def PyTorchModule(helper, model, sample_arguments, caffe2_inputs, prefix_name=No
     helper.param_init_net.AppendNet(init_net)
 
     results = tuple(
-        [
-            BlobReference(remap_blob_name(x.name), helper.net)
-            for x in onnx_model.graph.output
-        ]
+        BlobReference(remap_blob_name(x.name), helper.net)
+        for x in onnx_model.graph.output
     )
     return results

--- a/test/onnx/test_caffe2_common.py
+++ b/test/onnx/test_caffe2_common.py
@@ -30,9 +30,7 @@ def run_generated_test(model_file, data_dir, device="CPU"):
     for i in range(input_num):
         inputs.append(
             numpy_helper.to_array(
-                load_tensor_as_numpy_array(
-                    os.path.join(data_dir, "input_{}.pb".format(i))
-                )
+                load_tensor_as_numpy_array(os.path.join(data_dir, f"input_{i}.pb"))
             )
         )
     output_num = len(glob.glob(os.path.join(data_dir, "output_*.pb")))
@@ -40,9 +38,7 @@ def run_generated_test(model_file, data_dir, device="CPU"):
     for i in range(output_num):
         outputs.append(
             numpy_helper.to_array(
-                load_tensor_as_numpy_array(
-                    os.path.join(data_dir, "output_{}.pb".format(i))
-                )
+                load_tensor_as_numpy_array(os.path.join(data_dir, f"output_{i}.pb"))
             )
         )
     prepared = c2.prepare(model, device=device)

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -25,7 +25,7 @@ def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7, opset_versions=None):
 
 
 TestModels = type(
-    str("TestModels"),
+    "TestModels",
     (unittest.TestCase,),
     dict(TestModels.__dict__, is_script_test_enabled=False, exportTest=exportTest),
 )
@@ -33,7 +33,7 @@ TestModels = type(
 
 # model tests for scripting with new JIT APIs and shape inference
 TestModels_new_jit_API = type(
-    str("TestModels_new_jit_API"),
+    "TestModels_new_jit_API",
     (unittest.TestCase,),
     dict(
         TestModels.__dict__,

--- a/test/onnx/test_onnx_opset.py
+++ b/test/onnx/test_onnx_opset.py
@@ -169,7 +169,7 @@ class TestONNXOpset(TestCase):
     def test_upsample(self):
         class MyModule(Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
 
             def forward(self, x):
                 size = [v * 2 for v in x.size()[2:]]
@@ -181,7 +181,7 @@ class TestONNXOpset(TestCase):
             {
                 "op_name": "Upsample",
                 "attributes": [
-                    {"name": "mode", "s": ("nearest").encode(), "type": 3},
+                    {"name": "mode", "s": (b"nearest"), "type": 3},
                     {"name": "scales", "floats": [1.0, 1.0, 2.0, 2.0], "type": 6},
                 ],
             }
@@ -190,7 +190,7 @@ class TestONNXOpset(TestCase):
             {"op_name": "Constant"},
             {
                 "op_name": "Upsample",
-                "attributes": [{"name": "mode", "s": ("nearest").encode(), "type": 3}],
+                "attributes": [{"name": "mode", "s": (b"nearest"), "type": 3}],
             },
         ]
         ops = {8: ops8, 9: ops9}
@@ -200,7 +200,7 @@ class TestONNXOpset(TestCase):
     def test_cast_constant(self):
         class MyModule(Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
 
             def forward(self, x):
                 return x - 1
@@ -301,7 +301,7 @@ class TestONNXOpset(TestCase):
     def test_dropout(self):
         class MyModule(Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.dropout = torch.nn.Dropout(0.5)
 
             def forward(self, x):
@@ -381,7 +381,7 @@ class TestONNXOpset(TestCase):
             {"op_name": "Concat"},
             {
                 "op_name": "Upsample",
-                "attributes": [{"name": "mode", "s": ("nearest").encode(), "type": 3}],
+                "attributes": [{"name": "mode", "s": (b"nearest"), "type": 3}],
             },
         ]
         ops_10 = [
@@ -410,7 +410,7 @@ class TestONNXOpset(TestCase):
             {"op_name": "Concat"},
             {
                 "op_name": "Resize",
-                "attributes": [{"name": "mode", "s": ("nearest").encode(), "type": 3}],
+                "attributes": [{"name": "mode", "s": (b"nearest"), "type": 3}],
             },
         ]
 
@@ -434,7 +434,7 @@ class TestONNXOpset(TestCase):
             {"op_name": "Concat"},
             {
                 "op_name": "Upsample",
-                "attributes": [{"name": "mode", "s": ("nearest").encode(), "type": 3}],
+                "attributes": [{"name": "mode", "s": (b"nearest"), "type": 3}],
             },
         ]
         ops_10 = [
@@ -465,14 +465,14 @@ class TestONNXOpset(TestCase):
             {"op_name": "Constant"},
             {
                 "op_name": "Upsample",
-                "attributes": [{"name": "mode", "s": ("nearest").encode(), "type": 3}],
+                "attributes": [{"name": "mode", "s": (b"nearest"), "type": 3}],
             },
         ]
         ops_10 = [
             {"op_name": "Constant"},
             {
                 "op_name": "Resize",
-                "attributes": [{"name": "mode", "s": ("nearest").encode(), "type": 3}],
+                "attributes": [{"name": "mode", "s": (b"nearest"), "type": 3}],
             },
         ]
         ops = {9: ops_9, 10: ops_10}

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -69,7 +69,7 @@ class FuncModule(Module):
     def __init__(self, f, params=None):
         if params is None:
             params = ()
-        super(FuncModule, self).__init__()
+        super().__init__()
         self.f = f
         self.params = nn.ParameterList(list(params))
 
@@ -120,7 +120,7 @@ class TestOperators(TestCase):
                 for index, var in enumerate(flatten(args)):
                     tensor = onnx.numpy_helper.from_array(var.data.numpy())
                     with open(
-                        os.path.join(data_dir, "input_{}.pb".format(index)), "wb"
+                        os.path.join(data_dir, f"input_{index}.pb"), "wb"
                     ) as file:
                         file.write(tensor.SerializeToString())
                 outputs = m(*args)
@@ -129,7 +129,7 @@ class TestOperators(TestCase):
                 for index, var in enumerate(flatten(outputs)):
                     tensor = onnx.numpy_helper.from_array(var.data.numpy())
                     with open(
-                        os.path.join(data_dir, "output_{}.pb".format(index)), "wb"
+                        os.path.join(data_dir, f"output_{index}.pb"), "wb"
                     ) as file:
                         file.write(tensor.SerializeToString())
 

--- a/test/onnx/test_pytorch_helper.py
+++ b/test/onnx/test_pytorch_helper.py
@@ -20,7 +20,7 @@ class TestCaffe2Backend(unittest.TestCase):
     def test_helper(self):
         class SuperResolutionNet(nn.Module):
             def __init__(self, upscale_factor, inplace=False):
-                super(SuperResolutionNet, self).__init__()
+                super().__init__()
 
                 self.relu = nn.ReLU(inplace=inplace)
                 self.conv1 = nn.Conv2d(1, 64, (5, 5), (1, 1), (2, 2))

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -293,7 +293,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_linear(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
                 self.many_fc = nn.Sequential(
                     nn.Linear(4, 5, bias=True),
                     nn.ReLU(inplace=True),
@@ -312,7 +312,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_onnx_export_with_parameter_renaming(self):
         class SimpleFcNet(nn.Module):
             def __init__(self):
-                super(SimpleFcNet, self).__init__()
+                super().__init__()
                 self.fc1 = nn.Linear(5, 10)
 
             def forward(self, input):
@@ -344,7 +344,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_onnx_export_param_name_duplication(self):
         class SimpleFcNet(nn.Module):
             def __init__(self):
-                super(SimpleFcNet, self).__init__()
+                super().__init__()
                 self.fc1 = nn.Linear(5, 10)
 
             def forward(self, input):
@@ -821,7 +821,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, input):
                 return input + c.type_as(input)
@@ -835,7 +835,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def _test_index_generic(self, fn):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, input):
                 return fn(input)
@@ -932,7 +932,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_chunk(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, input):
                 # TODO: Why index? This returns a tuple and test runner doesn't
@@ -944,7 +944,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_sqrt(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, input):
                 return input.sqrt()
@@ -963,7 +963,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_log(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, input):
                 return input.log()
@@ -975,7 +975,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_erf(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, input):
                 return input.erf()
@@ -987,7 +987,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         def test_func(name):
             class MyModel(torch.nn.Module):
                 def __init__(self):
-                    super(MyModel, self).__init__()
+                    super().__init__()
 
                 def forward(self, input):
                     return getattr(input, name)()
@@ -1007,7 +1007,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_addconstant(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, input):
                 # TODO: Why index? This returns a tuple and test runner doesn't
@@ -1019,7 +1019,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_subconstant(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, input):
                 # TODO: Why index? This returns a tuple and test runner doesn't
@@ -1123,7 +1123,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         self.run_model_test(model, train=False, input=x, batch_size=BATCH_SIZE)
 
     def test_adaptive_avg_pool1D(self):
-        model = torch.nn.AdaptiveAvgPool1d((5))
+        model = torch.nn.AdaptiveAvgPool1d(5)
         x = torch.randn(20, 16, 50, requires_grad=True)
         self.run_model_test(model, train=False, input=x, batch_size=BATCH_SIZE)
 
@@ -1139,7 +1139,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
     @skipIfUnsupportedMinOpsetVersion(8)
     def test_adaptive_max_pool1D(self):
-        model = torch.nn.AdaptiveMaxPool1d((5))
+        model = torch.nn.AdaptiveMaxPool1d(5)
         x = torch.randn(20, 16, 50, requires_grad=True)
         self.run_model_test(model, train=False, input=x, batch_size=BATCH_SIZE)
 
@@ -1176,7 +1176,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_mm(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, m1, m2):
                 return torch.mm(m1, m2)
@@ -1190,7 +1190,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_addmm(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, ma, m1, m2):
                 return torch.addmm(ma, m1, m2)
@@ -1266,7 +1266,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_consecutive_transposes(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, x):
                 return x.transpose(1, 2).transpose(2, 3)
@@ -1282,7 +1282,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
             class MyModel(torch.nn.Module):
                 def __init__(self):
-                    super(MyModel, self).__init__()
+                    super().__init__()
 
                 def forward(self, x):
                     return torch.sum(x, **params)
@@ -1298,7 +1298,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
             class MyModel(torch.nn.Module):
                 def __init__(self):
-                    super(MyModel, self).__init__()
+                    super().__init__()
 
                 def forward(self, x):
                     return torch.cumsum(x, **params)
@@ -1331,7 +1331,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_lstm_constant_folding(self):
         class LstmNet(nn.Module):
             def __init__(self, input_size, hidden_size, num_layers, bidirectional):
-                super(LstmNet, self).__init__()
+                super().__init__()
                 self.lstm = nn.LSTM(
                     input_size, hidden_size, num_layers, bidirectional=bidirectional
                 )
@@ -1376,7 +1376,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_gru_constant_folding(self):
         class GruNet(nn.Module):
             def __init__(self, input_size, hidden_size, num_layers, bidirectional):
-                super(GruNet, self).__init__()
+                super().__init__()
                 self.mygru = nn.GRU(
                     input_size, hidden_size, num_layers, bidirectional=bidirectional
                 )
@@ -1419,7 +1419,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_repeat(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, x):
                 return x.repeat(1, 2, 3, 4)
@@ -1441,7 +1441,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_interpolate_upsample(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, x):
                 size = [v * 2 for v in x.size()[2:]]
@@ -1459,7 +1459,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_interpolate_upsample_dynamic_sizes(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, x):
                 size = [v * 2 for v in x.size()[2:]]
@@ -1474,7 +1474,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_repeat_dim_overflow(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, x):
                 return x.repeat(1, 2, 3, 4)
@@ -1487,7 +1487,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_repeat_dynamic(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, x, y):
                 return x.repeat(y.size()[0] // 2, y.size()[1] * 2)
@@ -1518,7 +1518,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
             class MyModel(torch.nn.Module):
                 def __init__(self):
-                    super(MyModel, self).__init__()
+                    super().__init__()
 
                 def forward(self, x):
                     return torch.mean(x, **params)
@@ -1605,7 +1605,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
             class MyModel(torch.nn.Module):
                 def __init__(self):
-                    super(MyModel, self).__init__()
+                    super().__init__()
 
                 def forward(self, x):
                     return x.unsqueeze(dim)
@@ -1622,7 +1622,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
             class MyModel(torch.nn.Module):
                 def __init__(self):
-                    super(MyModel, self).__init__()
+                    super().__init__()
 
                 def forward(self, x):
                     return x.squeeze(dim)
@@ -1651,7 +1651,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_dynamic_sizes(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, x):
                 shape = torch.onnx.operators.shape_as_tensor(x)
@@ -1666,7 +1666,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_advanced_broadcast(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, x, y):
                 return torch.mul(x, y)
@@ -1680,7 +1680,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_int8_export(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
                 self.param = torch.ByteTensor(3, 4).random_()
 
             def forward(self, x):
@@ -2322,7 +2322,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         # so we have ListConstruct in the symbolic
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv2d(A, 4 * A, 1, stride=1)
 
             def forward(self, feature, im_info, anchors):
@@ -2369,7 +2369,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_c2_roi_align(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, feature, rois):
                 roi_feature = torch.ops._caffe2.RoIAlign(
@@ -2402,7 +2402,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_c2_generate_proposals(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, scores, bbox_deltas, im_info, anchors):
                 a, b = torch.ops._caffe2.GenerateProposals(
@@ -2440,7 +2440,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_c2_bbox_transform(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, rois, deltas, im_info):
                 a, b = torch.ops._caffe2.BBoxTransform(
@@ -2488,7 +2488,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, rotated
         )
-        pred_bbox, batch_splits = [
+        pred_bbox, batch_splits = (
             t.detach().numpy()
             for t in torch.ops._caffe2.BBoxTransform(
                 torch.tensor(rois),
@@ -2503,7 +2503,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 clip_angle_thresh,
                 legacy_plus_one=True,
             )
-        ]
+        )
         class_prob = np.random.randn(sum(roi_counts), num_classes).astype(np.float32)
         score_thresh = 0.5
         nms_thresh = 0.5
@@ -2511,7 +2511,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, class_prob, pred_bbox, batch_splits):
                 a, b, c, d, e, f = torch.ops._caffe2.BoxWithNMSLimit(
@@ -2552,7 +2552,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, lstm_in):
                 a, b, c = torch.ops._caffe2.InferenceLSTM(
@@ -2858,7 +2858,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     def test_dropout(self):
         class DropoutModel(torch.nn.Module):
             def __init__(self):
-                super(DropoutModel, self).__init__()
+                super().__init__()
                 self.dropout = torch.nn.Dropout(0.5)
 
             def forward(self, x):
@@ -3196,44 +3196,44 @@ setup_rnn_tests()
 # add the same test suite as above, but switch embed_params=False
 # to embed_params=True
 TestCaffe2BackendEmbed_opset9 = type(
-    str("TestCaffe2BackendEmbed_opset9"),
+    "TestCaffe2BackendEmbed_opset9",
     (unittest.TestCase,),
     dict(TestCaffe2Backend_opset9.__dict__, embed_params=True),
 )
 
 # opset 7 tests
 TestCaffe2Backend_opset7 = type(
-    str("TestCaffe2Backend_opset7"),
+    "TestCaffe2Backend_opset7",
     (unittest.TestCase,),
     dict(TestCaffe2Backend_opset9.__dict__, opset_version=7),
 )
 TestCaffe2BackendEmbed_opset7 = type(
-    str("TestCaffe2BackendEmbed_opset7"),
+    "TestCaffe2BackendEmbed_opset7",
     (unittest.TestCase,),
     dict(TestCaffe2Backend_opset9.__dict__, embed_params=True, opset_version=7),
 )
 
 # opset 8 tests
 TestCaffe2Backend_opset8 = type(
-    str("TestCaffe2Backend_opset8"),
+    "TestCaffe2Backend_opset8",
     (unittest.TestCase,),
     dict(TestCaffe2Backend_opset9.__dict__, opset_version=8),
 )
 TestCaffe2BackendEmbed_opset8 = type(
-    str("TestCaffe2BackendEmbed_opset8"),
+    "TestCaffe2BackendEmbed_opset8",
     (unittest.TestCase,),
     dict(TestCaffe2Backend_opset9.__dict__, embed_params=True, opset_version=8),
 )
 
 # opset 10 tests
 TestCaffe2Backend_opset10 = type(
-    str("TestCaffe2Backend_opset10"),
+    "TestCaffe2Backend_opset10",
     (unittest.TestCase,),
     dict(TestCaffe2Backend_opset9.__dict__, opset_version=10),
 )
 
 TestCaffe2BackendEmbed_opset10 = type(
-    str("TestCaffe2BackendEmbed_opset10"),
+    "TestCaffe2BackendEmbed_opset10",
     (unittest.TestCase,),
     dict(TestCaffe2Backend_opset9.__dict__, embed_params=True, opset_version=10),
 )
@@ -3241,7 +3241,7 @@ TestCaffe2BackendEmbed_opset10 = type(
 # add the same test suite as above, but switch embed_params=False
 # to embed_params=True
 TestCaffe2BackendEmbed_opset9_new_jit_API = type(
-    str("TestCaffe2BackendEmbed_opset9_new_jit_API"),
+    "TestCaffe2BackendEmbed_opset9_new_jit_API",
     (unittest.TestCase,),
     dict(TestCaffe2Backend_opset9.__dict__, embed_params=True),
 )

--- a/test/onnx/test_pytorch_onnx_caffe2_quantized.py
+++ b/test/onnx/test_pytorch_onnx_caffe2_quantized.py
@@ -65,7 +65,7 @@ class TestQuantizedOps(unittest.TestCase):
     def generic_unary_test(self, op):
         class QModule(torch.nn.Module):
             def __init__(self, op):
-                super(QModule, self).__init__()
+                super().__init__()
                 self.quant1 = torch.ao.quantization.QuantStub()
                 self.op = op
                 self.dequant = torch.ao.quantization.DeQuantStub()
@@ -80,7 +80,7 @@ class TestQuantizedOps(unittest.TestCase):
     def test_quantized_add(self):
         class QAddModule(torch.nn.Module):
             def __init__(self):
-                super(QAddModule, self).__init__()
+                super().__init__()
                 self.quant1 = torch.ao.quantization.QuantStub()
                 self.quant2 = torch.ao.quantization.QuantStub()
                 self.dequant = torch.ao.quantization.DeQuantStub()
@@ -121,7 +121,7 @@ class TestQuantizedOps(unittest.TestCase):
     def test_qlinear_model(self):
         class LinearModel(torch.nn.Module):
             def __init__(self):
-                super(LinearModel, self).__init__()
+                super().__init__()
                 self.qconfig = torch.ao.quantization.default_qconfig
                 self.fc1 = torch.ao.quantization.QuantWrapper(
                     torch.nn.Linear(5, 10).to(dtype=torch.float)
@@ -158,7 +158,7 @@ class TestQuantizedOps(unittest.TestCase):
     def test_qconv_model(self):
         class ConvModel(torch.nn.Module):
             def __init__(self):
-                super(ConvModel, self).__init__()
+                super().__init__()
                 self.qconfig = torch.ao.quantization.default_qconfig
                 self.fc1 = torch.ao.quantization.QuantWrapper(
                     torch.nn.Conv2d(3, 5, 2, bias=True).to(dtype=torch.float)
@@ -196,7 +196,7 @@ class TestQuantizedOps(unittest.TestCase):
     def test_upsample(self):
         class QUpsampleModule(torch.nn.Module):
             def __init__(self):
-                super(QUpsampleModule, self).__init__()
+                super().__init__()
                 self.quant1 = torch.ao.quantization.QuantStub()
                 self.dequant = torch.ao.quantization.DeQuantStub()
 
@@ -212,7 +212,7 @@ class TestQuantizedOps(unittest.TestCase):
     def test_avg_pool2d(self):
         class QAvgPool2dModule(torch.nn.Module):
             def __init__(self):
-                super(QAvgPool2dModule, self).__init__()
+                super().__init__()
                 self.quant1 = torch.ao.quantization.QuantStub()
                 self.dequant = torch.ao.quantization.DeQuantStub()
 
@@ -230,7 +230,7 @@ class TestQuantizedOps(unittest.TestCase):
     def test_reshape(self):
         class QReshapeModule(torch.nn.Module):
             def __init__(self):
-                super(QReshapeModule, self).__init__()
+                super().__init__()
                 self.quant1 = torch.ao.quantization.QuantStub()
                 self.dequant = torch.ao.quantization.DeQuantStub()
 
@@ -244,7 +244,7 @@ class TestQuantizedOps(unittest.TestCase):
     def test_slice(self):
         class QSliceModule(torch.nn.Module):
             def __init__(self):
-                super(QSliceModule, self).__init__()
+                super().__init__()
                 self.quant1 = torch.ao.quantization.QuantStub()
                 self.dequant = torch.ao.quantization.DeQuantStub()
 
@@ -259,7 +259,7 @@ class TestQuantizedOps(unittest.TestCase):
     def test_cat(self):
         class QConcatModule(torch.nn.Module):
             def __init__(self):
-                super(QConcatModule, self).__init__()
+                super().__init__()
                 self.quant1 = torch.ao.quantization.QuantStub()
                 self.dequant = torch.ao.quantization.DeQuantStub()
 
@@ -283,7 +283,7 @@ class TestQuantizedOps(unittest.TestCase):
     def test_max_pool2d(self):
         class QMaxPool2dModule(torch.nn.Module):
             def __init__(self):
-                super(QMaxPool2dModule, self).__init__()
+                super().__init__()
                 self.quant1 = torch.ao.quantization.QuantStub()
                 self.dequant = torch.ao.quantization.DeQuantStub()
 
@@ -302,7 +302,7 @@ class TestQuantizedOps(unittest.TestCase):
     def test_small_model(self):
         class SimpleModel(torch.nn.Module):
             def __init__(self):
-                super(SimpleModel, self).__init__()
+                super().__init__()
                 self.quant = torch.ao.quantization.QuantStub()
                 self.dequant = torch.ao.quantization.DeQuantStub()
                 self.func_add = nnq.FloatFunctional()

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -544,7 +544,7 @@ class _TestONNXRuntime:
     def test_embedding_model_with_external_data(self):
         class LargeModel(torch.nn.Module):
             def __init__(self):
-                super(LargeModel, self).__init__()
+                super().__init__()
                 dim = 15
                 n = 4 * 100
                 self.emb = torch.nn.Embedding(n, dim)
@@ -567,7 +567,7 @@ class _TestONNXRuntime:
     def test_large_model_with_external_data(self):
         class LargeModel(torch.nn.Module):
             def __init__(self):
-                super(LargeModel, self).__init__()
+                super().__init__()
                 dim = 5
                 n = 40 * 4 * 10**6
                 self.emb = torch.nn.Embedding(n, dim)
@@ -589,7 +589,7 @@ class _TestONNXRuntime:
     def test_large_model_with_non_str_file(self):
         class LargeModel(torch.nn.Module):
             def __init__(self):
-                super(LargeModel, self).__init__()
+                super().__init__()
                 dim = 5
                 n = 40 * 4 * 10**6
                 self.emb = torch.nn.Embedding(n, dim)
@@ -615,7 +615,7 @@ class _TestONNXRuntime:
     def test_fuse_conv_bn1d(self):
         class Fuse(torch.nn.Module):
             def __init__(self):
-                super(Fuse, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv1d(16, 33, 3, stride=2)
                 self.bn = torch.nn.BatchNorm1d(33)
 
@@ -630,7 +630,7 @@ class _TestONNXRuntime:
     def test_fuse_conv_bn2d(self):
         class Fuse(torch.nn.Module):
             def __init__(self):
-                super(Fuse, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv2d(
                     3, 2, kernel_size=1, stride=2, padding=3, bias=False
                 )
@@ -647,7 +647,7 @@ class _TestONNXRuntime:
     def test_fuse_conv_bn3d(self):
         class Fuse(torch.nn.Module):
             def __init__(self):
-                super(Fuse, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv3d(
                     3, 2, (3, 5, 2), stride=(2, 1, 1), padding=(3, 2, 0), bias=False
                 )
@@ -664,7 +664,7 @@ class _TestONNXRuntime:
     def test_fuse_conv_in_block(self):
         class Fuse(torch.nn.Module):
             def __init__(self):
-                super(Fuse, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv1d(
                     in_channels=5,
                     out_channels=5,
@@ -703,7 +703,7 @@ class _TestONNXRuntime:
 
         class ConvTBC(torch.nn.Module):
             def __init__(self, in_channels, out_channels, kernel_size, padding=0):
-                super(ConvTBC, self).__init__()
+                super().__init__()
                 self.in_channels = in_channels
                 self.out_channels = out_channels
                 self.kernel_size = _single(kernel_size)
@@ -739,7 +739,7 @@ class _TestONNXRuntime:
             def __init__(
                 self,
             ):
-                super(Reshape, self).__init__()
+                super().__init__()
                 self.register_buffer("weight", torch.ones(5))
 
             def forward(self, x):
@@ -1797,7 +1797,7 @@ class _TestONNXRuntime:
     def test_conv(self):
         class TraceModel(torch.nn.Module):
             def __init__(self):
-                super(TraceModel, self).__init__()
+                super().__init__()
                 self.conv1 = torch.nn.Conv1d(16, 33, 3, stride=2)
                 self.conv2 = torch.nn.Conv2d(
                     16, 33, (3, 5), stride=(2, 1), padding=(4, 2), dilation=(3, 1)
@@ -1818,7 +1818,7 @@ class _TestONNXRuntime:
     def test_conv_shape_inference(self):
         class Model(torch.nn.Module):
             def __init__(self):
-                super(Model, self).__init__()
+                super().__init__()
                 self.conv2 = torch.nn.Conv2d(
                     16, 33, (3, 5), stride=(2, 1), padding=(4, 2), dilation=(3, 1)
                 )
@@ -1834,7 +1834,7 @@ class _TestONNXRuntime:
     def test_conv_transpose(self):
         class TraceModel(torch.nn.Module):
             def __init__(self):
-                super(TraceModel, self).__init__()
+                super().__init__()
                 self.conv1 = torch.nn.ConvTranspose1d(16, 33, 3, stride=2)
                 self.conv2 = torch.nn.ConvTranspose2d(
                     16, 33, (3, 5), stride=(2, 1), padding=(4, 2), dilation=(3, 1)
@@ -1857,7 +1857,7 @@ class _TestONNXRuntime:
     def test_transpose_infer_shape(self):
         class TransposeModule(torch.jit.ScriptModule):
             def __init__(self):
-                super(TransposeModule, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv2d(3, 1, 3, stride=2)
 
             @torch.jit.script_method
@@ -1878,7 +1878,7 @@ class _TestONNXRuntime:
     def squeeze_model_tests(self, d, x1, x2):
         class Squeeze(torch.nn.Module):
             def __init__(self, d):
-                super(Squeeze, self).__init__()
+                super().__init__()
                 self.d = d
 
             def forward(self, x):
@@ -3003,7 +3003,7 @@ class _TestONNXRuntime:
 
         class ScriptModel(torch.nn.Module):
             def __init__(self):
-                super(ScriptModel, self).__init__()
+                super().__init__()
                 self.ngram = 2
                 self.max_target_positions = 512
 
@@ -3253,7 +3253,7 @@ class _TestONNXRuntime:
             ]
 
             def __init__(self, mode, use_size, is_upsample, align_corners):
-                super(MyModel, self).__init__()
+                super().__init__()
                 self.mode = mode
                 self.use_size = use_size
                 self.is_upsample = is_upsample
@@ -3372,7 +3372,7 @@ class _TestONNXRuntime:
 
         class ScriptModule(torch.jit.ScriptModule):
             def __init__(self):
-                super(ScriptModule, self).__init__()
+                super().__init__()
                 self.submodule = ScriptModel()
 
             @torch.jit.script_method
@@ -4023,7 +4023,7 @@ class _TestONNXRuntime:
     def test_index_select_scaler_index(self):
         class IndexSelectScalerIndexModel(torch.nn.Module):
             def __init__(self, index_base):
-                super(IndexSelectScalerIndexModel, self).__init__()
+                super().__init__()
                 self.index_base = torch.tensor(index_base)
 
             def forward(self, x, index_offset):
@@ -4413,7 +4413,7 @@ class _TestONNXRuntime:
     def test_gather_constant_fold(self):
         class GatherModule(torch.nn.Module):
             def __init__(self):
-                super(GatherModule, self).__init__()
+                super().__init__()
                 self.register_buffer("weight", torch.ones(5))
                 # torch.nn.Embedding is converted to ONNX::Gather.
                 # Constant folding will be triggerred for constant inputs.
@@ -4432,7 +4432,7 @@ class _TestONNXRuntime:
 
         class GatherModule(torch.nn.Module):
             def __init__(self):
-                super(GatherModule, self).__init__()
+                super().__init__()
                 self.register_buffer("weight", torch.ones(2))
 
             def forward(self, x):
@@ -4447,7 +4447,7 @@ class _TestONNXRuntime:
 
         class GatherModule(torch.nn.Module):
             def __init__(self):
-                super(GatherModule, self).__init__()
+                super().__init__()
                 self.register_buffer("rb", torch.randn(1, 1, 3, 1, 1))
 
             def forward(self, x):
@@ -4778,7 +4778,7 @@ class _TestONNXRuntime:
     def test_lstm_fixed_batch_size(self):
         class LSTMModel(torch.nn.Module):
             def __init__(self):
-                super(LSTMModel, self).__init__()
+                super().__init__()
                 self.lstm = torch.nn.LSTM(
                     RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, 1, bidirectional=False
                 )
@@ -4801,7 +4801,7 @@ class _TestONNXRuntime:
     def test_lstm_post_fix_init_state(self):
         class LSTMModel(torch.nn.Module):
             def __init__(self):
-                super(LSTMModel, self).__init__()
+                super().__init__()
                 self.lstm = torch.nn.LSTM(
                     RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, 1, bidirectional=False
                 )
@@ -4828,7 +4828,7 @@ class _TestONNXRuntime:
     def test_lstm_constant_folding(self):
         class LstmNet(torch.nn.Module):
             def __init__(self, input_size, hidden_size, num_layers, bidirectional):
-                super(LstmNet, self).__init__()
+                super().__init__()
                 self.lstm = torch.nn.LSTM(
                     input_size, hidden_size, num_layers, bidirectional=bidirectional
                 )
@@ -4858,7 +4858,7 @@ class _TestONNXRuntime:
     def test_lstm_no_bias(self):
         class LstmNet(torch.nn.Module):
             def __init__(self, num_layers, bidirectional):
-                super(LstmNet, self).__init__()
+                super().__init__()
                 self.lstm = torch.nn.LSTM(
                     RNN_INPUT_SIZE,
                     RNN_HIDDEN_SIZE,
@@ -4966,7 +4966,7 @@ class _TestONNXRuntime:
     def test_gru_no_bias(self):
         class GruNet(torch.nn.Module):
             def __init__(self, input_size, hidden_size, num_layers, bidirectional):
-                super(GruNet, self).__init__()
+                super().__init__()
                 self.mygru = torch.nn.GRU(
                     input_size,
                     hidden_size,
@@ -5006,7 +5006,7 @@ class _TestONNXRuntime:
     def test_gru_constant_folding(self):
         class GruNet(torch.nn.Module):
             def __init__(self, input_size, hidden_size, num_layers, bidirectional):
-                super(GruNet, self).__init__()
+                super().__init__()
                 self.mygru = torch.nn.GRU(
                     input_size, hidden_size, num_layers, bidirectional=bidirectional
                 )
@@ -5640,7 +5640,7 @@ class _TestONNXRuntime:
     def test_linear(self):
         class LinearModel(torch.nn.Module):
             def __init__(self):
-                super(LinearModel, self).__init__()
+                super().__init__()
                 self.fc = torch.nn.Linear(16, 16)
 
             def forward(self, x):
@@ -5978,7 +5978,7 @@ class _TestONNXRuntime:
     def test_chunk(self):
         class ChunkModel(torch.nn.Module):
             def __init__(self, dim=1):
-                super(ChunkModel, self).__init__()
+                super().__init__()
                 self.dim = dim
 
             def forward(self, x):
@@ -6012,7 +6012,7 @@ class _TestONNXRuntime:
     def test_dynamic_chunk(self):
         class ChunkModel(torch.nn.Module):
             def __init__(self, dim=1):
-                super(ChunkModel, self).__init__()
+                super().__init__()
                 self.dim = dim
 
             def forward(self, x):
@@ -7128,7 +7128,7 @@ class _TestONNXRuntime:
     def test_unfold_infer_shape(self):
         class UnfoldModule(torch.jit.ScriptModule):
             def __init__(self):
-                super(UnfoldModule, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv1d(3, 1, 3, stride=2)
 
             @torch.jit.script_method
@@ -7193,7 +7193,7 @@ class _TestONNXRuntime:
     def test_prelu(self):
         class PReluModel(torch.nn.Module):
             def __init__(self):
-                super(PReluModel, self).__init__()
+                super().__init__()
                 self.prelu = torch.nn.PReLU()
 
             def forward(self, x):
@@ -7216,7 +7216,7 @@ class _TestONNXRuntime:
     def test_relu6(self):
         class Relu6Model(torch.nn.Module):
             def __init__(self):
-                super(Relu6Model, self).__init__()
+                super().__init__()
                 self.relu6 = torch.nn.ReLU6()
 
             def forward(self, x):
@@ -7235,7 +7235,7 @@ class _TestONNXRuntime:
     def test_silu(self):
         class SiLUModel(torch.nn.Module):
             def __init__(self):
-                super(SiLUModel, self).__init__()
+                super().__init__()
                 self.silu = torch.nn.SiLU()
 
             def forward(self, x):
@@ -7293,7 +7293,7 @@ class _TestONNXRuntime:
     def test_mish(self):
         class MishModel(torch.nn.Module):
             def __init__(self):
-                super(MishModel, self).__init__()
+                super().__init__()
                 self.mish = torch.nn.Mish()
 
             def forward(self, x):
@@ -8138,7 +8138,7 @@ class _TestONNXRuntime:
     def test_linalg_norm(self):
         class LinalgSingleDimModel(torch.nn.Module):
             def __init__(self, ord_val):
-                super(LinalgSingleDimModel, self).__init__()
+                super().__init__()
                 self.ord = ord_val
 
             def forward(self, x):
@@ -8154,7 +8154,7 @@ class _TestONNXRuntime:
 
         class LinalgMultiDimModel(torch.nn.Module):
             def __init__(self, ord_val):
-                super(LinalgMultiDimModel, self).__init__()
+                super().__init__()
                 self.ord = ord_val
 
             def forward(self, x):
@@ -8180,7 +8180,7 @@ class _TestONNXRuntime:
 
         class LinalgNoDim1DModel(torch.nn.Module):
             def __init__(self, ord_val):
-                super(LinalgNoDim1DModel, self).__init__()
+                super().__init__()
                 self.ord = ord_val
 
             def forward(self, x):
@@ -8196,7 +8196,7 @@ class _TestONNXRuntime:
 
         class LinalgNoDim2DModel(torch.nn.Module):
             def __init__(self, ord_val):
-                super(LinalgNoDim2DModel, self).__init__()
+                super().__init__()
                 self.ord = ord_val
 
             def forward(self, x):
@@ -8213,7 +8213,7 @@ class _TestONNXRuntime:
     def test_linalg_vector_norm_zero(self):
         class LinalgVectorNormModel(torch.nn.Module):
             def __init__(self, ord_val):
-                super(LinalgVectorNormModel, self).__init__()
+                super().__init__()
                 self.ord = ord_val
 
             def forward(self, x):
@@ -8225,7 +8225,7 @@ class _TestONNXRuntime:
     def test_linalg_vector_norm(self):
         class LinalgVectorNormModel(torch.nn.Module):
             def __init__(self, ord_val, dim_info):
-                super(LinalgVectorNormModel, self).__init__()
+                super().__init__()
                 self.ord = ord_val
                 self.dim, self.keepdim = dim_info
 
@@ -8244,7 +8244,7 @@ class _TestONNXRuntime:
     def test_linalg_matrix_norm(self):
         class LinalgMatrixNormModel(torch.nn.Module):
             def __init__(self, ord_val, dim_val=(-2, -1), keepdim_val=False):
-                super(LinalgMatrixNormModel, self).__init__()
+                super().__init__()
                 self.ord = ord_val
                 self.dim = dim_val
                 self.keepdim = keepdim_val
@@ -8436,7 +8436,7 @@ class _TestONNXRuntime:
     def _crossentropyloss(self, x, y, ignore_index):
         class CrossEntropyLossNone(torch.nn.Module):
             def __init__(self, ignore_index):
-                super(CrossEntropyLossNone, self).__init__()
+                super().__init__()
                 if ignore_index == -100:
                     self.loss = torch.nn.CrossEntropyLoss(reduction="none")
                 else:
@@ -8451,7 +8451,7 @@ class _TestONNXRuntime:
 
         class CrossEntropyLossNoneWeight(torch.nn.Module):
             def __init__(self, ignore_index):
-                super(CrossEntropyLossNoneWeight, self).__init__()
+                super().__init__()
                 if ignore_index == -100:
                     self.loss = torch.nn.CrossEntropyLoss(
                         reduction="none", weight=torch.randn(5)
@@ -8470,7 +8470,7 @@ class _TestONNXRuntime:
 
         class CrossEntropyLossSum(torch.nn.Module):
             def __init__(self, ignore_index):
-                super(CrossEntropyLossSum, self).__init__()
+                super().__init__()
                 if ignore_index == -100:
                     self.loss = torch.nn.CrossEntropyLoss(reduction="sum")
                 else:
@@ -8485,7 +8485,7 @@ class _TestONNXRuntime:
 
         class CrossEntropyLossSumWeight(torch.nn.Module):
             def __init__(self, ignore_index):
-                super(CrossEntropyLossSumWeight, self).__init__()
+                super().__init__()
                 if ignore_index == -100:
                     self.loss = torch.nn.CrossEntropyLoss(
                         reduction="sum", weight=torch.randn(5)
@@ -8504,7 +8504,7 @@ class _TestONNXRuntime:
 
         class CrossEntropyLossMean(torch.nn.Module):
             def __init__(self, ignore_index):
-                super(CrossEntropyLossMean, self).__init__()
+                super().__init__()
                 if ignore_index == -100:
                     self.loss = torch.nn.CrossEntropyLoss()
                 else:
@@ -8517,7 +8517,7 @@ class _TestONNXRuntime:
 
         class CrossEntropyLossMeanWeight(torch.nn.Module):
             def __init__(self, ignore_index):
-                super(CrossEntropyLossMeanWeight, self).__init__()
+                super().__init__()
                 if ignore_index == -100:
                     self.loss = torch.nn.CrossEntropyLoss(weight=torch.randn(5))
                 else:
@@ -8548,7 +8548,7 @@ class _TestONNXRuntime:
     def _kldiv_loss(self, x, y):
         class KLDivLossNone(torch.nn.Module):
             def __init__(self):
-                super(KLDivLossNone, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.KLDivLoss(reduction="none", log_target=True)
 
             def forward(self, input, target):
@@ -8558,7 +8558,7 @@ class _TestONNXRuntime:
 
         class KLDivLossMean(torch.nn.Module):
             def __init__(self):
-                super(KLDivLossMean, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.KLDivLoss(reduction="mean", log_target=False)
 
             def forward(self, input, target):
@@ -8568,7 +8568,7 @@ class _TestONNXRuntime:
 
         class KLDivLossSum(torch.nn.Module):
             def __init__(self):
-                super(KLDivLossSum, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.KLDivLoss(reduction="sum", log_target=True)
 
             def forward(self, input, target):
@@ -8578,7 +8578,7 @@ class _TestONNXRuntime:
 
         class KLDivLossBatchMean(torch.nn.Module):
             def __init__(self):
-                super(KLDivLossBatchMean, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.KLDivLoss(reduction="batchmean", log_target=False)
 
             def forward(self, input, target):
@@ -8588,7 +8588,7 @@ class _TestONNXRuntime:
 
         class KLDivLossMiniBatchMean(torch.nn.Module):
             def __init__(self):
-                super(KLDivLossMiniBatchMean, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.KLDivLoss(
                     reduction="batchmean", size_average=False, log_target=True
                 )
@@ -8602,7 +8602,7 @@ class _TestONNXRuntime:
     def test_nllloss(self):
         class NLLModel(torch.nn.Module):
             def __init__(self):
-                super(NLLModel, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.NLLLoss(reduction="none")
                 self.m = torch.nn.LogSoftmax(dim=1)
 
@@ -8622,7 +8622,7 @@ class _TestONNXRuntime:
     def test_nllloss_2d_none(self):
         class NLLModel(torch.nn.Module):
             def __init__(self):
-                super(NLLModel, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.NLLLoss(reduction="none")
                 self.conv = torch.nn.Conv2d(16, C, (3, 3))
                 self.m = torch.nn.LogSoftmax(dim=1)
@@ -8643,7 +8643,7 @@ class _TestONNXRuntime:
     def test_nllloss_2d_mean(self):
         class NLLModel(torch.nn.Module):
             def __init__(self):
-                super(NLLModel, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.NLLLoss(reduction="mean")
                 self.conv = torch.nn.Conv2d(16, C, (3, 3))
                 self.m = torch.nn.LogSoftmax(dim=1)
@@ -8664,7 +8664,7 @@ class _TestONNXRuntime:
     def test_nllloss_2d_sum(self):
         class NLLModel(torch.nn.Module):
             def __init__(self):
-                super(NLLModel, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.NLLLoss(reduction="sum")
                 self.conv = torch.nn.Conv2d(16, C, (3, 3))
                 self.m = torch.nn.LogSoftmax(dim=1)
@@ -8685,7 +8685,7 @@ class _TestONNXRuntime:
     def test_nllloss_2d_mean_weights(self):
         class NLLModel(torch.nn.Module):
             def __init__(self):
-                super(NLLModel, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.NLLLoss(reduction="mean", weight=torch.randn(C))
                 self.conv = torch.nn.Conv2d(16, C, (3, 3))
                 self.m = torch.nn.LogSoftmax(dim=1)
@@ -8706,7 +8706,7 @@ class _TestONNXRuntime:
     def test_nllloss_2d_mean_ignore_index(self):
         class NLLModel(torch.nn.Module):
             def __init__(self):
-                super(NLLModel, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.NLLLoss(reduction="mean", ignore_index=1)
                 self.conv = torch.nn.Conv2d(16, C, (3, 3))
                 self.m = torch.nn.LogSoftmax(dim=1)
@@ -8764,7 +8764,7 @@ class _TestONNXRuntime:
     def test_nllloss_2d_mean_ignore_index_weights(self):
         class NLLModel(torch.nn.Module):
             def __init__(self):
-                super(NLLModel, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.NLLLoss(
                     reduction="mean", weight=torch.randn(C), ignore_index=1
                 )
@@ -9084,7 +9084,7 @@ class _TestONNXRuntime:
     def test_dropout(self):
         class M(torch.nn.Module):
             def __init__(self):
-                super(M, self).__init__()
+                super().__init__()
                 self.dropout = torch.nn.Dropout(0.3)
 
             def forward(self, x):
@@ -9097,7 +9097,7 @@ class _TestONNXRuntime:
     def test_shape_constant_fold(self):
         class ShapeModule(torch.nn.Module):
             def __init__(self):
-                super(ShapeModule, self).__init__()
+                super().__init__()
                 self.register_buffer("weight", torch.ones(5))
 
             def forward(self, x):
@@ -9111,7 +9111,7 @@ class _TestONNXRuntime:
     def test_celu(self):
         class Celu(torch.nn.Module):
             def __init__(self):
-                super(Celu, self).__init__()
+                super().__init__()
                 self.celu = torch.nn.CELU(alpha=1.0)
 
             def forward(self, input):
@@ -9124,7 +9124,7 @@ class _TestONNXRuntime:
     def test_celu_default(self):
         class Celu(torch.nn.Module):
             def __init__(self):
-                super(Celu, self).__init__()
+                super().__init__()
                 self.celu = torch.nn.CELU()
 
             def forward(self, input):
@@ -9137,7 +9137,7 @@ class _TestONNXRuntime:
     def test_celu_alpha(self):
         class Celu(torch.nn.Module):
             def __init__(self):
-                super(Celu, self).__init__()
+                super().__init__()
                 self.celu = torch.nn.CELU(alpha=2.0)
 
             def forward(self, input):
@@ -9150,7 +9150,7 @@ class _TestONNXRuntime:
     def test_celu_cast(self):
         class Celu(torch.nn.Module):
             def __init__(self):
-                super(Celu, self).__init__()
+                super().__init__()
                 self.celu = torch.nn.CELU()
 
             def forward(self, input):
@@ -9434,7 +9434,7 @@ class _TestONNXRuntime:
     def test_onnx_proto_checker(self):
         class Model(torch.nn.Module):
             def __init__(self):
-                super(Model, self).__init__()
+                super().__init__()
 
             def forward(self, x):
                 return 2 * x
@@ -9564,7 +9564,7 @@ class _TestONNXRuntime:
     ):
         class ElmanWithStateModel(torch.nn.Module):
             def __init__(self, layers, nonlinearity, bidirect, dropout, batch_first):
-                super(ElmanWithStateModel, self).__init__()
+                super().__init__()
 
                 self.batch_first = batch_first
                 self.inner_model = torch.nn.RNN(
@@ -9582,7 +9582,7 @@ class _TestONNXRuntime:
 
         class ElmanWithoutStateModel(torch.nn.Module):
             def __init__(self, layers, nonlinearity, bidirect, dropout, batch_first):
-                super(ElmanWithoutStateModel, self).__init__()
+                super().__init__()
                 self.batch_first = batch_first
                 self.inner_model = torch.nn.RNN(
                     RNN_INPUT_SIZE,
@@ -9706,7 +9706,7 @@ class _TestONNXRuntime:
     def _gru_test(self, layers, bidirectional, initial_state, packed_sequence, dropout):
         class GRUWithStateModel(torch.nn.Module):
             def __init__(self, layers, bidirect, dropout, batch_first):
-                super(GRUWithStateModel, self).__init__()
+                super().__init__()
 
                 self.batch_first = batch_first
                 self.inner_model = torch.nn.GRU(
@@ -9723,7 +9723,7 @@ class _TestONNXRuntime:
 
         class GRUWithoutStateModel(torch.nn.Module):
             def __init__(self, layers, bidirect, dropout, batch_first):
-                super(GRUWithoutStateModel, self).__init__()
+                super().__init__()
                 self.batch_first = batch_first
                 self.inner_model = torch.nn.GRU(
                     RNN_INPUT_SIZE,
@@ -9739,7 +9739,7 @@ class _TestONNXRuntime:
 
         class GRUNoSeqLengthWithoutStateModel(torch.nn.Module):
             def __init__(self, layers, bidirect, dropout, batch_first):
-                super(GRUNoSeqLengthWithoutStateModel, self).__init__()
+                super().__init__()
                 self.batch_first = batch_first
                 self.inner_model = torch.nn.GRU(
                     RNN_INPUT_SIZE,
@@ -9755,7 +9755,7 @@ class _TestONNXRuntime:
 
         class GRUNoSeqLengthWithStateModel(torch.nn.Module):
             def __init__(self, layers, bidirect, dropout, batch_first):
-                super(GRUNoSeqLengthWithStateModel, self).__init__()
+                super().__init__()
                 self.batch_first = batch_first
                 self.inner_model = torch.nn.GRU(
                     RNN_INPUT_SIZE,
@@ -9837,7 +9837,7 @@ class _TestONNXRuntime:
 
         class MyModule(torch.nn.Module):
             def __init__(self, ninp, nhead, nhid, dropout, nlayers):
-                super(MyModule, self).__init__()
+                super().__init__()
                 encoder_layers = TransformerEncoderLayer(ninp, nhead, nhid, dropout)
                 self.transformer_encoder = TransformerEncoder(encoder_layers, nlayers)
 
@@ -9926,7 +9926,7 @@ class _TestONNXRuntime:
     def test_batchnorm_training(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.bn1 = torch.nn.BatchNorm2d(3, affine=False)
                 self.cv1 = torch.nn.Conv2d(3, 3, 10)
                 self.bn2 = torch.nn.BatchNorm2d(3, affine=True)
@@ -9962,7 +9962,7 @@ class _TestONNXRuntime:
     def test_batchnorm_training_mode_fix_layer(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.bn1 = torch.nn.BatchNorm2d(3, affine=True)
                 self.cv1 = torch.nn.Conv2d(3, 3, 10)
                 self.bn2 = torch.nn.BatchNorm2d(3, affine=False)
@@ -9999,7 +9999,7 @@ class _TestONNXRuntime:
     def test_batchnorm_eval_mode_train_layer(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.bn1 = torch.nn.BatchNorm2d(3, affine=True)
                 self.cv1 = torch.nn.Conv2d(3, 3, 10)
                 self.bn2 = torch.nn.BatchNorm2d(3, affine=False)
@@ -10036,7 +10036,7 @@ class _TestONNXRuntime:
     def test_instancenorm_training(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.in1 = torch.nn.InstanceNorm2d(3, affine=True)
                 self.cv1 = torch.nn.Conv2d(3, 3, 10)
                 self.in2 = torch.nn.InstanceNorm2d(3, affine=False)
@@ -10072,7 +10072,7 @@ class _TestONNXRuntime:
     def test_instancenorm_training_mode_fix_layer(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.in1 = torch.nn.InstanceNorm2d(3, affine=True)
                 self.cv1 = torch.nn.Conv2d(3, 3, 10)
                 self.in2 = torch.nn.InstanceNorm2d(3, affine=False)
@@ -10109,7 +10109,7 @@ class _TestONNXRuntime:
     def test_instancenorm_eval_mode_train_layer(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.in1 = torch.nn.InstanceNorm2d(8, affine=True)
                 self.cv1 = torch.nn.Conv2d(8, 8, 10)
                 self.in2 = torch.nn.InstanceNorm2d(8, affine=False)
@@ -10147,7 +10147,7 @@ class _TestONNXRuntime:
     def test_dropout_training(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.dropout = torch.nn.Dropout(0.4)
 
             def forward(self, x):
@@ -10182,7 +10182,7 @@ class _TestONNXRuntime:
     def test_dropout_training_zero(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.dropout = torch.nn.Dropout(0.5)
 
             def forward(self, x):
@@ -10238,7 +10238,7 @@ class _TestONNXRuntime:
     def test_conv_bn(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv2d(
                     3, 16, kernel_size=1, stride=2, padding=3, bias=True
                 )
@@ -10263,7 +10263,7 @@ class _TestONNXRuntime:
     def test_multiple_conv_bn(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.conv1 = torch.nn.Conv2d(
                     3, 64, kernel_size=7, stride=2, padding=3, bias=False
                 )
@@ -10303,7 +10303,7 @@ class _TestONNXRuntime:
         self.run_test(model_export, (x,), training=torch.onnx.TrainingMode.EVAL)
 
     def test_script_custom_class_error(self):
-        class BoxCoder(object):
+        class BoxCoder:
             def __init__(self, bbox_xform_clip: float) -> None:
                 self.bbox_xform_clip = bbox_xform_clip
 
@@ -10321,7 +10321,7 @@ class _TestONNXRuntime:
             }
 
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.box_coder = BoxCoder(1.4)
 
             def forward(self, box_regression: Tensor, proposals: List[Tensor]):
@@ -10337,7 +10337,7 @@ class _TestONNXRuntime:
     def test_initializer_sequence(self):
         class MyModule(torch.nn.Module):
             def __init__(self, input_size, hidden_size, num_classes):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.fc1 = torch.nn.Linear(input_size, hidden_size)
                 self.relu = torch.nn.ReLU()
                 self.fc2 = torch.nn.Linear(hidden_size, num_classes)
@@ -10391,7 +10391,7 @@ class _TestONNXRuntime:
 
         class MyModule(torch.nn.Module):
             def __init__(self, input_size, hidden_size, num_classes):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.fc1 = torch.nn.Linear(input_size, hidden_size)
                 self.relu = torch.nn.ReLU()
                 self.fc2 = torch.nn.Linear(hidden_size, num_classes)
@@ -10523,7 +10523,7 @@ class _TestONNXRuntime:
     def test_resize_images(self):
         class TransformModule(torch.nn.Module):
             def __init__(self):
-                super(TransformModule, self).__init__()
+                super().__init__()
                 self.transform = _init_test_generalized_rcnn_transform()
 
             def forward(self, images):
@@ -10544,7 +10544,7 @@ class _TestONNXRuntime:
     def test_transform_images(self):
         class TransformModule(torch.nn.Module):
             def __init__(self):
-                super(TransformModule, self).__init__()
+                super().__init__()
                 self.transform = _init_test_generalized_rcnn_transform()
 
             def forward(self, images: List[Tensor]):
@@ -10575,7 +10575,7 @@ class _TestONNXRuntime:
 
         class RPNModule(torch.nn.Module):
             def __init__(self):
-                super(RPNModule, self).__init__()
+                super().__init__()
                 self.rpn = _init_test_rpn()
 
             def forward(self, images, features: Dict[str, Tensor]):
@@ -10614,7 +10614,7 @@ class _TestONNXRuntime:
     def test_multi_scale_roi_align(self):
         class TransformModule(torch.nn.Module):
             def __init__(self):
-                super(TransformModule, self).__init__()
+                super().__init__()
                 self.model = ops.MultiScaleRoIAlign(["feat1", "feat2"], 3, 2)
                 self.image_sizes = [(512, 512)]
 
@@ -10656,7 +10656,7 @@ class _TestONNXRuntime:
     def test_roi_heads(self):
         class RoiHeadsModule(torch.nn.Module):
             def __init__(self):
-                super(RoiHeadsModule, self).__init__()
+                super().__init__()
                 self.transform = _init_test_generalized_rcnn_transform()
                 self.rpn = _init_test_rpn()
                 self.roi_heads = _init_test_roi_heads_faster_rcnn()
@@ -10773,7 +10773,7 @@ class _TestONNXRuntime:
 
         class Module(torch.nn.Module):
             def __init__(self):
-                super(Module, self).__init__()
+                super().__init__()
                 self.module = InnerModule(embedding_dim=8)
 
             def forward(self, x):
@@ -10813,7 +10813,7 @@ class _TestONNXRuntime:
 
         class Module(torch.nn.Module):
             def __init__(self):
-                super(Module, self).__init__()
+                super().__init__()
                 self.module = InnerModule(embedding_dim=8)
 
             def forward(self, x):
@@ -10826,7 +10826,7 @@ class _TestONNXRuntime:
     def test_set_attr(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv1d(3, 10, 2)
                 self.b = False
 
@@ -10849,7 +10849,7 @@ class _TestONNXRuntime:
     def test_set_attr_2(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv1d(10, 3, 3)
                 self.conv.bias = torch.nn.Parameter(torch.zeros(3, 10, 3))
 
@@ -10874,7 +10874,7 @@ class _TestONNXRuntime:
     def test_set_attr_3(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv1d(10, 3, 3)
                 self.conv.weight = torch.nn.Parameter(torch.zeros(3, 10))
                 self.conv.bias = torch.nn.Parameter(torch.zeros(3, 10, 3))
@@ -10901,7 +10901,7 @@ class _TestONNXRuntime:
     def test_set_attr_4(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv1d(10, 3, 3)
                 self.conv.bias = torch.nn.Parameter(torch.zeros(3, 10, 3))
 
@@ -10933,7 +10933,7 @@ class _TestONNXRuntime:
     def test_set_attr_5(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv1d(10, 3, 3)
                 self.conv.bias = torch.nn.Parameter(torch.zeros(3, 10, 3))
 
@@ -10964,7 +10964,7 @@ class _TestONNXRuntime:
     def test_set_attr_in_loop(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv1d(10, 3, 3)
                 self.conv.weight = torch.nn.Parameter(torch.zeros(3, 10))
                 self.conv.bias = torch.nn.Parameter(torch.zeros(3, 10, 3))
@@ -10992,7 +10992,7 @@ class _TestONNXRuntime:
     def test_set_attr_in_loop_with_list(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv1d(10, 3, 3)
                 self.conv.weight = torch.nn.Parameter(torch.zeros(3, 10))
                 self.conv.bias = torch.nn.Parameter(torch.zeros(3, 10, 3))
@@ -11418,7 +11418,7 @@ class _TestONNXRuntime:
     def test_input_mask_model(self):
         class InputMaskModel(torch.nn.Module):
             def __init__(self, output_size):
-                super(InputMaskModel, self).__init__()
+                super().__init__()
                 self.bias = torch.nn.Parameter(
                     torch.empty(output_size, dtype=torch.float)
                 )
@@ -11447,7 +11447,7 @@ class _TestONNXRuntime:
 
         class InputMaskModel(torch.nn.Module):
             def __init__(self, output_size):
-                super(InputMaskModel, self).__init__()
+                super().__init__()
 
             def forward(self, model_input_1, model_input_2, y):
                 input_mask_1 = (model_input_1 <= 0) | (model_input_1 > 25)
@@ -11767,7 +11767,7 @@ class _TestONNXRuntime:
     def test_hann_window_periodic(self):
         class HannWindowModule_Periodic(torch.nn.Module):
             def __init__(self):
-                super(HannWindowModule_Periodic, self).__init__()
+                super().__init__()
                 self.window_length = 0
 
             def forward(self, x, window_length: int):
@@ -11789,7 +11789,7 @@ class _TestONNXRuntime:
     def test_hann_window_not_periodic(self):
         class HannWindowModule_NotPeriodic(torch.nn.Module):
             def __init__(self):
-                super(HannWindowModule_NotPeriodic, self).__init__()
+                super().__init__()
                 self.window_length = 0
 
             def forward(self, x, window_length: int):
@@ -11812,7 +11812,7 @@ class _TestONNXRuntime:
     def test_hann_window_default_values(self):
         class HannWindowModule(torch.nn.Module):
             def __init__(self):
-                super(HannWindowModule, self).__init__()
+                super().__init__()
                 self.window_length = 0
 
             def forward(self, x, window_length: int):
@@ -11915,7 +11915,7 @@ class _TestONNXRuntime:
     def test_index_add_normal(self):
         class M(torch.nn.Module):
             def __init__(self, dim, index, updates):
-                super(M, self).__init__()
+                super().__init__()
                 self.dim = dim
                 self.index = index
                 self.updates = updates
@@ -11945,7 +11945,7 @@ class _TestONNXRuntime:
     def test_index_add_dim_size_differ(self):
         class M(torch.nn.Module):
             def __init__(self, dim, index, updates):
-                super(M, self).__init__()
+                super().__init__()
                 self.dim = dim
                 self.index = index
                 self.updates = updates
@@ -11963,7 +11963,7 @@ class _TestONNXRuntime:
     def test_index_add_in_loop(self):
         class M(torch.nn.Module):
             def __init__(self, dim, index, updates, loop_count):
-                super(M, self).__init__()
+                super().__init__()
                 self.dim = dim
                 self.index = index
                 self.updates = updates
@@ -11986,7 +11986,7 @@ class _TestONNXRuntime:
     def test_index_add_if(self):
         class M(torch.nn.Module):
             def __init__(self, dim, updates, index_true, index_false):
-                super(M, self).__init__()
+                super().__init__()
                 self.dim = dim
                 self.updates = updates
                 self.index_true = index_true
@@ -12014,7 +12014,7 @@ class _TestONNXRuntime:
     def test_index_add_dynamic_axes(self):
         class M(torch.nn.Module):
             def __init__(self, dim, index, updates):
-                super(M, self).__init__()
+                super().__init__()
                 self.dim = dim
                 self.index = index
                 self.updates = updates
@@ -12041,7 +12041,7 @@ class _TestONNXRuntime:
     def test_roll(self):
         class M(torch.nn.Module):
             def __init__(self, shifts, dims):
-                super(M, self).__init__()
+                super().__init__()
                 self.shifts = shifts
                 self.dims = dims
 
@@ -12257,7 +12257,7 @@ class _TestONNXRuntime:
     def test_tuple_output_from_if_with_raised_exception(self):
         class M(torch.nn.Module):
             def __init__(self):
-                super(M, self).__init__()
+                super().__init__()
 
             def forward(self, t: Tensor) -> Tuple[Tensor, Tensor]:
                 if float(t) < 0:
@@ -12824,7 +12824,7 @@ def setup_rnn_tests():
     # make sure no one accidentally disables all the tests without
     # noticing
     if test_count != 192:
-        raise ValueError("Expected 192 tests but found {}".format(test_count))
+        raise ValueError(f"Expected 192 tests but found {test_count}")
 
 
 setup_rnn_tests()

--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -48,7 +48,7 @@ class TestONNXRuntime_cuda(unittest.TestCase):
     def test_layer_norm_fp16(self):
         class LayerNormModel(torch.nn.Module):
             def __init__(self):
-                super(LayerNormModel, self).__init__()
+                super().__init__()
                 self.layer_norm = torch.nn.LayerNorm([10, 10])
 
             @autocast()
@@ -72,7 +72,7 @@ class TestONNXRuntime_cuda(unittest.TestCase):
     def test_softmaxCrossEntropy_fusion_fp16(self):
         class FusionModel(torch.nn.Module):
             def __init__(self):
-                super(FusionModel, self).__init__()
+                super().__init__()
                 self.loss = torch.nn.NLLLoss(reduction="none")
                 self.m = torch.nn.LogSoftmax(dim=1)
 
@@ -96,7 +96,7 @@ class TestONNXRuntime_cuda(unittest.TestCase):
     def test_apex_o2(self):
         class LinearModel(torch.nn.Module):
             def __init__(self):
-                super(LinearModel, self).__init__()
+                super().__init__()
                 self.linear = torch.nn.Linear(3, 5)
 
             def forward(self, x):

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -318,7 +318,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
     def test_constant_fold_unsqueeze_multi_axies(self):
         class PReluModel(torch.nn.Module):
             def __init__(self):
-                super(PReluModel, self).__init__()
+                super().__init__()
                 self.prelu = torch.nn.PReLU()
 
             def forward(self, x):
@@ -415,7 +415,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
     def test_constant_fold_lstm(self):
         class GruNet(torch.nn.Module):
             def __init__(self):
-                super(GruNet, self).__init__()
+                super().__init__()
                 self.mygru = torch.nn.GRU(7, 3, 1, bidirectional=False)
 
             def forward(self, input, initial_state):
@@ -446,7 +446,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
     def test_constant_fold_transpose_matmul(self):
         class MatMulNet(torch.nn.Module):
             def __init__(self):
-                super(MatMulNet, self).__init__()
+                super().__init__()
                 self.B = torch.nn.Parameter(torch.ones(5, 3))
 
             def forward(self, A):
@@ -468,7 +468,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             def __init__(
                 self,
             ):
-                super(ReshapeModule, self).__init__()
+                super().__init__()
                 self.register_buffer("weight", torch.ones(5))
 
             def forward(self, x):
@@ -491,7 +491,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             def __init__(
                 self,
             ):
-                super(Module, self).__init__()
+                super().__init__()
                 self.register_buffer("weight", torch.ones(5))
 
             def forward(self, x):
@@ -514,7 +514,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             def __init__(
                 self,
             ):
-                super(Module, self).__init__()
+                super().__init__()
                 self.register_buffer("weight", torch.ones(5))
 
             def forward(self, x):
@@ -537,7 +537,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             def __init__(
                 self,
             ):
-                super(Module, self).__init__()
+                super().__init__()
                 self.register_buffer("weight", torch.ones(5))
 
             def forward(self, x):
@@ -569,7 +569,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             def __init__(
                 self,
             ):
-                super(Module, self).__init__()
+                super().__init__()
                 self.register_buffer("weight", torch.ones(5))
 
             def forward(self, x):
@@ -601,7 +601,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             def __init__(
                 self,
             ):
-                super(Module, self).__init__()
+                super().__init__()
                 self.register_buffer("weight", torch.ones(5))
 
             def forward(self, x):
@@ -621,7 +621,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
     def test_constant_fold_shape(self):
         class ShapeModule(torch.nn.Module):
             def __init__(self):
-                super(ShapeModule, self).__init__()
+                super().__init__()
                 self.register_buffer("weight", torch.ones(5))
 
             def forward(self, x):
@@ -1240,7 +1240,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
     def test_unused_initializers(self):
         class Model(torch.nn.Module):
             def __init__(self):
-                super(Model, self).__init__()
+                super().__init__()
                 self.conv2 = torch.nn.ConvTranspose2d(
                     16, 33, (3, 5), stride=(2, 1), padding=(4, 2), dilation=(1, 1)
                 )
@@ -1267,7 +1267,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
     def test_scripting_param(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv2d(
                     3, 16, kernel_size=1, stride=2, padding=3, bias=True
                 )
@@ -1303,7 +1303,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
     def test_modifying_params(self):
         class MyModel(torch.nn.Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
                 self.param = torch.nn.Parameter(torch.tensor([2.0]))
 
             def forward(self, x):
@@ -1321,7 +1321,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
     def test_fuse_conv_bn(self):
         class Fuse(torch.nn.Module):
             def __init__(self):
-                super(Fuse, self).__init__()
+                super().__init__()
                 self.conv = torch.nn.Conv2d(
                     3, 2, kernel_size=1, stride=2, padding=3, bias=True
                 )
@@ -1367,7 +1367,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
 
         class MyModule(torch.nn.Module):
             def __init__(self):
-                super(MyModule, self).__init__()
+                super().__init__()
 
             def forward(self, x, y):
                 return f(x, y)
@@ -1478,7 +1478,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         model = torch.jit.script(MyModule()) if torchscript else MyModule()
 
         x = torch.randn(3, 3)
-        param_name_set = set([k for k, _ in model.named_parameters()])
+        param_name_set = {k for k, _ in model.named_parameters()}
 
         # Test training mode.
         model.train()
@@ -1491,9 +1491,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             opset_version=self.opset_version,
         )
         graph = onnx.load(io.BytesIO(f.getvalue()))
-        self.assertSetEqual(
-            set([i.name for i in graph.graph.initializer]), param_name_set
-        )
+        self.assertSetEqual({i.name for i in graph.graph.initializer}, param_name_set)
 
         model.train()
         f = io.BytesIO()
@@ -1505,9 +1503,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
             opset_version=self.opset_version,
         )
         graph = onnx.load(io.BytesIO(f.getvalue()))
-        self.assertSetEqual(
-            set([i.name for i in graph.graph.initializer]), param_name_set
-        )
+        self.assertSetEqual({i.name for i in graph.graph.initializer}, param_name_set)
 
         # Test eval mode.
         model.eval()
@@ -1515,9 +1511,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         torch.onnx.export(model, (x,), f, opset_version=self.opset_version)
         graph = onnx.load(io.BytesIO(f.getvalue()))
         param_name_set.remove("param2")
-        self.assertSetEqual(
-            set([i.name for i in graph.graph.initializer]), param_name_set
-        )
+        self.assertSetEqual({i.name for i in graph.graph.initializer}, param_name_set)
 
     def test_deduplicate_initializers(self):
         self._test_deduplicate_initializers(torchscript=False)
@@ -1545,12 +1539,12 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         f = io.BytesIO()
         torch.onnx.export(Model(), (x, y), f, opset_version=self.opset_version)
         graph = onnx.load(io.BytesIO(f.getvalue()))
-        self.assertSetEqual(set([i.name for i in graph.graph.initializer]), {"w_cpu"})
+        self.assertSetEqual({i.name for i in graph.graph.initializer}, {"w_cpu"})
 
     def test_duplicated_output_node(self):
         class DuplicatedOutputNet(torch.nn.Module):
             def __init__(self, input_size, num_classes):
-                super(DuplicatedOutputNet, self).__init__()
+                super().__init__()
                 self.fc1 = torch.nn.Linear(input_size, num_classes)
 
             def forward(self, input0, input1):

--- a/test/onnx/test_verify.py
+++ b/test/onnx/test_verify.py
@@ -50,7 +50,7 @@ class TestVerify(TestCase):
     def test_jumbled_params(self):
         class MyModel(Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
 
             def forward(self, x):
                 y = x * x
@@ -64,7 +64,7 @@ class TestVerify(TestCase):
     def test_dynamic_model_structure(self):
         class MyModel(Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
                 self.iters = 0
 
             def forward(self, x):
@@ -81,7 +81,7 @@ class TestVerify(TestCase):
     def test_embedded_constant_difference(self):
         class MyModel(Module):
             def __init__(self):
-                super(MyModel, self).__init__()
+                super().__init__()
                 self.iters = 0
 
             def forward(self, x):

--- a/test/onnx/verify.py
+++ b/test/onnx/verify.py
@@ -17,7 +17,7 @@ def colonize(msg, sep=": "):
         return msg + sep
 
 
-class Errors(object):
+class Errors:
     """
     An error-collecting object which supports error recovery.
 
@@ -72,7 +72,7 @@ class Errors(object):
                 )
             except AssertionError as e:
                 raise
-                k("{}{}".format(colonize(msg), str(e).lstrip()))
+                k(f"{colonize(msg)}{str(e).lstrip()}")
         else:
             raise RuntimeError("Unsupported almost equal test")
 
@@ -102,7 +102,7 @@ class Errors(object):
             # Use numpy for the comparison
             t1 = onnx.numpy_helper.to_array(x)
             t2 = onnx.numpy_helper.to_array(y)
-            new_msg = "{}In embedded parameter '{}'".format(colonize(msg), x.name)
+            new_msg = f"{colonize(msg)}In embedded parameter '{x.name}'"
             self.equalAndThen(t1, t2, new_msg, k)
         elif isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
             try:
@@ -124,7 +124,7 @@ class Errors(object):
                         )
                     )
                 else:
-                    k("{}{} != {}".format(colonize(msg), sx, sy))
+                    k(f"{colonize(msg)}{sx} != {sy}")
 
     def requireMultiLineEqual(self, x, y, msg=None):
         """
@@ -190,7 +190,7 @@ class Errors(object):
         """
         parent_self = self
 
-        class Recover(object):
+        class Recover:
             def __enter__(self):
                 pass
 
@@ -211,7 +211,7 @@ class Errors(object):
         """
         parent_self = self
 
-        class AddContext(object):
+        class AddContext:
             def __enter__(self):
                 parent_self.context.append(msg)
 
@@ -331,8 +331,7 @@ def verify(
                 return
             elif isinstance(obj, (list, tuple)):
                 for o in obj:
-                    for var in _iter(o):
-                        yield var
+                    yield from _iter(o)
             elif allow_unknown:
                 yield obj
             else:
@@ -526,9 +525,7 @@ def verify(
                 result_hint
             ):
                 for i, (x, y) in enumerate(zip(torch_out, backend_out)):
-                    errs.checkAlmostEqual(
-                        x.data.cpu().numpy(), y, "In output {}".format(i)
-                    )
+                    errs.checkAlmostEqual(x.data.cpu().numpy(), y, f"In output {i}")
 
         run_helper(torch_out, args, remained_onnx_input_idx)
 

--- a/torch/onnx/_patch_torch.py
+++ b/torch/onnx/_patch_torch.py
@@ -46,7 +46,7 @@ def _graph_op(
     """
     # Filter out None attributes, this can be convenient client side because
     # now they can pass through None attributes, and have them not show up
-    kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
     def const_if_tensor(arg):
         if arg is None:
@@ -184,7 +184,7 @@ def _graph_constant(
     assert isinstance(value, numbers.Number)
     assert type_ is not None
     isscalar = False
-    if dims is None or dims == 0 or set(dims) == set([0]):
+    if dims is None or dims == 0 or set(dims) == {0}:
         dims = [1]
         isscalar = True
     type_ = type_.lower()

--- a/torch/onnx/onnx_supported_ops.py
+++ b/torch/onnx/onnx_supported_ops.py
@@ -38,7 +38,7 @@ class _TorchSchema:
 
     def __hash__(self):
         # TODO(thiagocrepaldi): handle overload_name?
-        return hash((self.name))
+        return hash(self.name)
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, _TorchSchema):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -132,9 +132,8 @@ def _maybe_get_scalar(value):
 def _get_const(value, desc, arg_name):
     if not _is_constant(value):
         raise RuntimeError(
-            "ONNX symbolic expected a constant value of the {} argument, got `{}`".format(
-                arg_name, value
-            )
+            f"ONNX symbolic expected a constant value of the {arg_name} argument, "
+            f"got `{value}`"
         )
     return _parse_arg(value, desc)
 
@@ -149,9 +148,8 @@ def _unpack_tuple(tuple_value):
     tuple_node = tuple_value.node()
     if tuple_node.kind() != "prim::TupleConstruct":
         raise RuntimeError(
-            "ONNX symbolic expected node type `prim::TupleConstruct`, got `{}`".format(
-                tuple_node
-            )
+            f"ONNX symbolic expected node type `prim::TupleConstruct`, "
+            f"got `{tuple_node}`"
         )
     return list(tuple_node.inputs())
 
@@ -219,13 +217,15 @@ def parse_args(*arg_descriptors):
             ]
             # only support _outputs in kwargs
             assert len(kwargs) <= 1, (
-                f"Symbolic function {fn.__name__}'s '**kwargs' can contain a single key/value entry. "
+                f"Symbolic function {fn.__name__}'s '**kwargs' can contain a single "
+                f"key/value entry. "
                 f"{FILE_BUG_MSG}"
             )
 
             if len(kwargs) == 1:
                 assert "_outputs" in kwargs, (
-                    f"Symbolic function {fn.__name__}'s '**kwargs' can only contain '_outputs' key at '**kwargs'. "
+                    f"Symbolic function {fn.__name__}'s '**kwargs' can only contain "
+                    f"'_outputs' key at '**kwargs'. "
                     f"{FILE_BUG_MSG}"
                 )
             return fn(g, *args, **kwargs)
@@ -441,38 +441,31 @@ def _unimplemented(op, msg):
 
 def _onnx_unsupported(op_name):
     raise RuntimeError(
-        "Unsupported: ONNX export of operator {}. "
-        "Please feel free to request support or submit a pull request on PyTorch GitHub.".format(
-            op_name
-        )
+        f"Unsupported: ONNX export of operator {op_name}. "
+        "Please feel free to request support or submit a pull request on PyTorch GitHub."
     )
 
 
 def _onnx_opset_unsupported(op_name, current_opset, supported_opset):
     raise RuntimeError(
-        "Unsupported: ONNX export of {} in "
-        "opset {}. Please try opset version {}.".format(
-            op_name, current_opset, supported_opset
-        )
+        f"Unsupported: ONNX export of {op_name} in opset {current_opset}. "
+        f"Please try opset version {supported_opset}."
     )
 
 
 def _onnx_opset_unsupported_detailed(op_name, current_opset, supported_opset, reason):
     raise RuntimeError(
-        "Unsupported: ONNX export of {} in "
-        "opset {}. {}. Please try opset version {}.".format(
-            op_name, current_opset, reason, supported_opset
-        )
+        f"Unsupported: ONNX export of {op_name} in "
+        f"opset {current_opset}. {reason}. Please try opset version {supported_opset}."
     )
 
 
 def _block_list_in_opset(name):
     def symbolic_fn(*args, **kwargs):
         raise RuntimeError(
-            "ONNX export failed on {}, which is not implemented for opset {}. "
-            "Try exporting with other opset versions.".format(
-                name, GLOBALS.export_onnx_opset_version
-            )
+            f"ONNX export failed on {name}, which is not implemented for opset "
+            f"{GLOBALS.export_onnx_opset_version}. "
+            "Try exporting with other opset versions."
         )
 
     return symbolic_fn

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -106,14 +106,13 @@ def _parse_arg(value, desc, arg_name=None, node_name=None):
 
     if arg_name is None or node_name is None:
         raise RuntimeError(
-            "Expected node type 'onnx::Constant', got '{}'.".format(value.node().kind())
+            f"Expected node type 'onnx::Constant', got '{value.node().kind()}'."
         )
     else:
         raise RuntimeError(
             "Expected node type 'onnx::Constant' "
-            "for argument '{}' of node '{}', got '{}'.".format(
-                arg_name, node_name, value.node().kind()
-            )
+            f"for argument '{arg_name}' of node '{node_name}', "
+            f"got '{value.node().kind()}'."
         )
 
 
@@ -876,7 +875,7 @@ def __interpolate_helper(
         # and if not assume that it is not a scalar.
         try:
             is_scalar = not _is_packed_list(size) and (
-                (_maybe_get_const(size, "t").dim() == 0)
+                _maybe_get_const(size, "t").dim() == 0
             )
         except AttributeError:
             is_scalar = not _is_packed_list(size)

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -411,8 +411,8 @@ def fake_quantize_per_tensor_affine(
         )
     if (quant_min, quant_max) not in [(0, 255), (-128, 127)]:
         raise RuntimeError(
-            "For (quant_min, quant_max), ONNX allows only (0, 255) and (-128, 127). "
-            "Got ({}, {})".format(quant_min, quant_max)
+            f"For (quant_min, quant_max), ONNX allows only (0, 255) and (-128, 127). "
+            f"Got ({quant_min}, {quant_max})"
         )
     scale = symbolic_helper._maybe_get_scalar(scale)
     if scale is None:

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -148,7 +148,7 @@ def _try_cast_integer_to_float(g, *args):
 def _cast_to_type(g, input, to_type):
     if to_type is None:
         return input
-    return getattr(opset9, "_cast_{}".format(to_type))(g, input, False)
+    return getattr(opset9, f"_cast_{to_type}")(g, input, False)
 
 
 def _comparison_operator(g, input, other, op_name):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -808,9 +808,7 @@ def prelu(g, self, weight):
     if self_rank is not None and weight_rank is not None:
         assert (
             self_rank >= weight_rank
-        ), "rank(x) should be >= rank(slope) but got {} < {}".format(
-            self_rank, weight_rank
-        )
+        ), f"rank(x) should be >= rank(slope) but got {self_rank} < {weight_rank}"
     return g.op("PRelu", self, weight)
 
 
@@ -5119,8 +5117,7 @@ class Prim:
             for idx in range(len(if_output_list)):
                 if current_b_list[idx] not in env:
                     raise RuntimeError(
-                        "The sub block ATen output {}"
-                        " is not in env.".format(current_b_list[idx])
+                        f"The sub block ATen output {current_b_list[idx]} is not in env."
                     )  # type:ignore[operator]
                 onnx_b = env[current_b_list[idx]]
                 final_b_list.append(onnx_b)
@@ -5172,9 +5169,7 @@ class Prim:
             return g.op("Constant", value_t=torch.tensor(n["value"]))
         else:
             raise RuntimeError(
-                "Unsupported prim::Constant kind: `{}`. Send a bug report.".format(
-                    n.kindOf("value")
-                )
+                f"Unsupported prim::Constant kind: `{n.kindOf('value')}`. Send a bug report."
             )
 
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -413,7 +413,7 @@ def overload_by_arg_count(fn):
             arg_descriptors = overload._arg_descriptors
             if len(arg_descriptors) == len(args):
                 return overload(g, *args)
-        raise NotImplementedError("Unknown aten::{} signature".format(fn.__name__))
+        raise NotImplementedError(f"Unknown aten::{fn.__name__} signature")
 
     return wrapper
 
@@ -1431,7 +1431,7 @@ def wrap_logical_op_with_cast_to(to_type):
 def wrap_logical_op_with_cast_to_and_from(to_type):
     def decorator(fn):
         def wrap_with_cast(g, input, other):
-            to_cast_func = globals()["_cast_{}".format(to_type)]
+            to_cast_func = globals()[f"_cast_{to_type}"]
             from_cast_func = wrap_logical_op_with_cast_to(input.type().scalarType())(fn)
             return from_cast_func(
                 g, to_cast_func(g, input, False), to_cast_func(g, other, False)
@@ -2470,7 +2470,7 @@ def _unique2(g, input, sorted, return_inverse, return_counts):
 # TODO(justinchuby): Clean up this function generation magic by defining the functions
 # explicitly.
 for k, v in symbolic_helper.cast_pytorch_to_onnx.items():
-    name = "_cast_{}".format(k)
+    name = f"_cast_{k}"
     globals()[name] = symbolic_helper.parse_args("v", "i")(
         functools.partial(symbolic_helper._cast_func_template, v)
     )
@@ -3305,9 +3305,9 @@ def _generic_rnn(
         if variant == "RNN":
             weight_ih, weight_hh = weights
         elif variant == "GRU" or variant == "LSTM":
-            weight_ih, weight_hh = [
+            weight_ih, weight_hh = (
                 reform_weights(g, w, hidden_size, reform_permutation) for w in weights
-            ]
+            )
         return tuple(
             symbolic_helper._unsqueeze_helper(g, x, [0]) for x in (weight_ih, weight_hh)
         )
@@ -3317,9 +3317,9 @@ def _generic_rnn(
         if variant == "RNN":
             weight_ih, weight_hh, bias_ih, bias_hh = weights
         elif variant == "GRU" or variant == "LSTM":
-            weight_ih, weight_hh, bias_ih, bias_hh = [
+            weight_ih, weight_hh, bias_ih, bias_hh = (
                 reform_weights(g, w, hidden_size, reform_permutation) for w in weights
-            ]
+            )
         bias_concat = g.op("Concat", bias_ih, bias_hh, axis_i=0)
         return tuple(
             symbolic_helper._unsqueeze_helper(g, x, [0])

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -29,9 +29,7 @@ def _import_symbolic_opsets():
     for opset_version in itertools.chain(
         _constants.onnx_stable_opsets, [_constants.onnx_main_opset]
     ):
-        module = importlib.import_module(
-            "torch.onnx.symbolic_opset{}".format(opset_version)
-        )
+        module = importlib.import_module(f"torch.onnx.symbolic_opset{opset_version}")
         global _symbolic_versions
         _symbolic_versions[opset_version] = module
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -73,11 +73,10 @@ def select_model_mode_for_export(model, mode):
 
             if GLOBALS.export_onnx_opset_version < 12:
                 warnings.warn(
-                    "You are exporting the model in training mode with onnx opset version {}. "
-                    "Opset versions lower than opset 12 will not be able to export nodes such as "
-                    "Dropout and BatchNorm correctly.".format(
-                        GLOBALS.export_onnx_opset_version
-                    )
+                    "You are exporting the model in training mode with onnx opset "
+                    f"version {GLOBALS.export_onnx_opset_version}. "
+                    "Opset versions lower than opset 12 will not be able to export "
+                    "nodes such as Dropout and BatchNorm correctly."
                 )
             is_export_training = True
 
@@ -372,9 +371,9 @@ def _resolve_args_by_export_type(arg_name, arg_value, operator_export_type):
     ):
         if arg_value is True:
             warnings.warn(
-                "`{}' can be set to True only when 'operator_export_type' is "
+                f"'{arg_name}' can be set to True only when 'operator_export_type' is "
                 "`ONNX`. Since 'operator_export_type' is not set to 'ONNX', "
-                "`{}` argument will be ignored.".format(arg_name, arg_name)
+                f"'{arg_name}' argument will be ignored."
             )
         arg_value = False
     return arg_value
@@ -458,7 +457,7 @@ def _decide_input_format(model, args):
     try:
         sig = _signature(model)
     except ValueError as e:
-        warnings.warn("%s, skipping _decide_input_format" % e)
+        warnings.warn(f"{e}, skipping _decide_input_format")
         return args
     try:
         ordered_list_keys = list(sig.parameters.keys())
@@ -1510,16 +1509,12 @@ def _validate_dynamic_axes(dynamic_axes, model, input_names, output_names):
     for key, value in dynamic_axes.items():
         if key not in valid_names:
             warnings.warn(
-                "Provided key {} for dynamic axes is not a valid input/output name".format(
-                    key
-                )
+                f"Provided key {key} for dynamic axes is not a valid input/output name"
             )
         if isinstance(value, list):
             warnings.warn(
                 "No names were found for specified dynamic axes of provided input."
-                "Automatically generated names will be applied to each dynamic axes of input {}".format(
-                    key
-                )
+                f"Automatically generated names will be applied to each dynamic axes of input {key}"
             )
 
             value_dict = {}
@@ -1530,9 +1525,7 @@ def _validate_dynamic_axes(dynamic_axes, model, input_names, output_names):
                     )
                 if x in value_dict:
                     warnings.warn(
-                        "Duplicate dynamic axis index {} was provided for input {}.".format(
-                            x, key
-                        )
+                        f"Duplicate dynamic axis index {x} was provided for input {key}."
                     )
                 else:
                     value_dict[x] = str(key) + "_dynamic_axes_" + str(i + 1)

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -488,7 +488,7 @@ def _decide_input_format(model, args):
     except IndexError:
         warnings.warn("No input args, skipping _decide_input_format")
     except Exception as e:
-        warnings.warn("Skipping _decide_input_format\n {}".format(e.args[0]))
+        warnings.warn(f"Skipping _decide_input_format\n {e.args[0]}")
 
     return args
 
@@ -546,12 +546,10 @@ def _check_flatten_did_not_remove(original, jit_flattened):
     def flatten(x):
         if isinstance(x, (list, tuple)):
             for inner in x:
-                for y in flatten(inner):
-                    yield y
+                yield from flatten(inner)
         elif isinstance(x, dict):
             for inner in x.values():
-                for y in flatten(inner):
-                    yield y
+                yield from flatten(inner)
         else:
             yield x
 
@@ -1065,7 +1063,7 @@ def _export(
             if isinstance(f, str):
                 model_file_location = f
             else:
-                model_file_location = str()
+                model_file_location = ""
             args = _decide_input_format(model, args)
             if dynamic_axes is None:
                 dynamic_axes = {}
@@ -1257,7 +1255,7 @@ def _run_symbolic_method(g, op_name, symbolic_fn, args):
         # Handle the specific case where we didn't successfully dispatch
         # to symbolic_fn.  Otherwise, the backtrace will have the clues
         # you need.
-        e.args = ("{} (occurred when translating {})".format(e.args[0], op_name),)
+        e.args = (f"{e.args[0]} (occurred when translating {op_name})",)
         raise
 
 


### PR DESCRIPTION
Use pyupgrade(https://github.com/asottile/pyupgrade) and flynt to modernize python syntax

```sh
pyupgrade --py36-plus --keep-runtime-typing torch/onnx/**/*.py
pyupgrade --py36-plus --keep-runtime-typing test/onnx/**/*.py
flynt torch/onnx/ --line-length 120
```

- Use f-strings for string formatting
- Use the new `super()` syntax for class initialization
- Use dictionary / set comprehension