### PR TITLE
[c10d] Add AOT examples to trace all_reduce and all_gather

### DIFF
--- a/aot.py
+++ b/aot.py
@@ -29,7 +29,7 @@ def all_reduce(x):
     # So, let's work around by clone the input.
     xc = x.clone()
     dist.all_reduce(xc)
-    print(f"{os.getpid()} all_reduce: {x}")
+    print(f"{os.getpid()} all_reduce: {xc}")
     return xc
 
 def all_gather(xs, x):

--- a/aot.py
+++ b/aot.py
@@ -63,8 +63,8 @@ def demo_basic(rank, world_size):
     #all_gather
     xs = [torch.zeros(2,3, dtype=torch.int64).to(device) for _ in range(dist.get_world_size())]
     aot_print_fn = aot_function(all_gather, fw_compiler=compiler_fn, bw_compiler=compiler_fn)
-    ress = aot_print_fn(xs, copy.deepcopy(x))
-    refs = all_gather(xs, copy.deepcopy(x))
+    ress = aot_print_fn(copy.deepcopy(xs), copy.deepcopy(x))
+    refs = all_gather(copy.deepcopy(xs), copy.deepcopy(x))
     assert all([torch.allclose(ref, res) for ref, res in zip(refs, ress)])
 
     clear_compile_cache()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #77940
* #77813
* #77806
* #77686
* #77670
* #77443
* #77408
* #76946
* #76722

Summary:
This just adds examples on how AOT can trace all_reduce and all_gather.