### PR TITLE
functionalization: allow mixed functional/nonfunctional TensorList inputs

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -133,8 +133,8 @@ TORCH_API c10::List<c10::optional<Tensor>> to_functional_tensor(const c10::List<
 TORCH_API std::vector<Tensor> to_functional_tensor(const std::vector<Tensor>& t_list);
 TORCH_API std::vector<Tensor> to_functional_tensor(const TensorList& t_list);
 
-TORCH_API Tensor from_functional_tensor(const Tensor& tensor);
-TORCH_API c10::optional<Tensor> from_functional_tensor(const c10::optional<Tensor>& t);
+TORCH_API Tensor from_functional_tensor(const Tensor& tensor, bool assert_functional=true);
+TORCH_API c10::optional<Tensor> from_functional_tensor(const c10::optional<Tensor>& t, bool assert_functional=true);
 TORCH_API c10::List<Tensor> from_functional_tensor(const c10::List<Tensor>& t_list);
 TORCH_API c10::List<c10::optional<Tensor>> from_functional_tensor(const c10::List<c10::optional<Tensor>>& t_list);
 TORCH_API std::vector<Tensor> from_functional_tensor(const TensorList& tensors);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #75527
* #76358
* #78820
* __->__ #78819

This relaxes the restriction where you have a tensorlist with mixed inputs, since that can actually happen.

Planning to add a functorch tracing test later, since that's where it's more relevant (tracing the forward() of an FX module that has some state attached)

This fixes a bug in a traced executorch model, that was calling something like `torch.cat([input_tensor, self.global_state_tensor])