### PR TITLE
[CUDA graphs] Allows Adam and AdamW to be capture-safe (#77862)

### DIFF
--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -392,7 +392,7 @@ class TestFSDPOptimState(FSDPTest):
         ``on_gpu=True`` and on CPU if ``on_gpu=False``."""
         for param_state in osd["state"].values():
             for value in param_state.values():
-                if torch.is_tensor(value):
+                if torch.is_tensor(value) and value.dim() > 0:
                     if on_gpu:
                         self.assertTrue(value.is_cuda)
                     else:

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3811,6 +3811,65 @@ torch.cuda.synchronize()
         model_control.eval()
         self.assertEqual(model_graphed(real_inputs[0]), model_control(real_inputs[0]))
 
+    @unittest.skipIf((not TEST_CUDA) or
+                     TEST_WITH_ROCM or
+                     int(torch.version.cuda.split(".")[0]) < 11, "CUDA >= 11.0 required for graphs")
+    def test_graph_adam_adamw(self):
+        OptClasses = (torch.optim.Adam, torch.optim.AdamW)
+        cases = []
+        # Needs generalization if we want to extend this test to non-Adam-like optimizers.
+        for Class, foreach, amsgrad in product(OptClasses, (False, True), (False, True)):
+            cases.append((Class, {"lr": 0.1, "betas": (0.8, 0.7), "foreach": foreach, "amsgrad": amsgrad}))
+
+        steps_warmup = 3
+        steps_train = 2
+
+        for OptClass, kwargs in cases:
+            for actually_do_graphs in (True, False):
+                params = [torch.randn((i + 5, i + 5), device="cuda") for i in range(2)]
+                params_control = [p.clone().requires_grad_() for p in params]
+                params_graphed = [p.clone().requires_grad_() for p in params]
+
+                grads = [[torch.randn_like(p) for p in params] for _ in range(steps_warmup + steps_train)]
+
+                # Control (capturable=False)
+
+                opt = OptClass(params_control, capturable=False, **kwargs)
+
+                for i in range(steps_warmup + steps_train):
+                    for j, p in enumerate(params_control):
+                        p.grad = grads[i][j]
+                    opt.step()
+
+                # capturable=True
+
+                opt = OptClass(params_graphed, capturable=True, **kwargs)
+
+                for i in range(steps_warmup):
+                    for j, p in enumerate(params_graphed):
+                        p.grad = grads[i][j]
+                    opt.step()
+
+                if actually_do_graphs:
+                    g = torch.cuda.CUDAGraph()
+                    with torch.cuda.graph(g):
+                        opt.step()
+
+                for i in range(steps_train):
+                    if actually_do_graphs:
+                        for j, p in enumerate(params_graphed):
+                            p.grad.copy_(grads[i + steps_warmup][j])
+                        g.replay()
+                    else:
+                        # Passing capturable=True to the constructor and running without graphs should still be
+                        # numerically correct, even if it's not ideal for performance.
+                        for j, p in enumerate(params_graphed):
+                            p.grad = grads[i + steps_warmup][j]
+                        opt.step()
+
+                for p_control, p_graphed in zip(params_control, params_graphed):
+                    self.assertEqual(p_control, p_graphed)
+
     def test_batch_norm_gather_stats(self):
         input = torch.randn(1, 3, 3, 3, device='cuda')
         mean, invstd = torch.batch_norm_gather_stats(

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -673,7 +673,6 @@ def _broadcast_processed_optim_state_dict(
     fsdp_flat_param_ids: Optional[Set[int]],
     rank: int,
     group,
-    device: torch.device,
 ) -> Tuple[Dict[str, Any], Set[int]]:
     """
     Broadcasts the processed optimizer state dict and the accompanying FSDP
@@ -685,8 +684,6 @@ def _broadcast_processed_optim_state_dict(
             with metadata if on rank 0; ignored otherwise.
         fsdp_flat_param_ids (Optional[Set[int]]): Parameter IDs corresponding
             to FSDP parameters if on rank 0; ignored otherwise.
-        device (torch.device): Device to move zero-dimension tensors post-
-            broadcast.
 
     Returns:
         Tuple[Dict[str, Any], Set[int]]: The processed optimizer state dict
@@ -699,11 +696,7 @@ def _broadcast_processed_optim_state_dict(
     processed_optim_state_dict, fsdp_flat_param_ids = obj_list  # type: ignore[assignment]
     assert processed_optim_state_dict is not None
     assert fsdp_flat_param_ids is not None
-    # Move zero-dimension tensors to `device`
-    for param_state in processed_optim_state_dict["state"].values():
-        for state_name, value in param_state.items():
-            if _is_zero_dim_tensor(value):
-                param_state[state_name] = value.to(device)
+    # Keep zero-dimension tensors on CPU
     return processed_optim_state_dict, fsdp_flat_param_ids
 
 

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3716,7 +3716,6 @@ class FullyShardedDataParallel(nn.Module):
             _broadcast_processed_optim_state_dict(
                 processed_osd if rank == 0 else None,
                 fsdp_flat_param_ids if rank == 0 else None, rank, group,
-                broadcast_device,
             )
         # Broadcast positive-dimension tensor state (both sharded tensors for
         # FSDP parameters and unsharded tensors for non-FSDP parameters)

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -1117,6 +1117,10 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
             else:
                 # Load the parameter state to the local optimizer
                 self.optim.state[param] = _recursive_copy_to_device(value, non_blocking=True, device=param.device)
+                # Force zero-dimensional tensors (like Adam "step") on CPU
+                for state_name, state_value in self.optim.state[param].items():
+                    if torch.is_tensor(state_value) and state_value.dim() == 0:
+                        self.optim.state[param][state_name] = state_value.cpu()
 
         super().load_state_dict(state_dict)
 

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -61,6 +61,9 @@ class Adam(Optimizer):
             is used (default: None)
         maximize (bool, optional): maximize the params based on the objective, instead of
             minimizing (default: False)
+        capturable (bool, optional): whether this instance is safe to capture in a CUDA graph.
+            Passing True can impair ungraphed performance, so if you don't intend to
+            graph capture this instance, leave it False (default: False)
 
     .. _Adam\: A Method for Stochastic Optimization:
         https://arxiv.org/abs/1412.6980
@@ -70,7 +73,7 @@ class Adam(Optimizer):
 
     def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
                  weight_decay=0, amsgrad=False, *, foreach: Optional[bool] = None,
-                 maximize: bool = False):
+                 maximize: bool = False, capturable: bool = False):
         if not 0.0 <= lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
         if not 0.0 <= eps:
@@ -83,7 +86,7 @@ class Adam(Optimizer):
             raise ValueError("Invalid weight_decay value: {}".format(weight_decay))
         defaults = dict(lr=lr, betas=betas, eps=eps,
                         weight_decay=weight_decay, amsgrad=amsgrad,
-                        maximize=maximize, foreach=foreach)
+                        maximize=maximize, foreach=foreach, capturable=capturable)
         super(Adam, self).__init__(params, defaults)
 
     def __setstate__(self, state):
