### PR TITLE
Prevent invariant assert failure on win+debug

### DIFF
--- a/aten/src/ATen/core/IListRef.h
+++ b/aten/src/ATen/core/IListRef.h
@@ -383,8 +383,10 @@ class IListRefIterator : public std::iterator<std::bidirectional_iterator_tag, T
     switch (tag_) {
       case IListRefTag::Boxed:
         payload_.boxed_iterator = iterator.payload_.boxed_iterator;
+        break;
       case IListRefTag::Unboxed:
         payload_.unboxed_iterator = iterator.payload_.unboxed_iterator;
+        break;
       default:
         TORCH_INTERNAL_ASSERT(false, "invalid IListRef tag.");
     }
@@ -397,8 +399,10 @@ class IListRefIterator : public std::iterator<std::bidirectional_iterator_tag, T
     switch (tag_) {
       case IListRefTag::Boxed:
         payload_.boxed_iterator.~boxed_iterator_type();
+        break;
       case IListRefTag::Unboxed:
         payload_.unboxed_iterator.~unboxed_iterator_type();
+        break;
       default:
         TORCH_INTERNAL_ASSERT(false, "invalid IListRef tag.");
     }


### PR DESCRIPTION
Summary:
Provide missing break statements to correct for IListRef
handling on Windows MSVC Debug builds.

Test Plan:
Run any torch IListRefIterator destruction on windows in a
debug mode build. Without this change, it will destruct incorrectly for
Boxed IListRefTag, and invariably hit an always-fail assert for IListRef
tag. With it, proper destruction, iterator payload assignment, and no
assert encounter with valid IListRefTag will occur.

Differential Revision: D36811554

