### PR TITLE
added stub script that prints out latest commits

### DIFF
--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -1,0 +1,28 @@
+import sys
+import subprocess
+from datetime import datetime
+from datetime import timedelta
+
+def print_latest_commits(mins = 60):
+    current_time = datetime.now()
+    time_since = current_time - timedelta(minutes=mins)
+    timestamp_since = datetime.timestamp(time_since)
+
+    commits = subprocess.check_output(
+            [
+                "git",
+                "rev-list",
+                f"--max-age={timestamp_since}",
+                "--all",
+            ],
+            encoding="ascii",
+        ).splitlines()
+
+    for commit in commits:
+        print(commit)
+
+def main() -> None:
+    print_latest_commits() if len(sys.argv) == 1 else print_latest_commits(int(sys.argv[1]))
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -1,13 +1,20 @@
 import sys
-import subprocess
+from typing import Any
 from datetime import datetime, timedelta
+from gitutils import _check_output
 
-def print_latest_commits(mins: int = 60) -> None:
+def parse_args() -> Any:
+    from argparse import ArgumentParser
+    parser = ArgumentParser("Print latest commits")
+    parser.add_argument("--minutes", type=int, help = "duration in minutes of last commits")
+    return parser.parse_args()
+
+def print_latest_commits(minutes: int = 60) -> None:
     current_time = datetime.now()
-    time_since = current_time - timedelta(minutes=mins)
+    time_since = current_time - timedelta(minutes=minutes)
     timestamp_since = datetime.timestamp(time_since)
 
-    commits = subprocess.check_output(
+    commits = _check_output(
         [
             "git",
             "rev-list",
@@ -21,7 +28,8 @@ def print_latest_commits(mins: int = 60) -> None:
         print(commit)
 
 def main() -> None:
-    print_latest_commits() if len(sys.argv) == 1 else print_latest_commits(int(sys.argv[1]))
+    args = parse_args()
+    print_latest_commits(args.minutes)
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -1,7 +1,6 @@
 import sys
 import subprocess
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 def print_latest_commits(mins: int = 60) -> None:
     current_time = datetime.now()

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -5,7 +5,7 @@ from gitutils import _check_output
 def parse_args() -> Any:
     from argparse import ArgumentParser
     parser = ArgumentParser("Print latest commits")
-    parser.add_argument("--minutes", type=int, help="duration in minutes of last commits")
+    parser.add_argument("--minutes", type=int, default=60, help="duration in minutes of last commits")
     return parser.parse_args()
 
 def print_latest_commits(minutes: int = 60) -> None:

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Any
 from datetime import datetime, timedelta
 from gitutils import _check_output
@@ -6,7 +5,7 @@ from gitutils import _check_output
 def parse_args() -> Any:
     from argparse import ArgumentParser
     parser = ArgumentParser("Print latest commits")
-    parser.add_argument("--minutes", type=int, help = "duration in minutes of last commits")
+    parser.add_argument("--minutes", type=int, help="duration in minutes of last commits")
     return parser.parse_args()
 
 def print_latest_commits(minutes: int = 60) -> None:

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -3,20 +3,20 @@ import subprocess
 from datetime import datetime
 from datetime import timedelta
 
-def print_latest_commits(mins = 60):
+def print_latest_commits(mins: int = 60) -> None:
     current_time = datetime.now()
     time_since = current_time - timedelta(minutes=mins)
     timestamp_since = datetime.timestamp(time_since)
 
     commits = subprocess.check_output(
-            [
-                "git",
-                "rev-list",
-                f"--max-age={timestamp_since}",
-                "--all",
-            ],
-            encoding="ascii",
-        ).splitlines()
+        [
+            "git",
+            "rev-list",
+            f"--max-age={timestamp_since}",
+            "--all",
+        ],
+        encoding="ascii",
+    ).splitlines()
 
     for commit in commits:
         print(commit)


### PR DESCRIPTION
Relates to #76700

Prints out a list of commit SHAs from the last M minutes. Takes in a command line argument for the minutes, otherwise defaults to 60 mins.

**Test Plan**: compare output with the SHAs from the HUD and see if they are correct. Some SHAS printed with the script are not included on the HUD, but all of the commits on the HUD are outputted correctly.