### PR TITLE
[Quant][docs] Replace qconfig_dict with QConfigMapping in docs

### DIFF
--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -296,7 +296,7 @@ by module basis. Specifically, for all quantization techniques, the user needs t
    additional parameters) from functionals to module form (for example,
    using ``torch.nn.ReLU`` instead of ``torch.nn.functional.relu``).
 2. Specify which parts of the model need to be quantized either by assigning
-   ``.qconfig`` attributes on submodules or by specifying ``qconfig_dict``.
+   ``.qconfig`` attributes on submodules or by specifying ``qconfig_mapping``.
    For example, setting ``model.conv1.qconfig = None`` means that the
    ``model.conv`` layer will not be quantized, and setting
    ``model.linear1.qconfig = custom_qconfig`` means that the quantization
@@ -322,10 +322,11 @@ to do the following in addition:
 (Prototype) FX Graph Mode Quantization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There are multiple quantization types in post training quantization (weight only, dynamic and static) and the configuration is done through `qconfig_dict` (an argument of the `prepare_fx` function).
+There are multiple quantization types in post training quantization (weight only, dynamic and static) and the configuration is done through `qconfig_mapping` (an argument of the `prepare_fx` function).
 
 API Example::
 
+  from torch.ao.quantization import QConfigMapping
   import torch.quantization.quantize_fx as quantize_fx
   import copy
 
@@ -338,9 +339,9 @@ API Example::
   # we need to deepcopy if we still want to keep model_fp unchanged after quantization since quantization apis change the input model
   model_to_quantize = copy.deepcopy(model_fp)
   model_to_quantize.eval()
-  qconfig_dict = {"": torch.quantization.default_dynamic_qconfig}
+  qconfig_mapping = QConfigMapping().set_global(torch.ao.quantization.default_dynamic_qconfig)
   # prepare
-  model_prepared = quantize_fx.prepare_fx(model_to_quantize, qconfig_dict)
+  model_prepared = quantize_fx.prepare_fx(model_to_quantize, qconfig_mapping)
   # no calibration needed when we only have dynamici/weight_only quantization
   # quantize
   model_quantized = quantize_fx.convert_fx(model_prepared)
@@ -350,10 +351,10 @@ API Example::
   #
 
   model_to_quantize = copy.deepcopy(model_fp)
-  qconfig_dict = {"": torch.quantization.get_default_qconfig('qnnpack')}
+  qconfig_mapping = QConfigMapping().set_global(torch.ao.quantization.get_default_qconfig('qnnpack'))
   model_to_quantize.eval()
   # prepare
-  model_prepared = quantize_fx.prepare_fx(model_to_quantize, qconfig_dict)
+  model_prepared = quantize_fx.prepare_fx(model_to_quantize, qconfig_mapping)
   # calibrate (not shown)
   # quantize
   model_quantized = quantize_fx.convert_fx(model_prepared)
@@ -363,10 +364,10 @@ API Example::
   #
 
   model_to_quantize = copy.deepcopy(model_fp)
-  qconfig_dict = {"": torch.quantization.get_default_qat_qconfig('qnnpack')}
+  qconfig_mapping = QConfigMapping().set_global(torch.ao.quantization.get_default_qat_qconfig('qnnpack'))
   model_to_quantize.train()
   # prepare
-  model_prepared = quantize_fx.prepare_qat_fx(model_to_quantize, qconfig_dict)
+  model_prepared = quantize_fx.prepare_qat_fx(model_to_quantize, qconfig_mapping)
   # training loop (not shown)
   # quantize
   model_quantized = quantize_fx.convert_fx(model_prepared)
@@ -793,6 +794,7 @@ Example::
 
     import torch
     import torch.nn.quantized as nnq
+    from torch.ao.quantization import QConfigMapping
     import torch.quantization.quantize_fx
 
     # original fp32 module to replace
@@ -868,7 +870,7 @@ Example::
 
     m = torch.nn.Sequential(CustomModule()).eval()
 
-    qconfig_dict = {'': torch.quantization.default_qconfig}
+    qconfig_mapping = QConfigMapping().set_global(torch.ao.quantization.default_qconfig)
     prepare_custom_config_dict = {
         "float_to_observed_custom_module_class": {
             "static": {
@@ -884,7 +886,7 @@ Example::
         }
     }
     mp = torch.quantization.quantize_fx.prepare_fx(
-        m, qconfig_dict, prepare_custom_config_dict=prepare_custom_config_dict)
+        m, qconfig_mapping, prepare_custom_config_dict=prepare_custom_config_dict)
     # calibration (not shown)
     mq = torch.quantization.quantize_fx.convert_fx(
         mp, convert_custom_config_dict=convert_custom_config_dict)

