### PR TITLE
Added a function that prints the check statuses run on a given commit SHA

### DIFF
--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -5,10 +5,10 @@ from gitutils import _check_output
 def parse_args() -> Any:
     from argparse import ArgumentParser
     parser = ArgumentParser("Print latest commits")
-    parser.add_argument("--minutes", type=int, default=60, help="duration in minutes of last commits")
+    parser.add_argument("--minutes", type=int, default=30, help="duration in minutes of last commits")
     return parser.parse_args()
 
-def print_latest_commits(minutes: int = 60) -> None:
+def print_latest_commits(minutes: int = 30) -> None:
     current_time = datetime.now()
     time_since = current_time - timedelta(minutes=minutes)
     timestamp_since = datetime.timestamp(time_since)
@@ -25,6 +25,10 @@ def print_latest_commits(minutes: int = 60) -> None:
 
     for commit in commits:
         print(commit)
+        print_commit_status(commit)
+
+def print_commit_status(sha: str) -> None:
+    print("sha is", sha)
 
 def main() -> None:
     args = parse_args()

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -20,7 +20,7 @@ def print_latest_commits(minutes: int = 30) -> None:
             "git",
             "rev-list",
             f"--max-age={timestamp_since}",
-            "--remotes=*master",
+            "--remotes=*origin/master",
         ],
         encoding="ascii",
     ).splitlines()

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -6,7 +6,7 @@ from rockset import Client, ParamDict  # type: ignore[import]
 import os
 
 rs = Client(api_key=os.getenv("ROCKSET_API_KEY", None))
-qlambda = rs.QueryLambda.retrieve(  
+qlambda = rs.QueryLambda.retrieve(
     'commit_jobs_query',
     version='c2a4dbce081d0144',
     workspace='commons')

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -26,7 +26,7 @@ def print_latest_commits(minutes: int = 30) -> None:
             "git",
             "rev-list",
             f"--max-age={timestamp_since}",
-            "--remotes=*master",
+            "--remotes=*origin/master",
         ],
         encoding="ascii",
     ).splitlines()
@@ -38,7 +38,6 @@ def print_latest_commits(minutes: int = 30) -> None:
 def print_commit_status(sha: str) -> None:
     params = ParamDict()
     params['sha'] = sha
-    print(params)
     results = qlambda.execute(parameters=params)
     for check in results['results']:
         print(f"\t{check['conclusion']:>10}: {check['name']}")

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -40,7 +40,7 @@ def print_commit_status(sha: str) -> None:
     params['sha'] = sha
     results = qlambda.execute(parameters=params)
     for check in results['results']:
-        print(f"\t{check['name']}: {check['conclusion']}")
+        print(f"\t{check['conclusion']:>10}: {check['name']}")
 
 def main() -> None:
     args = parse_args()

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -15,13 +15,12 @@ def print_latest_commits(minutes: int = 30) -> None:
     current_time = datetime.now()
     time_since = current_time - timedelta(minutes=minutes)
     timestamp_since = datetime.timestamp(time_since)
-
     commits = _check_output(
         [
             "git",
             "rev-list",
             f"--max-age={timestamp_since}",
-            "--all",
+            "--remotes=*master",
         ],
         encoding="ascii",
     ).splitlines()
@@ -41,7 +40,7 @@ def print_commit_status(sha: str) -> None:
     params['sha'] = sha
     results = qlambda.execute(parameters=params)
     for check in results['results']:
-        print(f"\t{check['jobName']}: {check['conclusion']}")
+        print(f"\t{check['name']}: {check['conclusion']}")
 
 def main() -> None:
     args = parse_args()


### PR DESCRIPTION
Relates to #76700

Gets the commit SHAs from the past M minutes, and prints out the SHAs along with the status checks for all of the jobs for each commit. The current output prints out each SHA and a list of all of the workflow job conclusions.

Example output:
![Screen Shot 2022-06-01 at 4 51 07 PM](https://user-images.githubusercontent.com/24441980/171499216-59f6d2f2-01b3-4d01-a7ae-5215b4ac4e5c.png)

**Test Plan:** compare output with HUD
