### PR TITLE
[Vulkan] Add cumsum op

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/cumsum.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/cumsum.glsl
@@ -1,0 +1,27 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
+  int axis;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  ivec3 spos = pos;
+  vec4 sum = vec4(0);
+  for(spos[uBlock.axis] = 0; spos!=pos; ++spos[uBlock.axis]) {
+    sum += texelFetch(uInput, spos, 0);
+  }
+  sum += texelFetch(uInput, spos, 0);
+  imageStore(uOutput, pos, sum);
+}

--- a/aten/src/ATen/native/vulkan/ops/cumsum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/cumsum.cpp
@@ -1,0 +1,102 @@
+#include <ATen/native/vulkan/api/OpProfiler.h>
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Utils.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor cumsum(
+    const at::Tensor& input_arg,
+    const int64_t dim,
+    const c10::optional<ScalarType> dtype) {
+  TORCH_CHECK(
+    input_arg.dim() <= 4,
+    "Vulkan cumsum expects input dimension <= 4!");
+
+  TORCH_CHECK(
+    batch_size(input_arg) == 1,
+    "Vulkan cumsum expects batch size <= 1!");
+
+  TORCH_CHECK(
+    dim < 4,
+    "Vulkan cumsum expects dim < 4!");
+
+  api::Context* const context = api::context();
+
+  const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
+  const vTensor& v_input = convert(input);
+  vTensor v_output{
+    context,
+    input.sizes(),
+    input.options(),
+  };
+
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+  {
+    api::OpProfiler profiler(command_buffer, context->querypool(), "aten::cumsum");
+
+    if C10_LIKELY(v_input.has_image()) {
+      const struct Block final {
+        int32_t axis;
+      } block {
+        (3-safe_downcast<int32_t>(dim)),
+      };
+
+      if(dim<=1) {
+          // TODO: dim<0, dim=0, dim=1(z axis)
+          TORCH_CHECK(false, "Not implemented!");
+      }
+
+      context->dispatch(
+          command_buffer,
+          {
+            VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+            VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+            VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          },
+          VK_KERNEL(cumsum),
+          v_input.extents(),
+          context->gpu().adapter->local_work_group_size(),
+          // Write-only access bypasses synchronization but inserts appropriate
+          // barriers if necessary.
+          v_output.image(
+              command_buffer,
+              vTensor::Stage::Compute,
+              vTensor::Access::Write),
+          // Read-only access is implied on const tensors and triggers an async
+          // synchronization if necessary.
+          v_input.image(
+              command_buffer,
+              vTensor::Stage::Compute),
+          // Object lifetime is managed by the resource pool.
+          // It is OK not to keep track of the handle.
+          context->resource().pool.uniform(block).object);
+    } else {
+      TORCH_CHECK(false, "Not implemented!");
+    }
+  }
+  command_pool.submit(context->gpu().queue, command_buffer);
+
+  return convert(v_output);
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::cumsum"), TORCH_FN(cumsum));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -810,6 +810,36 @@ TEST_F(VulkanAPITest, copy) {
   ASSERT_TRUE(check);
 }
 
+TEST_F(VulkanAPITest, cumsum) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+  c10::InferenceMode mode;
+
+  const auto in_cpu = at::rand({1, 17, 37, 49}, at::TensorOptions(at::kCPU).dtype(at::kFloat));
+  // 0 do nothing
+  // 1 frame
+  // not implemented
+
+  // 2 height
+  const auto out_cpu2 = at::cumsum(in_cpu, 2);
+  const auto out_vulkan2 = at::cumsum(in_cpu.vulkan(), 2);
+  const auto check2 = almostEqual(out_cpu2, out_vulkan2.cpu());
+  if (!check2) {
+    showRtol(out_cpu2, out_vulkan2.cpu());
+  }
+  ASSERT_TRUE(check2);
+
+  // 3 width
+  const auto out_cpu3 = at::cumsum(in_cpu, 3);
+  const auto out_vulkan3 = at::cumsum(in_cpu.vulkan(), 3);
+  const auto check3 = almostEqual(out_cpu3, out_vulkan3.cpu());
+  if (!check3) {
+    showRtol(out_cpu3, out_vulkan3.cpu());
+  }
+  ASSERT_TRUE(check3);
+}
+
 TEST_F(VulkanAPITest, div) {
   if (!at::is_vulkan_available()) {
     return;


### PR DESCRIPTION
Summary: Implement cumsum op for hight and width dimensions.

Test Plan:
```
buck run xplat/caffe2:pt_vulkan_api_test_binAppleMac
```

Check line 51, 52

https://pxl.cl/250s9

Reviewed By: SS-JIA

Differential Revision: D36726198

