### PR TITLE
Add DLPack support for XPU backend by mapping to kDLOneAPI in DLPack.

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -9,6 +9,7 @@
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <ATen/detail/HIPHooksInterface.h>
 #include <ATen/detail/ORTHooksInterface.h>
+#include <ATen/detail/XPUHooksInterface.h>
 #include <c10/core/QEngine.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/util/CallOnce.h>
@@ -88,6 +89,9 @@ class TORCH_API Context {
   }
   static bool hasXLA() {
     return c10::impl::hasDeviceGuardImpl(at::DeviceType::XLA);
+  }
+  static bool hasXPU() {
+    return detail::getXPUHooks().hasXPU();
   }
   static bool hasLazy() {
     return c10::impl::hasDeviceGuardImpl(at::DeviceType::Lazy);
@@ -326,6 +330,10 @@ static inline bool hasMPS() {
 
 static inline bool hasORT() {
   return globalContext().hasORT();
+}
+
+static inline bool hasXPU() {
+  return globalContext().hasXPU();
 }
 
 // Despite its name, this function returns the number of *CUDA* GPUs.

--- a/aten/src/ATen/Version.cpp
+++ b/aten/src/ATen/Version.cpp
@@ -195,6 +195,10 @@ std::string show_config() {
     ss << detail::getORTHooks().showConfig();
   }
 
+  if (hasXPU()) {
+    ss << detail::getXPUHooks().showConfig();
+  }
+
   ss << "  - Build settings: ";
   for (const auto& pair : caffe2::GetBuildOptions()) {
     if (!pair.second.empty()) {

--- a/aten/src/ATen/detail/XPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/XPUHooksInterface.cpp
@@ -1,0 +1,28 @@
+#include <ATen/detail/XPUHooksInterface.h>
+
+#include <c10/util/CallOnce.h>
+
+#include <memory>
+#include <mutex>
+
+namespace at {
+namespace detail {
+
+static XPUHooksInterface *xpu_hooks = nullptr;
+
+const XPUHooksInterface &getXPUHooks() {
+  static c10::once_flag once;
+  c10::call_once(once, [] {
+    xpu_hooks =
+        XPUHooksRegistry()->Create("XPUHooks", XPUHooksArgs{}).release();
+    if (!xpu_hooks) {
+      xpu_hooks = new XPUHooksInterface();
+    }
+  });
+  return *xpu_hooks;
+}
+} // namespace detail
+
+C10_DEFINE_REGISTRY(XPUHooksRegistry, XPUHooksInterface, XPUHooksArgs)
+
+} // namespace at

--- a/aten/src/ATen/detail/XPUHooksInterface.h
+++ b/aten/src/ATen/detail/XPUHooksInterface.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <ATen/dlpack.h>
+#include <c10/core/Device.h>
+#include <c10/util/Exception.h>
+
+#include <c10/util/Registry.h>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+
+namespace at {
+class Context;
+}
+
+namespace at {
+
+constexpr const char* XPU_HELP =
+    "The XPU backend requires Intel Extension for Pytorch;"
+    "this error has occurred because you are trying "
+    "to use some XPU's functionality, but the Intel Extension for Pytorch has not been "
+    "loaded for some reason. The Intel Extension for Pytorch MUST "
+    "be loaded, EVEN IF you don't directly use any symbols from that!";
+
+struct TORCH_API XPUHooksInterface {
+  virtual ~XPUHooksInterface() {}
+
+  virtual void initXPU() const {
+    TORCH_CHECK(
+        false,
+        "Cannot initialize XPU without Intel Extension for Pytorch.",
+        XPU_HELP);
+  }
+
+  virtual bool hasXPU() const {
+    return false;
+  }
+
+  virtual std::string showConfig() const {
+    TORCH_CHECK(
+        false,
+        "Cannot query detailed XPU version without Intel Extension for Pytorch. ",
+        XPU_HELP);
+  }
+
+  virtual Device getATenDeviceFromDLPackDevice(
+      const DLDevice& dl_device,
+      void* data) const {
+    TORCH_CHECK(
+        false,
+        "Cannot get XPU device without Intel Extension for Pytorch. ",
+        XPU_HELP);
+  };
+
+  virtual DLDevice getDLPackDeviceFromATenDevice(
+      const Device& aten_device,
+      void* data) const {
+    TORCH_CHECK(
+        false,
+        "Cannot get XPU DL device without Intel Extension for Pytorch. ",
+        XPU_HELP);
+  };
+};
+
+struct TORCH_API XPUHooksArgs {};
+
+C10_DECLARE_REGISTRY(XPUHooksRegistry, XPUHooksInterface, XPUHooksArgs);
+#define REGISTER_XPU_HOOKS(clsname) \
+  C10_REGISTER_CLASS(XPUHooksRegistry, clsname, clsname)
+
+namespace detail {
+TORCH_API const XPUHooksInterface& getXPUHooks();
+} // namespace detail
+} // namespace at

--- a/aten/src/ATen/ops/from_blob.h
+++ b/aten/src/ATen/ops/from_blob.h
@@ -127,10 +127,12 @@ inline Tensor from_blob(
     void* data,
     IntArrayRef sizes,
     const std::function<void(void*)>& deleter,
-    const TensorOptions& options = {}) {
+    const TensorOptions& options = {},
+    const c10::optional<Device> target_device = c10::nullopt) {
   return for_blob(data, sizes)
       .deleter(deleter)
       .options(options)
+      .target_device(target_device)
       .make_tensor();
 }
 

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1150,6 +1150,8 @@ class Tensor(torch._C._TensorBase):
             device_type = DLDeviceType.kDLGPU
         elif self.device.type == 'cpu':
             device_type = DLDeviceType.kDLCPU
+        elif self.device.type == 'xpu':
+            device_type = DLDeviceType.kDLOneAPI
         else:
             raise ValueError('Unknown device type {} for Dlpack'.format(self.device.type))
         return (device_type, idx)

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -18,6 +18,7 @@ class DLDeviceType(enum.IntEnum):
     kDLVPI = 9,
     kDLROCM = 10,
     kDLExtDev = 12,
+    kDLOneAPI = 14,
 
 
 torch._C._add_docstr(to_dlpack, r"""to_dlpack(tensor) -> PyCapsule


### PR DESCRIPTION
## Motivation
The DLPack device type kDLOneAPI stands for the Unified Shared Memory allocated on a oneAPI device. The corresponding Pytorch backend type is XPU. 
Support to export/import the Pytorch XPU tensor as a DLPack tensor of kDLOneAPI device.

## Solution
1. Update the DLPack protocol to v0.7.
2. Add the XPU hooks to map the Aten device and DLPack device with the address value and device information.


