### PR TITLE
[vulkan] Refactor Command

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Command.cpp
+++ b/aten/src/ATen/native/vulkan/api/Command.cpp
@@ -8,6 +8,28 @@ namespace at {
 namespace native {
 namespace vulkan {
 namespace api {
+
+//
+// CommandStream
+//
+
+CommandStream::CommandStream(const VkDevice device)
+  : device_(device),
+    pool_(VK_NULL_HANDLE) {
+}
+
+CommandStream::CommandStream(CommandStream&& other) noexcept
+  : device_(other.device_),
+    pool_(other.pool_) {
+  other.pool_ = VK_NULL_HANDLE;
+}
+
+CommandStream::~CommandStream() {
+  if C10_LIKELY(VK_NULL_HANDLE == pool_) {
+    return;
+  }
+}
+
 namespace {
 
 std::mutex queue_mutex;

--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -14,6 +14,24 @@ namespace native {
 namespace vulkan {
 namespace api {
 
+class CommandStream final {
+ public:
+  explicit CommandStream(const VkDevice);
+
+  CommandStream(const CommandStream&) = delete;
+  CommandStream& operator=(const CommandStream&) = delete;
+
+  CommandStream(CommandStream&&) noexcept;
+  CommandStream& operator=(CommandStream&&) = delete;
+
+  ~CommandStream();
+
+ private:
+  VkDevice device_;
+  VkCommandPool pool_;
+};
+
+
 struct Command final {
   class Pool;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77787 [vulkan][testing] only keep minimal tests
* #78653 [vulkan] Integrate refactored memory mapping and fences
* #78652 [vulkan] Integrate refactored resource
* **#78651 [vulkan] Refactor Command**
* #77786 [vulkan] Remove op profiling from Vulkan API test binary
* #78650 [vulkan] Add refactored Resource
* #78649 [vulkan] Remove ThreadContext
* #78648 [vulkan] Move ownership of Shader and Pipeline caches to Adapter
* #78647 [vulkan] Refactor Adapter to have PhysicalDevice hold physical device properties
* #77785 [vulkan] Refactor Shader and Pipeline
* #77784 [vulkan] Remove unused code for Winograd convolutions

Differential Revision: [D36824003](https://our.internmc.facebook.com/intern/diff/D36824003)