### PR TITLE
[vulkan] Move ownership of Shader and Pipeline caches to Adapter

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Adapter.cpp
+++ b/aten/src/ATen/native/vulkan/api/Adapter.cpp
@@ -159,7 +159,7 @@ VkDevice create_logical_device(
       physical_device.handle, &device_create_info, nullptr, &handle));
 
 #ifdef USE_VULKAN_VOLK
-  volkLoadDevice(handle_);
+  volkLoadDevice(handle);
 #endif
 
   // Obtain handles for the created queues and initialize queue usage heuristic
@@ -234,39 +234,65 @@ std::string get_queue_family_properties_str(const VkQueueFlags flags) {
 
 } // namespace
 
-Adapter::Adapter(
-    const PhysicalDevice physical_device, const uint32_t num_queues)
-  : mutex_{},
-    physical_device_(physical_device),
-    queues_{},
-    queue_usage_{},
-    handle_(create_logical_device(
-        physical_device_, num_queues, queues_, queue_usage_)) {
+//
+// DeviceHandle
+//
+
+DeviceHandle::DeviceHandle(const VkDevice device)
+  : handle_(device) {
 }
 
-Adapter::Adapter(Adapter&& other) noexcept
-  : mutex_{},
-    physical_device_{other.physical_device_} {
-  std::lock_guard<std::mutex> lock(other.mutex_);
-
-  queues_ = std::move(other.queues_);
-  queue_usage_ = std::move(other.queue_usage_);
-  handle_ = other.handle_;
-
+DeviceHandle::DeviceHandle(DeviceHandle&& other) noexcept
+  : handle_(other.handle_) {
   other.handle_ = VK_NULL_HANDLE;
 }
 
-Adapter::~Adapter() {
+DeviceHandle::~DeviceHandle() {
   if C10_LIKELY(VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyDevice(handle_, nullptr);
-  handle_ = VK_NULL_HANDLE;
+}
+
+//
+// Adapter
+//
+
+Adapter::Adapter(
+    const VkInstance instance,
+    const PhysicalDevice physical_device,
+    const uint32_t num_queues)
+  : queue_mutex_{},
+    physical_device_(physical_device),
+    queues_{},
+    queue_usage_{},
+    instance_(instance),
+    device_(create_logical_device(
+        physical_device_, num_queues, queues_, queue_usage_)),
+    shader_layout_cache_(device_.handle_),
+    shader_cache_(device_.handle_),
+    pipeline_layout_cache_(device_.handle_),
+    compute_pipeline_cache_(device_.handle_) {
+}
+
+Adapter::Adapter(Adapter&& other) noexcept
+  : queue_mutex_{},
+    physical_device_{other.physical_device_},
+    instance_(other.instance_),
+    device_(std::move(other.device_)),
+    shader_layout_cache_(std::move(other.shader_layout_cache_)),
+    shader_cache_(std::move(other.shader_cache_)),
+    pipeline_layout_cache_(std::move(other.pipeline_layout_cache_)),
+    compute_pipeline_cache_(std::move(other.compute_pipeline_cache_)) {
+  std::lock_guard<std::mutex> lock(other.queue_mutex_);
+
+  queues_ = std::move(other.queues_);
+  queue_usage_ = std::move(other.queue_usage_);
 }
 
 Adapter::Queue Adapter::request_queue() {
   // Lock the mutex as multiple threads can request a queue at the same time
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(queue_mutex_);
 
   uint32_t min_usage = UINT32_MAX;
   uint32_t min_used_i = 0;
@@ -285,7 +311,7 @@ void Adapter::return_queue(Adapter::Queue& compute_queue) {
   for (const uint32_t i : c10::irange(queues_.size())) {
     if ((queues_[i].family_index == compute_queue.family_index) &&
         (queues_[i].queue_index == compute_queue.queue_index)) {
-      std::lock_guard<std::mutex> lock(mutex_);
+      std::lock_guard<std::mutex> lock(queue_mutex_);
       queue_usage_[i] -= 1;
       break;
     }
@@ -357,7 +383,7 @@ std::string Adapter::stringize() const {
      << get_queue_family_properties_str(queue_family_props.queueFlags) << std::endl;
   }
   ss << "  }" << std::endl;
-  ss << "  VkDevice: " << handle_ << std::endl;
+  ss << "  VkDevice: " << device_.handle_ << std::endl;
   ss << "  Compute Queues [" << std::endl;
   for (const Adapter::Queue& compute_queue : queues_) {
   ss << "    Family " << compute_queue.family_index

--- a/aten/src/ATen/native/vulkan/api/Adapter.h
+++ b/aten/src/ATen/native/vulkan/api/Adapter.h
@@ -3,6 +3,8 @@
 #ifdef USE_VULKAN_API
 
 #include <ATen/native/vulkan/api/Common.h>
+#include <ATen/native/vulkan/api/Shader.h>
+#include <ATen/native/vulkan/api/Pipeline.h>
 #include <ATen/native/vulkan/api/Utils.h>
 #include <ostream>
 #include <iostream>
@@ -28,6 +30,24 @@ struct PhysicalDevice final {
   float timestamp_period;
 
   PhysicalDevice(const VkPhysicalDevice);
+};
+
+class DeviceHandle final {
+ public:
+  explicit DeviceHandle(const VkDevice device);
+
+  DeviceHandle(const DeviceHandle&) = delete;
+  DeviceHandle& operator=(const DeviceHandle&) = delete;
+
+  DeviceHandle(DeviceHandle&&) noexcept;
+  DeviceHandle& operator=(DeviceHandle&&) = delete;
+
+  ~DeviceHandle();
+
+ private:
+  VkDevice handle_;
+
+  friend class Adapter;
 };
 
 //
@@ -56,7 +76,9 @@ struct PhysicalDevice final {
 class Adapter final {
  public:
   explicit Adapter(
-      const PhysicalDevice physical_device, const uint32_t num_queues);
+      const VkInstance instance,
+      const PhysicalDevice physical_device,
+      const uint32_t num_queues);
 
   Adapter(const Adapter&) = delete;
   Adapter& operator=(const Adapter&) = delete;
@@ -64,7 +86,7 @@ class Adapter final {
   Adapter(Adapter&&) noexcept;
   Adapter& operator=(Adapter&&) = delete;
 
-  ~Adapter();
+  ~Adapter() = default;
 
   struct Queue {
     uint32_t family_index;
@@ -74,24 +96,33 @@ class Adapter final {
   };
 
  private:
-  // Use a mutex to manage resources held by this class since
+  // Use a mutex to manage queue usage info since
   // it can be accessed from multiple threads
-  std::mutex mutex_;
+  std::mutex queue_mutex_;
   // Physical Device Info
   PhysicalDevice physical_device_;
   // Queue Management
   std::vector<Queue> queues_;
   std::vector<uint32_t> queue_usage_;
   // Handles
-  VkDevice handle_;
+  VkInstance instance_;
+  DeviceHandle device_;
+  // Device-level resource caches
+  ShaderLayoutCache shader_layout_cache_;
+  ShaderCache shader_cache_;
+  PipelineLayoutCache pipeline_layout_cache_;
+  ComputePipelineCache compute_pipeline_cache_;
 
  public:
+
+  // Physical Device metadata
+
   inline VkPhysicalDevice physical_handle() const {
     return physical_device_.handle;
   }
 
   inline VkDevice device_handle() const {
-    return handle_;
+    return device_.handle_;
   }
 
   inline bool has_unified_memory() const {
@@ -110,8 +141,30 @@ class Adapter final {
     return physical_device_.timestamp_period;
   }
 
+  // Queue Management
+
   Queue request_queue();
   void return_queue(Queue&);
+
+  // Caches
+
+  inline ShaderLayoutCache& shader_layout_cache() {
+    return shader_layout_cache_;
+  }
+
+  inline ShaderCache& shader_cache() {
+    return shader_cache_;
+  }
+
+  inline PipelineLayoutCache& pipeline_layout_cache() {
+    return pipeline_layout_cache_;
+  }
+
+  inline ComputePipelineCache& compute_pipeline_cache() {
+    return compute_pipeline_cache_;
+  }
+
+  // Miscellaneous
 
   inline utils::uvec3 local_work_group_size() const {
     return { 4u, 4u, 4u, };

--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -13,18 +13,15 @@ namespace api {
 Context::Context(const VkInstance instance, size_t adapter_i)
     : instance_(instance),
       adapter_i_(adapter_i),
-      device_(runtime()->get_adapter(adapter_i).device_handle()),
-      queue_(runtime()->get_adapter(adapter_i).request_queue()),
-      shader_layout_cache_(device_),
-      shader_cache_(device_),
-      pipeline_layout_cache_(device_),
-      pipeline_cache_(device_),
+      adapter_p_(runtime()->get_adapter_p(adapter_i)),
+      device_(adapter_p_->device_handle()),
+      queue_(adapter_p_->request_queue()),
       threadcontext_(gpu()) {
 }
 
 Context::~Context() {
   // Let the device know the context is done with the queue
-  runtime()->get_adapter(adapter_i_).return_queue(queue_);
+  adapter_p_->return_queue(queue_);
   // Do not call flush() since all per-thread objects will be destroyed as each thread exits
 }
 

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -77,12 +77,9 @@ class Context final {
   // Construction and destruction order matters.  Do not move members around.
   VkInstance instance_;
   size_t adapter_i_;
+  Adapter* adapter_p_;
   VkDevice device_;
   Adapter::Queue queue_;
-  ShaderLayoutCache shader_layout_cache_;
-  ShaderCache shader_cache_;
-  PipelineLayoutCache pipeline_layout_cache_;
-  ComputePipelineCache pipeline_cache_;
   ThreadContext threadcontext_;
 };
 
@@ -98,7 +95,7 @@ Context* context();
 
 inline GPU Context::gpu() {
   // A GPU is simply a (physical device, logical device, device queue) trio.
-  const Adapter* p_adapter = runtime()->get_adapter_p(adapter_i_);
+  const Adapter* p_adapter = adapter_p_;
   return {
     instance_,
     p_adapter,
@@ -109,19 +106,19 @@ inline GPU Context::gpu() {
 }
 
 inline ShaderLayoutCache& Context::shader_layout_cache() {
-  return shader_layout_cache_;
+  return adapter_p_->shader_layout_cache();
 }
 
 inline ShaderCache& Context::shader_cache() {
-  return shader_cache_;
+  return adapter_p_->shader_cache();
 }
 
 inline PipelineLayoutCache& Context::pipeline_layout_cache() {
-  return pipeline_layout_cache_;
+  return adapter_p_->pipeline_layout_cache();
 }
 
 inline ComputePipelineCache& Context::pipeline_cache() {
-  return pipeline_cache_;
+  return adapter_p_->compute_pipeline_cache();
 }
 
 inline Command& Context::command() {

--- a/aten/src/ATen/native/vulkan/api/Runtime.cpp
+++ b/aten/src/ATen/native/vulkan/api/Runtime.cpp
@@ -281,6 +281,9 @@ Runtime::Runtime(const RuntimeConfiguration config)
     adapters_{},
     default_adapter_i_(-1),
     debug_report_callback_(create_debug_report_callback(instance_, config_)) {
+  // List of adapters will never exceed the number of physical devices
+  adapters_.reserve(device_mappings_.size());
+
   if (config.initDefaultDevice) {
     try {
       switch(config.defaultSelector) {
@@ -360,7 +363,8 @@ uint32_t Runtime::create_adapter(const Selector& selector) {
   }
   // Otherwise, create an adapter for the selected physical device
   adapter_i = adapters_.size();
-  adapters_.emplace_back(device_mapping.first, config_.numRequestedQueues);
+  adapters_.emplace_back(
+      new Adapter(instance_, device_mapping.first, config_.numRequestedQueues));
   device_mapping.second = adapter_i;
 
   return adapter_i;

--- a/aten/src/ATen/native/vulkan/api/Runtime.h
+++ b/aten/src/ATen/native/vulkan/api/Runtime.h
@@ -45,6 +45,7 @@ class Runtime final {
   ~Runtime();
 
   typedef std::pair<PhysicalDevice, int32_t> DeviceMapping;
+  typedef std::unique_ptr<Adapter> AdapterPtr;
 
  private:
   RuntimeConfiguration config_;
@@ -52,7 +53,7 @@ class Runtime final {
   VkInstance instance_;
 
   std::vector<DeviceMapping> device_mappings_;
-  std::vector<Adapter> adapters_;
+  std::vector<AdapterPtr> adapters_;
   uint32_t default_adapter_i_;
 
   VkDebugReportCallbackEXT debug_report_callback_;
@@ -66,28 +67,14 @@ class Runtime final {
     TORCH_CHECK(
         default_adapter_i_ >= 0 && default_adapter_i_ < adapters_.size(),
         "Pytorch Vulkan Runtime: Default device adapter is not set correctly!");
-    return &adapters_[default_adapter_i_];
-  }
-
-  inline Adapter& get_adapter() {
-    TORCH_CHECK(
-        default_adapter_i_ >= 0 && default_adapter_i_ < adapters_.size(),
-        "Pytorch Vulkan Runtime: Default device adapter is not set correctly!");
-    return adapters_[default_adapter_i_];
+    return adapters_[default_adapter_i_].get();
   }
 
   inline Adapter* get_adapter_p(uint32_t i) {
     TORCH_CHECK(
         i >= 0 && i < adapters_.size(),
         "Pytorch Vulkan Runtime: Adapter at index ", i, " is not available!");
-    return &adapters_[i];
-  }
-
-  inline Adapter& get_adapter(uint32_t i) {
-    TORCH_CHECK(
-        default_adapter_i_ >= 0 && default_adapter_i_ < adapters_.size(),
-        "Pytorch Vulkan Runtime: Adapter at index ", i, " is not available!");
-    return adapters_[i];
+    return adapters_[i].get();
   }
 
   inline uint32_t default_adapter_i() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77787 [vulkan][testing] only keep minimal tests
* #78653 [vulkan] Integrate refactored memory mapping and fences
* #78652 [vulkan] Integrate refactored resource
* #78651 [vulkan] Refactor Command
* #77786 [vulkan] Remove op profiling from Vulkan API test binary
* #78650 [vulkan] Add refactored Resource
* #78649 [vulkan] Remove ThreadContext
* **#78648 [vulkan] Move ownership of Shader and Pipeline caches to Adapter**
* #78647 [vulkan] Refactor Adapter to have PhysicalDevice hold physical device properties
* #77785 [vulkan] Refactor Shader and Pipeline
* #77784 [vulkan] Remove unused code for Winograd convolutions

Differential Revision: [D36824006](https://our.internmc.facebook.com/intern/diff/D36824006)