### PR TITLE
Refactored print_latest_commits.py to return the latest viable commit from master

### DIFF
--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, NamedTuple
+from typing import Any, Dict, List, NamedTuple, Tuple
 from gitutils import _check_output
 
 import rockset  # type: ignore[import]
@@ -69,7 +69,7 @@ def get_commit_results(commit: str, results: Dict[str, Any]) -> List[Dict[str, A
             )._asdict())
     return workflow_checks
 
-def isGreen(commit: str, results: Dict[str, Any]) -> bool:
+def isGreen(commit: str, results: Dict[str, Any]) -> Tuple[bool, str]:
     workflow_checks = get_commit_results(commit, results)
 
     for check in workflow_checks:
@@ -80,14 +80,14 @@ def isGreen(commit: str, results: Dict[str, Any]) -> bool:
                 pass
                 # there are trunk checks that run the same tests, so this pull workflow check can be skipped
             else:
-                return False
+                return (False, workflowName + " checks were not successful")
         elif workflowName in ["periodic", "docker-release-builds"] and conclusion not in ["success", "skipped"]:
-            return False
-    return True
+            return (False, workflowName + " checks were not successful")
+    return (True, "")
 
 def get_latest_green_commit(commits: List[str], results: Dict[str, Any]) -> Any:
     for commit in commits:
-        if isGreen(commit, results):
+        if isGreen(commit, results)[0]:
             return commit
     return None
 

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -69,7 +69,7 @@ def get_commit_results(commit: str, results: Dict[str, Any]) -> List[Dict[str, A
             )._asdict())
     return workflow_checks
 
-def isGreen(commit: str, results: Dict[str, Any]) -> Any:
+def isGreen(commit: str, results: Dict[str, Any]) -> bool:
     workflow_checks = get_commit_results(commit, results)
 
     for check in workflow_checks:
@@ -80,14 +80,14 @@ def isGreen(commit: str, results: Dict[str, Any]) -> Any:
                 pass
                 # there are trunk checks that run the same tests, so this pull workflow check can be skipped
             else:
-                return workflowName + " checks were not successful"
+                return False
         elif workflowName in ["periodic", "docker-release-builds"] and conclusion not in ["success", "skipped"]:
-            return workflowName + " checks were not successful"
+            return False
     return True
 
 def get_latest_green_commit(commits: List[str], results: Dict[str, Any]) -> Any:
     for commit in commits:
-        if isGreen(commit, results) is True:
+        if isGreen(commit, results):
             return commit
     return None
 

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, List, NamedTuple
-from datetime import datetime, timedelta
 from gitutils import _check_output
 
 import rockset  # type: ignore[import]
@@ -21,33 +20,36 @@ class WorkflowCheck(NamedTuple):
     jobName: str
     conclusion: str
 
-def parse_args() -> Any:
-    from argparse import ArgumentParser
-    parser = ArgumentParser("Print latest commits")
-    parser.add_argument("--minutes", type=int, default=30, help="duration in minutes of last commits")
-    return parser.parse_args()
-
-def print_latest_commits(qlambda: Any, minutes: int = 30) -> None:
-    current_time = datetime.now()
-    time_since = current_time - timedelta(minutes=minutes)
-    timestamp_since = datetime.timestamp(time_since)
+def get_latest_commits() -> List[str]:
+    latest_viable_commit = _check_output(
+        [
+            "git",
+            "log",
+            "-n",
+            "1",
+            "--pretty=format:%H",
+            "origin/viable/strict",
+        ],
+        encoding="ascii",
+    )
     commits = _check_output(
         [
             "git",
             "rev-list",
-            f"--max-age={timestamp_since}",
+            f"{latest_viable_commit}^..HEAD",
             "--remotes=*origin/master",
         ],
         encoding="ascii",
     ).splitlines()
 
+    return commits
+
+def query_commits(commits: List[str], qlambda: Any) -> Any:
     params = rockset.ParamDict()
     params['shas'] = ",".join(commits)
     results = qlambda.execute(parameters=params)
 
-    for commit in commits:
-        print_commit_status(commit, results)
-        print("isGreen:", isGreen(commit, results))
+    return results
 
 def print_commit_status(commit: str, results: Dict[str, Any]) -> None:
     print(commit)
@@ -83,8 +85,13 @@ def isGreen(commit: str, results: Dict[str, Any]) -> Any:
             return workflowName + " checks were not successful"
     return True
 
+def get_latest_green_commit(commits: List[str], results: Dict[str, Any]) -> Any:
+    for commit in commits:
+        if isGreen(commit, results) is True:
+            return commit
+    return None
+
 def main() -> None:
-    args = parse_args()
     rs = rockset.Client(
         api_server="api.rs2.usw2.rockset.com", api_key=os.environ["ROCKSET_API_KEY"]
     )
@@ -92,7 +99,12 @@ def main() -> None:
         'commit_jobs_batch_query',
         version='15aba20837ae9d75',
         workspace='commons')
