### PR TITLE
[FSDP] Allow different `optim_input` orders across ranks

### DIFF
--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -231,6 +231,7 @@ class TestFSDPOptimState(FSDPTest):
         group=None,
         optim_class: Type[torch.optim.Optimizer] = torch.optim.Adam,
         use_multiple_param_groups: bool = False,
+        use_diff_optim_inputs: bool = False,
     ):
         model = NestedModel().to(device)
         if wrap:
@@ -243,23 +244,32 @@ class TestFSDPOptimState(FSDPTest):
                 {"params": model.param_group0()},
                 {"params": model.param_group1(), "weight_decay": 0.9}
             ]
+        # Use a reversed parameter order for the optimizer input on odd ranks
+        if use_diff_optim_inputs and self.rank % 2 == 1:
+            if isinstance(optim_input[0], dict):
+                for param_group in optim_input:
+                    param_group["params"] = list(reversed(param_group["params"]))
+            else:
+                optim_input = list(reversed(optim_input))
         optim = optim_class(optim_input, lr=0.01)
         return model, optim, optim_input
 
     def _init_transformer_model(
         self,
         wrap: bool,
-        device: torch.device = torch.device("cuda"),
+        device: torch.device = torch.device("cuda"),  # unused
         group=None,
         optim_class: Type[torch.optim.Optimizer] = torch.optim.Adam,
-        use_multiple_param_groups: bool = False,
+        use_multiple_param_groups: bool = False,  # unused
+        use_diff_optim_inputs: bool = False,  # unused
     ):
-        assert not use_multiple_param_groups, \
-            "Multiple parameter groups for the transformer is not implemented"
+        if use_multiple_param_groups or use_diff_optim_inputs:
+            # Keep these as arguments for parity with `_init_nested_model()`
+            raise NotImplementedError()
         if group is None:
             group = dist.distributed_c10d._get_default_group()
-        model = self._get_wrapped_model(group=group).to(device) if wrap \
-            else self._get_nonwrapped_model(group=group).to(device)
+        model = self._get_wrapped_model(group=group, cuda_first=True) if wrap \
+            else self._get_nonwrapped_model(group=group, cuda_first=True)
         model.eval()  # disable dropout for determinism
         optim = optim_class(model.parameters(), lr=0.01)
         return model, optim, None
@@ -335,10 +345,11 @@ class TestFSDPOptimState(FSDPTest):
         ref_osd_state = ref_osd["state"]
         full_osd_state = full_osd["state"]
         if check_same_param_keys:
-            # Check parameter keys are the same
+            # Check parameter keys are the same first for earlier erroring
             ref_osd_param_ids = set(ref_osd_state.keys())
             full_osd_param_ids = set(full_osd_state.keys())
-            self.assertTrue(ref_osd_param_ids == full_osd_param_ids)
+            self.assertEqual(ref_osd_param_ids, full_osd_param_ids)
+            # Check state values are the same
             for param_id, param_state in full_osd_state.items():
                 for state_name, value in param_state.items():
                     ref_value = ref_osd_state[param_id][state_name]
@@ -348,7 +359,7 @@ class TestFSDPOptimState(FSDPTest):
         # between IDs and names)
         ref_osd_states = list(ref_osd["state"].values())
         full_osd_states = list(full_osd["state"].values())
-        assert len(ref_osd_states) == len(full_osd_states)
+        self.assertEqual(len(ref_osd_states), len(full_osd_states))
         # Use brute-force quadratic-time comparison since it is hard to
         # hash a tensor by value instead of by object
         for full_osd_state in full_osd_states:
@@ -375,17 +386,16 @@ class TestFSDPOptimState(FSDPTest):
         ref_osd_param_groups = ref_osd["param_groups"]
         full_osd_param_groups = full_osd["param_groups"]
         self.assertTrue(len(full_osd_param_groups), len(ref_osd_param_groups))
-        if self.rank == 0:
-            for full_osd_pg, ref_osd_pg in zip(
-                full_osd_param_groups, ref_osd_param_groups,
-            ):
-                self.assertEqual(
-                    set(full_osd_pg.keys()), set(ref_osd_pg.keys()),
-                )
-                for name, full_osd_value in full_osd_pg.items():
-                    if name == "params" and not check_same_param_keys:
-                        continue
-                    self.assertEqual(full_osd_value, ref_osd_pg[name])
+        for full_osd_pg, ref_osd_pg in zip(
+            full_osd_param_groups, ref_osd_param_groups,
+        ):
+            self.assertEqual(
+                set(full_osd_pg.keys()), set(ref_osd_pg.keys()),
+            )
+            for name, full_osd_value in full_osd_pg.items():
+                if name == "params" and not check_same_param_keys:
+                    continue
+                self.assertEqual(full_osd_value, ref_osd_pg[name])
 
     def _check_state_device(self, osd: Dict[str, Any], on_gpu: bool):
         """Checks that all tensors in ``osd["state"]`` are on GPU if
@@ -401,23 +411,27 @@ class TestFSDPOptimState(FSDPTest):
     @skip_if_lt_x_gpu(2)
     @parametrize("use_multiple_param_groups", [False, True])
     @parametrize("rank0_only", [False, True])
+    @parametrize("use_diff_optim_inputs", [False, True])
     def test_full_optim_state_dict_nested(
         self,
         use_multiple_param_groups: bool,
         rank0_only: bool,
+        use_diff_optim_inputs: bool,
     ) -> None:
         """
         Tests :meth:`full_optim_state_dict` by comparing the returned dict for
         an FSDP-wrapped model with that of an equivalent non-wrapped model.
 
