### PR TITLE
Enable torch._refs.var for nvFuser executor

### DIFF
--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -4,7 +4,7 @@ from functools import partial
 
 import torch
 from torch.testing import make_tensor
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
@@ -102,6 +102,27 @@ class TestPrims(TestCase):
             len(ops_without_nvfuser_impl) == 0
         ), (f"The following prims do not have 'impl_nvfuser' defined: {ops_without_nvfuser_impl} ",
             "while there exists nvfuser implementations for them.")
+
+    @onlyCUDA
+    @skipCUDAIfRocm
+    @dtypes(torch.float32)
+    @parametrize("correction", [0, 1])
+    def test_var(self, device, dtype, correction):
+        def _wrapper(a):
+            return prims.var(a, [0, 1], correction=correction)
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten', 'nvfuser'):
+            fn = partial(traced, executor=executor)
+            shape = (5, 5)
+            a = make_arg(shape)
+            result = fn(a)
+
+            self.assertEqual(result.shape, ())
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(_wrapper(a), result)
 
     @onlyCUDA
     @skipCUDAIfRocm

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -2179,12 +2179,13 @@ def _make_reduction_prim(name: str, impl_aten, doc, impl_nvfuser=None):
     )
 
 
-def _make_var_reduction_prim(name: str, impl_aten, doc):
+def _make_var_reduction_prim(name: str, impl_aten, doc, impl_nvfuser):
     """Creates a reduction prim."""
     return _make_prim(
         schema=f"{name}(Tensor inp, int[]? dims, *, int correction, ScalarType? output_dtype=None) -> Tensor",
         meta=_var_reduction_meta,
         impl_aten=impl_aten,
+        impl_nvfuser=impl_nvfuser,
         return_type=RETURN_TYPE.NEW,
         doc=doc,
     )
@@ -2230,9 +2231,22 @@ prod = _make_reduction_prim(
     doc=_prod_doc,
 )
 
+
+def _var_nvfuser(
+    fd: Any,
+    a: TensorLikeType,
+    dims: DimsSequenceType,
+    *,
+    correction: int,
+):
+    keep_dims = False
+    return fd.Ops.var(a, dims, correction, keep_dims)
+
+
 var = _make_var_reduction_prim(
     name="var",
     impl_aten=torch.var,
+    impl_nvfuser=_var_nvfuser,
     doc=_var_doc,
 )
 

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -49,9 +49,7 @@ TensorView* variance(
   TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
 
   TORCH_CHECK(
-      correction >= 0,
-      "correction must be non-negative, but got ",
-      correction);
+      correction >= 0, "correction must be non-negative, but got ", correction);
 
   const int kNumberOfDims =
       TensorDomain::noReductions(x->getMaybeRFactorDomain()).size();

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.cpp
@@ -37,6 +37,21 @@ TensorView* variance(
     bool unbiased,
     bool keepdim) {
   TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+  int64_t correction = unbiased ? 1 : 0;
+  return variance(x, dims, correction, keepdim);
+}
+
+TensorView* variance(
+    TensorView* x,
+    const std::vector<int>& dims,
+    int64_t correction,
+    bool keepdim) {
+  TORCH_INTERNAL_ASSERT(x != nullptr, "Input is invalid.");
+
+  TORCH_CHECK(
+      correction >= 0,
+      "correction must be non-negative, but got ",
+      correction);
 
   const int kNumberOfDims =
       TensorDomain::noReductions(x->getMaybeRFactorDomain()).size();
@@ -47,9 +62,9 @@ TensorView* variance(
   auto sum_x_mean_sub_sq = sum(x_mean_sub_sq, dims, keepdim);
 
   auto num_features = numFeatures(x, dims, kNumberOfDims);
-  if (unbiased) {
+  if (correction > 0) {
     num_features =
-        sub(num_features, IrBuilder::create<Double>(x->container(), 1.));
+        sub(num_features, IrBuilder::create<Int>(x->container(), correction));
   }
   auto y = div(sum_x_mean_sub_sq, num_features);
 

--- a/torch/csrc/jit/codegen/cuda/ops/normalization.h
+++ b/torch/csrc/jit/codegen/cuda/ops/normalization.h
@@ -49,6 +49,12 @@ TORCH_CUDA_CU_API TensorView* variance(
     bool unbiased,
     bool keepdim);
 
+TORCH_CUDA_CU_API TensorView* variance(
+    TensorView* x,
+    const std::vector<int>& dims,
+    int64_t correction,
+    bool keepdim);
+
 TORCH_CUDA_CU_API TensorView* standard_deviation(
     TensorView* x,
     const std::vector<int>& dims,

--- a/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
@@ -8,8 +8,8 @@
 #include <torch/csrc/jit/codegen/cuda/ir_all_nodes.h>
 #include <torch/csrc/jit/codegen/cuda/ir_builder.h>
 #include <torch/csrc/jit/codegen/cuda/kernel_cache.h>
-#include <torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.h>
 #include <torch/csrc/jit/codegen/cuda/ops/normalization.h>
+#include <torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <iostream>
 

--- a/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
@@ -9,6 +9,7 @@
 #include <torch/csrc/jit/codegen/cuda/ir_builder.h>
 #include <torch/csrc/jit/codegen/cuda/kernel_cache.h>
 #include <torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.h>
+#include <torch/csrc/jit/codegen/cuda/ops/normalization.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <iostream>
 
@@ -570,6 +571,16 @@ void initNvFuserPythonBindings(PyObject* module) {
       "min", &torch::jit::fuser::cuda::min, py::return_value_policy::reference);
   nvf_ops.def_static(
       "sum", &torch::jit::fuser::cuda::sum, py::return_value_policy::reference);
+  nvf_ops.def_static(
+      "var",
+      [](TensorView* input,
+         const std::vector<int>& dims,
+         int64_t correction,
+         bool keepdim) -> TensorView* {
+        return torch::jit::fuser::cuda::variance(
+            input, dims, correction, keepdim);
+      },
+      py::return_value_policy::reference);
 
   // Broadcast operations
   nvf_ops.def_static(


### PR DESCRIPTION
This PR adds variance function with correction argument to nvFuser.

Now it's possible to run
```py
import torch
import torch._refs
from torch._prims.executor import make_traced

def foo1(a):
    return torch._refs.var(a, keepdim=False, unbiased=False)

def foo2(a):
    return torch._refs.var(a, keepdim=False, correction=2)

a = torch.randn(3, 3, device='cuda')
make_traced(foo1)(a, executor="nvfuser")
make_traced(foo2)(a, executor="nvfuser")
```
