### PR TITLE
[primTorch] Adds any, all, equal, item references

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -452,8 +452,8 @@ class TestCommon(TestCase):
                 torch_distance = torch_distance + _distance(a, b)
 
             # TODO: consider adding some tolerance to this comparison
-            msg = f"Reference result was farther ({ref_distance}) from the precise \
-                    computation than the torch result was ({torch_distance})!"
+            msg = f"Reference result was farther ({ref_distance}) from the precise " \
+                  "computation than the torch result was ({torch_distance})!"
             self.assertTrue(ref_distance <= torch_distance, msg=msg)
 
         # Reports numerical accuracy discrepancies

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -1770,8 +1770,9 @@ device_put = _make_prim(
     doc=_device_put_doc,
 )
 
+# NOTE: need to model meta scalars
 # See https://github.com/pytorch/pytorch/issues/78070
-def _item_meta(a: TensorLikeType) -> NumberType:
+def _item_meta(a: TensorLikeType) -> TensorMeta:
     number_type = utils.dtype_to_type(a.dtype)
     return TensorMeta(number_type(-1))
 

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -1901,10 +1901,6 @@ def _reduction_meta(inp, dims, *, output_dtype=None):
     )
 
 
-def _bool_return_reduction_meta(inp, dims):
-    return _reduction_meta(inp, dims, output_dtype=torch.bool)
-
-
 def _var_reduction_meta(inp, dims, *, correction):
     if utils.is_complex_dtype(inp.dtype):
         output_dtype = utils.corresponding_real_dtype(inp.dtype)
@@ -1956,17 +1952,6 @@ def _make_var_reduction_prim(name: str, impl_aten, doc):
     )
 
 
