### PR TITLE
Add  Dynamic Output Shape Tag For data-dependent ops, handle in FakeTensor

### DIFF
--- a/aten/src/ATen/native/Onehot.cpp
+++ b/aten/src/ATen/native/Onehot.cpp
@@ -16,6 +16,9 @@ Tensor one_hot(const Tensor &self, int64_t num_classes) {
             return at::empty(shape, self.options());
         }
     }
+    if (self.is_meta()) {
+        AT_ERROR("Can not infer total number of classes from meta tensor.");
+    }
 
     // non-empty tensor
     if (self.device().type() != at::kCUDA) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11596,6 +11596,7 @@
   variants: function
   dispatch:
     CPU, CUDA: linalg_lstsq_out
+  tags: dynamic_output_shape
 
 # torch.linalg.matmul, alias for torch.matmul
 - func: linalg_matmul(Tensor self, Tensor other) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -969,6 +969,7 @@
   dispatch:
     CPU: _bincount_cpu
     CUDA: _bincount_cuda
+  tags: dynamic_output_shape
 
 - func: bitwise_not(Tensor self) -> Tensor
   device_check: NoCheck   # TensorIterator
@@ -4844,6 +4845,7 @@
 - func: one_hot(Tensor self, int num_classes=-1) -> Tensor
   python_module: nn
   variants: function
+  tags: dynamic_output_shape
 
 - func: flip(Tensor self, int[] dims) -> Tensor
   variants: function, method
@@ -4959,18 +4961,21 @@
   dispatch:
     CPU: unique_dim_cpu
     CUDA: unique_dim_cuda
+  tags: dynamic_output_shape
 
 - func: unique_consecutive(Tensor self, bool return_inverse=False, bool return_counts=False, int? dim=None) -> (Tensor, Tensor, Tensor)
   variants: function
   dispatch:
     CPU: unique_consecutive_cpu
     CUDA: unique_consecutive_cuda
+  tags: dynamic_output_shape
 
 - func: unique_dim_consecutive(Tensor self, int dim, bool return_inverse=False, bool return_counts=False) -> (Tensor, Tensor, Tensor)
   variants: function
   dispatch:
     CPU: unique_dim_consecutive_cpu
     CUDA: unique_dim_consecutive_cuda
+  tags: dynamic_output_shape
 
 # _unique and _unique_dim are fragile and modifying them easily cause internal break
 # the below operator is a temporary hack for adding return_counts support
@@ -4981,6 +4986,7 @@
   dispatch:
     CPU: _unique2_cpu
     CUDA: _unique2_cuda
+  tags: dynamic_output_shape
 
 - func: _unsafe_view(Tensor self, int[] size) -> Tensor
   dispatch:
@@ -7406,6 +7412,7 @@
     CPU, QuantizedCPU: index_select_out_cpu_
     CUDA, QuantizedCUDA: index_select_out_cuda
     MPS: index_select_out_mps
+  tags: dynamic_output_shape
 
 - func: index_select(Tensor self, int dim, Tensor index) -> Tensor
   variants: method, function
@@ -7417,11 +7424,14 @@
     SparseCPU: index_select_sparse_cpu
     SparseCUDA: index_select_sparse_cuda
     MPS: index_select_mps
+  tags: dynamic_output_shape
 
 - func: index_select.dimname_out(Tensor self, Dimname dim, Tensor index, *, Tensor(a!) out) -> Tensor(a!)
+  tags: dynamic_output_shape
 
 - func: index_select.dimname(Tensor self, Dimname dim, Tensor index) -> Tensor
   variants: method, function
+  tags: dynamic_output_shape
 
 - func: index_select_backward(Tensor grad, int[] self_sizes, int dim, Tensor index) -> Tensor
   variants: function
@@ -7432,12 +7442,14 @@
   dispatch:
     CPU: masked_select_out_cpu
     CUDA: masked_select_out_cuda
