### PR TITLE
ci: Remove verbose windows compilation commands

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -10,7 +10,8 @@ set PATH=C:\Program Files\CMake\bin;C:\Program Files\7-Zip;C:\ProgramData\chocol
 :: able to see what our cl.exe commands are (since you can actually
 :: just copy-paste them into a local Windows setup to just rebuild a
 :: single file.)
-set CMAKE_VERBOSE_MAKEFILE=1
+:: log sizes are too long, but leaving this here incase someone wants to use it locally
+:: set CMAKE_VERBOSE_MAKEFILE=1
 
 
 set INSTALLER_DIR=%SCRIPT_HELPERS_DIR%\installation-helpers


### PR DESCRIPTION
Fixes #65717

redo of #65720 since i cant seem to reopen that pr


