### PR TITLE
[quant] Add APoT tensor class and tests

### DIFF
--- a/test/quantization/core/experimental/test_quantized_tensor.py
+++ b/test/quantization/core/experimental/test_quantized_tensor.py
@@ -1,0 +1,22 @@
+# Owner(s): ["oncall: quantization"]
+
+import torch
+from torch.ao.quantization.experimental.APoT_tensor import TensorAPoT
+import unittest
+
+class TestQuantizedTensor(unittest.TestCase):
+    def test_quantize_APoT(self):
+        t = torch.Tensor()
+        with self.assertRaises(NotImplementedError):
+            TensorAPoT.quantize_APoT(t)
+
+    def test_dequantize(self):
+        with self.assertRaises(NotImplementedError):
+            TensorAPoT.dequantize(self)
+
+    def test_q_apot_alpha(self):
+        with self.assertRaises(NotImplementedError):
+            TensorAPoT.q_apot_alpha(self)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/torch/ao/quantization/experimental/APoT_tensor.py
+++ b/torch/ao/quantization/experimental/APoT_tensor.py
@@ -1,0 +1,14 @@
+import torch
+from torch import Tensor
+
+# class to store APoT quantized tensor
+class TensorAPoT(torch.Tensor):
+    @staticmethod
+    def quantize_APoT(tensor2quantize: Tensor) -> Tensor:
+        raise NotImplementedError
+
+    def dequantize(self) -> Tensor:
+        raise NotImplementedError
+
+    def q_apot_alpha(self) -> float:
+        raise NotImplementedError


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #78579
* __->__ #78577

### Summary:
Previously, there was no suport for APoT quantized tensors.
This PR introduces a class skeleton for APoT quantized tensors as well as test cases.

### Test Plan:

`python pytorch/test/quantization/core/experimental/test_quantized_tensor.py`

Differential Revision: [D36817781](https://our.internmc.facebook.com/intern/diff/D36817781)