### PR TITLE
Fuse matmul in row-wise sharded linear to have a single matmul.

### DIFF
--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/linear.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/linear.py
@@ -296,19 +296,25 @@ def _handle_row_wise_sharding_tensor(
     all_to_all_single(
         gathered_input, input_t, input_split_sizes=input_split_sizes, group=pg
     )
-    gathered_input = gathered_input.transpose(0, -1)
 
-    # Perform local matmuls for all shards
-    results = []
+    # Reshape gathered_input appropriately for matmul
     shard_size = local_shard_t.size()[0]
-    for r in range(world_size):
-        inp = torch.narrow(gathered_input, -1, r * shard_size, shard_size)
-        results.append(
-            inp.matmul(local_shard_t) + _BiasTensorPartial.apply(world_size, bias)
-        )
+    reshaped_inputs = [
+        torch.narrow(gathered_input, 0, r * shard_size, shard_size).transpose(0, -1)
+        for r in range(world_size)
+    ]
+    reshaped_input = torch.cat(reshaped_inputs)
+    if reshaped_input.dim() == 1:
+        reshaped_input = reshaped_input.view(-1, local_shard_t.size(0))
+
+    # Perform appropriate local matmul
+    if reshaped_input.dim() <= 2:
+        result = torch.addmm(_BiasTensorPartial.apply(world_size, bias), reshaped_input, local_shard_t)
+    else:
+        result = reshaped_input.matmul(local_shard_t) + _BiasTensorPartial.apply(world_size, bias)
 
     # Return the partial local result.
-    return _PartialTensor(torch.cat(results), pg)
+    return _PartialTensor(result, pg)
 
 
 def _handle_row_wise_sharding_sharded_tensor(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #78672
* #78598
* #78477
* #78449

Performing a single large matmul is more efficient than having to
perform multiple matmuls in a loop.

Similar improvement to https://github.com/pytorch/pytorch/pull/78449

Differential Revision: [D36828505](https://our.internmc.facebook.com/intern/diff/D36828505/)