### PR TITLE
Fix jit schema_matching ignoring self resulting in wrong operator schema

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -604,6 +604,19 @@ class TestJit(JitTestCase):
         # a_copy is modified
         torch.testing.assert_close(orig_res, a_copy)
 
+    def test_repeat_interleave_script(self):
+        def fn(input: torch.Tensor, repeats: torch.Tensor) -> torch.Tensor:
+            output = input.repeat_interleave(repeats)
+            return output
+        fn_scripted = torch.jit.script(fn)
+
+        input = torch.tensor([5, 7], dtype=torch.int64)
+        repeats = torch.tensor([3, 6], dtype=torch.int64)
+
+        output = fn(input, repeats)
+        output_scripted = fn_scripted(input, repeats)
+        self.assertEqual(output_scripted, output)
+
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.LEGACY, "Simple executor doesn't have shape information")
     def test_peephole_optimize_shape_ops(self):
         def test_input(func, input, result):

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -452,8 +452,11 @@ static c10::optional<MatchedSchema> tryMatchSchema(
     positional_inputs.push_back(positional);
   }
   // check for unused self argument
-  if (self != c10::nullopt && failure_messages) {
-    err() << "Provided self argument not used in schema.\n";
+  if (self != c10::nullopt) {
+    if (failure_messages) {
+      err() << "Provided self argument not used in schema.\n";
+    }
+    return c10::nullopt;
   }
 
   if (schema.is_vararg()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79101

attempt to fix #78787
where `c = a.repeat_interleave(b)` is jit scripted into `c = torch.repeat_interleave(b)`. 

I think the reason is `a.repeat_interleave(b)` is matched to https://github.com/pytorch/pytorch/blob/acecd4acc1411052a2a59b27518faad20fc6aa20/aten/src/ATen/native/native_functions.yaml#L3841, and the self tensor `a` gets dropped. 
