### PR TITLE
generate_torch_version: Print exception info when get_sha fails

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import subprocess
+import traceback
 from pathlib import Path
 from setuptools import distutils  # type: ignore[import]
 from typing import Optional, Union
@@ -14,6 +15,7 @@ def get_sha(pytorch_root: Union[str, Path]) -> str:
             .strip()
         )
     except Exception:
+        traceback.print_exc()
         return "Unknown"
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#78664**

Summary:
See #78659.  We want more information on why this is happening.

Test Plan:
Will run nightlies in CI.