### PR TITLE
remove unnecessary quotes in per_file_copt regexps

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -48,11 +48,11 @@ build:cpu-only --@rules_cuda//cuda:enable_cuda=False
 #
 # On the bright side, this means we don't have to more broadly apply
 # the exceptions to an entire target.
-build --per_file_copt='^//.*\.(cpp|cc)$'@-Werror=type-limits
+build --per_file_copt=^//.*\.(cpp|cc)$@-Werror=type-limits
 build --per_file_copt=^//.*\.cu$@--compiler-options=-Werror=type-limits
-build --per_file_copt='^//.*\.(cpp|cc)$'@-Werror=unused-function
+build --per_file_copt=^//.*\.(cpp|cc)$@-Werror=unused-function
 build --per_file_copt=^//.*\.cu$@--compiler-options=-Werror=unused-function
-build --per_file_copt='^//.*\.(cpp|cc)$'@-Werror=unused-variable
+build --per_file_copt=^//.*\.(cpp|cc)$@-Werror=unused-variable
 build --per_file_copt=^//.*\.cu$@--compiler-options=-Werror=unused-variable
 
 build --per_file_copt=//:aten/src/ATen/RegisterCompositeExplicitAutograd.cpp@-Wno-error=unused-function


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #79306
* #79305
* __->__ #79310
* #79308
* #79156

Summary:
We were being extra cautious because of the parens in the regexp which
could conflict with the Bash parser, but Bash is not used to evaluate
these command lines, hence they are fine as is.

Test Plan: Verified with `bazel build --subcommands`.

Reviewers: seemethere

Subscribers:

Tasks:

Tags: