### PR TITLE
Remove hardcoded -pthread

### DIFF
--- a/.jenkins/pytorch/build-asan.sh
+++ b/.jenkins/pytorch/build-asan.sh
@@ -20,23 +20,9 @@ if [ -n "$(which conda)" ]; then
   export CMAKE_PREFIX_PATH=/opt/conda
 fi
 
-# FIXME: Remove the hardcoded "-pthread" option.
-# With asan build, the cmake thread CMAKE_HAVE_LIBC_CREATE[1] checking will
-# succeed because "pthread_create" is in libasan.so. However, libasan doesn't
-# have the full pthread implementation. Other advanced pthread functions doesn't
-# exist in libasan.so[2]. If we need some pthread advanced functions, we still
-# need to link the pthread library.
-# This issue is already fixed in cmake 3.13[3]. If we use the newer cmake, we
-# could remove this hardcoded option.
-#
-# [1] https://github.com/Kitware/CMake/blob/8cabaaf054a16ea9c8332ce8e9291bd026b38c62/Modules/FindThreads.cmake#L135
-# [2] https://wiki.gentoo.org/wiki/AddressSanitizer/Problems
-# [3] https://github.com/Kitware/CMake/commit/e9a1ddc594de6e6251bf06d732775dae2cabe4c8
-#
 # TODO: Make the ASAN flags a centralized env var and unify with USE_ASAN option
 CC="clang" CXX="clang++" LDSHARED="clang --shared" \
-  CFLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -fsanitize-address-use-after-scope -shared-libasan -pthread" \
-  CXX_FLAGS="-pthread" \
+  CFLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -fsanitize-address-use-after-scope -shared-libasan" \
   USE_ASAN=1 USE_CUDA=0 USE_MKLDNN=0 \
   python setup.py bdist_wheel
   python -mpip install dist/*.whl


### PR DESCRIPTION
As the minimum cmake now is 3.13, the hardcoded pthread flag is no longer needed.