### PR TITLE
[GHF] Better "Reviews missing" error message

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -718,8 +718,11 @@ class GitHubPR:
         if not dry_run:
             gh_add_labels(self.org, self.project, self.pr_num, ["merged"])
 
+
 class MandatoryChecksMissingError(Exception):
     pass
+
+
 @dataclass
 class MergeRule:
     name: str
@@ -784,7 +787,7 @@ def find_matching_merge_rule(pr: GitHubPR,
         if len(rule.approved_by) > 0 and len(approved_by) == 0:
             if reject_reason_score < 10000:
                 reject_reason_score = 10000
-                reject_reason = f"Matched rule {rule_name}, but PR has not been reviewed yet"
+                reject_reason = f"Matched rule {rule_name}, but PR #{pr.pr_num} has not been reviewed yet"
             continue
 
         rule_approvers_set = set()
@@ -799,7 +802,7 @@ def find_matching_merge_rule(pr: GitHubPR,
         if len(approvers_intersection) == 0 and len(rule_approvers_set) > 0:
             if reject_reason_score < 10000:
                 reject_reason_score = 10000
-                reject_reason = (f"Matched rule {rule_name}, but it was not reviewed yet by any of:" +
+                reject_reason = (f"Matched rule {rule_name}, but PR #{pr.pr_num} was not reviewed yet by any of:" +
                                  f"{','.join(list(rule_approvers_set)[:5])}{', ...' if len(rule_approvers_set) > 5 else ''}")
             continue
         if rule.mandatory_checks_name is not None:


### PR DESCRIPTION
When merging stack, it could be confusing to see which PRs are missing
reviews as one can observe in https://github.com/pytorch/pytorch/pull/77667#issuecomment-1136255521

Print PR number in needs-review message

