### PR TITLE
test revert of all the quant code

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/fused_obs_fake_quant.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fused_obs_fake_quant.cpp
@@ -143,7 +143,6 @@ std::tuple<at::Tensor, at::Tensor> fused_moving_avg_obs_fake_quant_cpu(
     const int64_t ch_axis,
     bool per_row_fake_quant,
     bool symmetric_quant) {
-  TORCH_CHECK(ch_axis < self.dim(), "Error in fused_moving_avg_obs_fake_quant_cpu: ch_axis must be < self.dim()");
   // Calculate min/max
   auto observe = observer_on.item().toInt();
   // Calculate the size of the dimension we need to quantize over,

--- a/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
+++ b/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
@@ -235,7 +235,6 @@ std::tuple<at::Tensor, at::Tensor> fused_moving_avg_obs_fake_quant_cuda(
     const int64_t ch_axis,
     bool per_row_fq,
     bool symmetric_quant) {
-  TORCH_CHECK(ch_axis < x.dim(), "Error in fused_moving_avg_obs_fake_quant_cpu: ch_axis must be < self.dim()");
   const auto x_contig = x.contiguous();
   // Calculate the size of the dimension we need to quantize over,
   // For per-channel quant we default to axis 0, since it is only for

--- a/aten/src/ATen/native/quantized/cudnn/BinaryOps.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/BinaryOps.cpp
@@ -109,8 +109,9 @@ Tensor add(Tensor qa, Tensor qb, double output_scale, int64_t output_zero_point)
   at::Tensor add_output = at::empty(qa.sizes(), at::device(at::kCUDA).dtype(at::kFloat), memory_format);
   at::Tensor quantized_output = at::_empty_affine_quantized(qa.sizes(), at::device(at::kCUDA).dtype(at::ScalarType::QInt8),
                                                             output_scale, output_zero_point, memory_format);
-  double requantize_multiplier = qa.q_scale() / output_scale;
-  at::Tensor requantize_multiplier_tensor = cudnn_utils::getRequantMultiplierTensor(requantize_multiplier, quantized_output.dim());
+  // TODO: When cudnn enables support for broadcasting, we can remove this tensor
+  at::Tensor requantize_multiplier_tensor = at::empty(quantized_output.sizes(), at::device(at::kCUDA).dtype(at::kFloat), memory_format);
+  requantize_multiplier_tensor.fill_(qa.q_scale() / output_scale);
   at::Tensor rhs_multiplier_tensor = at::empty(quantized_output.sizes(), at::device(at::kCUDA).dtype(at::kFloat), memory_format);
   rhs_multiplier_tensor.fill_(qb.q_scale() / qa.q_scale());
 

--- a/aten/src/ATen/native/quantized/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/Conv.cpp
@@ -17,7 +17,6 @@
 #include <ATen/native/quantized/packed_params.h>
 #include <ATen/native/utils/ParamsHash.h>
 #include <ATen/TensorUtils.h>
-#include <c10/cuda/CUDACachingAllocator.h>
 #include <cudnn_frontend.h>
 #include <torch/library.h>
 
@@ -51,7 +50,7 @@ struct CacheKey {
   int8_t bias_alignment;
   bool kReluFused;
 };
-std::unordered_map<CacheKey, cudnn_frontend::ExecutionPlan, at::native::ParamsHash<CacheKey>, at::native::ParamsEqual<CacheKey>> execution_plan_cache;
+std::unordered_map<CacheKey, cudnn_frontend::ManagedOpaqueDescriptor, at::native::ParamsHash<CacheKey>, at::native::ParamsEqual<CacheKey>> execution_plan_cache;
 }
 // TODO: we can use cudnn_frontend::ExecutionPlanCache when it supports caching
 // multiple operators
@@ -140,9 +139,9 @@ void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& qua
   }
   key.kReluFused = kReluFused;
 
