### PR TITLE
[vulkan] replication_pad2d.glsl: use clamp() instead of min(max())

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/replication_pad2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/replication_pad2d.glsl
@@ -21,11 +21,10 @@ void main() {
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
     const ivec3 corresponding_input_pos = ivec3(
-        min(
-          max(ivec2(0, 0),
-              pos.xy - uBlock.pad.xz),
-          uBlock.size.xy - uBlock.pad.xz - uBlock.pad.yw - ivec2(1, 1)),
-        pos.z);
+      clamp(pos.xy - uBlock.pad.xz,
+        ivec2(0, 0),
+        uBlock.size.xy - uBlock.pad.xz - uBlock.pad.yw - ivec2(1, 1)),
+      pos.z);
 
     imageStore(uOutput, pos, texelFetch(uInput, corresponding_input_pos, 0));
   }


### PR DESCRIPTION
Summary:
clamp — constrain a value to lie between two further values

use `clamp` instead of `min(max())` to calculate the coordinate.

Test Plan:
```
buck run //xplat/caffe2:pt_vulkan_api_test_binAppleMac

[ RUN      ] VulkanAPITest.replication_pad2d
[       OK ] VulkanAPITest.replication_pad2d (161 ms)
```

Differential Revision: D37063026

