### PR TITLE
[quant] Add utility function get_fqn_to_example_inputs

### DIFF
--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -220,6 +220,23 @@
     "QuantizedGraphModule",
     "Tuple"
   ],
+  "torch.ao.quantization.fx.match_utils": [
+    "Any",
+    "Callable",
+    "Dict",
+    "Graph",
+    "List",
+    "MatchAllNode",
+    "MatchResult",
+    "Node",
+    "Optional",
+    "Pattern",
+    "QConfigAny",
+    "QuantizeHandler",
+    "Set",
+    "Tuple",
+    "is_observed_standalone_module"
+  ],
   "torch.ao.quantization.fx.pattern_utils": [
     "Any",
     "Dict",
@@ -460,16 +477,6 @@
     "QConfig",
     "QuantType",
     "wrap_cpp_module"
-  ],
-  "torch.ao.quantization.utils": [
-    "Any",
-    "Callable",
-    "Pattern",
-    "QuantType",
-    "Tuple",
-    "Union",
-    "is_parametrized",
-    "quant_type_to_str"
   ],
   "torch.ao.sparsity.experimental.pruner.base_pruner": [
     "ActivationReconstruction",

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -220,23 +220,6 @@
     "QuantizedGraphModule",
     "Tuple"
   ],
-  "torch.ao.quantization.fx.match_utils": [
-    "Any",
-    "Callable",
-    "Dict",
-    "Graph",
-    "List",
-    "MatchAllNode",
-    "MatchResult",
-    "Node",
-    "Optional",
-    "Pattern",
-    "QConfigAny",
-    "QuantizeHandler",
-    "Set",
-    "Tuple",
-    "is_observed_standalone_module"
-  ],
   "torch.ao.quantization.fx.pattern_utils": [
     "Any",
     "Dict",

--- a/test/quantization/core/test_utils.py
+++ b/test/quantization/core/test_utils.py
@@ -1,3 +1,5 @@
+# Owner(s): ["oncall: quantization"]
+
 import torch
 from torch.testing._internal.common_utils import TestCase
 from torch.ao.quantization.utils import get_fqn_to_example_inputs

--- a/test/quantization/core/test_utils.py
+++ b/test/quantization/core/test_utils.py
@@ -1,0 +1,89 @@
+import torch
+from torch.testing._internal.common_utils import TestCase
+from torch.ao.quantization.utils import get_fqn_to_example_inputs
+
+
+class TestUtils(TestCase):
+    def _test_get_fqn_to_example_inputs(self, M, example_inputs, expected_fqn_to_dim):
+        m = M().eval()
+        fqn_to_example_inputs = get_fqn_to_example_inputs(m, example_inputs)
+        for fqn, expected_dims in expected_fqn_to_dim.items():
+            assert fqn in expected_fqn_to_dim
+            example_inputs = fqn_to_example_inputs[fqn]
+            for example_input, expected_dim in zip(example_inputs, expected_dims):
+                assert example_input.dim() == expected_dim
+
+    def test_get_fqn_to_example_inputs_simple(self):
+        class Sub(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = torch.nn.Linear(5, 5)
+                self.linear2 = torch.nn.Linear(5, 5)
+
+            def forward(self, x):
+                x = self.linear1(x)
+                x = self.linear2(x)
+                return x
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = torch.nn.Linear(5, 5)
+                self.linear2 = torch.nn.Linear(5, 5)
+                self.sub = Sub()
+
+            def forward(self, x):
+                x = self.linear1(x)
+                x = self.linear2(x)
+                x = self.sub(x)
+                return x
+
+        expected_fqn_to_dim = {
+            "": (2,),
+            "linear1": (2,),
+            "linear2": (2,),
+            "sub": (2,),
+            "sub.linear1": (2,),
+            "sub.linear2": (2,)
+        }
+        example_inputs = (torch.rand(1, 5),)
+        self._test_get_fqn_to_example_inputs(M, example_inputs, expected_fqn_to_dim)
+
+    def test_get_fqn_to_example_inputs_kwargs(self):
+        class Sub(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = torch.nn.Linear(5, 5)
+                self.linear2 = torch.nn.Linear(5, 5)
+
+            def forward(self, x, key1=torch.rand(1), key2=torch.rand(1)):
+                x = self.linear1(x)
+                x = self.linear2(x)
+                return x
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = torch.nn.Linear(5, 5)
+                self.linear2 = torch.nn.Linear(5, 5)
+                self.sub = Sub()
+
+            def forward(self, x):
+                x = self.linear1(x)
+                x = self.linear2(x)
+                # only override `key2`, `key1` will use default
+                x = self.sub(x, key2=torch.rand(1, 2))
+                return x
+
+        expected_fqn_to_dim = {
+            "": (2,),
+            "linear1": (2,),
+            "linear2": (2,),
+            # second arg is `key1`, which is using default argument
+            # third arg is `key2`, override by callsite
+            "sub": (2, 1, 2),
+            "sub.linear1": (2,),
+            "sub.linear2": (2,)
+        }
+        example_inputs = (torch.rand(1, 5),)
+        self._test_get_fqn_to_example_inputs(M, example_inputs, expected_fqn_to_dim)

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -36,6 +36,7 @@ from quantization.core.test_workflow_module import TestRecordHistogramObserver  
 from quantization.core.test_workflow_module import TestHistogramObserver  # noqa: F401
 from quantization.core.test_workflow_module import TestDistributed  # noqa: F401
 from quantization.core.test_workflow_module import TestFusedObsFakeQuantModule  # noqa: F401
+from quantization.core.test_utils import TestUtils  # noqa: F401
 
 
 # Eager Mode Workflow. Tests for the functionality of APIs and different features implemented

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -6,6 +6,7 @@ import functools
 import torch
 from torch.ao.quantization.quant_type import QuantType, quant_type_to_str
 from typing import Tuple, Any, Union, Callable, Dict, Optional
+import typing
 from torch.nn.utils.parametrize import is_parametrized
 from collections import OrderedDict
 from inspect import signature
@@ -408,7 +409,7 @@ def _get_signature_locals(f: Callable, loc: Dict[str, Any]) -> Dict[str, Any]:
     """
     return {k: v for k, v in loc.items() if k in signature(f).parameters}
 
-def _get_default_kwargs(f: Callable) -> OrderedDict[str, Any]:
+def _get_default_kwargs(f: Callable) -> typing.OrderedDict[str, Any]:
     """ Get all default keyword arguments from function signature
 
     Example::
@@ -428,7 +429,7 @@ def _get_default_kwargs(f: Callable) -> OrderedDict[str, Any]:
             kwargs[name] = {}
     return OrderedDict(kwargs)
 
-def _normalize_kwargs(func: Callable, loc: Dict[str, Any]) -> OrderedDict[str, Any]:
+def _normalize_kwargs(func: Callable, loc: Dict[str, Any]) -> typing.OrderedDict[str, Any]:
     """ Given a function and local function arguments, normalize the keyword
     arguments by filling in default arguments from function signature
 

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -533,6 +533,6 @@ __all__ = [
     "Tuple",
     "Union",
     "is_parametrized",
-    "quant_type_to_str"
+    "quant_type_to_str",
     "get_fqn_to_example_inputs",
 ]

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -452,7 +452,7 @@ def get_fqn_to_example_inputs(model, example_inputs):
 
             def _patched_module_call(self, *args, **kwargs):
                 submodule_example_inputs = list(args).copy()
-                noramlized_kwargs = _normalized_kwargs(self.forward, kwargs)
+                normalized_kwargs = _normalize_kwargs(self.forward, kwargs)
                 # minus 1 to skipping counting `self`
                 num_args = _get_num_pos_args(self.forward) - 1
                 num_to_pop = num_args - len(submodule_example_inputs)

--- a/torch/ao/quantization/utils.py
+++ b/torch/ao/quantization/utils.py
@@ -5,7 +5,7 @@ import warnings
 import functools
 import torch
 from torch.ao.quantization.quant_type import QuantType, quant_type_to_str
-from typing import Tuple, Any, Union, Callable, Dict, OrderedDict, Optional
+from typing import Tuple, Any, Union, Callable, Dict, Optional
 from torch.nn.utils.parametrize import is_parametrized
 from collections import OrderedDict
 from inspect import signature


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #78146

Summary:
After https://github.com/pytorch/pytorch/pull/77608 `example_inputs` is required input for `prepare_fx` and `prepare_qat_fx`.
This makes quantizing submodules harder, so we added this utility function to get a dictionary from fqn to submodule example_inputs

Example Call:

```
example_inputs = (tensor0,)
get_fqn_to_example_inputs(m, example_inputs)
```

Example output:
```
{
   "linear1": (tensor1,),
   "linear2": (tensor2,),
   "sub": (tensor3,),
   "sub.linear1": (tensor4,),
   ...
}
```

Test Plan:
python test/test_quantization.py TestUtils

Reviewers:

Subscribers:

Tasks:

Tags: