### PR TITLE
[quant][improvement] Enabled support for per channel weight observers for ungrouped ConvTranspose*d

### DIFF
--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -402,8 +402,8 @@ def assert_valid_qconfig(qconfig: Optional[QConfig],
             isinstance(example_observer, torch.ao.quantization.PerChannelMinMaxObserver) or
             isinstance(example_observer, torch.ao.quantization.MovingAveragePerChannelMinMaxObserver)
         )
-        assert not is_per_channel, \
-            'Per channel weight observer is not supported yet for ConvTranspose{n}d.'
+        assert not (is_per_channel and mod.groups > 1), \
+            'Per channel weight observer is not supported yet for grouped (groups > 1) ConvTranspose{n}d.'
 
 # TODO: remove QConfigAny and replace it with Optional[QConfig]
 QConfigAny = Optional[QConfig]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79233

Summary:
Current logic prevented per channel weight observers from being used
with ConvTranspose (even for groups==1). This PR makes the assertion
logic specific to grouped ConvTranspose as ungrouped ConvTranspose
should work in the existing codebase.

Fixes #54816

Differential Revision: [D37050670](https://our.internmc.facebook.com/intern/diff/D37050670)