### PR TITLE
[quant][core][improvement] Added warnings to quantized dynamic conv and linear ops when reduce_range=true

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/QnnpackUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/QnnpackUtils.h
@@ -99,7 +99,7 @@ struct PackedLinearWeightsQnnp : public LinearPackedParamsBase {
       int64_t output_zero_point);
 
   template <bool ReluFused>
-  at::Tensor apply_dynamic_impl(at::Tensor input);
+  at::Tensor apply_dynamic_impl(at::Tensor input, bool reduce_range);
 };
 
 template <int kSpatialDim = 2>

--- a/aten/src/ATen/native/quantized/cpu/QnnpackUtils.h
+++ b/aten/src/ATen/native/quantized/cpu/QnnpackUtils.h
@@ -99,7 +99,7 @@ struct PackedLinearWeightsQnnp : public LinearPackedParamsBase {
       int64_t output_zero_point);
 
   template <bool ReluFused>
-  at::Tensor apply_dynamic_impl(at::Tensor input, bool reduce_range);
+  at::Tensor apply_dynamic_impl(at::Tensor input);
 };
 
 template <int kSpatialDim = 2>

--- a/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
@@ -74,7 +74,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_dynamic(
     bool reduce_range) {
   if (reduce_range) {
     TORCH_WARN("reduce_range is set to true for the conv operator while using qnnpack backend, but qnnpack does "
-    " not require a reduction in range. We recommend switching this flag to false");
+    " not require a reduction in range. We recommend switching this flag to false so that accuracy isn't compromised");
   }
 
   // On empty input, no output data will be generated,