-        The parameter groups in the "param_groups" part and the values in the
-        "state" part should be the same, but the parameter keys may be
-        different (e.g. the full optimizer state dict uses parameter names
-        while the non-wrapped equivalent uses parameter IDs).
+        The test checks the equivalence excluding the parameter keys since the
+        FSDP and normal optimizer state dicts key by names and IDs,
+        respectively. This means that the test can pass even if parameter keys
+        are incorrectly mapped to values. Their correct mapping is tested in
+        other tests that exercise the save/load workflow.
         """
         NUM_ITERS = 3
         model1, optim1, optim_input = self._init_nested_model(
             wrap=True, use_multiple_param_groups=use_multiple_param_groups,
+            use_diff_optim_inputs=use_diff_optim_inputs,
         )
         losses1 = self._step_model(model1, optim1, num_iters=NUM_ITERS)
         full_osd = FSDP.full_optim_state_dict(
@@ -429,6 +443,7 @@ class TestFSDPOptimState(FSDPTest):
             return
         model2, optim2, _ = self._init_nested_model(
             wrap=False, use_multiple_param_groups=use_multiple_param_groups,
+            use_diff_optim_inputs=use_diff_optim_inputs,
         )
         losses2 = self._step_model(model2, optim2, num_iters=NUM_ITERS)
         ref_osd = optim2.state_dict()
@@ -447,22 +462,64 @@ class TestFSDPOptimState(FSDPTest):
         )
 
     @skip_if_lt_x_gpu(2)
+    def test_full_optim_state_dict_nested_invalid(self):
+        """Tests that :meth:`full_optim_state_dict` raises an error when
+        nonzero ranks are missing the optimizer state for parameters on rank
+        0."""
+        device = torch.device("cuda")
+        model = NestedModel.wrap(NestedModel().to(device), None)
+        optim_input = list(model.parameters())
+        if self.rank != 0:
+            # Exclude a parameter so that nonzero ranks are missing state
+            optim_input = optim_input[:-1]
+        optim = torch.optim.Adam(optim_input, lr=1e-3)
+        self._step_model(model, optim, num_iters=3)
+        error_regex = (
+            "FSDP currently requires each rank to have at least the "
+            "optimizer states needed by rank 0's optimizer but some ranks "
+            "are missing some of those states"
+        )
+        with self.assertRaisesRegex(RuntimeError, error_regex):
+            FSDP.full_optim_state_dict(
+                model, optim, optim_input,
+            )
+
+    @skip_if_lt_x_gpu(2)
     @parametrize("use_multiple_param_groups", [False, True])
     @parametrize("wrap_alt", [False, True])
-    @parametrize("halve_world_size", [False, True])
+    @parametrize("use_diff_optim_inputs", [False, True])
     def test_shard_full_optim_state_dict_nested(
         self,
         use_multiple_param_groups: bool,
         wrap_alt: bool,
-        halve_world_size: bool,
+        use_diff_optim_inputs: bool,
     ):
         """Tests :meth:`shard_full_optim_state_dict` for a non-FSDP-root model
         with nested FSDP instances."""
         self._test_shard_full_optim_state(
             model_class="nested",
             use_multiple_param_groups=use_multiple_param_groups,
-            halve_world_size=halve_world_size,
+            halve_world_size=False,
             osd_comm_method=_OSDCommMethod.BROADCAST_OBJECT_LIST,
+            use_diff_optim_inputs=use_diff_optim_inputs,
+            wrap_alt=wrap_alt,
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_shard_full_optim_state_dict_nested_halve_world_size(self):
+        """Tests :meth:`shard_full_optim_state_dict` for a non-FSDP-root model
+        with nested FSDP instances when loading into a new process group with
+        halved world size."""
+        # To save CI costs, we test with the "harder" settings:
+        use_multiple_param_groups = True
+        use_diff_optim_inputs = True
+        wrap_alt = True
+        self._test_shard_full_optim_state(
+            model_class="nested",
+            use_multiple_param_groups=use_multiple_param_groups,
+            halve_world_size=True,
+            osd_comm_method=_OSDCommMethod.BROADCAST_OBJECT_LIST,
+            use_diff_optim_inputs=use_diff_optim_inputs,
             wrap_alt=wrap_alt,
         )
 
@@ -474,25 +531,45 @@ class TestFSDPOptimState(FSDPTest):
             model_class="transformer", use_multiple_param_groups=False,
             halve_world_size=True,
             osd_comm_method=_OSDCommMethod.BROADCAST_OBJECT_LIST,
+            use_diff_optim_inputs=False,
         )
 
     @skip_if_lt_x_gpu(2)
     @parametrize("use_multiple_param_groups", [False, True])
     @parametrize("wrap_alt", [False, True])
-    @parametrize("halve_world_size", [False, True])
+    @parametrize("use_diff_optim_inputs", [False, True])
     def test_scatter_full_optim_state_dict_nested(
         self,
         use_multiple_param_groups: bool,
         wrap_alt: bool,
-        halve_world_size: bool,
+        use_diff_optim_inputs: bool,
     ):
         """Tests :meth:`scatter_full_optim_state_dict` for a non-FSDP-root
         model with nested FSDP instances."""
         self._test_shard_full_optim_state(
             model_class="nested",
             use_multiple_param_groups=use_multiple_param_groups,
-            halve_world_size=halve_world_size,
+            halve_world_size=False,
             osd_comm_method=_OSDCommMethod.SCATTER_FULL_OSD,
+            use_diff_optim_inputs=use_diff_optim_inputs,
+            wrap_alt=wrap_alt,
+        )
+
+    @skip_if_lt_x_gpu(2)
+    def test_scatter_full_optim_state_dict_nested_halve_world_size(self):
+        """Tests :meth:`scatter_full_optim_state_dict` for a non-FSDP-root
+        model with nested FSDP instances when loading into a new process group
+        with halved world size."""
+        # To save CI costs, we test with the "harder" settings:
+        use_multiple_param_groups = True
+        use_diff_optim_inputs = True
+        wrap_alt = True
+        self._test_shard_full_optim_state(
+            model_class="nested",
+            use_multiple_param_groups=use_multiple_param_groups,
+            halve_world_size=True,
+            osd_comm_method=_OSDCommMethod.SCATTER_FULL_OSD,
+            use_diff_optim_inputs=use_diff_optim_inputs,
             wrap_alt=wrap_alt,
         )
 
@@ -504,6 +581,7 @@ class TestFSDPOptimState(FSDPTest):
             model_class="transformer", use_multiple_param_groups=False,
             halve_world_size=True,
             osd_comm_method=_OSDCommMethod.SCATTER_FULL_OSD,
+            use_diff_optim_inputs=False,
         )
 
     def _test_shard_full_optim_state(
@@ -512,6 +590,7 @@ class TestFSDPOptimState(FSDPTest):
         use_multiple_param_groups: bool,
         halve_world_size: bool,
         osd_comm_method: _OSDCommMethod,
+        use_diff_optim_inputs: bool,
         **new_model_kwargs,
     ):
         """
