### PR TITLE
[vulkan] Integrate refactored memory mapping and fences

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Command.cpp
+++ b/aten/src/ATen/native/vulkan/api/Command.cpp
@@ -452,7 +452,7 @@ void Command::Pool::purge() {
 void Command::Pool::submit(
     const VkQueue queue,
     const c10::ArrayRef<const Buffer> buffers,
-    const Resource::Fence fence) {
+    const VkFence fence) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       device_ && command_pool_,
       "This command pool is in an invalid state! "
@@ -481,7 +481,7 @@ void Command::Pool::submit(
       // - The user has implictly signaled interest in the results via a fence.
       // - We are over the submission cutoff.  We don't want to starve the GPU.
 
-      if (fence || (stream_.counter++ > Configuration::kSubmit)) {
+      if (fence != VK_NULL_HANDLE || (stream_.counter++ > Configuration::kSubmit)) {
         stream_.buffer.end();
         stream_.buffer.invalidate();
       }
@@ -517,7 +517,7 @@ void Command::Pool::submit(
       // When running Vulkan backend in different threads without any locking mechanism,
       // vkQueueSubmit will get the VK_ERROR_INITIALIZATION_FAILED(-3) error.
       std::lock_guard<std::mutex> guard(queue_mutex);
-      VK_CHECK(vkQueueSubmit(queue, 1u, &submit_info, fence.handle()));
+      VK_CHECK(vkQueueSubmit(queue, 1u, &submit_info, fence));
     }
   }
 }

--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -118,7 +118,7 @@ struct Command final {
     void submit(
         VkQueue queue,
         c10::ArrayRef<const Buffer> buffers,
-        Resource::Fence fence = {});
+        const VkFence fence = VK_NULL_HANDLE);
 
    private:
     void invalidate();

--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -18,6 +18,7 @@ Context::Context(const VkInstance instance, size_t adapter_i)
       command_(gpu()),
       descriptor_(gpu()),
       resource_(gpu()),
+      fences_(device_),
       querypool_(
         device_,
         adapter_p_->timestamp_compute_and_graphics(),

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -48,6 +48,7 @@ class Context final {
   Command command_;
   Descriptor descriptor_;
   Resource resource_;
+  FencePool fences_;
   QueryPool querypool_;
   // Memory Management
   std::vector<VulkanBuffer> buffers_to_clear_;
@@ -102,6 +103,10 @@ class Context final {
 
   inline Resource& resource() {
     return resource_;
+  }
+
+  inline FencePool& fences() {
+    return fences_;
   }
 
   inline QueryPool& querypool() {

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -158,6 +158,12 @@ class vTensor final {
     waited on.
   */
 
+  inline void wait_for_fence() const {
+    view_->wait_for_fence();
+  }
+
+  api::VulkanBuffer& host_buffer(api::Command::Buffer&, const Access::Flags) &;
+
   template<typename Type>
   Future<Type, Access::Read> host(api::Command::Buffer&) const &;
 
@@ -262,6 +268,8 @@ class vTensor final {
     */
 
     api::VulkanBuffer& staging(api::Command::Buffer&, Stage::Flags, Access::Flags) const;
+
+    void wait_for_fence() const;
     vTensor::Memory& wait() const;
 
     /*
@@ -345,7 +353,7 @@ class vTensor final {
     api::VulkanImage& image(CMD&, Stage::Flags, Access::Flags) const;
     api::VulkanBuffer& staging() const;
     api::VulkanBuffer& staging(CMD&, Stage::Flags, Access::Flags) const;
-    Fence& fence(Access::Flags) const;
+    api::VulkanFence& fence(Access::Flags) const;
 
     // Validation
     void verify() const;
@@ -356,7 +364,7 @@ class vTensor final {
     mutable api::VulkanImage image_;
     mutable api::VulkanBuffer staging_;
     mutable Memory staging_memory_;
-    mutable Fence fence_;
+    mutable api::VulkanFence fence_;
 
     // Context
     api::Context* context_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #77787 [vulkan][testing] only keep minimal tests
* **#78653 [vulkan] Integrate refactored memory mapping and fences**
* #78652 [vulkan] Integrate refactored resource
* #78651 [vulkan] Refactor Command
* #77786 [vulkan] Remove op profiling from Vulkan API test binary
* #78650 [vulkan] Add refactored Resource
* #78649 [vulkan] Remove ThreadContext
* #78648 [vulkan] Move ownership of Shader and Pipeline caches to Adapter
* #78647 [vulkan] Refactor Adapter to have PhysicalDevice hold physical device properties
* #77785 [vulkan] Refactor Shader and Pipeline
* #77784 [vulkan] Remove unused code for Winograd convolutions

Differential Revision: [D36824010](https://our.internmc.facebook.com/intern/diff/D36824010)