### PR TITLE
Use appropriate dtype for sharded linear implementation.

### DIFF
--- a/test/distributed/_shard/sharded_tensor/ops/test_linear.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_linear.py
@@ -51,12 +51,12 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 class TestShardedTensorOpsLinear(ShardedTensorTestBase):
     def _run_sharded_linear(
-        self, spec, input_size, linear_size, sharded_dim
+        self, spec, input_size, linear_size, sharded_dim, dtype
     ):
         # Use same seed.
         torch.manual_seed(0)
-        local_linear = torch.nn.Linear(*linear_size).cuda(self.rank)
-        sharded_linear = torch.nn.Linear(*linear_size)
+        local_linear = torch.nn.Linear(*linear_size, dtype=dtype).cuda(self.rank)
+        sharded_linear = torch.nn.Linear(*linear_size, dtype=dtype)
 
         # Copy the weights and bias from local linear
         sharded_linear.weight = clone_module_parameter(local_linear, "weight")
@@ -67,7 +67,7 @@ class TestShardedTensorOpsLinear(ShardedTensorTestBase):
 
         # Run sharded computation
         torch.manual_seed(self.rank)  # inputs different on each rank
-        inp = torch.rand(*input_size).cuda(self.rank)
+        inp = torch.rand(*input_size, dtype=dtype).cuda(self.rank)
         reshard_spec = copy.deepcopy(spec)
         reshard_spec.dim = 0
         reshard_spec.placements.sort(key=lambda placement: placement.rank())
@@ -80,7 +80,7 @@ class TestShardedTensorOpsLinear(ShardedTensorTestBase):
         local_output = local_linear(inp)
 
         # Verify
-        self.assertEqual(local_output, sharded_output)
+        self.assertEqual(local_output, sharded_output, atol=1e-3, rtol=1e-3)
 
         # Validate for torch.nn.functional.linear version.
         local_output = torch.nn.functional.linear(
@@ -94,7 +94,7 @@ class TestShardedTensorOpsLinear(ShardedTensorTestBase):
         # for reshard. We need to squeeze the # of dimensions manually.
         if inp.dim() == 1:
             sharded_output = sharded_output.squeeze(reshard_spec.dim)
-        self.assertEqual(local_output, sharded_output)
+        self.assertEqual(local_output, sharded_output, atol=1e-3, rtol=1e-3)
 
         # Compute loss and run backward pass.
         local_output.sum().backward()
@@ -116,8 +116,8 @@ class TestShardedTensorOpsLinear(ShardedTensorTestBase):
         dist.all_reduce(local_bias_grad)
 
         # Test backward gradient calculation.
-        self.assertEqual(sharded_linear.bias.grad, local_bias_grad)
-        self.assertEqual(sharded_weight.grad, local_grad_narrowed)
+        self.assertEqual(sharded_linear.bias.grad, local_bias_grad, atol=1e-3, rtol=1e-3)
+        self.assertEqual(sharded_weight.grad, local_grad_narrowed, atol=1e-3, rtol=1e-3)
 
         # Test optimizer.
         previous = local_linear.weight.clone().detach()
@@ -138,31 +138,31 @@ class TestShardedTensorOpsLinear(ShardedTensorTestBase):
         )
         self.assertEqual(sharded_weight.size(), local_weight_narrowed.size())
         self.assertNotEqual(previous_sharded_weight, sharded_weight)
-        self.assertEqual(sharded_weight, local_weight_narrowed)
+        self.assertEqual(sharded_weight, local_weight_narrowed, atol=1e-3, rtol=1e-3)
         self.assertNotEqual(previous_sharded_bias, sharded_linear.bias)
-        self.assertEqual(sharded_linear.bias, local_linear.bias)
+        self.assertEqual(sharded_linear.bias, local_linear.bias, atol=1e-3, rtol=1e-3)
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()
     def test_sharded_linear_colwise(self):
         for spec in generate_chunk_sharding_specs_for_test(0):
