### PR TITLE
Add bazel_cuda_stuck_repro

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1872,3 +1872,13 @@ test_suite(
         "torch/csrc/lazy/ts_backend/ts_native_functions.cpp",
     ]
 ]
+
+cc_binary(
+    name = "bazel_cuda_stuck_repro",
+    srcs = [
+        "test/bazel_cuda_stuck_repro.cpp",
+    ],
+    deps = [
+        ":torch",
+    ],
+)

--- a/test/bazel_cuda_stuck_repro.cpp
+++ b/test/bazel_cuda_stuck_repro.cpp
@@ -1,0 +1,14 @@
+#include <torch/torch.h>
+#include <iostream>
+
+using namespace torch::nn;
+
+
+int main() {
+  std::cout << "Hello0\n" << std::flush;
+  const at::Device device("cuda");
+  std::cout << "Hello1\n" << std::flush;
+  const auto x = torch::full({1}, 0, torch::TensorOptions().dtype(torch::kUInt8).device(device));
+  std::cout << "Hello2\n" << std::flush;
+}
+


### PR DESCRIPTION
Here is a small repro for torch being stuck on a basic operation with CUDA.

```
bazel run //:bazel_cuda_stuck_repro
```

Expected output:
```
Hello0
Hello1
Hello3
```

Actual output:
```
Hello0
Hello1
```

Then the program gets stuck.