@@ -92,6 +95,7 @@ class Adam(Optimizer):
             group.setdefault('amsgrad', False)
             group.setdefault('maximize', False)
             group.setdefault('foreach', None)
+            group.setdefault('capturable', False)
         state_values = list(self.state.values())
         step_is_tensor = (len(state_values) != 0) and torch.is_tensor(state_values[0]['step'])
         if not step_is_tensor:
@@ -106,6 +110,8 @@ class Adam(Optimizer):
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """
+        self._cuda_graph_capture_health_check()
+
         loss = None
         if closure is not None:
             with torch.enable_grad():
@@ -130,7 +136,8 @@ class Adam(Optimizer):
                     state = self.state[p]
                     # Lazy state initialization
                     if len(state) == 0:
-                        state['step'] = torch.tensor(0.)
+                        state['step'] = torch.zeros((1,), dtype=torch.float, device=p.device) \
+                            if self.defaults['capturable'] else torch.tensor(0.)
                         # Exponential moving average of gradient values
                         state['exp_avg'] = torch.zeros_like(p, memory_format=torch.preserve_format)
                         # Exponential moving average of squared gradient values
@@ -160,7 +167,8 @@ class Adam(Optimizer):
                  weight_decay=group['weight_decay'],
                  eps=group['eps'],
                  maximize=group['maximize'],
-                 foreach=group['foreach'])
+                 foreach=group['foreach'],
+                 capturable=group['capturable'])
 
         return loss
 
@@ -174,6 +182,7 @@ def adam(params: List[Tensor],
          # kwonly args with defaults are not supported by functions compiled with torchscript issue #70627
          # setting this as kwarg for now as functional API is compiled by torch/distributed/optim
          foreach: bool = None,
+         capturable: bool = False,
          *,
          amsgrad: bool,
          beta1: float,
@@ -213,7 +222,8 @@ def adam(params: List[Tensor],
          lr=lr,
          weight_decay=weight_decay,
          eps=eps,
-         maximize=maximize)
+         maximize=maximize,
+         capturable=capturable)
 
 
 def _single_tensor_adam(params: List[Tensor],
@@ -229,7 +239,8 @@ def _single_tensor_adam(params: List[Tensor],
                         lr: float,
                         weight_decay: float,
                         eps: float,
-                        maximize: bool):
+                        maximize: bool,
+                        capturable: bool):
 
     for i, param in enumerate(params):
 
@@ -237,12 +248,14 @@ def _single_tensor_adam(params: List[Tensor],
         exp_avg = exp_avgs[i]
         exp_avg_sq = exp_avg_sqs[i]
         step_t = state_steps[i]
+
+        if capturable:
+            assert param.is_cuda and step_t.is_cuda, "If capturable=True, params and state_steps must be CUDA tensors."
+        else:
+            assert not step_t.is_cuda, "If capturable=False, state_steps should not be CUDA tensors."
+
         # update step
         step_t += 1
-        step = step_t.item()
-
-        bias_correction1 = 1 - beta1 ** step
-        bias_correction2 = 1 - beta2 ** step
 
         if weight_decay != 0:
             grad = grad.add(param, alpha=weight_decay)
@@ -250,18 +263,50 @@ def _single_tensor_adam(params: List[Tensor],
         # Decay the first and second moment running average coefficient
         exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
         exp_avg_sq.mul_(beta2).addcmul_(grad, grad.conj(), value=1 - beta2)
-        if amsgrad:
-            # Maintains the maximum of all 2nd moment running avg. till now
-            torch.maximum(max_exp_avg_sqs[i], exp_avg_sq, out=max_exp_avg_sqs[i])
-            # Use the max. for normalizing running avg. of gradient
-            denom = (max_exp_avg_sqs[i].sqrt() / math.sqrt(bias_correction2)).add_(eps)
+
+        if capturable:
+            step = step_t
+
+            # 1 - beta1 ** step can't be captured in a CUDA graph, even if step is a CUDA tensor
+            # (incurs "RuntimeError: CUDA error: operation not permitted when stream is capturing")
+            bias_correction1 = 1 - torch.pow(beta1, step)
+            bias_correction2 = 1 - torch.pow(beta2, step)
+
+            step_size = lr / bias_correction1
+            step_size_neg = step_size.neg()
+
+            bias_correction2_sqrt = bias_correction2.sqrt()
+
+            if amsgrad:
+                # Maintains the maximum of all 2nd moment running avg. till now
+                torch.maximum(max_exp_avg_sqs[i], exp_avg_sq, out=max_exp_avg_sqs[i])
+                # Uses the max. for normalizing running avg. of gradient
+                # Folds in (admittedly ugly) 1-elem step_size math here to avoid extra param-set-sized read+write
+                # (can't fold it into addcdiv_ below because addcdiv_ requires value is a Number, not a Tensor)
+                denom = (max_exp_avg_sqs[i].sqrt() / (bias_correction2_sqrt * step_size_neg)).add_(eps / step_size_neg)
+            else:
+                denom = (exp_avg_sq.sqrt() / (bias_correction2_sqrt * step_size_neg)).add_(eps / step_size_neg)
+
+            param.addcdiv_(exp_avg, denom)
         else:
-            denom = (exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(eps)
+            step = step_t.item()
 
+            bias_correction1 = 1 - beta1 ** step
+            bias_correction2 = 1 - beta2 ** step
 
+            step_size = lr / bias_correction1
 
-        step_size = lr / bias_correction1
-        param.addcdiv_(exp_avg, denom, value=-step_size)
+            bias_correction2_sqrt = math.sqrt(bias_correction2)
+
+            if amsgrad:
+                # Maintains the maximum of all 2nd moment running avg. till now
+                torch.maximum(max_exp_avg_sqs[i], exp_avg_sq, out=max_exp_avg_sqs[i])
+                # Use the max. for normalizing running avg. of gradient
+                denom = (max_exp_avg_sqs[i].sqrt() / bias_correction2_sqrt).add_(eps)
+            else:
+                denom = (exp_avg_sq.sqrt() / bias_correction2_sqrt).add_(eps)
+
+            param.addcdiv_(exp_avg, denom, value=-step_size)
 
 
 def _multi_tensor_adam(params: List[Tensor],
@@ -277,42 +322,90 @@ def _multi_tensor_adam(params: List[Tensor],
                        lr: float,
                        weight_decay: float,
                        eps: float,
-                       maximize: bool):
-
+                       maximize: bool,
+                       capturable: bool):
     if len(params) == 0:
         return
 
-    # update steps
-    torch._foreach_add_(state_steps, 1)
+    if capturable:
+        assert all(p.is_cuda and step.is_cuda for p, step in zip(params, state_steps)), \
+            "If capturable=True, params and state_steps must be CUDA tensors."
+    else:
+        assert all(not step.is_cuda for step in state_steps), \
+            "If capturable=False, state_steps should not be CUDA tensors."
 
     if maximize:
         grads = torch._foreach_neg(tuple(grads))  # type: ignore[assignment]
 
-    bias_correction1 = [1 - beta1 ** step.item() for step in state_steps]
-    bias_correction2 = [1 - beta2 ** step.item() for step in state_steps]
+    # update steps
+    torch._foreach_add_(state_steps, 1)
+
     if weight_decay != 0:
         torch._foreach_add_(grads, params, alpha=weight_decay)
 
+    # Decay the first and second moment running average coefficient
     torch._foreach_mul_(exp_avgs, beta1)
     torch._foreach_add_(exp_avgs, grads, alpha=1 - beta1)
 
     torch._foreach_mul_(exp_avg_sqs, beta2)
     torch._foreach_addcmul_(exp_avg_sqs, grads, grads, 1 - beta2)
 
-    if amsgrad:
-        # Maintains the maximum of all 2nd moment running avg. till now
-        max_exp_avg_sqs = torch._foreach_maximum(max_exp_avg_sqs, exp_avg_sqs)  # type: ignore[assignment]
+    if capturable:
+        # TODO: use foreach_pow if/when foreach_pow is added
+        bias_correction1 = [torch.pow(beta1, step) for step in state_steps]
+        bias_correction2 = [torch.pow(beta2, step) for step in state_steps]
+        # foreach_sub doesn't allow a scalar as the first arg
+        torch._foreach_sub_(bias_correction1, 1)
+        torch._foreach_sub_(bias_correction2, 1)
+        torch._foreach_neg_(bias_correction1)
+        torch._foreach_neg_(bias_correction2)
 
-        # Use the max. for normalizing running avg. of gradient
-        max_exp_avg_sq_sqrt = torch._foreach_sqrt(max_exp_avg_sqs)
-        bias_correction_sqrt = [math.sqrt(bc) for bc in bias_correction2]
-        torch._foreach_div_(max_exp_avg_sq_sqrt, bias_correction_sqrt)
-        denom = torch._foreach_add(max_exp_avg_sq_sqrt, eps)
+        # foreach_div doesn't allow a scalar as the first arg
+        step_size = torch._foreach_div(bias_correction1, lr)
+        torch._foreach_reciprocal_(step_size)
+        torch._foreach_neg_(step_size)
+
+        bias_correction2_sqrt = torch._foreach_sqrt(bias_correction2)
+
+        if amsgrad:
+            # Maintains the maximum of all 2nd moment running avg. till now
+            max_exp_avg_sqs = torch._foreach_maximum(max_exp_avg_sqs, exp_avg_sqs)  # type: ignore[assignment]
+
+            # Use the max. for normalizing running avg. of gradient
+            max_exp_avg_sq_sqrt = torch._foreach_sqrt(max_exp_avg_sqs)
+            # Folds in (admittedly ugly) 1-elem step_size math here to avoid extra param-set-sized read+write
+            # (can't fold it into addcdiv_ below because addcdiv_ requires value is a Number, not a Tensor)
+            torch._foreach_div_(max_exp_avg_sq_sqrt, torch._foreach_mul(bias_correction2_sqrt, step_size))
+            eps_over_step_size = torch._foreach_div(step_size, eps)
+            torch._foreach_reciprocal_(eps_over_step_size)
+            denom = torch._foreach_add(max_exp_avg_sq_sqrt, eps_over_step_size)
+        else:
+            exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sqs)
+            torch._foreach_div_(exp_avg_sq_sqrt, torch._foreach_mul(bias_correction2_sqrt, step_size))
+            eps_over_step_size = torch._foreach_div(step_size, eps)
+            torch._foreach_reciprocal_(eps_over_step_size)
+            denom = torch._foreach_add(exp_avg_sq_sqrt, eps_over_step_size)
+
+        torch._foreach_addcdiv_(params, exp_avgs, denom)
     else:
-        exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sqs)
-        bias_correction_sqrt = [math.sqrt(bc) for bc in bias_correction2]
-        torch._foreach_div_(exp_avg_sq_sqrt, bias_correction_sqrt)
-        denom = torch._foreach_add(exp_avg_sq_sqrt, eps)
+        bias_correction1 = [1 - beta1 ** step.item() for step in state_steps]
+        bias_correction2 = [1 - beta2 ** step.item() for step in state_steps]
 
-    step_size = [(lr / bc) * -1 for bc in bias_correction1]
-    torch._foreach_addcdiv_(params, exp_avgs, denom, step_size)
+        step_size = [(lr / bc) * -1 for bc in bias_correction1]
+
+        bias_correction2_sqrt = [math.sqrt(bc) for bc in bias_correction2]
+
+        if amsgrad:
+            # Maintains the maximum of all 2nd moment running avg. till now
+            max_exp_avg_sqs = torch._foreach_maximum(max_exp_avg_sqs, exp_avg_sqs)  # type: ignore[assignment]
+
+            # Use the max. for normalizing running avg. of gradient
+            max_exp_avg_sq_sqrt = torch._foreach_sqrt(max_exp_avg_sqs)
+            torch._foreach_div_(max_exp_avg_sq_sqrt, bias_correction2_sqrt)
+            denom = torch._foreach_add(max_exp_avg_sq_sqrt, eps)
+        else:
+            exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sqs)
+            torch._foreach_div_(exp_avg_sq_sqrt, bias_correction2_sqrt)
+            denom = torch._foreach_add(exp_avg_sq_sqrt, eps)
+
+        torch._foreach_addcdiv_(params, exp_avgs, denom, step_size)

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -61,6 +61,9 @@ class AdamW(Optimizer):
             minimizing (default: False)
         foreach (bool, optional): whether foreach implementation of optimizer
             is used (default: None)
+        capturable (bool, optional): whether this instance is safe to capture in a CUDA graph.
+            Passing True can impair ungraphed performance, so if you don't intend to
+            graph capture this instance, leave it False (default: False)
 
     .. _Decoupled Weight Decay Regularization:
         https://arxiv.org/abs/1711.05101
@@ -70,7 +73,8 @@ class AdamW(Optimizer):
 
     def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
                  weight_decay=1e-2, amsgrad=False, *, maximize: bool = False,
-                 foreach: Optional[bool] = None):
+                 foreach: Optional[bool] = None,
+                 capturable: bool = False):
         if not 0.0 <= lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
         if not 0.0 <= eps:
@@ -83,7 +87,7 @@ class AdamW(Optimizer):
             raise ValueError("Invalid weight_decay value: {}".format(weight_decay))
         defaults = dict(lr=lr, betas=betas, eps=eps,
                         weight_decay=weight_decay, amsgrad=amsgrad,
-                        foreach=foreach, maximize=maximize)
+                        foreach=foreach, maximize=maximize, capturable=capturable)
         super(AdamW, self).__init__(params, defaults)
 
     def __setstate__(self, state):
@@ -92,6 +96,7 @@ class AdamW(Optimizer):
             group.setdefault('amsgrad', False)
             group.setdefault('maximize', False)
             group.setdefault('foreach', None)
+            group.setdefault('capturable', False)
         state_values = list(self.state.values())
         step_is_tensor = (len(state_values) != 0) and torch.is_tensor(state_values[0]['step'])
         if not step_is_tensor:
@@ -106,6 +111,8 @@ class AdamW(Optimizer):
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """
+        self._cuda_graph_capture_health_check()
+
         loss = None
         if closure is not None:
             with torch.enable_grad():
