### PR TITLE
[ci] remove COMPACT_JOB_NAME env var

### DIFF
--- a/.jenkins/pytorch/build-asan.sh
+++ b/.jenkins/pytorch/build-asan.sh
@@ -4,9 +4,6 @@
 # (This is set by default in the Docker images we build, so you don't
 # need to set it yourself.
 
-# shellcheck disable=SC2034
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
-
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 

--- a/.jenkins/pytorch/build-mobile.sh
+++ b/.jenkins/pytorch/build-mobile.sh
@@ -6,9 +6,6 @@ set -eu -o pipefail
 # build & test mobile libtorch without having to setup Android/iOS
 # toolchain/simulator.
 
-# shellcheck disable=SC2034
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
-
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -6,9 +6,6 @@ set -ex
 # (This is set by default in the Docker images we build, so you don't
 # need to set it yourself.
 
-# shellcheck disable=SC2034
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
-
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 

--- a/.jenkins/pytorch/codegen-test.sh
+++ b/.jenkins/pytorch/codegen-test.sh
@@ -12,8 +12,6 @@
 set -eu -o pipefail
 
 if [ "$#" -eq 0 ]; then
-  # shellcheck disable=SC2034
-  COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
   # shellcheck source=./common.sh
   source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
   OUT="$(dirname "${BASH_SOURCE[0]}")/../../codegen_result"

--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -125,15 +125,6 @@ if [[ "$BUILD_ENVIRONMENT" != *win-* ]]; then
   fi
 fi
 
-# It's called a COMPACT_JOB_NAME because it's distinct from the
-# Jenkin's provided JOB_NAME, which also includes a prefix folder
-# e.g. pytorch-builds/
-
-if [ -z "$COMPACT_JOB_NAME" ]; then
-  echo "Jenkins build scripts must set COMPACT_JOB_NAME"
-  exit 1
-fi
-
 # TODO: Renable libtorch testing for MacOS, see https://github.com/pytorch/pytorch/issues/62598
 # shellcheck disable=SC2034
 BUILD_TEST_LIBTORCH=0

--- a/.jenkins/pytorch/docker-build-test.sh
+++ b/.jenkins/pytorch/docker-build-test.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# shellcheck disable=SC2034
-COMPACT_JOB_NAME="docker-build-test"
-
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 

--- a/.jenkins/pytorch/docs-test.sh
+++ b/.jenkins/pytorch/docs-test.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# shellcheck disable=SC2034
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
-
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 

--- a/.jenkins/pytorch/multigpu-test.sh
+++ b/.jenkins/pytorch/multigpu-test.sh
@@ -4,9 +4,6 @@
 # (This is set by default in the Docker images we build, so you don't
 # need to set it yourself.
 
-# shellcheck disable=SC2034
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
-
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 

--- a/.jenkins/pytorch/short-perf-test-cpu.sh
+++ b/.jenkins/pytorch/short-perf-test-cpu.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# shellcheck disable=SC2034
-COMPACT_JOB_NAME="short-perf-test-cpu"
-
 SCRIPT_PARENT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 # shellcheck source=.jenkins/pytorch/common.sh

--- a/.jenkins/pytorch/short-perf-test-gpu.sh
+++ b/.jenkins/pytorch/short-perf-test-gpu.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# shellcheck disable=SC2034
-COMPACT_JOB_NAME="short-perf-test-gpu"
-
 # shellcheck source=./common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -6,9 +6,6 @@
 
 set -ex
 
-# shellcheck disable=SC2034
-COMPACT_JOB_NAME="${BUILD_ENVIRONMENT}"
-
 TORCH_INSTALL_DIR=$(python -c "import site; print(site.getsitepackages()[0])")/torch
 TORCH_BIN_DIR="$TORCH_INSTALL_DIR"/bin
 TORCH_LIB_DIR="$TORCH_INSTALL_DIR"/lib

--- a/.jenkins/pytorch/win-build.sh
+++ b/.jenkins/pytorch/win-build.sh
@@ -9,9 +9,6 @@ if [ ! -f setup.py ]; then
   exit 1
 fi
 
-# shellcheck disable=SC2034
-COMPACT_JOB_NAME=pytorch-win-ws2019-cuda10.1-py3-build
-
 SCRIPT_PARENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # shellcheck source=./common.sh
 source "$SCRIPT_PARENT_DIR/common.sh"

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -ex
-# shellcheck disable=SC2034
-COMPACT_JOB_NAME=pytorch-win-ws2019-cuda10.1-py3-test
 
 SCRIPT_PARENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # shellcheck source=./common.sh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #79247
* #79229
* #79219
* __->__ #79214
* #79213
* #79212

This is a holdover from jenkins days. It is unused now, so remove it.