### PR TITLE
fix generate-code caching by indicating that the binary is an executable

### DIFF
--- a/build.bzl
+++ b/build.bzl
@@ -38,7 +38,7 @@ def define_targets(rules):
         ],
         tools = ["//tools/setup_helpers:generate_code"],
         outs = GENERATED_AUTOGRAD_CPP + GENERATED_AUTOGRAD_PYTHON + GENERATED_TESTING_PY,
-        cmd = "$(location //tools/setup_helpers:generate_code) " +
+        cmd = "$(execpath //tools/setup_helpers:generate_code) " +
               "--gen-dir=$(RULEDIR) " +
               "--native-functions-path $(location :native_functions.yaml) " +
               "--tags-path=$(location :tags.yaml) " +


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Per Josiah Gaskin's followup on
https://www.internalfb.com/intern/qa/365579, using $(exe ...) instead
of $(location ...) should address the caching behavior.

Differential Revision: [D36970846](https://our.internmc.facebook.com/intern/diff/D36970846/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D36970846/)!