### PR TITLE
[onnx] have all classes that call setUp inherit from common_utils.setUp

### DIFF
--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -135,7 +135,7 @@ class TestCaffe2Backend_opset9(TestCase):
     embed_params = False
 
     def setUp(self):
-        super().setUp()
+        TestCase.setUp()
         torch.manual_seed(0)
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(0)

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -135,6 +135,7 @@ class TestCaffe2Backend_opset9(TestCase):
     embed_params = False
 
     def setUp(self):
+        # the following should ideally be super().setUp(), https://github.com/pytorch/pytorch/issues/79630
         TestCase.setUp()
         torch.manual_seed(0)
         if torch.cuda.is_available():

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -136,7 +136,7 @@ class TestCaffe2Backend_opset9(TestCase):
 
     def setUp(self):
         # the following should ideally be super().setUp(), https://github.com/pytorch/pytorch/issues/79630
-        TestCase.setUp()
+        TestCase.setUp(self)
         torch.manual_seed(0)
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(0)

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -135,6 +135,7 @@ class TestCaffe2Backend_opset9(TestCase):
     embed_params = False
 
     def setUp(self):
+        super().setUp()
         torch.manual_seed(0)
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(0)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -201,11 +201,10 @@ class _TestONNXRuntime:
     keep_initializers_as_inputs = True  # For IR version 3 type export.
 
     def setUp(self):
-        torch.manual_seed(0)
+        set_rng_seed(0)
         onnxruntime.set_seed(0)
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(0)
-        np.random.seed(seed=0)
         os.environ["ALLOW_RELEASED_ONNX_OPSET_ONLY"] = "0"
         self.is_script_test_enabled = True
 

--- a/test/onnx/test_verification.py
+++ b/test/onnx/test_verification.py
@@ -1,13 +1,13 @@
 # Owner(s): ["module: onnx"]
 
-import unittest
-
 import torch
 from torch.onnx import _experimental, verification
+from test_pytorch_common import TestCase
 
 
-class TestVerification(unittest.TestCase):
+class TestVerification(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         torch.manual_seed(0)
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(0)

--- a/test/onnx/test_verification.py
+++ b/test/onnx/test_verification.py
@@ -2,10 +2,10 @@
 
 import torch
 from torch.onnx import _experimental, verification
-from test_pytorch_common import TestCase
+from torch.testing._internal import common_utils
 
 
-class TestVerification(TestCase):
+class TestVerification(common_utils.TestCase):
     def setUp(self) -> None:
         super().setUp()
         torch.manual_seed(0)


### PR DESCRIPTION
The remaining one is `class _TestONNXRuntime:`, which intentionally doesn't want to inherit from anything, so I left it alone.