### PR TITLE
update tensor impl support_as_strided for nested tensors

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1042,7 +1042,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * It can be expanded as needed in the future, e.g sparse Tensor.
    */
   inline bool support_as_strided() const {
-    return device().supports_as_strided();
+    return is_nested() ? false : device().supports_as_strided();
   }
 
   // ~~~~~ Autograd API ~~~~~


### PR DESCRIPTION
This is needed for supporting nested tensors with autograd. See this discussion: https://github.com/pytorch/pytorch/pull/79446#discussion_r896334299

I was deciding between 3 options:
1. The proposed change- update impl base
2. Override function without making the base class method virtual
3. Make support_as_strided() virtual on base and override on nested

The comment above in impl made me think that option 1 is okay but feel free to correct me