-            self._run_sharded_linear(spec, [2, 17], [17, 12], 0)
-            self._run_sharded_linear(spec, [8, 21], [21, 11], 0)
-            self._run_sharded_linear(spec, [7, 23], [23, 13], 0)
-            self._run_sharded_linear(spec, [4, 15], [15, 14], 0)
+            self._run_sharded_linear(spec, [2, 17], [17, 12], 0, torch.float16)
+            self._run_sharded_linear(spec, [8, 21], [21, 11], 0, torch.float32)
+            self._run_sharded_linear(spec, [7, 23], [23, 13], 0, torch.float64)
+            self._run_sharded_linear(spec, [4, 15], [15, 14], 0, torch.float16)
 
             # Test multiple input dims
-            self._run_sharded_linear(spec, [10, 2, 17], [17, 12], 0)
-            self._run_sharded_linear(spec, [13, 8, 21], [21, 11], 0)
-            self._run_sharded_linear(spec, [27, 7, 23], [23, 13], 0)
-            self._run_sharded_linear(spec, [100, 12, 4, 15], [15, 14], 0)
+            self._run_sharded_linear(spec, [10, 2, 17], [17, 12], 0, torch.float32)
+            self._run_sharded_linear(spec, [13, 8, 21], [21, 11], 0, torch.float64)
+            self._run_sharded_linear(spec, [27, 7, 23], [23, 13], 0, torch.float16)
+            self._run_sharded_linear(spec, [100, 12, 4, 15], [15, 14], 0, torch.float32)
 
             # Test single input dim
-            self._run_sharded_linear(spec, [17], [17, 12], 0)
-            self._run_sharded_linear(spec, [21], [21, 11], 0)
-            self._run_sharded_linear(spec, [23], [23, 13], 0)
-            self._run_sharded_linear(spec, [15], [15, 14], 0)
+            self._run_sharded_linear(spec, [17], [17, 12], 0, torch.float64)
+            self._run_sharded_linear(spec, [21], [21, 11], 0, torch.float16)
+            self._run_sharded_linear(spec, [23], [23, 13], 0, torch.float32)
+            self._run_sharded_linear(spec, [15], [15, 14], 0, torch.float64)
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
@@ -170,21 +170,21 @@ class TestShardedTensorOpsLinear(ShardedTensorTestBase):
     def test_sharded_linear_rowwise(self):
         for spec in generate_chunk_sharding_specs_for_test(1):
             # Test even split.
-            self._run_sharded_linear(spec, [8, 16], [16, 11], 1)
+            self._run_sharded_linear(spec, [8, 16], [16, 11], 1, torch.float16)
 
             # Test uneven split.
-            self._run_sharded_linear(spec, [5, 19], [19, 11], 1)
-            self._run_sharded_linear(spec, [10, 21], [21, 11], 1)
+            self._run_sharded_linear(spec, [5, 19], [19, 11], 1, torch.float32)
+            self._run_sharded_linear(spec, [10, 21], [21, 11], 1, torch.float64)
 
             # Test multiple input dims
-            self._run_sharded_linear(spec, [13, 8, 16], [16, 11], 1)
-            self._run_sharded_linear(spec, [10, 5, 19], [19, 11], 1)
-            self._run_sharded_linear(spec, [12, 15, 10, 21], [21, 11], 1)
+            self._run_sharded_linear(spec, [13, 8, 16], [16, 11], 1, torch.float16)
+            self._run_sharded_linear(spec, [10, 5, 19], [19, 11], 1, torch.float32)
+            self._run_sharded_linear(spec, [12, 15, 10, 21], [21, 11], 1, torch.float64)
 
             # Test single input dim
-            self._run_sharded_linear(spec, [16], [16, 11], 1)
-            self._run_sharded_linear(spec, [19], [19, 11], 1)
-            self._run_sharded_linear(spec, [21], [21, 11], 1)
+            self._run_sharded_linear(spec, [16], [16, 11], 1, torch.float16)
+            self._run_sharded_linear(spec, [19], [19, 11], 1, torch.float32)
+            self._run_sharded_linear(spec, [21], [21, 11], 1, torch.float64)
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)

