### PR TITLE
[S271837] alias torch._utils_internal

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -6,7 +6,7 @@ import sys
 import types
 
 import torch.jit
-import torch._utils_internal
+import torch._utils_internal as torch_utils_internal
 
 # Query `hasattr` only once.
 _SET_GLOBAL_FLAGS = hasattr(sys, 'getdlopenflags') and hasattr(sys, 'setdlopenflags')
@@ -247,7 +247,7 @@ class _Ops(types.ModuleType):
         if sys.executable == "torch_deploy":
             return
 
-        path = torch._utils_internal.resolve_library_path(path)
+        path = torch_utils_internal.resolve_library_path(path)
         with dl_open_guard():
             # Import the shared library into the process, thus running its
             # static (global) initialization code in order to register custom


### PR DESCRIPTION
Summary:
This is an attempt to fix error:

```
...

  File "/mnt/xarfuse/uid-202090/bfc19816-seed-6bb89c2f-e1c0-4c48-8376-657c47aee7ea-ns-4026533122/torchvision/__init__.py", line 5, in <module>
    from torchvision import datasets
  File "/mnt/xarfuse/uid-202090/bfc19816-seed-6bb89c2f-e1c0-4c48-8376-657c47aee7ea-ns-4026533122/torchvision/datasets/__init__.py", line 1, in <module>
    from ._optical_flow import KittiFlow, Sintel, FlyingChairs, FlyingThings3D, HD1 (https://github.com/pytorch/pytorch/commit/2d884f226365f94833df91de532e3a31b0db310d)K
  File "/mnt/xarfuse/uid-202090/bfc19816-seed-6bb89c2f-e1c0-4c48-8376-657c47aee7ea-ns-4026533122/torchvision/datasets/_optical_flow.py", line 12, in <module>
    from ..io.image import _read_png_16
  File "/mnt/xarfuse/uid-202090/bfc19816-seed-6bb89c2f-e1c0-4c48-8376-657c47aee7ea-ns-4026533122/torchvision/io/__init__.py", line 11, in <module>
    from ._video_opt import (
  File "/mnt/xarfuse/uid-202090/bfc19816-seed-6bb89c2f-e1c0-4c48-8376-657c47aee7ea-ns-4026533122/torchvision/io/_video_opt.py", line 8, in <module>
    from ..extension import _load_library
  File "/mnt/xarfuse/uid-202090/bfc19816-seed-6bb89c2f-e1c0-4c48-8376-657c47aee7ea-ns-4026533122/torchvision/extension.py", line 20, in <module>
    torch.ops.load_library(lib_path)
  File "/mnt/xarfuse/uid-202090/bfc19816-seed-6bb89c2f-e1c0-4c48-8376-657c47aee7ea-ns-4026533122/torch/_ops.py", line 250, in load_library
    path = torch._utils_internal.resolve_library_path(path)
AttributeError: module 'torch' has no attribute '_utils_internal'
```

I don't completely understand the import mechanism, but I tried this in notebook:

```
# module 'torch' has no attribute '_torch_docs'
import torch._torch_docs
torch._torch_docs.common_args

# works
import torch._torch_docs as t
t.common_args
```

Figured I'd try it to see if it works, because in these files, there does exist a `import torch._utils_internal` at the top which didn't fail.

Test Plan: sc

Differential Revision: D36795248

