### PR TITLE
Add check for no grad in transformer encoder nestedtensor conversion

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -226,7 +226,7 @@ class TransformerEncoder(Module):
                         first_layer.linear2.bias,
                     )
                     if not torch.overrides.has_torch_function(tensor_args):
-                        if not torch.is_grad_enabled() or all([not x.requires_grad for x in tensor_args])):
+                        if not torch.is_grad_enabled() or all([not x.requires_grad for x in tensor_args]):
                             if output.is_cuda or 'cpu' in str(output.device):
                                 convert_to_nested = True
                                 output = torch._nested_tensor_from_mask(output, src_key_padding_mask.logical_not())

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -226,9 +226,10 @@ class TransformerEncoder(Module):
                         first_layer.linear2.bias,
                     )
                     if not torch.overrides.has_torch_function(tensor_args):
-                        if output.is_cuda or 'cpu' in str(output.device):
-                            convert_to_nested = True
-                            output = torch._nested_tensor_from_mask(output, src_key_padding_mask.logical_not())
+                        if not torch.is_grad_enabled() or all([not x.requires_grad for x in tensor_args])):
+                            if output.is_cuda or 'cpu' in str(output.device):
+                                convert_to_nested = True
+                                output = torch._nested_tensor_from_mask(output, src_key_padding_mask.logical_not())
 
         for mod in self.layers:
             if convert_to_nested:


### PR DESCRIPTION
Before, we allowed inputs with grad to be converted to NestedTensors. Autograd attempts to find the size of the NestedTensor, but NestedTensor throws an exception for its size function. This causes all calls to nn.TransformerEncoder with grad enabled to fail.

Fix: we add a check for no grad in transformer encoder so we do not convert tensor with grad to nestedtensor.