### PR TITLE
Ported hardtanh decomposition to ref

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -136,12 +136,6 @@ def hardsigmoid_backward(grad_output: Tensor, self: Tensor):
     )
 
 
-@register_decomposition(aten.hardtanh)
-@pw_cast_for_opmath
-def hardtanh(self: Tensor, min_val: float = -1, max_val: float = 1) -> Tensor:
-    return torch.clamp(self, min_val, max_val)
-
-
 @register_decomposition(aten.hardtanh_backward)
 @pw_cast_for_opmath
 def hardtanh_backward(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -7134,6 +7134,20 @@ def sample_inputs_softshrink_hardshrink_hardtanh(op_info, device, dtype, require
                requires_grad=requires_grad)) for _ in range(1, N)]
     return tensors
 
+
+def reference_inputs_hardtanh(op, device, dtype, requires_grad, **kwargs):
+    yield from sample_inputs_softshrink_hardshrink_hardtanh(op, device, dtype, requires_grad, **kwargs)
+    inp = make_tensor((), dtype=dtype, device=device, requires_grad=requires_grad)
+    kwarg_dtypes = [True, 1, 2.0]
+    for a, b in product(kwarg_dtypes, kwarg_dtypes):
+        yield SampleInput(inp, kwargs={"min_val": a, "max_val": b})
+
+
+def error_inputs_hardtanh(op, device, **kwargs):
+    yield ErrorInput(SampleInput(make_tensor((1,), dtype=torch.uint8, device=device), kwargs={"min_val": -1}),
+                     error_regex="unsigned type with negative limits")
+
+
 def sample_inputs_eig(op_info, device, dtype, requires_grad=False, **kwargs):
     eigvecs = make_tensor((S, S), device=device, dtype=dtype,
                           low=None, high=None)
@@ -14666,9 +14680,11 @@ op_db: List[OpInfo] = [
            backward_dtypes=all_types(),
            dtypesIfCUDA=floating_types_and(torch.int8, torch.int16, torch.int32, torch.int64, torch.float16, torch.bfloat16),
            backward_dtypesIfCUDA=floating_types_and(torch.float16),
+           error_inputs_func=error_inputs_hardtanh,
            supports_autograd=True,
            assert_autodiffed=True,
            sample_inputs_func=sample_inputs_softshrink_hardshrink_hardtanh,
+           reference_inputs_func=reference_inputs_hardtanh,
            supports_gradgrad=True,
            supports_out=False,
            supports_forward_ad=True,
@@ -19727,6 +19743,14 @@ python_ref_db = [
     ElementwiseUnaryPythonRefInfo(
         "_refs.nn.functional.elu",
         torch_opinfo_name="nn.functional.elu",
+    ),
+    PythonRefInfo(
+        "_refs.nn.functional.hardtanh",
+        torch_opinfo_name="nn.functional.hardtanh",
+        decorators=(
+            # Need FakeTensor support for meta coverage
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_meta',),
+        ),
     ),
     PythonRefInfo(
         "_refs.nn.functional.leaky_relu",


### PR DESCRIPTION
One note:

The logic for handling scalar boundary conditions seems to be a bit different than other ops - I simply copied the ATen logic (https://github.com/pytorch/pytorch/blob/hardtanh_ref/aten/src/ATen/native/Activation.cpp#L370). Not sure if it's an inconsistency we should fix.

Will add error opinfo after figuring out the scalar boundary condition stuff.