### PR TITLE
implemented isGreen functionality to verify whether a commit SHA is promote-able

### DIFF
--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -74,7 +74,7 @@ def isGreen(commit: str, results: Dict[str, Any]) -> Any:
         workflowName = check['workflowName']
         conclusion = check['conclusion']
         if re.search("|".join(regex), workflowName) and conclusion != 'success':
-            if check['name'] == "pull / win-vs2019-cuda11.3-py3" and check['conclusion'] == 'skipped':
+            if check['name'] == "pull / win-vs2019-cuda11.3-py3" and conclusion == 'skipped':
                 pass
                 # there are trunk checks that run the same tests, so this pull workflow check can be skipped
             else:

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -73,7 +73,7 @@ def isGreen(commit: str, results: Dict[str, Any]) -> Any:
     for check in workflow_checks:
         workflowName = check['workflowName']
         conclusion = check['conclusion']
-        if re.search("|".join(regex), workflowName) and conclusion != 'success':
+        if re.search("|".join(regex), workflowName, flags=re.IGNORECASE) and conclusion != 'success':
             if check['name'] == "pull / win-vs2019-cuda11.3-py3" and conclusion == 'skipped':
                 pass
                 # there are trunk checks that run the same tests, so this pull workflow check can be skipped

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -6,6 +6,15 @@ import rockset  # type: ignore[import]
 import os
 import re
 
+regex = [
+    "^pull+",
+    "^trunk+",
+    "^lint+",
+    "^linux-binary+",
+    "^android-tests+",
+    "^windows-binary+"
+]
+
 class WorkflowCheck(NamedTuple):
     workflowName: str
     name: str
@@ -62,16 +71,15 @@ def isGreen(commit: str, results: Dict[str, Any]) -> bool:
     workflow_checks = get_commit_results(commit, results)
 
     for check in workflow_checks:
-        regex = "^linux-binary+|^android-tests+|^windows-binary+"
-        if check['workflowName'] in ["pull", "trunk", "lint"] and check['conclusion'] != 'success':
+        workflowName = check['workflowName']
+        conclusion = check['conclusion']
+        if re.search("|".join(regex), workflowName) and conclusion != 'success':
             if check['name'] == "pull / win-vs2019-cuda11.3-py3" and check['conclusion'] == 'skipped':
                 pass
                 # there are trunk checks that run the same tests, so this pull workflow check can be skipped
             else:
                 return False
-        elif check['workflowName'] in ["periodic", "docker-release-builds"] and check['conclusion'] not in ["success", "skipped"]:
-            return False
-        elif re.search(regex, check['workflowName']) and check['conclusion'] != 'success':
+        elif workflowName in ["periodic", "docker-release-builds"] and conclusion not in ["success", "skipped"]:
             return False
     return True
 

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -36,7 +36,7 @@ def print_latest_commits(qlambda: Any, minutes: int = 30) -> None:
             "git",
             "rev-list",
             f"--max-age={timestamp_since}",
-            "--remotes=*master",
+            "--remotes=*origin/master",
         ],
         encoding="ascii",
     ).splitlines()

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -36,7 +36,7 @@ def print_latest_commits(qlambda: Any, minutes: int = 30) -> None:
             "git",
             "rev-list",
             f"--max-age={timestamp_since}",
-            "--remotes=*origin/master",
+            "--remotes=*master",
         ],
         encoding="ascii",
     ).splitlines()
@@ -67,7 +67,7 @@ def get_commit_results(commit: str, results: Dict[str, Any]) -> List[Dict[str, A
             )._asdict())
     return workflow_checks
 
-def isGreen(commit: str, results: Dict[str, Any]) -> bool:
+def isGreen(commit: str, results: Dict[str, Any]) -> Any:
     workflow_checks = get_commit_results(commit, results)
 
     for check in workflow_checks:
@@ -78,9 +78,9 @@ def isGreen(commit: str, results: Dict[str, Any]) -> bool:
                 pass
                 # there are trunk checks that run the same tests, so this pull workflow check can be skipped
             else:
-                return False
+                return workflowName + " checks were not successful"
         elif workflowName in ["periodic", "docker-release-builds"] and conclusion not in ["success", "skipped"]:
-            return False
+            return workflowName + " checks were not successful"
     return True
 
 def main() -> None:

--- a/.github/scripts/test_print_latest_commits.py
+++ b/.github/scripts/test_print_latest_commits.py
@@ -19,7 +19,7 @@ class TestPrintCommits(TestCase):
     def test_match_rules(self, mock_get_commit_results: Any) -> None:
         "Test that passes all conditions for promote-able"
         workflow_checks = mock_get_commit_results()
-        self.assertTrue(isGreen(workflow_checks))
+        self.assertTrue(isGreen("sha", workflow_checks))
 
     @mock.patch('print_latest_commits.get_commit_results', return_value=TestChecks().make_test_checks())
     def test_jobs_failing(self, mock_get_commit_results: Any) -> None:


### PR DESCRIPTION
Relates to #76700

**Overview:** I implemented the isGreen method in `print_latest_commits.py` which takes in a commit SHA and returns if the commit is promote-able to viable/strict. I use a regex for checks that must be successful, and a short allow-list for the checks that can either be success or skipped. If a commit SHA is not promote-able, the method will output a short error message specifying which workflow name (ex: pull, android-tests) that had unpromote-able check results.

**Example Outputs:**
Example of a promote-able SHA:
![Screen Shot 2022-06-07 at 5 08 44 PM](https://user-images.githubusercontent.com/24441980/172483287-84eb414d-e431-4fca-bb20-61ac3d9c9b69.png)
![Screen Shot 2022-06-07 at 5 08 52 PM](https://user-images.githubusercontent.com/24441980/172483298-27874f5e-30fd-4bc1-b50b-a2293311a265.png)
This matches the current viable/strict branch as this SHA is part of viable/strict on the HUD.

Example of an unpromote-able SHA:
![Screen Shot 2022-06-09 at 11 40 55 AM](https://user-images.githubusercontent.com/24441980/172888402-b627556b-03a9-411c-9024-f017730cfaa6.png)
![Screen Shot 2022-06-09 at 11 41 14 AM](https://user-images.githubusercontent.com/24441980/172888455-e9ab10bc-ed62-476d-9835-045338494f9c.png)

**Test Plan:** Compare commit SHAs with those found on the viable/strict branch on the HUD. I have also looked manually at the check results for commits on the HUD in the master branch to see if they are green and promoteable to viable/strict. Since I did not use the original specifications for green-ness that were mentioned in #76700, I will modify my test cases in the next PR. 