### PR TITLE
Fix bfloat16 tests for refs.fmod on CPU

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -844,13 +844,21 @@ void fmod_kernel(TensorIteratorBase& iter) {
     });
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "fmod_cpu", [&]() {
-      cpu_kernel_vec(
+      // TODO: there's a bug in vectorized fmod
+      // See https://github.com/pytorch/pytorch/issues/79009
+      // cpu_kernel_vec(
+      //   iter,
+      //   [](scalar_t x, scalar_t d) -> scalar_t {
+      //     return std::fmod(x, d);
+      //   },
+      //   [](Vectorized<scalar_t> x, Vectorized<scalar_t> d) {
+      //     return x.fmod(d);
+      //   });
+      // TODO: Remove cpu_kernel and uncomment cpu_kernel_vec once the bug is fixed
+      cpu_kernel(
         iter,
         [](scalar_t x, scalar_t d) -> scalar_t {
           return std::fmod(x, d);
-        },
-        [](Vectorized<scalar_t> x, Vectorized<scalar_t> d) {
-          return x.fmod(d);
         });
     });
   }

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -847,7 +847,7 @@ fmin = _make_elementwise_binary_reference(
 # TODO: add docstring
 fmod = _make_elementwise_binary_reference(
     prims.fmod,
-    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.NO_OPMATH,
     aten_op=torch.ops.aten.fmod,
 )
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -847,7 +847,7 @@ fmin = _make_elementwise_binary_reference(
 # TODO: add docstring
 fmod = _make_elementwise_binary_reference(
     prims.fmod,
-    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.NO_OPMATH,
+    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
     aten_op=torch.ops.aten.fmod,
 )
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -19927,10 +19927,6 @@ python_ref_db = [
         rhs_make_tensor_kwargs={'exclude_zero': True},
         skips=(
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref_errors'),
-            DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_python_ref',
-                         dtypes=(torch.bfloat16,), device_type='cpu'),
-            DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_python_ref_torch_fallback',
-                         dtypes=(torch.bfloat16,), device_type='cpu'),
         ),
     ),
     ElementwiseBinaryPythonRefInfo(


### PR DESCRIPTION
This PR fixes bfloat16 tests on the CPU.

Initially, I tried NO_OPMATH for type promotion and tests passed, but further investigation led to https://github.com/pytorch/pytorch/issues/79009. I disabled vectorization for the `fmod` function on the CPU as a temporary workaround for correctness. 
