### PR TITLE
[LTS] Fix Linux & MacOS LTS build errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ commands:
             brew install moreutils
             brew link parallel --overwrite
             brew install expect
+            brew install libomp
 
   brew_install:
     description: "Install Homebrew formulae"

--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -76,7 +76,7 @@ if [[ "$PACKAGE_TYPE" == conda ]]; then
   )
 elif [[ "$PACKAGE_TYPE" != libtorch ]]; then
   pip install "\$pkg"
-  retry pip install -q future numpy protobuf typing-extensions six
+  retry pip install -q future numpy protobuf==3.19.4 typing-extensions six
 fi
 if [[ "$PACKAGE_TYPE" == libtorch ]]; then
   pkg="\$(ls /final_pkgs/*-latest.zip)"


### PR DESCRIPTION
### Fixes LTS build error on Linux, MacOS, Windows 
- The build errors
https://app.circleci.com/pipelines/github/pytorch/pytorch/507942/workflows/1f2a1ec8-ea72-4a58-b8ac-3eab101726c9

### Solution
- Update the protobuf version on Linux machine
- Install the `libomp` on Macos

### Test validation:

All the tests succeeded and please check here:
https://app.circleci.com/pipelines/github/pytorch/pytorch/510286/workflows/e4ec1175-4d5c-4963-ba55-2919cac3c5a0
