### PR TITLE
[quant] Make APoTObserver inherit from ObserverBase

### DIFF
--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -18,7 +18,7 @@ class APoTObserver(ObserverBase):
         level_indices: torch.Tensor,
             b: int,
             k: int) -> None:
-        super(APoTObserver, self).__init__(min_val, max_val, level_indices, b, k)
+        super().__init__
 
     def calculate_qparams(self):
         return self._calculate_qparams()

--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -5,25 +5,8 @@ the values observed during calibration (PTQ) or training (QAT).
 
 import torch
 from torch.ao.quantization.observer import ObserverBase
-from typing import Tuple
 
-class NonUniformQuantizationObserverBase(ObserverBase):
-    quant_min = None
-    quant_max = None
-
-    def __init__(
-        self,
-        min_val: torch.Tensor,
-        max_val: torch.Tensor,
-        level_indices: torch.Tensor,
-            b: int,
-            k: int) -> None:
-        super().__init__
-
-    def _calculate_qparams(self) -> Tuple[torch.Tensor, torch.Tensor]:
-        pass
-
-class APoTObserver(NonUniformQuantizationObserverBase):
+class APoTObserver(ObserverBase):
     alpha = 0
     gamma = 0
     level_indices = torch.Tensor()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #79198
* #78905
* __->__ #79068

### Summary:
This PR removes the class "NonUniformQuantizationObserverBase" as the extra inheritance level is not yet needed (following YAGNI https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it). It has APoTObserver instead inherit from ObserverBase.

### Test Plan:
python pytorch/test/quantization/core/experimental/test_nonuniform_observer.py