@@ -133,7 +140,8 @@ class AdamW(Optimizer):
 
                 # State initialization
                 if len(state) == 0:
-                    state['step'] = torch.tensor(0.)
+                    state['step'] = torch.zeros((1,), dtype=torch.float, device=p.device) \
+                        if self.defaults['capturable'] else torch.tensor(0.)
                     # Exponential moving average of gradient values
                     state['exp_avg'] = torch.zeros_like(p, memory_format=torch.preserve_format)
                     # Exponential moving average of squared gradient values
@@ -163,7 +171,8 @@ class AdamW(Optimizer):
                   weight_decay=group['weight_decay'],
                   eps=group['eps'],
                   maximize=group['maximize'],
-                  foreach=group['foreach'])
+                  foreach=group['foreach'],
+                  capturable=group['capturable'])
 
         return loss
 
@@ -177,6 +186,7 @@ def adamw(params: List[Tensor],
           # kwonly args with defaults are not supported by functions compiled with torchscript issue #70627
           # setting this as kwarg for now as functional API is compiled by torch/distributed/optim
           foreach: bool = None,
+          capturable: bool = False,
           *,
           amsgrad: bool,
           beta1: float,
@@ -217,7 +227,8 @@ def adamw(params: List[Tensor],
          lr=lr,
          weight_decay=weight_decay,
          eps=eps,
-         maximize=maximize)
+         maximize=maximize,
+         capturable=capturable)
 
 
 def _single_tensor_adamw(params: List[Tensor],
@@ -233,37 +244,73 @@ def _single_tensor_adamw(params: List[Tensor],
                          lr: float,
                          weight_decay: float,
                          eps: float,
-                         maximize: bool):
+                         maximize: bool,
+                         capturable: bool):
 
     for i, param in enumerate(params):
         grad = grads[i] if not maximize else -grads[i]
         exp_avg = exp_avgs[i]
         exp_avg_sq = exp_avg_sqs[i]
         step_t = state_steps[i]
