### PR TITLE
[Do Not Merge] Test if 4 GPU test runs

### DIFF
--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -763,6 +763,10 @@ class TestFSDPOptimState(FSDPTest):
         optim1.load_state_dict(sharded_osd)
         self._step_model(model1, optim1, num_iters=NUM_ITERS)
 
+    @skip_if_lt_x_gpu(4)
+    def test_multigpu(self):
+        raise RuntimeError("4 GPU test is indeed running!")
+
 
 instantiate_parametrized_tests(TestFSDPOptimState)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#78209 [Do Not Merge] Test if 4 GPU test runs**
* #78224 [FSDP] Add optim state dict shape check
* #78208 [FSDP] Remove unneeded padding logic for optim state dict

Checking to see if FSDP tests will run with 4 GPUs when using the label `ciflow/all`.