### PR TITLE
[mergebot] Create land time check options

### DIFF
--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -259,7 +259,6 @@ class GitRepo:
         return self._run_git("remote", "get-url", self.remote)
 
     def gh_owner_and_name(self) -> Tuple[str, str]:
-        return ['pytorch', 'pytorch']
         url = os.getenv("GIT_REMOTE_URL", None)
         if url is None:
             url = self.remote_url()

--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -259,6 +259,7 @@ class GitRepo:
         return self._run_git("remote", "get-url", self.remote)
 
     def gh_owner_and_name(self) -> Tuple[str, str]:
+        return ['pytorch', 'pytorch']
         url = os.getenv("GIT_REMOTE_URL", None)
         if url is None:
             url = self.remote_url()

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -74,6 +74,7 @@ def mock_parse_args(revert: bool = False,
             self.comment_id = 0
             self.on_mandatory = False
             self.on_green = False
+            self.land_checks = False
             self.reason = 'this is for testing'
 
     return Object()
@@ -90,6 +91,7 @@ def mock_merge(pr_num: int, repo: GitRepo,
                comment_id: Optional[int] = None,
                mandatory_only: bool = False,
                on_green: bool = False,
+               land_checks: bool = False,
                timeout_minutes: int = 400,
                stale_pr_days: int = 3) -> None:
     pass
@@ -273,6 +275,7 @@ class TestGitHubPR(TestCase):
                                            force=True,
                                            comment_id=mock.ANY,
                                            on_green=False,
+                                           land_checks=False,
                                            mandatory_only=False)
 
     @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
@@ -286,6 +289,7 @@ class TestGitHubPR(TestCase):
                                            force=False,
                                            comment_id=mock.ANY,
                                            on_green=False,
+                                           land_checks=False,
                                            mandatory_only=False)
 
 if __name__ == "__main__":

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -747,9 +747,6 @@ class GitHubPR:
         find_matching_merge_rule(self, repo, force=force, skip_internal_checks=can_skip_internal_checks(self, comment_id))
         self.merge_changes(repo, force, comment_id)
 
