### PR TITLE
[primTorch] Use the same error message as in ATen for canonicalize_dim

### DIFF
--- a/torch/_prims/utils.py
+++ b/torch/_prims/utils.py
@@ -405,10 +405,11 @@ def canonicalize_dim(rank: int, idx: int) -> int:
         _idx = idx
 
     if _idx < 0 or _idx > _rank:
-        msg = "Received out of bounds index {0} for tensor of rank {1}!".format(
-            idx, rank
+        # Same error message as in aten/src/ATen/WrapDimUtils.h:49
+        msg = "Dimension out of range (expected to be in range of [{0}, {1}], but got {2})".format(
+            -rank, rank - 1, idx
         )
-        raise ValueError(msg)
+        raise IndexError(msg)
 
     return _idx
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19935,11 +19935,6 @@ python_ref_db = [
         "_refs.roll",
         torch_opinfo_name="roll",
         validate_view_consistency=False,
-        skips=(
-            # TODO: decide on the error message for the reference implementation
-            # See https://github.com/pytorch/pytorch/issues/78252
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_errors'),
-        ),
     ),
     PythonRefInfo(
         "_refs.rot90",


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/78252.

Locally nothing seems to break when changing the error type and the error message meaning there were no tests.
At least one xfailed test from https://github.com/pytorch/pytorch/pull/78080 wouldn't pass with this PR.

