### PR TITLE
[ONNX] Fix `check_training_mode` in symbolic_helper

### DIFF
--- a/test/onnx/test_symbolic_helper.py
+++ b/test/onnx/test_symbolic_helper.py
@@ -30,11 +30,13 @@ class TestHelperFunctions(common_utils.TestCase):
             ),
         ],
     )
-    def test_check_training_mode_does_nothing_when(
+    def test_check_training_mode_does_not_warn_when(
         self, op_train_mode: int, export_mode: torch.onnx.TrainingMode
     ):
         GLOBALS.training_mode = export_mode
-        symbolic_helper.check_training_mode(op_train_mode, "testop")
+        self.assertNotWarn(
+            lambda: symbolic_helper.check_training_mode(op_train_mode, "testop")
+        )
 
     @common_utils.parametrize(
         "op_train_mode,export_mode",

--- a/test/onnx/test_symbolic_helper.py
+++ b/test/onnx/test_symbolic_helper.py
@@ -21,11 +21,11 @@ class TestHelperFunctions(common_utils.TestCase):
                 [1, torch.onnx.TrainingMode.PRESERVE], name="export_mode_is_preserve"
             ),
             common_utils.subtest(
-                [0, torch.onnx.TrainingMode.TRAINING],
+                [0, torch.onnx.TrainingMode.EVAL],
                 name="modes_match_op_train_mode_0_export_mode_eval",
             ),
             common_utils.subtest(
-                [0, torch.onnx.TrainingMode.TRAINING],
+                [1, torch.onnx.TrainingMode.TRAINING],
                 name="modes_match_op_train_mode_1_export_mode_training",
             ),
         ],

--- a/test/onnx/test_symbolic_helper.py
+++ b/test/onnx/test_symbolic_helper.py
@@ -1,0 +1,68 @@
+"""Unit tests on `torch.onnx.symbolic_helper`."""
+
+import torch
+from torch.onnx import symbolic_helper
+from torch.onnx._globals import GLOBALS
+from torch.testing._internal import common_utils
+
+
+class TestHelperFunctions(common_utils.TestCase):
+    def setUp(self):
+        super().setUp()
+        self._initial_training_mode = GLOBALS.training_mode
+
+    def tearDown(self):
+        GLOBALS.training_mode = self._initial_training_mode
+
+    @common_utils.parametrize(
+        "op_train_mode,export_mode",
+        [
+            common_utils.subtest(
+                [1, torch.onnx.TrainingMode.PRESERVE], name="export_mode_is_preserve"
+            ),
+            common_utils.subtest(
+                [0, torch.onnx.TrainingMode.TRAINING],
+                name="modes_match_op_train_mode_0_export_mode_eval",
+            ),
+            common_utils.subtest(
+                [0, torch.onnx.TrainingMode.TRAINING],
+                name="modes_match_op_train_mode_1_export_mode_training",
+            ),
+        ],
+    )
+    def test_check_training_mode_does_nothing_when(
+        self, op_train_mode: int, export_mode: torch.onnx.TrainingMode
+    ):
+        GLOBALS.training_mode = export_mode
+        symbolic_helper.check_training_mode(op_train_mode, "testop")
+
+    @common_utils.parametrize(
+        "op_train_mode,export_mode",
+        [
+            common_utils.subtest(
+                [0, torch.onnx.TrainingMode.TRAINING],
+                name="modes_do_not_match_op_train_mode_0_export_mode_training",
+            ),
+            common_utils.subtest(
+                [1, torch.onnx.TrainingMode.EVAL],
+                name="modes_do_not_match_op_train_mode_1_export_mode_eval",
+            ),
+        ],
+    )
+    def test_check_training_mode_warns_when(
+        self,
+        op_train_mode: int,
+        export_mode: torch.onnx.TrainingMode,
+    ):
+        with self.assertWarnsRegex(
+            UserWarning, f"ONNX export mode is set to {export_mode}"
+        ):
+            GLOBALS.training_mode = export_mode
+            symbolic_helper.check_training_mode(op_train_mode, "testop")
+
+
+common_utils.instantiate_parametrized_tests(TestHelperFunctions)
+
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/test/onnx/test_symbolic_helper.py
+++ b/test/onnx/test_symbolic_helper.py
@@ -1,3 +1,4 @@
+# Owner(s): ["module: onnx"]
 """Unit tests on `torch.onnx.symbolic_helper`."""
 
 import torch

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1133,13 +1133,13 @@ def check_training_mode(op_train_mode: int, op_name: str):
         _C_onnx.TrainingMode.EVAL,
     }, "Bug: training_mode should only be 'TRAINING' or 'EVAL' at this point"
 