+  tags: dynamic_output_shape
 
 - func: masked_select(Tensor self, Tensor mask) -> Tensor
   variants: method, function
   dispatch:
     CPU: masked_select_cpu
     CUDA: masked_select_cuda
+  tags: dynamic_output_shape
 
 - func: masked_select_backward(Tensor grad, Tensor input, Tensor mask) -> Tensor
   variants: function
@@ -7448,18 +7460,21 @@
   dispatch:
     CPU: nonzero_out_cpu
     CUDA: nonzero_out_cuda
+  tags: dynamic_output_shape
 
 - func: nonzero(Tensor self) -> Tensor
   variants: method, function
   dispatch:
     CPU: nonzero_cpu
     CUDA: nonzero_cuda
+  tags: dynamic_output_shape
 
 - func: nonzero_numpy(Tensor self) -> Tensor[]
   variants: method, function
 
 - func: argwhere(Tensor self) -> Tensor
   variants: method, function
+  tags: dynamic_output_shape
 
 - func: gather.out(Tensor self, int dim, Tensor index, *, bool sparse_grad=False, Tensor(a!) out) -> Tensor(a!)
   structured: True
@@ -11574,6 +11589,7 @@
   variants: function
   dispatch:
     CompositeExplicitAutograd: linalg_lstsq
+  tags: dynamic_output_shape
 
 - func: linalg_lstsq.out(Tensor self, Tensor b, float? rcond=None, *, str? driver=None, Tensor(a!) solution, Tensor(b!) residuals, Tensor(c!) rank, Tensor(d!) singular_values) -> (Tensor(a!) solution, Tensor(b!) residuals, Tensor(c!) rank, Tensor(d!) singular_values)
   python_module: linalg

--- a/aten/src/ATen/native/tags.yaml
+++ b/aten/src/ATen/native/tags.yaml
@@ -8,3 +8,7 @@
           This tag indicates operators that are *_copy* variants
           of view/aliasing operators. If an operator has a view_copy tag,
           then it should have the name {op}_copy, where {op} is a view operator.
