### PR TITLE
ci: Only pull image if not available locally

### DIFF
--- a/.github/actions/pull-docker-image/action.yml
+++ b/.github/actions/pull-docker-image/action.yml
@@ -16,4 +16,6 @@ runs:
         DOCKER_IMAGE: ${{ inputs.docker-image }}
       run: |
         retry () { "$@"  || (sleep 1 && "$@") || (sleep 2 && "$@") }
-        retry docker pull "${DOCKER_IMAGE}"
+        if docker inspect --type=image "${DOCKER_IMAGE}"; then
+          retry docker pull "${DOCKER_IMAGE}"
+        fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #78576

This should make it so that if we already have a local version of the
image that we'll just use the local image instead

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>