### PR TITLE
[symint] Make TensorImpl::sizes_and_strides_ contain SymInt

### DIFF
--- a/aten/src/ATen/BatchingRegistrations.cpp
+++ b/aten/src/ATen/BatchingRegistrations.cpp
@@ -182,7 +182,7 @@ Tensor expand_batching_rule(const Tensor& self, IntArrayRef size, bool implicit)
 }
 
 Tensor expand_batching_rule_symint(const Tensor& self, SymIntArrayRef psize, bool implicit) {
-  return expand_batching_rule(self, expectIntArrayRef(psize), implicit);
+  return expand_batching_rule(self, asIntArrayRefSlow(psize), implicit);
 }
 
 

--- a/aten/src/ATen/FunctionalInverses.cpp
+++ b/aten/src/ATen/FunctionalInverses.cpp
@@ -142,7 +142,7 @@ Tensor FunctionalInverses::expand_copy_inverse(const Tensor& base, const Tensor&
 }
 
 Tensor FunctionalInverses::expand_copy_SymInt_inverse(const Tensor& base, const Tensor& mutated_view, bool reapply_views, c10::SymIntArrayRef size, bool implicit) {
-    return at::sum_to(mutated_view, c10::expectIntArrayRef(base.sym_sizes()),/*always_return_non_view=*/!reapply_views);
+    return at::sum_to(mutated_view, c10::asIntArrayRefSlow(base.sym_sizes()),/*always_return_non_view=*/!reapply_views);
 }
 
 Tensor FunctionalInverses::permute_copy_inverse(const Tensor& base, const Tensor& mutated_view, bool reapply_views, at::IntArrayRef dims) {

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -70,7 +70,11 @@ struct TORCH_API OpaqueTensorImpl : public TensorImpl {
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<OpaqueTensorImpl<OpaqueHandle>>(
-        key_set(), dtype(), device(), opaque_handle_, sizes_and_strides_.sizes_arrayref());
+        key_set(),
+        dtype(),
+        device(),
+        opaque_handle_,
+        asIntArrayRefSlow(sizes_and_strides_.sizes_arrayref()));
     copy_tensor_metadata(
         /*src_opaque_impl=*/this,
         /*dest_opaque_impl=*/impl.get(),
@@ -90,7 +94,11 @@ struct TORCH_API OpaqueTensorImpl : public TensorImpl {
       c10::VariableVersion&& version_counter,
       bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<OpaqueTensorImpl<OpaqueHandle>>(
-        key_set(), dtype(), device(), opaque_handle_, sizes_and_strides_.sizes_arrayref());
+        key_set(),
+        dtype(),
+        device(),
+        opaque_handle_,
+        asIntArrayRefSlow(sizes_and_strides_.sizes_arrayref()));
     copy_tensor_metadata(
         /*src_opaque_impl=*/this,
         /*dest_opaque_impl=*/impl.get(),

--- a/aten/src/ATen/SparseCsrTensorImpl.cpp
+++ b/aten/src/ATen/SparseCsrTensorImpl.cpp
@@ -82,6 +82,9 @@ const char* SparseCsrTensorImpl::tensorimpl_type_name() const {
 }
 
 void SparseCsrTensorImpl::resize_(int64_t nnz, IntArrayRef size) {
+  TORCH_CHECK(
+      !has_symbolic_sizes_strides_,
+      "resize_ called on tensor with symbolic shape")
   auto rows = size[size.size() - 2];
   auto cols = size[size.size() - 1];
   auto old_crow_indices_size = crow_indices_.size(-1);
@@ -102,6 +105,9 @@ void SparseCsrTensorImpl::resize_(int64_t nnz, IntArrayRef size) {
 }
 
 void SparseCsrTensorImpl::resize_as_sparse_csr_tensor_(const Tensor& src) {
+  TORCH_CHECK(
+      !has_symbolic_sizes_strides_,
+      "resize_as_sparse_csr_tensor_ called on tensor with symbolic shape")
   set_layout(src.layout());
   crow_indices_ = at::empty_like(
       src.crow_indices(),
@@ -124,6 +130,9 @@ void SparseCsrTensorImpl::set_member_tensors(
     const Tensor& col_indices,
     const Tensor& values,
     IntArrayRef size) {
+  TORCH_CHECK(
+      !has_symbolic_sizes_strides_,
+      "set_member_tensors called on tensor with symbolic shape")
 
   // CSR Type Invariants
   TORCH_CHECK(

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -66,6 +66,9 @@ public:
   // respect to indices and values
   void raw_resize_(int64_t sparse_dim, int64_t dense_dim, IntArrayRef size) {
     TORCH_CHECK(allow_tensor_metadata_change(), "raw_resize_ ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        !has_symbolic_sizes_strides_,
+        "raw_resize_ called on tensor with symbolic shape")
     sizes_and_strides_.set_sizes(size);
     sparse_dim_ = sparse_dim;
     dense_dim_ = dense_dim;
@@ -96,6 +99,9 @@ public:
   // (this could make some of the stored indices out-of-bound and thus unsafe).
   void resize_(int64_t sparse_dim, int64_t dense_dim, IntArrayRef size) {
     TORCH_CHECK(allow_tensor_metadata_change(), "resize_ ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        !has_symbolic_sizes_strides_,
+        "resize_ called on tensor with symbolic shape")
     TORCH_CHECK(sparse_dim + dense_dim == static_cast<int64_t>(size.size()), "number of dimensions must be sparse_dim (", sparse_dim, ") + dense_dim (", dense_dim, "), but got ", size.size());
     if (nnz() > 0) {
       auto alt_options_msg = "You could try the following options:\n\
@@ -136,7 +142,8 @@ public:
         "shrinking the size of dense dimensions (from ", dense_size_original, " to ", dense_size_new, ") on a non-empty sparse tensor is not supported.\n", alt_options_msg);
     }
 
-    const bool size_equals_sizes = std::equal(size.begin(), size.end(), sizes_and_strides_.sizes_begin(), sizes_and_strides_.sizes_end());
+    IntArrayRef sizes_and_strides = asIntArrayRefSlow(sizes_and_strides_.sizes_arrayref());
+    const bool size_equals_sizes = std::equal(size.begin(), size.end(), sizes_and_strides.begin(), sizes_and_strides.end());
     if ((!size_equals_sizes) || (sparse_dim != sparse_dim_) || (dense_dim != dense_dim_)) {
       auto nnz = values().size(0);
       std::vector<int64_t> values_size = {nnz};
@@ -157,6 +164,9 @@ public:
   // NOTE: this function will resize the sparse tensor and also set `indices` and `values` to empty.
   void resize_and_clear_(int64_t sparse_dim, int64_t dense_dim, IntArrayRef size) {
     TORCH_CHECK(allow_tensor_metadata_change(), "resize_and_clear_ ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        !has_symbolic_sizes_strides_,
+        "resize_and_clear_ called on tensor with symbolic shape")
     TORCH_CHECK(sparse_dim + dense_dim == static_cast<int64_t>(size.size()), "number of dimensions must be sparse_dim (", sparse_dim, ") + dense_dim (", dense_dim, "), but got ", size.size());
 
     sizes_and_strides_.set_sizes(size);

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -843,7 +843,7 @@ Tensor diag_embed(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim
 }
 
 Tensor expand_symint(const Tensor& self, c10::SymIntArrayRef packed_size, bool implicit) {
-  auto size = expectIntArrayRef(packed_size);
+  auto size = asIntArrayRefSlow(packed_size);
   return expand(self, size, implicit);
 }
 

--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -17,4 +17,46 @@ c10::SymInt SymInt::toSymInt(std::shared_ptr<SymbolicIntNode> sin_sp) {
   uint64_t data = idx | IS_SYM;
   return c10::SymInt(static_cast<int64_t>(data));
 }
+
+SymInt SymInt::operator+(SymInt sci) const {
+  TORCH_CHECK(
+      !this->is_symbolic() && !sci.is_symbolic(),
+      "Symbolic Add isn't supported yet");
+  return SymInt(data_ + sci.data_);
+}
+
+bool SymInt::operator<(SymInt sci) const {
+  TORCH_CHECK(
+      !this->is_symbolic() && !sci.is_symbolic(),
+      "Symbolic lt isn't supported yet");
+  return data_ < sci.data_;
+}
+
+void SymInt::operator*=(SymInt sci) {
+  TORCH_CHECK(
+      !this->is_symbolic() && !sci.is_symbolic(),
+      "Symbolic mul_ isn't supported yet");
+  data_ = data_ * sci.data_;
+}
+
+bool SymInt::operator<(int64_t sci) const {
+  TORCH_CHECK(!this->is_symbolic(), "Symbolic lt isn't supported yet");
+  return data_ < sci;
+}
+
+bool SymInt::operator==(int64_t sci) const {
+  TORCH_CHECK(!this->is_symbolic(), "Symbolic eq isn't supported yet");
+  return data_ == sci;
+}
+
+bool SymInt::operator!=(int64_t sci) const {
+  TORCH_CHECK(!this->is_symbolic(), "Symbolic neq isn't supported yet");
+  return data_ != sci;
+}
+
+SymInt SymInt::operator*(int64_t sci) const {
+  TORCH_CHECK(!this->is_symbolic(), "Symbolic mul isn't supported yet");
+  return SymInt(data_ * sci);
+}
+
 } // namespace c10

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -27,7 +27,8 @@ class SymbolicIntNode;
 // named data_.
 class C10_API SymInt {
  public:
-  explicit SymInt(int64_t d) : data_(d){};
+  /*implicit*/ SymInt(int64_t d) : data_(d){};
+  SymInt() = default;
 
   int64_t expect_int() const {
     TORCH_CHECK(!is_symbolic());
@@ -42,15 +43,25 @@ class C10_API SymInt {
     return data_ == p2.data_;
   }
 
-  SymInt operator+(SymInt sci) const {
-    TORCH_CHECK(
-        !this->is_symbolic() && !sci.is_symbolic(),
-        "Symbolic Add isn't supported yet");
-    return SymInt(data_ + sci.data_);
+  bool operator!=(const SymInt& p2) const {
+    return data_ != p2.data_;
   }
+
+  SymInt operator+(SymInt sci) const;
+  bool operator<(SymInt sci) const;
+  void operator*=(SymInt sci);
+
+  SymInt operator*(int64_t sci) const;
+  bool operator<(int64_t sci) const;
+  bool operator==(int64_t sci) const;
+  bool operator!=(int64_t sci) const;
 
   std::shared_ptr<SymbolicIntNode> toSymbolicIntNode();
   static c10::SymInt toSymInt(std::shared_ptr<SymbolicIntNode> sin);
+
+  int64_t as_int_unchecked() const {
+    return data_;
+  }
 
   // This is needed for interoperability with IValue
   int64_t data() const {

--- a/c10/core/SymIntArrayRef.cpp
+++ b/c10/core/SymIntArrayRef.cpp
@@ -3,11 +3,14 @@
 
 namespace c10 {
 
-at::IntArrayRef expectIntArrayRef(c10::SymIntArrayRef ar) {
+at::IntArrayRef asIntArrayRefSlow(c10::SymIntArrayRef ar) {
   for (c10::SymInt sci : ar) {
     TORCH_CHECK(!sci.is_symbolic());
   }
+  return asIntArrayRefUnchecked(ar);
+}
 
+at::IntArrayRef asIntArrayRefUnchecked(c10::SymIntArrayRef ar) {
   return IntArrayRef(reinterpret_cast<const int64_t*>(ar.data()), ar.size());
 }
 

--- a/c10/core/SymIntArrayRef.h
+++ b/c10/core/SymIntArrayRef.h
@@ -73,6 +73,17 @@ class SymIntArrayRef final {
   /* implicit */ constexpr SymIntArrayRef(const c10::SymInt (&Arr)[N])
       : wrapped_symint_array_ref(Arr) {}
 
+  static SymIntArrayRef fromIntArrayRef(IntArrayRef array_ref) {
+    for (size_t i = 0; i < array_ref.size(); ++i) {
+      TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+          SymInt::check_range(array_ref[i]),
+          "IntArrayRef contains int that cannot be representative as a SymInt",
+          array_ref[i]);
+    }
+    return SymIntArrayRef(
+        reinterpret_cast<const SymInt*>(array_ref.data()), array_ref.size());
+  }
+
   /// @}
   /// @name Simple Operations
   /// @{
@@ -176,7 +187,8 @@ class SymIntArrayRef final {
   /// @}
 };
 
-TORCH_API at::IntArrayRef expectIntArrayRef(c10::SymIntArrayRef ar);
+TORCH_API at::IntArrayRef asIntArrayRefSlow(c10::SymIntArrayRef ar);
+TORCH_API at::IntArrayRef asIntArrayRefUnchecked(c10::SymIntArrayRef ar);
 
 std::ostream& operator<<(std::ostream& out, const c10::SymIntArrayRef& list);
 

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -211,9 +211,10 @@ bool TensorImpl::compute_contiguous() const {
     return is_contiguous;
   int64_t z = 1;
   for (int64_t d = dim() - 1; d >= 0; d--) {
-    const auto size_d = sizes_and_strides_.size_at_unchecked(d);
+    const auto size_d =
+        sizes_and_strides_.size_at_unchecked(d).as_int_unchecked();
     if (size_d != 1) {
-      if (sizes_and_strides_.stride_at_unchecked(d) == z) {
+      if (sizes_and_strides_.stride_at_unchecked(d).as_int_unchecked() == z) {
         z *= size_d;
       } else {
         is_contiguous = false;
@@ -231,9 +232,11 @@ bool TensorImpl::compute_channels_last_contiguous_2d() const {
     case 4: {
       int64_t expected = 1;
       for (auto& d : {1, 3, 2, 0}) {
-        const auto size_d = sizes_and_strides_.size_at_unchecked(d);
+        const auto size_d =
+            sizes_and_strides_.size_at_unchecked(d).as_int_unchecked();
         if (size_d != 1) {
-          if (sizes_and_strides_.stride_at_unchecked(d) != expected) {
+          if (sizes_and_strides_.stride_at_unchecked(d).as_int_unchecked() !=
+              expected) {
             return false;
           }
           expected *= size_d;
@@ -257,9 +260,11 @@ bool TensorImpl::compute_channels_last_contiguous_3d() const {
     case 5: {
       int64_t expected = 1;
       for (auto& d : {1, 4, 3, 2, 0}) {
-        const auto size_d = sizes_and_strides_.size_at_unchecked(d);
+        const auto size_d =
+            sizes_and_strides_.size_at_unchecked(d).as_int_unchecked();
         if (size_d != 1) {
-          if (sizes_and_strides_.stride_at_unchecked(d) != expected) {
+          if (sizes_and_strides_.stride_at_unchecked(d).as_int_unchecked() !=
+              expected) {
             return false;
           }
           expected *= size_d;
@@ -306,7 +311,7 @@ bool TensorImpl::compute_non_overlapping_and_dense() const {
     return sizes_and_strides_.stride_at_unchecked(a) <
         sizes_and_strides_.stride_at_unchecked(b);
   });
-  auto require_stride = 1;
+  SymInt require_stride = 1;
   for (const auto i : c10::irange(dim())) {
     const auto size_perm_i = sizes_and_strides_.size_at_unchecked(perm[i]);
     if (size_perm_i < 2) {
@@ -606,9 +611,14 @@ void TensorImpl::Extend(int64_t num, float growthPct) {
   TORCH_CHECK(
       is_contiguous_,
       "Right now Extend is only supported for contiguous Tensor.");
+  TORCH_CHECK(
+      !has_symbolic_sizes_strides_,
+      "Extend() called on tensor with symbolic shape")
+
   using SizesVector = SmallVector<int64_t, 5>;
-  SizesVector newDims(
-      sizes_and_strides_.sizes_begin(), sizes_and_strides_.sizes_end());
+  IntArrayRef sizes_and_strides =
+      asIntArrayRefUnchecked(sizes_and_strides_.sizes_arrayref());
+  SizesVector newDims(sizes_and_strides.begin(), sizes_and_strides.end());
   newDims[0] += num;
   if (!storage_.data()) {
     Resize(newDims);
@@ -616,16 +626,16 @@ void TensorImpl::Extend(int64_t num, float growthPct) {
   }
   const auto newNumel = c10::multiply_integers(newDims.begin(), newDims.end());
   if (newNumel * data_type_.itemsize() <= storage_.nbytes()) {
-    sizes_and_strides_.set_sizes(newDims);
+    sizes_and_strides_.set_sizes(SymIntArrayRef::fromIntArrayRef(newDims));
     numel_ = newNumel;
     return;
   }
-  SizesVector newCapacity(
-      sizes_and_strides_.sizes_begin(), sizes_and_strides_.sizes_end());
+  SizesVector newCapacity(sizes_and_strides.begin(), sizes_and_strides.end());
   newCapacity[0] = std::max(
       newDims[0],
       static_cast<int64_t>(std::ceil(
-          sizes_and_strides_.size_at_unchecked(0) * (1 + growthPct / 100))));
+          sizes_and_strides_.size_at_unchecked(0).as_int_unchecked() *
+          (1 + growthPct / 100))));
   auto oldData = std::move(storage_.data_ptr());
   auto oldSize = numel_;
   Resize(newCapacity);
@@ -653,7 +663,7 @@ void TensorImpl::Extend(int64_t num, float growthPct) {
         true); // non-blocking
   }
   reserved_ = true;
-  sizes_and_strides_.set_sizes(newDims);
+  sizes_and_strides_.set_sizes(SymIntArrayRef::fromIntArrayRef(newDims));
   numel_ = newNumel;
 }
 
@@ -661,10 +671,16 @@ void TensorImpl::ReserveSpace(int64_t outer_dim) {
   TORCH_CHECK(
       is_contiguous_,
       "Right now ReserveSpace is only supported for contiguous Tensor.");
+  TORCH_CHECK(
+      !has_symbolic_sizes_strides_,
+      "ReserveSpace() called on tensor with symbolic shape")
+
   TORCH_CHECK(storage_.unique(), "Can't call ReserveSpace on shared storage.");
   // TODO: eliminate newCapacity.
+  IntArrayRef sizes_and_strides =
+      asIntArrayRefUnchecked(sizes_and_strides_.sizes_arrayref());
   SmallVector<int64_t, 5> newCapacity(
-      sizes_and_strides_.sizes_begin(), sizes_and_strides_.sizes_end());
+      sizes_and_strides.begin(), sizes_and_strides.end());
   newCapacity[0] = outer_dim;
   auto newNumel = c10::multiply_integers(newCapacity);
   if (newNumel * data_type_.itemsize() <= storage_.nbytes()) {
@@ -674,11 +690,11 @@ void TensorImpl::ReserveSpace(int64_t outer_dim) {
   storage_.data_ptr().clear();
   auto oldSize = numel_;
   SmallVector<int64_t, 5> oldDims(
-      sizes_and_strides_.sizes_begin(), sizes_and_strides_.sizes_end());
+      sizes_and_strides.begin(), sizes_and_strides.end());
   Resize(newCapacity);
   // Allocate new memory but don't copy over the data
   raw_mutable_data(data_type_);
-  sizes_and_strides_.set_sizes(oldDims);
+  sizes_and_strides_.set_sizes(SymIntArrayRef::fromIntArrayRef(oldDims));
   numel_ = oldSize;
   reserved_ = true;
 }
@@ -687,6 +703,10 @@ void TensorImpl::Reshape(const std::vector<int64_t>& dims) {
   TORCH_CHECK(
       is_contiguous_,
       "Right now Reshape is only supported for contiguous Tensor.");
+  TORCH_CHECK(
+      !has_symbolic_sizes_strides_,
+      "Reshape() called on tensor with symbolic shape")
+
   int64_t new_size = 1;
   for (auto d : dims) {
     TORCH_CHECK(d >= 0);
@@ -701,7 +721,7 @@ void TensorImpl::Reshape(const std::vector<int64_t>& dims) {
       " The old caffe2 mixes Reshape and Resize but this behavior has "
       "been changed. If you find this error, most likely you will need "
       "to change corresponding code from Reshape to Resize.");
-  sizes_and_strides_.set_sizes(dims);
+  sizes_and_strides_.set_sizes(SymIntArrayRef::fromIntArrayRef(dims));
   empty_tensor_restride(MemoryFormat::Contiguous);
 }
 

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -584,7 +584,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
             static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
       return sizes_custom()[d]; // unchecked (maybe_wrap_dim enforces bounds)
     }
-    return sizes_and_strides_.size_at_unchecked(d);
+    return sizes_and_strides_.size_at_unchecked(d).as_int_unchecked();
   }
 
   /**
@@ -601,7 +601,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
             static_cast<uint8_t>(SizesStridesPolicy::CustomStrides))) {
       return strides_custom()[d]; // unchecked (maybe_wrap_dim enforces bounds)
     }
-    return sizes_and_strides_.stride_at_unchecked(d);
+    return sizes_and_strides_.stride_at_unchecked(d).as_int_unchecked();
   }
 
   /**
@@ -673,7 +673,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // These are factored into separate functions in case subclasses
   // want to use them
   inline IntArrayRef strides_default() const {
-    return sizes_and_strides_.strides_arrayref();
+    return c10::IntArrayRef(
+        reinterpret_cast<const int64_t*>(sizes_and_strides_.strides_data()),
+        sizes_and_strides_.size());
   }
   inline bool is_contiguous_default(at::MemoryFormat memory_format) const {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(compute_contiguous() == is_contiguous_);
@@ -685,7 +687,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return is_contiguous_;
   }
   inline IntArrayRef sizes_default() const {
-    return sizes_and_strides_.sizes_arrayref();
+    return c10::IntArrayRef(
+        reinterpret_cast<const int64_t*>(sizes_and_strides_.sizes_data()),
+        sizes_and_strides_.size());
   }
   inline c10::SymIntArrayRef sym_sizes_default() const {
     return c10::SymIntArrayRef(
@@ -1315,6 +1319,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         allow_tensor_metadata_change(),
         "set_size ",
         err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        !has_symbolic_sizes_strides_,
+        "set_size() called on tensor with symbolic shape")
     sizes_and_strides_.size_at(dim) = new_size;
     refresh_numel();
     refresh_contiguous();
@@ -1331,6 +1338,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         allow_tensor_metadata_change(),
         "set_stride ",
         err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        !has_symbolic_sizes_strides_,
+        "set_stride() called on tensor with symbolic shape")
     sizes_and_strides_.stride_at_unchecked(dim) = new_stride;
     refresh_contiguous();
   }
@@ -1362,8 +1372,16 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         allow_tensor_metadata_change(),
         "set_sizes_contiguous ",
         err_msg_tensor_metadata_change_not_allowed);
+    if (C10_UNLIKELY(
+            sizes_strides_policy_ >=
+            static_cast<uint8_t>(SizesStridesPolicy::CustomStrides))) {
+      TORCH_CHECK(false, "todo, I guess we want to throw here");
+    }
 
-    sizes_and_strides_.set_sizes(new_size);
+    TORCH_CHECK(
+        !has_symbolic_sizes_strides_,
+        "set_sizes_contiguous() called on tensor with symbolic shape")
+    sizes_and_strides_.set_sizes(SymIntArrayRef::fromIntArrayRef(new_size));
 
     refresh_numel();
     empty_tensor_restride(MemoryFormat::Contiguous);
@@ -1382,6 +1400,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         "set_sizes_and_strides ",
         err_msg_tensor_metadata_change_not_allowed);
     TORCH_CHECK(
+        !has_symbolic_sizes_strides_,
+        "set_sizes_and_strides() called on tensor with symbolic shape")
+    TORCH_CHECK(
         new_size.size() == new_stride.size(),
         "dimensionality of sizes (",
         new_size.size(),
@@ -1390,7 +1411,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
         ")");
     const auto new_dim = new_size.size();
 
-    sizes_and_strides_.set_sizes(new_size);
+    sizes_and_strides_.set_sizes(SymIntArrayRef::fromIntArrayRef(new_size));
 
     if (new_dim > 0) {
       for (size_t dim = new_dim - 1;; dim--) {
@@ -1406,8 +1427,11 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
             // Keep stride monotonically increasing to match NumPy.
             sizes_and_strides_.stride_at_unchecked(dim) =
                 std::max<int64_t>(
-                    sizes_and_strides_.size_at_unchecked(dim + 1), 1) *
-                sizes_and_strides_.stride_at_unchecked(dim + 1);
+                    sizes_and_strides_.size_at_unchecked(dim + 1)
+                        .as_int_unchecked(),
+                    1) *
+                sizes_and_strides_.stride_at_unchecked(dim + 1)
+                    .as_int_unchecked();
           }
         }
         if (dim == 0)
@@ -1971,6 +1995,9 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * memory contiguous
    */
   void empty_tensor_restride(MemoryFormat memory_format) {
+    TORCH_CHECK(
+        !has_symbolic_sizes_strides_,
+        "empty_tensor_restride() called on tensor with symbolic shape")
 #ifdef DEBUG
     TORCH_INTERNAL_ASSERT(
         compute_numel() == numel_,
@@ -1987,9 +2014,12 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
           sizes_and_strides_.stride_at_unchecked(last_idx) = 1;
           for (auto i = last_idx - 1; i >= 0; --i) {
             sizes_and_strides_.stride_at_unchecked(i) =
-                sizes_and_strides_.stride_at_unchecked(i + 1) *
+                sizes_and_strides_.stride_at_unchecked(i + 1)
+                    .as_int_unchecked() *
                 std::max<int64_t>(
-                    sizes_and_strides_.size_at_unchecked(i + 1), 1);
+                    sizes_and_strides_.size_at_unchecked(i + 1)
+                        .as_int_unchecked(),
+                    1);
           }
         }
         break;
@@ -2048,6 +2078,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
       typename T,
       typename = typename std::enable_if<std::is_integral<T>::value>::type>
   bool SetDimsTemplate(ArrayRef<T> src) {
+    TORCH_CHECK(
+        !has_symbolic_sizes_strides_,
+        "SetDims() called on tensor with symbolic shape")
+
     auto old_numel = numel_;
     sizes_and_strides_.resize(src.size());
     int64_t new_numel = 1;
@@ -2169,6 +2203,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * or strides.
    */
   void refresh_contiguous() {
+    TORCH_CHECK(
+        !has_symbolic_sizes_strides_,
+        "refresh_contiguous() called on tensor with symbolic shape")
+
     is_contiguous_ = compute_contiguous();
     // Note:
     // Dim 0, 1, 2 will never be a channels last 2d/3d format
@@ -2397,17 +2435,10 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // (which do not have a device.)
   c10::optional<c10::Device> device_opt_;
 
-  // Tensor is contiguous
-  bool is_contiguous_ : 1;
-
-  // Tensor is a subclass that does not permit storage access.
-  bool storage_access_should_throw_ : 1;
-
   // default member initializers for bit-fields only available with -std=c++2a
   // or -std=gnu++2a
   inline void init_bitfields() {
     is_contiguous_ = true;
-
     is_channels_last_ = false;
     is_channels_last_contiguous_ = false;
     is_channels_last_3d_ = false;
@@ -2419,7 +2450,14 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     sizes_strides_policy_ = static_cast<uint8_t>(SizesStridesPolicy::Default);
     custom_device_ = false;
     storage_access_should_throw_ = false;
+    has_symbolic_sizes_strides_ = false;
   }
+
+  // Tensor is contiguous
+  bool is_contiguous_ : 1;
+
+  // Tensor is a subclass that does not permit storage access.
+  bool storage_access_should_throw_ : 1;
 
   // Tensor is stored in the channels last 2d memory format, when dimensions
   // order is (N)CHW and C-strides < W-strides < H-strides (< N-strides)

--- a/c10/core/impl/SizesAndStrides.cpp
+++ b/c10/core/impl/SizesAndStrides.cpp
@@ -10,7 +10,7 @@ void SizesAndStrides::resizeSlowPath(
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
         !isInline(),
         "resizeSlowPath called when fast path should have been hit!");
-    int64_t* tempStorage = outOfLineStorage_;
+    SymInt* tempStorage = outOfLineStorage_;
     memcpy(
         &inlineStorage_[0],
         &tempStorage[0],
@@ -28,8 +28,7 @@ void SizesAndStrides::resizeSlowPath(
       // CANNOT USE allocateOutOfLineStorage(newSize) HERE! WOULD
       // OVERWRITE inlineStorage_!
       // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
-      int64_t* tempStorage =
-          static_cast<int64_t*>(malloc(storageBytes(newSize)));
+      SymInt* tempStorage = static_cast<SymInt*>(malloc(storageBytes(newSize)));
       TORCH_CHECK(
           tempStorage,
           "Could not allocate memory to change Tensor SizesAndStrides!");

--- a/c10/core/impl/SizesAndStrides.h
+++ b/c10/core/impl/SizesAndStrides.h
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <cstdint>
 
+#include <c10/core/SymInt.h>
+#include <c10/core/SymIntArrayRef.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/SmallVector.h>
@@ -25,10 +27,10 @@ class C10_API SizesAndStrides {
  public:
   // TODO: different iterator types for sizes & strides to prevent
   // mixing the two accidentally.
-  using sizes_iterator = int64_t*;
-  using sizes_const_iterator = const int64_t*;
-  using strides_iterator = int64_t*;
-  using strides_const_iterator = const int64_t*;
+  using sizes_iterator = SymInt*;
+  using sizes_const_iterator = const SymInt*;
+  using strides_iterator = SymInt*;
+  using strides_const_iterator = const SymInt*;
 
   SizesAndStrides() : size_(1) {
     size_at_unchecked(0) = 0;
@@ -111,7 +113,7 @@ class C10_API SizesAndStrides {
     return size_;
   }
 
-  const int64_t* sizes_data() const noexcept {
+  const SymInt* sizes_data() const noexcept {
     if (C10_LIKELY(isInline())) {
       return &inlineStorage_[0];
     } else {
@@ -119,7 +121,23 @@ class C10_API SizesAndStrides {
     }
   }
 
-  int64_t* sizes_data() noexcept {
+  bool has_sym_slow() const noexcept {
+    if (std::any_of(sizes_begin(), sizes_end(), [](const auto i) {
+          return i.is_symbolic();
+        })) {
+      return true;
+    }
+
+    if (std::any_of(strides_begin(), strides_end(), [](const auto i) {
+          return i.is_symbolic();
+        })) {
+      return true;
+    }
+
+    return false;
+  }
+
+  SymInt* sizes_data() noexcept {
     if (C10_LIKELY(isInline())) {
       return &inlineStorage_[0];
     } else {
@@ -143,16 +161,20 @@ class C10_API SizesAndStrides {
     return sizes_begin() + size();
   }
 
-  IntArrayRef sizes_arrayref() const noexcept {
-    return IntArrayRef{sizes_data(), size()};
+  SymIntArrayRef sizes_arrayref() const noexcept {
+    return SymIntArrayRef{sizes_data(), size()};
   }
 
-  void set_sizes(IntArrayRef newSizes) {
+  void set_sizes(SymIntArrayRef newSizes) {
     resize(newSizes.size());
     std::copy(newSizes.begin(), newSizes.end(), sizes_begin());
   }
 
-  const int64_t* strides_data() const noexcept {
+  void set_sizes(IntArrayRef newSizes) {
+    set_sizes(SymIntArrayRef::fromIntArrayRef(newSizes));
+  }
+
+  const SymInt* strides_data() const noexcept {
     if (C10_LIKELY(isInline())) {
       return &inlineStorage_[C10_SIZES_AND_STRIDES_MAX_INLINE_SIZE];
     } else {
@@ -160,7 +182,7 @@ class C10_API SizesAndStrides {
     }
   }
 
-  int64_t* strides_data() noexcept {
+  SymInt* strides_data() noexcept {
     if (C10_LIKELY(isInline())) {
       return &inlineStorage_[C10_SIZES_AND_STRIDES_MAX_INLINE_SIZE];
     } else {
@@ -192,45 +214,45 @@ class C10_API SizesAndStrides {
     return strides_begin() + size();
   }
 
-  IntArrayRef strides_arrayref() const noexcept {
-    return IntArrayRef{strides_data(), size()};
+  SymIntArrayRef strides_arrayref() const noexcept {
+    return SymIntArrayRef{strides_data(), size()};
   }
 
   // Size accessors.
-  int64_t size_at(size_t idx) const noexcept {
+  SymInt size_at(size_t idx) const noexcept {
     assert(idx < size());
     return sizes_data()[idx];
   }
 
-  int64_t& size_at(size_t idx) noexcept {
+  SymInt& size_at(size_t idx) noexcept {
     assert(idx < size());
     return sizes_data()[idx];
   }
 
-  int64_t size_at_unchecked(size_t idx) const noexcept {
+  SymInt size_at_unchecked(size_t idx) const noexcept {
     return sizes_data()[idx];
   }
 
-  int64_t& size_at_unchecked(size_t idx) noexcept {
+  SymInt& size_at_unchecked(size_t idx) noexcept {
     return sizes_data()[idx];
   }
 
   // Size accessors.
-  int64_t stride_at(size_t idx) const noexcept {
+  SymInt stride_at(size_t idx) const noexcept {
     assert(idx < size());
     return strides_data()[idx];
   }
 
-  int64_t& stride_at(size_t idx) noexcept {
+  SymInt& stride_at(size_t idx) noexcept {
     assert(idx < size());
     return strides_data()[idx];
   }
 
-  int64_t stride_at_unchecked(size_t idx) const noexcept {
+  SymInt stride_at_unchecked(size_t idx) const noexcept {
     return strides_data()[idx];
   }
 
-  int64_t& stride_at_unchecked(size_t idx) noexcept {
+  SymInt& stride_at_unchecked(size_t idx) noexcept {
     return strides_data()[idx];
   }
 
@@ -273,7 +295,7 @@ class C10_API SizesAndStrides {
   }
 
   void allocateOutOfLineStorage(size_t size) {
-    outOfLineStorage_ = static_cast<int64_t*>(malloc(storageBytes(size)));
+    outOfLineStorage_ = static_cast<SymInt*>(malloc(storageBytes(size)));
     TORCH_CHECK(
         outOfLineStorage_,
         "Could not allocate memory for Tensor SizesAndStrides!");
@@ -281,8 +303,8 @@ class C10_API SizesAndStrides {
 
   void resizeOutOfLineStorage(size_t newSize) {
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!isInline());
-    outOfLineStorage_ = static_cast<int64_t*>(
-        realloc(outOfLineStorage_, storageBytes(newSize)));
+    outOfLineStorage_ =
+        static_cast<SymInt*>(realloc(outOfLineStorage_, storageBytes(newSize)));
     TORCH_CHECK(
         outOfLineStorage_,
         "Could not allocate memory for Tensor SizesAndStrides!");
@@ -294,8 +316,8 @@ class C10_API SizesAndStrides {
 
   size_t size_;
   union {
-    int64_t* outOfLineStorage_;
-    int64_t inlineStorage_[C10_SIZES_AND_STRIDES_MAX_INLINE_SIZE * 2]{};
+    SymInt* outOfLineStorage_;
+    SymInt inlineStorage_[C10_SIZES_AND_STRIDES_MAX_INLINE_SIZE * 2]{};
   };
 };
 

--- a/c10/test/core/impl/SizesAndStrides_test.cpp
+++ b/c10/test/core/impl/SizesAndStrides_test.cpp
@@ -26,7 +26,7 @@ static void checkData(
     EXPECT_EQ(*(sz.sizes_begin() + idx), x) << "index: " << idx;
     idx++;
   }
-  EXPECT_EQ(sz.sizes_arrayref(), sizes);
+  EXPECT_EQ(asIntArrayRefSlow(sz.sizes_arrayref()), sizes);
 
   idx = 0;
   for (auto x : strides) {
@@ -37,7 +37,7 @@ static void checkData(
 
     idx++;
   }
-  EXPECT_EQ(sz.strides_arrayref(), strides);
+  EXPECT_EQ(asIntArrayRefSlow(sz.strides_arrayref()), strides);
 }
 
 TEST(SizesAndStridesTest, DefaultConstructor) {

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -605,7 +605,7 @@
   result: auto_linear
 
 - name: expand.SymInt(Tensor(a) self, SymInt[] size, *, bool implicit=False) -> Tensor(a)
-  self: at::sum_to(grad, c10::expectIntArrayRef(self.sym_sizes()))
+  self: at::sum_to(grad, c10::asIntArrayRefSlow(self.sym_sizes()))
   result: auto_linear
 
 - name: exponential_(Tensor(a!) self, float lambd=1, *, Generator? generator=None) -> Tensor(a!)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #78272

Change our representation of sizes and strides to contain SymInts
instead of int64_t.

Right now it's not actually possible to create a Tensor with symbolic
shape, so this change is intended to be a no-op.

But the intended behavior is:
- If you create a Tensor with symbolic shape, a `CustomSizes` policy
will be set, and the `has_symbolic_sizes_strides_` bit will be set. (not
currently implemented)
- Calling any TensorImpl function that naively interacts with sizes and
strides will throw. For hot-path functions (`sizes()`, `strides()`), we
make use of the existing policy check to throw. For others, we just have
a regular `TORCH_CHECK(!has_symbolic_sizes_strides_)`.

This also undoes the explicit constructor I made in
https://github.com/pytorch/pytorch/pull/77666; it ended up being more
annoying than useful when making these changes.