### PR TITLE
Subscribe onnx _BaseTestCase to TestCase setUp()

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -36,6 +36,7 @@ from torch.onnx.symbolic_helper import (
 
 class _BaseTestCase(TestCase):
     def setUp(self):
+        super().setUp()
         torch.manual_seed(0)
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(0)


### PR DESCRIPTION
This seems like an unintended mistake where the ONNX _BaseTestCase isn't calling the TestCase setUp first.