### PR TITLE
[Docker] Pin protobuf to 3.20.1

### DIFF
--- a/.circleci/docker/requirements-ci.txt
+++ b/.circleci/docker/requirements-ci.txt
@@ -128,9 +128,9 @@ numba==0.54.1 ; python_version == "3.9"
 #Pinned versions:
 #test that import:
 
-#protobuf
+protobuf==3.20.1
 #Description:  Google’s data interchange format
-#Pinned versions:
+#Pinned versions: 3.20.1
 #test that import: test_tensorboard.py
 
 psutil


### PR DESCRIPTION
To protect CI from sudden version updates, that are not compatible with other packages

Fixes https://github.com/pytorch/pytorch/issues/78362
