### PR TITLE
[ci] don't upload test stats for cancelled workflows

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   upload-test-stats:
-    if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'cancelled'
+    if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
     runs-on: [self-hosted, linux.2xlarge]
     name: Upload test stats for ${{ github.event.workflow_run.id }}, attempt ${{ github.event.workflow_run.run_attempt }}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #79180

Switching it back to the old behavior. It is causing a bunch of noise
when I am monitoring the workflow for failures. For example, this job
fails https://github.com/pytorch/pytorch/actions/runs/2465525187 because
its source workflow was cancelled before any tests were run:
https://github.com/pytorch/pytorch/actions/runs/2465519366.

Since we don't use this info today (and I have a kind of hard
time imagining how we would use info from cancelled workflows), I think
we should just skip these.