### PR TITLE
MPS: Implement aten::count_nonzero.dim_IntList

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -281,6 +281,21 @@ Tensor prod_mps(const Tensor &self, c10::optional<ScalarType> opt_dtype) {
   return output_t;
 }
 
+
+Tensor count_nonzero_mps(const Tensor& self, IntArrayRef dims){
+  Tensor output_t = at::native::empty_mps(
+                      {},
+                      self.scalar_type(),
+                      c10::nullopt,
+                      kMPS,
+                      c10::nullopt,
+                      c10::nullopt);
+
+  reduction_out_mps(self, dims, false, self.scalar_type(), const_cast<Tensor&>(output_t), "sum", "count_nonzero_mps");
+
+  return output_t;
+}
+
 TORCH_IMPL_FUNC(mean_out_mps)
    (const Tensor& input_t,
     IntArrayRef dim,

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -210,7 +210,7 @@ void reduction_out_mps
                                                  name:nil];
           } else if(reduction_type == "count_nonzero") {
             MPSGraphTensor* zeros = [mpsGraph constantWithScalar:0
-                                                        dataType:MPSDataTypeFloat32];
+                                                        dataType:castInputTensor.dataType];
 
             MPSGraphTensor* nonZeros = [mpsGraph notEqualWithPrimaryTensor:castInputTensor
                                                            secondaryTensor:zeros
@@ -223,7 +223,7 @@ void reduction_out_mps
 
           MPSGraphTensor* outputTensor = nil;
 
-          if(input_t.scalar_type() != ScalarType::Float)
+          if(output_t.scalar_type() != ScalarType::Float)
             outputTensor = [mpsGraph castTensor:castOutputTensor
                                          toType:(native_mps::getMPSDataType(output_t.scalar_type()))
                                            name:@"outputTensor"];
@@ -332,7 +332,7 @@ Tensor count_nonzero_mps(const Tensor& self, IntArrayRef dims){
 
   Tensor output_t = at::native::empty_mps(
                       IntArrayRef(raw_output_shape, [output_shape count]),
-                      self.scalar_type(),
+                      ScalarType::Long,
                       c10::nullopt,
                       kMPS,
                       c10::nullopt,

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -173,18 +173,30 @@ void reduction_out_mps
 
           MPSGraphTensor* castOutputTensor = nil;
 
-          if(reduction_type == "sum")
+          if(reduction_type == "sum") {
             castOutputTensor = [mpsGraph reductionSumWithTensor:castInputTensor
                                                            axes:axes
                                                            name:nil];
-          else if(reduction_type == "prod")
+          } else if(reduction_type == "prod") {
             castOutputTensor = [mpsGraph reductionProductWithTensor:castInputTensor
                                                                axes:axes
                                                                name:nil];
-          else if(reduction_type == "mean")
+          } else if(reduction_type == "mean") {
             castOutputTensor = [mpsGraph meanOfTensor:inputTensor
                                                  axes:axes
                                                  name:nil];
+          } else if(reduction_type == "count_nonzero") {
+            MPSGraphTensor* zeros = [mpsGraph constantWithScalar:0
+                                                        dataType:MPSDataTypeFloat32];
+
+            MPSGraphTensor* nonZeros = [mpsGraph notEqualWithPrimaryTensor:castInputTensor
+                                                           secondaryTensor:zeros
+                                                                      name:nil];
+
+            castOutputTensor = [mpsGraph reductionSumWithTensor:nonZeros
+                                                           axes:axes
+                                                           name:nil];
+          }
 
           MPSGraphTensor* outputTensor = nil;
 
@@ -291,7 +303,7 @@ Tensor count_nonzero_mps(const Tensor& self, IntArrayRef dims){
                       c10::nullopt,
                       c10::nullopt);
 
-  reduction_out_mps(self, dims, false, self.scalar_type(), const_cast<Tensor&>(output_t), "sum", "count_nonzero_mps");
+  reduction_out_mps(self, dims, false, self.scalar_type(), const_cast<Tensor&>(output_t), "count_nonzero", "count_nonzero_mps");
 
   return output_t;
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1489,6 +1489,7 @@
   dispatch:
     CPU: count_nonzero_cpu
     CUDA: count_nonzero_cuda
+    MPS: count_nonzero_mps
 
 - func: count_nonzero(Tensor self, int? dim=None) -> Tensor
   variants: function, method

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1319,30 +1319,35 @@ class TestMPS(TestCase):
         helper((3, 4, 5), (2, 2, 2))
 
     def test_count_nonzero(self):
-        n = [
-            [[1, 0, 2], [3, 0, 2], [7, 9, -4]],
-            [[0, 2, 3], [3, 2, 1], [2, 0, 0]],
-        ]
-        cpu_x = torch.tensor(n)
-        mps_x = torch.tensor(n).to('mps')
+        def helper(dtype):
+            n = [
+                [[1, 0, 2], [3, 0, 2], [7, 9, -4]],
+                [[0, 2, 3], [3, 2, 1], [2, 0, 0]],
+            ]
+            cpu_x = torch.tensor(n, dtype=dtype)
+            mps_x = torch.tensor(n, dtype=dtype).to('mps')
 
-        # All non-zeros
-        self.assertEqual(
-            torch.count_nonzero(cpu_x),
-            torch.count_nonzero(mps_x)
-        )
+            # All non-zeros
+            self.assertEqual(
+                torch.count_nonzero(cpu_x),
+                torch.count_nonzero(mps_x)
+            )
 
-        # dim=1
-        self.assertEqual(
-            torch.count_nonzero(cpu_x, dim=1),
-            torch.count_nonzero(mps_x, dim=1)
-        )
+            # dim=1
+            self.assertEqual(
+                torch.count_nonzero(cpu_x, dim=1),
+                torch.count_nonzero(mps_x, dim=1)
+            )
 
-        # dim=(0, 1)
-        self.assertEqual(
-            torch.count_nonzero(cpu_x, dim=(0, 1)),
-            torch.count_nonzero(mps_x, dim=(0, 1))
-        )
+            # dim=(0, 1)
+            self.assertEqual(
+                torch.count_nonzero(cpu_x, dim=(0, 1)),
+                torch.count_nonzero(mps_x, dim=(0, 1))
+            )
+        helper(torch.int32)
+        helper(torch.int64)
+        helper(torch.float16)
+        helper(torch.float32)
 
     def _test_module_empty_input(self, module, inp, check_size=True):
         inp.requires_grad_(True)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1318,6 +1318,32 @@ class TestMPS(TestCase):
         helper((3, 4, 5), (2, 3, 4, 5))
         helper((3, 4, 5), (2, 2, 2))
 
+    def test_count_nonzero(self):
+        n = [
+            [[1, 0, 2], [3, 0, 2], [7, 9, -4]],
+            [[0, 2, 3], [3, 2, 1], [2, 0, 0]],
+        ]
+        cpu_x = torch.tensor(n)
+        mps_x = torch.tensor(n).to('mps')
+
+        # All non-zeros
+        self.assertEqual(
+            torch.count_nonzero(cpu_x),
+            torch.count_nonzero(mps_x)
+        )
+
+        # dim=1
+        self.assertEqual(
+            torch.count_nonzero(cpu_x, dim=1),
+            torch.count_nonzero(mps_x, dim=1)
+        )
+
+        # dim=(0, 1)
+        self.assertEqual(
+            torch.count_nonzero(cpu_x, dim=(0, 1)),
+            torch.count_nonzero(mps_x, dim=(0, 1))
+        )
+
     def _test_module_empty_input(self, module, inp, check_size=True):
         inp.requires_grad_(True)
         out = module(inp)


### PR DESCRIPTION
- See: #77764

Implements the `aten::count_nonzero.dim_IntList` operator (as used by [torch.count_nonzero](https://pytorch.org/docs/stable/generated/torch.count_nonzero.html)) for [MPS](https://pytorch.org/blog/introducing-accelerated-pytorch-training-on-mac/).

