### PR TITLE
Fix embedding jvp support by making embedding_renorm ignore forward mode AD

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16474,6 +16474,37 @@ class TestNNDeviceType(NNTestCase):
     @dtypesIfCUDA(*((torch.float, torch.double, torch.bfloat16, torch.half)
                     if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
     @dtypes(torch.float32)
+    def test_embedding_max_norm_backward(self, device, dtype):
+        # can't use gradcheck since in place renorm makes analytical gradients different from produced ones
+        weight = torch.randn((4, 4), device=device, dtype=dtype) * 2
+        weight.requires_grad_()
+        inp_list = [0, 1, 2, 2]
+        inp = torch.tensor(inp_list, device=device)
+        out = nn.functional.embedding(inp, weight, max_norm=1.).sum()
+        out.backward()
+
+        expected_grad = torch.tensor([[1., 1., 2., 0.]], device=device, dtype=dtype).transpose(0, 1).expand(4, 4)
+        self.assertEqual(weight.grad, expected_grad)
+
+    @dtypesIfCUDA(*((torch.float, torch.double, torch.bfloat16, torch.half)
+                    if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
+    @dtypes(torch.float32)
+    def test_embedding_max_norm_fwd_AD(self, device, dtype):
+        # can't use gradcheck since in place renorm makes analytical gradients different from produced ones
+        weight = torch.randn((4, 4), device=device, dtype=dtype) * 2
+        tangent = torch.ones((4, 4), device=device, dtype=dtype)
+        inp = torch.tensor([[0, 1], [2, 2]], device=device)
+        with torch.autograd.forward_ad.dual_level():
+            dual_weight = torch.autograd.forward_ad.make_dual(weight, tangent)
+            out = nn.functional.embedding(inp, dual_weight, max_norm=1.)
+            jvp = torch.autograd.forward_ad.unpack_dual(out).tangent
+
+        expected_grad = torch.ones((2, 2, 4), device=device, dtype=dtype)
+        self.assertEqual(jvp, expected_grad)
+
+    @dtypesIfCUDA(*((torch.float, torch.double, torch.bfloat16, torch.half)
+                    if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
+    @dtypes(torch.float32)
     def test_embedding_padding_idx(self, device, dtype):
         embedding = nn.Embedding(10, 20, padding_idx=0).to(device, dtype)
         input = torch.tensor([[0, 2, 4, 5], [4, 3, 0, 9]], dtype=torch.long).to(device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16490,6 +16490,9 @@ class TestNNDeviceType(NNTestCase):
                     if TEST_WITH_ROCM else (torch.float, torch.double, torch.half)))
     @dtypes(torch.float32)
     def test_embedding_max_norm_fwd_AD(self, device, dtype):
+        if torch.device(device).type == 'xla':
+            self.skipTest("forward AD doesn't work on xla")
+
         # can't use gradcheck since in place renorm makes analytical gradients different from produced ones
         weight = torch.randn((4, 4), device=device, dtype=dtype) * 2
         tangent = torch.ones((4, 4), device=device, dtype=dtype)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2049,14 +2049,8 @@ def hardswish(input: Tensor, inplace: bool = False) -> Tensor:
     return torch._C._nn.hardswish(input)
 
 
-def _no_grad_embedding_renorm_(weight: Tensor, input: Tensor, max_norm: float, norm_type: float) -> Tensor:
-    prev_state = get_fwd_grad_enabled()
-    with torch.no_grad():
-        set_fwd_grad_enabled(False)
-        try:
-          torch.embedding_renorm_(weight, input, max_norm, norm_type)
-        finally:
-          set_fwd_grad_enabled(prev_state)
+def _no_grad_embedding_renorm_(weight: Tensor, input: Tensor, max_norm: float, norm_type: float) -> Tuple[Tensor, Tensor]:
+    torch.embedding_renorm_(weight.detach(), input, max_norm, norm_type)
 
 
 def embedding(

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2050,8 +2050,13 @@ def hardswish(input: Tensor, inplace: bool = False) -> Tensor:
 
 
 def _no_grad_embedding_renorm_(weight: Tensor, input: Tensor, max_norm: float, norm_type: float) -> Tensor:
+    prev_state = get_fwd_grad_enabled()
     with torch.no_grad():
-        torch.embedding_renorm_(weight, input, max_norm, norm_type)
+        set_fwd_grad_enabled(False)
+        try:
+          torch.embedding_renorm_(weight, input, max_norm, norm_type)
+        finally:
+          set_fwd_grad_enabled(prev_state)
 
 
 def embedding(


### PR DESCRIPTION
On functorch, we started seeing [embedding forward mode fail](https://github.com/pytorch/functorch/pull/816). From looking at it, we figured out that recently [embedding got forward mode support enabled](https://github.com/pytorch/pytorch/commit/369d9f4137a8bfc20e6a4e1d6ab35eeae4e9b345) and then doing forward mode with embedding and [max_norm doesn't work with gradcheck](https://github.com/pytorch/pytorch/blob/master/torch/testing/_internal/common_methods_invocations.py#L8877-L8881), so it's not checked.

What was happening is that `embedding_renorm` was setting `torch.no_grad()` which only turns off the backwards mode AD so functorch's jvp tests were still using forward mode AD during the `embedding_renorm` call. This makes it so that we don't use forward mode during the embedding_renorm call