### PR TITLE
added shape checking to WeightedRandomSampler

### DIFF
--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -187,7 +187,7 @@ class WeightedRandomSampler(Sampler[int]):
         if not isinstance(replacement, bool):
             raise ValueError("replacement should be a boolean value, but got "
                              "replacement={}".format(replacement))
-        
+
         weights = torch.as_tensor(weights, dtype=torch.double)
         if len(weights.shape) != 1:
             raise ValueError("weights should be a 1d sequence but given "

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -187,7 +187,13 @@ class WeightedRandomSampler(Sampler[int]):
         if not isinstance(replacement, bool):
             raise ValueError("replacement should be a boolean value, but got "
                              "replacement={}".format(replacement))
-        self.weights = torch.as_tensor(weights, dtype=torch.double)
+        
+        weights = torch.as_tensor(weights, dtype=torch.double)
+        if len(weights.shape) != 1:
+            raise ValueError("weights should be a 1d sequence but given "
+                             "weights have shape {}".format(tuple(weights.shape)))
+
+        self.weights = weights
         self.num_samples = num_samples
         self.replacement = replacement
         self.generator = generator

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -188,12 +188,12 @@ class WeightedRandomSampler(Sampler[int]):
             raise ValueError("replacement should be a boolean value, but got "
                              "replacement={}".format(replacement))
 
-        weights = torch.as_tensor(weights, dtype=torch.double)
-        if len(weights.shape) != 1:
+        weights_tensor = torch.as_tensor(weights, dtype=torch.double)
+        if len(weights_tensor.shape) != 1:
             raise ValueError("weights should be a 1d sequence but given "
-                             "weights have shape {}".format(tuple(weights.shape)))
+                             "weights have shape {}".format(tuple(weights_tensor.shape)))
 
-        self.weights = weights
+        self.weights = weights_tensor
         self.num_samples = num_samples
         self.replacement = replacement
         self.generator = generator


### PR DESCRIPTION
Fixes #78236

An erronously shaped weights vector will result in the following output

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
~/datarwe/pytorch/torch/utils/data/sampler.py in <module>
      [274](file:///home/oliver/datarwe/pytorch/torch/utils/data/sampler.py?line=273) WeightedRandomSampler([1,2,3], 10)
----> [275](file:///home/oliver/datarwe/pytorch/torch/utils/data/sampler.py?line=274) WeightedRandomSampler([[1,2,3], [4,5,6]], 10)

~/datarwe/pytorch/torch/utils/data/sampler.py in __init__(self, weights, num_samples, replacement, generator)
    [192](file:///home/oliver/datarwe/pytorch/torch/utils/data/sampler.py?line=191)         weights = torch.as_tensor(weights, dtype=torch.double)
    [193](file:///home/oliver/datarwe/pytorch/torch/utils/data/sampler.py?line=192)         if len(weights.shape) != 1:
--> [194](file:///home/oliver/datarwe/pytorch/torch/utils/data/sampler.py?line=193)             raise ValueError("weights should be a 1d sequence but given "
    [195](file:///home/oliver/datarwe/pytorch/torch/utils/data/sampler.py?line=194)                              "weights have shape {}".format(tuple(weights.shape)))
    [196](file:///home/oliver/datarwe/pytorch/torch/utils/data/sampler.py?line=195) 

ValueError: weights should be a 1d sequence but given weights have shape (2, 3)
```