### PR TITLE
[quant][core][improvement] Added earlier termination and improved error message for calling min and max ops on per channel quantized tensors.

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -12,6 +12,7 @@
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/TensorIndexing.h>
 #include <ATen/native/TypeProperties.h>
+#include <c10/core/QScheme.h>
 
 namespace at {
 namespace meta {
@@ -532,6 +533,8 @@ TORCH_IMPL_FUNC(min_out)
 }
 
 std::tuple<Tensor, Tensor> qmax(const Tensor& self, int64_t dim, bool keepdim) {
+  TORCH_CHECK(self.qscheme() == at::kPerTensorAffine, "Max operator for quantized tensors only works for per tensor quantized tensors. "
+  "Please open an issue on https://github.com/pytorch/pytorch/issues if you need per channel quantized tensor support.");
   Tensor max_indices = at::empty({0}, self.options().dtype(kLong));
   Tensor max = at::empty({0}, self.options().dtype(toUnderlying(self.scalar_type())));
   at::max_outf(self.int_repr(), dim, keepdim, max, max_indices);
@@ -541,6 +544,8 @@ std::tuple<Tensor, Tensor> qmax(const Tensor& self, int64_t dim, bool keepdim) {
 }
 
 std::tuple<Tensor, Tensor> qmin(const Tensor& self, int64_t dim, bool keepdim) {
+  TORCH_CHECK(self.qscheme() == at::kPerTensorAffine, "Min operator for quantized tensors only works for per tensor quantized tensors. "
+  "Please open an issue on https://github.com/pytorch/pytorch/issues if you need per channel quantized tensor support.");
   Tensor min_indices = at::empty({0}, self.options().dtype(kLong));
   Tensor min = at::empty({0}, self.options().dtype(toUnderlying(self.scalar_type())));
   at::min_outf(self.int_repr(), dim, keepdim, min, min_indices);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79036

Summary:
Fixes #42598

Max and min operators for quantized tensors only supports per tensor
quantized tensors. Previously, an exception is thrown further down the
stack of involved operator calls. This PR adds an earlier termination
with a clearer  error message.

```
import torch
x = torch.rand(2, 2, 2, 2)
qx = torch.quantize_per_channel(x, scales=torch.tensor([0.5, 0.1]), zero_points=torch.tensor([102, 2]), axis=0, dtype=torch.qint8)
qx.min()
``` 
previously produced the following ambiguous error:
```
RuntimeError: Expected quantizer->qscheme() == kPerTensorAffine to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
```

Now it produces:
```
RuntimeError: Min operator for quantized tensors only works for per tensor quantized tensors. Please open an issue on https://github.com/pytorch/pytorch/issues if you need per channel quantized tensor support.
```

Differential Revision: [D36979122](https://our.internmc.facebook.com/intern/diff/D36979122)