### PR TITLE
Fix coreml ios workflow

### DIFF
--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -159,7 +159,7 @@ jobs:
           cd "${GITHUB_WORKSPACE}/ios/TestApp/benchmark"
           mkdir -p ../models
           if [ "${USE_COREML_DELEGATE}" == 1 ]; then
-            pip install coremltools==5.0b5
+            pip install coremltools==5.0b5 protobuf==3.20.1
             pip install six==1.16.0
             python coreml_backend.py
           else


### PR DESCRIPTION
Which were broken by https://pypi.org/project/protobuf/4.21.0/ release
Fix by installing pinned version of coremltools with pinned version of protobuf
