### PR TITLE
Don't check overflow for scalar arg in comparison ops

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -1092,14 +1092,6 @@ Tensor bitwise_right_shift(const Scalar& self, const Tensor& other) {
 
 template <typename Stub>
 Tensor& comparison_op_out(Tensor& result, const Tensor& self, const Tensor& other, Stub& stub) {
-  // Validate that is possible to convert zero-dim tensor's dtype to other dtype without overflow
-  // if (self.scalar_type() != other.scalar_type()) {
-  //   if (self.dim() != 0 && other.dim() == 0) {
-  //     check_convert(other.item(), self.scalar_type());
-  //   } else if (self.dim() == 0 && other.dim() != 0) {
-  //     check_convert(self.item(), other.scalar_type());
-  //   }
-  // }
   auto iter = TensorIterator::comparison_op(result, self, other);
   stub(iter.device_type(), iter);
   return result;

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -64,6 +64,7 @@ from torch.testing._internal.common_methods_invocations import (
     generate_elementwise_binary_extremal_value_tensors,
     generate_elementwise_binary_broadcasting_tensors,
     generate_elementwise_binary_with_scalar_samples,
+    generate_elementwise_binary_with_scalar_and_type_promotion_samples,
 )
 
 if TEST_SCIPY:
@@ -269,6 +270,11 @@ class TestBinaryUfuncs(TestCase):
             op, device=device, dtype=dtype
         )
         self._test_reference_numerics(dtype, op, gen, equal_nan=True)
+        gen = generate_elementwise_binary_with_scalar_and_type_promotion_samples(
+            op, device=device, dtype=dtype
+        )
+        self._test_reference_numerics(dtype, op, gen, equal_nan=True)
+
 
     @ops(binary_ufuncs)
     def test_contig_vs_every_other(self, device, dtype, op):

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -868,36 +868,6 @@ class TestBinaryUfuncs(TestCase):
         x = torch.tensor(2.0, requires_grad=True)
         self.assertRaises(Exception, lambda: y.addcmul(y, y, value=x))
 
-    # TODO: update to work on CUDA, too
-    @onlyCPU
-    def test_comparison_ops(self, device):
-        x = torch.randn(5, 5)
-        y = torch.randn(5, 5)
-
-        eq = x == y
-        for idx in iter_indices(x):
-            self.assertEqual(x[idx] == y[idx], eq[idx] == 1)
-
-        ne = x != y
-        for idx in iter_indices(x):
-            self.assertEqual(x[idx] != y[idx], ne[idx] == 1)
-
-        lt = x < y
-        for idx in iter_indices(x):
-            self.assertEqual(x[idx] < y[idx], lt[idx] == 1)
-
-        le = x <= y
-        for idx in iter_indices(x):
-            self.assertEqual(x[idx] <= y[idx], le[idx] == 1)
-
-        gt = x > y
-        for idx in iter_indices(x):
-            self.assertEqual(x[idx] > y[idx], gt[idx] == 1)
-
-        ge = x >= y
-        for idx in iter_indices(x):
-            self.assertEqual(x[idx] >= y[idx], ge[idx] == 1)
-
     @onlyCUDA
     def test_comparison_ops_device_computation(self, device):
         operands = (
@@ -931,68 +901,6 @@ class TestBinaryUfuncs(TestCase):
             self.assertEqual(
                 op(torch.tensor([True]), torch.tensor([False])).dtype, torch.bool
             )
-
-    # TODO: update to work on CUDA, too
-    @onlyCPU
-    def test_comparison_ops_check_for_scalar_overflow(self, device):
-        s = 1 << 20
-        t = torch.tensor([1 << 5], dtype=torch.uint8)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t < s)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(s < t)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t <= s)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(s <= t)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t > s)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(s > t)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t >= s)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(s >= t)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t == s)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(s == t)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t != s)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(s != t)
-
-    # TODO: update to work on CUDA, too
-    @onlyCPU
-    def test_comparison_ops_check_for_zerodim_tensor_overflow(self, device):
-        t1 = torch.tensor([1 << 5], dtype=torch.uint8)
-        t2 = torch.tensor([1 << 30], dtype=torch.int32)
-        ts1 = torch.tensor(1 << 20, dtype=torch.int32)
-        ts2 = torch.tensor(1 << 40, dtype=torch.int64)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t1 < ts1)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(ts2 < t2)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t1 <= ts1)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(ts2 <= t2)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t1 > ts1)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(ts2 > t2)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t1 >= ts1)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(ts2 >= t2)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t1 == ts1)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(ts2 == t2)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(t1 != ts1)
-        with self.assertRaisesRegex(RuntimeError, "value cannot be converted to type"):
-            self.assertTrue(ts2 != t2)
 
     # Tests that the binary operators and, or, and xor (as well as their reflected and inplace versions)
     # work properly (AKA &, ||, ^ and &=, |=, ^=)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -868,40 +868,6 @@ class TestBinaryUfuncs(TestCase):
         x = torch.tensor(2.0, requires_grad=True)
         self.assertRaises(Exception, lambda: y.addcmul(y, y, value=x))
 
