### PR TITLE
[ci] add retry to clean before checkout step

### DIFF
--- a/.github/actions/checkout-pytorch/action.yml
+++ b/.github/actions/checkout-pytorch/action.yml
@@ -23,11 +23,14 @@ runs:
       env:
         NO_SUDO: ${{ inputs.no-sudo }}
       run: |
+        retry () {
+          $* || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
+        }
         echo "${GITHUB_WORKSPACE}"
         if [ -z "${NO_SUDO}" ]; then
-          sudo rm -rf "${GITHUB_WORKSPACE}"
+          retry sudo rm -rf "${GITHUB_WORKSPACE}"
         else
-          rm -rf "${GITHUB_WORKSPACE}"
+          retry rm -rf "${GITHUB_WORKSPACE}"
         fi
         mkdir "${GITHUB_WORKSPACE}"
 

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -45,7 +45,7 @@ jobs:
       # checkout because when we run this action we don't *have* a local
       # checkout. In other cases you should prefer a local checkout.
       - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@gh/suo/524/orig
 
       - name: Check for new workflows
         run: |

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -45,7 +45,7 @@ jobs:
       # checkout because when we run this action we don't *have* a local
       # checkout. In other cases you should prefer a local checkout.
       - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@gh/suo/524/orig
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Check for new workflows
         run: |


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #78098

This was failing intermittently (e.g.
https://github.com/pytorch/pytorch/runs/6556614531?check_suite_focus=true).

I suspect it is due to this:
https://unix.stackexchange.com/questions/506319/why-am-i-getting-directory-not-empty-with-rm-rf

So adding a retry.