### PR TITLE
[MPS] Copy and view ops fixes

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -288,12 +288,13 @@ id<MTLBuffer> _gatherViewTensor(const at::Tensor& src, id<MTLBuffer> sourceBuffe
   };
 
   CachedGraph* cachedGraph = static_cast<CachedGraph *>(mpsCachedGraph);
+  const size_t storageElemCount = src.storage().nbytes() / src.dtype().itemsize();
 
   @autoreleasepool {
     MPSGraphTensor* inputTensor = cachedGraph->inputTensor_;
     MPSGraphTensorData* inputTensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer: sourceBuffer
-                                                                        shape: [inputTensor shape]
-                                                                        dataType: [inputTensor dataType]] autorelease];
+                                                                       shape: @[[NSNumber numberWithUnsignedInteger: storageElemCount]]
+                                                                       dataType: [inputTensor dataType]] autorelease];
     id<MTLBuffer> resultBuffer = __builtin_bit_cast(id<MTLBuffer>, output.storage().data());
     MPSGraphTensorData* outputTensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer: resultBuffer
                                                                         shape: getMPSShape(src.sizes())

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -138,7 +138,7 @@ Tensor as_strided_tensorimpl_mps(const Tensor& self, IntArrayRef size,
               newCachedGraph = new CachedGraph(mpsGraph);
 
               // Self is the input tensor we are creating view of
-              MPSGraphTensor* inputTensor = [mpsGraph placeholderWithShape : getMPSShape(self)
+              MPSGraphTensor* inputTensor = [mpsGraph placeholderWithShape : nil
                                                                   dataType : getMPSDataType(self.scalar_type())
                                                                       name : nil];
               newCachedGraph->inputTensor_ = inputTensor;

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -340,14 +340,15 @@ static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_,
   }
 
   const void* host_src = src.storage().data();
-  uint64_t size = src.nbytes();
+  uint64_t src_storage_size = src.storage().nbytes();
+  uint64_t src_tensor_size = src.nbytes();
 
   NSUInteger sourceOffset = 0;
   @autoreleasepool {
     MTLResourceOptions options = MTLResourceOptionCPUCacheModeDefault | MTLResourceStorageModeShared;
     NSUInteger alignedLength = 0;
 
-    void* alignedPtr = pageAlignedBlockPtr(host_src, (NSUInteger)size, &alignedLength);
+    void* alignedPtr = pageAlignedBlockPtr(host_src, (NSUInteger)src_storage_size, &alignedLength);
     id<MTLBuffer> sourceBuffer = [device newBufferWithBytesNoCopy:alignedPtr
                                           length:alignedLength
                                          options:options
@@ -366,7 +367,7 @@ static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_,
                        sourceOffset:(NSUInteger)sourceOffset
                            toBuffer:destBuffer
                   destinationOffset:(NSUInteger)dst_byte_offset
-                               size:(NSUInteger)size];
+                               size:(NSUInteger)src_tensor_size];
         [blitEncoder endEncoding];
         if (non_blocking) {
           stream->commit(true);

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -17,7 +17,7 @@ namespace native {
 
 MPSGraphTensor* chainViewOperation(MPSGraph* mpsGraph, IntArrayRef size,
                              IntArrayRef stride, int64_t storage_offset,
-                             MPSGraphTensor* inputTensor, const Tensor& self) {
+                             MPSGraphTensor* inputTensor) {
   MPSGraphTensor *outputTensor = nil;
   const size_t shape_size = size.size();
 
@@ -143,7 +143,7 @@ Tensor as_strided_tensorimpl_mps(const Tensor& self, IntArrayRef size,
                                                                       name : nil];
               newCachedGraph->inputTensor_ = inputTensor;
               newCachedGraph->outputTensor_ = chainViewOperation(mpsGraph, size, stride,
-                                                                 storage_offset, inputTensor, self);
+                                                                 storage_offset, inputTensor);
           }
           return newCachedGraph;
         }, self.storage().data());

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -240,8 +240,6 @@ Tensor& addmm_out_mps_impl(
 
   MPSStream* stream = getCurrentMPSStream();
 
-  MPSGraph* mpsGraph = make_mps_graph();
-
   bool transpose_mat1_times_mat2 = false;
   bool transpose_mat1            = false;
   bool transpose_mat2            = false;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1428,6 +1428,12 @@ class TestMPS(TestCase):
 
         self.assertEqual(shared_np[9], mps_tensor.cpu().numpy())
 
+    def test_materialize_expanded_view(self):
+        tensor_mps = torch.ones((1, 1, 3, 3), device='mps').expand((32, 32, 3, 3)).view((1024, 3, 3)).contiguous()
+        tensor_cpu = torch.ones((1, 1, 3, 3)).expand((32, 32, 3, 3)).view((1024, 3, 3)).contiguous()
+
+        self.assertEqual(tensor_cpu, tensor_mps)
+
 
 class TestSmoothL1Loss(TestCase):
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1420,6 +1420,14 @@ class TestMPS(TestCase):
                     self.assertEqual(t[2, 1], j)
                     self.assertEqual(t.sum(), 1 + i + j)
 
+    def test_copy_from_shared_storage(self):
+        shared_np = np.ones((10, 256, 256, 3), dtype=np.float32)
+        shared_torch = torch.from_numpy(shared_np)
+
+        mps_tensor = shared_torch[9].to('mps')
+
+        self.assertEqual(shared_np[9], mps_tensor.cpu().numpy())
+
 
 class TestSmoothL1Loss(TestCase):
 


### PR DESCRIPTION
This fixes two issues I discovered in the MPS backend:

- An out-of-bounds access when creating an MPS tensor from a CPU tensor when the source offset is > 0.
- Attempting to create MPSGraphTensorData objects with the view tensor size rather than the storage size. This is an issue in cases when the storage size is smaller than the tensor size, e.g. due to striding.

I also included a commit deleting some unused variables I found when debugging the other issues.

I haven't opened issues for either of these - I'm happy to do so if needed.