### PR TITLE
[FSDP][Docs] Fix typo in `full_optim_state_dict()`

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3492,7 +3492,7 @@ class FullyShardedDataParallel(nn.Module):
             Dict[str, Any]: A :class:`dict` containing the optimizer state for
             ``model`` 's original unflattened parameters and including keys
             "state" and "param_groups" following the convention of
-            :meth:`torch.optim.Optimizer.state_dict`. If ``rank0_only=False``,
+            :meth:`torch.optim.Optimizer.state_dict`. If ``rank0_only=True``,
             then nonzero ranks return an empty :class:`dict`.
         """
         osd = optim.state_dict()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #78599 [FSDP] Allow different `optim_input` orders across ranks
* **#78784 [FSDP][Docs] Fix typo in `full_optim_state_dict()`**

This fixes a typo in the docstring of `full_optim_state_dict()`, where `False` and `True` were incorrectly mixed.