### PR TITLE
fixing invalid upstream for rebase to viable/strict

### DIFF
--- a/.github/scripts/test_tryrebase.py
+++ b/.github/scripts/test_tryrebase.py
@@ -31,11 +31,11 @@ class TestRebase(TestCase):
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
         rebase_onto(pr, repo, False, True)
         calls = [mock.call('fetch', 'origin', 'pull/31093/head:pull/31093/head'),
-                 mock.call('rebase', 'viable/strict', 'pull/31093/head'),
+                 mock.call('rebase', 'refs/remotes/origin/viable/strict', 'pull/31093/head'),
                  mock.call('push', '-f', 'https://github.com/mingxiaoh/pytorch.git', 'pull/31093/head:master')]
         mocked_run_git.assert_has_calls(calls)
         self.assertTrue(
-            "Successfully rebased `master` onto `viable/strict`" in mocked_post_comment.call_args[0][3])
+            "Successfully rebased `master` onto `refs/remotes/origin/viable/strict`" in mocked_post_comment.call_args[0][3])
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
     @mock.patch('gitutils.GitRepo._run_git', return_value="Everything up-to-date")

--- a/.github/scripts/tryrebase.py
+++ b/.github/scripts/tryrebase.py
@@ -20,7 +20,7 @@ def parse_args() -> Any:
 
 def rebase_onto(pr: GitHubPR, repo: GitRepo, dry_run: bool = False, stable: bool = False) -> None:
     branch = f"pull/{pr.pr_num}/head"
-    onto_branch = "viable/strict" if stable else pr.default_branch()
+    onto_branch = "refs/remotes/origin/viable/strict" if stable else pr.default_branch()
     remote_url = f"https://github.com/{pr.info['headRepository']['nameWithOwner']}.git"
     refspec = f"{branch}:{pr.head_ref()}"
 
@@ -44,7 +44,7 @@ def rebase_ghstack_onto(pr: GitHubPR, repo: GitRepo, dry_run: bool = False, stab
     if subprocess.run([sys.executable, "-m", "ghstack", "--help"], capture_output=True).returncode != 0:
         subprocess.run([sys.executable, "-m", "pip", "install", "ghstack"])
     orig_ref = f"{re.sub(r'/head$', '/orig', pr.head_ref())}"
-    onto_branch = "viable/strict" if stable else pr.default_branch()
+    onto_branch = "refs/remotes/origin/viable/strict" if stable else pr.default_branch()
 
     repo.fetch(orig_ref, orig_ref)
     repo._run_git("rebase", onto_branch, orig_ref)

--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -1,7 +1,6 @@
 name: Rebase PR
 
 on:
-  pull_request:
   repository_dispatch:
     types: [try-rebase]
 
@@ -19,6 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.MERGEBOT_TOKEN }}
 
       - name: Setup committer id
         run: |
@@ -27,8 +27,14 @@ jobs:
 
       - name: Rebase
         env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
           GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           STABLE: ${{ github.event.client_payload.stable}}
         run: |
-          python3 .github/scripts/tryrebase.py --stable 78360
+          set -ex
+          if [ -n "${STABLE}" ]; then
+            python3 .github/scripts/tryrebase.py --stable "${PR_NUM}"
+          else
+            python3 .github/scripts/tryrebase.py "${PR_NUM}"
+          fi

--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -1,6 +1,7 @@
 name: Rebase PR
 
 on:
+  pull_request:
   repository_dispatch:
     types: [try-rebase]
 
@@ -32,9 +33,4 @@ jobs:
           GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           STABLE: ${{ github.event.client_payload.stable}}
         run: |
-          set -ex
-          if [ -n "${STABLE}" ]; then
-            python3 .github/scripts/tryrebase.py --stable "${PR_NUM}"
-          else
-            python3 .github/scripts/tryrebase.py "${PR_NUM}"
-          fi
+          python3 .github/scripts/tryrebase.py --stable 78360

--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.MERGEBOT_TOKEN }}
 
       - name: Setup committer id
         run: |
@@ -28,7 +27,6 @@ jobs:
 
       - name: Rebase
         env:
-          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
           GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           STABLE: ${{ github.event.client_payload.stable}}


### PR DESCRIPTION
Testing rebase functionality [#78360](https://github.com/pytorch/pytorch/pull/78360) failed due to `invalid upstream 'viable/strict'`. Fixing by changing branch string to "refs/remotes/origin/viable/strict"