### PR TITLE
Skip stale check when facebook-github-bot is merging

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -929,7 +929,8 @@ def merge(pr_num: int, repo: GitRepo,
     org, project = repo.gh_owner_and_name()
     pr = GitHubPR(org, project, pr_num)
     initial_commit_sha = pr.last_commit()['oid']
-    if force:
+    if force or can_skip_internal_checks(pr, comment_id):
+        # do not wait for any pending signals if PR is closed as part of co-development process
         return pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)
     if (datetime.utcnow() - pr.last_pushed_at()).days > stale_pr_days:
         raise RuntimeError("This PR is too stale; the last push date was more than 3 days ago. Please rebase and try again.")


### PR DESCRIPTION
# Summary

ShipIt jobs triggered by co-development workflows are failing to merge PRs due to stale checks.  This diff skips the stale check when merge is triggered by `facebook-github-bot`.


Sample merge failure: https://github.com/pytorch/pytorch/pull/78654#issuecomment-1155607617