### PR TITLE
[Static Runtime] Exception handling during fork subgraph execution

### DIFF
--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -857,10 +857,15 @@ class TORCH_API ForkedSubgraphSRLauncher {
         future_(std::move(future)) {}
 
   void operator()() {
-    StaticModule smodule(graph_, opts_, {});
-    StaticRuntime runtime(smodule);
-    auto output = runtime(args_, {});
-    future_->markCompleted(output);
+    try {
+      StaticModule smodule(graph_, opts_, {});
+      StaticRuntime runtime(smodule);
+      auto output = runtime(args_, {});
+      future_->markCompleted(output);
+    } catch (const std::exception& e) {
+      future_->setErrorIfNeeded(
+          std::make_exception_ptr(c10::ivalue::Future::FutureError(e.what())));
+    }
   }
 
  private:


### PR DESCRIPTION
Summary:
- Exception handling was not performed in forked subgraph execution
- forked subgraph runtime can throw runtime exception. Future returned by prim::fork needs to handle exceptions so that aten::wait handles it.

Test Plan:
local test cases:
  - buck test caffe2/benchmarks/static_runtime/fb:test_fb_operators
  - buck test mode/opt caffe2/benchmarks/static_runtime:static_runtime_cpptest
  - buck test mode/opt caffe2/test:static_runtime

Async execution of the subgraph is tested by adding pytorch profiler hooks on the StaticRuntime execution via below code. Async execution in threadpool is verfiied by checking trace
  with profile(activities=[ProfilerActivity.CPU]) as prof:
      static_runtime_module(inputs)
  prof.export_chrome_trace("trace.json")

Differential Revision: D37072493