--- a/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
@@ -73,9 +73,10 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_dynamic(
     const at::Tensor& input,
     bool reduce_range) {
   if (reduce_range) {
-    TORCH_WARN("reduce_range is set to true for qnnpack backend. qnnpack does not require a reduction in range. The Conv operator "
-    "will ignore this setting and use the full range");
+    TORCH_WARN("reduce_range is set to true for the conv operator while using qnnpack backend, but qnnpack does "
+    " not require a reduction in range. We recommend switching this flag to false");
   }
+
   // On empty input, no output data will be generated,
   // so use arbitrary qparams.
   float x_min = 0;
@@ -99,8 +100,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_dynamic(
       is_signed ? ((1 << (precision - 1)) - 1) : (1 << precision) - 1,
       /*preserve_sparsity=*/false,
       /*force_scale_power_of_two=*/false,
-      /*reduce_range=*/false); // note: this is set to false rather than
-                               // reduce_range for qnnpack
+      /*reduce_range=*/reduce_range);
 
   // Quantize input
   at::Tensor q_input = at::quantize_per_tensor(

--- a/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
@@ -71,7 +71,11 @@ template at::Tensor PackedConvWeight<3>::apply_dynamic(
 template <int kSpatialDim>
 at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_dynamic(
     const at::Tensor& input,
-    bool /*reduce_range*/) {
+    bool reduce_range) {
+  if (reduce_range) {
+    TORCH_WARN("reduce_range is set to true for qnnpack backend. qnnpack does not require a reduction in range. The Conv operator "
+    "will ignore this setting and use the full range");
+  }
   // On empty input, no output data will be generated,
   // so use arbitrary qparams.
   float x_min = 0;

--- a/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
@@ -71,10 +71,10 @@ template at::Tensor PackedConvWeight<3>::apply_dynamic(
 template <int kSpatialDim>
 at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_dynamic(
     const at::Tensor& input,
-    bool reduce_range) {
+    bool /*reduce_range*/) {
   if (reduce_range) {
-    TORCH_WARN("reduce_range is set to true for the conv operator while using qnnpack backend, but qnnpack does "
-    " not require a reduction in range. We recommend switching this flag to false so that accuracy isn't compromised");
+    TORCH_WARN("Currently, qnnpack incorrectly ignores reduce_range when it is set to true; this may change in a future release. "
+    "Reducing the range for qnnpack would currently lead to bc-breaking behavior.");
   }
 
   // On empty input, no output data will be generated,
@@ -100,7 +100,8 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_dynamic(
       is_signed ? ((1 << (precision - 1)) - 1) : (1 << precision) - 1,
       /*preserve_sparsity=*/false,
       /*force_scale_power_of_two=*/false,
-      /*reduce_range=*/reduce_range);
+      /*reduce_range=*/false); // note: this is set to false rather than
+                               // reduce_range for qnnpack
 
   // Quantize input
   at::Tensor q_input = at::quantize_per_tensor(

--- a/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
@@ -73,8 +73,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_dynamic(
     const at::Tensor& input,
     bool /*reduce_range*/) {
   if (reduce_range) {
-    TORCH_WARN("Currently, qnnpack incorrectly ignores reduce_range when it is set to true; this may change in a future release. "
-    "Reducing the range for qnnpack would currently lead to bc-breaking behavior.");
+    TORCH_WARN("Currently, qnnpack incorrectly ignores reduce_range when it is set to true; this may change in a future release.");
   }
 
   // On empty input, no output data will be generated,

--- a/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
@@ -71,7 +71,7 @@ template at::Tensor PackedConvWeight<3>::apply_dynamic(
 template <int kSpatialDim>
 at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_dynamic(
     const at::Tensor& input,
-    bool /*reduce_range*/) {
+    bool reduce_range) {
   if (reduce_range) {
     TORCH_WARN("Currently, qnnpack incorrectly ignores reduce_range when it is set to true; this may change in a future release.");
   }

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -375,7 +375,11 @@ at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(
 
 at::Tensor PackedLinearWeightsQnnp::apply_dynamic(
     at::Tensor input,
-    bool /* reduce_range */) {
+    bool reduce_range) {
+  if (reduce_range) {
+    TORCH_WARN("reduce_range is set to true for qnnpack backend. qnnpack does not require a reduction in range. The linear operator "
+    "will ignore this setting and use the full range");
+  }
   return apply_dynamic_impl</*ReluFused=*/false>(std::move(input));
 }
 

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -233,11 +233,10 @@ at::Tensor PackedLinearWeight::apply_dynamic_relu(
 #ifdef USE_PYTORCH_QNNPACK
 template <bool ReluFused>
 at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(
-    at::Tensor input,
-    bool reduce_range) {
+    at::Tensor input) {
   if (reduce_range) {
-    TORCH_WARN("reduce_range is set to true for the linear operator while using qnnpack backend, but qnnpack does "
-    " not require a reduction in range. We recommend switching this flag to false so that accuracy isn't compromised");
+    TORCH_WARN("Currently, qnnpack incorrectly ignores reduce_range when it is set to true; this may change in a future release. "
+    "Reducing the range for qnnpack would currently lead to bc-breaking behavior.");
   }
 
   using at::Tensor;
@@ -281,11 +280,7 @@ at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(
       /*min=*/x_min,
       /*max=*/x_max,
       /*qmin=*/0,
-      /*qmax=*/255,
-      /*preserve_sparsity=*/false,
-      /*force_scale_power_of_two=*/false,
-      /*reduce_range=*/reduce_range);
-
+      /*qmax=*/255);
   float* weight_scales_data = w_scales.data_ptr<float>();
 
   if (!input_scale.has_value() || input_scale.value() != q_params.scale) {
@@ -385,14 +380,14 @@ at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(
 
 at::Tensor PackedLinearWeightsQnnp::apply_dynamic(
     at::Tensor input,
-    bool reduce_range) {
-  return apply_dynamic_impl</*ReluFused=*/false>(std::move(input), reduce_range);
+    bool /* reduce_range */) {
+  return apply_dynamic_impl</*ReluFused=*/false>(std::move(input));
 }
 
 at::Tensor PackedLinearWeightsQnnp::apply_dynamic_relu(
     at::Tensor input,
-    bool reduce_range) {
-  return apply_dynamic_impl</*ReluFused=*/true>(std::move(input), reduce_range);
+    bool /* reduce_range */) {
+  return apply_dynamic_impl</*ReluFused=*/true>(std::move(input));
 }
 
 #endif // USE_PYTORCH_QNNPACK

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -235,8 +235,7 @@ template <bool ReluFused>
 at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(
     at::Tensor input) {
   if (reduce_range) {
-    TORCH_WARN("Currently, qnnpack incorrectly ignores reduce_range when it is set to true; this may change in a future release. "
-    "Reducing the range for qnnpack would currently lead to bc-breaking behavior.");
+    TORCH_WARN("Currently, qnnpack incorrectly ignores reduce_range when it is set to true; this may change in a future release.");
   }
 
   using at::Tensor;

--- a/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear_dynamic.cpp
@@ -233,7 +233,8 @@ at::Tensor PackedLinearWeight::apply_dynamic_relu(
 #ifdef USE_PYTORCH_QNNPACK
 template <bool ReluFused>
 at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(
-    at::Tensor input) {
+    at::Tensor input,
+    bool reduce_range) {
   if (reduce_range) {
     TORCH_WARN("Currently, qnnpack incorrectly ignores reduce_range when it is set to true; this may change in a future release.");
   }
@@ -379,14 +380,14 @@ at::Tensor PackedLinearWeightsQnnp::apply_dynamic_impl(
 
 at::Tensor PackedLinearWeightsQnnp::apply_dynamic(
     at::Tensor input,
-    bool /* reduce_range */) {
-  return apply_dynamic_impl</*ReluFused=*/false>(std::move(input));
+    bool reduce_range) {
+  return apply_dynamic_impl</*ReluFused=*/false>(std::move(input), reduce_range);
 }
 
 at::Tensor PackedLinearWeightsQnnp::apply_dynamic_relu(
     at::Tensor input,
-    bool /* reduce_range */) {
-  return apply_dynamic_impl</*ReluFused=*/true>(std::move(input));
+    bool reduce_range ) {
+  return apply_dynamic_impl</*ReluFused=*/true>(std::move(input), reduce_range);
 }
 
 #endif // USE_PYTORCH_QNNPACK

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -3323,16 +3323,12 @@ class TestDynamicQuantizedOps(TestCase):
         # lstm op
         seq_len = 1
 
+        reduce_range = True
         for rnn_type in ['LSTMCell', 'GRUCell', 'RNNTanh', 'RNNReLU']:
             for dtype in [torch.qint8, torch.float16]:
                 # Fp16 quantization is not supported for qnnpack or onednn
                 if torch.backends.quantized.engine in ('qnnpack', 'onednn') and dtype == torch.float16:
                     continue
-
-                if torch.backends.quantized.engine == 'qnnpack':
-                    reduce_range = False
-                else:
-                    reduce_range = True
 
                 Xq, Hq, Cq = self._get_rnn_inputs(seq_len, num_batches, input_size, hidden_size, 1, reduce_range)
                 Wq1, Wq2, b1, b2 = self._get_rnn_weights_and_bias(

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -3323,12 +3323,16 @@ class TestDynamicQuantizedOps(TestCase):
         # lstm op
         seq_len = 1
 
-        reduce_range = True
         for rnn_type in ['LSTMCell', 'GRUCell', 'RNNTanh', 'RNNReLU']:
             for dtype in [torch.qint8, torch.float16]:
                 # Fp16 quantization is not supported for qnnpack or onednn
                 if torch.backends.quantized.engine in ('qnnpack', 'onednn') and dtype == torch.float16:
                     continue
+
+                if torch.backends.quantized.engine == 'qnnpack':
+                    reduce_range = False
+                else:
+                    reduce_range = True
 
                 Xq, Hq, Cq = self._get_rnn_inputs(seq_len, num_batches, input_size, hidden_size, 1, reduce_range)
                 Wq1, Wq2, b1, b2 = self._get_rnn_weights_and_bias(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79273

Summary:
Previously, the backend code "silently" ignores reduce_range=true when
using the qnnpack backend (which does not require a reduction in range).
We evaluated either 1) respecting the reduction in range to conform with
other backends (e.g., fbgemm) even when qnnpack does support the full
range and outputting a warning to let the user know that reduce_range
shoudl be set to false for qnnpack backend 2) throwing a warning and letting the user know that the
reduce_range=true setting is being ignored.

Option 1 would halve the range which could have some negative
implications to accuracy and lead to bc-breaking changes. Option 2 is also not ideal because it ignores any user settings
for reduce_range=true when using the qnnpack backend with dynamic and
linear quantized ops. We decided to go with option 2 as it is not
bc-breaking.

Fixes #68278

Test plan:

Differential Revision: [D37068897](https://our.internmc.facebook.com/intern/diff/D37068897)