--- a/test/distributed/_shard/sharded_tensor/test_megatron_prototype.py
+++ b/test/distributed/_shard/sharded_tensor/test_megatron_prototype.py
@@ -41,9 +41,18 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
-
 class TestShardedTensorMegatronLinear(ShardedTensorTestBase):
-    def _run_megatron_linear(self, spec, input_size, linear_size):
+    def assertEdistNorm(self, t1, t2):
+        """
+        Use a normalized euclidean distance measure to validate two tensors
+        are close since comparing each element individually is not a good
+        measure where majority of elements are similar and maybe only a few
+        elements are slightly off.
+        """
+        dist = torch.sqrt(((t1 - t2) ** 2).sum() / t1.numel())
+        self.assertTrue(dist.item() <= 0.5)
+
+    def _run_megatron_linear(self, spec, input_size, linear_size, dtype):
         def _weight_override(module_dst, module_src):
             module_dst.fc1.weight = clone_module_parameter(module_src.fc1, "weight")
             module_dst.fc1.bias = clone_module_parameter(module_src.fc1, "bias")
@@ -56,10 +65,8 @@ class TestShardedTensorMegatronLinear(ShardedTensorTestBase):
 
         # Use same seed.
         torch.manual_seed(0)
-        local_megatron_lm = SimpleMegatronLM(linear_size, rank=self.rank).cuda(
-            self.rank
-        )
-        sharded_megatron_lm = SimpleMegatronLM(linear_size)
+        local_megatron_lm = SimpleMegatronLM(linear_size, rank=self.rank, dtype=dtype)
+        sharded_megatron_lm = SimpleMegatronLM(linear_size, dtype=dtype)
         _weight_override(sharded_megatron_lm, local_megatron_lm)
 
         # Shard the parameter. First col-wise sharding and then row-wise
@@ -76,7 +83,7 @@ class TestShardedTensorMegatronLinear(ShardedTensorTestBase):
 
 
         torch.manual_seed(self.rank)  # inputs different on each rank
-        inp = torch.rand(*input_size, requires_grad=True, device=self.rank)
+        inp = torch.rand(*input_size, requires_grad=True, device=self.rank, dtype=dtype)
 
         # Run local computation
         local_output = local_megatron_lm(inp)
@@ -93,14 +100,14 @@ class TestShardedTensorMegatronLinear(ShardedTensorTestBase):
         sharded_output = sharded_megatron_lm(inp)
 
         # Verify local and sharded results
-        self.assertEqual(local_output, sharded_output)
+        self.assertEqual(local_output, sharded_output, atol=1e-3, rtol=1e-6)
 
         sharded_output.sum().backward()
         sharded_input_grad = inp.grad
         self.assertIsNotNone(inp.grad)
 
         # Verify sharded and local grads.
-        self.assertEqual(local_input_grad, sharded_input_grad)
+        self.assertEqual(local_input_grad, sharded_input_grad, atol=1e-3, rtol=1e-6)
 
         (
             local_weight_grad_fc1,
@@ -145,18 +152,18 @@ class TestShardedTensorMegatronLinear(ShardedTensorTestBase):
         )
 
         # Test backward gradient calculation.
-        self.assertEqual(sharded_weight_fc1.grad, local_grad_narrowed_fc1, atol=1e-3, rtol=1e-6)
-        self.assertEqual(sharded_weight_fc2.grad, local_grad_narrowed_fc2, atol=1e-4, rtol=1e-6)
-        self.assertEqual(bias_grad_fc1, local_bias_grad_fc1, atol=1e-4, rtol=1e-6)
-        self.assertEqual(bias_grad_fc2, local_bias_grad_fc2, atol=1e-4, rtol=1e-6)
+        self.assertEdistNorm(sharded_weight_fc1.grad, local_grad_narrowed_fc1)
+        self.assertEdistNorm(sharded_weight_fc2.grad, local_grad_narrowed_fc2)
+        self.assertEdistNorm(bias_grad_fc1, local_bias_grad_fc1)
+        self.assertEdistNorm(bias_grad_fc2, local_bias_grad_fc2)
 
         # Test optimizer.
         bias_fc1, bias_fc2 = sharded_megatron_lm.get_biases()
         local_bias_fc1, local_bias_fc2 = local_megatron_lm.get_biases()
