### PR TITLE
[Pytorch NNAPI] Add compilation_preference & relax_f32_to_f16 APIs

### DIFF
--- a/aten/src/ATen/nnapi/nnapi_bind.h
+++ b/aten/src/ATen/nnapi/nnapi_bind.h
@@ -36,7 +36,20 @@ struct NnapiCompilation : torch::jit::CustomClassHolder {
     NnapiCompilation() = default;
     ~NnapiCompilation() override = default;
 
-    TORCH_API void init(at::Tensor serialized_model_tensor, std::vector<at::Tensor> parameter_buffers);
+    // only necessary for older models that still call init()
+    TORCH_API void init(
+      at::Tensor serialized_model_tensor,
+      std::vector<at::Tensor> parameter_buffers
+    );
+
+    TORCH_API void init2(
+      at::Tensor serialized_model_tensor,
+      std::vector<at::Tensor> parameter_buffers,
+      int64_t compilation_preference,
+      bool relax_f32_to_f16
+    );
+
+
     TORCH_API void run(std::vector<at::Tensor> inputs, std::vector<at::Tensor> outputs);
     static void get_operand_type(const at::Tensor& t, ANeuralNetworksOperandType* operand, std::vector<uint32_t>* dims);
 

--- a/aten/src/ATen/nnapi/nnapi_register.cpp
+++ b/aten/src/ATen/nnapi/nnapi_register.cpp
@@ -13,6 +13,7 @@ TORCH_LIBRARY(_nnapi, m) {
   m.class_<torch::nnapi::bind::NnapiCompilation>("Compilation")
     .def(torch::jit::init<>())
     .def("init", &torch::nnapi::bind::NnapiCompilation::init)
+    .def("init2", &torch::nnapi::bind::NnapiCompilation::init2)
     .def("run", &torch::nnapi::bind::NnapiCompilation::run)
     ;
 }


### PR DESCRIPTION
Summary:
compilation_preference is one of:

ANEURALNETWORKS_PREFER_LOW_POWER = 0
ANEURALNETWORKS_PREFER_FAST_SINGLE_ANSWER = 1
ANEURALNETWORKS_PREFER_SUSTAINED_SPEED = 2

relax_f32_to_f16 calls Model_relaxComputationFloat32toFloat16

Test Plan:
Tested on device with nnapi models

* Works with existing exported models
* Works with new exported models with options

Differential Revision: D36433236

