### PR TITLE
Clone tensor to write in ShardedTensor checkpoint

### DIFF
--- a/torch/distributed/_shard/checkpoint/resharding.py
+++ b/torch/distributed/_shard/checkpoint/resharding.py
@@ -27,6 +27,12 @@ from .metadata import (
     TensorWriteRequest,
 )
 
+def _trim(tensor: torch.Tensor) -> torch.Tensor:
+    tensor = tensor.detach()
+    if tensor.storage().size() != tensor.numel():
+        return tensor.clone()
+    return tensor
+
 def _create_storage_key(
     storage_key_to_fqn: Dict[str, str],
     fqn: str
@@ -183,7 +189,7 @@ def _prepare_sharded_tensor_write(
         shard_storage_key = shard_to_storage_key[_get_shard_key(shard.metadata)]
 
         wr = TensorWriteRequest(
-            tensor=tensor,
+            tensor=_trim(tensor),
             storage_key=shard_storage_key,
         )
         write_requests.append(wr)
@@ -271,7 +277,7 @@ def _prepare_tensor_write(
 
     write_reqs = [
         TensorWriteRequest(
-            tensor=tensor.detach(),
+            tensor=_trim(tensor),
             storage_key=storage_key,
         )
     ]


### PR DESCRIPTION
The `torch.save` api will save the origin tensor of a view, which will results in saving a much larger checkpoint when parameters are fused, e.g. in torchrec.

Relates to #79016
