### PR TITLE
[Vulkan] Fix bug in GRU op

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Gru.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Gru.cpp
@@ -40,7 +40,7 @@ std::tuple<Tensor, Tensor> gru_input(
   TORCH_INTERNAL_ASSERT(batch_first, "Vulkan gru expects 'batch_first' to be true.");
   TORCH_INTERNAL_ASSERT(dropout < std::numeric_limits<double>::epsilon()*1000, "Vulkan gru expects 'dropout' to be 0.0.");
 
-  const auto h_in = input_vk.size(2);
+  const auto hidden_size = hx_vk.size(2);
   std::vector<at::Tensor> h_n_list;  // hidden output
 
   // reshape to 2D due to Vulkan at::mm op accepts only 2D
@@ -56,10 +56,10 @@ std::tuple<Tensor, Tensor> gru_input(
     const auto& b_ih = params_cpu[i * 4 + 2];
     const auto& b_hh = params_cpu[i * 4 + 3];
 
-    const auto&  w_i_rzn = w_ih.split(h_in);
-    const auto&  w_h_rzn = w_hh.split(h_in);
-    const auto&  b_i_rzn = b_ih.split(h_in);
-    const auto&  b_h_rzn = b_hh.split(h_in);
+    const auto&  w_i_rzn = w_ih.split(hidden_size);
+    const auto&  w_h_rzn = w_hh.split(hidden_size);
+    const auto&  b_i_rzn = b_ih.split(hidden_size);
+    const auto&  b_h_rzn = b_hh.split(hidden_size);
 
     const auto&  w_ir = w_i_rzn[0];
     const auto&  w_iz = w_i_rzn[1];
@@ -108,12 +108,12 @@ std::vector<LinearOpContext> pack_linear_op_contexts(
     const auto& w_hh = params_cpu.at(i * 4 + 1);
     const auto& b_ih = params_cpu.at(i * 4 + 2);
     const auto& b_hh = params_cpu.at(i * 4 + 3);
-    const auto& h_in = w_ih.size(0) / 3;
+    const auto& hidden_size = w_ih.size(0) / 3;
 
-    const auto&  w_i_rzn = w_ih.split(h_in);
-    const auto&  w_h_rzn = w_hh.split(h_in);
-    const auto&  b_i_rzn = b_ih.split(h_in);
-    const auto&  b_h_rzn = b_hh.split(h_in);
+    const auto&  w_i_rzn = w_ih.split(hidden_size);
+    const auto&  w_h_rzn = w_hh.split(hidden_size);
+    const auto&  b_i_rzn = b_ih.split(hidden_size);
+    const auto&  b_h_rzn = b_hh.split(hidden_size);
 
     const auto&  w_ir = w_i_rzn[0];
     const auto&  w_iz = w_i_rzn[1];

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3074,6 +3074,78 @@ TEST_F(VulkanAPITest, mobilenetv2) {
   ASSERT_TRUE(check);
 }
 
+TEST_F(VulkanAPITest, gru_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const int H_in = 5;  // input_size
+  const int H_out = 7; // hidden_size
+  const int num_layers = 3;
+  const double gru_dropout = .0;
+  const bool has_biases = true;
+  const bool train = false;
+  const bool bidirectional = false;
+  const bool batch_first = true;
+  const auto in_cpu = at::rand({1, 1, H_in}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto h0_cpu = at::rand({num_layers, 1, H_out}, at::device(at::kCPU).dtype(at::kFloat));
+
+  c10::List<at::Tensor> weight_ih_l; // shape (3 * hidden_size, input_size)
+  c10::List<at::Tensor> weight_hh_l; // shape (3 * hidden_size, hidden_size)
+  c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
+  c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
+  for (int i = 0; i < num_layers; ++i) {
+    if (i == 0) {
+      weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    } else {
+      weight_ih_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    }
+    weight_hh_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_ih_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_hh_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+  }
+
+  // put this guard here to run inference inststead of training
+  // to avoid the following error:
+  //     C++ exception with description "0INTERNAL ASSERT FAILED at "xplat/caffe2/aten/src/ATen/core/boxing/KernelFunction.cpp":31, please report a bug to PyTorch. aten::gru.input has kernels registered to both CompositeImplicitAutograd and a backend mapped to AutogradOther. This makes the backend kernel unreachable; the dispatcher will always prefer the CompositeImplicitAutograd lowering (see Note [Ambiguity in AutogradOther kernel]). If you want to override CompositeImplicitAutograd, please open an issue to request a dedicated Autograd dispatch key for the backend.
+  //     If you only want to run inference instead of training, add `c10::InferenceMode mode;` before model.forward(). Note this guard is only available in C++ but not Python at present.
+  c10::InferenceMode mode;
+
+  // Act
+  const auto out_cpu = at::gru(in_cpu, h0_cpu,
+      { weight_ih_l[0], weight_hh_l[0], bias_ih_l[0], bias_hh_l[0],
+        weight_ih_l[1], weight_hh_l[1], bias_ih_l[1], bias_hh_l[1],
+        weight_ih_l[2], weight_hh_l[2], bias_ih_l[2], bias_hh_l[2] },
+      has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+
+  // weights/biases should be always on CPU.
+  const auto out_vulkan = at::gru(in_cpu.vulkan(), h0_cpu.vulkan(),
+      { weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+        weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1),
+        weight_ih_l.get(2), weight_hh_l.get(2), bias_ih_l.get(2), bias_hh_l.get(2) },
+      has_biases, num_layers, gru_dropout, train, bidirectional, batch_first);
+
+  auto cpu_output = std::get<0>(out_cpu);
+  auto cpu_hidden = std::get<1>(out_cpu);
+  auto vulkan_output = std::get<0>(out_vulkan);
+  auto vulkan_hidden = std::get<1>(out_vulkan);
+
+  // Assert
+  const auto check_output = almostEqual(cpu_output, vulkan_output.cpu());
+  if (!check_output) {
+    showRtol(cpu_output, vulkan_output.cpu());
+  }
+  ASSERT_TRUE(check_output);
+
+  const auto check_hidden = almostEqual(cpu_hidden, vulkan_hidden.cpu());
+  if (!check_hidden) {
+    showRtol(cpu_hidden, vulkan_hidden.cpu());
+  }
+  ASSERT_TRUE(check_hidden);
+}
+
 TEST_F(VulkanAPITest, gru_mclareninputs_success) {
   // Guard
   if (!at::is_vulkan_available()) {
@@ -3097,7 +3169,11 @@ TEST_F(VulkanAPITest, gru_mclareninputs_success) {
   c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
   for (int i = 0; i < num_layers; ++i) {
-    weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    if (i == 0) {
+      weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    } else {
+      weight_ih_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    }
     weight_hh_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
     bias_ih_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
     bias_hh_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
@@ -3145,8 +3221,8 @@ TEST_F(VulkanAPITest, gru_invalidinputs_exceptions) {
   }
 
   // Arrange
-  const int H_in = 384;  // input_size
-  const int H_out = 384; // hidden_size
+  const int H_in = 17;  // input_size
+  const int H_out = 50; // hidden_size
   const int num_layers = 2;
   const double gru_dropout = .0;
   const bool has_biases = true;
@@ -3161,7 +3237,11 @@ TEST_F(VulkanAPITest, gru_invalidinputs_exceptions) {
   c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
   for (int i = 0; i < num_layers; ++i) {
-    weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    if (i == 0) {
+      weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    } else {
+      weight_ih_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    }
     weight_hh_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
     bias_ih_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
     bias_hh_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
@@ -3239,8 +3319,8 @@ TEST_F(VulkanAPITest, gru_prepack_success) {
   }
 
   // Arrange
-  const int H_in = 384;  // input_size
-  const int H_out = 384; // hidden_size
+  const int H_in = 81;  // input_size
+  const int H_out = 10; // hidden_size
   const int num_layers = 2;
   const double gru_dropout = .0;
   const bool has_biases = true;
@@ -3255,7 +3335,11 @@ TEST_F(VulkanAPITest, gru_prepack_success) {
   c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
   for (int i = 0; i < num_layers; ++i) {
-    weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    if (i == 0) {
+      weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    } else {
+      weight_ih_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    }
     weight_hh_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
     bias_ih_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
     bias_hh_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
@@ -3309,8 +3393,8 @@ TEST_F(VulkanAPITest, gru_prepack_invalidinputs_exceptions) {
   }
 
   // Arrange
-  const int H_in = 384;  // input_size
-  const int H_out = 384; // hidden_size
+  const int H_in = 70;  // input_size
+  const int H_out = 2; // hidden_size
   const int num_layers = 2;
   const double gru_dropout = .0;
   const bool has_biases = true;
@@ -3325,7 +3409,11 @@ TEST_F(VulkanAPITest, gru_prepack_invalidinputs_exceptions) {
   c10::List<at::Tensor> bias_ih_l;   // shape (3 * hidden_size)
   c10::List<at::Tensor> bias_hh_l;   // shape (3 * hidden_size)
   for (int i = 0; i < num_layers; ++i) {
-    weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    if (i == 0) {
+      weight_ih_l.emplace_back(at::rand({3 * H_out, H_in}, at::device(at::kCPU).dtype(at::kFloat)));
+    } else {
+      weight_ih_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
+    }
     weight_hh_l.emplace_back(at::rand({3 * H_out, H_out}, at::device(at::kCPU).dtype(at::kFloat)));
     bias_ih_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));
     bias_hh_l.emplace_back(at::rand({3 * H_out}, at::device(at::kCPU).dtype(at::kFloat)));


### PR DESCRIPTION
Summary:
All of the current Vulkan API Tests of the GRU op, use the same H_in and H_out sizes (H_in = 384 and H_out = 384). Which means, these tests don't test the behavior when H_in != H_out.

There is indeed a bug: H_in is used at some point to split the weights/biases when it should have been H_out (the hidden_size).

Differential Revision: D36895889

