### PR TITLE
using new rockset commit_jobs_batch_query to print check statuses

### DIFF
--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -36,10 +36,10 @@ def print_latest_commits(minutes: int = 30) -> None:
     results = qlambda.execute(parameters=params)
 
     for commit in commits:
-        print(commit)
-        print_commit_status_batch(commit, results)
+        print_commit_status(commit, results)
 
-def print_commit_status_batch(commit, results) -> None:
+def print_commit_status(commit, results) -> None:
+    print(commit)
     for check in results['results']:
         if check['sha'] == commit:
             print(f"\t{check['conclusion']:>10}: {check['name']}")

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -26,7 +26,7 @@ def print_latest_commits(minutes: int = 30) -> None:
             "git",
             "rev-list",
             f"--max-age={timestamp_since}",
-            "--remotes=*master",
+            "--remotes=*origin/master",
         ],
         encoding="ascii",
     ).splitlines()

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 from datetime import datetime, timedelta
 from gitutils import _check_output
 
@@ -38,7 +38,7 @@ def print_latest_commits(minutes: int = 30) -> None:
     for commit in commits:
         print_commit_status(commit, results)
 
-def print_commit_status(commit, results) -> None:
+def print_commit_status(commit: str, results: Dict[str, Any]) -> None:
     print(commit)
     for check in results['results']:
         if check['sha'] == commit:


### PR DESCRIPTION
Relates to #76700

**Overview:** Made a new Rockset Query Lambda called `commit_jobs_batch_query` that takes in a string composed of multiple SHAs separated with commas. Only one query execution is necessary to get all of the workflow job conclusions for all SHAs, which saves time. 

**Example output:**
![Screen Shot 2022-06-02 at 3 19 31 PM](https://user-images.githubusercontent.com/24441980/171720582-260ac000-2db4-4a98-a2eb-32d2f29915a5.png)

**Test Plan**: Compare output with HUD and verify that workflow conclusions are correct
