### PR TITLE
[ONNX] Enable test_fill script test

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -11393,7 +11393,6 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test(M_ToDeviceDtype(), (x, y))
 
     @skipIfUnsupportedMinOpsetVersion(9)
-    @skipScriptTest()
     def test_fill(self):
         class FillModule(torch.nn.Module):
             def forward(self, x, filled_value: int):
@@ -11402,6 +11401,14 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         x = torch.randn((4, 5, 6))
         filled_value = 7
         self.run_test(FillModule(), (x, filled_value))
+
+        class FillFloatModule(torch.nn.Module):
+            def forward(self, x, filled_value: float):
+                return x.fill_(filled_value)
+
+        x = torch.randn((4, 5, 6))
+        filled_value = 7.5
+        self.run_test(FillFloatModule(), (x, filled_value))
 
         class FillScalarModule(torch.nn.Module):
             def forward(self, x):

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -137,12 +137,19 @@ Node* addDummyClone(
     auto* noneNode = graph->create(prim::Constant);
     noneNode->output()->setType(NoneType::get());
     // For scripting mode, aten::clone requires input to be a TensorType
-    // Hence if we encounter an IntType or loatType, we set the input
+    // Hence if we encounter an IntType or FloatType, we set the input
     // to the appropriate TensorType
-    if (orig_data->type()->kind() == TypeKind::IntType) {
+    if (orig_data->type()->kind() == TypeKind::IntType &&
+        insertBefore == false) {
       orig_data->setType(TensorType::fromNumberType(*IntType::get()));
-    } else if (orig_data->type()->kind() == TypeKind::FloatType) {
+    } else if (
+        orig_data->type()->kind() == TypeKind::FloatType &&
+        insertBefore == false) {
       orig_data->setType(TensorType::fromNumberType(*FloatType::get()));
+    } else if (
+        orig_data->type()->kind() == TypeKind::BoolType &&
+        insertBefore == false) {
+      orig_data->setType(TensorType::fromBoolType());
     }
     newNode = graph->create(aten::clone, /*num_outputs =*/1);
     newNode->addInput(orig_data);

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -137,8 +137,8 @@ Node* addDummyClone(
     auto* noneNode = graph->create(prim::Constant);
     noneNode->output()->setType(NoneType::get());
     // For scripting mode, aten::clone requires input to be a TensorType
-    // Hence if we encounter an IntType or FloatType, we set the input
-    // to the appropriate TensorType
+    // Hence if we encounter an IntType, FloatType, or BoolType,
+    // we set the input to the appropriate TensorType
     if (orig_data->type()->kind() == TypeKind::IntType &&
         insertBefore == false) {
       orig_data->setType(TensorType::fromNumberType(*IntType::get()));

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -137,14 +137,12 @@ Node* addDummyClone(
     auto* noneNode = graph->create(prim::Constant);
     noneNode->output()->setType(NoneType::get());
     // For scripting mode, aten::clone requires input to be a TensorType
-    // Hence if we encounter an IntType, FloatType or BoolType input,
-    // We set the input to the appropriate TensorType
+    // Hence if we encounter an IntType or loatType, we set the input
+    // to the appropriate TensorType
     if (orig_data->type()->kind() == TypeKind::IntType) {
       orig_data->setType(TensorType::fromNumberType(*IntType::get()));
     } else if (orig_data->type()->kind() == TypeKind::FloatType) {
       orig_data->setType(TensorType::fromNumberType(*FloatType::get()));
-    } else if (orig_data->type()->kind() == TypeKind::BoolType) {
-      orig_data->setType(TensorType::fromBoolType());
     }
     newNode = graph->create(aten::clone, /*num_outputs =*/1);
     newNode->addInput(orig_data);

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -136,6 +136,16 @@ Node* addDummyClone(
       orig_data->type()->kind() == TypeKind::BoolType) {
     auto* noneNode = graph->create(prim::Constant);
     noneNode->output()->setType(NoneType::get());
+    // For scripting mode, aten::clone requires input to be a TensorType
+    // Hence if we encounter an IntType, FloatType or BoolType input,
+    // We set the input to the appropriate TensorType
+    if (orig_data->type()->kind() == TypeKind::IntType) {
+      orig_data->setType(TensorType::fromNumberType(*IntType::get()));
+    } else if (orig_data->type()->kind() == TypeKind::FloatType) {
+      orig_data->setType(TensorType::fromNumberType(*FloatType::get()));
+    } else if (orig_data->type()->kind() == TypeKind::BoolType) {
+      orig_data->setType(TensorType::fromBoolType());
+    }
     newNode = graph->create(aten::clone, /*num_outputs =*/1);
     newNode->addInput(orig_data);
     newNode->addInput(noneNode->output());


### PR DESCRIPTION
For scripting mode, aten::clone requires input to be a TensorType. Hence if we encounter an IntType, FloatType or BoolType input, we set the input to the appropriate TensorType