### PR TITLE
Update PyTorch/XLA git clone branch name for 1.12

### DIFF
--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -99,6 +99,6 @@ function checkout_install_torchvision() {
 
 function clone_pytorch_xla() {
   if [[ ! -d ./xla ]]; then
-    git clone --recursive -b release/1.12 https://github.com/pytorch/xla.git
+    git clone --recursive -b r1.12 https://github.com/pytorch/xla.git
   fi
 }


### PR DESCRIPTION
Update PyTorch/XLA git clone branch name for 1.12

Originally approved in https://github.com/pytorch/pytorch/pull/77993#pullrequestreview-985473713. Opened a new PR since local git history was messed up. 