### PR TITLE
GenCode: Only gen lazy ts backend if enabled

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -435,7 +435,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       $<$<BOOL:${INTERN_DISABLE_AUTOGRAD}>:--disable-autograd>
       $<$<BOOL:${SELECTED_OP_LIST}>:--selected-op-list-path="${SELECTED_OP_LIST}">
       --force_schema_registration
-      --gen_lazy_ts_backend
+      $<$<BOOL:${BUILD_LAZY_TS_BACKEND}>:--gen_lazy_ts_backend>
       ${GEN_PER_OPERATOR_FLAG}
     DEPENDS
     "${TORCH_ROOT}/aten/src/ATen/native/native_functions.yaml"


### PR DESCRIPTION
Self-explanatory. I found it was generating the code even though I didn't build the backend.