### PR TITLE
reorder cpuinfo and clog deps in TorchConfig.cmake

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -104,7 +104,7 @@ else()
   append_torchlib_if_found(onnx onnx_proto)
 
   append_torchlib_if_found(foxi_loader fmt)
-  append_torchlib_if_found(clog cpuinfo)
+  append_torchlib_if_found(cpuinfo clog)
 
   if(NOT @USE_INTERNAL_PTHREADPOOL_IMPL@)
     append_torchlib_if_found(pthreadpool)


### PR DESCRIPTION
cpuinfo has some symbols that need to be resolved with clog.
```

Static builds fail without this fix with this error:
api.c:(.text+0xc2): undefined reference to `clog_vlog_fatal'
init.c:(.text+0x19d1): undefined reference to `clog_vlog_error'
processors.c:(.text+0x551): undefined reference to `clog_vlog_error'
smallfile.c:(.text+0x172): undefined reference to `clog_vlog_error'


```