### PR TITLE
[ci] turn sccache stats error into warning

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -147,7 +147,7 @@ jobs:
           s3-prefix: |
             ${{ github.repository }}/${{ github.run_id }}/${{ github.run_attempt }}/artifact
           retention-days: 365
-          if-no-files-found: error
+          if-no-files-found: warn
           path: sccache-stats-*.json
 
       - name: Teardown Linux

--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -97,7 +97,7 @@ jobs:
           s3-prefix: |
             ${{ github.repository }}/${{ github.run_id }}/${{ github.run_attempt }}/artifact
           retention-days: 14
-          if-no-files-found: error
+          if-no-files-found: warn
           path: sccache-stats-*.json
 
       - name: Teardown Windows


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79443

This unbreaks ci