### PR TITLE
functionalization: update wrapper to propagate symints

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -260,6 +260,68 @@ const char* FunctionalTensorWrapper::tensorimpl_type_name() const {
     return "FunctionalTensorWrapper";
 }
 
+template <typename VariableVersion>
+c10::intrusive_ptr<TensorImpl> FunctionalTensorWrapper::shallow_copy_and_detach_core(
+    VariableVersion&& version_counter,
+    bool allow_tensor_metadata_change) const {
+  if (key_set_.has(DispatchKey::Python) &&
+      !c10::impl::tls_is_dispatch_key_excluded(DispatchKey::Python)) {
+    auto r = pyobj_interpreter_.load(std::memory_order_acquire)->detach(this);
+    if (r) {
+      r->set_version_counter(std::forward<VariableVersion>(version_counter));
+      r->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
+      return r;
+    }
+  }
+  auto impl = c10::make_intrusive<FunctionalTensorWrapper>(value_);
+  copy_tensor_metadata(
+      /*src_impl=*/this,
+      /*dest_impl=*/impl.get(),
+      /*version_counter=*/std::forward<VariableVersion>(version_counter),
+      // I want to confirm with someone that this is reasonable.
+      // The autograd kernel for detach() always creates a view of the output
+      // with "allow_tensor_metadata_changes" set to false.
+      // We *always* want this flag to be true for FunctionalTensorWrapper though,
+      // Since mutations later on can changes the size/stride metadata on the wrapper.
+      /*allow_tensor_metadata_change=*/true);
+  impl->refresh_numel();
+  impl->refresh_contiguous();
+  return impl;
+}
+
+c10::intrusive_ptr<TensorImpl> FunctionalTensorWrapper::shallow_copy_and_detach(
+    const c10::VariableVersion& version_counter,
+    bool allow_tensor_metadata_change) const {
+  return shallow_copy_and_detach_core(
+      version_counter, allow_tensor_metadata_change);
+}
+
+c10::intrusive_ptr<TensorImpl> FunctionalTensorWrapper::shallow_copy_and_detach(
+    c10::VariableVersion&& version_counter,
+    bool allow_tensor_metadata_change) const {
+  return shallow_copy_and_detach_core(
+      std::move(version_counter), allow_tensor_metadata_change);
+}
+
+at::IntArrayRef FunctionalTensorWrapper::sizes_custom() const {
+  return value_.unsafeGetTensorImpl()->sizes();
+}
+at::IntArrayRef FunctionalTensorWrapper::strides_custom() const {
+  return value_.unsafeGetTensorImpl()->strides();
+}
+int64_t FunctionalTensorWrapper::dim_custom() const {
+  return value_.unsafeGetTensorImpl()->dim();
+}
+int64_t FunctionalTensorWrapper::numel_custom() const {
+  return value_.unsafeGetTensorImpl()->numel();
+}
+bool FunctionalTensorWrapper::is_contiguous_custom(at::MemoryFormat memory_format) const {
+  return value_.unsafeGetTensorImpl()->is_contiguous();
+}
+c10::SymIntArrayRef FunctionalTensorWrapper::sym_sizes_custom() const {
+  return value_.unsafeGetTensorImpl()->sym_sizes();
+}
+
 namespace functionalization {
 namespace impl {
 

--- a/aten/src/ATen/FunctionalTensorWrapper.h
+++ b/aten/src/ATen/FunctionalTensorWrapper.h
@@ -96,6 +96,16 @@ struct TORCH_API FunctionalTensorWrapper : public c10::TensorImpl {
 
   ~FunctionalTensorWrapper() override = default;
 
+  // FunctionalTensorWrapper overrides all custom size/stride function,
+  // so that if the inner tensor has a custo implementation
+  // we make sure to call that implementation.
+  at::IntArrayRef sizes_custom() const override;
+  at::IntArrayRef strides_custom() const override;
+  int64_t dim_custom() const override;
+  int64_t numel_custom() const override;
+  bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
+  c10::SymIntArrayRef sym_sizes_custom() const override;
+
  private:
   const char* tensorimpl_type_name() const override;
   void set_constructor_metadata();

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -556,6 +556,7 @@ void TensorImpl::copy_generic_tensor_metadata(
   if (src_impl->named_tensor_meta_ != nullptr) {
     dest_impl->named_tensor_meta_ = src_impl->named_tensor_meta_->clone();
   }
+  dest_impl->sizes_strides_policy_ = src_impl->sizes_strides_policy_;
 }
 
 void TensorImpl::copy_tensor_metadata_except_version_counter(
@@ -574,7 +575,6 @@ void TensorImpl::copy_tensor_metadata_except_version_counter(
   dest_impl->key_set_ = (src_impl->key_set_ - c10::python_ks) |
       (dest_impl->key_set_ & c10::python_ks);
   dest_impl->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
-  dest_impl->sizes_strides_policy_ = src_impl->sizes_strides_policy_;
   dest_impl->storage_access_should_throw_ =
       src_impl->storage_access_should_throw_;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #75527
* #76358
* __->__ #78820
* #78819

Tested in the next PR by LTC tests (they were failing before). It's no longer enough just to copy the size/stride data from the inner tensor - if it has a custom sizes/strides policy, we need to make sure that we invoke the inner tensor's custom function, in order for functional tensors to properly "propagate" symbolic shapes

Differential Revision: [D37003884](https://our.internmc.facebook.com/intern/diff/D37003884)