### PR TITLE
[ONNX] Fix shape inconsistency when exporting scalar log2

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -7445,6 +7445,15 @@ class _TestONNXRuntime:
         model = Log10()
         self.run_test(model, x)
 
+    def test_log2(self):
+        class Log2(torch.nn.Module):
+            def forward(self, input):
+                return torch.log2(input)
+
+        x = torch.tensor(1.0)
+        model = Log2()
+        self.run_test(model, x)
+
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_round(self):
         class Round(torch.nn.Module):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -3889,7 +3889,7 @@ def scatter_add(g, self, dim, index, src):
 
 def log2(g, self):
     _ln2 = 0.693147180559945309
-    return g.op("Div", log(g, self), g.op("Constant", value_t=torch.tensor([_ln2])))
+    return g.op("Div", log(g, self), g.op("Constant", value_t=torch.tensor(_ln2)))
 
 
 def is_floating_point(g, self):

--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -113,8 +113,13 @@ def _compare_ort_pytorch_outputs(ort_outs, pt_outs, rtol, atol):
 
     assert len(pt_outs) == len(ort_outs), "number of outputs differ"
 
-    for ort_out, pt_out in zip(ort_outs, pt_outs):
+    for i, (ort_out, pt_out) in enumerate(zip(ort_outs, pt_outs)):
         np.testing.assert_allclose(ort_out, pt_out, rtol=rtol, atol=atol)
+        assert (
+            ort_out.shape == pt_out.shape
+        ), "{}-th tensor's shape differ, ort: {}, pt: {}".format(
+            i, ort_out.shape, pt_out.shape
+        )
 
 
 def _prepare_input_for_pytorch(args, kwargs):

--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -113,13 +113,8 @@ def _compare_ort_pytorch_outputs(ort_outs, pt_outs, rtol, atol):
 
     assert len(pt_outs) == len(ort_outs), "number of outputs differ"
 
-    for i, (ort_out, pt_out) in enumerate(zip(ort_outs, pt_outs)):
+    for ort_out, pt_out in zip(ort_outs, pt_outs):
         np.testing.assert_allclose(ort_out, pt_out, rtol=rtol, atol=atol)
-        assert (
-            ort_out.shape == pt_out.shape
-        ), "{}-th tensor's shape differ, ort: {}, pt: {}".format(
-            i, ort_out.shape, pt_out.shape
-        )
 
 
 def _prepare_input_for_pytorch(args, kwargs):


### PR DESCRIPTION
This is a simple fix addressing the exportation when the input to `torch.log2` is scalar. `log2(x)` will be exported as `log(x) / log(2)`, which creates a `log` node followed by a `div` node that divides it by a constant. The constant is constructed not as a scalar but as a tensor of shape `[1]`, so a scalar input here will get broadcasted creating the output tensor with shape `[1]`, while originally the torch model's output is a scalar.

```python
import torch
import onnx
import numpy as np


class Model(torch.nn.Module):
    def forward(self, x):
        return torch.log2(x)


x = torch.tensor(1.)  # scalar
model = Model()
torch.onnx.export(model, (x, ), "output.onnx", opset_version=14,
                  output_names=['o0'], input_names=['i0'])
y_trh = model(x).numpy()

model = onnx.load("output.onnx")
print(model.graph.output[0])


import onnxruntime as ort
sess = ort.InferenceSession(
    "output.onnx", providers=['CPUExecutionProvider'])
y_ort = sess.run(['o0'], {'i0': x.numpy()})[0]
assert y_ort.shape == y_trh.shape, 'shape mismatch, ORT is `{}` but PyTorch is `{}`'.format(
    y_ort.shape, y_trh.shape)

```
The resulting ONNX model has an output of shape `[1]` and causes shape mismatch between ORT and PyTorch. The output:
```
name: "o0"
type {
  tensor_type {
    elem_type: 1
    shape {
      dim {
        dim_value: 1
      }
    }
  }
}

Traceback (most recent call last):
  File "test.py", line 501, in <module>
    y_ort.shape, y_trh.shape)
AssertionError: shape mismatch, ORT is `(1,)` but PyTorch is `()`
```
After the fix, the output becomes:
```
name: "o0"
type {
  tensor_type {
    elem_type: 1
    shape {
    }
  }
}
```
