### PR TITLE
[primTorch] add exp2 (prim and ref), log10 (prim and ref), frac (ref)

### DIFF
--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "erfc",
     "exp",
     "expm1",
+    "exp2",
     "floor",
     "is_finite",
     "is_infinite",
@@ -63,6 +64,7 @@ __all__ = [
     "log",
     "log1p",
     "log2",
+    "log10",
     "neg",
     "reciprocal",
     "round",
@@ -464,6 +466,13 @@ expm1 = _make_elementwise_unary_prim(
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
+exp2 = _make_elementwise_unary_prim(
+    "exp2",
+    impl_aten=torch.special.exp2,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
 floor = _make_elementwise_unary_prim(
     "floor",
     impl_aten=torch.floor,
@@ -509,6 +518,13 @@ log1p = _make_elementwise_unary_prim(
 log2 = _make_elementwise_unary_prim(
     "log2",
     impl_aten=torch.log2,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
+log10 = _make_elementwise_unary_prim(
+    "log10",
+    impl_aten=torch.log10,
     doc="",
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -372,8 +372,8 @@ floor = _make_elementwise_unary_reference(
 
 def _frac(x: TensorLikeType) -> TensorLikeType:
     # frac(x) = x - floor(abs(x)) * sign(x)
-    trunc_x = floor(abs(x))
-    return sub(x, mul(trunc_x, sign(x)))
+    trunc_x = mul(floor(abs(x)), sign(x))
+    return sub(x, trunc_x)
 
 
 frac = _make_elementwise_unary_reference(

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -361,7 +361,6 @@ expm1 = _make_elementwise_unary_reference(
 exp2 = _make_elementwise_unary_reference(
     prims.exp2,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
-    aten_op=torch.ops.aten.exp2,
 )
 
 floor = _make_elementwise_unary_reference(
@@ -371,7 +370,6 @@ floor = _make_elementwise_unary_reference(
 
 
 def _frac(x: TensorLikeType) -> TensorLikeType:
-    # frac(x) = x - floor(abs(x)) * sign(x)
     trunc_x = mul(floor(abs(x)), sign(x))
     return sub(x, trunc_x)
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -53,7 +53,9 @@ __all__ = [
     "erfc",
     "exp",
     "expm1",
+    "exp2",
     "floor",
+    "frac",
     "isfinite",
     "isinf",
     "isnan",
@@ -61,6 +63,7 @@ __all__ = [
     "log",
     "log1p",
     "log2",
+    "log10",
     "neg",
     "reciprocal",
     "round",  # TODO: model kwargs
@@ -355,9 +358,28 @@ expm1 = _make_elementwise_unary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
 )
 
+exp2 = _make_elementwise_unary_reference(
+    prims.exp2,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+    aten_op=torch.ops.aten.exp2,
+)
+
 floor = _make_elementwise_unary_reference(
     prims.floor,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
+
+def _frac(x: TensorLike) -> TensorLikeType:
+    # frac(x) = x - floor(abs(x)) * sign(x)
+    trunc_x = floor(abs(x))
+    return sub(x, mul(trunc_x, sign(x)))
+
+
+frac = _make_elementwise_unary_reference(
+    _frac,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    aten_op=torch.ops.aten.frac,
 )
 
 
@@ -424,6 +446,10 @@ log2 = _make_elementwise_unary_reference(
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
 )
 
+log10 = _make_elementwise_unary_reference(
+    prims.log10,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+)
 
 def _neg_meta(a: TensorLikeType):
     if a.dtype is torch.bool:

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -370,7 +370,7 @@ floor = _make_elementwise_unary_reference(
 )
 
 
-def _frac(x: TensorLike) -> TensorLikeType:
+def _frac(x: TensorLikeType) -> TensorLikeType:
     # frac(x) = x - floor(abs(x)) * sign(x)
     trunc_x = floor(abs(x))
     return sub(x, mul(trunc_x, sign(x)))
@@ -450,6 +450,7 @@ log10 = _make_elementwise_unary_reference(
     prims.log10,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
 )
+
 
 def _neg_meta(a: TensorLikeType):
     if a.dtype is torch.bool:

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -18706,8 +18706,16 @@ python_ref_db = [
         torch_opinfo_name="expm1",
     ),
     ElementwiseUnaryPythonRefInfo(
+        "_refs.exp2",
+        torch_opinfo_name="exp2",
+    ),
+    ElementwiseUnaryPythonRefInfo(
         "_refs.floor",
         torch_opinfo_name="floor",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.frac",
+        torch_opinfo_name="frac",
     ),
     ElementwiseUnaryPythonRefInfo(
         "_refs.isfinite",
@@ -18761,6 +18769,10 @@ python_ref_db = [
     ElementwiseUnaryPythonRefInfo(
         "_refs.log1p",
         torch_opinfo_name="log1p",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.log10",
+        torch_opinfo_name="log10",
     ),
     ElementwiseUnaryPythonRefInfo(
         "_refs.log2",


### PR DESCRIPTION
Adds `exp2`, `log10` to the prims (both also exist in C++ lib and Intel SIMD intrinsic has `exp2`)

Adds `exp2`, `log10`, `frac` to refs with corresponding entries to OpInfo.

Tried to decompose `exp2` (before adding it as prim) as
* `exp(log(2) * x)` but it wasn't stable at large numbers.
* `pow(2, x)` in which case there was stride mismatch. At cursory look, `pow` tries to preserve stride of first arg if possible.

Tried to decompose `log10` (before adding it as prim) as
* `log(x) / log(10)` passed for real dtypes. Failed for complex at extremals. Probably related to https://github.com/pytorch/pytorch/issues/52332 (not a 100% sure)