### PR TITLE
Make ShufflerDataPipe deterministic for persistent DL and distributed DL

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1491,14 +1491,18 @@ class TestFunctionalIterDataPipe(TestCase):
             self.assertEqual(sorted(res), exp)
 
             # Test Deterministic
-            for num_workers in (0, 1, 2):
+            for num_workers, pw in itertools.product((0, 1, 2), (True, False)):
+                if num_workers == 0 and pw:
+                    continue
+
                 mp_ctx = "spawn" if num_workers > 0 else None
                 dl = DataLoader(
                     shuffle_dp,
                     num_workers=num_workers,
                     shuffle=True,
                     multiprocessing_context=mp_ctx,
-                    worker_init_fn=_worker_init_fn
+                    worker_init_fn=_worker_init_fn,
+                    persistent_workers=pw
                 )
 
                 # No seed
@@ -1520,46 +1524,6 @@ class TestFunctionalIterDataPipe(TestCase):
                 self.assertEqual(len(dl_res[0]), len(dl_res[2]))
                 self.assertNotEqual(dl_res[0], dl_res[2])
                 self.assertEqual(sorted(dl_res[0]), sorted(dl_res[2]))
-
-                if num_workers == 0:
-                    continue
-
-                # Persistent workers
-                ps_dl_res = []
-                for _ in range(2):
-                    dl = DataLoader(
-                        shuffle_dp,
-                        num_workers=num_workers,
-                        shuffle=True,
-                        multiprocessing_context="spawn",
-                        worker_init_fn=_worker_init_fn,
-                        persistent_workers=True
-                    )
-                    ps_res = []
-                    torch.manual_seed(123)
-                    for epoch in range(2):
-                        ps_res.extend(list(dl))
-                    ps_dl_res.append(ps_res)
-                self.assertEqual(ps_dl_res[0], ps_dl_res[1])
-
-                # Different Seeds
-                dl = DataLoader(
-                    shuffle_dp,
-                    num_workers=num_workers,
-                    shuffle=True,
-                    multiprocessing_context="spawn",
-                    worker_init_fn=_worker_init_fn,
-                    persistent_workers=True
-                )
-                ps_res = []
-                torch.manual_seed(321)
-                for epoch in range(2):
-                    ps_res.extend(list(dl))
-                ps_dl_res.append(ps_res)
-
-                self.assertEqual(len(ps_dl_res[0]), len(ps_dl_res[2]))
-                self.assertNotEqual(ps_dl_res[0], ps_dl_res[2])
-                self.assertEqual(sorted(ps_dl_res[0]), sorted(ps_dl_res[2]))
 
 
         shuffle_dp_nl = IDP_NoLen(range(20)).shuffle(buffer_size=5)

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -10,7 +10,7 @@ import os
 import queue
 from dataclasses import dataclass
 from torch._utils import ExceptionWrapper
-from typing import Union
+from typing import Optional, Union
 from . import signal_handling, MP_STATUS_CHECK_INTERVAL, IS_WINDOWS, HAS_NUMPY
 
 if IS_WINDOWS:
@@ -117,7 +117,7 @@ class _IterableDatasetStopIteration(object):
 r"""Dummy class used to resume the fetching when worker reuse is enabled"""
 @dataclass(frozen=True)
 class _ResumeIteration(object):
-    pass
+    seed: Optional[int] = None
 
 # The function `_generate_state` is adapted from `numpy.random.SeedSequence`
 # from https://github.com/numpy/numpy/blob/main/numpy/random/bit_generator.pyx
@@ -201,7 +201,7 @@ def _generate_state(base_seed, worker_id):
 
 def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
                  auto_collation, collate_fn, drop_last, base_seed, init_fn, worker_id,
-                 num_workers, persistent_workers):
+                 num_workers, persistent_workers, shared_seed):
     # See NOTE [ Data Loader Multiprocessing Shutdown Logic ] for details on the
     # logic of this function.
 
@@ -222,14 +222,15 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
             import numpy as np
             np.random.seed(np_seed)
 
-        process_shared_rng = torch.Generator()
-        process_shared_rng.manual_seed(base_seed)
+        shared_rng = torch.Generator()
+        shared_rng.manual_seed(shared_seed)
+
 
         from torch.utils.data import IterDataPipe
         from torch.utils.data.graph_settings import apply_shuffle_seed
 
         if isinstance(dataset, IterDataPipe):
