### PR TITLE
Back out "add mixed data type mode for LayerNorm forward path"

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -699,23 +699,6 @@ inline void convert(const BFloat16* src, BFloat16* dst, int64_t n) {
 }
 
 template <>
-inline void convert(const BFloat16* src, float* dst, int64_t n) {
-  int64_t i;
-#pragma unroll
-  for (i = 0; i <= (n - Vectorized<BFloat16>::size()); i += Vectorized<BFloat16>::size()) {
-    auto vsrc = _mm256_loadu_si256(reinterpret_cast<__m256i*>((void*)(src + i)));
-    __m256 o1, o2;
-    cvtbf16_fp32(vsrc, o1, o2);
-    _mm256_storeu_ps(dst + i, o1);
-    _mm256_storeu_ps(dst + i + Vectorized<float>::size(), o2);
-  }
-#pragma unroll
-  for (; i < n; i++) {
-    dst[i] = static_cast<float>(src[i]);
-  }
-}
-
-template <>
 Vectorized<BFloat16> inline fmadd(const Vectorized<BFloat16>& a,
     const Vectorized<BFloat16>& b, const Vectorized<BFloat16>& c) {
   __m256 a_lo, a_hi;

--- a/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec512/vec512_bfloat16.h
@@ -801,23 +801,6 @@ inline void convert(const BFloat16* src, BFloat16* dst, int64_t n) {
 }
 
 template <>
-inline void convert(const BFloat16* src, float* dst, int64_t n) {
-  int64_t i;
-#pragma unroll
-  for (i = 0; i <= (n - Vectorized<BFloat16>::size()); i += Vectorized<BFloat16>::size()) {
-    auto vsrc = _mm512_loadu_si512(reinterpret_cast<__m512i*>((void*)(src + i)));
-    __m512 o1, o2;
-    cvtbf16_fp32(vsrc, o1, o2);
-    _mm512_storeu_ps(dst + i, o1);
-    _mm512_storeu_ps(dst + i + Vectorized<float>::size(), o2);
-  }
-#pragma unroll
-  for (; i < n; i++) {
-    dst[i] = static_cast<float>(src[i]);
-  }
-}
-
-template <>
 Vectorized<BFloat16> inline fmadd(const Vectorized<BFloat16>& a,
     const Vectorized<BFloat16>& b, const Vectorized<BFloat16>& c) {
   __m512 a_lo, a_hi;

--- a/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
@@ -9,7 +9,6 @@
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
 #include <ATen/native/cpu/moments_utils.h>
-#include <ATen/native/cpu/mixed_data_type.h>
 #include <c10/util/irange.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -23,161 +22,158 @@ namespace native {
 
 namespace {
 
-template <typename T, typename T_ACC>
-struct LayerNormKernelImplInternal {
-  constexpr static void apply(
-      const Tensor& X,
-      const Tensor& gamma,
-      const Tensor& beta,
-      int64_t M,
-      int64_t N,
-      T eps,
-      Tensor* Y,
-      Tensor* mean,
-      Tensor* rstd) {
-    using Vec = vec::Vectorized<T>;
-    const T* X_data = X.data_ptr<T>();
-    const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
-    const T* beta_data = beta.defined() ? beta.data_ptr<T>() : nullptr;
-    T* Y_data = Y->data_ptr<T>();
-    T* mean_data = mean ? mean->data_ptr<T>() : nullptr;
-    T* rstd_data = rstd ? rstd->data_ptr<T>() : nullptr;
-    const bool gamma_null = gamma_data == nullptr;
-    const bool beta_null = beta_data == nullptr;
-    const bool mean_null = mean_data == nullptr;
-    const bool rstd_null = rstd_data == nullptr;
-    at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
-      for (const auto i : c10::irange(start, end)) {
-        const T* X_ptr = X_data + i * N;
-        T* Y_ptr = Y_data + i * N;
-        T mean_val;
-        T rstd_val;
-        std::tie(mean_val, rstd_val) = utils::RowwiseMoments(X_ptr, N);
-        rstd_val = T(1) / std::sqrt(rstd_val + eps);
-        const T scale = rstd_val;
-        const T bias = -rstd_val * mean_val;
-        if (gamma_null || beta_null) {
-          for (const auto j : c10::irange(N)) {
-            const T gamma_v = gamma_null ? T(1) : gamma_data[j];
-            const T beta_v = beta_null ? T(0) : beta_data[j];
-            Y_ptr[j] = (X_ptr[j] * scale + bias) * gamma_v + beta_v;
-          }
-        } else {
-          vec::map3<T>(
-              [scale, bias](Vec x, Vec gamma, Vec beta) {
-                return (x * Vec(scale) + Vec(bias)) * gamma + beta;
-              },
-              Y_ptr,
-              X_ptr,
-              gamma_data,
-              beta_data,
-              N);
+template <typename T>
+void LayerNormKernelImplInternal(
+    const Tensor& X,
+    const Tensor& gamma,
+    const Tensor& beta,
+    int64_t M,
+    int64_t N,
+    T eps,
+    Tensor* Y,
+    Tensor* mean,
+    Tensor* rstd) {
+  using Vec = vec::Vectorized<T>;
+  DCHECK_EQ(X.numel(), M * N);
+  DCHECK(!gamma.defined() || gamma.numel() == N);
+  DCHECK(!beta.defined() || beta.numel() == N);
+  const T* X_data = X.data_ptr<T>();
+  const T* gamma_data = gamma.defined() ? gamma.data_ptr<T>() : nullptr;
+  const T* beta_data = beta.defined() ? beta.data_ptr<T>() : nullptr;
+  T* Y_data = Y->data_ptr<T>();
+  T* mean_data = mean ? mean->data_ptr<T>() : nullptr;
+  T* rstd_data = rstd ? rstd->data_ptr<T>() : nullptr;
+
+  const bool gamma_null = gamma_data == nullptr;
+  const bool beta_null = beta_data == nullptr;
+  const bool mean_null = mean_data == nullptr;
+  const bool rstd_null = rstd_data == nullptr;
+  at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
+    for (const auto i : c10::irange(start, end)) {
+      const T* X_ptr = X_data + i * N;
+      T* Y_ptr = Y_data + i * N;
+      T mean_val;
+      T rstd_val;
+      std::tie(mean_val, rstd_val) = utils::RowwiseMoments(X_ptr, N);
+      rstd_val = T(1) / std::sqrt(rstd_val + eps);
+      const T scale = rstd_val;
+      const T bias = -rstd_val * mean_val;
+      if (gamma_null || beta_null) {
+        for (const auto j : c10::irange(N)) {
+          const T gamma_v = gamma_null ? T(1) : gamma_data[j];
+          const T beta_v = beta_null ? T(0) : beta_data[j];
+          Y_ptr[j] = (X_ptr[j] * scale + bias) * gamma_v + beta_v;
         }
-        if (!mean_null) {
-          mean_data[i] = mean_val;
+      } else {
+        vec::map3<T>(
+            [scale, bias](Vec x, Vec gamma, Vec beta) {
+              return (x * Vec(scale) + Vec(bias)) * gamma + beta;
+            },
+            Y_ptr,
+            X_ptr,
+            gamma_data,
+            beta_data,
+            N);
+      }
+      if (!mean_null) {
+        mean_data[i] = mean_val;
+      }
+      if (!rstd_null) {
+        rstd_data[i] = rstd_val;
+      }
+    }
+  });
+}
+
+template <>
+void LayerNormKernelImplInternal<BFloat16>(
+    const Tensor& X,
+    const Tensor& gamma,
+    const Tensor& beta,
+    int64_t M,
+    int64_t N,
+    BFloat16 eps,
+    Tensor* Y,
+    Tensor* mean,
+    Tensor* rstd) {
+  using bVec = vec::Vectorized<BFloat16>;
+  using fVec = vec::Vectorized<float>;
+  DCHECK_EQ(X.numel(), M * N);
+  DCHECK(!gamma.defined() || gamma.numel() == N);
+  DCHECK(!beta.defined() || beta.numel() == N);
+  const BFloat16* X_data = X.data_ptr<BFloat16>();
+  const BFloat16* gamma_data = gamma.defined() ? gamma.data_ptr<BFloat16>() : nullptr;
+  const BFloat16* beta_data = beta.defined() ? beta.data_ptr<BFloat16>() : nullptr;
+  BFloat16* Y_data = Y->data_ptr<BFloat16>();
+  BFloat16* mean_data = mean->data_ptr<BFloat16>();
+  BFloat16* rstd_data = rstd->data_ptr<BFloat16>();
+  const bool gamma_null = gamma_data == nullptr;
+  const bool beta_null = beta_data == nullptr;
+
+  // pre convert `gamma` and `beta` to float when they are both defined
+  const bool pre_convert_gamma_beta = !gamma_null && !beta_null;
+
+  at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
+    // temp buffer holding input, gamma/beta (if defined) in float
+    //
+    // pre convert input slice to float has 2 benefits:
+    //   a. Welford algorithm involves more arithmetic operations,
+    //      this will reduce rounding error and improve performance.
+    //   b. The input slice (float) can be reused when updating
+    //      corresponding output slice.
+    //
+    int64_t buffer_size = pre_convert_gamma_beta ? 3 * N : N;
+    std::unique_ptr<float []> buffer(new float[buffer_size]);
+    float* input_buffer_ptr = buffer.get();
+    float* gamma_buffer_ptr = nullptr;
+    float* beta_buffer_ptr = nullptr;
+    if (pre_convert_gamma_beta) {
+      gamma_buffer_ptr = buffer.get() + N;
+      beta_buffer_ptr = buffer.get() + 2 * N;
+      vec::convert(gamma_data, gamma_buffer_ptr, N);
+      vec::convert(beta_data, beta_buffer_ptr, N);
+    }
+
+    for (const auto i : c10::irange(start, end)) {
+      const BFloat16* X_ptr = X_data + i * N;
+      BFloat16* Y_ptr = Y_data + i * N;
+      vec::convert(X_ptr, input_buffer_ptr, N);
+
+      float mean_val;
+      float rstd_val;
+      std::tie(mean_val, rstd_val) = utils::RowwiseMoments(input_buffer_ptr, N);
+      rstd_val = float(1) / std::sqrt(rstd_val + eps);
+      const float scale = rstd_val;
+      const float bias = -rstd_val * mean_val;
+      if (gamma_null || beta_null) {
+        for (const auto j : c10::irange(N)) {
+          const float gamma_v = gamma_null ? float(1) : float(gamma_data[j]);
+          const float beta_v = beta_null ? float(0) : float(beta_data[j]);
+          Y_ptr[j] = (input_buffer_ptr[j] * scale + bias) * gamma_v + beta_v;
         }
-        if (!rstd_null) {
-          rstd_data[i] = rstd_val;
+      } else {
+        int64_t d = 0;
+        for (; d < N - (N % bVec::size()); d += bVec::size()) {
+          fVec x_fvec0 = fVec::loadu(input_buffer_ptr + d);
+          fVec x_fvec1 = fVec::loadu(input_buffer_ptr + d + fVec::size());
+          fVec gamma_fvec0 = fVec::loadu(gamma_buffer_ptr + d);
+          fVec gamma_fvec1 = fVec::loadu(gamma_buffer_ptr + d + fVec::size());
+          fVec beta_fvec0 = fVec::loadu(beta_buffer_ptr + d);
+          fVec beta_fvec1 = fVec::loadu(beta_buffer_ptr + d + fVec::size());
+          fVec y_fvec0 = (x_fvec0 * fVec(scale) + fVec(bias)) * gamma_fvec0 + beta_fvec0;
+          fVec y_fvec1 = (x_fvec1 * fVec(scale) + fVec(bias)) * gamma_fvec1 + beta_fvec1;
+          bVec y_bvec = convert_float_bfloat16(y_fvec0, y_fvec1);
+          y_bvec.store(Y_ptr + d);
+        }
+        for (; d < N; d++) {
+          Y_ptr[d] = (input_buffer_ptr[d] * scale + bias) * gamma_data[d] + beta_data[d];
         }
       }
-    });
-  }
-};
-
-template <typename T_ACC>
-struct LayerNormKernelImplInternal<BFloat16, T_ACC> {
-  constexpr static void apply(
-      const Tensor& X,
-      const Tensor& gamma,
-      const Tensor& beta,
-      int64_t M,
-      int64_t N,
-      BFloat16 eps,
-      Tensor* Y,
-      Tensor* mean,
-      Tensor* rstd) {
-    using bVec = vec::Vectorized<BFloat16>;
-    using fVec = vec::Vectorized<float>;
-    const BFloat16* X_data = X.data_ptr<BFloat16>();
-    const T_ACC* gamma_data = gamma.defined() ? gamma.data_ptr<T_ACC>() : nullptr;
-    const T_ACC* beta_data = beta.defined() ? beta.data_ptr<T_ACC>() : nullptr;
-    BFloat16* Y_data = Y->data_ptr<BFloat16>();
-    T_ACC* mean_data = mean ? mean->data_ptr<T_ACC>() : nullptr;
-    T_ACC* rstd_data = rstd ? rstd->data_ptr<T_ACC>() : nullptr;
-    const bool gamma_null = gamma_data == nullptr;
-    const bool beta_null = beta_data == nullptr;
-    const bool mean_null = mean_data == nullptr;
-    const bool rstd_null = rstd_data == nullptr;
-
-    // pre convert `gamma` and `beta` to float when they are both defined
-    const bool pre_convert_gamma_beta = !gamma_null && !beta_null;
-
-    at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
-      // temp buffer holding input, gamma/beta (if defined) in float
-      //
-      // pre convert input slice to float has 2 benefits:
-      //   a. Welford algorithm involves more arithmetic operations,
-      //      this will reduce rounding error and improve performance.
-      //   b. The input slice (float) can be reused when updating
-      //      corresponding output slice.
-      //
-      int64_t buffer_size = pre_convert_gamma_beta ? 3 * N : N;
-      std::unique_ptr<float []> buffer(new float[buffer_size]);
-      float* input_buffer_ptr = buffer.get();
-      float* gamma_buffer_ptr = nullptr;
-      float* beta_buffer_ptr = nullptr;
-      if (pre_convert_gamma_beta) {
-        gamma_buffer_ptr = buffer.get() + N;
-        beta_buffer_ptr = buffer.get() + 2 * N;
-        vec::convert(gamma_data, gamma_buffer_ptr, N);
-        vec::convert(beta_data, beta_buffer_ptr, N);
-      }
-
-      for (const auto i : c10::irange(start, end)) {
-        const BFloat16* X_ptr = X_data + i * N;
-        BFloat16* Y_ptr = Y_data + i * N;
-        vec::convert(X_ptr, input_buffer_ptr, N);
-
-        float mean_val;
-        float rstd_val;
-        std::tie(mean_val, rstd_val) = utils::RowwiseMoments(input_buffer_ptr, N);
-        rstd_val = float(1) / std::sqrt(rstd_val + eps);
-        const float scale = rstd_val;
-        const float bias = -rstd_val * mean_val;
-        if (gamma_null || beta_null) {
-          for (const auto j : c10::irange(N)) {
-            const float gamma_v = gamma_null ? float(1) : float(gamma_data[j]);
-            const float beta_v = beta_null ? float(0) : float(beta_data[j]);
-            Y_ptr[j] = (input_buffer_ptr[j] * scale + bias) * gamma_v + beta_v;
-          }
-        } else {
-          int64_t d = 0;
-          for (; d < N - (N % bVec::size()); d += bVec::size()) {
-            fVec x_fvec0 = fVec::loadu(input_buffer_ptr + d);
-            fVec x_fvec1 = fVec::loadu(input_buffer_ptr + d + fVec::size());
-            fVec gamma_fvec0 = fVec::loadu(gamma_buffer_ptr + d);
-            fVec gamma_fvec1 = fVec::loadu(gamma_buffer_ptr + d + fVec::size());
-            fVec beta_fvec0 = fVec::loadu(beta_buffer_ptr + d);
-            fVec beta_fvec1 = fVec::loadu(beta_buffer_ptr + d + fVec::size());
-            fVec y_fvec0 = (x_fvec0 * fVec(scale) + fVec(bias)) * gamma_fvec0 + beta_fvec0;
-            fVec y_fvec1 = (x_fvec1 * fVec(scale) + fVec(bias)) * gamma_fvec1 + beta_fvec1;
-            bVec y_bvec = convert_float_bfloat16(y_fvec0, y_fvec1);
-            y_bvec.store(Y_ptr + d);
-          }
-          for (; d < N; d++) {
-            Y_ptr[d] = (input_buffer_ptr[d] * scale + bias) * gamma_data[d] + beta_data[d];
-          }
-        }
-        if (!mean_null) {
-          mean_data[i] = T_ACC(mean_val);
-        }
-        if (!rstd_null) {
-          rstd_data[i] = T_ACC(rstd_val);
-        }
-      }
-    });
-  }
-};
+      mean_data[i] = BFloat16(mean_val);
+      rstd_data[i] = BFloat16(rstd_val);
+    }
+  });
+}
 
 void LayerNormKernelImpl(
     const Tensor& X,
@@ -189,21 +185,10 @@ void LayerNormKernelImpl(
     Tensor* Y,
     Tensor* mean,
     Tensor* rstd) {
-  DCHECK_EQ(X.numel(), M * N);
-  DCHECK(!gamma.defined() || gamma.numel() == N);
-  DCHECK(!beta.defined() || beta.numel() == N);
   AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::BFloat16, X.scalar_type(),
       "LayerNormKernelImpl", [&]() {
-    using accscalar_t = at::acc_type<scalar_t, /*is_cuda=*/false>;
-    const bool mixed_type = is_mixed_type(X, gamma, beta);
-    if (mixed_type) {
-      check_mixed_data_type(X, gamma, beta);
-      LayerNormKernelImplInternal<scalar_t, accscalar_t>::apply(
-          X, gamma, beta, M, N, static_cast<scalar_t>(eps), Y, mean, rstd);
-    } else {
-      LayerNormKernelImplInternal<scalar_t, scalar_t>::apply(
-          X, gamma, beta, M, N, static_cast<scalar_t>(eps), Y, mean, rstd);
-    }
+    LayerNormKernelImplInternal<scalar_t>(
+        X, gamma, beta, M, N, static_cast<scalar_t>(eps), Y, mean, rstd);
   });
 }
 

