### PR TITLE
[ci] harden test stats reporting

### DIFF
--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -60,6 +60,8 @@ runs:
       uses: seemethere/upload-artifact-s3@v5
       if: ${{ !inputs.use-gha }}
       with:
+        s3-prefix: |
+          ${{ github.repository }}/${{ github.run_id }}/${{ github.run_attempt }}/artifact
         retention-days: 14
         if-no-files-found: warn
         path: test-jsons-*.zip
@@ -68,6 +70,8 @@ runs:
       uses: seemethere/upload-artifact-s3@v5
       if: ${{ !inputs.use-gha }}
       with:
+        s3-prefix: |
+          ${{ github.repository }}/${{ github.run_id }}/${{ github.run_attempt }}/artifact
         retention-days: 14
         if-no-files-found: error
         path: test-reports-*.zip

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -10,6 +10,7 @@ jobs:
   upload-test-stats:
     if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled'
     runs-on: [self-hosted, linux.2xlarge]
+    name: Upload test stats for ${{ github.even.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}
 
     steps:
       - name: Print workflow information

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -10,7 +10,7 @@ jobs:
   upload-test-stats:
     if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled'
     runs-on: [self-hosted, linux.2xlarge]
-    name: Upload test stats for ${{ github.even.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}
+    name: Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}
 
     steps:
       - name: Print workflow information

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -155,12 +155,19 @@ def download_and_extract_s3_reports(
         Prefix=f"pytorch/pytorch/{workflow_run_id}/{workflow_run_attempt}/artifact/test-reports"
     )
 
+    found_one = False
     for obj in objs:
+        found_one = True
         p = Path(Path(obj.key).name)
         print(f"Downloading and extracting {p}")
         with open(p, "wb") as f:
             f.write(obj.get()["Body"].read())
         unzip(p)
+
+    if not found_one:
+        raise RuntimeError(
+            "Didn't find any test reports in s3, there is probably a bug!"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #78763

1. Fix bug where we were uploading stats to the wrong place in s3
2. Hard error when upload_test_stats.py didn't find any stats in s3
3. Change the name of the workflow job to include the corresponding id,
to make debugging easier in the future.