+
+        if capturable:
+            assert param.is_cuda and step_t.is_cuda, "If capturable=True, params and state_steps must be CUDA tensors."
+        else:
+            assert not step_t.is_cuda, "If capturable=False, state_steps should not be CUDA tensors."
+
         # update step
         step_t += 1
-        step = step_t.item()
 
         # Perform stepweight decay
         param.mul_(1 - lr * weight_decay)
 
-        bias_correction1 = 1 - beta1 ** step
-        bias_correction2 = 1 - beta2 ** step
-
         # Decay the first and second moment running average coefficient
         exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
         exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
-        if amsgrad:
-            # Maintains the maximum of all 2nd moment running avg. till now
-            torch.maximum(max_exp_avg_sqs[i], exp_avg_sq, out=max_exp_avg_sqs[i])
-            # Use the max. for normalizing running avg. of gradient
-            denom = (max_exp_avg_sqs[i].sqrt() / math.sqrt(bias_correction2)).add_(eps)
+
+        if capturable:
+            step = step_t
+
+            # 1 - beta1 ** step can't be captured in a CUDA graph, even if step is a CUDA tensor
+            # (incurs "RuntimeError: CUDA error: operation not permitted when stream is capturing")
+            bias_correction1 = 1 - torch.pow(beta1, step)
+            bias_correction2 = 1 - torch.pow(beta2, step)
+
+            step_size = lr / bias_correction1
+            step_size_neg = step_size.neg()
+
+            bias_correction2_sqrt = bias_correction2.sqrt()
+
+            if amsgrad:
+                # Maintains the maximum of all 2nd moment running avg. till now
+                torch.maximum(max_exp_avg_sqs[i], exp_avg_sq, out=max_exp_avg_sqs[i])
+                # Uses the max. for normalizing running avg. of gradient
+                # Folds in (admittedly ugly) 1-elem step_size math here to avoid extra param-set-sized read+write
+                # (can't fold it into addcdiv_ below because addcdiv_ requires value is a Number, not a Tensor)
+                denom = (max_exp_avg_sqs[i].sqrt() / (bias_correction2_sqrt * step_size_neg)).add_(eps / step_size_neg)
+            else:
+                denom = (exp_avg_sq.sqrt() / (bias_correction2_sqrt * step_size_neg)).add_(eps / step_size_neg)
+
+            param.addcdiv_(exp_avg, denom)
         else:
