### PR TITLE
Propagate batch_sampler attributes to dataloader if available

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -314,8 +314,8 @@ class DataLoader(Generic[T_co]):
                 raise ValueError('batch_sampler option is mutually exclusive '
                                  'with batch_size, shuffle, sampler, and '
                                  'drop_last')
-            batch_size = None
-            drop_last = False
+            batch_size = getattr(batch_sampler, 'batch_size', None)
+            drop_last = getattr(batch_sampler, 'drop_last', False)
         elif batch_size is None:
             # no auto_collation
             if drop_last:


### PR DESCRIPTION
Currently, if a batch_sampler is passed to the dataloader, batch_size and drop_last are set to None/False respectively. If I want to check the batch size (or drop_last) for my dataloader, I need to check if the dataloader attribute is none, and then the batch_sampler. Instead, it would be cleaner if the batch_sampler attributes were propagated to the dataloader attribtues so only they need to be checked. I implemented this with getattr so that if the batch_sampler did not have those attributes, the old behaviour is retained.

I didn't make an issue first because I feel this is pretty straight-forward. Dataloader.batch_size/drop_last attributes are only used in __len__ as far as I can tell, so I can't see any side-effects to this change. I did see an [issue](https://github.com/pytorch/pytorch/issues/71872) that describes some reason for setting batch_size to None, but I don't understand why, and it seems to be working as intended with the change.