### PR TITLE
[CI]Preserve `.ninja_log` for Mac builds

### DIFF
--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Archive artifacts into zip
         if: inputs.build-generates-artifacts
         run: |
-          zip -1 -r artifacts.zip dist/
+          zip -1 -r artifacts.zip dist/ build/.ninja_log build/compile_commands.json
 
       - name: Store PyTorch Build Artifacts on GHA
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
And `compile_commands.json` which would be very useful for debug

