### PR TITLE
fix Python parent id

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -213,7 +213,7 @@ struct EventFieldsVisitor {
     annotations_.emplace_back("Python id", std::to_string(t.id_));
     annotations_.emplace_back(
         "Python parent id",
-        !py_metadata_.empty() ? py_metadata_.at(0).name_ : "null");
+        !py_metadata_.empty() ? std::to_string(py_metadata_.at(0).id_) : "null");
     annotations_.emplace_back("Python thread", std::to_string(t.python_tid_));
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79356
* #79301

Broke this in a recent refactor.

Test plan: Added a unit test to `test_profiler.py`