### PR TITLE
fix set item to scalar tensor missing gradient info

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -353,9 +353,6 @@ static inline void copy_to(const Tensor& dst, const Tensor& src) {
     // appear. Users can workaround that case by dst[index..] = src.reshape(..)
     dst.copy_(src);
     return;
-  } else if (src.sizes().size() == 0 && src.device().type() == at::kCPU) {
-    dst.fill_(src.item());
-    return;
   }
   auto src_view = src.view(slicePrefix1sSize(src.sizes()));
   c10::MaybeOwned<Tensor> b_src = expand_inplace(dst, src_view, "setitem");

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -353,6 +353,9 @@ static inline void copy_to(const Tensor& dst, const Tensor& src) {
     // appear. Users can workaround that case by dst[index..] = src.reshape(..)
     dst.copy_(src);
     return;
+  } else if (src.dim() == 0 && src.device().type() == at::kCPU) {
+    dst.fill_(src);
+    return;
   }
   auto src_view = src.view(slicePrefix1sSize(src.sizes()));
   c10::MaybeOwned<Tensor> b_src = expand_inplace(dst, src_view, "setitem");

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -649,6 +649,15 @@ class TestIndexing(TestCase):
         self.assertEqual(reference[[0, 123, 44488, 68807, 123343], ],
                          torch.tensor([0, 123, 44488, 68807, 123343], dtype=torch.int))
 
+    def test_set_item_to_scalar_tensor(self, device):
+        m, n = 3, 2
+        z = torch.randn([m, n], device=device)
+        a = 1.0
+        w = torch.tensor(a, requires_grad=True, device=device)
+        z[:, 0] = w
+        z.sum().backward()
+        self.assertEqual(w.grad, m * a)
+
     def test_single_int(self, device):
         v = torch.randn(5, 7, 3, device=device)
         self.assertEqual(v[4].shape, (7, 3))

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -650,7 +650,8 @@ class TestIndexing(TestCase):
                          torch.tensor([0, 123, 44488, 68807, 123343], dtype=torch.int))
 
     def test_set_item_to_scalar_tensor(self, device):
-        m, n = 3, 2
+        m = random.randint(1, 10)
+        n = random.randint(1, 10)
         z = torch.randn([m, n], device=device)
         a = 1.0
         w = torch.tensor(a, requires_grad=True, device=device)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #78246

fix https://github.com/pytorch/pytorch/issues/77565