### PR TITLE
[Codegen] Remove view operator check in NativeFunctionGroups and allow skipping native function generation

### DIFF
--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -162,6 +162,7 @@ def parse_native_yaml_struct(
     valid_tags: Set[str],
     ignore_keys: Optional[Set[DispatchKey]] = None,
     path: str = "<stdin>",
+    skip_native_fns_gen: bool = False,
 ) -> ParsedYaml:
     assert isinstance(es, list)
     rs: List[NativeFunction] = []
@@ -185,7 +186,8 @@ def parse_native_yaml_struct(
             index={},
         )
     )
-    add_generated_native_functions(rs, bs)
+    if not skip_native_fns_gen:
+        add_generated_native_functions(rs, bs)
     for k, v in bs.items():
         # All structured in-tree operators are implemented in terms of their out operator.
         indices[k] = BackendIndex(
@@ -226,7 +228,11 @@ def parse_tags_yaml(path: str) -> Set[str]:
 
 
 def parse_native_yaml(
-    path: str, tags_yaml_path: str, ignore_keys: Optional[Set[DispatchKey]] = None
+    path: str,
+    tags_yaml_path: str,
+    ignore_keys: Optional[Set[DispatchKey]] = None,
+    *,
+    skip_native_fns_gen: bool = False,
 ) -> ParsedYaml:
     # TODO: parse tags.yaml and create a tags database (a dict of tag name mapping to a Tag object)
     global _GLOBAL_PARSE_NATIVE_YAML_CACHE
@@ -235,7 +241,11 @@ def parse_native_yaml(
         with open(path, "r") as f:
             es = yaml.load(f, Loader=LineLoader)
         _GLOBAL_PARSE_NATIVE_YAML_CACHE[path] = parse_native_yaml_struct(
-            es, valid_tags, ignore_keys, path=path
+            es,
+            valid_tags,
+            ignore_keys,
+            path=path,
+            skip_native_fns_gen=skip_native_fns_gen,
         )
 
     return _GLOBAL_PARSE_NATIVE_YAML_CACHE[path]

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -816,11 +816,6 @@ class NativeFunctionsGroup:
                     f"that don't have matching signatures: {test_sig} != {f.func.signature()}"
                 )
         assert self.functional.func.kind() == SchemaKind.functional
-        assert not self.functional.is_view_op, (
-            "View operator shouldn't be grouped into NativeFunctionsGroup objects."
-            f"This is likely because you tried to add an out= variant for '{f.func.name}', which is an existing view operator."
-            "out= variants of view operators are not valid. Please reach out to to the core team if you have questions."
-        )
         assert self.out.func.kind() == SchemaKind.out
 
         if self.inplace is not None:


### PR DESCRIPTION
Summary:
This PR adds two features:
* A boolean to turn off native function generation in codegen
* Relaxing `view` operator check for `NativeFunctionGroups`


Differential Revision: D36604646

