### PR TITLE
[primTorch] Implements refs for gcd, lcm and remainder

### DIFF
--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -108,7 +108,7 @@ __all__ = [
     "ne",
     "nextafter",
     "pow",
-    "rem",
+    "remainder",
     "rsqrt",
     "shift_left",
     "shift_right_arithmetic",
@@ -1058,14 +1058,14 @@ pow = _make_elementwise_binary_prim(
 )
 
 
-def _rem_nvfuser(fd: Any, a: TensorLikeType, b: TensorLikeType):
+def _remainder_nvfuser(fd: Any, a: TensorLikeType, b: TensorLikeType):
     return fd.Ops.remainder(a, b)  # type: ignore[attr-defined]
 
 
-rem = _make_elementwise_binary_prim(
+remainder = _make_elementwise_binary_prim(
     "remainder",
     impl_aten=torch.remainder,
-    impl_nvfuser=_rem_nvfuser,
+    impl_nvfuser=_remainder_nvfuser,
     doc="",
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -95,6 +95,7 @@ __all__ = [
     "fmax",
     "fmin",
     "fmod",
+    "gcd",
     "ge",
     "gt",
     "igamma",
@@ -107,6 +108,7 @@ __all__ = [
     "ne",
     "nextafter",
     "pow",
+    "rem",
     "rsqrt",
     "shift_left",
     "shift_right_arithmetic",
@@ -919,6 +921,15 @@ fmod = _make_elementwise_binary_prim(
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
+
+gcd = _make_elementwise_binary_prim(
+    "gcd",
+    impl_aten=torch.gcd,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
+
 ge = _make_elementwise_binary_prim(
     "ge",
     impl_aten=torch.ge,
@@ -1045,6 +1056,20 @@ pow = _make_elementwise_binary_prim(
     doc="",
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
+
+
+def _rem_nvfuser(fd: Any, a: TensorLikeType, b: TensorLikeType):
+    return fd.Ops.remainder(a, b)  # type: ignore[attr-defined]
+
+
+rem = _make_elementwise_binary_prim(
+    "remainder",
+    impl_aten=torch.remainder,
+    impl_nvfuser=_rem_nvfuser,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
 
 shift_left = _make_elementwise_binary_prim(
     "shift_left",

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -107,7 +107,7 @@ __all__ = [
     "fmax",
     "fmin",
     "fmod",
-    # 'gcd',
+    "gcd",
     "ge",
     "gt",
     # 'heaviside',
@@ -115,7 +115,7 @@ __all__ = [
     "igamma",
     "igammac",
     "isclose",
-    # 'lcm',
+    "lcm",
     # 'ldexp',
     "le",
     "logical_and",
@@ -131,7 +131,7 @@ __all__ = [
     "nextafter",
     # 'polar',  # abs, cos, sin
     "pow",
-    # 'remainder',
+    "remainder",
     # 'rsub', # unblocked
     # # special.xlog1py
     # # special.zeta
@@ -873,6 +873,13 @@ fmod = _make_elementwise_binary_reference(
 )
 
 # TODO: add docstring
+gcd = _make_elementwise_binary_reference(
+    prims.gcd,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    aten_op=torch.ops.aten.gcd,
+)
+
+# TODO: add docstring
 ge = _make_elementwise_binary_reference(
     prims.ge,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.ALWAYS_BOOL,
@@ -960,6 +967,18 @@ def isclose(
     )
 
     return result
+
+
+def _lcm(a: TensorLikeType, b: TensorLikeType):
+    g = gcd(a, b)
+    return where(eq(g, 0), 0, abs(mul(true_divide(a, g), b)))
+
+
+lcm = _make_elementwise_binary_reference(
+    _lcm,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    aten_op=torch.ops.aten.lcm,
+)
 
 
 # TODO: add docstring
@@ -1060,6 +1079,13 @@ nextafter = _make_elementwise_binary_reference(
 pow = _make_elementwise_binary_reference(
     prims.pow,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.BOOL_TO_LONG,
+)
+
+# TODO: add docstring
+remainder = _make_elementwise_binary_reference(
+    prims.rem,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    aten_op=torch.ops.aten.remainder,
 )
 
 # TODO: add docstring

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -877,6 +877,8 @@ gcd = _make_elementwise_binary_reference(
     prims.gcd,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     aten_op=torch.ops.aten.gcd,
+    supports_lhs_python_scalar=False,
+    supports_rhs_python_scalar=False,
 )
 
 # TODO: add docstring
@@ -979,6 +981,8 @@ lcm = _make_elementwise_binary_reference(
     _lcm,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     aten_op=torch.ops.aten.lcm,
+    supports_lhs_python_scalar=False,
+    supports_rhs_python_scalar=False,
 )
 
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -877,8 +877,6 @@ gcd = _make_elementwise_binary_reference(
     prims.gcd,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     aten_op=torch.ops.aten.gcd,
-    supports_lhs_python_scalar=False,
-    supports_rhs_python_scalar=False,
 )
 
 # TODO: add docstring
@@ -981,8 +979,6 @@ lcm = _make_elementwise_binary_reference(
     _lcm,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     aten_op=torch.ops.aten.lcm,
-    supports_lhs_python_scalar=False,
-    supports_rhs_python_scalar=False,
 )
 
 
@@ -1088,7 +1084,7 @@ pow = _make_elementwise_binary_reference(
 
 # TODO: add docstring
 remainder = _make_elementwise_binary_reference(
-    prims.rem,
+    prims.remainder,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     aten_op=torch.ops.aten.remainder,
 )

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -974,6 +974,7 @@ def _lcm(a: TensorLikeType, b: TensorLikeType):
     return where(eq(g, 0), 0, abs(mul(true_divide(a, g), b)))
 
 
+# TODO: add docstring
 lcm = _make_elementwise_binary_reference(
     _lcm,
     type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20566,9 +20566,6 @@ python_ref_db = [
     ElementwiseBinaryPythonRefInfo(
         "_refs.gcd",
         torch_opinfo_name="gcd",
-        skips=(
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_errors'),
-        ),
     ),
     ElementwiseBinaryPythonRefInfo(
         "_refs.ge",
@@ -20603,9 +20600,6 @@ python_ref_db = [
     ElementwiseBinaryPythonRefInfo(
         "_refs.lcm",
         torch_opinfo_name="lcm",
-        skips=(
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_errors'),
-        ),
     ),
     ElementwiseBinaryPythonRefInfo(
         "_refs.le",

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20566,6 +20566,7 @@ python_ref_db = [
     ElementwiseBinaryPythonRefInfo(
         "_refs.gcd",
         torch_opinfo_name="gcd",
+        supports_nvfuser=False,
     ),
     ElementwiseBinaryPythonRefInfo(
         "_refs.ge",
@@ -20600,6 +20601,7 @@ python_ref_db = [
     ElementwiseBinaryPythonRefInfo(
         "_refs.lcm",
         torch_opinfo_name="lcm",
+        supports_nvfuser=False,
     ),
     ElementwiseBinaryPythonRefInfo(
         "_refs.le",
@@ -20734,6 +20736,7 @@ python_ref_db = [
     ElementwiseBinaryPythonRefInfo(
         "_refs.remainder",
         torch_opinfo_name="remainder",
+        supports_nvfuser=False,
         skips=(
             DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_python_ref',
                          dtypes=(torch.bfloat16,), device_type='cpu'),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20564,6 +20564,13 @@ python_ref_db = [
         ),
     ),
     ElementwiseBinaryPythonRefInfo(
+        "_refs.gcd",
+        torch_opinfo_name="gcd",
+        skips=(
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_errors'),
+        ),
+    ),
+    ElementwiseBinaryPythonRefInfo(
         "_refs.ge",
         torch_opinfo_name="ge",
         supports_nvfuser=False,
@@ -20591,6 +20598,13 @@ python_ref_db = [
             DecorateInfo(unittest.expectedFailure, 'TestBinaryUfuncs', 'test_type_promotion'),
             # RuntimeError: Tracing expected 5 arguments but got 2 concrete arguments
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_executor'),
+        ),
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.lcm",
+        torch_opinfo_name="lcm",
+        skips=(
+            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_errors'),
         ),
     ),
     ElementwiseBinaryPythonRefInfo(
@@ -20721,6 +20735,16 @@ python_ref_db = [
                 unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
                 dtypes=(torch.complex32,), device_type="cuda", active_if=not TEST_WITH_ROCM
             ),
+        ),
+    ),
+    ElementwiseBinaryPythonRefInfo(
+        "_refs.remainder",
+        torch_opinfo_name="remainder",
+        skips=(
+            DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_python_ref',
+                         dtypes=(torch.bfloat16,), device_type='cpu'),
+            DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_python_ref_torch_fallback',
+                         dtypes=(torch.bfloat16,), device_type='cpu'),
         ),
     ),
     ElementwiseBinaryPythonRefInfo(


### PR DESCRIPTION
This PR implements the references for gcd, lcm and remainder. Additionally, `gcd` is added as a prim, since we currently don't have a while loop construct. 