### PR TITLE
[FSDP] Fix exec order validation for diff ignored modules across ranks

### DIFF
--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -25,19 +25,33 @@ if TEST_WITH_DEV_DBG_ASAN:
     sys.exit(0)
 
 
-class Model(torch.nn.Module):
-    def __init__(self) -> None:
+class IgnoredModule(torch.nn.Module):
+    def __init__(self, in_dim: int, out_dim: int) -> None:
         super().__init__()
-        self.layer0 = torch.nn.Linear(3, 5)
-        self.layer1 = torch.nn.Sequential(
-            torch.nn.Linear(5, 5),
-            torch.nn.Linear(5, 4),
-            torch.nn.Linear(4, 4),
-        )
-        self.layer2 = torch.nn.Linear(4, 1)
+        self.weight = torch.nn.Parameter(torch.randn((in_dim, out_dim)))
 
     def forward(self, x):
-        return self.layer2(self.layer1(self.layer0(x)))
+        return x @ self.weight
+
+
+class ModelWithIgnoredModules(torch.nn.Module):
+    def __init__(self, num_ignored: int) -> None:
+        super().__init__()
+        self.layer0 = torch.nn.Linear(3, 5)
+        layer1_modules = [torch.nn.Linear(5, 4), torch.nn.Linear(4, 4)] + \
+            [IgnoredModule(4, 4) for _ in range(num_ignored)] + \
+            [torch.nn.Linear(4, 4)]
+        self.layer1 = torch.nn.Sequential(*layer1_modules)
+        self.layer2 = torch.nn.Linear(4, 2)
+        self.layer3 = torch.nn.Linear(2, 2)
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, x):
+        z = self.relu(self.layer0(x))
+        z = self.relu(self.layer1(z))
+        z = self.relu(self.layer2(z))
+        z = self.relu(self.layer3(z))
+        return z
 
     def get_input(self, device):
         return (torch.randn((8, 3)).to(device),)
@@ -48,7 +62,16 @@ class Model(torch.nn.Module):
     def run_backward(self, loss):
         loss.backward()
 
+
 class TestFSDPIgnoredModules(FSDPTest):
+    def _train_model(self, model, optim, num_iters, device=torch.device("cuda")):
+        for _ in range(num_iters):
+            inp = model.module.get_input(device)
+            output = model(*inp)
+            loss = model.module.get_loss(inp, output).to(device)
+            model.module.run_backward(loss)
+            optim.step()
+
     @skip_if_lt_x_gpu(2)
     def test_ignored_modules_transformer(self):
         """Tests that ignored modules' parameters are not flattened for a
@@ -69,28 +92,22 @@ class TestFSDPIgnoredModules(FSDPTest):
             flat_param_numel = wrapped_model.params[0].numel()
             self.assertEqual(flat_param_numel, nonignored_numel)
         # Check that we can run a few iterations
-        device = torch.device("cuda")
         optim = torch.optim.Adam(wrapped_model.parameters(), lr=1e-3)
-        for _ in range(3):
-            inp = wrapped_model.module.get_input(device)
-            output = wrapped_model(*inp)
-            loss = wrapped_model.module.get_loss(inp, output).to(device)
-            wrapped_model.module.run_backward(loss)
-            optim.step()
+        self._train_model(wrapped_model, optim, 3)
 
     @skip_if_lt_x_gpu(2)
     def test_ignored_modules_nested(self):
         """Tests that passing a module with nested FSDP modules does not
         error and still ignores non-FSDP modules' parameters."""
         # Initialize an FSDP-wrapped nested model that first wraps the nested
-        # sequential's middle linear layer (`layer1[1]`) and then wraps the
+        # sequential's second linear layer (`layer1[1]`) and then wraps the
         # overall model while ignoring the nested sequential (`layer1`)
-        model = Model().cuda()
+        model = ModelWithIgnoredModules(num_ignored=0).cuda()
         model.layer1[1] = FSDP(model.layer1[1])
         wrapped_model = FSDP(model, ignored_modules=[model.layer1])
         # Check that the wrapped model's flattened parameter does not include
         # the ignored nested sequential's parameters
