### PR TITLE
print available modules in predictor error message

### DIFF
--- a/caffe2/predictor/predictor_utils.cc
+++ b/caffe2/predictor/predictor_utils.cc
@@ -10,12 +10,22 @@ namespace caffe2 {
 namespace predictor_utils {
 
 TORCH_API const NetDef& getNet(const MetaNetDef& def, const std::string& name) {
+  std::string net_names;
+  bool is_first = true;
   for (const auto& n : def.nets()) {
+    if (!is_first) {
+      net_names += ", ";
+    }
+    is_first = false;
+    net_names += n.key();
     if (n.key() == name) {
       return n.value();
     }
   }
-  CAFFE_THROW("Net not found: ", name);
+  CAFFE_THROW("Net not found: ",
+              name,
+              "; available nets: ",
+              net_names);
 }
 
 std::unique_ptr<MetaNetDef> extractMetaNetDef(


### PR DESCRIPTION
Summary:
print available modules when throwing a module not found exception

I believe that improves UX

Differential Revision: D36580924

