### PR TITLE
Add __all__ definition in torch.profiler to fix Pylance type check er…

### DIFF
--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -23,7 +23,7 @@ from . import forward_ad
 from . import graph
 from .. import _vmap_internals
 
-__all__ = ['Variable', 'Function', 'backward', 'grad_mode']
+__all__ = ['Variable', 'Function', 'backward', 'grad_mode', 'ProfilerActivity']
 
 _OptionalTensor = Optional[torch.Tensor]
 

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -23,7 +23,7 @@ from . import forward_ad
 from . import graph
 from .. import _vmap_internals
 
-__all__ = ['Variable', 'Function', 'backward', 'grad_mode', 'ProfilerActivity']
+__all__ = ['Variable', 'Function', 'backward', 'grad_mode', 'ProfilerActivity', 'kineto_available', 'DeviceType']
 
 _OptionalTensor = Optional[torch.Tensor]
 

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -23,7 +23,7 @@ from . import forward_ad
 from . import graph
 from .. import _vmap_internals
 
-__all__ = ['Variable', 'Function', 'backward', 'grad_mode', 'ProfilerActivity', 'kineto_available', 'DeviceType']
+__all__ = ['Variable', 'Function', 'backward', 'grad_mode', 'ProfilerActivity']
 
 _OptionalTensor = Optional[torch.Tensor]
 

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -23,7 +23,7 @@ from . import forward_ad
 from . import graph
 from .. import _vmap_internals
 
-__all__ = ['Variable', 'Function', 'backward', 'grad_mode', 'ProfilerActivity']
+__all__ = ['Variable', 'Function', 'backward', 'grad_mode']
 
 _OptionalTensor = Optional[torch.Tensor]
 

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -7,9 +7,12 @@ examine their input shapes and stack traces, study device kernel activity and vi
     An earlier version of the API in :mod:`torch.autograd` module is considered legacy and will be deprecated.
 
 '''
-
 from .profiler import profile, _KinetoProfile, \
-    schedule, supported_activities, tensorboard_trace_handler, ProfilerAction,\
-    ProfilerActivity, _ExperimentalConfig, ExecutionGraphObserver
-from torch.autograd import kineto_available, _supported_activities, DeviceType
+    schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, \
+    _ExperimentalConfig, ExecutionGraphObserver
+from torch._C._autograd import ProfilerActivity, kineto_available, _supported_activities, DeviceType
 from torch.autograd.profiler import record_function
+
+__all__ = ['profile', 'schedule', 'supported_activities', '_KinetoProfile',
+           'tensorboard_trace_handler', 'ProfilerAction', 'ProfilerActivity',
+           'kineto_available', 'DeviceType', 'record_function', 'ExecutionGraphObserver']

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -10,9 +10,9 @@ examine their input shapes and stack traces, study device kernel activity and vi
 from .profiler import profile, _KinetoProfile, \
     schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, \
     _ExperimentalConfig, ExecutionGraphObserver
-from torch._C._autograd import ProfilerActivity, kineto_available, _supported_activities, DeviceType
+from torch.autograd import ProfilerActivity, kineto_available, _supported_activities, DeviceType
 from torch.autograd.profiler import record_function
 
-__all__ = ['profile', 'schedule', 'supported_activities', '_KinetoProfile',
-           'tensorboard_trace_handler', 'ProfilerAction', 'ProfilerActivity',
-           'kineto_available', 'DeviceType', 'record_function', 'ExecutionGraphObserver']
+__all__ = ['profile', 'schedule', 'supported_activities', 'tensorboard_trace_handler',
+           'ProfilerAction', 'ProfilerActivity', 'kineto_available', 'DeviceType',
+           'record_function', 'ExecutionGraphObserver']

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -10,9 +10,10 @@ examine their input shapes and stack traces, study device kernel activity and vi
 from .profiler import profile, _KinetoProfile, \
     schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, \
     _ExperimentalConfig, ExecutionGraphObserver
-from torch._C._autograd import ProfilerActivity, kineto_available, _supported_activities, DeviceType
+from torch.autograd import ProfilerActivity
+from torch._C._autograd import kineto_available, _supported_activities, DeviceType
 from torch.autograd.profiler import record_function
 
-__all__ = ['profile', 'schedule', 'supported_activities', '_KinetoProfile',
+__all__ = ['profile', 'schedule', 'supported_activities',
            'tensorboard_trace_handler', 'ProfilerAction', 'ProfilerActivity',
            'kineto_available', 'DeviceType', 'record_function', 'ExecutionGraphObserver']

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -10,9 +10,9 @@ examine their input shapes and stack traces, study device kernel activity and vi
 from .profiler import profile, _KinetoProfile, \
     schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, \
     _ExperimentalConfig, ExecutionGraphObserver
-from torch.autograd import ProfilerActivity, kineto_available, _supported_activities, DeviceType
+from torch._C._autograd import ProfilerActivity, kineto_available, _supported_activities, DeviceType
 from torch.autograd.profiler import record_function
 
-__all__ = ['profile', 'schedule', 'supported_activities', 'tensorboard_trace_handler',
-           'ProfilerAction', 'ProfilerActivity', 'kineto_available', 'DeviceType',
-           'record_function', 'ExecutionGraphObserver']
+__all__ = ['profile', 'schedule', 'supported_activities', '_KinetoProfile',
+           'tensorboard_trace_handler', 'ProfilerAction', 'ProfilerActivity',
+           'kineto_available', 'DeviceType', 'record_function', 'ExecutionGraphObserver']

--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -10,8 +10,7 @@ examine their input shapes and stack traces, study device kernel activity and vi
 from .profiler import profile, _KinetoProfile, \
     schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, \
     _ExperimentalConfig, ExecutionGraphObserver
-from torch.autograd import ProfilerActivity
-from torch._C._autograd import kineto_available, _supported_activities, DeviceType
+from torch._C._autograd import ProfilerActivity, kineto_available, _supported_activities, DeviceType
 from torch.autograd.profiler import record_function
 
 __all__ = ['profile', 'schedule', 'supported_activities',


### PR DESCRIPTION
- Declare __all__ to make sure all the import is marked as public, so Pylance won't complain.
- Import modules directly from torch._C._autograd to suppress Pylance warnings.

Fixes #76652
