### PR TITLE
[RFC][Codegen] Add custom namespace support

### DIFF
--- a/aten/src/ATen/templates/RegisterSchema.cpp
+++ b/aten/src/ATen/templates/RegisterSchema.cpp
@@ -4,10 +4,10 @@
 
 namespace at {
 TORCH_LIBRARY(aten, m) {
-  ${schema_registrations};
-
+  ${aten_schema_registrations};
   // Distributed Ops
   // Implementations located in torch/csrc/jit/runtime/register_distributed_ops.cpp
   m.def("get_gradients(int context_id) -> Dict(Tensor, Tensor)");
 }
+${schema_registrations}
 }  // namespace at

--- a/torchgen/dest/register_dispatch_key.py
+++ b/torchgen/dest/register_dispatch_key.py
@@ -231,9 +231,6 @@ class RegisterDispatchKey:
     # Whether or not we are actually code-genning for ROCm
     rocm: bool
 
-    # The namespace that the kernels are written in. This is just `at::native` for in-tree kernels.
-    cpp_namespace: str
-
     # The class that all unstructured native functions live under. This is used to improve
     # compiler error messages when a kernel writer adds a native function with the wrong signature.
     # This is only used in unstructured kernels, since structured kernels already live in a class.
@@ -342,13 +339,11 @@ class RegisterDispatchKey:
             )
         elif metadata is None or not metadata.structured:
             return list(mapMaybe(lambda f: self.gen_unstructured(f, g), g.functions()))
