### PR TITLE
Only emit distributed launch OMP and deprecation warnings for rank 0

### DIFF
--- a/test/distributed/test_launcher.py
+++ b/test/distributed/test_launcher.py
@@ -7,6 +7,7 @@ from contextlib import closing
 import torch.distributed as dist
 import torch.distributed.launch as launch
 from torch.distributed.elastic.utils import get_socket_with_port
+import subprocess
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -51,6 +52,57 @@ class TestDistributedLaunch(TestCase):
         ]
         launch.main(args)
 
+    def test_launch_deprecated_warning(self):
+        script_path = path("bin/test_script.py")
+        processes = []
+
+        for node_rank in [0, 1]:
+            launch_script = f'''
+import torch
+import torch.distributed.launch as launch
+launch.main([
+    '--nnodes', '2',
+    '--node_rank', '{node_rank}',
+    '{script_path}'])
+'''
+
+            processes.append(subprocess.Popen(
+                ['python', '-c', launch_script],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE))
+
+        for rank, process in enumerate(processes):
+            process.wait()
+            process_out, process_err = process.communicate()
+            if rank == 0:
+                self.assertIn('launch is deprecated', str(process_err))
+            else:
+                self.assertNotIn('launch is deprecated', str(process_err))
+
+    def test_omp_threads_warning(self):
+        script_path = path("bin/test_script.py")
+        processes = []
+
+        if 'OMP_NUM_THREADS' in os.environ:
+            del os.environ['OMP_NUM_THREADS']
+
+        for node_rank in [0, 1]:
+            processes.append(subprocess.Popen([
+                'torchrun',
+                '--nnodes', '2',
+                '--nproc_per_node', '2',
+                '--node_rank', str(node_rank),
+                script_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE))
+
+        for rank, process in enumerate(processes):
+            process.wait()
+            process_out, process_err = process.communicate()
+            if rank == 0:
+                self.assertIn('Setting OMP_NUM_THREADS', str(process_err))
+            else:
+                self.assertNotIn('Setting OMP_NUM_THREADS', str(process_err))
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -175,17 +175,18 @@ def launch(args):
 
 
 def main(args=None):
-    warnings.warn(
-        "The module torch.distributed.launch is deprecated\n"
-        "and will be removed in future. Use torchrun.\n"
-        "Note that --use_env is set by default in torchrun.\n"
-        "If your script expects `--local_rank` argument to be set, please\n"
-        "change it to read from `os.environ['LOCAL_RANK']` instead. See \n"
-        "https://pytorch.org/docs/stable/distributed.html#launch-utility for \n"
-        "further instructions\n",
-        FutureWarning,
-    )
     args = parse_args(args)
+    if args.node_rank == 0:
+        warnings.warn(
+            "The module torch.distributed.launch is deprecated\n"
+            "and will be removed in future. Use torchrun.\n"
+            "Note that --use_env is set by default in torchrun.\n"
+            "If your script expects `--local_rank` argument to be set, please\n"
+            "change it to read from `os.environ['LOCAL_RANK']` instead. See \n"
+            "https://pytorch.org/docs/stable/distributed.html#launch-utility for \n"
+            "further instructions\n",
+            FutureWarning,
+        )
     launch(args)
 
 

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -659,14 +659,15 @@ def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str
     nproc_per_node = determine_local_world_size(args.nproc_per_node)
     if "OMP_NUM_THREADS" not in os.environ and nproc_per_node > 1:
         omp_num_threads = 1
-        log.warning(
-            f"\n*****************************************\n"
-            f"Setting OMP_NUM_THREADS environment variable for each process to be "
-            f"{omp_num_threads} in default, to avoid your system being overloaded, "
-            f"please further tune the variable for optimal performance in "
-            f"your application as needed. \n"
-            f"*****************************************"
-        )
+        if args.node_rank == 0:
+            log.warning(
+                f"\n*****************************************\n"
+                f"Setting OMP_NUM_THREADS environment variable for each process to be "
+                f"{omp_num_threads} in default, to avoid your system being overloaded, "
+                f"please further tune the variable for optimal performance in "
+                f"your application as needed. \n"
+                f"*****************************************"
+            )
         # This env variable will be passed down to the subprocesses
         os.environ["OMP_NUM_THREADS"] = str(omp_num_threads)
 


### PR DESCRIPTION
Part of #68768

@stas00 mentioned that these two warnings are being emitted for all ranks. I've disabled them for all ranks except 0.

I made this a draft PR because this might not be quite what we want. We should probably have a setting to turn these warnings on for all ranks, similar to the `log_level_replica` mentioned here: https://github.com/pytorch/pytorch/issues/68768#issuecomment-976080923. But if we do want to add a setting to toggle replica warnings like this, it might be better to wait to implement this change until we have a new warning message API like the one described in #72948