### PR TITLE
move CUDA flags out of --per_file_copts into the cu_library macro

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -49,11 +49,16 @@ build:cpu-only --@rules_cuda//cuda:enable_cuda=False
 # On the bright side, this means we don't have to more broadly apply
 # the exceptions to an entire target.
 build --per_file_copt='^//.*\.(cpp|cc)$'@-Werror=type-limits
-build --per_file_copt='^//.*\.cu$'@--compiler-options=-Werror=type-limits
 build --per_file_copt='^//.*\.(cpp|cc)$'@-Werror=unused-function
-build --per_file_copt='^//.*\.cu$'@--compiler-options=-Werror=unused-function
 build --per_file_copt='^//.*\.(cpp|cc)$'@-Werror=unused-variable
-build --per_file_copt='^//.*\.cu$'@--compiler-options=-Werror=unused-variable
+
+# Looking for CUDA flags? We have a cu_library macro that we can edit
+# directly. Look in //tools/rules:cu.bzl for details. Editing the
+# macro over this has the following advantages:
+#  * making changes does not require discarding the Bazel analysis
+#    cache
+#  * it allows for selective overrides on individual targets since the
+#    macro-level opts will come earlier than target level overrides
 
 build --per_file_copt='//:aten/src/ATen/RegisterCompositeExplicitAutograd\.cpp$'@-Wno-error=unused-function
 build --per_file_copt='//:aten/src/ATen/RegisterCompositeImplicitAutograd\.cpp$'@-Wno-error=unused-function

--- a/tools/rules/cu.bzl
+++ b/tools/rules/cu.bzl
@@ -1,6 +1,12 @@
 load("@rules_cuda//cuda:defs.bzl", "cuda_library")
 
-NVCC_COPTS = ["--expt-relaxed-constexpr", "--expt-extended-lambda"]
+NVCC_COPTS = [
+    "--expt-relaxed-constexpr",
+    "--expt-extended-lambda",
+    "--compiler-options=-Werror=type-limits",
+    "--compiler-options=-Werror=unused-function",
+    "--compiler-options=-Werror=unused-variable",
+]
 
 def cu_library(name, srcs, copts = [], **kwargs):
     cuda_library(name, srcs = srcs, copts = NVCC_COPTS + copts, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #79327
* #79345
* #79306
* #79305
* __->__ #79414
* #79313
* #79312
* #79308

Summary:
This has a few advantages:
 * changes do not discard the Bazel analysis cache
 * allows for per-target overrides

Test Plan: Verified with `bazel build --subcommands`.

Reviewers: seemethere

Subscribers:

Tasks:

Tags: