### PR TITLE
Correct var_mean in _refs/__init__.py

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -161,7 +161,7 @@ __all__ = [
     "any",
     "mean",
     "std_mean",
-    "std_var",
+    "var_mean",
     "sum",
     "prod",
     "var",


### PR DESCRIPTION
I've found this by looking at https://lgtm.com/projects/g/pytorch/pytorch/

Maybe there is value in lgtm.com integration, as proposed in https://github.com/pytorch/pytorch/issues/78425