### PR TITLE
[WIP][FSDP] Introduce `FlatParamHandle` for non-recursive wrapping

### DIFF
--- a/test/distributed/fsdp/test_flatten_params_wrapper.py
+++ b/test/distributed/fsdp/test_flatten_params_wrapper.py
@@ -5,12 +5,9 @@ import unittest
 
 import torch
 from torch import distributed as dist
-from torch.distributed.fsdp.flatten_params_wrapper import (
-    FlattenParamsWrapper,
-    ShardMetadata,
-)
-from torch.testing._internal.common_utils import run_tests, TestCase
-
+from torch.distributed.fsdp._flat_param import FlatParamShardMetadata
+from torch.distributed.fsdp.flatten_params_wrapper import FlattenParamsWrapper
+from torch.testing._internal.common_utils import TestCase, run_tests
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -104,7 +101,7 @@ class TestFlattenParams(TestCase):
         )
         num_params_to_flatten = sum(p.numel() for p in params_to_flatten)
 
-        module = FlattenParamsWrapper(module, param_list=params_to_flatten)
+        module = FlattenParamsWrapper(module, params_to_flatten)
         self.assertEqual(module.flat_param.numel(), num_params_to_flatten)
         self.assertEqual(sum(p.numel() for p in module.parameters()), num_params)
 
@@ -131,14 +128,14 @@ class TestFlattenParams(TestCase):
 
     def test_flatten_nothing(self):
         module = self._get_transformer()
-        module = FlattenParamsWrapper(module, param_list=[])
+        module = FlattenParamsWrapper(module, [])
         self.assertIsNone(module.flat_param)
 
     def test_empty_module(self):
         module = self._get_empty_module()
         in_data = torch.rand(1)
         ref_out = module(in_data)
-        module = FlattenParamsWrapper(module, param_list=[])
+        module = FlattenParamsWrapper(module, [])
         self.assertEqual(len(list(module.parameters())), 0)
         self.assertIsNone(module.flat_param)
         fpw_out = module(in_data)
@@ -184,126 +181,115 @@ class TestFlattenParams(TestCase):
         )
         params_to_flatten = list(module.parameters())
         flat_module = FlattenParamsWrapper(module, params_to_flatten)
-        flat_p = flat_module.flat_param
+        flat_param_handle = flat_module.handle
 
