### PR TITLE
Add nlohmann/json submodule for c++ json support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,3 +142,6 @@
 [submodule "third_party/flatbuffers"]
 	path = third_party/flatbuffers
 	url = https://github.com/google/flatbuffers.git
+[submodule "third_party/json"]
+	path = third_party/json
+	url = https://github.com/nlohmann/json


### PR DESCRIPTION
Add nlohmann/json as a submodule. This library is already in our license file, as its used by the cudnn_frontend submodule. Adding it as a submodule directly will allow its use from other targets in the repo. Im particular it's needed in the coreml delegate backend to replace a usage of NSJSONSerialization.