-        self.assertEqual(bias_fc1, local_bias_fc1, atol=1e-4, rtol=1e-6)
-        self.assertEqual(bias_fc2, local_bias_fc2, atol=1e-4, rtol=1e-6)
-        self.assertEqual(bias_fc1.grad, local_bias_fc1.grad, atol=1e-4, rtol=1e-6)
-        self.assertEqual(bias_fc2.grad, local_bias_fc2.grad, atol=1e-4, rtol=1e-6)
+        self.assertEdistNorm(bias_fc1, local_bias_fc1)
+        self.assertEdistNorm(bias_fc2, local_bias_fc2)
+        self.assertEdistNorm(bias_fc1.grad, local_bias_fc1.grad)
+        self.assertEdistNorm(bias_fc2.grad, local_bias_fc2.grad)
         previous_sharded_weight_fc1 = sharded_weight_fc1.clone()
         previous_sharded_weight_fc2 = sharded_weight_fc2.clone()
         previous_bias_fc1 = bias_fc1.clone()
@@ -177,19 +184,19 @@ class TestShardedTensorMegatronLinear(ShardedTensorTestBase):
         )
 
         # Test weight value after optimizer.
-        self.assertEqual(sharded_weight_fc1.size(), local_weight_fc1_narrowed.size(), atol=1e-4, rtol=1e-6)
-        self.assertEqual(sharded_weight_fc2.size(), local_weight_fc2_narrowed.size(), atol=1e-4, rtol=1e-6)
+        self.assertEqual(sharded_weight_fc1.size(), local_weight_fc1_narrowed.size())
+        self.assertEqual(sharded_weight_fc2.size(), local_weight_fc2_narrowed.size())
         self.assertNotEqual(previous_sharded_weight_fc1, sharded_weight_fc1)
         self.assertNotEqual(previous_sharded_weight_fc2, sharded_weight_fc2)
-        self.assertEqual(sharded_weight_fc1, local_weight_fc1_narrowed, atol=1e-4, rtol=1e-6)
-        self.assertEqual(sharded_weight_fc2, local_weight_fc2_narrowed, atol=1e-4, rtol=1e-6)
+        self.assertEdistNorm(sharded_weight_fc1, local_weight_fc1_narrowed)
+        self.assertEdistNorm(sharded_weight_fc2, local_weight_fc2_narrowed)
 
         # Test bias value after optimizer.
         local_bias_fc1, local_bias_fc2 = local_megatron_lm.get_biases()
         self.assertNotEqual(previous_bias_fc1, bias_fc1)
-        self.assertEqual(bias_fc1, local_bias_fc1, atol=1e-4, rtol=1e-6)
+        self.assertEdistNorm(bias_fc1, local_bias_fc1)
         self.assertNotEqual(previous_bias_fc2, bias_fc2)
-        self.assertEqual(bias_fc2, local_bias_fc2, atol=1e-4, rtol=1e-6)
+        self.assertEdistNorm(bias_fc2, local_bias_fc2)
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
@@ -198,22 +205,22 @@ class TestShardedTensorMegatronLinear(ShardedTensorTestBase):
         colwise_sharding_spec = generate_chunk_sharding_specs_for_test(0)
         rowwise_sharding_spec = generate_chunk_sharding_specs_for_test(1)
         for spec in zip(colwise_sharding_spec, rowwise_sharding_spec):