-    @onlyCUDA
-    def test_comparison_ops_device_computation(self, device):
-        operands = (
-            torch.tensor(0),
-            torch.tensor(2, device="cuda"),
-            torch.tensor([0, 2], device="cuda"),
-        )
-        # Checks that comparison operators compute the correct
-        # output device, given a combination of devices
-        # TODO: test all comparison ops after porting them to structured kernel
-        # logical_and, logical_or, and logical_xor
-        for op in [torch.lt, torch.le, torch.gt, torch.ge, torch.eq, torch.ne]:
-            for lhs in operands:
-                for rhs in operands:
-                    self.assertEqual(op(lhs, rhs), op(lhs.cpu(), rhs.cpu()))
-
-    # TODO: update to work on CUDA, too
-    @onlyCPU
-    def test_comparison_ops_must_take_bool_output(self, device):
-        for op in [
-            torch.lt,
-            torch.le,
-            torch.gt,
-            torch.ge,
-            torch.eq,
-            torch.ne,
-            torch.logical_and,
-            torch.logical_or,
-            torch.logical_xor,
-        ]:
-            self.assertEqual(
-                op(torch.tensor([True]), torch.tensor([False])).dtype, torch.bool
-            )
-
     # Tests that the binary operators and, or, and xor (as well as their reflected and inplace versions)
     # work properly (AKA &, ||, ^ and &=, |=, ^=)
     @dtypes(*integral_types_and(torch.bool))

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11332,11 +11332,7 @@ op_db: List[OpInfo] = [
                     dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16, torch.chalf),
                     always_returns_bool=True,
                     supports_autograd=False,
-                    sample_inputs_func=sample_inputs_comparison_ops,
-                    skips=(
-                        # https://github.com/pytorch/pytorch/issues/76805
-                        DecorateInfo(unittest.expectedFailure, 'TestBinaryUfuncs', 'test_type_promotion'),
-                    )),
+                    sample_inputs_func=sample_inputs_comparison_ops),
     BinaryUfuncInfo('fmax',
                     op=torch.fmax,
                     dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
@@ -14760,11 +14756,7 @@ op_db: List[OpInfo] = [
                     aliases=('not_equal',),
                     dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
                     always_returns_bool=True,
-                    supports_autograd=False,
-                    skips=(
-                        # https://github.com/pytorch/pytorch/issues/76805
-                        DecorateInfo(unittest.expectedFailure, 'TestBinaryUfuncs', 'test_type_promotion'),
-                    )),
+                    supports_autograd=False),
     OpInfo('narrow',
            dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16, torch.chalf),
            supports_out=False,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2221,11 +2221,11 @@ def generate_elementwise_binary_with_scalar_samples(
         make_tensor, device=device, dtype=dtype, requires_grad=requires_grad
     )
 
-    scalar_shapes = ((), (3,), (5, 3), (0, 1, 3), (1, 5))
+    shapes = ((), (3,), (5, 3), (0, 1, 3), (1, 5))
     if op.supports_rhs_python_scalar:
-        for scalar_shape in scalar_shapes:
-            lhs = make_arg(scalar_shape, **op.lhs_make_tensor_kwargs)
-            rhs = make_arg(scalar_shape, **op.rhs_make_tensor_kwargs)
+        for shape in shapes:
+            lhs = make_arg(shape, **op.lhs_make_tensor_kwargs)
+            rhs = make_arg(shape, **op.rhs_make_tensor_kwargs)
             lhs_scalar = make_arg((), **op.lhs_make_tensor_kwargs).item()
             rhs_scalar = make_arg((), **op.rhs_make_tensor_kwargs).item()
 