-            denom = (exp_avg_sq.sqrt() / math.sqrt(bias_correction2)).add_(eps)
+            step = step_t.item()
 
-        step_size = lr / bias_correction1
+            bias_correction1 = 1 - beta1 ** step
+            bias_correction2 = 1 - beta2 ** step
 
-        param.addcdiv_(exp_avg, denom, value=-step_size)
+            step_size = lr / bias_correction1
+
+            bias_correction2_sqrt = math.sqrt(bias_correction2)
+
+            if amsgrad:
+                # Maintains the maximum of all 2nd moment running avg. till now
+                torch.maximum(max_exp_avg_sqs[i], exp_avg_sq, out=max_exp_avg_sqs[i])
+                # Use the max. for normalizing running avg. of gradient
+                denom = (max_exp_avg_sqs[i].sqrt() / bias_correction2_sqrt).add_(eps)
+            else:
+                denom = (exp_avg_sq.sqrt() / bias_correction2_sqrt).add_(eps)
+
+            param.addcdiv_(exp_avg, denom, value=-step_size)
 
 
 def _multi_tensor_adamw(params: List[Tensor],
@@ -279,22 +326,26 @@ def _multi_tensor_adamw(params: List[Tensor],
                         lr: float,
                         weight_decay: float,
                         eps: float,
-                        maximize: bool):
-
+                        maximize: bool,
+                        capturable: bool):
     if len(params) == 0:
         return
