### PR TITLE
Create decoder class

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12459,6 +12459,16 @@
   dispatch:
     CPU, CUDA, NestedTensorCPU, NestedTensorCUDA: native_multi_head_attention
 
+- func: _transformer_decoder_only_layer_fwd(Tensor src, int embed_dim, int num_heads, Tensor qkv_weight, Tensor qkv_bias, Tensor proj_weight, Tensor proj_bias, bool use_gelu, bool norm_first, float eps, Tensor norm_weight_1, Tensor norm_bias_1, Tensor norm_weight_2, Tensor norm_bias_2, Tensor ffn_weight_1, Tensor ffn_bias_1, Tensor ffn_weight_2, Tensor ffn_bias_2, Tensor? mask=None, Tensor? incr_key=None, Tensor? incr_value=None) -> (Tensor, Tensor, Tensor)
+  variants: function
+  dispatch:
+    CPU, CUDA, NestedTensorCPU, NestedTensorCUDA: transformer_decoder_only_layer_forward
+
+- func: _native_decoder_only_multi_head_attention(Tensor query, Tensor key, Tensor value, int embed_dim, int num_head, Tensor qkv_weight, Tensor qkv_bias, Tensor proj_weight, Tensor proj_bias, Tensor? mask=None, Tensor? incr_key=None, Tensor? incr_value=None, bool need_weights=True, bool average_attn_weights=True) -> (Tensor, Tensor, Tensor, Tensor)
+  variants: function
+  dispatch:
+    CPU, CUDA, NestedTensorCPU, NestedTensorCUDA: native_decoder_only_multi_head_attention
+
 - func: special_bessel_j0(Tensor self) -> Tensor
   python_module: special
   structured_delegate: special_bessel_j0.out

--- a/aten/src/ATen/native/transformers/attention.cpp
+++ b/aten/src/ATen/native/transformers/attention.cpp
@@ -491,5 +491,182 @@ std::tuple<Tensor, Tensor> native_multi_head_attention(
   return std::make_tuple(std::move(proj), std::move(qkt));
 }
 
