### PR TITLE
[bazel] Plumb all cc tests through rules.cc_test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library")
 load("//third_party:substitution.bzl", "header_template_rule")
 load("//:tools/bazel.bzl", "rules")
 load("//tools/rules:cu.bzl", "cu_library")
@@ -1774,7 +1774,7 @@ cc_test(
 )
 
 [
-  cc_test(
+  rules.cc_test(
       name = paths.split_extension(paths.basename(filename))[0].replace("-","_") + "_test",
       size = "medium",
       srcs = [filename],
@@ -1816,7 +1816,7 @@ test_suite(
 )
 
 # dist autograd tests
-cc_test(
+rules.cc_test(
     name = "torch_dist_autograd_test",
     size = "small",
     srcs = ["test/cpp/dist_autograd/test_dist_autograd.cpp"],
@@ -1833,7 +1833,7 @@ cc_test(
 # jit tests
 # Because these individual unit tests require custom registering,
 # it is easier to mimic the cmake build by globing together a single test.
-cc_test(
+rules.cc_test(
     name = "jit_tests",
     size = "small",
     srcs = glob([
@@ -1856,7 +1856,7 @@ cc_test(
     ],
 )
 
-cc_test(
+rules.cc_test(
     name = "lazy_tests",
     size = "small",
     srcs = glob([

--- a/tools/bazel.bzl
+++ b/tools/bazel.bzl
@@ -20,10 +20,10 @@ def _requirement(_pypi_project):
 def pytorch_cc_test(name, srcs, tags = [], **kwargs):
     """PyTorch cc test rule.
 
-    One of the reason to proxy all tests through this central location
+    One of the reasons to proxy all tests through this central location
     is ability to change the behavior on all of them instead of one-by-one.
 
-    For example, sombody using Remote Build Execution can add exec_properties for tests here.
+    For example, somebody using Remote Build Execution can add exec_properties for tests here.
     """
     if "gpu-required" in tags:
         exec_properties = {

--- a/tools/bazel.bzl
+++ b/tools/bazel.bzl
@@ -17,13 +17,29 @@ def _py_library(name, **kwds):
 def _requirement(_pypi_project):
     return None
 
+def pytorch_cc_test(name, srcs, tags = [], **kwargs):
+    """PyTorch cc test rule.
+
+    One of the reason to proxy all tests through this central location
+    is ability to change the behavior on all of them instead of one-by-one.
+
+    For example, sombody using Remote Build Execution can add exec_properties for tests here.
+    """
+    if "gpu-required" in tags:
+        exec_properties = {
+            "test.dockerRuntime": "nvidia",
+        }
+    else:
+        exec_properties = {}
+    native.cc_test(name=name, srcs=srcs, tags=tags, exec_properties=exec_properties, **kwargs)
+
 # Rules implementation for the Bazel build system. Since the common
 # build structure aims to replicate Bazel as much as possible, most of
 # the rules simply forward to the Bazel definitions.
 rules = struct(
     cc_binary = cc_binary,
     cc_library = cc_library,
-    cc_test = cc_test,
+    cc_test = pytorch_cc_test,
     cmake_configure_file = cmake_configure_file,
     filegroup = native.filegroup,
     genrule = _genrule,


### PR DESCRIPTION
Fixes #79351

Allows RBE users to have a central place for customizations of cc tests.
See issue for full context.