-        def _test(kwargs, expected, exception=None, regex=None):
-            flat_p._is_sharded = True
-            if exception is not None:
-                with self.assertRaisesRegex(exception, regex):
-                    flat_p.shard_by_offsets(**kwargs)
-            else:
-                flat_p.shard_by_offsets(**kwargs)
-                self.assertEqual(
-                    flat_p.shard_metadata(),
-                    expected,
-                    msg=f"{flat_p.shard_metadata()}, {expected}",
-                )
-                self.assertEqual(flat_p.num_padded, kwargs["num_padded"])
+        def _test(kwargs, expected):
+            """
+            Tests the subroutine ``_get_shard_metadta()`` that computes shard
+            metadata based on start and end indices in the unsharded flattened
+            parameter.
 
-        _test(
-            kwargs={"start": -1, "end": -1, "num_padded": 0},
-            expected=None,
-            exception=ValueError,
-            regex="Shard the flatten parameter with an invalid offset pair",
-        )
-        _test(
-            kwargs={"start": 1, "end": 0, "num_padded": 0},
-            expected=None,
-            exception=ValueError,
-            regex="Shard the flatten parameter with an invalid offset pair",
-        )
-        _test(
-            kwargs={"start": 0, "end": 1, "num_padded": 3},
-            expected=None,
-            exception=ValueError,
-            regex="The number of padding is larger than the shard size.",
-        )
+            We manually set the relevant attributes on the flattened parameter
+            to be able to check the effect of ``_get_shard_metadta()`` via
+            ``shard_metadata()`` since normally the attributes are set in
+            ``init_shard_info()`` with the start and end indices fixed based on
+            rank and world size.
+            """
+            flat_param = flat_module.flat_param
+            flat_param._is_sharded = True
+            flat_param._shard_param_offsets, flat_param._shard_indices = \
+                flat_param_handle._get_shard_metadata(kwargs["start"], kwargs["end"])
+            self.assertEqual(
+                flat_param_handle.shard_metadata(),
+                expected,
+                msg=f"{flat_param_handle.shard_metadata()}, {expected}",
+            )
 
         _test(
-            kwargs={"start": 0, "end": 0, "num_padded": 0},
-            expected=ShardMetadata(
-                param_names=["_fpw_module.0.weight"],
+            kwargs={"start": 0, "end": 0},
+            expected=FlatParamShardMetadata(
+                param_names=["0.weight"],
                 param_shapes=[(10, 10)],
                 param_numels=[100],
                 param_offsets=[(0, 0)],
             ),
         )
         _test(
-            kwargs={"start": 0, "end": 50, "num_padded": 0},
-            expected=ShardMetadata(
-                param_names=["_fpw_module.0.weight"],
+            kwargs={"start": 0, "end": 50},
+            expected=FlatParamShardMetadata(
+                param_names=["0.weight"],
                 param_shapes=[(10, 10)],
                 param_numels=[100],
                 param_offsets=[(0, 50)],
             ),
         )
         _test(
-            kwargs={"start": 0, "end": 99, "num_padded": 0},
-            expected=ShardMetadata(
-                param_names=["_fpw_module.0.weight"],
+            kwargs={"start": 0, "end": 99},
+            expected=FlatParamShardMetadata(
+                param_names=["0.weight"],
                 param_shapes=[(10, 10)],
                 param_numels=[100],
                 param_offsets=[(0, 99)],
             ),
         )
         _test(
-            kwargs={"start": 50, "end": 149, "num_padded": 0},
-            expected=ShardMetadata(
-                param_names=["_fpw_module.0.weight", "_fpw_module.2.weight"],
+            kwargs={"start": 50, "end": 149},
+            expected=FlatParamShardMetadata(
+                param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
                 param_numels=[100, 100],
                 param_offsets=[(50, 99), (0, 49)],
             ),
         )
         _test(
-            kwargs={"start": 50, "end": 199, "num_padded": 0},
-            expected=ShardMetadata(
-                param_names=["_fpw_module.0.weight", "_fpw_module.2.weight"],
+            kwargs={"start": 50, "end": 199},
+            expected=FlatParamShardMetadata(
+                param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
                 param_numels=[100, 100],
                 param_offsets=[(50, 99), (0, 99)],
             ),
         )
         _test(
-            kwargs={"start": 99, "end": 199, "num_padded": 0},
-            expected=ShardMetadata(
-                param_names=["_fpw_module.0.weight", "_fpw_module.2.weight"],
+            kwargs={"start": 99, "end": 199},
+            expected=FlatParamShardMetadata(
+                param_names=["0.weight", "2.weight"],
                 param_shapes=[(10, 10), (10, 10)],
                 param_numels=[100, 100],
                 param_offsets=[(99, 99), (0, 99)],
             ),
         )
         _test(
-            kwargs={"start": 100, "end": 199, "num_padded": 0},
-            expected=ShardMetadata(
-                param_names=["_fpw_module.2.weight"],
+            kwargs={"start": 100, "end": 199},
+            expected=FlatParamShardMetadata(
+                param_names=["2.weight"],
                 param_shapes=[(10, 10)],
                 param_numels=[100],
                 param_offsets=[(0, 99)],
             ),
         )
         _test(
-            kwargs={"start": 100, "end": 299, "num_padded": 0},
-            expected=ShardMetadata(
-                param_names=["_fpw_module.2.weight", "_fpw_module.4.weight"],
+            kwargs={"start": 100, "end": 299},
+            expected=FlatParamShardMetadata(
+                param_names=["2.weight", "4.weight"],
                 param_shapes=[(10, 10), (10, 10)],
                 param_numels=[100, 100],
                 param_offsets=[(0, 99), (0, 99)],
             ),
         )
         _test(
-            kwargs={"start": 100, "end": 1000, "num_padded": 0},
-            expected=ShardMetadata(
-                param_names=["_fpw_module.2.weight", "_fpw_module.4.weight"],
+            kwargs={"start": 100, "end": 1000},
+            expected=FlatParamShardMetadata(
+                param_names=["2.weight", "4.weight"],
                 param_shapes=[(10, 10), (10, 10)],
                 param_numels=[100, 100],
                 param_offsets=[(0, 99), (0, 99)],
             ),
         )
         _test(
-            kwargs={"start": 299, "end": 299, "num_padded": 0},
-            expected=ShardMetadata(
-                param_names=["_fpw_module.4.weight"],
+            kwargs={"start": 299, "end": 299},
+            expected=FlatParamShardMetadata(
+                param_names=["4.weight"],
                 param_shapes=[(10, 10)],
                 param_numels=[100],
                 param_offsets=[(99, 99)],

--- a/test/distributed/fsdp/test_fsdp_exec_order_policy.py
+++ b/test/distributed/fsdp/test_fsdp_exec_order_policy.py
@@ -1,9 +1,9 @@
 # Owner(s): ["oncall: distributed"]
-
 import copy
 import sys
 import warnings
 from contextlib import suppress
+from typing import Any, Dict, List, Tuple
 
 import torch
 import torch.nn as nn
@@ -11,8 +11,11 @@ import torch.nn.functional as F
 from torch import distributed as dist
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.fully_sharded_data_parallel import (
+    FlatParameter,
     FullyShardedDataParallel,
+    OptimStateKeyType,
     ShardingStrategy,
+    StateDictType,
     _ExecOrderPolicy,
 )
 from torch.nn.parallel.distributed import DistributedDataParallel
@@ -36,6 +39,14 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
+# TODO (awgu): refactor with `test_fsdp_state_dict.py`
+_UNFLATTENED_STATE_DICT_IMPLS = ["state_dict", "sharded_state_dict"]
+STATE_DICT_MAPPING = {
+    "state_dict": StateDictType.FULL_STATE_DICT,
+    "local_state_dict": StateDictType.LOCAL_STATE_DICT,
+    "sharded_state_dict": StateDictType.SHARDED_STATE_DICT,
+}
+
 
 class CNN(nn.Module):
     def __init__(self) -> None:
@@ -56,57 +67,167 @@ class CNN(nn.Module):
         x = self.fc3(x)
         return x
 
+    @staticmethod
+    def get_inp_shape() -> torch.Size:
+        return torch.Size([4, 3, 32, 32])  # (N, C, H, W)
 
 class TestFSDPExecOrderPolicy(FSDPTest):
-    def _test_parity_with_ddp(
-        self,
-        model_ctor,
-        bucket_size: int,
-        num_iters: int,
-        num_warmup_iters: int,
-    ):
+    def _init_fsdp_ddp(self, model_class, optim_class, *model_args, **model_kwargs):
         torch.manual_seed(42)
-        # TODO (awgu): Add *args, **kwargs as needed to `model_ctor()`
-        model = model_ctor().cuda()
+        model = model_class(*model_args, **model_kwargs).cuda()
         group = dist.distributed_c10d._get_default_group()
 
         fsdp_model = FullyShardedDataParallel(
-            copy.deepcopy(model), group, auto_wrap_policy=_ExecOrderPolicy(bucket_size),
+            copy.deepcopy(model), group, auto_wrap_policy=_ExecOrderPolicy(0),
         )
-        fsdp_optim = torch.optim.Adam(fsdp_model.parameters(), lr=1e-3)
+        fsdp_optim = optim_class(fsdp_model.parameters(), lr=1e-3)
         ddp_model = DistributedDataParallel(model, device_ids=[self.rank], process_group=group)
-        ddp_optim = torch.optim.Adam(ddp_model.parameters(), lr=1e-3)
+        ddp_optim = optim_class(ddp_model.parameters(), lr=1e-3)
+        return fsdp_model, fsdp_optim, ddp_model, ddp_optim
 
+    def _warmup_fsdp(self, fsdp_model, optim_class, inp_shape, num_warmup_iters: int = 1):
         for _ in range(num_warmup_iters):
-            inp = torch.randn((4, 3, 32, 32)).to(self.rank)
-            out = fsdp_model(inp)
-            loss = out.sum()
-            loss.backward()
-            # No optimizer step to keep model parameters unchanged
-        # Reset gradients and optimizer for new `FlatParameter`s
-        fsdp_model.zero_grad(set_to_none=True)
-        fsdp_optim = torch.optim.Adam(fsdp_model.parameters(), lr=1e-3)
+            inp = torch.randn(inp_shape).to(self.rank)
+            # No optimizer step to keep the model parameters unchanged
+            self._step_model(fsdp_model, inp)
+        # Reset gradients and construct new optimizer
+        fsdp_model.zero_grad(set_to_none=True)  # TODO (awgu): unnecessary with current implementation
+        return optim_class(fsdp_model.parameters(), lr=1e-3)
 
+    def _check_fsdp_param_parity(self, fsdp_model, ref_model):
         with FSDP.summon_full_params(fsdp_model):
-            for p1, p2 in zip(fsdp_model.parameters(), ddp_model.parameters()):
-                torch.testing.assert_close(p1, p2)
+            for p1, p2 in zip(fsdp_model.parameters(), ref_model.parameters()):
+                torch.testing.assert_close(p1, p2, rtol=1e-4, atol=1e-4)
 
+    def _step_model(self, model, inp, optim=None):
+        if optim is not None:
+            optim.zero_grad()
+        out = model(inp)
+        loss = out.sum()
+        loss.backward()
+        if optim is not None:
+            optim.step()
+        return loss
+
+    def _check_fsdp_train_parity(
+        self,
+        fsdp_model: FullyShardedDataParallel,
+        fsdp_optim: torch.optim.Optimizer,
+        ref_model: nn.Module,
+        ref_optim: torch.optim.Optimizer,
+        inp_shape: torch.Size,
+        num_iters: int,
+    ):
+        """Checks that FSDP model parameters match those of the reference,
+        trains both for a few iterations, and checks that the losses and
+        parameters match."""
+        self._check_fsdp_param_parity(fsdp_model, ref_model)
+        losses: List[List[torch.Tensor]] = []
         for _ in range(num_iters):
-            inp = torch.randn((4, 3, 32, 32)).to(self.rank)
-            iter_losses = []
-            for model, optim in ((fsdp_model, fsdp_optim), (ddp_model, ddp_optim)):
-                optim.zero_grad()
-                out = model(inp)
-                loss = out.sum()
-                iter_losses.append(loss.item())
-                loss.backward()
-                optim.step()
-            self.assertEqual(iter_losses[0], iter_losses[1])
+            inp = torch.randn(inp_shape).to(self.rank)
+            iter_losses = [
+                self._step_model(fsdp_model, inp, fsdp_optim),
+                self._step_model(ref_model, inp, ref_optim),
+            ]
+            losses.append(iter_losses)        
+        for l1, l2 in losses:
+            self.assertEqual(l1.item(), l2.item())
+        self._check_fsdp_param_parity(fsdp_model, ref_model)
+
+    def _strip_module_prefix(self, optim_state_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Strips the prefix "module." from the parameter name keys in
+        ``optim_state_dict``. The prefix arises from wrapping a model with DDP.
+
+        Args:
+            optim_state_dict (Dict[str, Any]): Optimizer state dict from an
+                optimizer used for a DDP model that has been rekeyed to
+                parameter names.
+        """
+        new_osd = {"state": {}, "param_groups": []}
+        prefix = "module."
+        for param_name, param_state in optim_state_dict["state"].items():
+            assert param_name.startswith(prefix)
+            new_osd["state"][param_name.lstrip(prefix)] = param_state
+        for param_group in optim_state_dict["param_groups"]:
+            new_params = []
+            for param_name in param_group["params"]:
+                assert param_name.startswith(prefix)
+                new_params.append(param_name.lstrip(prefix))
+            new_param_group = copy.copy(param_group)
+            new_param_group["params"] = new_params
+            new_osd["param_groups"].append(new_param_group)
+        return new_osd
 
     @skip_if_lt_x_gpu(2)
-    @parametrize("bucket_size", [0])
-    def test_fwd_bwd(self, bucket_size: int):
-        self._test_parity_with_ddp(CNN, bucket_size, 3, 1)
+    def test_pre_warmup(self):
+        """Tests that on the FSDP model is constructed with one original
+        parameter per ``FlatParameter``."""
+        model_class = CNN
+        optim_class = torch.optim.Adam
+        fsdp_model, _, ddp_model, _ = self._init_fsdp_ddp(
+            model_class, optim_class,
+        )
+        num_ddp_params = len(list(ddp_model.parameters()))
+        num_fsdp_params = 0
+        for param in fsdp_model.parameters():
+            self.assertTrue(isinstance(param, FlatParameter))
+            self.assertEqual(param._num_params, 1)
+            num_fsdp_params += 1
+        self.assertEqual(num_ddp_params, num_fsdp_params)
+
+    @skip_if_lt_x_gpu(2)
+    def test_train(self):
+        """Tests training parity with DDP."""
+        model_class = CNN
+        optim_class = torch.optim.Adam
+        num_iters = 5
+        fsdp_model, fsdp_optim, ddp_model, ddp_optim = self._init_fsdp_ddp(
+            model_class, optim_class,
+        )
+        inp_shape = model_class.get_inp_shape()
+        fsdp_optim = self._warmup_fsdp(fsdp_model, optim_class, inp_shape)
+        
+        self._check_fsdp_train_parity(
+            fsdp_model, fsdp_optim, ddp_model, ddp_optim, inp_shape, num_iters,
+        )
+
+    # TODO (awgu): `_sharded_pre_load_state_dict_hook()` needs some work to
+    # support non-recursive wrapping
+    @skip_if_lt_x_gpu(2)
+    @parametrize("model_state_dict_type", ["state_dict"])
+    def test_train_with_full_state_dict(self, model_state_dict_type: str):
+        """Tests training parity with DDP when loading FSDP from a full state
+        dict (for both model and optimizer)."""
+        num_iters = 5
+        model_class = CNN
+        optim_class = torch.optim.Adam
+        fsdp_model, fsdp_optim, ddp_model, ddp_optim = self._init_fsdp_ddp(
+            model_class,optim_class,
+        )
+        inp_shape = model_class.get_inp_shape()
+        fsdp_optim = self._warmup_fsdp(fsdp_model, optim_class, inp_shape)
+        # Run the DDP model for a few iterations
+        for _ in range(num_iters):
+            inp = torch.randn(inp_shape).to(self.rank)
+            self._step_model(ddp_model, inp, ddp_optim)
+        # Load model state dict from DDP to FSDP
+        ddp_state_dict = ddp_model.module.state_dict()
+        with FSDP.state_dict_type(fsdp_model, STATE_DICT_MAPPING[model_state_dict_type]):
+            fsdp_model.load_state_dict(ddp_state_dict)
+        # Load optim state dict from DDP to FSDP
+        ddp_optim_state_dict = self._strip_module_prefix(
+            FSDP.rekey_optim_state_dict(
+                ddp_optim.state_dict(), OptimStateKeyType.PARAM_NAME, ddp_model,
+            )
+        )
+        fsdp_optim.load_state_dict(
+            FSDP.shard_full_optim_state_dict(ddp_optim_state_dict, fsdp_model),
+        )
+        # Run both models and check parity
+        self._check_fsdp_train_parity(
+            fsdp_model, fsdp_optim, ddp_model, ddp_optim, inp_shape, num_iters,
+        )
 
 
 instantiate_parametrized_tests(TestFSDPExecOrderPolicy)

--- a/test/distributed/fsdp/test_fsdp_exec_order_policy.py
+++ b/test/distributed/fsdp/test_fsdp_exec_order_policy.py
@@ -1,0 +1,131 @@
+# Owner(s): ["oncall: distributed"]
+
+import copy
+import sys
+import warnings
+from contextlib import suppress
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import distributed as dist
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.fully_sharded_data_parallel import (
+    FullyShardedDataParallel,
+    ShardingStrategy,
+    _ExecOrderPolicy,
+)
+from torch.nn.parallel.distributed import DistributedDataParallel
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import FSDPTest
+from torch.testing._internal.common_utils import (
+    TEST_WITH_DEV_DBG_ASAN,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
+
+if not dist.is_available():
+    print("Distributed not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+if TEST_WITH_DEV_DBG_ASAN:
+    print(
+        "Skip dev-asan as torch + multiprocessing spawn have known issues",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+
+class CNN(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = torch.flatten(x, 1) # flatten all dimensions except batch
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+class TestFSDPExecOrderPolicy(FSDPTest):
+    def _test_parity_with_ddp(
+        self,
+        model_ctor,
+        bucket_size: int,
+        num_iters: int,
+    ):
+        torch.manual_seed(42)
+        # TODO (awgu): Add *args, **kwargs as needed to `model_ctor()`
+        model = model_ctor().cuda()
+        group = dist.distributed_c10d._get_default_group()
+
+        fsdp_model = FullyShardedDataParallel(
+            copy.deepcopy(model), group, auto_wrap_policy=_ExecOrderPolicy(bucket_size),
+        )
+        fsdp_optim = torch.optim.Adam(fsdp_model.parameters(), lr=1e-3)
+        ddp_model = DistributedDataParallel(model, device_ids=[self.rank], process_group=group)
+        ddp_optim = torch.optim.Adam(ddp_model.parameters(), lr=1e-3)
+
+        for _ in range(num_iters):
+            inp = torch.randn((4, 3, 32, 32)).to(self.rank)
+            iter_losses = []
+            for model, optim in ((fsdp_model, fsdp_optim), (ddp_model, ddp_optim)):
+                optim.zero_grad()
+                out = model(inp)
+                loss = out.sum()
+                iter_losses.append(loss.item())
+                loss.backward()
+                optim.step()
+            self.assertEqual(iter_losses[0], iter_losses[1])
+
+
+
+
+
+    @skip_if_lt_x_gpu(2)
+    def test_constructor(self):
+        group = dist.distributed_c10d._get_default_group()
+        model = self._get_nonwrapped_model(group).cuda()
+        fsdp_model = FSDP(model, group, auto_wrap_policy=_ExecOrderPolicy(4e3))
+        print(f"[Rank {self.rank}] printing parameters!")
+        for param_name, param in fsdp_model.named_parameters():
+            print(f"[Rank {self.rank}] {param_name} {param.shape}")
+
+    @skip_if_lt_x_gpu(2)
+    def test_fwd_bwd(self):
+        self._test_parity_with_ddp(CNN, 1e2, 3)
+        # group = dist.distributed_c10d._get_default_group()
+        # model = self._get_nonwrapped_model(group).cuda()
+        # fsdp_model = FSDP(model, group, auto_wrap_policy=_ExecOrderPolicy(4e3))
+        # # model = torch.nn.Sequential(
+        # #     torch.nn.Linear(2, 3),
+        # #     torch.nn.ReLU(),
+        # #     torch.nn.Sequential(torch.nn.Linear(3, 2)),
+        # # )
+        # # fsdp_model = FSDP(model.cuda(), group, auto_wrap_policy=_ExecOrderPolicy(1))
+        # optim = torch.optim.Adam(list(fsdp_model.parameters()), lr=1e-3)
+        # # module = fsdp_model.module
+        # device = torch.device("cuda")
+        # for _ in range(3):
+        #     inp = fsdp_model.module.get_input(device)
+        #     output = fsdp_model(*inp)
+        #     # inp = (torch.randn((8, 2)).to(device),)
+        #     # loss = module.get_loss(inp, output).to(device)
+        #     # module.run_backward(loss)
+        #     loss = output.sum()
+        #     loss.backward()
+        #     optim.step()
+
+
+instantiate_parametrized_tests(TestFSDPExecOrderPolicy)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/fsdp/test_fsdp_exec_order_policy.py
+++ b/test/distributed/fsdp/test_fsdp_exec_order_policy.py
@@ -86,19 +86,6 @@ class TestFSDPExecOrderPolicy(FSDPTest):
                 optim.step()
             self.assertEqual(iter_losses[0], iter_losses[1])
 
-
-
-
-
-    @skip_if_lt_x_gpu(2)
-    def test_constructor(self):
-        group = dist.distributed_c10d._get_default_group()
-        model = self._get_nonwrapped_model(group).cuda()
-        fsdp_model = FSDP(model, group, auto_wrap_policy=_ExecOrderPolicy(4e3))
-        print(f"[Rank {self.rank}] printing parameters!")
-        for param_name, param in fsdp_model.named_parameters():
-            print(f"[Rank {self.rank}] {param_name} {param.shape}")
-
     @skip_if_lt_x_gpu(2)
     def test_fwd_bwd(self):
         self._test_parity_with_ddp(CNN, 1e2, 3)

--- a/test/distributed/fsdp/test_fsdp_summon_full_params.py
+++ b/test/distributed/fsdp/test_fsdp_summon_full_params.py
@@ -7,25 +7,26 @@ from copy import deepcopy
 import torch
 import torch.nn as nn
 from torch import distributed as dist
-from torch.distributed.fsdp import CPUOffload, MixedPrecision
-from torch.distributed.fsdp import FlatParameter
+from torch.distributed.fsdp import CPUOffload, FlatParamHandle
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel
-from torch.distributed.fsdp.wrap import wrap, enable_wrap
+from torch.distributed.fsdp import MixedPrecision
+from torch.distributed.fsdp.fully_sharded_data_parallel import (
+    FullyShardedDataParallel,
+)
+from torch.distributed.fsdp.wrap import enable_wrap, wrap
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
+    DeterministicModel,
     FSDPInitMode,
     FSDPTest,
     NestedWrappedModule,
-    DeterministicModel,
 )
 from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
-    run_tests,
     instantiate_parametrized_tests,
     parametrize,
+    run_tests,
 )
-
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -146,7 +147,7 @@ class TestSummonFullParams(FSDPTest):
         with model.summon_full_params(model):
             self.assertEqual(raw_model_size, self.get_model_param_count(model))
             parameters = list(model.parameters())
-            all_shards = FlatParameter(parameters, requires_grad=False)
+            all_shards = FlatParamHandle.flatten_params(parameters, requires_grad=False)
             my_slice = torch.chunk(all_shards, self.world_size)[self.rank]
 
             # shards are padded but the full_param tensor is not

--- a/torch/distributed/fsdp/__init__.py
+++ b/torch/distributed/fsdp/__init__.py
@@ -1,4 +1,4 @@
-from .flatten_params_wrapper import FlatParameter
+from .flatten_params_wrapper import FlatParameter, FlatParamHandle
 from .fully_sharded_data_parallel import FullyShardedDataParallel
 from .fully_sharded_data_parallel import (
     CPUOffload,

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -108,6 +108,9 @@ class FlatParameter(nn.Parameter):
             construct this flattened parameter via :class:`FlatParamHandle`;
             the prefixed names are guaranteed to be unique within the subtree
             rooted in that module.
+        _num_params (int): Number of parameters flattened into this flattened
+            parameter; this is the length of ``_param_infos``, ``_numels``,
+            ``_shapes``, and ``_prefixed_param_names``.
         _shared_param_infos (Tuple[SharedParamInfo, ...]): Shared parameter
             info entries; see :class:`SharedParamInfo`.
 
@@ -163,6 +166,7 @@ class FlatParameter(nn.Parameter):
         assert len(param_infos) == len(numels)
         assert len(param_infos) == len(shapes)
         assert len(param_infos) == len(prefixed_param_names)
+        self._num_params = len(param_infos)
         self._param_infos = tuple(param_infos)
         self._numels = tuple(numels)
         self._shapes = tuple(shapes)

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -1,0 +1,522 @@
+import contextlib
+from itertools import accumulate
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Iterable,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from ._utils import _apply_to_modules
+
+
+class ParamInfo(NamedTuple):
+    """Information for an original module parameter."""
+    # TODO (awgu): uncomment for multiple parameter groups
+    # param: nn.Parameter
+    param_name: str  # unprefixed
+    module: nn.Module
+    module_name: str
+
+
+class SharedParamInfo(NamedTuple):
+    """
+    Additional information for a shared parameter.
+
+    For each shared parameter, we designate one module and its parameter
+    variable to be the primary owner, determined as the first one encountered
+    in the parameter walk. These are prefixed with "prim". The primary module
+    and parameter do not have their own :class:`SharedParamInfo` instance.
+    """
+    # TODO (awgu): uncomment for multiple parameter groups
+    # param: nn.Parameter
+    param_name: str  # unprefixed
+    module: nn.Module
+    module_name: str
+    prim_param_name: str  # unprefixed
+    prim_module: nn.Module
+    prim_module_name: str
+
+
+class FlatParamShardMetadata(NamedTuple):
+    """
+    This holds metadata specific to this rank's shard of the flattened
+    parameter.
+
+    Attributes:
+        param_names (Tuple[str, ...]): Prefixed parameter names of this rank's
+            shard of the parameters; see :class:`FlatParameter`.
+        param_shapes (Tuple[torch.Size, ...]): Parameter shapes of this rank's
+            shard of the parameters; see :class:`FlatParameter`.
+        param_numels (Tuple[int, ...]): Parameter numels of this rank's shard
+            of the parameters; see :class:`FlatParameter`.
+        param_offsets (Tuple[Tuple[int, int], ...]): [start, end] offsets (in
+            units of numels) giving this rank's part of each flattened
+            original module parameter.
+    """
+    param_names: Tuple[str, ...]
+    param_shapes: Tuple[torch.Size, ...]
+    param_numels: Tuple[int, ...]
+    param_offsets: Tuple[Tuple[int, int], ...]
+
+
+class FlatParameter(nn.Parameter):
+    """
+    This is the flattened parameter used by :class:`FullyShardedDataParallel`.
+    It is comprised of one or more original parameters, which are flattened
+    and concatenated to construct the flattened parameter.
+
+    Under the current design, this parameter logically represents both the
+    unsharded and sharded flattened parameter, and its data changes storages
+    dynamically.
+        - In the :class:`FullyShardedDataParallel` constructor, the parameter
+        is initialized as unsharded and then sharded in-place.
+        - At runtime, the parameter is lazily (re)-initialized. The sharded
+        parameter data is saved in ``self._local_shard``, and a new ``Tensor``
+        ``self._full_param_padded`` is created, which is the all-gather
+        destination and owns the unsharded parameter storage thereafter. (See
+        :meth:`FullyShardedDataParallel._init_param_attributes`.)
+        - Throughout runtime, the parameter data changes storages as needed,
+        e.g. to the sharded flattened parameter, reduced-precision sharded
+        flattened parameter, or the unsharded flattened parameter.
+
+    TODO (awgu): Investigate the need for pickling support.
+
+    Attributes:
+        _is_sharded (bool): Whether the flattened parameter is *ever* sharded
+            across ranks (not whether it is *currently* sharded).
+        _unsharded_size (torch.Size): Unsharded flattened parameter's size.
+
+        _param_infos (Tuple[ParamInfo, ...]): Each parameter's parameter info
+            entry; see :class:`ParamInfo`.
+        _numels (Tuple[int, ...]): Each parameter's numel.
+        _shapes (Tuple[torch.Size, ...]): Each parameter's shape.
+        _prefixed_param_names (Tuple[str, ...]): Each parameter's name prefixed
+            with the parent module names starting from the module passed to
+            construct this flattened parameter via :class:`FlatParamHandle`;
+            the prefixed names are guaranteed to be unique within the subtree
+            rooted in that module.
+        _shared_param_infos (Tuple[SharedParamInfo, ...]): Shared parameter
+            info entries; see :class:`SharedParamInfo`.
+
+        _shard_param_offsets (List[Tuple[int, int])): [start, end] offsets (in
+            units of numel) giving this rank's part of each flattened original
+            module parameter; for any parameter ``p`` that is not sharded
+            across ranks, this will be [0, ``p.numel()``-1].
+        _shard_indices (Tuple[int, int]): [start, end] indices (in units of
+            parameters) for this rank's shard of the original model parameters,
+            where the parameters follow the order in which they were originally
+            flattened; this indexes appropriately into any data structure that
+            follows the flattening order (e.g. ``_param_infos``, ``_numels``,
+            etc.).
+        _shard_numel_padded (int): Numel padded for this rank's sharded
+            flattened parameter.
+
+        _local_shard (Tensor):
+        _full_param_padded (Tensor):
+        _shard_bwd_hook (Tuple[AccumulateGrad, RemovableHandle]):
+
+        _mp_shard (Tensor):
+        _cpu_grad (Tensor):
+        _saved_grad_shard (Tensor):
+    """
+    ...
+
+    def init_metadata(
+        self,
+        param_infos: List[ParamInfo],
+        numels: List[int],
+        shapes: List[torch.Size],
+        prefixed_param_names: List[str],
+        shared_param_infos: List[SharedParamInfo],
+    ) -> None:
+        """
+        Initializes attributes holding metadata about the original parameters
+        comprising the flattened parameter.
+
+        We expose this method separate from the constructor to keep the
+        constructor only responsible for the flattened parameter's tensor data.
+        This method should only be called once per model, while the constructor
+        may be called multiple times, e.g. when reloading from a checkpoint, in
+        which case only the tensor data needs to be passed to the constructor.
+        Since :meth:`load_state_dict` is implemented via :meth:`copy_`, the
+        metadata is correctly assumed to be unchanged.
+
+        Args:
+            See the Attributes in the class docstring.
+        """
+        assert len(param_infos) == len(numels)
+        assert len(param_infos) == len(shapes)
+        assert len(param_infos) == len(prefixed_param_names)
+        self._param_infos = tuple(param_infos)
+        self._numels = tuple(numels)
+        self._shapes = tuple(shapes)
+        self._prefixed_param_names = tuple(prefixed_param_names)
+        self._shared_param_infos = tuple(shared_param_infos)
+
+    @property
+    def _flat_param_name(self) -> str:
+        return ",".join(self._prefixed_param_names).replace(".", "_")
+
+    def _get_debug_name(self) -> str:
+        # TODO (awgu): Very useful for debugging since we can see all the of
+        # the prefixed parameter names of this `FlatParameter`; we may make
+        # this into a real method later
+        return f"{[n for n in self._prefixed_param_names]}"
+
+
+class FlatParamHandle:
+    """
+    This handle manages a flattened parameter (:class:`FlatParameter`).
+
+    Args:
+        params (Sequence[nn.Parameter]): The parameters to use for the
+                flattened parameter.
+        module (nn.Module): A module that is the root of the subtree containing
+            all parameters in ``params``; for non-recursive wrapping, this must
+            be the top-level module, while for recursive wrapping, this may not
+            be the top-level module.
+    """
+    def __init__(
+        self,
+        params: Sequence[nn.Parameter],
+        module: nn.Module,
+    ) -> None:
+        super().__init__()
+        self._init_flat_param(module, params)
+        self._unflatten(as_params=False)
+
+    def _init_flat_param(
+        self,
+        module: nn.Module,
+        params: Sequence[Optional[nn.Parameter]],
+    ) -> None:
+        """
+        Initializes the flattened parameter ``self.flat_param`` by flattening
+        the parameters in ``params`` into a single :class:`FlatParameter` and
+        saves relevant metadata. Shared parameters are only included into the
+        flattened parameter once.
+
+        This checks that all comprising parameters have the same dtype and
+        ``requires_grad`` and does not support nested construction of
+        :class:`FlatParameter` s.
+
+        Args:
+            See the Args in the class docstring.
+        """
+        params_set = set(params)
+        params_set.discard(None)
+        assert len(params_set) > 0
+        param_infos: List[ParamInfo] = []
+        numels: List[int] = []
+        shapes: List[torch.Size] = []
+        prefixed_param_names: List[str] = []
+        shared_param_infos: List[SharedParamInfo] = []
+        shared_param_memo: Dict[nn.Parameter, Tuple[nn.Module, str, str]] = {}
+        params_to_flatten: List[nn.Parameter] = []
+        dtype: Optional[torch.dtype] = None
+        requires_grad: Optional[bool] = None
+        param_to_param_name = _get_param_to_param_name(module)
+        for submodule_name, submodule in module.named_modules():
+            for param_name, param in submodule.named_parameters(recurse=False):
+                if param not in params_set:
+                    continue
+                if param in shared_param_memo:
+                    prim_module, prim_module_name, prim_param_name = shared_param_memo[param]
+                    shared_param_infos.append(SharedParamInfo(
+                        # param,  TODO (awgu): uncomment for multiple parameter groups
+                        param_name, submodule, submodule_name,
+                        prim_param_name, prim_module, prim_module_name,
+                    ))
+                else:
+                    if isinstance(param, FlatParameter):
+                        raise ValueError("`FlatParameter` does not support nesting")
+                    if not isinstance(param, torch.Tensor):
+                        raise ValueError("Elements of `params` must have type `Tensor`")
+                    if dtype is not None and param.dtype != dtype:
+                        raise ValueError(
+                            "`FlatParameter` requires uniform dtype but got "
+                            f"{dtype} and {param.dtype}"
+                        )
+                    if requires_grad is not None and param.requires_grad != requires_grad:
+                        raise ValueError("`FlatParameter` requires uniform `requires_grad`")
+                    dtype = param.dtype
+                    requires_grad = param.requires_grad
+                    # prefixed_param_name = ".".join([submodule_name, param_name]) \
+                    #     if submodule_name else param_name
+                    shared_param_memo[param] = (submodule, submodule_name, param_name)
+                    params_to_flatten.append(param)
+                    param_infos.append(ParamInfo(
+                        # param,  TODO (awgu): uncomment for multiple parameter groups
+                        param_name, submodule, submodule_name,
+                    ))
+                    numels.append(param.numel())
+                    shapes.append(param.shape)
+                    prefixed_param_names.append(param_to_param_name[param])
+        assert requires_grad is not None
+        self.flat_param = FlatParamHandle.flatten_params(params_to_flatten, requires_grad)
+        self.flat_param.init_metadata(param_infos, numels, shapes, prefixed_param_names, shared_param_infos)
+
+    @staticmethod
+    def flatten_params(
+        params: Sequence[torch.Tensor],
+        requires_grad: bool,
+    ) -> FlatParameter:
+        """
+        Flattens the parameters in ``params`` into a single
+        :class:`FlatParameter`. This should be the only way used to construct
+        :class:`FlatParameter` s.
+
+        We expose this factory method for checkpointing (e.g. sharded state
+        dict). The flattened parameter's metadata should only be initialized
+        once (see :meth:`init_metadata`), but its tensor data may be reloaded.
+        """
+        with torch.no_grad():
+            flat_params = [
+                p.detach().reshape(-1) if isinstance(p, nn.Parameter)
+                else p.reshape(-1) for p in params
+            ]
+            flat_param_data = torch.cat(flat_params, dim=0)
+        flat_param = FlatParameter(flat_param_data, requires_grad=requires_grad)
+        flat_param._is_sharded = False
+        flat_param._unsharded_size = flat_param.size()
+        return flat_param
+
+    @staticmethod
+    def _get_unflat_views(
+        flat_param: FlatParameter,
+        tensor: Optional[torch.Tensor] = None,
+    ) -> Iterator[Tensor]:
+        """
+        Returns unflattened ``Tensor`` views into ``tensor`` if it is not
+        ``None`` or ``flat_param`` otherwise based on ``flat_param`` 's
+        metadata. In other words, to get views into the unsharded flattened
+        parameter, pass ``tensor`` as ``None``, but to get views into tensor
+        optimizer state, pass ``tensor`` as the optimizer state tensor.
+        """
+        if tensor is None:
+            tensor = flat_param
+        assert tensor.numel() == flat_param._unsharded_size.numel(), \
+            f"Expects {flat_param._unsharded_size.numel()} numel but got " \
+            f"{tensor.numel()} numel"
+        views = (
+            tensor.view(shape) for (tensor, shape) in
+            zip(torch.split(tensor, flat_param._numels, dim=0), flat_param._shapes)
+        )
+        return views
+
+    def _unflatten(self, as_params: bool) -> None:
+        """
+        Unflattens the unsharded flattened parameter by setting the original
+        module parameter variables to be views into it.
+
+        Args:
+            as_params (bool): If ``True``, then registers the original
+                parameters as ``nn.Parameter`` s; if ``False``, then registers
+                the original parameters only as ``Tensor`` s. ``False`` should
+                be used during forward/backward computation and when hiding the
+                original parameters from ``named_parameters()``.
+        """
+        views = self._get_unflat_views(self.flat_param)
+        for view, (param_name, module, _) in zip(views, self.flat_param._param_infos):
+            if hasattr(module, param_name):
+                delattr(module, param_name)
+            if as_params:
+                # TODO (awgu): Change to this for multiple parameter groups
+                # setattr(module, param_name, param)
+                # param.data = view
+                module.register_parameter(param_name, nn.Parameter(view))
+            else:
+                setattr(module, param_name, view)
+        for (param_name, module, _, prim_param_name, prim_module, _) in self.flat_param._shared_param_infos:
+            if hasattr(module, param_name):
+                delattr(module, param_name)
+            assert hasattr(prim_module, prim_param_name)
+            param: Union[Tensor, nn.Parameter] = getattr(prim_module, prim_param_name)
+            if as_params:
+                # TODO (awgu): Change to this for multiple parameter groups
+                # setattr(module, param_name, param)
+                # param.data = view
+                module.register_parameter(param_name, param)
+            else:
+                setattr(module, param_name, param)
+
+    @contextlib.contextmanager
+    def unflatten_as_params(self) -> Generator:
+        """
+        Assumes the flattened parameter is unsharded. When in the context,
+        unflattens the original parameters as ``nn.Parameter`` views into the
+        flattened parameter, and after the context, restores the original
+        parameters as ``Tensor`` views into the flattened parameter.
+        """
+        self._unflatten(as_params=True)
+        try:
+            yield
+        finally:
+            self._unflatten(as_params=False)
+
+    def init_shard_metadata(
+        self,
+        sharded_flat_param_numel: int,
+        numel_padded: int,
+        rank: int,
+    ) -> None:
+        """
+        Initializes metadata for this rank's shard of the flattened parameter:
+        ``_shard_param_offsets``, ``_shard_indices``, and
+        ``_shard_numel_padded``.
+
+        Args:
+            sharded_flat_param_numel (int): Numel of this rank's sharded
+                flattened parameter.
+            numel_padded (int): Numel padded for this rank's sharded flattened
+                parameter.
+            rank (int): Caller's rank.
+        """
+        if numel_padded > sharded_flat_param_numel:
+            raise ValueError(
+                f"Sharded flattened parameter with {sharded_flat_param_numel} "
+                f"numel cannot have {numel_padded} numel padded"
+            )
+        start = sharded_flat_param_numel * rank
+        end = sharded_flat_param_numel * (rank + 1) - 1  # inclusive
+        self.flat_param._shard_param_offsets, self.flat_param._shard_indices = \
+            self._get_shard_metadata(start, end)
+        self.flat_param._shard_numel_padded = numel_padded
+
+    def _get_shard_metadata(
+        self,
+        start: int,
+        end: int,
+    ) -> Tuple[Tuple[Tuple[int, int], ...], Tuple[int, int]]:
+        """
+        Computes the shard metadata based on ``start`` and ``end``, which give
+        the closed interval of the unsharded flattened parameter specifying the
+        shard.
+
+        Args:
+            start (int): Start index (in units of numel) of this rank's shard
+                of the flattened parameter.
+            end (int): End index (in units of numel and inclusive) of this
+                rank's shard of the flattened parameter.
+
+        Return:
+            Tuple[Tuple[Tuple[int, int], ...], Tuple[int, int]]: See
+            ``_shard_param_offsets`` and ``_shard_indices`` in
+            :class:`FlatParameter` 's docstring.
+        """
+        flat_param_offsets = self._get_flat_param_offsets()
+        # Indices of the original parameters in this rank's sharded flattened
+        # parameter
+        shard_param_indices_range = []  # elements will be consecutive
+        # [start, end] offsets giving this rank's part of the flattened
+        # original module parameter (which will be [0, `p.numel()`-1] for any
+        # parameter that is not sharded across ranks)
+        shard_intra_param_offsets = []
+        for i, (param_start, param_end) in enumerate(flat_param_offsets):
+            if start > param_end or end < param_start:
+                continue
+            if start <= param_start:
+                intra_param_start = 0
+            else:
+                intra_param_start = start - param_start
+            intra_param_end = min(param_end, end) - param_start
+            shard_param_indices_range.append(i)
+            shard_intra_param_offsets.append((intra_param_start, intra_param_end))  # both inclusive
+        if len(shard_param_indices_range) == 0:
+            shard_param_indices = (0, 0)
+            assert len(shard_intra_param_offsets) == 0
+        else:
+            shard_param_indices = (
+                shard_param_indices_range[0], shard_param_indices_range[-1],
+            )
+            assert len(shard_intra_param_offsets) == \
+                shard_param_indices[-1] - shard_param_indices[0] + 1
+        return tuple(shard_intra_param_offsets), shard_param_indices
+
+    def _get_flat_param_offsets(self) -> List[Tuple[int, int]]:
+        """Returns [start, end] offsets of each original parameter's flattened
+        data in the unsharded flattened parameter (without padding)."""
+        cumulative_sum = list(accumulate(self.flat_param._numels))
+        starts = [0] + cumulative_sum[:-1]
+        ends = [end - 1 for end in cumulative_sum]  # inclusive
+        param_offsets = list(zip(starts, ends))
+        return param_offsets
+
+    def shard_metadata(
+        self,
+    ) -> FlatParamShardMetadata:
+        """Returns metadata specific to this rank's shard of the flattened
+        parameter."""
+        # TODO (awgu): This seems to only be used for testing. Should we make
+        # this method private?
+        shard_param_start_index = self.flat_param._shard_indices[0]
+        shard_param_end_index = self.flat_param._shard_indices[1]  # inclusive
+        sl = slice(shard_param_start_index, shard_param_end_index + 1) \
+            if shard_param_start_index <= shard_param_end_index else slice(0, 0)
+        return FlatParamShardMetadata(
+            self.flat_param._prefixed_param_names[sl],
+            self.flat_param._shapes[sl],
+            self.flat_param._numels[sl],
+            self.flat_param._shard_param_offsets[:],
+        )
+
+    def _get_modules(self) -> Set[nn.Module]:
+        """Returns a :class:`set` of the modules whose parameters are included
+        in this handle's flattened parameter."""
+        return set(pi.module for pi in self.flat_param._param_infos).union(
+            set(spi.module for spi in self.flat_param._shared_param_infos)
+        )
+
+    def _get_flat_param_name(self) -> str:
+        """
+        TODO (awgu): Use this for now..
+        dedup with ``_get_debug_name()``
+        """
+        return self.flat_param._flat_param_name
+
+
+# TODO (awgu): refactor with FSDP?
+def _get_param_to_param_name(
+    model: torch.nn.Module,
+) -> Dict[torch.nn.Parameter, List[str]]:
+    """
+    Constructs a mapping from flattened parameter (including non-FSDP-module
+    parameters) to its unflattened parameter names. For non-FSDP-module
+    parameters, these mapped-to lists always contain a single element. The
+    unflattened parameter names should match the keys of the model state dict.
+
+    For shared parameters, only the first parameter name is included (following
+    the ``torch.nn.Module.parameters()`` order).
+
+    Args:
+        model (torch.nn.Module): Root module (which may or may not be a
+            :class:`FullyShardedDataParallel` instance).
+        dedup_shared_params (bool): If ``True``, only includes the first
+            list of unflattened parameter names corresponding to a parameter
+            in the module walk order; if ``False``, then includes all of the
+            unflattened parameter names.
+    """
+    def module_fn(module, prefix, param_to_param_name):
+        for param_name, param in module.named_parameters(recurse=False):
+            param_to_param_name[param] = prefix + param_name
+
+    def return_fn(param_to_param_name):
+        return param_to_param_name
+
+    param_to_param_name: Dict[nn.Parameter, str] = {}
+    return _apply_to_modules(
+        model, module_fn, return_fn, param_to_param_name,
+    )

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -8,6 +8,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Sequence,
     Tuple,
     Union,
 )
@@ -16,7 +17,10 @@ import torch
 import torch.distributed as dist
 # Import the entire FSDP file to avoid circular imports
 import torch.distributed.fsdp.fully_sharded_data_parallel as FSDP
-from torch.distributed.fsdp.flatten_params_wrapper import FlatParameter
+from torch.distributed.fsdp.flatten_params_wrapper import (
+    FlatParameter,
+    FlatParamHandle,
+)
 
 
 class _ConsolidatedOptimState:
@@ -192,7 +196,7 @@ def _unflatten_communicated_optim_state(
     """
     unflat_param_state: List[Dict[str, Any]] = []
     flat_param_views: Dict[str, Iterator] = {}
-    num_unflat_params = flat_param._num_unflattened_params
+    num_unflat_params = len(flat_param._param_infos)
     tensor_state, zero_dim_tensor_state, non_tensor_state = \
         state.tensor_state, state.zero_dim_tensor_state, state.non_tensor_state
 
@@ -202,11 +206,11 @@ def _unflatten_communicated_optim_state(
         for state_name, flat_tensor in tensor_state.items():
             views_generated = state_name in flat_param_views
             if not views_generated:
-                param_views = flat_param.get_param_views(flat_tensor)
-                flat_param_views[state_name] = param_views
+                views = FlatParamHandle._get_unflat_views(flat_param, flat_tensor)
+                flat_param_views[state_name] = views
             else:
-                param_views = flat_param_views[state_name]
-            unflat_state_param[state_name] = next(param_views)
+                views = flat_param_views[state_name]
+            unflat_state_param[state_name] = next(views)
         # Add zero-dimension tensor state: take the target rank's value
         for state_name, zero_dim_tensor in zero_dim_tensor_state.items():
             unflat_state_param[state_name] = zero_dim_tensor
@@ -306,7 +310,7 @@ def _flatten_optim_state(
     assert num_unflat_params > 0, \
         "Expects at least one unflattened parameter corresponding to the " \
         "flattened parameter"
-    unflat_param_shapes = flat_param._param_shapes
+    unflat_param_shapes = flat_param._shapes
     num_unflat_param_shapes = len(unflat_param_shapes)
     assert num_unflat_params == num_unflat_param_shapes, \
         f"Expects {num_unflat_params} shapes but got {num_unflat_param_shapes}"
@@ -394,7 +398,7 @@ def _flatten_tensor_optim_state(
     state_name: str,
     pos_dim_tensors: List[torch.Tensor],
     unflat_param_names: List[str],
-    unflat_param_shapes: List[torch.Size],
+    unflat_param_shapes: Sequence[torch.Size],
     flat_param: FlatParameter,
 ) -> torch.Tensor:
     """

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -196,7 +196,7 @@ def _unflatten_communicated_optim_state(
     """
     unflat_param_state: List[Dict[str, Any]] = []
     flat_param_views: Dict[str, Iterator] = {}
-    num_unflat_params = len(flat_param._param_infos)
+    num_unflat_params = flat_param._num_params
     tensor_state, zero_dim_tensor_state, non_tensor_state = \
         state.tensor_state, state.zero_dim_tensor_state, state.non_tensor_state
 

--- a/torch/distributed/fsdp/_utils.py
+++ b/torch/distributed/fsdp/_utils.py
@@ -2,8 +2,8 @@ from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Set, Tuple, Union
 
 import torch
+import torch.nn as nn
 from torch.nn.modules.batchnorm import _BatchNorm
-
 from torch.nn.utils.rnn import PackedSequence
 
 """Useful functions to deal with tensor types with other python container types."""
@@ -67,3 +67,15 @@ def _apply_to_modules(
 
     f(root_module, "", *args, **kwargs)
     return return_fn(*args, **kwargs)
+
+
+def _get_param_from_param_name(param_name: str, module: nn.Module):
+    names = param_name.split(".")
+    assert len(names) >= 2, \
+        "Expects at least the parameter name and its immediate module's name"
+    var = module
+    for name in names:
+        assert hasattr(var, name), \
+            f"{var} is missing attribute {name} for prefixed name {param_name}"
+        var = getattr(var, name)
+    return var

--- a/torch/distributed/fsdp/_utils.py
+++ b/torch/distributed/fsdp/_utils.py
@@ -67,15 +67,3 @@ def _apply_to_modules(
 
     f(root_module, "", *args, **kwargs)
     return return_fn(*args, **kwargs)
-
-
-def _get_param_from_param_name(param_name: str, module: nn.Module):
-    names = param_name.split(".")
-    assert len(names) >= 2, \
-        "Expects at least the parameter name and its immediate module's name"
-    var = module
-    for name in names:
-        assert hasattr(var, name), \
-            f"{var} is missing attribute {name} for prefixed name {param_name}"
-        var = getattr(var, name)
-    return var

--- a/torch/distributed/fsdp/flatten_params_wrapper.py
+++ b/torch/distributed/fsdp/flatten_params_wrapper.py
@@ -23,9 +23,9 @@ from typing import (
 import torch
 import torch.nn as nn
 from torch import Tensor
-
 from torch.distributed.utils import _replace_by_prefix
 
+from ._flat_param import FlatParameter, FlatParamHandle
 
 ParamOffset = Tuple[int, int]
 SharedParamInfo = Tuple[str, str, nn.Module, str, nn.Module, str]
@@ -70,407 +70,100 @@ def _pre_load_state_dict_hook(
             _replace_by_prefix(state_dict, k, prefix + last_part)
 
 
-class ParamInfo(NamedTuple):
-    module_name: str
-    module: nn.Module
-    param_name: str
-
-
-class ShardMetadata(NamedTuple):
-    param_names: List[str]
-    param_shapes: List[torch.Size]
-    param_numels: List[int]
-    param_offsets: List[ParamOffset]
-
-
-class FlatParameter(nn.Parameter):
-    """
-    A parameter that is initialized from a list of parameters. All the
-    parameters will be flattened and concatened to form the flat parameter.
-
-    Args:
-        params (Sequence[nn.Parameter])
-            The parameters to be flattend and concatened.
-        requires_grad (bool):
-            Set to True if gradients need to be computed for this parameter,
-            False otherwise.
-    """
-
-    def __new__(
-        cls, params: Sequence[nn.Parameter], requires_grad: bool = True
-    ) -> "FlatParameter":
-        """Make an object using the parent's __new__ function."""
-
-        # A empty or non-list input doesn't make sense.
-        if not isinstance(params, (list, tuple)) or len(params) == 0:
-            raise ValueError("An non-empty list or tuple argument is needed")
-
-        # Normally, all items are Parameters. But during pickling, we will have a single
-        # Tensor as the input and later in __init__, the correct _param_numels and _param_shapes
-        # are set.
-        if not all(isinstance(p, (nn.Parameter, Tensor)) for p in params):
-            incorrect_parameters = [
-                p for p in params if not isinstance(p, (nn.Parameter, Tensor))
-            ]
-            raise ValueError(
-                f"List items need to be Parameter types {incorrect_parameters}"
-            )
-
-        # Flattening involves (1) making a tensor flat (i.e. single dimensional) and
-        # (2) making a module hierarchy flat (using a single tensor to replace a tree of
-        # tensors). Therefore, adding back nesting and hierarchy is counter-productive.
-        # If nesting is encountered in the future, the reasonable thing to do is likely
-        # for the top level FlatParameter to absorb the nested one and keep the result flat,
-        # free from hierarchy.
-        if any(isinstance(p, FlatParameter) for p in params):
-            raise ValueError("Nesting FlatParameter is not supported")
-
-        data = torch.cat(
-            [
-                p.detach().reshape(-1) if isinstance(p, nn.Parameter) else p.reshape(-1)
-                for p in params
-            ],
-            0,
-        )
-
-        return super(FlatParameter, cls).__new__(
-            cls, data, requires_grad=requires_grad
-        )  # type: ignore[call-arg]
-
-    def __init__(self, params: Sequence[nn.Parameter], requires_grad: bool = True):
-        self._is_sharded = False
-        self._param_numels = [p.numel() for p in params]
-        # The total element numbers. This is equal to the summation of the
-        # ``numel()`` of all the parameters.
-        self.full_numel = sum(self._param_numels)
-        assert self.numel() <= self.full_numel, (
-            "Parameter numbers mismatched. "
-            f"The number of elements in FlatParameter: {self.numel()} vs. "
-            f"the number of elements in original parameters: {self.full_numel}."
-        )
-        # The shapes of each individual parameter.
-        self._param_shapes = [p.size() for p in params]
-        cumulative_sum = list(accumulate(self._param_numels))
-        begin = [0] + cumulative_sum[:-1]
-        end = [e - 1 for e in cumulative_sum]
-
-        self._param_infos: List[ParamInfo] = []
-        self._shared_param_infos: List[SharedParamInfo] = []
-
-        # The element offsets (begin/end pair) in the flat parameter of each
-        # individual parameter.
-        self._param_offsets = list(zip(begin, end))
-        # The indices (begin/end pair) of the parameters that are included in
-        # this FlatParameter. The default value is all the parameters because
-        # no sharding happen yet.
-        self._param_indice_in_shard = (0, len(self._param_infos) - 1)
-        # The offsets in each parameter that is included in the FlatParameter.
-        self._sharded_param_offsets: List[ParamOffset] = [
-            (0, numel) for numel in self._param_numels
-        ]
-        # The number of padding elements.
-        self.num_padded = 0
-
-    def shard_by_offsets(self, start: int, end: int, num_padded: int) -> None:
-        assert self._is_sharded
-        if start < 0 or end < 0 or end < start:
-            raise ValueError(
-                f"Shard the flatten parameter with an invalid offset pair {(start, end)}."
-            )
-        _shard_size = end - start + 1
-        self.num_padded = num_padded
-        if self.num_padded > _shard_size:
-            raise ValueError("The number of padding is larger than the shard size.")
-        self._sharded_param_offsets.clear()
-
-        ranges = []
-        for idx, offset in enumerate(self._param_offsets):
-            if start > offset[1] or end < offset[0]:
-                continue
-            if start <= offset[0]:
-                sharded_param_start = 0
-                sharded_param_end = min(offset[1], end) - offset[0]
-            else:
-                sharded_param_start = start - offset[0]
-                sharded_param_end = min(offset[1], end) - offset[0]
-            ranges.append(idx)
-            self._sharded_param_offsets.append((sharded_param_start, sharded_param_end))
-        if ranges:
-            self._param_indice_in_shard = (ranges[0], ranges[-1])
-
-    def _offset_to_slice(self) -> slice:
-        if self._param_indice_in_shard[0] > self._param_indice_in_shard[1]:
-            return slice(0, 0)
-        return slice(self._param_indice_in_shard[0], self._param_indice_in_shard[1] + 1)
-
-    def get_param_views(
-        self, external_data: Optional[Tensor] = None
-    ) -> Iterator[Tensor]:
-        """Return a generator of views that map to the original parameters."""
-        # Note, self.data could be sharded, so its numel is <= to the sum.
-        assert (
-            self.data.numel() <= self.full_numel
-        ), f"Incorrect internal state {self.data.numel()} vs. {self.full_numel}"
-        data = external_data if external_data is not None else self
-        if data.numel() != self.full_numel:
-            raise ValueError(
-                f"Incorrect numel of supplied data: got {data.numel()} but expected {self.full_numel}"
-            )
-        return (
-            t.view(s)
-            for (t, s) in zip(data.split(self._param_numels), self._param_shapes)
-        )
-
-    @property
-    def _num_unflattened_params(self) -> int:
-        """Returns the number of unflattened parameters that comprise this
-        flattened parameter."""
-        assert hasattr(self, "_param_infos"), \
-            "`_param_infos` has not been set, meaning this `FlatParameter` " \
-            "has not been initialized yet"
-        num_unflat_params = len(self._param_infos)
-        assert num_unflat_params > 0, "`FlatParameter` corresponding to 0 " \
-            "unflattened parameters"
-        return num_unflat_params
-
-    @property
-    def param_info(self) -> List[ParamInfo]:
-        return self._param_infos
-
-    @property
-    def _param_names(self):
-        return [".".join([m, n]) if m else n for (m, _, n) in self._param_infos]
-
-    def metadata(self) -> Tuple[List[str], List[torch.Size], List[int]]:
-        """Return tuple of (names, shapes, numels) metadata for this flat parameter."""
-        return self._param_names, self._param_shapes, self._param_numels
-
-    def shard_metadata(
-        self,
-    ) -> ShardMetadata:
-        """
-        Return tuple of (names, shapes, numels) metadata for the sharded parameter
-        metadata of this flat parameter.
-        """
-        return ShardMetadata(
-            self._param_names[self._offset_to_slice()],
-            self._param_shapes[self._offset_to_slice()],
-            self._param_numels[self._offset_to_slice()],
-            self._sharded_param_offsets[:],
-        )
-
-
 class FlattenParamsWrapper(nn.Module):
     """
-    A wrapper for transparently flattening a Module's parameters.
-    The original implementation [1] reparameterizes a PyTorch module
-    that is called ReparamModule. The ReparamModule has only a flattened
-    parameter representing all parameters of the wrapped module.
-    Compared to the original implementation [1], this version:
-    - removes tracing
-    - supports shared parameters
-    - is renamed to FlattenParamsWrapper
+    This is a wrapper for flattening parameters in a ``nn.Module`` 's subtree
+    into a single flattened parameter and is based on [1]. This is used for
+    :class:`FullyShardedDataParallel` 's recursive wrapping.
     [1] https://github.com/SsnL/PyTorch-Reparam-Module
-    Args:
-        module (nn.Module):
-            The module to wrap.
-        param_list (List[nn.Parameter]):
-            Only flatten parameters appearing in the given list.
-            Note, if only a single param is in the list, it still gets
-            flattened and the original param is removed and replaced
-            with the flatten one.
-    """
 
-    def __init__(self, module: nn.Module, param_list: List[nn.Parameter]):
+    Args:
+        module (nn.Module): Module to wrap.
+        params (List[nn.Parameter]): Parameters in ``module`` 's subtree to
+            flatten into a single flattened parameter.
+        group (Optional[dist.ProcessGroup]): Process group of the
+            :class:`FullyShardedDataParallel` instance owning this wrapper.
+
+    Attributes:
+        flat_param (Optional[FlatParameter]): The flattened parameter.
+            ``flat_param`` is ``None`` either when (1) this wrapper manages no
+            parameters or (2) the wrapped module's parameters are unflattened.
+        _fpw_module (nn.Module): The wrapped module.
+        _flat_param_handle (FlatParamHandle): A handle for the flattened
+            parameter; only present if this wrapper manages parameters.
+    """
+    def __init__(
+        self,
+        module: nn.Module,
+        params: List[nn.Parameter],
+    ) -> None:
         super().__init__()
         self._fpw_module = module
-        # People may test whether this module contains parameters by using
-        # `getattr(module, "flat_param") is None`. This is not always accurate
-        # as the above condition is also true if this module is unflattened.
-        # `no_params` explicitly shows this module has no parameters and
-        # is always correct regardless flattened or unflattened.
-        self.no_params = True
         self.flat_param = None
-
-        # Register hook to be called after state_dict() to remove the
-        # "_fpw_module." prefix and before load_state_dict() to add it back.
-        # The hooks must be registered even if the target param_list is empty as
-        # all submodules in FlattenParamsWrapper should be pre/post processed by
-        # the hooks.
+        # Register hooks to clean parameter names for state dict (even if this
+        # wrapper itself manages no parameters since it must clean names from
+        # submodules)
         self._register_state_dict_hook(_post_state_dict_hook)
         self._register_load_state_dict_pre_hook(_pre_load_state_dict_hook)
-
-        if len(param_list) == 0:
+        if len(params) == 0:
             return
+        self._flat_param_handle = FlatParamHandle(params, module)
+        # Defining `self.flat_param` registers the `FlatParameter` and makes it
+        # visible to `named_parameters()`
+        self.flat_param = self._flat_param_handle.flat_param
 
-        # A list of parameters to be flatten
-        unique_param_list = set(param_list)
-        self.no_params = False
+    @property
+    def has_params(self) -> bool:
+        """Returns whether this wrapper manages any parameters."""
+        return hasattr(self, "_flat_param_handle")
 
-        # convert from list of Parameters to set of (Module, parameter_name) tuples, which
-        # will survive in case the Parameter instances are reset.
-        # it includes (m, n) that points to the same parameter.
-        self.param_set = set()
-        for m in self.modules():
-            for n, p in m.named_parameters(recurse=False):
-                if p in unique_param_list:
-                    self.param_set.add((m, n))
-
-        params, param_infos, shared_param_infos = self._init_flatten_params()
-        self.flat_param = FlatParameter(params, params[0].requires_grad)
-        self.flat_param._param_infos = param_infos
-        self.flat_param._shared_param_infos = shared_param_infos
-
-        # This attribute is used to remember the flat_param inside the unflatten_params()
-        # context. With this attribute, FSDP can access the flat parameter metadata
-        # even if flat_param is temporarily deleted.
-        # ``orig_flat_param` is a list to avoid being tracked by ``state_dict()``.
-        self.orig_flat_param: List[Optional[FlatParameter]] = [None]
-        self._flatten_params()
-
-        # Sanity check for the string constants.
-        assert getattr(self, FPW_MODULE) is self._fpw_module
-        assert getattr(self, FLAT_PARAM) is self.flat_param
+    @property
+    def handle(self) -> FlatParamHandle:
+        assert hasattr(self, "_flat_param_handle"), \
+            "Accessing the handle of a `FlattenParamsWrapper` that does not " \
+            "manage any parameters"
+        return self._flat_param_handle
 
     @property
     def module(self) -> Any:
-        """Support _fsdp_wrapped_module.module in case we are immitating DDP, which has .module
-        property to the underlying module.
-        """
+        """Returns the wrapped module (like DDP)."""
         return self._fpw_module
 
-    def _init_flatten_params(
-        self,
-    ) -> Tuple[List[nn.Parameter], List[ParamInfo], List[SharedParamInfo]]:
-        """Build metadata for need-to-be-flatten parameters and returns a list
-        contains the need-to-be-flatten parameters.
-        This also fills param_infos and shared_param_infos.
-        """
-        param_infos: List[ParamInfo] = []
-        shared_param_infos = []
-        shared_param_memo: Dict[nn.Parameter, Tuple[str, nn.Module, str]] = {}
-        params = []
-        for module_name, m in self.named_modules():
-            for n, p in m.named_parameters(recurse=False):
-                if p is not None and (m, n) in self.param_set:
-                    if p in shared_param_memo:
-                        mname, shared_m, shared_n = shared_param_memo[p]
-                        shared_param_infos.append(
-                            (module_name, mname, m, n, shared_m, shared_n)
-                        )
-                    else:
-                        shared_param_memo[p] = (module_name, m, n)
-                        param_infos.append(ParamInfo(module_name, m, n))
-                        params.append(p)
-        del shared_param_memo
-
-        assert (
-            len(set(p.dtype for p in params)) == 1
-        ), "expects all parameters to have same dtype"
-        assert (
-            len(set(p.requires_grad for p in params)) == 1
-        ), "expects all parameters to have same requires_grad"
-        assert len(params) == len(set(params)), "params list should not have dups"
-
-        return params, param_infos, shared_param_infos
-
-    def _flatten_params(self, external_data: Optional[FlatParameter] = None) -> None:
-        """Flatten the managed parameters and replaced the original
-        attributes with views to the flat param. If `external_data`
-        is passed, it will be used as the flat_param.
-        """
-        # register the flatten one
-        assert (
-            getattr(self, "flat_param", None) is not None or external_data is not None
-        ), "Can not flatten params when both flat_param and external_data are None."
-        if external_data is not None:
-            self.flat_param = external_data
-        self.register_parameter("flat_param", self.flat_param)
-
-        assert self.flat_param is not None  # avoid mypy complain.
-        # deregister the names as parameters
-        for _, m, n in self.flat_param._param_infos:
-            delattr(m, n)
-        for _, _, m, n, _, _ in self.flat_param._shared_param_infos:
-            delattr(m, n)
-
-        # register the views as plain attributes
-        self._unflatten_params_as_views()
-
-    def _unflatten_params_as_views(self) -> None:
-        """Unlike ``_unflatten_params``, this function unflatten into views and keep
-        self.flat_param unchanged.
-        """
-        assert (
-            self.flat_param is not None
-        ), "Can not unflatten params as views when flat_param is None."
-        ps = self._get_param_views()
-        for (_, m, n), p in zip(self.flat_param._param_infos, ps):
-            setattr(m, n, p)  # This will set as plain attr
-
-        for (_, _, m, n, shared_m, shared_n) in self.flat_param._shared_param_infos:
-            setattr(m, n, getattr(shared_m, shared_n))
-
-    def _unflatten_params(self) -> None:
-        """Undo flattening and create separate parameters from the already flattened
-        self.flat_param.
-        """
-        assert (
-            self.flat_param is not None
-        ), "Can not unflatten params when flat_param is None."
-        ps = self._get_param_views()
-        for (_, m, n), p in zip(self.flat_param._param_infos, ps):
-            if hasattr(m, n):
-                delattr(m, n)
-            m.register_parameter(n, nn.Parameter(p))
-        for (_, _, m, n, shared_m, shared_n) in self.flat_param._shared_param_infos:
-            if hasattr(m, n):
-                delattr(m, n)
-            m.register_parameter(n, getattr(shared_m, shared_n))
-
-        del self.flat_param
-
     @contextlib.contextmanager
-    def unflatten_params(self) -> Generator:
+    def unflatten_as_params(self) -> Generator:
         """
-        Unflatten params. If the current instance is already unflattened, then
-        it will remain unflattened after the context manager exits.
+        Assumes that the flattened parameter is unsharded. When in the context,
+        unflattens the original parameters as ``nn.Parameter`` views into the
+        flattened parameter and de-registers the flattened parameter. After the
+        context, restores the original parameters as ``Tensor`` views into the
+        flattened parameter and re-registers the flattened parameter.
         """
         if getattr(self, "flat_param", None) is None:
             yield
         else:
-            self.orig_flat_param[0] = self.flat_param
-            self._unflatten_params()
-            # Put yield in a try...finally in case the caller catches the exception and handles
-            # it. In that case, we need to properly handle the undoing of state here.
+            # De-register the `FlatParameter` from this wrapper to hide it from
+            # `named_parameters()` (though it still exists in memory)
+            del self.flat_param
             try:
-                yield
+                with self._flat_param_handle.unflatten_as_params():
+                    yield
             finally:
-                self._flatten_params(self.orig_flat_param[0])
-                self.orig_flat_param[0] = None
-
-    def _get_param_views(
-        self, external_data: Optional[Tensor] = None
-    ) -> Iterator[Tensor]:
-        """Return a generator of views that map to the original parameters."""
-        assert self.flat_param is not None
-        return self.flat_param.get_param_views(external_data)
+                # Re-register the `FlatParameter`
+                self.flat_param = self._flat_param_handle.flat_param
 
     def __getattr__(self, name: str) -> Any:
-        """Forward missing attributes to wrapped module."""
+        """Forward missing attributes of this wrapper to the wrapped module."""
         try:
-            return super().__getattr__(name)  # defer to nn.Module's logic
+            return super().__getattr__(name)  # defer to `nn.Module`'s logic
         except AttributeError:
-            return getattr(self.module, name)  # fallback to wrapped module
+            return getattr(self.module, name)  # fall back to the wrapped module
 
     def __getitem__(self, key: int) -> Any:
-        """Forward indexing calls in case the module is a nn.Sequential."""
+        """Forward indexing calls to the wrapped module in case the wrapped
+        module is an ``nn.Sequential``."""
         return self.module.__getitem__(key)
 
-    def _unflatten_params_if_needed(self) -> None:
-        if self.flat_param is not None:
-            self._unflatten_params_as_views()
-
     def forward(self, *inputs: Any, **kwinputs: Any) -> Any:
-        self._unflatten_params_if_needed()
+        if self.flat_param is not None:
+            self._flat_param_handle._unflatten(as_params=False)
         return self.module(*inputs, **kwinputs)


### PR DESCRIPTION
## Overview

1. This PR introduces `FlatParamHandle` to enable non-recursive FSDP wrapping. The class absorbs the unflattening/flattening logic from `FlattenParamsWrapper` but does not require wrapping a particular `nn.Module`.
2. This PR provides an initial non-recursive wrapping path with a naive `FlatParameter`/`FlatParamHandle` construction that iterates in `model.parameters()` order and uses a fixed bucket threshold. This is to ensure that the forward/backward code is adapted correctly for the non-recursive path, and we can focus on plugging the `FlatParameter` construction in the future.



## Discussion
### Introducing `FlatParamHandle`
There is flexibility in the design space for how to allocate attributes and methods to `FlatParameter` versus a wrapping class like `FlatParamHandle` or `FlattenParamsWrapper`. Several points in the design space provide the same functionality, so deciding on an allocation is arguably stylistic, though then preference should be given to cleaner designs.

The forefront consideration is that a `FlatParameter`'s metadata should be initialized once, while its data may be reloaded via checkpointing. This motivates decoupling the metadata initialization from the `FlatParameter` constructor, which should instead only handle the parameter data. Thus, we have both a `FlatParamHandle` managing a `FlatParameter` and the `FlatParameter` itself.
```
class FlatParamHandle:
    def __init__(self, module: nn.Module, params: Sequence[nn.Parameter]):
        # Calls `_init_flat_param()`
    def _init_flat_param(self, module: nn.Module, params: Sequence[nn.Parameter]):
	    # Calls `flatten_params()` and initializes metadata
    @staticmethod
	def flatten_params(params: Sequence[torch.Tensor], requires_grad: bool) -> FlatParameter:
		# Also may be used for checkpoint reloading
class FlatParameter(nn.Parameter):
	# Constructor is not overridden
```
Under this separation with `FlatParameter` as solely as a data container, we keep methods manipulating `FlatParameter` on the `FlatParamHandle`. Because `FlatParameter`'s constructor is not overridden, we should be able to replace it with another tensor type e.g. `ShardedTensor` with minimal changes.

### Compatibility with `FlattenParamsWrapper`
To ensure backward compatibility, `FlattenParamsWrapper` now holds a `FlatParamHandle`. Existing logic from `FlattenParamsWrapper` simply routes to the handle now.

A `FullyShardedDataParallel` instance holds references to all of its handles.
- For the recursive-wrapping paradigm, there is at most one handle, which is from its `FlattenParamsWrapper` if it manages parameters.
- For the non-recursive wrapping paradigm, there may be multiple handles, all owned by the single (root) `FullyShardedDataParallel` instance.

## For Reviewers
### `FlatParameter` Construction
In the existing implementation, a `FlatParameter`'s metadata was partially initialized in its constructor (e.g. `_param_numels`, `_param_shapes`) and partially initialized by the owning `FlattenParamsWrapper` (e.g. `_param_infos`, `_shared_param_infos`). The latter part was needed due to requiring module information. With this PR, the metadata initialization is consolidated in `FlatParamHandle`.
- During model construction, a `FlatParameter` should be initialized via the handle constructor`FlatParamHandle(params, module)`.
- During sharded checkpoint loading, a `FlatParameter` should be initialized via the static method `FlatParamHandle.flatten_params(new_params)`.
    - The checkpointing implementation is responsible for checking that `new_params` used to construct the `FlatParameter` data to load is consistent with the existing `FlatParameter`'s metadata.

These are the only two cases for `FlatParameter` construction right now, so there is no real functionality regression by not recomputing some of the metadata in the `FlatParameter` constructor. The `nn.Module.state_dict()` is implemented using in-place `copy_()`, so the new loaded `FlatParameter`'s metadata *should* match the existing `FlatParameter`'s metadata for correctness anyway. (I.e. we do not support a usage where we reload a `FlatParameter` with differing metadata into an existing `FlatParameter`.)

### BC Breaking
- `ShardMetadata` -> `FlatParamShardMetadata` to avoid name conflict with `ShardedTensor`
    - `param_names` prefixed only by immediate parent module's name -> `param_names` fully-prefixed starting from `module` passed into `FlattenParamsWrapper`/`FlatParamHandle`
        - This guarantees uniqueness within the `FullyShardedDataParallel` instance
        - For example, before, `Model(Sequential(Linear, Sequential(Linear)))` with `always_wrap_policy` will have have `0.weight` and `0.bias` for both `Linear`s
    - `metadata()` -> removed (unused)
- `FlatParameter` attributes
    - `_param_numels` -> `_numels`
    - `_param_shapes` -> `_shapes`
    - `full_numel` -> `_unsharded_size.numel()`
    - `_param_indice_in_shard` -> `_shard_indices`
    - `_sharded_param_offsets` -> `_shard_param_offsets`
    - `num_padded` -> `_shard_numel_padded`
    - `param_offsets` -> not saved; directly constructed in `_get_flat_param_offsets()` and used once
- `FlattenParamsWrapper` `param_list` argument -> `params` for consistency with `FlatParameter`

### Naming

We need to decide on a name for this "non-recursive wrapping" code path. Currently, I have a `_ExecOrderPolicy` class that is used to designate that code path. We should settle on something and stay consistent.

## Test Plan
### Backward Compatibility
- [] Run existing unit tests
- [] Run QPS benchmark
- [] Run accuracy benchmark
- [] Run large-model to check memory management
### Non-Recursive Wrapping
- [] Add training unit tests (forward/backward/optimizer step) covering Cartesian product of all features
    - [] Without shared parameters
    - [] With shared parameters
- [] Add model checkpointing unit tests
    - [] Full `state_dict()`
    - [] Local `state_dict()`
   - [] Sharded `state_dict()`
- [] Add optimizer checkpointing unit tests
- [] Run QPS benchmark
- [] Run accuracy benchmark

## Follow-Ups
- We need to clarify how to modify module `forward()`s for the long term.
    - Under the approach in this PR, we prefer to have native support for non-global `nn.Module.register_pre_forward_hook()` and `nn.Module.register_post_forward_hook()` to avoid patching `forward()`s.
    - The existing recursive-wrapping path relies on wrapping the original `nn.Module` with `FullyShardedDataParallel` and adding the additional logic to `FullyShardedDataParallel.forward()`. We could do something similar and wrap *every* original `nn.Module` with another `nn.Module` specific to FSDP that only overrides `forward()`. However, this modification to the `nn.Module` hierarchy may not be desirable.
- The current `FlatParameter`'s `data` represents either the sharded unflattened parameter, unsharded unflattened parameter, or reduced-precision sharded unflattened parameter, depending dynamically on the runtime context. When its `data` represents one quantity, the other quantities are still saved as attributes on the `FlatParameter` (e.g. `_local_shard`, `_full_param_padded`, `_mp_shard`). `FullyShardedDataParallel` directly manipulates the `data`.
We should investigate the tradeoffs of having those attributes on the `FlatParameter` versus moving them to the `FlatParamHandle`. The motivation for the latter is to define a clean interface for `FullyShardedDataParallel` to manage parameter data in preparation for generalizing to multiple parameter groups, to managing non-`FlatParameter`s, and to supporting non-CUDA devices. (More explicitly, `FullyShardedDataParallel`'s parameter *variables* would be set to different `Tensor` variables, none of which own another, instead of `FullyShardedDataParallel`'s parameter variables' *data* being set to different `Tensor` variables, all owned by the `FlatParameter`, and the data management would be folded into handle, hidden from `FullyShardedDataParallel`.)
- We should investigate if we can coalesce the remaining logic in `FlattenParamsWrapper` into `FullyShardedDataParallel` and remove `FlattenParamsWrapper`.
- We may want to move the mixed precision logic to the handle instead of the `FullyShardedDataParallel` instance to enable per-`FlatParameter` mixed precision instead of per-`FullyShardedDataParallel`. Otherwise, the non-recursive wrapping path is bound to all-or-nothing mixed precision.

---

## To-Do
- Implement re-flattening to enable iteration 1 -> iteration 2 transition
    - Working on this right now
- Obvious clean up and recursive-wrap testing
- Decide on only pre-forward resharding or both pre-forward and post-forward resharding and adjust the implementation as needed
- Decide on an initial API for users to use the non-recursive path
- Decide on what tests need are needed for the non-recursive path for this PR