-  auto run = [&](const cudnn_frontend::ExecutionPlan& plan_desc) {
-    auto workspace_size = plan_desc.getWorkspaceSize();
-    auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  auto run = [&](cudnn_frontend::ManagedOpaqueDescriptor plan_desc) {
+    auto workspace_size = 0;
+    auto workspace = at::empty({workspace_size}, input.options().dtype(at::kByte));
     at::SmallVector<void *, 7> data_ptrs;
     at::SmallVector<int64_t, 7> uids;
     data_ptrs = {input.data_ptr<int8_t>(), maybe_padded_weight_.data_ptr<int8_t>(),
@@ -154,17 +153,17 @@ void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& qua
       uids.insert(uids.end(), {'b', 'c', 'd'});
     }
     auto variantPack = cudnn_frontend::VariantPackBuilder()
-      .setWorkspacePointer(workspace_size ? workspace_ptr.get() : nullptr)
+      .setWorkspacePointer(workspace.data_ptr())
       .setDataPointers(uids.size(), data_ptrs.data())
       .setUids(uids.size(), uids.data())
       .build();
     auto variant_pack_desc = variantPack.get_raw_desc();
-    AT_CUDNN_CHECK(cudnnBackendExecute(handle, plan_desc.get_raw_desc(), variant_pack_desc));
+    AT_CUDNN_CHECK(cudnnBackendExecute(handle, plan_desc->get_backend_descriptor(), variant_pack_desc));
   };
 
   auto search = execution_plan_cache.find(key);
   if (search != execution_plan_cache.end()) {
-    cudnn_frontend::ExecutionPlan plan_desc = search->second;
+    cudnn_frontend::ManagedOpaqueDescriptor plan_desc = search->second;
     run(plan_desc);
     return;
   }
@@ -275,8 +274,9 @@ void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& qua
         .setHandle(handle)
         .setEngineConfig(cfg)
         .build();
-      run(plan);
-      execution_plan_cache.emplace(key, plan);
+      auto plan_desc = plan.get_desc();
+      run(plan_desc);
+      execution_plan_cache[key] = plan_desc;
       return;
     } catch (cudnn_frontend::cudnnException &e) {std::cout << "cudnn error:" << e.what() << std::endl;} catch(c10::CuDNNError &e) { std::cout << "other error" << e.what() << std::endl;}
   }

