### PR TITLE
[ONNX] Fix quantization outputs' dtype

### DIFF
--- a/torch/onnx/verification.py
+++ b/torch/onnx/verification.py
@@ -62,10 +62,12 @@ def _inline_flatten_list(inputs, res_list):
     return res_list
 
 
-def _unpack_to_numpy(values):
+def _unpack_to_numpy(values, cast_onnx_accepted=True):
     value_unpacked = []
     for value in values:
-        value_unpacked.extend(utils.unpack_quantized_tensor(value))
+        value_unpacked.extend(
+            utils.unpack_quantized_tensor(value, cast_onnx_accepted=cast_onnx_accepted)
+        )
     return [_to_numpy(v) for v in value_unpacked]
 
 
@@ -115,7 +117,7 @@ def _ort_session(
 
 def _compare_ort_pytorch_outputs(ort_outs, pt_outs, rtol, atol):
     pt_outs, _ = torch.jit._flatten(pt_outs)
-    pt_outs = _unpack_to_numpy(pt_outs)
+    pt_outs = _unpack_to_numpy(pt_outs, cast_onnx_accepted=False)
 
     assert len(pt_outs) == len(ort_outs), "number of outputs differ"
 


### PR DESCRIPTION
Part of #79263

Previously, all quantized PyTorch tensors are all casted to the dtypes which comply with ONNX's definition, i.e. `scale` is casted to `double`, and `zero_point` is casted to `int64`. These casts lead to inconsistent dtypes when comparing PyTorch's outputs and ONNX runtime's outputs.

Now, `cast_onnx_accepted` argument is added to `unpack_quantized_tensor` function. When making example inputs for ONNX, we cast them to the ONNX compliant dtypes; otherwise, they are casted to PyTorch default types for quantization.