-        if repo.current_branch() != self.default_branch():
-            repo.checkout(self.default_branch())
-
         repo.push(self.default_branch(), dry_run)
         gh_post_pr_comment(self.org, self.project, self.pr_num,
                            f"@{self.get_pr_creator_login()} your PR has been successfully merged.", dry_run)

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -995,8 +995,8 @@ def fetch_check_run_conclusions(repo: GitRepo, commit: str) -> Dict[str, Tuple[s
     if len(checks) == 0:
         raise MandatoryChecksMissingError("Refusing to merge as land check(s) are not yet run")
     for check_run in checks['check_runs']:
-        check_run_conclusions[check_run['name']] = (None if check_run['conclusion'] is None else check_run['conclusion'].upper(),
-                                                   check_run['html_url'])
+        check_run_conclusions[check_run['name']] = (check_run['conclusion'],
+                                                    check_run['html_url'])
     return check_run_conclusions
 
 def validate_land_time_checks(repo: GitRepo, commit: str) -> None:
@@ -1017,7 +1017,7 @@ def categorize_checks(check_runs: Dict[str, Tuple[str, str]],
             pending_checks.append((checkname, None))
         elif check_runs[checkname][0] is None:
             pending_checks.append((checkname, check_runs[checkname][1]))
-        elif check_runs[checkname][0] != 'SUCCESS' and check_runs[checkname][0] != 'SKIPPED':
+        elif check_runs[checkname][0].upper() != 'SUCCESS' and check_runs[checkname][0].upper() != 'SKIPPED':
             failed_checks.append((checkname, check_runs[checkname][1]))
     return (pending_checks, failed_checks)
 
@@ -1042,7 +1042,7 @@ def merge(pr_num: int, repo: GitRepo,
         raise RuntimeError("This PR is too stale; the last push date was more than 3 days ago. Please rebase and try again.")
 
     if land_checks:
-        commit = pr.create_land_time_check_branch(repo, 'viable/strict2', force=force, comment_id=comment_id)
+        commit = pr.create_land_time_check_branch(repo, 'viable/strict', force=force, comment_id=comment_id)
 
     start_time = time.time()
     last_exception = ''
@@ -1068,9 +1068,8 @@ def merge(pr_num: int, repo: GitRepo,
                                                   f"first few of them are: {' ,'.join(x[0] for x in pending[:5])}")
             if land_checks:
                 validate_land_time_checks(repo, commit)
-                return pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)
-            else:
-                return pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)
+
+            return pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)
         except MandatoryChecksMissingError as ex:
             last_exception = str(ex)
             print(f"Merge of https://github.com/{org}/{project}/pull/{pr_num} failed due to: {ex}. Retrying in 5 min")

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -993,7 +993,7 @@ def fetch_check_run_conclusions(repo: GitRepo, commit: str) -> Dict[str, Tuple[s
     checks = fetch_json_dict(f'https://api.github.com/repos/{owner}/{name}/commits/{commit}/check-runs')
     check_run_conclusions = {}
     if len(checks) == 0:
-        raise MandatoryChecksMissingError(f"Refusing to merge as land check(s) are not yet run")
+        raise MandatoryChecksMissingError("Refusing to merge as land check(s) are not yet run")
     for check_run in checks['check_runs']:
         check_run_conclusions[check_run['name']] = (check_run['conclusion'].upper(), check_run['html_url'])
     return check_run_conclusions

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -995,7 +995,8 @@ def fetch_check_run_conclusions(repo: GitRepo, commit: str) -> Dict[str, Tuple[s
     if len(checks) == 0:
         raise MandatoryChecksMissingError("Refusing to merge as land check(s) are not yet run")
     for check_run in checks['check_runs']:
-        check_run_conclusions[check_run['name']] = (check_run['conclusion'].upper(), check_run['html_url'])
+        check_run_conclusions[check_run['name']] = (None if check_run['conclusion'] is None else check_run['conclusion'].upper(),
+                                                   check_run['html_url'])
     return check_run_conclusions
 
 def validate_land_time_checks(repo: GitRepo, commit: str) -> None:
@@ -1041,7 +1042,7 @@ def merge(pr_num: int, repo: GitRepo,
         raise RuntimeError("This PR is too stale; the last push date was more than 3 days ago. Please rebase and try again.")
 
     if land_checks:
-        commit = pr.create_land_time_check_branch(repo, 'viable/strict', force=force, comment_id=comment_id)
+        commit = pr.create_land_time_check_branch(repo, 'viable/strict2', force=force, comment_id=comment_id)
 
     start_time = time.time()
     last_exception = ''

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -781,7 +781,7 @@ class GitHubPR:
         commit = repo.get_commit('HEAD').commit_hash
         gh_post_pr_comment(self.org, self.project, self.pr_num,
                            'Successfully started land time checks.' +
-                           f' See progress here: https://github.com/{self.org}/{self.project}/commit/{commit}')
+                           f' See progress here: https://hud.pytorch.org/{self.org}/{self.project}/commit/{commit}')
         return commit
 
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -992,6 +992,8 @@ def fetch_check_run_conclusions(repo: GitRepo, commit: str) -> Dict[str, Tuple[s
     [owner, name] = repo.gh_owner_and_name()
     checks = fetch_json_dict(f'https://api.github.com/repos/{owner}/{name}/commits/{commit}/check-runs')
     check_run_conclusions = {}
+    if len(checks) == 0:
+        raise MandatoryChecksMissingError(f"Refusing to merge as land check(s) are not yet run")
     for check_run in checks['check_runs']:
         check_run_conclusions[check_run['name']] = (check_run['conclusion'].upper(), check_run['html_url'])
     return check_run_conclusions

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ on:
       - master
       - main
       - release/*
+      - landchecks/*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -7,6 +7,7 @@ on:
       - master
       - main
       - release/*
+      - landchecks/*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -6,6 +6,7 @@ on:
       - master
       - main
       - release/*
+      - landchecks/*
     tags:
       - ciflow/trunk/*
   workflow_dispatch:

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -31,6 +31,7 @@ jobs:
           GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           FORCE: ${{ github.event.client_payload.force}}
           ON_GREEN: ${{ github.event.client_payload.on_green}}
+          LAND_CHECKS: ${{ github.event.client_payload.land_checks }}
           COMMENT_ID: ${{ github.event.client_payload.comment_id }}
         run: |
           set -ex
@@ -42,6 +43,8 @@ jobs:
             fi
           elif [ -n "${ON_GREEN}" ]; then
             python3 .github/scripts/trymerge.py --on-green "${PR_NUM}"
+          elif [ -n "${LAND_CHECKS}" ]; then
+            python3 .github/scripts/trymerge.py --land-checks "${PR_NUM}"
           elif [ -n "${COMMENT_ID}" ]; then
             python3 .github/scripts/trymerge.py --comment-id "${COMMENT_ID}" "${PR_NUM}"
           else


### PR DESCRIPTION
This adds land time checks before we try to merge. What this does is:
1. Merge changes into latest master, check out a new branch, push, and have a workflow that runs jobs from trunk (and maybe pull)
2. Wait for all checks in the landtime workflow to finish by using the GH API (graphql doesn't have this method from what I can see)
3. push the changes in

Test Plan:
Tested this in canary with a new workflow that passes and lint, tested what happens if i break the new workflow by exiting with 1, the normal flow, and some other flows.

Tested it breaking when land checks fail:
https://github.com/pytorch/pytorch-canary/pull/113#issuecomment-1165941716

Test that it works:
https://github.com/pytorch/pytorch-canary/pull/114#issuecomment-1165922791

Test that normal validations like PR is broken:
https://github.com/pytorch/pytorch-canary/pull/113#issuecomment-1165930037

Test that normal merge works:
https://github.com/pytorch/pytorch-canary/pull/113#issuecomment-1166751288

Test that force merge works:
https://github.com/pytorch/pytorch-canary/pull/113#issuecomment-1167507356