-            self._run_megatron_linear(spec, [22, 17], [[17, 12], [12, 29]])
-            self._run_megatron_linear(spec, [28, 21], [[21, 11], [11, 29]])
-            self._run_megatron_linear(spec, [37, 23], [[23, 13], [13, 24]])
-            self._run_megatron_linear(spec, [24, 15], [[15, 14], [14, 20]])
+            self._run_megatron_linear(spec, [22, 17], [[17, 12], [12, 29]], torch.float16)
+            self._run_megatron_linear(spec, [28, 21], [[21, 11], [11, 29]], torch.float32)
+            self._run_megatron_linear(spec, [37, 23], [[23, 13], [13, 24]], torch.float64)
+            self._run_megatron_linear(spec, [24, 15], [[15, 14], [14, 20]], torch.float16)
 
             # Test multiple input dims
-            self._run_megatron_linear(spec, [10, 22, 17], [[17, 12], [12, 29]])
-            self._run_megatron_linear(spec, [13, 28, 21], [[21, 11], [11, 29]])
-            self._run_megatron_linear(spec, [27, 37, 23], [[23, 13], [13, 24]])
-            self._run_megatron_linear(spec, [100, 24, 15], [[15, 14], [14, 20]])
+            self._run_megatron_linear(spec, [10, 22, 17], [[17, 12], [12, 29]], torch.float32)
+            self._run_megatron_linear(spec, [13, 28, 21], [[21, 11], [11, 29]], torch.float16)
+            self._run_megatron_linear(spec, [27, 37, 23], [[23, 13], [13, 24]], torch.float32)
+            self._run_megatron_linear(spec, [100, 24, 15], [[15, 14], [14, 20]], torch.float64)
 
             # Test single input dim
