### PR TITLE
Hackily use addSkip to track flakiness in common_utils.py

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1820,7 +1820,8 @@ class TestCase(expecttest.TestCase):
         using_unittest = isinstance(result, unittest.TestResult)
         if num_runs_left == 0:
             if num_green > 0 and num_red > 0 and using_unittest:
-                result.addSkip(self, f'{{"flaky": {True}, "num_red": {num_red}, "num_green": {num_green}, "max_num_retries": {MAX_NUM_RETRIES}}}')
+                result.addSkip(self, f'{{"flaky": {True}, "num_red": {num_red}, "num_green": {num_green},' +
+                                     f'"max_num_retries": {MAX_NUM_RETRIES}}}')
             return
 
         if using_unittest:
@@ -1857,22 +1858,26 @@ class TestCase(expecttest.TestCase):
                 _, traceback_str = result.failures.pop(-1)
                 print(traceback_str)
                 result.addExpectedFailure(self, err)
-            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only, num_red=num_red+1, num_green=num_green)
+            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only,
+                                 num_red=num_red + 1, num_green=num_green)
         elif errors_before < len(result.errors):
             print(f"    {self._testMethodName} errored - num_retries_left: {num_retries_left}")
             if (report_only and num_retries_left < MAX_NUM_RETRIES) or (not report_only and num_retries_left > 0):
                 _, traceback_str = result.errors.pop(-1)
                 print(traceback_str)
                 result.addExpectedFailure(self, err)
-            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only, num_red=num_red+1, num_green=num_green)
+            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only,
+                                 num_red=num_red + 1, num_green=num_green)
         elif report_only and num_retries_left < MAX_NUM_RETRIES:
             print(f"    {self._testMethodName} succeeded - num_retries_left: {num_retries_left}")
             result.addUnexpectedSuccess(self)
-            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only, num_red=num_red, num_green=num_green+1)
+            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only,
+                                 num_red=num_red, num_green=num_green + 1)
         elif not report_only and num_retries_left < MAX_NUM_RETRIES:
             # in this case, our test was rerun (as a retry has been used) and it just passed.
             # we incur one more recursive call with num_runs_left = 0 to allow for accurate flaky reporting
-            self._run_with_retry(result=result, num_runs_left=0, report_only=report_only, num_red=num_red, num_green=num_green+1)
+            self._run_with_retry(result=result, num_runs_left=0, report_only=report_only,
+                                 num_red=num_red, num_green=num_green + 1)
 
 
     def run(self, result=None):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1816,11 +1816,12 @@ class TestCase(expecttest.TestCase):
     # When report_only is True, flaky tests are only reported, but the signal remains the same (the test will still
     # show up red).
     # Otherwise, the flaky test will show up green while its stats are captured by test reports.
-    def _run_with_retry(self, result=None, num_runs_left=0, report_only=True):
-        if num_runs_left == 0:
-            return
-
+    def _run_with_retry(self, result=None, num_runs_left=0, report_only=True, num_red=0, num_green=0):
         using_unittest = isinstance(result, unittest.TestResult)
+        if num_runs_left == 0:
+            if num_green > 0 and num_red > 0 and using_unittest:
+                result.addSkip(self, f'{{"flaky": {True}, "num_red": {num_red}, "num_green": {num_green}, "max_num_retries": {MAX_NUM_RETRIES}}}')
+            return
 
         if using_unittest:
             failures_before = 0 if result is None else len(result.failures)  # num tests marked as failed before starting
@@ -1856,18 +1857,22 @@ class TestCase(expecttest.TestCase):
                 _, traceback_str = result.failures.pop(-1)
                 print(traceback_str)
                 result.addExpectedFailure(self, err)
-            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only)
+            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only, num_red=num_red+1, num_green=num_green)
         elif errors_before < len(result.errors):
             print(f"    {self._testMethodName} errored - num_retries_left: {num_retries_left}")
             if (report_only and num_retries_left < MAX_NUM_RETRIES) or (not report_only and num_retries_left > 0):
                 _, traceback_str = result.errors.pop(-1)
                 print(traceback_str)
                 result.addExpectedFailure(self, err)
-            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only)
+            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only, num_red=num_red+1, num_green=num_green)
         elif report_only and num_retries_left < MAX_NUM_RETRIES:
             print(f"    {self._testMethodName} succeeded - num_retries_left: {num_retries_left}")
             result.addUnexpectedSuccess(self)
-            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only)
+            self._run_with_retry(result=result, num_runs_left=num_retries_left, report_only=report_only, num_red=num_red, num_green=num_green+1)
+        elif not report_only and num_retries_left < MAX_NUM_RETRIES:
+            # in this case, our test was rerun (as a retry has been used) and it just passed.
+            # we incur one more recursive call with num_runs_left = 0 to allow for accurate flaky reporting
+            self._run_with_retry(result=result, num_runs_left=0, report_only=report_only, num_red=num_red, num_green=num_green+1)
 
 
     def run(self, result=None):
@@ -1875,7 +1880,12 @@ class TestCase(expecttest.TestCase):
             if TEST_WITH_CROSSREF:
                 stack.enter_context(torch.overrides.push_torch_function_mode(CrossRefMode))
             num_runs = MAX_NUM_RETRIES + 1 if RETRY_TEST_CASES else 1
-            self._run_with_retry(result=result, num_runs_left=num_runs, report_only=not OVERRIDE_FLAKY_SIGNAL)
+            self._run_with_retry(
+                result=result,
+                num_runs_left=num_runs,
+                report_only=not OVERRIDE_FLAKY_SIGNAL,
+                num_red=0,
+                num_green=0)
 
     def setUp(self):
         check_if_enable(self)


### PR DESCRIPTION
### Problem: 
The current way we detect flakiness is by aggregating results at the end of a job, which has worked so far but is inefficient and potentially inaccurate. We have also been delegating a workflow step towards doing this analysis at the end of every job.

### Solution: 
This PR uses unittest.TestResult's addSkip method, which adds a skipped test every time we detect something is flaky. This way, we no longer need to aggregate anything and we can easily scan through the test reports and filter for skipped tests with flaky = True. Not only is this much faster to query for, it rids us of needing to figure out janky aggregation logic.

### Test plan:
I simulated a flaky test locally (test_async_python) and observed that:
With overriding signal ON (so flaky test = green):
- Successes pass are reported just as they normally are with no skips. [override_signal_normal_success.txt](https://github.com/pytorch/pytorch/files/8774012/override_signal_normal_success.txt)
- Failures fail and are reported as they are with no skips. [override_signal_all_fails.txt](https://github.com/pytorch/pytorch/files/8774010/override_signal_all_fails.txt)
- Flaky tests have expected failures + a success + a skip denoting the correct information. [override_signal_1_1.txt](https://github.com/pytorch/pytorch/files/8774005/override_signal_1_1.txt)
 and [override_signal_2_1.txt](https://github.com/pytorch/pytorch/files/8774007/override_signal_2_1.txt)

With overriding signal OFF:
- Successes pass are reported just as they normally are with no skips. [report_only_one_success.txt](https://github.com/pytorch/pytorch/files/8774019/report_only_one_success.txt)
- Failures fail and are reported as they are with no skips. [report_only_all_fails.txt](https://github.com/pytorch/pytorch/files/8774018/report_only_all_fails.txt)
- Flaky tests have failures + unexpected successes + a skip denoting the correct
 information. [report_only_3_1.txt](https://github.com/pytorch/pytorch/files/8774015/report_only_3_1.txt)

