### PR TITLE
[DOC] Missing line in serialization notes

### DIFF
--- a/docs/source/notes/serialization.rst
+++ b/docs/source/notes/serialization.rst
@@ -282,6 +282,7 @@ given two integer inputs:
 ::
 
     # PyTorch 1.5 (and earlier)
+    >>> a = torch.tensor(5)
     >>> b = torch.tensor(3)
     >>> a / b
     tensor(1)


### PR DESCRIPTION
Small typo fix to serialization docs where there was a missing line in one of the examples.
