### PR TITLE
xla hash auto update - add token to trigger workflows

### DIFF
--- a/.github/workflows/update-xla-commit-hash.yml
+++ b/.github/workflows/update-xla-commit-hash.yml
@@ -48,6 +48,7 @@ jobs:
           ORIGINAL_COMMIT: ${{ steps.update-file.outputs.original_commit }}
           NEW_COMMIT: ${{ steps.update-file.outputs.new_commit }}
         with:
+          github-token: ${{ secrets.MERGEBOT_TOKEN }}
           script: |
             const { repo, owner } = context.repo;
             const { NEW_BRANCH_NAME, NEW_COMMIT, ORIGINAL_COMMIT } = process.env


### PR DESCRIPTION
prs dont automatically trigger workflows because they were using the github bot token, so use merge bot token instead