### PR TITLE
Foward fix sharding bug for DL

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -253,14 +253,14 @@ class DataLoader(Generic[T_co]):
                 self.worker_init_fn = functools.partial(
                     _sharding_worker_init_fn, self.worker_init_fn, ws, rank)
             else:
-                self.dataset = torch.utils.data.graph_settings.apply_sharding(self.dataset, ws, rank)
+                torch.utils.data.graph_settings.apply_sharding(self.dataset, ws, rank)
         elif isinstance(self.dataset, MapDataPipe):
             self.dataset = _MapDataPipeSerializationWrapper(self.dataset)
             if num_workers > 0:
                 self.worker_init_fn = functools.partial(
                     _sharding_worker_init_fn, self.worker_init_fn, ws, rank)
             else:
-                self.dataset = torch.utils.data.graph_settings.apply_sharding(self.dataset, ws, rank)
+                torch.utils.data.graph_settings.apply_sharding(self.dataset, ws, rank)
 
 
         # Arg-check dataset related before checking samplers because we want to


### PR DESCRIPTION
This PR solves a bug introduced by #79041

`torch.utils.data.graph_settings.apply_sharding` changes the datapipe in-place and returns `None`

It would resolve the Error in TorchData. See: https://github.com/pytorch/data/actions/runs/2461030312
I have validated on my local machine that the test in TorchData passes after this PR.