### PR TITLE
[vulkan] Integrate refactored resource

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Adapter.cpp
+++ b/aten/src/ATen/native/vulkan/api/Adapter.cpp
@@ -272,7 +272,9 @@ Adapter::Adapter(
     shader_layout_cache_(device_.handle_),
     shader_cache_(device_.handle_),
     pipeline_layout_cache_(device_.handle_),
-    compute_pipeline_cache_(device_.handle_) {
+    compute_pipeline_cache_(device_.handle_),
+    sampler_cache_(device_.handle_),
+    vma_(instance_, physical_device_.handle, device_.handle_) {
 }
 
 Adapter::Adapter(Adapter&& other) noexcept
@@ -283,7 +285,9 @@ Adapter::Adapter(Adapter&& other) noexcept
     shader_layout_cache_(std::move(other.shader_layout_cache_)),
     shader_cache_(std::move(other.shader_cache_)),
     pipeline_layout_cache_(std::move(other.pipeline_layout_cache_)),
-    compute_pipeline_cache_(std::move(other.compute_pipeline_cache_)) {
+    compute_pipeline_cache_(std::move(other.compute_pipeline_cache_)),
+    sampler_cache_(std::move(other.sampler_cache_)),
+    vma_(std::move(other.vma_)) {
   std::lock_guard<std::mutex> lock(other.queue_mutex_);
 
   queues_ = std::move(other.queues_);

--- a/aten/src/ATen/native/vulkan/api/Adapter.h
+++ b/aten/src/ATen/native/vulkan/api/Adapter.h
@@ -112,6 +112,9 @@ class Adapter final {
   ShaderCache shader_cache_;
   PipelineLayoutCache pipeline_layout_cache_;
   ComputePipelineCache compute_pipeline_cache_;
+  // Memory Management
+  SamplerCache sampler_cache_;
+  MemoryAllocator vma_;
 
  public:
 
@@ -162,6 +165,16 @@ class Adapter final {
 
   inline ComputePipelineCache& compute_pipeline_cache() {
     return compute_pipeline_cache_;
+  }
+
+  // Memory Allocation
+
+  inline SamplerCache& sampler_cache() {
+    return sampler_cache_;
+  }
+
+  inline MemoryAllocator& vma() {
+    return vma_;
   }
 
   // Miscellaneous

--- a/aten/src/ATen/native/vulkan/api/Command.cpp
+++ b/aten/src/ATen/native/vulkan/api/Command.cpp
@@ -218,27 +218,19 @@ void Command::Buffer::bind(const Descriptor::Set& set) {
 }
 
 void Command::Buffer::copy(
-    const Resource::Buffer::Object source,
-    const Resource::Buffer::Object destination) {
+  const api::VulkanBuffer::Package source,
+  const api::VulkanBuffer::Package destination) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       command_buffer_,
       "This command buffer is in an invalid state! "
       "Potential reason: This command buffer is moved from.");
-
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      source,
-      "Invalid Vulkan source buffer!");
-
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      destination,
-      "Invalid Vulkan destination buffer!");
 
   barrier();
 
   const VkBufferCopy buffer_copy{
     0u,
     0u,
-    std::min(source.range, destination.range),
+    std::min(source.buffer_range, destination.buffer_range),
   };
 
   vkCmdCopyBuffer(

--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -60,7 +60,9 @@ struct Command final {
         VkPipelineLayout pipeline_layout,
         utils::uvec3 local_work_group);
     void bind(const Descriptor::Set& set);
-    void copy(Resource::Buffer::Object source, Resource::Buffer::Object destination);
+    void copy(
+        const api::VulkanBuffer::Package source,
+        const api::VulkanBuffer::Package destination);
     void dispatch(const utils::uvec3& global_work_group);
 
    private:

--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -36,6 +36,9 @@ void Context::flush() {
   resource().pool.purge();
   descriptor().pool.purge();
   command().pool.purge();
+
+  buffers_to_clear_.clear();
+  images_to_clear_.clear();
 }
 
 void Context::wait(const at::Tensor& src) {

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -49,6 +49,9 @@ class Context final {
   Descriptor descriptor_;
   Resource resource_;
   QueryPool querypool_;
+  // Memory Management
+  std::vector<VulkanBuffer> buffers_to_clear_;
+  std::vector<VulkanImage> images_to_clear_;
 
  public:
 
@@ -105,6 +108,15 @@ class Context final {
     return querypool_;
   }
 
+  // Memory Management
+  void register_buffer_cleanup(VulkanBuffer& buffer) {
+    buffers_to_clear_.emplace_back(std::move(buffer));
+  };
+
+  void register_image_cleanup(VulkanImage& image) {
+    images_to_clear_.emplace_back(std::move(image));
+  };
+
   // GPU RPC
 
   template<typename... Arguments>
@@ -136,6 +148,29 @@ class Context final {
     return queue_.handle;
   }
 
+};
+
+class UniformParamsBuffer final {
+ private:
+  api::Context* context_p_;
+  VulkanBuffer vulkan_buffer_;
+ public:
+  template<typename Block>
+  UniformParamsBuffer(Context* context_p, const Block& block)
+    : context_p_(context_p),
+      vulkan_buffer_(
+                    context_p_->adapter_ptr()->vma().create_params_buffer(block)) {
+        }
+  UniformParamsBuffer(const UniformParamsBuffer&) = delete;
+  UniformParamsBuffer& operator=(const UniformParamsBuffer&) = delete;
+  UniformParamsBuffer(UniformParamsBuffer&&) = delete;
+  UniformParamsBuffer& operator=(UniformParamsBuffer&&) = delete;
+  ~UniformParamsBuffer() {
+      context_p_->register_buffer_cleanup(vulkan_buffer_);
+    }
+  VulkanBuffer& buffer() {
+      return vulkan_buffer_;
+    }
 };
 
 bool available();

--- a/aten/src/ATen/native/vulkan/api/Descriptor.h
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.h
@@ -71,6 +71,9 @@ struct Descriptor final {
     Set& bind(uint32_t binding, const Resource::Buffer::Object& buffer);
     Set& bind(uint32_t binding, const Resource::Image::Object& image);
 
+    Set& bind(uint32_t binding, const VulkanBuffer::Package&);
+    Set& bind(uint32_t binding, const VulkanImage::Package&);
+
     VkDescriptorSet handle() const;
 
    private:

--- a/aten/src/ATen/native/vulkan/api/Helper.cpp
+++ b/aten/src/ATen/native/vulkan/api/Helper.cpp
@@ -10,8 +10,8 @@ namespace helper {
 
 void copy_texture_to_texture(
     api::Command::Buffer& command_buffer,
-    api::Resource::Image::Object& src_image,
-    api::Resource::Image::Object& dst_image,
+    api::VulkanImage::Package& src_image,
+    api::VulkanImage::Package& dst_image,
     api::utils::uvec3 copy_extents,
     api::utils::uvec3 src_offset,
     api::utils::uvec3 dst_offset) {

--- a/aten/src/ATen/native/vulkan/api/Helper.h
+++ b/aten/src/ATen/native/vulkan/api/Helper.h
@@ -16,8 +16,8 @@ namespace helper {
 
 void copy_texture_to_texture(
     api::Command::Buffer& command_buffer,
-    api::Resource::Image::Object& src_image,
-    api::Resource::Image::Object& dst_image,
+    api::VulkanImage::Package& src_image,
+    api::VulkanImage::Package& dst_image,
     api::utils::uvec3 copy_extents,
     api::utils::uvec3 src_offset,
     api::utils::uvec3 dst_offset);

--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -216,6 +216,8 @@ Tensor arithmetic_tensor(
           alpha,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -239,7 +241,7 @@ Tensor arithmetic_tensor(
           v_other.image(command_buffer, vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     } else {
       TORCH_CHECK(false, "Not implemented!");
     }

--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -432,42 +432,42 @@ vTensor* vTensor::host(
   return this;
 }
 
-vTensor::Buffer::Object vTensor::buffer(
+api::VulkanBuffer::Package vTensor::buffer(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage) const & {
   return view_->buffer(
       command_buffer,
       stage,
-      Access::Read).object;
+      Access::Read).package();
 }
 
-vTensor::Buffer::Object vTensor::buffer(
+api::VulkanBuffer::Package vTensor::buffer(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage,
     const Access::Flags access) & {
   return view_->buffer(
       command_buffer,
       stage,
-      access).object;
+      access).package();
 }
 
-vTensor::Image::Object vTensor::image(
+api::VulkanImage::Package vTensor::image(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage) const & {
   return view_->image(
       command_buffer,
       stage,
-      Access::Read).object;
+      Access::Read).package();
 }
 
-vTensor::Image::Object vTensor::image(
+api::VulkanImage::Package vTensor::image(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage,
     const Access::Flags access) & {
   return view_->image(
       command_buffer,
       stage,
-      access).object;
+      access).package();
 }
 
 vTensor::View::View()
@@ -478,7 +478,6 @@ vTensor::View::View()
     fence_{},
     // Context
     context_(nullptr),
-    pool_(nullptr),
     // State
     state_{},
     // Metadata
@@ -494,10 +493,10 @@ vTensor::View::View(
   : buffer_{},
     image_{},
     staging_{},
+    staging_memory_{},
     fence_{},
     // Context
     context_(context),
-    pool_(pool),
     // State
     state_(context->gpu().adapter, sizes),
     // Metadata
@@ -513,10 +512,10 @@ vTensor::View::~View() {
 }
 
 void vTensor::View::release() {
-  pool_->register_image_cleanup(image_);
-  pool_->register_buffer_cleanup(buffer_);
+  context_->register_image_cleanup(image_);
+  context_->register_buffer_cleanup(buffer_);
   if (staging_) {
-      pool_->register_buffer_cleanup(staging_);
+      context_->register_buffer_cleanup(staging_);
   }
 }
 
@@ -537,23 +536,23 @@ class vTensor::View::CMD final {
 
   void copy_buffer_to_staging(
       State& state,
-      const Buffer::Object& buffer,
-      Buffer::Object& staging);
+      const api::VulkanBuffer& buffer,
+      api::VulkanBuffer& staging);
 
   void copy_staging_to_buffer(
       State& state,
-      const Buffer::Object& staging,
-      Buffer::Object& buffer);
+      const api::VulkanBuffer& staging,
+      api::VulkanBuffer& buffer);
 
   void copy_buffer_to_image(
       State& state,
-      const Buffer::Object& buffer,
-      Image::Object& image);
+      const api::VulkanBuffer& buffer,
+      api::VulkanImage& image);
 
   void copy_image_to_buffer(
       State& state,
-      const Image::Object& image,
-      Buffer::Object& buffer);
+      const api::VulkanImage& image,
+      api::VulkanBuffer& buffer);
 
   void submit(Fence fence);
 
@@ -609,13 +608,19 @@ void vTensor::View::CMD::barrier(State::Transition transition) {
         from.access,
         to.access);
 
+    api::VulkanBuffer::Package package = view_.staging().package();
+
     if (Barrier::None != category) {
       barrier.stage.src |= from.stage;
       barrier.stage.dst |= to.stage;
 
       if (Barrier::Memory == category) {
         barrier.buffers.push_back({
-          view_.staging().object,
+          {
+            package.handle,
+            package.buffer_offset,
+            package.buffer_range,
+          },
           {
             from.access,
             to.access,
@@ -633,13 +638,18 @@ void vTensor::View::CMD::barrier(State::Transition transition) {
         from.access,
         to.access);
 
+    api::VulkanBuffer::Package package = view_.buffer().package();
+
     if (Barrier::None != category) {
       barrier.stage.src |= from.stage;
       barrier.stage.dst |= to.stage;
-
       if (Barrier::Memory == category) {
         barrier.buffers.push_back({
-          view_.buffer().object,
+          {
+            package.handle,
+            package.buffer_offset,
+            package.buffer_range,
+          },
           {
             from.access,
             to.access,
@@ -665,11 +675,17 @@ void vTensor::View::CMD::barrier(State::Transition transition) {
 
       if (Barrier::Memory == category) {
         TORCH_INTERNAL_ASSERT(
-            from.layout == view_.image().object.layout,
+            from.layout == view_.image().layout(),
             "Invalid image layout!");
+        api::VulkanImage::Package package = view_.image().package();
 
         barrier.images.push_back({
-          view_.image().object,
+          {
+            package.handle,
+            package.image_layout,
+            package.image_view,
+            package.image_sampler,
+          },
           {
             from.access,
             to.access,
@@ -680,7 +696,7 @@ void vTensor::View::CMD::barrier(State::Transition transition) {
           },
         });
 
-        view_.image().object.layout = to.layout;
+        view_.image().set_layout(to.layout);
       }
     }
   }
@@ -702,8 +718,8 @@ void vTensor::View::CMD::barrier(State::Transition transition) {
 
 void vTensor::View::CMD::copy_buffer_to_staging(
     State& state,
-    const Buffer::Object& buffer,
-    Buffer::Object& staging) {
+    const api::VulkanBuffer& buffer,
+    api::VulkanBuffer& staging) {
   if (state.is_clean(Component::Staging) || state.is_uma()) {
     return;
   }
@@ -724,13 +740,13 @@ void vTensor::View::CMD::copy_buffer_to_staging(
           {},
         }));
 
-  command_buffer_.copy(buffer, staging);
+  command_buffer_.copy(buffer.package(), staging.package());
 }
 
 void vTensor::View::CMD::copy_staging_to_buffer(
     State& state,
-    const Buffer::Object& staging,
-    Buffer::Object& buffer) {
+    const api::VulkanBuffer& staging,
+    api::VulkanBuffer& buffer) {
   if (state.is_clean(Component::Buffer) || state.is_uma()) {
     return;
   }
@@ -751,13 +767,13 @@ void vTensor::View::CMD::copy_staging_to_buffer(
           {},
         }));
 
-  command_buffer_.copy(staging, buffer);
+  command_buffer_.copy(staging.package(), buffer.package());
 }
 
 void vTensor::View::CMD::copy_buffer_to_image(
     State& state,
-    const Buffer::Object& buffer,
-    Image::Object& image) {
+    const api::VulkanBuffer& buffer,
+    api::VulkanImage& image) {
   if (state.is_clean(Component::Image)) {
     return;
   }
@@ -799,6 +815,8 @@ void vTensor::View::CMD::copy_buffer_to_image(
     },
   };
 
+  api::UniformParamsBuffer params(view_.context_, block);
+
   view_.context_->dispatch(
       command_buffer_,
       {
@@ -809,15 +827,15 @@ void vTensor::View::CMD::copy_buffer_to_image(
       VK_KERNEL(nchw_to_image),
       extents,
       adaptive_work_group_size(extents),
-      image,
-      buffer,
-      view_.context_->resource().pool.uniform(block).object);
+      image.package(),
+      buffer.package(),
+      params.buffer().package());
 }
 
 void vTensor::View::CMD::copy_image_to_buffer(
     State& state,
-    const Image::Object& image,
-    Buffer::Object& buffer) {
+    const api::VulkanImage& image,
+    api::VulkanBuffer& buffer) {
   if (state.is_clean(Component::Buffer)) {
     return;
   }
@@ -859,6 +877,8 @@ void vTensor::View::CMD::copy_image_to_buffer(
     },
   };
 
+  api::UniformParamsBuffer params(view_.context_, block);
+
   view_.context_->dispatch(
       command_buffer_,
       {
@@ -869,9 +889,9 @@ void vTensor::View::CMD::copy_image_to_buffer(
       VK_KERNEL(image_to_nchw),
       view_.extents(),
       adaptive_work_group_size(view_.extents()),
-      image,
-      buffer,
-      view_.context_->resource().pool.uniform(block).object);
+      image.package(),
+      buffer.package(),
+      params.buffer().package());
 }
 
 void vTensor::View::CMD::submit(const api::Resource::Fence fence) {
@@ -881,19 +901,18 @@ void vTensor::View::CMD::submit(const api::Resource::Fence fence) {
       fence);
 }
 
-vTensor::Buffer& vTensor::View::buffer() const {
+api::VulkanBuffer& vTensor::View::buffer() const {
   if (!buffer_) {
-    buffer_ = allocate_buffer(
-        context_->gpu().adapter,
-        pool_,
-        sizes(),
-        options());
+    api::Adapter* adapter_ptr = context_->adapter_ptr();
+    const bool gpu_only = !(adapter_ptr->has_unified_memory());
+    buffer_ = adapter_ptr->vma().create_storage_buffer(
+        buffer_bytes(sizes(), options().dtype()), gpu_only);
   }
 
   return buffer_;
 }
 
-vTensor::Buffer& vTensor::View::buffer(
+api::VulkanBuffer& vTensor::View::buffer(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage,
     const Access::Flags access) const {
@@ -901,7 +920,7 @@ vTensor::Buffer& vTensor::View::buffer(
   return buffer(cmd, stage, access);
 }
 
-vTensor::Buffer& vTensor::View::buffer(
+api::VulkanBuffer& vTensor::View::buffer(
     CMD& cmd,
     const Stage::Flags stage,
     const Access::Flags access) const {
@@ -909,14 +928,14 @@ vTensor::Buffer& vTensor::View::buffer(
     if (state_.is_clean(Component::Staging)) {
       cmd.copy_staging_to_buffer(
           state_,
-          staging(cmd, Stage::Transfer, Access::Read).object,
-          buffer().object);
+          staging(cmd, Stage::Transfer, Access::Read),
+          buffer());
     }
     else if (state_.is_clean(Component::Image)) {
       cmd.copy_image_to_buffer(
           state_,
-          image(cmd, Stage::Compute, Access::Read).object,
-          buffer().object);
+          image(cmd, Stage::Compute, Access::Read),
+          buffer());
     }
     else {
       TORCH_INTERNAL_ASSERT(
@@ -947,18 +966,28 @@ vTensor::Buffer& vTensor::View::buffer(
   return buffer();
 }
 
-vTensor::Image& vTensor::View::image() const {
+api::VulkanImage& vTensor::View::image() const {
   if (!image_ && state_.is_available(Component::Image)) {
-    image_ = allocate_image(
-        pool_,
-        vk_extent(extents()),
-        options());
+    api::Adapter* adapter_ptr = context_->adapter_ptr();
+
+    api::ImageSampler::Properties sampler_props{
+      VK_FILTER_NEAREST,
+      VK_SAMPLER_MIPMAP_MODE_NEAREST,
+      VK_SAMPLER_ADDRESS_MODE_REPEAT,
+      VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
+    };
+
+    VkSampler sampler = adapter_ptr->sampler_cache().retrieve(sampler_props);
+
+    image_ = adapter_ptr->vma().create_image3d_fp(
+        vk_extent(extents()), sampler_props, sampler, true);
+
   }
 
   return image_;
 }
 
-vTensor::Image& vTensor::View::image(
+api::VulkanImage& vTensor::View::image(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage,
     const Access::Flags access) const {
@@ -966,15 +995,15 @@ vTensor::Image& vTensor::View::image(
   return image(cmd, stage, access);
 }
 
-vTensor::Image& vTensor::View::image(
+api::VulkanImage& vTensor::View::image(
     CMD& cmd,
     const Stage::Flags stage,
     const Access::Flags access) const {
   if ((access & Access::Read) && state_.is_dirty(Component::Image)) {
     cmd.copy_buffer_to_image(
         state_,
-        buffer(cmd, stage, Access::Read).object,
-        image().object);
+        buffer(cmd, stage, Access::Read),
+        image());
   }
 
   cmd.barrier(
@@ -1000,42 +1029,40 @@ vTensor::Image& vTensor::View::image(
   return image();
 }
 
-vTensor::Buffer& vTensor::View::staging() const {
+api::VulkanBuffer& vTensor::View::staging() const {
   if (!state_.is_available(Component::Staging)) {
     return buffer();
   }
 
   if (!staging_) {
-    staging_ = allocate_staging(
-        context_->gpu().adapter,
-        pool_,
-        sizes(),
-        options());
+    api::Adapter* adapter_ptr = context_->adapter_ptr();
+    staging_ = adapter_ptr->vma().create_staging_buffer(
+        buffer_bytes(sizes(), options().dtype()));
   }
 
   return staging_;
 }
 
-vTensor::Buffer& vTensor::View::staging(
+api::VulkanBuffer& vTensor::View::staging(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage,
     const Access::Flags access) const {
   CMD cmd(*this, command_buffer);
-  Buffer& staging = this->staging(cmd, stage, access);
+  api::VulkanBuffer& staging = this->staging(cmd, stage, access);
   cmd.submit(fence(access));
 
   return staging;
 }
 
-vTensor::Buffer& vTensor::View::staging(
+api::VulkanBuffer& vTensor::View::staging(
     CMD& cmd,
     const Stage::Flags stage,
     const Access::Flags access) const {
   if ((access & Access::Read) && state_.is_dirty(Component::Staging)) {
     cmd.copy_buffer_to_staging(
         state_,
-        buffer(cmd, Stage::Transfer, Access::Read).object,
-        staging().object);
+        buffer(cmd, Stage::Transfer, Access::Read),
+        staging());
   }
 
   cmd.barrier(
@@ -1073,7 +1100,12 @@ vTensor::Memory& vTensor::View::wait() const {
     fence_.wait();
   }
 
-  return staging().memory;
+  staging_memory_ = {
+    staging().vma_allocator(),
+    staging().allocation(),
+  };
+
+  return staging_memory_;
 }
 
 void vTensor::View::verify() const {

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -180,12 +180,12 @@ class vTensor final {
     predictability of usage and efficiency.
   */
 
-  Buffer::Object buffer(api::Command::Buffer&, Stage::Flags) const &;
-  Buffer::Object buffer(api::Command::Buffer&, Stage::Flags, Access::Flags) &;
+  api::VulkanBuffer::Package buffer(api::Command::Buffer&, Stage::Flags) const &;
+  api::VulkanBuffer::Package buffer(api::Command::Buffer&, Stage::Flags, Access::Flags) &;
 
   bool has_image() const;
-  Image::Object image(api::Command::Buffer&, Stage::Flags) const &;
-  Image::Object image(api::Command::Buffer&, Stage::Flags, Access::Flags) &;
+  api::VulkanImage::Package image(api::Command::Buffer&, Stage::Flags) const &;
+  api::VulkanImage::Package image(api::Command::Buffer&, Stage::Flags, Access::Flags) &;
 
   /*
     Metadata
@@ -248,20 +248,20 @@ class vTensor final {
       Buffer
     */
 
-    Buffer& buffer(api::Command::Buffer&, Stage::Flags, Access::Flags) const;
+    api::VulkanBuffer& buffer(api::Command::Buffer&, Stage::Flags, Access::Flags) const;
 
     /*
       Image
     */
 
     bool has_image() const;
-    Image& image(api::Command::Buffer&, Stage::Flags, Access::Flags) const;
+    api::VulkanImage& image(api::Command::Buffer&, Stage::Flags, Access::Flags) const;
 
     /*
       Host
     */
 
-    Buffer& staging(api::Command::Buffer&, Stage::Flags, Access::Flags) const;
+    api::VulkanBuffer& staging(api::Command::Buffer&, Stage::Flags, Access::Flags) const;
     vTensor::Memory& wait() const;
 
     /*
@@ -339,12 +339,12 @@ class vTensor final {
 
    private:
     // Accessors / Lazy Allocation
-    Buffer& buffer() const;
-    Buffer& buffer(CMD&, Stage::Flags, Access::Flags) const;
-    Image& image() const;
-    Image& image(CMD&, Stage::Flags, Access::Flags) const;
-    Buffer& staging() const;
-    Buffer& staging(CMD&, Stage::Flags, Access::Flags) const;
+    api::VulkanBuffer& buffer() const;
+    api::VulkanBuffer& buffer(CMD&, Stage::Flags, Access::Flags) const;
+    api::VulkanImage& image() const;
+    api::VulkanImage& image(CMD&, Stage::Flags, Access::Flags) const;
+    api::VulkanBuffer& staging() const;
+    api::VulkanBuffer& staging(CMD&, Stage::Flags, Access::Flags) const;
     Fence& fence(Access::Flags) const;
 
     // Validation
@@ -352,14 +352,14 @@ class vTensor final {
 
    private:
     // Resources
-    mutable Buffer buffer_;
-    mutable Image image_;
-    mutable Buffer staging_;
+    mutable api::VulkanBuffer buffer_;
+    mutable api::VulkanImage image_;
+    mutable api::VulkanBuffer staging_;
+    mutable Memory staging_memory_;
     mutable Fence fence_;
 
     // Context
     api::Context* context_;
-    api::Resource::Pool* pool_;
 
     // State
     mutable State state_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77787 [vulkan][testing] only keep minimal tests
* #78653 [vulkan] Integrate refactored memory mapping and fences
* **#78652 [vulkan] Integrate refactored resource**
* #78651 [vulkan] Refactor Command
* #77786 [vulkan] Remove op profiling from Vulkan API test binary
* #78650 [vulkan] Add refactored Resource
* #78649 [vulkan] Remove ThreadContext
* #78648 [vulkan] Move ownership of Shader and Pipeline caches to Adapter
* #78647 [vulkan] Refactor Adapter to have PhysicalDevice hold physical device properties
* #77785 [vulkan] Refactor Shader and Pipeline
* #77784 [vulkan] Remove unused code for Winograd convolutions

Differential Revision: [D36824005](https://our.internmc.facebook.com/intern/diff/D36824005)