### PR TITLE
[ONNX] Improve shape inference supporting inferred values and unspecified optionals

### DIFF
--- a/test/onnx/expect/TestOperators.test_clip_max.expect
+++ b/test/onnx/expect/TestOperators.test_clip_max.expect
@@ -45,16 +45,16 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "Clip5_dim_0"
+            dim_value: 1
           }
           dim {
-            dim_param: "Clip5_dim_1"
+            dim_value: 2
           }
           dim {
-            dim_param: "Clip5_dim_2"
+            dim_value: 3
           }
           dim {
-            dim_param: "Clip5_dim_3"
+            dim_value: 4
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_clip_min.expect
+++ b/test/onnx/expect/TestOperators.test_clip_min.expect
@@ -45,16 +45,16 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "Clip5_dim_0"
+            dim_value: 1
           }
           dim {
-            dim_param: "Clip5_dim_1"
+            dim_value: 2
           }
           dim {
-            dim_param: "Clip5_dim_2"
+            dim_value: 3
           }
           dim {
-            dim_param: "Clip5_dim_3"
+            dim_value: 4
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_scale.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_scale.expect
@@ -66,16 +66,16 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "Resize5_dim_0"
+            dim_value: 1
           }
           dim {
-            dim_param: "Resize5_dim_1"
+            dim_value: 2
           }
           dim {
-            dim_param: "Resize5_dim_2"
+            dim_value: 6
           }
           dim {
-            dim_param: "Resize5_dim_3"
+            dim_value: 8
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
@@ -66,16 +66,16 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "Resize5_dim_0"
+            dim_value: 1
           }
           dim {
-            dim_param: "Resize5_dim_1"
+            dim_value: 2
           }
           dim {
-            dim_param: "Resize5_dim_2"
+            dim_value: 6
           }
           dim {
-            dim_param: "Resize5_dim_3"
+            dim_value: 8
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_size.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_size.expect
@@ -136,16 +136,16 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "Resize11_dim_0"
+            dim_value: 1
           }
           dim {
-            dim_param: "Resize11_dim_1"
+            dim_value: 2
           }
           dim {
-            dim_param: "Resize11_dim_2"
+            dim_value: 16
           }
           dim {
-            dim_param: "Resize11_dim_3"
+            dim_value: 16
           }
         }
       }

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -257,6 +257,7 @@ class TestONNXShapeInference(unittest.TestCase):
         scale_2 = self.insert_tensor_constant(
             g, torch.tensor([2, 2], dtype=torch.float)
         )
+        # `scales` values should be statically known due to constant folding in shape inference.
         scales = g.op("Concat", scale_1, scale_2, axis_i=0)
         resize = g.op(
             "Resize",

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -284,6 +284,7 @@ Node* CloneNodeToGraph(
       n, [&n_graph, &vals_to_params_map, opset_version](Value* v) {
         auto v_n = v->node();
         switch (v_n->kind()) {
+          case ::c10::prim::Constant:
           case ::c10::onnx::Constant: {
             // Clone the input if it is constant.
             auto constant_n = n_graph->insertNode(
@@ -299,22 +300,25 @@ Node* CloneNodeToGraph(
             return input;
           }
           default: {
+            // Try to lookup input value and insert it into the graph.
+            // If the input value is unknown, set it to graph input in the new
+            // graph, and copy over metadata, such as datatype and shape.
+            ::c10::optional<at::Tensor> val = ::c10::nullopt;
             if (vals_to_params_map.find(v) != vals_to_params_map.end()) {
-              // If the input is a parameter, insert a constant of its value as
-              // input.
-              auto val = vals_to_params_map.find(v)->second.second.toTensor();
+              val = vals_to_params_map.find(v)->second.second.toTensor();
+            } else if (ConstantValueMap::HasValue(v->debugName())) {
+              val = ConstantValueMap::GetValue(v->debugName());
+            }
+
+            if (val.has_value()) {
               return n_graph
                   ->insertNode(n_graph->create(::c10::onnx::Constant)
-                                   ->t_(attr::value, val))
+                                   ->t_(attr::value, val.value()))
                   ->output();
-            } else {
-              // If the input is not constant, we cannot depend on its value
-              // in shape inference. Set it to graph input in the new graph,
-              // and copy over metadata, such as datatype and shape.
-              auto input = n_graph->addInput();
-              input->copyMetadata(v);
-              return input;
             }
+            auto input = n_graph->addInput();
+            input->copyMetadata(v);
+            return input;
           }
         }
       });
@@ -1854,6 +1858,10 @@ std::pair<bool, bool> AreInputsReliableOrStatic(Node* n) {
       continue;
     }
     auto input = n->inputs()[idx];
+    // Skip None input.
+    if (input->node()->mustBeNone()) {
+      continue;
+    }
     reliable &=
         ConstantValueMap::GetTypeReliable(input->debugName()).value_or(false);
     if (auto pt = input->type()->cast<TensorType>()) {

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1858,7 +1858,8 @@ std::pair<bool, bool> AreInputsReliableOrStatic(Node* n) {
       continue;
     }
     auto input = n->inputs()[idx];
-    // Skip None input.
+    // Always consider None reliable and complete, because it represents
+    // unspecified optional inputs in ONNX.
     if (input->node()->mustBeNone()) {
       continue;
     }


### PR DESCRIPTION
Extend to support the following in onnx shape inference:
* Utilizing inferred constant values. Provides more information than just shape and type of the input.
   E.g. Enables `onnx::Resize` when `scales` input are constructed by `onnx::Concat` of constants. 
* `prim::Constant`, especially the one that represents `None`, which later represents unspecified optional input in ONNX.
   E.g. Enables `onnx::Resize` when the second optional input `roi` is not provided.

Fixes #69346