### PR TITLE
Register the extension device module as a native module under torch namespace

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -920,6 +920,8 @@ def _register_device_module(device_type, module):
         raise RuntimeError("The runtime module of '{}' has already "
                            "been registered with '{}'".format(device_type, getattr(m, device_type)))
     setattr(m, device_type, module)
+    torch_module_name = '.'.join([__name__, device_type])
+    sys.modules[torch_module_name] = module
 
 # expose return_types
 from . import return_types


### PR DESCRIPTION
## Motivation
Enhance the _register_device_module to register the extension device module as a native module under torch namespace. The user can use the extension device module as a native module in torch namespace.
e.g:
```
import torch.xpu as gpu
from torch.xpu import Event

```