### PR TITLE
[ONNX] reduce log spam when exporting dropout in training mode

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -10162,6 +10162,7 @@ class _TestONNXRuntime:
             model,
             input=(x,),
             opset_version=self.opset_version,
+            do_constant_folding=False,
             training=torch.onnx.TrainingMode.TRAINING,
         )
         ort_outs = run_ort(ort_sess, (x,))
@@ -10173,6 +10174,7 @@ class _TestONNXRuntime:
             script_model,
             input=(x,),
             opset_version=self.opset_version,
+            do_constant_folding=False,
             training=torch.onnx.TrainingMode.TRAINING,
         )
         ort_outs = run_ort(ort_sess, (x,))
@@ -10203,6 +10205,7 @@ class _TestONNXRuntime:
             model,
             input=(x,),
             opset_version=self.opset_version,
+            do_constant_folding=False,
             training=torch.onnx.TrainingMode.TRAINING,
         )
         ort_outs = run_ort(ort_sess, (x,))
@@ -10224,6 +10227,7 @@ class _TestONNXRuntime:
             script_model,
             input=(x,),
             opset_version=self.opset_version,
+            do_constant_folding=False,
             training=torch.onnx.TrainingMode.TRAINING,
         )
         ort_outs = run_ort(ort_sess, (x,))

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -1,5 +1,4 @@
 import sys
-import warnings
 
 import torch
 from torch.onnx import symbolic_helper
@@ -51,15 +50,11 @@ def outer(g, input, other):
 @symbolic_helper.parse_args("v", "f", "i")
 def dropout(g, input, p, train):
     symbolic_helper.check_training_mode(train, "dropout")
-    # in eval mode, dropout is non-op - if the node's train param is set to False, dropout is non-op
+    # if train is False, dropout is no-op
     if not train:
         return input
-    warnings.warn(
-        "Dropout is a training op and should not be exported in inference mode. "
-        "For inference, make sure to call eval() on the model and to export it with param training=False."
-    )
     p = g.op("Constant", value_t=torch.tensor(p))
-    t = g.op("Constant", value_t=torch.tensor(True))
+    t = g.op("Constant", value_t=torch.tensor(train))
     r, _ = g.op("Dropout", input, p, t, outputs=2)
     return r
 

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -54,7 +54,7 @@ def dropout(g, input, p, train):
     if not train:
         return input
     p = g.op("Constant", value_t=torch.tensor(p))
-    t = g.op("Constant", value_t=torch.tensor(train))
+    t = g.op("Constant", value_t=torch.tensor(train, dtype=torch.bool))
     r, _ = g.op("Dropout", input, p, t, outputs=2)
     return r
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2376,13 +2376,9 @@ def exp(g, self):
 @symbolic_helper.parse_args("v", "f", "i")
 def dropout(g, input, p, train):
     symbolic_helper.check_training_mode(train, "dropout")
-    # in eval mode, dropout is non-op - if the node's train param is set to False, dropout is non-op
+    # if train is False, dropout is no-op
     if not train:
         return input
-    warnings.warn(
-        "Dropout is a training op and should not be exported in inference mode. "
-        "For inference, make sure to call eval() on the model and to export it with param training=False."
-    )
     r, _ = g.op("Dropout", input, ratio_f=p, outputs=2)
     return r
 


### PR DESCRIPTION
The default for `torch.onnx.export` is `TrainingMode.EVAL`:
https://github.com/pytorch/pytorch/blob/0d76299ff782224810b997d99f8af490cd96eede/torch/onnx/__init__.py#L63

That means that this warning is only printed when the caller overrides
that and explicitly specifies that they want training ops like Dropout.
We should assume the user knows what they're doing and not warn.

Also set `do_constant_folding=False` in the dropout related training tests. Without this, warnings are printed like:
```
UserWarning: It is recommended that constant folding be turned off ('do_constant_folding=False') when exporting the model in training-amenable mode
```