### PR TITLE
tools: Add ability to grab release versions

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -1,10 +1,14 @@
 import argparse
 import os
+import re
 import subprocess
 from pathlib import Path
 from setuptools import distutils  # type: ignore[import]
 from typing import Optional, Union
 
+
+UNKNOWN = "Unknown"
+RELEASE_PATTERN = re.compile(r"/v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/")
 
 def get_sha(pytorch_root: Union[str, Path]) -> str:
     try:
@@ -14,7 +18,24 @@ def get_sha(pytorch_root: Union[str, Path]) -> str:
             .strip()
         )
     except Exception:
-        return "Unknown"
+        return UNKNOWN
+
+
+def get_tag(pytorch_root: Union[str, Path]) -> str:
+    try:
+        tag = (
+            subprocess.check_output(
+                ["git", "describe", "--tags", "--exact"], cwd=pytorch_root
+            )
+            .decode("ascii")
+            .strip()
+        )
+        if RELEASE_PATTERN.match(tag):
+            return tag
+        else:
+            return UNKNOWN
+    except Exception:
+        return UNKNOWN
 
 
 def get_torch_version(sha: Optional[str] = None) -> str:
@@ -27,7 +48,7 @@ def get_torch_version(sha: Optional[str] = None) -> str:
         version = os.getenv("PYTORCH_BUILD_VERSION", "")
         if build_number > 1:
             version += ".post" + str(build_number)
-    elif sha != "Unknown":
+    elif sha != UNKNOWN:
         if sha is None:
             sha = get_sha(pytorch_root)
         version += "+git" + sha[:7]
@@ -54,8 +75,13 @@ if __name__ == "__main__":
 
     pytorch_root = Path(__file__).parent.parent
     version_path = pytorch_root / "torch" / "version.py"
+    # Attempt to get tag first, fall back to sha if a tag was not found
+    tagged_version = get_tag(pytorch_root)
     sha = get_sha(pytorch_root)
-    version = get_torch_version(sha)
+    if tagged_version == UNKNOWN:
+        version = get_torch_version(sha)
+    else:
+        version = tagged_version
 
     with open(version_path, "w") as f:
         f.write("__version__ = '{}'\n".format(version))

--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -10,6 +10,7 @@ from typing import Optional, Union
 UNKNOWN = "Unknown"
 RELEASE_PATTERN = re.compile(r"/v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/")
 
+
 def get_sha(pytorch_root: Union[str, Path]) -> str:
     try:
         return (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #78584

Adds the ability for generate_torch_version to grab release versions
based on the current tag. Also includes a regex to check if the tagged
version matches our release pattern (vX.Y.Z) so we don't collide with
ciflow tags

Fixes https://github.com/pytorch/pytorch/issues/77052

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>