--- a/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/layer_norm_kernel.cpp
@@ -33,7 +33,8 @@ void LayerNormKernelImplInternal(
     Tensor* Y,
     Tensor* mean,
     Tensor* rstd) {
-  using Vec = vec::Vectorized<T>;
+  using T_ACC = vec::vec_scalar_t<T>;
+  using Vec = vec::Vectorized<T_ACC>;
   DCHECK_EQ(X.numel(), M * N);
   DCHECK(!gamma.defined() || gamma.numel() == N);
   DCHECK(!beta.defined() || beta.numel() == N);
@@ -56,8 +57,8 @@ void LayerNormKernelImplInternal(
       T rstd_val;
       std::tie(mean_val, rstd_val) = utils::RowwiseMoments(X_ptr, N);
       rstd_val = T(1) / std::sqrt(rstd_val + eps);
-      const T scale = rstd_val;
-      const T bias = -rstd_val * mean_val;
+      const T_ACC scale = rstd_val;
+      const T_ACC bias = -rstd_val * mean_val;
       if (gamma_null || beta_null) {
         for (const auto j : c10::irange(N)) {
           const T gamma_v = gamma_null ? T(1) : gamma_data[j];
@@ -81,96 +82,6 @@ void LayerNormKernelImplInternal(
       if (!rstd_null) {
         rstd_data[i] = rstd_val;
       }
-    }
-  });
-}
-
-template <>
-void LayerNormKernelImplInternal<BFloat16>(
-    const Tensor& X,
-    const Tensor& gamma,
-    const Tensor& beta,
-    int64_t M,
-    int64_t N,
-    BFloat16 eps,
-    Tensor* Y,
-    Tensor* mean,
-    Tensor* rstd) {
-  using bVec = vec::Vectorized<BFloat16>;
-  using fVec = vec::Vectorized<float>;
-  DCHECK_EQ(X.numel(), M * N);
-  DCHECK(!gamma.defined() || gamma.numel() == N);
-  DCHECK(!beta.defined() || beta.numel() == N);
-  const BFloat16* X_data = X.data_ptr<BFloat16>();
-  const BFloat16* gamma_data = gamma.defined() ? gamma.data_ptr<BFloat16>() : nullptr;
-  const BFloat16* beta_data = beta.defined() ? beta.data_ptr<BFloat16>() : nullptr;
-  BFloat16* Y_data = Y->data_ptr<BFloat16>();
-  BFloat16* mean_data = mean->data_ptr<BFloat16>();
-  BFloat16* rstd_data = rstd->data_ptr<BFloat16>();
-  const bool gamma_null = gamma_data == nullptr;
-  const bool beta_null = beta_data == nullptr;
-
-  // pre convert `gamma` and `beta` to float when they are both defined
-  const bool pre_convert_gamma_beta = !gamma_null && !beta_null;
-
-  at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
-    // temp buffer holding input, gamma/beta (if defined) in float
-    //
-    // pre convert input slice to float has 2 benefits:
-    //   a. Welford algorithm involves more arithmetic operations,
-    //      this will reduce rounding error and improve performance.
-    //   b. The input slice (float) can be reused when updating
-    //      corresponding output slice.
-    //
-    int64_t buffer_size = pre_convert_gamma_beta ? 3 * N : N;
-    std::unique_ptr<float []> buffer(new float[buffer_size]);
-    float* input_buffer_ptr = buffer.get();
-    float* gamma_buffer_ptr = nullptr;
-    float* beta_buffer_ptr = nullptr;
-    if (pre_convert_gamma_beta) {
-      gamma_buffer_ptr = buffer.get() + N;
-      beta_buffer_ptr = buffer.get() + 2 * N;
-      vec::convert(gamma_data, gamma_buffer_ptr, N);
-      vec::convert(beta_data, beta_buffer_ptr, N);
-    }
-
-    for (const auto i : c10::irange(start, end)) {
-      const BFloat16* X_ptr = X_data + i * N;
-      BFloat16* Y_ptr = Y_data + i * N;
-      vec::convert(X_ptr, input_buffer_ptr, N);
-
-      float mean_val;
-      float rstd_val;
-      std::tie(mean_val, rstd_val) = utils::RowwiseMoments(input_buffer_ptr, N);
-      rstd_val = float(1) / std::sqrt(rstd_val + eps);
-      const float scale = rstd_val;
-      const float bias = -rstd_val * mean_val;
-      if (gamma_null || beta_null) {
-        for (const auto j : c10::irange(N)) {
-          const float gamma_v = gamma_null ? float(1) : float(gamma_data[j]);
-          const float beta_v = beta_null ? float(0) : float(beta_data[j]);
-          Y_ptr[j] = (input_buffer_ptr[j] * scale + bias) * gamma_v + beta_v;
-        }
-      } else {
-        int64_t d = 0;
-        for (; d < N - (N % bVec::size()); d += bVec::size()) {
-          fVec x_fvec0 = fVec::loadu(input_buffer_ptr + d);
-          fVec x_fvec1 = fVec::loadu(input_buffer_ptr + d + fVec::size());
-          fVec gamma_fvec0 = fVec::loadu(gamma_buffer_ptr + d);
-          fVec gamma_fvec1 = fVec::loadu(gamma_buffer_ptr + d + fVec::size());
-          fVec beta_fvec0 = fVec::loadu(beta_buffer_ptr + d);
-          fVec beta_fvec1 = fVec::loadu(beta_buffer_ptr + d + fVec::size());
-          fVec y_fvec0 = (x_fvec0 * fVec(scale) + fVec(bias)) * gamma_fvec0 + beta_fvec0;
-          fVec y_fvec1 = (x_fvec1 * fVec(scale) + fVec(bias)) * gamma_fvec1 + beta_fvec1;
-          bVec y_bvec = convert_float_bfloat16(y_fvec0, y_fvec1);
-          y_bvec.store(Y_ptr + d);
-        }
-        for (; d < N; d++) {
-          Y_ptr[d] = (input_buffer_ptr[d] * scale + bias) * gamma_data[d] + beta_data[d];
-        }
-      }
-      mean_data[i] = BFloat16(mean_val);
-      rstd_data[i] = BFloat16(rstd_val);
     }
   });
 }