+
+    if capturable:
+        assert all(p.is_cuda and step.is_cuda for p, step in zip(params, state_steps)), \
+            "If capturable=True, params and state_steps must be CUDA tensors."
+    else:
+        assert all(not step.is_cuda for step in state_steps), \
+            "If capturable=False, state_steps should not be CUDA tensors."
 
     if maximize:
         grads = torch._foreach_neg(tuple(grads))  # type: ignore[assignment]
 
-    # Perform stepweight decay
-    torch._foreach_mul_(params, 1 - lr * weight_decay)
-
     # update steps
     torch._foreach_add_(state_steps, 1)
 
-    bias_correction1 = [1 - beta1 ** step.item() for step in state_steps]
-    bias_correction2 = [1 - beta2 ** step.item() for step in state_steps]
+    # Perform stepweight decay
+    torch._foreach_mul_(params, 1 - lr * weight_decay)
 
     # Decay the first and second moment running average coefficient
     torch._foreach_mul_(exp_avgs, beta1)
@@ -303,20 +354,62 @@ def _multi_tensor_adamw(params: List[Tensor],
     torch._foreach_mul_(exp_avg_sqs, beta2)
     torch._foreach_addcmul_(exp_avg_sqs, grads, grads, 1 - beta2)
 
-    if amsgrad:
-        # Maintains the maximum of all 2nd moment running avg. till now
-        max_exp_avg_sqs = torch._foreach_maximum(max_exp_avg_sqs, exp_avg_sqs)  # type: ignore[assignment]
+    if capturable:
+        # TODO: use foreach_pow if/when foreach_pow is added
+        bias_correction1 = [torch.pow(beta1, step) for step in state_steps]
+        bias_correction2 = [torch.pow(beta2, step) for step in state_steps]
+        # foreach_sub doesn't allow a scalar as the first arg
+        torch._foreach_sub_(bias_correction1, 1)
+        torch._foreach_sub_(bias_correction2, 1)
+        torch._foreach_neg_(bias_correction1)
+        torch._foreach_neg_(bias_correction2)
 
-        # Use the max. for normalizing running avg. of gradient
-        max_exp_avg_sq_sqrt = torch._foreach_sqrt(max_exp_avg_sqs)
-        bias_correction_sqrt = [math.sqrt(bc) for bc in bias_correction2]
-        torch._foreach_div_(max_exp_avg_sq_sqrt, bias_correction_sqrt)
-        denom = torch._foreach_add(max_exp_avg_sq_sqrt, eps)
+        # foreach_div doesn't allow a scalar as the first arg
+        step_size = torch._foreach_div(bias_correction1, lr)
+        torch._foreach_reciprocal_(step_size)
+        torch._foreach_neg_(step_size)
+
+        bias_correction2_sqrt = torch._foreach_sqrt(bias_correction2)
+
+        if amsgrad:
+            # Maintains the maximum of all 2nd moment running avg. till now
+            max_exp_avg_sqs = torch._foreach_maximum(max_exp_avg_sqs, exp_avg_sqs)  # type: ignore[assignment]
+
+            # Use the max. for normalizing running avg. of gradient
+            max_exp_avg_sq_sqrt = torch._foreach_sqrt(max_exp_avg_sqs)
+            # Folds in (admittedly ugly) 1-elem step_size math here to avoid extra param-set-sized read+write
+            # (can't fold it into addcdiv_ below because addcdiv_ requires value is a Number, not a Tensor)
+            torch._foreach_div_(max_exp_avg_sq_sqrt, torch._foreach_mul(bias_correction2_sqrt, step_size))
+            eps_over_step_size = torch._foreach_div(step_size, eps)
+            torch._foreach_reciprocal_(eps_over_step_size)
+            denom = torch._foreach_add(max_exp_avg_sq_sqrt, eps_over_step_size)
+        else:
+            exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sqs)
+            torch._foreach_div_(exp_avg_sq_sqrt, torch._foreach_mul(bias_correction2_sqrt, step_size))
+            eps_over_step_size = torch._foreach_div(step_size, eps)
+            torch._foreach_reciprocal_(eps_over_step_size)
+            denom = torch._foreach_add(exp_avg_sq_sqrt, eps_over_step_size)
+
+        torch._foreach_addcdiv_(params, exp_avgs, denom)
     else:
-        exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sqs)
-        bias_correction_sqrt = [math.sqrt(bc) for bc in bias_correction2]
-        torch._foreach_div_(exp_avg_sq_sqrt, bias_correction_sqrt)
-        denom = torch._foreach_add(exp_avg_sq_sqrt, eps)
+        bias_correction1 = [1 - beta1 ** step.item() for step in state_steps]
+        bias_correction2 = [1 - beta2 ** step.item() for step in state_steps]
 
-    step_size = [-1 * (lr / bc) for bc in bias_correction1]
-    torch._foreach_addcdiv_(params, exp_avgs, denom, step_size)
+        step_size = [(lr / bc) * -1 for bc in bias_correction1]
+
+        bias_correction2_sqrt = [math.sqrt(bc) for bc in bias_correction2]
+
+        if amsgrad:
+            # Maintains the maximum of all 2nd moment running avg. till now
+            max_exp_avg_sqs = torch._foreach_maximum(max_exp_avg_sqs, exp_avg_sqs)  # type: ignore[assignment]
+
+            # Use the max. for normalizing running avg. of gradient
+            max_exp_avg_sq_sqrt = torch._foreach_sqrt(max_exp_avg_sqs)
+            torch._foreach_div_(max_exp_avg_sq_sqrt, bias_correction2_sqrt)
+            denom = torch._foreach_add(max_exp_avg_sq_sqrt, eps)
+        else:
+            exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sqs)
+            torch._foreach_div_(exp_avg_sq_sqrt, bias_correction2_sqrt)
+            denom = torch._foreach_add(exp_avg_sq_sqrt, eps)
+
+        torch._foreach_addcdiv_(params, exp_avgs, denom, step_size)

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -53,6 +53,11 @@ class Optimizer(object):
         for param_group in param_groups:
             self.add_param_group(param_group)
 