-        nonwrapped_model = Model()
+        nonwrapped_model = ModelWithIgnoredModules(num_ignored=0)
         total_numel = sum(p.numel() for p in nonwrapped_model.parameters())
         ignored_numel = sum(
             p.numel() for p in nonwrapped_model.layer1.parameters()
@@ -100,20 +117,14 @@ class TestFSDPIgnoredModules(FSDPTest):
             flat_param_numel = wrapped_model.params[0].numel()
             self.assertEqual(flat_param_numel, nonignored_numel)
         # Check that we can run a few iterations
-        device = torch.device("cuda")
         optim = torch.optim.Adam(wrapped_model.parameters(), lr=1e-3)
-        for _ in range(3):
-            inp = wrapped_model.get_input(device)
-            output = wrapped_model(*inp)
-            loss = wrapped_model.get_loss(inp, output).to(device)
-            wrapped_model.run_backward(loss)
-            optim.step()
+        self._train_model(wrapped_model, optim, 3)
 
     @skip_if_lt_x_gpu(2)
     def test_ignored_modules_invalid(self):
         """Tests that passing an FSDP module as an ignored module or the
         top-level module itself errors."""
-        model = Model()
+        model = ModelWithIgnoredModules(num_ignored=0).cuda()
         model.layer1 = FSDP(model.layer1)
         # Passing an FSDP module as an ignored module should error
         with self.assertRaises(
@@ -123,11 +134,28 @@ class TestFSDPIgnoredModules(FSDPTest):
             FSDP(model, ignored_modules=[model.layer1])
         with self.assertWarnsRegex(
             expected_warning=UserWarning,
-            expected_regex="Trying to ignore the top-level module passed into the FSDP "
-            "constructor itself will result in all parameters being ignored "
-            "and is not supported",
+            expected_regex="Trying to ignore the top-level module passed into "
+            "the FSDP constructor itself will result in all parameters being "
+            "ignored and is not supported",
         ):
             FSDP(model, ignored_modules=[model])
+
+    @skip_if_lt_x_gpu(2)
+    def test_diff_ignored_modules_across_ranks(self):
+        """Tests ignoring different modules across ranks."""
+        num_ignored = self.rank + 1
+        model = ModelWithIgnoredModules(num_ignored=num_ignored).cuda()
+        layer1_ignored_modules = [
+            m for m in model.layer1.modules() if isinstance(m, IgnoredModule)
+        ]
+        model.layer1 = FSDP(model.layer1, ignored_modules=layer1_ignored_modules)
+        model.layer3 = FSDP(model.layer3)
+        model_ignored_modules = [
+            m for m in model.modules() if isinstance(m, IgnoredModule)
+        ]
+        wrapped_model = FSDP(model, ignored_modules=model_ignored_modules)
+        optim = torch.optim.Adam(wrapped_model.parameters(), lr=1e-3)
+        self._train_model(wrapped_model, optim, 3)
 
 
 instantiate_parametrized_tests(TestFSDPIgnoredModules)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -368,14 +368,18 @@ class _ExecOrderData():
     def init(self, root_module: "FullyShardedDataParallel"):
         assert root_module._is_root, "This data structure should only be " \
             "initialized on an FSDP root module"
-        # Save `root_modules.parameters()` to `_all_flat_params` instead of
-        # re-materializing each time to avoid the result depending on the
-        # calling context (e.g. when some parameters have been rebuilt)
-        self._all_flat_params = list(root_module.parameters())
+        # Save all `FlatParameter`s in `root_module`'s hierarchy to
+        # `_all_flat_params` instead of re-materializing each time to avoid the
+        # result depending on the calling context (e.g. when some parameters
+        # have been rebuilt)
+        self._all_flat_params = [
+            param for param in root_module.parameters()
+            if isinstance(param, FlatParameter)
+        ]
         self._param_to_unflat_param_names = cast(
             Dict[FlatParameter, List[str]],
             _get_param_to_unflat_param_names(root_module)
-        )  # `root_module.parameters()` should only contain `FlatParameter`s
+        )
 
     def get_param_index(self, param: FlatParameter) -> int:
         """Returns a unique non-negative parameter index for ``param`` if it is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #79584 [FSDP] Default to not checking exec order
* #79557 [FSDP] Extend ignored modules test to not pass to root
* **#79533 [FSDP] Fix exec order validation for diff ignored modules across ranks**

The execution order validation implementation did not account for ignored modules nor differing ignored modules across ranks. It assumed that all parameters in the root FSDP module were `FlatParameter`s. This PR removes the assumption.

It is still critical that the `FlatParameter`s follow the same order within `fsdp_root.parameters()`, but this should be ensured if the model definition is the same across ranks since the model is recursively-wrapped following an order-stable module traversal.

If we want to support arbitrary `FlatParameter` order within `fsdp_root.parameters()`, then we need more logic. We need something like calling `dist.broadcast_object_list()` to broadcast a data structure that gives rank 0's `FlatParameter` order in `fsdp_root.parameters()`, where `FlatParameter`s are identified by a `str` key constructed from the unflattened names that comprise it. We need such a key to uniquely identify `FlatParameter`s and determine if any two represent the same logical entity.
- FYI: This unique keying by unflattened parameter names is added in my non-recursive wrapping refactor.
- To have differing `FlatParameter` order within `fsdp_root.parameters()`, we need the child `nn.Module`s wrapped in FSDP to be registered in different orders in the original model definition. E.g.:
```
Rank 0:
FSDP(Model(
    FSDP(Layer1()),
    FSDP(Layer2()),
))
Rank 1:
FSDP(Model(
    FSDP(Layer2()),
    FSDP(Layer1()),
))
```

---
Example:
```
[Rank 0]
FullyShardedDataParallel(
  (_fsdp_wrapped_module): FlattenParamsWrapper(
    (_fpw_module): ModelWithIgnoredModules(
      (layer0): Linear(in_features=3, out_features=5, bias=True)
      (layer1): FullyShardedDataParallel(
        (_fsdp_wrapped_module): FlattenParamsWrapper(
          (_fpw_module): Sequential(
            (0): Linear(in_features=5, out_features=4, bias=True)
            (1): Linear(in_features=4, out_features=4, bias=True)
            (2): IgnoredModule()
            (3): Linear(in_features=4, out_features=4, bias=True)
          )
        )
      )
      (layer2): Linear(in_features=4, out_features=2, bias=True)
      (layer3): FullyShardedDataParallel(
        (_fsdp_wrapped_module): FlattenParamsWrapper(
          (_fpw_module): Linear(in_features=2, out_features=2, bias=True)
        )
      )
      (relu): ReLU()
    )
  )
)
```
Note the additional `IgnoredModule` designated by the `---->`.
```
[Rank 1]
FullyShardedDataParallel(
  (_fsdp_wrapped_module): FlattenParamsWrapper(
    (_fpw_module): ModelWithIgnoredModules(
      (layer0): Linear(in_features=3, out_features=5, bias=True)
      (layer1): FullyShardedDataParallel(
        (_fsdp_wrapped_module): FlattenParamsWrapper(
          (_fpw_module): Sequential(
            (0): Linear(in_features=5, out_features=4, bias=True)
            (1): Linear(in_features=4, out_features=4, bias=True)
            (2): IgnoredModule()
---->       (3): IgnoredModule()
            (4): Linear(in_features=4, out_features=4, bias=True)
          )
        )
      )
      (layer2): Linear(in_features=4, out_features=2, bias=True)
      (layer3): FullyShardedDataParallel(
        (_fsdp_wrapped_module): FlattenParamsWrapper(
          (_fpw_module): Linear(in_features=2, out_features=2, bias=True)
        )
      )
      (relu): ReLU()
    )
  )
)
```
Because rank 1 has an additional `IgnoredModule` and `layer3` is wrapped in FSDP, rank 1's root module's `enumerate(parameters())` will assign `layer3`'s `FlatParameter` an index that is one higher than that of rank 0. In the existing execution order validation, this led to an incorrect association of `FlatParameter`s to indices. 

---

Differential Revision: [D37143127](https://our.internmc.facebook.com/intern/diff/D37143127)