--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -8,7 +8,6 @@
 #include <ATen/Parallel.h>
 #include <c10/util/irange.h>
 #include <torch/library.h>
-#include <ATen/native/cpu/mixed_data_type.h>
 
 #include <array>
 #include <functional>
@@ -75,7 +74,6 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_cpu(
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
 
-  bool mixed_type = is_mixed_type(input, weight, bias);
 
   auto M_N = _check_layer_norm_inputs(input, normalized_shape, weight, bias);
   auto M = M_N.first;
@@ -91,9 +89,8 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_cpu(
       c10::nullopt /* device */,
       c10::nullopt /* pin_memory */,
       at::MemoryFormat::Contiguous);
-  const auto dtype = param_scalar_type(input, mixed_type);
-  Tensor mean = at::empty({M}, X->options().dtype(dtype));
-  Tensor rstd = at::empty({M}, X->options().dtype(dtype));
+  Tensor mean = at::empty({M}, X->options());
+  Tensor rstd = at::empty({M}, X->options());
 
   layer_norm_with_mean_rstd_out(Y, mean, rstd, *X, normalized_shape, *gamma, *beta, eps, M, N);
   return std::make_tuple(std::move(Y), std::move(mean), std::move(rstd));

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -13123,17 +13123,6 @@ class TestNNDeviceType(NNTestCase):
         output.sum().backward()
         self.assertEqualTypeString(output, input)
 
-    def _test_LayerNorm_cpu_mixed_dtype(self, device):
-        for elementwise_affine in [True, False]:
-            # layer norm input shape is normalized to m x n, cpu vectorized on n,
-            # so make sure n exceeds vector length
-            input = torch.empty(2, 3, 11, 3, device=device, dtype=torch.bfloat16).random_(1, 10)
-            m = nn.LayerNorm([11, 3], elementwise_affine=elementwise_affine).to(device, torch.bfloat16)
-            m2 = deepcopy(m).to(device, torch.float)
-            out = m(input)
-            out2 = m2(input)
-            self.assertEqual(out, out2)
-
     def _test_GroupNorm_general(self, device, dtype=torch.float):
         good_shape_g = {
             (1, 2, 3, 4): 2,
@@ -14510,9 +14499,6 @@ class TestNNDeviceType(NNTestCase):
 
         if self.device_type == 'cuda':
             self._test_LayerNorm_cuda_half(device)
-
-        if self.device_type == 'cpu':
-            self._test_LayerNorm_cpu_mixed_dtype(device)
 
     @onlyNativeDeviceTypes
     def test_LayerNorm_numeric(self, device):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #78298

Also back out "improve LayerNorm bfloat16 performance on CPU".

These layer norm changes seem fine, but they are causing `LayerNorm` to not use AVX2 instructions, which is causing performance on internal models to degrade. More investigation is needed to find the true root cause, but we should unland to mitigate the issue ASAP.

I left `mixed_data_type.h` around since there are some other files depending on it.

Differential Revision: [D36675352](https://our.internmc.facebook.com/intern/diff/D36675352/)