### PR TITLE
Support percentages in random_split

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -133,9 +133,37 @@ class TestDatasetRandomSplit(TestCase):
         self.assertEqual(len(splits[0]), 2)
         self.assertEqual(len(splits[1]), 4)
 
+        splits = random_split([1, 2, 3, 4, 5, 6], [0.5, 0.5])
+        self.assertEqual(len(splits), 2)
+        self.assertEqual(len(splits[0]), 3)
+        self.assertEqual(len(splits[1]), 3)
+
+        # Odd size splits
+        self.assertEqual(
+            len(random_split(range(3), [0.5], generator=torch.Generator().manual_seed(1))),
+            2
+        )
+
     def test_splits_are_mutually_exclusive(self):
         data = [5, 2, 3, 4, 1, 6]
         splits = random_split(data, [2, 4])
+        all_values = []
+        all_values.extend(list(splits[0]))
+        all_values.extend(list(splits[1]))
+        data.sort()
+        all_values.sort()
+        self.assertListEqual(data, all_values)
+
+        splits = random_split(data, [0.33])
+        all_values = []
+        all_values.extend(list(splits[0]))
+        all_values.extend(list(splits[1]))
+        data.sort()
+        all_values.sort()
+        self.assertListEqual(data, all_values)
+
+        data = [1, 2, 3, 4]
+        splits = random_split(data, [0.25, 0.75])
         all_values = []
         all_values.extend(list(splits[0]))
         all_values.extend(list(splits[1]))
@@ -166,6 +194,13 @@ class TestDatasetRandomSplit(TestCase):
         for batch in data_loader:
             pass
 
