### PR TITLE
[vulkan] Add refactored Resource

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Resource.cpp
+++ b/aten/src/ATen/native/vulkan/api/Resource.cpp
@@ -61,6 +61,602 @@ VmaAllocationCreateInfo create_allocation_create_info(
 
 } // namespace
 
+//
+// VulkanBuffer
+//
+
+VulkanBuffer::VulkanBuffer()
+  : memory_properties_{},
+    buffer_properties_{},
+    allocator_(VK_NULL_HANDLE),
+    allocation_(VK_NULL_HANDLE),
+    handle_(VK_NULL_HANDLE) {
+}
+
+VulkanBuffer::VulkanBuffer(
+    const VmaAllocator vma_allocator,
+    const VkDeviceSize size,
+    const VulkanBuffer::MemoryProperties& mem_props)
+  : memory_properties_(mem_props),
+    buffer_properties_({
+      size,
+      0u,
+      size,
+    }),
+    allocator_(vma_allocator),
+    allocation_(VK_NULL_HANDLE),
+    handle_(VK_NULL_HANDLE) {
+  const VkBufferCreateInfo buffer_create_info{
+    VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,  // sType
+    nullptr,  // pNext
+    0u,  // flags
+    size,  // size
+    memory_properties_.buffer_usage,  // usage
+    VK_SHARING_MODE_EXCLUSIVE,  // sharingMode
+    0u,  // queueFamilyIndexCount
+    nullptr,  // pQueueFamilyIndices
+  };
+
+  // TODO: enable creation with a custom pool
+  VmaAllocationCreateInfo alloc_create_info {
+    VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT, // flags
+    memory_properties_.memory_usage,  // usage
+    memory_properties_.required_mem_flags,  // requiredFlags
+    memory_properties_.preferred_mem_flags,  // preferredFlags
+    0u,  // memoryTypeBits
+    VK_NULL_HANDLE,  // pool
+    nullptr,  // pUserData
+    0.5f,  // priority
+  };
+
+  VK_CHECK(vmaCreateBuffer(
+      allocator_, &buffer_create_info, &alloc_create_info,
+      &handle_, &allocation_, nullptr));
+}
+
+VulkanBuffer::VulkanBuffer(VulkanBuffer&& other) noexcept
+  : memory_properties_(other.memory_properties_),
+    buffer_properties_(other.buffer_properties_),
+    allocator_(other.allocator_),
+    allocation_(other.allocation_),
+    handle_(other.handle_) {
+  other.allocation_ = VK_NULL_HANDLE;
+  other.handle_ = VK_NULL_HANDLE;
+}
+
+VulkanBuffer& VulkanBuffer::operator=(VulkanBuffer&& other) noexcept {
+  const VmaAllocation tmp_allocation = allocation_;
+  const VkBuffer tmp_buffer = handle_;
+
+  memory_properties_ = other.memory_properties_;
+  buffer_properties_ = other.buffer_properties_;
+  allocator_ = other.allocator_;
+  allocation_ = other.allocation_;
+  handle_ = other.handle_;
+
+  other.allocation_ = tmp_allocation;
+  other.handle_ = tmp_buffer;
+
+  return *this;
+}
+
+VulkanBuffer::~VulkanBuffer() {
+  if (VK_NULL_HANDLE != handle_) {
+    vmaDestroyBuffer(allocator_, handle_, allocation_);
+  }
+}
+
+//
+// MemoryMap
+//
+
+MemoryMap::MemoryMap(const VulkanBuffer& buffer, const uint8_t access)
+  : access_(access),
+    allocator_(buffer.vma_allocator()),
+    allocation_(buffer.allocation()),
+    data_(nullptr) {
+  VK_CHECK(vmaMapMemory(allocator_, allocation_, &data_));
+}
+
+MemoryMap::MemoryMap(MemoryMap&& other) noexcept
+  : access_(other.access_),
+    allocator_(other.allocator_),
+    allocation_(other.allocation_),
+    data_(other.data_) {
+  other.allocation_ = VK_NULL_HANDLE;
+  other.data_ = nullptr;
+}
+
+MemoryMap::~MemoryMap() {
+  if (C10_UNLIKELY(!data_)) {
+    return;
+  }
+
+  if (access_ & MemoryAccessType::WRITE) {
+    // Call will be ignored by implementation if the memory type this allocation
+    // belongs to is not HOST_VISIBLE or is HOST_COHERENT, which is the behavior
+    // we want.
+    VK_CHECK(vmaFlushAllocation(allocator_, allocation_, 0u, VK_WHOLE_SIZE));
+  }
+
+  vmaUnmapMemory(allocator_, allocation_);
+}
+
+void MemoryMap::invalidate() {
+  if (access_ & MemoryAccessType::READ) {
+    // Call will be ignored by implementation if the memory type this allocation
+    // belongs to is not HOST_VISIBLE or is HOST_COHERENT, which is the behavior
+    // we want.
+    VK_CHECK(vmaInvalidateAllocation(
+        allocator_, allocation_, 0u, VK_WHOLE_SIZE));
+  }
+}
+
+//
+// ImageSampler
+//
+
+bool operator==(
+    const ImageSampler::Properties& _1,
+    const ImageSampler::Properties& _2) {
+  return (_1.filter == _2.filter && \
+          _1.mipmap_mode == _2.mipmap_mode && \
+          _1.address_mode == _2.address_mode && \
+          _1.border_color == _2.border_color);
+}
+
+ImageSampler::ImageSampler(
+    const VkDevice device,
+    const ImageSampler::Properties& props)
+  : device_(device),
+    handle_(VK_NULL_HANDLE) {
+  const VkSamplerCreateInfo sampler_create_info{
+    VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,  // sType
+    nullptr,  // pNext
+    0u,  // flags
+    props.filter,  // magFilter
+    props.filter,  // minFilter
+    props.mipmap_mode,  // mipmapMode
+    props.address_mode,  // addressModeU
+    props.address_mode,  // addressModeV
+    props.address_mode,  // addressModeW
+    0.0f,  // mipLodBias
+    VK_FALSE,  // anisotropyEnable
+    1.0f,  // maxAnisotropy,
+    VK_FALSE,  // compareEnable
+    VK_COMPARE_OP_NEVER,  // compareOp
+    0.0f,  // minLod
+    VK_LOD_CLAMP_NONE,  // maxLod
+    props.border_color,  // borderColor
+    VK_FALSE,  // unnormalizedCoordinates
+  };
+
+  VK_CHECK(vkCreateSampler(
+      device_, &sampler_create_info, nullptr, &handle_));
+}
+
+ImageSampler::ImageSampler(ImageSampler&& other) noexcept
+  : device_(other.device_),
+    handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
+}
+
+ImageSampler::~ImageSampler() {
+  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroySampler(device_, handle_, nullptr);
+}
+
+size_t ImageSampler::Hasher::operator()(
+    const ImageSampler::Properties& props) const {
+  return c10::get_hash(
+      props.filter,
+      props.mipmap_mode,
+      props.address_mode,
+      props.border_color);
+}
+
+void swap(ImageSampler& lhs, ImageSampler& rhs) {
+  VkDevice tmp_device = lhs.device_;
+  VkSampler tmp_handle = lhs.handle_;
+
+  lhs.device_ = rhs.device_;
+  lhs.handle_ = rhs.handle_;
+
+  rhs.device_ = tmp_device;
+  rhs.handle_ = tmp_handle;
+}
+
+//
+// VulkanImage
+//
+
+VulkanImage::VulkanImage()
+  : memory_properties_{},
+    image_properties_{},
+    view_properties_{},
+    sampler_properties_{},
+    allocator_(VK_NULL_HANDLE),
+    allocation_(VK_NULL_HANDLE),
+    handles_{
+        VK_NULL_HANDLE,
+        VK_NULL_HANDLE,
+        VK_NULL_HANDLE,
+    },
+    layout_{} {
+}
+
+VulkanImage::VulkanImage(
+    const VmaAllocator vma_allocator,
+    const VkDevice device,
+    const MemoryProperties& mem_props,
+    const ImageProperties& image_props,
+    const ViewProperties& view_props,
+    const SamplerProperties& sampler_props,
+    const VkImageLayout layout,
+    const VkSampler sampler)
+  : memory_properties_(mem_props),
+    image_properties_(image_props),
+    view_properties_(view_props),
+    sampler_properties_(sampler_props),
+    allocator_(vma_allocator),
+    allocation_(VK_NULL_HANDLE),
+    handles_{
+        VK_NULL_HANDLE,
+        VK_NULL_HANDLE,
+        sampler,
+    },
+    layout_(layout) {
+  const VkImageCreateInfo image_create_info{
+    VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,  // sType
+    nullptr,  // pNext
+    0u,  // flags
+    image_properties_.image_type,  // imageType
+    image_properties_.image_format,  // format
+    image_properties_.image_extents,  // extents
+    1u,  // mipLevels
+    1u,  // arrayLayers
+    VK_SAMPLE_COUNT_1_BIT,  // samples
+    VK_IMAGE_TILING_OPTIMAL,  // tiling
+    memory_properties_.image_usage,  // usage
+    VK_SHARING_MODE_EXCLUSIVE,  // sharingMode
+    0u,  // queueFamilyIndexCount
+    nullptr,  // pQueueFamilyIndices
+    layout_,  // initialLayout
+  };
+
+  // TODO: enable creation with a custom pool
+  const VmaAllocationCreateInfo alloc_create_info{
+    VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT, // flags
+    memory_properties_.memory_usage,  // usage
+    memory_properties_.required_mem_flags,  // requiredFlags
+    memory_properties_.preferred_mem_flags,  // preferredFlags
+    0u,  // memoryTypeBits
+    VK_NULL_HANDLE,  // pool
+    nullptr,  // pUserData
+    0.5f,  // priority
+  };
+
+  VK_CHECK(vmaCreateImage(
+      allocator_, &image_create_info, &alloc_create_info,
+      &(handles_.image), &allocation_, nullptr));
+
+  // Image View
+
+  const VkComponentMapping component_mapping{
+    VK_COMPONENT_SWIZZLE_IDENTITY,  // r
+    VK_COMPONENT_SWIZZLE_IDENTITY,  // g
+    VK_COMPONENT_SWIZZLE_IDENTITY,  // b
+    VK_COMPONENT_SWIZZLE_IDENTITY,  // a
+  };
+
+  const VkImageSubresourceRange subresource_range{
+    VK_IMAGE_ASPECT_COLOR_BIT,  // aspectMask
+    0u,  // baseMipLevel
+    VK_REMAINING_MIP_LEVELS,  // levelCount
+    0u,  // baseArrayLayer
+    VK_REMAINING_ARRAY_LAYERS,  // layerCount
+  };
+
+  const VkImageViewCreateInfo image_view_create_info{
+    VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,  // sType
+    nullptr,  // pNext
+    0u,  // flags
+    handles_.image,  // image
+    view_properties_.view_type,  // viewType
+    view_properties_.view_format,  // format
+    component_mapping,  // components
+    subresource_range,  // subresourceRange
+  };
+
+  VK_CHECK(vkCreateImageView(
+      device, &image_view_create_info, nullptr, &(handles_.image_view)));
+}
+
+VulkanImage::VulkanImage(VulkanImage&& other) noexcept
+  : memory_properties_(other.memory_properties_),
+    image_properties_(other.image_properties_),
+    view_properties_(other.view_properties_),
+    sampler_properties_(other.sampler_properties_),
+    allocator_(other.allocator_),
+    allocation_(other.allocation_),
+    handles_(other.handles_),
+    layout_(other.layout_) {
+  other.allocation_ = VK_NULL_HANDLE;
+  other.handles_.image = VK_NULL_HANDLE;
+  other.handles_.image_view = VK_NULL_HANDLE;
+  other.handles_.sampler = VK_NULL_HANDLE;
+}
+
+VulkanImage& VulkanImage::operator=(VulkanImage&& other) noexcept {
+  const VmaAllocation tmp_allocation = allocation_;
+  const VkImage tmp_image = handles_.image;
+  const VkImageView tmp_image_view = handles_.image_view;
+
+  memory_properties_ = other.memory_properties_;
+  image_properties_ = other.image_properties_;
+  view_properties_ = other.view_properties_;
+  sampler_properties_ = other.sampler_properties_;
+  allocator_ = other.allocator_;
+  allocation_ = other.allocation_;
+  handles_ = other.handles_;
+  layout_ = other.layout_;
+
+  other.allocation_ = tmp_allocation;
+  other.handles_.image = tmp_image;
+  other.handles_.image_view = tmp_image_view;
+
+  return *this;
+}
+
+VulkanImage::~VulkanImage() {
+  if (VK_NULL_HANDLE != handles_.image_view) {
+    VmaAllocatorInfo allocator_info{};
+    vmaGetAllocatorInfo(allocator_, &allocator_info);
+    vkDestroyImageView(allocator_info.device, handles_.image_view, nullptr);
+  }
+
+  if (VK_NULL_HANDLE != handles_.image) {
+    vmaDestroyImage(allocator_, handles_.image, allocation_);
+  }
+}
+
+//
+// SamplerCache
+//
+
+SamplerCache::SamplerCache(const VkDevice device)
+  : cache_mutex_{},
+    device_(device),
+    cache_{} {
+}
+
+SamplerCache::SamplerCache(SamplerCache&& other) noexcept
+  : cache_mutex_{},
+    device_(other.device_) {
+  std::lock_guard<std::mutex> lock(other.cache_mutex_);
+  cache_ = std::move(other.cache_);
+}
+
+SamplerCache::~SamplerCache() {
+  purge();
+}
+
+VkSampler SamplerCache::retrieve(const SamplerCache::Key& key) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  auto it = cache_.find(key);
+  if C10_UNLIKELY(cache_.cend() == it) {
+    it = cache_.insert({key, SamplerCache::Value(device_, key)}).first;
+  }
+
+  return it->second.handle();
+}
+
+void SamplerCache::purge() {
+  cache_.clear();
+}
+
+//
+// MemoryAllocator
+//
+
+MemoryAllocator::MemoryAllocator(
+    const VkInstance instance,
+    const VkPhysicalDevice physical_device,
+    const VkDevice device)
+  : instance_{},
+    physical_device_(physical_device),
+    device_(device) {
+  const VmaAllocatorCreateInfo allocator_create_info{
+    0u,  // flags
+    physical_device_,  // physicalDevice
+    device_,  // device
+    0u,  // preferredLargeHeapBlockSize
+    nullptr,  // pAllocationCallbacks
+    nullptr,  // pDeviceMemoryCallbacks
+    1u,  // frameinUseCount
+    nullptr,  // pHeapSizeLimit
+    nullptr,  // pVulkanFunctions
+    nullptr,  // pRecordSettings
+    instance,  // instance
+    VK_API_VERSION_1_0,  // vulkanApiVersion
+  };
+
+  VK_CHECK(vmaCreateAllocator(&allocator_create_info, &allocator_));
+}
+
+MemoryAllocator::MemoryAllocator(MemoryAllocator&& other) noexcept
+  : instance_(other.instance_),
+    physical_device_(other.physical_device_),
+    device_(other.device_),
+    allocator_(other.allocator_) {
+  other.allocator_ = VK_NULL_HANDLE;
+  other.device_ = VK_NULL_HANDLE;
+  other.physical_device_ = VK_NULL_HANDLE;
+  other.instance_ = VK_NULL_HANDLE;
+}
+
+MemoryAllocator::~MemoryAllocator() {
+  if C10_LIKELY(VK_NULL_HANDLE == allocator_) {
+    return;
+  }
+  vmaDestroyAllocator(allocator_);
+}
+
+VulkanImage MemoryAllocator::create_image3d_fp(
+      const VkExtent3D& extents,
+      const VulkanImage::SamplerProperties& sampler_props,
+      const VkSampler sampler,
+      bool allow_transfer) {
+  VkImageUsageFlags usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+  if (allow_transfer) {
+    usage |= (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+  }
+
+  const VulkanImage::MemoryProperties mem_props{
+    VMA_MEMORY_USAGE_GPU_ONLY,
+    0u,
+    0u,
+    usage,
+  };
+
+#ifdef USE_VULKAN_FP16_INFERENCE
+    const VkFormat image_format = VK_FORMAT_R16G16B16A16_SFLOAT;
+#else
+    const VkFormat image_format = VK_FORMAT_R32G32B32A32_SFLOAT;
+#endif
+
+  const VulkanImage::ImageProperties image_props{
+    VK_IMAGE_TYPE_3D,
+    image_format,
+    extents,
+  };
+
+  const VulkanImage::ViewProperties view_props{
+    VK_IMAGE_VIEW_TYPE_3D,
+    image_format,
+  };
+
+  const VkImageLayout initial_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+  return VulkanImage(
+      allocator_, device_,
+      mem_props, image_props, view_props, sampler_props,
+      initial_layout, sampler);
+}
+
+VulkanBuffer MemoryAllocator::create_storage_buffer(
+    const VkDeviceSize size, const bool gpu_only) {
+  const VkBufferUsageFlags buffer_usage = \
+      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+      VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+      VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+
+  const VmaMemoryUsage vma_usage = \
+      gpu_only ? VMA_MEMORY_USAGE_GPU_ONLY : VMA_MEMORY_USAGE_GPU_TO_CPU;
+
+  const VkMemoryPropertyFlags preferred_mem_props = \
+      gpu_only ? 0u : VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+
+  const VulkanBuffer::MemoryProperties mem_props{
+    vma_usage,
+    0u,
+    preferred_mem_props,
+    buffer_usage,
+  };
+
+  return VulkanBuffer(allocator_, size, mem_props);
+}
+
+VulkanBuffer MemoryAllocator::create_staging_buffer(const VkDeviceSize size) {
+  const VulkanBuffer::MemoryProperties mem_props{
+    VMA_MEMORY_USAGE_CPU_COPY,
+    0u,
+    0u,
+    VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+  };
+
+  return VulkanBuffer(allocator_, size, mem_props);
+}
+
+//
+// VulkanFence
+//
+
+VulkanFence::VulkanFence()
+  : device_(VK_NULL_HANDLE),
+    handle_(VK_NULL_HANDLE),
+    waiting_(false) {
+}
+
+VulkanFence::VulkanFence(const VkDevice device)
+  : device_(device),
+    handle_(VK_NULL_HANDLE),
+    waiting_(VK_NULL_HANDLE) {
+  const VkFenceCreateInfo fence_create_info{
+    VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,  // sType
+    nullptr,  // pNext
+    0u,  // flags
+  };
+
+  VK_CHECK(vkCreateFence(
+      device_,
+      &fence_create_info,
+      nullptr,
+      &handle_));
+}
+
+VulkanFence::VulkanFence(VulkanFence&& other) noexcept
+  : device_(other.device_),
+    handle_(other.handle_),
+    waiting_(other.waiting_) {
+  other.handle_ = VK_NULL_HANDLE;
+  other.waiting_ = false;
+}
+
+VulkanFence& VulkanFence::operator=(VulkanFence&& other) noexcept {
+  device_ = other.device_;
+  handle_ = other.handle_;
+  waiting_ = other.waiting_;
+
+  other.device_ = VK_NULL_HANDLE;
+  other.handle_ = VK_NULL_HANDLE;
+  other.waiting_ = false;
+
+  return *this;
+}
+
+VulkanFence::~VulkanFence() {
+  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroyFence(device_, handle_, nullptr);
+}
+
+void VulkanFence::wait() {
+  // if get_submit_handle() has not been called, then this will no-op
+  if (waiting_) {
+    VK_CHECK(vkWaitForFences(
+        device_,
+        1u,
+        &handle_,
+        VK_TRUE,
+        UINT64_MAX));
+
+    VK_CHECK(vkResetFences(
+        device_,
+        1u,
+        &handle_));
+
+    waiting_ = false;
+  }
+}
+
+/* ----- Old Code --- */
+
+
 void release_buffer(const Resource::Buffer& buffer) {
   // Safe to pass null as buffer or allocation.
   vmaDestroyBuffer(

--- a/aten/src/ATen/native/vulkan/api/Resource.h
+++ b/aten/src/ATen/native/vulkan/api/Resource.h
@@ -12,6 +12,412 @@ namespace native {
 namespace vulkan {
 namespace api {
 
+enum MemoryAccessType : uint8_t {
+  NONE = 0u << 0u,
+  READ = 1u << 0u,
+  WRITE = 1u << 1u,
+};
+
+class VulkanBuffer final {
+ public:
+  struct MemoryProperties final {
+    VmaMemoryUsage memory_usage;
+    VkMemoryPropertyFlags required_mem_flags;
+    VkMemoryPropertyFlags preferred_mem_flags;
+
+    VkBufferUsageFlags buffer_usage;
+  };
+
+  struct BufferProperties final {
+    VkDeviceSize size;
+    VkDeviceSize mem_offset;
+    VkDeviceSize mem_range;
+  };
+
+  explicit VulkanBuffer();
+
+  explicit VulkanBuffer(
+      const VmaAllocator, const VkDeviceSize, const MemoryProperties&);
+
+  VulkanBuffer(const VulkanBuffer&) = delete;
+  VulkanBuffer& operator=(const VulkanBuffer&) = delete;
+
+  VulkanBuffer(VulkanBuffer&&) noexcept;
+  VulkanBuffer& operator=(VulkanBuffer&&) noexcept;
+
+  ~VulkanBuffer();
+
+  struct Package final {
+    VkBuffer handle;
+    VkDeviceSize buffer_offset;
+    VkDeviceSize buffer_range;
+  };
+
+ private:
+  MemoryProperties memory_properties_;
+  BufferProperties buffer_properties_;
+  // The allocator object this was allocated from
+  VmaAllocator allocator_;
+  // Handles to the allocated memory
+  VmaAllocation allocation_;
+  VkBuffer handle_;
+
+ public:
+  VmaAllocator vma_allocator() const {
+    return allocator_;
+  }
+
+  VmaAllocation allocation() const {
+    return allocation_;
+  }
+
+  Package package() const {
+    return {
+      handle_,
+      buffer_properties_.mem_offset,
+      buffer_properties_.mem_range
+    };
+  }
+
+  operator bool() const {
+    return (allocation_ != VK_NULL_HANDLE);
+  }
+};
+
+class MemoryMap final {
+ public:
+  explicit MemoryMap(const VulkanBuffer& buffer, const uint8_t access);
+
+  MemoryMap(const MemoryMap&) = delete;
+  MemoryMap& operator=(const MemoryMap&) = delete;
+
+  MemoryMap(MemoryMap&&) noexcept;
+  MemoryMap& operator=(MemoryMap&&) = delete;
+
+  ~MemoryMap();
+
+ private:
+  uint8_t access_;
+  VmaAllocator allocator_;
+  VmaAllocation allocation_;
+  void* data_;
+
+ public:
+  template<typename T>
+  T* data() {
+    return reinterpret_cast<T*>(data_);
+  };
+
+  void invalidate();
+};
+
+struct BufferBarrier final {
+  VkAccessFlags src_flags;
+  VkAccessFlags dst_flags;
+
+  VkBuffer buffer;
+  VkDeviceSize buffer_offset;
+  VkDeviceSize buffer_range;
+};
+
+class ImageSampler final {
+ public:
+  struct Properties final {
+    VkFilter filter;
+    VkSamplerMipmapMode mipmap_mode;
+    VkSamplerAddressMode address_mode;
+    VkBorderColor border_color;
+  };
+
+  explicit ImageSampler(const VkDevice, const Properties&);
+
+  ImageSampler(const ImageSampler&) = delete;
+  ImageSampler& operator=(const ImageSampler&) = delete;
+
+  ImageSampler(ImageSampler&&) noexcept;
+  ImageSampler& operator=(ImageSampler&&) = delete;
+
+  ~ImageSampler();
+
+ private:
+  VkDevice device_;
+  VkSampler handle_;
+
+ public:
+  VkSampler handle() const {
+    return handle_;
+  }
+
+  struct Hasher {
+    size_t operator()(const Properties&) const;
+  };
+
+  // We need to define a custom swap function since this class
+  // does not allow for move assignment. The swap function will
+  // be used in the hash map.
+  friend void swap(ImageSampler& lhs, ImageSampler& rhs);
+};
+
+class VulkanImage final {
+ public:
+  struct MemoryProperties final {
+    VmaMemoryUsage memory_usage;
+    VkMemoryPropertyFlags required_mem_flags;
+    VkMemoryPropertyFlags preferred_mem_flags;
+
+    VkImageUsageFlags image_usage;
+  };
+
+  struct ImageProperties final {
+    VkImageType image_type;
+    VkFormat image_format;
+    VkExtent3D image_extents;
+  };
+
+  struct ViewProperties final {
+    VkImageViewType view_type;
+    VkFormat view_format;
+  };
+
+  typedef ImageSampler::Properties SamplerProperties;
+
+  struct Handles final {
+    VkImage image;
+    VkImageView image_view;
+    VkSampler sampler;
+  };
+
+  explicit VulkanImage();
+
+  explicit VulkanImage(
+      const VmaAllocator,
+      const VkDevice,
+      const MemoryProperties&,
+      const ImageProperties&,
+      const ViewProperties&,
+      const SamplerProperties&,
+      const VkImageLayout layout,
+      const VkSampler);
+
+  VulkanImage(const VulkanImage&) = delete;
+  VulkanImage& operator=(const VulkanImage&) = delete;
+
+  VulkanImage(VulkanImage&&) noexcept;
+  VulkanImage& operator=(VulkanImage&&) noexcept;
+
+  ~VulkanImage();
+
+  struct Package final {
+    VkImage handle;
+    VkImageLayout image_layout;
+    VkImageView image_view;
+    VkSampler image_sampler;
+  };
+
+ private:
+  MemoryProperties memory_properties_;
+  ImageProperties image_properties_;
+  ViewProperties view_properties_;
+  SamplerProperties sampler_properties_;
+  // The allocator object this was allocated from
+  VmaAllocator allocator_;
+  // Handles to the allocated memory
+  VmaAllocation allocation_;
+  Handles handles_;
+  // Layout
+  VkImageLayout layout_;
+
+ public:
+  inline VmaAllocator vma_allocator() const {
+    return allocator_;
+  }
+
+  inline VmaAllocation allocation() const {
+    return allocation_;
+  }
+
+  inline VkImage handle() const {
+    return handles_.image;
+  }
+
+  Package package() const {
+    return {
+      handles_.image,
+      layout_,
+      handles_.image_view,
+      handles_.sampler,
+    };
+  }
+
+  inline VkImageLayout layout() const {
+    return layout_;
+  }
+
+  inline void set_layout(const VkImageLayout layout) {
+    layout_ = layout;
+  }
+
+  inline operator bool() const {
+    return (allocation_ != VK_NULL_HANDLE);
+  }
+};
+
+struct ImageBarrier final {
+  VkAccessFlags src_flags;
+  VkImageLayout src_layout;
+
+  VkAccessFlags dst_flags;
+  VkImageLayout dst_layout;
+
+  VkImage image;
+};
+
+class SamplerCache final {
+ public:
+  explicit SamplerCache(const VkDevice device);
+
+  SamplerCache(const SamplerCache&) = delete;
+  SamplerCache& operator=(const SamplerCache&) = delete;
+
+  SamplerCache(SamplerCache&&) noexcept;
+  SamplerCache& operator=(SamplerCache&&) = delete;
+
+  ~SamplerCache();
+
+  typedef ImageSampler::Properties Key;
+  typedef ImageSampler Value;
+  typedef ImageSampler::Hasher Hasher;
+
+ private:
+  // Multiple threads could potentially be adding entries into the cache, so use
+  // a mutex to manage access
+  std::mutex cache_mutex_;
+
+  VkDevice device_;
+  ska::flat_hash_map<Key, Value, Hasher> cache_;
+
+ public:
+  VkSampler retrieve(const Key&);
+  void purge();
+};
+
+class MemoryAllocator final {
+ public:
+  explicit MemoryAllocator(
+      const VkInstance instance,
+      const VkPhysicalDevice physical_device,
+      const VkDevice device);
+
+  MemoryAllocator(const MemoryAllocator&) = delete;
+  MemoryAllocator& operator=(const MemoryAllocator&) = delete;
+
+  MemoryAllocator(MemoryAllocator&&) noexcept;
+  MemoryAllocator& operator=(MemoryAllocator&&) = delete;
+
+  ~MemoryAllocator();
+
+ private:
+  VkInstance instance_;
+  VkPhysicalDevice physical_device_;
+  VkDevice device_;
+  VmaAllocator allocator_;
+
+ public:
+  VulkanImage create_image3d_fp(
+      const VkExtent3D&,
+      const VulkanImage::SamplerProperties&,
+      const VkSampler,
+      const bool allow_transfer = false);
+
+  VulkanBuffer create_storage_buffer(
+      const VkDeviceSize, const bool gpu_only = true);
+
+  VulkanBuffer create_staging_buffer(const VkDeviceSize);
+
+  template<typename Block>
+  VulkanBuffer create_params_buffer(const Block& block);
+};
+
+class VulkanFence final {
+ public:
+  // TODO: This is required for the lazy allocation pattern in api/Tensor.
+  //       It will be disabled pending future refactors.
+  explicit VulkanFence();
+
+  explicit VulkanFence(const VkDevice);
+
+  VulkanFence(const VulkanFence&) = delete;
+  VulkanFence& operator=(const VulkanFence&) = delete;
+
+  VulkanFence(VulkanFence&&) noexcept;
+  VulkanFence& operator=(VulkanFence&&) noexcept;
+
+  ~VulkanFence();
+
+ private:
+  VkDevice device_;
+  VkFence handle_;
+  bool waiting_;
+
+ public:
+  // Used to get the handle for a queue submission.
+  VkFence get_submit_handle() {
+    if (handle_ != VK_NULL_HANDLE) {
+      // Indicate we are now waiting for this fence to be signaled
+      waiting_ = true;
+    }
+    return handle_;
+  }
+
+  VkFence handle() {
+    return handle_;
+  }
+
+  // Trigger a synchronous wait for the fence to be signaled
+  void wait();
+
+  bool waiting() const {
+    return waiting_;
+  }
+
+  operator bool() const {
+    return (VK_NULL_HANDLE != handle_);
+  }
+};
+
+// A pool to track created Fences and reuse ones that are available.
+// Only intended to be modified by one thread at a time.
+struct FencePool final {
+  VkDevice device_;
+
+  std::stack<VulkanFence> pool_;
+
+  explicit FencePool(const VkDevice device)
+    : device_(device),
+      pool_{} {
+  }
+
+  // Returns an rvalue reference to a fence, so that it can be moved
+  inline VulkanFence get_fence() {
+    if (pool_.empty()) {
+      VulkanFence new_fence = VulkanFence(device_);
+      return new_fence;
+    }
+
+    VulkanFence top_fence = std::move(pool_.top());
+    pool_.pop();
+
+    return top_fence;
+  }
+
+  // Marks the fence as available
+  inline void return_fence(VulkanFence& fence) {
+    pool_.push(std::move(fence));
+  }
+};
+
+/* ---- Old Code ---- */
+
 struct Resource final {
   class Pool;
 
@@ -61,6 +467,7 @@ struct Resource final {
     };
 
     class Scope;
+
     template<typename Type>
     using Handle = Handle<Type, Scope>;
 
@@ -456,6 +863,29 @@ inline Resource::Buffer Resource::Pool::uniform(const Block& block) {
 
   return uniform;
 }
+
+template<typename Block>
+inline VulkanBuffer MemoryAllocator::create_params_buffer(const Block& block) {
+  const VulkanBuffer::MemoryProperties mem_props{
+    VMA_MEMORY_USAGE_CPU_TO_GPU,
+    0u,
+    0u,
+    VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+  };
+
+  VulkanBuffer uniform_buffer(allocator_, sizeof(Block), mem_props);
+
+  // Fill the uniform buffer with data in block
+  {
+    MemoryMap mapping(uniform_buffer, MemoryAccessType::WRITE);
+    Block* data_ptr = mapping.template data<Block>();
+
+    *data_ptr = block;
+  }
+
+  return uniform_buffer;
+}
+
 
 } // namespace api
 } // namespace vulkan


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77787 [vulkan][testing] only keep minimal tests
* #78653 [vulkan] Integrate refactored memory mapping and fences
* #78652 [vulkan] Integrate refactored resource
* #78651 [vulkan] Refactor Command
* #77786 [vulkan] Remove op profiling from Vulkan API test binary
* **#78650 [vulkan] Add refactored Resource**
* #78649 [vulkan] Remove ThreadContext
* #78648 [vulkan] Move ownership of Shader and Pipeline caches to Adapter
* #78647 [vulkan] Refactor Adapter to have PhysicalDevice hold physical device properties
* #77785 [vulkan] Refactor Shader and Pipeline
* #77784 [vulkan] Remove unused code for Winograd convolutions

Differential Revision: [D36824004](https://our.internmc.facebook.com/intern/diff/D36824004)