### PR TITLE
Added edge case checking in isGreen

### DIFF
--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -5,15 +5,6 @@ import rockset  # type: ignore[import]
 import os
 import re
 
-regex = {
-    "^pull+": False,
-    "^trunk+": False,
-    "^lint+": False,
-    "^linux-binary+": False,
-    "^android-tests+": False,
-    "^windows-binary+": False,
-}
-
 class WorkflowCheck(NamedTuple):
     workflowName: str
     name: str
@@ -72,8 +63,14 @@ def get_commit_results(commit: str, results: Dict[str, Any]) -> List[Dict[str, A
 def isGreen(commit: str, results: Dict[str, Any]) -> Tuple[bool, str]:
     workflow_checks = get_commit_results(commit, results)
 
-    for required_check in regex:
-        regex[required_check] = False
+    regex = {
+        "^pull+": False,
+        "^trunk+": False,
+        "^lint+": False,
+        "^linux-binary+": False,
+        "^android-tests+": False,
+        "^windows-binary+": False,
+    }
 
     for check in workflow_checks:
         workflowName = check['workflowName']
@@ -92,7 +89,11 @@ def isGreen(commit: str, results: Dict[str, Any]) -> Tuple[bool, str]:
             return (False, workflowName + " checks were not successful")
 
     if not all(regex.values()):
-        return (False, "missing required workflows")
+        missing_workflows = ''
+        for required_check in regex:
+            if not regex[required_check]:
+                missing_workflows += required_check[1:-1] + ', '
+        return (False, "missing required workflows: " + missing_workflows[:-2])
 
     return (True, "")
 

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -5,6 +5,15 @@ import rockset  # type: ignore[import]
 import os
 import re
 
+regex = {
+    "^pull+": False,
+    "^trunk+": False,
+    "^lint+": False,
+    "^linux-binary+": False,
+    "^android-tests+": False,
+    "^windows-binary+": False,
+}
+
 class WorkflowCheck(NamedTuple):
     workflowName: str
     name: str
@@ -63,14 +72,8 @@ def get_commit_results(commit: str, results: Dict[str, Any]) -> List[Dict[str, A
 def isGreen(commit: str, results: Dict[str, Any]) -> Tuple[bool, str]:
     workflow_checks = get_commit_results(commit, results)
 
-    regex = {
-        "^pull+": False,
-        "^trunk+": False,
-        "^lint+": False,
-        "^linux-binary+": False,
-        "^android-tests+": False,
-        "^windows-binary+": False,
-    }
+    for required_check in regex:
+        regex[required_check] = False
 
     for check in workflow_checks:
         workflowName = check['workflowName']
@@ -89,11 +92,7 @@ def isGreen(commit: str, results: Dict[str, Any]) -> Tuple[bool, str]:
             return (False, workflowName + " checks were not successful")
 
     if not all(regex.values()):
-        missing_workflows = ''
-        for required_check in regex:
-            if not regex[required_check]:
-                missing_workflows += required_check[1:-1] + ', '
-        return (False, "missing required workflows: " + missing_workflows[:-2])
+        return (False, "missing required workflows")
 
     return (True, "")
 

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -72,6 +72,9 @@ def get_commit_results(commit: str, results: Dict[str, Any]) -> List[Dict[str, A
 def isGreen(commit: str, results: Dict[str, Any]) -> Tuple[bool, str]:
     workflow_checks = get_commit_results(commit, results)
 
+    if len(workflow_checks) == 0:
+        return (False, "no workflows")
+
     for check in workflow_checks:
         workflowName = check['workflowName']
         conclusion = check['conclusion']

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -5,14 +5,14 @@ import rockset  # type: ignore[import]
 import os
 import re
 
-regex = [
-    "^pull+",
-    "^trunk+",
-    "^lint+",
-    "^linux-binary+",
-    "^android-tests+",
-    "^windows-binary+"
-]
+regex = {
+    "^pull+": False,
+    "^trunk+": False,
+    "^lint+": False,
+    "^linux-binary+": False,
+    "^android-tests+": False,
+    "^windows-binary+": False,
+}
 
 class WorkflowCheck(NamedTuple):
     workflowName: str
@@ -72,20 +72,28 @@ def get_commit_results(commit: str, results: Dict[str, Any]) -> List[Dict[str, A
 def isGreen(commit: str, results: Dict[str, Any]) -> Tuple[bool, str]:
     workflow_checks = get_commit_results(commit, results)
 
-    if len(workflow_checks) == 0:
-        return (False, "no workflows")
+    for required_check in regex:
+        regex[required_check] = False
 
     for check in workflow_checks:
         workflowName = check['workflowName']
         conclusion = check['conclusion']
-        if re.search("|".join(regex), workflowName, flags=re.IGNORECASE) and conclusion != 'success':
-            if check['name'] == "pull / win-vs2019-cuda11.3-py3" and conclusion == 'skipped':
-                pass
-                # there are trunk checks that run the same tests, so this pull workflow check can be skipped
-            else:
-                return (False, workflowName + " checks were not successful")
-        elif workflowName in ["periodic", "docker-release-builds"] and conclusion not in ["success", "skipped"]:
+        for required_check in regex:
+            if re.search(required_check, workflowName, flags=re.IGNORECASE):
+                if conclusion != 'success':
+                    if check['name'] == "pull / win-vs2019-cuda11.3-py3" and conclusion == 'skipped':
+                        pass
+                        # there are trunk checks that run the same tests, so this pull workflow check can be skipped
+                    else:
+                        return (False, workflowName + " checks were not successful")
+                else:
+                    regex[required_check] = True
+        if workflowName in ["periodic", "docker-release-builds"] and conclusion not in ["success", "skipped"]:
             return (False, workflowName + " checks were not successful")
+
+    if not all(regex.values()):
+        return (False, "missing required workflows")
+
     return (True, "")
 
 def get_latest_green_commit(commits: List[str], results: Dict[str, Any]) -> Any:

--- a/.github/scripts/test_print_latest_commits.py
+++ b/.github/scripts/test_print_latest_commits.py
@@ -92,11 +92,11 @@ class TestPrintCommits(TestCase):
 
     @mock.patch('print_latest_commits.get_commit_results', return_value={})
     def test_no_workflows(self, mock_get_commit_results: Any) -> None:
-        "Test with no workflows"
+        "Test with missing workflows"
         workflow_checks = mock_get_commit_results()
         result = isGreen("sha", workflow_checks)
         self.assertFalse(result[0])
-        self.assertEqual(result[1], "no workflows")
+        self.assertEqual(result[1], "missing required workflows")
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_print_latest_commits.py
+++ b/.github/scripts/test_print_latest_commits.py
@@ -90,5 +90,13 @@ class TestPrintCommits(TestCase):
         self.assertFalse(result[0])
         self.assertEqual(result[1], "docker-release-builds checks were not successful")
 
+    @mock.patch('print_latest_commits.get_commit_results', return_value={})
+    def test_no_workflows(self, mock_get_commit_results: Any) -> None:
+        "Test with no workflows"
+        workflow_checks = mock_get_commit_results()
+        result = isGreen("sha", workflow_checks)
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], "no workflows")
+
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_print_latest_commits.py
+++ b/.github/scripts/test_print_latest_commits.py
@@ -96,7 +96,7 @@ class TestPrintCommits(TestCase):
         workflow_checks = mock_get_commit_results()
         result = isGreen("sha", workflow_checks)
         self.assertFalse(result[0])
-        self.assertEqual(result[1], "missing required workflows")
+        self.assertEqual(result[1], "missing required workflows: pull, trunk, lint, linux-binary, android-tests, windows-binary")
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_print_latest_commits.py
+++ b/.github/scripts/test_print_latest_commits.py
@@ -96,7 +96,7 @@ class TestPrintCommits(TestCase):
         workflow_checks = mock_get_commit_results()
         result = isGreen("sha", workflow_checks)
         self.assertFalse(result[0])
-        self.assertEqual(result[1], "missing required workflows: pull, trunk, lint, linux-binary, android-tests, windows-binary")
+        self.assertEqual(result[1], "missing required workflows")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Relates to #76700

**Overview**: One edge case not accounted for in the original logic of `isGreen` was for commits with no workflow checks. Similarly, if any of the required checks are not present (ex: if all of the pull checks are skipped), the workflow should not be promoteble. A commit should only be promoteable if there is it least one workflow check from each required group present (i.e. none of them are skipped)

**Test Plan:** Verify that commits on the HUD with no workflow checks are not considered promote-able. Added a test case with no workflows in `test_print_latest_commits.py`