### PR TITLE
 Fix warning: cast from type `const char*` to type `char*` casts away qualifiers

### DIFF
--- a/c10/util/logging_is_not_google_glog.h
+++ b/c10/util/logging_is_not_google_glog.h
@@ -91,17 +91,17 @@ static_assert(
 // should not generate anything in optimized code.
 #define LOG(n)                                 \
   if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD) \
-  ::c10::MessageLogger((char*)__FILE__, __LINE__, ::c10::GLOG_##n).stream()
+  ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_##n).stream()
 #define VLOG(n)                   \
   if (-n >= CAFFE2_LOG_THRESHOLD) \
-  ::c10::MessageLogger((char*)__FILE__, __LINE__, -n).stream()
+  ::c10::MessageLogger((const char*)__FILE__, __LINE__, -n).stream()
 
 #define LOG_IF(n, condition)                                  \
   if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD && (condition)) \
-  ::c10::MessageLogger((char*)__FILE__, __LINE__, ::c10::GLOG_##n).stream()
+  ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_##n).stream()
 #define VLOG_IF(n, condition)                    \
   if (-n >= CAFFE2_LOG_THRESHOLD && (condition)) \
-  ::c10::MessageLogger((char*)__FILE__, __LINE__, -n).stream()
+  ::c10::MessageLogger((const char*)__FILE__, __LINE__, -n).stream()
 
 #define VLOG_IS_ON(verboselevel) (CAFFE2_LOG_THRESHOLD <= -(verboselevel))
 
@@ -115,7 +115,7 @@ static_assert(
 #define FATAL_IF(condition)                                                  \
   condition ? (void)0                                                        \
             : ::c10::LoggerVoidify() &                                       \
-          ::c10::MessageLogger((char*)__FILE__, __LINE__, ::c10::GLOG_FATAL) \
+          ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_FATAL) \
               .stream()
 
 // Check for a given boolean condition.
@@ -134,7 +134,7 @@ static_assert(
 #define DLOG(n)                                                            \
   true ? (void)0                                                           \
        : ::c10::LoggerVoidify() &                                          \
-          ::c10::MessageLogger((char*)__FILE__, __LINE__, ::c10::GLOG_##n) \
+          ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_##n) \
               .stream()
 #endif // NDEBUG
 

--- a/c10/util/logging_is_not_google_glog.h
+++ b/c10/util/logging_is_not_google_glog.h
@@ -89,16 +89,18 @@ static_assert(
     "CAFFE2_LOG_THRESHOLD should at most be GLOG_FATAL.");
 // If n is under the compile time caffe log threshold, The _CAFFE_LOG(n)
 // should not generate anything in optimized code.
-#define LOG(n)                                 \
-  if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD) \
-  ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_##n).stream()
+#define LOG(n)                                                           \
+  if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD)                           \
+  ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_##n) \
+      .stream()
 #define VLOG(n)                   \
   if (-n >= CAFFE2_LOG_THRESHOLD) \
   ::c10::MessageLogger((const char*)__FILE__, __LINE__, -n).stream()
 
-#define LOG_IF(n, condition)                                  \
-  if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD && (condition)) \
-  ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_##n).stream()
+#define LOG_IF(n, condition)                                             \
+  if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD && (condition))            \
+  ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_##n) \
+      .stream()
 #define VLOG_IF(n, condition)                    \
   if (-n >= CAFFE2_LOG_THRESHOLD && (condition)) \
   ::c10::MessageLogger((const char*)__FILE__, __LINE__, -n).stream()
