### PR TITLE
tools: Ensure compat for collect_env with python 3.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -230,9 +230,16 @@ jobs:
     runs-on: linux.20_04.4x
     strategy:
       matrix:
-        with_torch: [with_torch, without_torch]
+        test_type: [with_torch, without_torch, older_python_version]
     steps:
-      - name: Setup Python
+      - name: Setup Python 3.5
+        if: matrix.test_type == 'older_python_version'
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.5
+          architecture: x64
+      - name: Setup Python 3.8
+        if: matrix.test_type != 'older_python_version'
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
@@ -245,7 +252,7 @@ jobs:
           submodules: false
           fetch-depth: 1
       - name: Install torch
-        if: matrix.with_torch == 'with_torch'
+        if: matrix.test_type == 'with_torch'
         run: |
           # Doesn't really matter what torch version, we just need ANY torch installed
           pip install 'torch==1.*'

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -89,7 +89,7 @@ def run_and_return_first_line(run_lambda, command):
 
 def get_conda_packages(run_lambda):
     conda = os.environ.get('CONDA_EXE', 'conda')
-    out = run_and_read_all(run_lambda, f"{conda} list")
+    out = run_and_read_all(run_lambda, "{} list".format(conda))
     if out is None:
         return out
 
@@ -283,7 +283,7 @@ def get_pip_packages(run_lambda):
     # People generally have `pip` as `pip` or `pip3`
     # But here it is incoved as `python -mpip`
     def run_with_pip(pip):
-        out = run_and_read_all(run_lambda, f"{pip} list --format=freeze")
+        out = run_and_read_all(run_lambda, "{} list --format=freeze".format(pip))
         return "\n".join(
             line
             for line in out.splitlines()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #78946

Users were reporting errors of not being able to use collect_env with
older versions of python. This adds a test to ensure that we maintain
compat for this script with older versions of python

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>