### PR TITLE
[ONNX] Fix typo when comparing DeviceObjType (#78085)

### DIFF
--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -5009,11 +5009,11 @@ class Prim:
     def device(ctx: torch.onnx.SymbolicContext, g, *inputs, **kwargs):
         n = ctx.cur_node
 
-        if n.output().type().kind() == "_C.DeviceObjType":
+        if n.output().type().kind() == "DeviceObjType":
             return None
 
         return symbolic_helper._unimplemented(
-            "prim::device", "output type is not `_C.DeviceObjType`."
+            "prim::device", "output type is not `DeviceObjType`."
         )
 
     @staticmethod


### PR DESCRIPTION
#77423 Introduced a typo in

https://github.com/pytorch/pytorch/blob/1db9be70a7a76a028dbeae427839c9541fd5a7ab/torch/onnx/symbolic_opset9.py#L5012-L5017

where the string `DeviceObjType` was replaced with `_C.DeviceObjType`. This PR reverts the changes to the strings.

**Tested:**

With torchvision,

```
pytest test/test_onnx.py::TestONNXExporter::test_mask_rcnn
pytest -n auto test/test_onnx.py::TestONNXExporter
```
Pull Request resolved: https://github.com/pytorch/pytorch/pull/78085
Approved by: https://github.com/datumbox, https://github.com/BowenBao, https://github.com/ezyang


