### PR TITLE
[ci] try pinning protobuf version for coreml build

### DIFF
--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -159,7 +159,7 @@ jobs:
           cd "${GITHUB_WORKSPACE}/ios/TestApp/benchmark"
           mkdir -p ../models
           if [ "${USE_COREML_DELEGATE}" == 1 ]; then
-            pip install coremltools==5.0b5
+            pip install coremltools==5.0b5 protobuf==3.20.1
             pip install six==1.16.0
             python coreml_backend.py
           else


### PR DESCRIPTION
coreml jobs started failing due to a BC-breaking update to protobuf
(see:
https://hud.pytorch.org/pytorch/pytorch/commit/e9d0f5fb17ad30939b7217f1a1d0552a6d005ba0
for an example error).

This PR attempts to pin the protobuf version as suggested by the error
message.
