### PR TITLE
[mergebot] post comment on finishing

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -730,7 +730,7 @@ class GitHubPR:
             self.merge_ghstack_into(repo, force, comment_id=comment_id)
 
         repo.push(self.default_branch(), dry_run)
-        gh_post_comment(self.org, self.project, self.pr_num, f"@{self.get_author()} your PR has been successfully merged.", dry_run)
+        gh_post_comment(self.org, self.project, self.pr_num, f"@{self.get_pr_creator_login()} your PR has been successfully merged.", dry_run)
         if not dry_run:
             gh_add_labels(self.org, self.project, self.pr_num, ["merged"])
 
@@ -911,7 +911,7 @@ def try_revert(repo: GitRepo, pr: GitHubPR, *,
     msg += f" due to {reason}\n" if reason is not None else "\n"
     repo.amend_commit_message(msg)
     repo.push(pr.default_branch(), dry_run)
-    post_comment(f"@{pr.get_author()} your PR has been successfully reverted.")
+    post_comment(f"@{pr.get_pr_creator_login()} your PR has been successfully reverted.")
     if not dry_run:
         gh_add_labels(pr.org, pr.project, pr.pr_num, ["reverted"])
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -730,7 +730,8 @@ class GitHubPR:
             self.merge_ghstack_into(repo, force, comment_id=comment_id)
 
         repo.push(self.default_branch(), dry_run)
-        gh_post_comment(self.org, self.project, self.pr_num, f"@{self.get_pr_creator_login()} your PR has been successfully merged.", dry_run)
+        gh_post_comment(self.org, self.project, self.pr_num,
+                        f"@{self.get_pr_creator_login()} your PR has been successfully merged.", dry_run)
         if not dry_run:
             gh_add_labels(self.org, self.project, self.pr_num, ["merged"])
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -730,6 +730,7 @@ class GitHubPR:
             self.merge_ghstack_into(repo, force, comment_id=comment_id)
 
         repo.push(self.default_branch(), dry_run)
+        gh_post_comment(self.org, self.project, self.pr_num, f"@{self.get_author()} your PR has been successfully merged.", dry_run)
         if not dry_run:
             gh_add_labels(self.org, self.project, self.pr_num, ["merged"])
 
@@ -910,6 +911,7 @@ def try_revert(repo: GitRepo, pr: GitHubPR, *,
     msg += f" due to {reason}\n" if reason is not None else "\n"
     repo.amend_commit_message(msg)
     repo.push(pr.default_branch(), dry_run)
+    post_comment(f"@{pr.get_author()} your PR has been successfully reverted.")
     if not dry_run:
         gh_add_labels(pr.org, pr.project, pr.pr_num, ["reverted"])
 


### PR DESCRIPTION
This makes the bot comment to ping the user whenever the merge or revert finishes completing. Also does a bit of refactoring. 

Addreses https://github.com/pytorch/test-infra/issues/392