### PR TITLE
[WIP] Dynamic shape poc

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -58,7 +58,7 @@ NestedTensorImpl::NestedTensorImpl(
   key_set_ =
       key_set_ - c10::DispatchKeySet({c10::DispatchKey::ADInplaceOrView});
   refresh_dim();
-  set_sizes_strides_policy(c10::TensorImpl::SizesStridesPolicy::CustomSizes);
+  set_sizes_strides_policy(c10::TensorImpl::SizesStridesPolicy::CustomSymSizes);
 }
 
 void NestedTensorImpl::refresh_dim() {
@@ -77,6 +77,9 @@ bool NestedTensorImpl::is_contiguous_custom(MemoryFormat) const {
   TORCH_CHECK(false, "is_contiguous is disabled.");
 }
 IntArrayRef NestedTensorImpl::sizes_custom() const {
+  TORCH_CHECK(false, "Internal error: NestedTensorImpl doesn't support sizes. Please file an issue on https://github.com/pytorch/nestedtensor");
+}
+c10::SymIntArrayRef NestedTensorImpl::sym_sizes_custom() const {
   TORCH_CHECK(false, "Internal error: NestedTensorImpl doesn't support sizes. Please file an issue on https://github.com/pytorch/nestedtensor");
 }
 

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -58,7 +58,7 @@ NestedTensorImpl::NestedTensorImpl(
   key_set_ =
       key_set_ - c10::DispatchKeySet({c10::DispatchKey::ADInplaceOrView});
   refresh_dim();
-  set_sizes_strides_policy(c10::TensorImpl::SizesStridesPolicy::CustomSymSizes);
+  set_sizes_strides_policy(c10::TensorImpl::SizesStridesPolicy::CustomSizes);
 }
 
 void NestedTensorImpl::refresh_dim() {
@@ -81,6 +81,10 @@ IntArrayRef NestedTensorImpl::sizes_custom() const {
 }
 c10::SymIntArrayRef NestedTensorImpl::sym_sizes_custom() const {
   TORCH_CHECK(false, "Internal error: NestedTensorImpl doesn't support sizes. Please file an issue on https://github.com/pytorch/nestedtensor");
+}
+
+c10::SymIntArrayRef NestedTensorImpl::sym_sizes() const {
+  return sym_sizes_custom();
 }
 
 IntArrayRef NestedTensorImpl::strides_custom() const {

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -42,6 +42,7 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   int64_t numel_custom() const override;
   bool is_contiguous_custom(MemoryFormat) const override;
   IntArrayRef sizes_custom() const override;
+  c10::SymIntArrayRef sym_sizes_custom() const override;
   IntArrayRef strides_custom() const override;
 
   // this one is real

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -43,6 +43,7 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   bool is_contiguous_custom(MemoryFormat) const override;
   IntArrayRef sizes_custom() const override;
   c10::SymIntArrayRef sym_sizes_custom() const override;
+  c10::SymIntArrayRef sym_sizes() const override;
   IntArrayRef strides_custom() const override;
 
   // this one is real

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -156,6 +156,14 @@ class TORCH_API TensorBase {
     return at::isSignedType(this->scalar_type());
   }
 
+  c10::SymInt sym_size(int64_t dim) const {
+    const auto sizes = this->sym_sizes();
+    const auto ndim = static_cast<int64_t>(sizes.size());
+    // false is passed to maybe_wrap_dim so behavior is identical to array access (but with wrapping)
+    return sizes[c10::maybe_wrap_dim(dim, ndim, /*wrap_scalar=*/false)];
+
+  }
+
   int64_t size(int64_t dim) const {
     const auto sizes = this->sizes();
     const auto ndim = static_cast<int64_t>(sizes.size());

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -321,6 +321,10 @@ Tensor broadcast_to(const Tensor& self, IntArrayRef size) {
   return self.expand(size);
 }
 
+Tensor broadcast_to(const Tensor& self, c10::SymIntArrayRef sym_size) {
+  return self.expand(self.sym_sizes());
+}
+
 std::vector<Tensor> broadcast_tensors(TensorList tensors) {
   return expand_outplace(tensors);
 }
@@ -2748,6 +2752,9 @@ Tensor flatten(const Tensor& self, int64_t start_dim, int64_t end_dim) {
   // of freedom we don't want; for example, consider shape [0, 1, 3, 0], with start_dim=1, end_dim=2.
   // It's clear we want result shape [0, 3, 0] but passing [0, -1, 0] to infer_size means the -1
   // can take on any value and satisfy the constraints.
+  std::cout<<"HEY"<<std::endl;
+  std::cout<<self.sizes()<<std::endl;
+  std::cout<<"HEY2"<<std::endl;
   auto slice_numel = c10::multiply_integers(self.sizes().slice(start_dim, end_dim - start_dim + 1));
   std::vector<int64_t> shape;
   shape.reserve(self.dim() - end_dim + start_dim);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1115,6 +1115,8 @@
 - func: broadcast_to(Tensor(a) self, int[] size) -> Tensor(a)
   variants: function, method
 
+- func: broadcast_to.SymInt(Tensor(a) self, SymInt[] size) -> Tensor(a)
+
 - func: _sparse_broadcast_to(Tensor(a) self, int[] size) -> Tensor(a)
   variants: function
   dispatch:

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -132,6 +132,7 @@ class TORCH_API Tensor: public TensorBase {
 
   // Aliased by Dimname overloads, so need explicit using
   using TensorBase::size;
+  using TensorBase::sym_size;
   using TensorBase::stride;
 
   /// Should be used if *this can reasonably be expected to be contiguous and

--- a/c10/core/SymIntTable.cpp
+++ b/c10/core/SymIntTable.cpp
@@ -25,4 +25,5 @@ SymIntTable& getSymIntTable() {
   static SymIntTable sit;
   return sit;
 }
+
 } // namespace c10

--- a/c10/core/SymbolicIntNode.h
+++ b/c10/core/SymbolicIntNode.h
@@ -58,7 +58,7 @@ class C10_API SymbolicIntNode
   virtual std::string str() {
     TORCH_CHECK(false, "NYI");
   };
-  virtual std::ostream& operator<<(std::ostream& os) {
+  std::ostream& operator<<(std::ostream& os) {
     os << str();
     return os;
   };

--- a/c10/core/SymbolicIntNode.h
+++ b/c10/core/SymbolicIntNode.h
@@ -13,7 +13,53 @@ class C10_API SymbolicIntNode
  public:
   c10::SymInt toSymInt();
   virtual ~SymbolicIntNode(){};
+  // these could be pure virtual when we implement LTC versions
+  virtual std::shared_ptr<SymbolicIntNode> add(
+      std::shared_ptr<SymbolicIntNode> other) {
+    TORCH_CHECK(false, "NYI");
+  };
+  virtual std::shared_ptr<SymbolicIntNode> sub(
+      std::shared_ptr<SymbolicIntNode> other) {
+    TORCH_CHECK(false, "NYI");
+  };
+  virtual std::shared_ptr<SymbolicIntNode> mul(
+      std::shared_ptr<SymbolicIntNode> other) {
+    TORCH_CHECK(false, "NYI");
+  };
+  virtual std::shared_ptr<SymbolicIntNode> div(
+      std::shared_ptr<SymbolicIntNode> other) {
+    TORCH_CHECK(false, "NYI");
+  };
+  virtual std::shared_ptr<SymbolicIntNode> mod(
+      std::shared_ptr<SymbolicIntNode> other) {
+    TORCH_CHECK(false, "NYI");
+  };
+  virtual std::shared_ptr<SymbolicIntNode> eq(
+      std::shared_ptr<SymbolicIntNode> other) {
+    TORCH_CHECK(false, "NYI");
+  };
+  virtual std::shared_ptr<SymbolicIntNode> gt(
+      std::shared_ptr<SymbolicIntNode> other) {
+    TORCH_CHECK(false, "NYI");
+  };
+  virtual std::shared_ptr<SymbolicIntNode> lt(
+      std::shared_ptr<SymbolicIntNode> other) {
+    TORCH_CHECK(false, "NYI");
+  };
+  virtual std::shared_ptr<SymbolicIntNode> wrap(int64_t num) {
+    TORCH_CHECK(false, "NYI");
+  };
+  virtual bool bool_() {
+    TORCH_CHECK(false, "NYI");
+  };
+  virtual int64_t int_() {
+    TORCH_CHECK(false, "NYI");
+  }
+  virtual std::string str() {
+    TORCH_CHECK(false, "NYI");
+  };
   virtual std::ostream& operator<<(std::ostream& os) {
+    os << str();
     return os;
   };
 };

--- a/c10/core/SymbolicIntNode.h
+++ b/c10/core/SymbolicIntNode.h
@@ -15,35 +15,35 @@ class C10_API SymbolicIntNode
   virtual ~SymbolicIntNode(){};
   // these could be pure virtual when we implement LTC versions
   virtual std::shared_ptr<SymbolicIntNode> add(
-      std::shared_ptr<SymbolicIntNode> other) {
+      const std::shared_ptr<SymbolicIntNode>& other) {
     TORCH_CHECK(false, "NYI");
   };
   virtual std::shared_ptr<SymbolicIntNode> sub(
-      std::shared_ptr<SymbolicIntNode> other) {
+      const std::shared_ptr<SymbolicIntNode>& other) {
     TORCH_CHECK(false, "NYI");
   };
   virtual std::shared_ptr<SymbolicIntNode> mul(
-      std::shared_ptr<SymbolicIntNode> other) {
+      const std::shared_ptr<SymbolicIntNode>& other) {
     TORCH_CHECK(false, "NYI");
   };
   virtual std::shared_ptr<SymbolicIntNode> div(
-      std::shared_ptr<SymbolicIntNode> other) {
+      const std::shared_ptr<SymbolicIntNode>& other) {
     TORCH_CHECK(false, "NYI");
   };
   virtual std::shared_ptr<SymbolicIntNode> mod(
-      std::shared_ptr<SymbolicIntNode> other) {
+      const std::shared_ptr<SymbolicIntNode>& other) {
     TORCH_CHECK(false, "NYI");
   };
   virtual std::shared_ptr<SymbolicIntNode> eq(
-      std::shared_ptr<SymbolicIntNode> other) {
+      const std::shared_ptr<SymbolicIntNode>& other) {
     TORCH_CHECK(false, "NYI");
   };
   virtual std::shared_ptr<SymbolicIntNode> gt(
-      std::shared_ptr<SymbolicIntNode> other) {
+      const std::shared_ptr<SymbolicIntNode>& other) {
     TORCH_CHECK(false, "NYI");
   };
   virtual std::shared_ptr<SymbolicIntNode> lt(
-      std::shared_ptr<SymbolicIntNode> other) {
+      const std::shared_ptr<SymbolicIntNode>& other) {
     TORCH_CHECK(false, "NYI");
   };
   virtual std::shared_ptr<SymbolicIntNode> wrap(int64_t num) {

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -795,6 +795,15 @@ void TensorImpl::ShareExternalPointer(
   }
 }
 
+void TensorImpl::set_sym_sizes_and_strides(
+    c10::SymIntArrayRef sizes,
+    c10::SymIntArrayRef strides) {
+  has_symbolic_sizes_strides_ = true;
+  sizes_strides_policy_ = static_cast<uint8_t>(SizesStridesPolicy::CustomSizes);
+  sizes_and_strides_.set_sizes(sizes);
+  sizes_and_strides_.set_strides(strides);
+}
+
 namespace impl {
 
 namespace {

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -2321,8 +2321,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     // Customizable sizes behavior, e.g., nested tensor
     //
     // Can override: strides(), is_contiguous(), sizes(), dim(), numel()
-    CustomSizes = 2,
-    CustomSymSizes = 3,
+    CustomSizes = 2
   };
 
   void set_sizes_strides_policy(SizesStridesPolicy policy) {

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -551,7 +551,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   c10::SymIntArrayRef sym_sizes() const {
     if (C10_UNLIKELY(
             sizes_strides_policy_ >=
-            static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
+            static_cast<uint8_t>(SizesStridesPolicy::CustomSymSizes))) {
       return sym_sizes_custom();
     }
     return sym_sizes_default();
@@ -1305,6 +1305,12 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   inline bool is_empty() const {
     return numel() == 0;
   }
+
+  // if we are going to use sym sizes, we should be setting sym strides at the
+  // same time, otherwise it's very easy to misuse this API
+  void set_sym_sizes_and_strides(
+      c10::SymIntArrayRef sizes,
+      c10::SymIntArrayRef strides);
 
   /**
    * Change the size at some dimension.  This DOES NOT update strides;
@@ -2321,6 +2327,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     //
     // Can override: strides(), is_contiguous(), sizes(), dim(), numel()
     CustomSizes = 2,
+    CustomSymSizes = 3,
   };
 
   void set_sizes_strides_policy(SizesStridesPolicy policy) {
@@ -2331,6 +2338,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     custom_device_ = custom_device;
   }
 
+ protected:
   Storage storage_;
 
  private:

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -548,12 +548,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     return sizes_default();
   }
 
-  c10::SymIntArrayRef sym_sizes() const {
-    if (C10_UNLIKELY(
-            sizes_strides_policy_ >=
-            static_cast<uint8_t>(SizesStridesPolicy::CustomSymSizes))) {
-      return sym_sizes_custom();
-    }
+  virtual c10::SymIntArrayRef sym_sizes() const {
     return sym_sizes_default();
   }
 

--- a/c10/core/impl/SizesAndStrides.h
+++ b/c10/core/impl/SizesAndStrides.h
@@ -170,6 +170,11 @@ class C10_API SizesAndStrides {
     std::copy(newSizes.begin(), newSizes.end(), sizes_begin());
   }
 
+  void set_strides(SymIntArrayRef strides) {
+    TORCH_INTERNAL_ASSERT(strides.size() == size());
+    std::copy(strides.begin(), strides.end(), strides_begin());
+  }
+
   void set_sizes(IntArrayRef newSizes) {
     set_sizes(SymIntArrayRef::fromIntArrayRef(newSizes));
   }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -320,6 +320,7 @@ coverage_ignore_classes = [
     "Quantize",
     # torch.utils.backcompat
     "Warning",
+    "SymbolicIntNode"
 ]
 
 # The suffix(es) of source filenames.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ setuptools
 six
 types-dataclasses
 typing_extensions
+sympy

--- a/test/lazy/test_reuse_ir.py
+++ b/test/lazy/test_reuse_ir.py
@@ -8,7 +8,7 @@ import torch._lazy.ts_backend
 import torch._lazy.metrics as metrics
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
 import os
-from unittest import skip, skipIf
+from unittest import skipIf
 
 torch._lazy.ts_backend.init()
 torch._lazy.config.set_reuse_ir(True)

--- a/test/lazy/test_reuse_ir.py
+++ b/test/lazy/test_reuse_ir.py
@@ -16,7 +16,7 @@ torch._lazy.config.set_reuse_ir(True)
 def get_test_device():
     return 'cuda' if 'LTC_TS_CUDA' in os.environ else 'cpu'
 
-unittest.skipIf(IS_WINDOWS, "To be fixed")
+@unittest.skipIf(IS_WINDOWS, "To be fixed")
 class TestLazyReuseIr(TestCase):
     def testAdd(self):
         device = get_test_device()

--- a/test/lazy/test_reuse_ir.py
+++ b/test/lazy/test_reuse_ir.py
@@ -8,7 +8,7 @@ import torch._lazy.ts_backend
 import torch._lazy.metrics as metrics
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
 import os
-from unittest import skipIf
+import unittest
 
 torch._lazy.ts_backend.init()
 torch._lazy.config.set_reuse_ir(True)
@@ -16,7 +16,7 @@ torch._lazy.config.set_reuse_ir(True)
 def get_test_device():
     return 'cuda' if 'LTC_TS_CUDA' in os.environ else 'cpu'
 
-skipIf(IS_WINDOWS, "To be fixed")
+unittest.skipIf(IS_WINDOWS, "To be fixed")
 class TestLazyReuseIr(TestCase):
     def testAdd(self):
         device = get_test_device()

--- a/test/lazy/test_ts_opinfo.py
+++ b/test/lazy/test_ts_opinfo.py
@@ -17,6 +17,7 @@ import itertools
 import yaml
 import os
 import pathlib
+from unittest import skip
 
 torch._lazy.ts_backend.init()
 
@@ -66,6 +67,9 @@ def clone_move(t):
     return copy_t
 
 class TestLazyTensor(JitTestCase):
+
+
+    @skip("Disable until autograd supports symints")
     def testConvolutionBackward(self):
         test_device = get_test_device()
         inp = torch.rand(1, 3, 128, 128, device=test_device, requires_grad=True)
@@ -220,8 +224,9 @@ class TestLazyDynamicOps(TestCase):
         x1 = torch.tensor([[0, 1.0, 2.0], [3.0, 0, 0]], device=test_device, requires_grad=True)
         x1_lazy = clone_move(x1)
         x2_lazy = torch.nonzero(x1_lazy)
-        print(x2_lazy.size())
-        self.assertEqual(tuple(x2_lazy.size()), (6, 2))
+
+        # FIXME: Add bindings to get upper bounds
+        # self.assertEqual(tuple(x2_lazy.size()), (6, 2))
 
         # We should still be able to instantiate it and get the actual result
         x2_eager = x2_lazy.cpu()

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+# Owner(s): ["oncall: jit"]
+
+from torch._C import _disabled_torch_function_impl
+from torch.testing._internal.common_utils import run_tests, TestCase
+import unittest
+import torch
+from torch.utils._pytree import tree_map
+from contextlib import contextmanager
+aten = torch.ops.aten
+
+
+try:
+    import sympy
+    HAS_SYMPY = True
+except ImportError:
+    HAS_SYMPY = False
+skipIfNoSympy = unittest.skipIf(not HAS_SYMPY, "no sympy")
+
+
+@contextmanager
+def no_dispatch():
+    guard = torch._C._DisableTorchDispatch()  # type: ignore[attr-defined]
+    try:
+        yield
+    finally:
+        del guard
+
+
+meta_funcs = {}
+
+
+def register_meta(op):
+    def decorator(f):
+        def add_func(op):
+            meta_funcs[op] = f
+        tree_map(add_func, op)
+        return f
+    return decorator
+
+
+@register_meta([aten.add.Tensor, aten.sub.Tensor])
+def binary_meta(a, b):
+    return a.new_empty(a.shape)
+
+
+@register_meta(aten.cat.default)
+def cat_meta(tensors, dim=0):
+    concat_length = 0
+    shape = tensors[0].shape
+    for tensor in tensors:
+        for idx, (common_length, length) in enumerate(zip(shape, tensor.shape)):
+            if idx == dim:
+                concat_length = concat_length + length
+            else:
+                assert length == common_length
+    new_shape = list(shape)
+    new_shape[dim] = concat_length
+    return tensors[0].new_empty(new_shape)
+
+
+@register_meta([aten.narrow_copy.SymInt])
+def narrow_copy_symint_meta(a, dim, start, length, **kwargs):
+    shape = []
+    for i, x in enumerate(a.shape):
+        if i == dim:
+            shape.append(length)
+        else:
+            shape.append(x)
+    return a.new_empty(tuple(shape))
+
+
+@register_meta([aten.expand.SymInt])
+def expand_symint_meta(a, size, implicit=False):
+    return a.new_empty(size)
+
+
+class PySymInt(object):
+    def __init__(self, expr, shape_env):
+        self.expr = expr
+        self.shape_env = shape_env
+
+    def wrap(self, num):
+        return PySymInt(sympy.Integer(num), self.shape_env)
+
+    def __str__(self):
+        return f"PySymInt({self.expr})"
+
+    def __int__(self):
+        return self.shape_env.evaluate_expr(self.expr)
+
+    def __bool__(self):
+        return bool(self.shape_env.evaluate_expr(self.expr))
+
+
+magic_methods = {
+    'add': lambda a, b: a + b,
+    'radd': lambda a, b: a + b,
+    'sub': lambda a, b: a - b,
+    'mul': lambda a, b: a * b,
+    'div': lambda a, b: a / b,
+    'mod': lambda a, b: a % b,
+    'eq': lambda a, b: sympy.Eq(a, b),
+    'gt': lambda a, b: sympy.Gt(a, b),
+    'lt': lambda a, b: sympy.Lt(a, b),
+}
+
+for method, func in magic_methods.items():
+    method_name = f'{method}'
+
+    def create_magic_impl(func):
+        def magic_impl(self, other):
+            if isinstance(other, PySymInt):
+                other = other.expr
+            return PySymInt(func(self.expr, other), self.shape_env)
+        return magic_impl
+
+    # this should be wrapped transparently into torch._C.SymbolicIntNode
+    setattr(PySymInt, method_name, create_magic_impl(func))
+
+
+class ShapeEnv(object):
+    def __init__(self):
+        self.guards = []
+        self.shape_env = {}
+
+    def create_symint(self, name, val):
+        sympy_expr = sympy.Symbol(name)
+        py_sym_int = PySymInt(sympy_expr, self)
+        cpp_sym_int = torch._C.SymbolicIntNode.new_symint(py_sym_int)
+        self.shape_env[sympy_expr] = val
+        return cpp_sym_int
+
+    def evaluate_expr(self, expr):
+        concrete_val = expr.subs(self.shape_env)
+        self.guards.append((expr, concrete_val))
+        return concrete_val
+
+
+def create_contiguous(shape):
+    strides = [1]
+    for dim in reversed(shape[:-1]):
+        strides.append(dim * strides[-1])
+    return list(reversed(strides))
+
+
+class FakeSymbolicTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, sym_shape, sym_strides, dtype, layout, requires_grad, device):
+        # sym_strides doesn't work yet
+        # TODO: this is wrong in general
+        offset = 0
+        r = torch.Tensor._make_wrapper_subclass(
+            cls, sym_shape,
+            create_contiguous(sym_shape), offset,
+            dtype=dtype, layout=layout, requires_grad=requires_grad,
+            device=device,
+        )
+        return r
+
+    __torch_function__ = _disabled_torch_function_impl
+
+    def new_empty(self, shape):
+        return FakeSymbolicTensor(shape, None, self.dtype, self.layout, self.requires_grad, self.device)
+
+    @classmethod
+    def __torch_dispatch__(cls, func_overload, types, args=(), kwargs=None):
+        if func_overload in meta_funcs:
+            return meta_funcs[func_overload](*args, **kwargs)
+
+        if func_overload == torch.ops.aten.new_empty.default:
+            self = args[0]
+            shape = args[1]
+            return FakeSymbolicTensor(shape, self.stride(), self.dtype, self.layout, self.requires_grad, self.device)
+
+        raise RuntimeError(f"operator {func_overload} not supported")
+
+
+def create_symbolic_tensor(name, arg, shape_env):
+    sym_shapes = tuple([shape_env.create_symint(f"{name}_{idx}", val) for idx, val in enumerate(arg.size())])
+    sym_strides = tuple([shape_env.create_symint(f"{name}_{idx}_stride", val) for idx, val in enumerate(arg.stride())])
+    return FakeSymbolicTensor(sym_shapes, sym_strides, arg.dtype, arg.layout, arg.requires_grad, arg.device)
+
+
+CPP_SYMINT_CLASS = type(torch._C.SymbolicIntNode.new_symint(1))
+
+
+class TestPySymInt(TestCase):
+
+    @skipIfNoSympy
+    def test_roundtrip(self):
+        shape_env = ShapeEnv()
+        x = create_symbolic_tensor("x", torch.randn(5, 4, 3), shape_env)
+        self.assertTrue(not isinstance(x.shape[0], PySymInt))
+        self.assertTrue(isinstance(x.shape[0], CPP_SYMINT_CLASS))
+
+        self.assertEqual(int(x.shape[0]), 5)
+        self.assertEqual(int(x.shape[1]), 4)
+        self.assertEqual(int(x.shape[2]), 3)
+
+        self.assertEqual(int(x.size()[0]), 5)
+        self.assertEqual(int(x.size()[1]), 4)
+        self.assertTrue(isinstance(x.size()[1], CPP_SYMINT_CLASS))
+        self.assertEqual(int(x.size()[2]), 3)
+
+        self.assertEqual(int(x.size(0)), 5)
+        self.assertEqual(int(x.size(1)), 4)
+        self.assertEqual(int(x.size(2)), 3)
+        self.assertTrue(isinstance(x.size(2), CPP_SYMINT_CLASS))
+
+    @skipIfNoSympy
+    def test_binary(self):
+        shape_env = ShapeEnv()
+        x = create_symbolic_tensor("x", torch.randn(5, 4, 3), shape_env)
+        y = create_symbolic_tensor("y", torch.randn(5, 4, 3), shape_env)
+
+        z = x + y
+        self.assertEqual(int(z.shape[0]), 5)
+        self.assertEqual(int(z.shape[1]), 4)
+        self.assertEqual(int(z.shape[2]), 3)
+
+        # broadcasting
+        y = create_symbolic_tensor("y", torch.randn(1, 4, 1), shape_env)
+        z = x + y
+        self.assertEqual(int(z.shape[0]), 5)
+        self.assertEqual(int(z.shape[1]), 4)
+        self.assertEqual(int(z.shape[2]), 3)
+
+    @skipIfNoSympy
+    def test_symint_args(self):
+        shape_env = ShapeEnv()
+        x = create_symbolic_tensor("x", torch.randn(5, 4, 3), shape_env)
+        y = create_symbolic_tensor("y", torch.randn(5, 4, 1), shape_env)
+        LAST_DIM = 2
+        z = x.narrow_copy(LAST_DIM, 0, y.shape[LAST_DIM])
+        self.assertEqual(int(z.shape[2]), int(y.shape[2]))
+
+        # arithmetic expr with two symints
+        z = x.narrow_copy(LAST_DIM, 0, x.shape[LAST_DIM] - y.shape[LAST_DIM])
+        self.assertEqual(int(z.shape[2]), 2)
+
+        # arithmetic expr with a symint and python int
+        z = x.narrow_copy(LAST_DIM, 0, x.shape[LAST_DIM] - 1)
+        self.assertEqual(int(z.shape[2]), 2)
+
+    @skipIfNoSympy
+    def test_symint_vargs(self):
+        shape_env = ShapeEnv()
+        x = create_symbolic_tensor("x", torch.randn(5, 4, 3), shape_env)
+        y = create_symbolic_tensor("y", torch.randn(1, 4, 1), shape_env)
+
+        # varargs
+        z = y.expand(x.shape[0], y.shape[1], x.shape[2])
+        self.assertEqual(int(z.shape[0]), 5)
+        self.assertEqual(int(z.shape[1]), 4)
+        self.assertEqual(int(z.shape[2]), 3)
+
+        # shape list
+        z = y.expand((x.shape[0], y.shape[1], x.shape[2]))
+        self.assertEqual(int(z.shape[0]), 5)
+        self.assertEqual(int(z.shape[1]), 4)
+        self.assertEqual(int(z.shape[2]), 3)
+
+        # mixed python symints and ints
+        z = y.expand(x.shape[0], y.shape[1], 3)
+        self.assertEqual(int(z.shape[0]), 5)
+        self.assertEqual(int(z.shape[1]), 4)
+        self.assertEqual(int(z.shape[2]), 3)
+
+        # mixed python symints and ints in a list
+        z = y.expand((x.shape[0], y.shape[1], 3))
+        self.assertEqual(int(z.shape[0]), 5)
+        self.assertEqual(int(z.shape[1]), 4)
+        self.assertEqual(int(z.shape[2]), 3)
+
+        # mixed python symints and ints
+        z = y.expand(5, y.shape[1], x.shape[2])
+        self.assertEqual(int(z.shape[0]), 5)
+        self.assertEqual(int(z.shape[1]), 4)
+        self.assertEqual(int(z.shape[2]), 3)
+
+        # mixed python ints and symints in a list
+        z = y.expand((5, y.shape[1], x.shape[2]))
+        self.assertEqual(int(z.shape[0]), 5)
+        self.assertEqual(int(z.shape[1]), 4)
+        self.assertEqual(int(z.shape[2]), 3)
+
+    @skipIfNoSympy
+    def test_size_expressions(self):
+        shape_env = ShapeEnv()
+        x = create_symbolic_tensor("x", torch.randn(5), shape_env)
+        expand_x = x.expand(x.shape[0], x.shape[0])
+        if expand_x.shape[0] > 3:
+            result = expand_x + expand_x
+        else:
+            result = expand_x + expand_x
+
+        gt_op = shape_env.guards[0][0]
+        self.assertTrue(isinstance(gt_op, sympy.core.relational.StrictGreaterThan))
+        self.assertTrue(str(x.shape[0]), str(gt_op.args[0]))
+        self.assertTrue(str(expand_x.shape[1]), str(x.shape[0]))
+        self.assertTrue(str(expand_x.shape[1]), str(result.shape[0]))
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -6,9 +6,7 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 import unittest
 import torch
 from torch.utils._pytree import tree_map
-from contextlib import contextmanager
 aten = torch.ops.aten
-
 
 try:
     import sympy
@@ -16,15 +14,6 @@ try:
 except ImportError:
     HAS_SYMPY = False
 skipIfNoSympy = unittest.skipIf(not HAS_SYMPY, "no sympy")
-
-
-@contextmanager
-def no_dispatch():
-    guard = torch._C._DisableTorchDispatch()  # type: ignore[attr-defined]
-    try:
-        yield
-    finally:
-        del guard
 
 
 meta_funcs = {}

--- a/test/test_dynamic_shapes_horace.py
+++ b/test/test_dynamic_shapes_horace.py
@@ -64,125 +64,14 @@ def sum_meta(x):
 def expand_symint_meta(a, size, implicit=False):
     return a.new_empty(size)
 
-
-class PySymInt(object):
-    def __init__(self, expr, shape_env):
-        self.expr = expr
-        self.shape_env = shape_env
-
-    def wrap(self, num):
-        return PySymInt(sympy.Integer(num), self.shape_env)
-
-    def __str__(self):
-        return f"PySymInt({self.expr})"
-
-    def __int__(self):
-        # import pdb; pdb.set_trace()
-        return self.shape_env.evaluate_expr(self.expr)
-
-    def __bool__(self):
-        return bool(self.shape_env.evaluate_expr(self.expr))
-
-magic_methods = {
-    'add': lambda a, b: a + b,
-    'radd': lambda a, b: a + b,
-    'sub': lambda a, b: a - b,
-    'mul': lambda a, b: a * b,
-    'div': lambda a, b: a / b,
-    'mod': lambda a, b: a % b,
-    'eq': lambda a, b: sympy.Eq(a, b),
-    'gt': lambda a, b: sympy.Gt(a, b),
-    'lt': lambda a, b: sympy.Lt(a, b),
-}
-
-for method, func in magic_methods.items():
-    method_name = f'{method}'
-    def create_magic_impl(func):
-        def magic_impl(self, other):
-            if isinstance(other, PySymInt):
-                other = other.expr
-            return PySymInt(func(self.expr, other), self.shape_env)
-        return magic_impl
-
-    # this should be wrapped transparently into torch._C.SymbolicIntNode
-    setattr(PySymInt, method_name, create_magic_impl(func))
-
-
-class ShapeEnv(object):
-    def __init__(self):
-        self.guards = []
-        self.shape_env = {}
-
-    def create_symint(self, name, val):
-        sympy_expr = sympy.Symbol(name)
-        py_sym_int = PySymInt(sympy_expr, self)
-        cpp_sym_int = torch._C.SymbolicIntNode.new_symint(py_sym_int)
-        self.shape_env[sympy_expr] = val
-        return cpp_sym_int
-
-    def evaluate_expr(self, expr):
-        concrete_val = expr.subs(self.shape_env)
-        self.guards.append((expr, concrete_val))
-        return concrete_val
-
-
-def create_contiguous(shape):
-    if len(shape) == 0:
-        return []
-    strides = [1]
-    for dim in reversed(shape[:-1]):
-        strides.append(dim * strides[-1])
-    return list(reversed(strides))
-
-class FakeSymbolicTensor(torch.Tensor):
-    @staticmethod
-    def __new__(cls, sym_shape, sym_strides, dtype, layout, requires_grad, device):
-        # sym_strides doesn't work yet
-        # TODO: this is wrong in general
-        offset = 0
-        contiguous_strides = create_contiguous(sym_shape)
-        print(sym_shape, contiguous_strides)
-        r = torch.Tensor._make_wrapper_subclass(
-            cls, sym_shape,
-            contiguous_strides, offset,
-            dtype=dtype, layout=layout, requires_grad=requires_grad,
-            device=device
-        )
-        return r
-
-    __torch_function__ = _disabled_torch_function_impl
-
-
-    def new_empty(self, shape):
-        return FakeSymbolicTensor(shape, None, self.dtype, self.layout, self.requires_grad, self.device)
-
-    @classmethod
-    def __torch_dispatch__(cls, func_overload, types, args=(), kwargs=None):
-        if func_overload in meta_funcs:
-            return meta_funcs[func_overload](*args, **kwargs)
-
-        if func_overload == torch.ops.aten.new_empty.default:
-            self = args[0]
-            shape = args[1]
-            return FakeSymbolicTensor(shape, self.stride(), self.dtype, self.layout, self.requires_grad, self.device)
-
-        raise RuntimeError(f"operator {func_overload} not supported")
-
-
-def create_symbolic_tensor(name, arg, shape_env):
-   sym_shapes = tuple([shape_env.create_symint(f"{name}_{idx}", val) for idx, val in enumerate(arg.size())])
-   sym_strides = tuple([shape_env.create_symint(f"{name}_{idx}_stride", val) for idx, val in enumerate(arg.stride())])
-   return FakeSymbolicTensor(sym_shapes, sym_strides, arg.dtype, arg.layout, arg.requires_grad, arg.device)
-
 from functorch import make_fx
 
-shape_env = ShapeEnv()
-x = create_symbolic_tensor("x", torch.randn(3,4,5, requires_grad=True), shape_env)
+x = torch.randn(3, 4, 5, requires_grad=True)
 
 def f(y):
     x = y * 2
+    assert x.shape[0] > 1
     x = x.sum()
-    # x = x.expand(y.shape)
     # return x
     return torch.autograd.grad(x, y)
 
@@ -190,7 +79,7 @@ traced_graph = make_fx(f, decomposition_table={torch.ops.aten.detach.default: la
 traced_graph.graph.eliminate_dead_code()
 traced_graph.recompile()
 print(traced_graph)
-print(shape_env.guards)
+print(traced_graph.shape_env.guards)
 
 exit(0)
 y = (x + 2).sum()

--- a/test/test_dynamic_shapes_horace.py
+++ b/test/test_dynamic_shapes_horace.py
@@ -1,0 +1,206 @@
+from typing import Sequence
+import sympy
+import torch
+import torch.fx as fx
+from torch.utils._pytree import tree_map
+import operator
+from contextlib import contextmanager
+from torch._meta_registrations import meta_funcs, register_meta
+# from torch.fx.experimental.proxy_tensor import PySymInt
+aten = torch.ops.aten
+
+from torch._C import _disabled_torch_function_impl
+
+@contextmanager
+def no_dispatch():
+    guard = torch._C._DisableTorchDispatch()  # type: ignore[attr-defined]
+    try:
+        yield
+    finally:
+        del guard
+
+@register_meta(aten.detach.default)
+def nop(x):
+    return x
+# meta_funcs = {}
+
+# def register_meta(op):
+#     def decorator(f):
+#         def add_func(op):
+#             meta_funcs[op] = f
+#         tree_map(add_func, op)
+#         return f
+#     return decorator
+
+@register_meta(aten.ones_like.default)
+def n_like(arg, **kwargs):
+    return arg.new_empty(arg.shape)
+
+@register_meta([aten.add.Tensor, aten.sub.Tensor, aten.mul.Tensor])
+def binary_meta(a, b):
+    return a.new_empty(a.shape)
+
+@register_meta(aten.cat.default)
+def cat_meta(tensors, dim=0):
+    concat_length = 0
+    shape = tensors[0].shape
+    for tensor in tensors:
+        for idx, (common_length, length) in enumerate(zip(shape, tensor.shape)):
+            if idx == dim:
+                concat_length = concat_length + length
+            else:
+                assert length == common_length
+    new_shape = list(shape)
+    new_shape[dim] = concat_length
+    return tensors[0].new_empty(new_shape)
+
+
+@register_meta(aten.sum.default)
+def sum_meta(x):
+    return x.new_empty(())
+
+
+@register_meta(aten.expand.SymInt)
+def expand_symint_meta(a, size, implicit=False):
+    return a.new_empty(size)
+
+
+class PySymInt(object):
+    def __init__(self, expr, shape_env):
+        self.expr = expr
+        self.shape_env = shape_env
+
+    def wrap(self, num):
+        return PySymInt(sympy.Integer(num), self.shape_env)
+
+    def __str__(self):
+        return f"PySymInt({self.expr})"
+
+    def __int__(self):
+        # import pdb; pdb.set_trace()
+        return self.shape_env.evaluate_expr(self.expr)
+
+    def __bool__(self):
+        return bool(self.shape_env.evaluate_expr(self.expr))
+
+magic_methods = {
+    'add': lambda a, b: a + b,
+    'radd': lambda a, b: a + b,
+    'sub': lambda a, b: a - b,
+    'mul': lambda a, b: a * b,
+    'div': lambda a, b: a / b,
+    'mod': lambda a, b: a % b,
+    'eq': lambda a, b: sympy.Eq(a, b),
+    'gt': lambda a, b: sympy.Gt(a, b),
+    'lt': lambda a, b: sympy.Lt(a, b),
+}
+
+for method, func in magic_methods.items():
+    method_name = f'{method}'
+    def create_magic_impl(func):
+        def magic_impl(self, other):
+            if isinstance(other, PySymInt):
+                other = other.expr
+            return PySymInt(func(self.expr, other), self.shape_env)
+        return magic_impl
+
+    # this should be wrapped transparently into torch._C.SymbolicIntNode
+    setattr(PySymInt, method_name, create_magic_impl(func))
+
+
+class ShapeEnv(object):
+    def __init__(self):
+        self.guards = []
+        self.shape_env = {}
+
+    def create_symint(self, name, val):
+        sympy_expr = sympy.Symbol(name)
+        py_sym_int = PySymInt(sympy_expr, self)
+        cpp_sym_int = torch._C.SymbolicIntNode.new_symint(py_sym_int)
+        self.shape_env[sympy_expr] = val
+        return cpp_sym_int
+
+    def evaluate_expr(self, expr):
+        concrete_val = expr.subs(self.shape_env)
+        self.guards.append((expr, concrete_val))
+        return concrete_val
+
+
+def create_contiguous(shape):
+    if len(shape) == 0:
+        return []
+    strides = [1]
+    for dim in reversed(shape[:-1]):
+        strides.append(dim * strides[-1])
+    return list(reversed(strides))
+
+class FakeSymbolicTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, sym_shape, sym_strides, dtype, layout, requires_grad, device):
+        # sym_strides doesn't work yet
+        # TODO: this is wrong in general
+        offset = 0
+        contiguous_strides = create_contiguous(sym_shape)
+        print(sym_shape, contiguous_strides)
+        r = torch.Tensor._make_wrapper_subclass(
+            cls, sym_shape,
+            contiguous_strides, offset,
+            dtype=dtype, layout=layout, requires_grad=requires_grad,
+            device=device
+        )
+        return r
+
+    __torch_function__ = _disabled_torch_function_impl
+
+
+    def new_empty(self, shape):
+        return FakeSymbolicTensor(shape, None, self.dtype, self.layout, self.requires_grad, self.device)
+
+    @classmethod
+    def __torch_dispatch__(cls, func_overload, types, args=(), kwargs=None):
+        if func_overload in meta_funcs:
+            return meta_funcs[func_overload](*args, **kwargs)
+
+        if func_overload == torch.ops.aten.new_empty.default:
+            self = args[0]
+            shape = args[1]
+            return FakeSymbolicTensor(shape, self.stride(), self.dtype, self.layout, self.requires_grad, self.device)
+
+        raise RuntimeError(f"operator {func_overload} not supported")
+
+
+def create_symbolic_tensor(name, arg, shape_env):
+   sym_shapes = tuple([shape_env.create_symint(f"{name}_{idx}", val) for idx, val in enumerate(arg.size())])
+   sym_strides = tuple([shape_env.create_symint(f"{name}_{idx}_stride", val) for idx, val in enumerate(arg.stride())])
+   return FakeSymbolicTensor(sym_shapes, sym_strides, arg.dtype, arg.layout, arg.requires_grad, arg.device)
+
+from functorch import make_fx
+
+shape_env = ShapeEnv()
+x = create_symbolic_tensor("x", torch.randn(3,4,5, requires_grad=True), shape_env)
+
+def f(y):
+    x = y * 2
+    x = x.sum()
+    # x = x.expand(y.shape)
+    # return x
+    return torch.autograd.grad(x, y)
+
+traced_graph = make_fx(f, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(x)
+traced_graph.graph.eliminate_dead_code()
+traced_graph.recompile()
+print(traced_graph)
+print(shape_env.guards)
+
+exit(0)
+y = (x + 2).sum()
+out = torch.autograd.grad(y, x)
+print(out[0].shape)
+exit(0)
+expand_x = x.expand(x.shape[0], x.shape[0])
+if expand_x.shape[0] > 3:
+    result = expand_x + expand_x
+else:
+    result = expand_x + expand_x
+print(torch.cat([expand_x, expand_x]).shape[0])
+print(shape_env.guards)

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -146,7 +146,7 @@ class TestNestedTensor(TestCase):
             a1 = constructor([])
             self.assertRaisesRegex(
                 RuntimeError,
-                "Tensors of type NestedTensorImpl do not have sizes"
+                "Tensors of type NestedTensorImpl do not have sym sizes"
                 if IS_FBCODE
                 else "NestedTensorImpl doesn't support sizes",
                 lambda: a1.size(),

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -188,6 +188,7 @@ class TestPublicBindings(TestCase):
             "StreamObjType",
             "StringType",
             "SUM",
+            "SymbolicIntNode",
             "TensorType",
             "ThroughputBenchmark",
             "TracingState",

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1514,7 +1514,7 @@
   result: auto_element_wise
 
 - name: sum(Tensor self, *, ScalarType? dtype=None) -> Tensor
-  self: grad.expand(self.sizes())
+  self: grad.expand(self.sym_sizes())
   result: auto_linear
 
 - name: sum.dim_IntList(Tensor self, int[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -110,17 +110,15 @@ static PyObject * THPVariable_size(PyObject* self, PyObject* args, PyObject* kwa
   if(r.has_torch_function()){
     return handle_torch_function(r, self, args, kwargs, THPVariableClass, "torch.Tensor");
   }
-
   if (r.idx == 0) {
     if (jit::tracer::isTracing()) {
+      // will error out if a tensor has symints
       return wrap(jit::tracer::getSizeOf(self_, r.toInt64(0)));
     } else {
-      return wrap(self_.size(r.toInt64(0)));
+      return torch::toPyObject(self_.sym_size(r.toInt64(0)));
     }
   } else if (r.idx == 1) {
-    // we can't do the normal wrapping here because IntArrayRef maps to both
-    // torch.Size and tuple in python.
-    return THPSize_New(self_);
+    return THPSize_NewFromSymSizes(self_);
   }
   else if (r.idx == 2) {
     if (jit::tracer::isTracing()) {

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -63,8 +63,8 @@ def _make_grads(outputs: Sequence[torch.Tensor], grads: Sequence[_OptionalTensor
             new_grads.append(grad)
         elif grad is None:
             if out.requires_grad:
-                if out.numel() != 1:
-                    raise RuntimeError("grad can be implicitly created only for scalar outputs")
+                # if out.numel() != 1:
+                #     raise RuntimeError("grad can be implicitly created only for scalar outputs")
                 new_grads.append(torch.ones_like(out, memory_format=torch.preserve_format))
             else:
                 new_grads.append(None)

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -1,8 +1,10 @@
 #include <c10/util/irange.h>
+#include <pybind11/pytypes.h>
 #include <torch/csrc/Size.h>
 
 #include <string>
 #include <torch/csrc/utils/object_ptr.h>
+#include <torch/csrc/utils/python_arg_parser.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
 #include <torch/csrc/utils/python_tuples.h>
@@ -13,6 +15,9 @@
 struct THPSize {
   PyTupleObject tuple;
 };
+
+
+
 
 PyObject * THPSize_New(const torch::autograd::Variable& var)
 {
@@ -40,6 +45,32 @@ PyObject * THPSize_NewFromSizes(int dim, const int64_t *sizes)
   return self.release();
 }
 
+PyObject * THPSize_NewFromSymSizes(const at::Tensor& self_)
+{
+    auto sym_sizes = self_.sym_sizes();
+
+    auto ret = THPObjectPtr(THPSizeType.tp_alloc(&THPSizeType, sym_sizes.size()));
+    if (!ret) throw python_error();
+
+    for (auto i: c10::irange(sym_sizes.size())) {
+      auto si = sym_sizes[i];
+      if (si.is_symbolic()) {
+        TORCH_CHECK(!torch::jit::tracer::isTracing(), "JIT Tracing of SymInts isn't supported");
+        auto py_symint = py::cast(si.toSymbolicIntNode()).release().ptr();
+        PyTuple_SET_ITEM(ret.get(), i, py_symint);
+      } else {
+        if (torch::jit::tracer::isTracing()) {
+          PyObject *py_size_tensor = THPVariable_Wrap(torch::jit::tracer::getSizeOf(self_, i));
+          if (!py_size_tensor) throw python_error();
+          PyTuple_SET_ITEM(ret.get(), i, py_size_tensor);
+        } else {
+          PyTuple_SET_ITEM(ret.get(), i, THPUtils_packInt64(si.data()));
+        }
+      }
+    }
+    return ret.release();
+}
+
 static bool isTracedZeroDimVar(PyObject *item) {
   if (!THPVariable_Check(item)) return false;
   auto & var = THPVariable_Unpack(item);
@@ -54,6 +85,9 @@ static PyObject * THPSize_pynew(PyTypeObject *type, PyObject *args, PyObject *kw
     for (Py_ssize_t i = 0; i < PyTuple_Size(self); ++i) {
       PyObject *item = PyTuple_GET_ITEM(self.get(), i);
       if (THPUtils_checkLong(item)) {
+        continue;
+      }
+      if (torch::is_symint_node(item)) {
         continue;
       }
       if (torch::jit::tracer::isTracing() && isTracedZeroDimVar(item)) {
@@ -86,7 +120,12 @@ static PyObject * THPSize_repr(THPSize *self)
     if (i != 0) {
       repr += ", ";
     }
-    repr += std::to_string(THPUtils_unpackLong(PyTuple_GET_ITEM(self, i)));
+    auto item = PyTuple_GET_ITEM(self, i);
+    auto ih = py::handle(item);
+
+    repr += torch::is_symint_node(ih) ?
+      std::string(py::str(ih)) :
+      std::to_string(THPUtils_unpackLong(PyTuple_GET_ITEM(self, i)));
   }
   repr += "])";
   return THPUtils_packString(repr);

--- a/torch/csrc/Size.h
+++ b/torch/csrc/Size.h
@@ -10,5 +10,6 @@ extern PyTypeObject THPSizeType;
 
 PyObject * THPSize_New(const torch::autograd::Variable& t);
 PyObject * THPSize_NewFromSizes(int dim, const int64_t *sizes);
+PyObject * THPSize_NewFromSymSizes(const at::Tensor& t);
 
 void THPSize_init(PyObject *module);

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -691,16 +691,16 @@ void validate_outputs(
       // AT_ERROR(format_error(ss.str()));
       continue;
     }
-    if (!grad.sizes().equals(metadata.shape())) {
-      if (!at::is_expandable_to(metadata.shape(), grad.sizes())) {
-        std::stringstream ss;
-        ss << "invalid gradient at index " << i << " - got ";
-        ss << grad.sizes() << " but expected shape compatible with ";
-        ss << metadata.shape();
-        AT_ERROR(format_error(ss.str()));
-      }
-      grad = at::sum_to(std::move(grad), metadata.shape());
-    }
+    // if (!grad.sym_sizes().equals(metadata.shape())) {
+    //   if (!at::is_expandable_to(asIntArrayRefSlow(metadata.shape()), asIntArrayRefSlow(grad.sym_sizes()))) {
+    //     std::stringstream ss;
+    //     ss << "invalid gradient at index " << i << " - got ";
+    //     ss << asIntArrayRefSlow(grad.sym_sizes()) << " but expected shape compatible with ";
+    //     ss << asIntArrayRefSlow(metadata.shape());
+    //     AT_ERROR(format_error(ss.str()));
+    //   }
+    //   grad = at::sum_to(std::move(grad), asIntArrayRefSlow(metadata.shape()));
+    // }
 
     bool input_is_complex = isComplexType(c10::typeMetaToScalarType(metadata.options().dtype()));
     bool grad_is_complex = isComplexType(grad.scalar_type());

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -185,7 +185,7 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
   /// of the new input.
   uint32_t add_input_metadata(
     const at::TensorOptions& options,
-    at::IntArrayRef shape,
+    c10::SymIntArrayRef shape,
     bool is_tensor_subclass) noexcept {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     uint32_t input_nr = input_metadata_.size();

--- a/torch/csrc/autograd/functions/accumulate_grad.cpp
+++ b/torch/csrc/autograd/functions/accumulate_grad.cpp
@@ -19,6 +19,7 @@ namespace torch { namespace autograd {
 AccumulateGrad::AccumulateGrad(Variable variable_)
    : Node(/*sequence_nr=*/UINT64_MAX),
    variable(std::move(variable_)) {
+  std::cout<<"22"<<std::endl;
   add_input_metadata(variable);
 }
 

--- a/torch/csrc/autograd/input_metadata.h
+++ b/torch/csrc/autograd/input_metadata.h
@@ -5,6 +5,7 @@
 #include <c10/core/DeviceType.h>
 #include <c10/core/Stream.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
+#include <iostream>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -26,20 +27,20 @@ namespace torch { namespace autograd {
 struct InputMetadata {
   InputMetadata() = default;
 
-  InputMetadata(const at::TensorOptions options, at::IntArrayRef shape, bool is_tensor_subclass)
+  InputMetadata(const at::TensorOptions options, c10::SymIntArrayRef shape, bool is_tensor_subclass)
   : options_{options}, shape_{shape}, is_tensor_subclass_{is_tensor_subclass} {
     auto device_ = options.device();
     stream_ = c10::impl::getDeviceGuardImpl(device_.type())->getStream(device_);
   }
 
   InputMetadata(const at::Tensor& t)
-  : InputMetadata(t.options(), t.sizes(), t.unsafeGetTensorImpl()->is_python_dispatch()) { }
+  : InputMetadata(t.options(), t.sym_sizes(), t.unsafeGetTensorImpl()->is_python_dispatch()) { std::cout<<"36"<<std::endl; }
 
   const at::TensorOptions options() const {
     return options_;
   }
 
-  at::IntArrayRef shape() const {
+  c10::SymIntArrayRef shape() const {
     return shape_;
   }
 
@@ -64,12 +65,12 @@ struct InputMetadata {
   }
 
   at::Tensor zeros_like() const {
-    return at::zeros(shape_, options_);
+    return at::zeros(asIntArrayRefSlow(shape_), options_);
   }
 
 private:
   const at::TensorOptions options_;
-  at::DimVector shape_;
+  c10::SymIntArrayRef shape_;
   c10::Stream stream_ = c10::Stream(c10::Stream::Default::DEFAULT, device());
   bool is_tensor_subclass_ = false;
 };

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -678,8 +678,11 @@ static PyObject* THPVariable_make_wrapper_subclass(PyObject*, PyObject* args, Py
       tensor_impl->set_storage_offset(*storage_offset);
     }
 
-    // TODO: r.toBool(10)/dispatch_strides is ignored since setting sym_sizes/sym_strides
-    // will set a different custom policy
+
+    const auto sizes_strides_policy = r.stringViewOptional(10);
+    if (sizes_strides_policy.has_value()) {
+      TORCH_CHECK(false, "Setting sizes_strides_policy isn't suppored for this overload")
+    }
   }
 
   tensor.set_requires_grad(r.toBool(9));

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -602,6 +602,10 @@ static PyObject* THPVariable_make_wrapper_subclass(PyObject*, PyObject* args, Py
       "int64_t? storage_offset=None, MemoryFormat? memory_format=None, ScalarType dtype=None, "
       "Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False, "
       "c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False)",
+      "_make_wrapper_subclass(PyObject* cls, SymIntArrayRef size, SymIntArrayRef strides, "
+      "int64_t? storage_offset=None, MemoryFormat? memory_format=None, ScalarType dtype=None, "
+      "Layout layout=torch.strided, Device device=None, bool pin_memory=False, bool requires_grad=False, "
+      "c10::string_view? dispatch_sizes_strides_policy=None, bool dispatch_device=False)",
   });
   ParsedArgs<12> parsed_args{};
   auto r = parser.parse(args, kwargs, parsed_args);
@@ -634,27 +638,59 @@ static PyObject* THPVariable_make_wrapper_subclass(PyObject*, PyObject* args, Py
   // data
   // TODO: for_blob produces non-resizable tensors, we might want this to be
   // resizable (have to define a custom allocator in that case)
-  auto data = at::for_blob(nullptr, r.intlist(1))
-        .strides(r.intlistOptional(2))
-        .storage_offset(r.toInt64Optional(3))
-        .context(nullptr, [](void *ctx) {})
-        .target_device(options.device())  // TODO: this shouldn't be necessary if it came from options
-        .options(options)
-        .make_tensor();
-  data.set_requires_grad(r.toBool(9));
 
-  const auto sizes_strides_policy = r.stringViewOptional(10);
-  if (sizes_strides_policy.has_value()) {
-    data.unsafeGetTensorImpl()->set_sizes_strides_policy(
-        parseSizesStridesPolicyArgument(*sizes_strides_policy));
+  Tensor tensor;
+  if (r.idx == 0) {
+    tensor = at::for_blob(nullptr, r.intlist(1))
+          .strides(r.intlistOptional(2))
+          .storage_offset(r.toInt64Optional(3))
+          .context(nullptr, [](void *ctx) {})
+          .target_device(options.device())  // TODO: this shouldn't be necessary if it came from options
+          .options(options)
+          .make_tensor();
+
+    const auto sizes_strides_policy = r.stringViewOptional(10);
+    if (sizes_strides_policy.has_value()) {
+      tensor.unsafeGetTensorImpl()->set_sizes_strides_policy(
+          parseSizesStridesPolicyArgument(*sizes_strides_policy));
+    }
+  } else {
+    AutoDispatchBelowADInplaceOrView guard{}; // TODO: Remove.
+    tracer::impl::NoTracerDispatchMode tracer_guard{};
+
+    // We shouldn't need storage
+    Storage storage{Storage::use_byte_size_t{}, 0, at::DataPtr{}};
+
+    tensor = at::detail::make_tensor<TensorImpl>(
+        std::move(storage), options.computeDispatchKey(), options.dtype());
+
+    auto sym_sizes = r.symintlist(1);
+    auto sym_strides = r.symintlist(2);
+
+    TensorImpl* tensor_impl = tensor.unsafeGetTensorImpl();
+
+    // TODO: this should probably be sym_sizes, sym_strides AND offset
+    tensor_impl->set_sym_sizes_and_strides(sym_sizes, sym_strides);
+
+    // TODO: this may need to be symbolic as well
+    auto storage_offset = r.toInt64Optional(3);
+    if (storage_offset) {
+      tensor_impl->set_storage_offset(*storage_offset);
+    }
+
+    // TODO: r.toBool(10)/dispatch_strides is ignored since setting sym_sizes/sym_strides
+    // will set a different custom policy
   }
+
+  tensor.set_requires_grad(r.toBool(9));
+
   if (r.toBool(11)) {
-    data.unsafeGetTensorImpl()->set_custom_device(true);
+    tensor.unsafeGetTensorImpl()->set_custom_device(true);
   }
 
   return THPVariable_NewWithVar(
       (PyTypeObject*)cls,
-      std::move(data),
+      std::move(tensor),
       c10::impl::PyInterpreterStatus::DEFINITELY_UNINITIALIZED);
   END_HANDLE_TH_ERRORS
 }
@@ -1092,7 +1128,7 @@ PyObject *THPVariable_get_shape(THPVariable *self, void *unused)
   if (check_has_torch_function((PyObject *)self)) {
     return handle_torch_function_getter(self, "shape");
   }
-  return THPSize_New(THPVariable_Unpack(self));
+  return THPSize_NewFromSymSizes(THPVariable_Unpack(self));
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch/csrc/autograd/utils/grad_layout_contract.h
+++ b/torch/csrc/autograd/utils/grad_layout_contract.h
@@ -17,7 +17,7 @@ inline bool obeys_layout_contract(const at::Tensor& grad, const at::Tensor& vari
   TORCH_INTERNAL_ASSERT(!variable.is_sparse_csr());
   if (variable.is_non_overlapping_and_dense()) {
     // Only look at stride for dimensions that are not of size 1.
-    const auto& grad_sizes = grad.sizes();
+    const auto& grad_sizes = grad.sym_sizes();
     const auto& grad_strides = grad.strides();
     const auto& variable_strides = variable.strides();
     for (const auto idx : c10::irange(grad_sizes.size())) {

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -598,7 +598,7 @@ const std::shared_ptr<torch::autograd::Node>& VariableHooks::grad_fn(const at::T
         fn->set_next_edges(torch::autograd::collect_next_edges(view_info.base_));
         fn->add_input_metadata(
           view_info.base_.options(),
-          self.sizes(), // Note: sizes(), not base_.sizes(), is intentional
+          self.sym_sizes(), // Note: sizes(), not base_.sizes(), is intentional
           self.unsafeGetTensorImpl()->is_python_dispatch());
         diff_view_meta->grad_fn_ = std::move(fn);
       }

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1179,7 +1179,8 @@ void initJITBindings(PyObject* module) {
       .def(
           "get_pyobj",
           [](std::shared_ptr<c10::SymbolicIntNode> a) -> py::object {
-            if (auto psn = std::dynamic_pointer_cast<PythonSymbolicIntNode>(a)) {
+            if (auto psn =
+                    std::dynamic_pointer_cast<PythonSymbolicIntNode>(a)) {
               return py::reinterpret_borrow<py::object>(psn->getPyObj());
             }
             return py::none();

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1177,6 +1177,14 @@ void initJITBindings(PyObject* module) {
             return std::make_shared<PythonSymbolicIntNode>(obj);
           })
       .def(
+          "get_pyobj",
+          [](std::shared_ptr<c10::SymbolicIntNode> a) -> py::object {
+            if (auto psn = std::dynamic_pointer_cast<PythonSymbolicIntNode>(a)) {
+              return py::reinterpret_borrow<py::object>(psn->getPyObj());
+            }
+            return py::none();
+          })
+      .def(
           "__add__",
           [](std::shared_ptr<c10::SymbolicIntNode> a,
              py::object b) -> std::shared_ptr<c10::SymbolicIntNode> {

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -143,7 +143,7 @@ class PythonSymbolicIntNode : public c10::SymbolicIntNode {
 
   virtual std::shared_ptr<SymbolicIntNode> wrap(int64_t num) override {
     auto r = getPyObj().attr("wrap")(num);
-    return std::shared_ptr<SymbolicIntNode>(new PythonSymbolicIntNode(r));
+    return std::make_shared<PythonSymbolicIntNode>(r);
   }
 
   virtual bool bool_() override {
@@ -163,51 +163,51 @@ class PythonSymbolicIntNode : public c10::SymbolicIntNode {
 
   virtual std::shared_ptr<SymbolicIntNode> dispatch_common_(
       const char* fname,
-      std::shared_ptr<SymbolicIntNode> other) {
+      const std::shared_ptr<SymbolicIntNode>& other) {
     auto pother = std::dynamic_pointer_cast<PythonSymbolicIntNode>(other);
     TORCH_CHECK(pother);
     py::gil_scoped_acquire acquire;
     auto r = getPyObj().attr(fname)(pother->getPyObj());
-    return std::shared_ptr<SymbolicIntNode>(new PythonSymbolicIntNode(r));
+    return std::make_shared<PythonSymbolicIntNode>(r);
   }
 
   virtual std::shared_ptr<SymbolicIntNode> add(
-      std::shared_ptr<SymbolicIntNode> other) override {
+      const std::shared_ptr<SymbolicIntNode>& other) override {
     return dispatch_common_(__FUNCTION__, other);
   }
 
   virtual std::shared_ptr<SymbolicIntNode> sub(
-      std::shared_ptr<SymbolicIntNode> other) override {
+      const std::shared_ptr<SymbolicIntNode>& other) override {
     return dispatch_common_(__FUNCTION__, other);
   }
 
   virtual std::shared_ptr<SymbolicIntNode> mul(
-      std::shared_ptr<SymbolicIntNode> other) override {
+      const std::shared_ptr<SymbolicIntNode>& other) override {
     return dispatch_common_(__FUNCTION__, other);
   }
 
   virtual std::shared_ptr<SymbolicIntNode> div(
-      std::shared_ptr<SymbolicIntNode> other) override {
+      const std::shared_ptr<SymbolicIntNode>& other) override {
     return dispatch_common_(__FUNCTION__, other);
   }
 
   virtual std::shared_ptr<SymbolicIntNode> mod(
-      std::shared_ptr<SymbolicIntNode> other) override {
+      const std::shared_ptr<SymbolicIntNode>& other) override {
     return dispatch_common_(__FUNCTION__, other);
   }
 
   virtual std::shared_ptr<SymbolicIntNode> eq(
-      std::shared_ptr<SymbolicIntNode> other) override {
+      const std::shared_ptr<SymbolicIntNode>& other) override {
     return dispatch_common_(__FUNCTION__, other);
   }
 
   virtual std::shared_ptr<SymbolicIntNode> gt(
-      std::shared_ptr<SymbolicIntNode> other) override {
+      const std::shared_ptr<SymbolicIntNode>& other) override {
     return dispatch_common_(__FUNCTION__, other);
   }
 
   virtual std::shared_ptr<SymbolicIntNode> lt(
-      std::shared_ptr<SymbolicIntNode> other) override {
+      const std::shared_ptr<SymbolicIntNode>& other) override {
     return dispatch_common_(__FUNCTION__, other);
   }
 

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1176,14 +1176,6 @@ void initJITBindings(PyObject* module) {
           [](py::object obj) -> std::shared_ptr<c10::SymbolicIntNode> {
             return std::make_shared<PythonSymbolicIntNode>(obj);
           })
-      .def_static(
-          "cast_to_shared_ptr",
-          [](py::object obj) {
-            std::cerr << "torch::is_symint_node(obj) = " << obj << std::endl;
-            auto n = obj.cast<std::shared_ptr<c10::SymbolicIntNode>>();
-            std::cerr << "symint for " << n->toSymInt() << std::endl;
-            // return false;
-          })
       .def(
           "__add__",
           [](std::shared_ptr<c10::SymbolicIntNode> a,

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1,3 +1,4 @@
+#include <pybind11/pytypes.h>
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/utils/python_arg_parser.h>
 
@@ -11,6 +12,7 @@
 #if (!defined(FBCODE_CAFFE2) && defined(BUILD_ONEDNN_GRAPH))
 #include <torch/csrc/jit/codegen/onednn/interface.h>
 #endif
+#include <c10/core/SymbolicIntNode.h>
 #include <torch/csrc/jit/frontend/ir_emitter.h>
 #include <torch/csrc/jit/frontend/tracer.h>
 #include <torch/csrc/jit/ir/irparser.h>
@@ -103,6 +105,7 @@
 
 #include <ATen/core/function_schema.h>
 
+#include <pybind11/cast.h>
 #include <pybind11/functional.h>
 #include <pybind11/iostream.h>
 #include <pybind11/operators.h>
@@ -122,6 +125,97 @@ using ::c10::Argument;
 using ::c10::FunctionSchema;
 using caffe2::serialize::PyTorchStreamReader;
 using caffe2::serialize::PyTorchStreamWriter;
+
+static std::shared_ptr<c10::SymbolicIntNode> toSymIntNode(
+    std::shared_ptr<c10::SymbolicIntNode> a,
+    py::object b) {
+  return torch::is_symint_node(b)
+      ? b.cast<std::shared_ptr<c10::SymbolicIntNode>>()
+      : a->wrap(b.cast<int64_t>());
+}
+
+class PythonSymbolicIntNode : public c10::SymbolicIntNode {
+ public:
+  PythonSymbolicIntNode(py::object pyobj) : c10::SymbolicIntNode() {
+    pyobj_ = std::make_shared<c10::SafePyObject>(
+        pyobj.release().ptr(), getPyInterpreter());
+  };
+
+  virtual std::shared_ptr<SymbolicIntNode> wrap(int64_t num) override {
+    auto r = getPyObj().attr("wrap")(num);
+    return std::shared_ptr<SymbolicIntNode>(new PythonSymbolicIntNode(r));
+  }
+
+  virtual bool bool_() override {
+    py::gil_scoped_acquire acquire;
+    return getPyObj().attr("__bool__")().is(py::handle(Py_True));
+  }
+
+  virtual int64_t int_() override {
+    py::gil_scoped_acquire acquire;
+    return getPyObj().attr("__int__")().cast<int64_t>();
+  }
+
+  virtual std::string str() override {
+    py::gil_scoped_acquire acquire;
+    return getPyObj().attr("__str__")().cast<std::string>();
+  }
+
+  virtual std::shared_ptr<SymbolicIntNode> dispatch_common_(
+      const char* fname,
+      std::shared_ptr<SymbolicIntNode> other) {
+    auto pother = std::dynamic_pointer_cast<PythonSymbolicIntNode>(other);
+    TORCH_CHECK(pother);
+    py::gil_scoped_acquire acquire;
+    auto r = getPyObj().attr(fname)(pother->getPyObj());
+    return std::shared_ptr<SymbolicIntNode>(new PythonSymbolicIntNode(r));
+  }
+
+  virtual std::shared_ptr<SymbolicIntNode> add(
+      std::shared_ptr<SymbolicIntNode> other) override {
+    return dispatch_common_(__FUNCTION__, other);
+  }
+
+  virtual std::shared_ptr<SymbolicIntNode> sub(
+      std::shared_ptr<SymbolicIntNode> other) override {
+    return dispatch_common_(__FUNCTION__, other);
+  }
+
+  virtual std::shared_ptr<SymbolicIntNode> mul(
+      std::shared_ptr<SymbolicIntNode> other) override {
+    return dispatch_common_(__FUNCTION__, other);
+  }
+
+  virtual std::shared_ptr<SymbolicIntNode> div(
+      std::shared_ptr<SymbolicIntNode> other) override {
+    return dispatch_common_(__FUNCTION__, other);
+  }
+
+  virtual std::shared_ptr<SymbolicIntNode> mod(
+      std::shared_ptr<SymbolicIntNode> other) override {
+    return dispatch_common_(__FUNCTION__, other);
+  }
+
+  virtual std::shared_ptr<SymbolicIntNode> eq(
+      std::shared_ptr<SymbolicIntNode> other) override {
+    return dispatch_common_(__FUNCTION__, other);
+  }
+
+  virtual std::shared_ptr<SymbolicIntNode> gt(
+      std::shared_ptr<SymbolicIntNode> other) override {
+    return dispatch_common_(__FUNCTION__, other);
+  }
+
+  virtual std::shared_ptr<SymbolicIntNode> lt(
+      std::shared_ptr<SymbolicIntNode> other) override {
+    return dispatch_common_(__FUNCTION__, other);
+  }
+
+  py::handle getPyObj() {
+    return py::handle(pyobj_.get()->ptr(getPyInterpreter()));
+  }
+  std::shared_ptr<c10::SafePyObject> pyobj_ = nullptr;
+};
 
 namespace {
 
@@ -1073,6 +1167,100 @@ void initJITBindings(PyObject* module) {
                 c10::nullopt));
           }
         }
+      });
+
+  py::class_<c10::SymbolicIntNode, std::shared_ptr<c10::SymbolicIntNode>>(
+      m, "SymbolicIntNode")
+      .def_static(
+          "new_symint",
+          [](py::object obj) -> std::shared_ptr<c10::SymbolicIntNode> {
+            return std::make_shared<PythonSymbolicIntNode>(obj);
+          })
+      .def_static(
+          "cast_to_shared_ptr",
+          [](py::object obj) {
+            std::cerr << "torch::is_symint_node(obj) = " << obj << std::endl;
+            auto n = obj.cast<std::shared_ptr<c10::SymbolicIntNode>>();
+            std::cerr << "symint for " << n->toSymInt() << std::endl;
+            // return false;
+          })
+      .def(
+          "__add__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a,
+             py::object b) -> std::shared_ptr<c10::SymbolicIntNode> {
+            auto snb = toSymIntNode(a, b);
+            return a->add(snb);
+          })
+      .def(
+          "__radd__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a,
+             py::object b) -> std::shared_ptr<c10::SymbolicIntNode> {
+            auto snb = toSymIntNode(a, b);
+            return a->add(snb);
+          })
+      .def(
+          "__sub__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a,
+             py::object b) -> std::shared_ptr<c10::SymbolicIntNode> {
+            auto snb = toSymIntNode(a, b);
+            return a->sub(snb);
+          })
+      .def(
+          "__mul__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a,
+             py::object b) -> std::shared_ptr<c10::SymbolicIntNode> {
+            auto snb = toSymIntNode(a, b);
+            return a->mul(snb);
+          })
+      .def(
+          "__rmul__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a,
+             py::object b) -> std::shared_ptr<c10::SymbolicIntNode> {
+            auto snb = toSymIntNode(a, b);
+            return a->mul(snb);
+          })
+      .def(
+          "__div__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a,
+             py::object b) -> std::shared_ptr<c10::SymbolicIntNode> {
+            auto snb = toSymIntNode(a, b);
+            return a->div(snb);
+          })
+      .def(
+          "__mod__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a,
+             py::object b) -> std::shared_ptr<c10::SymbolicIntNode> {
+            auto snb = toSymIntNode(a, b);
+            return a->mod(snb);
+          })
+      .def(
+          "__eq__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a,
+             py::object b) -> std::shared_ptr<c10::SymbolicIntNode> {
+            auto snb = toSymIntNode(a, b);
+            return a->eq(snb);
+          })
+      .def(
+          "__gt__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a, py::object b) {
+            auto snb = toSymIntNode(a, b);
+            return a->gt(snb);
+          })
+      .def(
+          "__lt__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a,
+             py::object b) -> std::shared_ptr<c10::SymbolicIntNode> {
+            auto snb = toSymIntNode(a, b);
+            return a->lt(snb);
+          })
+      .def(
+          "__bool__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a) { return a->bool_(); })
+      .def(
+          "__int__",
+          [](std::shared_ptr<c10::SymbolicIntNode> a) { return a->int_(); })
+      .def("__str__", [](std::shared_ptr<c10::SymbolicIntNode> a) {
+        return a->str();
       });
 
   // NOLINTNEXTLINE(bugprone-unused-raii)

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -837,6 +837,10 @@ inline py::object toPyObject(IValue ivalue) {
 #else
     TORCH_CHECK(false, "RRef is only supported with the distributed package");
 #endif
+  } else if (ivalue.isSymInt()) {
+    auto si = ivalue.toSymInt();
+    return si.is_symbolic() ? py::cast(si.toSymbolicIntNode())
+                            : py::cast(si.expect_int());
   } else {
     AT_ERROR(
         "Missing cases in 'toPyObject'! Can't convert ",

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -15,7 +15,7 @@ namespace lazy {
 class TORCH_API SymbolicIntNode: public c10::SymbolicIntNode {
 public:
   SymbolicIntNode(NodePtr ptr): node_(std::move(ptr)) {};
-  virtual std::shared_ptr<c10::SymbolicIntNode> add(std::shared_ptr<c10::SymbolicIntNode> other) override {
+  std::shared_ptr<c10::SymbolicIntNode> add(const std::shared_ptr<c10::SymbolicIntNode>& other) override {
     TORCH_CHECK(false, "NYI");
   }
   NodePtr node_;

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -15,6 +15,9 @@ namespace lazy {
 class TORCH_API SymbolicIntNode: public c10::SymbolicIntNode {
 public:
   SymbolicIntNode(NodePtr ptr): node_(std::move(ptr)) {};
+  virtual std::shared_ptr<c10::SymbolicIntNode> add(std::shared_ptr<c10::SymbolicIntNode> other) override {
+    TORCH_CHECK(false, "NYI");
+  }
   NodePtr node_;
 };
 

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -83,7 +83,7 @@ LTCTensorImpl::LTCTensorImpl(LazyTensor&& tensor)
   // This is a temporary fix for a PyTorch core issue,
   // according to https://github.com/pytorch/xla/pull/2682.
   is_non_overlapping_and_dense_ = false;
-  set_sizes_strides_policy(SizesStridesPolicy::CustomSymSizes);
+  set_sizes_strides_policy(SizesStridesPolicy::CustomSizes);
 
   auto rank = tensor_->shape().Get().sizes().size();
   sym_sizes_.reserve(rank);
@@ -138,6 +138,10 @@ void LTCTensorImpl::shallow_copy_from(
 
 c10::SymIntArrayRef LTCTensorImpl::sym_sizes_custom() const {
   return c10::SymIntArrayRef(sym_sizes_.data(), sym_sizes_.size());
+}
+
+c10::SymIntArrayRef LTCTensorImpl::sym_sizes() const {
+  return sym_sizes_custom();
 }
 
 void LTCTensorImpl::setup_size_properties() {

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -83,7 +83,7 @@ LTCTensorImpl::LTCTensorImpl(LazyTensor&& tensor)
   // This is a temporary fix for a PyTorch core issue,
   // according to https://github.com/pytorch/xla/pull/2682.
   is_non_overlapping_and_dense_ = false;
-  set_sizes_strides_policy(SizesStridesPolicy::CustomSizes);
+  set_sizes_strides_policy(SizesStridesPolicy::CustomSymSizes);
 
   auto rank = tensor_->shape().Get().sizes().size();
   sym_sizes_.reserve(rank);

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -40,6 +40,7 @@ class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
   bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
 
   virtual c10::SymIntArrayRef sym_sizes_custom() const override;
+  virtual c10::SymIntArrayRef sym_sizes() const override;
 
 #ifndef C10_DISABLE_TENSORIMPL_EXTENSIBILITY
   const at::Storage& storage() const override { return tensor_->Storage(); }

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -547,16 +547,30 @@ bool is_float_or_complex_list(PyObject* obj) {
   return true;
 }
 
-static bool is_int_list_(PyObject* obj, int broadcast_size) {
+static bool all_ints_in_tuple(PyObject* obj) {
+    for (auto i: c10::irange(PySequence_Size(obj))) {
+        auto item = py::reinterpret_steal<py::object>(
+        PySequence_GetItem(obj, i));
+      if (!THPUtils_checkIndex(item.ptr())) {
+        return false;
+      }
+    }
+
+    return true;
+}
+
+static bool is_int_list(PyObject* obj, int broadcast_size) {
   if (PyTuple_Check(obj) || PyList_Check(obj)) {
     if (PySequence_Size(obj) == 0) {
       return true;
     }
-    auto item = py::reinterpret_steal<py::object>(
-        PySequence_GetItem(obj, 0));
-    if (THPUtils_checkIndex(item.ptr())) {
+
+    if (all_ints_in_tuple(obj)) {
       return true;
     }
+
+    auto item = py::reinterpret_steal<py::object>(
+      PySequence_GetItem(obj, 0));
     // NOTE: JIT tracer allows arbitrary scalar tensors to act as ints
     // in an intlist argument. Even float or complex scalar tensors.
     return (
@@ -568,22 +582,36 @@ static bool is_int_list_(PyObject* obj, int broadcast_size) {
   return broadcast_size > 0 && THPUtils_checkLong(obj);
 }
 
-static bool is_int_list(PyObject* obj, int broadcast_size) {
-  return is_int_list_(obj, broadcast_size);
-}
-
 static bool is_int_or_symint(PyObject* obj) {
-  if (THPUtils_checkLong(obj)) {
-      return true;
-  }
-
-  // TODO: test if it's the Python binding for SymbolicIntNode
-  return false;
+  // THPUtils_checkIndex may call __index__ or __int__
+  // which may have side effects if obj is a symint node
+  // so we do `is_symint_node` check first
+  // TODO: maybe we should be using checkLong here?
+  return torch::is_symint_node(py::handle(obj)) || THPUtils_checkIndex(obj);
 }
 
 static bool is_int_or_symint_list(PyObject* obj, int broadcast_size) {
-  // TODO: add a check for SymbolicIntNode
-  return is_int_list_(obj, broadcast_size);
+
+  if (PyTuple_Check(obj) || PyList_Check(obj)) {
+    if (PySequence_Size(obj) == 0) {
+      return true;
+    }
+    auto item = py::reinterpret_steal<py::object>(
+        PySequence_GetItem(obj, 0));
+
+    if (is_int_or_symint(item.ptr())) {
+      return true;
+    }
+    // NOTE: JIT tracer allows arbitrary scalar tensors to act as ints
+    // in an intlist argument. Even float or complex scalar tensors.
+    return (
+        jit::tracer::isTracing() &&
+        THPVariable_Check(item.ptr()) &&
+        THPVariable_Unpack(item.ptr()).sizes() == c10::IntArrayRef{});
+  }
+  // if a size is specified (e.g. IntArrayRef[2]) we also allow passing a single int
+  return broadcast_size > 0 && THPUtils_checkLong(obj);
+
 }
 
 // argnum is needed for raising the TypeError, it's used in the error message.
@@ -1036,7 +1064,8 @@ bool FunctionSignature::parse(PyObject* self, PyObject* args, PyObject* kwargs, 
 
   // if there is a single positional IntArrayRef argument, i.e. expand(..), view(...),
   // allow a var-args style IntArrayRef, so expand(5,3) behaves as expand((5,3))
-  if (max_pos_args == 1 && params[0].type_ == ParameterType::INT_LIST) {
+  if (max_pos_args == 1 && (params[0].type_ == ParameterType::INT_LIST ||
+  params[0].type_ == ParameterType::SYM_INT_LIST)) {
     allow_varargs_intlist = true;
   }
 
@@ -1093,7 +1122,9 @@ bool FunctionSignature::parse(PyObject* self, PyObject* args, PyObject* kwargs, 
     // tracer is enabled. This behavior easily leads to ambiguities, and we
     // should avoid having complex signatures that make use of it...
     } else if (allow_varargs_intlist && arg_pos == 0 && !is_kwd &&
-               THPUtils_checkIndex(obj)) {
+                ((param.type_ ==
+                ParameterType::SYM_INT_LIST && is_int_or_symint(obj)
+               ) || all_ints_in_tuple(args))) {
       // take all positional arguments as this parameter
       // e.g. permute(1, 2, 3) -> permute((1, 2, 3))
       dst[i++] = args;

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -40,6 +40,7 @@
 //      they only bind to Tensor).
 
 
+#include <pybind11/pytypes.h>
 #include <torch/csrc/python_headers.h>
 
 #include <torch/csrc/Stream.h>
@@ -74,6 +75,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <c10/core/SymbolicIntNode.h>
 
 namespace torch {
 
@@ -389,9 +391,64 @@ inline std::vector<int64_t> PythonArgs::intlist(int i) {
   return intlistWithDefault(i, signature.params[i].default_intlist);
 }
 
+inline bool is_symint_node(py::handle obj) {
+      auto static tp_symn = py::type::of<c10::SymbolicIntNode>();
+      if (obj.get_type().equal(tp_symn)) {
+        TORCH_CHECK(!jit::tracer::isTracing(), "JIT tracing of SymInts isn't supported!");
+        return true;
+      }
+      return false;
+}
+
+inline PyObject* toPyObject(c10::SymInt symint) {
+      if (symint.is_symbolic()) {
+        return py::cast(symint.toSymbolicIntNode()).release().ptr();
+      } else {
+        return THPUtils_packInt64(symint.data());
+      }
+}
+
 inline std::vector<c10::SymInt> PythonArgs::symintlist(int i) {
-  auto intlist = intlistWithDefault(i, signature.params[i].default_intlist);
-  return c10::fmap(intlist, [](int64_t n) {return c10::SymInt(n); });
+
+  if (!args[i]) {
+    return c10::fmap(signature.params[i].default_intlist, [](int64_t di) {
+      return c10::SymInt(di);
+    });
+  }
+
+  const auto size1 = signature.params[i].size;
+  if (size1 > 0 && THPUtils_checkLong(args[i])) {
+    return std::vector<c10::SymInt>(size1, c10::SymInt(THPUtils_unpackIndex(args[i])));
+  }
+
+  if (size1 > 0 && torch::is_symint_node(py::handle(args[i]))) {
+    auto si = py::handle(args[i]).cast<c10::SymbolicIntNode*>()->toSymInt();
+    return std::vector<c10::SymInt>(size1, si);
+  }
+
+  PyObject* arg = args[i];
+  auto tuple = PyTuple_Check(arg);
+  // NOLINTNEXTLINE(bugprone-branch-clone)
+  const auto size2 = tuple ? PyTuple_GET_SIZE(arg) : PyList_GET_SIZE(arg);
+  std::vector<c10::SymInt> res;
+  res.reserve(size2);
+  for(const auto idx : c10::irange(size2)) {
+    PyObject* obj = tuple ? PyTuple_GET_ITEM(arg, idx) : PyList_GET_ITEM(arg, idx);
+    try {
+      if (is_symint_node(py::handle(obj))) {
+        res.push_back(py::handle(obj).cast<c10::SymbolicIntNode*>()->toSymInt());
+      } else {
+        res.push_back(c10::SymInt(THPUtils_unpackIndex(obj)));
+      }
+    } catch (const std::exception &e) {
+      auto te = TypeError("%s(): argument '%s' must be %s, but found element of type %s at pos %ld",
+          signature.name.c_str(), signature.params[i].name.c_str(),
+          signature.params[i].type_name().c_str(), Py_TYPE(obj)->tp_name, idx + 1);
+    }
+
+  }
+
+  return res;
 }
 
 inline std::vector<int64_t> PythonArgs::intlistWithDefault(int i, std::vector<int64_t> default_intlist) {
@@ -648,6 +705,9 @@ inline c10::SymInt PythonArgs::toSymInt(int i) {
     auto & var = THPVariable_Unpack(args[i]);
     jit::tracer::ArgumentStash::stashValue(
         signature.params[i].name, idx, var, c10::IntType::get());
+  }
+  if (torch::is_symint_node(py::handle(args[i]))) {
+    return py::handle(args[i]).cast<c10::SymbolicIntNode*>()->toSymInt();
   }
   return c10::SymInt(THPUtils_unpackLong(args[i]));
 }

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -393,6 +393,7 @@ inline std::vector<int64_t> PythonArgs::intlist(int i) {
 
 inline bool is_symint_node(py::handle obj) {
       auto static tp_symn = py::type::of<c10::SymbolicIntNode>();
+      // TODO: switch this to `isinstance`
       if (obj.get_type().equal(tp_symn)) {
         TORCH_CHECK(!jit::tracer::isTracing(), "JIT tracing of SymInts isn't supported!");
         return true;

--- a/torch/fx/experimental/fake_symbolic_tensor.py
+++ b/torch/fx/experimental/fake_symbolic_tensor.py
@@ -1,0 +1,105 @@
+import torch
+import sympy
+from torch._C import _disabled_torch_function_impl
+from torch._meta_registrations import meta_funcs, register_meta
+
+def create_contiguous(shape):
+    if len(shape) == 0:
+        return []
+    strides = [1]
+    for dim in reversed(shape[:-1]):
+        strides.append(dim * strides[-1])
+    return list(reversed(strides))
+
+class FakeSymbolicTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, sym_shape, sym_strides, dtype, layout, requires_grad, device):
+        # sym_strides doesn't work yet
+        # TODO: this is wrong in general
+        offset = 0
+        contiguous_strides = create_contiguous(sym_shape)
+        r = torch.Tensor._make_wrapper_subclass(
+            cls, sym_shape,
+            contiguous_strides, offset,
+            dtype=dtype, layout=layout, requires_grad=requires_grad,
+            device=device
+        )
+        return r
+
+    __torch_function__ = _disabled_torch_function_impl
+
+
+    def new_empty(self, shape):
+        return FakeSymbolicTensor(shape, None, self.dtype, self.layout, self.requires_grad, self.device)
+
+    @classmethod
+    def __torch_dispatch__(cls, func_overload, types, args=(), kwargs=None):
+        if func_overload in meta_funcs:
+            return meta_funcs[func_overload](*args, **kwargs)
+
+        if func_overload == torch.ops.aten.new_empty.default:
+            self = args[0]
+            shape = args[1]
+            return FakeSymbolicTensor(shape, self.stride(), self.dtype, self.layout, self.requires_grad, self.device)
+
+        raise RuntimeError(f"operator {func_overload} not supported")
+
+
+class PySymInt(object):
+    def __init__(self, expr, shape_env):
+        self.expr = expr
+        self.shape_env = shape_env
+
+    def wrap(self, num):
+        return PySymInt(sympy.Integer(num), self.shape_env)
+
+    def __str__(self):
+        return f"PySymInt({self.expr})"
+
+    def __int__(self):
+        # import pdb; pdb.set_trace()
+        return self.shape_env.evaluate_expr(self.expr)
+
+    def __bool__(self):
+        return bool(self.shape_env.evaluate_expr(self.expr))
+
+magic_methods = {
+    'add': lambda a, b: a + b,
+    'radd': lambda a, b: a + b,
+    'sub': lambda a, b: a - b,
+    'mul': lambda a, b: a * b,
+    'div': lambda a, b: a / b,
+    'mod': lambda a, b: a % b,
+    'eq': lambda a, b: sympy.Eq(a, b),
+    'gt': lambda a, b: sympy.Gt(a, b),
+    'lt': lambda a, b: sympy.Lt(a, b),
+}
+
+for method, func in magic_methods.items():
+    method_name = f'{method}'
+    def create_magic_impl(func):
+        def magic_impl(self, other):
+            if isinstance(other, PySymInt):
+                other = other.expr
+            return PySymInt(func(self.expr, other), self.shape_env)
+        return magic_impl
+
+    # this should be wrapped transparently into torch._C.SymbolicIntNode
+    setattr(PySymInt, method_name, create_magic_impl(func))
+
+class ShapeEnv(object):
+    def __init__(self):
+        self.guards = []
+        self.shape_env = {}
+
+    def create_symint(self, name, val):
+        sympy_expr = sympy.Symbol(name)
+        py_sym_int = PySymInt(sympy_expr, self)
+        cpp_sym_int = torch._C.SymbolicIntNode.new_symint(py_sym_int)
+        self.shape_env[sympy_expr] = val
+        return cpp_sym_int
+
+    def evaluate_expr(self, expr):
+        concrete_val = expr.subs(self.shape_env)
+        self.guards.append((expr, concrete_val))
+        return concrete_val

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -7,12 +7,14 @@ import functools
 from typing import Any, Dict, Optional, Tuple, Callable, Union
 import torch
 from torch._C import _disabled_torch_function_impl
+from torch.fx.experimental.fake_symbolic_tensor import PySymInt
 import torch.utils._pytree as pytree
 from torch.fx import Tracer, GraphModule
 import torch.fx as fx
 from torch.utils._mode_utils import no_dispatch
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
 from contextlib import contextmanager
+from .fake_symbolic_tensor import FakeSymbolicTensor, create_contiguous, ShapeEnv
 
 from torch.utils._python_dispatch import push_torch_dispatch_mode, TorchDispatchMode
 
@@ -43,7 +45,7 @@ def wrap_output(real_out, proxy_out):
     def wrap_with_proxy(e, proxy):
         if isinstance(e, torch.Tensor):
             with no_dispatch():
-                return ProxyTensor(e, proxy)
+                return ProxyTensor(proxy_out, e.shape, create_contiguous(e.shape), e.dtype, e.layout, e.requires_grad, e.device)
         else:
             return e
 
@@ -61,64 +63,22 @@ def wrap_output(real_out, proxy_out):
 
 from torch.overrides import enable_reentrant_dispatch
 
-def proxy_call(func_overload, args, kwargs=None):
-    func = func_overload.overloadpacket
-    if func_overload in CURRENT_DECOMPOSITION_TABLE:
-        return CURRENT_DECOMPOSITION_TABLE[func_overload](*args, **kwargs)
-    if func_overload == aten._local_scalar_dense.default:
-        raise RuntimeError("It appears that you're trying to get value out of a tracing tensor - erroring out! "
-                           "It's likely that this is caused by data-dependent control flow or similar."
-                           "Try torch.fx.experimental.proxy_tensor.enable_strict(False) to disable this check")
-    def unwrap_elem(e):
-        return e.elem if isinstance(e, ProxyTensor) else e
 
-    def unwrap_proxy(e):
-        return e.proxy if isinstance(e, ProxyTensor) else e
-
-    proxy_args = pytree.tree_map(unwrap_proxy, args)
-    proxy_kwargs = pytree.tree_map(unwrap_proxy, kwargs)
-
-    proxy_out = func(*proxy_args, **proxy_kwargs)
-
-    # Kind of a hacky way to test if an op is in-place or not
-    if func.__name__[-1] == "_" and func.__name__[0] != "_":
-        args[0].proxy = proxy_out
-        proxy_out.node.meta['tensor_meta'] = _extract_tensor_metadata(args[0])
-
-    with enable_reentrant_dispatch():
-        real_out = func_overload(*pytree.tree_map(unwrap_elem, args), **pytree.tree_map(unwrap_elem, kwargs))
-
-    return wrap_output(real_out, proxy_out)
-
-def create_contiguous(shape):
-    if len(shape) == 0:
-        return []
-    strides = [1]
-    for dim in reversed(shape[:-1]):
-        strides.append(dim * strides[-1])
-    return list(reversed(strides))
-
-class ProxyTensor(torch.Tensor):
+class ProxyTensor(FakeSymbolicTensor):
     proxy: fx.Proxy
 
     @staticmethod
-    def __new__(cls, elem, proxy, *, requires_grad=None):
+    def __new__(cls, proxy, sym_shape, sym_strides, dtype, layout, requires_grad, device):
         # Hack to deal with super().__new__ not working for sparse tensors
         def create_proxy_symint(sym_int, new_proxy):
             return torch._C.SymbolicIntNode.new_symint(ProxySymInt(sym_int, new_proxy))
 
-        r = torch.Tensor._make_wrapper_subclass(
-            cls, [create_proxy_symint(elem.shape[i], proxy.size(i)) for i in range(len(elem.shape))],
-            create_contiguous(elem.shape), 0,
-            dtype=elem.dtype, layout=elem.layout, requires_grad=requires_grad if requires_grad is not None else False,
-            device=elem.device
-        )
+        r = super().__new__(cls, [create_proxy_symint(sym_shape[i], proxy.size(i)) for i in range(len(sym_shape))], sym_strides, dtype, layout, requires_grad, device)
+        r.proxy = proxy
         # if elem.is_sparse:
         #     proxy.node.meta['tensor_meta'] = {}
         # else:
         #     proxy.node.meta['tensor_meta'] = _extract_tensor_metadata(r)
-        r.proxy = proxy  # type: ignore[attr-defined]
-        r.elem = elem
 
         return r
 
@@ -133,12 +93,44 @@ class ProxyTensor(torch.Tensor):
 
     @classmethod
     def __torch_dispatch__(cls, func_overload, types, args=(), kwargs=None):
-        return proxy_call(func_overload, args, kwargs)
+        # print(func_overload)
+        func = func_overload.overloadpacket
+        if func_overload in CURRENT_DECOMPOSITION_TABLE:
+            return CURRENT_DECOMPOSITION_TABLE[func_overload](*args, **kwargs)
+        if func_overload == aten._local_scalar_dense.default:
+            raise RuntimeError("It appears that you're trying to get value out of a tracing tensor - erroring out! "
+                            "It's likely that this is caused by data-dependent control flow or similar."
+                            "Try torch.fx.experimental.proxy_tensor.enable_strict(False) to disable this check")
 
-import sympy
+        def unwrap_proxy(e):
+            return e.proxy if isinstance(e, ProxyTensor) else e
+
+        def unwrap_proxyints(shape):
+            return [e.get_pyobj().sym_int if isinstance(e.get_pyobj(), ProxySymInt) else e for e in shape]
+
+        def unwrap_fake(e):
+            if isinstance(e, ProxyTensor):
+                return FakeSymbolicTensor(unwrap_proxyints(e.shape), None, e.dtype, e.layout, e.requires_grad, e.device)
+            return e
+
+        proxy_args = pytree.tree_map(unwrap_proxy, args)
+        proxy_kwargs = pytree.tree_map(unwrap_proxy, kwargs)
+
+        proxy_out = func(*proxy_args, **proxy_kwargs)
+
+        # Kind of a hacky way to test if an op is in-place or not
+        if func.__name__[-1] == "_" and func.__name__[0] != "_":
+            args[0].proxy = proxy_out
+            proxy_out.node.meta['tensor_meta'] = _extract_tensor_metadata(args[0])
+
+        real_out = super().__torch_dispatch__(func_overload, types, pytree.tree_map(unwrap_fake, args), pytree.tree_map(unwrap_fake, kwargs))
+
+        return wrap_output(real_out, proxy_out)
+
 
 class ProxySymInt(object):
     def __init__(self, sym_int, proxy):
+        assert isinstance(sym_int, torch._C.SymbolicIntNode) or isinstance(sym_int, int)
         self.sym_int = sym_int
         self.proxy = proxy
 
@@ -171,17 +163,17 @@ import operator
 for method in magic_methods:
     method_name = f'{method}'
     op = getattr(operator, method_name)
-    def create_magic_impl():
+    def create_magic_impl(op):
         def magic_impl(self, other):
-            def unwrap_proxy(x): return x.proxy if isinstance(x, ProxyTensor) else x
+            def unwrap_proxy(x): return x.proxy if isinstance(x, ProxySymInt) else x
             out_proxy = op(unwrap_proxy(self), unwrap_proxy(other))
             def unwrap_proxyint(x): return x.sym_int if isinstance(x, ProxySymInt) else x
-            out_sym_int = op(unwrap_proxy(self), unwrap_proxyint(other))
+            out_sym_int = op(unwrap_proxyint(self), unwrap_proxyint(other))
             return ProxySymInt(out_sym_int, out_proxy)
         return magic_impl
 
     # this should be wrapped transparently into torch._C.SymbolicIntNode
-    setattr(ProxySymInt, method_name, create_magic_impl())
+    setattr(ProxySymInt, method_name, create_magic_impl(op))
 
 class PythonKeyTracer(Tracer):
     def __init__(self):
@@ -234,7 +226,13 @@ def dispatch_trace(
     return GraphModule(tracer.root, graph, name)
 
 
-def wrap_key(f, inps):
+def create_proxy_tensor_symbolic(proxy, arg, shape_env):
+    sym_shapes = tuple([shape_env.create_symint(f"{proxy.node.name}_{idx}", val) for idx, val in enumerate(arg.size())])
+    sym_strides = tuple([shape_env.create_symint(f"{proxy.node.name}_{idx}_stride", val) for idx, val in enumerate(arg.stride())])
+    return ProxyTensor(proxy, sym_shapes, sym_strides, arg.dtype, arg.layout, arg.requires_grad, arg.device)
+
+
+def wrap_key(f, inps, create_proxy_tensor):
     flat_inps, _ = pytree.tree_flatten(inps)
 
     @functools.wraps(f)
@@ -244,9 +242,7 @@ def wrap_key(f, inps):
         for idx, arg in enumerate(flat_args):
             if isinstance(flat_inps[idx], torch.Tensor):
                 with no_dispatch():
-                    flat_args[idx] = ProxyTensor(flat_inps[idx], arg, requires_grad=(
-                        flat_inps[idx].is_leaf and flat_inps[idx].requires_grad
-                    ))
+                    flat_args[idx] = create_proxy_tensor(flat_args[idx], flat_inps[idx])
             else:
                 flat_args[idx] = flat_inps[idx]
 
@@ -278,17 +274,20 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
 
             return wrap_output(real_out, proxy_out)
 
+from functools import partial
+
 
 def make_fx(f, decomposition_table=None, trace_factory_functions=False):
     if decomposition_table is None:
         decomposition_table = {}
-
     @functools.wraps(f)
     def wrapped(*args):
         phs = pytree.tree_map(lambda x: fx.PH, args)  # type: ignore[attr-defined]
+        shape_env = ShapeEnv()
         with decompose(decomposition_table):
-            t = dispatch_trace(wrap_key(f, args), concrete_args=tuple(phs),
+            t = dispatch_trace(wrap_key(f, args, partial(create_proxy_tensor_symbolic, shape_env = shape_env)), concrete_args=tuple(phs),
                                trace_factory_functions=trace_factory_functions)
+            t.shape_env = shape_env
         return t
 
     return wrapped


### PR DESCRIPTION
Built off of https://github.com/pytorch/pytorch/pull/78135 (code in https://github.com/pytorch/pytorch/blob/25aaa68cffb5dd8e456f2647e83dda0630c5aa9e/test/test_dynamic_shapes_horace.py)

Things we'd like to validate:

- [x] Passing symbolic dims through `shape/sizes` on tensor subclasses (i.e. propagate symints through `__torch_dispatch__`).
- [x] Redispatching operations on SymInts back into the Python-based tensor subclass
- [x] Verify passing SymInts into an operator that takes in SymInts as an input
- [x] Verify passing SymInts through a CompositeImplicitAutograd op
- [x] Verify passing SymInts through autograd.
- [x] Prototype tracing operations on SymInts.
- [x] Prototype how tracing looks like.
