### PR TITLE
Functionality/pickling for commhooks

### DIFF
--- a/docs/source/ddp_comm_hooks.rst
+++ b/docs/source/ddp_comm_hooks.rst
@@ -96,6 +96,119 @@ As the name implies, debugging communication hooks are **only** used for debuggi
 
 .. autofunction:: noop_hook
 
+Checkpointing of Communication Hooks
+------------------------------------
+
+.. currentmodule:: torch.distributed.algorithms.ddp_comm_hooks.powerSGD_hook
+
+A stateful communication hook can be saved as a part of model checkpointing to enable trainer restarts.
+To make a hook serializable, ``__setstate__`` and ``__getstate__`` should be defined.
+
+.. warning ::
+    ``__getstate__`` should exclude non-serializable attributes from a returned dictionary.
+
+.. warning ::
+    ``__setstate__`` should properly initialize non-serializable attributes, excluded from a provided ``state``.
+
+:class:`PowerSGDState` has ``__setstate__`` and ``__getstate__`` implemented and can be used as a reference.
+
+.. class:: PowerSGDState
+    :noindex:
+
+    .. automethod:: PowerSGDState.__getstate__
+    .. automethod:: PowerSGDState.__getstate__
+
+Here is a simple, end-to-end example of saving and reloading PowerSGD state and hook.
+
+::
+    import os
+    import sys
+    import tempfile
+    import torch
+    import torch.distributed as dist
+    import torch.nn as nn
+    import torch.optim as optim
+
+    from torch.distributed.algorithms.ddp_comm_hooks import powerSGD_hook as powerSGD
+
+    class SimpleModel(nn.Module):
+        def __init__(self):
+            super(SimpleModel, self).__init__()
+            self.fc1 = nn.Linear(24,24)
+            self.relu = nn.ReLU()
+            self.fc2 = nn.Linear(24,12)
+
+        def forward(self, x):
+            return self.fc2(self.relu(self.fc1(x)))
+
+    def setup(rank, world_size):
+        os.environ['MASTER_ADDR'] = 'localhost'
+        os.environ['MASTER_PORT'] = '12355'
+
+        # initialize the process group
+        dist.init_process_group("nccl", rank=rank, world_size=world_size)
+
+    def cleanup():
+        dist.destroy_process_group()
+
+    def run_demo(demo_fn, world_size):
+        mp.spawn(
+            demo_fn,
+            args=(world_size,),
+            nprocs=world_size,
+            join=True
+        )
+
+    def demo_serialization(rank, world_size):
+        setup(rank, world_size)
+
+        CHECKPOINT = tempfile.gettempdir() + "/checkpoint.pt"
+
+        model = SimpleModel().to(rank)
+        ddp_model = DistributedDataParallel(
+            model,
+            device_ids=[rank]
+        )
+        powersgd_hook = powerSGD.powerSGD_hook
+        powersgd_state = powerSGD.PowerSGDState(
+                process_group=None,
+                matrix_approximation_rank=1,
+                start_powerSGD_iter=4,
+        )
+
+        optimizer = optim.SGD(ddp_model.parameters(), lr=0.001)
+        ddp_model.register_comm_hook(powersgd_state, powersgd_hook)
+
+        state = {
+            'state_dict': ddp_model.state_dict(),
+            'comm_hook': hook,
+            'comm_hook_state': hook_state
+        }
+
+        if rank == 0:
+            torch.save(state, CHECKPOINT)
+
+        dist.barrier()
+        map_location = {'cuda:%d' % 0: 'cuda:%d' % rank}
+        checkpoint = torch.load(CHECKPOINT, map_location=map_location)
+
+        ddp_model.load_state_dict(checkpoint['state_dict'])
+        powersgd_hook = checkpoint['comm_hook']
+        powersgd_state = checkpoint['comm_hook_state']
+
+        ddp_model.register_comm_hook(powersgd_state, powersgd_hook)
+
+        if rank == 0:
+            os.remove(CHECKPOINT)
+
+        cleanup()
+
+    if __name__ == "__main__":
+        n_gpus = torch.cuda.device_count()
+        assert n_gpus >= 2, f"Requires at least 2 GPUs to run, but got {n_gpus}"
+        world_size = n_gpus
+        run_demo(demo_serialization, world_size)
+
 Acknowledgements
 ----------------
 

--- a/docs/source/ddp_comm_hooks.rst
+++ b/docs/source/ddp_comm_hooks.rst
@@ -121,6 +121,7 @@ To make a hook serializable, ``__setstate__`` and ``__getstate__`` should be def
 Here is a simple, end-to-end example of saving and reloading PowerSGD state and hook.
 
 ::