@@ -546,10 +625,12 @@ class TestFSDPOptimState(FSDPTest):
         else:
             # Continue using the same group and hence world size
             new_group = dist.distributed_c10d._get_default_group()
-        # Second, run a wrapped model with (possibly) halved world size
+        # Second, run a wrapped model with (possibly) halved world size and
+        # (possibly) differing `optim_input` across ranks
         model2, optim2, optim_input2 = initializer(
             wrap=True, group=new_group,
             use_multiple_param_groups=use_multiple_param_groups,
+            use_diff_optim_inputs=use_diff_optim_inputs,
             **new_model_kwargs,  # specify `wrap_alt` to change wrapping
         )
         self._step_model(model2, optim2, num_iters=NUM_ITERS)

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -264,7 +264,10 @@ class TestFSDPOptimState(FSDPTest):
         use_diff_optim_inputs: bool = False,
     ):
         if use_multiple_param_groups or use_diff_optim_inputs:
-            # Keep these as arguments for parity with `_init_nested_model()`
+            # Keep these as arguments for parity with `_init_nested_model()`;
+            # these settings are not implemented since the transformer is
+            # wrapped with FSDP at the top-level, which means that there is
+            # only a single flattened parameter, making these booleans vacuous
             raise NotImplementedError()
         if group is None:
             group = dist.distributed_c10d._get_default_group()

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -257,11 +257,11 @@ class TestFSDPOptimState(FSDPTest):
     def _init_transformer_model(
         self,
         wrap: bool,
-        device: torch.device = torch.device("cuda"),  # unused
+        device: torch.device = torch.device("cuda"),
         group=None,
         optim_class: Type[torch.optim.Optimizer] = torch.optim.Adam,
-        use_multiple_param_groups: bool = False,  # unused
-        use_diff_optim_inputs: bool = False,  # unused
+        use_multiple_param_groups: bool = False,
+        use_diff_optim_inputs: bool = False,
     ):
         if use_multiple_param_groups or use_diff_optim_inputs:
             # Keep these as arguments for parity with `_init_nested_model()`

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -8,7 +8,6 @@ from typing import (
     List,
     NamedTuple,
     Optional,
-    Set,
     Tuple,
     Union,
 )
@@ -59,11 +58,22 @@ class _PosDimTensorInfo(NamedTuple):
     dtype: torch.dtype
 
 
