### PR TITLE
Expose _export_data from C++ to Python

### DIFF
--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -59,6 +59,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
+#include <torch/csrc/jit/mobile/train/export_data.h>
 #include <chrono>
 #include <cstddef>
 #include <memory>
@@ -2293,6 +2294,14 @@ void initJitScriptBindings(PyObject* module) {
         return "invalid";
     }
   });
+
+  m.def(
+      "_save_parameters",
+      [](const std::map<std::string, at::Tensor>& map,
+         const std::string& filename,
+         bool use_flatbuffer = false) {
+        _save_parameters(map, filename, use_flatbuffer);
+      });
 
   initScriptDictBindings(module);
   initScriptListBindings(module);


### PR DESCRIPTION
Summary:
https://www.internalfb.com/code/fbsource/[477a5768452957f87e56044169de47f051197567]/fbcode/caffe2/torch/csrc/jit/mobile/train/export_data.cpp
export_data is used to serialize data.

I binded this method to Python with PyBind11

Test Plan:
Wrote a file pybind_check.py which checks if the binding works.

Then, tried to read the produced data file from C++ with "torch::jit::_load_parameters" and checked that content matched.

Differential Revision: D37029253

