### PR TITLE
true up c10::FunctionSchema::operator<< to print native_functions.yaml syntax

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -509,6 +509,18 @@ inline std::ostream& operator<<(std::ostream& out, const Argument& arg) {
         unopt_type->kind() == c10::TypeKind::StringType) &&
         arg.default_value().value().isString()) {
       printQuotedString(out, arg.default_value().value().toStringRef());
+    } else if (type->kind() == TypeKind::ListType && type->castRaw<ListType>()->getElementType()->kind() == c10::TypeKind::IntType) {
+      // We want to faithfully replicate JIT schema.
+      // in native_functions.yaml defaults for int arrays always look like
+      //   int[2] stride=1
+      // instead of
+      //   int[2] stride=[1, 1]
+      auto default_val = arg.default_value().value().toIntList();
+      if (default_val.size() > 1) {
+        out << default_val[0];
+      } else {
+        out << arg.default_value().value();
+      }
     } else {
       out << arg.default_value().value();
     }

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -511,13 +511,21 @@ inline std::ostream& operator<<(std::ostream& out, const Argument& arg) {
       printQuotedString(out, arg.default_value().value().toStringRef());
     } else if (type->kind() == TypeKind::ListType && type->castRaw<ListType>()->getElementType()->kind() == c10::TypeKind::IntType) {
       // We want to faithfully replicate JIT schema.
-      // in native_functions.yaml defaults for int arrays always look like
+      // in native_functions.yaml defaults for int arrays with a single value always look like
       //   int[2] stride=1
       // instead of
       //   int[2] stride=[1, 1]
       auto default_val = arg.default_value().value().toIntList();
       if (default_val.size() > 1) {
-        out << default_val[0];
+        auto all_defaults_the_same = true;
+        for (const auto& i : c10::irange(1, default_val.size())) {
+          if (default_val[0] != default_val[i]) all_defaults_the_same = false;
+        }
+        if (all_defaults_the_same) {
+          out << default_val[0];
+        } else {
+          out << arg.default_value().value();
+        }
       } else {
         out << arg.default_value().value();
       }


### PR DESCRIPTION
Specifically, `int[n]` default values are specified in `native_functions.yaml` by a single integer that then fills the whole array, while printing a `FunctionSchema` object will print out e.g. `[1, 1]` instead of 1.

True-ing this up will let executorch faithfully re-use `torchgen` infra to parse function schema objects from `torch.ops.aten.<foo>._schema`.

This is a one off fix, but it comes up again we should consider doing what Ed said and just directly plumbing the schema string into the `FunctionSchema` object.

Before:
```
>>> print(torch.ops.aten.conv2d.default._schema)
aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=[1, 1], int[2] padding=[0, 0], int[2] dilation=[1, 1], int groups=1) -> Tensor
```
After:
```
>>> print(torch.ops.aten.conv2d.default._schema)
aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor
```

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #79645

