### PR TITLE
[DataPipe] Add function for deprecation of functional DataPipe names

### DIFF
--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -3,7 +3,11 @@ import pickle
 from typing import Dict, Callable, Optional, TypeVar, Generic, Iterator
 
 from torch.utils.data.datapipes._typing import _DataPipeMeta, _IterDataPipeMeta
-from torch.utils.data.datapipes.utils.common import _deprecated_functional_names, _deprecation_warning
+from torch.utils.data.datapipes.utils.common import (
+    _deprecation_warning,
+    _iter_deprecated_functional_names,
+    _map_deprecated_functional_names,
+)
 from torch.utils.data.dataset import Dataset, IterableDataset
 
 try:
@@ -110,10 +114,9 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
 
     def __getattr__(self, attribute_name):
         if attribute_name in IterDataPipe.functions:
-            if attribute_name in _deprecated_functional_names:
-                type, kwargs = _deprecated_functional_names[attribute_name]
-                if type == "IterDataPipe":
-                    _deprecation_warning(**kwargs)
+            if attribute_name in _iter_deprecated_functional_names:
+                type, kwargs = _iter_deprecated_functional_names[attribute_name]
+                _deprecation_warning(**kwargs)
             function = functools.partial(IterDataPipe.functions[attribute_name], self)
             return function
         else:
@@ -237,10 +240,9 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
 
     def __getattr__(self, attribute_name):
         if attribute_name in MapDataPipe.functions:
-            if attribute_name in _deprecated_functional_names:
-                type, kwargs = _deprecated_functional_names[attribute_name]
-                if type == "MapDataPipe":
-                    _deprecation_warning(**kwargs)
+            if attribute_name in _map_deprecated_functional_names:
+                type, kwargs = _map_deprecated_functional_names[attribute_name]
+                _deprecation_warning(**kwargs)
             function = functools.partial(MapDataPipe.functions[attribute_name], self)
             return function
         else:

--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -3,6 +3,7 @@ import pickle
 from typing import Dict, Callable, Optional, TypeVar, Generic, Iterator
 
 from torch.utils.data.datapipes._typing import _DataPipeMeta, _IterDataPipeMeta
+from torch.utils.data.datapipes.utils.common import _deprecated_functional_names, _deprecation_warning
 from torch.utils.data.dataset import Dataset, IterableDataset
 
 try:
@@ -109,6 +110,9 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
 
     def __getattr__(self, attribute_name):
         if attribute_name in IterDataPipe.functions:
+            if attribute_name in _deprecated_functional_names:
+                kwargs = _deprecated_functional_names[attribute_name]
+                _deprecation_warning(**kwargs)
             function = functools.partial(IterDataPipe.functions[attribute_name], self)
             return function
         else:

--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -111,8 +111,9 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
     def __getattr__(self, attribute_name):
         if attribute_name in IterDataPipe.functions:
             if attribute_name in _deprecated_functional_names:
-                kwargs = _deprecated_functional_names[attribute_name]
-                _deprecation_warning(**kwargs)
+                type, kwargs = _deprecated_functional_names[attribute_name]
+                if type == "IterDataPipe":
+                    _deprecation_warning(**kwargs)
             function = functools.partial(IterDataPipe.functions[attribute_name], self)
             return function
         else:
@@ -236,6 +237,10 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
 
     def __getattr__(self, attribute_name):
         if attribute_name in MapDataPipe.functions:
+            if attribute_name in _deprecated_functional_names:
+                type, kwargs = _deprecated_functional_names[attribute_name]
+                if type == "MapDataPipe":
+                    _deprecation_warning(**kwargs)
             function = functools.partial(MapDataPipe.functions[attribute_name], self)
             return function
         else:

--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -115,7 +115,7 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
     def __getattr__(self, attribute_name):
         if attribute_name in IterDataPipe.functions:
             if attribute_name in _iter_deprecated_functional_names:
