### PR TITLE
[docs] Move a sentence from `nn.Transformer` to `nn.TransformerEncoder`

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/transformer.h
+++ b/torch/csrc/api/include/torch/nn/modules/transformer.h
@@ -19,8 +19,7 @@ namespace nn {
 /// is based on the paper "Attention Is All You Need". Ashish Vaswani, Noam Shazeer,
 /// Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N Gomez, Lukasz Kaiser, and
 /// Illia Polosukhin. 2017. Attention is all you need. In Advances in Neural Information
-/// Processing Systems, pages 6000-6010. Users can build the BERT(https://arxiv.org/abs/1810.04805)
-/// model with corresponding parameters.
+/// Processing Systems, pages 6000-6010.
 ///
 /// See https://pytorch.org/docs/stable/generated/torch.nn.Transformer.html to
 /// learn about the exact behavior of this transformer model

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -18,8 +18,7 @@ class Transformer(Module):
     is based on the paper "Attention Is All You Need". Ashish Vaswani, Noam Shazeer,
     Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N Gomez, Lukasz Kaiser, and
     Illia Polosukhin. 2017. Attention is all you need. In Advances in Neural Information
-    Processing Systems, pages 6000-6010. Users can build the BERT(https://arxiv.org/abs/1810.04805)
-    model with corresponding parameters.
+    Processing Systems, pages 6000-6010.
 
     Args:
         d_model: the number of expected features in the encoder/decoder inputs (default=512).
@@ -164,7 +163,8 @@ class Transformer(Module):
 
 
 class TransformerEncoder(Module):
-    r"""TransformerEncoder is a stack of N encoder layers
+    r"""TransformerEncoder is a stack of N encoder layers. Users can build the
+    BERT(https://arxiv.org/abs/1810.04805) model with corresponding parameters.
 
     Args:
         encoder_layer: an instance of the TransformerEncoderLayer() class (required).


### PR DESCRIPTION
`nn.Transformer` is not possible to be used to implement BERT, while `nn.TransformerEncoder` does. So this PR moves the sentence 'Users can build the BERT model with corresponding parameters.' from `nn.Transformer` to `nn.TransformerEncoder`.

Fixes #68053