### PR TITLE
reenable torch function tests, fix small bug

### DIFF
--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -1117,7 +1117,6 @@ class TestTorchFunctionWarning(TestCase):
                 # Function that handles torch_function in C++
                 torch.abs(a)
 
-@skipIfCrossRef
 class TestTorchFunctionMode(TestCase):
     def test_basic(self):
         class A(TorchFunctionMode):

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1753,7 +1753,7 @@ def _wrap_torch_function(f):
 
 class _TorchFunctionMetaInitErrorInfo(MetaInitErrorInfo):
     def __init__(self):
-        super().__init__(mode_class_name="TorchDispatchMode", mode_name="torch_dispatch")
+        super().__init__(mode_class_name="TorchFunctionMode", mode_name="torch_function")
 
 
 class TorchFunctionModeMeta(type):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #78215
* #78214
* __->__ #78213

Found a bug in torch function mode. There's a test for it, so turns out the tests weren't running locally (or on CI because the bug wasn't caught). I took out the `@skipIfCrossRef` and fixed the bug