### PR TITLE
Make GHA workflow to retrieve latest promote-able SHA from master

### DIFF
--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -28,7 +28,7 @@ def get_latest_commits() -> List[str]:
             "-n",
             "1",
             "--pretty=format:%H",
-            "upstream/viable/strict",
+            "origin/viable/strict",
         ],
         encoding="ascii",
     )
@@ -37,7 +37,7 @@ def get_latest_commits() -> List[str]:
             "git",
             "rev-list",
             f"{latest_viable_commit}^..HEAD",
-            "--remotes=*upstream/master",
+            "--remotes=*origin/master",
         ],
         encoding="ascii",
     ).splitlines()

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -28,7 +28,7 @@ def get_latest_commits() -> List[str]:
             "-n",
             "1",
             "--pretty=format:%H",
-            "origin/viable/strict",
+            "upstream/viable/strict",
         ],
         encoding="ascii",
     )
@@ -37,7 +37,7 @@ def get_latest_commits() -> List[str]:
             "git",
             "rev-list",
             f"{latest_viable_commit}^..HEAD",
-            "--remotes=*origin/master",
+            "--remotes=*upstream/master",
         ],
         encoding="ascii",
     ).splitlines()

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -1,0 +1,43 @@
+name: Update viable/strict
+
+on:
+  schedule:
+    - cron: */30 * * * *
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  do_update_viablestrict:
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+          
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+
+      - name: Install Python Packages
+        run: |
+          pip3 install rockset==0.8.10
+
+      - name: Get latest viable commit
+        env:
+          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+        run: |
+          output=$(python3 -m .github/scripts/print_latest_commits.py)
+          echo "::set-output name=latest_viable_sha::$output"
+        id: get-latest-commit
+
+      - name: Push SHA to viable/strict branch
+        run: |
+          git config --global user.email "pytorchmergebot@users.noreply.github.com"
+          git config --global user.name "PyTorch MergeBot"
+          echo "::debug::Set the latest sha variable to be ${{ steps.get-latest-commit.outputs.latest_viable_sha }}" 
+        # git push origin "${{ steps.get-latest-commit.outputs.latest_viable_sha }}":refs/remotes/origin/viable/strict 
+       
+      # is this origin? also is the remote branch name this or refs/heads/<remotebranchname> 

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -2,7 +2,7 @@ name: Update viable/strict
 
 on:
   schedule:
-    - cron: */30 * * * *
+    - cron: 17,47 * * * *
   workflow_dispatch:
 
 concurrency:
@@ -11,19 +11,22 @@ concurrency:
 
 jobs:
   do_update_viablestrict:
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
           architecture: x64
-          
+
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
       - name: Install Python Packages
         run: |
           pip3 install rockset==0.8.10
+          pip3 install boto3==1.19.12
+          pip3 install six==1.16.0
 
       - name: Get latest viable commit
         env:
@@ -34,10 +37,9 @@ jobs:
         id: get-latest-commit
 
       - name: Push SHA to viable/strict branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
         run: |
           git config --global user.email "pytorchmergebot@users.noreply.github.com"
           git config --global user.name "PyTorch MergeBot"
-          echo "::debug::Set the latest sha variable to be ${{ steps.get-latest-commit.outputs.latest_viable_sha }}" 
-        # git push origin "${{ steps.get-latest-commit.outputs.latest_viable_sha }}":refs/remotes/origin/viable/strict 
-       
-      # is this origin? also is the remote branch name this or refs/heads/<remotebranchname> 
+          echo "::debug::Set the latest sha variable to be ${{ steps.get-latest-commit.outputs.latest_viable_sha }}"


### PR DESCRIPTION
Relates to #76700

**Overview:** Wrote GHA to get the latest commit SHA. Another component of the script is pushing this SHA to the viable/strict branch but I'm planning to test that locally after verifying that this part is correct. 

**Test Plan:** Monitor github actions results to see if the SHA printed is correct -- I wasn't able to check this on my personal fork. 