### PR TITLE
[Static Runtime] prim::fork asyunchronous execution on JIT interpreter

### DIFF
--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -860,8 +860,10 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         for (auto i : c10::irange(p_node->num_inputs())) {
           stack.emplace_back(p_node->Input(i));
         }
-        InterpreterState interpreter{code};
-        interpreter.runAsync(stack);
+        TaskLauncher taskLauncher_ = at::launch;
+        InterpreterState interpreter{code, taskLauncher_};
+        InterpreterContinuation continuation(interpreter, stack);
+        taskLauncher_(std::move(continuation));
         p_node->Output(0) = interpreter.getFuture();
       };
     });


### PR DESCRIPTION
Summary:
prim::fork was executed synchronously in the main thread
- Added changes that executes the prim::fork calls on asynchronously on one of the threads from TaskThreadPoolBase defined in aten
- Changes are tested via pytorch profiler tracing. Fork calls are executed on different threads

Test Plan:
local tests scripts exected:
- buck run mode/opt caffe2/test:static_runtime
- buck run caffe2/benchmarks/static_runtime/fb:test_fb_operators
- buck run caffe2/benchmarks/static_runtime:static_runtime_cpptest

Executing pytorch profiler to see the spawned execution of fork operations in parallel on different threads

Differential Revision: D36909308

