### PR TITLE
[1.12] Fix sharding strategy for distributed DL (#79041)

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -92,24 +92,26 @@ class _InfiniteConstantSampler(Sampler):
             yield None
 
 
-def _apply_distributed_sharding(datapipe):
+def _get_distributed_settings():
     if dist.is_available() and dist.is_initialized():
-        total_workers = dist.get_world_size()
-        global_worker_id = dist.get_rank()
-        torch.utils.data.graph_settings.apply_sharding(datapipe, total_workers, global_worker_id)
-    return datapipe
+        return dist.get_world_size(), dist.get_rank()
+    else:
+        return 1, 0
 
-def _sharding_worker_init_fn(worker_init_fn, worker_id):
+
+def _sharding_worker_init_fn(worker_init_fn, world_size, rank_id, worker_id):
     global_worker_id = worker_id
     info = torch.utils.data.get_worker_info()
     total_workers = info.num_workers
     datapipe = info.dataset
-    if dist.is_available() and dist.is_initialized():
-        total_workers *= dist.get_world_size()
-        global_worker_id = dist.get_rank() * info.num_workers + global_worker_id
+    # To distribute elements across distributed process evenly, we should shard data on distributed
+    # processes first then shard on worker processes
+    total_workers *= world_size
+    global_worker_id = global_worker_id * world_size + rank_id
     torch.utils.data.graph_settings.apply_sharding(datapipe, total_workers, global_worker_id)
     if worker_init_fn is not None:
         worker_init_fn(worker_id)
+
 
 class DataLoader(Generic[T_co]):
     r"""
@@ -246,19 +248,19 @@ class DataLoader(Generic[T_co]):
         # 2. Additional worker init function will take care of sharding in MP and Distributed
         if isinstance(self.dataset, IterDataPipe):
             self.dataset = _IterDataPipeSerializationWrapper(self.dataset)
+            ws, rank = _get_distributed_settings()
             if num_workers > 0:
                 self.worker_init_fn = functools.partial(
-                    _sharding_worker_init_fn, self.worker_init_fn)
+                    _sharding_worker_init_fn, self.worker_init_fn, ws, rank)
             else:
-                self.dataset = _apply_distributed_sharding(self.dataset)
+                self.dataset = torch.utils.data.graph_settings.apply_sharding(self.dataset, ws, rank)
         elif isinstance(self.dataset, MapDataPipe):
             self.dataset = _MapDataPipeSerializationWrapper(self.dataset)
             if num_workers > 0:
                 self.worker_init_fn = functools.partial(
-                    _sharding_worker_init_fn, self.worker_init_fn)
+                    _sharding_worker_init_fn, self.worker_init_fn, ws, rank)
             else:
-                self.dataset = _apply_distributed_sharding(self.dataset)
-
+                self.dataset = torch.utils.data.graph_settings.apply_sharding(self.dataset, ws, rank)
 
 
         # Arg-check dataset related before checking samplers because we want to


### PR DESCRIPTION
1. Change the sharding strategy from sharding by worker first then by rank to sharding in the order of rank then workers.
2. Change to fetch Rank and World size in main process for the sake of `spawn`.

For the change 1:
Before this PR, for the case when dataset can not be evenly divided by `worker_num * world_size`, more data will be retrieved by workers in first RANKs.
Using the following example:
- dataset size: 100
- world_size: 4
- num_worker: 2

The number of data retrieved by each rank before this PR
- Rank 0: 26
- Rank 1: 26
- Rank 2: 24
- Rank 3: 24

The number of data retrieved by each rank after this PR
- Rank 0: 25
- Rank 1: 25
- Rank 2: 25
- Rank 3: 25

For the change 2:
Before this PR, `dist` functions are invoked inside worker processes. It's fine when the worker processes are forked from the parent process. All environment variables are inherited and exposed to these `dist` functions. However, when the worker processes are spawned, they won't be able to access to these environment variables, then the dataset won't be sharded by rank.
After this PR, `_sharding_worker_init_fn` should be working for both `spawn` and `fork` case.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/79041
Approved by: https://github.com/VitalyFedyunin, https://github.com/NivekT

Fixes #ISSUE_NUMBER
