### PR TITLE
[1.12] Don't package torchgen with PT1.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1080,7 +1080,6 @@ if __name__ == '__main__':
                 'utils/model_dump/code.js',
                 'utils/model_dump/*.mjs',
             ],
-            'torchgen': [],
             'caffe2': [
                 'python/serialized_test/data/operator_test/*.zip',
             ],


### PR DESCRIPTION
Context
- Before 1.12, PyTorch codegen (the tools/codegen folder) was not packaged with
PyTorch wheels
- tools/codegen was renamed and moved to torchgen/
- torchgen is currently incomplete, so there is no value with packaging
it.
- This PR makes it so that we match the previous (e.g. 1.11) state where
PyTorch codegen is not packaged with PyTorch.

Test Plan:
- check that pytorch still builds

Fixes #ISSUE_NUMBER
