### PR TITLE
[static runtime] Disable unit test for linalg_svdvals

### DIFF
--- a/benchmarks/static_runtime/test_generated_ops.cc
+++ b/benchmarks/static_runtime/test_generated_ops.cc
@@ -7705,7 +7705,8 @@ TEST(StaticRuntime, autogen_outer) {
       /*check_resize=*/true);
 }
 
-TEST(StaticRuntime, autogen_linalg_svdvals) {
+// Disabling the test because JIT alias analysis does not support linalg_svdvals at this point.
+TEST(StaticRuntime, DISABLED_autogen_linalg_svdvals) {
   const std::string script = R"IR(
     graph(%A: Tensor):
         %bias: None = prim::Constant()


### PR DESCRIPTION
Summary: The test is throwing a jit alias analysis not supporting error. Disabling it for now.

Test Plan: buck run mode/opt caffe2/benchmarks/static_runtime:static_runtime_cpptest

Reviewed By: mikeiovine

Differential Revision: D37056032

