### PR TITLE
[NVFuser] add "canBeEnabled" interface

### DIFF
--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -4844,7 +4844,7 @@ class TestCudaFuser(JitTestCase):
         self._run_helper(t2_jit, t2, x0, x1, x2, check_stride=True)
 
 
-class TestPassManagerCudaFuser(JitTestCase):
+class TestEnableDisableCudaFuser(JitTestCase):
     def setUp(self):
         super().setUp()
         if RUN_NVFUSER:
@@ -4912,6 +4912,14 @@ class TestPassManagerCudaFuser(JitTestCase):
         with self.assertRaises(RuntimeError):
             torch._C._jit_set_nvfuser_enabled(True)
             torch._C._jit_set_nvfuser_enabled(False)
+
+    def test_can_be_enabled_nvfuser(self):
+        if TEST_WITH_ROCM:
+            expected = False
+        else:
+            expected = RUN_CUDA
+
+        self.assertEqual(expected, torch._C._jit_nvfuser_can_be_enabled())
 
 # See TestNNCOpInfoParent
 class TestCudaFuserOpInfoParent(JitCommonTestCase):

--- a/torch/csrc/jit/codegen/cuda/interface.cpp
+++ b/torch/csrc/jit/codegen/cuda/interface.cpp
@@ -37,6 +37,7 @@ class NVFuserEnabler {
   std::once_flag enabled_check_flag_;
   std::mutex mutex_;
 
+ public:
   static bool nvfuserCanBeEnabled() {
 #ifdef USE_ROCM
     return false;
@@ -46,6 +47,7 @@ class NVFuserEnabler {
 #endif
   }
 
+ private:
   static void assertFuserCanBeEnabled(bool is_enabled) {
     if (!is_enabled) {
       return;
@@ -142,6 +144,10 @@ bool isEnabled() {
 
 bool setEnabled(bool is_enabled) {
   return nvfuser_enabler.setEnabled(is_enabled);
+}
+
+bool canBeEnabled() {
+  return nvfuser_enabler.nvfuserCanBeEnabled();
 }
 
 bool getSingletonFusion() {

--- a/torch/csrc/jit/codegen/cuda/interface.h
+++ b/torch/csrc/jit/codegen/cuda/interface.h
@@ -54,6 +54,7 @@ TORCH_API bool complyWith(
 
 TORCH_API bool isEnabled();
 TORCH_API bool setEnabled(bool is_enabled);
+TORCH_API bool canBeEnabled();
 
 struct TORCH_API NVFuserPassManager : public PassManager<NVFuserPassManager> {
   static bool registerPass(bool enabled) {

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -687,6 +687,7 @@ void initJITBindings(PyObject* module) {
             return fuser::cuda::skipNode(op_name, flip);
           })
       .def("_jit_set_nvfuser_enabled", &fuser::cuda::setEnabled)
+      .def("_jit_nvfuser_can_be_enabled", &fuser::cuda::canBeEnabled)
       .def(
           "_jit_set_nvfuser_single_node_mode",
           [](bool flag) { return fuser::cuda::setSingletonFusion(flag); })


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #79648

If you try to enable NVFuser when it's not possible, it will error out.
This will allow you to check whether or not it's possible before trying
to enable it.

Differential Revision: [D37191611](https://our.internmc.facebook.com/intern/diff/D37191611)