### PR TITLE
Revert "move Functionalize dispatch key closer to backends"

### DIFF
--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -219,18 +219,6 @@ enum class DispatchKey : uint16_t {
   // See https://pytorch.org/torchdistx/latest/fake_tensor.html
   Fake,
 
-  // See Note [Out-of-tree vmap+grad prototype]. The purpose of this key
-  // is to insert code after the "autograd subsystem" runs, so this key should
-  // be directly after ADInplaceOrView and all of the autograd keys.
-  FuncTorchDynamicLayerBackMode,
-
-  // Alias and mutation removal.
-  // If some backends want to opt into only alias removal or only mutation
-  // removal,
-  // we can consider adding separate keys dedicated to those individual passes.
-  // See Note [Functionalization Pass In Core] for details.
-  Functionalize,
-
   // The named dispatch key is set for any tensors with named dimensions.
   // Although we have a dispatch key for named tensors, for historical reasons,
   // this dispatch key doesn't do any of the substantive functionality for named
@@ -256,6 +244,11 @@ enum class DispatchKey : uint16_t {
   Negative,
 
   ZeroTensor, // registered at build/aten/src/ATen/RegisterZeroTensor.cpp
+
+  // See Note [Out-of-tree vmap+grad prototype]. The purpose of this key
+  // is to insert code after the "autograd subsystem" runs, so this key should
+  // be directly after ADInplaceOrView and all of the autograd keys.
+  FuncTorchDynamicLayerBackMode,
 
   // Note [ADInplaceOrView key]
   // ADInplaceOrView key is used by inplace or view ops to register a kernel
@@ -359,6 +352,13 @@ enum class DispatchKey : uint16_t {
   VmapMode,
 
   FuncTorchGradWrapper, // See Note [Out-of-tree vmap+grad prototype]
+
+  // Alias and mutation removal.
+  // If some backends want to opt into only alias removal or only mutation
+  // removal,
+  // we can consider adding separate keys dedicated to those individual passes.
+  // See Note [Functionalization Pass In Core] for details.
+  Functionalize,
 
   // Out-of-core key for Deferred Module Initialization in torchdistx.
   // See https://pytorch.org/torchdistx/latest/deferred_init.html

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -175,6 +175,8 @@ $1, $2 = torch._ops.aten.aminmax.default($0, dim=0)""")
             z.add_(1)
             return y
         self.assert_functionalization(f, torch.arange(3, dtype=torch.float32))
+        logs = self.get_logs(f, torch.arange(3, dtype=torch.float32))
+        self.assertExpectedInline('\n'.join(logs), """$0 = input('input')""")
 
     def test_inplace_on_non_view(self):
         def f(x):
@@ -464,11 +466,11 @@ $4 = torch._ops.aten.mul.Tensor($3, $3)""")
 
         # Test 1: copy_() with same dtype and shape
         # to() is a composite op that noops when the dtype/shape match, so nothing gets logged.
-        # self.assert_functionalization(f, torch.ones(2))
+        self.assert_functionalization(f, torch.ones(2))
         logs = self.get_logs(f, torch.ones(2))
         self.assertExpectedInline('\n'.join(logs), """\
 $0 = input('input')
-$1 = torch._ops.aten.copy.default(tensor([0., 0.]), $0)
+$1 = torch._ops.aten.expand_copy.default($0, [2])
 $2 = torch._ops.aten.add.Tensor($1, $0)""")
 
         # Test 2: copy_() with same dtype, different shape
@@ -476,7 +478,7 @@ $2 = torch._ops.aten.add.Tensor($1, $0)""")
         logs = self.get_logs(f, torch.ones(1))
         self.assertExpectedInline('\n'.join(logs), """\
 $0 = input('input')
-$1 = torch._ops.aten.copy.default(tensor([0., 0.]), $0)
+$1 = torch._ops.aten.expand_copy.default($0, [2])
 $2 = torch._ops.aten.add.Tensor($1, $0)""")
 
         # Test 3: copy_() with different dtype, same shape
@@ -484,16 +486,18 @@ $2 = torch._ops.aten.add.Tensor($1, $0)""")
         logs = self.get_logs(f, torch.ones(2, dtype=torch.long))
         self.assertExpectedInline('\n'.join(logs), """\
 $0 = input('input')
-$1 = torch._ops.aten.copy.default(tensor([0., 0.]), $0)
-$2 = torch._ops.aten.add.Tensor($1, $0)""")
+$1 = torch._ops.aten._to_copy.default($0, dtype=torch.float32, layout=torch.strided, device=device(type='cpu'), pin_memory=False)
+$2 = torch._ops.aten.expand_copy.default($1, [2])
+$3 = torch._ops.aten.add.Tensor($2, $0)""")
 
         # Test 4: copy_() with different dtype, different shape
         self.assert_functionalization(f, torch.ones(1, dtype=torch.long))
         logs = self.get_logs(f, torch.ones(1, dtype=torch.long))
         self.assertExpectedInline('\n'.join(logs), """\
 $0 = input('input')
-$1 = torch._ops.aten.copy.default(tensor([0., 0.]), $0)
-$2 = torch._ops.aten.add.Tensor($1, $0)""")
+$1 = torch._ops.aten._to_copy.default($0, dtype=torch.float32, layout=torch.strided, device=device(type='cpu'), pin_memory=False)
+$2 = torch._ops.aten.expand_copy.default($1, [2])
+$3 = torch._ops.aten.add.Tensor($2, $0)""")
 
     def test_fill_(self):
         def f(x):

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -334,8 +334,6 @@ Tensor internal_new_from_data(
   // torch.jit.trace will continue to trace out `.to()` instead of `.lift()`, since
   // changing it is BC-breaking.
   at::tracer::impl::NoTracerDispatchMode tracer_guard;
-  // lift has no autograd implementation, so we need to make sure we don't try to dispatch to it.
-  at::AutoDispatchBelowADInplaceOrView guard;
   return tensor.lift();
 }
 


### PR DESCRIPTION
Reverting because this PR broke some functorch tests

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #78538 reland "move Functionalize dispatch key closer to backends"
* **#78537 Revert "move Functionalize dispatch key closer to backends"**

This reverts commit 7ff091fc4e66f18c2fd463ca038688b67548a6b0.