--- a/aten/src/ATen/native/quantized/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/Conv.cpp
@@ -90,6 +90,8 @@ at::SmallVector<int64_t, 4> MakeConvOutputShape<2>(
 template <int kSpatialDim>
 template <bool kReluFused>
 void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& quantized_output, const at::Tensor& input, double output_scale) {
+  at::Tensor conv_output = at::empty(quantized_output.sizes(), at::device(at::kCUDA).dtype(at::kFloat), at::MemoryFormat::ChannelsLast);
+
   auto act_scale = input.q_scale();
   auto weight_scale = maybe_padded_weight_.q_scale();
   auto requantize_multiplier = act_scale * weight_scale / output_scale;
@@ -130,7 +132,7 @@ void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& qua
   // set the datatype for output tensor to int32 or fp32
   key.params.dataType = CUDNN_DATA_INT32;
   key.input_alignment = cudnn_utils::getAlignment(input);
-  key.output_alignment = cudnn_utils::getAlignment(quantized_output);
+  key.output_alignment = cudnn_utils::getAlignment(conv_output);
   key.weight_alignment = cudnn_utils::getAlignment(maybe_padded_weight_);
   if (bias_.has_value()) {
     key.bias_alignment = cudnn_utils::getAlignment(broadcasted_bias.value());
@@ -142,15 +144,26 @@ void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& qua
   auto run = [&](cudnn_frontend::ManagedOpaqueDescriptor plan_desc) {
     auto workspace_size = 0;
     auto workspace = at::empty({workspace_size}, input.options().dtype(at::kByte));
-    at::SmallVector<void *, 7> data_ptrs;
-    at::SmallVector<int64_t, 7> uids;
-    data_ptrs = {input.data_ptr<int8_t>(), maybe_padded_weight_.data_ptr<int8_t>(),
+    std::vector<void *> data_ptrs;
+    std::vector<int64_t> uids;
+    data_ptrs.reserve(10);
+    uids.reserve(10);
+    data_ptrs = {input.data_ptr<int8_t>(), conv_output.data_ptr(), maybe_padded_weight_.data_ptr<int8_t>(),
                  requantize_multiplier_tensor.data_ptr(), quantized_output.data_ptr<int8_t>()};
-    uids = {'x', 'w', 's', 'r'};
+    uids = {'x', 'y', 'w', 's', 'r'};
     if (bias_.has_value()) {
       data_ptrs.insert(data_ptrs.end(), {broadcasted_bias.value().data_ptr(), bias_multiplier_tensor.value().data_ptr(),
-                                         broadcasted_bias.value().data_ptr()});
-      uids.insert(uids.end(), {'b', 'c', 'd'});
+                                         broadcasted_bias.value().data_ptr(), conv_output.data_ptr()});
+      uids.insert(uids.end(), {'b', 'c', 'd', 'e'});
+      if (kReluFused) {
+        data_ptrs.emplace_back(conv_output.data_ptr()),
+        uids.emplace_back('f');
+      }
+    } else {
+      if (kReluFused) {
+        data_ptrs.emplace_back(conv_output.data_ptr());
+        uids.emplace_back('f');
+      }
     }
     auto variantPack = cudnn_frontend::VariantPackBuilder()
       .setWorkspacePointer(workspace.data_ptr())
@@ -172,8 +185,7 @@ void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& qua
   // output is a fp32 tensor
   auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
       .setxDesc(cudnn_utils::getTensorDescriptor(input.sizes(), input.strides(), CUDNN_DATA_INT8, 'x', key.input_alignment))
-      // for virtual tensors, the alignment is not used, so we can just put an arbitrary value here, e.g., key.output_alignment
-      .setyDesc(cudnn_utils::getTensorDescriptor(quantized_output.sizes(), quantized_output.strides(), CUDNN_DATA_FLOAT, 'y', key.output_alignment, true))
+      .setyDesc(cudnn_utils::getTensorDescriptor(conv_output, 'y', key.output_alignment))
       .setwDesc(cudnn_utils::getTensorDescriptor(maybe_padded_weight_.sizes(), maybe_padded_weight_.strides(), CUDNN_DATA_INT8, 'w', key.weight_alignment))
       .setcDesc(getConvDescriptor(key.params.dataType, padding_vec, stride_vec, dilation_vec))
       .build();
@@ -198,14 +210,13 @@ void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& qua
       .build());
 
     // computes (act_int8 * w_int8 + [bias_fp32/(act_scale * w_scale)])
-    // where the 1st and 2nd summands is output of conv_op and broadcasted_bias, resp.
+    // where the 1st and 2nd summands is conv_output and broadcasted_bias, resp.
     // output is a fp32 tensor
     // we use inplace operation here where the output is assigned to the input
     sum_conv_bias_op.emplace(cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
       .setxDesc(conv_op.getOutputTensor())
       .setbDesc(cudnn_utils::getTensorDescriptor(broadcasted_bias.value(), 'd', cudnn_utils::getAlignment(broadcasted_bias.value())))
-      // for virtual tensors, the alignment is not used, so we can just put an arbitrary value here, e.g., key.output_alignment
-      .setyDesc(cudnn_utils::getTensorDescriptor(quantized_output.sizes(), quantized_output.strides(), CUDNN_DATA_FLOAT, 'e', key.output_alignment, true))
+      .setyDesc(cudnn_utils::getTensorDescriptor(conv_output, 'e', key.output_alignment))
       .setpwDesc(cudnn_utils::getPointWiseAddDescriptor(at::native::getCudnnDataType(broadcasted_bias.value())))
       .build());
   }
@@ -219,9 +230,8 @@ void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& qua
     // we use inplace operation here where the output is assigned to the input
     relu_op.emplace(cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
       .setxDesc(tensor2requant_ptr)
-      // for virtual tensors, the alignment is not used, so we can just put an arbitrary value here, e.g., key.output_alignment
-      .setyDesc(cudnn_utils::getTensorDescriptor(quantized_output.sizes(), quantized_output.strides(), CUDNN_DATA_FLOAT, 'f', key.output_alignment, true))
-      .setpwDesc(cudnn_utils::getPointWiseReluDescriptor(CUDNN_DATA_FLOAT))
+      .setyDesc(cudnn_utils::getTensorDescriptor(conv_output, 'f', key.output_alignment))
+      .setpwDesc(cudnn_utils::getPointWiseReluDescriptor(at::native::getCudnnDataType(conv_output)))
       .build());
   }
 
