### PR TITLE
Deprecate `TSNodeLoweringInterface`

### DIFF
--- a/torch/csrc/lazy/backend/lowering_context.h
+++ b/torch/csrc/lazy/backend/lowering_context.h
@@ -88,6 +88,8 @@ class TORCH_API LoweringContext {
                             const Shape& shape,
                             const std::string& name) = 0;
 
+  virtual void Lower(Node*) = 0;
+
   // Build the computation capturing all the operations created with the
   // embedded builder (returned by the builder() API).
   virtual ComputationPtr Build() = 0;

--- a/torch/csrc/lazy/backend/lowering_context.h
+++ b/torch/csrc/lazy/backend/lowering_context.h
@@ -88,7 +88,7 @@ class TORCH_API LoweringContext {
                             const Shape& shape,
                             const std::string& name) = 0;
 
-  virtual void Lower(Node*) = 0;
+  virtual void Lower(const Node*) = 0;
 
   // Build the computation capturing all the operations created with the
   // embedded builder (returned by the builder() API).

--- a/torch/csrc/lazy/backend/lowering_context.h
+++ b/torch/csrc/lazy/backend/lowering_context.h
@@ -88,8 +88,6 @@ class TORCH_API LoweringContext {
                             const Shape& shape,
                             const std::string& name) = 0;
 
-  virtual void Lower(const Node*) = 0;
-
   // Build the computation capturing all the operations created with the
   // embedded builder (returned by the builder() API).
   virtual ComputationPtr Build() = 0;

--- a/torch/csrc/lazy/ts_backend/ops/batch_norm_ops.h
+++ b/torch/csrc/lazy/ts_backend/ops/batch_norm_ops.h
@@ -58,6 +58,9 @@ class TSNativeBatchNormBackward : public torch::lazy::TsNode {
 
   const std::array<bool, 3>& output_mask() const { return output_mask_; }
 
+  TSOpVector Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+                   TSLoweringContext* loctx) const override;
+
  private:
   bool training_;
   double eps_;
@@ -94,6 +97,9 @@ class TSNativeBatchNormForward : public torch::lazy::TsNode {
   double momentum() const { return momentum_; }
 
   double eps() const { return eps_; }
+
+  TSOpVector Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+                   TSLoweringContext* loctx) const override;
 
  private:
   bool training_;

--- a/torch/csrc/lazy/ts_backend/ops/device_data.h
+++ b/torch/csrc/lazy/ts_backend/ops/device_data.h
@@ -38,6 +38,9 @@ class TORCH_API DeviceData : public TsNode {
   // instead of calling the constructor directly.
   static NodePtr Create(std::shared_ptr<BackendData> data);
 
+  TSOpVector Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+                   TSLoweringContext* loctx) const override;
+
  private:
   std::shared_ptr<BackendData> data_;
 };

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
@@ -27,7 +27,7 @@ TSLoweringContext::TSLoweringContext(
 }
 
 
