### PR TITLE
ci: Set NUM_PROC_THREADS for docs build

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -94,6 +94,7 @@ jobs:
             -e DOCS_TYPE \
             -e PR_LABELS \
             -e WITH_PUSH \
+            -e NUM_PROC_THREADS=$(nproc --ignore=2) \
             --env-file="/tmp/github_env_${GITHUB_RUN_ID}" \
             --security-opt seccomp=unconfined \
             --cap-add=SYS_PTRACE \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #78853

Sets NUM_PROC_THREADS to hopefully make the doxygen build go faster.

See https://doxygen.nl/manual/config.html for more info

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>