@@ -231,7 +241,7 @@ void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& qua
   auto requant_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
     .setxDesc(kReluFused ? relu_op.value().getOutputTensor() : tensor2requant_ptr)
     .setbDesc(cudnn_utils::getTensorDescriptor(requantize_multiplier_tensor, 's', cudnn_utils::getAlignment(requantize_multiplier_tensor)))
-    .setyDesc(cudnn_utils::getTensorDescriptor(quantized_output.sizes(), quantized_output.strides(), CUDNN_DATA_INT8, 'r', key.output_alignment))
+    .setyDesc(cudnn_utils::getTensorDescriptor(quantized_output.sizes(), quantized_output.strides(), CUDNN_DATA_INT8, 'r', cudnn_utils::getAlignment(quantized_output)))
     .setpwDesc(cudnn_utils::getPointWiseMulDescriptor(at::native::getCudnnDataType(requantize_multiplier_tensor)))
     .build();
   // std::cout << "operator:" << requant_op.describe() << std::endl;

--- a/aten/src/ATen/native/quantized/cudnn/Conv.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/Conv.cpp
@@ -90,13 +90,16 @@ at::SmallVector<int64_t, 4> MakeConvOutputShape<2>(
 template <int kSpatialDim>
 template <bool kReluFused>
 void PackedConvWeightCudnn<kSpatialDim>::apply_impl_helper(const at::Tensor& quantized_output, const at::Tensor& input, double output_scale) {
+  if (quantized_output.numel() == 0) {
+    return;
+  }
   at::Tensor conv_output = at::empty(quantized_output.sizes(), at::device(at::kCUDA).dtype(at::kFloat), at::MemoryFormat::ChannelsLast);
-
+  // TODO: combine empty & fill_ using full_like or full
+  at::Tensor requantize_multiplier_tensor = at::empty(quantized_output.sizes(), at::device(at::kCUDA).dtype(at::kFloat), at::MemoryFormat::ChannelsLast);
   auto act_scale = input.q_scale();
   auto weight_scale = maybe_padded_weight_.q_scale();
   auto requantize_multiplier = act_scale * weight_scale / output_scale;
-  at::Tensor requantize_multiplier_tensor = cudnn_utils::getRequantMultiplierTensor(requantize_multiplier, kSpatialDim + 2);
-
+  requantize_multiplier_tensor.fill_(requantize_multiplier);
   c10::optional<at::Tensor> bias_multiplier_tensor;
   c10::optional<at::Tensor> broadcasted_bias;
   if (bias_.has_value()) {

--- a/aten/src/ATen/native/quantized/cudnn/Linear.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/Linear.cpp
@@ -94,6 +94,7 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
   if (quantized_output.numel() == 0) {
     return;
   }
+  at::Tensor linear_output = at::empty(quantized_output.sizes(), at::device(at::kCUDA).dtype(at::kFloat));
   auto act_scale = input.q_scale();
   auto weight_scale = orig_weight.q_scale();
   auto requantize_multiplier = act_scale * weight_scale / output_scale;
@@ -125,7 +126,7 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
   setLinearParams(&key.params, input, orig_weight, deterministic, allow_tf32);
 
   key.input_alignment = cudnn_utils::getAlignment(input);
-  key.output_alignment = cudnn_utils::getAlignment(quantized_output);
+  key.output_alignment = cudnn_utils::getAlignment(linear_output);
   key.weight_alignment = cudnn_utils::getAlignment(orig_weight);
   if (bias_.has_value()) {
     key.bias_alignment = cudnn_utils::getAlignment(broadcasted_bias.value());
@@ -145,15 +146,17 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
   auto run = [&](cudnn_frontend::ManagedOpaqueDescriptor plan_desc) {
     auto workspace_size = 0;
     auto workspace = at::empty({workspace_size}, input.options().dtype(at::kByte));
-    at::SmallVector<void *, 8> data_ptrs;
-    at::SmallVector<int64_t, 8> uids;
+    std::vector<void *> data_ptrs;
+    std::vector<int64_t> uids;
+    data_ptrs.reserve(9);
+    uids.reserve(9);
     data_ptrs = {input.data_ptr<int8_t>(), weight_transposed.data_ptr<int8_t>(),
                  requantize_multiplier_tensor.data_ptr(), quantized_output.data_ptr<int8_t>()};
     uids = {'x', 'w', 's', 'r'};
     if (bias_.has_value()) {
       data_ptrs.insert(data_ptrs.end(), {broadcasted_bias.value().data_ptr(), bias_multiplier_tensor.value().data_ptr(),
-                                         broadcasted_bias.value().data_ptr(), broadcasted_bias.value().data_ptr()});
-      uids.insert(uids.end(), {'b', 'c', 'd', 'n'});
+                                         broadcasted_bias.value().data_ptr(), broadcasted_bias.value().data_ptr(), linear_output.data_ptr()});
+      uids.insert(uids.end(), {'b', 'c', 'd', 'n', 'e'});
     }
     auto variantPack = cudnn_frontend::VariantPackBuilder()
       .setWorkspacePointer(workspace.data_ptr())
@@ -177,8 +180,7 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
   auto linear_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
       .setaMatDesc(cudnn_utils::getTensorDescriptor(input.sizes(), input.strides(), CUDNN_DATA_INT8, 'x', key.input_alignment))
       .setbMatDesc(cudnn_utils::getTensorDescriptor(weight_transposed.sizes(), weight_transposed.strides(), CUDNN_DATA_INT8, 'w', key.weight_alignment))
-      // for virtual tensors, the alignment is not used, so we can just put an arbitrary value here, e.g., key.output_alignment
-      .setcMatDesc(cudnn_utils::getTensorDescriptor(quantized_output.sizes(), quantized_output.strides(), CUDNN_DATA_FLOAT, 'y', key.output_alignment, true))
+      .setcMatDesc(cudnn_utils::getTensorDescriptor(linear_output, 'y', key.output_alignment, true))
       .setmatmulDesc(getLinearDescriptor(key.params.dataType))
       .build();
   // std::cout << "operator:" << linear_op.describe() << std::endl;
@@ -204,7 +206,7 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
       .build());
 
     // computes (act_int8 * w_int8 + [bias_fp32/(act_scale * w_scale)])
-    // where the 1st and 2nd summands is output of linear op and broadcasted_bias, resp.
+    // where the 1st and 2nd summands is linear_output and broadcasted_bias, resp.
     // output is a fp32 tensor
     // we use inplace operation here where the output is assigned to the input
     sum_linear_bias_op.emplace(cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
@@ -214,7 +216,7 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
       // test cases are failing. NVIDIA is currently investigating this issue.
       // When this issue is fixed, we can change 'n' back to 'd' and remove the additional entry in uid and data_ptrs in variant pack above
       .setbDesc(cudnn_utils::getTensorDescriptor(broadcasted_bias.value(), 'n', cudnn_utils::getAlignment(broadcasted_bias.value())))
-      .setyDesc(cudnn_utils::getTensorDescriptor(quantized_output.sizes(), quantized_output.strides(), CUDNN_DATA_FLOAT, 'e', key.output_alignment, true))
+      .setyDesc(cudnn_utils::getTensorDescriptor(linear_output, 'e', key.output_alignment))
       .setpwDesc(cudnn_utils::getPointWiseAddDescriptor(at::native::getCudnnDataType(broadcasted_bias.value())))
       .build());
   }
@@ -228,9 +230,8 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
     // we use inplace operation here where the output is assigned to the input
     relu_op.emplace(cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
       .setxDesc(tensor2requant_ptr)
-      // for virtual tensors, the alignment is not used, so we can just put an arbitrary value here, e.g., key.output_alignment
-      .setyDesc(cudnn_utils::getTensorDescriptor(quantized_output.sizes(), quantized_output.strides(), CUDNN_DATA_FLOAT, 'f', key.output_alignment, true))
-      .setpwDesc(cudnn_utils::getPointWiseReluDescriptor(CUDNN_DATA_FLOAT))
+      .setyDesc(cudnn_utils::getTensorDescriptor(linear_output, 'f', key.output_alignment, true))
+      .setpwDesc(cudnn_utils::getPointWiseReluDescriptor(at::native::getCudnnDataType(linear_output)))
       .build());
   }
 