-                type, kwargs = _iter_deprecated_functional_names[attribute_name]
+                kwargs = _iter_deprecated_functional_names[attribute_name]
                 _deprecation_warning(**kwargs)
             function = functools.partial(IterDataPipe.functions[attribute_name], self)
             return function
@@ -241,7 +241,7 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
     def __getattr__(self, attribute_name):
         if attribute_name in MapDataPipe.functions:
             if attribute_name in _map_deprecated_functional_names:
-                type, kwargs = _map_deprecated_functional_names[attribute_name]
+                kwargs = _map_deprecated_functional_names[attribute_name]
                 _deprecation_warning(**kwargs)
             function = functools.partial(MapDataPipe.functions[attribute_name], self)
             return function

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -104,21 +104,23 @@ def validate_pathname_binary_tuple(data: Tuple[str, IOBase]):
         )
 
 
-# Deprecated function names and its corresponding kwargs for the `_deprecation_warning` function
-_deprecated_functional_names: Dict[str, Dict] = {"open_file_by_fsspec":
-                                                 {"old_class_name": "FSSpecFileOpener",
-                                                  "deprecation_version": "1.12",
-                                                  "removal_version": "1.14",
-                                                  "old_functional_name": "open_file_by_fsspec",
-                                                  "new_functional_name": "open_files_by_fsspec",
-                                                  "deprecate_functional_name_only": True},
-                                                 "open_file_by_iopath":
-                                                 {"old_class_name": "IoPathFileOpener",
-                                                  "deprecation_version": "1.12",
-                                                  "removal_version": "1.14",
-                                                  "old_functional_name": "open_file_by_iopath",
-                                                  "new_functional_name": "open_files_by_iopath",
-                                                  "deprecate_functional_name_only": True}}
+# Deprecated function names and its corresponding DataPipe type and kwargs for the `_deprecation_warning` function
+_deprecated_functional_names: Dict[str, Tuple] = {"open_file_by_fsspec":
+                                                  ("IterDataPipe",
+                                                   {"old_class_name": "FSSpecFileOpener",
+                                                    "deprecation_version": "1.12",
+                                                    "removal_version": "1.14",
+                                                    "old_functional_name": "open_file_by_fsspec",
+                                                    "new_functional_name": "open_files_by_fsspec",
+                                                    "deprecate_functional_name_only": True}),
+                                                  "open_file_by_iopath":
+                                                  ("IterDataPipe",
+                                                   {"old_class_name": "IoPathFileOpener",
+                                                    "deprecation_version": "1.12",
+                                                    "removal_version": "1.14",
+                                                    "old_functional_name": "open_file_by_iopath",
+                                                    "new_functional_name": "open_files_by_iopath",
+                                                    "deprecate_functional_name_only": True})}
 
 
 def _deprecation_warning(

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -3,7 +3,7 @@ import fnmatch
 import warnings
 
 from io import IOBase
-from typing import Iterable, List, Tuple, Union, Optional
+from typing import Dict, Iterable, List, Tuple, Union, Optional
 
 from torch.utils.data._utils.serialization import DILL_AVAILABLE
 
@@ -104,6 +104,23 @@ def validate_pathname_binary_tuple(data: Tuple[str, IOBase]):
         )
 
 
