### PR TITLE
Make lintrunner compatible with M1

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -118,7 +118,7 @@ init_command = [
     'python3',
     'tools/linter/adapters/pip_init.py',
     '--dry-run={{DRYRUN}}',
-    'numpy==1.20',
+    'numpy==1.21.6',
     'expecttest==0.1.3',
     'mypy==0.950',
     'types-requests==2.27.25',


### PR DESCRIPTION
numpy-1.20 is not available on the platform, so change pinned version to 1.21.6

