### PR TITLE
Populate the torch._decomp table on import

### DIFF
--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -1,7 +1,7 @@
 import torch
 import torch._ops
 import torch.library
-from typing import Callable, Union, Dict, Sequence, List
+from typing import Callable, Union, Dict, Sequence
 from torch.utils._pytree import tree_map
 from collections import defaultdict
 
@@ -103,3 +103,5 @@ def get_decompositions(
 # populate the table
 import torch._decomp.decompositions
 import torch._refs
+import torch._refs.nn.functional
+import torch._refs.special

--- a/torch/_decomp/__init__.py
+++ b/torch/_decomp/__init__.py
@@ -103,5 +103,3 @@ def get_decompositions(
 # populate the table
 import torch._decomp.decompositions
 import torch._refs
-import torch._refs.nn.functional
-import torch._refs.special

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -2041,3 +2041,8 @@ def equal(a: TensorLikeType, b: TensorLikeType) -> bool:
         return True
 
     return item(all(eq(a, b)))  # type: ignore[return-value]
+
+
+# populate the decomp table
+import torch._refs.nn.functional
+import torch._refs.special


### PR DESCRIPTION
#78041 broke TorchInductor, because of:
```
>>> from torch import _decomp
>>> import torch
>>> _decomp.get_decompositions([torch.ops.aten.leaky_relu])
{}
>>> import torch._refs.nn.functional
>>> _decomp.get_decompositions([torch.ops.aten.leaky_relu])
{<OpOverload(op='aten.leaky_relu', overload='default')>: <function leaky_relu at 0x7f5a39b56c10>, <OpOverload(op='aten.leaky_relu', overload='out')>: <function leaky_relu at 0x7f5a39b56c10>}
```

cc @Chillee 