+- tag: dynamic_output_shape
+  desc: |
+          This tag indicates if an operator's output's shape depends on input Tensor
+          data.

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1502,7 +1502,6 @@ fake_skips = (
 )
 
 dynamic_output_op_tests = (
-    "__getitem___",
     "argwhere",
     "bincount",
     "index_select",
@@ -1512,8 +1511,13 @@ dynamic_output_op_tests = (
     "nonzero",
     "unique_consecutive",
     "unique",
+    "linalg.lstsq.grad_oriented",
 )
 
+# some inputs invoke dynamic output shape operators, some do not
+sometimes_dynamic_output_op_test = (
+    "__getitem__",
+)
 
 class TestFakeTensorNonErroring(TestCase):
     @onlyCPU
@@ -1555,13 +1559,14 @@ class TestFakeTensorNonErroring(TestCase):
                     # if you see a shape exception here, you may need to add
                     # a `dynamic_output_shape` tag to an operator
                     prims.utils.compare_tensor_meta(fake_out, real_out)
+                self.assertTrue(name not in dynamic_output_op_tests)
 
             except torch._subclasses.fake_tensor.ComplexInputException:
                 pass
             except torch._subclasses.fake_tensor.SparseInputException:
                 pass
             except torch._subclasses.fake_tensor.DynamicOutputShapeException:
-                self.assertTrue(name in dynamic_output_op_tests)
+                self.assertTrue(name in dynamic_output_op_tests or name in sometimes_dynamic_output_op_test)
 
 
 instantiate_device_type_tests(TestCommon, globals())

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1505,6 +1505,7 @@ dynamic_output_op_tests = (
     "__getitem___",
     "argwhere",
     "bincount",
+    "index_select",
     "combinations",
     "linalg.lstsq",
     "masked_select",

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -377,7 +377,7 @@ class FakeTensorMode(TorchDispatchMode):
                 return torch.device("meta")
             else:
                 return args[0].fake_device
-        
+
         # prims already wrap FakeTensor inputs to FakeTensor outputs
         # and do device logic, we dont need do anything but run them
         if "prims::" in func._schema.name:

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -11,6 +11,8 @@ from torch.utils._python_dispatch import TorchDispatchMode, enable_torch_dispatc
 import weakref
 import functools
 import itertools
+from dataclasses import dataclass
+
 
 aten = torch.ops.aten
 
@@ -21,6 +23,29 @@ class ComplexInputException(Exception):
 class SparseInputException(Exception):
     pass
 
+@dataclass
+class DynamicOutputShapeException(Exception):
+    func: OpOverload
+
+
+# TODO: use tags when available
+# operators whose output shape depends on input tensor data
+_data_dependent_operators = (
+    aten.nonzero.out,
+    aten.nonzero.default,
+    aten.nonzero_numpy.default,
+    aten.unique_dim.default,
+    aten.unique_consecutive.default,
+    aten.unique_dim_consecutive.default,
+    aten._unique2.default,
+    aten.index.Tensor,
+    aten.index_select.out,
+    aten.index_select.default,
+    aten.index_select.dimname_out,
+    aten.index_select.dimname,
+    aten.masked_select.out,
+    aten.masked_select.default,
+)
 
 _device_not_kwarg_ops = (
     aten._resize_output_.default,
@@ -202,6 +227,9 @@ def clone(fake_mode, func, input, memory_format=None):
         out = torch.ops.aten._to_copy(input.to("meta"), memory_format=memory_format)
         return FakeTensor(fake_mode, out, out_device)
 
+@register_op_impl(lambda func: func in _data_dependent_operators)
+def data_dep_op(fake_mode, func, *args, **kwargs):
+    raise DynamicOutputShapeException(func)
 
 # Meta tensors give you the ability to run PyTorch code without having to
 # actually do computation through tensors allocated on a `meta` device.
@@ -349,7 +377,7 @@ class FakeTensorMode(TorchDispatchMode):
                 return torch.device("meta")
             else:
                 return args[0].fake_device
-
+        
         # prims already wrap FakeTensor inputs to FakeTensor outputs
         # and do device logic, we dont need do anything but run them
         if "prims::" in func._schema.name:

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -31,6 +31,8 @@ class DynamicOutputShapeException(Exception):
 # TODO: use tags when available
 # operators whose output shape depends on input tensor data
 _data_dependent_operators = (
+    aten.bincount.default,
+    aten.one_hot.default,
     aten.nonzero.out,
     aten.nonzero.default,
     aten.nonzero_numpy.default,
@@ -45,6 +47,8 @@ _data_dependent_operators = (
     aten.index_select.dimname,
     aten.masked_select.out,
     aten.masked_select.default,
+    aten.linalg_lstsq.default,
+    aten.linalg_lstsq.out,
 )
 
 _device_not_kwarg_ops = (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79170
* #78972
* #78523
* #78522
* #78677

Adds a tag for operators which have an output whose shape depends on input Tensor data. This tag is tested through the fake_tensor tests. If an operator is not tagged appropriately, the fake tensor test will fallback to cpu to run the operator, and then output metadata will diverge. This helped me find `linalg_lstsq` among others. 

I included in the tags CompositeImplicitAutograd ops, although I'm not sure what the general policy is for these operators. 

One difficulty wrt/fake tensors was [aten::one_hot](https://codebrowser.bddppq.com/pytorch/pytorch/aten/src/ATen/native/Onehot.cpp.html#23). Because it is a `CompositeImplicitAutograd`, it won't be seen by `__torch_dispatch__`. It would be possible to handle this case either 
a) always throwing with `local_scalar_dense`, but this would add a huge amount of false negatives where we think operators have data-dependent output shapes but are actually not. 
b) Maybe I should also be defining `__torch_function__`  for fake_tensor to error on specific composites. (this didn't work when I tried it, didn't get invoked, so maybe there's something I'm missing)


Feel free to suggest a different name than `dynamic_output_shape`.
