### PR TITLE
[mergebot] Make merge on green default behavior

### DIFF
--- a/.github/scripts/gql_mocks.json
+++ b/.github/scripts/gql_mocks.json
@@ -16933,5 +16933,158 @@
         "team": null
       }
     }
+  },
+  "query_sha=62ce809793481ce6ddce6e1a19d9b0761755ff0ff75decaf8a79419eaf793110 cursor=Y3Vyc29yOnYyOpHOQqri9w== name=pytorch number=76123 owner=pytorch": {
+    "data": {
+      "repository": {
+        "pullRequest": {
+          "comments": {
+            "nodes": [
+              {
+                "bodyText": "\ud83d\udd17 Helpful links\n\n\ud83e\uddea \u00a0See artifacts and rendered test results at hud.pytorch.org/pr/76123\n\ud83d\udcc4 \u00a0Preview Python docs built from this PR\n\ud83d\udcc4 \u00a0Preview C++ docs built from this PR\n\u2753Need help or want to give feedback on the CI? Visit our office hours\n\u21a9\ufe0f \u00a0[fb-only] Re-run with SSH instructions\n\n\ud83d\udc8a CI failures summary and remediations\nAs of commit 96c5299 (more details on the Dr. CI page):\nExpand to see more\n\n\n3/3 failures introduced in this PR\n\n\n\ud83d\udd75\ufe0f 3 new failures recognized by patterns\nThe following CI failures do not appear to be due to upstream breakages\n pull / linux-xenial-py3.7-gcc5.4 / test (backwards_compat, 1, 1, linux.2xlarge) (1/3)\nStep: \"Test\" (full log | diagnosis details | \ud83d\udd01 rerun)\n\n\n2022-05-05T16:09:27.0340973Z The PR is introduc...m to confirm whether this change is wanted or not.\n\n2022-05-05T16:09:27.0325517Z processing existing schema:  text(__torch__.torch.classes.profiling.SourceRef _0) -> (str _0)\n2022-05-05T16:09:27.0326788Z processing existing schema:  count(__torch__.torch.classes.profiling.InstructionStats _0) -> (int _0)\n2022-05-05T16:09:27.0328838Z processing existing schema:  duration_ns(__torch__.torch.classes.profiling.InstructionStats _0) -> (int _0)\n2022-05-05T16:09:27.0330436Z processing existing schema:  source(__torch__.torch.classes.profiling.SourceStats _0) -> (__torch__.torch.classes.profiling.SourceRef _0)\n2022-05-05T16:09:27.0333056Z processing existing schema:  line_map(__torch__.torch.classes.profiling.SourceStats _0) -> (Dict(int, __torch__.torch.classes.profiling.InstructionStats) _0)\n2022-05-05T16:09:27.0333966Z processing existing schema:  __init__(__torch__.torch.classes.profiling._ScriptProfile _0) -> (NoneType _0)\n2022-05-05T16:09:27.0335812Z processing existing schema:  enable(__torch__.torch.classes.profiling._ScriptProfile _0) -> (NoneType _0)\n2022-05-05T16:09:27.0337445Z processing existing schema:  disable(__torch__.torch.classes.profiling._ScriptProfile _0) -> (NoneType _0)\n2022-05-05T16:09:27.0339361Z processing existing schema:  _dump_stats(__torch__.torch.classes.profiling._ScriptProfile _0) -> (__torch__.torch.classes.profiling.SourceStats[] _0)\n2022-05-05T16:09:27.0340656Z processing existing schema:  __init__(__torch__.torch.classes.dist_rpc.WorkerInfo _0, str _1, int _2) -> (NoneType _0)\n2022-05-05T16:09:27.0340973Z The PR is introducing backward incompatible changes to the operator library. Please contact PyTorch team to confirm whether this change is wanted or not. \n2022-05-05T16:09:27.0340981Z \n2022-05-05T16:09:27.0341055Z Broken ops: [\n2022-05-05T16:09:27.0341503Z \taten::_sparse_bsr_tensor_unsafe(Tensor crow_indices, Tensor col_indices, Tensor values, int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None) -> (Tensor)\n2022-05-05T16:09:27.0341908Z \taten::sparse_bsc_tensor.ccol_row_value_size(Tensor ccol_indices, Tensor row_indices, Tensor values, int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=False) -> (Tensor)\n2022-05-05T16:09:27.0342288Z \taten::sparse_bsc_tensor.ccol_row_value(Tensor ccol_indices, Tensor row_indices, Tensor values, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=False) -> (Tensor)\n2022-05-05T16:09:27.0342686Z \taten::sparse_bsr_tensor.crow_col_value_size(Tensor crow_indices, Tensor col_indices, Tensor values, int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=False) -> (Tensor)\n2022-05-05T16:09:27.0343063Z \taten::sparse_bsr_tensor.crow_col_value(Tensor crow_indices, Tensor col_indices, Tensor values, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=False) -> (Tensor)\n2022-05-05T16:09:27.0343459Z \taten::sparse_csc_tensor.ccol_row_value_size(Tensor ccol_indices, Tensor row_indices, Tensor values, int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=False) -> (Tensor)\n2022-05-05T16:09:27.0343837Z \taten::sparse_csc_tensor.ccol_row_value(Tensor ccol_indices, Tensor row_indices, Tensor values, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=False) -> (Tensor)\n2022-05-05T16:09:27.0344275Z \taten::sparse_compressed_tensor.comp_plain_value_size(Tensor compressed_indices, Tensor plain_indices, Tensor values, int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=False) -> (Tensor)\n\n\n pull / linux-xenial-cuda11.3-py3.7-gcc7 / test (distributed, 1, 2, linux.8xlarge.nvidia.gpu) (2/3)\nStep: \"Test\" (full log | diagnosis details | \ud83d\udd01 rerun)\n\n\n2022-05-05T17:44:17.5621127Z   test_rnn (__main...as.so.11: undefined symbol: cublasGetSmCountTarget\n\n2022-05-05T17:44:14.3331226Z \n2022-05-05T17:44:14.3331614Z Generating XML reports...\n2022-05-05T17:44:14.3364495Z Generated XML report: test-reports/dist-gloo/distributed.test_c10d_spawn_gloo/TEST-DistributedDataParallelSingleProcessTest-20220505174414.xml\n2022-05-05T17:44:15.4328518Z INFO:torch.distributed.nn.jit.instantiator:Created a temporary directory at /tmp/tmppkaiddzk\n2022-05-05T17:44:15.4329548Z INFO:torch.distributed.nn.jit.instantiator:Writing /tmp/tmppkaiddzk/_remote_module_non_sriptable.py\n2022-05-05T17:44:17.0055093Z INFO:numba.cuda.cudadrv.driver:init\n2022-05-05T17:44:17.0124550Z Test results will be stored in test-reports/dist-gloo/distributed.test_c10d_spawn_gloo\n2022-05-05T17:44:17.0140782Z \n2022-05-05T17:44:17.0141038Z Running tests...\n2022-05-05T17:44:17.0141470Z ----------------------------------------------------------------------\n2022-05-05T17:44:17.5621127Z   test_rnn (__main__.DistributedDataParallelSingleProcessTest) ... Could not load symbol cublasGetSmCountTarget from libcublas.so.11. Error: /usr/local/cuda/lib64/libcublas.so.11: undefined symbol: cublasGetSmCountTarget\n2022-05-05T17:44:17.6693126Z INFO:torch.nn.parallel.distributed:Reducer buckets have been rebuilt in this iteration.\n2022-05-05T17:44:18.1650025Z ok (1.151s)\n2022-05-05T17:44:18.1651272Z \n2022-05-05T17:44:18.1651813Z ----------------------------------------------------------------------\n2022-05-05T17:44:18.1652170Z Ran 1 test in 1.151s\n2022-05-05T17:44:18.1652338Z \n2022-05-05T17:44:18.1652429Z OK\n2022-05-05T17:44:18.1652546Z \n2022-05-05T17:44:18.1652676Z Generating XML reports...\n2022-05-05T17:44:18.1686537Z Generated XML report: test-reports/dist-gloo/distributed.test_c10d_spawn_gloo/TEST-DistributedDataParallelSingleProcessTest-20220505174417.xml\n\n\n pull / pytorch-xla-linux-bionic-py3.7-clang8 / test (xla, 1, 1, linux.2xlarge) (3/3)\nStep: \"Test\" (full log | diagnosis details | \ud83d\udd01 rerun)\n\n\n2022-05-05T18:18:06.1360060Z \ufffd[0;31m[  FAILED  ] \ufffd[mAtenXlaTensorTest.TestMaxUnpool3DBackward\n\n2022-05-05T18:18:06.1355251Z \ufffd[0;32m[----------] \ufffd[m1 test from XlaUtilCacheTest (0 ms total)\n2022-05-05T18:18:06.1355519Z \n2022-05-05T18:18:06.1355847Z \ufffd[0;32m[----------] \ufffd[mGlobal test environment tear-down\n2022-05-05T18:18:06.1356397Z \ufffd[0;32m[==========] \ufffd[m623 tests from 8 test suites ran. (510109 ms total)\n2022-05-05T18:18:06.1356818Z \ufffd[0;32m[  PASSED  ] \ufffd[m619 tests.\n2022-05-05T18:18:06.1357247Z \ufffd[0;32m[  SKIPPED ] \ufffd[m1 test, listed below:\n2022-05-05T18:18:06.1357814Z \ufffd[0;32m[  SKIPPED ] \ufffd[mAtenXlaTensorTest.TestGroupNormBackward\n2022-05-05T18:18:06.1358319Z \ufffd[0;31m[  FAILED  ] \ufffd[m3 tests, listed below:\n2022-05-05T18:18:06.1358823Z \ufffd[0;31m[  FAILED  ] \ufffd[mAtenXlaTensorTest.TestMatmul_1x2\n2022-05-05T18:18:06.1359424Z \ufffd[0;31m[  FAILED  ] \ufffd[mAtenXlaTensorTest.TestMaxUnpool2DBackward\n2022-05-05T18:18:06.1360060Z \ufffd[0;31m[  FAILED  ] \ufffd[mAtenXlaTensorTest.TestMaxUnpool3DBackward\n2022-05-05T18:18:06.1360345Z \n2022-05-05T18:18:06.1360463Z  3 FAILED TESTS\n2022-05-05T18:18:06.3154942Z + cleanup\n2022-05-05T18:18:06.3155169Z + retcode=1\n2022-05-05T18:18:06.3155327Z + set +x\n2022-05-05T18:18:06.3695951Z ##[error]Process completed with exit code 1.\n2022-05-05T18:18:06.3873716Z ##[group]Run pytorch/pytorch/.github/actions/get-workflow-job-id@master\n2022-05-05T18:18:06.3873966Z with:\n2022-05-05T18:18:06.3874336Z   github-token: ***\n2022-05-05T18:18:06.3874505Z env:\n\n\n\nThis comment was automatically generated by Dr. CI (expand for details).\nPlease report bugs/suggestions to the (internal) Dr. CI Users group.\nClick here  to manually regenerate this comment.",
+                "author": {
+                  "login": "facebook-github-bot"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": {
+                  "login": "facebook-github-bot"
+                },
+                "databaseId": 1104245131
+              },
+              {
+                "bodyText": "Thanks for the PR. qq, what is the naming conversation for prototype feature in test folder?  I notice that it is \"_checkpoint\" in the src but \"checkpoint\" in the test.\nSince we have been through the review cycle for this prototype feature already, shall we stamp and merge this",
+                "author": {
+                  "login": "zzzwen"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1105854055
+              },
+              {
+                "bodyText": "Thanks for the PR. qq, what is the naming conversation for prototype feature in test folder? I notice that it is \"_checkpoint\" in the src but \"checkpoint\" in the test.\nSince we have been through the review cycle for this prototype feature already, shall we stamp and merge this\n\nTests are not part of the API so it's ok to land them checkpoint and I don't think there will be any confusion on how it's supposed to work.\nWhile we need this stamped, it can't be merged before our tests are green.",
+                "author": {
+                  "login": "kumpera"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1106726326
+              },
+              {
+                "bodyText": "Awesome work @kumpera!",
+                "author": {
+                  "login": "pritamdamania87"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1107350566
+              },
+              {
+                "bodyText": "@kumpera has imported this pull request. If you are a Meta employee, you can view this diff on Phabricator.",
+                "author": {
+                  "login": "facebook-github-bot"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1108958721
+              },
+              {
+                "bodyText": "linux-xenial-py3.7-gcc5.4 / test (backwards_compat, 1, 1, linux.2xlarge) failure is unrelated.",
+                "author": {
+                  "login": "kumpera"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1110207153
+              },
+              {
+                "bodyText": "@kumpera has imported this pull request. If you are a Meta employee, you can view this diff on Phabricator.",
+                "author": {
+                  "login": "facebook-github-bot"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1110207988
+              },
+              {
+                "bodyText": "@wanchaol  @pritamdamania87 I believe I addressed all review issues, broken tests.\nThere's a lot of work ahead beyond this prototype, I filed half a dozen issues on it under sharded_tensor",
+                "author": {
+                  "login": "kumpera"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1110249740
+              },
+              {
+                "bodyText": "@kumpera has imported this pull request. If you are a Meta employee, you can view this diff on Phabricator.",
+                "author": {
+                  "login": "facebook-github-bot"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1112182036
+              },
+              {
+                "bodyText": "@pritamdamania87\n\nIn that case, we can just have prepare_storage take the metadata as a parameter instead?\nRegarding prepare_storage.\n\nMetadata is actually not enough because it doesn't have any information telling which rank is saving what, making it quite error prone.\nPass a list of FQNs would be annoying for Shards since you'd need to scan through the list of ShardStorageMetadata.\nPassing a list of storage keys is the most reasonable approach for now, given it's the best way to tie back to write calls.\nI expect this method to completely go away based on a storage coalescing prototype.",
+                "author": {
+                  "login": "kumpera"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1112598769
+              },
+              {
+                "bodyText": "I don't think we should add flags like this in the code just for testing purposes. We can test this accordingly in unit tests by doing things like if self.rank == 0: validate_something(). I feel the latter is more robust since otherwise your unit tests are testing a codepath that is never actually triggered in practice.\n\n@pritamdamania87 makes sense, this is just part of an overall issue of the current design of PTD that none of its building blocks operate without a properly initialized PG.",
+                "author": {
+                  "login": "kumpera"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1112605213
+              },
+              {
+                "bodyText": "@simpkins  I'm tracking future work to improve the serialization story here: #76441",
+                "author": {
+                  "login": "kumpera"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1115311085
+              },
+              {
+                "bodyText": "@kumpera has imported this pull request. If you are a Meta employee, you can view this diff on Phabricator.",
+                "author": {
+                  "login": "facebook-github-bot"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1115389763
+              },
+              {
+                "bodyText": "Metadata is actually not enough because it doesn't have any information telling which rank is saving what, making it quite error prone.\n\n\nPass a list of FQNs would be annoying for Shards since you'd need to scan through the list of ShardStorageMetadata.\n\n\nPassing a list of storage keys is the most reasonable approach for now, given it's the best way to tie back to write calls.\n\n\nI expect this method to completely go away based on a storage coalescing prototype.\n\nAh my bad, I actually meant to say passing a List[WriteRequests] to prepare_storage so that it is more generic and has all the information about future incoming writes. But if this is probably going to change quite a bit based on the coalescing prototype we can revisit this in a follow up PR.",
+                "author": {
+                  "login": "pritamdamania87"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1116714017
+              },
+              {
+                "bodyText": "@pytorchbot merge this",
+                "author": {
+                  "login": "kumpera"
+                },
+                "authorAssociation": "MEMBER",
+                "editor": null,
+                "databaseId": 1118494220
+              }
+            ],
+            "pageInfo": {
+              "startCursor": "Y3Vyc29yOnYyOpHOQdFxiw==",
+              "hasPreviousPage": false
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -63,6 +63,7 @@ def mock_parse_args(revert: bool = False,
             self.dry_run = True
             self.comment_id = 0
             self.mandatory_only = False
+            self.on_green = False
             self.reason = 'this is for testing'
 
     return Object()
@@ -248,6 +249,7 @@ class TestGitHubPR(TestCase):
                                            dry_run=mock.ANY,
                                            force=True,
                                            comment_id=mock.ANY,
+                                           on_green=False,
                                            mandatory_only=False)
 
     @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
@@ -261,6 +263,7 @@ class TestGitHubPR(TestCase):
                                            dry_run=mock.ANY,
                                            force=False,
                                            comment_id=mock.ANY,
+                                           on_green=False,
                                            mandatory_only=False)
 
 if __name__ == "__main__":

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -61,6 +61,7 @@ def mock_parse_args(revert: bool = False,
             self.pr_num = 76123
             self.dry_run = True
             self.comment_id = 0
+            self.mandatory_only = False
             self.reason = 'this is for testing'
 
     return Object()
@@ -75,6 +76,7 @@ def mock_merge(pr_num: int, repo: GitRepo,
                dry_run: bool = False,
                force: bool = False,
                comment_id: Optional[int] = None,
+               mandatory_only: bool = False,
                timeout_minutes: int = 400) -> None:
     pass
 
@@ -240,7 +242,12 @@ class TestGitHubPR(TestCase):
     def test_main_force(self, mock_merge: Any, mock_parse_args: Any, mock_gh_get_info: Any) -> None:
         import trymerge
         trymerge.main()
-        mock_merge.assert_called_once_with(mock.ANY, mock.ANY, dry_run=mock.ANY, force=True, comment_id=mock.ANY)
+        mock_merge.assert_called_once_with(mock.ANY,
+                                           mock.ANY,
+                                           dry_run=mock.ANY,
+                                           force=True,
+                                           comment_id=mock.ANY,
+                                           mandatory_only=False)
 
     @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
     @mock.patch('trymerge.parse_args', return_value=mock_parse_args(False, False))
@@ -248,7 +255,12 @@ class TestGitHubPR(TestCase):
     def test_main_merge(self, mock_merge: Any, mock_parse_args: Any, mock_gh_get_info: Any) -> None:
         import trymerge
         trymerge.main()
-        mock_merge.assert_called_once_with(mock.ANY, mock.ANY, dry_run=mock.ANY, force=False, comment_id=mock.ANY)
+        mock_merge.assert_called_once_with(mock.ANY,
+                                           mock.ANY,
+                                           dry_run=mock.ANY,
+                                           force=False,
+                                           comment_id=mock.ANY,
+                                           mandatory_only=False)
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -54,24 +54,35 @@ def mocked_gh_graphql(query: str, **kwargs: Any) -> Any:
     return rc
 
 def mock_parse_args(revert: bool = False,
-                    force: bool = False,
-                    comment_id: int = 0,
-                    pr_num: int = 0) -> Any:
+                    force: bool = False) -> Any:
     class Object(object):
         pass
-    out = Object()
-    out.revert = True
-    out.pr_num = 76123
-    out.dry_run=True
-    out.comment_id=None
-    out.reason='this is a bad thing'
-    return out
+    args = Object()
+    args.revert = revert
+    args.force = force
+    args.pr_num = 76123
+    args.dry_run=True
+    args.comment_id=0
+    args.reason='this is for testing'
+    return args
 
 def mock_revert(repo: GitRepo, pr: GitHubPR, *,
                   dry_run: bool = False,
                   comment_id: Optional[int] = None,
                   reason: Optional[str] = None) -> None:
+        print('revertin')
         pass
+
+def mock_merge(pr_num: int, repo: GitRepo,
+          dry_run: bool = False,
+          force: bool = False,
+          comment_id: Optional[int] = None,
+          timeout_minutes: int = 400) -> None:
+        print("BEING CALLED" , pr_num, repo, dry_run, force, comment_id, timeout_minutes)
+        pass
+
+def mock_gh_get_info():
+    return {"closed": False, "isCrossRepository": False}
 
 
 def mocked_read_merge_rules(repo: Optional[GitRepo], org: str, project: str) -> List[MergeRule]:
@@ -94,100 +105,100 @@ def mocked_read_merge_rules(repo: Optional[GitRepo], org: str, project: str) -> 
 
 
 class TestGitHubPR(TestCase):
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_match_rules(self, mocked_gql: Any) -> None:
-    #     "Tests that PR passes merge rules"
-    #     pr = GitHubPR("pytorch", "pytorch", 77700)
-    #     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-    #     self.assertTrue(find_matching_merge_rule(pr, repo) is not None)
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_match_rules(self, mocked_gql: Any) -> None:
+        "Tests that PR passes merge rules"
+        pr = GitHubPR("pytorch", "pytorch", 77700)
+        repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
+        self.assertTrue(find_matching_merge_rule(pr, repo) is not None)
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_lint_fails(self, mocked_gql: Any) -> None:
-    #     "Tests that PR fails mandatory lint check"
-    #     pr = GitHubPR("pytorch", "pytorch", 74649)
-    #     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-    #     self.assertRaises(RuntimeError, lambda: find_matching_merge_rule(pr, repo))
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_lint_fails(self, mocked_gql: Any) -> None:
+        "Tests that PR fails mandatory lint check"
+        pr = GitHubPR("pytorch", "pytorch", 74649)
+        repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
+        self.assertRaises(RuntimeError, lambda: find_matching_merge_rule(pr, repo))
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_get_last_comment(self, mocked_gql: Any) -> None:
-    #     "Tests that last comment can be fetched"
-    #     pr = GitHubPR("pytorch", "pytorch", 71759)
-    #     comment = pr.get_last_comment()
-    #     self.assertEqual(comment.author_login, "github-actions")
-    #     self.assertIsNone(comment.editor_login)
-    #     self.assertTrue("You've committed this PR" in comment.body_text)
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_get_last_comment(self, mocked_gql: Any) -> None:
+        "Tests that last comment can be fetched"
+        pr = GitHubPR("pytorch", "pytorch", 71759)
+        comment = pr.get_last_comment()
+        self.assertEqual(comment.author_login, "github-actions")
+        self.assertIsNone(comment.editor_login)
+        self.assertTrue("You've committed this PR" in comment.body_text)
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_get_author_null(self, mocked_gql: Any) -> None:
-    #     """ Tests that PR author can be computed
-    #         If reply contains NULL
-    #     """
-    #     pr = GitHubPR("pytorch", "pytorch", 71759)
-    #     author = pr.get_author()
-    #     self.assertTrue(author is not None)
-    #     self.assertTrue("@" in author)
-    #     self.assertTrue(pr.get_diff_revision() is None)
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_get_author_null(self, mocked_gql: Any) -> None:
+        """ Tests that PR author can be computed
+            If reply contains NULL
+        """
+        pr = GitHubPR("pytorch", "pytorch", 71759)
+        author = pr.get_author()
+        self.assertTrue(author is not None)
+        self.assertTrue("@" in author)
+        self.assertTrue(pr.get_diff_revision() is None)
 
-    #     # PR with multiple contributors, but creator id is not among authors
-    #     pr = GitHubPR("pytorch", "pytorch", 75095)
-    #     self.assertEqual(pr.get_pr_creator_login(), "mruberry")
-    #     author = pr.get_author()
-    #     self.assertTrue(author is not None)
+        # PR with multiple contributors, but creator id is not among authors
+        pr = GitHubPR("pytorch", "pytorch", 75095)
+        self.assertEqual(pr.get_pr_creator_login(), "mruberry")
+        author = pr.get_author()
+        self.assertTrue(author is not None)
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_large_diff(self, mocked_gql: Any) -> None:
-    #     "Tests that PR with 100+ files can be fetched"
-    #     pr = GitHubPR("pytorch", "pytorch", 73099)
-    #     self.assertTrue(pr.get_changed_files_count() > 100)
-    #     flist = pr.get_changed_files()
-    #     self.assertEqual(len(flist), pr.get_changed_files_count())
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_large_diff(self, mocked_gql: Any) -> None:
+        "Tests that PR with 100+ files can be fetched"
+        pr = GitHubPR("pytorch", "pytorch", 73099)
+        self.assertTrue(pr.get_changed_files_count() > 100)
+        flist = pr.get_changed_files()
+        self.assertEqual(len(flist), pr.get_changed_files_count())
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_internal_changes(self, mocked_gql: Any) -> None:
-    #     "Tests that PR with internal changes is detected"
-    #     pr = GitHubPR("pytorch", "pytorch", 73969)
-    #     self.assertTrue(pr.has_internal_changes())
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_internal_changes(self, mocked_gql: Any) -> None:
+        "Tests that PR with internal changes is detected"
+        pr = GitHubPR("pytorch", "pytorch", 73969)
+        self.assertTrue(pr.has_internal_changes())
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_checksuites_pagination(self, mocked_gql: Any) -> None:
-    #     "Tests that PR with lots of checksuits can be fetched"
-    #     pr = GitHubPR("pytorch", "pytorch", 73811)
-    #     self.assertGreater(len(pr.get_checkrun_conclusions()), 0)
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_checksuites_pagination(self, mocked_gql: Any) -> None:
+        "Tests that PR with lots of checksuits can be fetched"
+        pr = GitHubPR("pytorch", "pytorch", 73811)
+        self.assertGreater(len(pr.get_checkrun_conclusions()), 0)
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_comments_pagination(self, mocked_gql: Any) -> None:
-    #     "Tests that PR with 50+ comments can be fetched"
-    #     pr = GitHubPR("pytorch", "pytorch", 31093)
-    #     self.assertGreater(len(pr.get_comments()), 50)
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_comments_pagination(self, mocked_gql: Any) -> None:
+        "Tests that PR with 50+ comments can be fetched"
+        pr = GitHubPR("pytorch", "pytorch", 31093)
+        self.assertGreater(len(pr.get_comments()), 50)
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_gql_complexity(self, mocked_gql: Any) -> None:
-    #     "Fetch comments and conclusions for PR with 60 commits"
-    #     # Previous version of GrapQL query used to cause HTTP/502 error
-    #     # see https://gist.github.com/malfet/9b93bc7eeddeaf1d84546efc4f0c577f
-    #     pr = GitHubPR("pytorch", "pytorch", 68111)
-    #     self.assertGreater(len(pr.get_comments()), 20)
-    #     self.assertGreater(len(pr.get_checkrun_conclusions()), 3)
-    #     self.assertGreater(pr.get_commit_count(), 60)
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_gql_complexity(self, mocked_gql: Any) -> None:
+        "Fetch comments and conclusions for PR with 60 commits"
+        # Previous version of GrapQL query used to cause HTTP/502 error
+        # see https://gist.github.com/malfet/9b93bc7eeddeaf1d84546efc4f0c577f
+        pr = GitHubPR("pytorch", "pytorch", 68111)
+        self.assertGreater(len(pr.get_comments()), 20)
+        self.assertGreater(len(pr.get_checkrun_conclusions()), 3)
+        self.assertGreater(pr.get_commit_count(), 60)
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_team_members(self, mocked_gql: Any) -> None:
-    #     "Test fetching team members works"
-    #     dev_infra_team = gh_get_team_members("pytorch", "pytorch-dev-infra")
-    #     self.assertGreater(len(dev_infra_team), 2)
-    #     with self.assertWarns(Warning):
-    #         non_existing_team = gh_get_team_members("pytorch", "qwertyuiop")
-    #         self.assertEqual(len(non_existing_team), 0)
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_team_members(self, mocked_gql: Any) -> None:
+        "Test fetching team members works"
+        dev_infra_team = gh_get_team_members("pytorch", "pytorch-dev-infra")
+        self.assertGreater(len(dev_infra_team), 2)
+        with self.assertWarns(Warning):
+            non_existing_team = gh_get_team_members("pytorch", "qwertyuiop")
+            self.assertEqual(len(non_existing_team), 0)
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_get_author_many_commits(self, mocked_gql: Any) -> None:
-    #     """ Tests that authors for all commits can be fetched
-    #     """
-    #     pr = GitHubPR("pytorch", "pytorch", 76118)
-    #     authors = pr.get_authors()
-    #     self.assertGreater(pr.get_commit_count(), 100)
-    #     self.assertGreater(len(authors), 50)
-    #     self.assertTrue("@" in pr.get_author())
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_get_author_many_commits(self, mocked_gql: Any) -> None:
+        """ Tests that authors for all commits can be fetched
+        """
+        pr = GitHubPR("pytorch", "pytorch", 76118)
+        authors = pr.get_authors()
+        self.assertGreater(pr.get_commit_count(), 100)
+        self.assertGreater(len(authors), 50)
+        self.assertTrue("@" in pr.get_author())
 
     @mock.patch('trymerge.read_merge_rules', side_effect=mocked_read_merge_rules)
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
@@ -218,14 +229,29 @@ class TestGitHubPR(TestCase):
     #     conclusions = pr.get_checkrun_conclusions()
     #     self.assertTrue("linux-docs / build-docs (cpp)" in conclusions.keys())
 
-    @mock.patch('trymerge.gh_get_pr_info', return_value=None)
-    @mock.patch('trymerge.parse_args', side_effect=mock_parse_args)
+    @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
+    @mock.patch('trymerge.parse_args', return_value=mock_parse_args(True, False))
     @mock.patch('trymerge.try_revert', side_effect=mock_revert)
-    def test_main_revert(self, mocked_gql: Any, mock_parse_args: Any, mock_revert: Any) -> None:
+    def test_main_revert(self, mock_revert: Any, mock_parse_args: Any, gh_get_pr_info: Any) -> None:
         import trymerge
         trymerge.main()
-        assert(mock_revert.called_once())
+        mock_revert.assert_called_once()
 
+    @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
+    @mock.patch('trymerge.parse_args', return_value=mock_parse_args(False, True))
+    @mock.patch('trymerge.merge', side_effect=mock_merge)
+    def test_main_force(self, mock_merge: Any, mock_parse_args: Any, mock_gh_get_info: Any) -> None:
+        import trymerge
+        trymerge.main()
+        mock_merge.assert_called_once_with(mock.ANY, mock.ANY, dry_run=mock.ANY, force=True, comment_id=mock.ANY)
+
+    @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
+    @mock.patch('trymerge.parse_args', return_value=mock_parse_args(False, False))
+    @mock.patch('trymerge.merge', side_effect=mock_merge)
+    def test_main_merge(self, mock_merge: Any, mock_parse_args: Any, mock_gh_get_info: Any) -> None:
+        import trymerge
+        trymerge.main()
+        mock_merge.assert_called_once_with(mock.ANY, mock.ANY, dry_run=mock.ANY, force=False, comment_id=mock.ANY)
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -10,7 +10,6 @@
 import json
 import os
 from hashlib import sha256
-from argparse import ArgumentParser
 
 from trymerge import find_matching_merge_rule, gh_graphql, gh_get_team_members, GitHubPR, MergeRule, MandatoryChecksMissingError
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
@@ -56,32 +55,30 @@ def mocked_gh_graphql(query: str, **kwargs: Any) -> Any:
 def mock_parse_args(revert: bool = False,
                     force: bool = False) -> Any:
     class Object(object):
-        pass
-    args = Object()
-    args.revert = revert
-    args.force = force
-    args.pr_num = 76123
-    args.dry_run=True
-    args.comment_id=0
-    args.reason='this is for testing'
-    return args
+        def __init__(self) -> None:
+            self.revert = revert
+            self.force = force
+            self.pr_num = 76123
+            self.dry_run = True
+            self.comment_id = 0
+            self.reason = 'this is for testing'
+
+    return Object()
 
 def mock_revert(repo: GitRepo, pr: GitHubPR, *,
-                  dry_run: bool = False,
-                  comment_id: Optional[int] = None,
-                  reason: Optional[str] = None) -> None:
-        print('revertin')
-        pass
+                dry_run: bool = False,
+                comment_id: Optional[int] = None,
+                reason: Optional[str] = None) -> None:
+    pass
 
 def mock_merge(pr_num: int, repo: GitRepo,
-          dry_run: bool = False,
-          force: bool = False,
-          comment_id: Optional[int] = None,
-          timeout_minutes: int = 400) -> None:
-        print("BEING CALLED" , pr_num, repo, dry_run, force, comment_id, timeout_minutes)
-        pass
+               dry_run: bool = False,
+               force: bool = False,
+               comment_id: Optional[int] = None,
+               timeout_minutes: int = 400) -> None:
+    pass
 
-def mock_gh_get_info():
+def mock_gh_get_info() -> Any:
     return {"closed": False, "isCrossRepository": False}
 
 

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -30,6 +30,7 @@ def mocked_gh_graphql(query: str, **kwargs: Any) -> Any:
         with open(gql_db_fname, encoding="utf-8", mode="w") as f:
             json.dump(obj, f, indent=2)
             f.write("\n")
+
     key = f"query_sha={sha256(query.encode('utf-8')).hexdigest()} " + " ".join([f"{k}={kwargs[k]}" for k in sorted(kwargs.keys())])
     mocked_queries = get_mocked_queries()
 

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -10,6 +10,7 @@
 import json
 import os
 from hashlib import sha256
+from argparse import ArgumentParser
 
 from trymerge import find_matching_merge_rule, gh_graphql, gh_get_team_members, GitHubPR, MergeRule, MandatoryChecksMissingError
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
@@ -30,7 +31,6 @@ def mocked_gh_graphql(query: str, **kwargs: Any) -> Any:
         with open(gql_db_fname, encoding="utf-8", mode="w") as f:
             json.dump(obj, f, indent=2)
             f.write("\n")
-
     key = f"query_sha={sha256(query.encode('utf-8')).hexdigest()} " + " ".join([f"{k}={kwargs[k]}" for k in sorted(kwargs.keys())])
     mocked_queries = get_mocked_queries()
 
@@ -53,6 +53,26 @@ def mocked_gh_graphql(query: str, **kwargs: Any) -> Any:
 
     return rc
 
+def mock_parse_args(revert: bool = False,
+                    force: bool = False,
+                    comment_id: int = 0,
+                    pr_num: int = 0) -> Any:
+    class Object(object):
+        pass
+    out = Object()
+    out.revert = True
+    out.pr_num = 76123
+    out.dry_run=True
+    out.comment_id=None
+    out.reason='this is a bad thing'
+    return out
+
+def mock_revert(repo: GitRepo, pr: GitHubPR, *,
+                  dry_run: bool = False,
+                  comment_id: Optional[int] = None,
+                  reason: Optional[str] = None) -> None:
+        pass
+
 
 def mocked_read_merge_rules(repo: Optional[GitRepo], org: str, project: str) -> List[MergeRule]:
     mock_merge_rules = """
@@ -74,100 +94,100 @@ def mocked_read_merge_rules(repo: Optional[GitRepo], org: str, project: str) -> 
 
 
 class TestGitHubPR(TestCase):
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_match_rules(self, mocked_gql: Any) -> None:
-        "Tests that PR passes merge rules"
-        pr = GitHubPR("pytorch", "pytorch", 77700)
-        repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        self.assertTrue(find_matching_merge_rule(pr, repo) is not None)
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_match_rules(self, mocked_gql: Any) -> None:
+    #     "Tests that PR passes merge rules"
+    #     pr = GitHubPR("pytorch", "pytorch", 77700)
+    #     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
+    #     self.assertTrue(find_matching_merge_rule(pr, repo) is not None)
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_lint_fails(self, mocked_gql: Any) -> None:
-        "Tests that PR fails mandatory lint check"
-        pr = GitHubPR("pytorch", "pytorch", 74649)
-        repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        self.assertRaises(RuntimeError, lambda: find_matching_merge_rule(pr, repo))
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_lint_fails(self, mocked_gql: Any) -> None:
+    #     "Tests that PR fails mandatory lint check"
+    #     pr = GitHubPR("pytorch", "pytorch", 74649)
+    #     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
+    #     self.assertRaises(RuntimeError, lambda: find_matching_merge_rule(pr, repo))
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_get_last_comment(self, mocked_gql: Any) -> None:
-        "Tests that last comment can be fetched"
-        pr = GitHubPR("pytorch", "pytorch", 71759)
-        comment = pr.get_last_comment()
-        self.assertEqual(comment.author_login, "github-actions")
-        self.assertIsNone(comment.editor_login)
-        self.assertTrue("You've committed this PR" in comment.body_text)
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_get_last_comment(self, mocked_gql: Any) -> None:
+    #     "Tests that last comment can be fetched"
+    #     pr = GitHubPR("pytorch", "pytorch", 71759)
+    #     comment = pr.get_last_comment()
+    #     self.assertEqual(comment.author_login, "github-actions")
+    #     self.assertIsNone(comment.editor_login)
+    #     self.assertTrue("You've committed this PR" in comment.body_text)
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_get_author_null(self, mocked_gql: Any) -> None:
-        """ Tests that PR author can be computed
-            If reply contains NULL
-        """
-        pr = GitHubPR("pytorch", "pytorch", 71759)
-        author = pr.get_author()
-        self.assertTrue(author is not None)
-        self.assertTrue("@" in author)
-        self.assertTrue(pr.get_diff_revision() is None)
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_get_author_null(self, mocked_gql: Any) -> None:
+    #     """ Tests that PR author can be computed
+    #         If reply contains NULL
+    #     """
+    #     pr = GitHubPR("pytorch", "pytorch", 71759)
+    #     author = pr.get_author()
+    #     self.assertTrue(author is not None)
+    #     self.assertTrue("@" in author)
+    #     self.assertTrue(pr.get_diff_revision() is None)
 
-        # PR with multiple contributors, but creator id is not among authors
-        pr = GitHubPR("pytorch", "pytorch", 75095)
-        self.assertEqual(pr.get_pr_creator_login(), "mruberry")
-        author = pr.get_author()
-        self.assertTrue(author is not None)
+    #     # PR with multiple contributors, but creator id is not among authors
+    #     pr = GitHubPR("pytorch", "pytorch", 75095)
+    #     self.assertEqual(pr.get_pr_creator_login(), "mruberry")
+    #     author = pr.get_author()
+    #     self.assertTrue(author is not None)
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_large_diff(self, mocked_gql: Any) -> None:
-        "Tests that PR with 100+ files can be fetched"
-        pr = GitHubPR("pytorch", "pytorch", 73099)
-        self.assertTrue(pr.get_changed_files_count() > 100)
-        flist = pr.get_changed_files()
-        self.assertEqual(len(flist), pr.get_changed_files_count())
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_large_diff(self, mocked_gql: Any) -> None:
+    #     "Tests that PR with 100+ files can be fetched"
+    #     pr = GitHubPR("pytorch", "pytorch", 73099)
+    #     self.assertTrue(pr.get_changed_files_count() > 100)
+    #     flist = pr.get_changed_files()
+    #     self.assertEqual(len(flist), pr.get_changed_files_count())
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_internal_changes(self, mocked_gql: Any) -> None:
-        "Tests that PR with internal changes is detected"
-        pr = GitHubPR("pytorch", "pytorch", 73969)
-        self.assertTrue(pr.has_internal_changes())
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_internal_changes(self, mocked_gql: Any) -> None:
+    #     "Tests that PR with internal changes is detected"
+    #     pr = GitHubPR("pytorch", "pytorch", 73969)
+    #     self.assertTrue(pr.has_internal_changes())
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_checksuites_pagination(self, mocked_gql: Any) -> None:
-        "Tests that PR with lots of checksuits can be fetched"
-        pr = GitHubPR("pytorch", "pytorch", 73811)
-        self.assertGreater(len(pr.get_checkrun_conclusions()), 0)
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_checksuites_pagination(self, mocked_gql: Any) -> None:
+    #     "Tests that PR with lots of checksuits can be fetched"
+    #     pr = GitHubPR("pytorch", "pytorch", 73811)
+    #     self.assertGreater(len(pr.get_checkrun_conclusions()), 0)
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_comments_pagination(self, mocked_gql: Any) -> None:
-        "Tests that PR with 50+ comments can be fetched"
-        pr = GitHubPR("pytorch", "pytorch", 31093)
-        self.assertGreater(len(pr.get_comments()), 50)
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_comments_pagination(self, mocked_gql: Any) -> None:
+    #     "Tests that PR with 50+ comments can be fetched"
+    #     pr = GitHubPR("pytorch", "pytorch", 31093)
+    #     self.assertGreater(len(pr.get_comments()), 50)
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_gql_complexity(self, mocked_gql: Any) -> None:
-        "Fetch comments and conclusions for PR with 60 commits"
-        # Previous version of GrapQL query used to cause HTTP/502 error
-        # see https://gist.github.com/malfet/9b93bc7eeddeaf1d84546efc4f0c577f
-        pr = GitHubPR("pytorch", "pytorch", 68111)
-        self.assertGreater(len(pr.get_comments()), 20)
-        self.assertGreater(len(pr.get_checkrun_conclusions()), 3)
-        self.assertGreater(pr.get_commit_count(), 60)
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_gql_complexity(self, mocked_gql: Any) -> None:
+    #     "Fetch comments and conclusions for PR with 60 commits"
+    #     # Previous version of GrapQL query used to cause HTTP/502 error
+    #     # see https://gist.github.com/malfet/9b93bc7eeddeaf1d84546efc4f0c577f
+    #     pr = GitHubPR("pytorch", "pytorch", 68111)
+    #     self.assertGreater(len(pr.get_comments()), 20)
+    #     self.assertGreater(len(pr.get_checkrun_conclusions()), 3)
+    #     self.assertGreater(pr.get_commit_count(), 60)
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_team_members(self, mocked_gql: Any) -> None:
-        "Test fetching team members works"
-        dev_infra_team = gh_get_team_members("pytorch", "pytorch-dev-infra")
-        self.assertGreater(len(dev_infra_team), 2)
-        with self.assertWarns(Warning):
-            non_existing_team = gh_get_team_members("pytorch", "qwertyuiop")
-            self.assertEqual(len(non_existing_team), 0)
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_team_members(self, mocked_gql: Any) -> None:
+    #     "Test fetching team members works"
+    #     dev_infra_team = gh_get_team_members("pytorch", "pytorch-dev-infra")
+    #     self.assertGreater(len(dev_infra_team), 2)
+    #     with self.assertWarns(Warning):
+    #         non_existing_team = gh_get_team_members("pytorch", "qwertyuiop")
+    #         self.assertEqual(len(non_existing_team), 0)
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_get_author_many_commits(self, mocked_gql: Any) -> None:
-        """ Tests that authors for all commits can be fetched
-        """
-        pr = GitHubPR("pytorch", "pytorch", 76118)
-        authors = pr.get_authors()
-        self.assertGreater(pr.get_commit_count(), 100)
-        self.assertGreater(len(authors), 50)
-        self.assertTrue("@" in pr.get_author())
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_get_author_many_commits(self, mocked_gql: Any) -> None:
+    #     """ Tests that authors for all commits can be fetched
+    #     """
+    #     pr = GitHubPR("pytorch", "pytorch", 76118)
+    #     authors = pr.get_authors()
+    #     self.assertGreater(pr.get_commit_count(), 100)
+    #     self.assertGreater(len(authors), 50)
+    #     self.assertTrue("@" in pr.get_author())
 
     @mock.patch('trymerge.read_merge_rules', side_effect=mocked_read_merge_rules)
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
@@ -180,23 +200,31 @@ class TestGitHubPR(TestCase):
                                ".*are pending/not yet run.*",
                                lambda: find_matching_merge_rule(pr, repo))
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_get_author_many_reviews(self, mocked_gql: Any) -> None:
-        """ Tests that all reviews can be fetched
-        """
-        pr = GitHubPR("pytorch", "pytorch", 76123)
-        approved_by = pr.get_approved_by()
-        self.assertGreater(len(approved_by), 0)
-        assert pr._reviews is not None  # to pacify mypy
-        self.assertGreater(len(pr._reviews), 100)
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_get_author_many_reviews(self, mocked_gql: Any) -> None:
+    #     """ Tests that all reviews can be fetched
+    #     """
+    #     pr = GitHubPR("pytorch", "pytorch", 76123)
+    #     approved_by = pr.get_approved_by()
+    #     self.assertGreater(len(approved_by), 0)
+    #     assert pr._reviews is not None  # to pacify mypy
+    #     self.assertGreater(len(pr._reviews), 100)
 
-    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_get_checkruns_many_runs(self, mocked_gql: Any) -> None:
-        """ Tests that all checkruns can be fetched
-        """
-        pr = GitHubPR("pytorch", "pytorch", 77700)
-        conclusions = pr.get_checkrun_conclusions()
-        self.assertTrue("linux-docs / build-docs (cpp)" in conclusions.keys())
+    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    # def test_get_checkruns_many_runs(self, mocked_gql: Any) -> None:
+    #     """ Tests that all checkruns can be fetched
+    #     """
+    #     pr = GitHubPR("pytorch", "pytorch", 77700)
+    #     conclusions = pr.get_checkrun_conclusions()
+    #     self.assertTrue("linux-docs / build-docs (cpp)" in conclusions.keys())
+
+    @mock.patch('trymerge.gh_get_pr_info', return_value=None)
+    @mock.patch('trymerge.parse_args', side_effect=mock_parse_args)
+    @mock.patch('trymerge.try_revert', side_effect=mock_revert)
+    def test_main_revert(self, mocked_gql: Any, mock_parse_args: Any, mock_revert: Any) -> None:
+        import trymerge
+        trymerge.main()
+        assert(mock_revert.called_once())
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -211,23 +211,23 @@ class TestGitHubPR(TestCase):
                                ".*are pending/not yet run.*",
                                lambda: find_matching_merge_rule(pr, repo))
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_get_author_many_reviews(self, mocked_gql: Any) -> None:
-    #     """ Tests that all reviews can be fetched
-    #     """
-    #     pr = GitHubPR("pytorch", "pytorch", 76123)
-    #     approved_by = pr.get_approved_by()
-    #     self.assertGreater(len(approved_by), 0)
-    #     assert pr._reviews is not None  # to pacify mypy
-    #     self.assertGreater(len(pr._reviews), 100)
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_get_author_many_reviews(self, mocked_gql: Any) -> None:
+        """ Tests that all reviews can be fetched
+        """
+        pr = GitHubPR("pytorch", "pytorch", 76123)
+        approved_by = pr.get_approved_by()
+        self.assertGreater(len(approved_by), 0)
+        assert pr._reviews is not None  # to pacify mypy
+        self.assertGreater(len(pr._reviews), 100)
 
-    # @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    # def test_get_checkruns_many_runs(self, mocked_gql: Any) -> None:
-    #     """ Tests that all checkruns can be fetched
-    #     """
-    #     pr = GitHubPR("pytorch", "pytorch", 77700)
-    #     conclusions = pr.get_checkrun_conclusions()
-    #     self.assertTrue("linux-docs / build-docs (cpp)" in conclusions.keys())
+    @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
+    def test_get_checkruns_many_runs(self, mocked_gql: Any) -> None:
+        """ Tests that all checkruns can be fetched
+        """
+        pr = GitHubPR("pytorch", "pytorch", 77700)
+        conclusions = pr.get_checkrun_conclusions()
+        self.assertTrue("linux-docs / build-docs (cpp)" in conclusions.keys())
 
     @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
     @mock.patch('trymerge.parse_args', return_value=mock_parse_args(True, False))

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -383,6 +383,7 @@ def parse_args() -> Any:
     from argparse import ArgumentParser
     parser = ArgumentParser("Merge PR into default branch")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--on-mandatory", action="store_true")
     parser.add_argument("--revert", action="store_true")
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--comment-id", type=int)

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -915,6 +915,10 @@ def merge(pr_num: int, repo: GitRepo,
           timeout_minutes: int = 400) -> None:
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
     org, project = repo.gh_owner_and_name()
+    if force:
+        pr = GitHubPR(org, project, pr_num)
+        pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)
+
     start_time = time.time()
     last_exception = ''
     elapsed_time = 0.0

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -384,6 +384,7 @@ def parse_args() -> Any:
     parser = ArgumentParser("Merge PR into default branch")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--on-mandatory", action="store_true")
+    parser.add_argument("--on-green", action="store_true")
     parser.add_argument("--revert", action="store_true")
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--comment-id", type=int)
@@ -913,6 +914,7 @@ def merge(pr_num: int, repo: GitRepo,
           force: bool = False,
           comment_id: Optional[int] = None,
           mandatory_only: bool = False,
+          on_green: bool = False,
           timeout_minutes: int = 400) -> None:
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
     org, project = repo.gh_owner_and_name()
@@ -932,10 +934,10 @@ def merge(pr_num: int, repo: GitRepo,
             find_matching_merge_rule(pr, repo)
             pending = pr_get_pending_checks(pr)
             failing = pr_get_failed_checks(pr)
-            if not mandatory_only and len(failing) > 0:
+            if (not mandatory_only and on_green) and len(failing) > 0:
                 raise RuntimeError(f"{len(failing)} additional jobs have failed, first few of them are: " +
                                    ' ,'.join(f"[{x[0]}]({x[1]})" for x in failing[:5]))
-            if not mandatory_only and len(pending) > 0:
+            if (not mandatory_only and on_green) and len(pending) > 0:
                 raise MandatoryChecksMissingError(f"Still waiting for {len(pending)} additional jobs to finish, " +
                                                   f"first few of them are: {' ,'.join(x[0] for x in pending[:5])}")
             return pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)
@@ -989,6 +991,7 @@ def main() -> None:
               dry_run=args.dry_run,
               force=args.force,
               comment_id=args.comment_id,
+              on_green=args.on_green,
               mandatory_only=args.mandatory_only)
     except Exception as e:
         handle_exception(e)

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -383,8 +383,6 @@ def parse_args() -> Any:
     from argparse import ArgumentParser
     parser = ArgumentParser("Merge PR into default branch")
     parser.add_argument("--dry-run", action="store_true")
-    parser.add_argument("--on-green", action="store_true")
-    parser.add_argument("--on-mandatory", action="store_true")
     parser.add_argument("--revert", action="store_true")
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--comment-id", type=int)
@@ -909,10 +907,12 @@ def prefix_with_github_url(suffix_str: str) -> str:
     return f"https://github.com/{suffix_str}"
 
 
-def merge_on_green(pr_num: int, repo: GitRepo,
-                   dry_run: bool = False,
-                   mandatory_only: bool = False,
-                   timeout_minutes: int = 400) -> None:
+def merge(pr_num: int, repo: GitRepo,
+          dry_run: bool = False,
+          force: bool = False,
+          comment_id: Optional[int] = None,
+          mandatory_only: bool = False,
+          timeout_minutes: int = 400) -> None:
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
     org, project = repo.gh_owner_and_name()
     start_time = time.time()
@@ -934,7 +934,7 @@ def merge_on_green(pr_num: int, repo: GitRepo,
             if not mandatory_only and len(pending) > 0:
                 raise MandatoryChecksMissingError(f"Still waiting for {len(pending)} additional jobs to finish, " +
                                                   f"first few of them are: {' ,'.join(x[0] for x in pending[:5])}")
-            return pr.merge_into(repo, dry_run=dry_run)
+            return pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)
         except MandatoryChecksMissingError as ex:
             last_exception = str(ex)
             print(f"Merge of https://github.com/{org}/{project}/pull/{pr_num} failed due to: {ex}. Retrying in 5 min")
@@ -980,16 +980,15 @@ def main() -> None:
         gh_post_comment(org, project, args.pr_num, "Cross-repo ghstack merges are not supported", dry_run=args.dry_run)
         return
 
-    if args.on_green or args.on_mandatory:
-        try:
-            merge_on_green(args.pr_num, repo, dry_run=args.dry_run, mandatory_only=args.on_mandatory)
-        except Exception as e:
-            handle_exception(e)
-    else:
-        try:
-            pr.merge_into(repo, dry_run=args.dry_run, force=args.force, comment_id=args.comment_id)
-        except Exception as e:
-            handle_exception(e)
+    try:
+        merge(args.pr_num, repo,
+              dry_run=args.dry_run,
+              force=args.force,
+              comment_id=args.comment_id,
+              mandatory_only=args.mandatory_only)
+    except Exception as e:
+        handle_exception(e)
+
 
 
 if __name__ == "__main__":

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -911,10 +911,7 @@ def merge(pr_num: int, repo: GitRepo,
           dry_run: bool = False,
           force: bool = False,
           comment_id: Optional[int] = None,
-<<<<<<< HEAD
           mandatory_only: bool = False,
-=======
->>>>>>> 2d37087a614 (add options)
           timeout_minutes: int = 400) -> None:
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
     org, project = repo.gh_owner_and_name()
@@ -924,11 +921,9 @@ def merge(pr_num: int, repo: GitRepo,
     while elapsed_time < timeout_minutes * 60:
         current_time = time.time()
         elapsed_time = current_time - start_time
-
         print(f"Attempting merge of https://github.com/{org}/{project}/pull/{pr_num} ({elapsed_time / 60} minutes elapsed)")
         pr = GitHubPR(org, project, pr_num)
         try:
-<<<<<<< HEAD
             find_matching_merge_rule(pr, repo)
             pending = pr_get_pending_checks(pr)
             failing = pr_get_failed_checks(pr)
@@ -939,9 +934,6 @@ def merge(pr_num: int, repo: GitRepo,
                 raise MandatoryChecksMissingError(f"Still waiting for {len(pending)} additional jobs to finish, " +
                                                   f"first few of them are: {' ,'.join(x[0] for x in pending[:5])}")
             return pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)
-=======
-            return pr.merge_into(repo, force=force, dry_run=dry_run, comment_id=comment_id)
->>>>>>> 2d37087a614 (add options)
         except MandatoryChecksMissingError as ex:
             last_exception = str(ex)
             print(f"Merge of https://github.com/{org}/{project}/pull/{pr_num} failed due to: {ex}. Retrying in 5 min")

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -911,7 +911,10 @@ def merge(pr_num: int, repo: GitRepo,
           dry_run: bool = False,
           force: bool = False,
           comment_id: Optional[int] = None,
+<<<<<<< HEAD
           mandatory_only: bool = False,
+=======
+>>>>>>> 2d37087a614 (add options)
           timeout_minutes: int = 400) -> None:
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
     org, project = repo.gh_owner_and_name()
@@ -925,6 +928,7 @@ def merge(pr_num: int, repo: GitRepo,
         print(f"Attempting merge of https://github.com/{org}/{project}/pull/{pr_num} ({elapsed_time / 60} minutes elapsed)")
         pr = GitHubPR(org, project, pr_num)
         try:
+<<<<<<< HEAD
             find_matching_merge_rule(pr, repo)
             pending = pr_get_pending_checks(pr)
             failing = pr_get_failed_checks(pr)
@@ -935,6 +939,9 @@ def merge(pr_num: int, repo: GitRepo,
                 raise MandatoryChecksMissingError(f"Still waiting for {len(pending)} additional jobs to finish, " +
                                                   f"first few of them are: {' ,'.join(x[0] for x in pending[:5])}")
             return pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)
+=======
+            return pr.merge_into(repo, force=force, dry_run=dry_run, comment_id=comment_id)
+>>>>>>> 2d37087a614 (add options)
         except MandatoryChecksMissingError as ex:
             last_exception = str(ex)
             print(f"Merge of https://github.com/{org}/{project}/pull/{pr_num} failed due to: {ex}. Retrying in 5 min")

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -388,8 +388,7 @@ def parse_args() -> Any:
     parser.add_argument("--comment-id", type=int)
     parser.add_argument("--reason", type=str)
     parser.add_argument("pr_num", type=int)
-    test = parser.parse_args()
-    return test
+    return parser.parse_args()
 
 def can_skip_internal_checks(pr: "GitHubPR", comment_id: Optional[int] = None) -> bool:
     if comment_id is None:

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -388,7 +388,8 @@ def parse_args() -> Any:
     parser.add_argument("--comment-id", type=int)
     parser.add_argument("--reason", type=str)
     parser.add_argument("pr_num", type=int)
-    return parser.parse_args()
+    test = parser.parse_args()
+    return test
 
 def can_skip_internal_checks(pr: "GitHubPR", comment_id: Optional[int] = None) -> bool:
     if comment_id is None:

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -30,6 +30,7 @@ jobs:
           PR_NUM: ${{ github.event.client_payload.pr_num }}
           GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           FORCE: ${{ github.event.client_payload.force}}
+          ON_GREEN: ${{ github.event.client_payload.on_green}}
           COMMENT_ID: ${{ github.event.client_payload.comment_id }}
         run: |
           set -ex
@@ -39,6 +40,8 @@ jobs:
             else
               python3 .github/scripts/trymerge.py --force "${PR_NUM}"
             fi
+          elif [ -n "${ON_GREEN}" ]; then
+            python3 .github/scripts/trymerge.py --on-green "${PR_NUM}"
           elif [ -n "${COMMENT_ID}" ]; then
             python3 .github/scripts/trymerge.py --comment-id "${COMMENT_ID}" "${PR_NUM}"
           else

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -30,7 +30,6 @@ jobs:
           PR_NUM: ${{ github.event.client_payload.pr_num }}
           GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           FORCE: ${{ github.event.client_payload.force}}
-          ON_GREEN: ${{ github.event.client_payload.on_green}}
           COMMENT_ID: ${{ github.event.client_payload.comment_id }}
         run: |
           set -ex
@@ -40,8 +39,6 @@ jobs:
             else
               python3 .github/scripts/trymerge.py --force "${PR_NUM}"
             fi
-          elif [ -n "${ON_GREEN}" ]; then
-            python3 .github/scripts/trymerge.py --on-green "${PR_NUM}"
           elif [ -n "${COMMENT_ID}" ]; then
             python3 .github/scripts/trymerge.py --comment-id "${COMMENT_ID}" "${PR_NUM}"
           else


### PR DESCRIPTION
This makes the merge on green behavior default as we tried to do it earlier, but forgot to pass in the force arguments.

This also adds a few tests so that we don't make that mistake again (although people can still forget to pass in the arguments through shell). 