### PR TITLE
Explicitly default a copy constructor

### DIFF
--- a/c10/util/variant.h
+++ b/c10/util/variant.h
@@ -2248,6 +2248,7 @@ class impl : public copy_assignment<traits<Ts...>> {
  public:
   C10_MPARK_INHERITING_CTOR(impl, super)
   impl& operator=(const impl& other) = default;
+  impl(const impl& other) = default;
 
   template <std::size_t I, typename Arg>
   inline void assign(Arg&& arg) {


### PR DESCRIPTION
Summary:
The explicitly defaulted copy assignment operator here makes the
automatic generation of a default copy constructor invalid. clang-13 now warns
against this and thus it's an error for us under -Werror. So simply do here what
clang would do otherwise.

Test Plan: mostly sandcastle. But the behavior can be observed with `-fsyntax-only -ast-dump`

Reviewed By: drodriguez

Differential Revision: D37050081