+        # Allows _cuda_graph_capture_health_check to rig a poor man's TORCH_WARN_ONCE in python,
+        # which I don't think exists
+        # https://github.com/pytorch/pytorch/issues/72948
+        self._warned_capturable_if_run_uncaptured = True
+
     def __getstate__(self):
         return {
             'defaults': self.defaults,
@@ -74,6 +79,22 @@ class Optimizer(object):
                     format_string += '    {0}: {1}\n'.format(key, group[key])
         format_string += ')'
         return format_string
+
+    # Currently needed by Adam and AdamW
+    def _cuda_graph_capture_health_check(self):
+        if torch.has_cuda and torch.cuda.is_available():
+            capturing = torch.cuda.is_current_stream_capturing()
+
+            if capturing and not self.defaults['capturable']:
+                raise RuntimeError("Attempting CUDA graph capture of step() for an instance of " +
+                                   self.__class__.__name__ +
+                                   " but this instance was constructed with capturable=False.")
+
+            if (not self._warned_capturable_if_run_uncaptured) and self.defaults['capturable'] and (not capturing):
+                print("Warning: This instance was constructed with capturable=True, but step() " +
+                      "is running without CUDA graph capture. If you never intend to graph-capture this " +
+                      "instance, capturable=True can impair performance, and you should set capturable=False.")
+                self._warned_capturable_if_run_uncaptured = True
 
     def _hook_for_profile(self):
         self._zero_grad_profile_name = "Optimizer.zero_grad#{}.zero_grad".format(self.__class__.__name__)


### PR DESCRIPTION
Cherry-pick of https://github.com/pytorch/pytorch/pull/77862 for 1.12.

@awgu helped resolve the cherry-pick's conflicts with 
torch/distributed/fsdp/fully_sharded_data_parallel.py
and
torch/distributed/fsdp/_optim_utils.py.