### PR TITLE
finalized GHA for promoting to viable/strict

### DIFF
--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -19,7 +19,7 @@ def get_latest_commits() -> List[str]:
             "-n",
             "1",
             "--pretty=format:%H",
-            "upstream/viable/strict",
+            "origin/viable/strict",
         ],
         encoding="ascii",
     )
@@ -28,7 +28,7 @@ def get_latest_commits() -> List[str]:
             "git",
             "rev-list",
             f"{latest_viable_commit}^..HEAD",
-            "--remotes=*upstream/master",
+            "--remotes=*origin/master",
         ],
         encoding="ascii",
     ).splitlines()

--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -19,7 +19,7 @@ def get_latest_commits() -> List[str]:
             "-n",
             "1",
             "--pretty=format:%H",
-            "origin/viable/strict",
+            "upstream/viable/strict",
         ],
         encoding="ascii",
     )
@@ -28,7 +28,7 @@ def get_latest_commits() -> List[str]:
             "git",
             "rev-list",
             f"{latest_viable_commit}^..HEAD",
-            "--remotes=*origin/master",
+            "--remotes=*upstream/master",
         ],
         encoding="ascii",
     ).splitlines()
@@ -77,12 +77,8 @@ def isGreen(commit: str, results: Dict[str, Any]) -> Tuple[bool, str]:
         conclusion = check['conclusion']
         for required_check in regex:
             if re.match(required_check, workflowName, flags=re.IGNORECASE):
-                if conclusion != 'success':
-                    if check['name'] == "pull / win-vs2019-cuda11.3-py3" and conclusion == 'skipped':
-                        pass
-                        # there are trunk checks that run the same tests, so this pull workflow check can be skipped
-                    else:
-                        return (False, workflowName + " checks were not successful")
+                if conclusion not in ["success", "skipped"]:
+                    return (False, workflowName + " checks were not successful")
                 else:
                     regex[required_check] = True
         if workflowName in ["periodic", "docker-release-builds"] and conclusion not in ["success", "skipped"]:

--- a/.github/scripts/test_print_latest_commits.py
+++ b/.github/scripts/test_print_latest_commits.py
@@ -60,8 +60,7 @@ class TestPrintCommits(TestCase):
         workflow_checks = mock_get_commit_results()
         workflow_checks = set_workflow_job_status(workflow_checks, "pull", "skipped")
         result = isGreen("sha", workflow_checks)
-        self.assertFalse(result[0])
-        self.assertEqual(result[1], "pull checks were not successful")
+        self.assertTrue(result[0])
 
     @mock.patch('print_latest_commits.get_commit_results', return_value=TestChecks().make_test_checks())
     def test_skippable_skipped(self, mock_get_commit_results: Any) -> None:

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -19,8 +19,11 @@ jobs:
           python-version: 3.8
           architecture: x64
 
-      - name: Checkout PyTorch
-        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.MERGEBOT_TOKEN }}
 
       - name: Install Python Packages
         run: |

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -42,4 +42,5 @@ jobs:
         run: |
           git config --global user.email "pytorchmergebot@users.noreply.github.com"
           git config --global user.name "PyTorch MergeBot"
-          echo "::debug::Set the latest sha variable to be ${{ steps.get-latest-commit.outputs.latest_viable_sha }}"
+          echo "Set the latest sha variable to be ${{ steps.get-latest-commit.outputs.latest_viable_sha }}"
+          git push origin "${{ steps.get-latest-commit.outputs.latest_viable_sha }}":viable/strict

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
         run: |
-          output=$(python3.8 .github/scripts/print_latest_commits.py)
+          output=$(python3 .github/scripts/print_latest_commits.py)
           echo "::set-output name=latest_viable_sha::$output"
         id: get-latest-commit
 


### PR DESCRIPTION
Relates to #76700

**Overview:** Finalized GHA to push commits to viable/strict. Added `git push` statement to GHA that updates the viable/strict branch, modified checkout repo step.

**Test Plan:** Tested on `pytorch/pytorch-canary` [here.](https://github.com/pytorch/pytorch-canary/runs/6922229055?check_suite_focus=true ) Need to edit branch protection rules in https://fburl.com/code/w3tiegy6 