@@ -240,7 +241,7 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
   auto requant_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
     .setxDesc(kReluFused ? relu_op.value().getOutputTensor() : tensor2requant_ptr)
     .setbDesc(cudnn_utils::getTensorDescriptor(requantize_multiplier_tensor, 's', cudnn_utils::getAlignment(requantize_multiplier_tensor)))
-    .setyDesc(cudnn_utils::getTensorDescriptor(quantized_output.sizes(), quantized_output.strides(), CUDNN_DATA_INT8, 'r', key.output_alignment))
+    .setyDesc(cudnn_utils::getTensorDescriptor(quantized_output.sizes(), quantized_output.strides(), CUDNN_DATA_INT8, 'r', cudnn_utils::getAlignment(quantized_output)))
     .setpwDesc(cudnn_utils::getPointWiseMulDescriptor(at::native::getCudnnDataType(requantize_multiplier_tensor)))
     .build();
   // // std::cout << "operator:" << requant_op.describe() << std::endl;

--- a/aten/src/ATen/native/quantized/cudnn/Linear.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/Linear.cpp
@@ -98,7 +98,8 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
   auto act_scale = input.q_scale();
   auto weight_scale = orig_weight.q_scale();
   auto requantize_multiplier = act_scale * weight_scale / output_scale;
