### PR TITLE
[bazel] Add --config=shell for easier debugging

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,6 +31,10 @@ build --copt=-isystem --copt=bazel-out/k8-fastbuild-cpu-only/bin
 # rules_cuda configuration
 build:cpu-only --@rules_cuda//cuda:enable_cuda=False
 
+# Definition of --config=shell
+# interactive shell immediately before execution
+build:shell --run_under="//tools/bazel_tools:shellwrap"
+
 # Disable all warnings for external repositories. We don't care about
 # their warnings.
 build --per_file_copt=^external/@-w

--- a/tools/bazel_tools/BUILD.bazel
+++ b/tools/bazel_tools/BUILD.bazel
@@ -1,12 +1,5 @@
 sh_binary(
     name = "shellwrap",
     srcs = ["shellwrap.sh"],
-    args = [
-        "--ttywrap_bin_path",
-        "$(location :ttywrap)",
-    ],
-    data = [
-        ":ttywrap",
-    ],
     visibility = ["//visibility:public"],
 )

--- a/tools/bazel_tools/BUILD.bazel
+++ b/tools/bazel_tools/BUILD.bazel
@@ -1,0 +1,12 @@
+sh_binary(
+    name = "shellwrap",
+    srcs = ["shellwrap.sh"],
+    args = [
+        "--ttywrap_bin_path",
+        "$(location :ttywrap)",
+    ],
+    data = [
+        ":ttywrap",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/tools/bazel_tools/shellwrap.sh
+++ b/tools/bazel_tools/shellwrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script is helpful in entering an interactive shell from a bazel build 
+# This script is helpful in entering an interactive shell from a bazel build
 # before running a given bazel executable.
 # This can provide a quick way to explore the sandbox directory and filesystem.
 # Typical use is with

--- a/tools/bazel_tools/shellwrap.sh
+++ b/tools/bazel_tools/shellwrap.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# This script is helpful in entering an interactive shell from a bazel build 
+# before running a given bazel executable.
+# This can provide a quick way to explore the sandbox directory and filesystem.
+# Typical use is with
+#
+#     bazel run --run_under=//tools/bazel:shell_wrapper //:target
+#     OR
+#     bazel run --config=shell //:target
+
+shell="/bin/bash"
+rcfile="/tmp/pytorch_bazel_tools_shellwrap"
+while [[ $# -gt 0 ]] ; do
+    case "$1" in
+        --shell_bin_path)
+            # path for the shell executable
+            shell="$2"
+            shift 2
+            ;;
+        --rcfile)
+            # path for the file used to write the environment
+            rcfile="$2"
+            shift 2
+            ;;
+        *)
+            # remaining arguments are part of the command for execution
+            break
+            ;;
+    esac
+done
+
+if ! tty -s; then
+    echo "A tty is not available."
+    echo "Use \`bazel run\`, not \`bazel test\`."
+    exit 1
+fi
+
+NOCOLOR='\033[0m'
+YELLOW='\033[1;33m'
+
+# store the environment in a file
+export PYTORCH_SHELL_COMMAND=$*
+echo "alias run=\"$*\"" > "$rcfile"
+echo "PS1='\s-\v\$ '" >> "$rcfile"
+echo "cat"
+cat "$rcfile"
+echo "cat"
+
+echo =====
+# print the execution command (command is yellow)
+echo -e "alias run=${YELLOW}$PYTORCH_SHELL_COMMAND${NOCOLOR}"
+echo =====
+
+echo "Entering interactive shell at the execution root:"
+
+# run the command in a script psuedo terminal and dump to null
+"$shell" --noprofile --rcfile /tmp/pytorch_bazel_tools_shellwrap

--- a/tools/bazel_tools/shellwrap.sh
+++ b/tools/bazel_tools/shellwrap.sh
@@ -54,5 +54,8 @@ echo =====
 
 echo "Entering interactive shell at the execution root:"
 
+# quote escape all the arguments to use as a single input string
+cmd="'$shell' --noprofile --rcfile '$rcfile'"
+
 # run the command in a script psuedo terminal and dump to null
-"$shell" --noprofile --rcfile /tmp/pytorch_bazel_tools_shellwrap
+/usr/bin/script -c "$cmd" -q /dev/null

--- a/tools/bazel_tools/shellwrap.sh
+++ b/tools/bazel_tools/shellwrap.sh
@@ -9,8 +9,8 @@
 #     OR
 #     bazel run --config=shell //:target
 
-shell="/bin/bash"
-rcfile="/tmp/pytorch_bazel_tools_shellwrap"
+shell='/bin/bash'
+rcfile='/tmp/pytorch_bazel_tools_shellwrap'
 while [[ $# -gt 0 ]] ; do
     case "$1" in
         --shell_bin_path)
@@ -31,7 +31,7 @@ while [[ $# -gt 0 ]] ; do
 done
 
 if ! tty -s; then
-    echo "A tty is not available."
+    echo 'A tty is not available.'
     echo "Use \`bazel run\`, not \`bazel test\`."
     exit 1
 fi
@@ -43,9 +43,6 @@ YELLOW='\033[1;33m'
 export PYTORCH_SHELL_COMMAND=$*
 echo "alias run=\"$*\"" > "$rcfile"
 echo "PS1='\s-\v\$ '" >> "$rcfile"
-echo "cat"
-cat "$rcfile"
-echo "cat"
 
 echo =====
 # print the execution command (command is yellow)


### PR DESCRIPTION
Bazel quality of life improvement.

This change adds a new option `--config=shell` which allows you to drop-in the shell right before the `bazel run` command is executed. For example you will have ability to examine bazel sandbox this way, run things under gdb instead of a normal run and so on.

Example usage:

```
bazel run --config=shell //:init_test
```