### PR TITLE
Print output during MPS test import tests

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4358,6 +4358,7 @@ class TestRNNMPS(TestCase):
         self.assertEqual(cpu_weight_grad, mps_weight_grad)
 
 class TestFallbackWarning(TestCase):
+    # TODO: Remove once test_testing.py is running on MPS devices
     def test_no_warning_on_import(self):
         out = subprocess.check_output(
             [sys.executable, "-W", "all", "-c", "import torch"],

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1803,6 +1803,7 @@ class TestImports(TestCase):
                     raise RuntimeError(f"Failed to import {mod_name}: {e}") from e
                 self.assertTrue(inspect.ismodule(mod))
 
+    @unittest.skipIf(IS_WINDOWS, "importing torch+CUDA on CPU results in warning")
     def test_no_warning_on_import(self) -> None:
         out = subprocess.check_output(
             [sys.executable, "-W", "all", "-c", "import torch"],

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -9,6 +9,7 @@ import itertools
 import math
 import os
 import re
+import subprocess
 import sys
 import unittest.mock
 from typing import Any, Callable, Iterator, List, Tuple
@@ -1801,6 +1802,15 @@ class TestImports(TestCase):
                 except Exception as e:
                     raise RuntimeError(f"Failed to import {mod_name}: {e}") from e
                 self.assertTrue(inspect.ismodule(mod))
+
+    def test_no_warning_on_import(self) -> None:
+        out = subprocess.check_output(
+            [sys.executable, "-W", "all", "-c", "import torch"],
+            stderr=subprocess.STDOUT,
+            # On Windows, opening the subprocess with the default CWD makes `import torch`
+            # fail, so just set CWD to this script's directory
+            cwd=os.path.dirname(os.path.realpath(__file__)),).decode("utf-8")
+        self.assertEquals(out, "")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Simplify `test_no_warnings_on_input` to simply capture any output.
Copy its implementation to `test_testing.py` as this is not specific to MPS