### PR TITLE
test unused-local-typedef in internal CI

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2543,6 +2543,7 @@ Tensor linalg_matrix_norm(
   TORCH_CHECK(ord == "fro" || ord == "nuc", "linalg.matrix_norm: Order ", ord, " not supported.");
 
   auto A_ = opt_dtype.has_value() ? A.to(*opt_dtype) : A;
+  using Int = IntArrayRef::value_type;
 
   if (ord == "fro") {
     return at::linalg_vector_norm(A_, 2, dim, keepdim);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79458

Summary:
This exact line slipped past OSS CI before only to die in internal
builds.

See https://github.com/pytorch/pytorch/pull/77910.

Test Plan: DO NOT SUBMIT.

Reviewers:

Subscribers:

Tasks:

Tags: