### PR TITLE
Fix docs for torch.real

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2066,9 +2066,6 @@ real(input) -> Tensor
 Returns a new tensor containing real values of the :attr:`self` tensor.
 The returned tensor and :attr:`self` share the same underlying storage.
 
-.. warning::
-    :func:`real` is only supported for tensors with complex dtypes.
-
 Args:
     {input}
 


### PR DESCRIPTION
Non-complex types are supported

```python
>>> import torch
>>> z = torch.zeros(5)
>>> torch.real(z.float())
tensor([0., 0., 0., 0., 0.])
>>> torch.real(z.int())
tensor([0, 0, 0, 0, 0], dtype=torch.int32)
```