### PR TITLE
generate kernels for codegend out= operators

### DIFF
--- a/aten/src/ATen/templates/CompositeViewCopyKernels.cpp
+++ b/aten/src/ATen/templates/CompositeViewCopyKernels.cpp
@@ -28,10 +28,23 @@ std::vector<at::Tensor> clone_arg(const at::TensorList& t_list) {
     return out;
 }
 
+void copy_arg(const at::Tensor& dst, const at::Tensor& src) {
+    dst.copy_(src);
+}
+
+void copy_arg(const at::TensorList& dst, const at::TensorList& src) {
+    TORCH_INTERNAL_ASSERT(dst.size() == src.size());
+    for (const auto& i : c10::irange(dst.size())) {
+        dst[i].copy_(src[i]);
+    }
+}
+
 
 ${CompositeViewCopyKernel_Definitions}
 
 ${GeneratedCompositeFunctional_Definitions}
+
+${GeneratedCompositeOut_Definitions}
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/templates/CompositeViewCopyKernels.cpp
+++ b/aten/src/ATen/templates/CompositeViewCopyKernels.cpp
@@ -2,6 +2,7 @@
 // ${generated_comment}
 
 #include <ATen/Tensor.h>
+#include <ATen/native/Resize.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Operators.h>
@@ -36,6 +37,17 @@ void copy_arg(const at::TensorList& dst, const at::TensorList& src) {
     TORCH_INTERNAL_ASSERT(dst.size() == src.size());
     for (const auto& i : c10::irange(dst.size())) {
         dst[i].copy_(src[i]);
+    }
+}
+
+void resize_out_helper(const at::Tensor& dst, const at::Tensor& src) {
+    at::native::resize_output(dst, src.sizes());
+}
+
+void resize_out_helper(const at::TensorList& dst, const at::TensorList& src) {
+    TORCH_INTERNAL_ASSERT(dst.size() == src.size());
+    for (const auto& i : c10::irange(dst.size())) {
+        at::native::resize_output(dst[i], src[i].sizes());
     }
 }
 

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -36,6 +36,8 @@ from torchgen.model import (
 from torchgen.native_function_generation import (
     pre_group_native_functions,
     add_generated_native_functions,
+    gen_composite_functional_kernel,
+    gen_composite_out_kernel,
 )
 from torchgen.api.types import (
     Binding,
@@ -76,7 +78,6 @@ from torchgen.gen_functionalization_type import (
     gen_functionalization_registration,
     gen_functionalization_view_inverse_declaration,
     gen_composite_view_copy_kernel,
-    gen_composite_functional_kernel,
 )
 
 T = TypeVar("T")
@@ -2274,6 +2275,12 @@ TORCH_LIBRARY_IMPL(aten, $dispatch_key, m) {
             "GeneratedCompositeFunctional_Definitions": list(
                 mapMaybe(
                     gen_composite_functional_kernel,
+                    structured_native_functions,
+                )
+            ),
+            "GeneratedCompositeOut_Definitions": list(
+                mapMaybe(
+                    gen_composite_out_kernel,
                     structured_native_functions,
                 )
             ),

--- a/torchgen/gen_functionalization_type.py
+++ b/torchgen/gen_functionalization_type.py
@@ -4,7 +4,6 @@ from torchgen.api.types import (
     Binding,
     FunctionalizationLambda,
     ViewInverseSignature,
-    Expr,
     NativeSignature,
     CType,
     BaseCType,
@@ -122,81 +121,6 @@ def return_str(rets: Tuple[Return, ...], names: List[str]) -> str:
         return f"return {names[0]};"
     else:
         return f"return {dispatcher.returns_type(rets).cpp_type()}({', '.join(names)});"
-
-
-# Given a function, and the name of a variable correponding to the output of that function,
-# gather up all of the individual returns that are not aliased
-def gather_nonaliased_inner_rets(func: FunctionSchema, out_var: str) -> List[str]:
-    aliased_rets = func.aliased_return_names()
-    non_aliased_names = []
-    is_out_var_a_tuple = len(func.returns) > 1
-    for (i, r) in enumerate(aliased_rets):
-        if r is None:
-            non_aliased_names.append(
-                f"std::get<{i}>({out_var})" if is_out_var_a_tuple else out_var
-            )
-    return non_aliased_names
-
-
-@with_native_function
-def gen_composite_functional_kernel(g: NativeFunctionsGroup) -> Optional[str]:
-    # We should only be generating these for code-generated NativeFunctions
-    if "generated" not in g.functional.tags:
-        return None
-    # And we always write the kernel for a generated op in terms of a non-generated op.
-    if g.inplace is not None and "generated" not in g.inplace.tags:
-        target_f = g.inplace
-    elif g.mutable is not None and "generated" not in g.mutable.tags:
-        target_f = g.mutable
-    else:
-        # We should be guaranteed to have a valid inplace/mutable variant to call into.
-        # See Note: [Mutable Ops Not Using Functionalization]
-        raise AssertionError(str(g.functional.func))
-
-    sig = DispatcherSignature(g.functional.func)
-    target_sig = DispatcherSignature(target_f.func)
-
-    context: List[Union[Binding, Expr]] = []
-    clone_mutable_inputs = []
-    cloned_return_names = []
-    # We can't just directly pass all of the arguments from the functional op into the mutating op.
-    # We need to check for which inputs to the mutating operator are mutable,
-    # and clone those inputs first.
-    for a_curr, a_tgt in zip(
-        dispatcher.jit_arguments(g.functional.func),
-        dispatcher.jit_arguments(target_f.func),
-    ):
-        if a_tgt.annotation is not None and a_tgt.annotation.is_write:
-            clone_mutable_inputs.append(
-                f"auto {a_curr.name}_clone = clone_arg({a_curr.name});"
-            )
-            context.append(
-                Expr(
-                    expr=f"{a_curr.name}_clone",
-                    type=dispatcher.argument_type(a_curr, binds=a_curr.name),
-                )
-            )
-            # Invariant: mutable arguments on the inner mutable op are always returns on the functional op.
-            cloned_return_names.append(f"{a_curr.name}_clone")
-        else:
-            context.append(dispatcher.argument(a_curr))
-    exprs = ", ".join([e.expr for e in translate(context, target_sig.arguments())])
-
-    out_name = "output"
-    maybe_assign = f"auto {out_name} = " if len(target_f.func.returns) > 0 else ""
-    inner_return_names = gather_nonaliased_inner_rets(target_f.func, out_name)
-    ret_str = return_str(
-        g.functional.func.returns, inner_return_names + cloned_return_names
-    )
-
-    clone_mutable_inputs_str = "\n".join(clone_mutable_inputs)
-    return f"""
-{sig.defn()} {{
-  {clone_mutable_inputs_str}
-  {maybe_assign}at::_ops::{target_f.func.name.unambiguous_name()}::call({exprs});
-  {ret_str}
-}}
-"""
 
 
 def modifies_arguments(f: NativeFunction) -> bool:

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -502,7 +502,11 @@ def gen_composite_out_kernel(g: NativeFunctionsGroup) -> Optional[str]:
             if len(g.functional.func.returns) == 1
             else f"std::get<{i}>({out_name})"
         )
-        copy_outs.append(f"copy_arg({out_arg.name}, {functional_return_name});")
+        copy_outs.append(
+            f"""\
+  resize_out_helper({out_arg.name}, {functional_return_name});
+  copy_arg({out_arg.name}, {functional_return_name});"""
+        )
 
     rets = []
     # For each return arg in the calling (out=) operator,

--- a/torchgen/native_function_generation.py
+++ b/torchgen/native_function_generation.py
@@ -7,6 +7,7 @@ from torchgen.model import (
     Return,
     Annotation,
     NativeFunction,
+    NativeFunctionsGroup,
     OperatorName,
     BackendIndex,
     BackendMetadata,
@@ -17,9 +18,19 @@ from torchgen.model import (
 from torchgen.utils import (
     concatMap,
 )
+from torchgen.context import (
+    with_native_function,
+)
+from torchgen.api.types import (
+    DispatcherSignature,
+    Expr,
+    Binding,
+)
+import torchgen.api.dispatcher as dispatcher
+from torchgen.api.translate import translate
 
 
-from typing import List, Tuple, Sequence, Dict
+from typing import List, Tuple, Sequence, Dict, Optional, Union
 from collections import defaultdict
 
 # See Note: [Out ops with functional variants that don't get grouped properly]
@@ -186,7 +197,6 @@ def generate_function(
 
     if k == SchemaKind.functional:
         assert f.func.kind() != SchemaKind.functional
-        gets_composite_kernel = True
         # The new "functional" NativeFunction has:
         # - any mutable arguments have been converted into (immutable) returns.
         #   (if a mutable argument was not also a return, it gets converted to one)
@@ -204,7 +214,6 @@ def generate_function(
         # We generate out= ops mostly just so that we can pair up NativeFunctions into groups easily,
         # but at least today, there is no good reason to actually use them.
         # we'll generate a dispatcher entry for them, but won't actually register any kernels for them.
-        gets_composite_kernel = False
         if f.func.kind() == SchemaKind.inplace:
             func = self_to_out_signature(f.func)
         elif f.func.kind() == SchemaKind.mutable:
@@ -218,14 +227,11 @@ def generate_function(
             "We currently only generate either functional or out= NativeFunctions"
         )
 
-    if gets_composite_kernel:
-        backend_metadata = {
-            DispatchKey.CompositeExplicitAutograd: {
-                func.name: BackendMetadata(cpp.name(func), structured=False)
-            }
+    backend_metadata = {
+        DispatchKey.CompositeExplicitAutograd: {
+            func.name: BackendMetadata(cpp.name(func), structured=False)
         }
-    else:
-        backend_metadata = {}
+    }
 
     return (
         NativeFunction(
@@ -249,7 +255,7 @@ def generate_function(
             cpp_no_default_args=set(),
             is_abstract=f.is_abstract,
             has_composite_implicit_autograd_kernel=False,
-            has_composite_explicit_autograd_kernel=gets_composite_kernel,
+            has_composite_explicit_autograd_kernel=True,
             # Every generated NativeFunction gets a "generated" tag, so it's easy to tell
             # which NativeFunction objects did not come directly from native_functions.yaml.
             tags=set(["generated"]),
@@ -380,3 +386,145 @@ please convert it to an inplace operator"""
                 d[SchemaKind.functional] = fn
                 BackendIndex.grow_index(indices, metadata)
                 rs.append(fn)
+
+
+def return_str(rets: Tuple[Return, ...], names: List[str]) -> str:
+    assert len(rets) == len(names)
+    if len(rets) == 0:
+        return ""
+    elif len(rets) == 1:
+        return f"return {names[0]};"
+    else:
+        return f"return {dispatcher.returns_type(rets).cpp_type()}({', '.join(names)});"
+
+
+# Given a function, and the name of a variable correponding to the output of that function,
+# gather up all of the individual returns that are not aliased
+def gather_nonaliased_inner_rets(func: FunctionSchema, out_var: str) -> List[str]:
+    aliased_rets = func.aliased_return_names()
+    non_aliased_names = []
+    is_out_var_a_tuple = len(func.returns) > 1
+    for (i, r) in enumerate(aliased_rets):
+        if r is None:
+            non_aliased_names.append(
+                f"std::get<{i}>({out_var})" if is_out_var_a_tuple else out_var
+            )
+    return non_aliased_names
+
+
+# Generates functional kernels in terms of their inplace.mutable counterparts.
+# We only do this for "generated" NativeFunctions
+@with_native_function
+def gen_composite_functional_kernel(g: NativeFunctionsGroup) -> Optional[str]:
+    # We should only be generating these for code-generated NativeFunctions
+    if "generated" not in g.functional.tags:
+        return None
+    # And we always write the kernel for a generated op in terms of a non-generated op.
+    if g.inplace is not None and "generated" not in g.inplace.tags:
+        target_f = g.inplace
+    elif g.mutable is not None and "generated" not in g.mutable.tags:
+        target_f = g.mutable
+    else:
+        # We should be guaranteed to have a valid inplace/mutable variant to call into.
+        # See Note: [Mutable Ops Not Using Functionalization]
+        raise AssertionError(str(g.functional.func))
+
+    sig = DispatcherSignature(g.functional.func)
+    target_sig = DispatcherSignature(target_f.func)
+
+    context: List[Union[Binding, Expr]] = []
+    clone_mutable_inputs = []
+    cloned_return_names = []
+    # We can't just directly pass all of the arguments from the functional op into the mutating op.
+    # We need to check for which inputs to the mutating operator are mutable,
+    # and clone those inputs first.
+    for a_curr, a_tgt in zip(
+        dispatcher.jit_arguments(g.functional.func),
+        dispatcher.jit_arguments(target_f.func),
+    ):
+        if a_tgt.annotation is not None and a_tgt.annotation.is_write:
+            clone_mutable_inputs.append(
+                f"auto {a_curr.name}_clone = clone_arg({a_curr.name});"
+            )
+            context.append(
+                Expr(
+                    expr=f"{a_curr.name}_clone",
+                    type=dispatcher.argument_type(a_curr, binds=a_curr.name),
+                )
+            )
+            # Invariant: mutable arguments on the inner mutable op are always returns on the functional op.
+            cloned_return_names.append(f"{a_curr.name}_clone")
+        else:
+            context.append(dispatcher.argument(a_curr))
+    exprs = ", ".join([e.expr for e in translate(context, target_sig.arguments())])
+
+    out_name = "output"
+    maybe_assign = f"auto {out_name} = " if len(target_f.func.returns) > 0 else ""
+    inner_return_names = gather_nonaliased_inner_rets(target_f.func, out_name)
+    ret_str = return_str(
+        g.functional.func.returns, inner_return_names + cloned_return_names
+    )
+
+    clone_mutable_inputs_str = "\n".join(clone_mutable_inputs)
+    return f"""
+{sig.defn()} {{
+  {clone_mutable_inputs_str}
+  {maybe_assign}at::_ops::{target_f.func.name.unambiguous_name()}::call({exprs});
+  {ret_str}
+}}
+"""
+
+
+# Generates out= kernels in terms of their functional counterparts.
+# We only do this for "generated" NativeFunctions
+@with_native_function
+def gen_composite_out_kernel(g: NativeFunctionsGroup) -> Optional[str]:
+    # We should only be generating these for code-generated NativeFunctions
+    if "generated" not in g.out.tags:
+        return None
+    # And we always write the kernel for the out= op in terms of the functional.
+    # Note that the functional op might have also been generated, but we don't have to
+    # worry about cycles, because the generated functional kernels are always implemented
+    # in terms of non-generated kernels (see gen_composite_functional_kernel).
+
+    sig = DispatcherSignature(g.out.func)
+    target_sig = DispatcherSignature(g.functional.func)
+
+    exprs = ", ".join(
+        [e.expr for e in translate(sig.arguments(), target_sig.arguments())]
+    )
+
+    copy_outs = []
+    out_name = "tmp_output"
+    for i, out_arg in enumerate(g.out.func.arguments.out):
+        functional_return_name = (
+            out_name
+            if len(g.functional.func.returns) == 1
+            else f"std::get<{i}>({out_name})"
+        )
+        copy_outs.append(f"copy_arg({out_arg.name}, {functional_return_name});")
+
+    rets = []
+    # For each return arg in the calling (out=) operator,
+    # If it corresponds to an aliased input, return the input.
+    # Otherwise, return the corresponding output from calling the functional operator.
+    for i, ret_name in enumerate(g.out.func.aliased_return_names()):
+        if ret_name is not None:
+            rets.append(ret_name)
+        else:
+            functional_return_name = (
+                out_name
+                if len(g.functional.func.returns) == 1
+                else f"std::get<{i}>({out_name})"
+            )
+            rets.append(functional_return_name)
+
+    copy_outs_str = "\n".join(copy_outs)
+
+    return f"""
+{sig.defn()} {{
+  auto {out_name} = at::_ops::{g.functional.func.name.unambiguous_name()}::call({exprs});
+  {copy_outs_str}
+  {return_str(g.out.func.returns, rets)}
+}}
+"""


### PR DESCRIPTION
We already generate out= variants of NativeFunctions for all (non-CompositeImplicitAutograd) ops today, but the main benefit was to be able to properly group them up in the codegen, so we didn't have kernels for them. This PR generates out= kernels for all of the existing code-generated out= NativeFunctions.

Martin mentioned that having working kernels for all out= ops will be useful to mobile for development (you can run a mobile model E2E, without having 100% out= custom kernel coverage)

The kernels are generated by calling into their functional versions, and coping the results back into the out= arguments.

**Testing?**
Testing is kind of hard, because these kernels aren't actually used anywhere in core, and aren't exposed to python. I just stared at the output and made sure it looked reasonable (we properly resize and copy the output), but if anyone is concerned / has suggestions on tests I could add some.

some example outputs:
```
at::Tensor & add_out(const at::Tensor & self, const at::Scalar & other, const at::Scalar & alpha, at::Tensor & out) {
  auto tmp_output = at::_ops::add_Scalar::call(self, other, alpha);
    resize_out_helper(out, tmp_output);
  copy_arg(out, tmp_output);
  return out;
}


void _foreach_add_out(at::TensorList self, const at::Scalar & scalar, at::TensorList out) {
  auto tmp_output = at::_ops::_foreach_add_Scalar_functional::call(self, scalar);
    resize_out_helper(out, tmp_output);
  copy_arg(out, tmp_output);

}


::std::tuple<at::Tensor &,at::Tensor &> _fused_moving_avg_obs_fq_helper_out(const at::Tensor & self, const at::Tensor & observer_on, const at::Tensor & fake_quant_on, at::Tens
  auto tmp_output = at::_ops::_fused_moving_avg_obs_fq_helper_functional::call(self, observer_on, fake_quant_on, running_min, running_max, scale, zero_point, averaging_const,
    resize_out_helper(out0, std::get<0>(tmp_output));
  copy_arg(out0, std::get<0>(tmp_output));
  resize_out_helper(out1, std::get<1>(tmp_output));
  copy_arg(out1, std::get<1>(tmp_output));
  return ::std::tuple<at::Tensor &,at::Tensor &>(out0, out1);
}
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #78626

