### PR TITLE
MSVC: Asking for <format> produces a spammy warning

### DIFF
--- a/c10/util/strong_type.h
+++ b/c10/util/strong_type.h
@@ -41,7 +41,7 @@
 #endif
 
 #ifndef STRONG_HAS_FMT_FORMAT
-#if __has_include(<fmt/format.h>)
+#if __has_include(<fmt/format.h>) && __cplusplus >= 202002L
 #define STRONG_HAS_FMT_FORMAT 1
 #else
 #define STRONG_HAS_FMT_FORMAT 0


### PR DESCRIPTION
The build log contains spam:

> The contents of < format > are available only with C++20 or later.

Fixes #ISSUE_NUMBER
