### PR TITLE
[GHF] Make `-g` wait for all

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -384,6 +384,7 @@ def parse_args() -> Any:
     parser = ArgumentParser("Merge PR into default branch")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--on-green", action="store_true")
+    parser.add_argument("--on-mandatory", action="store_true")
     parser.add_argument("--revert", action="store_true")
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--comment-id", type=int)
@@ -846,6 +847,15 @@ def find_matching_merge_rule(pr: GitHubPR,
     raise RuntimeError(reject_reason)
 
 
+def get_pending_checks(pr: GitHubPR) -> List[Tuple[str, str]]:
+    checks = pr.get_checkrun_conclusions()
+    return [(name, status[1]) for name, status in checks.items() if status[0] is None]
+
+def pr_has_pending_checks(pr: GitHubPR) -> bool:
+    return len(get_pending_checks(pr)) > 0
+
+
+
 def try_revert(repo: GitRepo, pr: GitHubPR, *,
                dry_run: bool = False,
                comment_id: Optional[int] = None,
@@ -895,7 +905,10 @@ def prefix_with_github_url(suffix_str: str) -> str:
     return f"https://github.com/{suffix_str}"
 
 
-def merge_on_green(pr_num: int, repo: GitRepo, dry_run: bool = False, timeout_minutes: int = 400) -> None:
+def merge_on_green(pr_num: int, repo: GitRepo,
+                   dry_run: bool = False,
+                   mandatory_only: bool = False,
+                   timeout_minutes: int = 400) -> None:
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
     org, project = repo.gh_owner_and_name()
     start_time = time.time()
@@ -909,11 +922,16 @@ def merge_on_green(pr_num: int, repo: GitRepo, dry_run: bool = False, timeout_mi
         print(f"Attempting merge of https://github.com/{org}/{project}/pull/{pr_num} ({elapsed_time / 60} minutes elapsed)")
         pr = GitHubPR(org, project, pr_num)
         try:
+            find_matching_merge_rule(pr, repo)
+            if not mandatory_only and pr_has_pending_checks(pr):
+                pending = get_pending_checks(pr)
+                raise MandatoryChecksMissingError(f"Still waiting for {len(pending)} additional jobs to finish, " +
+                                                  f"first few of them are: {' ,'.join(x[0] for x in pending[:5])}")
             return pr.merge_into(repo, dry_run=dry_run)
         except MandatoryChecksMissingError as ex:
             last_exception = str(ex)
-            print(f"Merge of https://github.com/{org}/{project}/pull/{pr_num} failed due to: {ex}. Retrying in 60 seconds.")
-            time.sleep(60)
+            print(f"Merge of https://github.com/{org}/{project}/pull/{pr_num} failed due to: {ex}. Retrying in 5 min")
+            time.sleep(5 * 60)
     # Finally report timeout back
     msg = f"Merged timed out after {timeout_minutes} minutes. Please contact the pytorch_dev_infra team."
     msg += f"The last exception was: {last_exception}"
@@ -955,9 +973,9 @@ def main() -> None:
         gh_post_comment(org, project, args.pr_num, "Cross-repo ghstack merges are not supported", dry_run=args.dry_run)
         return
 
-    if args.on_green:
+    if args.on_green or args.on_mandatory:
         try:
-            merge_on_green(args.pr_num, repo, dry_run=args.dry_run)
+            merge_on_green(args.pr_num, repo, dry_run=args.dry_run, mandatory_only=args.on_mandatory)
         except Exception as e:
             handle_exception(e)
     else:

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -855,7 +855,6 @@ def pr_has_pending_checks(pr: GitHubPR) -> bool:
     return len(get_pending_checks(pr)) > 0
 
 
-
 def try_revert(repo: GitRepo, pr: GitHubPR, *,
                dry_run: bool = False,
                comment_id: Optional[int] = None,


### PR DESCRIPTION
Introduce `pr_has_pending_checks` and `get_pending_checks` functions,
increase wait time between checks to 5 min to reduce GH token
utilization

TODO: Need to propagate "on-mandatory" via bot, but IMO it's low priority
