### PR TITLE
[Vulkan] Fix cat registration

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -259,7 +259,7 @@ Tensor cat(
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
-  m.impl(TORCH_SELECTIVE_NAME("aten::_cat"), TORCH_FN(cat));
+  m.impl(TORCH_SELECTIVE_NAME("aten::cat"), TORCH_FN(cat));
 }
 
 #endif /* USE_VULKAN_API */


### PR DESCRIPTION
Summary:
Fix cat registration.
9 Vulkan API Tests are failing because of this.

Reviewed By: SS-JIA

Differential Revision: D36882414

