### PR TITLE
Fixing JIT compatibility

### DIFF
--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -726,7 +726,7 @@ class SyncBatchNorm(_BatchNorm):
         need_sync = (bn_training and self.training)
         if need_sync:
             process_group = torch.distributed.group.WORLD
-            if self.process_group:
+            if self.process_group is not None:
                 process_group = self.process_group
             world_size = torch.distributed.get_world_size(process_group)
             need_sync = world_size > 1

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Optional
 
 import torch
 from torch import Tensor
@@ -10,6 +10,7 @@ from ._functions import SyncBatchNorm as sync_batch_norm
 from .lazy import LazyModuleMixin
 from .module import Module
 
+from torch._C._distributed_c10d import ProcessGroup
 
 class _NormBase(Module):
     """Common base of _InstanceNorm and _BatchNorm"""
@@ -654,7 +655,7 @@ class SyncBatchNorm(_BatchNorm):
         momentum: float = 0.1,
         affine: bool = True,
         track_running_stats: bool = True,
-        process_group: Optional[Any] = None,
+        process_group: Optional[ProcessGroup] = None,
         device=None,
         dtype=None
     ) -> None:

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Any
 
 import torch
 from torch import Tensor
@@ -10,7 +10,6 @@ from ._functions import SyncBatchNorm as sync_batch_norm
 from .lazy import LazyModuleMixin
 from .module import Module
 
-from torch._C._distributed_c10d import ProcessGroup
 
 class _NormBase(Module):
     """Common base of _InstanceNorm and _BatchNorm"""
@@ -655,7 +654,7 @@ class SyncBatchNorm(_BatchNorm):
         momentum: float = 0.1,
         affine: bool = True,
         track_running_stats: bool = True,
-        process_group: Optional[ProcessGroup] = None,
+        process_group: Optional[Any] = None,
         device=None,
         dtype=None
     ) -> None:


### PR DESCRIPTION
Fixing JIT compatibility by changing process group vs None comparison to proper type without implicit type casting.

Fixes not yet reported bug,
