### PR TITLE
Variable Name Clarity

### DIFF
--- a/aten/src/ATen/native/cuda/im2col.cuh
+++ b/aten/src/ATen/native/cuda/im2col.cuh
@@ -167,8 +167,8 @@ void col2im(
     const int64_t channels,
     const int64_t height,
     const int64_t width,
-    const int64_t output_height,
-    const int64_t output_width,
+    const int64_t height_col,
+    const int64_t width_col,
     const int64_t patch_height,
     const int64_t patch_width,
     const int64_t pad_height,
@@ -197,8 +197,8 @@ void col2im(
           stride_width,
           dilation_height,
           dilation_width,
-          output_height,
-          output_width,
+          height_col,
+          width_cpl,
           data_im);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }

--- a/aten/src/ATen/native/cuda/im2col.cuh
+++ b/aten/src/ATen/native/cuda/im2col.cuh
@@ -198,7 +198,7 @@ void col2im(
           dilation_height,
           dilation_width,
           height_col,
-          width_cpl,
+          width_col,
           data_im);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }


### PR DESCRIPTION
The current "output_height" and "output_width" names on lines 198 and 199 are not consistent with [lines 132 and 133 in Col2Im.h](https://github.com/pytorch/pytorch/blob/3ee863cb7c07699b94e36715a82a25744560f2d9/aten/src/ATen/native/cuda/Col2Im.cu#L126). This was confusing to me, so this PR is a quick fix. This fix is also more consistent with [lines 122 and 132 from the same file](https://github.com/pytorch/pytorch/blob/3ee863cb7c07699b94e36715a82a25744560f2d9/aten/src/ATen/native/cuda/im2col.cuh#L108).

Fixes no issue number.
