### PR TITLE
[fx] Typing annotations as member variables in fx.Node

### DIFF
--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -119,6 +119,15 @@ class Node:
     - ``output`` contains the output of the traced function in its ``args[0]`` attribute. This corresponds to the "return" statement
       in the Graph printout.
     """
+    graph: 'Graph'
+    name: str
+    op: str
+    target: 'Target'
+    args: Tuple['Argument']
+    kwargs: Dict[str, 'Argument']
+    users: Dict['Node', None]
+    type: Optional[Any]
+    meta: Dict[str, Any]
 
     @compatibility(is_backward_compatible=True)
     def __init__(self, graph: 'Graph', name: str, op: str, target: 'Target',


### PR DESCRIPTION
Summary:
Would be helpful for type-hinting mypy errors like this
{F733944909}

Test Plan: Sandcastle

Differential Revision: D36548374