+class _OptimStateKey(NamedTuple):
+    """
+    This represents an optimizer state key that may be used commonly across
+    ranks. It is based on the unflattened parameter names rather than parameter
+    IDs to make it inedpenendent of each rank's own optimizer construction.
+    """
+    unflat_param_names: Tuple[str, ...]
+    is_flat_param: bool
+
+
+
 def _unflatten_optim_state(
-    fsdp_module,
     flat_param: FlatParameter,
     flat_param_state: Dict[str, Any],
     to_save: bool,
+    process_group,
 ) -> List[Dict[str, Any]]:
     """
     Unflattens the optimizer state, consisting of the "state" part and the
@@ -73,8 +83,6 @@ def _unflatten_optim_state(
     flattened to unflattened parameter IDs.
 
     Args:
-        fsdp_module (FullyShardedDataParallel): FSDP module that owns
-            ``flat_param``, i.e. holds it in ``self.params``.
         flat_param (FlatParameter): The flattened parameter.
         flat_param_state (Dict[str, Any]): Entry for the flattened parameter
             in the "state" part of the optimizer state dict.
@@ -88,13 +96,10 @@ def _unflatten_optim_state(
         otherwise. The final optimizer state dict will need to map these
         entries using the proper unflattened parameter IDs.
     """
-    assert sum(p is flat_param for p in fsdp_module.params) == 1, \
-        "`fsdp_module` must own `flat_param`"
     consolidated_state = _communicate_optim_state(
-        fsdp_module, flat_param, flat_param_state, to_save,
+        flat_param, flat_param_state, to_save, process_group,
     )
     unflat_param_state = _unflatten_communicated_optim_state(
-        fsdp_module,
         flat_param,
         consolidated_state,
     ) if to_save else []