--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -326,7 +326,7 @@ There are multiple quantization types in post training quantization (weight only
 
 API Example::
 
-  from torch.ao.quantization import QConfigMapping
+  from torch.quantization import QConfigMapping
   import torch.quantization.quantize_fx as quantize_fx
   import copy
 
@@ -339,7 +339,7 @@ API Example::
   # we need to deepcopy if we still want to keep model_fp unchanged after quantization since quantization apis change the input model
   model_to_quantize = copy.deepcopy(model_fp)
   model_to_quantize.eval()
-  qconfig_mapping = QConfigMapping().set_global(torch.ao.quantization.default_dynamic_qconfig)
+  qconfig_mapping = QConfigMapping().set_global(torch.quantization.default_dynamic_qconfig)
   # prepare
   model_prepared = quantize_fx.prepare_fx(model_to_quantize, qconfig_mapping)
   # no calibration needed when we only have dynamici/weight_only quantization
@@ -351,7 +351,7 @@ API Example::
   #
 
   model_to_quantize = copy.deepcopy(model_fp)
-  qconfig_mapping = QConfigMapping().set_global(torch.ao.quantization.get_default_qconfig('qnnpack'))
+  qconfig_mapping = QConfigMapping().set_global(torch.quantization.get_default_qconfig('qnnpack'))
   model_to_quantize.eval()
   # prepare
   model_prepared = quantize_fx.prepare_fx(model_to_quantize, qconfig_mapping)
@@ -364,7 +364,7 @@ API Example::
   #
 
   model_to_quantize = copy.deepcopy(model_fp)
-  qconfig_mapping = QConfigMapping().set_global(torch.ao.quantization.get_default_qat_qconfig('qnnpack'))
+  qconfig_mapping = QConfigMapping().set_global(torch.quantization.get_default_qat_qconfig('qnnpack'))
   model_to_quantize.train()
   # prepare
   model_prepared = quantize_fx.prepare_qat_fx(model_to_quantize, qconfig_mapping)
@@ -794,7 +794,7 @@ Example::
 
     import torch
     import torch.nn.quantized as nnq
-    from torch.ao.quantization import QConfigMapping
+    from torch.quantization import QConfigMapping
     import torch.quantization.quantize_fx
 
     # original fp32 module to replace
@@ -870,7 +870,7 @@ Example::
 
     m = torch.nn.Sequential(CustomModule()).eval()
 
-    qconfig_mapping = QConfigMapping().set_global(torch.ao.quantization.default_qconfig)
+    qconfig_mapping = QConfigMapping().set_global(torch.quantization.default_qconfig)
     prepare_custom_config_dict = {
         "float_to_observed_custom_module_class": {
             "static": {

--- a/torch/ao/quantization/quantize_fx.py
+++ b/torch/ao/quantization/quantize_fx.py
@@ -353,6 +353,8 @@ def prepare_fx(
 
       * `qconfig_mapping` (required): mapping from model ops to qconfigs::
 
+          from torch.ao.quantization import QConfigMapping
+
           qconfig_mapping = QConfigMapping() \
               .set_global(global_qconfig) \
               .set_object_type(torch.nn.Linear, qconfig1) \

--- a/torch/ao/quantization/quantize_fx.py
+++ b/torch/ao/quantization/quantize_fx.py
@@ -353,7 +353,7 @@ def prepare_fx(
 
       * `qconfig_mapping` (required): mapping from model ops to qconfigs::
 
-          from torch.ao.quantization import QConfigMapping
+          from torch.quantization import QConfigMapping
 
           qconfig_mapping = QConfigMapping() \
               .set_global(global_qconfig) \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #78533

Summary: https://github.com/pytorch/pytorch/pull/78452 replaced
qconfig_dict with QConfigMapping as the default API for prepare_fx,
prepare_qat_fx, and convert_fx. We should update the docs to reflect
this change as well.

Test Plan:
```
cd docs
make html
cd build/html
python -m server.http
```

Reviewers: jerryzh168, vkuzo

Subscribers: jerryzh168, vkuzo