### PR TITLE
Rocm enable tensorexpr

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -65,8 +65,13 @@ fi
 pip_install -r requirements.txt || true
 
 # Enable LLVM dependency for TensorExpr testing
-export USE_LLVM=/opt/llvm
-export LLVM_DIR=/opt/llvm/lib/cmake/llvm
+if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+  export USE_LLVM=/opt/rocm/llvm
+  export LLVM_DIR=/opt/rocm/llvm/lib/cmake/llvm
+else
+  export USE_LLVM=/opt/llvm
+  export LLVM_DIR=/opt/llvm/lib/cmake/llvm
+fi
 
 # TODO: Don't install this here
 if ! which conda; then

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -251,6 +251,7 @@ ROCM_BLOCKLIST = [
     "distributed/_shard/test_replicated_tensor",
     "test_determination",
     "test_jit_legacy",
+    "test_openmp",
 ]
 
 RUN_PARALLEL_BLOCKLIST = [

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -251,7 +251,6 @@ ROCM_BLOCKLIST = [
     "distributed/_shard/test_replicated_tensor",
     "test_determination",
     "test_jit_legacy",
-    "test_openmp",
 ]
 
 RUN_PARALLEL_BLOCKLIST = [


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

The following tests are being re-enabled for ROCM:

test_n_threads
test_one_thread
test_alloc_in_loop
test_kernel_shape_prop
test_kernel_shape_prop_module
test_kernel_with_custom_lowering
test_kernel_with_expand
test_kernel_with_permute
test_kernel_with_scalar_inputs
test_kernel_with_t
test_kernel_with_tensor_inputs
test_kernel_with_transpose