+        # fractional splitting
+        dataset = CustomDataset(self, x)
+        dataset = random_split(dataset, [1.0])[0]
+        data_loader = DataLoader(dataset)
+        for batch in data_loader:
+            pass
+
     def test_splits_reproducibility(self):
         self.assertEqual(
             [list(x) for x in random_split(range(10), [3, 7], generator=torch.Generator().manual_seed(1))],
@@ -174,6 +209,24 @@ class TestDatasetRandomSplit(TestCase):
         self.assertEqual(
             random_split(range(100), [60, 40], generator=torch.Generator().manual_seed(42)),
             random_split(range(100), [60, 40], generator=torch.Generator().manual_seed(42)),
+        )
+        self.assertEqual(
+            random_split(range(100), [0.5, 0.5], generator=torch.Generator().manual_seed(42)),
+            random_split(range(100), [0.5, 0.5], generator=torch.Generator().manual_seed(42)),
+        )
+        self.assertEqual(
+            random_split(range(100), [0.33, 0.33], generator=torch.Generator().manual_seed(42)),
+            random_split(range(100), [0.33, 0.33], generator=torch.Generator().manual_seed(42)),
+        )
+
+    def test_incomplete_fractional_splits(self):
+        self.assertEqual(
+            random_split(range(10), [0.5], generator=torch.Generator().manual_seed(1)),
+            random_split(range(10), [0.5, 0.5], generator=torch.Generator().manual_seed(1)),
+        )
+        self.assertEqual(
+            len(random_split(range(10), [0.33, 0.33, 0.33])),
+            4
         )
 
     def test_splits_generator(self):

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -233,6 +233,10 @@ class TestDatasetRandomSplit(TestCase):
             # should raise since the sum of fractions is not 1
             random_split([1, 2, 3, 4], [0.1])
 
+        with self.assertRaises(ValueError):
+            # should raise since fraction > 1
+            random_split([1, 2, 3, 4], [1.1])
+
     def test_splits_generator(self):
         # A random_split without a specific generator should affect the default one
         state = torch.get_rng_state()

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -147,10 +147,10 @@ class TestDatasetRandomSplit(TestCase):
         # Odd sized round-robin splits
         splits = random_split(range(106), [0.1, 0.2, 0.3, 0.4],
                               generator=torch.Generator().manual_seed(1))
-        self.assertEqual(len(splits[0]), 12)
+        self.assertEqual(len(splits[0]), 11)
         self.assertEqual(len(splits[1]), 22)
         self.assertEqual(len(splits[2]), 31)
-        self.assertEqual(len(splits[3]), 41)
+        self.assertEqual(len(splits[3]), 42)
 
 
     def test_splits_are_mutually_exclusive(self):

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -316,13 +316,18 @@ def random_split(dataset: Dataset[T], lengths_or_frac: Sequence[Union[int, float
     if 0 <= sum(lengths_or_frac) <= 1.0:
         import math
         # if lengths is a float, it is a percentage. We convert it to a sequence of ints
-        lengths_or_frac = [int(math.floor(len(dataset) * pct)) for pct in lengths_or_frac]  # type: ignore[arg-type]
-        remainder = len(dataset) - sum(lengths_or_frac)
+        lengths = []
+        for frac in lengths_or_frac:
+            n_items_in_split = int(math.floor(len(dataset) * frac))
+            lengths.append(n_items_in_split)
+        remainder = len(dataset) - sum(lengths)
         if remainder > 0:
-            lengths_or_frac.append(remainder)
+            lengths.append(remainder)
+    else:
+        lengths = lengths_or_frac
     # Cannot verify that dataset is Sized
-    if sum(lengths_or_frac) != len(dataset):    # type: ignore[arg-type]
+    if sum(lengths) != len(dataset):    # type: ignore[arg-type]
         raise ValueError("Sum of input lengths does not equal the length of the input dataset!")
 
-    indices = randperm(sum(lengths_or_frac), generator=generator).tolist()
-    return [Subset(dataset, indices[offset - length : offset]) for offset, length in zip(_accumulate(lengths_or_frac), lengths_or_frac)]
+    indices = randperm(sum(lengths), generator=generator).tolist()
+    return [Subset(dataset, indices[offset - length : offset]) for offset, length in zip(_accumulate(lengths), lengths)]

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -324,7 +324,7 @@ def random_split(dataset: Dataset[T], lengths_or_frac: Sequence[Union[int, float
         if remainder > 0:
             lengths.append(remainder)
     else:
-        lengths = lengths_or_frac
+        lengths = lengths_or_frac  # type: ignore[assignment]
     # Cannot verify that dataset is Sized
     if sum(lengths) != len(dataset):    # type: ignore[arg-type]
         raise ValueError("Sum of input lengths does not equal the length of the input dataset!")

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -310,7 +310,7 @@ def random_split(dataset: Dataset[T], lengths_or_frac: Sequence[Union[int, float
 
     Args:
         dataset (Dataset): Dataset to be split
-        lengths_or_frac (sequence): lengths of splits to be produced
+        lengths_or_frac (sequence): lengths or fractions of splits to be produced
         generator (Generator): Generator used for the random permutation.
     """
     if 0 <= sum(lengths_or_frac) <= 1.0:

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -313,14 +313,14 @@ def random_split(dataset: Dataset[T], lengths_or_frac: Sequence[Union[int, float
         lengths_or_frac (sequence): lengths or fractions of splits to be produced
         generator (Generator): Generator used for the random permutation.
     """
-    if 0 <= sum(lengths_or_frac) <= 1.0:
+    if 0 <= sum(lengths_or_frac) <= 1.0:  # type: ignore[arg-type]
         import math
         # if lengths is a float, it is a percentage. We convert it to a sequence of ints
         lengths = []
         for frac in lengths_or_frac:
-            n_items_in_split = int(math.floor(len(dataset) * frac))
+            n_items_in_split = int(math.floor(len(dataset) * frac))  # type: ignore[arg-type]
             lengths.append(n_items_in_split)
-        remainder = len(dataset) - sum(lengths)
+        remainder = len(dataset) - sum(lengths)  # type: ignore[arg-type]
         if remainder > 0:
             lengths.append(remainder)
     else:

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -298,8 +298,9 @@ def random_split(dataset: Dataset[T], lengths_or_frac: Sequence[Union[int, float
                  generator: Optional[Generator] = default_generator) -> List[Subset[T]]:
     r"""
     Randomly split a dataset into non-overlapping new datasets of given lengths.
-    If a list of fractions is given, the lengths will be computed automatically.
-    If the sum of the list of the fractions is not equal to 1 or the split leaves a remainder, a new entry will be appended
+    If a list of fractions is given, the lengths will be computed automatically as floor(frac * len(dataset)).
+    If the sum of the list of the fractions is not equal to 1 or the split leaves a remainder,
+    a new entry will be appended
     to the end of the list with the remaining fraction
 
     Optionally fix the generator for reproducible results, e.g.:
@@ -313,8 +314,9 @@ def random_split(dataset: Dataset[T], lengths_or_frac: Sequence[Union[int, float
         generator (Generator): Generator used for the random permutation.
     """
     if 0 <= sum(lengths_or_frac) <= 1.0:
+        import math
         # if lengths is a float, it is a percentage. We convert it to a sequence of ints
-        lengths_or_frac = [int(round(len(dataset) * pct)) for pct in lengths_or_frac]  # type: ignore[arg-type]
+        lengths_or_frac = [int(math.floor(len(dataset) * pct)) for pct in lengths_or_frac]  # type: ignore[arg-type]
         remainder = len(dataset) - sum(lengths_or_frac)
         if remainder > 0:
             lengths_or_frac.append(remainder)

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -329,11 +329,12 @@ def random_split(dataset: Dataset[T], lengths: Sequence[Union[int, float]],
         # add 1 to all the lengths in round-robin fashion until the remainder is 0
         for i in range(remainder):
             idx_to_add_at = i % len(subset_lengths)
-            if subset_lengths[idx_to_add_at] == 0:
-                warnings.warn(f"Fraction at index {idx_to_add_at} is 0, "
-                              f"but the remainder is {remainder}")
             subset_lengths[idx_to_add_at] += 1
         lengths = subset_lengths
+        for i, length in enumerate(lengths):
+            if length == 0:
+                warnings.warn(f"Length of split at index {i} is 0. "
+                              f"This might result in an empty dataset.")
 
     # Cannot verify that dataset is Sized
     if sum(lengths) != len(dataset):    # type: ignore[arg-type]

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -295,28 +295,31 @@ class Subset(Dataset[T_co]):
         return len(self.indices)
 
 
-def random_split(dataset: Dataset[T], lengths_or_frac: Sequence[Union[int, float]],
+def random_split(dataset: Dataset[T], lengths: Sequence[Union[int, float]],
                  generator: Optional[Generator] = default_generator) -> List[Subset[T]]:
     r"""
     Randomly split a dataset into non-overlapping new datasets of given lengths.
-    If a list of fractions is given, the lengths will be computed automatically as floor(frac * len(dataset)).
-    If the sum of the list of the fractions is not equal to 1 or the split leaves a remainder,
+    If a list of fractions is given, the lengths will be computed automatically as
+    floor(frac * len(dataset)).
+    If the sum of the list of the fractions is not equal to 1 or the split leaves a
+    remainder,
     a new entry will be appended
     to the end of the list with the remaining fraction
 
     Optionally fix the generator for reproducible results, e.g.:
 
     >>> random_split(range(10), [3, 7], generator=torch.Generator().manual_seed(42))
-    >>> random_split(range(30), [0.3, 0.3, 0.4], generator=torch.Generator().manual_seed(42))
+    >>> random_split(range(30), [0.3, 0.3, 0.4], generator=torch.Generator(
+    ).manual_seed(42))
 
     Args:
         dataset (Dataset): Dataset to be split
-        lengths_or_frac (sequence): lengths or fractions of splits to be produced
+        lengths (sequence): lengths or fractions of splits to be produced
         generator (Generator): Generator used for the random permutation.
     """
-    if math.isclose(sum(lengths_or_frac), 1):
+    if math.isclose(sum(lengths), 1):
         lengths = []
-        for i, frac in enumerate(lengths_or_frac):
+        for i, frac in enumerate(lengths):
             if frac < 0 or frac > 1:
                 raise ValueError(f"Fraction at index {i} is not between 0 and 1")
             n_items_in_split = int(
@@ -327,8 +330,7 @@ def random_split(dataset: Dataset[T], lengths_or_frac: Sequence[Union[int, float
         # add 1 to all the lengths in round-robin fashion until the remainder is 0
         for i in range(remainder):
             lengths[i % len(lengths)] += 1
-    else:
-        lengths = lengths_or_frac  # type: ignore[assignment]
+
     # Cannot verify that dataset is Sized
     if sum(lengths) != len(dataset):    # type: ignore[arg-type]
         raise ValueError("Sum of input lengths does not equal the length of the input dataset!")

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -319,7 +319,7 @@ def random_split(dataset: Dataset[T], lengths: Sequence[Union[int, float]],
     """
     if math.isclose(sum(lengths), 1) and sum(lengths) <= 1:
         subset_lengths: List[int] = []
-        for i, frac in enumerate(subset_lengths):
+        for i, frac in enumerate(lengths):
             if frac < 0 or frac > 1:
                 raise ValueError(f"Fraction at index {i} is not between 0 and 1")
             n_items_in_split = int(
@@ -329,10 +329,11 @@ def random_split(dataset: Dataset[T], lengths: Sequence[Union[int, float]],
         remainder = len(dataset) - sum(subset_lengths)  # type: ignore[arg-type]
         # add 1 to all the lengths in round-robin fashion until the remainder is 0
         for i in range(remainder):
-            if subset_lengths[i] == 0:
-                warnings.warn(f"Fraction at index {i} is 0, "
+            idx_to_add_at = i % len(subset_lengths)
+            if subset_lengths[idx_to_add_at] == 0:
+                warnings.warn(f"Fraction at index {idx_to_add_at} is 0, "
                               f"but the remainder is {remainder}")
-            subset_lengths[i % len(subset_lengths)] += 1
+            subset_lengths[idx_to_add_at] += 1
         lengths = subset_lengths
 
     # Cannot verify that dataset is Sized

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -340,5 +340,6 @@ def random_split(dataset: Dataset[T], lengths: Sequence[Union[int, float]],
     if sum(lengths) != len(dataset):    # type: ignore[arg-type]
         raise ValueError("Sum of input lengths does not equal the length of the input dataset!")
 
-    indices = randperm(sum(lengths), generator=generator).tolist()
+    # lengths are already set to be a list of integers, so no worries.
+    indices = randperm(sum(lengths), generator=generator).tolist()  # type: ignore[call-overload]
     return [Subset(dataset, indices[offset - length : offset]) for offset, length in zip(_accumulate(lengths), lengths)]

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -302,9 +302,8 @@ def random_split(dataset: Dataset[T], lengths: Sequence[Union[int, float]],
     If a list of fractions is given, the lengths will be computed automatically as
     floor(frac * len(dataset)).
     If the sum of the list of the fractions is not equal to 1 or the split leaves a
-    remainder,
-    a new entry will be appended
-    to the end of the list with the remaining fraction
+    remainder, a new entry will be appended to the end of the list with the
+    remaining fraction
 
     Optionally fix the generator for reproducible results, e.g.:
 
@@ -340,6 +339,5 @@ def random_split(dataset: Dataset[T], lengths: Sequence[Union[int, float]],
     if sum(lengths) != len(dataset):    # type: ignore[arg-type]
         raise ValueError("Sum of input lengths does not equal the length of the input dataset!")
 
-    # lengths are already set to be a list of integers, so no worries.
     indices = randperm(sum(lengths), generator=generator).tolist()  # type: ignore[call-overload]
     return [Subset(dataset, indices[offset - length : offset]) for offset, length in zip(_accumulate(lengths), lengths)]

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -299,11 +299,14 @@ def random_split(dataset: Dataset[T], lengths: Sequence[Union[int, float]],
                  generator: Optional[Generator] = default_generator) -> List[Subset[T]]:
     r"""
     Randomly split a dataset into non-overlapping new datasets of given lengths.
-    If a list of fractions is given, the lengths will be computed automatically as
-    floor(frac * len(dataset)).
-    If the sum of the list of the fractions is not equal to 1 or the split leaves a
-    remainder, a new entry will be appended to the end of the list with the
-    remaining fraction
+
+    If a list of fractions that sum up to 1 is given,
+    the lengths will be computed automatically as
+    floor(frac * len(dataset)) for each fraction provided.
+
+    After computing the lengths, if there are any remainders, 1 count will be
+    distributed in round-robin fashion to the lengths
+    until there are no remainders left.
 
     Optionally fix the generator for reproducible results, e.g.:
 


### PR DESCRIPTION
Fixes #78510

This PR adds support for using fractions with `random_split`. This should be completely backwards-compatible as the fractional-style splitting is only applied when the sum across the input lengths is lower than 1.0