### PR TITLE
[MPS] Add version check

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -21,6 +21,13 @@ MPSDevice::~MPSDevice() {
 }
 
 MPSDevice::MPSDevice(): _mtl_device(nil) {
+  // Check that MacOS 12.3+ version of MPS framework is available
+  id mpsCD = NSClassFromString(@"MPSGraphCompilationDescriptor");
+  if (![mpsCD instancesRespondToSelector:@selector(optimizationLevel)]) {
+    // According to https://developer.apple.com/documentation/metalperformanceshadersgraph/mpsgraphcompilationdescriptor/3922624-optimizationlevel
+    // this means we are running on older MacOS
+    return;
+  }
   NSArray* devices = [MTLCopyAllDevices() autorelease];
   for (unsigned long i = 0 ; i < [devices count] ; i++) {
     id<MTLDevice>  device = devices[i];


### PR DESCRIPTION
Use `instancesRespondToSelector:` to test the presence of
`optimizationLevel` in `MPSGraphCompilationDescriptor`, which according
to
https://developer.apple.com/documentation/metalperformanceshadersgraph/mpsgraphcompilationdescriptor/3922624-optimizationlevel
is only available on 12.3 or newer

This works around a limitations of `@available(macOS 12.3, *)` macro in
shared libraries dynamically loaded by apps targeting older runtime.
And deployment target for macos Python conda binaries is 10.14:
```
% otool -l `which python3`
...
Load command 9
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 10.14
      sdk 10.14
...
```
