### PR TITLE
Allow pytrees as output for make_traced and nvfuser executor

### DIFF
--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -106,12 +106,15 @@ class PrimContext(torch.overrides.TorchFunctionMode):
 
         return a
 
-    def output(self, tm: TensorMeta):
+    def output(self, tms: Sequence[TensorMeta]):
         # TODO: allow other output types
-        assert isinstance(tm, TensorMeta)
+        flat_tms, _ = torch.utils._pytree.tree_flatten(tms)
+        for tm in flat_tms:
+            assert isinstance(tm, TensorMeta), f"Got non-TensorMeta output!, {type(tm)}"
 
-        node = self.graph.output(tm)
-        self._add_user(tm, node)
+        node = self.graph.output(tms)
+        for tm in flat_tms:
+            self._add_user(tm, node)
 
     def __torch_function__(
         self,

--- a/torch/_prims/executor.py
+++ b/torch/_prims/executor.py
@@ -58,11 +58,16 @@ def execute(ctx: PrimContext, *args, executor: str = "aten", **kwargs):
 
             gm = GraphModule({}, ctx.graph)
             out = gm.forward(*nv_args)
-            fd.add_output(out)
+            flat_out, unflatten_spec = torch.utils._pytree.tree_flatten(out)
+            for o in flat_out:
+                fd.add_output(o)
 
-            return fusion.execute(
-                tuple(arg for arg in args if isinstance(arg, torch.Tensor))
-            )[0]
+            return torch.utils._pytree.tree_unflatten(
+                fusion.execute(
+                    tuple(arg for arg in args if isinstance(arg, torch.Tensor))
+                ),
+                unflatten_spec,
+            )
 
     msg = "Received unexpected value for 'executor': {0}. Allowed values are: aten, nvfuser.".format(
         executor
@@ -79,8 +84,8 @@ def make_traced(fn: Callable):
 
     Only supports the torch operations defined in _torch_to_reference_map
     in context.py and operations with positional args. All args must
-    be tensors and the function must return a single tensor. In the
-    near future all these restrictions will be lifted.
+    be tensors.
+    In the near future all these restrictions will be lifted.
 
     Example usage:
 


### PR DESCRIPTION
This PR lifts the restriction that the output of a function traced with `make_traced` and executed with nvFuser must be a single tensor. Now it's possible to return a "pytree", a tensor's nested data structure (see https://github.com/pytorch/pytorch/blob/master/torch/utils/_pytree.py).

I added a test with a function that returns a tuple of two objects where one of the objects is a dictionary with a tensor value.

```py
def fn(a, b):
    d = {}
    d["c"] = torch.add(a, b)
    return (d, torch.add(a, d["c"]))
```