### PR TITLE
Update linter to validate file names are compatible across OSes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Ensure cross-OS compatible file names
         if: always()
         run: |
-          (! git ls-files | grep -E '([<>:"|?*]|[ .]$)' || (echo "The above file names are not valid across all operating systems. Please ensure they don't contain the characters '<>:""|?*' and don't end with a whitespace or a '.' "; false))
+          (! git ls-files | grep -E '([<>:"|?*]|[ .]$)' || (echo "The above file names are not valid across all operating systems. Please ensure they don't contain the characters '<>:""|?*' and don't end with a white space or a '.' "; false))
       - name: Ensure no versionless Python shebangs
         if: always()
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,6 +87,10 @@ jobs:
           # NB: We use 'printf' below rather than '\u000a' since bash pre-4.2
           # does not support the '\u000a' syntax (which is relevant for local linters)
           (! git --no-pager grep -In "$(printf '\xC2\xA0')" -- . || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
+      - name: Ensure cross-OS compatible file names
+        if: always()
+        run: |
+          (! git ls-files | grep -E '([<>:"|?*]|[ .]$)' || (echo "The above file names are not valid across all operating systems. Please ensure they don't contain the characters '<>:""|?*' and don't end with a whitespace or a '.' "; false))
       - name: Ensure no versionless Python shebangs
         if: always()
         run: |


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/74341

Ensure all files have names that are valid across all operating systems, including checking for a trailing white space

Note: This is not a fully comprehensive check since there are various quicks some the OSes have ([namely Windows](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file)) that make it reserves certain names and characters. 

Still, it covers the file names we are most likely to run into, including one that caused https://github.com/pytorch/pytorch/commit/7cf9b942daa824267ec3902f1026b3e6353561ff to need a revert

## Testing
Created another PR with four invalid file names and verified that the linter caught all of them:
https://github.com/pytorch/pytorch/runs/6712731938?check_suite_focus=true
<img width="1093" alt="image" src="https://user-images.githubusercontent.com/4468967/171684679-c968fecf-9bc5-480c-9e18-012def25df06.png">
