### PR TITLE
[ONNX] Constant folding to not add folded constant as initializer

### DIFF
--- a/test/onnx/expect/TestOperators.test_baddbmm.expect
+++ b/test/onnx/expect/TestOperators.test_baddbmm.expect
@@ -10,37 +10,53 @@ graph {
     op_type: "MatMul"
   }
   node {
+    output: "onnx::Mul_11"
+    name: "Constant_1"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 1
+        raw_data: "\000\000\200?"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::Mul_5"
     input: "onnx::Mul_11"
     output: "onnx::Add_7"
-    name: "Mul_1"
+    name: "Mul_2"
     op_type: "Mul"
+  }
+  node {
+    output: "onnx::Mul_12"
+    name: "Constant_3"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 1
+        raw_data: "\000\000\200?"
+      }
+      type: TENSOR
+    }
   }
   node {
     input: "onnx::Mul_0"
     input: "onnx::Mul_12"
     output: "onnx::Add_9"
-    name: "Mul_2"
+    name: "Mul_4"
     op_type: "Mul"
   }
   node {
     input: "onnx::Add_7"
     input: "onnx::Add_9"
     output: "10"
-    name: "Add_3"
+    name: "Add_5"
     op_type: "Add"
   }
   name: "torch_jit"
-  initializer {
-    data_type: 1
-    name: "onnx::Mul_11"
-    raw_data: "\000\000\200?"
-  }
-  initializer {
-    data_type: 1
-    name: "onnx::Mul_12"
-    raw_data: "\000\000\200?"
-  }
   input {
     name: "onnx::Mul_0"
     type {

--- a/test/onnx/expect/TestOperators.test_bitshift.expect
+++ b/test/onnx/expect/TestOperators.test_bitshift.expect
@@ -3,21 +3,22 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    input: "onnx::BitShift_0"
-    input: "onnx::BitShift_7"
-    output: "3"
-    name: "BitShift_0"
-    op_type: "BitShift"
+    output: "onnx::BitShift_7"
+    name: "Constant_0"
+    op_type: "Constant"
     attribute {
-      name: "direction"
-      s: "RIGHT"
-      type: STRING
+      name: "value"
+      t {
+        data_type: 2
+        raw_data: "\001"
+      }
+      type: TENSOR
     }
   }
   node {
     input: "onnx::BitShift_0"
-    input: "onnx::BitShift_8"
-    output: "6"
+    input: "onnx::BitShift_7"
+    output: "3"
     name: "BitShift_1"
     op_type: "BitShift"
     attribute {
@@ -26,17 +27,32 @@ graph {
       type: STRING
     }
   }
+  node {
+    output: "onnx::BitShift_8"
+    name: "Constant_2"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 2
+        raw_data: "\002"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "onnx::BitShift_0"
+    input: "onnx::BitShift_8"
+    output: "6"
+    name: "BitShift_3"
+    op_type: "BitShift"
+    attribute {
+      name: "direction"
+      s: "RIGHT"
+      type: STRING
+    }
+  }
   name: "torch_jit"
-  initializer {
-    data_type: 2
-    name: "onnx::BitShift_7"
-    raw_data: "\001"
-  }
-  initializer {
-    data_type: 2
-    name: "onnx::BitShift_8"
-    raw_data: "\002"
-  }
   input {
     name: "onnx::BitShift_0"
     type {

--- a/test/onnx/expect/TestOperators.test_clip.expect
+++ b/test/onnx/expect/TestOperators.test_clip.expect
@@ -3,24 +3,40 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
+    output: "onnx::Clip_6"
+    name: "Constant_0"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 1
+        raw_data: "\000\000\000\277"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "onnx::Clip_7"
+    name: "Constant_1"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 1
+        raw_data: "\000\000\000?"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::Clip_0"
     input: "onnx::Clip_6"
     input: "onnx::Clip_7"
     output: "5"
-    name: "Clip_0"
+    name: "Clip_2"
     op_type: "Clip"
   }
   name: "torch_jit"
-  initializer {
-    data_type: 1
-    name: "onnx::Clip_6"
-    raw_data: "\000\000\000\277"
-  }
-  initializer {
-    data_type: 1
-    name: "onnx::Clip_7"
-    raw_data: "\000\000\000?"
-  }
   input {
     name: "onnx::Clip_0"
     type {

--- a/test/onnx/expect/TestOperators.test_clip_max.expect
+++ b/test/onnx/expect/TestOperators.test_clip_max.expect
@@ -3,19 +3,27 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
+    output: "onnx::Clip_7"
+    name: "Constant_0"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 1
+        raw_data: "\315\314\314="
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::Clip_0"
     input: ""
     input: "onnx::Clip_7"
     output: "5"
-    name: "Clip_0"
+    name: "Clip_1"
     op_type: "Clip"
   }
   name: "torch_jit"
-  initializer {
-    data_type: 1
-    name: "onnx::Clip_7"
-    raw_data: "\315\314\314="
-  }
   input {
     name: "onnx::Clip_0"
     type {

--- a/test/onnx/expect/TestOperators.test_clip_min.expect
+++ b/test/onnx/expect/TestOperators.test_clip_min.expect
@@ -3,19 +3,27 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
+    output: "onnx::Clip_7"
+    name: "Constant_0"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 1
+        raw_data: "\315\314\314\275"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::Clip_0"
     input: "onnx::Clip_7"
     input: ""
     output: "5"
-    name: "Clip_0"
+    name: "Clip_1"
     op_type: "Clip"
   }
   name: "torch_jit"
-  initializer {
-    data_type: 1
-    name: "onnx::Clip_7"
-    raw_data: "\315\314\314\275"
-  }
   input {
     name: "onnx::Clip_0"
     type {

--- a/test/onnx/expect/TestOperators.test_embedding_bags.expect
+++ b/test/onnx/expect/TestOperators.test_embedding_bags.expect
@@ -3,8 +3,21 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
-    output: "5"
+    output: "onnx::Loop_33"
     name: "Constant_0"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        data_type: 9
+        raw_data: "\001"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "5"
+    name: "Constant_1"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -19,12 +32,12 @@ graph {
   node {
     input: "input"
     output: "onnx::Gather_6"
-    name: "Shape_1"
+    name: "Shape_2"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_7"
-    name: "Constant_2"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -39,7 +52,7 @@ graph {
     input: "onnx::Gather_6"
     input: "onnx::Gather_7"
     output: "onnx::Unsqueeze_8"
-    name: "Gather_3"
+    name: "Gather_4"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -49,7 +62,7 @@ graph {
   }
   node {
     output: "onnx::Unsqueeze_9"
-    name: "Constant_4"
+    name: "Constant_5"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -65,14 +78,14 @@ graph {
     input: "onnx::Unsqueeze_8"
     input: "onnx::Unsqueeze_9"
     output: "onnx::Concat_10"
-    name: "Unsqueeze_5"
+    name: "Unsqueeze_6"
     op_type: "Unsqueeze"
   }
   node {
     input: "offsets"
     input: "onnx::Concat_10"
     output: "onnx::Slice_11"
-    name: "Concat_6"
+    name: "Concat_7"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -82,7 +95,7 @@ graph {
   }
   node {
     output: "onnx::Slice_12"
-    name: "Constant_7"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -96,7 +109,7 @@ graph {
   }
   node {
     output: "onnx::Slice_13"
-    name: "Constant_8"
+    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -110,7 +123,7 @@ graph {
   }
   node {
     output: "onnx::Slice_14"
-    name: "Constant_9"
+    name: "Constant_10"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -124,7 +137,7 @@ graph {
   }
   node {
     output: "onnx::Slice_15"
-    name: "Constant_10"
+    name: "Constant_11"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -143,18 +156,18 @@ graph {
     input: "onnx::Slice_12"
     input: "onnx::Slice_15"
     output: "onnx::Shape_16"
-    name: "Slice_11"
+    name: "Slice_12"
     op_type: "Slice"
   }
   node {
     input: "onnx::Shape_16"
     output: "onnx::Gather_17"
-    name: "Shape_12"
+    name: "Shape_13"
     op_type: "Shape"
   }
   node {
     output: "onnx::Gather_18"
-    name: "Constant_13"
+    name: "Constant_14"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -169,7 +182,7 @@ graph {
     input: "onnx::Gather_17"
     input: "onnx::Gather_18"
     output: "onnx::Loop_19"
-    name: "Gather_14"
+    name: "Gather_15"
     op_type: "Gather"
     attribute {
       name: "axis"
@@ -181,7 +194,7 @@ graph {
     input: "onnx::Loop_19"
     input: "onnx::Loop_33"
     output: "20"
-    name: "Loop_15"
+    name: "Loop_16"
     op_type: "Loop"
     attribute {
       name: "body"
@@ -190,7 +203,7 @@ graph {
           input: "onnx::Slice_11"
           input: "21"
           output: "23"
-          name: "Gather_16"
+          name: "Gather_17"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -202,7 +215,7 @@ graph {
           input: "onnx::Shape_16"
           input: "21"
           output: "24"
-          name: "Gather_17"
+          name: "Gather_18"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -212,7 +225,7 @@ graph {
         }
         node {
           output: "25"
-          name: "Constant_18"
+          name: "Constant_19"
           op_type: "Constant"
           attribute {
             name: "value"
@@ -228,12 +241,12 @@ graph {
           input: "23"
           input: "25"
           output: "26"
-          name: "Unsqueeze_19"
+          name: "Unsqueeze_20"
           op_type: "Unsqueeze"
         }
         node {
           output: "27"
-          name: "Constant_20"
+          name: "Constant_21"
           op_type: "Constant"
           attribute {
             name: "value"
@@ -249,7 +262,7 @@ graph {
           input: "24"
           input: "27"
           output: "28"
-          name: "Unsqueeze_21"
+          name: "Unsqueeze_22"
           op_type: "Unsqueeze"
         }
         node {
@@ -258,14 +271,14 @@ graph {
           input: "28"
           input: "5"
           output: "29"
-          name: "Slice_22"
+          name: "Slice_23"
           op_type: "Slice"
         }
         node {
           input: "weight"
           input: "29"
           output: "30"
-          name: "Gather_23"
+          name: "Gather_24"
           op_type: "Gather"
           attribute {
             name: "axis"
@@ -276,7 +289,7 @@ graph {
         node {
           input: "30"
           output: "31"
-          name: "ReduceMean_24"
+          name: "ReduceMean_25"
           op_type: "ReduceMean"
           attribute {
             name: "axes"
@@ -292,7 +305,7 @@ graph {
         node {
           input: "onnx::Loop_33"
           output: "32"
-          name: "Cast_25"
+          name: "Cast_26"
           op_type: "Cast"
           attribute {
             name: "to"
@@ -356,11 +369,6 @@ graph {
     name: "weight"
     raw_data: "\264\314\344\275\017A\376\276\313\374&>J\266a\277s\306\\=\212\032+?\211[t\275\344[\357\276Dk\\\276OKb?\234\'B\277A\334\274\2767N\257\276\320s\263\277\371+\244>:\314\202\277K\200L??\001\275\275\236u4\2774\032\315\277\214\004\224>Z\320\372>\267B\305\276\346G6\277N\265.\276\343\316\272\277t\364a>\201)|>p\223\251\277Qm2?\346\275)\277\354\235\233?\027X\277\277\253\206a?\354\335\226\277L\032o\277\251J\021\277\311\360\215\276\312\274\013\300\252\320\273>\220\"p?\267\020\000<R\262\240\276\343\016\224\2779\241\353?8;\202\277\023\020\234?E\370#>\222\233\314?\334\360?\275|t\303\277\214\351\000\300\3065\302\2775\206\306>X\251\227\277x\2160?U^\251?d\221\350?\237F.?\rp9?9X\004=/c\324\277SL\360\277\'\274<?t\375l?\342\270l?\240\352:>\332\356\226\275\211\035\241>*\271\204\277>\025W>\036K\035?\036\233\200=\035\313\250\276\017\003\346\277\374p_?\313WD?!\006\351\275\232\\q\277\230\007A?"
   }
-  initializer {
-    data_type: 9
-    name: "onnx::Loop_33"
-    raw_data: "\001"
-  }
   input {
     name: "input"
     type {
@@ -399,16 +407,6 @@ graph {
           dim {
             dim_value: 8
           }
-        }
-      }
-    }
-  }
-  input {
-    name: "onnx::Loop_33"
-    type {
-      tensor_type {
-        elem_type: 9
-        shape {
         }
       }
     }

--- a/test/onnx/expect/TestOperators.test_expand.expect
+++ b/test/onnx/expect/TestOperators.test_expand.expect
@@ -17,9 +17,23 @@ graph {
     }
   }
   node {
+    output: "onnx::ConstantOfShape_10"
+    name: "Constant_1"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\003\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::ConstantOfShape_10"
     output: "onnx::Mul_3"
-    name: "ConstantOfShape_1"
+    name: "ConstantOfShape_2"
     op_type: "ConstantOfShape"
     attribute {
       name: "value"
@@ -33,7 +47,7 @@ graph {
   }
   node {
     output: "onnx::Mul_4"
-    name: "Constant_2"
+    name: "Constant_3"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -48,12 +62,12 @@ graph {
     input: "onnx::Mul_3"
     input: "onnx::Mul_4"
     output: "onnx::Equal_5"
-    name: "Mul_3"
+    name: "Mul_4"
     op_type: "Mul"
   }
   node {
     output: "onnx::Equal_6"
-    name: "Constant_4"
+    name: "Constant_5"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -69,7 +83,7 @@ graph {
     input: "onnx::Equal_6"
     input: "onnx::Equal_5"
     output: "onnx::Where_7"
-    name: "Equal_5"
+    name: "Equal_6"
     op_type: "Equal"
   }
   node {
@@ -77,23 +91,17 @@ graph {
     input: "onnx::Mul_3"
     input: "onnx::Where_1"
     output: "onnx::Expand_8"
-    name: "Where_6"
+    name: "Where_7"
     op_type: "Where"
   }
   node {
     input: "onnx::Expand_0"
     input: "onnx::Expand_8"
     output: "9"
-    name: "Expand_7"
+    name: "Expand_8"
     op_type: "Expand"
   }
   name: "torch_jit"
-  initializer {
-    dims: 1
-    data_type: 7
-    name: "onnx::ConstantOfShape_10"
-    raw_data: "\003\000\000\000\000\000\000\000"
-  }
   input {
     name: "onnx::Expand_0"
     type {

--- a/test/onnx/expect/TestOperators.test_narrow.expect
+++ b/test/onnx/expect/TestOperators.test_narrow.expect
@@ -3,33 +3,57 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
+    output: "onnx::Slice_14"
+    name: "Constant_0"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\000\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "onnx::Slice_15"
+    name: "Constant_1"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\002\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "onnx::Slice_16"
+    name: "Constant_2"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\000\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::Slice_0"
     input: "onnx::Slice_14"
     input: "onnx::Slice_15"
     input: "onnx::Slice_16"
     output: "12"
-    name: "Slice_0"
+    name: "Slice_3"
     op_type: "Slice"
   }
   name: "torch_jit"
-  initializer {
-    dims: 1
-    data_type: 7
-    name: "onnx::Slice_14"
-    raw_data: "\000\000\000\000\000\000\000\000"
-  }
-  initializer {
-    dims: 1
-    data_type: 7
-    name: "onnx::Slice_15"
-    raw_data: "\002\000\000\000\000\000\000\000"
-  }
-  initializer {
-    dims: 1
-    data_type: 7
-    name: "onnx::Slice_16"
-    raw_data: "\000\000\000\000\000\000\000\000"
-  }
   input {
     name: "onnx::Slice_0"
     type {

--- a/test/onnx/expect/TestOperators.test_pad.expect
+++ b/test/onnx/expect/TestOperators.test_pad.expect
@@ -3,9 +3,37 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
+    output: "onnx::ConstantOfShape_27"
+    name: "Constant_0"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\004\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "onnx::Concat_28"
+    name: "Constant_1"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 4
+        data_type: 7
+        raw_data: "\002\000\000\000\000\000\000\000\003\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\001\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::ConstantOfShape_27"
     output: "onnx::Concat_10"
-    name: "ConstantOfShape_0"
+    name: "ConstantOfShape_2"
     op_type: "ConstantOfShape"
     attribute {
       name: "value"
@@ -21,7 +49,7 @@ graph {
     input: "onnx::Concat_28"
     input: "onnx::Concat_10"
     output: "onnx::Reshape_11"
-    name: "Concat_1"
+    name: "Concat_3"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -31,7 +59,7 @@ graph {
   }
   node {
     output: "onnx::Reshape_12"
-    name: "Constant_2"
+    name: "Constant_4"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -47,12 +75,12 @@ graph {
     input: "onnx::Reshape_11"
     input: "onnx::Reshape_12"
     output: "onnx::Slice_13"
-    name: "Reshape_3"
+    name: "Reshape_5"
     op_type: "Reshape"
   }
   node {
     output: "onnx::Slice_14"
-    name: "Constant_4"
+    name: "Constant_6"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -66,7 +94,7 @@ graph {
   }
   node {
     output: "onnx::Slice_15"
-    name: "Constant_5"
+    name: "Constant_7"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -80,7 +108,7 @@ graph {
   }
   node {
     output: "onnx::Slice_16"
-    name: "Constant_6"
+    name: "Constant_8"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -94,7 +122,7 @@ graph {
   }
   node {
     output: "onnx::Slice_17"
-    name: "Constant_7"
+    name: "Constant_9"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -113,13 +141,13 @@ graph {
     input: "onnx::Slice_14"
     input: "onnx::Slice_17"
     output: "onnx::Transpose_18"
-    name: "Slice_8"
+    name: "Slice_10"
     op_type: "Slice"
   }
   node {
     input: "onnx::Transpose_18"
     output: "onnx::Reshape_19"
-    name: "Transpose_9"
+    name: "Transpose_11"
     op_type: "Transpose"
     attribute {
       name: "perm"
@@ -130,7 +158,7 @@ graph {
   }
   node {
     output: "onnx::Reshape_20"
-    name: "Constant_10"
+    name: "Constant_12"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -146,13 +174,13 @@ graph {
     input: "onnx::Reshape_19"
     input: "onnx::Reshape_20"
     output: "onnx::Cast_21"
-    name: "Reshape_11"
+    name: "Reshape_13"
     op_type: "Reshape"
   }
   node {
     input: "onnx::Cast_21"
     output: "onnx::Pad_22"
-    name: "Cast_12"
+    name: "Cast_14"
     op_type: "Cast"
     attribute {
       name: "to"
@@ -164,7 +192,7 @@ graph {
     input: "onnx::Pad_0"
     input: "onnx::Pad_22"
     output: "23"
-    name: "Pad_13"
+    name: "Pad_15"
     op_type: "Pad"
     attribute {
       name: "mode"
@@ -173,18 +201,6 @@ graph {
     }
   }
   name: "torch_jit"
-  initializer {
-    dims: 1
-    data_type: 7
-    name: "onnx::ConstantOfShape_27"
-    raw_data: "\004\000\000\000\000\000\000\000"
-  }
-  initializer {
-    dims: 4
-    data_type: 7
-    name: "onnx::Concat_28"
-    raw_data: "\002\000\000\000\000\000\000\000\003\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\001\000\000\000\000\000\000\000"
-  }
   input {
     name: "onnx::Pad_0"
     type {

--- a/test/onnx/expect/TestOperators.test_repeat.expect
+++ b/test/onnx/expect/TestOperators.test_repeat.expect
@@ -17,9 +17,23 @@ graph {
     }
   }
   node {
+    output: "onnx::ConstantOfShape_6"
+    name: "Constant_1"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\004\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::ConstantOfShape_6"
     output: "onnx::Expand_3"
-    name: "ConstantOfShape_1"
+    name: "ConstantOfShape_2"
     op_type: "ConstantOfShape"
     attribute {
       name: "value"
@@ -35,23 +49,17 @@ graph {
     input: "onnx::Expand_0"
     input: "onnx::Expand_3"
     output: "onnx::Tile_4"
-    name: "Expand_2"
+    name: "Expand_3"
     op_type: "Expand"
   }
   node {
     input: "onnx::Tile_4"
     input: "onnx::Tile_1"
     output: "5"
-    name: "Tile_3"
+    name: "Tile_4"
     op_type: "Tile"
   }
   name: "torch_jit"
-  initializer {
-    dims: 1
-    data_type: 7
-    name: "onnx::ConstantOfShape_6"
-    raw_data: "\004\000\000\000\000\000\000\000"
-  }
   input {
     name: "onnx::Expand_0"
     type {

--- a/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
+++ b/test/onnx/expect/TestOperators.test_repeat_dim_overflow.expect
@@ -17,9 +17,23 @@ graph {
     }
   }
   node {
+    output: "onnx::ConstantOfShape_6"
+    name: "Constant_1"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\004\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::ConstantOfShape_6"
     output: "onnx::Expand_3"
-    name: "ConstantOfShape_1"
+    name: "ConstantOfShape_2"
     op_type: "ConstantOfShape"
     attribute {
       name: "value"
@@ -35,23 +49,17 @@ graph {
     input: "onnx::Expand_0"
     input: "onnx::Expand_3"
     output: "onnx::Tile_4"
-    name: "Expand_2"
+    name: "Expand_3"
     op_type: "Expand"
   }
   node {
     input: "onnx::Tile_4"
     input: "onnx::Tile_1"
     output: "5"
-    name: "Tile_3"
+    name: "Tile_4"
     op_type: "Tile"
   }
   name: "torch_jit"
-  initializer {
-    dims: 1
-    data_type: 7
-    name: "onnx::ConstantOfShape_6"
-    raw_data: "\004\000\000\000\000\000\000\000"
-  }
   input {
     name: "onnx::Expand_0"
     type {

--- a/test/onnx/expect/TestOperators.test_shape_value_map.expect
+++ b/test/onnx/expect/TestOperators.test_shape_value_map.expect
@@ -55,12 +55,54 @@ graph {
     op_type: "Unsqueeze"
   }
   node {
+    output: "onnx::Concat_26"
+    name: "Constant_5"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\001\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "onnx::Concat_27"
+    name: "Constant_6"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\002\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "onnx::Concat_28"
+    name: "Constant_7"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\377\377\377\377\377\377\377\377"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::Concat_8"
     input: "onnx::Concat_26"
     input: "onnx::Concat_27"
     input: "onnx::Concat_28"
     output: "onnx::Reshape_15"
-    name: "Concat_5"
+    name: "Concat_8"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -72,13 +114,13 @@ graph {
     input: "x"
     input: "onnx::Reshape_15"
     output: "onnx::Transpose_16"
-    name: "Reshape_6"
+    name: "Reshape_9"
     op_type: "Reshape"
   }
   node {
     input: "onnx::Transpose_16"
     output: "x.1"
-    name: "Transpose_7"
+    name: "Transpose_10"
     op_type: "Transpose"
     attribute {
       name: "perm"
@@ -92,7 +134,7 @@ graph {
   node {
     input: "x.1"
     output: "onnx::Reshape_18"
-    name: "Softmax_8"
+    name: "Softmax_11"
     op_type: "Softmax"
     attribute {
       name: "axis"
@@ -102,7 +144,7 @@ graph {
   }
   node {
     output: "onnx::Unsqueeze_20"
-    name: "Constant_9"
+    name: "Constant_12"
     op_type: "Constant"
     attribute {
       name: "value"
@@ -118,14 +160,28 @@ graph {
     input: "onnx::Unsqueeze_3"
     input: "onnx::Unsqueeze_20"
     output: "onnx::Concat_21"
-    name: "Unsqueeze_10"
+    name: "Unsqueeze_13"
     op_type: "Unsqueeze"
+  }
+  node {
+    output: "onnx::Concat_29"
+    name: "Constant_14"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\377\377\377\377\377\377\377\377"
+      }
+      type: TENSOR
+    }
   }
   node {
     input: "onnx::Concat_21"
     input: "onnx::Concat_29"
     output: "onnx::Reshape_24"
-    name: "Concat_11"
+    name: "Concat_15"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -137,34 +193,10 @@ graph {
     input: "onnx::Reshape_18"
     input: "onnx::Reshape_24"
     output: "25"
-    name: "Reshape_12"
+    name: "Reshape_16"
     op_type: "Reshape"
   }
   name: "torch_jit"
-  initializer {
-    dims: 1
-    data_type: 7
-    name: "onnx::Concat_26"
-    raw_data: "\001\000\000\000\000\000\000\000"
-  }
-  initializer {
-    dims: 1
-    data_type: 7
-    name: "onnx::Concat_27"
-    raw_data: "\002\000\000\000\000\000\000\000"
-  }
-  initializer {
-    dims: 1
-    data_type: 7
-    name: "onnx::Concat_28"
-    raw_data: "\377\377\377\377\377\377\377\377"
-  }
-  initializer {
-    dims: 1
-    data_type: 7
-    name: "onnx::Concat_29"
-    raw_data: "\377\377\377\377\377\377\377\377"
-  }
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_scale.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_scale.expect
@@ -3,11 +3,25 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
+    output: "onnx::Resize_6"
+    name: "Constant_0"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 4
+        data_type: 1
+        raw_data: "\000\000\200?\000\000\200?\000\000\000@\000\000\000@"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "x"
     input: ""
     input: "onnx::Resize_6"
     output: "5"
-    name: "Resize_0"
+    name: "Resize_1"
     op_type: "Resize"
     attribute {
       name: "coordinate_transformation_mode"
@@ -31,12 +45,6 @@ graph {
     }
   }
   name: "torch_jit"
-  initializer {
-    dims: 4
-    data_type: 1
-    name: "onnx::Resize_6"
-    raw_data: "\000\000\200?\000\000\200?\000\000\000@\000\000\000@"
-  }
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_scale_default_scale_factor.expect
@@ -3,11 +3,25 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
+    output: "onnx::Resize_6"
+    name: "Constant_0"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 4
+        data_type: 1
+        raw_data: "\000\000\200?\000\000\200?\000\000\000@\000\000\000@"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "x"
     input: ""
     input: "onnx::Resize_6"
     output: "5"
-    name: "Resize_0"
+    name: "Resize_1"
     op_type: "Resize"
     attribute {
       name: "coordinate_transformation_mode"
@@ -31,12 +45,6 @@ graph {
     }
   }
   name: "torch_jit"
-  initializer {
-    dims: 4
-    data_type: 1
-    name: "onnx::Resize_6"
-    raw_data: "\000\000\200?\000\000\200?\000\000\000@\000\000\000@"
-  }
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_upsample_nearest_size.expect
+++ b/test/onnx/expect/TestOperators.test_upsample_nearest_size.expect
@@ -60,10 +60,24 @@ graph {
     op_type: "Slice"
   }
   node {
+    output: "onnx::Concat_12"
+    name: "Constant_5"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 2
+        data_type: 7
+        raw_data: "\020\000\000\000\000\000\000\000\020\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::Concat_6"
     input: "onnx::Concat_12"
     output: "onnx::Resize_8"
-    name: "Concat_5"
+    name: "Concat_6"
     op_type: "Concat"
     attribute {
       name: "axis"
@@ -77,7 +91,7 @@ graph {
     input: ""
     input: "onnx::Resize_8"
     output: "11"
-    name: "Resize_6"
+    name: "Resize_7"
     op_type: "Resize"
     attribute {
       name: "coordinate_transformation_mode"
@@ -101,12 +115,6 @@ graph {
     }
   }
   name: "torch_jit"
-  initializer {
-    dims: 2
-    data_type: 7
-    name: "onnx::Concat_12"
-    raw_data: "\020\000\000\000\000\000\000\000\020\000\000\000\000\000\000\000"
-  }
   input {
     name: "x"
     type {

--- a/test/onnx/expect/TestOperators.test_view_flatten.expect
+++ b/test/onnx/expect/TestOperators.test_view_flatten.expect
@@ -3,19 +3,27 @@ producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
   node {
+    output: "onnx::Reshape_11"
+    name: "Constant_0"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 2
+        data_type: 7
+        raw_data: "\001\000\000\000\000\000\000\000\030\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  node {
     input: "onnx::Reshape_0"
     input: "onnx::Reshape_11"
     output: "8"
-    name: "Reshape_0"
+    name: "Reshape_1"
     op_type: "Reshape"
   }
   name: "torch_jit"
-  initializer {
-    dims: 2
-    data_type: 7
-    name: "onnx::Reshape_11"
-    raw_data: "\001\000\000\000\000\000\000\000\030\000\000\000\000\000\000\000"
-  }
   input {
     name: "onnx::Reshape_0"
     type {

--- a/test/onnx/test_onnx_opset.py
+++ b/test/onnx/test_onnx_opset.py
@@ -96,6 +96,7 @@ class TestONNXOpset(TestCase):
             }
         ]
         ops_10 = [
+            {"op_name": "Constant"},
             {"op_name": "TopK", "attributes": [{"name": "axis", "i": -1, "type": 2}]}
         ]
         ops = {9: ops_9, 10: ops_10}
@@ -253,10 +254,12 @@ class TestONNXOpset(TestCase):
             {"op_name": "Shape"},
             {"op_name": "Constant"},
             {"op_name": "Gather", "attributes": [{"name": "axis", "i": 0, "type": 2}]},
+            {"op_name": "Constant"},
             {
                 "op_name": "Unsqueeze",
                 "attributes": [{"name": "axes", "i": 0, "type": 7}],
             },
+            {"op_name": "Constant"},
             {"op_name": "Constant"},
             {"op_name": "Slice", "attributes": []},
         ]
@@ -426,6 +429,7 @@ class TestONNXOpset(TestCase):
         )
 
         ops_9 = [
+            {"op_name": "Constant"},
             {"op_name": "Shape"},
             {"op_name": "Slice"},
             {"op_name": "Cast"},
@@ -438,6 +442,7 @@ class TestONNXOpset(TestCase):
             },
         ]
         ops_10 = [
+            {"op_name": "Constant"},
             {"op_name": "Shape"},
             {"op_name": "Constant"},
             {"op_name": "Constant"},

--- a/test/onnx/test_onnx_opset.py
+++ b/test/onnx/test_onnx_opset.py
@@ -97,7 +97,7 @@ class TestONNXOpset(TestCase):
         ]
         ops_10 = [
             {"op_name": "Constant"},
-            {"op_name": "TopK", "attributes": [{"name": "axis", "i": -1, "type": 2}]}
+            {"op_name": "TopK", "attributes": [{"name": "axis", "i": -1, "type": 2}]},
         ]
         ops = {9: ops_9, 10: ops_10}
         x = torch.arange(1.0, 6.0, requires_grad=True)

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -170,8 +170,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         for node in graph.nodes():
             self.assertNotEqual(node.kind(), "onnx::Transpose")
             self.assertNotEqual(node.kind(), "onnx::Cast")
-            self.assertNotEqual(node.kind(), "onnx::Constant")
-        self.assertEqual(len(list(graph.nodes())), 1)
+        self.assertEqual(len(list(graph.nodes())), 2)
 
     def test_constant_fold_reduceL2(self):
         class ReduceModule(torch.nn.Module):
@@ -189,7 +188,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
 
         for node in graph.nodes():
             self.assertNotEqual(node.kind(), "onnx::ReduceL2")
-        self.assertEqual(len(list(graph.nodes())), 1)
+        self.assertEqual(len(list(graph.nodes())), 2)
 
     def test_constant_fold_reduceL1(self):
         class NormModule(torch.nn.Module):
@@ -207,7 +206,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
 
         for node in graph.nodes():
             self.assertNotEqual(node.kind(), "onnx::ReduceL1")
-        self.assertEqual(len(list(graph.nodes())), 1)
+        self.assertEqual(len(list(graph.nodes())), 2)
 
     def test_constant_fold_slice(self):
         class NarrowModule(torch.nn.Module):
@@ -226,8 +225,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         for node in graph.nodes():
             self.assertNotEqual(node.kind(), "onnx::Slice")
             self.assertNotEqual(node.kind(), "onnx::Cast")
-            self.assertNotEqual(node.kind(), "onnx::Constant")
-        self.assertEqual(len(list(graph.nodes())), 1)
+        self.assertEqual(len(list(graph.nodes())), 2)
 
     def test_constant_fold_slice_index_exceeds_dim(self):
         class SliceIndexExceedsDimModule(torch.nn.Module):
@@ -249,8 +247,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         for node in graph.nodes():
             self.assertNotEqual(node.kind(), "onnx::Slice")
             self.assertNotEqual(node.kind(), "onnx::Cast")
-            self.assertNotEqual(node.kind(), "onnx::Constant")
-        self.assertEqual(len(list(graph.nodes())), 1)
+        self.assertEqual(len(list(graph.nodes())), 2)
 
     def test_constant_fold_slice_negative_index(self):
         class SliceNegativeIndexModule(torch.nn.Module):
@@ -274,7 +271,6 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         for node in graph.nodes():
             self.assertNotEqual(node.kind(), "onnx::Slice")
             self.assertNotEqual(node.kind(), "onnx::Cast")
-            self.assertNotEqual(node.kind(), "onnx::Constant")
 
     def test_constant_fold_gather(self):
         class GatherModule(torch.nn.Module):
@@ -313,8 +309,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         for node in graph.nodes():
             self.assertNotEqual(node.kind(), "onnx::Unsqueeze")
             self.assertNotEqual(node.kind(), "onnx::Cast")
-            self.assertNotEqual(node.kind(), "onnx::Constant")
-        self.assertEqual(len(list(graph.nodes())), 1)
+        self.assertEqual(len(list(graph.nodes())), 2)
 
     def test_constant_fold_unsqueeze_multi_axies(self):
         class PReluModel(torch.nn.Module):
@@ -336,8 +331,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         for node in graph.nodes():
             self.assertNotEqual(node.kind(), "onnx::Unsqueeze")
             self.assertNotEqual(node.kind(), "onnx::Cast")
-            self.assertNotEqual(node.kind(), "onnx::Constant")
-        self.assertEqual(len(list(graph.nodes())), 4)
+        self.assertEqual(len(list(graph.nodes())), 5)
 
     def test_constant_fold_squeeze_without_axes(self):
         class SqueezeModule(torch.nn.Module):
@@ -354,8 +348,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         for node in graph.nodes():
             self.assertNotEqual(node.kind(), "onnx::Squeeze")
             self.assertNotEqual(node.kind(), "onnx::Cast")
-            self.assertNotEqual(node.kind(), "onnx::Constant")
-        self.assertEqual(len(list(graph.nodes())), 2)
+        self.assertEqual(len(list(graph.nodes())), 4)
 
     def test_constant_fold_squeeze_with_axes(self):
         class SqueezeAxesModule(torch.nn.Module):
@@ -373,8 +366,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         for node in graph.nodes():
             self.assertNotEqual(node.kind(), "onnx::Squeeze")
             self.assertNotEqual(node.kind(), "onnx::Cast")
-            self.assertNotEqual(node.kind(), "onnx::Constant")
-        self.assertEqual(len(list(graph.nodes())), 1)
+        self.assertEqual(len(list(graph.nodes())), 2)
 
     def test_constant_fold_concat(self):
         class ConcatModule(torch.nn.Module):
@@ -410,8 +402,7 @@ class TestUtilityFuns_opset9(_BaseTestCase):
         for node in graph.nodes():
             self.assertNotEqual(node.kind(), "onnx::Concat")
             self.assertNotEqual(node.kind(), "onnx::Cast")
-            self.assertNotEqual(node.kind(), "onnx::Constant")
-        self.assertEqual(len(list(graph.nodes())), 1)
+        self.assertEqual(len(list(graph.nodes())), 2)
 
     def test_constant_fold_lstm(self):
         class GruNet(torch.nn.Module):

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -167,6 +167,16 @@ Node* createONNXUnsqueeze(
   return unsqueeze_node;
 }
 
+Node* createONNXConstant(
+    Graph* graph,
+    Node* n_to_insert_before,
+    at::Tensor value) {
+  Node* constant_node = graph->create(onnx::Constant, 1);
+  constant_node->insertBefore(n_to_insert_before);
+  constant_node->t_(attr::value, value);
+  return constant_node;
+}
+
 bool isValidToTransformToONNXConcatNode(Node* lc_node) {
   return !lc_node->inputs().empty();
 }

--- a/torch/csrc/jit/passes/onnx/helper.h
+++ b/torch/csrc/jit/passes/onnx/helper.h
@@ -53,6 +53,10 @@ Node* createONNXUnsqueeze(
     Value* input,
     int axis,
     int opset_version);
+Node* createONNXConstant(
+    Graph* graph,
+    Node* n_to_insert_before,
+    at::Tensor value);
 
 bool isValidToTransformToONNXConcatNode(Node* lc_node);
 


### PR DESCRIPTION
Previous behavior adds all folded values as initializers(model parameters).

Now only add folded values as initializers, if the original values were initializers.

Fixes: #78505