### PR TITLE
rename torch.version.hip to torch.version.rocm

### DIFF
--- a/docs/source/notes/hip.rst
+++ b/docs/source/notes/hip.rst
@@ -64,7 +64,7 @@ Whether you are using PyTorch for CUDA or HIP, the result of calling
 that has been built with GPU support, it will return `True`. If you must check
 which version of PyTorch you are using, refer to this example below::
 
-    if torch.cuda.is_available() and torch.version.hip:
+    if torch.cuda.is_available() and torch.version.rocm:
         # do something specific for HIP
     elif torch.cuda.is_available() and torch.version.cuda:
         # do something specific for CUDA

--- a/test/cpp_extensions/setup.py
+++ b/test/cpp_extensions/setup.py
@@ -55,14 +55,14 @@ if (not IS_WINDOWS) and torch.cuda.is_available() and CUDA_HOME is not None:
     cublas_extension = CUDAExtension(
         name='torch_test_cpp_extension.cublas_extension',
         sources=['cublas_extension.cpp'],
-        libraries=['cublas'] if torch.version.hip is None else [],
+        libraries=['cublas'] if torch.version.rocm is None else [],
     )
     ext_modules.append(cublas_extension)
 
     cusolver_extension = CUDAExtension(
         name='torch_test_cpp_extension.cusolver_extension',
         sources=['cusolver_extension.cpp'],
-        libraries=['cusolver'] if torch.version.hip is None else [],
+        libraries=['cusolver'] if torch.version.rocm is None else [],
     )
     ext_modules.append(cusolver_extension)
 

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -13,7 +13,7 @@ from torch.testing._internal.common_utils import (TestCase, run_tests,
 from torch.testing._internal.common_cuda import CUDA11OrLater, TEST_CUDA, TEST_MULTIGPU
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes
 import re
-HIP_VERSION = 0.0 if torch.version.hip is None else float(re.search(r"^\d+\.\d+", torch.version.hip)[0])
+HIP_VERSION = 0.0 if torch.version.rocm is None else float(re.search(r"^\d+\.\d+", torch.version.hip)[0])
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings

--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -13,7 +13,7 @@ from torch.testing._internal.common_utils import (TestCase, run_tests,
 from torch.testing._internal.common_cuda import CUDA11OrLater, TEST_CUDA, TEST_MULTIGPU
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes
 import re
-HIP_VERSION = 0.0 if torch.version.rocm is None else float(re.search(r"^\d+\.\d+", torch.version.hip)[0])
+HIP_VERSION = 0.0 if torch.version.rocm is None else float(re.search(r"^\d+\.\d+", torch.version.rocm)[0])
 
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
                        "instead.")
 
 TEST_CUDA = torch.cuda.is_available()
-TEST_ROCM = torch.cuda.is_available() and torch.version.hip is not None
+TEST_ROCM = torch.cuda.is_available() and torch.version.rocm is not None
 TEST_CUDNN = False
 if TEST_CUDA and not TEST_ROCM:  # Skip ROCM
     torch.ones(1).cuda()  # initialize cuda context

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2826,7 +2826,7 @@ class TestBinaryUfuncs(TestCase):
             if self.device_type == "cpu":
                 with self.assertRaisesRegex(RuntimeError, "ZeroDivisionError"):
                     fn(x, zero)
-            elif torch.version.hip is not None:
+            elif torch.version.rocm is not None:
                 # ROCm behavior: x % 0 is a no-op; x is returned
                 self.assertEqual(fn(x, zero), x)
             else:

--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -20,7 +20,7 @@ from torch.testing._internal.common_utils import gradcheck
 
 TEST_CUDA = torch.cuda.is_available() and CUDA_HOME is not None
 TEST_CUDNN = False
-TEST_ROCM = torch.cuda.is_available() and torch.version.hip is not None and ROCM_HOME is not None
+TEST_ROCM = torch.cuda.is_available() and torch.version.rocm is not None and ROCM_HOME is not None
 if TEST_CUDA and torch.version.cuda is not None:  # the skip CUDNN test for ROCm
     CUDNN_HEADER_EXISTS = os.path.isfile(os.path.join(CUDA_HOME, "include/cudnn.h"))
     TEST_CUDNN = (

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1119,7 +1119,7 @@ class TestTensorCreation(TestCase):
         # Note: CUDA max float -> integer conversion is divergent on some dtypes
         vals = (min, -2, -1.5, -.5, 0, .5, 1.5, 2, max)
         if self.device_type == 'cuda':
-            if torch.version.hip:
+            if torch.version.rocm:
                 # HIP min float -> int64 conversion is divergent
                 vals = (-2, -1.5, -.5, 0, .5, 1.5, 2)
             else:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4649,7 +4649,7 @@ else:
                 return self.tensor.__dlpack_device__()
 
             def __dlpack__(self, stream=None):
-                if torch.version.hip is None:
+                if torch.version.rocm is None:
                     assert stream == 1
                 else:
                     assert stream == 0

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -44,13 +44,13 @@ if __name__ == "__main__":
         help="Whether this build is debug mode or not.",
     )
     parser.add_argument("--cuda_version", type=str)
-    parser.add_argument("--hip_version", type=str)
+    parser.add_argument("--rocm_version", type=str)
 
     args = parser.parse_args()
 
     assert args.is_debug is not None
     args.cuda_version = None if args.cuda_version == "" else args.cuda_version
-    args.hip_version = None if args.hip_version == "" else args.hip_version
+    args.rocm_version = None if args.rocm_version == "" else args.rocm_version
 
     pytorch_root = Path(__file__).parent.parent
     version_path = pytorch_root / "torch" / "version.py"
@@ -65,4 +65,4 @@ if __name__ == "__main__":
         f.write("debug = {}\n".format(repr(bool(args.is_debug))))
         f.write("cuda = {}\n".format(repr(args.cuda_version)))
         f.write("git_version = {}\n".format(repr(sha)))
-        f.write("hip = {}\n".format(repr(args.hip_version)))
+        f.write("rocm = {}\n".format(repr(args.rocm_version)))

--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -449,7 +449,7 @@ add_custom_command(
     "${PYTHON_EXECUTABLE}" ${TOOLS_PATH}/generate_torch_version.py
       --is_debug=${TORCH_VERSION_DEBUG}
       --cuda_version=${CUDA_VERSION}
-      --hip_version=${HIP_VERSION}
+      --rocm_version=${ROCM_VERSION_DEV}
   DEPENDS ${TOOLS_PATH}/generate_torch_version.py
   WORKING_DIRECTORY ${TORCH_ROOT}
 )

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1175,7 +1175,7 @@ class Tensor(torch._C._TensorBase):
         if has_torch_function_unary(self):
             return handle_torch_function(Tensor.__dlpack_device__, (self,), self)
         idx = self.device.index if self.device.index is not None else 0
-        if self.device.type == 'cuda' and torch.version.hip is not None:
+        if self.device.type == 'cuda' and torch.version.rocm is not None:
             device_type = DLDeviceType.kDLROCM
         elif self.device.type == 'cpu' and self.is_pinned():
             device_type = DLDeviceType.kDLCPUPinned

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1257,7 +1257,7 @@ def skipCUDAIfRocmVersionLessThan(version=None):
                 if not TEST_WITH_ROCM:
                     reason = "ROCm not available"
                     raise unittest.SkipTest(reason)
-                rocm_version = str(torch.version.hip)
+                rocm_version = str(torch.version.rocm)
                 rocm_version = rocm_version.split("-")[0]    # ignore git sha
                 rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
                 if rocm_version_tuple is None or version is None or rocm_version_tuple < tuple(version):
@@ -1316,10 +1316,10 @@ def skipCUDAIfNoCudnn(fn):
     return skipCUDAIfCudnnVersionLessThan(0)(fn)
 
 def skipCUDAIfMiopen(fn):
-    return skipCUDAIf(torch.version.hip is not None, "Marked as skipped for MIOpen")(fn)
+    return skipCUDAIf(torch.version.rocm is not None, "Marked as skipped for MIOpen")(fn)
 
 def skipCUDAIfNoMiopen(fn):
-    return skipCUDAIf(torch.version.hip is None, "MIOpen is not available")(skipCUDAIfNoCudnn(fn))
+    return skipCUDAIf(torch.version.rocm is None, "MIOpen is not available")(skipCUDAIfNoCudnn(fn))
 
 def skipMeta(fn):
     return skipMetaIf(True, "test doesn't work with meta tensors")(fn)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -901,7 +901,7 @@ def skipIfRocmVersionLessThan(version=None):
             if not TEST_WITH_ROCM:
                 reason = "ROCm not available"
                 raise unittest.SkipTest(reason)
-            rocm_version = str(torch.version.hip)
+            rocm_version = str(torch.version.rocm)
             rocm_version = rocm_version.split("-")[0]    # ignore git sha
             rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
             if rocm_version_tuple is None or version is None or rocm_version_tuple < tuple(version):

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -43,7 +43,7 @@ RUN_CUDA = torch.cuda.is_available()
 RUN_CUDA_MULTI_GPU = RUN_CUDA and torch.cuda.device_count() > 1
 RUN_CUDA_HALF = RUN_CUDA
 # HIP supports half, no version check necessary
-if torch.cuda.is_available() and not torch.version.hip:
+if torch.cuda.is_available() and not torch.version.rocm:
     CUDA_VERSION = torch._C._cuda_getCompiledVersion()
     for d in range(torch.cuda.device_count()):
         major = torch.cuda.get_device_capability(d)[0]

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -132,7 +132,7 @@ def get_nvidia_driver_version(run_lambda):
 
 
 def get_gpu_info(run_lambda):
-    if get_platform() == 'darwin' or (TORCH_AVAILABLE and hasattr(torch.version, 'hip') and torch.version.hip is not None):
+    if get_platform() == 'darwin' or (TORCH_AVAILABLE and hasattr(torch.version, 'rocm') and torch.version.rocm is not None):
         if TORCH_AVAILABLE and torch.cuda.is_available():
             return torch.cuda.get_device_name(None)
         return None
@@ -323,14 +323,14 @@ def get_env_info():
         debug_mode_str = str(torch.version.debug)
         cuda_available_str = str(torch.cuda.is_available())
         cuda_version_str = torch.version.cuda
-        if not hasattr(torch.version, 'hip') or torch.version.hip is None:  # cuda version
+        if not hasattr(torch.version, 'hip') or torch.version.rocm is None:  # cuda version
             hip_compiled_version = hip_runtime_version = miopen_runtime_version = 'N/A'
         else:  # HIP version
             cfg = torch._C._show_config().split('\n')
             hip_runtime_version = [s.rsplit(None, 1)[-1] for s in cfg if 'HIP Runtime' in s][0]
             miopen_runtime_version = [s.rsplit(None, 1)[-1] for s in cfg if 'MIOpen' in s][0]
             cuda_version_str = 'N/A'
-            hip_compiled_version = torch.version.hip
+            hip_compiled_version = torch.version.rocm
     else:
         version_str = debug_mode_str = cuda_available_str = cuda_version_str = 'N/A'
         hip_compiled_version = hip_runtime_version = miopen_runtime_version = 'N/A'

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -126,7 +126,7 @@ def _find_rocm_home() -> Optional[str]:
             rocm_home = '/opt/rocm'
             if not os.path.exists(rocm_home):
                 rocm_home = None
-    if rocm_home and torch.version.hip is None:
+    if rocm_home and torch.version.rocm is None:
         print(f"No ROCm runtime is found, using ROCM_HOME='{rocm_home}'")
     return rocm_home
 
@@ -191,10 +191,10 @@ environment variable or add NVCC to your system PATH. The extension compilation 
 ROCM_HOME = _find_rocm_home()
 MIOPEN_HOME = _join_rocm_home('miopen') if ROCM_HOME else None
 HIP_HOME = _join_rocm_home('hip') if ROCM_HOME else None
-IS_HIP_EXTENSION = True if ((ROCM_HOME is not None) and (torch.version.hip is not None)) else False
+IS_HIP_EXTENSION = True if ((ROCM_HOME is not None) and (torch.version.rocm is not None)) else False
 ROCM_VERSION = None
-if torch.version.hip is not None:
-    ROCM_VERSION = tuple(int(v) for v in torch.version.hip.split('.')[:2])
+if torch.version.rocm is not None:
+    ROCM_VERSION = tuple(int(v) for v in torch.version.rocm.split('.')[:2])
 
 CUDA_HOME = _find_cuda_home()
 CUDNN_HOME = os.environ.get('CUDNN_HOME') or os.environ.get('CUDNN_PATH')


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
rename torch.version.hip to torch.version.rocm , and torch.version.rocm to reflect installed rocm version