### PR TITLE
[MPS] Make it compilable with either xCode or CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ if(APPLE)
     # Determine if we can link against MPSGraph
     set(MPS_FOUND OFF)
     execute_process(
-      COMMAND bash -c "xcodebuild -sdk macosx -version SDKVersion"
+      COMMAND bash -c "xcrun --sdk macosx --show-sdk-version"
       RESULT_VARIABLE _exit_code
       OUTPUT_VARIABLE _macosx_sdk_version
       OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
`xcrun --sdk macosx --show-sdk-version` works with either CommandLineTools or Xcode, but `xcodebuild -sdk macosx -version SDKVersion` works only if full Xcode is installed, which is not necessary to build PyTorch

Above command yield the same output when Xcode is installed:
```
% xcodebuild -sdk macosx -version SDKVersion     
12.3
 %  xcrun --sdk macosx --show-sdk-version 
12.3
```

But first one fails if Xcode is missing:
```
% xcodebuild -sdk macosx -version SDKVersion
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
% xcrun --sdk macosx --show-sdk-version     
12.3

```

