### PR TITLE
[DataPipe] Fix error message coming from single iterator constraint

### DIFF
--- a/torch/utils/data/datapipes/_typing.py
+++ b/torch/utils/data/datapipes/_typing.py
@@ -412,7 +412,7 @@ def _generate_iterdatapipe_msg(datapipe):
 
 
 def _gen_invalid_iterdatapipe_msg(datapipe):
-    return ("This iterator has been invalidated because another iterator has been created"
+    return ("This iterator has been invalidated because another iterator has been created "
             f"from the same IterDataPipe: {_generate_iterdatapipe_msg(datapipe)}\n"
             "This may be caused multiple references to the same IterDataPipe. We recommend "
             "using `.fork()` if that is necessary.")
@@ -530,8 +530,10 @@ def hook_iterator(namespace, profile_name):
                 #       Part of https://github.com/pytorch/data/issues/284
                 datapipe = args[0]
                 msg = "thrown by __iter__ of"
-                full_msg = f"{msg} {datapipe.__class__.__name__}({_generate_input_args_string(datapipe)})"
-                if len(e.args) >= 1 and msg not in e.args[0]:
+                single_iterator_msg = "single iterator per IterDataPipe constraint"
+                has_len = hasattr(e.args, '__len__') and len(e.args) >= 1
+                if has_len and msg not in e.args[0] and single_iterator_msg not in e.args[0]:
+                    full_msg = f"{msg} {datapipe.__class__.__name__}({_generate_input_args_string(datapipe)})"
                     e.args = (e.args[0] + f'\nThis exception is {full_msg}',) + e.args[1:]
                 raise
 

--- a/torch/utils/data/datapipes/_typing.py
+++ b/torch/utils/data/datapipes/_typing.py
@@ -531,10 +531,12 @@ def hook_iterator(namespace, profile_name):
                 datapipe = args[0]
                 msg = "thrown by __iter__ of"
                 single_iterator_msg = "single iterator per IterDataPipe constraint"
-                has_len = hasattr(e.args, '__len__') and len(e.args) >= 1
-                if has_len and msg not in e.args[0] and single_iterator_msg not in e.args[0]:
+                if hasattr(e.args, '__len__'):
                     full_msg = f"{msg} {datapipe.__class__.__name__}({_generate_input_args_string(datapipe)})"
-                    e.args = (e.args[0] + f'\nThis exception is {full_msg}',) + e.args[1:]
+                    if len(e.args) == 0:  # If an exception message doesn't exist
+                        e.args = (f'\nThis exception is {full_msg}',)
+                    elif msg not in e.args[0] and single_iterator_msg not in e.args[0]:
+                        e.args = (e.args[0] + f'\nThis exception is {full_msg}',) + e.args[1:]
                 raise
 
         namespace['__iter__'] = wrap_generator


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #79547

Fixes https://github.com/pytorch/data/issues/516

* Prevent confusion by not adding the extra string about `__iter__` when the exception is raised because of single iterator constraint
* Added a missing space
* Make sure `__len__` exists before calling it during exception handling
* Handles the case where there was no initial exception message (previously skipped)


Exception example:
```python
from torchdata.datapipes.iter import IterableWrapper

source_dp = IterableWrapper(range(10))
it1 = iter(source_dp)
next(it1)
it2 = iter(source_dp)
next(it2)
next(it1)
```
Will raise:
```
Traceback (most recent call last):
  File "/Users/scratch/fast_forward.py", line 32, in <module>
    next(it1)
  File "/Users/pytorch/torch/utils/data/datapipes/_typing.py", line 524, in wrap_generator
    _check_iterator_valid(datapipe, iterator_id)
  File "/Users/pytorch/torch/utils/data/datapipes/_typing.py", line 445, in _check_iterator_valid
    raise RuntimeError(_gen_invalid_iterdatapipe_msg(datapipe) + _feedback_msg)
RuntimeError: This iterator has been invalidated because another iterator has been created from the same IterDataPipe: IterableWrapperIterDataPipe(deepcopy=True, iterable=range(0, 10))
This may be caused multiple references to the same IterDataPipe. We recommend using `.fork()` if that is necessary.
For feedback regarding this single iterator per IterDataPipe constraint, feel free to comment on this issue: https://github.com/pytorch/data/issues/45.
```