-
         structured_gen = StructuredRegisterDispatchKey(
             self.backend_index,
             self.target,
             self.selector,
             self.rocm,
-            self.cpp_namespace,
             self.class_method_name,
             self.skip_dispatcher_op_registration,
             g,
@@ -443,9 +438,9 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
                 if metadata is None:
                     return None
                 if self.class_method_name is None:
-                    impl_name = f"{self.cpp_namespace}::{metadata.kernel}"
+                    impl_name = f"{metadata.cpp_namespace}::{metadata.kernel}"
                 else:
-                    impl_name = f"{self.cpp_namespace}::{self.class_method_name}::{metadata.kernel}"
+                    impl_name = f"{metadata.cpp_namespace}::{self.class_method_name}::{metadata.kernel}"
 
                 args_exprs_str = ", ".join(a.name for a in args)
 
@@ -780,7 +775,7 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
                 metadata = self.backend_index.get_kernel(self.g)
                 assert metadata is not None
                 class_name = f"structured_{metadata.kernel}_{k.name}"
-                parent_class = f"{self.cpp_namespace}::structured_{metadata.kernel}"
+                parent_class = f"{metadata.cpp_namespace}::structured_{metadata.kernel}"
 
             if self.backend_index.device_guard:
                 device_check_args = itertools.chain(

--- a/torchgen/gen_backend_stubs.py
+++ b/torchgen/gen_backend_stubs.py
@@ -123,7 +123,9 @@ Only the following keys are supported: {", ".join(valid_keys)}'
             # See Note [External Backends Follow Dispatcher API]
             kernel_name = dispatcher.name(native_functions_map[op_name].func)
             # TODO: allow structured external backends later.
-            m = BackendMetadata(kernel=kernel_name, structured=False)
+            m = BackendMetadata(
+                kernel=kernel_name, structured=False, cpp_namespace=cpp_namespace
+            )
             metadata[op_name] = m
         return BackendIndex(
             dispatch_key=dispatch_key,
@@ -373,7 +375,6 @@ def gen_dispatcher_registrations(
     fm: FileManager,
     output_dir: str,
     class_name: str,
-    cpp_namespace: str,
     backend_indices: Dict[DispatchKey, BackendIndex],
     grouped_native_functions: Sequence[Union[NativeFunction, NativeFunctionsGroup]],
     backend_dispatch_key: DispatchKey,
@@ -403,7 +404,6 @@ def gen_dispatcher_registrations(
                 Target.REGISTRATION,
                 selector,
                 rocm=False,
-                cpp_namespace=cpp_namespace,
                 class_method_name=f"{class_name}",
                 skip_dispatcher_op_registration=False,
             ),
@@ -462,7 +462,6 @@ TORCH_API void Register${backend_name}${dispatch_key}NativeFunctions() {
                         Target.ANONYMOUS_DEFINITION,
                         selector,
                         rocm=False,
-                        cpp_namespace=cpp_namespace,
                         class_method_name=f"{class_name}",
                         skip_dispatcher_op_registration=False,
                     ),
@@ -548,7 +547,6 @@ def run(
             fm,
             output_dir,
             class_name,
-            cpp_namespace,
             backend_indices,
             grouped_native_functions,
             backend_key,

--- a/torchgen/gen_lazy_tensor.py
+++ b/torchgen/gen_lazy_tensor.py
@@ -413,7 +413,6 @@ def run_gen_lazy_tensor(
             fm,
             output_dir,
             class_name,
-            cpp_namespace,
             backend_indices,
             grouped_native_functions,
             backend_key,

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -1,12 +1,12 @@
+import dataclasses
+import itertools
 import re
 
-from torchgen.utils import assert_never
-
 from dataclasses import dataclass
-import dataclasses
-from typing import List, Dict, Optional, Iterator, Tuple, Set, Sequence, Callable, Union
-from enum import Enum, auto
-import itertools
+from enum import auto, Enum
+from typing import Callable, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union
+
+from torchgen.utils import assert_never
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 #
@@ -44,6 +44,9 @@ class Location:
 
 # Valid values of the 'variants' field in native_functions.yaml
 Variant = Enum("Variant", ("function", "method"))
+
+# Default kernel namespace
+DEFAULT_KERNEL_NAMESPACE = "at::native"
 
 # NOTE: Keep the list in sync with `DispatchKey` in c10/core/DispatchKey.h
 class DispatchKey(Enum):
@@ -315,6 +318,12 @@ ViewSchemaKind = Enum(
 # of this at FunctionSchema.
 @dataclass(frozen=True)
 class NativeFunction:
+    # The namespace for this operator. For example, if we have "at::add"
+    # then the namespace would be "at". This enables ops to be registered
+    # through the same DSL with a custom namespace. If not specified, the
+    # default namespace would be "at".
+    namespace: str
+
     # The function schema of the operator in question.  This schema
     # has been parsed; see FunctionSchema for more about its structure.
     # (This type is quoted as we are forward referencing a type
@@ -440,7 +449,13 @@ class NativeFunction:
 
         funcs = e.pop("func")
         assert isinstance(funcs, str), f"not a str: {funcs}"
-        func = FunctionSchema.parse(funcs)
+        # only support one level of namespace. E.g., aten::add
+        namespaced_funcs = funcs.split("::", 1)
+        if len(namespaced_funcs) == 1:
+            namespace = "aten"
+        else:
+            namespace = namespaced_funcs[0]
+        func = FunctionSchema.parse(namespaced_funcs[-1])
 
         cpp_no_default_args_list = e.pop("cpp_no_default_args", [])
         assert isinstance(cpp_no_default_args_list, list)
@@ -489,7 +504,11 @@ class NativeFunction:
         structured_delegate_s = e.pop("structured_delegate", None)
         assert structured_delegate_s is None or isinstance(
             structured_delegate_s, str
-        ), f"not a str: {structured_delegate}"
+        ), f"not a str: {structured_delegate_s}"
+        assert structured_delegate_s is None or "::" not in structured_delegate_s, (
+            "namespace is not supported in structured delegate,"
+            " using the same namespace as the native function"
+        )
         structured_delegate: Optional[OperatorName] = None
         if structured_delegate_s is not None:
             structured_delegate = OperatorName.parse(structured_delegate_s)
@@ -498,6 +517,10 @@ class NativeFunction:
         assert structured_inherits is None or isinstance(
             structured_inherits, str
         ), f"not a str: {structured_inherits}"
+        assert structured_inherits is None or "::" not in structured_inherits, (
+            "namespace is not supported in structured inherits,"
+            " using the same namespace as the native function"
+        )
 
         python_module = e.pop("python_module", None)
         assert python_module is None or isinstance(
@@ -552,13 +575,19 @@ class NativeFunction:
                         f"Dispatch key {dispatch_key} of kernel {v} "
                         "is not a supported dispatch key."
                     )
+                    # We only allow one level of namespace for kernels and operator.
+                    # We will append "native" to a custom kernel namespace.
+                    tokens = v.split("::", 1)
                     # Why is 'structured' included? External backends (e.g.
                     # XLA) opt into which ops are structured independently
                     # of which in-tree ops are structured
                     dispatch[dispatch_key] = BackendMetadata(
-                        v,
+                        kernel=tokens[-1],
                         structured=structured
                         and is_structured_dispatch_key(dispatch_key),
+                        cpp_namespace=(tokens[0] + "::native")
+                        if len(tokens) > 1
+                        else DEFAULT_KERNEL_NAMESPACE,
                     )
                     if (
                         dispatch_key is DispatchKey.CompositeImplicitAutograd
@@ -581,7 +610,7 @@ class NativeFunction:
             )
         elif not structured and structured_delegate is None:
             dispatch[DispatchKey.CompositeImplicitAutograd] = BackendMetadata(
-                cpp.name(func), structured=False
+                cpp.name(func), structured=False, cpp_namespace=DEFAULT_KERNEL_NAMESPACE
             )
 
         assert not (
@@ -627,7 +656,9 @@ class NativeFunction:
                     dispatch_key not in dispatch
                 ), f"ufunc should not have explicit dispatch entry for {dispatch_key}"
                 dispatch[dispatch_key] = BackendMetadata(
-                    kernel=ufunc.schema_kernel_name(func, dispatch_key), structured=True
+                    kernel=ufunc.schema_kernel_name(func, dispatch_key),
+                    structured=True,
+                    cpp_namespace=DEFAULT_KERNEL_NAMESPACE,
                 )
 
         if structured_delegate:
@@ -685,6 +716,7 @@ class NativeFunction:
                 has_composite_implicit_autograd_kernel=has_composite_implicit_autograd_kernel,
                 has_composite_explicit_autograd_kernel=has_composite_explicit_autograd_kernel,
                 tags=tags,
+                namespace=namespace,
             ),
             backend_metadata,
         )
@@ -817,12 +849,14 @@ class NativeFunctionsGroup:
                 )
         assert self.functional.func.kind() == SchemaKind.functional
         assert self.out.func.kind() == SchemaKind.out
-
+        assert self.functional.namespace == self.out.namespace
         if self.inplace is not None:
             assert self.inplace.func.kind() == SchemaKind.inplace
+            assert self.inplace.namespace == self.functional.namespace
 
         if self.mutable is not None:
             assert self.mutable.func.kind() == SchemaKind.mutable
+            assert self.mutable.namespace == self.functional.namespace
 
         if self.structured:
             # For now, structured composite kernels are not supported (need some
@@ -888,7 +922,7 @@ class NativeFunctionsGroup:
         # these don't count as structured for our purposes here
         if out is None:
             return None
-
+        # assuming all variants have the same namespace
         return NativeFunctionsGroup(
             functional=functional,
             inplace=inplace,
@@ -912,6 +946,9 @@ class BackendMetadata:
     # in native_functions.yaml.
     # However, external backends like XLA can indendently toggle which ops are structured.
     structured: bool
+
+    # The namespace for kernels, default value: DEFAULT_KERNEL_NAMESPACE
+    cpp_namespace: str
 
 
 @dataclass(frozen=True)

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -1,37 +1,30 @@
+from collections import defaultdict
+
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+import torchgen.api.dispatcher as dispatcher
+from torchgen.api.translate import translate
+from torchgen.api.types import Binding, DispatcherSignature, Expr
+from torchgen.context import with_native_function
 from torchgen.model import (
+    Annotation,
     Argument,
+    BackendIndex,
+    BackendMetadata,
+    BaseTy,
+    BaseType,
+    DEFAULT_KERNEL_NAMESPACE,
+    DeviceCheckType,
     DispatchKey,
     FunctionSchema,
-    BaseType,
-    BaseTy,
-    Return,
-    Annotation,
     NativeFunction,
     NativeFunctionsGroup,
     OperatorName,
-    BackendIndex,
-    BackendMetadata,
-    DeviceCheckType,
+    Return,
     SchemaKind,
     Variant,
 )
-from torchgen.utils import (
-    concatMap,
-)
-from torchgen.context import (
-    with_native_function,
-)
-from torchgen.api.types import (
-    DispatcherSignature,
-    Expr,
-    Binding,
-)
-import torchgen.api.dispatcher as dispatcher
-from torchgen.api.translate import translate
-
-
-from typing import List, Tuple, Sequence, Dict, Optional, Union
-from collections import defaultdict
+from torchgen.utils import concatMap
 
 # See Note: [Out ops with functional variants that don't get grouped properly]
 OUT_OPS_THAT_DONT_GET_GROUPED_PROPERLY = [
@@ -229,7 +222,9 @@ def generate_function(
 
     backend_metadata = {
         DispatchKey.CompositeExplicitAutograd: {
-            func.name: BackendMetadata(cpp.name(func), structured=False)
+            func.name: BackendMetadata(
+                cpp.name(func), structured=False, cpp_namespace=DEFAULT_KERNEL_NAMESPACE
+            )
         }
     }
 
@@ -259,6 +254,7 @@ def generate_function(
             # Every generated NativeFunction gets a "generated" tag, so it's easy to tell
             # which NativeFunction objects did not come directly from native_functions.yaml.
             tags=set(["generated"]),
+            namespace=f.namespace,
         ),
         backend_metadata,
     )


### PR DESCRIPTION
Summary:
Adding a feature to allow user to specify namespaces for operator and kernels.

# Feature
There's a feature request to allow DSL to:
1. take in an operator namespace other than `aten`.
2. take in a kernel that is in a different namespace than `at::native`.


For both features, we only allow user to have a single layer of namespace for the sake of simplicity. If user specify `custom::function` as kernel, the codegen will depend on `custom::native::function` where `native` is hardcoded.

# Proposal

For feature 1, add a `namespace` attribute to data class `NativeFunction`. The namespace will be extract out by matching pattern "::" on the `func` variable. For `NativeFunctionsGroup` there's an assumption that all variants (function, inplace, out) will have the same namespace. By default (if not specified) the namespace will be "aten".

For feature 2, add a `namespace` attribute to `BackendMetadata` class, similarly match pattern "::" on the kernel field. Remove the `cpp_namespace` field from `register_dispatch_key` data class. By default (if not specified) the namespace for a kernel would be "at::native".

Test Plan:
Example yaml entries:
```
- func: custom::gelu.out(Tensor self, *, str approximate='none', Tensor(a!) out) -> Tensor(a!)
  structured: True
  structured_inherits: TensorIteratorBase
  device_check: NoCheck   # TensorIterator
  python_module: nn
  dispatch:
    CPU: custom::gelu_out_cpu
    CUDA: custom::gelu_out_cuda
    MPS: custom::gelu_out_mps

- func: custom::gelu_(Tensor(a!) self, *, str approximate='none') -> Tensor(a!)
  structured_delegate: gelu.out
  device_check: NoCheck   # TensorIterator
  python_module: nn
  dispatch:
    NestedTensorCPU, NestedTensorCUDA: custom::NestedTensor_gelu_

- func: custom::gelu(Tensor self, *, str approximate='none') -> Tensor
  structured_delegate: gelu.out
  device_check: NoCheck   # TensorIterator
  python_module: nn
  dispatch:
    MkldnnCPU: custom::mkldnn_gelu
    QuantizedCPU: custom::gelu_quantized_cpu
    NestedTensorCPU, NestedTensorCUDA: custom::NestedTensor_gelu
```

see generated code:

`RegisterCPU.cpp`:
```
TORCH_LIBRARY_IMPL(aten, CPU, m) {
  ...
}
TORCH_LIBRARY_IMPL(custom, CPU, m) {
    m.impl("gelu", TORCH_FN(wrapper_gelu));
    m.impl("gelu.out", TORCH_FN(wrapper_gelu_out_out));
    m.impl("gelu_", TORCH_FN(wrapper_gelu_));
};
```
```
struct structured_gelu_out_cpu_inplace final : public custom::native::structured_gelu_out_cpu {
    structured_gelu_out_cpu_inplace(Tensor& self) : outputs_{std::ref(self)} {}

    void set_output_strided(
        int64_t output_idx, IntArrayRef sizes, IntArrayRef strides,
        TensorOptions options, DimnameList names
    ) override {

        const auto& out = outputs_[output_idx].get();
        check_inplace(out, sizes, options);

        auto maybe_proxy = maybe_create_proxy(out, sizes, strides, options);
        if (C10_UNLIKELY(maybe_proxy.has_value())) {
            proxy_outputs_[output_idx] = c10::ExclusivelyOwned<Tensor>(std::move(maybe_proxy).value());
        }

        if (!names.empty()) {
          namedinference::propagate_names(outputs_[output_idx], names);
        }
        // super must happen after, so that downstream can use maybe_get_output
        // to retrieve the output
        custom::native::structured_gelu_out_cpu::set_output_raw_strided(output_idx, sizes, strides, options, names);
    }

    void set_output_raw_strided(
        int64_t output_idx, IntArrayRef sizes, IntArrayRef strides,
        TensorOptions options, DimnameList names
    ) override {

        const auto& out = outputs_[output_idx].get();
        check_inplace(out, sizes, options);

        if (!names.empty()) {
          namedinference::propagate_names(outputs_[output_idx], names);
        }
        // super must happen after, so that downstream can use maybe_get_output
        // to retrieve the output
        custom::native::structured_gelu_out_cpu::set_output_raw_strided(output_idx, sizes, strides, options, names);
    }

    const Tensor& maybe_get_output(int64_t output_idx) override {
      return proxy_outputs_[output_idx].has_value() ? **proxy_outputs_[output_idx] : outputs_[output_idx].get();

    }
    std::array<std::reference_wrapper<Tensor>, 1> outputs_;
    std::array<c10::optional<c10::ExclusivelyOwned<Tensor>>, 1> proxy_outputs_;
};
```

`RegisterSchema.cpp`
```
TORCH_LIBRARY(aten, m) {
  ...
}
TORCH_LIBRARY(custom, m) {
    m.def("gelu.out(Tensor self, *, str approximate='none', Tensor(a!) out) -> Tensor(a!)");
    
    m.def("gelu_(Tensor(a!) self, *, str approximate='none') -> Tensor(a!)");
    
    m.def("gelu(Tensor self, *, str approximate='none') -> Tensor");
};
```

Differential Revision: D36558459

