### PR TITLE
[ONNX] Disable parallel run for custom op related tests in CI

### DIFF
--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -71,14 +71,14 @@ if [[ "${SHARD_NUMBER}" == "1" ]]; then
   # Tests that cannot run in parallel.
   pytest "${args[@]}" \
     "$top_dir/test/onnx/test_onnx_export.py" \
-    "$top_dir/test/onnx/test_models_onnxruntime.py"
+    "$top_dir/test/onnx/test_models_onnxruntime.py" \
+    "$top_dir/test/onnx/test_custom_ops.py" \
+    "$top_dir/test/onnx/test_utility_funs.py"
 
   pytest "${args[@]}" "${args_parallel[@]}" \
     "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset7" \
     "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset8" \
     "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset9" \
-    "$top_dir/test/onnx/test_custom_ops.py" \
-    "$top_dir/test/onnx/test_utility_funs.py" \
     "$top_dir/test/onnx/test_pytorch_onnx_shape_inference.py" \
     "$top_dir/test/onnx/test_pytorch_onnx_caffe2.py" \
     "$top_dir/test/onnx/test_pytorch_onnx_caffe2_quantized.py"

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -13,7 +13,6 @@ from test_pytorch_common import (
     skipIfUnsupportedMaxOpsetVersion,
     skipIfUnsupportedMinOpsetVersion,
 )
-from unittest import skip
 from verify import verify
 
 import torch
@@ -1006,7 +1005,6 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         iter = graph.nodes()
         self.assertEqual(next(iter).kind(), "aten::erfc")
 
-    @skip("Test is flaky on trunk, see https://github.com/pytorch/pytorch/issues/78844")
     def test_custom_op_fallthrough(self):
         # Test custom op
         op_source = """


### PR DESCRIPTION
Should fix #78844
Custom op related tests utilize inline cpp extension to build custom
operator from c++ source snippet. Only two test cases become flaky after
parallel run, and both use inline cpp extension. Reverting to run these
tests in single process to try resolve the flakiness.
Reverts test skip added previously #78936.