### PR TITLE
[GH1] let PR num distinguish different merge attempts in concurrency key

### DIFF
--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -50,4 +50,4 @@ jobs:
 
 # TODO: Separate merge on green merges from regular merges to not hold up try-merge workflows overall concurrency
 # NOTE: force pushes are also put in their concurrency group to put them higher than regular merges
-concurrency: try-merge-${{ github.event.client_payload.force}}-${{ github.event.client_payload.on_green }}
+concurrency: try-merge-${{ github.event.client_payload.force}}-${{ github.event.client_payload.on_green }}-${{ github.event.client_payload.pr_num }}


### PR DESCRIPTION
try merges are cancelling each other even though they don't touch the same PRs.