### PR TITLE
moved logit to use torch ops instead of refs + added a couple more decompositions

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1176,27 +1176,6 @@ def cudnn_batch_norm_backward(
     )
 
 
-@register_decomposition(aten.rot90.default)
-def rot90(self: Tensor, k: int = 1, dims: List[int] = [0, 1]) -> Tensor:  # noqa: B006
-    total_dims = self.dim()
-    total_rot_dims = len(dims)
-    assert total_rot_dims == 2, f"expected total rotation dims == 2, but got dims = {total_rot_dims}"
-    assert total_dims >= 2, f"expected total dims >= 2, but got total dims = {total_dims}"
-    assert dims[0] != dims[1] and abs(dims[0] - dims[1]) != total_dims,\
-           f"expected rotation dims to be different, but got dim0 = {dims[0]} and dim1 = {dims[1]}"
-    assert dims[0] < total_dims and dims[0] >= -total_dims, f"Rotation dim0 out of range, dim0 = {dims[0]}"
-    assert dims[1] < total_dims and dims[1] >= -total_dims, f"Rotation dim1 out of range, dim1 = {dims[1]}"
-    k = k % 4
-    if k == 1:
-        return self.flip(dims[1]).transpose(dims[0], dims[1])
-    elif k == 2:
-        return self.flip(dims)
-    elif k == 3:
-        return self.flip(dims[0]).transpose(dims[0], dims[1])
-    else:
-        return self.clone(memory_format=torch.contiguous_format)
-
-
 @register_decomposition(aten.transpose.int)
 def transpose_int(self: Tensor, dim0: int, dim1: int) -> Tensor:
     dim0, dim1 = utils.canonicalize_dims(self.dim(), (dim0, dim1))  # type: ignore[misc]

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1661,6 +1661,7 @@ def broadcast_to(a: TensorLikeType, size: ShapeType) -> TensorLikeType:
     return prims.broadcast_in_dim(a, size, dims)
 
 
+@register_decomposition(torch.ops.aten.cat)
 @out_wrapper
 @elementwise_type_promotion_wrapper(
     type_promoting_args=("tensors",),
@@ -1781,6 +1782,7 @@ def narrow(a: TensorLikeType, dim: int, start: int, length: int) -> TensorLikeTy
     return prims.slice_in_dim(a, start, start + length, axis=dim)
 
 
+@register_decomposition(torch.ops.aten.permute)
 def permute(a: TensorLikeType, dims: DimsSequenceType) -> TensorLikeType:
     _permutation = utils.canonicalize_dims(a.ndim, dims)
     return prims.transpose(a, _permutation)

--- a/torch/_refs/special/__init__.py
+++ b/torch/_refs/special/__init__.py
@@ -50,8 +50,8 @@ def logit(self: TensorLikeType, eps: Optional[float] = None) -> TensorLikeType:
         eps = -1.0
     lo = eps
     hi = 1 - eps
-    self = refs.clamp(self, lo, hi)
-    return refs.log(refs.true_divide(self, refs.sub(1, self)))
+    self = torch.clamp(self, lo, hi)
+    return torch.log(torch.true_divide(self, torch.sub(1, self)))
 
 
 zeta = _make_elementwise_binary_reference(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #79000
* #78994
* #78991
* __->__ #78984
* #78978