-void TSLoweringContext::Lower(Node* node) {
+void TSLoweringContext::Lower(const Node* node) {
   if (auto* tsnode = dynamic_cast<const torch::lazy::TsNode*>(node)) {
     // First, we call the node lowering function, which exists for newly
     // codegenned or refactored nodes

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.cpp
@@ -10,9 +10,8 @@ TSLoweringContext::TSLoweringContext(
     const std::string& name,
     BackendDevice device)
     : torch::lazy::LoweringContext(name, device),
-      graph_(std::make_shared<torch::jit::Graph>()) {
-  lowering_ = TSNodeLoweringInterface::Create(this);
-}
+      graph_(std::make_shared<torch::jit::Graph>()),
+      function_(std::make_shared<torch::jit::GraphFunction>(name, graph_, nullptr)) {}
 
 TSLoweringContext::TSLoweringContext(
     const std::string& name,
@@ -20,11 +19,28 @@ TSLoweringContext::TSLoweringContext(
     c10::ArrayRef<Node*> post_order,
     Util::EmissionMap emit_status)
     : torch::lazy::LoweringContext(name, device, post_order, emit_status),
-      graph_(std::make_shared<torch::jit::Graph>()) {
-  lowering_ = TSNodeLoweringInterface::Create(this);
+      graph_(std::make_shared<torch::jit::Graph>()),
+      function_(std::make_shared<torch::jit::GraphFunction>(name, graph_, nullptr)) {
   for (auto node : post_order) {
-    bool ok = lowering_->Lower(node);
-    CHECK(ok) << "Failed to lower: " << *node;
+    Lower(node);
+  }
+}
+
+
+void TSLoweringContext::Lower(Node* node) {
+  if (auto* tsnode = dynamic_cast<const torch::lazy::TsNode*>(node)) {
+    // First, we call the node lowering function, which exists for newly
+    // codegenned or refactored nodes
+    TSOpVector ops = tsnode->Lower(function_, this);
+    CHECK(!ops.empty()) << "Failed to lower: " << *node;
+    CHECK_EQ(node->num_outputs(), ops.size());
+    for (size_t i = 0; i < ops.size(); ++i) {
+      AssignOutputOp(torch::lazy::Output(node, i), ops[i]);
+    }
+  }
+  else {
+    throw std::runtime_error(
+        "Expected torch::lazy::TsNode but could not dynamic cast");
   }
 }
 

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.h
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.h
@@ -87,7 +87,7 @@ class TORCH_API TSLoweringContext : public LoweringContext {
     TORCH_INTERNAL_ASSERT(false, "not implemented");
   }
 
-  void Lower(const Node* node) override;
+  void Lower(const Node* node);
 
   ComputationPtr Build() override {
     for (torch::jit::Value* output : root_tuple_) {

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.h
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.h
@@ -87,7 +87,7 @@ class TORCH_API TSLoweringContext : public LoweringContext {
     TORCH_INTERNAL_ASSERT(false, "not implemented");
   }
 
-  void Lower(Node* node) override;
+  void Lower(const Node* node) override;
 
   ComputationPtr Build() override {
     for (torch::jit::Value* output : root_tuple_) {

--- a/torch/csrc/lazy/ts_backend/ts_lowering_context.h
+++ b/torch/csrc/lazy/ts_backend/ts_lowering_context.h
@@ -13,22 +13,6 @@ namespace lazy {
 
 using TSOpVector = std::vector<torch::jit::Value*>;
 
-class TORCH_API TSNodeLoweringInterface {
-  /**
-   * This interface is only needed for legacy ops, and can be removed once all
-   * ops implement TSNode->lower().
-   * */
- public:
-  TSNodeLoweringInterface() = default;
-
-  virtual ~TSNodeLoweringInterface() = default;
-
-  virtual bool Lower(const Node* node) = 0;
-
-  static std::unique_ptr<TSNodeLoweringInterface> Create(
-      LoweringContext* loctx);
-};
-
 class TORCH_API TSComputation : public Computation {
  public:
   TSComputation(const std::shared_ptr<torch::jit::Graph>& graph)
@@ -99,8 +83,11 @@ class TORCH_API TSLoweringContext : public LoweringContext {
       size_t index,
       const Shape& shape,
       const std::string& name) override {
+
     TORCH_INTERNAL_ASSERT(false, "not implemented");
   }
+
+  void Lower(Node* node) override;
 
   ComputationPtr Build() override {
     for (torch::jit::Value* output : root_tuple_) {
@@ -117,8 +104,7 @@ class TORCH_API TSLoweringContext : public LoweringContext {
     if (it == emitted_outputs_.end()) {
       auto post_order = Util::ComputePostOrder(output.node, &emit_status_);
       for (auto node : post_order) {
-        bool ok = lowering_->Lower(node);
-        TORCH_CHECK(ok, "Failed to lower: ", node->ToString());
+        Lower(node);
       }
       // At this point the output better be present, otherwise there is an issue
       // with the lowering code.
@@ -157,10 +143,10 @@ class TORCH_API TSLoweringContext : public LoweringContext {
   }
 
   std::shared_ptr<torch::jit::Graph> graph_;
+  std::shared_ptr<torch::jit::GraphFunction> function_;
   std::unordered_map<BackendData::Handle, Parameter> parameters_map_;
   std::vector<torch::jit::Value*> root_tuple_;
   OutputMap<torch::jit::Value*> emitted_outputs_;
-  std::unique_ptr<TSNodeLoweringInterface> lowering_;
 };
 
 } // namespace lazy

--- a/torch/csrc/lazy/ts_backend/ts_node.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_node.cpp
@@ -63,16 +63,6 @@ const std::string TsNode::getPythonStacktrace() const {
   return GetFirstUserFrameInPythonIfEnabled();
 }
 
-TSOpVector TsNode::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
-                         TSLoweringContext* loctx) const {
-  // TODO(whc) beginning to invert the design here.  Move to provide a Lower()
-  // method on each node, starting with codegen.  Once we delete most
-  // non-codegen ops, make this pure-virtual and put Lower() on the remaining
-  // non-codegen ops.  For now, returning empty list here triggers fallback to
-  // old lowering path.
-  return {};
-}
-
 TensorList::TensorList(OpList values)
   : TsNode(/*op=*/ClassOpKind(),
            /*operands=*/values,

--- a/torch/csrc/lazy/ts_backend/ts_node_lowering.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_node_lowering.cpp
@@ -33,11 +33,6 @@ class TSNodeLowering : public TSNodeLoweringInterface {
       // codegenned or refactored nodes
       TSOpVector ops = tsnode->Lower(function_, loctx());
       if (ops.empty()) {
-        // Then fall back to legacy lowering code, which should be gradually
-        // removed
-        ops = LowerNonCodegenOps(node);
-      }
-      if (ops.empty()) {
         return false;
       }
       CHECK_EQ(node->num_outputs(), ops.size());
@@ -50,342 +45,6 @@ class TSNodeLowering : public TSNodeLoweringInterface {
         "Expected torch::lazy::TsNode but could not dynamic cast");
   }
 
-  // TODO(whc) this is for legacy/non-codegen Ops, and after moving most ops
-  // to codegen we should delete this and put all the lowering logic into Node
-  // classes
-  TSOpVector LowerNonCodegenOps(const torch::lazy::Node* node) {
-    if (node->op().op == at::aten::as_strided) {
-      return LowerAsStrided(torch::lazy::NodeCast<torch::lazy::AsStrided>(node));
-    }
-    if (node->op() == *torch::lazy::ltc_as_strided_view_update) {
-      return LowerAsStridedViewUpdate(
-          torch::lazy::NodeCast<torch::lazy::AsStridedViewUpdate>(node));
-    }
-    if (node->op() == *torch::lazy::ltc_cast) {
-      return LowerCast(torch::lazy::NodeCast<torch::lazy::Cast>(node));
-    }
-    if (node->op() == *torch::lazy::ltc_select_view_update) {
-      return LowerSelectViewUpdate(
-          torch::lazy::NodeCast<torch::lazy::SelectViewUpdate>(node));
-    }
-    if (node->op() == *torch::lazy::ltc_narrow_view_update) {
-      return LowerNarrowViewUpdate(
-          torch::lazy::NodeCast<torch::lazy::NarrowViewUpdate>(node));
-    }
-    if (node->op().op == at::prim::Constant) {
-      return LowerScalar(torch::lazy::NodeCast<torch::lazy::Scalar>(node));
-    }
-    if (node->op().op == at::aten::native_batch_norm) {
-      return LowerBatchNorm(
-          torch::lazy::NodeCast<TSNativeBatchNormForward>(node));
-    }
-    if (node->op().op == at::aten::native_batch_norm_backward) {
-      return LowerBatchNormBackward(
-          torch::lazy::NodeCast<TSNativeBatchNormBackward>(node));
-    }
-    if (node->op().op == at::aten::expand) {
-      return LowerExpand(
-          torch::lazy::NodeCast<torch::lazy::Expand>(node));
-    }
-    if (node->op().op == at::aten::narrow) {
-      return LowerNarrow(torch::lazy::NodeCast<torch::lazy::Narrow>(node));
-    }
-    if (node->op().op == at::aten::permute) {
-      return LowerPermute(torch::lazy::NodeCast<torch::lazy::Permute>(node));
-    }
-    if (node->op().op == at::aten::select) {
-      return LowerSelect(torch::lazy::NodeCast<torch::lazy::Select>(node));
-    }
-    if (node->op().op == at::aten::squeeze) {
-      return LowerSqueeze(
-          torch::lazy::NodeCast<Squeeze>(node));
-    }
-    if (node->op().op == at::aten::unsqueeze) {
-      return LowerUnsqueeze(
-          torch::lazy::NodeCast<Unsqueeze>(node));
-    }
-    if (node->op().op == at::aten::view) {
-      return LowerView(torch::lazy::NodeCast<torch::lazy::View>(node));
-    }
-    if (node->op().op == at::aten::diagonal) {
-      return LowerDiagonal(torch::lazy::NodeCast<torch::lazy::Diagonal>(node));
-    }
-    if (node->op() == *torch::lazy::ltc_diagonal_view_update) {
-      return LowerDiagonalViewUpdate(torch::lazy::NodeCast<torch::lazy::DiagonalViewUpdate>(node));
-    }
-    if (node->op() == *torch::lazy::ltc_device_data) {
-      const torch::lazy::DeviceData* device_data_node =
-          torch::lazy::NodeCast<torch::lazy::DeviceData>(node);
-      auto infoptr = device_data_node->data()->info();
-      auto deviceDataInfoPtr = (torch::lazy::LazyGraphExecutor::DeviceDataInfo*) infoptr;
-      if (GRAPH_DUMP_ENABLED) {
-        LOG(ERROR) << "Lowering device data node, tensor id " << deviceDataInfoPtr->tensor_id << std::endl;
-      }
-      return {loctx()->GetParameter(device_data_node->data())};
-    }
-
-    std::vector<torch::jit::NamedValue> arguments;
-    for (const torch::lazy::Output& output : node->operands()) {
-      arguments.emplace_back(loctx()->GetOutputOp(output));
-    }
-    return LowerBuiltin(node, arguments);
-  }
-
-  TSOpVector LowerBuiltin(
-      const torch::lazy::Node* node,
-      const std::vector<torch::jit::NamedValue>& arguments,
-      const std::vector<torch::jit::NamedValue>& kwarguments = {}) {
-    return LowerTSBuiltin(function_, node->op().op, arguments, kwarguments);
-  }
-  TSOpVector LowerBuiltin(
-      c10::Symbol sym, const std::vector<torch::jit::NamedValue>& arguments,
-      const std::vector<torch::jit::NamedValue>& kwarguments = {}) {
-    return LowerTSBuiltin(function_, sym, arguments, kwarguments);
-  }
-
-  TSOpVector LowerAsStrided(const torch::lazy::AsStrided* node) {
-    std::vector<torch::jit::NamedValue> arguments;
-    arguments.emplace_back(loctx()->GetOutputOp(node->operand(0)));
-    arguments.emplace_back(node->size);
-    arguments.emplace_back(node->stride);
-    arguments.emplace_back(node->storage_offset);
-    TSOpVector as_strided_out = LowerBuiltin(node, arguments);
-    CHECK_EQ(as_strided_out.size(), 1);
-    return {GenerateClone(as_strided_out.front())};
-  }
-
-  TSOpVector LowerAsStridedViewUpdate(
-      const torch::lazy::AsStridedViewUpdate* node) {
-    torch::jit::Value* destination =
-        GenerateClone(loctx()->GetOutputOp(node->operand(0)));
-    const torch::lazy::Output& input_op = node->operand(1);
-    const torch::lazy::Shape& input_shape = input_op.shape();
-    const auto input_dimensions = input_shape.sizes();
-    std::vector<torch::jit::NamedValue> dest_arguments;
-    dest_arguments.emplace_back(destination);
-    dest_arguments.emplace_back(
-        std::vector<int64_t>(input_dimensions.begin(), input_dimensions.end()));
-    dest_arguments.emplace_back(node->stride);
-    dest_arguments.emplace_back(node->storage_offset
-    );
-    TSOpVector as_strided_out =
-        LowerBuiltin(at::aten::as_strided, dest_arguments);
-    CHECK_EQ(as_strided_out.size(), 1);
-    torch::jit::Value* as_strided = as_strided_out.front();
-    GenerateCopy(as_strided, loctx()->GetOutputOp(input_op));
-    return {destination};
-  }
-
-  TSOpVector LowerBatchNorm(const TSNativeBatchNormForward* node) {
-    std::vector<torch::jit::NamedValue> arguments;
-    for (size_t i = 0; i < 5; ++i) {
-      arguments.emplace_back(loctx()->GetOutputOp(node->operand(i)));
-    }
-    arguments.emplace_back(node->training());
-    arguments.emplace_back(node->momentum());
-    arguments.emplace_back(node->eps());
-    return LowerBuiltin(node, arguments);
-  }
-
-  TSOpVector LowerBatchNormBackward(const TSNativeBatchNormBackward* node) {
-    std::vector<torch::jit::NamedValue> arguments;
-    for (size_t i = 0; i < 3; ++i) {
-      arguments.emplace_back(loctx()->GetOutputOp(node->operand(i)));
-    }
-    const auto& operands = node->operands();
-    c10::optional<at::Tensor> null_arg;
-    if (operands.size() == 5) {
-      arguments.emplace_back(null_arg);
-      arguments.emplace_back(null_arg);
-    }
-    for (size_t i = 3; i < operands.size(); ++i) {
-      arguments.emplace_back(loctx()->GetOutputOp(node->operand(i)));
-    }
-    arguments.emplace_back(node->training());
-    arguments.emplace_back(node->eps());
-    arguments.emplace_back(node->output_mask());
-    return LowerBuiltin(node, arguments);
-  }
-
-  TSOpVector LowerCast(const torch::lazy::Cast* node) {
-    std::vector<torch::jit::NamedValue> arguments;
-    arguments.emplace_back(loctx()->GetOutputOp(node->operand(0)));
-    arguments.emplace_back(node->dtype);
-    return LowerBuiltin(at::aten::to, arguments);
-  }
-
-  TSOpVector LowerExpand(const torch::lazy::Expand* node) {
-    std::vector<torch::jit::NamedValue> arguments;
-    arguments.emplace_back(loctx()->GetOutputOp(node->operand(0)));
-    arguments.emplace_back(node->size);
-    auto expand_out = LowerBuiltin(node, arguments);
-    if (node->is_scalar_expand) {
-      // The aten::expand operations sets all strides to 0 when the original is
-      // of rank 0. This leads to false positives when checking for internal
-      // memory overlap, because at::has_internal_overlap returns
-      // MemOverlap::YES when a stride is set to 0.
-      CHECK_EQ(expand_out.size(), 1);
-      return {GenerateClone(expand_out.front())};
-    }
-    return expand_out;
-  }
-
-  TSOpVector LowerNarrow(const torch::lazy::Narrow* node) {
-    const torch::lazy::Output& input = node->operand(0);
-    torch::jit::Value* base = loctx()->GetOutputOp(input);
-    const auto& base_indices = node->base_indices;
-    const auto& sizes = node->sizes;
-    const torch::lazy::Shape& input_shape = input.shape();
-    CHECK_EQ(sizes.size(), base_indices.size());
-    CHECK_EQ(input_shape.dim(), base_indices.size());
-    for (size_t dim = 0; dim < base_indices.size(); ++dim) {
-      int64_t start = base_indices[dim];
-      base = GenerateSlice(/*base=*/base, /*dim=*/dim, /*start=*/start,
-                           /*end=*/start + sizes[dim], /*step=*/1);
-    }
-    return {base};
-  }
-
-  TSOpVector LowerPermute(const torch::lazy::Permute* node) {
-    std::vector<torch::jit::NamedValue> arguments;
-    arguments.emplace_back(loctx()->GetOutputOp(node->operand(0)));
-    arguments.emplace_back(node->dims);
-    return LowerBuiltin(node, arguments);
-  }
-
-  TSOpVector LowerScalar(const torch::lazy::Scalar* node) {
-    const at::Scalar& value = node->value;
-    const torch::lazy::Shape& shape = node->shape();
-    auto options =
-        at::TensorOptions()
-            .device(torch::lazy::getBackend()->EagerFallbackDeviceType())
-            .dtype(shape.scalar_type());
-    return {
-        loctx()->graph()->insertConstant(at::scalar_tensor(value, options))};
-  }
-
-  TSOpVector LowerSelect(const torch::lazy::Select* node) {
-    int64_t step = torch::lazy::GetStride(node->start, node->end,
-                                                  node->stride);
-    torch::jit::Value* base = loctx()->GetOutputOp(node->operand(0));
-    return {GenerateSlice(/*base=*/base, /*dim=*/node->dim,
-                          /*start=*/node->start, /*end=*/node->end,
-                          /*step=*/step)};
-  }
-
-  TSOpVector LowerSqueeze(const Squeeze* node) {
-    std::vector<torch::jit::NamedValue> arguments;
-    arguments.emplace_back(loctx()->GetOutputOp(node->operand(0)));
-    if (node->dim != -1) {
-      arguments.emplace_back(node->dim);
-    }
-    return LowerBuiltin(node, arguments);
-  }
-
-  TSOpVector LowerSelectViewUpdate(const torch::lazy::SelectViewUpdate* node) {
-    torch::jit::Value* dest =
-        GenerateClone(loctx()->GetOutputOp(node->operand(0)));
-    int64_t step = torch::lazy::GetStride(node->start, node->end,
-                                                  node->stride);
-    torch::jit::Value* selected = GenerateSlice(
-        /*base=*/dest, /*dim=*/node->dim, /*start=*/node->start,
-        /*end=*/node->end, /*step=*/step);
-    GenerateCopy(selected, loctx()->GetOutputOp(node->operand(1)));
-    return {dest};
-  }
-
-  TSOpVector LowerNarrowViewUpdate(const torch::lazy::NarrowViewUpdate* node) {
-    torch::jit::Value* dest =
-        GenerateClone(loctx()->GetOutputOp(node->operand(0)));
-    const auto& base_indices = node->base_indices;
-    const torch::lazy::Output& source_argument = node->operand(1);
-    const torch::lazy::Shape& source_shape = source_argument.shape();
-    CHECK_EQ(source_shape.dim(), base_indices.size());
-    torch::jit::Value* base = dest;
-    for (size_t dim = 0; dim < base_indices.size(); ++dim) {
-      int64_t start = base_indices[dim];
-      base = GenerateSlice(/*base=*/base, /*dim=*/dim, /*start=*/start,
-                           /*end=*/start + source_shape.size(dim),
-                           /*step=*/1);
-    }
-    GenerateCopy(base, loctx()->GetOutputOp(source_argument));
-    return {dest};
-  }
-
-  TSOpVector LowerUnsqueeze(const Unsqueeze* node) {
-    std::vector<torch::jit::NamedValue> arguments;
-    arguments.emplace_back(loctx()->GetOutputOp(node->operand(0)));
-    arguments.emplace_back(node->dim);
-    return LowerBuiltin(node, arguments);
-  }
-
-  TSOpVector LowerView(const torch::lazy::View* node) {
-    std::vector<torch::jit::NamedValue> arguments;
-    arguments.emplace_back(loctx()->GetOutputOp(node->operand(0)));
-    arguments.emplace_back(node->output_size);
-    return LowerBuiltin(at::aten::reshape, arguments);
-  }
-
-  TSOpVector LowerDiagonal(const Diagonal* node) {
-    std::vector<torch::jit::NamedValue> arguments;
-    arguments.emplace_back(loctx()->GetOutputOp(node->operand(0)));
-    arguments.emplace_back(node->offset);
-    arguments.emplace_back(node->dim1);
-    arguments.emplace_back(node->dim2);
-    return LowerBuiltin(node, arguments);
-  }
-
-  // FIXME(alanwaketan): One day we should code-gen all view ops, or at
-  // least move the lowering to the IR nodes.
-  TSOpVector LowerDiagonalViewUpdate(const DiagonalViewUpdate* node) {
-    // Since we promise the backends that we never generate any aliased
-    // inplace update IR, therefore we clone the target first and then
-    // update the clone inplace instead. Since the clone is transient,
-    // it will never be aliased, and therefore it's safe.
-    auto* destination = GenerateClone(loctx()->GetOutputOp(node->operand(0)));
-
-    // Replay the diagonal.
-    std::vector<torch::jit::NamedValue> arguments;
-    arguments.emplace_back(destination);
-    arguments.emplace_back(node->offset);
-    arguments.emplace_back(node->dim1);
-    arguments.emplace_back(node->dim2);
-    auto diag = LowerBuiltin(at::aten::diagonal, arguments);
-
-    // Update the replayed diagonal view with the input.
-    GenerateCopy(diag.front(), loctx()->GetOutputOp(node->operand(1)));
-
-    // Destination's diag view should be updated.
-    return {destination};
-  }
-
-  torch::jit::Value* GenerateClone(torch::jit::Value* val) {
-    std::vector<torch::jit::NamedValue> clone_arguments;
-    clone_arguments.emplace_back(val);
-    TSOpVector cloned = LowerBuiltin(at::aten::clone, clone_arguments);
-    CHECK_EQ(cloned.size(), 1);
-    return cloned.front();
-  }
-
-  void GenerateCopy(torch::jit::Value* destination, torch::jit::Value* source) {
-    std::vector<torch::jit::NamedValue> arguments;
-    arguments.emplace_back(destination);
-    arguments.emplace_back(source);
-    LowerBuiltin(at::aten::copy_, arguments);
-  }
-
-  torch::jit::Value* GenerateSlice(torch::jit::Value* base, int64_t dim,
-                                   int64_t start, int64_t end, int64_t step) {
-    std::vector<torch::jit::NamedValue> arguments;
-    arguments.emplace_back(base);
-    arguments.emplace_back(dim);
-    arguments.emplace_back(start);
-    arguments.emplace_back(end);
-    arguments.emplace_back(step);
-    TSOpVector selected = LowerBuiltin(at::aten::slice, arguments);
-    CHECK_EQ(selected.size(), 1);
-    return selected.front();
-  }
   torch::lazy::TSLoweringContext* loctx_;
   std::shared_ptr<torch::jit::GraphFunction> function_;
 };
@@ -394,6 +53,21 @@ std::unique_ptr<TSNodeLoweringInterface> TSNodeLoweringInterface::Create(
     torch::lazy::LoweringContext* loctx) {
   return std::make_unique<TSNodeLowering>(
       "TSNodeLowering", static_cast<torch::lazy::TSLoweringContext*>(loctx));
+}
+
+TSOpVector LowerBuiltin(
+    const torch::lazy::Node* node,
+    std::shared_ptr<torch::jit::GraphFunction> function,
+    const std::vector<torch::jit::NamedValue>& arguments,
+    const std::vector<torch::jit::NamedValue>& kwarguments = {}) {
+  return LowerTSBuiltin(function, node->op().op, arguments, kwarguments);
+}
+TSOpVector LowerBuiltin(
+    c10::Symbol sym,
+    std::shared_ptr<torch::jit::GraphFunction> function,
+    const std::vector<torch::jit::NamedValue>& arguments,
+    const std::vector<torch::jit::NamedValue>& kwarguments = {}) {
+  return LowerTSBuiltin(function, sym, arguments, kwarguments);
 }
 
 TSOpVector LowerTSBuiltin(
@@ -417,6 +91,306 @@ TSOpVector LowerTSBuiltin(
     return tuple_result;
   }
   return {sv->getValue()};
+}
+
+
+torch::jit::Value* GenerateClone(
+        torch::jit::Value* val,
+        std::shared_ptr<torch::jit::GraphFunction> function) {
+  std::vector<torch::jit::NamedValue> clone_arguments;
+  clone_arguments.emplace_back(val);
+  TSOpVector cloned = LowerBuiltin(at::aten::clone, function, clone_arguments);
+  CHECK_EQ(cloned.size(), 1);
+  return cloned.front();
+}
+
+void GenerateCopy(
+        torch::jit::Value* destination,
+        torch::jit::Value* source,
+        std::shared_ptr<torch::jit::GraphFunction> function) {
+  std::vector<torch::jit::NamedValue> arguments;
+  arguments.emplace_back(destination);
+  arguments.emplace_back(source);
+  LowerBuiltin(at::aten::copy_, function, arguments);
+}
+
+torch::jit::Value* GenerateSlice(
+        torch::jit::Value* base, int64_t dim,
+        int64_t start, int64_t end, int64_t step,
+        std::shared_ptr<torch::jit::GraphFunction> function) {
+  std::vector<torch::jit::NamedValue> arguments;
+  arguments.emplace_back(base);
+  arguments.emplace_back(dim);
+  arguments.emplace_back(start);
+  arguments.emplace_back(end);
+  arguments.emplace_back(step);
+  TSOpVector selected = LowerBuiltin(at::aten::slice, function, arguments);
+  CHECK_EQ(selected.size(), 1);
+  return selected.front();
+}
+
+// Node Lowerings
+
+// Default node lowering
+TSOpVector TsNode::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+                         TSLoweringContext* loctx) const {
+  std::vector<torch::jit::NamedValue> arguments;
+  for (const torch::lazy::Output& output : operands()) {
+    arguments.emplace_back(loctx->GetOutputOp(output));
+  }
+  return LowerBuiltin(this, function, arguments);
+}
+
+// TS specific ops
+TSOpVector TSNativeBatchNormForward::Lower(
+    std::shared_ptr<torch::jit::GraphFunction> function,
+    TSLoweringContext* loctx) const {
+  std::vector<torch::jit::NamedValue> arguments;
+  for (size_t i = 0; i < 5; ++i) {
+    arguments.emplace_back(loctx->GetOutputOp(operand(i)));
+  }
+  arguments.emplace_back(training_);
+  arguments.emplace_back(momentum_);
+  arguments.emplace_back(eps_);
+  return LowerBuiltin(this, function, arguments);
+}
+
+TSOpVector TSNativeBatchNormBackward::Lower(
+    std::shared_ptr<torch::jit::GraphFunction> function,
+    TSLoweringContext* loctx) const {
+  std::vector<torch::jit::NamedValue> arguments;
+  for (size_t i = 0; i < 3; ++i) {
+    arguments.emplace_back(loctx->GetOutputOp(operand(i)));
+  }
+  c10::optional<at::Tensor> null_arg;
+  if (operands().size() == 5) {
+    arguments.emplace_back(null_arg);
+    arguments.emplace_back(null_arg);
+  }
+  for (size_t i = 3; i < operands().size(); ++i) {
+    arguments.emplace_back(loctx->GetOutputOp(operand(i)));
+  }
+  arguments.emplace_back(training_);
+  arguments.emplace_back(eps_);
+  arguments.emplace_back(output_mask_);
+  return LowerBuiltin(this, function, arguments);
+}
+
+
+// Non-native ops
+torch::lazy::TSOpVector Cast::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  std::vector<torch::jit::NamedValue> arguments;
+  arguments.emplace_back(loctx->GetOutputOp(operand(0)));
+  arguments.emplace_back(dtype);
+  return LowerBuiltin(at::aten::to, function, arguments);
+}
+
+torch::lazy::TSOpVector DeviceData::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  auto infoptr = data_->info();
+  auto deviceDataInfoPtr = (torch::lazy::LazyGraphExecutor::DeviceDataInfo*) infoptr;
+  if (GRAPH_DUMP_ENABLED) {
+    LOG(ERROR) << "Lowering device data node, tensor id " << deviceDataInfoPtr->tensor_id << std::endl;
+  }
+  return {loctx->GetParameter(data_)};
+}
+
+torch::lazy::TSOpVector Expand::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  std::vector<torch::jit::NamedValue> arguments;
+  arguments.emplace_back(loctx->GetOutputOp(operand(0)));
+  arguments.emplace_back(size);
+  auto expand_out = LowerBuiltin(this, function, arguments);
+  if (is_scalar_expand) {
+    // The aten::expand operations sets all strides to 0 when the original is
+    // of rank 0. This leads to false positives when checking for internal
+    // memory overlap, because at::has_internal_overlap returns
+    // MemOverlap::YES when a stride is set to 0.
+    CHECK_EQ(expand_out.size(), 1);
+    return {GenerateClone(expand_out.front(), function)};
+  }
+  return expand_out;
+}
+
+torch::lazy::TSOpVector Scalar::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  auto options =
+      at::TensorOptions()
+          .device(torch::lazy::getBackend()->EagerFallbackDeviceType())
+          .dtype(shape().scalar_type());
+  return {
+      loctx->graph()->insertConstant(at::scalar_tensor(value, options))};
+}
+
+// View Ops
+
+torch::lazy::TSOpVector AsStrided::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+
+  std::vector<torch::jit::NamedValue> arguments;
+  arguments.emplace_back(loctx->GetOutputOp(operand(0)));
+  arguments.emplace_back(size);
+  arguments.emplace_back(stride);
+  arguments.emplace_back(storage_offset);
+  TSOpVector as_strided_out = LowerBuiltin(this, function, arguments);
+  CHECK_EQ(as_strided_out.size(), 1);
+  return {GenerateClone(as_strided_out.front(), function)};
+}
+
+torch::lazy::TSOpVector AsStridedViewUpdate::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+
+  torch::jit::Value* destination =
+      GenerateClone(loctx->GetOutputOp(operand(0)), function);
+  const torch::lazy::Output& input_op = operand(1);
+  const torch::lazy::Shape& input_shape = input_op.shape();
+  const auto input_dimensions = input_shape.sizes();
+  std::vector<torch::jit::NamedValue> dest_arguments;
+  dest_arguments.emplace_back(destination);
+  dest_arguments.emplace_back(
+      std::vector<int64_t>(input_dimensions.begin(), input_dimensions.end()));
+  dest_arguments.emplace_back(stride);
+  dest_arguments.emplace_back(storage_offset);
+  TSOpVector as_strided_out =
+      LowerBuiltin(at::aten::as_strided, function, dest_arguments);
+  CHECK_EQ(as_strided_out.size(), 1);
+  torch::jit::Value* as_strided = as_strided_out.front();
+  GenerateCopy(as_strided, loctx->GetOutputOp(input_op), function);
+  return {destination};
+}
+
+torch::lazy::TSOpVector Diagonal::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+
+  std::vector<torch::jit::NamedValue> arguments;
+  arguments.emplace_back(loctx->GetOutputOp(operand(0)));
+  arguments.emplace_back(offset);
+  arguments.emplace_back(dim1);
+  arguments.emplace_back(dim2);
+  return LowerBuiltin(this, function, arguments);
+}
+
+torch::lazy::TSOpVector DiagonalViewUpdate::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  // Since we promise the backends that we never generate any aliased
+  // inplace update IR, therefore we clone the target first and then
+  // update the clone inplace instead. Since the clone is transient,
+  // it will never be aliased, and therefore it's safe.
+  torch::jit::Value* destination = GenerateClone(loctx->GetOutputOp(operand(0)), function);
+
+  // Replay the diagonal.
+  std::vector<torch::jit::NamedValue> arguments;
+  arguments.emplace_back(destination);
+  arguments.emplace_back(offset);
+  arguments.emplace_back(dim1);
+  arguments.emplace_back(dim2);
+  auto diag = LowerBuiltin(at::aten::diagonal, function, arguments);
+
+  // Update the replayed diagonal view with the input.
+  GenerateCopy(diag.front(), loctx->GetOutputOp(operand(1)), function);
+
+  // Destination's diag view should be updated.
+  return {destination};
+}
+
+torch::lazy::TSOpVector Narrow::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  const torch::lazy::Output& input = operand(0);
+  torch::jit::Value* base = loctx->GetOutputOp(input);
+  const torch::lazy::Shape& input_shape = input.shape();
+  CHECK_EQ(sizes.size(), base_indices.size());
+  CHECK_EQ(input_shape.dim(), base_indices.size());
+  for (size_t dim = 0; dim < base_indices.size(); ++dim) {
+    int64_t start = base_indices[dim];
+    base = GenerateSlice(/*base=*/base, /*dim=*/dim, /*start=*/start,
+                         /*end=*/start + sizes[dim], /*step=*/1,
+                         /*function=*/function);
+  }
+  return {base};
+}
+
+torch::lazy::TSOpVector NarrowViewUpdate::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  torch::jit::Value* dest =
+      GenerateClone(loctx->GetOutputOp(operand(0)), function);
+  const torch::lazy::Output& source_argument = operand(1);
+  const torch::lazy::Shape& source_shape = source_argument.shape();
+  CHECK_EQ(source_shape.dim(), base_indices.size());
+  torch::jit::Value* base = dest;
+  for (size_t dim = 0; dim < base_indices.size(); ++dim) {
+    int64_t start = base_indices[dim];
+    base = GenerateSlice(/*base=*/base, /*dim=*/dim, /*start=*/start,
+                         /*end=*/start + source_shape.size(dim), /*step=*/1,
+                         /*function=*/function);
+  }
+  GenerateCopy(base, loctx->GetOutputOp(source_argument), function);
+  return {dest};
+}
+
+torch::lazy::TSOpVector Permute::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  std::vector<torch::jit::NamedValue> arguments;
+  arguments.emplace_back(loctx->GetOutputOp(operand(0)));
+  arguments.emplace_back(dims);
+  return LowerBuiltin(this, function, arguments);
+}
+
+torch::lazy::TSOpVector Resize::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+
+  std::vector<torch::jit::NamedValue> arguments;
+  for (const torch::lazy::Output& output : operands()) {
+    arguments.emplace_back(loctx->GetOutputOp(output));
+  }
+  return LowerBuiltin(this, function, arguments);
+}
+
+torch::lazy::TSOpVector Select::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  int64_t step = torch::lazy::GetStride(start, end, stride);
+  torch::jit::Value* base = loctx->GetOutputOp(operand(0));
+  return {GenerateSlice(/*base=*/base, /*dim=*/dim,
+                        /*start=*/start, /*end=*/end,
+                        /*step=*/step, /*function=*/function)};
+}
+
+torch::lazy::TSOpVector SelectViewUpdate::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  torch::jit::Value* dest =
+      GenerateClone(loctx->GetOutputOp(operand(0)), function);
+  int64_t step = torch::lazy::GetStride(start, end, stride);
+  torch::jit::Value* selected = GenerateSlice(
+      /*base=*/dest, /*dim=*/dim, /*start=*/start,
+      /*end=*/end, /*step=*/step, /*function=*/function);
+  GenerateCopy(selected, loctx->GetOutputOp(operand(1)), function);
+  return {dest};
+}
+
+torch::lazy::TSOpVector Squeeze::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  std::vector<torch::jit::NamedValue> arguments;
+  arguments.emplace_back(loctx->GetOutputOp(operand(0)));
+  if (dim != -1) {
+    arguments.emplace_back(dim);
+  }
+  return LowerBuiltin(this, function, arguments);
+}
+
+torch::lazy::TSOpVector Unsqueeze::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  std::vector<torch::jit::NamedValue> arguments;
+  arguments.emplace_back(loctx->GetOutputOp(operand(0)));
+  arguments.emplace_back(dim);
+  return LowerBuiltin(this, function, arguments);
+}
+
+torch::lazy::TSOpVector View::Lower(std::shared_ptr<torch::jit::GraphFunction> function,
+    torch::lazy::TSLoweringContext* loctx) const {
+  std::vector<torch::jit::NamedValue> arguments;
+  arguments.emplace_back(loctx->GetOutputOp(operand(0)));
+  arguments.emplace_back(output_size);
+  return LowerBuiltin(at::aten::reshape, function, arguments);
 }
 
 }  // namespace lazy

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -587,7 +587,7 @@ def generate_non_native_lazy_ir_nodes(
     nodes = []
     for op in non_native:
         # Set default properties for Non-Native IRs
-        properties = LazyIrProperties("ShapeCache", "CanBeReused")
+        properties = LazyIrProperties("ShapeCache", "CanBeReused", "LowerDeclOnly")
         for p in op.get("properties", []):
             setattr(properties, p, True)
 


### PR DESCRIPTION
Fixes #78206

Deprecate `TSNodeLoweringInterface` and refactor lower functions into IR nodes.

CC: @wconstab @desertfire 