### PR TITLE
[JIT] Improve error message for InferredType

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -2225,7 +2225,11 @@ struct InferredType {
   /* implicit */ InferredType(std::string reason)
       : type_(nullptr), reason_(std::move(reason)) {}
   TypePtr type() const {
-    TORCH_INTERNAL_ASSERT(type_);
+    TORCH_INTERNAL_ASSERT(
+        type_,
+        "Tried to get the type from an InferredType but the type is null. ",
+        "Reason: ",
+        reason_);
     return type_;
   }
   bool success() const {

--- a/test/jit/test_types.py
+++ b/test/jit/test_types.py
@@ -306,3 +306,13 @@ class TestTypesAndAnnotation(JitTestCase):
 
             def set(self, val: int):
                 self.x = val
+
+    def test_inferred_type_error_message(self):
+        inferred_type = torch._C.InferredType("ErrorReason")
+
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Tried to get the type from an InferredType but the type is null."):
+            t = inferred_type.type()
+
+        with self.assertRaisesRegex(RuntimeError, "ErrorReason"):
+            t = inferred_type.type()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #79105

If we try to call `type()` on an InferredType object but the type is
null, then the assertion will fail. This adds a better error message.