### PR TITLE
[1.12][DataPipe] Disable profiler for IterDataPipe by default  and add deprecation of functional DataPipe names

### DIFF
--- a/torch/utils/data/datapipes/_typing.py
+++ b/torch/utils/data/datapipes/_typing.py
@@ -468,7 +468,7 @@ def hook_iterator(namespace, profile_name):
     Hook that is applied to all `__iter__` of metaclass `_DataPipeMeta`. This is done for the purpose of
     profiling and checking if an iterator is still valid.
     """
-    def context():
+    def profiler_record_fn_context():
         return torch.autograd.profiler.record_function(profile_name)
 
     class IteratorDecorator:
@@ -477,6 +477,7 @@ def hook_iterator(namespace, profile_name):
             self.iterator = iterator
             self.source_dp = source_dp
             self.iterator_id = iterator_id
+            self._profiler_enabled = torch.autograd._profiler_enabled()
 
         def __iter__(self):
             return self
@@ -484,7 +485,11 @@ def hook_iterator(namespace, profile_name):
         def __next__(self):
             # TODO: Add try-except to in-place reduce traceback from the Exception
             # See: https://github.com/pytorch/data/issues/284
-            with context():
+            if self._profiler_enabled:
+                with profiler_record_fn_context():
+                    _check_iterator_valid(self.source_dp, self.iterator_id)
+                    return next(self.iterator)
+            else:  # Decided against using `contextlib.nullcontext` for performance reasons
                 _check_iterator_valid(self.source_dp, self.iterator_id)
                 return next(self.iterator)
 
@@ -500,12 +505,22 @@ def hook_iterator(namespace, profile_name):
             gen = func(*args, **kwargs)
             datapipe = args[0]
             iterator_id = _set_datapipe_valid_iterator_id(datapipe)  # This ID is tied to each created iterator
+            _profiler_enabled = torch.autograd._profiler_enabled()
             try:
-                with context():
+                if _profiler_enabled:
+                    with profiler_record_fn_context():
+                        response = gen.send(None)
+                else:
                     response = gen.send(None)
+
                 while True:
                     request = yield response
-                    with context():  # Pass through here every time `__next__` is called
+                    # Pass through here every time `__next__` is called
+                    if _profiler_enabled:
+                        with profiler_record_fn_context():
+                            _check_iterator_valid(datapipe, iterator_id)
+                            response = gen.send(request)
+                    else:  # Decided against using `contextlib.nullcontext` for performance reasons
                         _check_iterator_valid(datapipe, iterator_id)
                         response = gen.send(request)
             except StopIteration as e:
@@ -529,7 +544,9 @@ def hook_iterator(namespace, profile_name):
 
             @functools.wraps(next_func)
             def wrap_next(*args, **kwargs):
-                with context():
+                if torch.autograd._profiler_enabled():
+                    return next_func(*args, **kwargs)
+                else:
                     return next_func(*args, **kwargs)
 
             namespace['__next__'] = wrap_next

--- a/torch/utils/data/datapipes/datapipe.py
+++ b/torch/utils/data/datapipes/datapipe.py
@@ -3,6 +3,11 @@ import pickle
 from typing import Dict, Callable, Optional, TypeVar, Generic, Iterator
 
 from torch.utils.data.datapipes._typing import _DataPipeMeta, _IterDataPipeMeta
+from torch.utils.data.datapipes.utils.common import (
+    _deprecation_warning,
+    _iter_deprecated_functional_names,
+    _map_deprecated_functional_names,
+)
 from torch.utils.data.dataset import Dataset, IterableDataset
 
 try:
@@ -109,6 +114,9 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_IterDataPipeMeta):
 
     def __getattr__(self, attribute_name):
         if attribute_name in IterDataPipe.functions:
+            if attribute_name in _iter_deprecated_functional_names:
+                kwargs = _iter_deprecated_functional_names[attribute_name]
+                _deprecation_warning(**kwargs)
             function = functools.partial(IterDataPipe.functions[attribute_name], self)
             return function
         else:
@@ -232,6 +240,9 @@ class MapDataPipe(Dataset[T_co], metaclass=_DataPipeMeta):
 
     def __getattr__(self, attribute_name):
         if attribute_name in MapDataPipe.functions:
+            if attribute_name in _map_deprecated_functional_names:
+                kwargs = _map_deprecated_functional_names[attribute_name]
+                _deprecation_warning(**kwargs)
             function = functools.partial(MapDataPipe.functions[attribute_name], self)
             return function
         else:

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -3,7 +3,7 @@ import fnmatch
 import warnings
 
 from io import IOBase
-from typing import Iterable, List, Tuple, Union, Optional
+from typing import Dict, Iterable, List, Tuple, Union, Optional
 
 from torch.utils.data._utils.serialization import DILL_AVAILABLE
 
@@ -104,6 +104,25 @@ def validate_pathname_binary_tuple(data: Tuple[str, IOBase]):
         )
 
 
+# Deprecated function names and its corresponding DataPipe type and kwargs for the `_deprecation_warning` function
+_iter_deprecated_functional_names: Dict[str, Dict] = {"open_file_by_fsspec":
+                                                      {"old_class_name": "FSSpecFileOpener",
+                                                       "deprecation_version": "1.12",
+                                                       "removal_version": "1.14",
+                                                       "old_functional_name": "open_file_by_fsspec",
+                                                       "new_functional_name": "open_files_by_fsspec",
+                                                       "deprecate_functional_name_only": True},
+                                                      "open_file_by_iopath":
+                                                      {"old_class_name": "IoPathFileOpener",
+                                                       "deprecation_version": "1.12",
+                                                       "removal_version": "1.14",
+                                                       "old_functional_name": "open_file_by_iopath",
+                                                       "new_functional_name": "open_files_by_iopath",
+                                                       "deprecate_functional_name_only": True}}
+
+_map_deprecated_functional_names: Dict[str, Dict] = {}
+
+
 def _deprecation_warning(
     old_class_name: str,
     *,
@@ -114,6 +133,7 @@ def _deprecation_warning(
     new_class_name: str = "",
     new_functional_name: str = "",
     new_argument_name: str = "",
+    deprecate_functional_name_only: bool = False,
 ) -> None:
     if new_functional_name and not old_functional_name:
         raise ValueError("Old functional API needs to be specified for the deprecation warning.")
@@ -124,7 +144,9 @@ def _deprecation_warning(
         raise ValueError("Deprecating warning for functional API and argument should be separated.")
 
     msg = f"`{old_class_name}()`"
-    if old_functional_name:
+    if deprecate_functional_name_only and old_functional_name:
+        msg = f"{msg}'s functional API `.{old_functional_name}()` is"
+    elif old_functional_name:
         msg = f"{msg} and its functional API `.{old_functional_name}()` are"
     elif old_argument_name:
         msg = f"The argument `{old_argument_name}` of {msg} is"


### PR DESCRIPTION
Cherry-pick of these PRs for release 1.12:
* https://github.com/pytorch/pytorch/pull/78674
* https://github.com/pytorch/pytorch/pull/78970
