### PR TITLE
Remove dataclasses from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ setuptools
 six
 types-dataclasses
 typing_extensions
-dataclasses; python_version<"3.7"


### PR DESCRIPTION
Because we don't support Python < 3.7 anymore.

