### PR TITLE
[1.12] Make ShufflerDataPipe deterministic for persistent DL and distributed DL

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1491,14 +1491,18 @@ class TestFunctionalIterDataPipe(TestCase):
             self.assertEqual(sorted(res), exp)
 
             # Test Deterministic
-            for num_workers in (0, 1, 2):
+            for num_workers, pw in itertools.product((0, 1, 2), (True, False)):
+                if num_workers == 0 and pw:
+                    continue
+
                 mp_ctx = "spawn" if num_workers > 0 else None
                 dl = DataLoader(
                     shuffle_dp,
                     num_workers=num_workers,
                     shuffle=True,
                     multiprocessing_context=mp_ctx,
-                    worker_init_fn=_worker_init_fn
+                    worker_init_fn=_worker_init_fn,
+                    persistent_workers=pw
                 )
 
                 # No seed
@@ -1520,46 +1524,6 @@ class TestFunctionalIterDataPipe(TestCase):
                 self.assertEqual(len(dl_res[0]), len(dl_res[2]))
                 self.assertNotEqual(dl_res[0], dl_res[2])
                 self.assertEqual(sorted(dl_res[0]), sorted(dl_res[2]))
-
-                if num_workers == 0:
-                    continue
-
-                # Persistent workers
-                ps_dl_res = []
-                for _ in range(2):
-                    dl = DataLoader(
-                        shuffle_dp,
-                        num_workers=num_workers,
-                        shuffle=True,
-                        multiprocessing_context="spawn",
-                        worker_init_fn=_worker_init_fn,
-                        persistent_workers=True
-                    )
-                    ps_res = []
-                    torch.manual_seed(123)
-                    for epoch in range(2):
-                        ps_res.extend(list(dl))
-                    ps_dl_res.append(ps_res)
-                self.assertEqual(ps_dl_res[0], ps_dl_res[1])
-
-                # Different Seeds
-                dl = DataLoader(
-                    shuffle_dp,
-                    num_workers=num_workers,
-                    shuffle=True,
-                    multiprocessing_context="spawn",
-                    worker_init_fn=_worker_init_fn,
-                    persistent_workers=True
-                )
-                ps_res = []
-                torch.manual_seed(321)
-                for epoch in range(2):
-                    ps_res.extend(list(dl))
-                ps_dl_res.append(ps_res)
-
-                self.assertEqual(len(ps_dl_res[0]), len(ps_dl_res[2]))
-                self.assertNotEqual(ps_dl_res[0], ps_dl_res[2])
-                self.assertEqual(sorted(ps_dl_res[0]), sorted(ps_dl_res[2]))
 
 
         shuffle_dp_nl = IDP_NoLen(range(20)).shuffle(buffer_size=5)

--- a/torch/utils/data/_utils/worker.py
+++ b/torch/utils/data/_utils/worker.py
@@ -10,7 +10,7 @@ import os
 import queue
 from dataclasses import dataclass
 from torch._utils import ExceptionWrapper
-from typing import Union
+from typing import Optional, Union
 from . import signal_handling, MP_STATUS_CHECK_INTERVAL, IS_WINDOWS, HAS_NUMPY
 
 if IS_WINDOWS:
@@ -117,7 +117,7 @@ class _IterableDatasetStopIteration(object):
 r"""Dummy class used to resume the fetching when worker reuse is enabled"""
 @dataclass(frozen=True)
 class _ResumeIteration(object):
-    pass
+    seed: Optional[int] = None
 
 # The function `_generate_state` is adapted from `numpy.random.SeedSequence`
 # from https://github.com/numpy/numpy/blob/main/numpy/random/bit_generator.pyx
@@ -201,7 +201,7 @@ def _generate_state(base_seed, worker_id):
 
 def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
                  auto_collation, collate_fn, drop_last, base_seed, init_fn, worker_id,
-                 num_workers, persistent_workers):
+                 num_workers, persistent_workers, shared_seed):
     # See NOTE [ Data Loader Multiprocessing Shutdown Logic ] for details on the
     # logic of this function.
 
@@ -222,14 +222,14 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
             import numpy as np
             np.random.seed(np_seed)
 
-        process_shared_rng = torch.Generator()
-        process_shared_rng.manual_seed(base_seed)
-
         from torch.utils.data import IterDataPipe
         from torch.utils.data.graph_settings import apply_shuffle_seed
 
+        shared_rng = torch.Generator()
         if isinstance(dataset, IterDataPipe):
-            dataset = apply_shuffle_seed(dataset, process_shared_rng)
+            assert shared_seed is not None
+            shared_rng.manual_seed(shared_seed)
+            dataset = apply_shuffle_seed(dataset, shared_rng)
 
         global _worker_info
         _worker_info = WorkerInfo(id=worker_id, num_workers=num_workers,
@@ -275,7 +275,9 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
                 iteration_end = False
 
                 if isinstance(dataset, IterDataPipe):
-                    dataset = apply_shuffle_seed(dataset, process_shared_rng)
+                    assert r.seed is not None
+                    shared_rng.manual_seed(r.seed)
+                    dataset = apply_shuffle_seed(dataset, shared_rng)
 
                 # Recreate the fetcher for worker-reuse policy
                 fetcher = _DatasetKind.create_fetcher(


### PR DESCRIPTION
Ref PR on master branch: #78765

Fixes https://github.com/pytorch/data/issues/426

This PR introduces two main changes:
- It ensures the `ShufflerDataPipe` would share the same seed across distributed processes.
- Users can reset `shuffle` for persistent workers per epoch.

Detail:
- `shared_seed` is shared across distributed and worker processes. It will seed a `shared_rng` to provide seeds to each `ShufflerDataPipe` in the pipeline
- `worker_loop` now accepts a new argument of `shared_seed` to accept this shared seed.
- The `shared_seed` is attached to `_ResumeIteration` for resetting seed per epoch for `persistent worker`
- I choose not to touch `base_seed` simply for BC issue

I used this [script](https://gist.github.com/ejguan/d88f75fa822cb696ab1bc5bc25844f47) to test the result with `world_size=4`. Please check the result in: https://gist.github.com/ejguan/6ee2d2de12ca57f9eb4b97ef5a0e300b

You can see there isn't any duplicated/missing element for each epoch. And, with the same seed, the order of data remains the same across epochs.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/78765
Approved by: https://github.com/VitalyFedyunin