### PR TITLE
Add MPS merge rules

### DIFF
--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -280,7 +280,7 @@
          "aten/src/ATen/mps/**",
          "aten/src/ATen/native/mps/**"
       ],
-      "approved_by": ["kulinseth"],
+      "approved_by": ["kulinseth", "razarmehr"],
       "mandatory_checks_name": [
          "Facebook CLA Check",
          "Lint"

--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -274,6 +274,19 @@
       ]
    },
    {
+      "name": "MPS",
+      "patterns": [
+         "test/test_mps.py",
+         "aten/src/ATen/mps/**",
+         "aten/src/ATen/native/mps/**"
+      ],
+      "approved_by": ["kulinseth"],
+      "mandatory_checks_name": [
+         "Facebook CLA Check",
+         "Lint"
+      ]
+   },
+   {
       "name": "superuser",
       "patterns": ["*"],
       "approved_by": ["pytorch/metamates"],


### PR DESCRIPTION
This enables MPS PR reviewed by @kulinseth and @razarmehr to be merged into default branch using mergebot.
"Lint" is the only mandatory check for this rule, as MacOS and iOS  builds are on trunk-only for now