-  at::Tensor requantize_multiplier_tensor = cudnn_utils::getRequantMultiplierTensor(requantize_multiplier, quantized_output.dim());
+  at::Tensor requantize_multiplier_tensor = at::full(quantized_output.sizes(), requantize_multiplier, at::device(at::kCUDA).dtype(at::kFloat));
+  requantize_multiplier_tensor.fill_(requantize_multiplier);
   c10::optional<at::Tensor> bias_multiplier_tensor;
   c10::optional<at::Tensor> broadcasted_bias;
   if (bias_.has_value()) {

--- a/aten/src/ATen/native/quantized/cudnn/Linear.cpp
+++ b/aten/src/ATen/native/quantized/cudnn/Linear.cpp
@@ -17,7 +17,6 @@
 #include <ATen/native/utils/ParamsHash.h>
 #include <ATen/TensorUtils.h>
 #include <c10/core/ScalarType.h>
-#include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <cudnn_frontend.h>
 #include <torch/library.h>
@@ -76,7 +75,7 @@ void setLinearParams(
   params->deterministic = deterministic;
   params->allow_tf32 = allow_tf32;
 }
-std::unordered_map<CacheKey, cudnn_frontend::ExecutionPlan, at::native::ParamsHash<CacheKey>, at::native::ParamsEqual<CacheKey>> execution_plan_cache;
+std::unordered_map<CacheKey, cudnn_frontend::ManagedOpaqueDescriptor, at::native::ParamsHash<CacheKey>, at::native::ParamsEqual<CacheKey>> execution_plan_cache;
 }
 // TODO: we can use cudnn_frontend::ExecutionPlanCache when it supports caching
 // multiple operators
@@ -143,9 +142,9 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
   new_sizes[1] = weight_transposed.size(0);
   weight_transposed = weight_transposed.view(new_sizes);
 