+
     import os
     import sys
     import tempfile

--- a/docs/source/ddp_comm_hooks.rst
+++ b/docs/source/ddp_comm_hooks.rst
@@ -164,15 +164,10 @@ Here is a simple, end-to-end example of saving and reloading PowerSGD state and 
         CHECKPOINT = tempfile.gettempdir() + "/checkpoint.pt"
 
         model = SimpleModel().to(rank)
-        ddp_model = DistributedDataParallel(
-            model,
-            device_ids=[rank])
+        ddp_model = DistributedDataParallel(model, device_ids=[rank])
 
         powersgd_hook = powerSGD.powerSGD_hook
-        powersgd_state = powerSGD.PowerSGDState(
-                process_group=None,
-                matrix_approximation_rank=1,
-                start_powerSGD_iter=4)
+        powersgd_state = powerSGD.PowerSGDState(process_group=None)
 
         optimizer = optim.SGD(ddp_model.parameters(), lr=0.001)
         ddp_model.register_comm_hook(powersgd_state, powersgd_hook)

--- a/docs/source/ddp_comm_hooks.rst
+++ b/docs/source/ddp_comm_hooks.rst
@@ -116,7 +116,7 @@ To make a hook serializable, ``__setstate__`` and ``__getstate__`` should be def
     :noindex:
 
     .. automethod:: PowerSGDState.__getstate__
-    .. automethod:: PowerSGDState.__getstate__
+    .. automethod:: PowerSGDState.__setstate__
 
 Here is a simple, end-to-end example of saving and reloading PowerSGD state and hook.
 
@@ -156,8 +156,7 @@ Here is a simple, end-to-end example of saving and reloading PowerSGD state and 
             demo_fn,
             args=(world_size,),
             nprocs=world_size,
-            join=True
-        )
+            join=True)
 
     def demo_serialization(rank, world_size):
         setup(rank, world_size)
@@ -167,14 +166,13 @@ Here is a simple, end-to-end example of saving and reloading PowerSGD state and 
         model = SimpleModel().to(rank)
         ddp_model = DistributedDataParallel(
             model,
-            device_ids=[rank]
-        )
+            device_ids=[rank])
+
         powersgd_hook = powerSGD.powerSGD_hook
         powersgd_state = powerSGD.PowerSGDState(
                 process_group=None,
                 matrix_approximation_rank=1,
-                start_powerSGD_iter=4,
-        )
+                start_powerSGD_iter=4)
 
         optimizer = optim.SGD(ddp_model.parameters(), lr=0.001)
         ddp_model.register_comm_hook(powersgd_state, powersgd_hook)
@@ -182,8 +180,7 @@ Here is a simple, end-to-end example of saving and reloading PowerSGD state and 
         state = {
             'state_dict': ddp_model.state_dict(),
             'comm_hook': hook,
-            'comm_hook_state': hook_state
-        }
+            'comm_hook_state': hook_state}
 
         if rank == 0:
             torch.save(state, CHECKPOINT)

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -268,15 +268,13 @@ class PowerSGDState(object):
 
     def __getstate__(self):
         r"""
-        Returns a ``PowerSGDState`` which will be pickled and saved.
+        Returns a ``Dict[str, Any]`` which will be pickled and saved.
         ``process_group`` is not serializable and excluded from
         a returned state.
         """
-        slots = copy.copy(self.__slots__)
-        slots.remove("process_group")
         return {
             slot: getattr(self, slot)
-            for slot in slots if hasattr(self, slot)
+            for slot in self.__slots__ if slot != "process_group"
         }
 
     def __setstate__(self, state):
@@ -286,7 +284,7 @@ class PowerSGDState(object):
         """
         self.process_group = distributed_c10d._get_default_group()
         logger.warning(
-            "NOTE: PowerSGDState is set to use the default process group."
+            "NOTE: Current process group is set to default."
         )
         for slot, value in state.items():
             setattr(self, slot, value)

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 import logging
 import math
-import copy
 from typing import Dict
 
 import numpy as np

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -271,6 +271,9 @@ class PowerSGDState(object):
         ``process_group`` is not serializable and excluded from
         a returned state.
         """
