### PR TITLE
Use python3 -m to fix tools not being found

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -36,8 +36,8 @@ jobs:
           WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
         run: |
           echo "${WORKFLOW_URL}"
-          python3 tools/stats/upload_test_stats.py --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
-          python3 tools/stats/upload_sccache_stats.py --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
+          python3 -m tools.stats.upload_test_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
+          python3 -m tools.stats.upload_test_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
 
   check-api-rate:
     if: ${{ always() }}


### PR DESCRIPTION
Uploading test stats have not been doing great due to this error
https://github.com/pytorch/pytorch/runs/6866279385?check_suite_focus=true

In the past, using python3 -m has fixed this