### PR TITLE
[JIT] autodiff - don't create groups for subgraphs without requires_grad

### DIFF
--- a/test/cpp/jit/test_create_autodiff_subgraphs.cpp
+++ b/test/cpp/jit/test_create_autodiff_subgraphs.cpp
@@ -3,12 +3,30 @@
 #include "test/cpp/jit/test_utils.h"
 
 #include "torch/csrc/jit/passes/create_autodiff_subgraphs.h"
+#include "torch/csrc/jit/runtime/graph_iterator.h"
 
 namespace torch {
 namespace jit {
 
 TEST(CreateAutodiffSubgraphsTest, Basic) {
   auto graph = build_lstm();
+  auto add_requires_grad_to_value = [](Value* v) {
+    if (v->type()->kind() == TypeKind::TensorType) {
+      v->setType(v->type()->expectRef<TensorType>().withRequiresGrad(true));
+    }
+  };
+
+  DepthFirstGraphNodeIterator it(graph);
+  Node* n = nullptr;
+  while ((n = it.next()) != nullptr) {
+    for (Value* v : n->outputs()) {
+      add_requires_grad_to_value(v);
+    }
+  }
+  for (Value* v : graph->inputs()) {
+    add_requires_grad_to_value(v);
+  }
+
   CreateAutodiffSubgraphs(graph, /*threshold=*/2);
   // all of the ops are within the DifferentiableGraph
   testing::FileCheck()

--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -484,7 +484,7 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
                 .check_not("aten::t") \
                 .run(graph)
 
-    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING)
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING, "Needs profiling executor")
     def test_has_profiled_info_aliasing_outputs(self):
         # The expectation is that CallFunction will prevent the final profile node from
         # getting merged into the DifferentiableGraph, and that create_autodiff_subgraphs
@@ -519,7 +519,7 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
             .check("aten::relu") \
             .run(graph)
 
-    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING)
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING, "Needs profiling executor")
     def test_diff_graph_inline_no_requires_grad(self):
         with enable_profiling_mode_for_profiling_tests():
             NUM_RUNS = 1

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -962,6 +962,11 @@ void initPythonIRBindings(PyObject* module_) {
       .def(
           "requires_grad",
           [](const TypePtr& self) -> bool { return self->requires_grad(); })
+      .def(
+          "withRequiresGrad",
+          [](const TypePtr& self, bool requires_grad) {
+            return self->expectRef<TensorType>().withRequiresGrad(requires_grad);
+          })
       .def_property_readonly(
           "annotation_str", [](const std::shared_ptr<Type>& self) {
             return self->annotation_str();

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -965,7 +965,8 @@ void initPythonIRBindings(PyObject* module_) {
       .def(
           "withRequiresGrad",
           [](const TypePtr& self, bool requires_grad) {
-            return self->expectRef<TensorType>().withRequiresGrad(requires_grad);
+            return self->expectRef<TensorType>().withRequiresGrad(
+                requires_grad);
           })
       .def_property_readonly(
           "annotation_str", [](const std::shared_ptr<Type>& self) {


### PR DESCRIPTION
Autodiff isn't helpful in graphs where requires_grad=False.