### PR TITLE
[JIT] Autodiff - use more accurate requires_grad info

### DIFF
--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -356,6 +356,28 @@ static Value* createAutogradAdd(Value* a, Value* b) {
   return graph->insertNode(graph->create(prim::AutogradAdd, {a, b}))->output();
 }
 
+namespace {
+bool outputRequiresGrad(Value* output) {
+  if (output->type()->castRaw<TensorType>() == nullptr) {
+    return output->requires_grad();
+  }
+  c10::optional<bool> requiresGrad =
+      output->type()->expectRef<TensorType>().requiresGrad();
+  if (requiresGrad.has_value()) {
+    return *requiresGrad;
+  }
+
+  Node* n = output->node();
+  if (n->kind() != prim::profile) {
+    return true;
+  }
+  if (!n->hasAttribute(attr::profiled_type)) {
+    return true;
+  }
+  return n->ty(attr::profiled_type)->requires_grad();
+}
+} // namespace
+
 // Before:
 //   - grad_desc has field f initialized to the original 0-stage graph
 // After:
@@ -395,7 +417,7 @@ static ReverseDetails addReverseInline(Gradient& grad_desc) {
   auto outputs = graph.outputs();
   for (size_t i = 0, num_outputs = outputs.size(); i < num_outputs; ++i) {
     Value* output = outputs[i];
-    if (!output->requires_grad())
+    if (!outputRequiresGrad(output))
       continue;
     Value* output_grad = reverse_block->addInput()->setType(output->type());
     GRAPH_DEBUG(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #78875
* __->__ #78392

When autodiff is constructing the Gradient object, it looks at the
forward graph and records all the outputs that requires_grad into
df_input_vjps. Then at runtime, graph_executor.cpp will detach the
tensors before running the autodiff forward graph, and then add
requires_grad back onto the outputs if they need requires_grad.

Before, the require_grad check was done by just checking
`output->requires_grad()`. But at the point when autodiff is called by
profiling executor, the profiled information is still in the profile
nodes, not on values. So requires_grad would not be set on the output
values, and requires_grad() would default to True on all tensors. As a
result more output tensors than expected would require_grad.

Differential Revision: [D36721504](https://our.internmc.facebook.com/intern/diff/D36721504)