### PR TITLE
Add support for BSR <-> Strided conversion

### DIFF
--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -1,5 +1,4 @@
 #include <ATen/ATen.h>
-#include <iostream>
 #include <ATen/NativeFunctions.h>
 #include <c10/util/Optional.h>
 #include <ATen/quantized/Quantizer.h>

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -418,19 +418,12 @@ Tensor sparse_compressed_to_dense(
       return dense;
     }
     if (self.dim() == 3) {
-      std::cout << "0 values.sizes(): " << values.sizes() << std::endl;
-      std::cout << "0 indices.sizes(): " << indices.sizes() << std::endl;
-      values = values.reshape(
-          {values.size(0) * values.size(1), values.size(2), values.size(3)});
-
       Tensor dense = at::zeros(self.sizes(), self.options().layout(kStrided));
       dense =
           dense.reshape({self.size(0), -1, values.size(-2), values.size(-1)});
       auto row_indices = indices.select(0, 0);
       auto col_indices = indices.select(0, 1);
-      std::cout << "indices: " << indices << std::endl;
       auto offsets = col_indices + row_indices * (self.size(-1) / blocksize[1]);
-      std::cout << "offsets: " << offsets << std::endl;
       dense.index_add_(1, offsets, values);
       dense = dense.reshape(
           {self.size(0),

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -424,6 +424,9 @@ Tensor sparse_compressed_to_dense(
       auto row_indices = indices.select(0, 0);
       auto col_indices = indices.select(0, 1);
       auto offsets = col_indices + row_indices * (self.size(-1) / blocksize[1]);
+      // NOTE: This only works because we're using the same indices
+      // per matrix entry. Generally BSR only supports 2 sparse dimensions,
+      // so this isn't likely to need to change any time soon.
       dense.index_add_(1, offsets, values);
       dense = dense.reshape(
           {self.size(0),

--- a/aten/src/ATen/native/TensorConversions.cpp
+++ b/aten/src/ATen/native/TensorConversions.cpp
@@ -4,9 +4,9 @@
 #include <ATen/quantized/Quantizer.h>
 #include <ATen/Parallel.h>
 
-#include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <ATen/SparseTensorUtils.h>
 #include <ATen/native/IndexingUtils.h>
+#include <c10/core/impl/DeviceGuardImplInterface.h>
 
 namespace at {
 namespace native {
@@ -646,7 +646,8 @@ std::pair<Tensor, Tensor> _not_zero_mask_to_col_row_indices(
           .expand_as(not_zero_mask)
           .masked_select(not_zero_mask);
   auto row_indices =
-      at::native::arange(not_zero_mask.size(-2), index_dtype, kStrided, index_device)
+      at::native::arange(
+          not_zero_mask.size(-2), index_dtype, kStrided, index_device)
           .view({not_zero_mask.size(-2), 1})
           .expand_as(not_zero_mask)
           .masked_select(not_zero_mask);
@@ -670,43 +671,91 @@ Tensor dense_to_sparse_bsr(const Tensor& self, IntArrayRef blocksize) {
       self.size(-1),
       " needs to be divisible by blocksize[1] ",
       blocksize[1]);
+
   auto block_size_0 = self.size(-2) / blocksize[0];
+  auto n_batch_dim = self.dim() - 2;
 
   auto values = _batch_tile_tensor(self, blocksize);
   auto not_zero_mask = _batch_tile_tensor((self != 0), blocksize);
   // Find tiles that have at least 1 non-zero value in them.
   not_zero_mask = not_zero_mask.any(-1).any(-1);
-  if (self.dim() == 3) {
-    TORCH_CHECK(self.size(0) > 0, "to_sparse_bsr: Expected batch dimension 0 to be non-zero.");
-    // If the input is 3D we assert that the same sparsity pattern
+
+  if (n_batch_dim > 0) {
+    // for 3D input the mask is already flat along the batch dims, avoid
+    // creating unnessesary view
+    if (n_batch_dim > 1) {
+      // flatten out the batch dims for N-D input
+      not_zero_mask = not_zero_mask.flatten(0, n_batch_dim - 1);
+    }
+    TORCH_CHECK(
+        not_zero_mask.size(0) > 0,
+        "to_sparse_bsr: Expected product of batch dimensions to be non-zero.");
+
+    // If the input is ND we assert that the same sparsity pattern
     // is used across matrices. That means the same number of materialized
     // values and *at the same location*.
+    // This requirement is not included in Pearu's blog post on BSR invariants.
+    // He specifically states that different batches may have different sparsity
+    // patterns as long as the number of specified elements is the same for all
+    // batches.
+
     auto not_zero_mask_0 = not_zero_mask.select(0, 0);
-    TORCH_CHECK(not_zero_mask.any(0).equal(not_zero_mask_0), "Expect the same sparsity pattern across matrices for 3D input.");
-    not_zero_mask = not_zero_mask_0;
+    auto nse_per_batch = not_zero_mask_0.sum().repeat(not_zero_mask.size(0));
+    TORCH_CHECK(
+        not_zero_mask.sum({-2, -1}).equal(nse_per_batch),
+        "Expect the same number of specified elements per batch.");
   }
+
   Tensor col_indices;
   Tensor row_indices;
   std::tie(col_indices, row_indices) = _not_zero_mask_to_col_row_indices(
       not_zero_mask, at::kLong, not_zero_mask.device());
-  Tensor crow_indices = at::_convert_indices_from_coo_to_csr(
-      row_indices.view({-1}), block_size_0, false /* out_int32 */);
-  not_zero_mask = not_zero_mask.reshape({-1});
-  if (self.dim() == 3) {
-    crow_indices = crow_indices.repeat({self.size(0), 1});
-    col_indices = col_indices.repeat({self.size(0), 1});
-    values = values.reshape({self.size(0), -1, values.size(-2), values.size(-1)});
-    values = values.index_select(
-        1,
-        _mask_to_indices(not_zero_mask));
-  } else {
-    values = values.reshape({-1, values.size(-2), values.size(-1)});
+  Tensor crow_indices;
+
+  if (n_batch_dim > 0) {
+    // reshape to put the (flattened) batch dims back in
+    col_indices = col_indices.reshape({not_zero_mask.size(0), -1});
+    row_indices = row_indices.reshape({not_zero_mask.size(0), -1});
+    crow_indices = at::empty(
+        {not_zero_mask.size(0), block_size_0 + 1}, col_indices.options());
+    // For each batch compute crow_indices
+    for (auto batch : c10::irange(not_zero_mask.size(0))) {
+      Tensor batch_crow_indices = crow_indices[batch];
+      at::_convert_indices_from_coo_to_csr_out(
+          batch_crow_indices,
+          row_indices[batch],
+          block_size_0,
+          false /* out_int32 */);
+    }
+    // At this point, we have constructed col_indices and crow_indices
+    // such that they are 2d with dim0 of length B = product(batchdims). We can
+    // now reshape them to the correct shapes.
+    auto batch_shape = self.sizes().slice(0, n_batch_dim);
+    crow_indices = crow_indices.unflatten(0, batch_shape);
+    col_indices = col_indices.unflatten(0, batch_shape);
+
+    // Mask is also leading dim B, but we can't masked select wit it (see below)
+    // unless it is flat, then we can partially faltten values, index it along
+    // and unfold the result to batchdims + (nnz(per batch), )
+    auto batch_sizes_nnz = DimVector(batch_shape);
+    batch_sizes_nnz.push_back(-1); // we can infer nnz
+    not_zero_mask = not_zero_mask.flatten();
     // TODO: masked_select does not support some form of broadcasting, so we're
     // using the mask to construct indices that are then passed into
     // index_select. This isn't ideal.
-    values = values.index_select(
-        0,
-        _mask_to_indices(not_zero_mask));
+    values = values.flatten(0, -3)
+                 .index_select(0, _mask_to_indices(not_zero_mask))
+                 .unflatten(0, batch_sizes_nnz);
+
+  } else {
+    crow_indices = at::_convert_indices_from_coo_to_csr(
+        row_indices.view({-1}), block_size_0, false /* out_int32 */);
+    not_zero_mask = not_zero_mask.reshape({-1});
+    // TODO: masked_select does not support some form of broadcasting, so we're
+    // using the mask to construct indices that are then passed into
+    // index_select. This isn't ideal.
+    values = values.reshape({-1, values.size(-2), values.size(-1)})
+                 .index_select(0, _mask_to_indices(not_zero_mask));
   }
 
   return at::native::_sparse_bsr_tensor_unsafe(

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -581,25 +581,26 @@ class TestSparseCSR(TestCase):
         sparse = self.genSparseBSRTensor(shape, (2, 2), nnz, dtype=dtype, device=device, index_dtype=index_dtype)
 
         # select from batch dimensions
-        sparse_selected12 = sparse.select(0, 2)
-        expected_sparse_selected12 = torch.sparse_bsr_tensor(sparse.crow_indices().select(0, 2).contiguous(),
+        sparse_selected02 = sparse.select(0, 2)
+        expected_sparse_selected02 = torch.sparse_bsr_tensor(sparse.crow_indices().select(0, 2).contiguous(),
                                                              sparse.col_indices().select(0, 2).contiguous(),
                                                              sparse.values().select(0, 2).contiguous(),
-                                                             size=(1, 6, 10),
+                                                             size=(6, 10),
                                                              dtype=dtype,
                                                              device=device)
-        self.assertEqual(expected_sparse_selected12, sparse_selected12)
+        self.assertEqual(expected_sparse_selected02, sparse_selected02)
 
+        msg = "selecting non-batch dimensions is currently only supported for CSR tensors"
         # selecting from rows or columns for batched CSR is not yet implemented
-        with self.assertRaisesRegex(RuntimeError, "selecting rows or columns is not implemented for batched"):
+        with self.assertRaisesRegex(RuntimeError, msg):
             sparse.select(-2, 0)
 
-        with self.assertRaisesRegex(RuntimeError, "selecting rows or columns is not implemented for batched"):
+        with self.assertRaisesRegex(RuntimeError, msg):
             sparse.select(-1, 0)
 
         # assigning to sparse via indexing is disabled
-        with self.assertRaisesRegex(TypeError, "Cannot assign to a sparse tensor"):
-            sparse[0, 0, 0, 0] = 99.0
+        with self.assertRaisesRegex(RuntimeError, msg):
+            sparse[0, 0, 0] = 99.0
 
     @skipMeta
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16))

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2292,6 +2292,10 @@ class TestSparseCSR(TestCase):
             _test_matrix(pt_matrix, dense, layout, blocksize)
             self.assertEqual(dense, pt_matrix.to_dense())
 
+        if layout is not torch.sparse_bsr:
+            # TODO: Remove this once support has been enabled
+            return
+
         # Test batch shapes (3D inputs)
 
         # Case 1: Same sparsity pattern across matrices

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2293,22 +2293,26 @@ class TestSparseCSR(TestCase):
             self.assertEqual(dense, pt_matrix.to_dense())
 
         # Test batch shapes (3D inputs)
-        shapes = [(b,) + s for b, s in itertools.product([3, 0], shapes)]
+
         # Case 1: Same sparsity pattern across matrices
         for shape, blocksize in itertools.product(shapes, blocksizes):
+            shape = (3,) + shape
             dense = make_tensor(shape, dtype=torch.float, device=device)
-            # Repeat the same sparsity pattern across batch entries
-            if shape[0] > 0:
-                mask = dense[0].relu().bool()
-                dense = dense * mask.unsqueeze(0)
-                pt_tensor = self._convert_to_layout(dense, layout, blocksize=blocksize)
-            else:
-                # TODO: Support zero sized batch dimensions
-                with self.assertRaisesRegex(RuntimeError, "to_sparse_bsr: Expected batch dimension 0 to be non-zero."):
-                    self._convert_to_layout(dense, layout, blocksize=blocksize)
+            mask = dense[0].relu().bool()
+            dense = dense * mask.unsqueeze(0)
+            pt_tensor = self._convert_to_layout(dense, layout, blocksize=blocksize)
             for i in range(shape[0]):
                 _test_matrix(pt_tensor[i], dense[i], layout, blocksize)
             self.assertEqual(dense, pt_tensor.to_dense())
+
+        # Verify exception when given 0 sized batch
+        for shape, blocksize in itertools.product(shapes, blocksizes):
+            dense = make_tensor((0,) + shape, dtype=torch.float, device=device)
+            # Repeat the same sparsity pattern across batch entries
+            if shape[0] == 0:
+                # TODO: Support zero sized batch dimensions
+                with self.assertRaisesRegex(RuntimeError, "to_sparse_bsr: Expected batch dimension 0 to be non-zero."):
+                    self._convert_to_layout(dense, layout, blocksize=blocksize)
 
         # TODO: Case 2: Different sparsity pattern across matrices, but same number of zeros
 

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2380,8 +2380,7 @@ class TestSparseCSR(TestCase):
             pt_tensor = self._convert_to_layout(dense, layout, blocksize=blocksize)
             for i in range(2):
                 _test_matrix(pt_tensor[i], dense[i], layout, blocksize)
-            # TODO: enable once to_dense supports this pattern
-            # self.assertEqual(dense, pt_tensor.to_dense())
+            self.assertEqual(dense, pt_tensor.to_dense())
         else:
             with self.assertRaisesRegex(RuntimeError, "Expect the same sparsity pattern across matrices for ND input."):
                 self._convert_to_layout(dense, layout, blocksize=blocksize)

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2303,7 +2303,7 @@ class TestSparseCSR(TestCase):
             pt_tensor = self._convert_to_layout(dense, layout, blocksize=blocksize)
             for i in range(shape[0]):
                 _test_matrix(pt_tensor[i], dense[i], layout, blocksize)
-            self.assertEqual(dense, pt_matrix.to_dense())
+            self.assertEqual(dense, pt_tensor.to_dense())
 
         # TODO: Case 2: Different sparsity pattern across matrices
 

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2305,6 +2305,7 @@ class TestSparseCSR(TestCase):
             dense = make_tensor(shape, dtype=torch.float, device=device)
             dense = dense * mask.unsqueeze(0)
             pt_matrix = self._convert_to_layout(dense, layout, blocksize=blocksize)
+            print("dense: ", dense, " pt_matrix: ", pt_matrix)
             for d, matrix in zip(dense, pt_matrix):
                 _test_matrix(pt_matrix, d, layout, blocksize)
 


### PR DESCRIPTION
Extends 2D to ND support for BSR <-> Strided conversions via `to_sparse_bsr` and `to_dense`.