@@ -102,10 +107,10 @@ def _unflatten_optim_state(
 
 
 def _communicate_optim_state(
-    fsdp_module,
     flat_param: FlatParameter,
     flat_param_state: Dict[str, Any],
     to_save: bool,
+    process_group,
 ) -> _ConsolidatedOptimState:
     """
     Communicates the optimizer state for a flattened parameter ``flat_param``
@@ -126,17 +131,9 @@ def _communicate_optim_state(
         ConsolidatedOptimState: Consolidated optimizer state for
         ``flat_param``; the state is not populated for non-target ranks.
     """
-    param_index = -1
-    for i, param in enumerate(fsdp_module.params):
-        if param is flat_param:
-            param_index = i
-            break
-    assert param_index >= 0, "`fsdp_module` must own `flat_param`"
-
     state = _ConsolidatedOptimState()
     tensor_state, zero_dim_tensor_state, non_tensor_state = \
         state.tensor_state, state.zero_dim_tensor_state, state.non_tensor_state
-    process_group = fsdp_module.process_group
 
     tensor_buffer = None  # initialize lazily in case it is not needed
     for state_name, value in flat_param_state.items():
@@ -170,7 +167,6 @@ def _communicate_optim_state(
 
 
 def _unflatten_communicated_optim_state(
-    fsdp_module,
     flat_param: FlatParameter,
     state: _ConsolidatedOptimState,
 ) -> List[Dict[str, Any]]:
@@ -180,8 +176,6 @@ def _unflatten_communicated_optim_state(
     parameter ``flat_param``. This should only be called on the target rank.
 
     Args:
-        fsdp_module (FullyShardedDataParallel): FSDP module that owns
-            ``flat_param``, i.e. holds it in ``self.params``.
         flat_param (FlatParameter): The flattened parameter.
         state (_ConsolidatedOptimState): Consolidated optimizer state.
 
@@ -192,8 +186,6 @@ def _unflatten_communicated_optim_state(
         ``flat_param``. The final optimizer state dict will need to map these
         entries using the proper unflattened parameter IDs.
     """
-    assert sum(p is flat_param for p in fsdp_module.params) == 1, \
-        "`fsdp_module` must own `flat_param`"
     unflat_param_state: List[Dict[str, Any]] = []
     flat_param_views: Dict[str, Iterator] = {}
     num_unflat_params = flat_param._num_unflattened_params
@@ -225,87 +217,55 @@ def _flatten_full_optim_state_dict(
     full_optim_state_dict: Dict[str, Any],
     model: torch.nn.Module,
     shard_state: bool,
-    optim_input: Optional[Union[
-        List[Dict[str, Any]], Iterable[torch.nn.Parameter],
-    ]] = None,
-) -> Tuple[Dict[str, Any], Set[int]]:
+) -> Dict[str, Any]:
     """
-    Args:
-        shard_state (bool): Whether to shard flattened positive-dimension
-            tensor state; if ``False``, then the full flattened tensor is
-            kept in the returned :class:`dict.
+    Flattens the full optimizer state dict, still keying by unflattened
+    parameter names. If ``shard_state=True``, then FSDP-managed
+    ``FlatParameter`` 's optimizer states are sharded, and otherwise, they are
+    kept unsharded.
 
     Returns:
-        Tuple[Dict[str, Any], Set[int]]: The flattened optimizer state dict
-            and a set of the parameter IDs corresponding to FSDP parameters.
+        Dict[str, Any]: The flattened optimizer state dict.
     """
-    full_osd = full_optim_state_dict  # alias
+    full_osd = full_optim_state_dict
     if "state" not in full_osd or "param_groups" not in full_osd:
         raise ValueError(
             "`full_optim_state_dict` must have the keys \"state\" and "
             "\"param_groups\" to be a valid optimizer state dict"
         )
-
-    flat_param_id_to_param = _get_param_id_to_param(model, optim_input)
     flat_param_to_fsdp_module = _get_flat_param_to_fsdp_module(model)
     param_to_unflat_param_names = FSDP._get_param_to_unflat_param_names(model)
 
-    # Handle the "state" part of the optimizer state dict
-    flat_osd_state: Dict[int, Any] = {}
+    # Construct the "state" part
+    flat_osd_state: Dict[_OptimStateKey, Any] = {}
     full_osd_state = full_osd["state"]
-    unflat_param_names_to_flat_param_id: Dict[str, int] = {}
-    fsdp_flat_param_ids = set()  # save which IDs are for FSDP parameters
-    for flat_param_id, param in enumerate(flat_param_id_to_param):  # type: ignore[assignment]
-        assert param in param_to_unflat_param_names, \
-            "Check the `param_to_unflat_params` construction\n" \
-            f"param: {param}"
-        unflat_param_names = param_to_unflat_param_names[param]
-        # For FSDP parameters, we need to flatten
-        if isinstance(param, FlatParameter):
+    for param, unflat_param_names in param_to_unflat_param_names.items():
+        if isinstance(param, FlatParameter):  # flatten FSDP parameters' states
             assert param in flat_param_to_fsdp_module, \
-                "Check the `flat_param_to_fsdp_module` mapping " \
-                f"construction\nparam={param}"
-            unflat_param_names = param_to_unflat_param_names[param]
+                "Check the `flat_param_to_fsdp_module` construction\n" \
+                f"param: {param}"
             fsdp_module = flat_param_to_fsdp_module[param]
             flat_state = _flatten_optim_state(
                 full_osd_state, unflat_param_names, fsdp_module, param,
                 shard_state,
             )
-            flat_osd_state[flat_param_id] = flat_state
-            for unflat_param_name in unflat_param_names:
-                unflat_param_names_to_flat_param_id[unflat_param_name] = flat_param_id
-            fsdp_flat_param_ids.add(flat_param_id)
-        # For parameters from non-FSDP modules, we do not need to flatten
-        else:
+            key = _OptimStateKey(tuple(unflat_param_names), True)
+            flat_osd_state[key] = flat_state
+        else:  # do not flatten non-FSDP parameters' states
             assert len(unflat_param_names) == 1
             unflat_param_name = unflat_param_names[0]
             if unflat_param_name not in full_osd_state:
-                # A non-FSDP module's parameter may be ignored and hence not
-                # have an entry in the optimizer state
+                # The state dict may not have an entry for a parameter if it
+                # was not passed into the optimizer (e.g. if it is not an
+                # FSDP-managed parameter)
                 continue
-            # Remap from unflattened to flattened parameter ID -- do not
-            # deepcopy to avoid unnecessarily duplicating tensor storage
-            flat_osd_state[flat_param_id] = \
-                copy.copy(full_osd_state[unflat_param_name])
-            unflat_param_names_to_flat_param_id[unflat_param_name] = flat_param_id
+            key = _OptimStateKey(tuple(unflat_param_names), False)
+            flat_osd_state[key] = copy.copy(full_osd_state[unflat_param_name])
 
-    # Handle the "param_groups" part of the optimizer state dict
-    sharded_osd_param_groups: List[Dict[str, Any]] = []
-    for unflat_param_group in full_osd["param_groups"]:
-        flat_param_group = copy.deepcopy(unflat_param_group)
-        # Map from unflattened parameter names to flattened parameter IDs
-        flat_param_ids = sorted(set(
-            unflat_param_names_to_flat_param_id[unflat_param_name]
-            for unflat_param_name in unflat_param_group["params"]
-        ))
-        flat_param_group["params"] = flat_param_ids
-        sharded_osd_param_groups.append(flat_param_group)
-
-    optim_state_dict = {
-        "state": flat_osd_state,
-        "param_groups": sharded_osd_param_groups,
-    }
-    return optim_state_dict, fsdp_flat_param_ids
+    # Construct the "param_groups" part -- copy as is since it will be
+    # rekeyed later according to the target rank's `optim_input`
+    flat_osd_param_groups = copy.deepcopy(full_osd["param_groups"])
+    return {"state": flat_osd_state, "param_groups": flat_osd_param_groups}
 
 
 def _flatten_optim_state(
@@ -336,8 +296,7 @@ def _flatten_optim_state(
     Returns:
         Dict[str, Any]: A :class:`dict` mapping state names to their values for
         a particular flattened parameter. The sharded optimizer state dict's
-        "state" part will map the flattened parameter ID to this returned
-        value.
+        "state" part will map a key to this returned value.
     """
     num_unflat_params = len(unflat_param_names)
     assert num_unflat_params > 0, \
@@ -445,7 +404,7 @@ def _flatten_tensor_optim_state(
     NOTE: We use zero tensors for any unflattened parameters without state
     since some value is required to fill those entries. This assumes that the
     zero tensor is mathematically equivalent to having no state, which is true
-    for Adam's ``exp_avg`` and ``exp_avg_sq`` but may not be true for all
+    for Adam's "exp_avg" and "exp_avg_sq" but may not be true for all
     optimizers.
 
     Args:
@@ -600,7 +559,6 @@ def _flatten_non_tensor_optim_state(
 
 def _process_pos_dim_tensor_state(
     flat_optim_state_dict: Dict[str, Any],
-    fsdp_flat_param_ids: Set[int],
     world_size: int,
 ) -> Dict[str, Any]:
     """
@@ -611,11 +569,7 @@ def _process_pos_dim_tensor_state(
 
     Args:
         flat_optim_state_dict (Dict[str, Any]): Flattened optimizer state dict
-            with the positive-dimension tensor states unsharded; this should
-            be returned by :meth:`_flatten_optim_state` with
-            ``shard_state=False``.
-        fsdp_flat_param_ids (Set[int]): Parameter IDs corresponding to FSDP
-            parameters.
+            with the positive-dimension tensor states unsharded.
 
     Returns:
         Dict[str, Any]: The flattened optimizer state dict with positive-
@@ -623,80 +577,61 @@ def _process_pos_dim_tensor_state(
     """
     flat_osd = flat_optim_state_dict  # alias
     no_tensor_osd: Dict[str, Any] = {"state": {}}
-    cpu_device = torch.device("cpu")
-    for param_id, param_state in flat_osd["state"].items():
-        no_tensor_osd["state"][param_id] = {}
-        for state_name, state_value in param_state.items():
-            is_pos_dim_tensor_state = torch.is_tensor(state_value) and \
-                state_value.dim() > 0
+    for key, param_state in flat_osd["state"].items():
+        no_tensor_osd["state"][key] = {}
+        for state_name, value in param_state.items():
+            is_pos_dim_tensor_state = torch.is_tensor(value) and value.dim() > 0
             if not is_pos_dim_tensor_state:
-                no_tensor_osd["state"][param_id][state_name] = state_value
+                no_tensor_osd["state"][key][state_name] = value
                 continue
-            if param_id in fsdp_flat_param_ids:  # FSDP parameter
-                # Use `_get_chunk()` to get a view and avoid allocating any new
-                # tensor storage via either `clone()` or `pad()`; each rank's
-                # chunk has the same padded shape, so we can pass rank 0
+            if key.is_flat_param:  # FSDP parameter
                 chunk, num_to_pad = FSDP.FullyShardedDataParallel._get_chunk(
-                    state_value, 0, world_size,
+                    value, rank=0, world_size=world_size,
                 )
-                assert len(chunk.shape) == 1, \
-                    f"Chunk should be 1D but got {chunk.shape}"
-                # Include the padding to get the final shard shape
-                info = _PosDimTensorInfo(
-                    shape=torch.Size([chunk.shape[0] + num_to_pad]),
-                    dtype=chunk.dtype,
-                )
+                assert len(chunk.shape) == 1, f"Chunk should be 1D but got {chunk.shape}"
+                info = _PosDimTensorInfo(torch.Size([chunk.shape[0] + num_to_pad]), chunk.dtype)
             else:  # non-FSDP parameter
-                info = _PosDimTensorInfo(
-                    shape=state_value.shape, dtype=state_value.dtype,
-                )
-            no_tensor_osd["state"][param_id][state_name] = info
-    no_tensor_osd["param_groups"] = copy.deepcopy(flat_osd["param_groups"])
+                info = _PosDimTensorInfo(value.shape, value.dtype)
+            no_tensor_osd["state"][key][state_name] = info
+    no_tensor_osd["param_groups"] = flat_osd["param_groups"]
     return no_tensor_osd
 
 
 def _broadcast_processed_optim_state_dict(
     processed_optim_state_dict: Optional[Dict[str, Any]],
-    fsdp_flat_param_ids: Optional[Set[int]],
     rank: int,
     group,
     device: torch.device,
-) -> Tuple[Dict[str, Any], Set[int]]:
+) -> Dict[str, Any]:
     """
-    Broadcasts the processed optimizer state dict and the accompanying FSDP
-    parameter IDs from rank 0 to all ranks.
+    Broadcasts the processed optimizer state dict from rank 0 to all ranks.
 
     Args:
-        processed_optim_state_dict (Optional[Dict[str, Any]]): The full
+        processed_optim_state_dict (Optional[Dict[str, Any]]): The flattened
             optimizer state dict with positive-dimension tensor states replaced
             with metadata if on rank 0; ignored otherwise.
-        fsdp_flat_param_ids (Optional[Set[int]]): Parameter IDs corresponding
-            to FSDP parameters if on rank 0; ignored otherwise.
         device (torch.device): Device to move zero-dimension tensors post-
             broadcast.
 
     Returns:
-        Tuple[Dict[str, Any], Set[int]]: The processed optimizer state dict
-        and the parameter IDs corresponding to FSDP parameters.
+        Dict[str, Any]: The processed optimizer state dict.
     """
     # Broadcast the two data structures rank 0 to all ranks
-    obj_list = [processed_optim_state_dict, fsdp_flat_param_ids] if rank == 0 \
-        else [None, None]
+    obj_list = [processed_optim_state_dict] if rank == 0 \
+        else [None]
     dist.broadcast_object_list(obj_list, src=0, group=group)
-    processed_optim_state_dict, fsdp_flat_param_ids = obj_list  # type: ignore[assignment]
+    processed_optim_state_dict = obj_list[0]  # type: ignore[assignment]
     assert processed_optim_state_dict is not None
-    assert fsdp_flat_param_ids is not None
     # Move zero-dimension tensors to `device`
     for param_state in processed_optim_state_dict["state"].values():
         for state_name, value in param_state.items():
             if _is_zero_dim_tensor(value):
                 param_state[state_name] = value.to(device)
-    return processed_optim_state_dict, fsdp_flat_param_ids
+    return processed_optim_state_dict
 
 
 def _broadcast_pos_dim_tensor_states(
     processed_optim_state_dict: Dict[str, Any],
-    fsdp_flat_param_ids: Set[int],
     flat_optim_state_dict: Optional[Dict[str, Any]],
     rank: int,
     world_size: int,
@@ -712,14 +647,13 @@ def _broadcast_pos_dim_tensor_states(
     tensor.
 
     Args:
-        processed_optim_state_dict (Dict[str, Any]): The full optimizer state
-            dict with positive-dimension tensor states replaced with metadata;
-            should be returned by :meth:`_process_pos_dim_tensor_state` and
-            non-empty on all ranks (e.g. via a ``broadcast()`` from rank 0).
-        fsdp_flat_param_ids (Set[int]): Parameter IDs corresponding to FSDP
-            parameters.
-        flat_optim_state_dict (Optional[Dict[str, Any]]): Flattened optimizer
-            state dict if on rank 0; ignored on nonzero ranks.
+        processed_optim_state_dict (Dict[str, Any]): The flattened optimizer
+            state dict with positive-dimension tensor states replaced with
+            metadata; this should be returned by
+            :meth:`_process_pos_dim_tensor_state` and non-empty on all ranks.
+        flat_optim_state_dict (Optional[Dict[str, Any]]): The flattened
+            unsharded optimizer state dict with the actual positive-dimension
+            tensor states if on rank 0; ignored on nonzero ranks.
 
     Returns:
         Dict[str, Any]: The optimizer state dict with the positive-dimension
@@ -729,18 +663,18 @@ def _broadcast_pos_dim_tensor_states(
         "Expects rank 0 to pass in the flattened optimizer state dict"
     no_tensor_osd = processed_optim_state_dict  # alias
     flat_osd = flat_optim_state_dict  # alias
-    for param_id, param_state in no_tensor_osd["state"].items():
+    for key, param_state in no_tensor_osd["state"].items():
         for state_name, value in param_state.items():
             is_pos_dim_tensor_state = isinstance(value, _PosDimTensorInfo)
             if not is_pos_dim_tensor_state:
                 continue
             if rank == 0:
                 assert flat_osd is not None
-                unsharded_tensor = flat_osd["state"][param_id][state_name]
+                unsharded_tensor = flat_osd["state"][key][state_name]
             else:
                 unsharded_tensor = None
             shape, dtype = value.shape, value.dtype
-            if param_id in fsdp_flat_param_ids:  # FSDP parameter
+            if key.is_flat_param:  # FSDP parameter
                 _broadcast_sharded_pos_dim_tensor_state(
                     unsharded_tensor, param_state, state_name, shape, dtype,
                     broadcast_device, rank, world_size, group,
@@ -838,6 +772,56 @@ def _broadcast_unsharded_pos_dim_tensor_state(
     dist.broadcast(unsharded_tensor, src=0, group=group)
     # Keep the tensor on the broadcast device, which is typically GPU
     param_state[state_name] = unsharded_tensor
+
+
+def _rekey_sharded_optim_state_dict(
+    sharded_osd: Dict[str, Any],
+    model: torch.nn.Module,
+    optim_input: Optional[Union[
+        List[Dict[str, Any]], Iterable[torch.nn.Parameter],
+    ]] = None,
+) -> Dict[str, Any]:
+    """
+    Rekeys the optimizer state dict from unflattened parameter names to
+    flattened parameter IDs according to the calling rank's ``optim_input``,
+    which may be different across ranks. In particular, the unflattened
+    parameter names are represented as :class:`_OptimStateKey` s.
+    """
+    param_to_flat_param_id = _get_param_to_param_id(model, optim_input)
+    param_to_unflat_param_names = FSDP._get_param_to_unflat_param_names(model)
+    # All parameter keys in `param_to_flat_param_id` should be in
+    # `param_to_unflat_param_names` -- strict inequality follows when not all
+    # parameters are passed to the optimizer via `optim_input`
+    assert len(param_to_flat_param_id) <= len(param_to_unflat_param_names)
+
+    unflat_param_names_to_flat_param_id: Dict[Tuple[str, ...], int] = {}  # for "state"
+    unflat_param_name_to_flat_param_id: Dict[str, int] = {}  # for "param_groups"
+    for param, unflat_param_names in param_to_unflat_param_names.items():
+        if param not in param_to_flat_param_id:
+            # This parameter was not passed to the optimizer via `optim_input`
+            continue
+        flat_param_id = param_to_flat_param_id[param]
+        unflat_param_names_to_flat_param_id[tuple(unflat_param_names)] = flat_param_id
+        for unflat_param_name in unflat_param_names:
+            unflat_param_name_to_flat_param_id[unflat_param_name] = flat_param_id
+
+    sharded_osd_state = sharded_osd["state"]
+    rekeyed_osd_state = {}
+    for key, param_state in sharded_osd_state.items():
+        flat_param_id = unflat_param_names_to_flat_param_id[key.unflat_param_names]
+        rekeyed_osd_state[flat_param_id] = param_state
+
+    rekeyed_osd_param_groups: List[Dict[str, Any]] = []
+    for unflat_param_group in sharded_osd["param_groups"]:
+        flat_param_group = copy.deepcopy(unflat_param_group)
+        flat_param_ids = sorted(set(
+            unflat_param_name_to_flat_param_id[unflat_param_name]
+            for unflat_param_name in unflat_param_group["params"]
+        ))
+        flat_param_group["params"] = flat_param_ids
+        rekeyed_osd_param_groups.append(flat_param_group)
+
+    return {"state": rekeyed_osd_state, "param_groups": rekeyed_osd_param_groups}
 
 
 def _get_flat_param_to_fsdp_module(model: torch.nn.Module):

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -62,7 +62,7 @@ class _OptimStateKey(NamedTuple):
     """
     This represents an optimizer state key that may be used commonly across
     ranks. It is based on the unflattened parameter names rather than parameter
-    IDs to make it inedpenendent of each rank's own optimizer construction.
+    IDs to make it indepenendent of each rank's own optimizer construction.
     """
     unflat_param_names: Tuple[str, ...]
     is_flat_param: bool

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -68,7 +68,6 @@ class _OptimStateKey(NamedTuple):
     is_flat_param: bool
 
 
-
 def _unflatten_optim_state(
     flat_param: FlatParameter,
     flat_param_state: Dict[str, Any],

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3513,7 +3513,7 @@ class FullyShardedDataParallel(nn.Module):
                     "Multiple process groups were found in the module "
                     "hierarchy. An arbitrary one will be used for collectives "
                     "in `full_optim_state_dict()`."
-                )  # TODO: Add note about multiple process groups not being supported
+                )
             group = next(iter(process_groups))
         rank = dist.get_rank(group)
         to_save = not rank0_only or rank == 0
@@ -3585,9 +3585,6 @@ class FullyShardedDataParallel(nn.Module):
 
         if not to_save:
             return {}
-
-        # TODO: for now, construct parameter groups according to local rank
-        # without considering rank 0 (only really matters for rank0_only=False)
 
         # Handle the "param_groups" part of the optimizer state dict
         full_osd_param_groups = full_osd["param_groups"]  # alias

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1,3 +1,4 @@
+import collections
 import contextlib
 import copy
 import functools
@@ -5,7 +6,6 @@ import itertools
 import math
 import traceback
 import warnings
-from collections import OrderedDict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -3525,7 +3525,7 @@ class FullyShardedDataParallel(nn.Module):
         flat_param_id_to_param: List[torch.nn.Parameter] = \
             _get_param_id_to_param(model, optim_input)
         optim_state_key_to_flat_param_id: Dict[_OptimStateKey, int] = {}  # local
-        r0_flat_param_id_to_optim_state_key: Dict[int, _OptimStateKey] = OrderedDict()  # rank 0
+        r0_flat_param_id_to_optim_state_key: Dict[int, _OptimStateKey] = collections.OrderedDict()  # rank 0
         for flat_param_id, param in enumerate(flat_param_id_to_param):
             # Do not include parameters without state to avoid empty mappings
             # just like in normal `torch.optim.Optimizer.state_dict()`


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#78599 [FSDP] Allow different `optim_input` orders across ranks**
* #78784 [FSDP][Docs] Fix typo in `full_optim_state_dict()`

This enables the first argument to the optimizer constructor, `optim_input`, to have different orders across ranks, e.g. if the parameters in one parameter group are permuted. This requires modification to `full_optim_state_dict()`, `shard_full_optim_state_dict()`, and `scatter_full_optim_state_dict()`.

The high-level algorithmic change is that the state dicts are kept as being keyed by unflattened parameter name until after sharding/unsharding and flattening/unflattening and are rekeyed to be by parameter ID according to each rank's own `optim_input` only at the end.

Because this PR adds non-parameter-specific collectives to `full_optim_state_dict()`, it adds a `group=None` argument to the method to have a process group to default to when running those common collectives.