### PR TITLE
[CUDAGraphs] Add an argument to specify warmup iterations in make_graphed_callables

### DIFF
--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -161,7 +161,7 @@ class graph(object):
         # returning None should propagate exceptions from either capture_end or stream_ctx.__exit__()
 
 
-def make_graphed_callables(callables, sample_args):
+def make_graphed_callables(callables, sample_args, num_warmup_iters=3):
     r"""
     Accepts callables (functions or :class:`nn.Module<torch.nn.Module>`\ s)
     and returns graphed versions.
@@ -189,6 +189,8 @@ def make_graphed_callables(callables, sample_args):
         sample_args (tuple of Tensors, or tuple of tuples of Tensors): Samples args for each callable.
             If a single callable was passed, ``sample_args`` must be a single tuple of argument Tensors.
             If a tuple of callables was passed, ``sample_args`` must be tuple of tuples of argument Tensors.
+        num_warmup_iters (int): The number of warmup iterations. Currently, ``DataDistributedParallel`` needs
+            11 iterations for warm up. Default: ``3``.
 
     .. note::
         The ``requires_grad`` state of each Tensor in ``sample_args`` must match the state
@@ -264,7 +266,7 @@ def make_graphed_callables(callables, sample_args):
         for func, args, static_input_surface in zip(callables,
                                                     sample_args,
                                                     per_callable_static_input_surfaces):
-            for _ in range(3):
+            for _ in range(num_warmup_iters):
                 outputs = func(*args)
                 outputs = (outputs,) if isinstance(outputs, torch.Tensor) else outputs
                 grad_inputs = torch.autograd.grad(outputs=outputs,


### PR DESCRIPTION
Summary: Add an argument to specify the number of warmup iterations to the API ``torch.cuda.make_graphed_callables``. By default, it needs 3 warm-up iterations. To work with NCCL, it needs 11 warm-up iterations.

Differential Revision: D36606758

