### PR TITLE
[MPS] Fix torch.mps.is_available()

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -21,6 +21,10 @@
 #include <fbgemm/Fbgemm.h>
 #endif // USE_FBGEMM
 
+#ifdef USE_MPS
+#include <ATen/mps/MPSDevice.h>
+#endif
+
 namespace at {
 
 Context::Context() = default;
@@ -233,17 +237,8 @@ bool Context::hasMKLDNN() {
 }
 
 bool Context::hasMPS() {
-#if defined(__APPLE__)
-#if __is_target_os(macOS)
-  _Pragma("clang diagnostic ignored \"-Wunsupported-availability-guard\"")
-  if (__builtin_available(macOS 12.3, *) || __builtin_available(macOSApplicationExtension 12.3, *)) {
-    return c10::impl::hasDeviceGuardImpl(at::DeviceType::MPS);
-  } else {
-    return false;
-  }
-#else
-  return false;
-#endif
+#if USE_MPS
+  return at::mps::is_available();
 #else
   return false;
 #endif

--- a/aten/src/ATen/mps/MPSDevice.h
+++ b/aten/src/ATen/mps/MPSDevice.h
@@ -56,6 +56,8 @@ class TORCH_API MPSDevice {
   MPSDevice();
 };
 
+TORCH_API bool is_available();
+
 at::Allocator* GetMPSAllocator(bool useSharedAllocator = false);
 
 } // namespace mps

--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -25,7 +25,7 @@ MPSDevice::MPSDevice(): _mtl_device(nil) {
   for (unsigned long i = 0 ; i < [devices count] ; i++) {
     id<MTLDevice>  device = devices[i];
     if(![device isLowPower]) { // exclude Intel GPUs
-      _mtl_device = device;
+      _mtl_device = [device retain];
       break;
     }
   }
@@ -35,6 +35,10 @@ MPSDevice::MPSDevice(): _mtl_device(nil) {
 at::Allocator* getMPSSharedAllocator();
 at::Allocator* GetMPSAllocator(bool useSharedAllocator) {
   return useSharedAllocator ? getMPSSharedAllocator() : GetAllocator(DeviceType::MPS);
+}
+
+bool is_available() {
+  return MPSDevice::getInstance()->device() != nil;
 }
 
 } // namespace mps

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -712,6 +712,7 @@ def _disabled_torch_function_impl(func: Callable, types: Iterable[Type], args: T
 def _disabled_torch_dispatch_impl(func: Callable, types: Iterable[Type], args: Tuple, kwargs: Dict) -> Any: ...  # THPModule_disable_dispatch_function
 def _get_linalg_preferred_backend() -> torch._C._LinalgBackend: ...
 def _set_linalg_preferred_backend(arg: torch._C._LinalgBackend): ...
+def _is_mps_available() -> _bool: ...
 class _LinalgBackend:
     Default: _LinalgBackend
     Cusolver: _LinalgBackend
@@ -725,7 +726,6 @@ def _valgrind_toggle_and_dump_stats() -> None: ...  # CALLGRIND_TOGGLE_COLLECT a
 has_openmp: _bool
 has_mkl: _bool
 has_mps: _bool
-_is_mps_available: _bool
 has_lapack: _bool
 has_cuda: _bool
 has_mkldnn: _bool

--- a/torch/backends/mps/__init__.py
+++ b/torch/backends/mps/__init__.py
@@ -1,13 +1,14 @@
-import sys
 import torch
+from functools import lru_cache as _lru_cache
 
-def is_built():
+def is_built() -> bool:
     r"""Returns whether PyTorch is built with MPS support. Note that this
     doesn't necessarily mean MPS is available; just that if this PyTorch
     binary were run a machine with working MPS drivers and devices, we
     would be able to use it."""
     return torch._C.has_mps
 
-def is_available():
+@_lru_cache()
+def is_available() -> bool:
     r"""Returns a bool indicating if MPS is currently available."""
-    return torch._C._is_mps_available
+    return torch._C._is_mps_available()

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1047,7 +1047,10 @@ Call this whenever a new thread is created in order to propagate values from
 
   ASSERT_TRUE(set_module_attr("has_cuda", has_cuda));
   ASSERT_TRUE(set_module_attr("has_mps", has_mps));
-  ASSERT_TRUE(set_module_attr("_is_mps_available", at::hasMPS() ? Py_True : Py_False));
+  py_module.def("_is_mps_available", []() {
+      return at::hasMPS();
+  });
+
 
   ASSERT_TRUE(set_module_attr("has_mkldnn", at::hasMKLDNN() ? Py_True : Py_False));
 


### PR DESCRIPTION
By introducing `at:mps::is_available()` and changing `torch._C._is_mps_available` from property to memoizable callable

Also, if `_mtl_device` is released in MPSDevice destructor, shouldn't it be retained in the constructor

Looks like GitHubActions Mac runner does not have any Metal devices available, according to https://github.com/malfet/deleteme/runs/6560871657?check_suite_focus=true#step:3:15
