### PR TITLE
[PyTorch] Don't create a new Storage in FreeMemory unnecessarily

### DIFF
--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -53,6 +53,13 @@ struct C10_API Storage {
         true));
   }
 
+  // Mimic create_legacy, but without requiring a newly-created StorageImpl.
+  void reset_legacy() {
+    TORCH_CHECK(resizable() && allocator());
+    set_nbytes(0);
+    set_data_ptr_noswap(allocator()->allocate(0));
+  }
+
   template <typename T>
   T* data() const {
     return storage_impl_->data<T>();

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -741,7 +741,11 @@ void TensorImpl::Reshape(const std::vector<int64_t>& dims) {
 
 void TensorImpl::FreeMemory() {
   // We'll detach from the old Storage and create a new one
-  storage_ = Storage::create_legacy(storage_.device());
+  if (storage_.use_count() != 1 || !storage_.resizable() || !storage_.allocator()) {
+    storage_ = Storage::create_legacy(storage_.device());
+  } else {
+    storage_.reset_legacy();
+  }
   storage_offset_ = 0;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79573

No reason to go through an extra heap allocation.

Differential Revision: [D37157595](https://our.internmc.facebook.com/intern/diff/D37157595/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D37157595/)!