### PR TITLE
Minor FX test fix for TorchDynamo

### DIFF
--- a/test/fx/test_subgraph_rewriter.py
+++ b/test/fx/test_subgraph_rewriter.py
@@ -403,21 +403,21 @@ class TestSubgraphRewriter(JitTestCase):
         class Replacement(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.id = torch.nn.Identity()
+                self.tanh = torch.nn.Tanh()
                 self.submod = torch.nn.ReLU()
 
             def forward(self, x):
-                return self.submod(self.id(x))
+                return self.submod(self.tanh(x))
 
         class Comparison(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.id = torch.nn.Identity()
+                self.tanh = torch.nn.Tanh()
                 self.submod = torch.nn.ReLU()
 
             def forward(self, x):
                 x = x + 1
-                return self.submod(self.id(x))
+                return self.submod(self.tanh(x))
 
         traced = symbolic_trace(M())
         comparison = Comparison()
@@ -432,7 +432,7 @@ class TestSubgraphRewriter(JitTestCase):
         test_outs = traced.forward(x)
         self.assertEqual(ref_outs, test_outs)
 
-        traced.get_submodule("id")
+        traced.get_submodule("tanh")
         with self.assertRaisesRegex(AttributeError, "has no attribute"):
             traced.get_submodule("sigmoid")
 


### PR DESCRIPTION
`torch.nn.Identity` gets optimized away with TorchDynamo. Replacing with `torch.nn.tanh`.

@jansel 