### PR TITLE
ci: Re-build when docker images aren't available

### DIFF
--- a/.circleci/docker/build_docker.sh
+++ b/.circleci/docker/build_docker.sh
@@ -46,7 +46,7 @@ fi
 # Build new image
 ./build.sh ${IMAGE_NAME} -t "${image}:${tag}"
 
-if [ "${DOCKER_SKIP_PUSH:-false}" = "true" ]; then
+if [ "${DOCKER_SKIP_PUSH:-true}" = "false" ]; then
   docker push "${image}:${tag}"
 fi
 

--- a/.circleci/docker/build_docker.sh
+++ b/.circleci/docker/build_docker.sh
@@ -46,7 +46,9 @@ fi
 # Build new image
 ./build.sh ${IMAGE_NAME} -t "${image}:${tag}"
 
-docker push "${image}:${tag}"
+if [ "${DOCKER_SKIP_PUSH:-false}" = "true" ]; then
+  docker push "${image}:${tag}"
+fi
 
 if [ -z "${DOCKER_SKIP_S3_UPLOAD:-}" ]; then
   trap "rm -rf ${IMAGE_NAME}:${tag}.tar" EXIT

--- a/.circleci/docker/build_docker.sh
+++ b/.circleci/docker/build_docker.sh
@@ -46,6 +46,7 @@ fi
 # Build new image
 ./build.sh ${IMAGE_NAME} -t "${image}:${tag}"
 
+# Only push if `DOCKER_SKIP_PUSH` = false
 if [ "${DOCKER_SKIP_PUSH:-true}" = "false" ]; then
   docker push "${image}:${tag}"
 fi

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -96,7 +96,7 @@ runs:
       env:
         IMAGE_NAME: ${{inputs.docker-image-name}}
         DOCKER_SKIP_S3_UPLOAD: "1"
-        DOCKER_SKIP_PUSH: ${{ steps.check.outputs.skip_push || "false" }}
+        DOCKER_SKIP_PUSH: ${{ steps.check.outputs.skip_push || 'false' }}
         DOCKER_TAG: ${{ steps.calculate-tag.outputs.docker-tag }}
       working-directory: .circleci/docker
       shell: bash

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -96,7 +96,7 @@ runs:
       env:
         IMAGE_NAME: ${{inputs.docker-image-name}}
         DOCKER_SKIP_S3_UPLOAD: "1"
-        DOCKER_SKIP_PUSH: ${{ steps.check.outputs.skip_push }}
+        DOCKER_SKIP_PUSH: ${{ steps.check.outputs.skip_push || "false" }}
         DOCKER_TAG: ${{ steps.calculate-tag.outputs.docker-tag }}
       working-directory: .circleci/docker
       shell: bash

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -17,6 +17,9 @@ inputs:
   pull:
     description: If set to any value, run `docker pull`` on the calculated image.
     required: false
+  force_push:
+    description: If set to any value, always run the push
+    required: false
 
 outputs:
   docker-image:
@@ -53,6 +56,7 @@ runs:
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
         DOCKER_IMAGE: ${{ steps.calculate-tag.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-tag.outputs.docker-tag }}
+        DOCKER_FORCE_PUSH: ${{ inputs.skip_push }}
       run: |
         set -x
         # Check if image already exists, if it does then skip building it
@@ -75,9 +79,15 @@ runs:
         PREVIOUS_DOCKER_TAG=$(git rev-parse "$MERGE_BASE:.circleci/docker")
         # If no image exists but the hash is the same as the previous hash then we should error out here
         if [[ "${PREVIOUS_DOCKER_TAG}" = "${DOCKER_TAG}" ]]; then
-          echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
-          echo "       contact the PyTorch team to restore the original images"
-          exit 1
+          echo "WARNING: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+          echo "         Will re-build docker image to store in local cache, TTS may be longer"
+          # NOTE: DOCKER_FORCE_PUSH will always be set to true for docker-builds.yml
+          if [[ "${DOCKER_FORCE_PUSH}" != "true" ]]; then
+            # In order to avoid a stampeding herd of jobs trying to push all at once we set it to
+            # skip the push. If this is negatively affecting TTS across the board the suggestion
+            # should be to run the docker-builds.yml workflow to generate the correct docker builds
+            echo ::set-output name=skip_push::true
+          fi
         fi
         echo ::set-output name=rebuild::yes
 
@@ -86,6 +96,7 @@ runs:
       env:
         IMAGE_NAME: ${{inputs.docker-image-name}}
         DOCKER_SKIP_S3_UPLOAD: "1"
+        DOCKER_SKIP_PUSH: ${{ steps.check.outputs.skip_push }}
         DOCKER_TAG: ${{ steps.calculate-tag.outputs.docker-tag }}
       working-directory: .circleci/docker
       shell: bash

--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -56,7 +56,7 @@ runs:
         BASE_REVISION: ${{ github.event.pull_request.base.sha || github.sha }}
         DOCKER_IMAGE: ${{ steps.calculate-tag.outputs.docker-image }}
         DOCKER_TAG: ${{ steps.calculate-tag.outputs.docker-tag }}
-        DOCKER_FORCE_PUSH: ${{ inputs.skip_push }}
+        DOCKER_FORCE_PUSH: ${{ inputs.force_push }}
       run: |
         set -x
         # Check if image already exists, if it does then skip building it

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           docker-image-name: ${{ matrix.docker-image-name }}
           always-rebuild: true
+          force_push: true
 
       - name: Pull docker image
         uses: ./.github/actions/pull-docker-image


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #78186

Adds a failsafe for when docker images aren't available at your base at
the expense of TTS. Also adds the ability to set force_push and note
about what to do when TTS gets out of hand because docker images are
always re-building.

Fixes https://github.com/pytorch/pytorch/issues/70881

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>