@@ -112,10 +114,11 @@ static_assert(
   ::c10::MessageLogger(file, line, ::c10::GLOG_##n).stream()
 
 // Log only if condition is met.  Otherwise evaluates to void.
-#define FATAL_IF(condition)                                                  \
-  condition ? (void)0                                                        \
-            : ::c10::LoggerVoidify() &                                       \
-          ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_FATAL) \
+#define FATAL_IF(condition)                                       \
+  condition ? (void)0                                             \
+            : ::c10::LoggerVoidify() &                            \
+          ::c10::MessageLogger(                                   \
+              (const char*)__FILE__, __LINE__, ::c10::GLOG_FATAL) \
               .stream()
 
 // Check for a given boolean condition.
@@ -131,10 +134,11 @@ static_assert(
   while (false)           \
   CHECK(condition)
 
-#define DLOG(n)                                                            \
-  true ? (void)0                                                           \
-       : ::c10::LoggerVoidify() &                                          \
-          ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_##n) \
+#define DLOG(n)                                                 \
+  true ? (void)0                                                \
+       : ::c10::LoggerVoidify() &                               \
+          ::c10::MessageLogger(                                 \
+              (const char*)__FILE__, __LINE__, ::c10::GLOG_##n) \
               .stream()
 #endif // NDEBUG
 

--- a/c10/util/logging_is_not_google_glog.h
+++ b/c10/util/logging_is_not_google_glog.h
@@ -89,21 +89,19 @@ static_assert(
     "CAFFE2_LOG_THRESHOLD should at most be GLOG_FATAL.");
 // If n is under the compile time caffe log threshold, The _CAFFE_LOG(n)
 // should not generate anything in optimized code.
-#define LOG(n)                                                           \
-  if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD)                           \
-  ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_##n) \
-      .stream()
+#define LOG(n)                                 \
+  if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD) \
+  ::c10::MessageLogger(__FILE__, __LINE__, ::c10::GLOG_##n).stream()
 #define VLOG(n)                   \
   if (-n >= CAFFE2_LOG_THRESHOLD) \
-  ::c10::MessageLogger((const char*)__FILE__, __LINE__, -n).stream()
+  ::c10::MessageLogger(__FILE__, __LINE__, -n).stream()
 
-#define LOG_IF(n, condition)                                             \
-  if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD && (condition))            \
-  ::c10::MessageLogger((const char*)__FILE__, __LINE__, ::c10::GLOG_##n) \
-      .stream()
+#define LOG_IF(n, condition)                                  \
+  if (::c10::GLOG_##n >= CAFFE2_LOG_THRESHOLD && (condition)) \
+  ::c10::MessageLogger(__FILE__, __LINE__, ::c10::GLOG_##n).stream()
 #define VLOG_IF(n, condition)                    \
   if (-n >= CAFFE2_LOG_THRESHOLD && (condition)) \
-  ::c10::MessageLogger((const char*)__FILE__, __LINE__, -n).stream()
+  ::c10::MessageLogger(__FILE__, __LINE__, -n).stream()
 
 #define VLOG_IS_ON(verboselevel) (CAFFE2_LOG_THRESHOLD <= -(verboselevel))
 
@@ -114,12 +112,10 @@ static_assert(
   ::c10::MessageLogger(file, line, ::c10::GLOG_##n).stream()
 
 // Log only if condition is met.  Otherwise evaluates to void.
-#define FATAL_IF(condition)                                       \
-  condition ? (void)0                                             \
-            : ::c10::LoggerVoidify() &                            \
-          ::c10::MessageLogger(                                   \
-              (const char*)__FILE__, __LINE__, ::c10::GLOG_FATAL) \
-              .stream()
+#define FATAL_IF(condition)            \
+  condition ? (void)0                  \
+            : ::c10::LoggerVoidify() & \
+          ::c10::MessageLogger(__FILE__, __LINE__, ::c10::GLOG_FATAL).stream()
 
 // Check for a given boolean condition.
 #define CHECK(condition) FATAL_IF(condition) << "Check failed: " #condition " "
@@ -134,12 +130,10 @@ static_assert(
   while (false)           \
   CHECK(condition)
 
-#define DLOG(n)                                                 \
-  true ? (void)0                                                \
-       : ::c10::LoggerVoidify() &                               \
-          ::c10::MessageLogger(                                 \
-              (const char*)__FILE__, __LINE__, ::c10::GLOG_##n) \
-              .stream()
+#define DLOG(n)                   \
+  true ? (void)0                  \
+       : ::c10::LoggerVoidify() & \
+          ::c10::MessageLogger(__FILE__, __LINE__, ::c10::GLOG_##n).stream()
 #endif // NDEBUG
 
 #define CHECK_OP(val1, val2, op)                                              \


### PR DESCRIPTION
Do not cast `__FILE__` to `(char*)` in order to eliminate the prevalent `-Wcast-qual` warnings from showing up.

Fixes #79519
