### PR TITLE
Do not do an inplace clone with `freeze_module`

### DIFF
--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -879,7 +879,7 @@ Module freeze_module(
     bool preserveParameters) {
   checkModuleDoesNotReturnSelf(module);
 
-  auto moduleClone = module.clone(/*inplace*/false);
+  auto moduleClone = module.clone(/*inplace*/ false);
   AttributePropagator attrPropagator(
       moduleClone, preservedAttrs, freezeInterfaces, preserveParameters);
   attrPropagator.run();

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -879,7 +879,7 @@ Module freeze_module(
     bool preserveParameters) {
   checkModuleDoesNotReturnSelf(module);
 
-  auto moduleClone = module.clone(true);
+  auto moduleClone = module.clone(/*inplace*/false);
   AttributePropagator attrPropagator(
       moduleClone, preservedAttrs, freezeInterfaces, preserveParameters);
   attrPropagator.run();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #79227

There is already a freeze_module_inplace for the case where people want the inplace version.
Freezing inplace while also returning the module orignally created is likely not what end users expect from this function.