### PR TITLE
Fix backward compat

### DIFF
--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -143,6 +143,8 @@ ALLOW_LIST = [
     ("aten::_csr_to_block_csr", datetime.date(2022, 5, 20)),
     ("aten::_weight_norm_cuda_interface", datetime.date(9999, 1, 1)),
     ("aten::_weight_norm_cuda_interface_backward", datetime.date(9999, 1, 1)),
+    ("aten::segment_reduce", datetime.date(9999, 1, 1)),
+    ("aten::_segment_reduce_backward", datetime.date(9999, 1, 1)),
     # TODO: FIXME: prims shouldn't be checked
     ("prims::.*", datetime.date(9999, 1, 1)),
 ]


### PR DESCRIPTION
Add `segment_reduce_backward` and `_segment_reduce_backward` to list of ignored ops
After https://github.com/pytorch/pytorch/pull/78907 got reverted