-def _make_bool_reduction_prim(name: str, impl_aten, doc):
-    """Creates a reduction prim that reduces to bool."""
-    return _make_prim(
-        schema=f"{name}(Tensor inp, int[]? dims, *, ScalarType? output_dtype=None) -> Tensor",
-        meta=_bool_return_reduction_meta,
-        impl_aten=impl_aten,
-        return_type=RETURN_TYPE.NEW,
-        doc=doc,
-    )
-
-
 sum = _make_reduction_prim(
     name="sum",
     impl_aten=torch.sum,
@@ -1995,12 +1980,6 @@ amin = _make_reduction_prim(
     name="amin",
     impl_aten=torch.amin,
     doc=_amin_doc,
-)
-
-any = _make_bool_reduction_prim(
-    name="any",
-    impl_aten=torch.any,
-    doc="",
 )
 
 # TODO: layout, pin_memory, memory_format

--- a/torch/_prims/utils.py
+++ b/torch/_prims/utils.py
@@ -609,6 +609,13 @@ def is_complex_dtype(dtype: torch.dtype) -> bool:
     return dtype in _complex_dtypes
 
 
+def is_grad_dtype(dtype: torch.dtype) -> bool:
+    """
+    Checks if the dtype can require a gradient.
+    """
+    return is_float_dtype(dtype) or is_complex_dtype(dtype)
+
+
 _complex_to_real_dtype_map = {
     torch.complex128: torch.float64,
     torch.complex64: torch.float32,

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1849,7 +1849,7 @@ def uniform(
 
 # TODO: add OpInfo for torch.equal and refs.equal
 def equal(a: TensorLikeType, b: TensorLikeType) -> bool:
-    utils.check_same_device(a, b)
+    utils.check_same_device(a, b, allow_cpu_scalar_tensors=False)
     utils.check_same_dtype(a, b)
 
     # Shape check

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1064,7 +1064,7 @@ def _reduction(
         dims = (dims,)  # type: ignore[assignment]
     dims = utils.reduction_dims(a.shape, dims)
     if not has_identity:
-        valid_shape = a.ndim == 0 or all(a.shape[i] for i in dims)
+        valid_shape = a.ndim == 0 or py_all(a.shape[i] for i in dims)
         if not valid_shape:
             raise RuntimeError(
                 "reducing over zero-size dimension for reduction operation without identity"
@@ -1092,6 +1092,10 @@ def _reduction(
         result = prims.convert_element_type(result, result_dtype)
 
     return result
+
+
+# Saves Python all
+py_all = all
 
 
 @out_wrapper

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1849,8 +1849,16 @@ def uniform(
 
 # TODO: add OpInfo for torch.equal and refs.equal
 def equal(a: TensorLikeType, b: TensorLikeType) -> bool:
-    utils.check_same_shape(a, b, allow_cpu_scalar_tensors=False)
-    utils.check_same_device(a, b, allow_cpu_scalar_tensors=False)
+    utils.check_same_device(a, b)
+    utils.check_same_dtype(a, b)
+
+    # Shape check
+    if a.ndim != b.ndim:
+        return False
+
+    for x, y in zip(a.shape, b.shape):
+        if x != y:
+            return False
 
     # Short-circuits if there are no elements to validate
     if a.numel() == 0:

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1107,7 +1107,7 @@ def all(
     nelem = 1 if a.ndim == 0 else reduce(operator.mul, (a.shape[i] for i in dims), 1)
 
     a_ = _maybe_convert_to_dtype(a, torch.bool)
-    result = eq(sum(a_, dim=dim, keepdim=keepdim), nelem)
+    result = eq(sum(a_, dim=dim, keepdim=keepdim), nelem)  # type: ignore[arg-type]
 
     # Preserves uint8 -- probably a legacy mask thing
     if a.dtype is torch.uint8:
@@ -1123,7 +1123,7 @@ def any(
     keepdim: bool = False,
 ) -> TensorLikeType:
     a_ = _maybe_convert_to_dtype(a, torch.bool)
-    result = ne(sum(a_, dim=dim, keepdim=keepdim), False)
+    result = ne(sum(a_, dim=dim, keepdim=keepdim), False)  # type: ignore[arg-type]
 
     # Preserves uint8 -- probably a legacy mask thing
     if a.dtype is torch.uint8:
@@ -1856,4 +1856,4 @@ def equal(a: TensorLikeType, b: TensorLikeType) -> bool:
     if a.numel() == 0:
         return True
 
-    return item(all(eq(a, b)))
+    return item(all(eq(a, b)))  # type: ignore[return-value]

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19257,27 +19257,25 @@ python_ref_db = [
     # Reduction Reference OpInfos
     #
     ReductionPythonRefInfo(
-        "_refs.sum",
-        torch_opinfo_name="sum",
-        supports_out=True,
-    ),
-    ReductionPythonRefInfo(
-        "_refs.mean",
-        torch_opinfo_name="mean",
-        supports_out=True,
-    ),
-    ReductionPythonRefInfo(
-        "_refs.amin",
-        torch_opinfo_name="amin",
+        "_refs.all",
+        torch_opinfo_name="all",
     ),
     ReductionPythonRefInfo(
         "_refs.amax",
         torch_opinfo_name="amax",
     ),
     ReductionPythonRefInfo(
-        "_refs.var",
-        torch_opinfo_name="var",
-        supports_out=True
+        "_refs.amin",
+        torch_opinfo_name="amin",
+    ),
+    ReductionPythonRefInfo(
+        "_refs.any",
+        torch_opinfo_name="any",
+    ),
+    ReductionPythonRefInfo(
+        "_refs.mean",
+        torch_opinfo_name="mean",
+        supports_out=True,
     ),
     ReductionPythonRefInfo(
         "_refs.std",
@@ -19289,6 +19287,16 @@ python_ref_db = [
         "_refs.std_mean",
         torch_opinfo_name="std_mean",
         validate_view_consistency=False
+    ),
+    ReductionPythonRefInfo(
+        "_refs.sum",
+        torch_opinfo_name="sum",
+        supports_out=True,
+    ),
+    ReductionPythonRefInfo(
+        "_refs.var",
+        torch_opinfo_name="var",
+        supports_out=True
     ),
     PythonRefInfo(
         "_refs.var_mean",


### PR DESCRIPTION
This PR adds the item, equal, any, and all references.

While doing this I found the following issues:
- https://github.com/pytorch/pytorch/issues/78070
- https://github.com/pytorch/pytorch/issues/78071

And I fixed a bug where the `convert_element_type` prim could not convert tensors requiring grad to datatypes that don't require grad.

Creating the item reference required adding item as a prim, but per @ngimel's suggestion I removed the prims for any and all and implemented them as references, so this is net negative one prim. 

Reference OpInfos are added for any and all, but item and equal don't even have regular OpInfos. 