-            dataset = apply_shuffle_seed(dataset, process_shared_rng)
+            dataset = apply_shuffle_seed(dataset, shared_rng)
 
         global _worker_info
         _worker_info = WorkerInfo(id=worker_id, num_workers=num_workers,
@@ -275,7 +276,9 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
                 iteration_end = False
 
                 if isinstance(dataset, IterDataPipe):
-                    dataset = apply_shuffle_seed(dataset, process_shared_rng)
+                    assert r.seed is not None
+                    shared_rng.manual_seed(r.seed)
+                    dataset = apply_shuffle_seed(dataset, shared_rng)
 
                 # Recreate the fetcher for worker-reuse policy
                 fetcher = _DatasetKind.create_fetcher(

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -222,14 +222,13 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
             import numpy as np
             np.random.seed(np_seed)
 
-        shared_rng = torch.Generator()
-        shared_rng.manual_seed(shared_seed)
-
-
         from torch.utils.data import IterDataPipe
         from torch.utils.data.graph_settings import apply_shuffle_seed
 
+        shared_rng = torch.Generator()
         if isinstance(dataset, IterDataPipe):
+            assert shared_seed is not None
+            shared_rng.manual_seed(shared_seed)
             dataset = apply_shuffle_seed(dataset, shared_rng)
 
         global _worker_info

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -552,13 +552,13 @@ class DataLoader(Generic[T_co]):
                 if rank == 0:
                     ws = dist.get_world_size()
                     reqs = []
-                    for rank_idx in range(1, ws):
-                        req = dist.isend(tensor=_shared_tensor_seed, dst=rank_idx)
+                    for rank_id in range(1, ws):
+                        req = dist.isend(tensor=_shared_tensor_seed, dst=rank_id, tag=rank_id)
                         reqs.append(req)
                     for req in reqs:
                         req.wait()
                 else:
-                    dist.recv(tensor=_shared_tensor_seed, src=0)
+                    dist.recv(tensor=_shared_tensor_seed, src=0, tag=rank)
             _shared_seed = _shared_tensor_seed.item()
             del _shared_tensor_seed
             return _shared_seed

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -18,7 +18,6 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as multiprocessing
 import torch.utils.data.graph_settings
-import torch.distributed as dist
 
 from torch._utils import ExceptionWrapper
 from torch._six import string_classes

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Iterable, TypeVar, Generic, Sequence, List, Op
 
 import multiprocessing as python_multiprocessing
 import torch
+import torch.distributed as dist
 import torch.multiprocessing as multiprocessing
 import torch.utils.data.graph_settings
 import torch.distributed as dist
@@ -543,12 +544,36 @@ class DataLoader(Generic[T_co]):
                 self.num_workers,
                 cpuset_checked))
 
+    def _get_shared_seed(self):
+        if isinstance(self.dataset, IterDataPipe):
+            _shared_tensor_seed = torch.empty((), dtype=torch.int64).random_(generator=self.generator)
+            if dist.is_available() and dist.is_initialized():
+                rank = dist.get_rank()
+                if rank == 0:
+                    ws = dist.get_world_size()
+                    reqs = []
+                    for rank_idx in range(1, ws):
+                        req = dist.isend(tensor=_shared_tensor_seed, dst=rank_idx)
+                        reqs.append(req)
+                    for req in reqs:
+                        req.wait()
+                else:
+                    dist.recv(tensor=_shared_tensor_seed, src=0)
+            _shared_seed = _shared_tensor_seed.item()
+            del _shared_tensor_seed
+            return _shared_seed
+        else:
+            return None
+
 
 class _BaseDataLoaderIter(object):
     def __init__(self, loader: DataLoader) -> None:
         self._dataset = loader.dataset
+        self._shared_seed = loader._get_shared_seed()
         if isinstance(self._dataset, IterDataPipe):
-            self._dataset = torch.utils.data.graph_settings.apply_shuffle_seed(self._dataset, loader.generator)
+            shared_rng = torch.Generator()
+            shared_rng.manual_seed(self._shared_seed)
+            self._dataset = torch.utils.data.graph_settings.apply_shuffle_seed(self._dataset, shared_rng)
         self._dataset_kind = loader._dataset_kind
         self._IterableDataset_len_called = loader._IterableDataset_len_called
         self._auto_collation = loader._auto_collation
@@ -585,6 +610,11 @@ class _BaseDataLoaderIter(object):
         self._sampler_iter = iter(self._index_sampler)
         self._num_yielded = 0
         self._IterableDataset_len_called = loader._IterableDataset_len_called
+        self._shared_seed = loader._get_shared_seed()
+        if isinstance(self._dataset, IterDataPipe):
+            shared_rng = torch.Generator()
+            shared_rng.manual_seed(self._shared_seed)
+            self._dataset = torch.utils.data.graph_settings.apply_shuffle_seed(self._dataset, shared_rng)
 
     def _next_index(self):
         return next(self._sampler_iter)  # may raise StopIteration
@@ -983,7 +1013,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
                       self._worker_result_queue, self._workers_done_event,
                       self._auto_collation, self._collate_fn, self._drop_last,
                       self._base_seed, self._worker_init_fn, i, self._num_workers,
-                      self._persistent_workers))
+                      self._persistent_workers, self._shared_seed))
             w.daemon = True
             # NB: Process.start() actually take some time as it needs to
             #     start a process and pass the arguments over via a pipe.
@@ -1053,7 +1083,7 @@ class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
         # We resume the prefetching in case it was enabled
         if not first_iter:
             for idx in range(self._num_workers):
-                self._index_queues[idx].put(_utils.worker._ResumeIteration())
+                self._index_queues[idx].put(_utils.worker._ResumeIteration(self._shared_seed))
             resume_iteration_cnt = self._num_workers
             while resume_iteration_cnt > 0:
                 return_idx, return_data = self._get_data()


### PR DESCRIPTION
Fixes https://github.com/pytorch/data/issues/426

This PR introduces two main changes:
- It ensures the `ShufflerDataPipe` would share the same seed across distributed processes.
- Users can reset `shuffle` for persistent workers per epoch.

Detail:
- `shared_seed` is shared across distributed and worker processes. It will seed a `shared_rng` to provide seeds to each `ShufflerDataPipe` in the pipeline
- `worker_loop` now accepts a new argument of `shared_seed` to accept this shared seed.
- The `shared_seed` is attached to `_ResumeIteration` for resetting seed per epoch for `persistent worker`
- I choose not to touch `base_seed` simply for BC issue


I used this [script](https://gist.github.com/ejguan/d88f75fa822cb696ab1bc5bc25844f47) to test the result with `world_size=4`. Please check the result in: https://gist.github.com/ejguan/6ee2d2de12ca57f9eb4b97ef5a0e300b

You can see there isn't any duplicated/missing element for each epoch. And, with the same seed, the order of data remains the same across epochs.