### PR TITLE
[flaky-test] fix duplication check after introducing skips

### DIFF
--- a/tools/stats/print_test_stats.py
+++ b/tools/stats/print_test_stats.py
@@ -857,9 +857,9 @@ def process_intentional_test_runs(runs: List[TestCase]) -> Tuple[int, int]:
                 f"{err_msg} There should be at most 1 successful run in an intentional rerun that stops"
                 f" at first success. The number of successful runs = {num_pass}"
             )
-        if num_skipped > 0:
+        if num_skipped > 1:
             raise RuntimeWarning(
-                f"{err_msg} No skips should occur in intentional reruns, but skips = {num_skipped}"
+                f"{err_msg} No more than 1 skip should occur in intentional reruns, but skips = {num_skipped}"
             )
     return (
         max(num_unexpected_success, num_pass),


### PR DESCRIPTION
My last change #78292 caused a regression in print test stats, which was entirely my fault. e.g., https://github.com/pytorch/pytorch/runs/6750407899

The eventual goal is to retire the flaky test calculations here, but for now let's keep reporting them before switching over our infra to the newer flaky test aggregation