+        logger.warning(
+            "NOTE: Process group is not serializable and excluded from a saved state."
+        )
         return {
             slot: getattr(self, slot)
             for slot in self.__slots__ if slot != "process_group"
@@ -283,7 +286,8 @@ class PowerSGDState(object):
         """
         self.process_group = distributed_c10d._get_default_group()
         logger.warning(
-            "NOTE: Current process group is set to default."
+            "NOTE: Process group will be set to a default group (i.e. the world size).\
+                If a different group is desired, please set `self.process_group` after PowerSGD state is loaded."
         )
         for slot, value in state.items():
             setattr(self, slot, value)

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -267,6 +267,11 @@ class PowerSGDState(object):
         self.batch_tensors_with_same_shape = batch_tensors_with_same_shape
 
     def __getstate__(self):
+        r"""
+        Returns a ``PowerSGDState`` which will be pickled and saved.
+        ``process_group`` is not serializable and excluded from
+        a returned state.
+        """
         slots = copy.copy(self.__slots__)
         slots.remove("process_group")
         return {
@@ -275,9 +280,13 @@ class PowerSGDState(object):
         }
 
     def __setstate__(self, state):
+        r"""
+        Takes a provided ``state`` and retrieves ``PowerSGDState``.
+        ``process_group`` is set to default.
+        """
         self.process_group = distributed_c10d._get_default_group()
         logger.warning(
-            "NOTE: State is set to use the default process group."
+            "NOTE: PowerSGDState is set to use the default process group."
         )
         for slot, value in state.items():
             setattr(self, slot, value)

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -8902,12 +8902,12 @@ class DistributedTest:
             self.assertEqual(dummy_hook_state.process_group, _get_default_group())
 
             # Check that a random state was restored properly:
-            # :met:`np.random.RandomState.get_state` returns a tuple with entries:
-            # `bit_generator` - str,
-            # `state.key` - ndarray dtype[uint32],
-            # `state.pos` - int,
-            # `has_gauss` - int,
-            # `gauss` - float
+            # ``np.random.RandomState.get_state`` returns a tuple with entries:
+            # ``bit_generator`` - str,
+            # ``state.key`` - ndarray dtype[uint32],
+            # ``state.pos`` - int,
+            # ``has_gauss`` - int,
+            # ``gauss`` - float
             #  (refer to https://github.com/numpy/numpy/blob/266aad7478bc7fbcc55eea7f942a0d373b838396/numpy/random/mtrand.pyi)
             # To make sure random state was restored properly, all entries should equal the original
             for entry1, entry2 in zip(hook_state.rng.get_state(), dummy_hook_state.rng.get_state()):
@@ -8928,11 +8928,9 @@ class DistributedTest:
                 optimizer.step()
                 dummy_optimizer.step()
 
-            original_grads = [p.grad for p in ddp_model.parameters()]
-            dummy_grads = [p.grad for p in dummy_ddp_model.parameters()]
-
             # Check that gradients after 10 epochs are the same
-            self.assertEqual(original_grads, dummy_grads)
+            for orig_param, dummy_param in zip(ddp_model.parameters(), dummy_ddp_model.parameters()):
+                self.assertEqual(orig_param.grad, dummy_param.grad)
 
             if rank == 0:
                 os.remove(chkpt_file)


### PR DESCRIPTION
This PR addresses issue address #75666.  
Stateful communication hook now can be saved and reloaded to resume training.

Current PR adds the functionality for PowerSGD communication hook and tests that communication hook can be properly saved and restored.

PowerSGD implementation uses ``__slots__``, as a result introduced __getstate__ and __setstate__ methods are implemented to work with `__slots__` and not` __dict__`.

`__getstate__ `
	
	 Returns:
           A dictionary that represents a ``PowerSGDState`` which will be pickled and saved.
          ``process_group`` is non-serializable and excluded from a returned state.

`__setstate__`

	Takes a provided ``state`` and retrieves ``PowerSGDState``.
        ``process_group`` is set to default with a proper warning issued to a user.


Unit test

A hook-independent `_test_hook_pickling` is added with this PR, as well as `test_ddp_hook_pickling_powerSGD`, which tests `powerSGD`’s ability to be saved and reloaded.

Currently, the test creates a ddp model with a provided hook, trains it for 10 epochs and saves model’s state and hook’s state. 
During reloading, unit test makes sure that a warning was logged (only one warning and the proper one). It then proceeds to check that reloaded hook and original hook are the same. Finally, it checks that a hook’s state was properly initialized:
	- it compares slot values (all, but 2: `process_group` and `rng`) for original and reloaded state
	- it checks that process group was set to a default group
	- it checks that a random state was restored properly with np.testing.assert_array_equal, because `rng` is an instance of `np.random.RandomState`, represented by a tuple. One of entries is of `ndarray dtype[uint32]` type and `np.testing.assert_array_equal` is used for assertion. 


Future To-Do:
	- Implement similar __getstate__ and __setstate__ for other stateful communication hooks
	- Add appropriate tests 
