### PR TITLE
Add pyproject.toml for black configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,17 +21,4 @@ build-backend = "setuptools.build_meta:__legacy__"
 [tool.black]
 # Uncomment if pyproject.toml worked fine to ensure consistency with flake8
 # line-length = 120
-skip-string-normalization = true
 target-version = ["py37", "py38", "py39", "py310"]
-include = '''
-(
-    ^/torchgen/.*\.py$
-    | ^/tools/.*\.py$
-    | ^/torch/package/.*\.py$
-    | ^/torch/onnx/.*\.py$
-    | ^/torch/_refs/.*\.py$
-    | ^/torch/_prims/.*\.py$
-    | ^/torch/_meta_registrations\.py$
-    | ^/test/onnx/.*\.py$
-)
-'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "astunparse",
+    "numpy",
+    "ninja",
+    "pyyaml",
+    "setuptools",
+    "cmake",
+    "cffi",
+    "typing_extensions",
+    "future",
+    "six",
+    "requests",
+    "dataclasses",
+]
+build-backend = "setuptools.build_meta:__legacy__"
+
+
+[tool.black]
+# Uncomment if pyproject.toml worked fine to ensure consistency with flake8
+# line-length = 120
+skip-string-normalization = true
+target-version = ["py37", "py38", "py39"]
+include = '''
+(
+    ^/torchgen/.*\.py$
+    | ^/tools/.*\.py$
+    | ^/torch/package/.*\.py$
+    | ^/torch/onnx/.*\.py$
+    | ^/torch/_refs/.*\.py$
+    | ^/torch/_prims/.*\.py$
+    | ^/torch/_meta_registrations\.py$
+    | ^/test/onnx/.*\.py$
+)
+'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 # Uncomment if pyproject.toml worked fine to ensure consistency with flake8
 # line-length = 120
 skip-string-normalization = true
-target-version = ["py37", "py38", "py39"]
+target-version = ["py37", "py38", "py39", "py310"]
 include = '''
 (
     ^/torchgen/.*\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires = [
     "requests",
     "dataclasses",
 ]
+# Use legacy backend to import local packages in setup.py
 build-backend = "setuptools.build_meta:__legacy__"
 
 

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -3106,7 +3106,7 @@ def make_test(
     initial_state,
     variable_length,
     dropout,
-    **extra_kwargs
+    **extra_kwargs,
 ):
     test_name = str(
         "_".join(
@@ -3133,7 +3133,7 @@ def make_test(
             initial_state=initial_state[0],
             packed_sequence=variable_length[0],
             dropout=dropout[0],
-            **extra_kwargs
+            **extra_kwargs,
         )
 
     f.__name__ = test_name
@@ -3179,7 +3179,7 @@ def setup_rnn_tests():
                 initial_state,
                 variable_length,
                 dropout,
-                **extra_kwargs
+                **extra_kwargs,
             )
             test_count += 1
 


### PR DESCRIPTION
Motivation

- Ensure black configuration consistency with other tools (flake8, isort)

Currently linter and formatter tools (flake8, isort and black) configuration about line length are inconsistent.
flake8 is 120,  isort is 79 (default), black is 88 (default).

https://github.com/pytorch/pytorch/blob/ba27ee9e8fc57f7509d2bf0c0be73510802806c0/.flake8#L3

isort.cfg does not specify line length.
https://github.com/pytorch/pytorch/blob/ba27ee9e8fc57f7509d2bf0c0be73510802806c0/.isort.cfg#L1-L6

black supports only `pyproject.toml` as a configuration file. However `pyproject.toml` was previously removed #61367 since it had some build issues.

I also resolved them by

- Use `setuptools.build_meta:__legacy__` as a build-backend to import local packages (e.g. tools) in setup.py (related https://github.com/pytorch/pytorch/pull/60408#issuecomment-873979383)
- Add build time dependencies to requires for PEP 517 isolation build environment.

This PR does not change line length of black and isort since they will cause a lot of file changes. We should apply in the future if  `pyproject.toml` worked fine.