@@ -2241,6 +2241,26 @@ def generate_elementwise_binary_with_scalar_samples(
 
         yield SampleInput(lhs_scalar, args=(rhs_scalar,))
 
+# Returns a generator of pairs of contiguous tensors and 0d tensos and scalars and type promotion
+def generate_elementwise_binary_with_scalar_and_type_promotion_samples(
+    op, *, device, dtype, requires_grad=False
+):
+    # add these samples only for logical and comparison ops, arithmetic ops are not happy about extremal scalars
+    if op.name in ('eq', 'ne', 'gt', 'ge', 'lt', 'le', 'logical_and', 'logical_or', 'logical_xor'):
+        make_arg = partial(
+            make_tensor, device=device, dtype=dtype, requires_grad=requires_grad
+        )
+        shape = (23,)  # this shape is big enough to trigger vectorization, and has non-vectorized tail
+        values = (float('nan'), float('inf'), -float('inf'))
+        scalar_tensors = tuple(torch.tensor(val) for val in values)
+        if op.supports_rhs_python_scalar:
+            lhs = make_arg(shape, **op.lhs_make_tensor_kwargs)
+            rhs = make_arg(shape, **op.rhs_make_tensor_kwargs)
+            for scalar in values + scalar_tensors:
+                yield SampleInput(lhs, args=(scalar,))
+                # Extends with scalar lhs
+                if op.supports_one_python_scalar:
+                    yield SampleInput(scalar, args=(rhs,))
 
 # Returns a generator of pairs of noncontiguous tensors
 def generate_elementwise_binary_noncontiguous_tensors(
@@ -2402,6 +2422,10 @@ def _reference_inputs_elementwise_binary(op, device, dtype, requires_grad, exclu
             op, device=device, dtype=dtype, requires_grad=requires_grad, exclude_zero=exclude_zero
         )
     yield from generate_elementwise_binary_with_scalar_samples(
+        op, device=device, dtype=dtype, requires_grad=requires_grad
+    )
+
+    yield from generate_elementwise_binary_with_scalar_and_type_promotion_samples(
         op, device=device, dtype=dtype, requires_grad=requires_grad
     )
 
@@ -11304,6 +11328,7 @@ op_db: List[OpInfo] = [
            supports_fwgrad_bwgrad=True,
            sample_inputs_func=sample_inputs_diagonal_scatter),
     BinaryUfuncInfo('eq',
+                    ref=np.equal,
                     dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16, torch.chalf),
                     always_returns_bool=True,
                     supports_autograd=False,
@@ -11906,6 +11931,7 @@ op_db: List[OpInfo] = [
                                     active_if=IS_WINDOWS),
                    )),
     BinaryUfuncInfo('ge',
+                    ref=np.greater_equal,
                     aliases=('greater_equal',),
                     dtypes=all_types_and(torch.bool, torch.bfloat16, torch.float16),
                     always_returns_bool=True,
@@ -11922,6 +11948,7 @@ op_db: List[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out'),
            )),
     BinaryUfuncInfo('gt',
+                    ref=np.greater,
                     aliases=('greater',),
                     dtypes=all_types_and(torch.bool, torch.bfloat16, torch.float16),
                     always_returns_bool=True,
@@ -11991,6 +12018,7 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_kthvalue,
            error_inputs_func=error_inputs_kthvalue),
     BinaryUfuncInfo('le',
+                    ref=np.less_equal,
                     aliases=('less_equal',),
                     dtypes=all_types_and(torch.bool, torch.bfloat16, torch.float16),
                     always_returns_bool=True,
@@ -12506,6 +12534,7 @@ op_db: List[OpInfo] = [
                                     dtypes=all_types_and_complex_and(torch.half, torch.bfloat16)),
                    )),
     BinaryUfuncInfo('lt',
+                    ref=np.less,
                     aliases=('less',),
                     dtypes=all_types_and(torch.bool, torch.bfloat16, torch.float16),
                     always_returns_bool=True,
@@ -14727,6 +14756,7 @@ op_db: List[OpInfo] = [
                  ),
                  sample_kwargs=lambda device, dtype, input: ({'p': 5}, {'d': 5})),
     BinaryUfuncInfo('ne',
+                    ref=np.not_equal,
                     aliases=('not_equal',),
                     dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
                     always_returns_bool=True,


### PR DESCRIPTION
That check was potentially synchronizing (people were running into synchronization in real workloads) and mostly unneeded. 
Type promotion takes care of comparing to values that cannot be safely converted to the type of other argument. 
This now works for `comp(int_tensor, float('inf'))` as expected. For `comp(uint8_tensor, large_int)` it silently wraps integer to uint8 whereas it would error out before, but this also happens with other arithmetic ops.
Also adds reference np implementation to comparison op OpInfos, and additional reference inputs to test newly enabled behavior. 

Fixes #76805