### PR TITLE
[ci] remove IS_GHA env var

### DIFF
--- a/.circleci/scripts/binary_macos_build.sh
+++ b/.circleci/scripts/binary_macos_build.sh
@@ -4,7 +4,7 @@ set -eux -o pipefail
 source "${BINARY_ENV_FILE:-/Users/distiller/project/env}"
 mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR"
 
-if [[ -z "${IS_GHA:-}" ]]; then
+if [[ -z "${GITHUB_ACTIONS:-}" ]]; then
   export PATH="${workdir:-${HOME}}/miniconda/bin:${PATH}"
 fi
 

--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -5,7 +5,7 @@ export TZ=UTC
 tagged_version() {
   # Grabs version from either the env variable CIRCLE_TAG
   # or the pytorch git described version
-  if [[ "$OSTYPE" == "msys" &&  -z "${IS_GHA:-}" ]]; then
+  if [[ "$OSTYPE" == "msys" &&  -z "${GITHUB_ACTIONS:-}" ]]; then
     GIT_DIR="${workdir}/p/.git"
   else
     GIT_DIR="${workdir}/pytorch/.git"
@@ -162,7 +162,7 @@ if [[ "$(uname)" != Darwin ]]; then
 EOL
 fi
 
-if [[ -z "${IS_GHA:-}" ]]; then
+if [[ -z "${GITHUB_ACTIONS:-}" ]]; then
   cat >>"$envfile" <<EOL
   export workdir="$workdir"
   export MAC_PACKAGE_WORK_DIR="$workdir"

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -55,7 +55,6 @@ runs:
           -e JOB_BASE_NAME \
           -e MAX_JOBS="$(nproc --ignore=2)" \
           -e AWS_DEFAULT_REGION \
-          -e IS_GHA \
           -e PR_NUMBER \
           -e SHA1 \
           -e BRANCH \

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -38,7 +38,6 @@ env:
   BUILDER_ROOT: /builder
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_FINAL_PACKAGE_DIR: /artifacts
@@ -82,7 +81,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -168,7 +166,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -79,6 +79,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -165,6 +165,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/templates/macos_binary_build_workflow.yml.j2
+++ b/.github/templates/macos_binary_build_workflow.yml.j2
@@ -48,7 +48,6 @@ env:
   BUILD_ENVIRONMENT: !{{ build_environment }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   SKIP_ALL_TESTS: 1

--- a/.github/templates/windows_binary_build_workflow.yml.j2
+++ b/.github/templates/windows_binary_build_workflow.yml.j2
@@ -48,7 +48,6 @@ env:
   BUILD_ENVIRONMENT: !{{ build_environment }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_RETRY_TEST_CASES: 1

--- a/.github/workflows/_android-build-test.yml
+++ b/.github/workflows/_android-build-test.yml
@@ -14,7 +14,6 @@ on:
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
-  IS_GHA: 1 # TODO delete in favor of GITHUB_ACTIONS
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:

--- a/.github/workflows/_android-full-build-test.yml
+++ b/.github/workflows/_android-full-build-test.yml
@@ -31,7 +31,6 @@ on:
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
-  IS_GHA: 1 # TODO delete in favor of GITHUB_ACTIONS
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:
@@ -143,7 +142,6 @@ jobs:
             -e BUILD_ENVIRONMENT="pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build" \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e AWS_DEFAULT_REGION \
-            -e IS_GHA \
             -e PR_NUMBER \
             -e SHA1 \
             -e BRANCH \

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -14,7 +14,6 @@ on:
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
-  IS_GHA: 1 # TODO delete in favor of GITHUB_ACTIONS
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:

--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -24,7 +24,6 @@ on:
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
-  IS_GHA: 1 # TODO delete in favor of GITHUB_ACTIONS
 
 jobs:
   build-docs:

--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -32,7 +32,6 @@ on:
 
 env:
   IN_CI: 1
-  IS_GHA: 1
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
   BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
   IOS_PLATFORM: ${{ inputs.ios-platform }}

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -29,7 +29,6 @@ on:
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
-  IS_GHA: 1 # TODO delete in favor of GITHUB_ACTIONS
 
 jobs:
   build:
@@ -102,7 +101,6 @@ jobs:
             -e JOB_BASE_NAME \
             -e MAX_JOBS="$(nproc --ignore=2)" \
             -e AWS_DEFAULT_REGION \
-            -e IS_GHA \
             -e PR_NUMBER \
             -e SHA1 \
             -e BRANCH \

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -18,7 +18,6 @@ on:
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
-  IS_GHA: 1 # TODO delete in favor of GITHUB_ACTIONS
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:
@@ -112,7 +111,6 @@ jobs:
             -e CUSTOM_TEST_ARTIFACT_BUILD_DIR \
             -e GITHUB_ACTIONS \
             -e IN_CI \
-            -e IS_GHA \
             -e BRANCH \
             -e SHA1 \
             -e AWS_DEFAULT_REGION \

--- a/.github/workflows/_mac-build.yml
+++ b/.github/workflows/_mac-build.yml
@@ -31,7 +31,6 @@ on:
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
-  IS_GHA: 1 # TODO delete in favor of GITHUB_ACTIONS
 
 # For setup-miniconda, see https://github.com/conda-incubator/setup-miniconda/issues/179
 defaults:
@@ -49,7 +48,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
       BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
-      COMPACT_JOB_NAME: ${{ inputs.build-environment }}
     steps:
       # [see note: pytorch repo ref]
       - name: Checkout PyTorch

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -22,7 +22,6 @@ on:
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
-  IS_GHA: 1 # TODO delete in favor of GITHUB_ACTIONS
 
 # For setup-miniconda, see https://github.com/conda-incubator/setup-miniconda/issues/179
 defaults:
@@ -41,7 +40,6 @@ jobs:
     env:
       GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
-      COMPACT_JOB_NAME: ${{ inputs.build-environment }}
       JOB_BASE_NAME: ${{ inputs.build-environment }}-test
       TEST_CONFIG: ${{ matrix.config }}
       SHARD_NUMBER: ${{ matrix.shard }}

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -30,7 +30,6 @@ on:
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
-  IS_GHA: 1 # TODO delete in favor of GITHUB_ACTIONS
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:
@@ -109,7 +108,6 @@ jobs:
             -e CUSTOM_TEST_ARTIFACT_BUILD_DIR \
             -e GITHUB_ACTIONS \
             -e IN_CI \
-            -e IS_GHA \
             -e BRANCH \
             -e SHA1 \
             -e AWS_DEFAULT_REGION \

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -19,7 +19,6 @@ on:
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
-  IS_GHA: 1 # TODO delete in favor of GITHUB_ACTIONS
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -18,7 +18,6 @@ on:
 
 env:
   IN_CI: 1 # TODO delete in favor of GITHUB_ACTIONS
-  IS_GHA: 1 # TODO delete in favor of GITHUB_ACTIONS
   GIT_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:

--- a/.github/workflows/generated-linux-binary-conda-nightly.yml
+++ b/.github/workflows/generated-linux-binary-conda-nightly.yml
@@ -27,7 +27,6 @@ env:
   BUILDER_ROOT: /builder
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_FINAL_PACKAGE_DIR: /artifacts
@@ -117,7 +116,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -247,7 +245,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -453,7 +450,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -595,7 +591,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -805,7 +800,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -947,7 +941,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1157,7 +1150,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1299,7 +1291,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1505,7 +1496,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1635,7 +1625,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1841,7 +1830,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1983,7 +1971,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2193,7 +2180,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2335,7 +2321,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2545,7 +2530,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2687,7 +2671,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2893,7 +2876,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3023,7 +3005,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3229,7 +3210,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3371,7 +3351,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3581,7 +3560,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3723,7 +3701,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3933,7 +3910,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4075,7 +4051,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4281,7 +4256,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4411,7 +4385,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4617,7 +4590,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4759,7 +4731,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4969,7 +4940,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5111,7 +5081,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5321,7 +5290,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5463,7 +5431,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \

--- a/.github/workflows/generated-linux-binary-conda-nightly.yml
+++ b/.github/workflows/generated-linux-binary-conda-nightly.yml
@@ -244,6 +244,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -591,6 +592,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -942,6 +944,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1293,6 +1296,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1628,6 +1632,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1975,6 +1980,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2326,6 +2332,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2677,6 +2684,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3012,6 +3020,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3359,6 +3368,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3710,6 +3720,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4061,6 +4072,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4396,6 +4408,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4743,6 +4756,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5094,6 +5108,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5445,6 +5460,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-conda-nightly.yml
+++ b/.github/workflows/generated-linux-binary-conda-nightly.yml
@@ -114,6 +114,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -448,6 +449,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -798,6 +800,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1148,6 +1151,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1494,6 +1498,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1828,6 +1833,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2178,6 +2184,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2528,6 +2535,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2874,6 +2882,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3208,6 +3217,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3558,6 +3568,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3908,6 +3919,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4254,6 +4266,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4588,6 +4601,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4938,6 +4952,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5288,6 +5303,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-master.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-master.yml
@@ -22,7 +22,6 @@ env:
   BUILDER_ROOT: /builder
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_FINAL_PACKAGE_DIR: /artifacts
@@ -113,7 +112,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -244,7 +242,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-master.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-master.yml
@@ -241,6 +241,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-master.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-master.yml
@@ -110,6 +110,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -115,6 +115,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -451,6 +452,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -787,6 +789,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1123,6 +1126,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1460,6 +1464,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1810,6 +1815,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2160,6 +2166,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2510,6 +2517,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2863,6 +2871,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3216,6 +3225,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3569,6 +3579,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3922,6 +3933,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4275,6 +4287,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4628,6 +4641,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4981,6 +4995,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5334,6 +5349,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5684,6 +5700,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6032,6 +6049,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6380,6 +6398,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6728,6 +6747,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -27,7 +27,6 @@ env:
   BUILDER_ROOT: /builder
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_FINAL_PACKAGE_DIR: /artifacts
@@ -118,7 +117,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -249,7 +247,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -456,7 +453,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -587,7 +583,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -794,7 +789,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -925,7 +919,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1132,7 +1125,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1263,7 +1255,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1471,7 +1462,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1614,7 +1604,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1823,7 +1812,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1966,7 +1954,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2175,7 +2162,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2318,7 +2304,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2527,7 +2512,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2670,7 +2654,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2882,7 +2865,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3025,7 +3007,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3237,7 +3218,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3380,7 +3360,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3592,7 +3571,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3735,7 +3713,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3947,7 +3924,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4090,7 +4066,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4302,7 +4277,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4445,7 +4419,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4657,7 +4630,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4800,7 +4772,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5012,7 +4983,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5155,7 +5125,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5367,7 +5336,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5510,7 +5478,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5719,7 +5686,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5870,7 +5836,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6069,7 +6034,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6220,7 +6184,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6419,7 +6382,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6570,7 +6532,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6769,7 +6730,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6920,7 +6880,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \

--- a/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-cxx11-abi-nightly.yml
@@ -246,6 +246,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -583,6 +584,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -920,6 +922,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1257,6 +1260,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1607,6 +1611,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1958,6 +1963,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2309,6 +2315,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2660,6 +2667,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3014,6 +3022,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3368,6 +3377,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3722,6 +3732,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4076,6 +4087,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4430,6 +4442,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4784,6 +4797,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5138,6 +5152,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5492,6 +5507,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5851,6 +5867,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6200,6 +6217,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6549,6 +6567,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6898,6 +6917,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-master.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-master.yml
@@ -22,7 +22,6 @@ env:
   BUILDER_ROOT: /builder
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_FINAL_PACKAGE_DIR: /artifacts
@@ -113,7 +112,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -244,7 +242,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-master.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-master.yml
@@ -241,6 +241,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-master.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-master.yml
@@ -110,6 +110,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -115,6 +115,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -451,6 +452,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -787,6 +789,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1123,6 +1126,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1460,6 +1464,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1810,6 +1815,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2160,6 +2166,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2510,6 +2517,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2863,6 +2871,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3216,6 +3225,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3569,6 +3579,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3922,6 +3933,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4275,6 +4287,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4628,6 +4641,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4981,6 +4995,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5334,6 +5349,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5684,6 +5700,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6032,6 +6049,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6380,6 +6398,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6728,6 +6747,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -27,7 +27,6 @@ env:
   BUILDER_ROOT: /builder
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_FINAL_PACKAGE_DIR: /artifacts
@@ -118,7 +117,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -249,7 +247,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -456,7 +453,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -587,7 +583,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -794,7 +789,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -925,7 +919,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1132,7 +1125,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1263,7 +1255,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1471,7 +1462,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1614,7 +1604,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1823,7 +1812,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1966,7 +1954,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2175,7 +2162,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2318,7 +2304,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2527,7 +2512,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2670,7 +2654,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2882,7 +2865,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3025,7 +3007,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3237,7 +3218,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3380,7 +3360,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3592,7 +3571,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3735,7 +3713,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3947,7 +3924,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4090,7 +4066,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4302,7 +4277,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4445,7 +4419,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4657,7 +4630,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4800,7 +4772,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5012,7 +4983,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5155,7 +5125,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5367,7 +5336,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5510,7 +5478,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5719,7 +5686,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5870,7 +5836,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6069,7 +6034,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6220,7 +6184,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6419,7 +6382,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6570,7 +6532,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6769,7 +6730,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6920,7 +6880,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \

--- a/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-linux-binary-libtorch-pre-cxx11-nightly.yml
@@ -246,6 +246,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -583,6 +584,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -920,6 +922,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1257,6 +1260,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1607,6 +1611,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1958,6 +1963,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2309,6 +2315,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2660,6 +2667,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3014,6 +3022,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3368,6 +3377,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3722,6 +3732,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4076,6 +4087,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4430,6 +4442,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4784,6 +4797,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5138,6 +5152,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5492,6 +5507,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5851,6 +5867,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6200,6 +6217,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6549,6 +6567,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6898,6 +6917,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-manywheel-master.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-master.yml
@@ -22,7 +22,6 @@ env:
   BUILDER_ROOT: /builder
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_FINAL_PACKAGE_DIR: /artifacts
@@ -113,7 +112,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -255,7 +253,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \

--- a/.github/workflows/generated-linux-binary-manywheel-master.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-master.yml
@@ -252,6 +252,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-manywheel-master.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-master.yml
@@ -110,6 +110,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -114,6 +114,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -448,6 +449,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -798,6 +800,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1148,6 +1151,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1495,6 +1499,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1840,6 +1845,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2184,6 +2190,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2518,6 +2525,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2868,6 +2876,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3218,6 +3227,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3565,6 +3575,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3910,6 +3921,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4254,6 +4266,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4588,6 +4601,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4938,6 +4952,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5288,6 +5303,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5635,6 +5651,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5980,6 +5997,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6324,6 +6342,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6658,6 +6677,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -7008,6 +7028,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -7358,6 +7379,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -7705,6 +7727,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -8050,6 +8073,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -244,6 +244,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -591,6 +592,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -942,6 +944,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1293,6 +1296,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1649,6 +1653,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -1995,6 +2000,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2320,6 +2326,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -2667,6 +2674,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3018,6 +3026,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3369,6 +3378,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -3725,6 +3735,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4071,6 +4082,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4396,6 +4408,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -4743,6 +4756,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5094,6 +5108,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5445,6 +5460,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -5801,6 +5817,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6147,6 +6164,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6472,6 +6490,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -6819,6 +6838,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -7170,6 +7190,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -7521,6 +7542,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -7877,6 +7899,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \
@@ -8223,6 +8246,7 @@ jobs:
             -e DESIRED_CUDA \
             -e DESIRED_DEVTOOLSET \
             -e DESIRED_PYTHON \
+            -e GITHUB_ACTIONS \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
             -e LIBTORCH_VARIANT \

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -27,7 +27,6 @@ env:
   BUILDER_ROOT: /builder
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_FINAL_PACKAGE_DIR: /artifacts
@@ -117,7 +116,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -247,7 +245,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -453,7 +450,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -595,7 +591,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -805,7 +800,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -947,7 +941,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1157,7 +1150,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1299,7 +1291,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1506,7 +1497,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1656,7 +1646,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -1853,7 +1842,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2003,7 +1991,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2199,7 +2186,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2329,7 +2315,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2535,7 +2520,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2677,7 +2661,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -2887,7 +2870,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3029,7 +3011,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3239,7 +3220,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3381,7 +3361,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3588,7 +3567,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3738,7 +3716,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -3935,7 +3912,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4085,7 +4061,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4281,7 +4256,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4411,7 +4385,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4617,7 +4590,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4759,7 +4731,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -4969,7 +4940,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5111,7 +5081,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5321,7 +5290,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5463,7 +5431,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5670,7 +5637,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -5820,7 +5786,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6017,7 +5982,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6167,7 +6131,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6363,7 +6326,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6493,7 +6455,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6699,7 +6660,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -6841,7 +6801,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -7051,7 +7010,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -7193,7 +7151,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -7403,7 +7360,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -7545,7 +7501,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -7752,7 +7707,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -7902,7 +7856,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -8099,7 +8052,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \
@@ -8249,7 +8201,6 @@ jobs:
             -e DESIRED_PYTHON \
             -e GPU_ARCH_TYPE \
             -e GPU_ARCH_VERSION \
-            -e IS_GHA \
             -e LIBTORCH_VARIANT \
             -e PACKAGE_TYPE \
             -e PYTORCH_FINAL_PACKAGE_DIR \

--- a/.github/workflows/generated-macos-arm64-binary-conda-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-conda-nightly.yml
@@ -26,7 +26,6 @@ env:
   BUILD_ENVIRONMENT: macos-arm64-binary-conda
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   SKIP_ALL_TESTS: 1

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -26,7 +26,6 @@ env:
   BUILD_ENVIRONMENT: macos-arm64-binary-wheel
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   SKIP_ALL_TESTS: 1

--- a/.github/workflows/generated-macos-binary-conda-nightly.yml
+++ b/.github/workflows/generated-macos-binary-conda-nightly.yml
@@ -26,7 +26,6 @@ env:
   BUILD_ENVIRONMENT: macos-binary-conda
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   SKIP_ALL_TESTS: 1

--- a/.github/workflows/generated-macos-binary-libtorch-cxx11-abi-nightly.yml
+++ b/.github/workflows/generated-macos-binary-libtorch-cxx11-abi-nightly.yml
@@ -26,7 +26,6 @@ env:
   BUILD_ENVIRONMENT: macos-binary-libtorch-cxx11-abi
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   SKIP_ALL_TESTS: 1

--- a/.github/workflows/generated-macos-binary-libtorch-pre-cxx11-nightly.yml
+++ b/.github/workflows/generated-macos-binary-libtorch-pre-cxx11-nightly.yml
@@ -26,7 +26,6 @@ env:
   BUILD_ENVIRONMENT: macos-binary-libtorch-pre-cxx11
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   SKIP_ALL_TESTS: 1

--- a/.github/workflows/generated-macos-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-binary-wheel-nightly.yml
@@ -26,7 +26,6 @@ env:
   BUILD_ENVIRONMENT: macos-binary-wheel
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   SKIP_ALL_TESTS: 1

--- a/.github/workflows/generated-windows-binary-conda-nightly.yml
+++ b/.github/workflows/generated-windows-binary-conda-nightly.yml
@@ -25,7 +25,6 @@ env:
   BUILD_ENVIRONMENT: windows-binary-conda
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_RETRY_TEST_CASES: 1

--- a/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-master.yml
@@ -20,7 +20,6 @@ env:
   BUILD_ENVIRONMENT: windows-binary-libtorch-debug
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_RETRY_TEST_CASES: 1

--- a/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-debug-nightly.yml
@@ -25,7 +25,6 @@ env:
   BUILD_ENVIRONMENT: windows-binary-libtorch-debug
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_RETRY_TEST_CASES: 1

--- a/.github/workflows/generated-windows-binary-libtorch-release-master.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-master.yml
@@ -20,7 +20,6 @@ env:
   BUILD_ENVIRONMENT: windows-binary-libtorch-release
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_RETRY_TEST_CASES: 1

--- a/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
+++ b/.github/workflows/generated-windows-binary-libtorch-release-nightly.yml
@@ -25,7 +25,6 @@ env:
   BUILD_ENVIRONMENT: windows-binary-libtorch-release
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_RETRY_TEST_CASES: 1

--- a/.github/workflows/generated-windows-binary-wheel-master.yml
+++ b/.github/workflows/generated-windows-binary-wheel-master.yml
@@ -20,7 +20,6 @@ env:
   BUILD_ENVIRONMENT: windows-binary-wheel
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_RETRY_TEST_CASES: 1

--- a/.github/workflows/generated-windows-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-windows-binary-wheel-nightly.yml
@@ -25,7 +25,6 @@ env:
   BUILD_ENVIRONMENT: windows-binary-wheel
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IN_CI: 1
-  IS_GHA: 1
   PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PYTORCH_RETRY_TEST_CASES: 1

--- a/tools/stats/scribe.py
+++ b/tools/stats/scribe.py
@@ -8,7 +8,7 @@ from typing import Dict, Any, List, Union, Optional
 _lambda_client = None
 
 
-IS_GHA = os.getenv("IS_GHA", "0") == "1"
+IS_GHA = os.getenv("GITHUB_ACTIONS", "0") == "1"
 
 
 def sprint(*args: Any) -> None:

--- a/tools/stats/upload_binary_size_to_scuba.py
+++ b/tools/stats/upload_binary_size_to_scuba.py
@@ -153,7 +153,7 @@ if __name__ == "__main__":
     if len(sys.argv) == 2:
         file_dir = sys.argv[1]
 
-    if os.getenv("IS_GHA", "0") == "1":
+    if os.getenv("GITHUB_ACTIONS", "0") == "1":
         sample_lib = {
             "library": "abcd",
             "size": 1234,
@@ -167,7 +167,7 @@ if __name__ == "__main__":
     if "-android" in os.environ.get("BUILD_ENVIRONMENT", ""):
         report_android_sizes(file_dir)
     else:
-        if os.getenv("IS_GHA", "0") == "1":
+        if os.getenv("GITHUB_ACTIONS", "0") == "1":
             build_path = pathlib.Path("build") / "lib"
             libraries = [
                 (path.name, os.stat(path).st_size) for path in build_path.glob("*")

--- a/tools/stats/upload_sccache_stats.py
+++ b/tools/stats/upload_sccache_stats.py
@@ -55,7 +55,7 @@ STAT_NAMES = {
 
 
 if __name__ == "__main__":
-    if os.getenv("IS_GHA", "0") == "1":
+    if os.getenv("GITHUB_ACTIONS", "0") == "1":
         data = {}
         if len(sys.argv) == 2:
             with open(sys.argv[1]) as f:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #79247
* #79229
* __->__ #79219
* #79214
* #79213
* #79212

This is unnecessary, GitHub automatically populates a `GITHUB_ACTION`
env var:
https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables

For docker, this env var is automatically propagated through our use of `--env-file`.