-  auto run = [&](const cudnn_frontend::ExecutionPlan& plan_desc) {
-    auto workspace_size = plan_desc.getWorkspaceSize();
-    auto workspace_ptr = c10::cuda::CUDACachingAllocator::get()->allocate(workspace_size);
+  auto run = [&](cudnn_frontend::ManagedOpaqueDescriptor plan_desc) {
+    auto workspace_size = 0;
+    auto workspace = at::empty({workspace_size}, input.options().dtype(at::kByte));
     at::SmallVector<void *, 8> data_ptrs;
     at::SmallVector<int64_t, 8> uids;
     data_ptrs = {input.data_ptr<int8_t>(), weight_transposed.data_ptr<int8_t>(),
@@ -157,17 +156,17 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
       uids.insert(uids.end(), {'b', 'c', 'd', 'n'});
     }
     auto variantPack = cudnn_frontend::VariantPackBuilder()
-      .setWorkspacePointer(workspace_size ? workspace_ptr.get() : nullptr)
+      .setWorkspacePointer(workspace.data_ptr())
       .setDataPointers(uids.size(), data_ptrs.data())
       .setUids(uids.size(), uids.data())
       .build();
     auto variant_pack_desc = variantPack.get_raw_desc();
-    AT_CUDNN_CHECK(cudnnBackendExecute(handle, plan_desc.get_raw_desc(), variant_pack_desc));
+    AT_CUDNN_CHECK(cudnnBackendExecute(handle, plan_desc->get_backend_descriptor(), variant_pack_desc));
   };
 
   auto search = execution_plan_cache.find(key);
   if (search != execution_plan_cache.end()) {
-    cudnn_frontend::ExecutionPlan plan_desc = search->second;
+    cudnn_frontend::ManagedOpaqueDescriptor plan_desc = search->second;
     run(plan_desc);
     return;
   }
@@ -284,8 +283,9 @@ void PackedLinearWeightCudnn::apply_impl_helper(const at::Tensor& quantized_outp
         .setHandle(handle)
         .setEngineConfig(cfg)
         .build();
-      run(plan);
-      execution_plan_cache.emplace(key, plan);
+      auto plan_desc = plan.get_desc();
+      run(plan_desc);
+      execution_plan_cache[key] = plan_desc;
       return;
     } catch (cudnn_frontend::cudnnException &e) {std::cout << "cudnn error:" << e.what() << std::endl;} catch(c10::CuDNNError &e) { std::cout << "other error" << e.what() << std::endl;}
   }

--- a/aten/src/ATen/native/quantized/cudnn/utils.h
+++ b/aten/src/ATen/native/quantized/cudnn/utils.h
@@ -192,17 +192,6 @@ struct PackedConvWeightCudnn : public ConvPackedParamsBase<kSpatialDim> {
 namespace cudnn_utils {
 namespace {
 
-// TODO: we can remove this function when cuDNN enables pass by value support for
-// pointwise multiplication operations. the only reason why we need this right now is
-// we use broadcasting scalar multiplication in conv, linear, and add ops, and cuDNN requires
-// the scalar to be a scalar tensor with the same number of dimensions (num_dim) as the tensor we're multiplying to
-at::Tensor getRequantMultiplierTensor(double requant_multiplier, uint8_t num_dim) {
-  at::SmallVector<int64_t, 4> requantize_multiplier_tensor_size(num_dim, 1);
-  at::Tensor requantize_multiplier_tensor = at::empty(requantize_multiplier_tensor_size, at::device(at::kCUDA).dtype(at::kFloat));
-  requantize_multiplier_tensor.fill_(requant_multiplier);
-  return requantize_multiplier_tensor;
-}
-
 uint8_t getAlignment(const at::Tensor &t) {
   // alignment are in bytes
   uint8_t alignment = 1;


### PR DESCRIPTION
- Revert "[quant][core][improvement][bug fix] Added channel axis bound checking in fused_moving_avg_obs_fake_quant_*"
- Revert "[quant][core][gpu][improvement] Made plan and run for quantized linear op conform with Conv_v8.cpp"
- Revert "[quant][core][gpu][improvement] Removed linear_output and set output tensors as virtual in quantized cudnn linear op"
- Revert "[quant][core][gpu][improvement] Made plan and run for quantized cudnn conv op conform with Conv_v8.cpp"
- Revert "[quant][core][gpu][improvement] Removed conv_output and set output tensors as virtual in quantized cudnn conv2d op"
- Revert "[quant][core][gpu][improvement] Enabled broadcasting multiplication support for requantize_multiplier_tensor in quantized cudnn add, linear, and conv2d ops"
