### PR TITLE
ns for fx: further fixes for kwargs-only

### DIFF
--- a/torch/ao/ns/fx/utils.py
+++ b/torch/ao/ns/fx/utils.py
@@ -60,7 +60,7 @@ def get_node_first_input_and_output_type(
         elif node.target in FUNS_IO_TYPE_INT8:
             return (NodeInputOrOutputType.INT8, NodeInputOrOutputType.INT8)
         elif node.target in FUNS_IO_TYPE_FP32_OR_INT8:
-            first_arg = node.args[0]
+            first_arg = get_normalized_nth_input(node, gm, 0)
             assert isinstance(first_arg, Node)
             (
                 _prev_node_input_type,
@@ -85,7 +85,7 @@ def get_node_first_input_and_output_type(
         ):
             # A logger or observer's input and output type is the output
             # type of the preceding node.
-            first_arg = node.args[0]
+            first_arg = get_normalized_nth_input(node, gm, 0)
             assert isinstance(first_arg, Node)
             (
                 _prev_node_input_type,
@@ -112,7 +112,7 @@ def get_node_first_input_and_output_type(
             # Dequantize is a special node because it allows multiple input types.
             # So, we look up the output type of the previous node and return that
             # as the input type of this node instance.
-            prev_node = node.args[0]
+            prev_node = get_normalized_nth_input(node, gm, 0)
             assert isinstance(prev_node, Node)
             (
                 _prev_node_input_type,
@@ -127,7 +127,7 @@ def get_node_first_input_and_output_type(
             # So, we look up the output type of the previous node and return that
             # as the input type of this node instance. We also look up the target
             # of to and return the correct output type.
-            prev_node = node.args[0]
+            prev_node = get_normalized_nth_input(node, gm, 0)
             assert isinstance(prev_node, Node)
             (
                 _prev_node_input_type,
@@ -136,7 +136,7 @@ def get_node_first_input_and_output_type(
                 prev_node, gm, logger_cls, node_type_to_io_type_map
             )
 
-            cur_node_dtype_target = node.args[1]
+            cur_node_dtype_target = get_normalized_nth_input(node, gm, 1)
             assert (
                 cur_node_dtype_target is torch.float16
             ), f"{cur_node_dtype_target} handling needs to be added"
@@ -144,7 +144,7 @@ def get_node_first_input_and_output_type(
             return (prev_node_output_type, NodeInputOrOutputType.FP16)
 
         elif node.target in METHS_IO_TYPE_FP32_OR_INT8:
-            first_arg = node.args[0]
+            first_arg = get_normalized_nth_input(node, gm, 0)
             assert isinstance(first_arg, Node)
             (
                 _prev_node_input_type,
@@ -168,7 +168,7 @@ def get_node_input_qparams(
     Returns the qparams (scale, zero_point) of the first input to `node`,
     if they can be inferred from the graph.
     """
-    prev_node = node.args[0]
+    prev_node = get_normalized_nth_input(node, gm, 0)
 
     if not isinstance(prev_node, Node):
         return None
@@ -176,7 +176,8 @@ def get_node_input_qparams(
     MODS_IO_TYPE_FP32_OR_INT8 = node_type_to_io_type_map["mods_io_type_fp32_or_int8"]
 
     def _get_scale_zp_from_function_args(node, gm, scale_arg_idx, zp_arg_idx):
-        scale_node, zp_node = node.args[scale_arg_idx], node.args[zp_arg_idx]
+        scale_node = get_normalized_nth_input(node, gm, scale_arg_idx)
+        zp_node = get_normalized_nth_input(node, gm, zp_arg_idx)
         assert isinstance(scale_node, Node) and isinstance(scale_node.target, str)
         assert isinstance(zp_node, Node) and isinstance(zp_node.target, str)
         scale_obj = getattr_from_fqn(gm, scale_node.target)
@@ -496,3 +497,37 @@ def op_type_supports_shadowing(node: Node) -> bool:
             # shadowing for ops with multiple tensor inputs is not implemented yet
             return False
     return True
+
+def get_normalized_nth_input(node: Node, gm: GraphModule, idx: int) -> Node:
+    """
+    Given a node, gets the n'th input to that node, normalizing
+    args and kwargs to the best of its ability.
+    """
+    try:
+        norm_args_and_kwargs = node.normalized_arguments(
+            gm, normalize_to_only_use_kwargs=True)
+        if norm_args_and_kwargs is not None:
+            norm_args, norm_kwargs = norm_args_and_kwargs
+            assert len(norm_args) + len(norm_kwargs) > idx
+            if idx < len(norm_args):
+                return norm_args[idx]
+            else:
+                # note: in Python 3.7+ dicts are ordered
+                return list(norm_kwargs.values())[idx]
+        else:
+            assert len(node.args) + len(node.kwargs) > idx
+            if idx < len(node.args):
+                return node.args[idx]  # type: ignore[return-value]
+            else:
+                kwargs_idx = idx + len(node.args)
+                return list(node.kwargs.values())[kwargs_idx]  # type: ignore[return-value]
+    except RuntimeError:
+        # this RuntimeError happens when node argument normalization
+        # requires typehints to proceed, such as for torch.add where
+        # either the first, second or both arguments could be tensors
+        assert len(node.args) + len(node.kwargs) > idx
+        if idx < len(node.args):
+            return node.args[idx]  # type: ignore[return-value]
+        else:
+            kwargs_idx = idx + len(node.args)
+            return list(node.kwargs.values())[kwargs_idx]  # type: ignore[return-value]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#79015 ns for fx: further fixes for kwargs-only**

Summary:

This is a follow-up to https://github.com/pytorch/pytorch/pull/78181,
apparently that PR did not fix all errors in a Meta model using
the NS shadow APIs.

We do not have an OSS repro, so putting the PR up so we can test in fbcode.

Test plan:

```
python test/test_quantization.py -k FXNumericSuite -f
```

Differential Revision: [D36970189](https://our.internmc.facebook.com/intern/diff/D36970189)