-    op_mode_text = (
-        "training" if op_mode_enum == _C_onnx.TrainingMode.TRAINING else "inference"
-    )
     export_mode_text = (
         "training"
         if GLOBALS.training_mode == _C_onnx.TrainingMode.TRAINING
         else "inference"
+    )
+    op_mode_text = (
+        "training" if op_mode_enum == _C_onnx.TrainingMode.TRAINING else "inference"
     )
     # setting the model mode could result in op_mode != _flags.training_mode
     # if the model is a FuncModule. In this case we warn the user of
@@ -1147,7 +1147,7 @@ def check_training_mode(op_train_mode: int, op_name: str):
     # This is to support use-cases of fixing certain layer weights
     # in training.
     warnings.warn(
-        f"ONNX export mode is set to {export_mode_text} mode, but operator {op_name} "
+        f"ONNX export mode is set to {export_mode_text} mode, but operator '{op_name}' "
         f"is set to {op_mode_text} mode. The operators will be exported in "
         f"{op_mode_text}, as specified by the functional operator."
     )

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1114,27 +1114,42 @@ def _avgpool_helper(tuple_fn, padding, kernel_size, stride, divisor_override, na
     return padding
 
 
-def check_training_mode(op_train_mode, op_name):
-    op_train_mode = True if op_train_mode == 1 else False
-    if GLOBALS.training_mode is not None and op_train_mode != GLOBALS.training_mode:
-        op_mode = "training " if op_train_mode else "inference"
-        training_mode = "training " if GLOBALS.training_mode else "inference"
-        # setting the model mode could result in op_mode != _flags.training_mode
-        # if the model is a FuncModule. In this case we warn the user of
-        # the state and export depending on op_mode
-        # This is to support use-cases of fixing certain layer weights
-        # in training.
-        warnings.warn(
-            "ONNX export mode is set to "
-            + training_mode
-            + " mode, but operator "
-            + op_name
-            + " is set to "
-            + op_mode
-            + " mode. The operators will be exported in "
-            + op_mode
-            + ", as specified by the functional operator."
-        )
+def check_training_mode(op_train_mode: int, op_name: str):
+    """Warning the user if the model's training mode and the export mode do not agree."""
+    if GLOBALS.training_mode == _C_onnx.TrainingMode.PRESERVE:
+        # Do not modify the training mode
+        return
+
+    if op_train_mode:
+        op_mode_enum = _C_onnx.TrainingMode.TRAINING
+    else:
+        op_mode_enum = _C_onnx.TrainingMode.EVAL
+    if op_mode_enum == GLOBALS.training_mode:
+        # The modes agree. Do nothing
+        return
+
+    assert (
+        GLOBALS.training_mode not in {_C_onnx.TrainingMode.TRAINING, _C_onnx.TrainingMode.EVAL}
+    ), "Bug: training_mode should only be 'TRAINING' or 'EVAL' at this point"
+
+    op_mode_text = (
+        "training" if op_mode_enum == _C_onnx.TrainingMode.TRAINING else "inference"
+    )
+    export_mode_text = (
+        "training"
+        if GLOBALS.training_mode == _C_onnx.TrainingMode.TRAINING
+        else "inference"
+    )
+    # setting the model mode could result in op_mode != _flags.training_mode
+    # if the model is a FuncModule. In this case we warn the user of
+    # the state and export depending on op_mode
+    # This is to support use-cases of fixing certain layer weights
+    # in training.
+    warnings.warn(
+        f"ONNX export mode is set to {export_mode_text} mode, but operator {op_name} "
+        f"is set to {op_mode_text} mode. The operators will be exported in "
+        f"{op_mode_text}, as specified by the functional operator."
+    )
 
 
 def _flatten_helper(g, input, start_dim, end_dim, dim):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1135,8 +1135,7 @@ def check_training_mode(op_train_mode: int, op_name: str) -> None:
     # in training.
     warnings.warn(
         f"ONNX export mode is set to {GLOBALS.training_mode}, but operator '{op_name}' "
-        f"is set to {op_mode_text}. Exporting with {op_mode_text}. "
-        f"{op_mode_text}."
+        f"is set to {op_mode_text}. Exporting with {op_mode_text}."
     )
 
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1135,7 +1135,7 @@ def check_training_mode(op_train_mode: int, op_name: str) -> None:
     # in training.
     warnings.warn(
         f"ONNX export mode is set to {GLOBALS.training_mode}, but operator '{op_name}' "
-        f"is set to {op_mode_text}. The operator will be exported in "
+        f"is set to {op_mode_text}. Exporting with {op_mode_text}. "
         f"{op_mode_text}."
     )
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1134,8 +1134,8 @@ def check_training_mode(op_train_mode: int, op_name: str) -> None:
     # This is to support use-cases of fixing certain layer weights
     # in training.
     warnings.warn(
-        f"ONNX export mode is set to {GLOBALS.training_mode} mode, but operator '{op_name}' "
-        f"is set to {op_mode_text} mode. The operator will be exported in "
+        f"ONNX export mode is set to {GLOBALS.training_mode}, but operator '{op_name}' "
+        f"is set to {op_mode_text}. The operator will be exported in "
         f"{op_mode_text}."
     )
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1117,7 +1117,6 @@ def _avgpool_helper(tuple_fn, padding, kernel_size, stride, divisor_override, na
 def check_training_mode(op_train_mode: int, op_name: str) -> None:
     """Warns the user if the model's training mode and the export mode do not agree."""
     if GLOBALS.training_mode == _C_onnx.TrainingMode.PRESERVE:
-        # Do not modify the training mode
         return
 
     if op_train_mode:
@@ -1128,28 +1127,16 @@ def check_training_mode(op_train_mode: int, op_name: str) -> None:
         # The modes agree. Do nothing
         return
 
-    assert GLOBALS.training_mode in {
-        _C_onnx.TrainingMode.TRAINING,
-        _C_onnx.TrainingMode.EVAL,
-    }, "Bug: training_mode should only be 'TRAINING' or 'EVAL' at this point"
-
-    export_mode_text = (
-        "training"
-        if GLOBALS.training_mode == _C_onnx.TrainingMode.TRAINING
-        else "inference"
-    )
-    op_mode_text = (
-        "training" if op_mode_enum == _C_onnx.TrainingMode.TRAINING else "inference"
-    )
-    # setting the model mode could result in op_mode != _flags.training_mode
+    op_mode_text = f"train={bool(op_train_mode)}"
+    # Setting the model mode could result in op_mode != GLOBALS.training_mode
     # if the model is a FuncModule. In this case we warn the user of
     # the state and export depending on op_mode
     # This is to support use-cases of fixing certain layer weights
     # in training.
     warnings.warn(
-        f"ONNX export mode is set to {export_mode_text} mode, but operator '{op_name}' "
-        f"is set to {op_mode_text} mode. The operators will be exported in "
-        f"{op_mode_text}, as specified by the functional operator."
+        f"ONNX export mode is set to {GLOBALS.training_mode} mode, but operator '{op_name}' "
+        f"is set to {op_mode_text} mode. The operator will be exported in "
+        f"{op_mode_text}."
     )
 
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1115,7 +1115,7 @@ def _avgpool_helper(tuple_fn, padding, kernel_size, stride, divisor_override, na
 
 
 def check_training_mode(op_train_mode: int, op_name: str):
-    """Warning the user if the model's training mode and the export mode do not agree."""
+    """Warns the user if the model's training mode and the export mode do not agree."""
     if GLOBALS.training_mode == _C_onnx.TrainingMode.PRESERVE:
         # Do not modify the training mode
         return
@@ -1128,9 +1128,10 @@ def check_training_mode(op_train_mode: int, op_name: str):
         # The modes agree. Do nothing
         return
 
-    assert (
-        GLOBALS.training_mode not in {_C_onnx.TrainingMode.TRAINING, _C_onnx.TrainingMode.EVAL}
-    ), "Bug: training_mode should only be 'TRAINING' or 'EVAL' at this point"
+    assert GLOBALS.training_mode not in {
+        _C_onnx.TrainingMode.TRAINING,
+        _C_onnx.TrainingMode.EVAL,
+    }, "Bug: training_mode should only be 'TRAINING' or 'EVAL' at this point"
 
     op_mode_text = (
         "training" if op_mode_enum == _C_onnx.TrainingMode.TRAINING else "inference"

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1128,7 +1128,7 @@ def check_training_mode(op_train_mode: int, op_name: str) -> None:
         # The modes agree. Do nothing
         return
 
-    assert GLOBALS.training_mode not in {
+    assert GLOBALS.training_mode in {
         _C_onnx.TrainingMode.TRAINING,
         _C_onnx.TrainingMode.EVAL,
     }, "Bug: training_mode should only be 'TRAINING' or 'EVAL' at this point"

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1114,7 +1114,7 @@ def _avgpool_helper(tuple_fn, padding, kernel_size, stride, divisor_override, na
     return padding
 
 
-def check_training_mode(op_train_mode: int, op_name: str):
+def check_training_mode(op_train_mode: int, op_name: str) -> None:
     """Warns the user if the model's training mode and the export mode do not agree."""
     if GLOBALS.training_mode == _C_onnx.TrainingMode.PRESERVE:
         # Do not modify the training mode


### PR DESCRIPTION
`check_training_mode` always warned that an op is set to training because it was comparing an int `op_train_mode` with an Enum `GLOBALS.training_mode`. This PR fixes the behavior.