### PR TITLE
Pass WITH_BLAS option from environment to CMake

### DIFF
--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -282,6 +282,7 @@ class CMake:
                 var: var
                 for var in (
                     "BLAS",
+                    "WITH_BLAS",
                     "BUILDING_WITH_TORCH_LIBS",
                     "CUDA_HOST_COMILER",
                     "CUDA_NVCC_EXECUTABLE",


### PR DESCRIPTION
Allows to choose the BLAS backend with Eigen. Previously this was a CMake option only and the env variable was ignored.

Related to https://github.com/pytorch/pytorch/commit/f1f3c8b0fad9d647454a4d0507a2db4381563c8e

The claimed options BLAS=BLIS WITH_BLAS=blis are misleading: When BLAS=BLIS is set the WITH_BLAS option does not matter at all, it would only matter for BLAS=Eigen hence this issue went undetected so far.

Supersedes #59220