+std::tuple<Tensor, Tensor, Tensor, Tensor> native_decoder_only_multi_head_attention(
+    const Tensor& query,
+    const Tensor& key,
+    const Tensor& value,
+    const int64_t embed_dim,
+    const int64_t num_head,
+    const Tensor& qkv_weight,
+    const Tensor& qkv_bias,
+    const Tensor& proj_weight,
+    const Tensor& proj_bias,
+    const c10::optional<Tensor>& mask,
+    const c10::optional<Tensor>& incr_key,
+    const c10::optional<Tensor>& incr_value,
+    bool need_weights,
+    bool average_attn_weights) {
+  // query shape: [B, T, D]
+  // qkv_weight shape: [3 * D, D]
+
+  TORCH_CHECK(
+      !mask || !query.is_nested(),
+      "NestedTensor with mask is not supported yet");
+  const auto D = embed_dim;
+  TORCH_CHECK(
+      query.dim() == 3,
+      "expected 3-D `query`, got ",
+      query.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      query.is_nested() || query.sizes()[2] == embed_dim,
+      "passed-in embed_dim ",
+      embed_dim,
+      " didn't match last dim of query ",
+      query.sizes()[2]);
+  TORCH_CHECK(
+      key.dim() == 3,
+      "expected 3-D `key`, got ",
+      key.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      value.dim() == 3,
+      "expected 3-D `value`, got ",
+      value.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      query.is_nested() || key.is_nested() || value.is_nested() ||
+          (query.sizes() == key.sizes() && key.sizes() == value.sizes()),
+      "expected `query`/`key`/`value` shapes to match");
+  TORCH_CHECK(
+      qkv_weight.dim() == 2,
+      "expected 2-D `qkv_weight`, got ",
+      qkv_weight.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      D * 3 == qkv_weight.sizes()[0],
+      "expected `qkv_weight` first dim to be 3x embed_dim");
+  TORCH_CHECK(
+      D == qkv_weight.sizes()[1],
+      "expected `qkv_weight` second dim to be embed_Dim");
+  TORCH_CHECK(
+      qkv_bias.dim() == 1,
+      "expected 2-D `qkv_bias`, got ",
+      qkv_bias.dim(),
+      "-D tensor");
+  TORCH_CHECK(
+      qkv_bias.sizes()[0] == 3 * D,
+      "expected `qkv_bias` first dim and first dim of query to be equal");
+  TORCH_CHECK(D % num_head == 0, "`embed_dim` must divide evenly by `num_heads`");
+
+#ifndef NDEBUG
+  const auto B = query.is_nested()
+      ? get_nested_tensor_impl(query)->get_nested_size_tensor().size(0)
+      : query.sizes()[0];
+  auto T = query.is_nested() ? 0 : query.sizes()[1];
+  const auto dim_per_head = D / num_head;
+#endif
+
+  // shape: [B, T, 3 x D]
+  const bool is_incremental_decoding = incr_key.has_value() && incr_value.has_value() && incr_key->sizes() == incr_value->sizes();
+  auto qkv = qkv_projection(query, query, query, embed_dim, qkv_weight);
+
+  if (!qkv.is_nested() && qkv.numel() == 0) {
+    if (query.is_nested()) {
+      return std::make_tuple(Tensor(), Tensor(), Tensor(), Tensor());
+    }
+    return std::make_tuple(at::empty_like(query), Tensor(), Tensor(), Tensor());
+  }
+
+#ifndef NDEBUG
+  if (!query.is_nested() || !qkv.is_nested()) {
+    if (query.is_nested()) {
+      T = qkv.size(1);
+    }
+    debug_assert_shape(__LINE__, qkv, {B, T, 3 * D});
+  }
+#endif
+
+#ifdef DEBUG_PRINT_EACH_STEP
+  if (!qkv.is_nested()) {
+    std::cerr << "qkv: " << qkv << std::endl;
+  }
+#endif
+  // shape: 3 x [B, num_head, T, dim_per_head]
+  auto q_k_v = _transform_bias_rescale_qkv(qkv, qkv_bias, num_head);
+  qkv = Tensor(); // Not used any more, allow free
+  auto& q = std::get<0>(q_k_v);
+  const auto& _k = std::get<1>(q_k_v);
+  const auto& _v = std::get<2>(q_k_v);
+#ifndef NDEBUG
+  debug_assert_shape(__LINE__, q, {B, num_head, T, dim_per_head});
+  debug_assert_shape(__LINE__, _k, {B, num_head, T, dim_per_head});
+  debug_assert_shape(__LINE__, _v, {B, num_head, T, dim_per_head});
+#endif
+#ifdef DEBUG_PRINT_EACH_STEP
+  std::cerr << "q: " << q << std::endl;
+  std::cerr << "k: " << _k << std::endl;
+  std::cerr << "v: " << _v << std::endl;
+#endif
+  Tensor k;
+  Tensor v;
+  if (is_incremental_decoding) {
+    // TODO: is this actually setting incr_key and incr_value in place
+    // what if k and incr k are nestedtensors? same for v case.
+    k = at::cat({incr_key.value(), _k}, 2);
+    v = at::cat({incr_value.value(), _v}, 2);
+  } else {
+    k = _k;
+    v = _v;
+  }
+  // shape: [B, num_head, T, T]
+  auto qkt = bmm_nt(q, k);
+  // q & k are dead but cannot be freed because they were packed with v
+#ifndef NDEBUG
+  debug_assert_shape(__LINE__, qkt, {B, num_head, T, T});
+#endif
+#ifdef DEBUG_PRINT_EACH_STEP
+  std::cerr << "qkt: " << qkt << std::endl;
+#endif
+
+  // shape: [B, num_head, T, T]
+  // TODO: long-term, have a kernel that works with
+  // NestedTensor directly if there is no mask passed
+  qkt = masked_softmax(qkt, mask, query);
+#ifdef DEBUG_PRINT_EACH_STEP
+  std::cerr << "qkt after softmax: " << qkt << std::endl;
+#endif
+
+  // shape: [B, num_head, T, dim_per_head]
+  // reuse storage for q; we're done with it
+  auto attn_ctx = bmm_nn(q, qkt, v);
+  // qkv is not dead; we just reused storage for q!
+  if (!need_weights) {
+    qkt = Tensor();
+  }
+#ifndef NDEBUG
+  debug_assert_shape(__LINE__, attn_ctx, {B, num_head, T, dim_per_head});
+#endif
+#ifdef DEBUG_PRINT_EACH_STEP
+  std::cerr << "attn_ctx: " << attn_ctx << std::endl;
+#endif
+
+  // shape: [B, T, D]
+  // Fuse transform_0213 inside
+  auto proj = transform0213_gemm_nt_bias(
+      attn_ctx, proj_weight, proj_bias, query);
+#ifndef NDEBUG
+  debug_assert_shape(__LINE__, proj, {B, T, D});
+#endif
+  if (need_weights && average_attn_weights) {
+    // weights are not needed for full transformer, so don't worry too
+    // much about performance -- we implement this just to make use
+    // cases that don't disable need_weights still get some speedup.
+    qkt = qkt.sum(1);
+    qkt /= num_head;
+  }
+  return std::make_tuple(std::move(proj), std::move(qkt), std::move(k), std::move(v));
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/transformers/transformer.cpp
+++ b/aten/src/ATen/native/transformers/transformer.cpp
@@ -132,5 +132,96 @@ Tensor transformer_encoder_layer_forward(
   return x;
 }
 
+std::tuple<Tensor, Tensor, Tensor>  transformer_decoder_only_layer_forward(
+    const Tensor& src,
+    const int64_t embed_dim,
+    const int64_t num_heads,
+    const Tensor& qkv_weight,
+    const Tensor& qkv_bias,
+    const Tensor& proj_weight,
+    const Tensor& proj_bias,
+    const bool use_gelu,
+    const bool norm_first,
+    const double layer_norm_eps,
+    const Tensor& layer_norm_weight_1,
+    const Tensor& layer_norm_bias_1,
+    const Tensor& layer_norm_weight_2,
+    const Tensor& layer_norm_bias_2,
+    const Tensor& ffn_weight_1,
+    const Tensor& ffn_bias_1,
+    const Tensor& ffn_weight_2,
+    const Tensor& ffn_bias_2,
+    const c10::optional<Tensor>& mask,
+    const c10::optional<Tensor>& incr_key,
+    const c10::optional<Tensor>& incr_value) {
+  {
+    const Tensor& check_for_empty = src.is_nested() ? get_nested_tensor_impl(src)->get_buffer() : src;
+    if (check_for_empty.numel() == 0) {
+      auto src_out = src.is_nested()
+        ? at::detail::make_tensor<NestedTensorImpl>(check_for_empty, get_nested_tensor_impl(src)->get_nested_size_tensor())
+        : src.clone();
+      return std::make_tuple(src_out, incr_key.value(), incr_value.value());
+    }
+  }
+  TORCH_CHECK(!norm_first, "norm_first is not supported yet");
+  const bool use_nested_tensor = src.is_nested();
+  auto mha_out = native_decoder_only_multi_head_attention(
+      src,
+      src,
+      src,
+      embed_dim,
+      num_heads,
+      qkv_weight,
+      qkv_bias,
+      proj_weight,
+      proj_bias,
+      mask,
+      incr_key,
+      incr_value,
+      false /* need_weights */);
+  auto x = std::get<0>(mha_out);
+  auto incr_key_out = std::get<2>(mha_out);
+  auto incr_value_out = std::get<3>(mha_out);
+  if (use_nested_tensor) {
+    NestedTensor_add_NestedTensor_in_place(x, src);
+    x = NestedTensor_layer_norm(
+        x, layer_norm_weight_1, layer_norm_bias_1, layer_norm_eps);
+  } else {
+    x.add_(src);
+    x = at::layer_norm(
+        x,
+        {embed_dim},
+        layer_norm_weight_1,
+        layer_norm_bias_1,
+        layer_norm_eps,
+        true);
+  }
+
+  auto pre_ffn_res = x;
+  x = ffn(
+      x,
+      ffn_weight_1,
+      ffn_bias_1,
+      ffn_weight_2,
+      ffn_bias_2,
+      use_gelu,
+      /* add_norm* */ false);
+  if (use_nested_tensor) {
+    NestedTensor_add_NestedTensor_in_place(x, pre_ffn_res);
+    x = NestedTensor_layer_norm(
+        x, layer_norm_weight_2, layer_norm_bias_2, layer_norm_eps);
+  } else {
+    x.add_(pre_ffn_res);
+    x = at::layer_norm(
+        x,
+        {embed_dim},
+        layer_norm_weight_2,
+        layer_norm_bias_2,
+        layer_norm_eps,
+        true);
+  }
+  return std::make_tuple(std::move(x), std::move(incr_key_out), std::move(incr_value_out));
+}
+
 } // namespace native
 } // namespace at


### PR DESCRIPTION
Summary: Implement decoder-only layer, which doesn't currently exist in torch. Implement incremental and forced decoding with a new multiheadattention and decoder forward pass. Rather similar to the transformer_encoder_layer_fwd. Not a public facing API, although may become public facing eventually. 

Stacked on top of https://github.com/pytorch/pytorch/pull/79437.

Test Plan: See D36140513 numerical tests.

Reviewed By: mikekgfb

Differential Revision: D36987004

