### PR TITLE
move gen_aten and gen_aten_hip into shared build structure

### DIFF
--- a/tools/bazel.bzl
+++ b/tools/bazel.bzl
@@ -7,6 +7,9 @@ def _genrule(**kwds):
     if _enabled(**kwds):
         native.genrule(**kwds)
 
+def _is_cpu_static_dispatch_build():
+    return False
+
 def _py_library(name, **kwds):
     deps = [dep for dep in kwds.pop("deps", []) if dep != None]
     native.py_library(name = name, deps = deps, **kwds)
@@ -26,6 +29,7 @@ rules = struct(
     genrule = _genrule,
     glob = native.glob,
     if_cuda = if_cuda,
+    is_cpu_static_dispatch_build = _is_cpu_static_dispatch_build,
     py_binary = native.py_binary,
     py_library = _py_library,
     requirement = _requirement,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79562

This requires two changes to rule generation:
 * pulling the cpu static dispatch prediction into the rules
 * disabling the Bazel-style generated file aliases

Differential Revision: [D36481918](https://our.internmc.facebook.com/intern/diff/D36481918/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D36481918/)!