### PR TITLE
[BE] Add clang-format changes to blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -18,7 +18,13 @@ cc11aaaa60aadf28e3ec278bce26a42c1cd68a4f
 e3900d2ba5c9f91a24a9ce34520794c8366d5c54
 # 2021-04-21 Removed all unqualified `type: ignore`
 75024e228ca441290b6a1c2e564300ad507d7af6
+# 2021-04-30 [PyTorch] Autoformat c10
+44cc873fba5e5ffc4d4d4eef3bd370b653ce1ce1
 # 2021-05-14 Removed all versionless Python shebangs
 2e26976ad3b06ce95dd6afccfdbe124802edf28f
 # 2021-06-07 Strictly typed everything in `.github` and `tools`
 737d920b21db9b4292d056ee1329945990656304
+# 2022-06-09 Apply clang-format to ATen headers
+95b15c266baaf989ef7b6bbd7c23a2d90bacf687
+# 2022-06-11 [lint] autoformat test/cpp and torch/csrc
+30fb2c4abaaaa966999eab11674f25b18460e609


### PR DESCRIPTION
Includes https://github.com/pytorch/pytorch/commit/30fb2c4abaaaa966999eab11674f25b18460e609 and https://github.com/pytorch/pytorch/commit/95b15c266baaf989ef7b6bbd7c23a2d90bacf687

