### PR TITLE
Add lazy shape inference for logical boolean ops

### DIFF
--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -50,6 +50,7 @@
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/WrapDimUtils.h>
+#include <aten/src/ATen/ExpandUtils.h>
 #include <aten/src/ATen/native/ReduceOpsUtils.h>
 #include <c10/core/ScalarType.h>
 #include <torch/csrc/api/include/torch/enum.h>
@@ -452,6 +453,25 @@ std::vector<Shape> compute_shape_slogdet(const at::Tensor & self) {
   // Sign and det outputs hold the same shape, dtype.
   return {Shape(self.scalar_type(), out_sizes),
           Shape(self.scalar_type(), out_sizes)};
+}
+
+std::vector<torch::lazy::Shape> compute_shape_logical_and(at::Tensor & self, const at::Tensor & other) {
+  TORCH_INTERNAL_ASSERT(at::are_expandable(self.sizes(), other.sizes()));
+  return {Shape(c10::ScalarType::Bool, at::infer_size(self.sizes(), other.sizes()))};
+}
+
+std::vector<torch::lazy::Shape> compute_shape_logical_not(at::Tensor & self) {
+  return {Shape(c10::ScalarType::Bool, self.sizes().vec())};
+}
+
+std::vector<torch::lazy::Shape> compute_shape_logical_or(at::Tensor & self, const at::Tensor & other) {
+  TORCH_INTERNAL_ASSERT(at::are_expandable(self.sizes(), other.sizes()));
+  return {Shape(c10::ScalarType::Bool, at::infer_size(self.sizes(), other.sizes()))};
+}
+
+std::vector<torch::lazy::Shape> compute_shape_logical_xor(at::Tensor & self, const at::Tensor & other) {
+  TORCH_INTERNAL_ASSERT(at::are_expandable(self.sizes(), other.sizes()));
+  return {Shape(c10::ScalarType::Bool, at::infer_size(self.sizes(), other.sizes()))};
 }
 
 std::vector<Shape> compute_shape_smooth_l1_loss_backward(

--- a/torch/csrc/lazy/core/shape_inference.h
+++ b/torch/csrc/lazy/core/shape_inference.h
@@ -38,6 +38,10 @@ TORCH_API std::vector<torch::lazy::Shape> compute_shape_l1_loss_backward(const a
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_log_sigmoid_backward(const at::Tensor & grad_output, const at::Tensor & self, const at::Tensor & buffer);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_log_sigmoid_forward(const at::Tensor & self);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_logdet(const at::Tensor & self);
+TORCH_API std::vector<torch::lazy::Shape> compute_shape_logical_and(at::Tensor & self, const at::Tensor & other);
+TORCH_API std::vector<torch::lazy::Shape> compute_shape_logical_not(at::Tensor & self);
+TORCH_API std::vector<torch::lazy::Shape> compute_shape_logical_or(at::Tensor & self, const at::Tensor & other);
+TORCH_API std::vector<torch::lazy::Shape> compute_shape_logical_xor(at::Tensor & self, const at::Tensor & other);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_masked_fill(const at::Tensor & self, const at::Tensor & mask, const at::Scalar & value);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_masked_fill(const at::Tensor & self, const at::Tensor & mask, const at::Tensor & value);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_max(const at::Tensor & self);


### PR DESCRIPTION
Add lazy shape inference for logical boolean ops
- logical_and
- logical_not
- logical_or
- logical_xor

Uses helper functions defined at https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/ExpandUtils.h#L21 to infer the shape. 