### PR TITLE
Enhance the _rebuild_qtensor to support other device type other than CPU

### DIFF
--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -219,18 +219,18 @@ def _rebuild_qtensor(storage, storage_offset, size, stride, quantizer_params, re
     qscheme = quantizer_params[0]
     if qscheme == torch.per_tensor_affine:
         _, scale, zero_point = quantizer_params
-        tensor = torch._empty_affine_quantized(size, scale=scale, zero_point=zero_point, dtype=storage.dtype)
+        tensor = torch._empty_affine_quantized(size, scale=scale, zero_point=zero_point, dtype=storage.dtype, device=storage.device)
     elif qscheme in (torch.per_channel_affine, torch.per_channel_affine_float_qparams):
         _, scales, zero_points, axis = quantizer_params
         if type(scales) is list and type(zero_points) is list:
             if qscheme == torch.per_channel_affine:
-                scales = torch.tensor(scales, dtype=torch.double)
-                zero_points = torch.tensor(zero_points, dtype=torch.long)
+                scales = torch.tensor(scales, dtype=torch.double, device=storage.device)
+                zero_points = torch.tensor(zero_points, dtype=torch.long, device=storage.device)
             else:
-                scales = torch.tensor(scales, dtype=torch.float)
-                zero_points = torch.tensor(zero_points, dtype=torch.float)
+                scales = torch.tensor(scales, dtype=torch.float, device=storage.device)
+                zero_points = torch.tensor(zero_points, dtype=torch.float, device=storage.device)
         tensor = torch._empty_per_channel_affine_quantized(
-            size, scales=scales, zero_points=zero_points, axis=axis, dtype=storage.dtype)
+            size, scales=scales, zero_points=zero_points, axis=axis, dtype=storage.dtype, device=storage.device)
     else:
         raise RuntimeError("Can't deserialize quantized tensor with qscheme {}".format(qscheme))
     tensor.set_(storage, storage_offset, size, stride)


### PR DESCRIPTION
## Motivation
There is a bug in torch._utils.rebuild_qtensor when to restore a qtensor from pickle for not CPU device type. The tensor is created on the CPU device but set to a storage which maybe a different device type.

## Solution
Create the qtensor based on the storage device type.


