### PR TITLE
[flatbuffer] Move saving storage to the last step.

### DIFF
--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -353,6 +353,22 @@ flatbuffers::DetachedBuffer FlatbufferSerializer::serializeModule(
   flatbuffers::Offset<flatbuffers::Vector<
       flatbuffers::Offset<mobile::serialization::StorageData>>>
       storage_data_offset = 0;
+  auto extra_files_offset = storeExtraFilesAndGetOffset(fbb, extra_files);
+
+  auto jit_source_offset = storeExtraFilesAndGetOffset(fbb, jit_sources);
+  std::vector<uint32_t> jit_constants_indexes;
+  jit_constants_indexes.reserve(jit_constants.size());
+  for (const auto& ival : jit_constants) {
+    jit_constants_indexes.emplace_back(storeIValueAndGetIndex(fbb, ival));
+  }
+  const uint32_t operator_version =
+      static_cast<uint32_t>(module.min_operator_version());
+  uint32_t bytecode_version = static_cast<uint32_t>(module.bytecode_version());
+  if (bytecode_version < kMinVersion) {
+    bytecode_version = kMinVersion;
+  }
+
+  // NOTE: saving of storage has to be the last thing to do.
   if (include_tensor_data_in_flatbuffer) {
     std::vector<flatbuffers::Offset<mobile::serialization::StorageData>>
         storage_data;
@@ -378,21 +394,6 @@ flatbuffers::DetachedBuffer FlatbufferSerializer::serializeModule(
       storage_data.push_back(storage_offset);
     }
     storage_data_offset = fbb.CreateVector(storage_data);
-  }
-
-  auto extra_files_offset = storeExtraFilesAndGetOffset(fbb, extra_files);
-
-  auto jit_source_offset = storeExtraFilesAndGetOffset(fbb, jit_sources);
-  std::vector<uint32_t> jit_constants_indexes;
-  jit_constants_indexes.reserve(jit_constants.size());
-  for (const auto& ival : jit_constants) {
-    jit_constants_indexes.emplace_back(storeIValueAndGetIndex(fbb, ival));
-  }
-  const uint32_t operator_version =
-      static_cast<uint32_t>(module.min_operator_version());
-  uint32_t bytecode_version = static_cast<uint32_t>(module.bytecode_version());
-  if (bytecode_version < kMinVersion) {
-    bytecode_version = kMinVersion;
   }
 
   auto mod = CreateModule(


### PR DESCRIPTION
Summary: Move storage saving to last step, because otherwise tensors saved after storage are already saved will not have storage.

Test Plan: Tested by loading the file in `clowder get GLDGLQnKrIsQFg8DAPxq9vg59ZwZbmQwAAAA orig.pt` and converting to flatbuffer and load again

Differential Revision: D36552645

