### PR TITLE
Added "dump ops" API to return ops instead of print

### DIFF
--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -248,6 +248,17 @@ void initDispatchBindings(PyObject* module) {
         std::cout << op << std::endl;
     }
   }, py::arg("dispatch_key") = static_cast<const char*>(""));
+
+  m.def("_dispatch_get_registrations_for_dispatch_key", [](const char* dispatch_key = "") {
+    auto k = std::string(dispatch_key) == "" ? c10::nullopt : c10::make_optional(c10::parseDispatchKey(dispatch_key));
+    auto op_names = c10::Dispatcher::singleton().getRegistrationsForDispatchKey(k);
+    std::vector<std::string> names;
+    names.reserve(op_names.size());
+    for (auto& op : op_names) {
+      names.push_back(op.name + (op.overload_name == "" ? "" : "." + op.overload_name));
+    }
+    return names;
+  }, py::arg("dispatch_key") = static_cast<const char*>(""));
 }
 
 }}} // namespace torch::impl::dispatch


### PR DESCRIPTION
Useful to use for grabbing info instead of the hacky "redirect C++ output" stuff I currently do.