### PR TITLE
Fix fx example for Proxy/Retracing

### DIFF
--- a/docs/source/fx.rst
+++ b/docs/source/fx.rst
@@ -270,7 +270,7 @@ on them and append them to the :class:`Graph`.
         graph : fx.Graph = tracer_class().trace(model)
         new_graph = fx.Graph()
         env = {}
-        tracer = torch.fx.proxy.GraphAppendingTracer(graph)
+        tracer = torch.fx.proxy.GraphAppendingTracer(new_graph)
         for node in graph.nodes:
             if node.op == 'call_function' and node.target in decomposition_rules:
                 # By wrapping the arguments with proxies,


### PR DESCRIPTION
Hi, new here. 👋


The example code In the Proxy/Retracing section (https://pytorch.org/docs/stable/fx.html#proxy-retracing) seems to be incorrect. It adds the decomposed nodes 
to the old `graph` instead of to `new_graph`. 

If you run `graph.lint()` on the result, it will raise an error. After the change - the graph passes lint, and the created code seems to be correct.

```python

class M1(torch.nn.Module):
    def forward(self, x):
        return F.relu(x)

m = M1()

m = decompose(m)
m.graph.lint()
print(m.code)
```

Prints:

```python
def forward(self, x):
    gt = x > 0
    mul = gt * x;  gt = x = None
    return mul
```

Fixes [#78705]
