### PR TITLE
Use generators with all/any in torch/optim

### DIFF
--- a/test/jit/test_parametrization.py
+++ b/test/jit/test_parametrization.py
@@ -43,27 +43,3 @@ class TestParametrization(JitTestCase):
                                     'Cannot trace a model while caching'):
             with parametrize.cached():
                 traced_model = torch.jit.trace_module(model, {'forward': x})
-
-    def test_scriptable(self):
-        # TODO: Need to fix the scripting in parametrizations
-        #       Currently, all the tests below will throw UnsupportedNodeError
-        model = nn.Linear(5, 5)
-        parametrize.register_parametrization(model, "weight", self.Symmetric())
-
-        x = torch.randn(3, 5)
-        y = model(x)
-
-        with self.assertRaises(torch.jit.frontend.UnsupportedNodeError):
-            # Check scripting works
-            scripted_model = torch.jit.script(model)
-            y_hat = scripted_model(x)
-            self.assertEqual(y, y_hat)
-
-            with parametrize.cached():
-                # Check scripted model works when caching
-                y_hat = scripted_model(x)
-                self.assertEqual(y, y_hat)
-
-                # Check the scripting process throws an error when caching
-                with self.assertRaisesRegex(RuntimeError, 'Caching is not implemented'):
-                    scripted_model = torch.jit.trace_module(model)

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -1021,6 +1021,11 @@ class ExprBuilder(Builder):
         return ListComp(r, elt_expr, target_expr, iter_expr)
 
     @staticmethod
+    def build_GeneratorExp(ctx, stmt):
+        # Convert Generator expression to ListComp
+        return ExprBuilder.build_ListComp(ctx, stmt)
+
+    @staticmethod
     def build_DictComp(ctx, stmt):
         r = ctx.make_range(stmt.lineno, stmt.col_offset, stmt.col_offset)
         if (len(stmt.generators) != 1):

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -254,6 +254,8 @@ class ParametrizationList(ModuleList):
                     original_i.set_(tensor)
 
     def forward(self) -> Tensor:
+        if torch.jit.is_scripting():
+            raise RuntimeError('Parametrization is not working with scripting.')
         # Unpack the originals for the first parametrization
         if self.is_tensor:
             x = self[0](self.original)
@@ -325,6 +327,8 @@ def _inject_property(module: Module, tensor_name: str) -> None:
         return tensor
 
     def get_parametrized(self) -> Tensor:
+        if torch.jit.is_scripting():
+            raise RuntimeError('Parametrization is not working with scripting.')
         parametrization = self.parametrizations[tensor_name]
         if _cache_enabled:
             if torch.jit.is_scripting():
@@ -341,6 +345,8 @@ def _inject_property(module: Module, tensor_name: str) -> None:
             return parametrization()
 
     def set_original(self, value: Tensor) -> None:
+        if torch.jit.is_scripting():
+            raise RuntimeError('Parametrization is not working with scripting.')
         self.parametrizations[tensor_name].right_inverse(value)
 
     setattr(module.__class__, tensor_name, property(get_parametrized, set_original))

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -188,7 +188,7 @@ def adagrad(
     See :class:`~torch.optim.Adagrad` for details.
     """
 
-    if not all([isinstance(t, torch.Tensor) for t in state_steps]):
+    if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError(
             "API has changed, `state_steps` argument must contain a list of singleton tensors"
         )
@@ -303,7 +303,7 @@ def _multi_tensor_adagrad(
         grads = torch._foreach_neg(grads)
 
     if has_sparse_grad is None:
-        has_sparse_grad = any([grad.is_sparse for grad in grads])
+        has_sparse_grad = any(grad.is_sparse for grad in grads)
 
     if has_sparse_grad:
         return _single_tensor_adagrad(

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -195,7 +195,7 @@ def adam(params: List[Tensor],
     See :class:`~torch.optim.Adam` for details.
     """
 
-    if not all([isinstance(t, torch.Tensor) for t in state_steps]):
+    if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError("API has changed, `state_steps` argument must contain a list of singleton tensors")
 
     if foreach is None:

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -160,7 +160,7 @@ def adamax(params: List[Tensor],
     See :class:`~torch.optim.Adamax` for details.
     """
 
-    if not all([isinstance(t, torch.Tensor) for t in state_steps]):
+    if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError("API has changed, `state_steps` argument must contain a list of singleton tensors")
 
     if foreach is None:

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -200,7 +200,7 @@ def adamw(params: List[Tensor],
     See :class:`~torch.optim.AdamW` for details.
     """
 
-    if not all([isinstance(t, torch.Tensor) for t in state_steps]):
+    if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError("API has changed, `state_steps` argument must contain a list of singleton tensors")
 
     if foreach is None:

--- a/torch/optim/nadam.py
+++ b/torch/optim/nadam.py
@@ -169,10 +169,10 @@ def nadam(params: List[Tensor],
     See :class:`~torch.optim.NAdam` for details.
     """
 
-    if not all([isinstance(t, torch.Tensor) for t in state_steps]):
+    if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError("API has changed, `state_steps` argument must contain a list of singleton tensors")
 
-    if not all([isinstance(t, torch.Tensor) for t in mu_products]):
+    if not all(isinstance(t, torch.Tensor) for t in mu_products):
         raise RuntimeError("API has changed, `mu_products` argument must contain a list of singleton tensors")
 
     if foreach is None:

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -160,7 +160,7 @@ def radam(params: List[Tensor],
     See :class:`~torch.optim.RAdam` for details.
     """
 
-    if not all([isinstance(t, torch.Tensor) for t in state_steps]):
+    if not all(isinstance(t, torch.Tensor) for t in state_steps):
         raise RuntimeError("API has changed, `state_steps` argument must contain a list of singleton tensors")
 
     if foreach is None:

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -257,7 +257,7 @@ def _multi_tensor_sgd(params: List[Tensor],
         return
 
     if has_sparse_grad is None:
-        has_sparse_grad = any([grad.is_sparse for grad in grads])
+        has_sparse_grad = any(grad.is_sparse for grad in grads)
 
     if weight_decay != 0:
         grads = torch._foreach_add(grads, params, alpha=weight_decay)


### PR DESCRIPTION
Generator comprehensions with any/all are less verbose and potentially help to save memory/CPU : https://eklitzke.org/generator-comprehensions-and-using-any-and-all-in-python

To make JIT work with this change, I added code to convert GeneratorExp to ListComp. So the whole PR is basically NoOp for JIT, but potentially memory and speed improvement for eager mode.