### PR TITLE
[PyTorch][easy] Tie DimVector inline size to SizesAndStrides inline size

### DIFF
--- a/c10/util/DimVector.h
+++ b/c10/util/DimVector.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <c10/core/impl/SizesAndStrides.h>
 #include <c10/util/SmallVector.h>
 #include <cstdint>
 
 namespace c10 {
 
-constexpr size_t kDimVectorStaticSize = 5;
+constexpr size_t kDimVectorStaticSize = C10_SIZES_AND_STRIDES_MAX_INLINE_SIZE;
 
 /// A container for sizes or strides
 using DimVector = SmallVector<int64_t, kDimVectorStaticSize>;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79128

These should be kept the same, right?

Differential Revision: [D37006473](https://our.internmc.facebook.com/intern/diff/D37006473/)