### PR TITLE
Apply clang-format to ATen headers

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -41,6 +41,7 @@ init_command = [
 [[linter]]
 code = 'CLANGFORMAT'
 include_patterns = [
+    'aten/src/ATen/*.h',
     'c10/**/*.h',
     'c10/**/*.cpp',
     'torch/csrc/jit/**/*.h',

--- a/aten/src/ATen/ATen.h
+++ b/aten/src/ATen/ATen.h
@@ -4,8 +4,6 @@
 #error C++14 or later compatible compiler is required to use ATen.
 #endif
 
-#include <c10/core/Allocator.h>
-#include <ATen/core/ATenGeneral.h>
 #include <ATen/Context.h>
 #include <ATen/Device.h>
 #include <ATen/DeviceGuard.h>
@@ -22,13 +20,14 @@
 #include <ATen/Version.h>
 #include <ATen/core/ATenGeneral.h>
 #include <ATen/core/Generator.h>
-#include <c10/core/Layout.h>
-#include <ATen/core/Scalar.h>
-#include <c10/core/Storage.h>
-#include <c10/core/TensorOptions.h>
 #include <ATen/core/Reduction.h>
-#include <c10/util/Exception.h>
+#include <ATen/core/Scalar.h>
 #include <ATen/core/UnsafeFromTH.h>
 #include <ATen/core/ivalue.h>
 #include <ATen/core/jit_type.h>
+#include <c10/core/Allocator.h>
 #include <c10/core/InferenceMode.h>
+#include <c10/core/Layout.h>
+#include <c10/core/Storage.h>
+#include <c10/core/TensorOptions.h>
+#include <c10/util/Exception.h>

--- a/aten/src/ATen/AccumulateType.h
+++ b/aten/src/ATen/AccumulateType.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <ATen/Config.h>
-#include <c10/util/Half.h>
-#include <c10/util/BFloat16.h>
 #include <c10/core/ScalarType.h>
+#include <c10/util/BFloat16.h>
+#include <c10/util/Half.h>
 
 // Defines the accumulation type for a scalar type.
 // Example:
@@ -43,48 +43,129 @@
 #include <cuda.h>
 #include <cuda_fp16.h>
 #elif defined(__HIPCC__)
-#include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
 #endif
 
 namespace at {
 
 template <typename T, bool is_cuda>
-struct AccumulateType { };
+struct AccumulateType {};
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
-template <> struct AccumulateType<half, true> { using type = float; };
+template <>
+struct AccumulateType<half, true> {
+  using type = float;
+};
 #endif
-template <> struct AccumulateType<BFloat16, true> {using type = float; };
-template <> struct AccumulateType<Half, true> { using type = float; };
-template <> struct AccumulateType<float, true> { using type = float; };
-template <> struct AccumulateType<double, true> { using type = double; };
-template <> struct AccumulateType<int8_t, true> { using type = int64_t; };
-template <> struct AccumulateType<uint8_t, true> { using type = int64_t; };
-template <> struct AccumulateType<char, true> { using type = int64_t; };
-template <> struct AccumulateType<int16_t, true> { using type = int64_t; };
-template <> struct AccumulateType<int32_t, true> { using type = int64_t; };
-template <> struct AccumulateType<int64_t, true> { using type = int64_t; };
-template <> struct AccumulateType<bool, true> {using type = bool; };
-template <> struct AccumulateType<Half, false> { using type = float; };
-template <> struct AccumulateType<BFloat16, false> { using type = float; };
-template <> struct AccumulateType<c10::complex<float>, false> { using type = c10::complex<double>; };
-template <> struct AccumulateType<c10::complex<double>, false> { using type = c10::complex<double>; };
-template <> struct AccumulateType<c10::complex<float>, true> { using type = c10::complex<float>; };
-template <> struct AccumulateType<c10::complex<double>, true> { using type = c10::complex<double>; };
-template <> struct AccumulateType<float, false> { using type = double; };
-template <> struct AccumulateType<double, false> { using type = double; };
-template <> struct AccumulateType<int8_t, false> { using type = int64_t; };
-template <> struct AccumulateType<uint8_t, false> { using type = int64_t; };
-template <> struct AccumulateType<char, false> { using type = int64_t; };
-template <> struct AccumulateType<int16_t, false> { using type = int64_t; };
-template <> struct AccumulateType<int32_t, false> { using type = int64_t; };
-template <> struct AccumulateType<int64_t, false> { using type = int64_t; };
-template <> struct AccumulateType<bool, false> {using type = bool; };
+template <>
+struct AccumulateType<BFloat16, true> {
+  using type = float;
+};
+template <>
+struct AccumulateType<Half, true> {
+  using type = float;
+};
+template <>
+struct AccumulateType<float, true> {
+  using type = float;
+};
+template <>
+struct AccumulateType<double, true> {
+  using type = double;
+};
+template <>
+struct AccumulateType<int8_t, true> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<uint8_t, true> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<char, true> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<int16_t, true> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<int32_t, true> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<int64_t, true> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<bool, true> {
+  using type = bool;
+};
+template <>
+struct AccumulateType<Half, false> {
+  using type = float;
+};
+template <>
+struct AccumulateType<BFloat16, false> {
+  using type = float;
+};
+template <>
+struct AccumulateType<c10::complex<float>, false> {
+  using type = c10::complex<double>;
+};
+template <>
+struct AccumulateType<c10::complex<double>, false> {
+  using type = c10::complex<double>;
+};
+template <>
+struct AccumulateType<c10::complex<float>, true> {
+  using type = c10::complex<float>;
+};
+template <>
+struct AccumulateType<c10::complex<double>, true> {
+  using type = c10::complex<double>;
+};
+template <>
+struct AccumulateType<float, false> {
+  using type = double;
+};
+template <>
+struct AccumulateType<double, false> {
+  using type = double;
+};
+template <>
+struct AccumulateType<int8_t, false> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<uint8_t, false> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<char, false> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<int16_t, false> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<int32_t, false> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<int64_t, false> {
+  using type = int64_t;
+};
+template <>
+struct AccumulateType<bool, false> {
+  using type = bool;
+};
 
-template<typename T, bool is_cuda>
+template <typename T, bool is_cuda>
 using acc_type = typename AccumulateType<T, is_cuda>::type;
 
 TORCH_API c10::ScalarType toAccumulateType(c10::ScalarType type, bool is_cuda);
 
-}  // namespace at
+} // namespace at

--- a/aten/src/ATen/BatchedFallback.h
+++ b/aten/src/ATen/BatchedFallback.h
@@ -18,6 +18,8 @@ namespace at {
 // The performance of the fallback is not very good because it introduces an
 // extra copy from stacking the sliced outputs. Because of this, we prefer to
 // write batching rules for operators whenever possible.
-void batchedTensorForLoopFallback(const c10::OperatorHandle& op, torch::jit::Stack* stack);
+void batchedTensorForLoopFallback(
+    const c10::OperatorHandle& op,
+    torch::jit::Stack* stack);
 
 } // namespace at

--- a/aten/src/ATen/BatchedTensorImpl.h
+++ b/aten/src/ATen/BatchedTensorImpl.h
@@ -24,8 +24,8 @@ constexpr int64_t kBatchDimsStackSize = 5;
 // vmap. It is a (level, dim) tuple, with the `dim` indicating which dimension
 // is being vmap'ed over and the `level` being an identifier for which vmap
 // said dimension was created inside. The `dim` corresponds to a "physical
-// dim" - it is a dimension index on the underlying physical tensor that is being
-// vmapped over.
+// dim" - it is a dimension index on the underlying physical tensor that is
+// being vmapped over.
 struct BatchDim {
   BatchDim(int64_t level, int64_t dim) : dim_(dim), level_(level) {}
   int64_t dim() const {
@@ -34,6 +34,7 @@ struct BatchDim {
   int64_t level() const {
     return level_;
   }
+
  private:
   int64_t dim_;
   int64_t level_;
@@ -46,27 +47,32 @@ using BatchDimsRef = ArrayRef<BatchDim>;
 // NB: We use the term "BatchedTensor" to mean a Tensor that is backed with a
 // BatchedTensorImpl.
 //
-// The batch dimensions are treated as being "private"; they are not user-visible.
-// For example, in the following Tensor,
+// The batch dimensions are treated as being "private"; they are not
+// user-visible. For example, in the following Tensor,
 //    bt = BatchedTensorImpl(ones(2, 3, 5, 7), [(lvl=1, dim=0), (lvl=2, dim=1)])
 // dimensions 0 and 1 are batch dimensions.
 //
 // bt.sizes() returns (5, 7); bt.sum(0) performs a reduction over the (public)
-// dim 0, which is equivalent to dim 3 in the underlying ones(2, 3, 5, 7) tensor.
+// dim 0, which is equivalent to dim 3 in the underlying ones(2, 3, 5, 7)
+// tensor.
 struct TORCH_API BatchedTensorImpl : public c10::TensorImpl {
   explicit BatchedTensorImpl(Tensor value, BatchDims bdims);
 
   // Returns a reference to BatchDims that represent which dimensions of this
   // tensor are private.
-  BatchDimsRef bdims() const { return bdims_; }
+  BatchDimsRef bdims() const {
+    return bdims_;
+  }
 
   // BatchedTensorImpl wraps a Tensor
-  const Tensor& value() const { return value_; };
+  const Tensor& value() const {
+    return value_;
+  };
 
-  // Given a public dimension index, return the dimension index in the underlying
-  // value() tensor.
-  // For example, if we have
-  //    bt = BatchedTensorImpl(ones(2, 3, 5, 7), [(lvl=1, dim=0), (lvl=2, dim=2)])
+  // Given a public dimension index, return the dimension index in the
+  // underlying value() tensor. For example, if we have
+  //    bt = BatchedTensorImpl(ones(2, 3, 5, 7), [(lvl=1, dim=0), (lvl=2,
+  //    dim=2)])
   // bt.actualDim(0) -> 1
   // bt.actualDim(1) -> 3
   // bt.actualDim(2) -> Error
@@ -74,7 +80,8 @@ struct TORCH_API BatchedTensorImpl : public c10::TensorImpl {
 
   // We have to override this because we opted into CustomStrides
   IntArrayRef strides_custom() const override;
-  // Override a bunch of methods inherited from TensorImpl to return error messages.
+  // Override a bunch of methods inherited from TensorImpl to return error
+  // messages.
   bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
   void set_size(int64_t dim, int64_t new_size) override;
   void set_stride(int64_t dim, int64_t new_stride) override;
@@ -91,8 +98,9 @@ struct TORCH_API BatchedTensorImpl : public c10::TensorImpl {
   Tensor value_;
 
   // Note: [BatchedTensorImpl levels invariant]
-  // There is an invariant that the BatchDims must be stored in increasing `level`
-  // order. That is, for i < j, bdims_[i].level must be less than bdims_[j].level.
+  // There is an invariant that the BatchDims must be stored in increasing
+  // `level` order. That is, for i < j, bdims_[i].level must be less than
+  // bdims_[j].level.
   BatchDims bdims_;
 };
 
@@ -116,7 +124,8 @@ inline BatchedTensorImpl* maybeGetBatchedImpl(Tensor tensor) {
 }
 
 // Returns a bitset. If bit i is set, then that means dim i is a batchdim.
-inline std::bitset<kVmapMaxTensorDims> createBatchDimBitset(BatchDimsRef bdims) {
+inline std::bitset<kVmapMaxTensorDims> createBatchDimBitset(
+    BatchDimsRef bdims) {
   std::bitset<kVmapMaxTensorDims> is_bdim;
   for (const auto& bdim : bdims) {
     is_bdim.set(bdim.dim());
@@ -148,5 +157,4 @@ TORCH_API Tensor addBatchDim(const Tensor& tensor, int64_t level, int64_t dim);
 // See NOTE: [vmap-incompatible in-place operations] for the definition of this.
 TORCH_API bool inplaceIsVmapCompatible(const Tensor& self, const Tensor& other);
 
-
-}
+} // namespace at

--- a/aten/src/ATen/CPUApplyUtils.h
+++ b/aten/src/ATen/CPUApplyUtils.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <ATen/CollapseDims.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorUtils.h>
-#include <ATen/CollapseDims.h>
 #include <c10/util/irange.h>
+#include <cstring>
 #include <limits>
 #include <utility>
-#include <cstring>
 
 namespace at {
 
@@ -75,9 +75,7 @@ struct strided_tensor_iter_fixed {
       std::memcpy(
           sizes_, tensor.sizes().data(), tensor.dim() * sizeof(int64_t));
       std::memcpy(
-          strides_,
-          tensor.strides().data(),
-          tensor.dim() * sizeof(int64_t));
+          strides_, tensor.strides().data(), tensor.dim() * sizeof(int64_t));
     }
     dim_ = std::get<1>(collapse_dims(sizes_, strides_, tensor.ndimension()));
   }
@@ -226,8 +224,11 @@ inline int64_t max_dim(Arg& iter, Args&... iter_tail) {
 inline void apply_op(){};
 
 template <typename Op, typename... Args>
-inline void
-apply_op(int64_t numel, int64_t offset, const Op& op, Args... iters) {
+inline void apply_op(
+    int64_t numel,
+    int64_t offset,
+    const Op& op,
+    Args... iters) {
   // For 0-dim tensors
   if (numel == 1 && max_dim(iters...) == 0) {
     op(*iters.data_...);
@@ -278,8 +279,11 @@ inline void CPU_tensor_apply2(Tensor tensor1, Tensor tensor2, const Op op) {
 }
 
 template <typename scalar1, typename scalar2, typename scalar3, typename Op>
-inline void
-CPU_tensor_apply3(Tensor tensor1, Tensor tensor2, Tensor tensor3, const Op op) {
+inline void CPU_tensor_apply3(
+    Tensor tensor1,
+    Tensor tensor2,
+    Tensor tensor3,
+    const Op op) {
   if (!_apply_preamble({tensor1, tensor2, tensor3}))
     return;
   if (_max_dim_tensors({tensor1, tensor2, tensor3}) <= 8) {

--- a/aten/src/ATen/CPUFixedAllocator.h
+++ b/aten/src/ATen/CPUFixedAllocator.h
@@ -11,21 +11,23 @@
 
 namespace at {
 
-static cpu_fixed_malloc(void *, ptrdiff_t) {
+static cpu_fixed_malloc(void*, ptrdiff_t) {
   AT_ERROR("attempting to resize a tensor view of an external blob");
 }
 
-static cpu_fixed_realloc(void *, void*, ptrdiff_t) {
+static cpu_fixed_realloc(void*, void*, ptrdiff_t) {
   AT_ERROR("attempting to resize a tensor view of an external blob");
 }
 
-static cpu_fixed_free(void * state, void * allocation) {
-    auto on_release = static_cast<std::function<void(void*)>*>(state);
-    (*on_release)(allocation);
-    delete on_release;
+static cpu_fixed_free(void* state, void* allocation) {
+  auto on_release = static_cast<std::function<void(void*)>*>(state);
+  (*on_release)(allocation);
+  delete on_release;
 }
 
-static Allocator CPU_fixed_allocator =
-  { cpu_fixed_malloc, cpu_fixed_realloc, cpu_fixed_free };
+static Allocator CPU_fixed_allocator = {
+    cpu_fixed_malloc,
+    cpu_fixed_realloc,
+    cpu_fixed_free};
 
-}
+} // namespace at

--- a/aten/src/ATen/CPUGeneratorImpl.h
+++ b/aten/src/ATen/CPUGeneratorImpl.h
@@ -2,8 +2,8 @@
 
 #include <ATen/core/Generator.h>
 #include <ATen/core/MT19937RNGEngine.h>
-#include <c10/util/Optional.h>
 #include <c10/core/GeneratorImpl.h>
+#include <c10/util/Optional.h>
 
 namespace at {
 
@@ -29,7 +29,7 @@ struct TORCH_API CPUGeneratorImpl : public c10::GeneratorImpl {
   at::mt19937 engine();
   void set_engine(at::mt19937 engine);
 
-private:
+ private:
   CPUGeneratorImpl* clone_impl() const override;
   at::mt19937 engine_;
   c10::optional<float> next_float_normal_sample_;
@@ -39,8 +39,9 @@ private:
 namespace detail {
 
 TORCH_API const Generator& getDefaultCPUGenerator();
-TORCH_API Generator createCPUGenerator(uint64_t seed_val = default_rng_seed_val);
+TORCH_API Generator
+createCPUGenerator(uint64_t seed_val = default_rng_seed_val);
 
 } // namespace detail
 
-}
+} // namespace at

--- a/aten/src/ATen/CollapseDims.h
+++ b/aten/src/ATen/CollapseDims.h
@@ -91,4 +91,4 @@ inline std::pair<int64_t, int64_t> collapse_dims(
   return std::pair<int64_t, int64_t>(remappedExcludedDim, dims);
 }
 
-}
+} // namespace at

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -1,28 +1,28 @@
 #pragma once
 
-#include <ATen/core/ATenGeneral.h>
-#include <ATen/core/Generator.h>
 #include <ATen/CPUGeneratorImpl.h>
 #include <ATen/LinalgBackend.h>
-#include <ATen/core/LegacyTypeDispatch.h>
+#include <ATen/core/ATenGeneral.h>
 #include <ATen/core/DeprecatedTypeProperties.h>
+#include <ATen/core/Generator.h>
+#include <ATen/core/LegacyTypeDispatch.h>
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <ATen/detail/HIPHooksInterface.h>
 #include <ATen/detail/ORTHooksInterface.h>
-#include <c10/util/Exception.h>
-#include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/core/QEngine.h>
+#include <c10/core/impl/DeviceGuardImplInterface.h>
+#include <c10/util/Exception.h>
 #include <c10/util/irange.h>
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
-#include <cstdint>
 
 namespace at {
 
 class Tensor;
 
-enum class TORCH_API Float32MatmulPrecision {HIGHEST, HIGH, MEDIUM};
+enum class TORCH_API Float32MatmulPrecision { HIGHEST, HIGH, MEDIUM };
 
 class TORCH_API Context {
  public:
@@ -54,10 +54,10 @@ class TORCH_API Context {
   static bool isPinnedPtr(void* data) {
     return detail::getCUDAHooks().isPinnedPtr(data);
   }
-  static bool hasOpenMP() ;
-  static bool hasMKL() ;
-  static bool hasLAPACK() ;
-  static bool hasMKLDNN() ;
+  static bool hasOpenMP();
+  static bool hasMKL();
+  static bool hasLAPACK();
+  static bool hasMKLDNN();
   static bool hasMAGMA() {
     return detail::getCUDAHooks().hasMAGMA();
   }
@@ -99,14 +99,10 @@ class TORCH_API Context {
   // defined in header so that getNonVariableType has ability to inline
   // call_once check. getNonVariableType is called fairly frequently
   void lazyInitCUDA() {
-    std::call_once(thc_init,[&] {
-      detail::getCUDAHooks().initCUDA();
-    });
+    std::call_once(thc_init, [&] { detail::getCUDAHooks().initCUDA(); });
   }
   void lazyInitHIP() {
-    std::call_once(thh_init,[&] {
-      detail::getHIPHooks().initHIP();
-    });
+    std::call_once(thh_init, [&] { detail::getHIPHooks().initHIP(); });
   }
   static const at::cuda::NVRTC& getNVRTC() {
     return detail::getCUDAHooks().nvrtc();
@@ -132,20 +128,23 @@ class TORCH_API Context {
 
   // Note [Enabling Deterministic Operations]
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // Operations in PyTorch that normally act nondeterministically, but have an alternate
-  // deterministic implementation, should satisfy the following requirements:
+  // Operations in PyTorch that normally act nondeterministically, but have an
+  // alternate deterministic implementation, should satisfy the following
+  // requirements:
   //
   // * Include this comment: "See Note [Enabling Deterministic Operations]"
   //
-  // * Check the value of `at::globalContext().deterministicAlgorithms()` to toggle
+  // * Check the value of `at::globalContext().deterministicAlgorithms()` to
+  // toggle
   //   between nondeterministic and deterministic implementations.
   //
-  // * Have an entry in the list of PyTorch operations that toggle between nondeterministic
-  //   and deterministic implementations, in the docstring of `use_deterministic_algorithms()`
-  //   in torch/__init__.py
+  // * Have an entry in the list of PyTorch operations that toggle between
+  // nondeterministic
+  //   and deterministic implementations, in the docstring of
+  //   `use_deterministic_algorithms()` in torch/__init__.py
   //
-  // `example_func()` below shows an example of toggling between nondeterministic and
-  // deterministic implementations:
+  // `example_func()` below shows an example of toggling between
+  // nondeterministic and deterministic implementations:
   //
   //    void example_func() {
   //      // See Note [Enabling Deterministic Operations]
@@ -162,8 +161,9 @@ class TORCH_API Context {
 
   // Note [Writing Nondeterministic Operations]
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  // Operations in PyTorch that act nondeterministically and do not have an alternate
-  // deterministic implementation should satisfy the following requirements:
+  // Operations in PyTorch that act nondeterministically and do not have an
+  // alternate deterministic implementation should satisfy the following
+  // requirements:
   //
   // * Include this comment: "See Note [Writing Nondeterministic Operations]"
   //
@@ -188,8 +188,8 @@ class TORCH_API Context {
   //   included in the `test_cublas_config_nondeterministic_alert` test. Any new
   //   tests should ideally follow a pattern similar to the existing ones.
   //
-  // `example_func()` below shows an example of the comments and error-throwing code
-  // for a nondeterministic operation:
+  // `example_func()` below shows an example of the comments and error-throwing
+  // code for a nondeterministic operation:
   //
   //    void example_func() {
   //      // See Note [Writing Nondeterministic Operations]
@@ -201,12 +201,13 @@ class TORCH_API Context {
   // Throws an error if `Context::deterministicAlgorithms()` is true
   static void alertNotDeterministic(c10::string_view const& caller);
 
-  // Throws an error if `Context::deterministicAlgorithms()` is true, CUDA >= 10.2, and
-  // CUBLAS_WORKSPACE_CONFIG is not set to either ":16:8" or ":4096:8". For more details:
+  // Throws an error if `Context::deterministicAlgorithms()` is true, CUDA
+  // >= 10.2, and CUBLAS_WORKSPACE_CONFIG is not set to either ":16:8" or
+  // ":4096:8". For more details:
   // https://docs.nvidia.com/cuda/cublas/index.html#cublasApi_reproducibility
   void alertCuBLASConfigNotDeterministic() const;
 
-  void setFloat32MatmulPrecision(const std::string & s);
+  void setFloat32MatmulPrecision(const std::string& s);
   bool allowTF32CuDNN() const;
   void setAllowTF32CuDNN(bool);
   bool allowTF32CuBLAS() const;
@@ -217,8 +218,8 @@ class TORCH_API Context {
   void setAllowFP16ReductionCuBLAS(bool);
   at::QEngine qEngine() const;
   void setQEngine(at::QEngine e);
-  static const std::vector<at::QEngine>& supportedQEngines() ;
-  static bool isXNNPACKAvailable() ;
+  static const std::vector<at::QEngine>& supportedQEngines();
+  static bool isXNNPACKAvailable();
   // This method is used to release the original weight after pre-packing.
   // It should be called once before loading/running the model.
   // NB: By default it is set to true for mobile builds.
@@ -250,16 +251,17 @@ class TORCH_API Context {
   bool _deterministic_algorithms = false;
   bool _deterministic_algorithms_warn_only = false;
   bool benchmark_cudnn = false;
-  Float32MatmulPrecision float32_matmul_precision = at::Float32MatmulPrecision::HIGHEST;
+  Float32MatmulPrecision float32_matmul_precision =
+      at::Float32MatmulPrecision::HIGHEST;
   bool allow_tf32_cudnn = true;
   bool allow_fp16_reduction_cublas = true;
   bool enabled_mkldnn = true;
   at::LinalgBackend linalg_preferred_backend = at::LinalgBackend::Default;
-  #ifdef C10_MOBILE
+#ifdef C10_MOBILE
   bool release_original_weights = true;
-  #else
+#else
   bool release_original_weights = false;
-  #endif
+#endif
   bool display_vmap_fallback_warnings_ = false;
   c10::optional<at::QEngine> quantized_engine = c10::nullopt;
 
@@ -274,7 +276,9 @@ static inline void init() {
 
 TORCH_API Allocator* getCPUAllocator();
 
-static inline DeprecatedTypeProperties& getDeprecatedTypeProperties(Backend p, ScalarType s) {
+static inline DeprecatedTypeProperties& getDeprecatedTypeProperties(
+    Backend p,
+    ScalarType s) {
   return globalDeprecatedTypePropertiesRegistry().getDeprecatedTypeProperties(
       p, s);
 }
@@ -376,8 +380,7 @@ static inline void manual_seed(uint64_t seed) {
   if (hasCUDA() && num_gpus > 0) {
     for (const auto i : c10::irange(num_gpus)) {
       auto cuda_gen = globalContext().defaultGenerator(
-        Device(at::kCUDA, static_cast<c10::DeviceIndex>(i))
-      );
+          Device(at::kCUDA, static_cast<c10::DeviceIndex>(i)));
       {
         // See Note [Acquire lock when using random generators]
         std::lock_guard<std::mutex> lock(cuda_gen.mutex());
@@ -399,7 +402,8 @@ struct TORCH_API NoTF32Guard {
   NoTF32Guard();
   ~NoTF32Guard();
   static bool should_disable_tf32();
-private:
+
+ private:
   bool changed = false;
 };
 
@@ -408,7 +412,8 @@ struct TORCH_API ROCmBackwardPassGuard {
   ROCmBackwardPassGuard();
   ~ROCmBackwardPassGuard();
   static bool is_backward_pass();
-private:
+
+ private:
   static thread_local bool is_backward_pass_;
 };
 #endif

--- a/aten/src/ATen/DLConvertor.h
+++ b/aten/src/ATen/DLConvertor.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <ATen/Tensor.h>
 #include <ATen/ATen.h>
+#include <ATen/Tensor.h>
 #include <ATen/dlpack.h>
 
 // this convertor will:
@@ -16,4 +16,4 @@ TORCH_API Tensor fromDLPack(const DLManagedTensor* src);
 TORCH_API DLDataType getDLDataType(const Tensor& t);
 TORCH_API DLDevice getDLContext(const Tensor& tensor, const int64_t& device_id);
 
-} //namespace at
+} // namespace at

--- a/aten/src/ATen/DeviceGuard.h
+++ b/aten/src/ATen/DeviceGuard.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <c10/core/DeviceGuard.h>
 #include <ATen/core/Tensor.h>
+#include <c10/core/DeviceGuard.h>
 #include <c10/core/ScalarType.h> // TensorList whyyyyy
 
 namespace at {

--- a/aten/src/ATen/DynamicLibrary.h
+++ b/aten/src/ATen/DynamicLibrary.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <ATen/Utils.h>
 #include <c10/macros/Export.h>
 #include <c10/util/Exception.h>
-#include <ATen/Utils.h>
 
 namespace c10 {
 
@@ -17,7 +17,10 @@ namespace at {
 struct DynamicLibrary {
   AT_DISALLOW_COPY_AND_ASSIGN(DynamicLibrary);
 
-  TORCH_API DynamicLibrary(const char* name, const char* alt_name = nullptr, bool leak_handle = false);
+  TORCH_API DynamicLibrary(
+      const char* name,
+      const char* alt_name = nullptr,
+      bool leak_handle = false);
 
   TORCH_API void* sym(const char* name);
 

--- a/aten/src/ATen/EmptyTensor.h
+++ b/aten/src/ATen/EmptyTensor.h
@@ -5,16 +5,25 @@ namespace at {
 namespace detail {
 
 inline void check_size_nonnegative(IntArrayRef size) {
-  for (auto x: size) {
-    TORCH_CHECK(x >= 0, "Trying to create tensor with negative dimension ", x, ": ", size);
+  for (auto x : size) {
+    TORCH_CHECK(
+        x >= 0,
+        "Trying to create tensor with negative dimension ",
+        x,
+        ": ",
+        size);
   }
 }
 
 TORCH_API size_t computeStorageNbytesContiguous(
-    IntArrayRef sizes, size_t itemsize, size_t storage_offset=0);
+    IntArrayRef sizes,
+    size_t itemsize,
+    size_t storage_offset = 0);
 TORCH_API size_t computeStorageNbytes(
-    IntArrayRef sizes, IntArrayRef strides,
-    size_t itemsize, size_t storage_offset=0);
+    IntArrayRef sizes,
+    IntArrayRef strides,
+    size_t itemsize,
+    size_t storage_offset = 0);
 
 TORCH_API TensorBase empty_generic(
     IntArrayRef size,
@@ -33,8 +42,8 @@ TORCH_API TensorBase empty_strided_generic(
 TORCH_API TensorBase empty_cpu(
     IntArrayRef size,
     ScalarType dtype,
-    bool pin_memory=false,
-    c10::optional<c10::MemoryFormat> memory_format_opt=c10::nullopt);
+    bool pin_memory = false,
+    c10::optional<c10::MemoryFormat> memory_format_opt = c10::nullopt);
 
 TORCH_API TensorBase empty_cpu(
     IntArrayRef size,
@@ -44,15 +53,13 @@ TORCH_API TensorBase empty_cpu(
     c10::optional<bool> pin_memory_opt,
     c10::optional<c10::MemoryFormat> memory_format_opt);
 
-TORCH_API TensorBase empty_cpu(
-    IntArrayRef size,
-    const TensorOptions &options);
+TORCH_API TensorBase empty_cpu(IntArrayRef size, const TensorOptions& options);
 
 TORCH_API TensorBase empty_strided_cpu(
     IntArrayRef size,
     IntArrayRef stride,
     ScalarType dtype,
-    bool pin_memory=false);
+    bool pin_memory = false);
 
 TORCH_API TensorBase empty_strided_cpu(
     IntArrayRef size,
@@ -65,12 +72,12 @@ TORCH_API TensorBase empty_strided_cpu(
 TORCH_API TensorBase empty_strided_cpu(
     IntArrayRef size,
     IntArrayRef stride,
-    const TensorOptions &options);
+    const TensorOptions& options);
 
 TORCH_API TensorBase empty_meta(
     IntArrayRef size,
     ScalarType dtype,
-    c10::optional<c10::MemoryFormat> memory_format_opt=c10::nullopt);
+    c10::optional<c10::MemoryFormat> memory_format_opt = c10::nullopt);
 
 TORCH_API TensorBase empty_meta(
     IntArrayRef size,
@@ -80,12 +87,10 @@ TORCH_API TensorBase empty_meta(
     c10::optional<bool> pin_memory_opt,
     c10::optional<c10::MemoryFormat> memory_format_opt);
 
-TORCH_API TensorBase empty_meta(
-    IntArrayRef size,
-    const TensorOptions &options);
+TORCH_API TensorBase empty_meta(IntArrayRef size, const TensorOptions& options);
 
-TORCH_API TensorBase empty_strided_meta(
-    IntArrayRef size, IntArrayRef stride, ScalarType dtype);
+TORCH_API TensorBase
+empty_strided_meta(IntArrayRef size, IntArrayRef stride, ScalarType dtype);
 
 TORCH_API TensorBase empty_strided_meta(
     IntArrayRef size,
@@ -98,6 +103,7 @@ TORCH_API TensorBase empty_strided_meta(
 TORCH_API TensorBase empty_strided_meta(
     IntArrayRef size,
     IntArrayRef stride,
-    const TensorOptions &options);
+    const TensorOptions& options);
 
-}}  // namespace at::detail
+} // namespace detail
+} // namespace at

--- a/aten/src/ATen/ExpandBase.h
+++ b/aten/src/ATen/ExpandBase.h
@@ -3,21 +3,28 @@
 // Broadcasting utilities for working with TensorBase
 namespace at {
 namespace internal {
-TORCH_API TensorBase expand_slow_path(const TensorBase &self, IntArrayRef size);
+TORCH_API TensorBase expand_slow_path(const TensorBase& self, IntArrayRef size);
 } // namespace internal
 
-inline c10::MaybeOwned<TensorBase> expand_size(const TensorBase &self, IntArrayRef size) {
+inline c10::MaybeOwned<TensorBase> expand_size(
+    const TensorBase& self,
+    IntArrayRef size) {
   if (size.equals(self.sizes())) {
     return c10::MaybeOwned<TensorBase>::borrowed(self);
   }
   return c10::MaybeOwned<TensorBase>::owned(
       at::internal::expand_slow_path(self, size));
 }
-c10::MaybeOwned<TensorBase> expand_size(TensorBase &&self, IntArrayRef size) = delete;
+c10::MaybeOwned<TensorBase> expand_size(TensorBase&& self, IntArrayRef size) =
+    delete;
 
-inline c10::MaybeOwned<TensorBase> expand_inplace(const TensorBase &tensor, const TensorBase &to_expand) {
+inline c10::MaybeOwned<TensorBase> expand_inplace(
+    const TensorBase& tensor,
+    const TensorBase& to_expand) {
   return expand_size(to_expand, tensor.sizes());
 }
-c10::MaybeOwned<TensorBase> expand_inplace(const TensorBase &tensor, TensorBase &&to_expand) = delete;
+c10::MaybeOwned<TensorBase> expand_inplace(
+    const TensorBase& tensor,
+    TensorBase&& to_expand) = delete;
 
 } // namespace at

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -6,8 +6,8 @@
 #include <ATen/ops/view_copy.h>
 #endif
 
-#include <ATen/core/DimVector.h>
 #include <ATen/Tensor.h>
+#include <ATen/core/DimVector.h>
 #include <c10/util/Exception.h>
 #include <c10/util/MaybeOwned.h>
 #include <c10/util/irange.h>
@@ -39,8 +39,7 @@ inferExpandGeometry(
     IntArrayRef tensor_strides,
     IntArrayRef sizes);
 
-TORCH_API InferExpandGeometryResult<DimVector>
-inferExpandGeometry_dimvector(
+TORCH_API InferExpandGeometryResult<DimVector> inferExpandGeometry_dimvector(
     IntArrayRef tensor_sizes,
     IntArrayRef tensor_strides,
     IntArrayRef sizes);
@@ -50,14 +49,16 @@ TORCH_API std::vector<int64_t> infer_dense_strides(
     IntArrayRef tensor_strides);
 
 // True if input shapes are expandable
-// NOTE: infer_size did a similar check, please keep them sync if change is needed
+// NOTE: infer_size did a similar check, please keep them sync if change is
+// needed
 inline bool are_expandable(IntArrayRef shape1, IntArrayRef shape2) {
   size_t ndim1 = shape1.size();
   size_t ndim2 = shape2.size();
   size_t ndim = ndim1 < ndim2 ? ndim1 : ndim2;
 
   for (int64_t i = ndim - 1; i >= 0; --i) {
-    if (shape1[--ndim1] == shape2[--ndim2] || shape1[ndim1] == 1 || shape2[ndim2] == 1) {
+    if (shape1[--ndim1] == shape2[--ndim2] || shape1[ndim1] == 1 ||
+        shape2[ndim2] == 1) {
       continue;
     }
     return false;
@@ -66,7 +67,9 @@ inline bool are_expandable(IntArrayRef shape1, IntArrayRef shape2) {
 }
 
 // avoid copy-construction of Tensor by using a reference_wrapper.
-inline void check_defined(std::initializer_list<std::reference_wrapper<const Tensor>> tensors, const char *api_name) {
+inline void check_defined(
+    std::initializer_list<std::reference_wrapper<const Tensor>> tensors,
+    const char* api_name) {
   for (auto& t : tensors) {
     if (!t.get().defined()) {
       AT_ERROR(api_name, "(...) called with an undefined Tensor");
@@ -87,24 +90,39 @@ inline void check_defined(std::initializer_list<std::reference_wrapper<const Ten
 // resulting from a function call, but it is still possible to make a
 // mistake.
 
-inline c10::MaybeOwned<Tensor> expand_inplace(const Tensor& tensor, const Tensor& to_expand) {
+inline c10::MaybeOwned<Tensor> expand_inplace(
+    const Tensor& tensor,
+    const Tensor& to_expand) {
   if (tensor.sizes().equals(to_expand.sizes())) {
     return c10::MaybeOwned<Tensor>::borrowed(to_expand);
   }
   return c10::MaybeOwned<Tensor>::owned(to_expand.expand(tensor.sizes()));
 }
 
-inline c10::MaybeOwned<Tensor> expand_inplace(const Tensor& tensor, Tensor&& to_expand) = delete;
+inline c10::MaybeOwned<Tensor> expand_inplace(
+    const Tensor& tensor,
+    Tensor&& to_expand) = delete;
 
-inline c10::MaybeOwned<Tensor> expand_inplace(const Tensor &tensor, const Tensor &to_expand, const char *api_name) {
+inline c10::MaybeOwned<Tensor> expand_inplace(
+    const Tensor& tensor,
+    const Tensor& to_expand,
+    const char* api_name) {
   check_defined({tensor, to_expand}, api_name);
   return expand_inplace(tensor, to_expand);
 }
 
-inline c10::MaybeOwned<Tensor> expand_inplace(const Tensor& tensor, Tensor&& to_expand, const char *api_name) = delete;
+inline c10::MaybeOwned<Tensor> expand_inplace(
+    const Tensor& tensor,
+    Tensor&& to_expand,
+    const char* api_name) = delete;
 
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>> expand_inplace(const Tensor &tensor, const Tensor &to_expand1, const Tensor &to_expand2) {
-  if (tensor.sizes().equals(to_expand1.sizes()) && tensor.sizes().equals((to_expand2.sizes()))) {
+inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
+expand_inplace(
+    const Tensor& tensor,
+    const Tensor& to_expand1,
+    const Tensor& to_expand2) {
+  if (tensor.sizes().equals(to_expand1.sizes()) &&
+      tensor.sizes().equals((to_expand2.sizes()))) {
     return std::make_tuple(
         c10::MaybeOwned<Tensor>::borrowed(to_expand1),
         c10::MaybeOwned<Tensor>::borrowed(to_expand2));
@@ -115,143 +133,258 @@ inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>> expand_inpla
       c10::MaybeOwned<Tensor>::owned(to_expand2.expand(tensor.sizes())));
 }
 
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>> expand_inplace(const Tensor &tensor, Tensor &&to_expand1, const Tensor &to_expand2) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>> expand_inplace(const Tensor &tensor, const Tensor &to_expand1, Tensor &&to_expand2) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>> expand_inplace(const Tensor &tensor, Tensor &&to_expand1, Tensor &&to_expand2) = delete;
+inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
+expand_inplace(
+    const Tensor& tensor,
+    Tensor&& to_expand1,
+    const Tensor& to_expand2) = delete;
+inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
+expand_inplace(
+    const Tensor& tensor,
+    const Tensor& to_expand1,
+    Tensor&& to_expand2) = delete;
+inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
+expand_inplace(const Tensor& tensor, Tensor&& to_expand1, Tensor&& to_expand2) =
+    delete;
 
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>> expand_inplace(const Tensor &tensor, const Tensor &to_expand1, const Tensor &to_expand2,
-                                                 const char *api_name) {
+inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
+expand_inplace(
+    const Tensor& tensor,
+    const Tensor& to_expand1,
+    const Tensor& to_expand2,
+    const char* api_name) {
   check_defined({tensor, to_expand1, to_expand2}, api_name);
   return expand_inplace(tensor, to_expand1, to_expand2);
 }
 
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>> expand_inplace(const Tensor &tensor, Tensor &&to_expand1, const Tensor &to_expand2, const char *api_name) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>> expand_inplace(const Tensor &tensor, const Tensor &to_expand1, Tensor &&to_expand2, const char *api_name) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>> expand_inplace(const Tensor &tensor, Tensor &&to_expand1, Tensor &&to_expand2, const char *api_name) = delete;
+inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
+expand_inplace(
+    const Tensor& tensor,
+    Tensor&& to_expand1,
+    const Tensor& to_expand2,
+    const char* api_name) = delete;
+inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
+expand_inplace(
+    const Tensor& tensor,
+    const Tensor& to_expand1,
+    Tensor&& to_expand2,
+    const char* api_name) = delete;
+inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
+expand_inplace(
+    const Tensor& tensor,
+    Tensor&& to_expand1,
+    Tensor&& to_expand2,
+    const char* api_name) = delete;
 
 // See NOTE [ ExpandUtils Borrowing ] above for `MaybeOwned` explanation.
 inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1, const Tensor &to_expand2) {
+expand_outplace(const Tensor& to_expand1, const Tensor& to_expand2) {
   if (to_expand1.sizes().equals(to_expand2.sizes())) {
     return std::make_tuple(
         c10::MaybeOwned<Tensor>::borrowed(to_expand1),
         c10::MaybeOwned<Tensor>::borrowed(to_expand2));
   }
 
-  auto expanded_size = infer_size_dimvector(to_expand1.sizes(), to_expand2.sizes());
+  auto expanded_size =
+      infer_size_dimvector(to_expand1.sizes(), to_expand2.sizes());
   return std::make_tuple(
       c10::MaybeOwned<Tensor>::owned(to_expand1.expand(expanded_size)),
       c10::MaybeOwned<Tensor>::owned(to_expand2.expand(expanded_size)));
 }
 
 inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1, const Tensor &to_expand2) = delete;
+expand_outplace(Tensor&& to_expand1, const Tensor& to_expand2) = delete;
 inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1, Tensor &&to_expand2) = delete;
+expand_outplace(const Tensor& to_expand1, Tensor&& to_expand2) = delete;
 inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1, Tensor &&to_expand2) = delete;
+expand_outplace(Tensor&& to_expand1, Tensor&& to_expand2) = delete;
 
 inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1, const Tensor &to_expand2, const char *api_name) {
+expand_outplace(
+    const Tensor& to_expand1,
+    const Tensor& to_expand2,
+    const char* api_name) {
   check_defined({to_expand1, to_expand2}, api_name);
   return expand_outplace(to_expand1, to_expand2);
 }
 
 inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1, const Tensor &to_expand2, const char *api_name) = delete;
+expand_outplace(
+    Tensor&& to_expand1,
+    const Tensor& to_expand2,
+    const char* api_name) = delete;
 inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1, Tensor &&to_expand2, const char *api_name) = delete;
+expand_outplace(
+    const Tensor& to_expand1,
+    Tensor&& to_expand2,
+    const char* api_name) = delete;
 inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1, Tensor &&to_expand2, const char *api_name) = delete;
+expand_outplace(
+    Tensor&& to_expand1,
+    Tensor&& to_expand2,
+    const char* api_name) = delete;
 
-
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1,
-                const Tensor &to_expand2,
-                const Tensor &to_expand3) {
-  if (to_expand1.sizes().equals(to_expand2.sizes()) && to_expand1.sizes().equals(to_expand3.sizes())) {
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    const Tensor& to_expand1,
+    const Tensor& to_expand2,
+    const Tensor& to_expand3) {
+  if (to_expand1.sizes().equals(to_expand2.sizes()) &&
+      to_expand1.sizes().equals(to_expand3.sizes())) {
     return std::make_tuple(
         c10::MaybeOwned<Tensor>::borrowed(to_expand1),
         c10::MaybeOwned<Tensor>::borrowed(to_expand2),
         c10::MaybeOwned<Tensor>::borrowed(to_expand3));
   }
 
-  auto expanded_size12 = infer_size_dimvector(to_expand1.sizes(), to_expand2.sizes());
-  auto expanded_size = infer_size_dimvector(expanded_size12, to_expand3.sizes());
+  auto expanded_size12 =
+      infer_size_dimvector(to_expand1.sizes(), to_expand2.sizes());
+  auto expanded_size =
+      infer_size_dimvector(expanded_size12, to_expand3.sizes());
   return std::make_tuple(
       c10::MaybeOwned<Tensor>::owned(to_expand1.expand(expanded_size)),
       c10::MaybeOwned<Tensor>::owned(to_expand2.expand(expanded_size)),
       c10::MaybeOwned<Tensor>::owned(to_expand3.expand(expanded_size)));
 }
 
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1,
-                const Tensor &to_expand2,
-                const Tensor &to_expand3) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1,
-                Tensor &&to_expand2,
-                const Tensor &to_expand3) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1,
-                Tensor &&to_expand2,
-                const Tensor &to_expand3) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1,
-                const Tensor &to_expand2,
-                Tensor &&to_expand3) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1,
-                const Tensor &to_expand2,
-                Tensor &&to_expand3) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1,
-                Tensor &&to_expand2,
-                Tensor &&to_expand3) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1,
-                Tensor &&to_expand2,
-                Tensor &&to_expand3) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    Tensor&& to_expand1,
+    const Tensor& to_expand2,
+    const Tensor& to_expand3) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    const Tensor& to_expand1,
+    Tensor&& to_expand2,
+    const Tensor& to_expand3) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    Tensor&& to_expand1,
+    Tensor&& to_expand2,
+    const Tensor& to_expand3) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    const Tensor& to_expand1,
+    const Tensor& to_expand2,
+    Tensor&& to_expand3) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    Tensor&& to_expand1,
+    const Tensor& to_expand2,
+    Tensor&& to_expand3) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    const Tensor& to_expand1,
+    Tensor&& to_expand2,
+    Tensor&& to_expand3) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(Tensor&& to_expand1, Tensor&& to_expand2, Tensor&& to_expand3) =
+    delete;
 
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1,
-                const Tensor &to_expand2,
-                const Tensor &to_expand3,
-                const char *api_name) {
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    const Tensor& to_expand1,
+    const Tensor& to_expand2,
+    const Tensor& to_expand3,
+    const char* api_name) {
   check_defined({to_expand1, to_expand2, to_expand3}, api_name);
   return expand_outplace(to_expand1, to_expand2, to_expand3);
 }
 
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1,
-                const Tensor &to_expand2,
-                const Tensor &to_expand3, const char *api_name) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1,
-                Tensor &&to_expand2,
-                const Tensor &to_expand3, const char *api_name) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1,
-                Tensor &&to_expand2,
-                const Tensor &to_expand3, const char *api_name) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1,
-                const Tensor &to_expand2,
-                Tensor &&to_expand3, const char *api_name) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1,
-                const Tensor &to_expand2,
-                Tensor &&to_expand3, const char *api_name) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(const Tensor &to_expand1,
-                Tensor &&to_expand2,
-                Tensor &&to_expand3, const char *api_name) = delete;
-inline std::tuple<c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>, c10::MaybeOwned<Tensor>>
-expand_outplace(Tensor &&to_expand1,
-                Tensor &&to_expand2,
-                Tensor &&to_expand3, const char *api_name) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    Tensor&& to_expand1,
+    const Tensor& to_expand2,
+    const Tensor& to_expand3,
+    const char* api_name) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    const Tensor& to_expand1,
+    Tensor&& to_expand2,
+    const Tensor& to_expand3,
+    const char* api_name) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    Tensor&& to_expand1,
+    Tensor&& to_expand2,
+    const Tensor& to_expand3,
+    const char* api_name) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    const Tensor& to_expand1,
+    const Tensor& to_expand2,
+    Tensor&& to_expand3,
+    const char* api_name) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    Tensor&& to_expand1,
+    const Tensor& to_expand2,
+    Tensor&& to_expand3,
+    const char* api_name) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    const Tensor& to_expand1,
+    Tensor&& to_expand2,
+    Tensor&& to_expand3,
+    const char* api_name) = delete;
+inline std::tuple<
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>,
+    c10::MaybeOwned<Tensor>>
+expand_outplace(
+    Tensor&& to_expand1,
+    Tensor&& to_expand2,
+    Tensor&& to_expand3,
+    const char* api_name) = delete;
 
-inline c10::MaybeOwned<Tensor> expand_size(const Tensor &to_expand, IntArrayRef sizes) {
+inline c10::MaybeOwned<Tensor> expand_size(
+    const Tensor& to_expand,
+    IntArrayRef sizes) {
   if (to_expand.sizes().equals(sizes)) {
     return c10::MaybeOwned<Tensor>::borrowed(to_expand);
   }
@@ -259,15 +392,22 @@ inline c10::MaybeOwned<Tensor> expand_size(const Tensor &to_expand, IntArrayRef 
   return c10::MaybeOwned<Tensor>::owned(to_expand.expand(sizes));
 }
 
-inline c10::MaybeOwned<Tensor> expand_size(Tensor &&to_expand, IntArrayRef sizes) = delete;
+inline c10::MaybeOwned<Tensor> expand_size(
+    Tensor&& to_expand,
+    IntArrayRef sizes) = delete;
 
-
-inline c10::MaybeOwned<Tensor> expand_size(const Tensor &to_expand, IntArrayRef sizes, const char *api_name) {
+inline c10::MaybeOwned<Tensor> expand_size(
+    const Tensor& to_expand,
+    IntArrayRef sizes,
+    const char* api_name) {
   check_defined({to_expand}, api_name);
   return expand_size(to_expand, sizes);
 }
 
-inline c10::MaybeOwned<Tensor> expand_size(Tensor &&to_expand, IntArrayRef sizes, const char *api_name) = delete;
+inline c10::MaybeOwned<Tensor> expand_size(
+    Tensor&& to_expand,
+    IntArrayRef sizes,
+    const char* api_name) = delete;
 
 inline std::vector<Tensor> expand_outplace(TensorList to_expand) {
   // expands a list of Tensors; ignores undefined (null) tensors
@@ -299,7 +439,10 @@ inline std::vector<Tensor> expand_outplace(TensorList to_expand) {
 
 // Sums `tensor` repeatedly to produce a tensor of shape `shape`.
 // Precondition: is_expandable_to(shape, tensor.sizes()) must be true
-static inline Tensor sum_to(Tensor tensor, const IntArrayRef shape, bool always_return_non_view=false) {
+static inline Tensor sum_to(
+    Tensor tensor,
+    const IntArrayRef shape,
+    bool always_return_non_view = false) {
   if (shape.size() == 0) {
     return tensor.sum();
   }
@@ -319,7 +462,8 @@ static inline Tensor sum_to(Tensor tensor, const IntArrayRef shape, bool always_
   }
   if (always_return_non_view) {
     // This is only actually used by the functionalization pass.
-    // We want to be able to guarantee that this function doesn't return a view of the input.
+    // We want to be able to guarantee that this function doesn't return a view
+    // of the input.
     return leading_dims > 0 ? at::view_copy(tensor, shape) : tensor.clone();
   } else {
     return leading_dims > 0 ? tensor.view(shape) : tensor;
@@ -343,4 +487,4 @@ static inline bool is_expandable_to(IntArrayRef shape, IntArrayRef desired) {
   return true;
 }
 
-}
+} // namespace at

--- a/aten/src/ATen/FuncTorchTLS.h
+++ b/aten/src/ATen/FuncTorchTLS.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <memory>
 #include <c10/macros/Macros.h>
+#include <memory>
 
-namespace at { namespace functorch {
+namespace at {
+namespace functorch {
 
 // NOTE [functorch TLS in pytorch/pytorch]
 //
@@ -15,7 +16,8 @@ namespace at { namespace functorch {
 // We need to store a pointer due to the indirection:
 // inside functorch, we will create a subclass of FunctorchTLSBase called
 // FuncTorchTLSImpl that actually contains metadata, like the DynamicLayerStack.
-// FuncTorchTLSBase doesn't have any metadata because it hasn't been defined yet.
+// FuncTorchTLSBase doesn't have any metadata because it hasn't been defined
+// yet.
 //
 // Here in pytorch/pytorch, we will pass around FuncTorchTLSBase*, but inside
 // functorch, we will assign a FuncTorchTLSImpl* to the FunctorchTLSBase*.
@@ -38,9 +40,11 @@ struct TORCH_API FuncTorchTLSBase {
 TORCH_API std::unique_ptr<FuncTorchTLSBase> getCopyOfFuncTorchTLS();
 
 // sets the functorch tls. always does a deep copy.
-TORCH_API void setFuncTorchTLS(const std::shared_ptr<const FuncTorchTLSBase>& state);
+TORCH_API void setFuncTorchTLS(
+    const std::shared_ptr<const FuncTorchTLSBase>& state);
 
 // get a mutable reference to the functorch tls
 TORCH_API std::unique_ptr<FuncTorchTLSBase>& functorchTLSAccessor();
 
-}}
+} // namespace functorch
+} // namespace at

--- a/aten/src/ATen/FunctionalStorageImpl.h
+++ b/aten/src/ATen/FunctionalStorageImpl.h
@@ -10,92 +10,105 @@ namespace functionalization {
 // ViewMeta is a class used by the functionalization pass to navigate between
 // a base tensor and a view tensor.
 // For example, if I call `b = a.view1(...)`
-// the functionalization pass will generate and store a ViewMeta on b that looks like:
+// the functionalization pass will generate and store a ViewMeta on b that looks
+// like:
 //
 // ViewMeta(
 //   [<captures>](const Tensor& base, int64_t mutated_view_idx) {
 //     return base.view1(...);
 //   },
-//   [<captures>](const at::Tensor& base, const at::Tensor& mutated_view, int64_t mutated_view_idx) -> at::Tensor {
-//     return at::functionalization::impl::view1_inverse(base, mutated_view, ...);
+//   [<captures>](const at::Tensor& base, const at::Tensor& mutated_view,
+//   int64_t mutated_view_idx) -> at::Tensor {
+//     return at::functionalization::impl::view1_inverse(base, mutated_view,
+//     ...);
 //   }
 //
 // The forward_fn lambda describes how to replay view1 on a tensor.
 //
-// The reverse_fn lambda describes how, given a tensor that is already a view, how to get the corresponding base tensor.
-// See Note [Functionalization Pass: View Inverses] for details.
+// The reverse_fn lambda describes how, given a tensor that is already a view,
+// how to get the corresponding base tensor. See Note [Functionalization Pass:
+// View Inverses] for details.
 struct ViewMeta {
   ViewMeta(
-          std::function<Tensor(const Tensor&, int64_t)> forward,
-          std::function<Tensor(const Tensor&, const Tensor&, int64_t)> reverse,
-          int64_t out_idx = 0) :
-      forward_fn(forward),
-      reverse_fn(reverse),
-      out_index(out_idx)
-      {}
+      std::function<Tensor(const Tensor&, int64_t)> forward,
+      std::function<Tensor(const Tensor&, const Tensor&, int64_t)> reverse,
+      int64_t out_idx = 0)
+      : forward_fn(forward), reverse_fn(reverse), out_index(out_idx) {}
 
   std::function<Tensor(const Tensor&, int64_t)> forward_fn;
   std::function<Tensor(const Tensor&, const Tensor&, int64_t)> reverse_fn;
   // See Note [out_idx in ViewMeta]
   int64_t out_index;
 
-  // Returns a copy of the current ViewMeta, if out_idx matches the current out_index.
-  // Otherwise, returns a new ViewMeta with the same forward/reverse functions, but a new out index.
+  // Returns a copy of the current ViewMeta, if out_idx matches the current
+  // out_index. Otherwise, returns a new ViewMeta with the same forward/reverse
+  // functions, but a new out index.
   ViewMeta to_out_idx(int64_t out_idx);
 };
 
-// Alias represents the state shared by (potentially multiple) views of the same tensor.
-// For example, in the following code:
+// Alias represents the state shared by (potentially multiple) views of the same
+// tensor. For example, in the following code:
 //
 // b = a.view1(...)
 // c = b.view2(...)
 // b.add_(1)
 // --> alias.add_update(b, {view1_meta})
 //
-// The call to add_(1) will result in a call to alias.add_update(b, {view1_meta}), queueing up
-// the mutation from b onto the alias.
-// Later, suppose c is used in an expression (e.g. you try to print c, or pass it to an operator).
-// Doing so will involve "syncing" c.
-// First we apply any pending updates to the alias, and then we regenerate c
-// by replaying its views off of the updated alias. E.g:
+// The call to add_(1) will result in a call to alias.add_update(b,
+// {view1_meta}), queueing up the mutation from b onto the alias. Later, suppose
+// c is used in an expression (e.g. you try to print c, or pass it to an
+// operator). Doing so will involve "syncing" c. First we apply any pending
+// updates to the alias, and then we regenerate c by replaying its views off of
+// the updated alias. E.g:
 //
 // print(str(c))
 // --> c.sync_()
-//     --> alias.apply_updates() // after this, the alias will be updated to reflect the mutation to b
+//     --> alias.apply_updates() // after this, the alias will be updated to
+//     reflect the mutation to b
 class Alias {
-  public:
-    struct Update {
-        const at::Tensor new_val;
-        const std::vector<ViewMeta> view_metas;
-    };
-    explicit Alias(const at::Tensor& base);
-    const at::Tensor& base() const;
-    size_t generation() const { return generation_; }
-    void add_update(const at::Tensor& updated_val, const std::vector<ViewMeta>& metas);
-    bool apply_updates();
-  private:
-    // NB: base_ should always point to a tensor BELOW the current functionalization layer.
-    // This is mainly to avoid reference cycles.
-    // e.g. given `b = a.view(...)`
-    // Both a.storage_ and b.storage_ are a FunctionStorageImpl containing an Alias, with contains a Tensor `base_`.
-    // In this case (where a and b are FunctionalTensorWrapper's), base_ should point not to a, but to a's unwrapped value, a.value_`
-    // See Note [Functionalization: Alias Removal] for a diagram that shows this visually.
-    at::Tensor base_;
-    std::vector<Update> updates_;
-    // generation_ gets incremented every time a mutation is queued onto the alias.
-    // It is used to determine if a given tensor is "up to date", or if it needs to be regenerated from the alias.
-    size_t generation_ = 0;
+ public:
+  struct Update {
+    const at::Tensor new_val;
+    const std::vector<ViewMeta> view_metas;
+  };
+  explicit Alias(const at::Tensor& base);
+  const at::Tensor& base() const;
+  size_t generation() const {
+    return generation_;
+  }
+  void add_update(
+      const at::Tensor& updated_val,
+      const std::vector<ViewMeta>& metas);
+  bool apply_updates();
+
+ private:
+  // NB: base_ should always point to a tensor BELOW the current
+  // functionalization layer. This is mainly to avoid reference cycles. e.g.
+  // given `b = a.view(...)` Both a.storage_ and b.storage_ are a
+  // FunctionStorageImpl containing an Alias, with contains a Tensor `base_`. In
+  // this case (where a and b are FunctionalTensorWrapper's), base_ should point
+  // not to a, but to a's unwrapped value, a.value_` See Note
+  // [Functionalization: Alias Removal] for a diagram that shows this visually.
+  at::Tensor base_;
+  std::vector<Update> updates_;
+  // generation_ gets incremented every time a mutation is queued onto the
+  // alias. It is used to determine if a given tensor is "up to date", or if it
+  // needs to be regenerated from the alias.
+  size_t generation_ = 0;
 };
 
-// FunctionalStorageImpl is a subclass of StorageImpl used by the functionalization pass.
-// It has no underlying data (similar to meta storage).
-// It also knows how to reflect mutations to tensors in the absence of a valid data pointer.
-// It does this by separately storing an Alias object, which knows how to reflect mutations
-// that may have happened to views of the original tensor.
+// FunctionalStorageImpl is a subclass of StorageImpl used by the
+// functionalization pass. It has no underlying data (similar to meta storage).
+// It also knows how to reflect mutations to tensors in the absence of a valid
+// data pointer. It does this by separately storing an Alias object, which knows
+// how to reflect mutations that may have happened to views of the original
+// tensor.
 struct TORCH_API FunctionalStorageImpl : public c10::StorageImpl {
   explicit FunctionalStorageImpl(const Tensor& value);
 
-  void add_update(const Tensor& updated_val, const std::vector<ViewMeta>& view_metas);
+  void add_update(
+      const Tensor& updated_val,
+      const std::vector<ViewMeta>& view_metas);
   bool apply_updates();
   const Tensor& base();
   size_t generation() const;

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -2,8 +2,8 @@
 #pragma once
 
 #include <ATen/ArrayRef.h>
-#include <ATen/core/List.h>
 #include <ATen/FunctionalStorageImpl.h>
+#include <ATen/core/List.h>
 
 #include <c10/core/DispatchKey.h>
 
@@ -13,73 +13,99 @@ namespace at {
 // The Functionalization pass is used to remove aliasing from a pytorch program.
 //
 // This is useful for backends that don't support aliasing, like XLA and Vulkan.
-// It's also necessary in order to remove mutation from a program, which is needed in Functorch.
+// It's also necessary in order to remove mutation from a program, which is
+// needed in Functorch.
 //
 // Consider this program:
 // a = torch.ones(...)
 // b = a.view(...)
 // b.add_(1)
 //
-// In this program, b is meant to alias with a due to the use of view(). At the end of the program, both a and b are full of 2's.
-// However, backends that don't support aliasing aren't able to correctly implement the view() operator.
-// Instead, they can opt into the Functionalization pass, which will sit between the user and the backend,
-// and provide the necessary aliasing logic.
+// In this program, b is meant to alias with a due to the use of view(). At the
+// end of the program, both a and b are full of 2's. However, backends that
+// don't support aliasing aren't able to correctly implement the view()
+// operator. Instead, they can opt into the Functionalization pass, which will
+// sit between the user and the backend, and provide the necessary aliasing
+// logic.
 //
-// The functionalization pass will turn the above program into a slightly different program that has the same semantics,
-// transparently to the user, that backends like XLA/Vulkan are able to implement
-// a = torch.ones(...)
-// b = a.view_copy(...)  # view() replaced with view_copy(). Backends like XLA/Vulkan can implement this!
-// b.add_(1)
-// a.add_(1)  # Our functionalization pass machinery knows that a and b are aliased - it applies b's mutation to a too.
+// The functionalization pass will turn the above program into a slightly
+// different program that has the same semantics, transparently to the user,
+// that backends like XLA/Vulkan are able to implement a = torch.ones(...) b =
+// a.view_copy(...)  # view() replaced with view_copy(). Backends like
+// XLA/Vulkan can implement this! b.add_(1) a.add_(1)  # Our functionalization
+// pass machinery knows that a and b are aliased - it applies b's mutation to a
+// too.
 //
-// So, how does the functionalization pass keep track of which tensors are aliased?
-// The pass works by wrapping EVERY tensor in the program inside of a FunctionalTensorWrapper, which knows about its alias'd tensors.
+// So, how does the functionalization pass keep track of which tensors are
+// aliased? The pass works by wrapping EVERY tensor in the program inside of a
+// FunctionalTensorWrapper, which knows about its alias'd tensors.
 //
-// See Note [Functionalization: Alias Removal] for details on the aliasing machinery.
-// See Note [Functionalization: Mutation Removal] for details on mutation removal.
+// See Note [Functionalization: Alias Removal] for details on the aliasing
+// machinery. See Note [Functionalization: Mutation Removal] for details on
+// mutation removal.
 struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
   explicit FunctionalTensorWrapper(const Tensor& value);
-  // Additional constructor to create a FunctionalTensorWrapper directly from an underlying tensor that was created from a view.
-  // For example, the code b = a.view1() will generate a constructor call to FunctionalTensorWrapper(b, a, view1_meta)
-  explicit FunctionalTensorWrapper(const Tensor& view_value, const FunctionalTensorWrapper* base, functionalization::ViewMeta meta);
+  // Additional constructor to create a FunctionalTensorWrapper directly from an
+  // underlying tensor that was created from a view. For example, the code b =
+  // a.view1() will generate a constructor call to FunctionalTensorWrapper(b, a,
+  // view1_meta)
+  explicit FunctionalTensorWrapper(
+      const Tensor& view_value,
+      const FunctionalTensorWrapper* base,
+      functionalization::ViewMeta meta);
 
-  // Get the underlying, actual tensor, that doesn't know anything about functionalization.
-  const Tensor& value() const { return value_; };
-  // The concept of "level" is only ever important to functorch; it's exposed here
-  // as more of a hook for functorch to use.
-  int64_t level() const { return level_; };
-  void set_level(int64_t level) { level_ = level; }
+  // Get the underlying, actual tensor, that doesn't know anything about
+  // functionalization.
+  const Tensor& value() const {
+    return value_;
+  };
+  // The concept of "level" is only ever important to functorch; it's exposed
+  // here as more of a hook for functorch to use.
+  int64_t level() const {
+    return level_;
+  };
+  void set_level(int64_t level) {
+    level_ = level;
+  }
 
-  // Sync's the underlying tensor with its alias, if it's out of date. This involves two steps:
-  // 1) Apply any pending updates/mutations to the alias
-  // 2) Replay the views (if any) to regenerate the current tensor off of the updated alias.
+  // Sync's the underlying tensor with its alias, if it's out of date. This
+  // involves two steps: 1) Apply any pending updates/mutations to the alias 2)
+  // Replay the views (if any) to regenerate the current tensor off of the
+  // updated alias.
   void sync_();
-  // Performs step (1) of the sync. This is its own public API because it's needed by view_inplace ops like transpose_.
-  // See Note [Functionalization Pass - Inplace View Ops]
+  // Performs step (1) of the sync. This is its own public API because it's
+  // needed by view_inplace ops like transpose_. See Note [Functionalization
+  // Pass - Inplace View Ops]
   void regenerate_from_base();
-  // Performs step (2) of the sync. This is its own public API because it's needed by functorch.
-  // functorch wants to make sure that all input tensors to a functionalized program have been properly synced
-  // so it can properly propagate mutations to inputs.
-  // It can't just call sync_(), because the FunctionalTensorWrapper will look like it has no aliases and sync_ will be a noop.
-  // We use the reference count on storage_ to determine if the wrapper is aliased, and by the time functorch
-  // is ready to propagate updates to inputs, any intermediate views of the input created by the program will have been deallocated.
-  // This function also returns whether or not the base actually had any updates to apply.
+  // Performs step (2) of the sync. This is its own public API because it's
+  // needed by functorch. functorch wants to make sure that all input tensors to
+  // a functionalized program have been properly synced so it can properly
+  // propagate mutations to inputs. It can't just call sync_(), because the
+  // FunctionalTensorWrapper will look like it has no aliases and sync_ will be
+  // a noop. We use the reference count on storage_ to determine if the wrapper
+  // is aliased, and by the time functorch is ready to propagate updates to
+  // inputs, any intermediate views of the input created by the program will
+  // have been deallocated. This function also returns whether or not the base
+  // actually had any updates to apply.
   bool apply_updates();
-  // Takes the current state of value_ and snapshots it, sending it as a pending update to the alias.
+  // Takes the current state of value_ and snapshots it, sending it as a pending
+  // update to the alias.
   void commit_update();
   // When any tensor is mutated, the tensor increments its alias's "generation".
-  // Separately, each tensor maintains its own "generation" counter, which is used to determine if it's up-to-date with its alias.
-  // The act of syncing a tensor will set a tensor's generation equal to its alias's generation.
+  // Separately, each tensor maintains its own "generation" counter, which is
+  // used to determine if it's up-to-date with its alias. The act of syncing a
+  // tensor will set a tensor's generation equal to its alias's generation.
   bool is_up_to_date() const;
-  // Every FunctionalTensorWrapper contains a vector<ViewMeta> objects describing the series of view ops that ran
-  // to generate the current tensor from the base tensor.
-  // This method is used by inplace-view ops like transpose_.
-  // It appends a ViewMeta to the existing stack, and refreshes the tensor by replaying the views off of the alias.
+  // Every FunctionalTensorWrapper contains a vector<ViewMeta> objects
+  // describing the series of view ops that ran to generate the current tensor
+  // from the base tensor. This method is used by inplace-view ops like
+  // transpose_. It appends a ViewMeta to the existing stack, and refreshes the
+  // tensor by replaying the views off of the alias.
   void mutate_view_meta(at::functionalization::ViewMeta meta);
 
   // The functionalization pass can be used to remove mutations.
-  // It does so by replacing any mutation op with it's corresponding out-of-place op, followed by a call to replace_().
-  // e.g:
+  // It does so by replacing any mutation op with it's corresponding
+  // out-of-place op, followed by a call to replace_(). e.g:
   //
   // a.add_(1)
   //
@@ -111,7 +137,8 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
   void set_constructor_metadata();
   functionalization::FunctionalStorageImpl* functional_storage_impl() const;
 
-  // Note that value is not taken by reference: internally, the wrapper will change the value tensor that it points to over time.
+  // Note that value is not taken by reference: internally, the wrapper will
+  // change the value tensor that it points to over time.
   Tensor value_;
   int64_t level_;
 
@@ -124,8 +151,10 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
 namespace functionalization {
 namespace impl {
 
-TORCH_API inline FunctionalTensorWrapper* unsafeGetFunctionalWrapper(const Tensor& tensor) {
-  auto functional_impl = static_cast<FunctionalTensorWrapper*>(tensor.unsafeGetTensorImpl());
+TORCH_API inline FunctionalTensorWrapper* unsafeGetFunctionalWrapper(
+    const Tensor& tensor) {
+  auto functional_impl =
+      static_cast<FunctionalTensorWrapper*>(tensor.unsafeGetTensorImpl());
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(functional_impl != nullptr);
   return functional_impl;
 }
@@ -133,20 +162,30 @@ TORCH_API inline FunctionalTensorWrapper* unsafeGetFunctionalWrapper(const Tenso
 TORCH_API bool isFunctionalTensor(const at::Tensor& tensor);
 TORCH_API bool isFunctionalTensor(const c10::optional<Tensor>& t);
 TORCH_API bool isFunctionalTensor(const c10::List<Tensor>& t_list);
-TORCH_API bool isFunctionalTensor(const c10::List<c10::optional<Tensor>>& t_list);
+TORCH_API bool isFunctionalTensor(
+    const c10::List<c10::optional<Tensor>>& t_list);
 TORCH_API bool isFunctionalTensor(const c10::ArrayRef<Tensor> t_list);
 
 TORCH_API Tensor to_functional_tensor(const Tensor& tensor);
-TORCH_API c10::optional<Tensor> to_functional_tensor(const c10::optional<Tensor>& tensor);
-TORCH_API c10::List<Tensor> to_functional_tensor(const c10::List<Tensor>& t_list);
-TORCH_API c10::List<c10::optional<Tensor>> to_functional_tensor(const c10::List<c10::optional<Tensor>>& t_list);
-TORCH_API std::vector<Tensor> to_functional_tensor(const std::vector<Tensor>& t_list);
+TORCH_API c10::optional<Tensor> to_functional_tensor(
+    const c10::optional<Tensor>& tensor);
+TORCH_API c10::List<Tensor> to_functional_tensor(
+    const c10::List<Tensor>& t_list);
+TORCH_API c10::List<c10::optional<Tensor>> to_functional_tensor(
+    const c10::List<c10::optional<Tensor>>& t_list);
+TORCH_API std::vector<Tensor> to_functional_tensor(
+    const std::vector<Tensor>& t_list);
 TORCH_API std::vector<Tensor> to_functional_tensor(const TensorList& t_list);
 
-TORCH_API Tensor from_functional_tensor(const Tensor& tensor, bool assert_functional=true);
-TORCH_API c10::optional<Tensor> from_functional_tensor(const c10::optional<Tensor>& t, bool assert_functional=true);
-TORCH_API c10::List<Tensor> from_functional_tensor(const c10::List<Tensor>& t_list);
-TORCH_API c10::List<c10::optional<Tensor>> from_functional_tensor(const c10::List<c10::optional<Tensor>>& t_list);
+TORCH_API Tensor
+from_functional_tensor(const Tensor& tensor, bool assert_functional = true);
+TORCH_API c10::optional<Tensor> from_functional_tensor(
+    const c10::optional<Tensor>& t,
+    bool assert_functional = true);
+TORCH_API c10::List<Tensor> from_functional_tensor(
+    const c10::List<Tensor>& t_list);
+TORCH_API c10::List<c10::optional<Tensor>> from_functional_tensor(
+    const c10::List<c10::optional<Tensor>>& t_list);
 TORCH_API std::vector<Tensor> from_functional_tensor(const TensorList& tensors);
 
 TORCH_API void sync(const at::Tensor& t);
@@ -161,15 +200,26 @@ TORCH_API void replace_(const TensorList functional_tensor, TensorList other);
 TORCH_API void commit_update(const Tensor& functional_tensor);
 TORCH_API void commit_update(const TensorList functional_tensor);
 
-Tensor create_functional_tensor_with_view_meta(const Tensor& view_to_wrap, const Tensor& base, functionalization::ViewMeta meta, int64_t out_idx = 0);
-std::vector<Tensor> create_functional_tensor_with_view_meta(const c10::List<Tensor>& view_to_wrap, const Tensor& base, functionalization::ViewMeta meta);
-std::vector<Tensor> create_functional_tensor_with_view_meta(const std::vector<Tensor>& view_to_wrap, const Tensor& base, functionalization::ViewMeta meta);
+Tensor create_functional_tensor_with_view_meta(
+    const Tensor& view_to_wrap,
+    const Tensor& base,
+    functionalization::ViewMeta meta,
+    int64_t out_idx = 0);
+std::vector<Tensor> create_functional_tensor_with_view_meta(
+    const c10::List<Tensor>& view_to_wrap,
+    const Tensor& base,
+    functionalization::ViewMeta meta);
+std::vector<Tensor> create_functional_tensor_with_view_meta(
+    const std::vector<Tensor>& view_to_wrap,
+    const Tensor& base,
+    functionalization::ViewMeta meta);
 
 void mutate_view_meta(const Tensor& self, functionalization::ViewMeta meta);
 
 void set_sizes_strides_offset(const Tensor& out, const Tensor& meta_out);
-void set_sizes_strides_offset(const std::vector<Tensor>& outs, const std::vector<Tensor>& meta_outs);
-
+void set_sizes_strides_offset(
+    const std::vector<Tensor>& outs,
+    const std::vector<Tensor>& meta_outs);
 
 //  ~~~~~ TLS used in functionalization ~~~~~
 
@@ -187,10 +237,14 @@ class TORCH_API FunctionalizationReapplyViewsGuard {
     setFunctionalizationReapplyViewsTLS(prev_);
   }
 
-  FunctionalizationReapplyViewsGuard(const FunctionalizationReapplyViewsGuard&) = delete;
-  FunctionalizationReapplyViewsGuard operator=(const FunctionalizationReapplyViewsGuard&) = delete;
-  FunctionalizationReapplyViewsGuard(FunctionalizationReapplyViewsGuard&&) = delete;
-  FunctionalizationReapplyViewsGuard operator=(FunctionalizationReapplyViewsGuard&&) = delete;
+  FunctionalizationReapplyViewsGuard(
+      const FunctionalizationReapplyViewsGuard&) = delete;
+  FunctionalizationReapplyViewsGuard operator=(
+      const FunctionalizationReapplyViewsGuard&) = delete;
+  FunctionalizationReapplyViewsGuard(FunctionalizationReapplyViewsGuard&&) =
+      delete;
+  FunctionalizationReapplyViewsGuard operator=(
+      FunctionalizationReapplyViewsGuard&&) = delete;
 
  private:
   bool prev_;

--- a/aten/src/ATen/InferSize.h
+++ b/aten/src/ATen/InferSize.h
@@ -15,7 +15,7 @@ namespace at {
 // below
 //
 template <typename ResultVec>
-inline void infer_size_impl(IntArrayRef shape, int64_t numel, ResultVec &res) {
+inline void infer_size_impl(IntArrayRef shape, int64_t numel, ResultVec& res) {
   int64_t newsize = 1;
   auto infer_dim = c10::optional<int64_t>();
   for (int64_t dim = 0, ndim = shape.size(); dim != ndim; dim++) {
@@ -41,9 +41,12 @@ inline void infer_size_impl(IntArrayRef shape, int64_t numel, ResultVec &res) {
       // works yet
       //   empty_tensor.view(-1, 0)
       // doesn't.
-      TORCH_CHECK(newsize != 0, "cannot reshape tensor of 0 elements into shape ",
-               shape, " because the unspecified dimension size -1 can be any "
-               "value and is ambiguous");
+      TORCH_CHECK(
+          newsize != 0,
+          "cannot reshape tensor of 0 elements into shape ",
+          shape,
+          " because the unspecified dimension size -1 can be any "
+          "value and is ambiguous");
       res[*infer_dim] = numel / newsize;
     }
     return;
@@ -66,4 +69,4 @@ inline at::DimVector infer_size_dv(IntArrayRef shape, int64_t numel) {
   return res;
 }
 
-}
+} // namespace at

--- a/aten/src/ATen/InitialTensorOptions.h
+++ b/aten/src/ATen/InitialTensorOptions.h
@@ -5,11 +5,11 @@
 namespace at {
 
 // Represents the initial TensorOptions, before the "defaults" are ever changed.
-// This is designed to be used in library code, where the explicit devices, dtypes, etc. are known.
-// NOTE: this is not a stable API.
+// This is designed to be used in library code, where the explicit devices,
+// dtypes, etc. are known. NOTE: this is not a stable API.
 inline TensorOptions initialTensorOptions() {
-  return TensorOptions(kCPU).dtype(kFloat).layout(kStrided)
-                            .requires_grad(false);
+  return TensorOptions(kCPU).dtype(kFloat).layout(kStrided).requires_grad(
+      false);
 }
 
-}
+} // namespace at

--- a/aten/src/ATen/LinalgBackend.h
+++ b/aten/src/ATen/LinalgBackend.h
@@ -28,4 +28,4 @@ inline std::ostream& operator<<(
   return stream << LinalgBackendToString(backend);
 }
 
-} // namespace c10
+} // namespace at

--- a/aten/src/ATen/MapAllocator.h
+++ b/aten/src/ATen/MapAllocator.h
@@ -29,7 +29,9 @@ class TORCH_API MapAllocator {
   MapAllocator(MapAllocator&&) = delete;
   MapAllocator& operator=(MapAllocator&&) = delete;
 
-  const char* filename() const { return filename_.c_str(); }
+  const char* filename() const {
+    return filename_.c_str();
+  }
   int fd() const {
 #ifdef _WIN32
     TORCH_CHECK(false, "MapAllocator::fd() is unsupported on Windows");
@@ -37,15 +39,29 @@ class TORCH_API MapAllocator {
     return fd_;
 #endif
   }
-  ptrdiff_t size() const { return size_; }
+  ptrdiff_t size() const {
+    return size_;
+  }
   // Return a pointer to the actual data for this allocator
   // (in the case of the refcounted allocator, this is offset
   // from the base pointer.)
-  virtual void* data() const { return base_ptr_; }
+  virtual void* data() const {
+    return base_ptr_;
+  }
 
   static MapAllocator* fromDataPtr(const at::DataPtr&);
-  static at::DataPtr makeDataPtr(std::string filename, int flags, size_t size, size_t* actual_size_out);
-  static at::DataPtr makeDataPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
+  static at::DataPtr makeDataPtr(
+      std::string filename,
+      int flags,
+      size_t size,
+      size_t* actual_size_out);
+  static at::DataPtr makeDataPtr(
+      WithFd,
+      const char* filename,
+      int fd,
+      int flags,
+      size_t size,
+      size_t* actual_size_out);
 
   // Closes the data.  Helps us avoid destructor shenanigans
   virtual void close();
@@ -54,7 +70,7 @@ class TORCH_API MapAllocator {
   // subclass
   virtual ~MapAllocator();
 
-protected:
+ protected:
   bool closed_ = false;
   std::string filename_;
   int flags_ = 0;
@@ -66,7 +82,7 @@ protected:
 #else
   int fd_ = -1;
 #endif
-  void *base_ptr_ = nullptr;
+  void* base_ptr_ = nullptr;
 };
 
 // Base-from-member idiom
@@ -74,16 +90,30 @@ struct TORCH_API RefcountedMapAllocatorArgCheck {
   RefcountedMapAllocatorArgCheck(int flags);
 };
 
-class TORCH_API RefcountedMapAllocator
-    : private RefcountedMapAllocatorArgCheck,
-      public MapAllocator {
+class TORCH_API RefcountedMapAllocator : private RefcountedMapAllocatorArgCheck,
+                                         public MapAllocator {
  public:
-  RefcountedMapAllocator(const char *filename, int flags, size_t size);
-  RefcountedMapAllocator(WithFd, const char *filename, int fd, int flags, size_t size);
+  RefcountedMapAllocator(const char* filename, int flags, size_t size);
+  RefcountedMapAllocator(
+      WithFd,
+      const char* filename,
+      int fd,
+      int flags,
+      size_t size);
 
   static RefcountedMapAllocator* fromDataPtr(const at::DataPtr&);
-  static at::DataPtr makeDataPtr(const char *filename, int flags, size_t size, size_t* actual_size_out);
-  static at::DataPtr makeDataPtr(WithFd, const char *filename, int fd, int flags, size_t size, size_t* actual_size_out);
+  static at::DataPtr makeDataPtr(
+      const char* filename,
+      int flags,
+      size_t size,
+      size_t* actual_size_out);
+  static at::DataPtr makeDataPtr(
+      WithFd,
+      const char* filename,
+      int fd,
+      int flags,
+      size_t size,
+      size_t* actual_size_out);
 
   void* data() const override;
 
@@ -91,11 +121,13 @@ class TORCH_API RefcountedMapAllocator
   int decref();
   void close() override;
 
-  virtual ~RefcountedMapAllocator() { close(); }
+  virtual ~RefcountedMapAllocator() {
+    close();
+  }
 
-protected:
+ protected:
   void checkFlags();
   void initializeAlloc();
 };
 
-}  // namespace at
+} // namespace at

--- a/aten/src/ATen/MatrixRef.h
+++ b/aten/src/ATen/MatrixRef.h
@@ -5,96 +5,105 @@
 #include <vector>
 
 namespace at {
-  /// MatrixRef - Like an ArrayRef, but with an extra recorded strides so that
-  /// we can easily view it as a multidimensional array.
-  ///
-  /// Like ArrayRef, this class does not own the underlying data, it is expected
-  /// to be used in situations where the data resides in some other buffer.
-  ///
-  /// This is intended to be trivially copyable, so it should be passed by
-  /// value.
-  ///
-  /// For now, 2D only (so the copies are actually cheap, without having
-  /// to write a SmallVector class) and contiguous only (so we can
-  /// return non-strided ArrayRef on index).
-  ///
-  /// P.S. dimension 0 indexes rows, dimension 1 indexes columns
-  template<typename T>
-  class MatrixRef {
-  public:
-    typedef size_t size_type;
+/// MatrixRef - Like an ArrayRef, but with an extra recorded strides so that
+/// we can easily view it as a multidimensional array.
+///
+/// Like ArrayRef, this class does not own the underlying data, it is expected
+/// to be used in situations where the data resides in some other buffer.
+///
+/// This is intended to be trivially copyable, so it should be passed by
+/// value.
+///
+/// For now, 2D only (so the copies are actually cheap, without having
+/// to write a SmallVector class) and contiguous only (so we can
+/// return non-strided ArrayRef on index).
+///
+/// P.S. dimension 0 indexes rows, dimension 1 indexes columns
+template <typename T>
+class MatrixRef {
+ public:
+  typedef size_t size_type;
 
-  private:
-    /// Underlying ArrayRef
-    ArrayRef<T> arr;
+ private:
+  /// Underlying ArrayRef
+  ArrayRef<T> arr;
 
-    /// Stride of dim 0 (outer dimension)
-    size_type stride0;
+  /// Stride of dim 0 (outer dimension)
+  size_type stride0;
 
-    // Stride of dim 1 is assumed to be 1
+  // Stride of dim 1 is assumed to be 1
 
-  public:
-    /// Construct an empty Matrixref.
-    /*implicit*/ MatrixRef() : arr(nullptr), stride0(0) {}
+ public:
+  /// Construct an empty Matrixref.
+  /*implicit*/ MatrixRef() : arr(nullptr), stride0(0) {}
 
-    /// Construct an MatrixRef from an ArrayRef and outer stride.
-    /*implicit*/ MatrixRef(ArrayRef<T> arr, size_type stride0)
+  /// Construct an MatrixRef from an ArrayRef and outer stride.
+  /*implicit*/ MatrixRef(ArrayRef<T> arr, size_type stride0)
       : arr(arr), stride0(stride0) {
-        TORCH_CHECK(arr.size() % stride0 == 0, "MatrixRef: ArrayRef size ", arr.size(), " not divisible by stride ", stride0)
-      }
+    TORCH_CHECK(
+        arr.size() % stride0 == 0,
+        "MatrixRef: ArrayRef size ",
+        arr.size(),
+        " not divisible by stride ",
+        stride0)
+  }
 
-    /// @}
-    /// @name Simple Operations
-    /// @{
+  /// @}
+  /// @name Simple Operations
+  /// @{
 
-    /// empty - Check if the matrix is empty.
-    bool empty() const { return arr.empty(); }
+  /// empty - Check if the matrix is empty.
+  bool empty() const {
+    return arr.empty();
+  }
 
-    const T *data() const { return arr.data(); }
+  const T* data() const {
+    return arr.data();
+  }
 
-    /// size - Get size a dimension
-    size_t size(size_t dim) const {
-      if (dim == 0) {
-        return arr.size() / stride0;
-      } else if (dim == 1) {
-        return stride0;
-      } else {
-        TORCH_CHECK(0, "MatrixRef: out of bounds dimension ", dim, "; expected 0 or 1");
-      }
+  /// size - Get size a dimension
+  size_t size(size_t dim) const {
+    if (dim == 0) {
+      return arr.size() / stride0;
+    } else if (dim == 1) {
+      return stride0;
+    } else {
+      TORCH_CHECK(
+          0, "MatrixRef: out of bounds dimension ", dim, "; expected 0 or 1");
     }
+  }
 
-    size_t numel() const {
-      return arr.size();
-    }
+  size_t numel() const {
+    return arr.size();
+  }
 
-    /// equals - Check for element-wise equality.
-    bool equals(MatrixRef RHS) const {
-      return stride0 == RHS.stride0 && arr.equals(RHS.arr);
-    }
+  /// equals - Check for element-wise equality.
+  bool equals(MatrixRef RHS) const {
+    return stride0 == RHS.stride0 && arr.equals(RHS.arr);
+  }
 
-    /// @}
-    /// @name Operator Overloads
-    /// @{
-    ArrayRef<T> operator[](size_t Index) const {
-      return arr.slice(Index*stride0, stride0);
-    }
+  /// @}
+  /// @name Operator Overloads
+  /// @{
+  ArrayRef<T> operator[](size_t Index) const {
+    return arr.slice(Index * stride0, stride0);
+  }
 
-    /// Disallow accidental assignment from a temporary.
-    ///
-    /// The declaration here is extra complicated so that "arrayRef = {}"
-    /// continues to select the move assignment operator.
-    template <typename U>
-    typename std::enable_if<std::is_same<U, T>::value, MatrixRef<T>>::type &
-    operator=(U &&Temporary) = delete;
+  /// Disallow accidental assignment from a temporary.
+  ///
+  /// The declaration here is extra complicated so that "arrayRef = {}"
+  /// continues to select the move assignment operator.
+  template <typename U>
+  typename std::enable_if<std::is_same<U, T>::value, MatrixRef<T>>::type&
+  operator=(U&& Temporary) = delete;
 
-    /// Disallow accidental assignment from a temporary.
-    ///
-    /// The declaration here is extra complicated so that "arrayRef = {}"
-    /// continues to select the move assignment operator.
-    template <typename U>
-    typename std::enable_if<std::is_same<U, T>::value, MatrixRef<T>>::type &
-    operator=(std::initializer_list<U>) = delete;
-
-  };
+  /// Disallow accidental assignment from a temporary.
+  ///
+  /// The declaration here is extra complicated so that "arrayRef = {}"
+  /// continues to select the move assignment operator.
+  template <typename U>
+  typename std::enable_if<std::is_same<U, T>::value, MatrixRef<T>>::type&
+  operator=(std::initializer_list<U>) = delete;
+};
 
 } // end namespace at

--- a/aten/src/ATen/MemoryOverlap.h
+++ b/aten/src/ATen/MemoryOverlap.h
@@ -26,13 +26,17 @@ TORCH_API MemOverlap has_internal_overlap(c10::TensorImpl* t);
 TORCH_API void assert_no_internal_overlap(const TensorBase& t);
 TORCH_API void assert_no_internal_overlap(c10::TensorImpl* t);
 
-TORCH_API MemOverlapStatus get_overlap_status(const TensorBase& a, const TensorBase& b);
-TORCH_API MemOverlapStatus get_overlap_status(c10::TensorImpl* a, c10::TensorImpl* b);
+TORCH_API MemOverlapStatus
+get_overlap_status(const TensorBase& a, const TensorBase& b);
+TORCH_API MemOverlapStatus
+get_overlap_status(c10::TensorImpl* a, c10::TensorImpl* b);
 
-TORCH_API void assert_no_partial_overlap(const TensorBase& a, const TensorBase& b);
+TORCH_API void assert_no_partial_overlap(
+    const TensorBase& a,
+    const TensorBase& b);
 void assert_no_partial_overlap(c10::TensorImpl* a, c10::TensorImpl* b);
 
 TORCH_API void assert_no_overlap(const TensorBase& a, const TensorBase& b);
 TORCH_API void assert_no_overlap(c10::TensorImpl* a, c10::TensorImpl* b);
 
-}
+} // namespace at

--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -2,8 +2,8 @@
 #include <ATen/NamedTensor.h>
 #include <ATen/TensorNames.h>
 
-#include <ATen/core/Tensor.h>
 #include <ATen/core/DimVector.h>
+#include <ATen/core/Tensor.h>
 #include <functional>
 
 namespace at {
@@ -11,14 +11,17 @@ namespace at {
 using NameVector = SmallVector<Dimname, kDimVectorStaticSize>;
 
 inline bool has_names(ITensorListRef tensors) {
-  return std::any_of(
-      tensors.begin(), tensors.end(), [](const Tensor& t) { return t.has_names(); });
+  return std::any_of(tensors.begin(), tensors.end(), [](const Tensor& t) {
+    return t.has_names();
+  });
 }
 
 // Converts dim to an positional index. Errors if `dim` cannot be used to
 // refer to any dimension of tensor.
 TORCH_API int64_t dimname_to_position(const Tensor& tensor, Dimname dim);
-TORCH_API std::vector<int64_t> dimnames_to_positions(const Tensor& tensor, DimnameList dims);
+TORCH_API std::vector<int64_t> dimnames_to_positions(
+    const Tensor& tensor,
+    DimnameList dims);
 
 // Unifies two DimnameList to produce a third. This is useful for implementing
 // the named inference rule for binary broadcasting operations like add.
@@ -27,14 +30,18 @@ TORCH_API std::vector<int64_t> dimnames_to_positions(const Tensor& tensor, Dimna
 // 1) Check matching: Names must match positionally from the right.
 // 2) Check misaligned: If a name `n` is in `names`, then it must appear at
 //    the same index from the right in other.
-// 3) The output names are obtained by unifying the names individually from the right.
-TORCH_API std::vector<Dimname>
-unify_from_right(DimnameList names, DimnameList other, const char* action = "broadcast");
+// 3) The output names are obtained by unifying the names individually from the
+// right.
+TORCH_API std::vector<Dimname> unify_from_right(
+    DimnameList names,
+    DimnameList other,
+    const char* action = "broadcast");
 
 [[noreturn]] inline void reportNYIDimnameOverload(const char* op_name) {
   TORCH_CHECK(
       false,
-      op_name, ": You passed a dimname (string) to this op in place of a dimension "
+      op_name,
+      ": You passed a dimname (string) to this op in place of a dimension "
       "index but it does not yet support this behavior. Please pass a dimension "
       "index to work around this.");
 }
@@ -63,15 +70,16 @@ unify_from_right(DimnameList names, DimnameList other, const char* action = "bro
 // - {} (if the inputs tensors are all unnamed)
 // - non-empty outnames.
 //
-// propagate_names_if_nonempty propagates the outnames if they exist to the result
-// tensors.
+// propagate_names_if_nonempty propagates the outnames if they exist to the
+// result tensors.
 //
 // The {} case is an optimization; if the user does not use named tensors they
 // pay no perf cost for it.
 
 namespace namedinference {
 
-const Tensor& propagate_names_if_present_and_nonempty(const Tensor& result,
+const Tensor& propagate_names_if_present_and_nonempty(
+    const Tensor& result,
     c10::optional<DimnameList> maybe_names,
     bool validate_names = false);
 // Propagates `names` to `result` if `names` is not empty.
@@ -83,8 +91,8 @@ TORCH_API const Tensor& propagate_names_if_nonempty(
     DimnameList maybe_names,
     bool validate_names = false);
 
-// Propagates `names` to `result`. Only use this if we are certain that there are
-// names to propagate (that names is not empty).
+// Propagates `names` to `result`. Only use this if we are certain that there
+// are names to propagate (that names is not empty).
 TORCH_API const Tensor& propagate_names(
     const Tensor& result,
     DimnameList names,
@@ -94,12 +102,21 @@ TORCH_API const Tensor& propagate_names(
 TORCH_API void propagate_names(const Tensor& result, const Tensor& src);
 
 // Propagates all names except for those at the excluded_idxs.
-TORCH_API void propagate_names_except(const Tensor& result, const Tensor& src, IntArrayRef excluded_idxs);
+TORCH_API void propagate_names_except(
+    const Tensor& result,
+    const Tensor& src,
+    IntArrayRef excluded_idxs);
 
 // Used for reduction ops that have a `keepdim` arg.
-TORCH_API void propagate_names_for_reduction(const Tensor& result, const Tensor& src, IntArrayRef excluded_idxs, bool keepdim);
+TORCH_API void propagate_names_for_reduction(
+    const Tensor& result,
+    const Tensor& src,
+    IntArrayRef excluded_idxs,
+    bool keepdim);
 
-TORCH_API void propagate_names_for_expand(const Tensor& result, const Tensor& self);
+TORCH_API void propagate_names_for_expand(
+    const Tensor& result,
+    const Tensor& self);
 
 TORCH_API std::vector<Dimname> compute_cat_outnames(ITensorListRef tensors);
 
@@ -112,9 +129,13 @@ TORCH_API std::vector<Dimname> broadcast_to_outnames(
     const Tensor& reference_tensor,
     const char* op_name);
 
-TORCH_API std::vector<Dimname> compute_matmul_outnames(const Tensor& self, const Tensor& other);
+TORCH_API std::vector<Dimname> compute_matmul_outnames(
+    const Tensor& self,
+    const Tensor& other);
 
-TORCH_API std::vector<Dimname> compute_cdist_outnames(const Tensor& self, const Tensor& other);
+TORCH_API std::vector<Dimname> compute_cdist_outnames(
+    const Tensor& self,
+    const Tensor& other);
 
 TORCH_API std::vector<Dimname> compute_bmm_outnames(
     const Tensor& result,
@@ -140,7 +161,7 @@ TORCH_API TensorImpl* propagate_names(
     DimnameList names,
     bool validate_names = false);
 
-TORCH_API void propagate_names(TensorImpl* result, /*const */TensorImpl* src);
+TORCH_API void propagate_names(TensorImpl* result, /*const */ TensorImpl* src);
 
 TORCH_API inline void propagate_names(
     const TensorBase& result,
@@ -153,10 +174,13 @@ TORCH_API inline void propagate_names_if_nonempty(
     const TensorBase& result,
     DimnameList names,
     bool validate_names = false) {
-  propagate_names_if_nonempty(result.unsafeGetTensorImpl(), names, validate_names);
+  propagate_names_if_nonempty(
+      result.unsafeGetTensorImpl(), names, validate_names);
 }
 
-TORCH_API inline void propagate_names(const TensorBase& result, const TensorBase& src) {
+TORCH_API inline void propagate_names(
+    const TensorBase& result,
+    const TensorBase& src) {
   propagate_names(result.unsafeGetTensorImpl(), src.unsafeGetTensorImpl());
 }
 

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -1,11 +1,11 @@
 #pragma once
+#include <ATen/MemoryOverlap.h>
 #include <ATen/Tensor.h>
+#include <c10/core/MemoryFormat.h>
 #include <c10/core/TensorImpl.h>
 #include <c10/util/Exception.h>
-#include <c10/util/irange.h>
-#include <ATen/MemoryOverlap.h>
-#include <c10/core/MemoryFormat.h>
 #include <c10/util/Metaprogramming.h>
+#include <c10/util/irange.h>
 
 namespace at {
 namespace native {
@@ -58,22 +58,19 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   std::vector<int64_t> opt_sizes_;
 };
 
-inline NestedTensorImpl* get_nested_tensor_impl_or_null(const at::Tensor& tensor) {
+inline NestedTensorImpl* get_nested_tensor_impl_or_null(
+    const at::Tensor& tensor) {
   if (tensor.is_nested()) {
     return static_cast<NestedTensorImpl*>(tensor.unsafeGetTensorImpl());
   }
   return nullptr;
 }
 
-inline NestedTensorImpl* get_nested_tensor_impl(
-    const at::Tensor& tensor) {
+inline NestedTensorImpl* get_nested_tensor_impl(const at::Tensor& tensor) {
   TORCH_CHECK(
-      tensor.is_nested(),
-      "get_nested_tensor_impl requires a NestedTensor.");
-  return static_cast<NestedTensorImpl*>(
-      tensor.unsafeGetTensorImpl());
+      tensor.is_nested(), "get_nested_tensor_impl requires a NestedTensor.");
+  return static_cast<NestedTensorImpl*>(tensor.unsafeGetTensorImpl());
 }
-
 
 // TODO: real implementation once we support strides.
 inline bool nested_tensor_impl_is_contiguous(

--- a/aten/src/ATen/NumericUtils.h
+++ b/aten/src/ATen/NumericUtils.h
@@ -4,12 +4,12 @@
 #include <hip/hip_runtime.h>
 #endif
 
+#include <c10/macros/Macros.h>
+#include <c10/util/BFloat16.h>
+#include <c10/util/Half.h>
 #include <cmath>
 #include <complex>
 #include <type_traits>
-#include <c10/util/BFloat16.h>
-#include <c10/util/Half.h>
-#include <c10/macros/Macros.h>
 
 namespace at {
 
@@ -17,14 +17,16 @@ namespace at {
 // (uselessly) convert to floating point and then do the test.
 // This function is.
 
-template <typename T,
-          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+template <
+    typename T,
+    typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
 inline C10_HOST_DEVICE bool _isnan(T /*val*/) {
   return false;
 }
 
-template <typename T,
-          typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+template <
+    typename T,
+    typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
 inline C10_HOST_DEVICE bool _isnan(T val) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return ::isnan(val);
@@ -33,21 +35,24 @@ inline C10_HOST_DEVICE bool _isnan(T val) {
 #endif
 }
 
-template <typename T,
-          typename std::enable_if<c10::is_complex<T>::value, int>::type = 0>
+template <
+    typename T,
+    typename std::enable_if<c10::is_complex<T>::value, int>::type = 0>
 inline bool _isnan(T val) {
   return std::isnan(val.real()) || std::isnan(val.imag());
 }
 
-template <typename T,
-         typename std::enable_if<std::is_same<T, at::Half>::value, int>::type = 0>
+template <
+    typename T,
+    typename std::enable_if<std::is_same<T, at::Half>::value, int>::type = 0>
 inline C10_HOST_DEVICE bool _isnan(T val) {
   return at::_isnan(static_cast<float>(val));
 }
 
-
-template <typename T,
-         typename std::enable_if<std::is_same<T, at::BFloat16>::value, int>::type = 0>
+template <
+    typename T,
+    typename std::enable_if<std::is_same<T, at::BFloat16>::value, int>::type =
+        0>
 inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
   return at::_isnan(static_cast<float>(val));
 }
@@ -55,20 +60,21 @@ inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
 inline C10_HOST_DEVICE bool _isnan(at::BFloat16 val) {
   return at::_isnan(static_cast<float>(val));
 }
-
 
 // std::isinf isn't performant to use on integral types; it will
 // (uselessly) convert to floating point and then do the test.
 // This function is.
 
-template <typename T,
-          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+template <
+    typename T,
+    typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
 inline C10_HOST_DEVICE bool _isinf(T /*val*/) {
   return false;
 }
 
-template <typename T,
-          typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+template <
+    typename T,
+    typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
 inline C10_HOST_DEVICE bool _isinf(T val) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return ::isinf(val);
@@ -81,14 +87,15 @@ inline C10_HOST_DEVICE bool _isinf(at::Half val) {
   return at::_isinf(static_cast<float>(val));
 }
 
-
 inline C10_HOST_DEVICE bool _isinf(at::BFloat16 val) {
   return at::_isinf(static_cast<float>(val));
 }
 
 template <typename T>
 C10_HOST_DEVICE inline T exp(T x) {
-  static_assert(!std::is_same<T, double>::value, "this template must be used with float or less precise type");
+  static_assert(
+      !std::is_same<T, double>::value,
+      "this template must be used with float or less precise type");
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __expf fast approximation for peak bandwidth
   return __expf(x);
@@ -104,7 +111,9 @@ C10_HOST_DEVICE inline double exp<double>(double x) {
 
 template <typename T>
 C10_HOST_DEVICE inline T log(T x) {
-  static_assert(!std::is_same<T, double>::value, "this template must be used with float or less precise type");
+  static_assert(
+      !std::is_same<T, double>::value,
+      "this template must be used with float or less precise type");
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __logf fast approximation for peak bandwidth
   return __logf(x);
@@ -120,7 +129,9 @@ C10_HOST_DEVICE inline double log<double>(double x) {
 
 template <typename T>
 C10_HOST_DEVICE inline T tan(T x) {
-  static_assert(!std::is_same<T, double>::value, "this template must be used with float or less precise type");
+  static_assert(
+      !std::is_same<T, double>::value,
+      "this template must be used with float or less precise type");
 #if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
   // use __tanf fast approximation for peak bandwidth
   return __tanf(x);

--- a/aten/src/ATen/OpMathType.h
+++ b/aten/src/ATen/OpMathType.h
@@ -1,36 +1,49 @@
 #pragma once
 
 #include <c10/core/ScalarType.h>
-#include <c10/util/Half.h>
 #include <c10/util/BFloat16.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Half.h>
 
 namespace at {
 
 // For FP16 or BFloat16 inputs, ops should perform internal math in FP32.
-template<typename scalar_t> struct OpMathType { using type = scalar_t; };
-template<> struct OpMathType<at::Half> { using type = float; };
-template<> struct OpMathType<at::BFloat16> { using type = float; };
-template<> struct OpMathType<c10::complex<Half>> { using type = c10::complex<float>; };
+template <typename scalar_t>
+struct OpMathType {
+  using type = scalar_t;
+};
+template <>
+struct OpMathType<at::Half> {
+  using type = float;
+};
+template <>
+struct OpMathType<at::BFloat16> {
+  using type = float;
+};
+template <>
+struct OpMathType<c10::complex<Half>> {
+  using type = c10::complex<float>;
+};
 
-template<typename T>
+template <typename T>
 using opmath_type = typename OpMathType<T>::type;
 
 namespace {
 
 c10::ScalarType toOpMathType(const c10::ScalarType type) {
   switch (type) {
-#define DEFINE_CASE(scalar_t, TypeNum)                                  \
-    case ScalarType::TypeNum:                                           \
-      return CppTypeToScalarType<at::opmath_type<scalar_t>>::value;
+#define DEFINE_CASE(scalar_t, TypeNum) \
+  case ScalarType::TypeNum:            \
+    return CppTypeToScalarType<at::opmath_type<scalar_t>>::value;
 
     AT_FORALL_SCALAR_TYPES_WITH_COMPLEX(DEFINE_CASE)
 #undef DEFINE_CASE
 
-    default: TORCH_INTERNAL_ASSERT(false, "Unrecognized ScalarType: ", type);
+    default:
+      TORCH_INTERNAL_ASSERT(false, "Unrecognized ScalarType: ", type);
   }
 }
 
-}
+} // namespace
 
 } // namespace at

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -55,7 +55,8 @@ struct TORCH_API OpaqueTensorImpl : public TensorImpl {
 
 #ifdef DEBUG
   bool has_storage() const override {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!storage_, "OpaqueTensorImpl assumes that storage_ is never set");
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+        !storage_, "OpaqueTensorImpl assumes that storage_ is never set");
     return false;
   }
 #endif

--- a/aten/src/ATen/PTThreadPool.h
+++ b/aten/src/ATen/PTThreadPool.h
@@ -6,14 +6,12 @@
 namespace at {
 
 class TORCH_API PTThreadPool : public c10::ThreadPool {
-public:
-  explicit PTThreadPool(
-      int pool_size,
-      int numa_node_id = -1)
-    : c10::ThreadPool(pool_size, numa_node_id, [](){
-        c10::setThreadName("PTThreadPool");
-        at::init_num_threads();
-      }) {}
+ public:
+  explicit PTThreadPool(int pool_size, int numa_node_id = -1)
+      : c10::ThreadPool(pool_size, numa_node_id, []() {
+          c10::setThreadName("PTThreadPool");
+          at::init_num_threads();
+        }) {}
 };
 
 } // namespace at

--- a/aten/src/ATen/Parallel-inl.h
+++ b/aten/src/ATen/Parallel-inl.h
@@ -19,10 +19,9 @@ inline void parallel_for(
 #ifdef INTRA_OP_PARALLEL
   at::internal::lazy_init_num_threads();
   const auto numiter = end - begin;
-  const bool use_parallel = (
-    numiter > grain_size && numiter > 1 &&
-    !at::in_parallel_region() &&
-    at::get_num_threads() > 1);
+  const bool use_parallel =
+      (numiter > grain_size && numiter > 1 && !at::in_parallel_region() &&
+       at::get_num_threads() > 1);
   if (!use_parallel) {
     internal::ThreadIdGuard tid_guard(0);
     f(begin, end);
@@ -52,22 +51,23 @@ inline scalar_t parallel_reduce(
 #ifdef INTRA_OP_PARALLEL
   at::internal::lazy_init_num_threads();
   const auto max_threads = at::get_num_threads();
-  const bool use_parallel = (
-      (end - begin) > grain_size &&
-      !at::in_parallel_region() &&
-      max_threads > 1);
+  const bool use_parallel =
+      ((end - begin) > grain_size && !at::in_parallel_region() &&
+       max_threads > 1);
   if (!use_parallel) {
     internal::ThreadIdGuard tid_guard(0);
     return f(begin, end, ident);
   }
 
   c10::SmallVector<scalar_t, 64> results(max_threads, ident);
-  internal::invoke_parallel(begin, end, grain_size,
-    [&](const int64_t my_begin, const int64_t my_end) {
-      const auto tid = at::get_thread_num();
-      results[tid] = f(my_begin, my_end, ident);
-    }
-  );
+  internal::invoke_parallel(
+      begin,
+      end,
+      grain_size,
+      [&](const int64_t my_begin, const int64_t my_end) {
+        const auto tid = at::get_thread_num();
+        results[tid] = f(my_begin, my_end, ident);
+      });
 
   scalar_t result = ident;
   for (auto partial_result : results) {

--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -39,9 +39,8 @@ inline TORCH_API void lazy_init_num_threads() {
 TORCH_API void set_thread_num(int);
 
 class TORCH_API ThreadIdGuard {
-public:
-  ThreadIdGuard(int new_id):
-    old_id_(at::get_thread_num()) {
+ public:
+  ThreadIdGuard(int new_id) : old_id_(at::get_thread_num()) {
     set_thread_num(new_id);
   }
 
@@ -49,11 +48,11 @@ public:
     set_thread_num(old_id_);
   }
 
-private:
+ private:
   int old_id_;
 };
 
-}  // namespace internal
+} // namespace internal
 
 /*
 parallel_for

--- a/aten/src/ATen/ParallelFuture.h
+++ b/aten/src/ATen/ParallelFuture.h
@@ -10,4 +10,4 @@ namespace at {
 TORCH_API c10::intrusive_ptr<c10::ivalue::Future> intraop_launch_future(
     std::function<void()> func);
 
-}  // namespace at
+} // namespace at

--- a/aten/src/ATen/ParallelNative.h
+++ b/aten/src/ATen/ParallelNative.h
@@ -12,10 +12,10 @@ namespace at {
 namespace internal {
 
 TORCH_API void invoke_parallel(
-  const int64_t begin,
-  const int64_t end,
-  const int64_t grain_size,
-  const std::function<void(int64_t, int64_t)>& f);
+    const int64_t begin,
+    const int64_t end,
+    const int64_t grain_size,
+    const std::function<void(int64_t, int64_t)>& f);
 
 } // namespace internal
 

--- a/aten/src/ATen/ParallelNativeTBB.h
+++ b/aten/src/ATen/ParallelNativeTBB.h
@@ -24,7 +24,6 @@ inline void invoke_parallel(
     const int64_t end,
     const int64_t grain_size,
     const F& f) {
-
   // Choose number of tasks based on grain size and number of threads.
   int64_t chunk_size = divup((end - begin), get_num_threads());
   // Make sure each task is at least grain_size size.
@@ -32,23 +31,24 @@ inline void invoke_parallel(
 
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
-  tbb::parallel_for(tbb::blocked_range<int64_t>(begin, end, chunk_size),
-    [&eptr, &err_flag, f](const tbb::blocked_range<int64_t>& r) {
-      try {
-        internal::ThreadIdGuard tid_guard(
-            tbb::this_task_arena::current_thread_index());
-        f(r.begin(), r.end());
-      } catch (...) {
-        if (!err_flag.test_and_set()) {
-          eptr = std::current_exception();
+  tbb::parallel_for(
+      tbb::blocked_range<int64_t>(begin, end, chunk_size),
+      [&eptr, &err_flag, f](const tbb::blocked_range<int64_t>& r) {
+        try {
+          internal::ThreadIdGuard tid_guard(
+              tbb::this_task_arena::current_thread_index());
+          f(r.begin(), r.end());
+        } catch (...) {
+          if (!err_flag.test_and_set()) {
+            eptr = std::current_exception();
+          }
         }
-      }
-    }, tbb::static_partitioner{});
+      },
+      tbb::static_partitioner{});
   if (eptr) {
     std::rethrow_exception(eptr);
   }
 }
-
 
 } // namespace internal
 } // namespace at

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -15,14 +15,19 @@ namespace at {
 #ifdef _OPENMP
 namespace internal {
 template <typename F>
-inline void invoke_parallel(int64_t begin, int64_t end, int64_t grain_size, const F& f) {
+inline void invoke_parallel(
+    int64_t begin,
+    int64_t end,
+    int64_t grain_size,
+    const F& f) {
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
 
 #pragma omp parallel
   {
     // choose number of tasks based on grain size and number of threads
-    // can't use num_threads clause due to bugs in GOMP's thread pool (See #32008)
+    // can't use num_threads clause due to bugs in GOMP's thread pool (See
+    // #32008)
     int64_t num_threads = omp_get_num_threads();
     if (grain_size > 0) {
       num_threads = std::min(num_threads, divup((end - begin), grain_size));

--- a/aten/src/ATen/PythonTorchFunctionTLS.h
+++ b/aten/src/ATen/PythonTorchFunctionTLS.h
@@ -17,7 +17,7 @@ struct TORCH_API PythonTorchFunctionTLS {
   static void set_state(const PythonTorchFunctionTLS& state);
   static const PythonTorchFunctionTLS& get_state();
 
-private:
+ private:
   bool disabled_;
   std::shared_ptr<c10::SafePyObject> mode_;
 };

--- a/aten/src/ATen/ScalarOps.h
+++ b/aten/src/ATen/ScalarOps.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <c10/core/Scalar.h>
 #include <ATen/Tensor.h>
+#include <c10/core/Scalar.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -17,16 +17,22 @@ namespace detail {
 // but we also want to skip compute_types which in not avoidable
 // in TensorIterator for now.
 Tensor& scalar_fill(Tensor& self, const Scalar& value);
-TORCH_API Tensor scalar_tensor_static(const Scalar& s, c10::optional<ScalarType> dtype_opt, c10::optional<Device> device_opt);
+TORCH_API Tensor scalar_tensor_static(
+    const Scalar& s,
+    c10::optional<ScalarType> dtype_opt,
+    c10::optional<Device> device_opt);
 } // namespace detail
 } // namespace at
 
 // This is in the c10 namespace because we use ADL to find the functions in it.
 namespace c10 {
 
-// FIXME: this should be (and was) Scalar::toTensor, but there is currently no way
-// to implement this without going through Derived Types (which are not part of core).
-inline at::Tensor scalar_to_tensor(const Scalar& s, const Device device = at::kCPU) {
+// FIXME: this should be (and was) Scalar::toTensor, but there is currently no
+// way to implement this without going through Derived Types (which are not part
+// of core).
+inline at::Tensor scalar_to_tensor(
+    const Scalar& s,
+    const Device device = at::kCPU) {
   // This is the fast track we have for CPU scalar tensors.
   if (device == at::kCPU) {
     if (s.isFloatingPoint()) {
@@ -57,11 +63,13 @@ inline at::Tensor scalar_to_tensor(const Scalar& s, const Device device = at::kC
 namespace at {
 namespace native {
 
-inline Tensor wrapped_scalar_tensor(const Scalar& scalar, const Device device = at::kCPU) {
+inline Tensor wrapped_scalar_tensor(
+    const Scalar& scalar,
+    const Device device = at::kCPU) {
   auto tensor = scalar_to_tensor(scalar, device);
   tensor.unsafeGetTensorImpl()->set_wrapped_number(true);
   return tensor;
 }
 
 } // namespace native
-} // namsepace at
+} // namespace at

--- a/aten/src/ATen/SequenceNumber.h
+++ b/aten/src/ATen/SequenceNumber.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <cstdint>
 #include <c10/macros/Export.h>
+#include <cstdint>
 
 namespace at {
 

--- a/aten/src/ATen/SparseCsrTensorImpl.h
+++ b/aten/src/ATen/SparseCsrTensorImpl.h
@@ -31,7 +31,10 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
   Layout layout_;
 
  public:
-  explicit SparseCsrTensorImpl(at::DispatchKeySet, Layout layout, const caffe2::TypeMeta);
+  explicit SparseCsrTensorImpl(
+      at::DispatchKeySet,
+      Layout layout,
+      const caffe2::TypeMeta);
 
   void resize_(int64_t nnz, IntArrayRef size);
   void resize_as_sparse_csr_tensor_(const Tensor& src);
@@ -41,10 +44,18 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
       const Tensor& values,
       IntArrayRef size);
 
-  const Tensor& compressed_indices() const { return crow_indices_; }
-  const Tensor& plain_indices() const { return col_indices_; }
-  const Tensor& values() const { return values_; }
-  int nnz() { return col_indices_.size(-1); }
+  const Tensor& compressed_indices() const {
+    return crow_indices_;
+  }
+  const Tensor& plain_indices() const {
+    return col_indices_;
+  }
+  const Tensor& values() const {
+    return values_;
+  }
+  int nnz() {
+    return col_indices_.size(-1);
+  }
 
  protected:
   IntArrayRef strides_custom() const override;
@@ -53,17 +64,19 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
   void set_size(int64_t dim, int64_t new_size) override;
   void set_stride(int64_t dim, int64_t new_stride) override;
   void set_storage_offset(int64_t storage_offset) override;
-  Layout layout_impl() const override { return layout_; }
+  Layout layout_impl() const override {
+    return layout_;
+  }
   void set_layout(Layout layout) {
     switch (layout) {
-    case kSparseCsr:
-    case kSparseCsc:
-    case kSparseBsr:
-    case kSparseBsc:
-      layout_ = layout;
-      break;
-    default:
-      TORCH_CHECK(false, "unsupported layout ", layout);
+      case kSparseCsr:
+      case kSparseCsc:
+      case kSparseBsr:
+      case kSparseBsc:
+        layout_ = layout;
+        break;
+      default:
+        TORCH_CHECK(false, "unsupported layout ", layout);
     }
   }
 
@@ -76,12 +89,13 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
   c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) const override {
-    auto impl = c10::make_intrusive<SparseCsrTensorImpl>(key_set(), layout_impl(), dtype());
+    auto impl = c10::make_intrusive<SparseCsrTensorImpl>(
+        key_set(), layout_impl(), dtype());
     copy_tensor_metadata(
-      /*src_impl=*/this,
-      /*dest_impl=*/impl.get(),
-      /*version_counter=*/version_counter,
-      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
+        /*src_impl=*/this,
+        /*dest_impl=*/impl.get(),
+        /*version_counter=*/version_counter,
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
     impl->refresh_numel();
     return impl;
   }
@@ -95,12 +109,13 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
   c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
       c10::VariableVersion&& version_counter,
       bool allow_tensor_metadata_change) const override {
-    auto impl = c10::make_intrusive<SparseCsrTensorImpl>(key_set(), layout_impl(), dtype());
+    auto impl = c10::make_intrusive<SparseCsrTensorImpl>(
+        key_set(), layout_impl(), dtype());
     copy_tensor_metadata(
-      /*src_impl=*/this,
-      /*dest_impl=*/impl.get(),
-      /*version_counter=*/std::move(version_counter),
-      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
+        /*src_impl=*/this,
+        /*dest_impl=*/impl.get(),
+        /*version_counter=*/std::move(version_counter),
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
     impl->refresh_numel();
     return impl;
   }
@@ -117,17 +132,22 @@ struct TORCH_API SparseCsrTensorImpl : public TensorImpl {
   const char* tensorimpl_type_name() const override;
 
   /**
-   * Copy the tensor metadata fields (e.g. sizes / strides / storage pointer / storage_offset)
-   * from one TensorImpl to another TensorImpl.
+   * Copy the tensor metadata fields (e.g. sizes / strides / storage pointer /
+   * storage_offset) from one TensorImpl to another TensorImpl.
    *
-   * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE [ TensorImpl Shallow-Copying ].
+   * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE
+   * [ TensorImpl Shallow-Copying ].
    */
   static void copy_tensor_metadata(
       const SparseCsrTensorImpl* src_sparse_impl,
       SparseCsrTensorImpl* dest_sparse_impl,
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) {
-    TensorImpl::copy_tensor_metadata(src_sparse_impl, dest_sparse_impl, version_counter, allow_tensor_metadata_change);
+    TensorImpl::copy_tensor_metadata(
+        src_sparse_impl,
+        dest_sparse_impl,
+        version_counter,
+        allow_tensor_metadata_change);
 
     // Sparse-specific fields
     dest_sparse_impl->crow_indices_ = src_sparse_impl->compressed_indices();

--- a/aten/src/ATen/SparseCsrTensorUtils.h
+++ b/aten/src/ATen/SparseCsrTensorUtils.h
@@ -1,101 +1,126 @@
 #pragma once
 
-#include <ATen/core/Tensor.h>
 #include <ATen/SparseCsrTensorImpl.h>
 #include <ATen/SparseTensorImpl.h>
 #include <ATen/SparseTensorUtils.h>
+#include <ATen/core/Tensor.h>
 
-#define AT_DISPATCH_ALL_SPARSE_COMPRESSED_LAYOUTS(LAYOUT, NAME, ...)    \
-  [&] {                                                                 \
-    const auto& the_layout = LAYOUT;                                    \
-    switch (the_layout) {                                               \
-    case kSparseCsr:                                                    \
-    case kSparseCsc:                                                    \
-    case kSparseBsr:                                                    \
-    case kSparseBsc:                                                    \
-      return __VA_ARGS__();                                             \
-    default:                                                            \
-      AT_ERROR(#NAME, " expected sparse compressed tensor layout but got ", the_layout); \
-    }                                                                   \
-  } ()
+#define AT_DISPATCH_ALL_SPARSE_COMPRESSED_LAYOUTS(LAYOUT, NAME, ...) \
+  [&] {                                                              \
+    const auto& the_layout = LAYOUT;                                 \
+    switch (the_layout) {                                            \
+      case kSparseCsr:                                               \
+      case kSparseCsc:                                               \
+      case kSparseBsr:                                               \
+      case kSparseBsc:                                               \
+        return __VA_ARGS__();                                        \
+      default:                                                       \
+        AT_ERROR(                                                    \
+            #NAME,                                                   \
+            " expected sparse compressed tensor layout but got ",    \
+            the_layout);                                             \
+    }                                                                \
+  }()
 
-#define AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(LAYOUT, NAME, ROW_DIM_ACTION, COLUMN_DIM_ACTION) \
-  [&]() {                                                               \
-    const auto& the_layout = LAYOUT;                                    \
-    switch (the_layout) {                                               \
-    case kSparseCsr:                                                    \
-    case kSparseBsr:                                                    \
-      return (ROW_DIM_ACTION)();                                        \
-    case kSparseCsc:                                                    \
-    case kSparseBsc:                                                    \
-      return (COLUMN_DIM_ACTION)();                                     \
-    default:                                                            \
-      AT_ERROR(#NAME, " expected sparse compressed tensor layout but got ", the_layout); \
-    }                                                                   \
-  } ()
+#define AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(                \
+    LAYOUT, NAME, ROW_DIM_ACTION, COLUMN_DIM_ACTION)              \
+  [&]() {                                                         \
+    const auto& the_layout = LAYOUT;                              \
+    switch (the_layout) {                                         \
+      case kSparseCsr:                                            \
+      case kSparseBsr:                                            \
+        return (ROW_DIM_ACTION)();                                \
+      case kSparseCsc:                                            \
+      case kSparseBsc:                                            \
+        return (COLUMN_DIM_ACTION)();                             \
+      default:                                                    \
+        AT_ERROR(                                                 \
+            #NAME,                                                \
+            " expected sparse compressed tensor layout but got ", \
+            the_layout);                                          \
+    }                                                             \
+  }()
 
-#define AT_DISPATCH_PLAIN_SPARSE_COMPRESSED_LAYOUTS(LAYOUT, NAME, NO_BLOCK_ACTION, BLOCK_ACTION) \
-  [&]() {                                                               \
-    const auto& the_layout = LAYOUT;                                    \
-    switch (the_layout) {                                               \
-    case kSparseCsr:                                                    \
-    case kSparseCsc:                                                    \
-      return (NO_BLOCK_ACTION)();                                       \
-    case kSparseBsr:                                                    \
-    case kSparseBsc:                                                    \
-      return (BLOCK_ACTION)();                                          \
-    default:                                                            \
-      AT_ERROR(#NAME, " expected sparse compressed tensor layout but got ", the_layout); \
-    }                                                                   \
-  } ()
+#define AT_DISPATCH_PLAIN_SPARSE_COMPRESSED_LAYOUTS(              \
+    LAYOUT, NAME, NO_BLOCK_ACTION, BLOCK_ACTION)                  \
+  [&]() {                                                         \
+    const auto& the_layout = LAYOUT;                              \
+    switch (the_layout) {                                         \
+      case kSparseCsr:                                            \
+      case kSparseCsc:                                            \
+        return (NO_BLOCK_ACTION)();                               \
+      case kSparseBsr:                                            \
+      case kSparseBsc:                                            \
+        return (BLOCK_ACTION)();                                  \
+      default:                                                    \
+        AT_ERROR(                                                 \
+            #NAME,                                                \
+            " expected sparse compressed tensor layout but got ", \
+            the_layout);                                          \
+    }                                                             \
+  }()
 
-#define AT_DISPATCH_SPARSE_ROW_COMPRESSED_LAYOUTS(LAYOUT, NAME, ROW_DIM_ACTION) \
-  [&]() {                                                               \
-    const auto& the_layout = LAYOUT;                                    \
-    switch (the_layout) {                                               \
-    case kSparseCsr:                                                    \
-    case kSparseBsr:                                                    \
-      return (ROW_DIM_ACTION)();                                        \
-    default:                                                            \
-      AT_ERROR(#NAME, " expected sparse row compressed tensor layout but got ", the_layout); \
-    }                                                                   \
-  } ()
+#define AT_DISPATCH_SPARSE_ROW_COMPRESSED_LAYOUTS(                    \
+    LAYOUT, NAME, ROW_DIM_ACTION)                                     \
+  [&]() {                                                             \
+    const auto& the_layout = LAYOUT;                                  \
+    switch (the_layout) {                                             \
+      case kSparseCsr:                                                \
+      case kSparseBsr:                                                \
+        return (ROW_DIM_ACTION)();                                    \
+      default:                                                        \
+        AT_ERROR(                                                     \
+            #NAME,                                                    \
+            " expected sparse row compressed tensor layout but got ", \
+            the_layout);                                              \
+    }                                                                 \
+  }()
 
-#define AT_DISPATCH_SPARSE_COL_COMPRESSED_LAYOUTS(LAYOUT, NAME, COL_DIM_ACTION) \
-  [&]() {                                                               \
-    const auto& the_layout = LAYOUT;                                    \
-    switch (the_layout) {                                               \
-    case kSparseCsc:                                                    \
-    case kSparseBsc:                                                    \
-      return (COL_DIM_ACTION)();                                        \
-    default:                                                            \
-      AT_ERROR(#NAME, " expected sparse column compressed tensor layout but got ", the_layout); \
-    }                                                                   \
-  } ()
+#define AT_DISPATCH_SPARSE_COL_COMPRESSED_LAYOUTS(                       \
+    LAYOUT, NAME, COL_DIM_ACTION)                                        \
+  [&]() {                                                                \
+    const auto& the_layout = LAYOUT;                                     \
+    switch (the_layout) {                                                \
+      case kSparseCsc:                                                   \
+      case kSparseBsc:                                                   \
+        return (COL_DIM_ACTION)();                                       \
+      default:                                                           \
+        AT_ERROR(                                                        \
+            #NAME,                                                       \
+            " expected sparse column compressed tensor layout but got ", \
+            the_layout);                                                 \
+    }                                                                    \
+  }()
 
-#define AT_DISPATCH_SPARSE_COMPRESSED_NONBLOCK_LAYOUTS(LAYOUT, NAME, ACTION) \
-  [&]() {                                                               \
-    const auto& the_layout = LAYOUT;                                    \
-    switch (the_layout) {                                               \
-    case kSparseCsr:                                                    \
-    case kSparseCsc:                                                    \
-      return (ACTION)();                                                \
-    default:                                                            \
-      AT_ERROR(#NAME, " expected sparse compressed (non-block) tensor layout but got ", the_layout); \
-    }                                                                   \
-  } ()
+#define AT_DISPATCH_SPARSE_COMPRESSED_NONBLOCK_LAYOUTS(LAYOUT, NAME, ACTION)  \
+  [&]() {                                                                     \
+    const auto& the_layout = LAYOUT;                                          \
+    switch (the_layout) {                                                     \
+      case kSparseCsr:                                                        \
+      case kSparseCsc:                                                        \
+        return (ACTION)();                                                    \
+      default:                                                                \
+        AT_ERROR(                                                             \
+            #NAME,                                                            \
+            " expected sparse compressed (non-block) tensor layout but got ", \
+            the_layout);                                                      \
+    }                                                                         \
+  }()
 
 #define AT_DISPATCH_SPARSE_COMPRESSED_BLOCK_LAYOUTS(LAYOUT, NAME, ACTION) \
-  [&]() {                                                               \
-    const auto& the_layout = LAYOUT;                                    \
-    switch (the_layout) {                                               \
-    case kSparseBsr:                                                    \
-    case kSparseBsc:                                                    \
-      return (ACTION)();                                                \
-    default:                                                            \
-      AT_ERROR(#NAME, " expected sparse compressed block tensor layout but got ", the_layout); \
-    }                                                                   \
-  } ()
+  [&]() {                                                                 \
+    const auto& the_layout = LAYOUT;                                      \
+    switch (the_layout) {                                                 \
+      case kSparseBsr:                                                    \
+      case kSparseBsc:                                                    \
+        return (ACTION)();                                                \
+      default:                                                            \
+        AT_ERROR(                                                         \
+            #NAME,                                                        \
+            " expected sparse compressed block tensor layout but got ",   \
+            the_layout);                                                  \
+    }                                                                     \
+  }()
 
 namespace at {
 namespace sparse_csr {
@@ -103,36 +128,57 @@ namespace sparse_csr {
 using SparseCsrTensor = Tensor;
 
 inline SparseCsrTensorImpl* get_sparse_csr_impl(const SparseCsrTensor& self) {
-  AT_DISPATCH_ALL_SPARSE_COMPRESSED_LAYOUTS(self.layout(), "get_sparse_csr_impl", [&] {});
+  AT_DISPATCH_ALL_SPARSE_COMPRESSED_LAYOUTS(
+      self.layout(), "get_sparse_csr_impl", [&] {});
   return static_cast<SparseCsrTensorImpl*>(self.unsafeGetTensorImpl());
 }
 
-inline std::string layoutToString(Layout layout, bool upper=false, bool lower=false) {
+inline std::string layoutToString(
+    Layout layout,
+    bool upper = false,
+    bool lower = false) {
   switch (layout) {
-  case kSparseCsr: return (upper ? "CSR" : (lower ? "csr" : "Csr"));
-  case kSparseCsc: return (upper ? "CSC" : (lower ? "csc" : "Csc"));
-  case kSparseBsr: return (upper ? "BSR" : (lower ? "bsr" : "Bsr"));
-  case kSparseBsc: return (upper ? "BSC" : (lower ? "bsc" : "Bsc"));
-  default:
-    TORCH_CHECK(false, "Not a sparse compressed layout:", layout);
-    return "";
+    case kSparseCsr:
+      return (upper ? "CSR" : (lower ? "csr" : "Csr"));
+    case kSparseCsc:
+      return (upper ? "CSC" : (lower ? "csc" : "Csc"));
+    case kSparseBsr:
+      return (upper ? "BSR" : (lower ? "bsr" : "Bsr"));
+    case kSparseBsc:
+      return (upper ? "BSC" : (lower ? "bsc" : "Bsc"));
+    default:
+      TORCH_CHECK(false, "Not a sparse compressed layout:", layout);
+      return "";
   }
 }
 
 inline bool isCompressedRow(Layout layout) {
-  return AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(layout, "isCompressedRow", [&]{ return true; }, [&]{ return false; });
+  return AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(
+      layout, "isCompressedRow", [&] { return true; }, [&] { return false; });
 }
 
 inline bool isCompressedColumn(Layout layout) {
-  return AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(layout, "isCompressedColumn", [&]{ return false; }, [&]{ return true; });
+  return AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(
+      layout,
+      "isCompressedColumn",
+      [&] { return false; },
+      [&] { return true; });
 }
 
 inline std::string compressedIndicesName(Layout layout) {
-  return AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(layout, "compressedIndicesName", [&]{ return "crow_indices"; }, [&]{ return "ccol_indices"; });
+  return AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(
+      layout,
+      "compressedIndicesName",
+      [&] { return "crow_indices"; },
+      [&] { return "ccol_indices"; });
 }
 
 inline std::string plainIndicesName(Layout layout) {
-  return AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(layout, "plainIndicesName", [&]{ return "col_indices"; }, [&]{ return "row_indices"; });
+  return AT_DISPATCH_ROW_SPARSE_COMPRESSED_LAYOUTS(
+      layout,
+      "plainIndicesName",
+      [&] { return "col_indices"; },
+      [&] { return "row_indices"; });
 }
 
 inline int rowDimension(Layout layout, IntArrayRef size) {
@@ -143,11 +189,17 @@ inline int columnDimension(Layout layout, IntArrayRef size) {
   return size.size() - (isCompressedColumn(layout) ? 2 : 1);
 }
 
-inline int compressedDimension(Layout layout, IntArrayRef size, size_t dense_ndim=0) {
+inline int compressedDimension(
+    Layout layout,
+    IntArrayRef size,
+    size_t dense_ndim = 0) {
   return size.size() - dense_ndim - (isCompressedRow(layout) ? 2 : 1);
 }
 
-inline int plainDimension(Layout layout, IntArrayRef size, size_t dense_ndim=0) {
+inline int plainDimension(
+    Layout layout,
+    IntArrayRef size,
+    size_t dense_ndim = 0) {
   return size.size() - dense_ndim - (isCompressedRow(layout) ? 1 : 2);
 }
 

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -19,7 +19,8 @@ struct TORCH_API SparseTensorImpl : public TensorImpl {
   // sparse_dim: range [0, len(shape)]; sparse_dim + dense_dim = len(shape)
   // dense_dim : range [0, len(shape)]; sparse_dim + dense_dim = len(shape)
   // _indices.shape: dimensionality: 2,  shape: (sparse_dim, nnz)
-  // _values.shape:  dimensionality: 1 + dense_dim.  shape: (nnz, shape[sparse_dim:])
+  // _values.shape:  dimensionality: 1 + dense_dim.  shape: (nnz,
+  // shape[sparse_dim:])
 
   int64_t sparse_dim_ = 0; // number of sparse dimensions
   int64_t dense_dim_ = 0; // number of dense dimensions
@@ -41,18 +42,30 @@ struct TORCH_API SparseTensorImpl : public TensorImpl {
     TensorImpl::safe_refresh_numel();
   }
 
-public:
+ public:
   // Public for now...
   explicit SparseTensorImpl(at::DispatchKeySet, const caffe2::TypeMeta);
 
   void release_resources() override;
 
-  int64_t nnz() const { return values_.size(0); }
-  int64_t sparse_dim() const { return sparse_dim_; }
-  int64_t dense_dim() const { return dense_dim_; }
-  bool coalesced() const { return coalesced_; }
-  Tensor indices() const { return indices_; }
-  Tensor values() const { return values_; }
+  int64_t nnz() const {
+    return values_.size(0);
+  }
+  int64_t sparse_dim() const {
+    return sparse_dim_;
+  }
+  int64_t dense_dim() const {
+    return dense_dim_;
+  }
+  bool coalesced() const {
+    return coalesced_;
+  }
+  Tensor indices() const {
+    return indices_;
+  }
+  Tensor values() const {
+    return values_;
+  }
 
   void set_size(int64_t dim, int64_t new_size) override;
   void set_stride(int64_t dim, int64_t new_stride) override;
@@ -62,10 +75,13 @@ public:
   bool has_storage() const override;
 #endif
 
-  // WARNING: This function does NOT preserve invariants of sparse_dim/dense_dim with
-  // respect to indices and values
+  // WARNING: This function does NOT preserve invariants of sparse_dim/dense_dim
+  // with respect to indices and values
   void raw_resize_(int64_t sparse_dim, int64_t dense_dim, IntArrayRef size) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "raw_resize_ ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "raw_resize_ ",
+        err_msg_tensor_metadata_change_not_allowed);
     TORCH_CHECK(
         !has_symbolic_sizes_strides_,
         "raw_resize_ called on tensor with symbolic shape")
@@ -75,46 +91,72 @@ public:
     refresh_numel();
   }
 
-  // NOTE: This function preserves invariants of sparse_dim/dense_dim with respect to
-  // indices and values.
+  // NOTE: This function preserves invariants of sparse_dim/dense_dim with
+  // respect to indices and values.
   //
   // NOTE: This function supports the following cases:
-  // 1. When we keep the number of dense dimensions unchanged, and NOT shrinking the size of
-  // any of the dense dimensions.
-  // 2. When we keep the number of sparse dimensions unchanged, and NOT shrinking the size of
-  // any of the sparse dimensions.
-  // 3. When the sparse tensor has zero nnz, in which case we are free to change the shapes of
-  // both its sparse and dense dimensions.
+  // 1. When we keep the number of dense dimensions unchanged, and NOT shrinking
+  // the size of any of the dense dimensions.
+  // 2. When we keep the number of sparse dimensions unchanged, and NOT
+  // shrinking the size of any of the sparse dimensions.
+  // 3. When the sparse tensor has zero nnz, in which case we are free to change
+  // the shapes of both its sparse and dense dimensions.
   //
-  // This function DOESN'T support (and will throw an error) the following cases:
-  // 1. When we attempt to change the number of sparse dimensions on a non-empty sparse tensor
-  // (such an operation will invalidate the indices stored).
-  // 2. When we attempt to change the number of dense dimensions on a non-empty sparse tensor
-  // (such an operation will behave differently from an equivalent dense tensor's resize method,
-  // and for API consistency we don't support it).
-  // 3. When we attempt to shrink the size of any of the dense dimensions on a non-empty sparse tensor
-  // (such an operation will behave differently from an equivalent dense tensor's resize method,
-  // and for API consistency we don't support it).
-  // 4. When we attempt to shrink the size of any of the sparse dimensions on a non-empty sparse tensor
-  // (this could make some of the stored indices out-of-bound and thus unsafe).
+  // This function DOESN'T support (and will throw an error) the following
+  // cases:
+  // 1. When we attempt to change the number of sparse dimensions on a non-empty
+  // sparse tensor (such an operation will invalidate the indices stored).
+  // 2. When we attempt to change the number of dense dimensions on a non-empty
+  // sparse tensor (such an operation will behave differently from an equivalent
+  // dense tensor's resize method, and for API consistency we don't support it).
+  // 3. When we attempt to shrink the size of any of the dense dimensions on a
+  // non-empty sparse tensor (such an operation will behave differently from an
+  // equivalent dense tensor's resize method, and for API consistency we don't
+  // support it).
+  // 4. When we attempt to shrink the size of any of the sparse dimensions on a
+  // non-empty sparse tensor (this could make some of the stored indices
+  // out-of-bound and thus unsafe).
   void resize_(int64_t sparse_dim, int64_t dense_dim, IntArrayRef size) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "resize_ ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "resize_ ",
+        err_msg_tensor_metadata_change_not_allowed);
     TORCH_CHECK(
         !has_symbolic_sizes_strides_,
         "resize_ called on tensor with symbolic shape")
-    TORCH_CHECK(sparse_dim + dense_dim == static_cast<int64_t>(size.size()), "number of dimensions must be sparse_dim (", sparse_dim, ") + dense_dim (", dense_dim, "), but got ", size.size());
+    TORCH_CHECK(
+        sparse_dim + dense_dim == static_cast<int64_t>(size.size()),
+        "number of dimensions must be sparse_dim (",
+        sparse_dim,
+        ") + dense_dim (",
+        dense_dim,
+        "), but got ",
+        size.size());
     if (nnz() > 0) {
-      auto alt_options_msg = "You could try the following options:\n\
+      auto alt_options_msg =
+          "You could try the following options:\n\
 1. If you need an empty sparse tensor of this size, call `x = torch.sparse_coo_tensor(size)`.\n\
 2. If you need to resize this tensor, you have the following options:\n\
     1. For both sparse and dense dimensions, keep the number of them constant and the size of them non-shrinking, and then try the same call again.\n\
     2. Or, create a new sparse tensor with the correct indices and values from this sparse tensor.";
 
-      TORCH_CHECK(sparse_dim == sparse_dim_,
-        "changing the number of sparse dimensions (from ", sparse_dim_, " to ", sparse_dim, ") on a non-empty sparse tensor is not supported.\n", alt_options_msg);
+      TORCH_CHECK(
+          sparse_dim == sparse_dim_,
+          "changing the number of sparse dimensions (from ",
+          sparse_dim_,
+          " to ",
+          sparse_dim,
+          ") on a non-empty sparse tensor is not supported.\n",
+          alt_options_msg);
 
-      TORCH_CHECK(dense_dim == dense_dim_,
-        "changing the number of dense dimensions (from ", dense_dim_, " to ", dense_dim, ") on a non-empty sparse tensor is not supported.\n", alt_options_msg);
+      TORCH_CHECK(
+          dense_dim == dense_dim_,
+          "changing the number of dense dimensions (from ",
+          dense_dim_,
+          " to ",
+          dense_dim,
+          ") on a non-empty sparse tensor is not supported.\n",
+          alt_options_msg);
 
       bool shrinking_sparse_dims = false;
       bool shrinking_dense_dim = false;
@@ -135,20 +177,39 @@ public:
         }
       }
 
-      TORCH_CHECK(!shrinking_sparse_dims,
-        "shrinking the size of sparse dimensions (from ", sparse_size_original, " to ", sparse_size_new, ") on a non-empty sparse tensor is not supported.\n", alt_options_msg);
+      TORCH_CHECK(
+          !shrinking_sparse_dims,
+          "shrinking the size of sparse dimensions (from ",
+          sparse_size_original,
+          " to ",
+          sparse_size_new,
+          ") on a non-empty sparse tensor is not supported.\n",
+          alt_options_msg);
 
-      TORCH_CHECK(!shrinking_dense_dim,
-        "shrinking the size of dense dimensions (from ", dense_size_original, " to ", dense_size_new, ") on a non-empty sparse tensor is not supported.\n", alt_options_msg);
+      TORCH_CHECK(
+          !shrinking_dense_dim,
+          "shrinking the size of dense dimensions (from ",
+          dense_size_original,
+          " to ",
+          dense_size_new,
+          ") on a non-empty sparse tensor is not supported.\n",
+          alt_options_msg);
     }
 
-    IntArrayRef sizes_and_strides = asIntArrayRefSlow(sizes_and_strides_.sizes_arrayref());
-    const bool size_equals_sizes = std::equal(size.begin(), size.end(), sizes_and_strides.begin(), sizes_and_strides.end());
-    if ((!size_equals_sizes) || (sparse_dim != sparse_dim_) || (dense_dim != dense_dim_)) {
+    IntArrayRef sizes_and_strides =
+        asIntArrayRefSlow(sizes_and_strides_.sizes_arrayref());
+    const bool size_equals_sizes = std::equal(
+        size.begin(),
+        size.end(),
+        sizes_and_strides.begin(),
+        sizes_and_strides.end());
+    if ((!size_equals_sizes) || (sparse_dim != sparse_dim_) ||
+        (dense_dim != dense_dim_)) {
       auto nnz = values().size(0);
       std::vector<int64_t> values_size = {nnz};
       auto dense_size = size.slice(sparse_dim);
-      values_size.insert(values_size.end(), dense_size.begin(), dense_size.end());
+      values_size.insert(
+          values_size.end(), dense_size.begin(), dense_size.end());
       values_.resize_(values_size);
       indices_.resize_({sparse_dim, nnz});
     }
@@ -161,13 +222,27 @@ public:
     refresh_numel();
   }
 
-  // NOTE: this function will resize the sparse tensor and also set `indices` and `values` to empty.
-  void resize_and_clear_(int64_t sparse_dim, int64_t dense_dim, IntArrayRef size) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "resize_and_clear_ ", err_msg_tensor_metadata_change_not_allowed);
+  // NOTE: this function will resize the sparse tensor and also set `indices`
+  // and `values` to empty.
+  void resize_and_clear_(
+      int64_t sparse_dim,
+      int64_t dense_dim,
+      IntArrayRef size) {
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "resize_and_clear_ ",
+        err_msg_tensor_metadata_change_not_allowed);
     TORCH_CHECK(
         !has_symbolic_sizes_strides_,
         "resize_and_clear_ called on tensor with symbolic shape")
-    TORCH_CHECK(sparse_dim + dense_dim == static_cast<int64_t>(size.size()), "number of dimensions must be sparse_dim (", sparse_dim, ") + dense_dim (", dense_dim, "), but got ", size.size());
+    TORCH_CHECK(
+        sparse_dim + dense_dim == static_cast<int64_t>(size.size()),
+        "number of dimensions must be sparse_dim (",
+        sparse_dim,
+        ") + dense_dim (",
+        dense_dim,
+        "), but got ",
+        size.size());
 
     sizes_and_strides_.set_sizes(size);
     sparse_dim_ = sparse_dim;
@@ -183,26 +258,34 @@ public:
   }
 
   void set_coalesced(bool coalesced) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "set_coalesced ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "set_coalesced ",
+        err_msg_tensor_metadata_change_not_allowed);
     coalesced_ = coalesced;
   }
 
-  // NOTE: this function is only used internally and not exposed to Python frontend
+  // NOTE: this function is only used internally and not exposed to Python
+  // frontend
   void set_nnz_and_narrow(int64_t new_nnz) {
-    TORCH_CHECK(allow_tensor_metadata_change(), "set_nnz_and_narrow ", err_msg_tensor_metadata_change_not_allowed);
+    TORCH_CHECK(
+        allow_tensor_metadata_change(),
+        "set_nnz_and_narrow ",
+        err_msg_tensor_metadata_change_not_allowed);
     AT_ASSERT(new_nnz <= nnz());
     indices_ = indices_.narrow(1, 0, new_nnz);
     values_ = values_.narrow(0, 0, new_nnz);
   }
 
-  // Takes indices and values and directly puts them into the sparse tensor, no copy.
-  // NOTE: this function is unsafe because it doesn't check whether any indices are
-  // out of boundaries of `sizes`, so it should ONLY be used where we know that the
-  // indices are guaranteed to be within bounds.
-  // This used to be called THSTensor_(_move)
-  // NB: This used to be able to avoid a refcount bump, but I was too lazy to
-  // make it happen
-  void set_indices_and_values_unsafe(const Tensor& indices, const Tensor& values);
+  // Takes indices and values and directly puts them into the sparse tensor, no
+  // copy. NOTE: this function is unsafe because it doesn't check whether any
+  // indices are out of boundaries of `sizes`, so it should ONLY be used where
+  // we know that the indices are guaranteed to be within bounds. This used to
+  // be called THSTensor_(_move) NB: This used to be able to avoid a refcount
+  // bump, but I was too lazy to make it happen
+  void set_indices_and_values_unsafe(
+      const Tensor& indices,
+      const Tensor& values);
 
   /**
    * Return a TensorImpl that is a shallow-copy of this TensorImpl.
@@ -215,10 +298,10 @@ public:
       bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<SparseTensorImpl>(key_set(), dtype());
     copy_tensor_metadata(
-      /*src_impl=*/this,
-      /*dest_impl=*/impl.get(),
-      /*version_counter=*/version_counter,
-      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
+        /*src_impl=*/this,
+        /*dest_impl=*/impl.get(),
+        /*version_counter=*/version_counter,
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
     impl->refresh_numel();
     return impl;
   }
@@ -234,10 +317,10 @@ public:
       bool allow_tensor_metadata_change) const override {
     auto impl = c10::make_intrusive<SparseTensorImpl>(key_set(), dtype());
     copy_tensor_metadata(
-      /*src_impl=*/this,
-      /*dest_impl=*/impl.get(),
-      /*version_counter=*/std::move(version_counter),
-      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
+        /*src_impl=*/this,
+        /*dest_impl=*/impl.get(),
+        /*version_counter=*/std::move(version_counter),
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
     impl->refresh_numel();
     return impl;
   }
@@ -245,34 +328,44 @@ public:
   /**
    * Shallow-copies data from another TensorImpl into this TensorImpl.
    *
-   * For why this function doesn't check this TensorImpl's `allow_tensor_metadata_change_`,
-   * see NOTE [ TensorImpl Shallow-Copying ].
+   * For why this function doesn't check this TensorImpl's
+   * `allow_tensor_metadata_change_`, see NOTE [ TensorImpl Shallow-Copying ].
    */
   void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override {
     AT_ASSERT(has_compatible_shallow_copy_type(impl->key_set()));
     auto sparse_impl = static_cast<const SparseTensorImpl*>(impl.get());
     copy_tensor_metadata(
-      /*src_impl=*/sparse_impl,
-      /*dest_impl=*/this,
-      /*version_counter=*/version_counter(),
-      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change());
+        /*src_impl=*/sparse_impl,
+        /*dest_impl=*/this,
+        /*version_counter=*/version_counter(),
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change());
     refresh_numel();
   }
-private:
-    explicit SparseTensorImpl(at::DispatchKeySet, const caffe2::TypeMeta, at::Tensor indices, at::Tensor values);
+
+ private:
+  explicit SparseTensorImpl(
+      at::DispatchKeySet,
+      const caffe2::TypeMeta,
+      at::Tensor indices,
+      at::Tensor values);
 
   /**
-   * Copy the tensor metadata fields (e.g. sizes / strides / storage pointer / storage_offset)
-   * from one TensorImpl to another TensorImpl.
+   * Copy the tensor metadata fields (e.g. sizes / strides / storage pointer /
+   * storage_offset) from one TensorImpl to another TensorImpl.
    *
-   * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE [ TensorImpl Shallow-Copying ].
+   * For usage of `version_counter` and `allow_tensor_metadata_change`, see NOTE
+   * [ TensorImpl Shallow-Copying ].
    */
   static void copy_tensor_metadata(
       const SparseTensorImpl* src_sparse_impl,
       SparseTensorImpl* dest_sparse_impl,
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) {
-    TensorImpl::copy_tensor_metadata(src_sparse_impl, dest_sparse_impl, version_counter, allow_tensor_metadata_change);
+    TensorImpl::copy_tensor_metadata(
+        src_sparse_impl,
+        dest_sparse_impl,
+        version_counter,
+        allow_tensor_metadata_change);
 
     // Sparse-specific fields
     dest_sparse_impl->sparse_dim_ = src_sparse_impl->sparse_dim();

--- a/aten/src/ATen/SparseTensorUtils.h
+++ b/aten/src/ATen/SparseTensorUtils.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <ATen/core/Tensor.h>
-#include <ATen/SparseTensorImpl.h>
 #include <ATen/Parallel.h>
+#include <ATen/SparseTensorImpl.h>
+#include <ATen/core/Tensor.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -10,12 +10,12 @@
 #include <ATen/ops/empty.h>
 #endif
 
-namespace at { namespace sparse {
+namespace at {
+namespace sparse {
 
 // Just for documentary purposes
 using SparseTensor = Tensor;
 using SparseType = Type;
-
 
 // This is an internal utility function for getting at the SparseTensorImpl,
 // so that we can write sparse tensor specific accessors for special fields
@@ -24,20 +24,28 @@ using SparseType = Type;
 // the low level setters/getters that were implemented using this.
 //
 // This may be called repeatedly, so make sure it's pretty cheap.
-inline  SparseTensorImpl* get_sparse_impl(const SparseTensor& self) {
-  TORCH_INTERNAL_ASSERT(self.is_sparse(), "_internal_get_SparseTensorImpl: not a sparse tensor");
+inline SparseTensorImpl* get_sparse_impl(const SparseTensor& self) {
+  TORCH_INTERNAL_ASSERT(
+      self.is_sparse(), "_internal_get_SparseTensorImpl: not a sparse tensor");
   return static_cast<SparseTensorImpl*>(self.unsafeGetTensorImpl());
 }
 
 // Takes indices and values and directly puts them into the sparse tensor, no
 // copy.  This used to be called THSTensor_(_move)
-inline void alias_into_sparse(const SparseTensor& self, const Tensor& indices, const Tensor& values) {
+inline void alias_into_sparse(
+    const SparseTensor& self,
+    const Tensor& indices,
+    const Tensor& values) {
   get_sparse_impl(self)->set_indices_and_values_unsafe(indices, values);
 }
 
-// Take indices and values and makes a (data) copy of them to put into the sparse
-// indices/values.  This used to be called THSTensor_(_set)
-inline void copy_into_sparse(const SparseTensor& self, const Tensor& indices, const Tensor& values, bool non_blocking) {
+// Take indices and values and makes a (data) copy of them to put into the
+// sparse indices/values.  This used to be called THSTensor_(_set)
+inline void copy_into_sparse(
+    const SparseTensor& self,
+    const Tensor& indices,
+    const Tensor& values,
+    bool non_blocking) {
   alias_into_sparse(
       self,
       indices.to(self._indices().options(), non_blocking, /*copy=*/true),
@@ -50,7 +58,8 @@ inline bool is_same_tensor(const Tensor& lhs, const Tensor& rhs) {
 }
 
 inline bool is_same_density(const SparseTensor& self, const SparseTensor& src) {
-  return self.sparse_dim() == src.sparse_dim() && self.dense_dim() == src.dense_dim();
+  return self.sparse_dim() == src.sparse_dim() &&
+      self.dense_dim() == src.dense_dim();
 }
 
 // Give us a new values tensor, with the same dimensionality
@@ -76,12 +85,16 @@ inline Tensor new_values_with_size_of(const Tensor& values, int64_t nnz) {
 // the flattened tensor `t.reshape( prod(full_size[:indices.size(0)]), -1 )`.
 // if forceClone is true, the result will forced to be a clone of self.
 // if force_clone is true, the result will forced to be a clone of self.
-TORCH_API Tensor flatten_indices(const Tensor& indices, IntArrayRef full_size, bool force_clone = false);
+TORCH_API Tensor flatten_indices(
+    const Tensor& indices,
+    IntArrayRef full_size,
+    bool force_clone = false);
 
-// Flatten sparse tensor's indices from nD to 1D, similar to NOTE [ Flatten Sparse Indices ],
-// except this one allows partial flatten: only flatten on specified dims. Note that
-// the flatten indices might be uncoalesced if dims_to_flatten.size() < sparse_dim.
-// Also if input indices is already coalesced, the flattened indices will also be sorted.
+// Flatten sparse tensor's indices from nD to 1D, similar to NOTE [ Flatten
+// Sparse Indices ], except this one allows partial flatten: only flatten on
+// specified dims. Note that the flatten indices might be uncoalesced if
+// dims_to_flatten.size() < sparse_dim. Also if input indices is already
+// coalesced, the flattened indices will also be sorted.
 //
 // args:
 //    indices: sparse tensor indices
@@ -98,9 +111,13 @@ TORCH_API Tensor flatten_indices(const Tensor& indices, IntArrayRef full_size, b
 // Ex2:
 //   dims_to_flatten = [1]
 //   new_indices = [ 3, 1, 3 ]  # uncoalesced
-TORCH_API Tensor flatten_indices_by_dims(const Tensor& indices, const IntArrayRef& sizes, const IntArrayRef& dims_to_flatten);
+TORCH_API Tensor flatten_indices_by_dims(
+    const Tensor& indices,
+    const IntArrayRef& sizes,
+    const IntArrayRef& dims_to_flatten);
 
 // Find the CSR representation for a row `indices` from the COO format
 TORCH_API Tensor coo_to_csr(const int64_t* indices, int64_t dim, int64_t nnz);
 
-}} // namespace at::sparse
+} // namespace sparse
+} // namespace at

--- a/aten/src/ATen/TensorGeometry.h
+++ b/aten/src/ATen/TensorGeometry.h
@@ -1,60 +1,80 @@
 #pragma once
 
-#include <c10/core/WrapDimMinimal.h>
 #include <ATen/core/TensorBase.h>
+#include <c10/core/WrapDimMinimal.h>
 
 namespace at {
 
-// Return if the tensor geometry represented by `sizes` and `strides` is contiguous
-// Although we cache is_contiguous in tensor now, this is till useful because it
-// allows checking if a particular geometry is contiguous without explicitly
-// constructing a tensor, e.g., when you want to choose a kernel strategy based
-// on whether a subgeometry is contiguous.
+// Return if the tensor geometry represented by `sizes` and `strides` is
+// contiguous Although we cache is_contiguous in tensor now, this is till useful
+// because it allows checking if a particular geometry is contiguous without
+// explicitly constructing a tensor, e.g., when you want to choose a kernel
+// strategy based on whether a subgeometry is contiguous.
 TORCH_API bool geometry_is_contiguous(IntArrayRef sizes, IntArrayRef strides);
 
 struct TORCH_API TensorGeometry {
   TensorGeometry() : storage_offset_(0) {}
 
   explicit TensorGeometry(IntArrayRef sizes)
-    : sizes_(sizes.vec())
-    , strides_(sizes.size())
-    , storage_offset_(0) {
-      int64_t dim = sizes.size();
-      int64_t expected_stride = 1;
-      for (int64_t i = dim - 1; i >= 0; i--) {
-        strides_[i] = expected_stride;
-        expected_stride *= sizes_[i];
-      }
-      numel_ = expected_stride;
+      : sizes_(sizes.vec()), strides_(sizes.size()), storage_offset_(0) {
+    int64_t dim = sizes.size();
+    int64_t expected_stride = 1;
+    for (int64_t i = dim - 1; i >= 0; i--) {
+      strides_[i] = expected_stride;
+      expected_stride *= sizes_[i];
+    }
+    numel_ = expected_stride;
   }
 
   explicit TensorGeometry(const TensorBase& t)
-    : sizes_(t.sizes().vec())
-    , strides_(t.strides().vec())
-    , storage_offset_(t.storage_offset())
-    , numel_(t.numel()) {}
+      : sizes_(t.sizes().vec()),
+        strides_(t.strides().vec()),
+        storage_offset_(t.storage_offset()),
+        numel_(t.numel()) {}
 
   // true if the tensor is contiguous
   bool is_contiguous() const;
 
-  int64_t dim() const { return sizes_.size(); }
+  int64_t dim() const {
+    return sizes_.size();
+  }
   int64_t size(int64_t dim) const {
     dim = c10::maybe_wrap_dim(dim, this->dim());
     return sizes_.at(static_cast<size_t>(dim));
   }
-  IntArrayRef sizes() const { return IntArrayRef{ sizes_ }; }
+  IntArrayRef sizes() const {
+    return IntArrayRef{sizes_};
+  }
   int64_t stride(int64_t dim) const {
     dim = c10::maybe_wrap_dim(dim, this->dim());
     return strides_.at(static_cast<size_t>(dim));
   }
-  IntArrayRef strides() const { return IntArrayRef{ strides_ }; }
-  int64_t storage_offset() const { return storage_offset_; }
-  int64_t numel() const { return numel_; }
+  IntArrayRef strides() const {
+    return IntArrayRef{strides_};
+  }
+  int64_t storage_offset() const {
+    return storage_offset_;
+  }
+  int64_t numel() const {
+    return numel_;
+  }
 
   TensorGeometry transpose(int64_t dim0, int64_t dim1) {
     TensorGeometry r = *this; // copy
-    TORCH_CHECK(dim0 < dim(), "transpose: dim0=", dim0, " out of range (dim=", dim(), ")")
-    TORCH_CHECK(dim1 < dim(), "transpose: dim1=", dim1, " out of range (dim=", dim(), ")")
+    TORCH_CHECK(
+        dim0 < dim(),
+        "transpose: dim0=",
+        dim0,
+        " out of range (dim=",
+        dim(),
+        ")")
+    TORCH_CHECK(
+        dim1 < dim(),
+        "transpose: dim1=",
+        dim1,
+        " out of range (dim=",
+        dim(),
+        ")")
     std::swap(r.sizes_[dim0], r.sizes_[dim1]);
     std::swap(r.strides_[dim0], r.strides_[dim1]);
     return r;

--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <c10/util/Optional.h>
-#include <c10/util/irange.h>
-#include <ATen/core/TensorBody.h>
 #include <ATen/ExpandUtils.h>
 #include <ATen/Functions.h>
 #include <ATen/ScalarOps.h>
+#include <ATen/core/TensorBody.h>
+#include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 // TODO: try to remove this
 // There is some back story, see https://github.com/pytorch/pytorch/issues/48684
@@ -23,16 +23,18 @@ enum class TensorIndexType { None, Ellipsis, Integer, Boolean, Slice, Tensor };
 
 constexpr c10::nullopt_t None = c10::nullopt;
 
-struct TORCH_API EllipsisIndexType final { EllipsisIndexType() {} };
+struct TORCH_API EllipsisIndexType final {
+  EllipsisIndexType() {}
+};
 TORCH_API extern const EllipsisIndexType Ellipsis;
 
 struct TORCH_API Slice final {
  public:
   // This mirrors `__PySlice_Unpack` in torch/csrc/utils/python_compat.h
   Slice(
-    c10::optional<int64_t> start_index = c10::nullopt,
-    c10::optional<int64_t> stop_index = c10::nullopt,
-    c10::optional<int64_t> step_index = c10::nullopt) {
+      c10::optional<int64_t> start_index = c10::nullopt,
+      c10::optional<int64_t> stop_index = c10::nullopt,
+      c10::optional<int64_t> step_index = c10::nullopt) {
     if (!step_index.has_value()) {
       step_ = 1;
     } else {
@@ -80,8 +82,8 @@ TORCH_API std::ostream& operator<<(std::ostream& stream, const Slice& slice);
 
 // `at::indexing::TensorIndex` is used for converting C++ tensor indices such as
 // `{None, "...", Ellipsis, 0, true, Slice(1, None, 2), torch::tensor({1, 2})}`
-// into its equivalent `std::vector<TensorIndex>`, so that further tensor indexing
-// operations can be performed using the supplied indices.
+// into its equivalent `std::vector<TensorIndex>`, so that further tensor
+// indexing operations can be performed using the supplied indices.
 //
 // There is one-to-one correspondence between Python and C++ tensor index types:
 // Python                  | C++
@@ -110,33 +112,40 @@ struct TORCH_API TensorIndex final {
 
   // Case 2: "..." / `at::indexing::Ellipsis`
   // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.UninitializedObject)
-  TensorIndex(at::indexing::EllipsisIndexType) : type_(TensorIndexType::Ellipsis) {}
-  TensorIndex(const char *str) : TensorIndex(at::indexing::Ellipsis) {
+  TensorIndex(at::indexing::EllipsisIndexType)
+      : type_(TensorIndexType::Ellipsis) {}
+  TensorIndex(const char* str) : TensorIndex(at::indexing::Ellipsis) {
     // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.UninitializedObject)
     TORCH_CHECK_VALUE(
-      strcmp(str, "...") == 0,
-      "Expected \"...\" to represent an ellipsis index, but got \"", str, "\"");
+        strcmp(str, "...") == 0,
+        "Expected \"...\" to represent an ellipsis index, but got \"",
+        str,
+        "\"");
   }
 
   // Case 3: Integer value
   // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.UninitializedObject)
-  TensorIndex(int64_t integer) : integer_(integer), type_(TensorIndexType::Integer) {}
+  TensorIndex(int64_t integer)
+      : integer_(integer), type_(TensorIndexType::Integer) {}
   // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.UninitializedObject)
   TensorIndex(int integer) : TensorIndex((int64_t)integer) {}
 
   // Case 4: Boolean value
-  template <class T,
-            class = typename std::enable_if<std::is_same<bool, T>::value>::type >
+  template <
+      class T,
+      class = typename std::enable_if<std::is_same<bool, T>::value>::type>
   // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.UninitializedObject)
   TensorIndex(T boolean) : boolean_(boolean), type_(TensorIndexType::Boolean) {}
 
   // Case 5: Slice represented in `at::indexing::Slice` form
   // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.UninitializedObject)
-  TensorIndex(Slice slice) : slice_(std::move(slice)), type_(TensorIndexType::Slice) {}
+  TensorIndex(Slice slice)
+      : slice_(std::move(slice)), type_(TensorIndexType::Slice) {}
 
   // Case 6: Tensor value
   // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.UninitializedObject)
-  TensorIndex(Tensor tensor) : tensor_(std::move(tensor)), type_(TensorIndexType::Tensor) {}
+  TensorIndex(Tensor tensor)
+      : tensor_(std::move(tensor)), type_(TensorIndexType::Tensor) {}
 
   inline bool is_none() const {
     return type_ == TensorIndexType::None;
@@ -186,8 +195,12 @@ struct TORCH_API TensorIndex final {
   TensorIndexType type_;
 };
 
-TORCH_API std::ostream& operator<<(std::ostream& stream, const TensorIndex& tensor_index);
-TORCH_API std::ostream& operator<<(std::ostream& stream, const std::vector<TensorIndex>& tensor_indices);
+TORCH_API std::ostream& operator<<(
+    std::ostream& stream,
+    const TensorIndex& tensor_index);
+TORCH_API std::ostream& operator<<(
+    std::ostream& stream,
+    const std::vector<TensorIndex>& tensor_indices);
 
 namespace impl {
 static inline Tensor applySlice(
@@ -198,7 +211,7 @@ static inline Tensor applySlice(
     int64_t step,
     bool disable_slice_optimization,
     const at::Device& self_device,
-    const c10::optional<IntArrayRef> & self_sizes) {
+    const c10::optional<IntArrayRef>& self_sizes) {
   // TODO: implement negative step
   TORCH_CHECK_VALUE(step > 0, "step must be greater than zero");
 
@@ -207,8 +220,11 @@ static inline Tensor applySlice(
     // Skip this optimization if we are tracing, as the trace may be polymorphic
     // over the shape of the `self` tensor, and we still want to record
     // the slice.
-    int64_t length = (self_device == at::kCPU || self_device == at::kCUDA) ? (*self_sizes)[dim] : self.size(dim);
-    if (!disable_slice_optimization && start == 0 && stop == length && step == 1) {
+    int64_t length = (self_device == at::kCPU || self_device == at::kCUDA)
+        ? (*self_sizes)[dim]
+        : self.size(dim);
+    if (!disable_slice_optimization && start == 0 && stop == length &&
+        step == 1) {
       return self;
     }
   }
@@ -221,28 +237,36 @@ static inline Tensor applySelect(
     int64_t index,
     int64_t real_dim,
     const at::Device& /*self_device*/,
-    const c10::optional<IntArrayRef> & self_sizes) {
+    const c10::optional<IntArrayRef>& self_sizes) {
   // See NOTE [nested tensor size for indexing]
   if (self_sizes.has_value()) {
     TORCH_CHECK_INDEX(
-      !(index == 0 && dim == 0 && self_sizes->size() == 0),
-      "invalid index of a 0-dim tensor. ",
-      "Use `tensor.item()` in Python or `tensor.item<T>()` in C++ to convert a 0-dim tensor to a number");
+        !(index == 0 && dim == 0 && self_sizes->size() == 0),
+        "invalid index of a 0-dim tensor. ",
+        "Use `tensor.item()` in Python or `tensor.item<T>()` in C++ to convert a 0-dim tensor to a number");
 
     int64_t size = (*self_sizes)[dim];
     TORCH_CHECK_INDEX(
-      index >= -size && index < size,
-      "index ", index, " is out of bounds for dimension ", real_dim, " with size ", size);
-    }
+        index >= -size && index < size,
+        "index ",
+        index,
+        " is out of bounds for dimension ",
+        real_dim,
+        " with size ",
+        size);
+  }
 
-  // if the index is negative, do not normalize it because that would fix the index
-  // on the current tensor size in the tracer.
-  // aten::select also works on negative indices
+  // if the index is negative, do not normalize it because that would fix the
+  // index on the current tensor size in the tracer. aten::select also works on
+  // negative indices
   return self.select(dim, index);
 }
 
-static inline Tensor boolToIndexingTensorCPUOrCUDA(const Tensor& self, bool value) {
-  // booleans add a dimension of size 1. true indexes this dimension as if 0:, false as empty.
+static inline Tensor boolToIndexingTensorCPUOrCUDA(
+    const Tensor& self,
+    bool value) {
+  // booleans add a dimension of size 1. true indexes this dimension as if 0:,
+  // false as empty.
   if (value) {
     return at::empty({1}, {}, self.options().dtype(kLong)).fill_(0.);
   } else {
@@ -250,8 +274,11 @@ static inline Tensor boolToIndexingTensorCPUOrCUDA(const Tensor& self, bool valu
   }
 }
 
-static inline Tensor boolToIndexingTensorNonNativeDeviceType(const Tensor& self, bool value) {
-  // booleans add a dimension of size 1. true indexes this dimension as if 0:, false as empty.
+static inline Tensor boolToIndexingTensorNonNativeDeviceType(
+    const Tensor& self,
+    bool value) {
+  // booleans add a dimension of size 1. true indexes this dimension as if 0:,
+  // false as empty.
   if (value) {
     return at::zeros({1}, {}, self.options().dtype(kLong));
   } else {
@@ -259,7 +286,10 @@ static inline Tensor boolToIndexingTensorNonNativeDeviceType(const Tensor& self,
   }
 }
 
-static inline Tensor boolToIndexingTensor(const Tensor& self, bool value, const at::Device& self_device) {
+static inline Tensor boolToIndexingTensor(
+    const Tensor& self,
+    bool value,
+    const at::Device& self_device) {
   if (self_device == at::kCPU || self_device == at::kCUDA) {
     return boolToIndexingTensorCPUOrCUDA(self, value);
   } else {
@@ -267,36 +297,45 @@ static inline Tensor boolToIndexingTensor(const Tensor& self, bool value, const 
   }
 }
 
-static inline Tensor scalarToTensorNonNativeDeviceType(const Scalar& v, const TensorOptions& options) {
+static inline Tensor scalarToTensorNonNativeDeviceType(
+    const Scalar& v,
+    const TensorOptions& options) {
   return at::scalar_tensor(v, options);
 }
 
-static inline void recordTensorIndex(const Tensor& tensor, std::vector<Tensor>& outIndices, int64_t* dim_ptr) {
+static inline void recordTensorIndex(
+    const Tensor& tensor,
+    std::vector<Tensor>& outIndices,
+    int64_t* dim_ptr) {
   // TODO: check scalarType
   outIndices.resize(*dim_ptr + 1);
   outIndices[*dim_ptr] = tensor;
   (*dim_ptr)++;
 };
 
-static inline c10::List<c10::optional<Tensor>> typeConvertIndices(const Tensor& /*self*/, std::vector<Tensor>&& indices) {
+static inline c10::List<c10::optional<Tensor>> typeConvertIndices(
+    const Tensor& /*self*/,
+    std::vector<Tensor>&& indices) {
   c10::List<c10::optional<Tensor>> converted_inds;
   converted_inds.reserve(indices.size());
-  for (const auto &i: indices){
+  for (const auto& i : indices) {
     converted_inds.push_back(std::move(i));
   }
   return converted_inds;
 }
 
-// NOTE: Why do we mirror instead of replace the `count_specified_dimensions` function
-// in torch/csrc/autograd/python_variable_indexing.cpp? It's because
-// `count_specified_dimensions` is on the hot path of Python tensor multi-dim indexing
-// (i.e. it's called by `applySlicing` which is called by `THPVariable_getitem` /
-// `THPVariable_setitem` when handling indexing of more than one dimension). If we were
-// to merge the Python/C++ `count_specified_dimensions` function, on the Python side
-// we would have to construct a `std::vector` container to be consumed by the C++
-// `count_specified_dimensions` function, which adds 100s of nanoseconds overhead and
-// is undesirable.
-static inline int64_t count_specified_dimensions(const ArrayRef<TensorIndex>& indices) {
+// NOTE: Why do we mirror instead of replace the `count_specified_dimensions`
+// function in torch/csrc/autograd/python_variable_indexing.cpp? It's because
+// `count_specified_dimensions` is on the hot path of Python tensor multi-dim
+// indexing (i.e. it's called by `applySlicing` which is called by
+// `THPVariable_getitem` / `THPVariable_setitem` when handling indexing of more
+// than one dimension). If we were to merge the Python/C++
+// `count_specified_dimensions` function, on the Python side we would have to
+// construct a `std::vector` container to be consumed by the C++
+// `count_specified_dimensions` function, which adds 100s of nanoseconds
+// overhead and is undesirable.
+static inline int64_t count_specified_dimensions(
+    const ArrayRef<TensorIndex>& indices) {
   // Count the number of indexed dimensions (everything but ellipsis and None)
   int64_t count = 0;
   for (auto& obj : indices) {
@@ -329,9 +368,13 @@ static inline int64_t count_specified_dimensions(const ArrayRef<TensorIndex>& in
 //
 // The rest of the functions are in `at::indexing::impl` namespace, signifying
 // that they shouldn't be used from Python indexing implementation.
-static inline Tensor scalarToTensor(const Scalar& v, const TensorOptions& options, const at::Device& self_device) {
+static inline Tensor scalarToTensor(
+    const Scalar& v,
+    const TensorOptions& options,
+    const at::Device& self_device) {
   if (self_device == at::kCPU) {
-    return at::detail::scalar_tensor_static(v, options.dtype_opt()->toScalarType(), self_device);
+    return at::detail::scalar_tensor_static(
+        v, options.dtype_opt()->toScalarType(), self_device);
   } else {
     return impl::scalarToTensorNonNativeDeviceType(v, options);
   }
@@ -355,8 +398,9 @@ static inline IntArrayRef slicePrefix1sSize(const IntArrayRef& sizes) {
 static inline void copy_to(const Tensor& dst, const Tensor& src) {
   if (dst.sizes().equals(src.sizes())) {
     // A shortcut to avoid generating hard-coded constant sizes during tracing.
-    // This is not a perfect solution: when src & dst have different shapes, constants will still
-    // appear. Users can workaround that case by dst[index..] = src.reshape(..)
+    // This is not a perfect solution: when src & dst have different shapes,
+    // constants will still appear. Users can workaround that case by
+    // dst[index..] = src.reshape(..)
     dst.copy_(src);
     return;
   } else if (src.dim() == 0 && src.device().type() == at::kCPU) {
@@ -368,7 +412,8 @@ static inline void copy_to(const Tensor& dst, const Tensor& src) {
   dst.copy_(*b_src);
 }
 
-// See NOTE [ Setting `disable_slice_optimization` when calling C++ tensor indexing functions from Python ]
+// See NOTE [ Setting `disable_slice_optimization` when calling C++ tensor
+// indexing functions from Python ]
 static inline Tensor handleDimInMultiDimIndexing(
     const Tensor& prev_dim_result,
     const Tensor& original_tensor,
@@ -379,19 +424,25 @@ static inline Tensor handleDimInMultiDimIndexing(
     std::vector<Tensor>& outIndices,
     bool disable_slice_optimization,
     const at::Device& original_tensor_device,
-    const c10::optional<IntArrayRef> & prev_dim_result_sizes) {
+    const c10::optional<IntArrayRef>& prev_dim_result_sizes) {
   if (index.is_integer()) {
-    return impl::applySelect(prev_dim_result, *dim_ptr, index.integer(), real_dim, original_tensor_device, prev_dim_result_sizes);
+    return impl::applySelect(
+        prev_dim_result,
+        *dim_ptr,
+        index.integer(),
+        real_dim,
+        original_tensor_device,
+        prev_dim_result_sizes);
   } else if (index.is_slice()) {
     Tensor result = impl::applySlice(
-      prev_dim_result,
-      *dim_ptr,
-      index.slice().start(),
-      index.slice().stop(),
-      index.slice().step(),
-      /*disable_slice_optimization=*/disable_slice_optimization,
-      original_tensor_device,
-      prev_dim_result_sizes);
+        prev_dim_result,
+        *dim_ptr,
+        index.slice().start(),
+        index.slice().stop(),
+        index.slice().step(),
+        /*disable_slice_optimization=*/disable_slice_optimization,
+        original_tensor_device,
+        prev_dim_result_sizes);
     (*dim_ptr)++;
     return result;
   } else if (index.is_ellipsis()) {
@@ -403,21 +454,40 @@ static inline Tensor handleDimInMultiDimIndexing(
     return result;
   } else if (index.is_boolean()) {
     Tensor result = prev_dim_result.unsqueeze(*dim_ptr);
-    impl::recordTensorIndex(impl::boolToIndexingTensor(result, index.boolean(), original_tensor_device), outIndices, dim_ptr);
+    impl::recordTensorIndex(
+        impl::boolToIndexingTensor(
+            result, index.boolean(), original_tensor_device),
+        outIndices,
+        dim_ptr);
     return result;
   } else if (index.is_tensor()) {
     Tensor result = prev_dim_result;
     const Tensor& tensor = index.tensor();
     auto scalar_type = tensor.scalar_type();
-    if (tensor.dim() == 0 && at::isIntegralType(scalar_type, /*includeBool=*/true)) {
+    if (tensor.dim() == 0 &&
+        at::isIntegralType(scalar_type, /*includeBool=*/true)) {
       if (scalar_type != at::kByte && scalar_type != at::kBool) {
-        result = impl::applySelect(result, *dim_ptr, tensor.item<int64_t>(), real_dim, original_tensor_device, prev_dim_result_sizes);
+        result = impl::applySelect(
+            result,
+            *dim_ptr,
+            tensor.item<int64_t>(),
+            real_dim,
+            original_tensor_device,
+            prev_dim_result_sizes);
       } else {
         result = result.unsqueeze(*dim_ptr);
         if (scalar_type == at::kBool) {
-          impl::recordTensorIndex(impl::boolToIndexingTensor(result, tensor.item<bool>() != 0, original_tensor_device), outIndices, dim_ptr);
+          impl::recordTensorIndex(
+              impl::boolToIndexingTensor(
+                  result, tensor.item<bool>() != 0, original_tensor_device),
+              outIndices,
+              dim_ptr);
         } else {
-          impl::recordTensorIndex(impl::boolToIndexingTensor(result, tensor.item<uint8_t>() != 0, original_tensor_device), outIndices, dim_ptr);
+          impl::recordTensorIndex(
+              impl::boolToIndexingTensor(
+                  result, tensor.item<uint8_t>() != 0, original_tensor_device),
+              outIndices,
+              dim_ptr);
         }
       }
     } else {
@@ -430,68 +500,82 @@ static inline Tensor handleDimInMultiDimIndexing(
 }
 
 namespace impl {
-// This mirrors `applySlicing` in torch/csrc/autograd/python_variable_indexing.cpp
+// This mirrors `applySlicing` in
+// torch/csrc/autograd/python_variable_indexing.cpp
 static inline Tensor applySlicing(
     const Tensor& self,
     const ArrayRef<TensorIndex>& indices,
     std::vector<Tensor>& outIndices,
     bool disable_slice_optimization,
     const at::Device& self_device,
-    const c10::optional<IntArrayRef> & self_sizes) {
+    const c10::optional<IntArrayRef>& self_sizes) {
   int64_t dim = 0;
   int64_t specified_dims = impl::count_specified_dimensions(indices);
 
   // See NOTE [nested tensor size for indexing]
   if (self_sizes.has_value()) {
     TORCH_CHECK_INDEX(
-      specified_dims <= (int64_t)self_sizes->size(),
-      "too many indices for tensor of dimension ", (int)self_sizes->size());
+        specified_dims <= (int64_t)self_sizes->size(),
+        "too many indices for tensor of dimension ",
+        (int)self_sizes->size());
   }
 
   Tensor result = self;
   for (const auto i : c10::irange(indices.size())) {
     auto& obj = indices[i];
     // See NOTE [nested tensor size for indexing]
-    c10::optional<IntArrayRef> result_sizes = result.is_nested() ? c10::optional<IntArrayRef>(c10::nullopt) : c10::optional<IntArrayRef>(result.sizes());
+    c10::optional<IntArrayRef> result_sizes = result.is_nested()
+        ? c10::optional<IntArrayRef>(c10::nullopt)
+        : c10::optional<IntArrayRef>(result.sizes());
     result = handleDimInMultiDimIndexing(
-      /*prev_dim_result=*/result,
-      /*original_tensor=*/self,
-      /*index=*/obj,
-      /*dim=*/&dim,
-      /*specified_dims=*/&specified_dims,
-      /*real_dim=*/i,
-      /*outIndices=*/outIndices,
-      /*disable_slice_optimization=*/disable_slice_optimization,
-      /*original_tensor_device=*/self_device,
-      /*prev_dim_result_sizes=*/result_sizes);
+        /*prev_dim_result=*/result,
+        /*original_tensor=*/self,
+        /*index=*/obj,
+        /*dim=*/&dim,
+        /*specified_dims=*/&specified_dims,
+        /*real_dim=*/i,
+        /*outIndices=*/outIndices,
+        /*disable_slice_optimization=*/disable_slice_optimization,
+        /*original_tensor_device=*/self_device,
+        /*prev_dim_result_sizes=*/result_sizes);
   }
   return result;
 }
 } // namespace impl
 
-static inline Tensor dispatch_index(const Tensor& self, std::vector<Tensor>&& indices) {
+static inline Tensor dispatch_index(
+    const Tensor& self,
+    std::vector<Tensor>&& indices) {
   return self.index(impl::typeConvertIndices(self, std::move(indices)));
 }
 
-static inline Tensor dispatch_index_put_(Tensor& self, std::vector<Tensor>&& indices, const Tensor& value) {
-  return self.index_put_(impl::typeConvertIndices(self, std::move(indices)), value);
+static inline Tensor dispatch_index_put_(
+    Tensor& self,
+    std::vector<Tensor>&& indices,
+    const Tensor& value) {
+  return self.index_put_(
+      impl::typeConvertIndices(self, std::move(indices)), value);
 }
 
-// NOTE [ Setting `disable_slice_optimization` when calling C++ tensor indexing functions from Python ]
+// NOTE [ Setting `disable_slice_optimization` when calling C++ tensor indexing
+// functions from Python ]
 //
-// Question: When should we set `disable_slice_optimization` to `true` when calling C++ tensor indexing
-// functions from Python indexing code?
+// Question: When should we set `disable_slice_optimization` to `true` when
+// calling C++ tensor indexing functions from Python indexing code?
 //
-// Answer: What "slice optimization" means: when we have a slicing expression like `x[0:5, 0]`, where the sliced tensor
-// was of size 5 in dimension 0, we would skip dispatching the actual slice call as an optimization. However, here are
-// the cases where we DON'T want this optimization:
+// Answer: What "slice optimization" means: when we have a slicing expression
+// like `x[0:5, 0]`, where the sliced tensor was of size 5 in dimension 0, we
+// would skip dispatching the actual slice call as an optimization. However,
+// here are the cases where we DON'T want this optimization:
 //
 // 1. When we are doing 1-D slicing (e.g. `tensor[:]`).
-//    Reason: we always return a shallow copy for expressions such as `tensor[:]` / `tensor[...]` / `tensor[:, :]`.
-//    (Note that for `tensor[:, :]`, we return an alias of `tensor` by doing the following:
+//    Reason: we always return a shallow copy for expressions such as
+//    `tensor[:]` / `tensor[...]` / `tensor[:, :]`. (Note that for `tensor[:,
+//    :]`, we return an alias of `tensor` by doing the following:
 //    ```
-//    Tensor sliced = impl::applySlicing(self, indices, tensorIndices, disable_slice_optimization, self_device, self_sizes);
-//    if (tensorIndices.empty()) {
+//    Tensor sliced = impl::applySlicing(self, indices, tensorIndices,
+//    disable_slice_optimization, self_device, self_sizes); if
+//    (tensorIndices.empty()) {
 //      if (sliced.is_same(self)) {
 //        // ensure we return a shallow copy for things like x[...]
 //        sliced = at::alias(sliced);
@@ -500,32 +584,42 @@ static inline Tensor dispatch_index_put_(Tensor& self, std::vector<Tensor>&& ind
 //    }
 //    ```)
 // 2. When we are doing JIT tracing.
-//    Reason: JIT tracing needs the `self.slice(...)` call to properly trace the slice operation.
+//    Reason: JIT tracing needs the `self.slice(...)` call to properly trace the
+//    slice operation.
 
-// This mirrors `THPVariable_getitem` in torch/csrc/autograd/python_variable_indexing.cpp
-// See NOTE [ Setting `disable_slice_optimization` when calling C++ tensor indexing functions from Python ]
-static inline Tensor get_item(const Tensor& self, const ArrayRef<TensorIndex>& indices, bool disable_slice_optimization = false) {
+// This mirrors `THPVariable_getitem` in
+// torch/csrc/autograd/python_variable_indexing.cpp See NOTE [ Setting
+// `disable_slice_optimization` when calling C++ tensor indexing functions from
+// Python ]
+static inline Tensor get_item(
+    const Tensor& self,
+    const ArrayRef<TensorIndex>& indices,
+    bool disable_slice_optimization = false) {
   at::Device self_device = self.device();
   // NOTE [nested tensor size for indexing]
-  // nested tensor does not have a size (yet) so for now we represent its size as null
-  // may need to be changed after we reach a better solution for nested tensor size
-  c10::optional<IntArrayRef> self_sizes = self.is_nested() ? c10::optional<IntArrayRef>(c10::nullopt) : c10::optional<IntArrayRef>(self.sizes());
+  // nested tensor does not have a size (yet) so for now we represent its size
+  // as null may need to be changed after we reach a better solution for nested
+  // tensor size
+  c10::optional<IntArrayRef> self_sizes = self.is_nested()
+      ? c10::optional<IntArrayRef>(c10::nullopt)
+      : c10::optional<IntArrayRef>(self.sizes());
 
   // handle simple types: integers, slices, none, ellipsis, bool
   if (indices.size() == 1) {
     const TensorIndex& index = indices[0];
     if (index.is_integer()) {
-      return impl::applySelect(self, 0, index.integer(), 0, self_device, self_sizes);
+      return impl::applySelect(
+          self, 0, index.integer(), 0, self_device, self_sizes);
     } else if (index.is_slice()) {
       return impl::applySlice(
-        self,
-        0,
-        index.slice().start(),
-        index.slice().stop(),
-        index.slice().step(),
-        /*disable_slice_optimization=*/true,
-        self_device,
-        *self_sizes);
+          self,
+          0,
+          index.slice().start(),
+          index.slice().stop(),
+          index.slice().step(),
+          /*disable_slice_optimization=*/true,
+          self_device,
+          *self_sizes);
     } else if (index.is_none()) {
       return self.unsqueeze(0);
     } else if (index.is_ellipsis()) {
@@ -533,14 +627,20 @@ static inline Tensor get_item(const Tensor& self, const ArrayRef<TensorIndex>& i
     } else if (index.is_boolean()) {
       Tensor result = self.unsqueeze(0);
       return dispatch_index(
-        result,
-        std::vector<Tensor>{impl::boolToIndexingTensor(result, index.boolean(), self_device)}
-      );
+          result,
+          std::vector<Tensor>{impl::boolToIndexingTensor(
+              result, index.boolean(), self_device)});
     }
   }
 
   std::vector<Tensor> tensorIndices;
-  Tensor sliced = impl::applySlicing(self, indices, tensorIndices, disable_slice_optimization, self_device, *self_sizes);
+  Tensor sliced = impl::applySlicing(
+      self,
+      indices,
+      tensorIndices,
+      disable_slice_optimization,
+      self_device,
+      *self_sizes);
   if (tensorIndices.empty()) {
     if (sliced.is_same(self)) {
       // ensure we return a shallow copy for things like x[...]
@@ -553,10 +653,15 @@ static inline Tensor get_item(const Tensor& self, const ArrayRef<TensorIndex>& i
   return dispatch_index(sliced, std::move(tensorIndices));
 }
 
-// This mirrors `THPVariable_setitem` in torch/csrc/autograd/python_variable_indexing.cpp
-// for "the assigned value is a Tensor" case
-// See NOTE [ Setting `disable_slice_optimization` when calling C++ tensor indexing functions from Python ]
-static inline void set_item(const Tensor& self, const ArrayRef<TensorIndex>& indices, const Tensor& value, bool disable_slice_optimization = false) {
+// This mirrors `THPVariable_setitem` in
+// torch/csrc/autograd/python_variable_indexing.cpp for "the assigned value is a
+// Tensor" case See NOTE [ Setting `disable_slice_optimization` when calling C++
+// tensor indexing functions from Python ]
+static inline void set_item(
+    const Tensor& self,
+    const ArrayRef<TensorIndex>& indices,
+    const Tensor& value,
+    bool disable_slice_optimization = false) {
   at::Device self_device = self.device();
   IntArrayRef self_sizes = self.sizes();
 
@@ -564,8 +669,8 @@ static inline void set_item(const Tensor& self, const ArrayRef<TensorIndex>& ind
   if (indices.size() == 1) {
     const TensorIndex& index = indices[0];
     if (index.is_boolean() && !index.boolean()) {
-      // do nothing for false (technically we should check the size, but we don't have
-      // real 0-sized shapes.
+      // do nothing for false (technically we should check the size, but we
+      // don't have real 0-sized shapes.
       return;
     } else if (index.is_ellipsis()) {
       copy_to(self, value);
@@ -574,24 +679,35 @@ static inline void set_item(const Tensor& self, const ArrayRef<TensorIndex>& ind
       copy_to(self.unsqueeze(0), value);
       return;
     } else if (index.is_integer()) {
-      copy_to(impl::applySelect(self, 0, index.integer(), 0, self_device, self_sizes), value);
+      copy_to(
+          impl::applySelect(
+              self, 0, index.integer(), 0, self_device, self_sizes),
+          value);
       return;
     } else if (index.is_slice()) {
-      copy_to(impl::applySlice(
-        self,
-        0,
-        index.slice().start(),
-        index.slice().stop(),
-        index.slice().step(),
-        /*disable_slice_optimization=*/disable_slice_optimization,
-        self_device,
-        self_sizes), value);
+      copy_to(
+          impl::applySlice(
+              self,
+              0,
+              index.slice().start(),
+              index.slice().stop(),
+              index.slice().step(),
+              /*disable_slice_optimization=*/disable_slice_optimization,
+              self_device,
+              self_sizes),
+          value);
       return;
     }
   }
 
   std::vector<Tensor> tensorIndices;
-  Tensor sliced = impl::applySlicing(self, indices, tensorIndices, disable_slice_optimization, self_device, self_sizes);
+  Tensor sliced = impl::applySlicing(
+      self,
+      indices,
+      tensorIndices,
+      disable_slice_optimization,
+      self_device,
+      self_sizes);
   if (tensorIndices.empty()) {
     copy_to(sliced, value);
     return;

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -1,15 +1,15 @@
 #pragma once
 
+#include <ATen/TensorMeta.h>
+#include <ATen/core/Dimname.h>
+#include <ATen/core/Range.h>
+#include <ATen/core/TensorBase.h>
 #include <c10/core/DynamicCast.h>
 #include <c10/util/FunctionRef.h>
 #include <c10/util/MaybeOwned.h>
 #include <c10/util/SmallVector.h>
 #include <c10/util/TypeCast.h>
 #include <c10/util/irange.h>
-#include <ATen/core/Dimname.h>
-#include <ATen/core/Range.h>
-#include <ATen/core/TensorBase.h>
-#include <ATen/TensorMeta.h>
 
 #include <array>
 #include <bitset>
@@ -26,7 +26,7 @@ namespace at {
 class Tensor;
 class OptionalTensorRef;
 using NameVector = SmallVector<Dimname, kDimVectorStaticSize>;
-}
+} // namespace at
 
 // TensorIterator is a helper class for element-wise operations, such as
 // arithmetic, comparisons, and trigonometric functions. It handles
@@ -56,8 +56,9 @@ using NameVector = SmallVector<Dimname, kDimVectorStaticSize>;
 // Note [Order of Construction]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // When setting up the tensor iterator configuration, the output Tensors
-// have to be added first via TensorIteratorConfig::add_owned_output(at::Tensor).
-// After adding all outputs, the inputs can be added via
+// have to be added first via
+// TensorIteratorConfig::add_owned_output(at::Tensor). After adding all outputs,
+// the inputs can be added via
 // TensorIteratorConfig::add_owned_input(at::Tensor).
 // Adding another output after inputs have been added will rise an exception.
 //
@@ -87,7 +88,8 @@ constexpr int64_t GRAIN_SIZE = 32768;
 // Storage for a non-owning Tensor, without needing to include Tensor.h
 class TORCH_API OpaqueOptionalTensorRef {
   alignas(alignof(TensorBase)) std::array<char, sizeof(TensorBase)> data_;
-public:
+
+ public:
   OpaqueOptionalTensorRef();
   ~OpaqueOptionalTensorRef();
 
@@ -98,10 +100,18 @@ public:
     return reinterpret_cast<const OptionalTensorRef*>(data_.data());
   }
 
-  OptionalTensorRef& operator*() { return *get(); }
-  const OptionalTensorRef& operator*() const { return *get(); }
-  OptionalTensorRef* operator->() { return get(); }
-  const OptionalTensorRef* operator->() const { return get(); }
+  OptionalTensorRef& operator*() {
+    return *get();
+  }
+  const OptionalTensorRef& operator*() const {
+    return *get();
+  }
+  OptionalTensorRef* operator->() {
+    return get();
+  }
+  const OptionalTensorRef* operator->() const {
+    return get();
+  }
 
   const Tensor& getTensor() const;
 };
@@ -125,21 +135,27 @@ struct TORCH_API OperandInfo {
   /// Stride after broadcasting. The stride is in bytes, not number of elements.
   StrideVector stride_bytes;
 
-  /// The desired device and type for the operand. For inputs, this specifies that
-  /// the input should be converted to this type if necessary. For outputs, this
-  /// specifies which type to allocate. target_dtype and device are initialized with the dtype and device of the tensor
-  /// but during type promotion target_dtype value can become different from tensor's dtype
-  /// also, during type promotion target_dtype and device can be set for an undefined tensor so that tensor can be properly
-  /// constructed later.
+  /// The desired device and type for the operand. For inputs, this specifies
+  /// that the input should be converted to this type if necessary. For outputs,
+  /// this specifies which type to allocate. target_dtype and device are
+  /// initialized with the dtype and device of the tensor but during type
+  /// promotion target_dtype value can become different from tensor's dtype
+  /// also, during type promotion target_dtype and device can be set for an
+  /// undefined tensor so that tensor can be properly constructed later.
   c10::optional<Device> device = c10::nullopt;
   ScalarType target_dtype = ScalarType::Undefined;
   // Caches dtype of the tensor, because scalar_type is an expensive operation
-  // If dtype of the tensor is changed (e.g. as a result of type promotion or in allocate_outputs), this
-  //value should be changed too.
+  // If dtype of the tensor is changed (e.g. as a result of type promotion or in
+  // allocate_outputs), this
+  // value should be changed too.
   ScalarType current_dtype = ScalarType::Undefined;
 
-  bool is_device_defined() const { return device.has_value(); }
-  bool is_type_defined() const { return target_dtype != ScalarType::Undefined; }
+  bool is_device_defined() const {
+    return device.has_value();
+  }
+  bool is_type_defined() const {
+    return target_dtype != ScalarType::Undefined;
+  }
   TensorOptions options() const {
     return TensorOptions(target_dtype).device(device);
   }
@@ -157,7 +173,8 @@ struct TORCH_API OperandInfo {
   void validate() {
     TORCH_CHECK(
         !tensor_base_->defined() || tensor_base_->layout() == kStrided,
-        "unsupported tensor layout: ", tensor_base_->layout());
+        "unsupported tensor layout: ",
+        tensor_base_->layout());
   }
 
   /// The tensor operand. Note that the strides, data pointer, and
@@ -169,7 +186,7 @@ struct TORCH_API OperandInfo {
   const TensorBase& tensor_base() const {
     return *tensor_base_;
   }
-  void tensor(c10::MaybeOwned<TensorBase> &&tensor);
+  void tensor(c10::MaybeOwned<TensorBase>&& tensor);
 
   // Save the original tensor operand in cases when an output is modified
   // (e.g. if dtype is changed)
@@ -180,14 +197,16 @@ struct TORCH_API OperandInfo {
     return *original_tensor_base_;
   }
 
-  // Set tensor to a new value, and store the old tensor value in original_tensor
-  // Should only ever be called once for the lifetime of an operand
-  void exchange_tensor(c10::MaybeOwned<TensorBase> &&new_tensor);
+  // Set tensor to a new value, and store the old tensor value in
+  // original_tensor Should only ever be called once for the lifetime of an
+  // operand
+  void exchange_tensor(c10::MaybeOwned<TensorBase>&& new_tensor);
 
-  // Move original_tensor back into tensor, exchange_tensor must have been called before
+  // Move original_tensor back into tensor, exchange_tensor must have been
+  // called before
   void restore_original_tensor();
 
-private:
+ private:
   c10::MaybeOwned<TensorBase> tensor_base_;
   c10::MaybeOwned<TensorBase> original_tensor_base_ =
       c10::MaybeOwned<TensorBase>::owned(c10::in_place);
@@ -230,19 +249,32 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   //
   // The `size` often matches shape[0], but may be smaller due to
   // parallelization of the inner loop.
-  using loop2d_t = c10::function_ref<void(char** data, const int64_t* strides, int64_t size0, int64_t size1)>;
+  using loop2d_t = c10::function_ref<
+      void(char** data, const int64_t* strides, int64_t size0, int64_t size1)>;
 
   using loop_subiter_t = c10::function_ref<void(TensorIteratorBase& subiter)>;
 
-  void foreach_reduced_elt(loop_subiter_t loop, bool parallelize=true);
+  void foreach_reduced_elt(loop_subiter_t loop, bool parallelize = true);
 
-  int ndim() const { return shape_.size(); }
-  IntArrayRef shape() const { return shape_; }
+  int ndim() const {
+    return shape_.size();
+  }
+  IntArrayRef shape() const {
+    return shape_;
+  }
   int64_t numel() const;
-  int ntensors() const { return operands_.size(); }
-  int noutputs() const { return num_outputs_; }
-  int ninputs() const { return ntensors() - noutputs(); }
-  IntArrayRef view_offsets() const { return view_offsets_; }
+  int ntensors() const {
+    return operands_.size();
+  }
+  int noutputs() const {
+    return num_outputs_;
+  }
+  int ninputs() const {
+    return ntensors() - noutputs();
+  }
+  IntArrayRef view_offsets() const {
+    return view_offsets_;
+  }
 
   /// number of elements in the output operand. this is the same as numel() for
   /// operations that are not reductions.
@@ -258,17 +290,31 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   bool is_dim_reduced(int dim) const;
 
   /// Accessors for each operand
-  IntArrayRef strides(int arg) const { return operands_[arg].stride_bytes; }
+  IntArrayRef strides(int arg) const {
+    return operands_[arg].stride_bytes;
+  }
   void* data_ptr(int arg) const;
-  ScalarType dtype(int arg=0) const { return operands_[arg].current_dtype; }
+  ScalarType dtype(int arg = 0) const {
+    return operands_[arg].current_dtype;
+  }
   ScalarType common_dtype() const {
-    TORCH_INTERNAL_ASSERT(common_dtype_ != ScalarType::Undefined, "Queried for invalid common dtype!");
+    TORCH_INTERNAL_ASSERT(
+        common_dtype_ != ScalarType::Undefined,
+        "Queried for invalid common dtype!");
     return common_dtype_;
   }
-  ScalarType input_dtype(int arg=0) const { return operands_[num_outputs_ + arg].current_dtype; }
-  Device device(int arg=0) const { return operands_[arg].device.value(); }
-  DeviceType device_type(int arg=0) const { return device(arg).type(); }
-  int64_t element_size(int arg) const { return elementSize(dtype(arg)); }
+  ScalarType input_dtype(int arg = 0) const {
+    return operands_[num_outputs_ + arg].current_dtype;
+  }
+  Device device(int arg = 0) const {
+    return operands_[arg].device.value();
+  }
+  DeviceType device_type(int arg = 0) const {
+    return device(arg).type();
+  }
+  int64_t element_size(int arg) const {
+    return elementSize(dtype(arg));
+  }
   bool is_scalar(int arg) const;
   bool is_cpu_scalar(int arg) const;
 
@@ -279,21 +325,21 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
     return operands_[arg].tensor();
   }
 
-  const TensorBase& output_base(int arg=0) const {
+  const TensorBase& output_base(int arg = 0) const {
     AT_ASSERT(arg < num_outputs_);
     return tensor_base(arg);
   }
 
-  const Tensor& output(int arg=0) const {
+  const Tensor& output(int arg = 0) const {
     AT_ASSERT(arg < num_outputs_);
     return tensor(arg);
   }
 
-  const TensorBase& input_base(int arg=0) const {
+  const TensorBase& input_base(int arg = 0) const {
     AT_ASSERT(arg >= 0 && arg < ntensors() - num_outputs_);
     return tensor_base(num_outputs_ + arg);
   }
-  const Tensor& input(int arg=0) const {
+  const Tensor& input(int arg = 0) const {
     AT_ASSERT(arg >= 0 && arg < ntensors() - num_outputs_);
     return tensor(num_outputs_ + arg);
   }
@@ -326,29 +372,34 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
     return c10::fetch_and_cast<T>(op.tensor_base().scalar_type(), op.data);
   }
 
-private:
+ private:
   template <typename loop1d_t>
   auto loop_2d_from_1d(const loop1d_t& loop) {
-    return [loop, ntensor=ntensors()](
-        char** base, const int64_t* strides, int64_t size0, int64_t size1) {
-      PtrVector data(base, base + ntensor);
-      const int64_t* outer_strides = &strides[ntensor];
-      for (const auto i : c10::irange(size1)) {
-        if (i > 0) {
-          for (const auto arg : c10::irange(ntensor)) {
-            data[arg] += outer_strides[arg];
+    return
+        [loop, ntensor = ntensors()](
+            char** base, const int64_t* strides, int64_t size0, int64_t size1) {
+          PtrVector data(base, base + ntensor);
+          const int64_t* outer_strides = &strides[ntensor];
+          for (const auto i : c10::irange(size1)) {
+            if (i > 0) {
+              for (const auto arg : c10::irange(ntensor)) {
+                data[arg] += outer_strides[arg];
+              }
+            }
+            loop(data.data(), strides, size0);
           }
-        }
-        loop(data.data(), strides, size0);
-      }
-    };
+        };
   }
 
-public:
-  template <typename loop1d_t,
-            std::enable_if_t<std::is_convertible<
-              loop1d_t, c10::function_ref<void(char**, const int64_t* strides, int64_t size)>
-            >::value, int> = 0>
+ public:
+  template <
+      typename loop1d_t,
+      std::enable_if_t<
+          std::is_convertible<
+              loop1d_t,
+              c10::function_ref<
+                  void(char**, const int64_t* strides, int64_t size)>>::value,
+          int> = 0>
   void for_each(loop1d_t loop, int64_t grain_size = at::internal::GRAIN_SIZE) {
     for_each(loop_2d_from_1d(loop), grain_size);
   }
@@ -357,10 +408,14 @@ public:
 
   void parallel_reduce(loop2d_t loop);
 
-  template <typename loop1d_t,
-            std::enable_if_t<std::is_convertible<
-              loop1d_t, c10::function_ref<void(char**, const int64_t* strides, int64_t size)>
-            >::value, int> = 0>
+  template <
+      typename loop1d_t,
+      std::enable_if_t<
+          std::is_convertible<
+              loop1d_t,
+              c10::function_ref<
+                  void(char**, const int64_t* strides, int64_t size)>>::value,
+          int> = 0>
   void serial_for_each(loop1d_t loop, Range range) {
     serial_for_each(loop_2d_from_1d(loop), range);
   }
@@ -383,28 +438,39 @@ public:
   /// Helper functions for CPU iteration
   StrideVector get_dim_strides(int dim) const;
   StrideVector get_strides() const;
-  StrideVector get_inner_strides() const { return get_dim_strides(0); }
+  StrideVector get_inner_strides() const {
+    return get_dim_strides(0);
+  }
   PtrVector get_base_ptrs() const;
 
   // Helper functions for advanced stride manipulations (e.g. torch.flip)
-  void _unsafe_set_arg_strides(const int arg, IntArrayRef strides) { operands_[arg].stride_bytes = std::move(strides); }
-  void _unsafe_set_arg_data(const int arg, void* data) { operands_[arg].data = data; }
+  void _unsafe_set_arg_strides(const int arg, IntArrayRef strides) {
+    operands_[arg].stride_bytes = std::move(strides);
+  }
+  void _unsafe_set_arg_data(const int arg, void* data) {
+    operands_[arg].data = data;
+  }
 
-  /// true if the stride computation can use 32-bit arithmetic. Used by GPU kernels
+  /// true if the stride computation can use 32-bit arithmetic. Used by GPU
+  /// kernels
   bool can_use_32bit_indexing() const;
 
-  /// An "iteratable" object that recursively splits this iterator into sub-iterators
-  /// that can use 32-bit indexing.
+  /// An "iteratable" object that recursively splits this iterator into
+  /// sub-iterators that can use 32-bit indexing.
   SplitUntil32Bit with_32bit_indexing() const;
 
   /// If the kernel should accumulate into the output. Only relevant for CUDA
   /// reductions.
-  bool should_accumulate() const { return accumulate_; }
+  bool should_accumulate() const {
+    return accumulate_;
+  }
 
   /// Whether this iterator produces the actual output,
-  /// as opposed to something that will be accumulated further. Only relevant for
-  /// CUDA reductions.
-  bool is_final_output() const { return final_output_; }
+  /// as opposed to something that will be accumulated further. Only relevant
+  /// for CUDA reductions.
+  bool is_final_output() const {
+    return final_output_;
+  }
 
   bool has_contiguous_first_dim() const {
     int num_tensors = ntensors();
@@ -416,45 +482,90 @@ public:
     return true;
   }
 
-  void set_output_raw_strided(int64_t output_idx, IntArrayRef sizes, IntArrayRef strides, TensorOptions options, DimnameList names) override;
+  void set_output_raw_strided(
+      int64_t output_idx,
+      IntArrayRef sizes,
+      IntArrayRef strides,
+      TensorOptions options,
+      DimnameList names) override;
 
-#define TORCH_DISALLOW_TEMPORARIES_IMPL(methodname, maybestatic)                               \
-  maybestatic void methodname(TensorBase&& out, const TensorBase& a, const TensorBase& b) = delete; \
-  maybestatic void methodname(const TensorBase& out, TensorBase&& a, const TensorBase& b) = delete; \
-  maybestatic void methodname(const TensorBase& out, const TensorBase& a, TensorBase&& b) = delete; \
-  maybestatic void methodname(TensorBase&& out, TensorBase&& a, const TensorBase& b) = delete; \
-  maybestatic void methodname(TensorBase&& out, const TensorBase& a, TensorBase&& b) = delete; \
-  maybestatic void methodname(const TensorBase& out, TensorBase&& a, TensorBase&& b) = delete; \
-  maybestatic void methodname(TensorBase&& out, TensorBase&& a, TensorBase&& b) = delete;
+#define TORCH_DISALLOW_TEMPORARIES_IMPL(methodname, maybestatic)            \
+  maybestatic void methodname(                                              \
+      TensorBase&& out, const TensorBase& a, const TensorBase& b) = delete; \
+  maybestatic void methodname(                                              \
+      const TensorBase& out, TensorBase&& a, const TensorBase& b) = delete; \
+  maybestatic void methodname(                                              \
+      const TensorBase& out, const TensorBase& a, TensorBase&& b) = delete; \
+  maybestatic void methodname(                                              \
+      TensorBase&& out, TensorBase&& a, const TensorBase& b) = delete;      \
+  maybestatic void methodname(                                              \
+      TensorBase&& out, const TensorBase& a, TensorBase&& b) = delete;      \
+  maybestatic void methodname(                                              \
+      const TensorBase& out, TensorBase&& a, TensorBase&& b) = delete;      \
+  maybestatic void methodname(                                              \
+      TensorBase&& out, TensorBase&& a, TensorBase&& b) = delete;
 
-#define TORCH_DISALLOW_TEMPORARIES(methodname) TORCH_DISALLOW_TEMPORARIES_IMPL(methodname,)
+#define TORCH_DISALLOW_TEMPORARIES(methodname) \
+  TORCH_DISALLOW_TEMPORARIES_IMPL(methodname, )
 
-  void build_binary_float_op(const TensorBase& out, const TensorBase& a, const TensorBase& b);
-  void build_borrowing_binary_float_op(const TensorBase& out, const TensorBase& a, const TensorBase& b);
+  void build_binary_float_op(
+      const TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b);
+  void build_borrowing_binary_float_op(
+      const TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b);
   TORCH_DISALLOW_TEMPORARIES(build_borrowing_binary_float_op)
-  void build_binary_op(const TensorBase& out, const TensorBase& a, const TensorBase& b);
-  void build_borrowing_binary_op(const TensorBase& out, const TensorBase& a, const TensorBase& b);
+  void build_binary_op(
+      const TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b);
+  void build_borrowing_binary_op(
+      const TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b);
   TORCH_DISALLOW_TEMPORARIES(build_borrowing_binary_op)
   void build_unary_float_op(const TensorBase& out, const TensorBase& a);
-  void build_borrowing_unary_float_op(const TensorBase& out, const TensorBase& a);
+  void build_borrowing_unary_float_op(
+      const TensorBase& out,
+      const TensorBase& a);
   TORCH_DISALLOW_TEMPORARIES(build_borrowing_unary_float_op)
   void build_unary_op(const TensorBase& out, const TensorBase& a);
   // Odd special case needed for pow. Has to borrow the output because
   // it's a structured kernel, but the argument is potentially a copy.
-  void build_output_borrowing_argument_owning_unary_op(const TensorBase& out, const TensorBase& a);
+  void build_output_borrowing_argument_owning_unary_op(
+      const TensorBase& out,
+      const TensorBase& a);
   void build_borrowing_unary_op(const TensorBase& out, const TensorBase& a);
   TORCH_DISALLOW_TEMPORARIES(build_borrowing_unary_op)
-  void build_borrowing_unary_force_boolean_op(const TensorBase& out, const TensorBase& a);
+  void build_borrowing_unary_force_boolean_op(
+      const TensorBase& out,
+      const TensorBase& a);
   TORCH_DISALLOW_TEMPORARIES(build_borrowing_unary_force_boolean_op)
-  void build_comparison_op(const TensorBase& out, const TensorBase& a, const TensorBase& b);
-  void build_borrowing_comparison_op(const TensorBase& out, const TensorBase& a, const TensorBase& b);
+  void build_comparison_op(
+      const TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b);
+  void build_borrowing_comparison_op(
+      const TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b);
   TORCH_DISALLOW_TEMPORARIES(build_borrowing_comparison_op)
-  // Another special case: we need to own the second argument for comparison ops.
-  void build_borrowing_except_last_argument_comparison_op(const TensorBase& out, const TensorBase& a, const TensorBase& b);
-  void build_ternary_op(const TensorBase& out, const TensorBase& a, const TensorBase& b, const TensorBase& c);
+  // Another special case: we need to own the second argument for comparison
+  // ops.
+  void build_borrowing_except_last_argument_comparison_op(
+      const TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b);
+  void build_ternary_op(
+      const TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b,
+      const TensorBase& c);
 
 #undef TORCH_DISALLOW_TEMPORARIES
-protected:
+ protected:
   // Mutable reference as it moves tensors out of TensorIteratorConfig
   void populate_operands(TensorIteratorConfig&);
   void mark_outputs();
@@ -473,8 +584,7 @@ protected:
   void propagate_names_to_outputs();
   void coalesce_dimensions();
 
-protected:
-
+ protected:
   /// Records the "computation" shape of the output tensor. The computation
   /// shape is different from the regular shape in a few ways:
   ///
@@ -518,8 +628,8 @@ protected:
   /// been called?  This is SOLELY used to check validity of perm_.
   bool has_coalesced_dimensions_ = false;
 
-  /// Whether iteration must be fixed. This disables dimension permuting and also
-  /// changes how for_each divides work among threads.
+  /// Whether iteration must be fixed. This disables dimension permuting and
+  /// also changes how for_each divides work among threads.
   bool enforce_linear_iteration_ = false;
 
   /// The index offsets into the original tensors for each dimension.
@@ -574,29 +684,50 @@ struct TORCH_API TensorIterator final : public TensorIteratorBase {
   // Slicing is OK, TensorIterator guaranteed NOT to have any fields
   TensorIterator(const TensorIteratorBase& iter) : TensorIteratorBase(iter) {}
 
-#define TORCH_DISALLOW_TEMPORARIES(methodname) TORCH_DISALLOW_TEMPORARIES_IMPL(methodname, static)
+#define TORCH_DISALLOW_TEMPORARIES(methodname) \
+  TORCH_DISALLOW_TEMPORARIES_IMPL(methodname, static)
 
-  static TensorIterator binary_float_op(TensorBase& out, const TensorBase& a, const TensorBase& b);
-  static TensorIterator binary_op(TensorBase& out, const TensorBase& a, const TensorBase& b);
-  static TensorIterator borrowing_binary_op(const TensorBase& out, const TensorBase& a, const TensorBase& b);
+  static TensorIterator binary_float_op(
+      TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b);
+  static TensorIterator binary_op(
+      TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b);
+  static TensorIterator borrowing_binary_op(
+      const TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b);
   TORCH_DISALLOW_TEMPORARIES(borrowing_binary_op)
-  static TensorIterator comparison_op(TensorBase& out, const TensorBase& a, const TensorBase& b);
+  static TensorIterator comparison_op(
+      TensorBase& out,
+      const TensorBase& a,
+      const TensorBase& b);
   static TensorIterator unary_op(TensorBase& out, const TensorBase& a);
   static TensorIterator unary_float_op(TensorBase& out, const TensorBase& a);
   static TensorIterator nullary_op(TensorBase& out);
   static TensorIterator borrowing_nullary_op(const TensorBase& out);
   static TensorIterator borrowing_nullary_op(TensorBase&& out) = delete;
   static TensorIterator reduce_op(TensorBase& out, const TensorBase& a);
-  static TensorIterator reduce_op(TensorBase& out1, TensorBase& out2, const TensorBase& a);
+  static TensorIterator reduce_op(
+      TensorBase& out1,
+      TensorBase& out2,
+      const TensorBase& a);
 #undef TORCH_DISALLOW_TEMPORARIES
 #undef TORCH_DISALLOW_TEMPORARIES_IMPL
 
   const Tensor& maybe_get_output(int64_t output_idx) override;
-  void set_output_raw_strided(int64_t output_idx, IntArrayRef sizes, IntArrayRef strides, TensorOptions options, DimnameList names) override;
+  void set_output_raw_strided(
+      int64_t output_idx,
+      IntArrayRef sizes,
+      IntArrayRef strides,
+      TensorOptions options,
+      DimnameList names) override;
 };
 
 class TORCH_API TensorIteratorConfig final {
-public:
+ public:
   friend struct TensorIteratorBase;
   friend struct TensorIterator;
 
@@ -665,7 +796,8 @@ public:
   // If true, all operands must be on the same device, with the possible
   //   exception of CPU scalars, which can be passed to some CUDA kernels
   //   as kernel arguments.
-  TensorIteratorConfig& check_all_same_device(const bool _check_all_same_device) {
+  TensorIteratorConfig& check_all_same_device(
+      const bool _check_all_same_device) {
     check_all_same_device_ = _check_all_same_device;
     return *this;
   }
@@ -674,7 +806,8 @@ public:
   // If true, the iterator's "common dtype" must be computable
   //   (see the [Common Dtype Computation] note) and
   //   canCast(common dtype, output dtype) must be true for all outputs.
-  TensorIteratorConfig& enforce_safe_casting_to_output(const bool _enforce_safe_casting_to_output) {
+  TensorIteratorConfig& enforce_safe_casting_to_output(
+      const bool _enforce_safe_casting_to_output) {
     enforce_safe_casting_to_output_ = _enforce_safe_casting_to_output;
     return *this;
   }
@@ -683,9 +816,10 @@ public:
   // If true, iteration goes in the same order as a C-contiguous tensor
   // is layed out in memory. i.e. last dimension iterates fastest.
   //
-  // This iteration order can be less efficient and may even prevent vectorization.
-  // So only use if the correctness of your kernel depends on it.
-  TensorIteratorConfig& enforce_linear_iteration(const bool _enforce_linear_iteration = true) {
+  // This iteration order can be less efficient and may even prevent
+  // vectorization. So only use if the correctness of your kernel depends on it.
+  TensorIteratorConfig& enforce_linear_iteration(
+      const bool _enforce_linear_iteration = true) {
     enforce_linear_iteration_ = _enforce_linear_iteration;
     return *this;
   }
@@ -696,7 +830,8 @@ public:
   //   the inputs in the common dtype are passed as the actual inputs to
   //   the operation.
   // Setting this flag to true sets check_all_same_dtype_ to false.
-  TensorIteratorConfig& promote_inputs_to_common_dtype(const bool _promote_inputs_to_common_dtype) {
+  TensorIteratorConfig& promote_inputs_to_common_dtype(
+      const bool _promote_inputs_to_common_dtype) {
     promote_inputs_to_common_dtype_ = _promote_inputs_to_common_dtype;
     if (_promote_inputs_to_common_dtype) {
       check_all_same_dtype_ = false;
@@ -705,12 +840,15 @@ public:
   }
 
   // Sets the promote_integer_inputs_to_float_ flag, which is false by default
-  // NOTE: If set to true, the promote_inputs_to_common_dtype_ must also be true.
-  // If true, if the iterator's "common dtype" is an integral type (including bool)
+  // NOTE: If set to true, the promote_inputs_to_common_dtype_ must also be
+  // true. If true, if the iterator's "common dtype" is an integral type
+  // (including bool)
   //   then it is changed to the default float scalar type.
-  TensorIteratorConfig& promote_integer_inputs_to_float(const bool _promote_integer_inputs_to_float) {
+  TensorIteratorConfig& promote_integer_inputs_to_float(
+      const bool _promote_integer_inputs_to_float) {
     promote_integer_inputs_to_float_ = _promote_integer_inputs_to_float;
-    TORCH_INTERNAL_ASSERT(!promote_integer_inputs_to_float_ || promote_inputs_to_common_dtype_);
+    TORCH_INTERNAL_ASSERT(
+        !promote_integer_inputs_to_float_ || promote_inputs_to_common_dtype_);
     return *this;
   }
 
@@ -731,7 +869,8 @@ public:
   //   These temporaries are then copied to the original outputs after
   //   the operation is performed (see cast_outputs()).
   // Setting this flag to true sets check_all_same_dtype_ to false.
-  TensorIteratorConfig& cast_common_dtype_to_outputs(const bool _cast_common_dtype_to_outputs) {
+  TensorIteratorConfig& cast_common_dtype_to_outputs(
+      const bool _cast_common_dtype_to_outputs) {
     cast_common_dtype_to_outputs_ = _cast_common_dtype_to_outputs;
     if (_cast_common_dtype_to_outputs) {
       check_all_same_dtype_ = false;
@@ -744,12 +883,17 @@ public:
     return *this;
   }
 
-  // Bypass output dtype/device computation and fix the dtype/device as specified here.
-  TensorIteratorConfig& declare_static_dtype_and_device(ScalarType dtype, Device device);
+  // Bypass output dtype/device computation and fix the dtype/device as
+  // specified here.
+  TensorIteratorConfig& declare_static_dtype_and_device(
+      ScalarType dtype,
+      Device device);
   TensorIteratorConfig& declare_static_dtype(ScalarType dtype);
   TensorIteratorConfig& declare_static_device(Device device);
   TensorIteratorConfig& declare_static_shape(IntArrayRef shape);
-  TensorIteratorConfig& declare_static_shape(IntArrayRef shape, IntArrayRef squash_dims);
+  TensorIteratorConfig& declare_static_shape(
+      IntArrayRef shape,
+      IntArrayRef squash_dims);
 
   // It would be better if this was && qualified, but this would be at the cost
   // of a lot of boilerplate above
@@ -759,7 +903,7 @@ public:
     return iter;
   }
 
-private:
+ private:
   SmallVector<c10::MaybeOwned<TensorBase>, 4> tensors_;
   int num_outputs_ = 0;
   int num_inputs_ = 0;
@@ -780,14 +924,12 @@ private:
   bool cast_common_dtype_to_outputs_ = false;
 };
 
-
-
 /// A container-like struct that acts as if it contains splits of a
 /// TensorIterator that can use 32-bit indexing. Taken together the splits cover
 /// the original TensorIterator.
 struct TORCH_API SplitUntil32Bit {
   struct TORCH_API iterator {
-    iterator() {};
+    iterator(){};
     iterator(const TensorIteratorBase& iter);
     iterator(iterator&&) = default;
 
@@ -795,11 +937,14 @@ struct TORCH_API SplitUntil32Bit {
     TensorIterator& operator*() const;
     iterator& operator++();
     bool operator==(const iterator& other) const {
-      // two iterators are equal if they are the same object or they're both empty
+      // two iterators are equal if they are the same object or they're both
+      // empty
       return this == &other || (vec.empty() && other.vec.empty());
     }
     // needed for C++11 range-based for loop
-    bool operator!=(const iterator& other) const { return !(*this == other); }
+    bool operator!=(const iterator& other) const {
+      return !(*this == other);
+    }
 
     /// stack of TensorIterators to be split
     std::vector<std::unique_ptr<TensorIterator>> vec;
@@ -810,10 +955,10 @@ struct TORCH_API SplitUntil32Bit {
   iterator begin() const;
   iterator end() const;
 
-private:
+ private:
   const TensorIteratorBase& iter;
 };
 
-}  // namespace at
+} // namespace at
 
 C10_CLANG_DIAGNOSTIC_POP()

--- a/aten/src/ATen/TensorIteratorInternal.h
+++ b/aten/src/ATen/TensorIteratorInternal.h
@@ -21,7 +21,10 @@ struct DimCounter {
 namespace internal {
 
 inline void get_data_ptrs(
-    char** ptrs, ArrayRef<char*> base, IntArrayRef strides, IntArrayRef counter) {
+    char** ptrs,
+    ArrayRef<char*> base,
+    IntArrayRef strides,
+    IntArrayRef counter) {
   const int64_t ntensors = base.size();
   const int64_t ndim = counter.size();
   std::copy(base.begin(), base.end(), ptrs);
@@ -34,9 +37,12 @@ inline void get_data_ptrs(
 }
 
 inline void serial_for_each(
-    IntArrayRef shape, IntArrayRef strides,
-    char** base_ptrs, size_t ntensors,
-    typename TensorIteratorBase::loop2d_t loop, Range range) {
+    IntArrayRef shape,
+    IntArrayRef strides,
+    char** base_ptrs,
+    size_t ntensors,
+    typename TensorIteratorBase::loop2d_t loop,
+    Range range) {
   const auto ndim = shape.size();
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       strides.size() == ntensors * std::max(size_t{2}, ndim));
@@ -53,13 +59,14 @@ inline void serial_for_each(
     c10::SmallBuffer<char*, 4> ptrs(ntensors);
     auto counter = DimCounter(shape, range);
     while (!counter.is_done()) {
-      get_data_ptrs(ptrs.data(), {base_ptrs, ntensors}, strides, counter.values);
+      get_data_ptrs(
+          ptrs.data(), {base_ptrs, ntensors}, strides, counter.values);
       auto step = counter.max_2d_step();
       loop(ptrs.data(), strides.data(), step[0], step[1]);
       counter.increment(step);
     }
   }
-
 }
 
-}}  // namespace at::internal
+} // namespace internal
+} // namespace at

--- a/aten/src/ATen/TensorMeta.h
+++ b/aten/src/ATen/TensorMeta.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <ATen/DimVector.h>
+#include <ATen/core/Dimname.h>
 #include <c10/core/TensorOptions.h>
 #include <c10/util/strides.h>
-#include <ATen/core/Dimname.h>
 
 C10_CLANG_DIAGNOSTIC_PUSH()
 #if C10_CLANG_HAS_WARNING("-Wdeprecated-copy-dtor")
@@ -30,17 +30,23 @@ namespace impl {
 //    }
 //
 #define TORCH_META_FUNC(name) void structured_##name::meta
-#define TORCH_META_FUNC2(name, overload) void structured_##name##_##overload::meta
+#define TORCH_META_FUNC2(name, overload) \
+  void structured_##name##_##overload::meta
 
-// These are versions of TORCH_META_FUNC(2) that include a precompute_out struct as a return value.
-// They should be used when the kernel in question has precomputed values declared in native_functions.yaml and
-// the corresponding implementation should return an instance of the aforementioned struct.
-#define TORCH_PRECOMPUTE_META_FUNC(name) structured_##name::meta_return_ty structured_##name::meta
-#define TORCH_PRECOMPUTE_META_FUNC2(name, overload) structured_##name##_##overload::meta_return_ty structured_##name##_##overload::meta
+// These are versions of TORCH_META_FUNC(2) that include a precompute_out struct
+// as a return value. They should be used when the kernel in question has
+// precomputed values declared in native_functions.yaml and the corresponding
+// implementation should return an instance of the aforementioned struct.
+#define TORCH_PRECOMPUTE_META_FUNC(name) \
+  structured_##name::meta_return_ty structured_##name::meta
+#define TORCH_PRECOMPUTE_META_FUNC2(name, overload) \
+  structured_##name##_##overload::meta_return_ty    \
+      structured_##name##_##overload::meta
 
 // Use this to create a precompute struct in a meta function.
 #define TORCH_PRECOMPUTE_STRUCT(name) structured_##name::precompute_out<>
-#define TORCH_PRECOMPUTE_STRUCT2(name, overload) structured_##name##_##overload::precompute_out<>
+#define TORCH_PRECOMPUTE_STRUCT2(name, overload) \
+  structured_##name##_##overload::precompute_out<>
 
 // Use this to define the prototype for an implementation.  This takes only
 // one argument, which is the name of the dispatch key entry you're
@@ -66,10 +72,10 @@ struct TORCH_API MetaBase {
   virtual const Tensor& maybe_get_output(int64_t output_idx) = 0;
 
   // See: https://github.com/pytorch/pytorch/issues/69813
-  // Whenever defining the output properties in the META function of a structured
-  // kernel (what was usually done with `set_output`), use one of these 3 variants,
-  // instead. In order to decide which variant to use, check the following
-  // decision tree:
+  // Whenever defining the output properties in the META function of a
+  // structured kernel (what was usually done with `set_output`), use one of
+  // these 3 variants, instead. In order to decide which variant to use, check
+  // the following decision tree:
   //
   // - Can the kernel you are going to implement support output tensors
   //   with arbitrary strides?
@@ -82,9 +88,9 @@ struct TORCH_API MetaBase {
   //         |
   //         -- NO: `set_output_strided`
   //
-  // Use this function whenever the kernel requires specific strides for the output.
-  // If `strides` does not match the given output strides, proxy outputs will be
-  // created and passed to the IMPL function.
+  // Use this function whenever the kernel requires specific strides for the
+  // output. If `strides` does not match the given output strides, proxy outputs
+  // will be created and passed to the IMPL function.
   virtual void set_output_strided(
       int64_t output_idx,
       IntArrayRef sizes,
@@ -94,9 +100,9 @@ struct TORCH_API MetaBase {
     TORCH_INTERNAL_ASSERT(false, "set_output_strided not implemented.");
   }
 
-  // Use this function whenever the kernel knows how to handle arbitrary strided outputs.
-  // This function has the same behavior as the old `set_output`: it will only
-  // re-stride if the given output was resized.
+  // Use this function whenever the kernel knows how to handle arbitrary strided
+  // outputs. This function has the same behavior as the old `set_output`: it
+  // will only re-stride if the given output was resized.
   virtual void set_output_raw_strided(
       int64_t output_idx,
       IntArrayRef sizes,
@@ -119,7 +125,9 @@ struct TORCH_API MetaBase {
 
   // Returns a reference to an undefined tensor if there is no presupplied
   // output
-  const Tensor& maybe_get_output() { return maybe_get_output(0); }
+  const Tensor& maybe_get_output() {
+    return maybe_get_output(0);
+  }
   virtual ~MetaBase() {}
 };
 

--- a/aten/src/ATen/TensorNames.h
+++ b/aten/src/ATen/TensorNames.h
@@ -2,15 +2,15 @@
 
 #include <ATen/WrapDimUtils.h>
 
-namespace at { namespace namedinference {
-
+namespace at {
+namespace namedinference {
 
 // TensorName and TensorNames are wrappers around Dimname and DimnameList
 // that contain helper functions to make writing name inference rules easier.
 //
-// A TensorName represents a Dimname associated with some DimnameList (from a Tensor).
-// This encapsulates all the information that is needed to check if names *match*
-// and to *unify* names.
+// A TensorName represents a Dimname associated with some DimnameList (from a
+// Tensor). This encapsulates all the information that is needed to check if
+// names *match* and to *unify* names.
 //
 // Definition: Two names in two tensors *match* if they are equal, or if at
 // least one of them is a wildcard that can be *refined* to the other name.
@@ -28,9 +28,9 @@ namespace at { namespace namedinference {
 // tensor.names [A, None] for the existence of A.
 struct TORCH_API TensorName {
   explicit TensorName(ArrayRef<Dimname> origin, int origin_idx)
-    : origin_(origin),
-      name_(origin[maybe_wrap_dim(origin_idx, origin.size())]),
-      origin_idx_(origin_idx) {}
+      : origin_(origin),
+        name_(origin[maybe_wrap_dim(origin_idx, origin.size())]),
+        origin_idx_(origin_idx) {}
 
   // op_name is only used for error reporting.
   const TensorName& unify(const TensorName& other, const char* op_name) const;
@@ -52,7 +52,8 @@ struct TORCH_API TensorNames {
   explicit TensorNames(ArrayRef<Dimname> names);
 
   // Create TensorNames from names[start:end]. Each individual TensorName stores
-  // `names`, NOT names[start:end], because the original tensor's names are `names`.
+  // `names`, NOT names[start:end], because the original tensor's names are
+  // `names`.
   explicit TensorNames(ArrayRef<Dimname> names, int64_t start, int64_t end);
 
   // op_name is only used for error reporting.
@@ -65,10 +66,10 @@ struct TORCH_API TensorNames {
   std::vector<Dimname> toDimnameVec() const;
 
  private:
-  explicit TensorNames(TensorNameVec&& names) : names_(names) {};
+  explicit TensorNames(TensorNameVec&& names) : names_(names){};
 
   TensorNameVec names_;
 };
 
-
-}} // namespace at::namedinference
+} // namespace namedinference
+} // namespace at

--- a/aten/src/ATen/TensorOperators.h
+++ b/aten/src/ATen/TensorOperators.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <c10/core/Scalar.h>
 #include <ATen/core/Tensor.h>
+#include <c10/core/Scalar.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -9,41 +9,46 @@
 #include <ATen/ops/empty_like.h>
 #endif
 
-#include <string>
 #include <stdexcept>
+#include <string>
 
 namespace at {
 
-#define AT_FORALL_BINARY_OPS(_) \
-_(+,x.add(y), y.add(x)) \
-_(*,x.mul(y), y.mul(x)) \
-_(-,x.sub(y), ::at::empty_like(y, at::MemoryFormat::Preserve).fill_(x).sub_(y)) \
-_(/,x.div(y), ::at::empty_like(y, at::MemoryFormat::Preserve).fill_(x).div_(y)) \
-_(%,x.remainder(y), ::at::empty_like(y, at::MemoryFormat::Preserve).fill_(x).remainder_(y)) \
-_(&,x.bitwise_and(y), y.bitwise_and(x)) \
-_(|,x.bitwise_or(y), y.bitwise_or(x)) \
-_(^,x.bitwise_xor(y), y.bitwise_xor(x)) \
-_(<,x.lt(y), y.gt(x)) \
-_(<=,x.le(y), y.ge(x)) \
-_(>,x.gt(y),y.lt(x)) \
-_(>=,x.ge(y), y.le(x)) \
-_(==,x.eq(y), y.eq(x)) \
-_(!=,x.ne(y), y.ne(x))
+#define AT_FORALL_BINARY_OPS(_)                                             \
+  _(+, x.add(y), y.add(x))                                                  \
+  _(*, x.mul(y), y.mul(x))                                                  \
+  _(-,                                                                      \
+    x.sub(y),                                                               \
+    ::at::empty_like(y, at::MemoryFormat::Preserve).fill_(x).sub_(y))       \
+  _(/,                                                                      \
+    x.div(y),                                                               \
+    ::at::empty_like(y, at::MemoryFormat::Preserve).fill_(x).div_(y))       \
+  _(%,                                                                      \
+    x.remainder(y),                                                         \
+    ::at::empty_like(y, at::MemoryFormat::Preserve).fill_(x).remainder_(y)) \
+  _(&, x.bitwise_and(y), y.bitwise_and(x))                                  \
+  _(|, x.bitwise_or(y), y.bitwise_or(x))                                    \
+  _(^, x.bitwise_xor(y), y.bitwise_xor(x))                                  \
+  _(<, x.lt(y), y.gt(x))                                                    \
+  _(<=, x.le(y), y.ge(x))                                                   \
+  _(>, x.gt(y), y.lt(x))                                                    \
+  _(>=, x.ge(y), y.le(x))                                                   \
+  _(==, x.eq(y), y.eq(x))                                                   \
+  _(!=, x.ne(y), y.ne(x))
 
-#define DEFINE_OPERATOR(op,body,reverse_scalar_body) \
-static inline Tensor operator op(const Tensor & x, const Tensor & y) { \
-  return body; \
-} \
-static inline Tensor operator op(const Tensor & x, const Scalar& y) { \
-  return body; \
-} \
-static inline Tensor operator op(const Scalar& x, const Tensor & y) { \
-  return reverse_scalar_body; \
-}
-
+#define DEFINE_OPERATOR(op, body, reverse_scalar_body)                 \
+  static inline Tensor operator op(const Tensor& x, const Tensor& y) { \
+    return body;                                                       \
+  }                                                                    \
+  static inline Tensor operator op(const Tensor& x, const Scalar& y) { \
+    return body;                                                       \
+  }                                                                    \
+  static inline Tensor operator op(const Scalar& x, const Tensor& y) { \
+    return reverse_scalar_body;                                        \
+  }
 
 AT_FORALL_BINARY_OPS(DEFINE_OPERATOR)
 #undef DEFINE_OPERATOR
 #undef AT_FORALL_BINARY_OPS
 
-}
+} // namespace at

--- a/aten/src/ATen/TensorSubclassLikeUtils.h
+++ b/aten/src/ATen/TensorSubclassLikeUtils.h
@@ -22,19 +22,21 @@ namespace at {
 //    If input is a Tensor subclass, then the above ends up either erroring out
 //    or returning a regular non-Tensor-subclass Tensor!
 
-constexpr auto kFunctorchWrappedTensors = DispatchKeySet({
-    DispatchKey::FuncTorchGradWrapper,
-    DispatchKey::FuncTorchBatched});
+constexpr auto kFunctorchWrappedTensors = DispatchKeySet(
+    {DispatchKey::FuncTorchGradWrapper, DispatchKey::FuncTorchBatched});
 
-constexpr auto kTensorSubclassLike = kFunctorchWrappedTensors | DispatchKeySet({
-    // WARNING: DO NOT put combined backend component + functionality keys
-    // here, you will incorrectly always match on the functionality key
-    // no matter the backend component
-    DispatchKey::Batched,
-    DispatchKey::Sparse,
-    DispatchKey::SparseCsrCPU,
-    DispatchKey::SparseCsrCUDA,
-    DispatchKey::Python}) | DispatchKeySet(BackendComponent::MetaBit);
+constexpr auto kTensorSubclassLike =
+    kFunctorchWrappedTensors |
+    DispatchKeySet(
+        {// WARNING: DO NOT put combined backend component + functionality keys
+         // here, you will incorrectly always match on the functionality key
+         // no matter the backend component
+         DispatchKey::Batched,
+         DispatchKey::Sparse,
+         DispatchKey::SparseCsrCPU,
+         DispatchKey::SparseCsrCUDA,
+         DispatchKey::Python}) |
+    DispatchKeySet(BackendComponent::MetaBit);
 
 inline bool isTensorSubclassLike(const Tensor& tensor) {
   auto key_set = tensor.unsafeGetTensorImpl()->key_set();
@@ -45,10 +47,13 @@ inline bool areAnyTensorSubclassLike(TensorList tensors) {
   return std::any_of(tensors.begin(), tensors.end(), isTensorSubclassLike);
 }
 
-inline bool areAnyOptionalTensorSubclassLike(const c10::List<c10::optional<Tensor>>& tensors) {
-  return std::any_of(tensors.begin(), tensors.end(), [](const optional<Tensor>& opt_tensor) {
-    return (opt_tensor.has_value() && isTensorSubclassLike(opt_tensor.value()));
-    });
+inline bool areAnyOptionalTensorSubclassLike(
+    const c10::List<c10::optional<Tensor>>& tensors) {
+  return std::any_of(
+      tensors.begin(), tensors.end(), [](const optional<Tensor>& opt_tensor) {
+        return (
+            opt_tensor.has_value() && isTensorSubclassLike(opt_tensor.value()));
+      });
 }
 
-}
+} // namespace at

--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -19,11 +19,15 @@ struct TORCH_API TensorArg {
   const char* name;
   int pos; // 1-indexed
   TensorArg(const Tensor& tensor, const char* name, int pos)
-    : tensor(tensor), name(name), pos(pos) {}
+      : tensor(tensor), name(name), pos(pos) {}
   // Try to mitigate any possibility of dangling reference to temporaries.
   TensorArg(Tensor&& tensor, const char* name, int pos) = delete;
-  const Tensor* operator->() const { return &tensor; }
-  const Tensor& operator*() const { return tensor; }
+  const Tensor* operator->() const {
+    return &tensor;
+  }
+  const Tensor& operator*() const {
+    return tensor;
+  }
 };
 
 struct TORCH_API TensorGeometryArg {
@@ -31,11 +35,15 @@ struct TORCH_API TensorGeometryArg {
   const char* name;
   int pos; // 1-indexed
   /* implicit */ TensorGeometryArg(TensorArg arg)
-    : tensor(TensorGeometry{arg.tensor}), name(arg.name), pos(arg.pos) {}
+      : tensor(TensorGeometry{arg.tensor}), name(arg.name), pos(arg.pos) {}
   TensorGeometryArg(TensorGeometry tensor, const char* name, int pos)
-    : tensor(tensor), name(name), pos(pos) {}
-  const TensorGeometry* operator->() const { return &tensor; }
-  const TensorGeometry& operator*() const { return tensor; }
+      : tensor(tensor), name(name), pos(pos) {}
+  const TensorGeometry* operator->() const {
+    return &tensor;
+  }
+  const TensorGeometry& operator*() const {
+    return tensor;
+  }
 };
 
 // A string describing which function did checks on its input
@@ -60,10 +68,7 @@ TORCH_API void checkDim(
     const char* name,
     int pos, // 1-indexed
     int64_t dim);
-TORCH_API void checkDim(
-    CheckedFrom c,
-    const TensorGeometryArg& t,
-    int64_t dim);
+TORCH_API void checkDim(CheckedFrom c, const TensorGeometryArg& t, int64_t dim);
 // NB: this is an inclusive-exclusive range
 TORCH_API void checkDimRange(
     CheckedFrom c,
@@ -94,10 +99,7 @@ TORCH_API void checkSameNumel(
     const TensorGeometryArg& t1,
     const TensorGeometryArg& t2);
 TORCH_API void checkAllSameNumel(CheckedFrom c, ArrayRef<TensorArg> tensors);
-TORCH_API void checkScalarType(
-    CheckedFrom c,
-    const TensorArg& t,
-    ScalarType s);
+TORCH_API void checkScalarType(CheckedFrom c, const TensorArg& t, ScalarType s);
 TORCH_API void checkScalarTypes(
     CheckedFrom c,
     const TensorArg& t,
@@ -132,7 +134,10 @@ TORCH_API void checkDeviceType(
 
 TORCH_API void checkLayout(CheckedFrom c, const Tensor& t, Layout layout);
 
-TORCH_API void checkLayout(CheckedFrom c, at::ArrayRef<Tensor> tensors, at::Layout layout);
+TORCH_API void checkLayout(
+    CheckedFrom c,
+    at::ArrayRef<Tensor> tensors,
+    at::Layout layout);
 
 // Methods for getting data_ptr if tensor is defined
 TORCH_API void* maybe_data_ptr(const Tensor& tensor);

--- a/aten/src/ATen/ThreadLocalState.h
+++ b/aten/src/ATen/ThreadLocalState.h
@@ -7,10 +7,10 @@
 #include <c10/util/Exception.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
 
-#include <ATen/record_function.h>
 #include <ATen/FuncTorchTLS.h>
-#include <ATen/core/TorchDispatchModeTLS.h>
 #include <ATen/PythonTorchFunctionTLS.h>
+#include <ATen/core/TorchDispatchModeTLS.h>
+#include <ATen/record_function.h>
 
 namespace at {
 

--- a/aten/src/ATen/TracerMode.h
+++ b/aten/src/ATen/TracerMode.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <c10/core/impl/LocalDispatchKeySet.h>
-#include <c10/macros/Macros.h>
 #include <c10/macros/Export.h>
+#include <c10/macros/Macros.h>
 
 // NOTE [Tracing Mode Switches]
 //
@@ -13,8 +13,8 @@
 //    Tracing function used to be script-generated inside `VariableType_*.cpp`
 //    kernels, sharing the same `Autograd` dispatch key with autograd function.
 //    Therefore, before tracing function was moved out of VariableType,
-//    `AutoDispatchBelowADInplaceOrView` guard can also disable tracing as a side effect
-//    of disabling `Autograd` dispatching.
+//    `AutoDispatchBelowADInplaceOrView` guard can also disable tracing as a
+//    side effect of disabling `Autograd` dispatching.
 //
 // - `setTracingState()` API in `torch/csrc/jit/frontend/tracer.h`
 //
@@ -42,8 +42,8 @@
 //
 // - `tracer::impl::NoTracerDispatchMode` guard
 //
-//    It's used to cover the old semantics of `AutoDispatchBelowADInplaceOrView` after
-//    tracing was moved out of VariableType.
+//    It's used to cover the old semantics of `AutoDispatchBelowADInplaceOrView`
+//    after tracing was moved out of VariableType.
 //
 // Before tracing function was moved out of VariableType, tracing was enabled
 // when the following conditions are satisfied:
@@ -69,11 +69,12 @@
 //   `setTracingState()` Python/C++ APIs (and other APIs calling it) so that
 //   these two can be unified.
 //
-// - `AutoDispatchBelowADInplaceOrView` v.s. `tracer::impl::NoTracerDispatchMode`
+// - `AutoDispatchBelowADInplaceOrView` v.s.
+// `tracer::impl::NoTracerDispatchMode`
 //
 //   We don't need to always set both guards together to keep semantics
-//   unchanged. For the follow use cases of `AutoDispatchBelowADInplaceOrView` we don't
-//   need set the new tracer guard:
+//   unchanged. For the follow use cases of `AutoDispatchBelowADInplaceOrView`
+//   we don't need set the new tracer guard:
 //
 //   * Script-generated VariableType kernels. The guard is not necessary as
 //     tracing is already disabled explicitly by `setTracingState(null)` in
@@ -99,7 +100,8 @@
 //   * Some manually maintained functions, e.g.:
 //     `torch/csrc/autograd/VariableTypeManual.cpp`.
 //     Set the new guard if it's not obvious whether `setTracingState(null)`
-//     has been called before it reaches the `AutoDispatchBelowADInplaceOrView` guard.
+//     has been called before it reaches the `AutoDispatchBelowADInplaceOrView`
+//     guard.
 //
 //   We might need tweak the usage of the new guard to optimize/fix things.
 //   It should only affect the correctness of tracing function, because the

--- a/aten/src/ATen/TypeDefault.h
+++ b/aten/src/ATen/TypeDefault.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <c10/core/TensorOptions.h>
-#include <c10/core/Scalar.h>
-#include <c10/core/QScheme.h>
+#include <ATen/Dimname.h>
 #include <c10/core/MemoryFormat.h>
+#include <c10/core/QScheme.h>
+#include <c10/core/Scalar.h>
+#include <c10/core/TensorOptions.h>
+#include <c10/macros/Export.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/intrusive_ptr.h>
-#include <c10/macros/Export.h>
-#include <ATen/Dimname.h>
 
 namespace c10 {
 struct Storage;

--- a/aten/src/ATen/Utils.h
+++ b/aten/src/ATen/Utils.h
@@ -1,25 +1,25 @@
 #pragma once
 
-#include <ATen/core/ATenGeneral.h>
-#include <ATen/core/Generator.h>
 #include <ATen/EmptyTensor.h>
 #include <ATen/Formatting.h>
+#include <ATen/core/ATenGeneral.h>
+#include <ATen/core/Generator.h>
 #include <c10/core/ScalarType.h>
 #include <c10/core/StorageImpl.h>
 #include <c10/core/UndefinedTensorImpl.h>
-#include <c10/util/accumulate.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>
+#include <c10/util/accumulate.h>
 #include <c10/util/irange.h>
 
 #include <algorithm>
+#include <memory>
+#include <numeric>
 #include <sstream>
 #include <typeinfo>
-#include <numeric>
-#include <memory>
 
 #define AT_DISALLOW_COPY_AND_ASSIGN(TypeName) \
-  TypeName(const TypeName&) = delete; \
+  TypeName(const TypeName&) = delete;         \
   void operator=(const TypeName&) = delete
 
 namespace at {
@@ -28,21 +28,53 @@ TORCH_API int _crash_if_asan(int);
 
 // TODO: This unwrapping code is ONLY used for TH bindings; once TH goes
 // away, we can delete this function
-static inline TensorImpl* checked_dense_tensor_unwrap(const Tensor& expr, const char * name, int pos, const char * api, bool allowNull, DeviceType device_type, ScalarType scalar_type) {
-  if(allowNull && !expr.defined()) {
+static inline TensorImpl* checked_dense_tensor_unwrap(
+    const Tensor& expr,
+    const char* name,
+    int pos,
+    const char* api,
+    bool allowNull,
+    DeviceType device_type,
+    ScalarType scalar_type) {
+  if (allowNull && !expr.defined()) {
     return nullptr;
   }
   if (expr.layout() != Layout::Strided) {
-    AT_ERROR("Expected dense tensor but got ", expr.layout(),
-             " for argument #", pos, " '", name, "' in call to ", api);
+    AT_ERROR(
+        "Expected dense tensor but got ",
+        expr.layout(),
+        " for argument #",
+        pos,
+        " '",
+        name,
+        "' in call to ",
+        api);
   }
   if (expr.device().type() != device_type) {
-    AT_ERROR("Expected object of device type ", device_type, " but got device type ", expr.device().type(),
-             " for argument #", pos, " '", name, "' in call to ", api);
+    AT_ERROR(
+        "Expected object of device type ",
+        device_type,
+        " but got device type ",
+        expr.device().type(),
+        " for argument #",
+        pos,
+        " '",
+        name,
+        "' in call to ",
+        api);
   }
   if (expr.scalar_type() != scalar_type) {
-    AT_ERROR("Expected object of scalar type ", scalar_type, " but got scalar type ", expr.scalar_type(),
-             " for argument #", pos, " '", name, "' in call to ", api);
+    AT_ERROR(
+        "Expected object of scalar type ",
+        scalar_type,
+        " but got scalar type ",
+        expr.scalar_type(),
+        " for argument #",
+        pos,
+        " '",
+        name,
+        "' in call to ",
+        api);
   }
   return expr.unsafeGetTensorImpl();
 }
@@ -50,22 +82,55 @@ static inline TensorImpl* checked_dense_tensor_unwrap(const Tensor& expr, const 
 // Converts a TensorList (i.e. ArrayRef<Tensor> to vector of TensorImpl*)
 // NB: This is ONLY used by legacy TH bindings, and ONLY used by cat.
 // Once cat is ported entirely to ATen this can be deleted!
-static inline std::vector<TensorImpl*> checked_dense_tensor_list_unwrap(ArrayRef<Tensor> tensors, const char * name, int pos, DeviceType device_type, ScalarType scalar_type) {
+static inline std::vector<TensorImpl*> checked_dense_tensor_list_unwrap(
+    ArrayRef<Tensor> tensors,
+    const char* name,
+    int pos,
+    DeviceType device_type,
+    ScalarType scalar_type) {
   std::vector<TensorImpl*> unwrapped;
   unwrapped.reserve(tensors.size());
   for (const auto i : c10::irange(tensors.size())) {
     const auto& expr = tensors[i];
     if (expr.layout() != Layout::Strided) {
-      AT_ERROR("Expected dense tensor but got ", expr.layout(),
-               " for sequence element ", i , " in sequence argument at position #", pos, " '", name, "'");
+      AT_ERROR(
+          "Expected dense tensor but got ",
+          expr.layout(),
+          " for sequence element ",
+          i,
+          " in sequence argument at position #",
+          pos,
+          " '",
+          name,
+          "'");
     }
     if (expr.device().type() != device_type) {
-      AT_ERROR("Expected object of device type ", device_type, " but got device type ", expr.device().type(),
-               " for sequence element ", i , " in sequence argument at position #", pos, " '", name, "'");
+      AT_ERROR(
+          "Expected object of device type ",
+          device_type,
+          " but got device type ",
+          expr.device().type(),
+          " for sequence element ",
+          i,
+          " in sequence argument at position #",
+          pos,
+          " '",
+          name,
+          "'");
     }
     if (expr.scalar_type() != scalar_type) {
-      AT_ERROR("Expected object of scalar type ", scalar_type, " but got scalar type ", expr.scalar_type(),
-               " for sequence element ", i , " in sequence argument at position #", pos, " '", name, "'");
+      AT_ERROR(
+          "Expected object of scalar type ",
+          scalar_type,
+          " but got scalar type ",
+          expr.scalar_type(),
+          " for sequence element ",
+          i,
+          " in sequence argument at position #",
+          pos,
+          " '",
+          name,
+          "'");
     }
     unwrapped.emplace_back(expr.unsafeGetTensorImpl());
   }
@@ -73,10 +138,13 @@ static inline std::vector<TensorImpl*> checked_dense_tensor_list_unwrap(ArrayRef
 }
 
 template <size_t N>
-std::array<int64_t, N> check_intlist(ArrayRef<int64_t> list, const char * name, int pos) {
+std::array<int64_t, N> check_intlist(
+    ArrayRef<int64_t> list,
+    const char* name,
+    int pos) {
   if (list.empty()) {
-    // TODO: is this necessary?  We used to treat nullptr-vs-not in IntList differently
-    // with strides as a way of faking optional.
+    // TODO: is this necessary?  We used to treat nullptr-vs-not in IntList
+    // differently with strides as a way of faking optional.
     list = {};
   }
   auto res = std::array<int64_t, N>();
@@ -85,7 +153,16 @@ std::array<int64_t, N> check_intlist(ArrayRef<int64_t> list, const char * name, 
     return res;
   }
   if (list.size() != N) {
-    AT_ERROR("Expected a list of ", N, " ints but got ", list.size(), " for argument #", pos, " '", name, "'");
+    AT_ERROR(
+        "Expected a list of ",
+        N,
+        " ints but got ",
+        list.size(),
+        " for argument #",
+        pos,
+        " '",
+        name,
+        "'");
   }
   std::copy_n(list.begin(), N, res.begin());
   return res;
@@ -96,21 +173,19 @@ using at::detail::check_size_nonnegative;
 namespace detail {
 
 template <typename T>
-TORCH_API
-Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options);
+TORCH_API Tensor tensor_cpu(ArrayRef<T> values, const TensorOptions& options);
 
 template <typename T>
-TORCH_API
-Tensor tensor_backend(ArrayRef<T> values, const TensorOptions& options);
+TORCH_API Tensor
+tensor_backend(ArrayRef<T> values, const TensorOptions& options);
 
 template <typename T>
-TORCH_API
-Tensor tensor_complex_cpu(ArrayRef<T> values, const TensorOptions& options);
+TORCH_API Tensor
+tensor_complex_cpu(ArrayRef<T> values, const TensorOptions& options);
 
 template <typename T>
-TORCH_API
-Tensor tensor_complex_backend(ArrayRef<T> values, const TensorOptions& options);
+TORCH_API Tensor
+tensor_complex_backend(ArrayRef<T> values, const TensorOptions& options);
 } // namespace detail
 
-
-} // at
+} // namespace at

--- a/aten/src/ATen/Version.h
+++ b/aten/src/ATen/Version.h
@@ -13,4 +13,4 @@ TORCH_API std::string get_openmp_version();
 
 TORCH_API std::string get_cxx_flags();
 
-}  // namespace at
+} // namespace at

--- a/aten/src/ATen/VmapTransforms.h
+++ b/aten/src/ATen/VmapTransforms.h
@@ -4,8 +4,9 @@
 
 namespace at {
 
-// This file contains abstractions used for transforming *logical* vmap arguments
-// into *physical* arguments. (Keep reading for definitions of these terms).
+// This file contains abstractions used for transforming *logical* vmap
+// arguments into *physical* arguments. (Keep reading for definitions of these
+// terms).
 
 // NOTE: [Logical vs physical args]
 // Consider the following vmap.
@@ -30,7 +31,8 @@ struct VmapPhysicalView;
 
 // Most PyTorch operators take 4 or fewer inputs.
 constexpr int64_t kVmapTransformStaticInputSize = 4;
-using VmapPhysicalViewVec = SmallVector<VmapPhysicalView, kVmapTransformStaticInputSize>;
+using VmapPhysicalViewVec =
+    SmallVector<VmapPhysicalView, kVmapTransformStaticInputSize>;
 
 // Pytorch generally advertises good performance for <= 5 dims.
 // (see ATen/core/DimVector.h). We add a few extra dims (~3) for vmap
@@ -63,12 +65,12 @@ struct TORCH_API MultiBatchVmapTransform {
 //   If a tensor does not have a batch dim for a vmap level, then it receives
 //   a size-one dimension for said level.
 // - aligns the non-batch dims to have the same dimensionality, adding extra
-//   size-1 dimensions in between the batch dimensions and the non-batch dimensions
-//   so that the batch dimensions are lined up from the right.
+//   size-1 dimensions in between the batch dimensions and the non-batch
+//   dimensions so that the batch dimensions are lined up from the right.
 //
 // For example: given inputs of size (B, 2) and (B, 3, 2) where B is the batch
-// dimension, BroadcastingVmapTransform returns VmapPhysicalViews that wrap tensors
-// of size (B, 1, 2) and (B, 3, 2).
+// dimension, BroadcastingVmapTransform returns VmapPhysicalViews that wrap
+// tensors of size (B, 1, 2) and (B, 3, 2).
 //
 // Given inputs of size (B, 2) and (2,), BroadcastingVmapTransform returns
 // VmapPhysicalViews wrapping tensors of size (B, 2) and (1, 2). We don't
@@ -113,8 +115,12 @@ struct TORCH_API VmapPhysicalView {
     TORCH_INTERNAL_ASSERT(!isBatchedTensor(tensor));
   }
 
-  Tensor& tensor() { return tensor_; }
-  const Tensor& tensor() const { return tensor_; }
+  Tensor& tensor() {
+    return tensor_;
+  }
+  const Tensor& tensor() const {
+    return tensor_;
+  }
 
   // Maps logical dim indices to physical dim indices. Also does dim wrapping.
   //
@@ -146,11 +152,12 @@ struct TORCH_API VmapPhysicalView {
 };
 
 // Convenience struct used for mapping a physical tensor (a non-BatchedTensor)
-// to a logical one (BatchedTensor). It holds some levels that are used to do the
-// mapping and assumes that the batch dimensions in the physical tensor all
+// to a logical one (BatchedTensor). It holds some levels that are used to do
+// the mapping and assumes that the batch dimensions in the physical tensor all
 // occur at the front of the tensor.
 struct TORCH_API VmapPhysicalToLogicalMap {
-  VmapPhysicalToLogicalMap(std::bitset<kVmapNumLevels> levels): levels_(levels) {}
+  VmapPhysicalToLogicalMap(std::bitset<kVmapNumLevels> levels)
+      : levels_(levels) {}
 
   // Maps a physical tensor to a new logical tensor (BatchedTensor).
   // Assumes that all of the "batch dimensions" are at the front
@@ -170,6 +177,5 @@ struct TORCH_API VmapPhysicalToLogicalMap {
 
   std::bitset<kVmapNumLevels> levels_;
 };
-
 
 } // namespace at

--- a/aten/src/ATen/WrapDimUtils.h
+++ b/aten/src/ATen/WrapDimUtils.h
@@ -1,71 +1,93 @@
 #pragma once
 
-#include <c10/core/WrapDimMinimal.h>
-#include <c10/core/TensorImpl.h>
-#include <c10/util/irange.h>
-#include <ATen/core/Tensor.h>
 #include <ATen/core/IListRef.h>
+#include <ATen/core/Tensor.h>
+#include <c10/core/TensorImpl.h>
+#include <c10/core/WrapDimMinimal.h>
+#include <c10/util/irange.h>
 
 namespace at {
 
-static inline int64_t maybe_wrap_dim(int64_t dim, int64_t dim_post_expr, bool wrap_scalar=true) {
-  // if dim_post_expr is 0 and wrap_scalar is true, then dim must be in the range [-1, 0].
-  // This is a special case for scalar tensors and manifests in e.g. torch.sum(scalar_tensor, 0)
-  // Otherwise, dim should be in the range [-dim_post_expr, dim_post_expr-1].
+static inline int64_t maybe_wrap_dim(
+    int64_t dim,
+    int64_t dim_post_expr,
+    bool wrap_scalar = true) {
+  // if dim_post_expr is 0 and wrap_scalar is true, then dim must be in the
+  // range [-1, 0]. This is a special case for scalar tensors and manifests in
+  // e.g. torch.sum(scalar_tensor, 0) Otherwise, dim should be in the range
+  // [-dim_post_expr, dim_post_expr-1].
   return c10::maybe_wrap_dim(dim, dim_post_expr, wrap_scalar);
 }
 
-static inline int64_t maybe_wrap_dim(int64_t dim, TensorImpl *tensor) {
+static inline int64_t maybe_wrap_dim(int64_t dim, TensorImpl* tensor) {
   return maybe_wrap_dim(dim, tensor->dim());
 }
 
 static inline int64_t maybe_wrap_dim(int64_t dim, TensorList tensors) {
   if (tensors.size() == 0) {
-    // can't wrap empty TensorList; rely on underlying implementation to throw error if necessary.
+    // can't wrap empty TensorList; rely on underlying implementation to throw
+    // error if necessary.
     return dim;
   }
   return maybe_wrap_dim(dim, tensors[0].dim());
 }
 
-static inline int64_t maybe_wrap_dim(int64_t dim, const std::vector<std::vector<int64_t>> & tensor_sizes) {
+static inline int64_t maybe_wrap_dim(
+    int64_t dim,
+    const std::vector<std::vector<int64_t>>& tensor_sizes) {
   if (tensor_sizes.size() == 0) {
-    // can't wrap empty list; rely on underlying implementation to throw error if necessary
+    // can't wrap empty list; rely on underlying implementation to throw error
+    // if necessary
     return dim;
   }
   return maybe_wrap_dim(dim, tensor_sizes[0].size());
 }
 
-// wrap each dim in the dims array, taking dim_post_expr as the true number of dimensions
-static inline void maybe_wrap_dims_n(int64_t* dims, int64_t ndims, int64_t dim_post_expr) {
+// wrap each dim in the dims array, taking dim_post_expr as the true number of
+// dimensions
+static inline void maybe_wrap_dims_n(
+    int64_t* dims,
+    int64_t ndims,
+    int64_t dim_post_expr) {
   if (dim_post_expr <= 0) {
     dim_post_expr = 1; // this will make range [-1, 0]
   }
   int64_t min = -dim_post_expr;
   int64_t max = dim_post_expr - 1;
   for (const auto i : c10::irange(ndims)) {
-    auto &dim = dims[i];
+    auto& dim = dims[i];
     if (dim < min || dim > max) {
-      TORCH_CHECK_INDEX(false,
-        "Dimension out of range (expected to be in range of [",
-        min, ", ", max, "], but got ", dim, ")");
+      TORCH_CHECK_INDEX(
+          false,
+          "Dimension out of range (expected to be in range of [",
+          min,
+          ", ",
+          max,
+          "], but got ",
+          dim,
+          ")");
     }
-    if (dim < 0) dim += dim_post_expr;
+    if (dim < 0)
+      dim += dim_post_expr;
   }
 }
 
-// Wrap each dim in a contiguous container, taking dim_post_expr as the true number of dimensions
-// E.g. could also be std::array or c10::SmallVector
+// Wrap each dim in a contiguous container, taking dim_post_expr as the true
+// number of dimensions E.g. could also be std::array or c10::SmallVector
 template <typename Container>
 inline void maybe_wrap_dims(Container& dims, int64_t dim_post_expr) {
   return maybe_wrap_dims_n(dims.data(), dims.size(), dim_post_expr);
 }
 
-// previously, size [0] tensors were the only possible empty tensors; thus, it wasn't possible
-// to cat empty tensors unless all the other tensors were 1-dimensional, so we allowed these tensors
-// to be "skipped" (both for wrap dimension behavior and dimension size checking).
-// We maintain this behavior for backwards compatibility, but only for this specific size
-// (i.e. other empty sizes are not skipped).
-static inline int64_t legacy_cat_wrap_dim(int64_t dim, const std::vector<std::vector<int64_t>>& tensor_sizes) {
+// previously, size [0] tensors were the only possible empty tensors; thus, it
+// wasn't possible to cat empty tensors unless all the other tensors were
+// 1-dimensional, so we allowed these tensors to be "skipped" (both for wrap
+// dimension behavior and dimension size checking). We maintain this behavior
+// for backwards compatibility, but only for this specific size (i.e. other
+// empty sizes are not skipped).
+static inline int64_t legacy_cat_wrap_dim(
+    int64_t dim,
+    const std::vector<std::vector<int64_t>>& tensor_sizes) {
   for (auto& sizes : tensor_sizes) {
     if (sizes == std::vector<int64_t>({0})) {
       continue;
@@ -86,10 +108,12 @@ static inline int64_t legacy_cat_wrap_dim(int64_t dim, ITensorListRef tensors) {
 }
 
 // wrap negative dims in a vector
-static inline void wrap_all_dims(std::vector<int64_t>& dims_to_wrap, int64_t tensor_total_dims) {
+static inline void wrap_all_dims(
+    std::vector<int64_t>& dims_to_wrap,
+    int64_t tensor_total_dims) {
   for (const auto i : c10::irange(dims_to_wrap.size())) {
     dims_to_wrap[i] = maybe_wrap_dim(dims_to_wrap[i], tensor_total_dims);
   }
 }
 
-}
+} // namespace at

--- a/aten/src/ATen/WrapDimUtilsMulti.h
+++ b/aten/src/ATen/WrapDimUtilsMulti.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <ATen/WrapDimUtils.h>
 #include <c10/core/TensorImpl.h>
 #include <c10/util/irange.h>
-#include <ATen/WrapDimUtils.h>
-#include <sstream>
 #include <bitset>
+#include <sstream>
 
 namespace at {
 
@@ -13,15 +13,22 @@ namespace at {
 
 constexpr size_t dim_bitset_size = 64;
 
-static inline std::bitset<dim_bitset_size> dim_list_to_bitset(IntArrayRef dims, int64_t ndims) {
-  TORCH_CHECK(ndims <= (int64_t) dim_bitset_size, "only tensors with up to ", dim_bitset_size, " dims are supported");
+static inline std::bitset<dim_bitset_size> dim_list_to_bitset(
+    IntArrayRef dims,
+    int64_t ndims) {
+  TORCH_CHECK(
+      ndims <= (int64_t)dim_bitset_size,
+      "only tensors with up to ",
+      dim_bitset_size,
+      " dims are supported");
   std::bitset<dim_bitset_size> seen;
   for (const auto i : c10::irange(dims.size())) {
     size_t dim = maybe_wrap_dim(dims[i], ndims);
-    TORCH_CHECK(!seen[dim], "dim ", dim, " appears multiple times in the list of dims");
+    TORCH_CHECK(
+        !seen[dim], "dim ", dim, " appears multiple times in the list of dims");
     seen[dim] = true;
   }
   return seen;
 }
 
-}
+} // namespace at

--- a/aten/src/ATen/autocast_mode.h
+++ b/aten/src/ATen/autocast_mode.h
@@ -21,20 +21,21 @@ TORCH_API void set_autocast_xpu_dtype(at::ScalarType dtype);
 TORCH_API bool is_autocast_cache_enabled();
 TORCH_API void set_autocast_cache_enabled(bool enabled);
 
-
 namespace {
-  bool is_autocast_eligible(const Tensor& tensor, DeviceType device_type) {
-    switch (device_type) {
-      case DeviceType::CUDA:
-        return  (tensor.is_cuda() || tensor.is_xla()) && tensor.is_floating_point();
-      case DeviceType::CPU:
-        return (tensor.is_cpu() || tensor.is_mkldnn()) && tensor.is_floating_point();
-      case DeviceType::XPU:
-        return tensor.is_xpu() && tensor.is_floating_point();
-      default:
-        return false;
-    }
+bool is_autocast_eligible(const Tensor& tensor, DeviceType device_type) {
+  switch (device_type) {
+    case DeviceType::CUDA:
+      return (tensor.is_cuda() || tensor.is_xla()) &&
+          tensor.is_floating_point();
+    case DeviceType::CPU:
+      return (tensor.is_cpu() || tensor.is_mkldnn()) &&
+          tensor.is_floating_point();
+    case DeviceType::XPU:
+      return tensor.is_xpu() && tensor.is_floating_point();
+    default:
+      return false;
   }
+}
 } // namespace
 
 inline DispatchKey get_autocast_dispatch_key_from_device_type(
@@ -77,7 +78,7 @@ Logic to extract the promote type from any Tensor or TensorList args.
 inline at::ScalarType prioritize(
     at::ScalarType current,
     const Tensor& nextArg,
-    DeviceType device_type=DeviceType::CUDA) {
+    DeviceType device_type = DeviceType::CUDA) {
   if (current == at::kDouble) {
     AT_ERROR("promote type is double in at::autocast::prioritize");
     return current;
@@ -106,7 +107,7 @@ inline at::ScalarType prioritize(
 inline at::ScalarType prioritize(
     at::ScalarType current,
     const TensorList& list,
-    DeviceType device_type=DeviceType::CUDA) {
+    DeviceType device_type = DeviceType::CUDA) {
   for (const auto& tensor : list) {
     current = prioritize(current, tensor, device_type);
   }
@@ -114,11 +115,11 @@ inline at::ScalarType prioritize(
 }
 
 // Template to catch non-Tensor args (no-op that returns current best guess)
-template<typename T>
+template <typename T>
 inline at::ScalarType prioritize(
     at::ScalarType current,
     T nextArg,
-    DeviceType device_type=DeviceType::CUDA) {
+    DeviceType device_type = DeviceType::CUDA) {
   return current;
 }
 
@@ -129,9 +130,9 @@ inline at::ScalarType promote_type(
   return current;
 }
 
-// Unpack args and determine if incoming lower_precision_fp tensors need to be promoted to float32.
-// Non-Tensor arguments are ignored.
-template<typename Arg0, typename... Args>
+// Unpack args and determine if incoming lower_precision_fp tensors need to be
+// promoted to float32. Non-Tensor arguments are ignored.
+template <typename Arg0, typename... Args>
 inline at::ScalarType promote_type(
     at::ScalarType current,
     DeviceType device_type,
@@ -146,23 +147,23 @@ Logic to apply cached casting to any Tensor argument.
 ****************************************************/
 inline bool is_eligible(
     const Tensor& arg,
-    DeviceType device_type=DeviceType::CUDA) {
-  return (arg.defined() &&
-          is_autocast_eligible(arg, device_type) &&
-          (arg.scalar_type() != at::kDouble));
+    DeviceType device_type = DeviceType::CUDA) {
+  return (
+      arg.defined() && is_autocast_eligible(arg, device_type) &&
+      (arg.scalar_type() != at::kDouble));
 }
 
 // Overload to catch Tensor args
 TORCH_API Tensor cached_cast(
     at::ScalarType to_type,
     const Tensor& arg,
-    DeviceType device_type=DeviceType::CUDA);
+    DeviceType device_type = DeviceType::CUDA);
 
 // Overload to process optional<Tensor>
 inline c10::optional<Tensor> cached_cast(
     at::ScalarType to_type,
     const c10::optional<Tensor>& arg,
-    DeviceType device_type=DeviceType::CUDA) {
+    DeviceType device_type = DeviceType::CUDA) {
   if (arg.has_value()) {
     return cached_cast(to_type, *arg, device_type);
   } else {
@@ -174,7 +175,7 @@ inline c10::optional<Tensor> cached_cast(
 inline std::vector<Tensor> cached_cast(
     at::ScalarType to_type,
     const TensorList& arg,
-    DeviceType device_type=DeviceType::CUDA) {
+    DeviceType device_type = DeviceType::CUDA) {
   std::vector<Tensor> vec;
   vec.reserve(arg.size());
   for (const auto& t : arg) {
@@ -184,11 +185,11 @@ inline std::vector<Tensor> cached_cast(
 }
 
 // Template to catch non-Tensor args.
-template<typename T>
+template <typename T>
 inline T cached_cast(
     at::ScalarType to_type,
     T arg,
-    DeviceType device_type=DeviceType::CUDA) {
+    DeviceType device_type = DeviceType::CUDA) {
   return arg;
 }
 
@@ -203,23 +204,28 @@ Otherwise, set it to the autocast type.
 ********************************************************/
 
 // Overload to catch dtype flags
-c10::optional<ScalarType> inline set_opt_dtype(at::ScalarType to_type, const c10::optional<ScalarType>& dtype) {
+c10::optional<ScalarType> inline set_opt_dtype(
+    at::ScalarType to_type,
+    const c10::optional<ScalarType>& dtype) {
   return dtype.has_value() ? dtype : to_type;
 }
 
 // Template to catch other args
-template<typename T>
+template <typename T>
 inline T set_opt_dtype(at::ScalarType to_type, T arg) {
   return arg;
 }
 
-template<typename... Args>
+template <typename... Args>
 inline bool firstarg_is_eligible(const Tensor& arg, Args... args) {
   return is_eligible(arg);
 }
 
-template<typename... Args>
-inline at::ScalarType type_from_firstarg(at::ScalarType to_type, const Tensor& arg, Args... args) {
+template <typename... Args>
+inline at::ScalarType type_from_firstarg(
+    at::ScalarType to_type,
+    const Tensor& arg,
+    Args... args) {
   return (is_eligible(arg) ? to_type : arg.scalar_type());
 }
 

--- a/aten/src/ATen/ceil_div.h
+++ b/aten/src/ATen/ceil_div.h
@@ -6,7 +6,7 @@ namespace at {
 /**
    Computes ceil(a / b)
 */
-template <typename T, typename=std::enable_if_t<std::is_integral<T>::value>>
+template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
 C10_ALWAYS_INLINE C10_HOST_DEVICE T ceil_div(T a, T b) {
   return (a + b - 1) / b;
 }
@@ -20,4 +20,4 @@ C10_ALWAYS_INLINE C10_HOST_DEVICE T round_up(T a, T b) {
   return ceil_div(a, b) * b;
 }
 
-}
+} // namespace at

--- a/aten/src/ATen/code_template.h
+++ b/aten/src/ATen/code_template.h
@@ -7,7 +7,8 @@
 #include <unordered_map>
 #include <vector>
 
-namespace at { namespace jit {
+namespace at {
+namespace jit {
 
 // A template environment is a mapping from template variable names, e.g.,
 // identifier (corresponding to $identifier) to their expansions.
@@ -243,4 +244,5 @@ static inline std::string format(const std::string& fmt, TemplateEnv& env) {
   return CodeTemplate(fmt).format(env);
 }
 
-}} // at::jit
+} // namespace jit
+} // namespace at

--- a/aten/src/ATen/core/IListRef.h
+++ b/aten/src/ATen/core/IListRef.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/core/ivalue_to.h>
+#include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>
 
 #include <functional>

--- a/aten/src/ATen/cpp_custom_type_hack.h
+++ b/aten/src/ATen/cpp_custom_type_hack.h
@@ -55,18 +55,20 @@ namespace at {
 namespace cpp_custom_type_hack {
 
 template <typename T>
-[[deprecated("Use custom classes instead: "
-  "https://pytorch.org/tutorials/advanced/torch_script_custom_classes.html")]]
-bool isa(const Tensor& packed) {
+[[deprecated(
+    "Use custom classes instead: "
+    "https://pytorch.org/tutorials/advanced/torch_script_custom_classes.html")]] bool
+isa(const Tensor& packed) {
   return (packed.scalar_type() == kByte) &&
       (packed.storage().data_ptr().get_deleter() ==
        caffe2::TypeMeta::Make<T>().deleteFn());
 }
 
 template <typename T>
-[[deprecated("Use custom classes instead: "
-  "https://pytorch.org/tutorials/advanced/torch_script_custom_classes.html")]]
-T& cast(const Tensor& packed) {
+[[deprecated(
+    "Use custom classes instead: "
+    "https://pytorch.org/tutorials/advanced/torch_script_custom_classes.html")]] T&
+cast(const Tensor& packed) {
   TORCH_CHECK(
       packed.scalar_type() == kByte, "Expected temporary cpp type wrapper");
   TORCH_CHECK(
@@ -78,11 +80,12 @@ T& cast(const Tensor& packed) {
 }
 
 template <typename T>
-[[deprecated("Use custom classes instead: "
-  "https://pytorch.org/tutorials/advanced/torch_script_custom_classes.html")]]
-Tensor create(std::unique_ptr<T> ptr, TensorOptions options) {
+[[deprecated(
+    "Use custom classes instead: "
+    "https://pytorch.org/tutorials/advanced/torch_script_custom_classes.html")]] Tensor
+create(std::unique_ptr<T> ptr, TensorOptions options) {
   // None of this should trace, so turn off Tracer dispatching
-  at::AutoDispatchBelowADInplaceOrView guard;  // TODO: remove
+  at::AutoDispatchBelowADInplaceOrView guard; // TODO: remove
   at::tracer::impl::NoTracerDispatchMode tracer_guard;
 
   // We store this instance away in a Tensor and register a deleter function

--- a/aten/src/ATen/div_rtn.h
+++ b/aten/src/ATen/div_rtn.h
@@ -1,10 +1,11 @@
 #pragma once
 
 // Integer division rounding to -Infinity
-template<typename T>
+template <typename T>
 static inline T div_rtn(T x, T y) {
-    int q = x/y;
-    int r = x%y;
-    if ((r!=0) && ((r<0) != (y<0))) --q;
-    return q;
+  int q = x / y;
+  int r = x % y;
+  if ((r != 0) && ((r < 0) != (y < 0)))
+    --q;
+  return q;
 }

--- a/aten/src/ATen/dlpack.h
+++ b/aten/src/ATen/dlpack.h
@@ -26,8 +26,8 @@
 #define DLPACK_DLL
 #endif
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -95,7 +95,8 @@ typedef enum {
   kDLFloat = 2U,
   /*!
    * \brief Opaque handle type, reserved for testing purposes.
-   * Frameworks need to agree on the handle data type for the exchange to be well-defined.
+   * Frameworks need to agree on the handle data type for the exchange to be
+   * well-defined.
    */
   kDLOpaqueHandle = 3U,
   /*! \brief bfloat16 */
@@ -185,15 +186,15 @@ typedef struct DLManagedTensor {
   /*! \brief the context of the original host framework of DLManagedTensor in
    *   which DLManagedTensor is used in the framework. It can also be NULL.
    */
-  void * manager_ctx;
+  void* manager_ctx;
   /*! \brief Destructor signature void (*)(void*) - this should be called
    *   to destruct manager_ctx which holds the DLManagedTensor. It can be NULL
    *   if there is no way for the caller to provide a reasonable destructor.
    *   The destructors deletes the argument self as well.
    */
-  void (*deleter)(struct DLManagedTensor * self);
+  void (*deleter)(struct DLManagedTensor* self);
 } DLManagedTensor;
 #ifdef __cplusplus
-}  // DLPACK_EXTERN_C
+} // DLPACK_EXTERN_C
 #endif
-#endif  // DLPACK_DLPACK_H_
+#endif // DLPACK_DLPACK_H_

--- a/aten/src/ATen/jit_macros.h
+++ b/aten/src/ATen/jit_macros.h
@@ -5,9 +5,10 @@
 // AT_USE_JITERATOR(), controls whether we jit some elementwise kernels
 // Currently unsupported on ROCm GPUs
 #if !AT_ROCM_ENABLED()
-    #define AT_USE_JITERATOR() true
-    #define jiterator_stringify(...) std::string(#__VA_ARGS__);
+#define AT_USE_JITERATOR() true
+#define jiterator_stringify(...) std::string(#__VA_ARGS__);
 #else
-    #define AT_USE_JITERATOR() false
-    #define jiterator_stringify(...) static_assert(false, "Jiterator is not supported on ROCm");
+#define AT_USE_JITERATOR() false
+#define jiterator_stringify(...) \
+  static_assert(false, "Jiterator is not supported on ROCm");
 #endif // USE_ROCM

--- a/aten/src/ATen/jiterator_macros.h
+++ b/aten/src/ATen/jiterator_macros.h
@@ -26,13 +26,13 @@
 // multiple arguments to the macro.
 #define jiterator_code(...) __VA_ARGS__
 #if defined(__CUDACC__)
-    // CPU and CUDA case
-    #define stringify_code(...) #__VA_ARGS__
-    #define jiterator_also_stringify_as(code, str_name)                    \
-        code /* define the function */                                  \
-        const std::string str_name = std::string(stringify_code(code));
+// CPU and CUDA case
+#define stringify_code(...) #__VA_ARGS__
+#define jiterator_also_stringify_as(code, str_name) \
+  code /* define the function */                    \
+      const std::string str_name = std::string(stringify_code(code));
 #else
-    // CPU only or CPU and ROCm case
-    // Only needs the function
-    #define jiterator_also_stringify_as(code, str_name) code
+// CPU only or CPU and ROCm case
+// Only needs the function
+#define jiterator_also_stringify_as(code, str_name) code
 #endif


### PR DESCRIPTION
Add `aten/src/ATen/*.h` to .lintrunner.toml and run `lintrunner -a`
Only non-formatting change to the code: add `#include <c10/util/ArrayRef.h>` to `IListRef.h`