### PR TITLE
[distributed] Make DDP work with python process group

### DIFF
--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -40,6 +40,9 @@ class LonelyRankProcessGroup(dist.ProcessGroup):
     """
     def __init__(self, rank, world):
         super(LonelyRankProcessGroup, self).__init__(rank, world)
+        assert rank == 0
+        assert world == 1
+
         self._rank = rank
         self._world = world
         self.wait_count = 0
@@ -80,7 +83,6 @@ class TestDDPSingleRank(test_c10d_common.CommonDistributedDataParallelTest, Test
         # replicate what MultiProcessTest _spawn_proccess does
         self.file_name = tempfile.NamedTemporaryFile(delete=False).name
         self.rank = 0
-        # self.world_size = 1
 
     @property
     def world_size(self):
@@ -95,8 +97,6 @@ class TestDDPSingleRank(test_c10d_common.CommonDistributedDataParallelTest, Test
 
     def _get_process_group(self):
         store = self._get_store()
-        assert self.rank == 0
-        assert self.world_size == 1
         return LonelyRankProcessGroup(self.rank, self.world_size)
 
     def test_ddp_invoke_work_object(self):
@@ -123,14 +123,11 @@ class TestDDPSingleRank(test_c10d_common.CommonDistributedDataParallelTest, Test
         pg = LonelyRankProcessGroup(0, 1)      
 
         self._test_ddp_with_process_group(pg, [torch.device("cpu")], device_ids=None)
-    #         def _test_ddp_with_process_group(
-    #     self,
-    #     process_group,
-    #     devices,
-    #     device_ids,
-    #     multi_device=False,
-    #     gradient_as_bucket_view=False,
-    # ):
+
+    def test_ddp_with_pypg_with_grad_views(self):
+        pg = LonelyRankProcessGroup(0, 1)      
+
+        self._test_ddp_with_process_group(pg, [torch.device("cpu")], device_ids=None, gradient_as_bucket_view=True)
 
 
 if __name__ == '__main__':

--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -5,7 +5,6 @@ import os
 import torch
 import torch.distributed as dist
 from torch.testing._internal.common_utils import (
-    TestCase,
     run_tests,
 )
 from torch.futures import Future
@@ -13,7 +12,6 @@ import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel as DDP
 import test_c10d_common
 import weakref
-import tempfile
 from torch._C._distributed_c10d import _create_work_from_future
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,

--- a/test/distributed/test_c10d_pypg.py
+++ b/test/distributed/test_c10d_pypg.py
@@ -1,0 +1,137 @@
+# Owner(s): ["oncall: distributed"]
+
+import os
+import sys
+from functools import wraps, partial
+
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.futures import Future
+import torch.distributed as dist
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+import test_c10d_common
+import weakref
+import tempfile
+
+
+class MyWork(dist._Work):
+    def __init__(self, result, pg):
+        super().__init__()
+        self.result_ = result
+        self.future_ = torch.futures.Future()
+        self.future_.set_result(result)
+        self.pg_ = weakref.ref(pg)
+
+    def wait(self, timeout):
+        self.pg_().wait_count += 1
+
+
+        return True
+
+    def get_future(self):
+        self.pg_().get_future_count += 1
+        return self.future_
+
+class LonelyRankProcessGroup(dist.ProcessGroup):
+    """
+    This PG only supports world_size of 1
+    """
+    def __init__(self, rank, world):
+        super(LonelyRankProcessGroup, self).__init__(rank, world)
+        self._rank = rank
+        self._world = world
+        self.wait_count = 0
+        self.get_future_count = 0
+        self._work = []
+
+    def broadcast(self, tensor_list, opts):
+        res = MyWork(tensor_list, self)
+        self._work.append(res)
+        return res
+
+    def allgather(self, output_tensors, input_tensor, opts):
+        for o, i in zip(output_tensors[0], input_tensor):
+            o.copy_(i)
+
+        res = MyWork(output_tensors, self)
+        self._work.append(res)
+
+        return res
+
+    def allreduce(self, tensors, opts):
+        res = MyWork(tensors, self)
+        self._work.append(res)
+        return res
+
+    def size(self):
+        return self._world
+
+    def getBackendName(self):
+        return "lonely-pg"
+
+    def __repr__(self):
+        return f"PLG w:{self._world} r:{self._rank}"
+
+class TestDDPSingleRank(test_c10d_common.CommonDistributedDataParallelTest, TestCase):
+    def setUp(self):
+        super(TestDDPSingleRank, self).setUp()
+        # replicate what MultiProcessTest _spawn_proccess does
+        self.file_name = tempfile.NamedTemporaryFile(delete=False).name
+        self.rank = 0
+        # self.world_size = 1
+
+    @property
+    def world_size(self):
+        return 1
+
+    def tearDown(self):
+        super(TestDDPSingleRank, self).tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    def _get_process_group(self):
+        store = self._get_store()
+        assert self.rank == 0
+        assert self.world_size == 1
+        return LonelyRankProcessGroup(self.rank, self.world_size)
+
+    def test_ddp_invoke_work_object(self):
+        pg = LonelyRankProcessGroup(0, 1)      
+
+        torch.manual_seed(123)
+        model = nn.Sequential(
+            nn.Linear(2, 2),
+            nn.ReLU()
+        )
+        wrapped_model = model
+        model = DDP(model, process_group=pg)
+        model(torch.tensor([0.99, 0.77])).sum().backward()
+        
+        ddp_grad = wrapped_model[0].bias.grad.clone()
+
+        wrapped_model.zero_grad()
+        wrapped_model(torch.tensor([0.99, 0.77])).sum().backward()
+        self.assertEqual(wrapped_model[0].bias.grad, ddp_grad)
+        self.assertTrue(pg.wait_count > 0)
+        self.assertTrue(pg.get_future_count > 0)
+
+    def test_ddp_with_pypg(self):
+        pg = LonelyRankProcessGroup(0, 1)      
+
+        self._test_ddp_with_process_group(pg, [torch.device("cpu")], device_ids=None)
+    #         def _test_ddp_with_process_group(
+    #     self,
+    #     process_group,
+    #     devices,
+    #     device_ids,
+    #     multi_device=False,
+    #     gradient_as_bucket_view=False,
+    # ):
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -149,6 +149,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
 
     OpType retrieveOpType();
 
+    static c10::intrusive_ptr<Work> create_from_future(c10::intrusive_ptr<c10::ivalue::Future>);
+
    protected:
     // Completes the work object and optionally sets the exception in a
     // thread-safe manner. Notifies all waiting condition variables as well.

--- a/torch/csrc/distributed/c10d/comm.cpp
+++ b/torch/csrc/distributed/c10d/comm.cpp
@@ -99,5 +99,26 @@ std::vector<at::Tensor> GradBucket::getGradients() const {
   }
   return per_parameter_tensors;
 }
+namespace detail {
+
+at::Tensor parseCppCommHookResult(const c10::IValue& result) {
+  if (result.isPyObject()) {
+    std::vector<at::Tensor> tensors =
+        result.toPyObjectHolder()->extractTensors();
+    return tensors[0];
+  }
+  TORCH_INTERNAL_ASSERT(
+      result.isTensor() || result.isTensorList(),
+      "expected the hook result is either a Tensor or a TensorList found ",
+      result.tagKind());
+
+  if (result.isTensor()) {
+    return result.toTensor();
+  }
+
+  return result.toTensorVector()[0];
+}
+
+} // namespace detail
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/comm.hpp
+++ b/torch/csrc/distributed/c10d/comm.hpp
@@ -106,18 +106,7 @@ class TORCH_API CommHookInterface {
 namespace detail {
 // This helper function is called both by CppCommHookInterface below and inside
 // reducer.
-inline at::Tensor parseCppCommHookResult(
-    const c10::IValue& result) {
-  TORCH_INTERNAL_ASSERT(
-      result.isTensor() || result.isTensorList(),
-      "expected the hook result is either a Tensor or a TensorList");
-
-  if (result.isTensor()) {
-    return result.toTensor();
-  }
-
-  return result.toTensorVector()[0];
-}
+ at::Tensor parseCppCommHookResult(const c10::IValue& result);
 } // namespace detail
 
 // This CppCommHook interface only requires implementing runHook method that


### PR DESCRIPTION
This PR enables python process group usage with DDP by doing the following:

- Surface PG::Work::getFuture() as overridable()
- Use Work::getFuture() to retrieve values from a PG.
- Add _create_work_from_future python method that creates a Work object that wraps a Future.

To test this changes we use both strategies to run DDP with a python based PG.

The reason for offering two methods is that both have short-comings.

The wrapper method is harder to troubleshoot as there's no visibility of how the future is used. 

The subclass method has memory management issues as can be noticed in the test suite by having to keep Work instances alive by storing them in PG fields.