-    print_latest_commits(qlambda, args.minutes)
+
+    commits = get_latest_commits()
+    results = query_commits(commits, qlambda)
+
+    latest_viable_commit = get_latest_green_commit(commits, results)
+    print(latest_viable_commit)
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_print_latest_commits.py
+++ b/.github/scripts/test_print_latest_commits.py
@@ -59,7 +59,7 @@ class TestPrintCommits(TestCase):
         "Test with necessary job (ex: pull) skipped"
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "pull", "skipped")
-        self.assertEqual(isGreen("sha", workflow_checks), "pull checks were not successful")
+        self.assertFalse(isGreen("sha", workflow_checks))
 
     @mock.patch('print_latest_commits.get_commit_results', return_value=TestChecks().make_test_checks())
     def test_skippable_skipped(self, mock_get_commit_results: Any) -> None:
@@ -74,7 +74,7 @@ class TestPrintCommits(TestCase):
         "Test with necessary job (ex: Lint) failed"
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "Lint", "failed")
-        self.assertEqual(isGreen("sha", workflow_checks), "Lint checks were not successful")
+        self.assertFalse(isGreen("sha", workflow_checks))
 
     @mock.patch('print_latest_commits.get_commit_results', return_value=TestChecks().make_test_checks())
     def test_skippable_failed(self, mock_get_commit_results: Any) -> None:
@@ -82,7 +82,7 @@ class TestPrintCommits(TestCase):
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "periodic", "skipped")
         workflow_checks = set_workflow_job_status(workflow_checks, "docker-release-builds", "failed")
-        self.assertEqual(isGreen("sha", workflow_checks), "docker-release-builds checks were not successful")
+        self.assertFalse(isGreen("sha", workflow_checks))
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_print_latest_commits.py
+++ b/.github/scripts/test_print_latest_commits.py
@@ -41,7 +41,7 @@ class TestPrintCommits(TestCase):
     def test_all_successful(self, mock_get_commit_results: Any) -> None:
         "Test with workflows are successful"
         workflow_checks = mock_get_commit_results()
-        self.assertTrue(isGreen("sha", workflow_checks))
+        self.assertTrue(isGreen("sha", workflow_checks)[0])
 
     @mock.patch('print_latest_commits.get_commit_results', return_value=TestChecks().make_test_checks())
     def test_necessary_successful(self, mock_get_commit_results: Any) -> None:
@@ -52,14 +52,16 @@ class TestPrintCommits(TestCase):
         workflow_checks = set_workflow_job_status(workflow_checks, workflowNames[10], "failed")
         workflow_checks = set_workflow_job_status(workflow_checks, workflowNames[11], "failed")
         workflow_checks = set_workflow_job_status(workflow_checks, workflowNames[12], "failed")
-        self.assertTrue(isGreen("sha", workflow_checks))
+        self.assertTrue(isGreen("sha", workflow_checks)[0])
 
     @mock.patch('print_latest_commits.get_commit_results', return_value=TestChecks().make_test_checks())
     def test_necessary_skipped(self, mock_get_commit_results: Any) -> None:
         "Test with necessary job (ex: pull) skipped"
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "pull", "skipped")
-        self.assertFalse(isGreen("sha", workflow_checks))
+        result = isGreen("sha", workflow_checks)
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], "pull checks were not successful")
 
     @mock.patch('print_latest_commits.get_commit_results', return_value=TestChecks().make_test_checks())
     def test_skippable_skipped(self, mock_get_commit_results: Any) -> None:
@@ -74,7 +76,9 @@ class TestPrintCommits(TestCase):
         "Test with necessary job (ex: Lint) failed"
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "Lint", "failed")
-        self.assertFalse(isGreen("sha", workflow_checks))
+        result = isGreen("sha", workflow_checks)
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], "Lint checks were not successful")
 
     @mock.patch('print_latest_commits.get_commit_results', return_value=TestChecks().make_test_checks())
     def test_skippable_failed(self, mock_get_commit_results: Any) -> None:
@@ -82,7 +86,9 @@ class TestPrintCommits(TestCase):
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "periodic", "skipped")
         workflow_checks = set_workflow_job_status(workflow_checks, "docker-release-builds", "failed")
-        self.assertFalse(isGreen("sha", workflow_checks))
+        result = isGreen("sha", workflow_checks)
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], "docker-release-builds checks were not successful")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Relates to #76700

**Overview:** Originally `print_latest_commits.py` returned a list of commit SHAs on master from the last M minutes, outputted the individual workflow results, and also displayed if a given commit was promoteable to the viable/strict branch. I realized using this time-based method of retrieving SHAs wasn't the most effective since it takes ~4 hours for all of the HUD tests to run. Since this script will be used to find the latest green commits to promote to viable/strict, I refactored the code to instead collect all of the SHAs that differ between master and viable/strict and output most recent stable commit.

**Example Output:** This script just prints out the latest viable commit on master. If no new commits on master are promote-able, the script outputs the latest commit on viable/strict. 
![Screen Shot 2022-06-13 at 11 49 47 AM](https://user-images.githubusercontent.com/24441980/173393609-6717883e-0056-401d-ad36-c85a2422c006.png)

**Test Plan:** While implementing the code, I compared the output of the `get_latest_commits` method with the HUD to make sure it matched. I also ensured that the results from `isGreen` matched those on the HUD and cross checked the final output with the HUD.