-            self._run_megatron_linear(spec, [17], [[17, 12], [12, 29]])
-            self._run_megatron_linear(spec, [21], [[21, 11], [11, 29]])
-            self._run_megatron_linear(spec, [23], [[23, 13], [13, 24]])
-            self._run_megatron_linear(spec, [15], [[15, 14], [14, 20]])
+            self._run_megatron_linear(spec, [17], [[17, 12], [12, 29]], torch.float16)
+            self._run_megatron_linear(spec, [21], [[21, 11], [11, 29]], torch.float32)
+            self._run_megatron_linear(spec, [23], [[23, 13], [13, 24]], torch.float64)
+            self._run_megatron_linear(spec, [15], [[15, 14], [14, 20]], torch.float16)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_shard/sharded_tensor/reshard.py
+++ b/torch/distributed/_shard/sharded_tensor/reshard.py
@@ -137,7 +137,7 @@ def reshuffle_local_shard(
     local_shard = local_shard.transpose(0, reshard_dim).contiguous()
     gathered_input_size = list(local_shard.size())
     gathered_input_size[0] = sharded_dim_size
-    gathered_input = torch.empty(gathered_input_size, device=local_shard.device)
+    gathered_input = torch.empty(gathered_input_size, device=local_shard.device, dtype=local_shard.dtype)
     # all2all.
     local_shard = all_to_all_single(
         gathered_input,
@@ -225,7 +225,7 @@ def reshard_local_shard(
         output_tensor_list[
             placement.rank()
         ] = torch.empty(  # type: ignore[union-attr, index]
-            output_tensor_size, device=local_tensor.device
+            output_tensor_size, device=local_tensor.device, dtype=local_tensor.dtype
         )
         indices.append(placement.rank())  # type: ignore[union-attr, index, arg-type]
         if idx != placement.rank():  # type: ignore[union-attr]

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py
@@ -186,7 +186,7 @@ def _result_distribute_with_col_rearrange(
     sharding_dim_size = weight.size(sharding_dim)
     dims = list(results[0].size())
     dims[0] = sharding_dim_size
-    output = torch.empty(*dims, device=input.device)
+    output = torch.empty(*dims, device=input.device, dtype=input.dtype)
     combined_results = torch.cat(results)
 
     # Compute output splits

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py
@@ -186,8 +186,8 @@ def _result_distribute_with_col_rearrange(
     sharding_dim_size = weight.size(sharding_dim)
     dims = list(results[0].size())
     dims[0] = sharding_dim_size
-    output = torch.empty(*dims, device=input.device, dtype=input.dtype)
     combined_results = torch.cat(results)
+    output = torch.empty(*dims, device=combined_results.device, dtype=combined_results.dtype)
 
     # Compute output splits
     split_size = get_split_size(sharding_dim_size, world_size)

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/linear.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/linear.py
@@ -198,7 +198,7 @@ def _handle_col_wise_sharding(input, world_size, weight, rank, local_shard_t, bi
     # allgather the inputs first.
     out_size = list(input.size())
     out_size[0] = input.size(0) * dist.get_world_size(pg)
-    output = torch.empty(out_size, device=input.device)
+    output = torch.empty(out_size, device=input.device, dtype=input.dtype)
     output = _all_gather_base(output, input, group=pg)
 
     # Adjust bias and perform local matmul.
@@ -290,7 +290,7 @@ def _handle_row_wise_sharding_tensor(
     gathered_input_size = [input_split_sizes[rank] * world_size] + list(
         input_t_size[1:]
     )
-    gathered_input = torch.empty(gathered_input_size, device=input_t.device)
+    gathered_input = torch.empty(gathered_input_size, device=input_t.device, dtype=input_t.dtype)
 
     # Perform autograd enabled alltoall
     all_to_all_single(

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -359,7 +359,7 @@ class _AllGatherBase(Function):
                     f'not have first dimension divisible by world_size: {world_size}'
                 )
             out_size[0] = out_size[0] // dist.get_world_size(group=ctx.group)
-            gx = torch.empty(out_size, device=grad_output.device)
+            gx = torch.empty(out_size, device=grad_output.device, dtype=grad_output.dtype)
             dist._reduce_scatter_base(gx, grad_output, ReduceOp.SUM, ctx.group)
         else:
             raise RuntimeError("Backend not supported!")
@@ -392,7 +392,7 @@ class _AlltoAll(Function):
     @staticmethod
     def backward(ctx, *grad_outputs):
         tensor_list = [
-            torch.empty(size, device=grad_outputs[0].device)
+            torch.empty(size, device=grad_outputs[0].device, dtype=grad_outputs[0].dtype)
             for size in ctx.input_tensor_size_list
         ]
         return (None, None) + _AlltoAll.apply(ctx.group, tensor_list, *grad_outputs)
@@ -416,7 +416,7 @@ class _AlltoAllSingle(Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        tensor = torch.empty(ctx.input_size, device=grad_output.device)
+        tensor = torch.empty(ctx.input_size, device=grad_output.device, dtype=grad_output.dtype)
         return (None, None, None, None) + (
             _AlltoAllSingle.apply(
                 ctx.group,

--- a/torch/testing/_internal/distributed/_shard/test_common.py
+++ b/torch/testing/_internal/distributed/_shard/test_common.py
@@ -1,17 +1,18 @@
+import torch
 import torch.nn as nn
 
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 
 
 class SimpleMegatronLM(nn.Module):
-    def __init__(self, linear_size, rank=None):
+    def __init__(self, linear_size, rank=None, dtype=torch.float32):
         super().__init__()
-        self.fc1 = nn.Linear(*linear_size[0])
+        self.fc1 = nn.Linear(*linear_size[0], dtype=dtype)
         self.gelu = nn.GELU()
-        self.fc2 = nn.Linear(*linear_size[1])
-        if rank:
-            self.fc1.cuda(rank)
-            self.fc2.cuda(rank)
+        self.fc2 = nn.Linear(*linear_size[1], dtype=dtype)
+        if rank is not None:
+            self.fc1 = self.fc1.cuda(rank)
+            self.fc2 = self.fc2.cuda(rank)
 
     def forward(self, inp):
         return self.fc2(self.gelu(self.fc1(inp)))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79255

We use several collective operations in our sharded linear
implementation and for many collectives, we do not set the `dtype` of the
output tensor appropriately. As a result, using a datatype like torch.float16
(which is not the default torch.float32) results in errors.

Fixing this across the board and adding appropriate tests.

Differential Revision: [D37059752](https://our.internmc.facebook.com/intern/diff/D37059752/)