### PR TITLE
Convert MPS Tensor data using MPSGraph API

### DIFF
--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -375,7 +375,7 @@ static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_,
   } else {
     src = src_;
     if (src.dtype() != dst_.dtype()) {
-      // Do datatype conversion on source device
+      // In case of dtype change, perform conversion on source device
       src = src.to(dst_.dtype());
     }
   }

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -434,9 +434,9 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_,
     });
   } else {
     @autoreleasepool {
-      id<MTLCommandBuffer> commandBuffer = stream->commandBuffer();
+      stream->commandBuffer();
       MPSGraph* mpsGraph = make_mps_graph();
-      MPSGraphTensor* srcTensor = at::native::mps::mpsGraphRankedPlaceHolder(mpsGraph, src);
+      MPSGraphTensor* srcTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, src);
       MPSGraphTensorData* srcData = [[[MPSGraphTensorData alloc]
                                       initWithMTLBuffer:sourceBuffer shape:srcShape dataType:srcDType]
                                      autorelease];

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -218,6 +218,58 @@ static bool copy_requires_temporaries(const Tensor& dst, const Tensor& src) {
   }
 }
 
+void copy_cast_mps(at::Tensor& dst, const at::Tensor& src,
+                   id<MTLBuffer> destBuffer, id<MTLBuffer> sourceBuffer) {
+  using namespace mps;
+  
+  struct CachedGraph : public MPSCachedGraph
+  {
+    CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
+    MPSGraphTensor* inputTensor_ = nil;
+    MPSGraphTensor* outputTensor_ = nil;
+  };
+
+  MPSStream* stream = getCurrentMPSStream();
+  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
+
+  MPSDataType dstDType = getMPSDataType(dst.scalar_type());
+  MPSDataType srcDType = getMPSDataType(src.scalar_type());
+  MPSShape* dstShape = getMPSShape(dst);
+  MPSShape* srcShape = getMPSShape(src);
+
+  @autoreleasepool {
+    string key = "copy_cast_mps" + getTensorsStringKey({src, dst});
+    CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
+
+    if (!cachedGraph) {
+      MPSCachedGraph *tmpCachedGraph = cache_->CreateCachedGraph(key, ^ MPSCachedGraph * () {
+        CachedGraph *newCachedGraph = nil;
+        @autoreleasepool {
+          MPSGraph* mpsGraph = make_mps_graph();
+          newCachedGraph = new CachedGraph(mpsGraph);
+
+          MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, src);
+          MPSGraphTensor* outputTensor = [mpsGraph castTensor:inputTensor toType:dstDType name:@"cast"];
+
+          newCachedGraph->inputTensor_ = inputTensor;
+          newCachedGraph->outputTensor_ = outputTensor;
+        }
+        return newCachedGraph;
+      });
+      cachedGraph = static_cast<CachedGraph *>(tmpCachedGraph);
+    }
+    MPSGraphTensorData* srcData = [[[MPSGraphTensorData alloc]
+                                    initWithMTLBuffer:sourceBuffer shape:srcShape dataType:srcDType]
+                                   autorelease];
+    MPSGraphTensorData* dstData = [[[MPSGraphTensorData alloc]
+                                    initWithMTLBuffer:destBuffer shape:dstShape dataType:dstDType]
+                                   autorelease];
+    NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{cachedGraph->inputTensor_: srcData};
+    NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{cachedGraph->outputTensor_: dstData};
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+  }
+}
+
 static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_,
                            bool non_blocking) {
 
@@ -262,21 +314,7 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_,
 
   // In case of dtype change, first convert src "inplace"
   if (src.dtype() != dst.dtype()) {
-    @autoreleasepool {
-      auto srcDType = getMPSDataType(src.scalar_type());
-      auto dstDType = getMPSDataType(dst.scalar_type());
-      auto srcShape = getMPSShape(src);
-      stream->commandBuffer();
-      MPSGraph* mpsGraph = make_mps_graph();
-      MPSGraphTensor* srcTensor = mps::mpsGraphRankedPlaceHolder(mpsGraph, src);
-      MPSGraphTensorData* srcData = [[[MPSGraphTensorData alloc]
-                                      initWithMTLBuffer:sourceBuffer shape:srcShape dataType:srcDType]
-                                     autorelease];
-      MPSGraphTensor *resultTensor = [mpsGraph castTensor:srcTensor toType:dstDType name:@"cast"];
-      NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{srcTensor: srcData};
-      NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{resultTensor: srcData};
-      runMPSGraph(stream, mpsGraph, feeds, results);
-    }
+    copy_cast_mps(dst, src, sourceBuffer, sourceBuffer);
   }
 
   @autoreleasepool {
@@ -409,8 +447,6 @@ void copy_blit_mps(void* dst, const void* src, size_t size) {
 
 static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_,
                             bool non_blocking) {
-  using namespace mps;
-  MPSStream* stream = getCurrentMPSStream();
   uint64_t size = src_.nbytes();
   auto src_byte_offset = src_.storage_offset() * src_.itemsize();
   id<MTLBuffer> sourceBuffer = __builtin_bit_cast(id<MTLBuffer>, src_.storage().data());
@@ -438,17 +474,8 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_,
   auto dst_byte_offset = dst.storage_offset() * dst.itemsize();
   id<MTLBuffer> destBuffer = __builtin_bit_cast(id<MTLBuffer>, dst.storage().data());
 
-  struct CachedGraph : public MPSCachedGraph
-  {
-    CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* inputTensor_ = nil;
-    MPSGraphTensor* outputTensor_ = nil;
-  };
-
-  auto srcDType = getMPSDataType(src.scalar_type());
-  auto dstDType = getMPSDataType(dst.scalar_type());
-
-  if (srcDType == dstDType) {
+  if (src.dtype() == dst.dtype()) {
+    MPSStream* stream = getCurrentMPSStream();
     dispatch_sync(stream->queue(), ^() {
       @autoreleasepool {
         id<MTLCommandBuffer> commandBuffer = stream->commandBuffer();
@@ -463,41 +490,7 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_,
       }
     });
   } else {
-    MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
-    @autoreleasepool {
-      string key = "copy_kernel_mps" + getTensorsStringKey({src, dst});
-      CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
-
-      if (!cachedGraph) {
-        MPSCachedGraph *tmpCachedGraph = cache_->CreateCachedGraph(key, ^ MPSCachedGraph * () {
-          CachedGraph *newCachedGraph = nil;
-          @autoreleasepool {
-            MPSGraph* mpsGraph = make_mps_graph();
-            newCachedGraph = new CachedGraph(mpsGraph);
-
-            MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, src);
-            MPSGraphTensor* outputTensor = [mpsGraph castTensor:inputTensor toType:dstDType name:@"cast"];
-
-            newCachedGraph->inputTensor_ = inputTensor;
-            newCachedGraph->outputTensor_ = outputTensor;
-          }
-          return newCachedGraph;
-        });
-        cachedGraph = static_cast<CachedGraph *>(tmpCachedGraph);
-      }
-      auto srcShape = getMPSShape(src);
-      auto dstShape = getMPSShape(dst);
-      MPSGraphTensorData* srcData = [[[MPSGraphTensorData alloc]
-                                      initWithMTLBuffer:sourceBuffer shape:srcShape dataType:srcDType]
-                                     autorelease];
-      MPSGraphTensorData* dstData = [[[MPSGraphTensorData alloc]
-                                      initWithMTLBuffer:destBuffer shape:dstShape dataType:dstDType]
-                                     autorelease];
-      NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds = @{cachedGraph->inputTensor_: srcData};
-      NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{cachedGraph->outputTensor_: dstData};
-      runMPSGraph(stream, cachedGraph->graph(), feeds, results);
-    }
+    copy_cast_mps(dst, src, destBuffer, sourceBuffer);
   }
   return dst;
 }

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -218,6 +218,8 @@ static bool copy_requires_temporaries(const Tensor& dst, const Tensor& src) {
   }
 }
 
+// Copy sourceBuffer into destBuffer, casting sourceBuffer to src.scalar_type().
+// The shapes and dtypes are taken from dst and src, but their storage pointers are not used.
 void copy_cast_mps(at::Tensor& dst, const at::Tensor& src,
                    id<MTLBuffer> destBuffer, id<MTLBuffer> sourceBuffer) {
   using namespace mps;
@@ -312,9 +314,9 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_,
   if (sourceBuffer == nil) return dst_;
   NSUInteger destOffset = dst.storage_offset() * dst.itemsize();
 
-  // In case of dtype change, first convert src "inplace"
-  if (src.dtype() != dst.dtype()) {
-    copy_cast_mps(dst, src, sourceBuffer, sourceBuffer);
+  // In case of dtype change, first convert src inplace
+  if (src_.dtype() != dst_.dtype()) {
+    copy_cast_mps(dst_, src_, sourceBuffer, sourceBuffer);
   }
 
   @autoreleasepool {
@@ -490,7 +492,7 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_,
       }
     });
   } else {
-    copy_cast_mps(dst, src, destBuffer, sourceBuffer);
+    copy_cast_mps(dst_, src_, destBuffer, sourceBuffer);
   }
   return dst;
 }

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -317,6 +317,10 @@ static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_,
     src = src_.to(dst_.dtype()).expand_as(dst_).contiguous();
   } else {
     src = src_;
+    if (src.dtype() != dst_.dtype()) {
+      // Do datatype conversion on source device
+      src = src.to(dst_.dtype());
+    }
   }
 
   if (!dst_.is_contiguous()) {

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -223,7 +223,7 @@ static bool copy_requires_temporaries(const Tensor& dst, const Tensor& src) {
 void copy_cast_mps(at::Tensor& dst, const at::Tensor& src,
                    id<MTLBuffer> destBuffer, id<MTLBuffer> sourceBuffer) {
   using namespace mps;
-  
+
   struct CachedGraph : public MPSCachedGraph
   {
     CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1275,6 +1275,31 @@ class TestMPS(TestCase):
                 self.assertEqual(p.grad, torch.zeros_like(p.grad))
         self.assertEqual(inp.grad, torch.zeros_like(inp))
 
+    # Test dtype casting, with and without simultaneous device change
+    def test_to(self):
+        values = [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]]
+        cpu_x = torch.tensor(values, device='cpu')
+        mps_x = torch.tensor(values, device='mps')
+
+        self.assertEqual(cpu_x.int(), mps_x.int().cpu())
+        self.assertEqual(cpu_x.bool(), mps_x.bool().cpu())
+        self.assertEqual(cpu_x.float(), mps_x.float().cpu())
+        
+        self.assertEqual(torch.tensor(1.3, device='mps').int().cpu(),
+                         torch.tensor(1, dtype=torch.int32))
+        self.assertEqual(torch.tensor(0.0, device='mps').bool().cpu(), torch.tensor(False))
+        self.assertEqual(torch.tensor(0.1, device='mps').bool().cpu(), torch.tensor(True))
+        self.assertEqual(torch.tensor(0.1, device='mps').bool().int().cpu(),
+                         torch.tensor(1, dtype=torch.int32))
+        self.assertEqual(torch.tensor(0.1, device='mps').bool().int().float().cpu(),
+                         torch.tensor(1.0))
+        self.assertEqual(torch.tensor(4.25, device='mps').to('cpu', torch.int),
+                         torch.tensor(4, dtype=torch.int32))
+        self.assertEqual(torch.tensor(4.25, device='cpu').to('mps', torch.int).cpu(),
+                         torch.tensor(4, dtype=torch.int32))
+        self.assertEqual(torch.tensor(-8.34, device='cpu').to('mps', torch.int),
+                         torch.tensor(-8.34, device='cpu').to('mps').to(torch.int))
+
 
 class TestSmoothL1Loss(TestCase):
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1284,7 +1284,7 @@ class TestMPS(TestCase):
         self.assertEqual(cpu_x.int(), mps_x.int().cpu())
         self.assertEqual(cpu_x.bool(), mps_x.bool().cpu())
         self.assertEqual(cpu_x.float(), mps_x.float().cpu())
-        
+
         self.assertEqual(torch.tensor(1.3, device='mps').int().cpu(),
                          torch.tensor(1, dtype=torch.int32))
         self.assertEqual(torch.tensor(0.0, device='mps').bool().cpu(), torch.tensor(False))


### PR DESCRIPTION
Fixes #78091
If you are already working on this, simply disregard this or take what may be helpful. This is my attempt at MPS-native Tensor datatype conversion. It works for everything tested ~~but is currently only implemented for MPS-to-MPS copy, not MPS-to-X or X-to-MPS, but the same approach could easily be used~~.

Before:
```python
In [5]: pt.full((40,), -10.3, device="mps")
Out[5]:
tensor([-10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000], device='mps:0')

In [6]: pt.full((40,), -10.3, device="mps").int()
Out[6]:
tensor([-1054552883, -1054552883, -1054552883, -1054552883, -1054552883,
        -1054552883, -1054552883, -1054552883, -1054552883, -1054552883,
        -1054552883, -1054552883, -1054552883, -1054552883, -1054552883,
        -1054552883, -1054552883, -1054552883, -1054552883, -1054552883,
        -1054552883, -1054552883, -1054552883, -1054552883, -1054552883,
        -1054552883, -1054552883, -1054552883, -1054552883, -1054552883,
        -1054552883, -1054552883, -1054552883, -1054552883, -1054552883,
        -1054552883, -1054552883, -1054552883, -1054552883, -1054552883],
       device='mps:0', dtype=torch.int32)

In [7]: pt.full((40,), -10.3, device="mps").int().float()
Out[7]:
tensor([-10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000], device='mps:0')

In [8]: pt.full((40,), -10.3, device="mps").int().float().bool()
Out[8]:
tensor([ True, False, False,  True,  True, False, False,  True,  True, False,
        False,  True,  True, False, False,  True,  True, False, False,  True,
         True, False, False,  True,  True, False, False,  True,  True, False,
        False,  True,  True, False, False,  True,  True, False, False,  True],
       device='mps:0')
```

After:
```python
In [3]: pt.full((40,), -10.3, device="mps")
Out[3]:
tensor([-10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000, -10.3000,
        -10.3000, -10.3000, -10.3000, -10.3000, -10.3000], device='mps:0')

In [4]: pt.full((40,), -10.3, device="mps").int()
Out[4]:
tensor([-10, -10, -10, -10, -10, -10, -10, -10, -10, -10, -10, -10, -10, -10,
        -10, -10, -10, -10, -10, -10, -10, -10, -10, -10, -10, -10, -10, -10,
        -10, -10, -10, -10, -10, -10, -10, -10, -10, -10, -10, -10],
       device='mps:0', dtype=torch.int32)

In [5]: pt.full((40,), -10.3, device="mps").int().float()
Out[5]:
tensor([-10., -10., -10., -10., -10., -10., -10., -10., -10., -10., -10., -10.,
        -10., -10., -10., -10., -10., -10., -10., -10., -10., -10., -10., -10.,
        -10., -10., -10., -10., -10., -10., -10., -10., -10., -10., -10., -10.,
        -10., -10., -10., -10.], device='mps:0')

In [6]: pt.full((40,), -10.3, device="mps").int().float().bool()
Out[6]:
tensor([True, True, True, True, True, True, True, True, True, True, True, True,
        True, True, True, True, True, True, True, True, True, True, True, True,
        True, True, True, True, True, True, True, True, True, True, True, True,
        True, True, True, True], device='mps:0')
```