### PR TITLE
[GHA] attempt to re-enable mac test workflows (#78000)

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -173,8 +173,8 @@ jobs:
       build-environment: macos-11-py3-x86-64
       test-matrix: |
         { include: [
-          { config: "default", shard: 1, num_shards: 2, runner: "macos-12", xcode-version: "13.3.1" },
-          { config: "default", shard: 2, num_shards: 2, runner: "macos-12", xcode-version: "13.3.1" },
+          { config: "default", shard: 1, num_shards: 2, runner: "macos-12" },
+          { config: "default", shard: 2, num_shards: 2, runner: "macos-12" },
         ]}
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}


### PR DESCRIPTION
Our mac tests have not been running since #77645 because of
<img width="1386" alt="image" src="https://user-images.githubusercontent.com/31798555/169602783-988a265a-ce4a-41a7-8f13-3eb4615b0d6f.png">

https://github.com/pytorch/pytorch/actions/runs/2345334995
Pull Request resolved: https://github.com/pytorch/pytorch/pull/78000
Approved by: https://github.com/malfet
