### PR TITLE
Add nn.module activation support in BetterTransformer

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -378,9 +378,9 @@ class TransformerEncoderLayer(Module):
 
         # We can't test self.activation in forward() in TorchScript,
         # so stash some information about it instead.
-        if activation is F.relu:
+        if activation is F.relu or isinstance(activation, torch.nn.ReLU):
             self.activation_relu_or_gelu = 1
-        elif activation is F.gelu:
+        elif activation is F.gelu or isinstance(activation, torch.nn.GELU):
             self.activation_relu_or_gelu = 2
         else:
             self.activation_relu_or_gelu = 0


### PR DESCRIPTION
Summary:
textray is using nn.module as activation function params, since functional is not scriptable in textray's module.
Therefore we should support this in nn.module as well.

Test Plan: CI

Differential Revision: D36678078

