### PR TITLE
[ONNX] Fix `any` and `all` outputs' shape

### DIFF
--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -4081,8 +4081,8 @@ def _any(g, *args):
     )
 
     if dim is None and keepdim == 0:
-        return symbolic_helper._squeeze_helper(
-            g, gt(g, input_sum, g.op("Constant", value_t=torch.LongTensor([0]))), [0]
+        return g.op(
+            "Squeeze", gt(g, input_sum, g.op("Constant", value_t=torch.LongTensor([0])))
         )
     return gt(g, input_sum, g.op("Constant", value_t=torch.LongTensor([0])))
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -4079,6 +4079,11 @@ def _any(g, *args):
     input_sum = symbolic_helper._reducesum_helper(
         g, input, axes_i=dim, keepdims_i=keepdim
     )
+
+    if dim is None and keepdim == 0:
+        return symbolic_helper._squeeze_helper(
+            g, gt(g, input_sum, g.op("Constant", value_t=torch.LongTensor([0]))), [0]
+        )
     return gt(g, input_sum, g.op("Constant", value_t=torch.LongTensor([0])))
 
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -4079,12 +4079,7 @@ def _any(g, *args):
     input_sum = symbolic_helper._reducesum_helper(
         g, input, axes_i=dim, keepdims_i=keepdim
     )
-
-    if dim is None and keepdim == 0:
-        return g.op(
-            "Squeeze", gt(g, input_sum, g.op("Constant", value_t=torch.LongTensor([0])))
-        )
-    return gt(g, input_sum, g.op("Constant", value_t=torch.LongTensor([0])))
+    return gt(g, input_sum, g.op("Constant", value_t=torch.tensor(0, dtype=torch.long)))
 
 
 def _all(g, *args):


### PR DESCRIPTION
Part of #79263

Before: When `dim` == `None` and `keepdim` == `0`(`False`), the reduced output has `[1]` shape.
After: Squeeze the output so that the shape will be `[]` as PyTorch's behavior.
