### PR TITLE
[PyTorch] Un-gate cat_serial_kernel for scalar types

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -343,7 +343,8 @@ TORCH_IMPL_FUNC(cat_out_cpu)
   // fast path for single thread when both inputs and result are contiguous and not empty
   bool use_serial_kernel = result.numel() < at::internal::GRAIN_SIZE || at::get_num_threads() == 1;
   ScalarType dtype = materialized[valid].get().scalar_type();
-  bool serial_dtype = (dtype == ScalarType::Double || dtype == ScalarType::Float || dtype == ScalarType::BFloat16);
+#define CHECK_DTYPE(_, type) || (dtype == (ScalarType::type))
+  bool serial_dtype = true AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, CHECK_DTYPE);
   if (use_serial_kernel && all_contiguous && all_same_dtype && serial_dtype) {
     cat_serial_stub(kCPU, result, materialized, dim);
     return;

--- a/aten/src/ATen/native/cpu/CatKernel.cpp
+++ b/aten/src/ATen/native/cpu/CatKernel.cpp
@@ -56,7 +56,7 @@ void cat_serial_kernel_impl(const Tensor& result, const MaterializedITensorListR
 }
 
 void cat_serial_kernel(const Tensor& result, const MaterializedITensorListRef& tensors, int64_t dim) {
-  AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, result.scalar_type(), "cat_serial_kernel", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND3(ScalarType::Bool, ScalarType::Half, ScalarType::BFloat16, result.scalar_type(), "cat_serial_kernel", [&]() {
     cat_serial_kernel_impl<scalar_t>(result, tensors, dim);
   });
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #78403

There doesn't seem to be any reason to gate it?

Differential Revision: [D36726796](https://our.internmc.facebook.com/intern/diff/D36726796/)