### PR TITLE
fix __torch_function__ bug in getindex that causes an error not set exception

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1479,6 +1479,14 @@ $1 = torch._ops.aten.add.Tensor($0, $0)""")
             t = DimImplementedTensor(torch.randn(3, 3), use_wrapper_subclass)
             self.assertEqual(t.dim(), 2)
 
+    def test_maybe_tuple_bug(self):
+        class T(torch.Tensor):
+            @classmethod
+            def __torch_function__(self, *args, **kwargs):
+                pass
+        a = torch.rand(3)
+
+        a[[T(), T()]]
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1482,7 +1482,7 @@ $1 = torch._ops.aten.add.Tensor($0, $0)""")
     def test_maybe_tuple_bug(self):
         class T(torch.Tensor):
             @classmethod
-            def __torch_function__(self, *args, **kwargs):
+            def __torch_function__(cls, *args, **kwargs):
                 pass
         a = torch.rand(3)
 

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -318,7 +318,7 @@ PyObject* THPVariable_getitem(PyObject* self, PyObject* index) {
   variable_list variableIndices;
   int64_t specified_dims = count_specified_dimensions(holder.get());
   if (specified_dims == -1) {
-    return handle_torch_function_indexing(self, index);
+    return handle_torch_function_indexing(self, holder.get());
   }
   Variable sliced = applySlicing(
     self_, holder.get(), variableIndices, /*is_tracing=*/is_tracing, self_.device(), self_.sizes(), specified_dims);


### PR DESCRIPTION
Without this change, the test will fail with `error return without exception set`. This is because of a difference between what `wrapTuple` considers a tuple (among other things, lists of Tensors under size 32!) and what handle_torch_function_indexing considers a tuple (just tuples).

```
SystemError                               Traceback (most recent call last)
[<ipython-input-4-d346ff1cd397>](https://op8nhaudj1-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab-20220601-060046-RC00_452259785#) in <module>()
      7 a = torch.rand(3)
      8 
----> 9 a[[T(), T()]]

SystemError: error return without exception set
```

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #78781

