### PR TITLE
Follow up on CR for "Replace TensorMeta with FakeTensor"

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -843,6 +843,9 @@ def _dispatch_has_kernel(name: str) -> _bool: ...
 def _dispatch_tls_is_dispatch_key_excluded(dispatch: str) -> _bool: ...
 def _dispatch_tls_set_dispatch_key_excluded(dispatch: str, val: _bool) -> None: ...
 
+class _AutoDispatchBelowAutograd:
+    pass
+
 # Defined in torch/csrc/utils/init.cpp
 class BenchmarkConfig(object):
     num_calling_threads: _int

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -332,7 +332,7 @@ def _make_prim(
         @staticmethod
         def forward(ctx, args_spec, *flat_args):
             args, kwargs = tree_unflatten(flat_args, args_spec)  # type: ignore[arg-type]
-            g = torch._C._DispatchBelowAutograd()
+            g = torch._C._AutoDispatchBelowAutograd()
             try:
                 return _prim(*args, **kwargs)
             finally:

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -301,17 +301,6 @@ def _wrap_tensor_meta(f):
     return wrapper
 
 
-@contextlib.contextmanager
-def _DispatchBelowAutograd():
-    # TODO: AutogradOther
-    old = torch._C._dispatch_tls_is_dispatch_key_excluded("AutogradFunctionality")
-    torch._C._dispatch_tls_set_dispatch_key_excluded("AutogradFunctionality", True)
-    try:
-        yield
-    finally:
-        torch._C._dispatch_tls_set_dispatch_key_excluded("AutogradFunctionality", old)
-
-
 def _make_prim(
     *,
     schema: str,
@@ -335,12 +324,19 @@ def _make_prim(
         meta(*args, **kwargs)
         return impl_aten(*args, **kwargs)
 
+    # Right now prims don't support autograd (we can and should add an
+    # argument that provides an implementation for backward here.)  Because we
+    # don't have derivative formulas, we must setup a custom autograd function
+    # that raises an error if backwards is invoked
     class BackwardsNotSupported(torch.autograd.Function):
         @staticmethod
         def forward(ctx, args_spec, *flat_args):
             args, kwargs = tree_unflatten(flat_args, args_spec)  # type: ignore[arg-type]
-            with _DispatchBelowAutograd():
+            g = torch._C._DispatchBelowAutograd()
+            try:
                 return _prim(*args, **kwargs)
+            finally:
+                del g
 
         @staticmethod
         def backward(ctx, *args):

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -233,6 +233,10 @@ void initDispatchBindings(PyObject* module) {
     return c10::impl::tls_is_dispatch_key_excluded(c10::parseDispatchKey(dispatch_key));
   });
 
+
+  py::class_<at::AutoDispatchBelowAutograd>(m, "_AutoDispatchBelowAutograd")
+    .def(py::init<>());
+
   // Prints out the name of every operator that has a kernel registered to the Dispatcher
   // under [dispatch_key].
   // If no arguments are specified, it'll print out the name of every operator that the Dispatcher knows of.

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19400,6 +19400,9 @@ def _inherit_constructor_args(name, op, inherited, overrides):
     kwargs.update(common_kwargs)
     kwargs.update(overrides)
 
+    # At the moment no prims support autograd, so we must not run autograd
+    # tests e.g. when testing dtype support.  Once we start writing autograd
+    # formulas for prims this can be removed.
     kwargs['supports_autograd'] = False
     kwargs['supports_gradgrad'] = False
     kwargs['supports_fwgrad_bwgrad'] = False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #78895

See https://github.com/pytorch/pytorch/pull/78836

Signed-off-by: Edward Z. Yang <ezyang@fb.com>