### PR TITLE
[Static Runtime] Implement prim::Fork and aten::wait

### DIFF
--- a/test/test_static_runtime.py
+++ b/test/test_static_runtime.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 from torch import nn
 from torch.testing._internal.common_utils import TestCase, run_tests
-
+from typing import List
 
 class StaticModule:
     def __init__(self, scripted):
@@ -108,6 +108,25 @@ def trivial_graph(a, b, c):
     s = torch.tensor([[3, 3], [3, 3]])
     return a + b * c + s
 
+def elementwise_square_addition(input1, input2):
+    return input1 * input1 + input2 * input2
+
+def fork_wait_graph1(input1, input2):
+    fut = torch.jit.fork(elementwise_square_addition, input1, input2)
+    return torch.jit.wait(fut)
+
+def fork_wait_graph2(input1, input2):
+    fut = torch.jit.fork(loop_graph, input1, input2, 5)
+    return torch.jit.wait(fut)
+
+def fork_wait_graph3(input):
+    futures : List[torch.jit.Future[torch.Tensor]] = []
+    for _ in range(100):
+        futures.append(torch.jit.fork(torch.neg, input))
+    results = []
+    for future in futures:
+        results.append(torch.jit.wait(future))
+    return torch.sum(torch.stack(results))
 
 def loop_graph(a, b, iters: int):
     c = a + b * 2
@@ -162,6 +181,45 @@ class TestModule(nn.Module):
 
 
 class TestStaticModule(TestCase):
+
+    """
+    Test Case: To test simple fork/wait operation in a graph
+    fork is called on simple addition operation on input tensors
+    """
+    def test_fork_wait_1(self):
+        inp1 = torch.ones(5, 5)
+        inp2 = torch.randn(5, 5)
+        torch_graph = torch.jit.script(fork_wait_graph1)
+        output_ref = torch_graph(inp1, inp2)
+        static_runtime_module = StaticModule(torch_graph)
+        output_test = static_runtime_module(inp1, inp2)
+        torch.testing.assert_close(output_test, output_ref)
+
+    """
+    Test Case: To test fork/wait operation in a graph on
+    a loop subgraph performing mix of operations
+    """
+    def test_fork_wait_2(self):
+        inp1 = torch.randn(5, 5)
+        inp2 = torch.randn(5, 5)
+        torch_graph = torch.jit.script(fork_wait_graph2)
+        output_ref = torch_graph(inp1, inp2)
+        static_runtime_module = StaticModule(torch_graph)
+        output_test = static_runtime_module(inp1, inp2)
+        torch.testing.assert_close(output_test, output_ref)
+
+    """
+    Test Case: To test fork/wait operation in a graph on
+    having multiple fork/wait operations
+    """
+    def test_fork_wait_3(self):
+        input = torch.ones(3, 3)
+        torch_graph = torch.jit.script(fork_wait_graph3)
+        output_ref = torch_graph(input)
+        static_runtime_module = StaticModule(torch_graph)
+        output_test = static_runtime_module(input)
+        torch.testing.assert_close(output_test, output_ref)
+
     def test_multihead_attention_layer(self):
         HID_DIM = 256
         QUERY_LEN = 8

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -834,6 +834,69 @@ std::vector<IValue> collectLoopSubBlockInputs(const ProcessedNode& p_node) {
 
 } // namespace
 
+/*
+prim::fork forks the execution of a subgraph. It returns a future on which
+the corresponding aten::wait op waits until future is marked complete
+Current implementation uses InterpreterState for async execution of subgraph.
+This will be removed in future for faster implementation of async subgraph
+*/
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    prim::fork,
+    prim_Fork,
+    [](Node* node) -> SROperator {
+      auto graph = node->g(attr::Subgraph);
+      Code code(graph, "");
+      return [code](ProcessedNode* p_node) {
+        auto num_outputs = p_node->num_outputs();
+        Stack stack;
+        if (p_node->Output(0).isNone()) {
+          stack.reserve(p_node->num_inputs());
+        } else {
+          stack.reserve(p_node->num_inputs() + num_outputs);
+          for (const auto& o : p_node->outputs()) {
+            stack.emplace_back(o);
+          }
+        }
+        for (auto i : c10::irange(p_node->num_inputs())) {
+          stack.emplace_back(p_node->Input(i));
+        }
+        InterpreterState interpreter{code};
+        interpreter.runAsync(stack);
+        p_node->Output(0) = interpreter.getFuture();
+      };
+    });
+/*
+  aten::wait waits on the future (present in corresponding fork)
+  to be executed. Once the execution is complete, the future is marked
+  completed and wait execution continues.
+*/
+REGISTER_NATIVE_OPERATOR_FUNCTOR(
+    aten::wait,
+    aten_Wait,
+    [](Node*) -> SROperator {
+      return [](ProcessedNode* p_node) {
+        TORCH_INTERNAL_ASSERT(p_node->Input(0).isFuture());
+        auto future = p_node->Input(0).toFuture();
+
+        // blocking call: waiting for the future to be completed
+        future->waitAndThrow();
+
+        TORCH_INTERNAL_ASSERT(future->completed());
+        TORCH_INTERNAL_ASSERT(!future->hasError());
+        TORCH_INTERNAL_ASSERT(future->hasValue());
+
+        if (!future->value().isTuple()) {
+          p_node->Output(0) = future->value();
+          return;
+        }
+        auto& elems = future->value().toTupleRef().elements();
+        DCHECK_EQ(elems.size(), p_node->num_outputs());
+        for (const auto i : c10::irange(elems.size())) {
+          p_node->Output(i) = elems[i];
+        }
+      };
+    });
+
 REGISTER_NATIVE_OPERATOR_FUNCTOR(
     prim::Loop,
     prim_Loop,


### PR DESCRIPTION
Summary:
basic implementation of prim::fork and aten::wait

- current implementation uses interpreter to call the forked subgraph
- interpreter call to be replaced in future
- Added custom test cases for fork/wait procedures in the graph

Test Plan:
custom tests are created in test_static_runtime.py file for verification of static_runtime output compared to reference pytorch output.

test command
- buck run caffe2/test:static_runtime
- buck run caffe2/benchmarks/static_runtime:static_runtime_cpptest
- buck test caffe2/benchmarks/static_runtime/fb:test_fb_operators

Differential Revision: D36881214

