### PR TITLE
[ci] set -e in get-workflow-job-id

### DIFF
--- a/.github/actions/get-workflow-job-id/action.yml
+++ b/.github/actions/get-workflow-job-id/action.yml
@@ -25,7 +25,7 @@ runs:
         max_attempts: 5
         retry_wait_seconds: 30
         command: |
-          set -x
+          set -eux
           python3 -m pip install requests==2.26.0
           GHA_WORKFLOW_JOB_ID=$(python3 .github/scripts/get_workflow_job_id.py "${GITHUB_RUN_ID}" "${RUNNER_NAME}")
           echo "::set-output name=job-id::${GHA_WORKFLOW_JOB_ID}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79433

So that errors get bubbled up and are retried properly