### PR TITLE
Fix internal build

### DIFF
--- a/c10/core/impl/PyInterpreter.cpp
+++ b/c10/core/impl/PyInterpreter.cpp
@@ -42,10 +42,6 @@ static c10::Device noop_device_fn(const PyInterpreter*, const TensorImpl*) {
       "attempted to device Tensor with nontrivial PyObject after corresponding interpreter died");
 }
 
-c10::Device PyInterpreter::device(const TensorImpl* self) const {
-  return (*device_fn_)(this, self);
-}
-
 void PyInterpreter::disarm() noexcept {
   name_fn_ = &noop_name_fn;
   decref_fn_ = &noop_decref_fn;

--- a/c10/core/impl/PyInterpreter.h
+++ b/c10/core/impl/PyInterpreter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/core/Device.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/python_stub.h>
@@ -13,7 +14,6 @@ struct IValue;
 class OperatorHandle;
 struct TensorImpl;
 struct SafePyObject;
-struct Device;
 } // namespace c10
 
 namespace torch {
@@ -188,7 +188,9 @@ struct C10_API PyInterpreter {
     return (*is_contiguous_fn_)(this, self);
   }
 
-  __ubsan_ignore_function__ c10::Device device(const TensorImpl* self) const;
+  __ubsan_ignore_function__ c10::Device device(const TensorImpl* self) const {
+    return (*device_fn_)(this, self);
+  }
 
   // Disarm this PyInterpreter, making all of its methods noops.
   // Because the function pointers are raw pointers (not atomics),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #78282

Differential Revision: [D36671215](https://our.internmc.facebook.com/intern/diff/D36671215)

There was a build internally that wasn't including the PyInterpreter cpp file