+# Deprecated function names and its corresponding kwargs for the `_deprecation_warning` function
+_deprecated_functional_names: Dict[str, Dict] = {"open_file_by_fsspec":
+                                                 {"old_class_name": "FSSpecFileOpener",
+                                                  "deprecation_version": "1.12",
+                                                  "removal_version": "1.14",
+                                                  "old_functional_name": "open_file_by_fsspec",
+                                                  "new_functional_name": "open_files_by_fsspec",
+                                                  "deprecate_functional_name_only": True},
+                                                 "open_file_by_iopath":
+                                                 {"old_class_name": "IoPathFileOpener",
+                                                  "deprecation_version": "1.12",
+                                                  "removal_version": "1.14",
+                                                  "old_functional_name": "open_file_by_iopath",
+                                                  "new_functional_name": "open_files_by_iopath",
+                                                  "deprecate_functional_name_only": True}}
+
+
 def _deprecation_warning(
     old_class_name: str,
     *,
@@ -114,6 +131,7 @@ def _deprecation_warning(
     new_class_name: str = "",
     new_functional_name: str = "",
     new_argument_name: str = "",
+    deprecate_functional_name_only: bool = False,
 ) -> None:
     if new_functional_name and not old_functional_name:
         raise ValueError("Old functional API needs to be specified for the deprecation warning.")
@@ -124,7 +142,9 @@ def _deprecation_warning(
         raise ValueError("Deprecating warning for functional API and argument should be separated.")
 
     msg = f"`{old_class_name}()`"
-    if old_functional_name:
+    if deprecate_functional_name_only and old_functional_name:
+        msg = f"{msg}'s functional API `.{old_functional_name}()` is"
+    elif old_functional_name:
         msg = f"{msg} and its functional API `.{old_functional_name}()` are"
     elif old_argument_name:
         msg = f"The argument `{old_argument_name}` of {msg} is"

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -105,22 +105,22 @@ def validate_pathname_binary_tuple(data: Tuple[str, IOBase]):
 
 
 # Deprecated function names and its corresponding DataPipe type and kwargs for the `_deprecation_warning` function
-_deprecated_functional_names: Dict[str, Tuple] = {"open_file_by_fsspec":
-                                                  ("IterDataPipe",
-                                                   {"old_class_name": "FSSpecFileOpener",
-                                                    "deprecation_version": "1.12",
-                                                    "removal_version": "1.14",
-                                                    "old_functional_name": "open_file_by_fsspec",
-                                                    "new_functional_name": "open_files_by_fsspec",
-                                                    "deprecate_functional_name_only": True}),
-                                                  "open_file_by_iopath":
-                                                  ("IterDataPipe",
-                                                   {"old_class_name": "IoPathFileOpener",
-                                                    "deprecation_version": "1.12",
-                                                    "removal_version": "1.14",
-                                                    "old_functional_name": "open_file_by_iopath",
-                                                    "new_functional_name": "open_files_by_iopath",
-                                                    "deprecate_functional_name_only": True})}
+_iter_deprecated_functional_names: Dict[str, Dict] = {"open_file_by_fsspec":
+                                                      {"old_class_name": "FSSpecFileOpener",
+                                                       "deprecation_version": "1.12",
+                                                       "removal_version": "1.14",
+                                                       "old_functional_name": "open_file_by_fsspec",
+                                                       "new_functional_name": "open_files_by_fsspec",
+                                                       "deprecate_functional_name_only": True},
+                                                      "open_file_by_iopath":
+                                                      {"old_class_name": "IoPathFileOpener",
+                                                       "deprecation_version": "1.12",
+                                                       "removal_version": "1.14",
+                                                       "old_functional_name": "open_file_by_iopath",
+                                                       "new_functional_name": "open_files_by_iopath",
+                                                       "deprecate_functional_name_only": True}}
+
+_map_deprecated_functional_names: Dict[str, Dict] = {}
 
 
 def _deprecation_warning(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #78970

Fixes https://github.com/pytorch/data/issues/480.

For the list of deprecated DataPipes (or functional names), see https://github.com/pytorch/data/issues/163

Testing:
```python
IterableWrapper(range(10)).open_file_by_iopath()
```
Returns:
```
/Users/.../pytorch/torch/utils/data/datapipes/utils/common.py:171: FutureWarning: `IoPathFileOpener()`'s functional API `.open_file_by_iopath()` is deprecated since 1.12 and will be removed in 1.14.
See https://github.com/pytorch/data/issues/163 for details.
Please use `.open_files_by_iopath()` instead.
  warnings.warn(msg, FutureWarning)
  ```