### PR TITLE
Slicing Bug that was effecting Nested Tensor

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -619,7 +619,7 @@ static inline Tensor get_item(
           index.slice().step(),
           /*disable_slice_optimization=*/true,
           self_device,
-          *self_sizes);
+          self_sizes);
     } else if (index.is_none()) {
       return self.unsqueeze(0);
     } else if (index.is_ellipsis()) {


### PR DESCRIPTION
While working on nested tensor I was getting aborts thrown while running Pytest. For nested tensors `self_sizes` is initialized with an c10::nullopt. The operator * which gets the value from the optional is not instantiated so it throws via a c++ assert.
