### PR TITLE
Add a consistent check API step so we can track our usage

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -33,3 +33,14 @@ jobs:
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           WORKFLOW_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
         run: python3 tools/stats/upload_test_stats.py --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
+
+  check-api-rate:
+    if: ${{ always() }}
+    runs-on: [self-hosted, linux.2xlarge]
+    continue-on-error: true
+    steps:
+      - name: Get our GITHUB_TOKEN API limit usage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/rate_limit


### PR DESCRIPTION
Followup action to our API Limit SEV: #77194

I added this to the upload-test-stats workflow because that one has repo secret access and is run regularly enough to be able to capture the API usage situation. 

The next step in the future will be to log our usage to Rockset so we can see a trend + better preempt this.