### PR TITLE
[quant] Add nonuniform observer class and tests

### DIFF
--- a/test/quantization/core/experimental/test_nonuniform_observer.py
+++ b/test/quantization/core/experimental/test_nonuniform_observer.py
@@ -1,0 +1,22 @@
+# Owner(s): ["oncall: quantization"]
+
+import torch
+from torch.ao.quantization.experimental.APoT_tensor import TensorAPoT
+import unittest
+
+class TestQuantizedTensor(unittest.TestCase):
+    def test_quantize_APoT(self):
+        t = torch.Tensor()
+        with self.assertRaises(NotImplementedError):
+            TensorAPoT.quantize_APoT(t)
+
+    def test_dequantize(self):
+        with self.assertRaises(NotImplementedError):
+            TensorAPoT.dequantize(self)
+
+    def test_q_apot_alpha(self):
+        with self.assertRaises(NotImplementedError):
+            TensorAPoT.q_apot_alpha(self)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/quantization/core/experimental/test_nonuniform_observer.py
+++ b/test/quantization/core/experimental/test_nonuniform_observer.py
@@ -10,7 +10,7 @@ class TestNonUniformObserver(unittest.TestCase):
         obs = APoTObserver(t, t, t, 0, 0)
 
         with self.assertRaises(NotImplementedError):
-            obs._calculate_qparams()
+            obs.calculate_qparams()
         # t = torch.Tensor()
         # obs = APoTObserver(t, t, t, 0, 0)
 

--- a/test/quantization/core/experimental/test_nonuniform_observer.py
+++ b/test/quantization/core/experimental/test_nonuniform_observer.py
@@ -11,15 +11,6 @@ class TestNonUniformObserver(unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             obs.calculate_qparams()
-        # t = torch.Tensor()
-        # obs = APoTObserver(t, t, t, 0, 0)
-
-        # raised = False
-        # try:
-        #     obs.calculate_qparams()
-        # except Exception:
-        #     raised = True
-        # self.assertFalse(raised, 'Exception raised')
 
     def test_override_calculate_qparams(self):
         t = torch.Tensor()

--- a/test/quantization/core/experimental/test_nonuniform_observer.py
+++ b/test/quantization/core/experimental/test_nonuniform_observer.py
@@ -1,22 +1,32 @@
 # Owner(s): ["oncall: quantization"]
 
-import torch
-from torch.ao.quantization.experimental.APoT_tensor import TensorAPoT
+from torch.ao.quantization.experimental.observer import APoTObserver
 import unittest
+import torch
 
-class TestQuantizedTensor(unittest.TestCase):
-    def test_quantize_APoT(self):
+class TestNonUniformObserver(unittest.TestCase):
+    def test_calculate_qparams(self):
         t = torch.Tensor()
-        with self.assertRaises(NotImplementedError):
-            TensorAPoT.quantize_APoT(t)
+        obs = APoTObserver(t, t, t, 0, 0)
 
-    def test_dequantize(self):
         with self.assertRaises(NotImplementedError):
-            TensorAPoT.dequantize(self)
+            obs._calculate_qparams()
+        # t = torch.Tensor()
+        # obs = APoTObserver(t, t, t, 0, 0)
 
-    def test_q_apot_alpha(self):
+        # raised = False
+        # try:
+        #     obs.calculate_qparams()
+        # except Exception:
+        #     raised = True
+        # self.assertFalse(raised, 'Exception raised')
+
+    def test_override_calculate_qparams(self):
+        t = torch.Tensor()
+        obs = APoTObserver(t, t, t, 0, 0)
+
         with self.assertRaises(NotImplementedError):
-            TensorAPoT.q_apot_alpha(self)
+            obs._calculate_qparams()
 
 if __name__ == '__main__':
     unittest.main()

--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -1,0 +1,44 @@
+"""
+This module implements nonuniform observers used to collect statistics about
+the values observed during calibration (PTQ) or training (QAT).
+"""
+
+import torch
+from torch.ao.quantization.observer import ObserverBase
+from typing import Tuple
+
+class NonUniformQuantizationObserverBase(ObserverBase):
+    alpha = 0
+    gamma = 0
+    level_indices = torch.Tensor()
+
+    def __init__(
+        self,
+        min_val: torch.Tensor,
+        max_val: torch.Tensor,
+        level_indices: torch.Tensor,
+            b: int,
+            k: int) -> None:
+        super().__init__
+
+    def _calculate_qparams(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        pass
+
+class APoTObserver(NonUniformQuantizationObserverBase):
+    def __init__(
+        self,
+        min_val: torch.Tensor,
+        max_val: torch.Tensor,
+        level_indices: torch.Tensor,
+            b: int,
+            k: int) -> None:
+        super(APoTObserver, self).__init__(min_val, max_val, level_indices, b, k)
+
+    def calculate_qparams(self):
+        return self._calculate_qparams()
+
+    # def _calculate_qparams(self):
+    #     return NonUniformQuantizationObserverBase._calculate_qparams()
+
+    def forward(self, x_orig):
+        pass

--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -10,7 +10,7 @@ from typing import Tuple
 class NonUniformQuantizationObserverBase(ObserverBase):
     quant_min = None
     quant_max = None
-    
+
     def __init__(
         self,
         min_val: torch.Tensor,
@@ -27,7 +27,7 @@ class APoTObserver(NonUniformQuantizationObserverBase):
     alpha = 0
     gamma = 0
     level_indices = torch.Tensor()
-    
+
     def __init__(
         self,
         min_val: torch.Tensor,

--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -8,10 +8,9 @@ from torch.ao.quantization.observer import ObserverBase
 from typing import Tuple
 
 class NonUniformQuantizationObserverBase(ObserverBase):
-    alpha = 0
-    gamma = 0
-    level_indices = torch.Tensor()
-
+    quant_min = None
+    quant_max = None
+    
     def __init__(
         self,
         min_val: torch.Tensor,
@@ -25,6 +24,10 @@ class NonUniformQuantizationObserverBase(ObserverBase):
         pass
 
 class APoTObserver(NonUniformQuantizationObserverBase):
+    alpha = 0
+    gamma = 0
+    level_indices = torch.Tensor()
+    
     def __init__(
         self,
         min_val: torch.Tensor,

--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -37,8 +37,8 @@ class APoTObserver(NonUniformQuantizationObserverBase):
     def calculate_qparams(self):
         return self._calculate_qparams()
 
-    # def _calculate_qparams(self):
-    #     return NonUniformQuantizationObserverBase._calculate_qparams()
+    def _calculate_qparams(self):
+        raise NotImplementedError
 
     def forward(self, x_orig):
         pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #78579
* #78577

### Summary:
Previously, there was no suport for nonuniform observers.
This PR introduces a class skeleton for nonuniform observers as well as test cases.

### Test Plan:
`python pytorch/test/quantization/core/experimental/test_nonuniform_observer.py`