### PR TITLE
[Vulkan] Optimize LSTM operator with pre-packing

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Lstm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Lstm.cpp
@@ -1,4 +1,6 @@
 #include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Mm.h>
+#include <ATen/native/vulkan/ops/VulkanOpContext.h>
 #include <torch/library.h>
 
 namespace at {
@@ -54,6 +56,9 @@ std::tuple<Tensor, Tensor, Tensor> lstm_input(
 
   // reshape to 2D due to Vulkan at::mm op accepts only 2D
   auto x = input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
+
+  h_n_list.reserve(num_layers);
+  c_n_list.reserve(num_layers);
 
   for (int64_t l = 0; l < num_layers; ++l) {
     // extract each hidden state and squeeze into 2D dim
@@ -117,6 +122,186 @@ TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
 #endif /* USE_VULKAN_API */
 
 } // namespace
+
+std::vector<c10::intrusive_ptr<VulkanOpContext>> pack_lstm_linear_op_contexts(
+    const std::vector<Tensor>& params_cpu,
+    int64_t num_layers) {
+  TORCH_CHECK(static_cast<int64_t>(params_cpu.size()) == 4 * num_layers,
+              "Vulkan LSTM expects 'params_cpu' size to be 4 * 'num_layers'.");
+  std::vector<c10::intrusive_ptr<VulkanOpContext>> linear_op_contexts;
+  linear_op_contexts.reserve(num_layers * 8);
+
+  for (int64_t l = 0; l < num_layers; ++l) {
+
+    const auto& w_ih = params_cpu[l * 4];
+    const auto& w_hh = params_cpu[l * 4 + 1];
+    const auto& b_ih = params_cpu[l * 4 + 2];
+    const auto& b_hh = params_cpu[l * 4 + 3];
+    const auto& hidden_size = w_ih.size(0) / 4;
+
+    const auto& w_i_ifgo = w_ih.split(hidden_size);
+    const auto& w_h_ifgo = w_hh.split(hidden_size);
+    const auto& b_i_ifgo = b_ih.split(hidden_size);
+    const auto& b_h_ifgo = b_hh.split(hidden_size);
+
+    const auto& w_ii = w_i_ifgo[0];
+    const auto& w_if = w_i_ifgo[1];
+    const auto& w_ig = w_i_ifgo[2];
+    const auto& w_io = w_i_ifgo[3];
+    const auto& w_hi = w_h_ifgo[0];
+    const auto& w_hf = w_h_ifgo[1];
+    const auto& w_hg = w_h_ifgo[2];
+    const auto& w_ho = w_h_ifgo[3];
+    const auto& b_ii = b_i_ifgo[0];
+    const auto& b_if = b_i_ifgo[1];
+    const auto& b_ig = b_i_ifgo[2];
+    const auto& b_io = b_i_ifgo[3];
+    const auto& b_hi = b_h_ifgo[0];
+    const auto& b_hf = b_h_ifgo[1];
+    const auto& b_hg = b_h_ifgo[2];
+    const auto& b_ho = b_h_ifgo[3];
+
+    linear_op_contexts.emplace_back(create_linear_context(w_ii.t(), b_ii));
+    linear_op_contexts.emplace_back(create_linear_context(w_hi.t(), b_hi));
+    linear_op_contexts.emplace_back(create_linear_context(w_if.t(), b_if));
+    linear_op_contexts.emplace_back(create_linear_context(w_hf.t(), b_hf));
+    linear_op_contexts.emplace_back(create_linear_context(w_ig.t(), b_ig));
+    linear_op_contexts.emplace_back(create_linear_context(w_hg.t(), b_hg));
+    linear_op_contexts.emplace_back(create_linear_context(w_io.t(), b_io));
+    linear_op_contexts.emplace_back(create_linear_context(w_ho.t(), b_ho));
+  }
+  return linear_op_contexts;
+}
+
+VulkanOpContext lstm_context_create(
+    const std::vector<Tensor>& params_cpu, // weights/biases (cpu)
+    bool has_biases,
+    int64_t num_layers,
+    double dropout,
+    bool train,
+    bool bidirectional,
+    bool batch_first) {
+
+  TORCH_INTERNAL_ASSERT(has_biases, "Vulkan LSTM expects 'has_biases' to be true.");
+  TORCH_INTERNAL_ASSERT(!train, "Vulkan LSTM expects 'train' to be false.");
+  TORCH_INTERNAL_ASSERT(!bidirectional, "Vulkan LSTM expects 'bidirectional' to be false.");
+  TORCH_INTERNAL_ASSERT(batch_first, "Vulkan LSTM expects 'batch_first' to be true.");
+  TORCH_INTERNAL_ASSERT(dropout < std::numeric_limits<double>::epsilon()*1000, "Vulkan LSTM expects 'dropout' to be 0.0.");
+
+  c10::impl::GenericList packed_context{c10::AnyType::get()};
+  packed_context.reserve(7);
+  packed_context.emplace_back(pack_lstm_linear_op_contexts(params_cpu, num_layers));
+  packed_context.emplace_back(has_biases);
+  packed_context.emplace_back(num_layers);
+  packed_context.emplace_back(dropout);
+  packed_context.emplace_back(train);
+  packed_context.emplace_back(bidirectional);
+  packed_context.emplace_back(batch_first);
+
+  c10::impl::GenericList unpacked_context{c10::AnyType::get()};
+  unpacked_context.reserve(7);
+  unpacked_context.emplace_back(params_cpu);
+  unpacked_context.emplace_back(has_biases);
+  unpacked_context.emplace_back(num_layers);
+  unpacked_context.emplace_back(dropout);
+  unpacked_context.emplace_back(train);
+  unpacked_context.emplace_back(bidirectional);
+  unpacked_context.emplace_back(batch_first);
+
+  return VulkanOpContext::create(packed_context, unpacked_context);
+}
+
+std::tuple<Tensor, Tensor, Tensor> lstm_context_run(
+    const Tensor& input_vk,      // input sequence (vulkan)
+    const Tensor& hx_vk,         // initial hidden state (vulkan)
+    const Tensor& cx_vk,         // initial cell state (vulkan)
+    const c10::impl::GenericList& packed_context,
+    const c10::impl::GenericList& unpacked_context) {
+  TORCH_INTERNAL_ASSERT(input_vk.sizes().size() == 3, "Vulkan LSTM expects input dims to be 3.");
+  TORCH_INTERNAL_ASSERT(hx_vk.sizes().size() == 3, "Vulkan LSTM expects hidden state dims to be 3.");
+  TORCH_INTERNAL_ASSERT(cx_vk.sizes().size() == 3, "Vulkan LSTM expects cell state dims to be 3.");
+
+  const c10::List<c10::IValue> packed_linear_op_contexts = packed_context.get(0).toList();
+  const int64_t packed_num_layers = packed_context.get(2).toInt();
+
+  const int64_t linear_op_contexts_per_layer = 8;   // (b_ii, w_ii), (b_hi, w_hi), (b_if, w_if), (b_hf, w_hf), (b_ig, w_ig), (b_hg, w_hg), (b_io, w_io), (b_ho, w_ho)
+  std::vector<at::Tensor> h_n_list;  // hidden state output
+  std::vector<at::Tensor> c_n_list;  // cell state output
+
+  // reshape to 2D due to Vulkan at::mm op accepts only 2D
+  auto x = input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
+
+  h_n_list.reserve(packed_num_layers);
+  c_n_list.reserve(packed_num_layers);
+
+  for (int64_t l = 0; l < packed_num_layers; ++l) {
+    // extract each hidden state and squeeze into 2D dim
+    auto h = at::slice(hx_vk, 0, l, l + 1, 1);
+    h = h.reshape({h.size(0) * h.size(1), h.size(2)});
+
+    auto c = at::slice(cx_vk, 0, l, l + 1, 1);
+    c = c.reshape({c.size(0) * c.size(1), c.size(2)});
+
+    const auto&  cxt_ii = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 0].toCustomClass<VulkanOpContext>();
+    const auto&  cxt_hi = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 1].toCustomClass<VulkanOpContext>();
+    const auto&  cxt_if = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 2].toCustomClass<VulkanOpContext>();
+    const auto&  cxt_hf = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 3].toCustomClass<VulkanOpContext>();
+    const auto&  cxt_ig = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 4].toCustomClass<VulkanOpContext>();
+    const auto&  cxt_hg = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 5].toCustomClass<VulkanOpContext>();
+    const auto&  cxt_io = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 6].toCustomClass<VulkanOpContext>();
+    const auto&  cxt_ho = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 7].toCustomClass<VulkanOpContext>();
+
+    const auto&  i = at::sigmoid(
+      linear_context_run(x, cxt_ii->get_packed(), cxt_ii->get_unpacked(), 1.0f, 1.0f, "aten::addmm")
+       + linear_context_run(h, cxt_hi->get_packed(), cxt_hi->get_unpacked(), 1.0f, 1.0f, "aten::addmm"));
+    const auto&  f = at::sigmoid(
+      linear_context_run(x, cxt_if->get_packed(), cxt_if->get_unpacked(), 1.0f, 1.0f, "aten::addmm")
+       + linear_context_run(h, cxt_hf->get_packed(), cxt_hf->get_unpacked(), 1.0f, 1.0f, "aten::addmm"));
+    const auto&  g = at::tanh(
+      linear_context_run(x, cxt_ig->get_packed(), cxt_ig->get_unpacked(), 1.0f, 1.0f, "aten::addmm")
+       + linear_context_run(h, cxt_hg->get_packed(), cxt_hg->get_unpacked(), 1.0f, 1.0f, "aten::addmm"));
+    const auto&  o = at::sigmoid(
+      linear_context_run(x, cxt_io->get_packed(), cxt_io->get_unpacked(), 1.0f, 1.0f, "aten::addmm")
+       + linear_context_run(h, cxt_ho->get_packed(), cxt_ho->get_unpacked(), 1.0f, 1.0f, "aten::addmm"));
+    c = f * c + i * g;
+    h = o * at::tanh(c);
+    x = h;  // next input
+    h_n_list.emplace_back(h.reshape({1, 1, h.size(0), h.size(1)}));  // 2D to 4D for cat op
+    c_n_list.emplace_back(c.reshape({1, 1, c.size(0), c.size(1)}));  // 2D to 4D for cat op
+  }
+
+  auto h_n = at::cat(h_n_list, 1);
+  auto c_n = at::cat(c_n_list, 1);
+  h_n = h_n.reshape({h_n.size(0) * h_n.size(1), h_n.size(2), h_n.size(3)});
+  c_n = c_n.reshape({c_n.size(0) * c_n.size(1), c_n.size(2), c_n.size(3)});
+  return std::tuple<Tensor, Tensor, Tensor>(x, h_n, c_n);
+}
+
+c10::intrusive_ptr<VulkanOpContext> create_lstm_context(
+    std::vector<Tensor>&& params_cpu,
+    bool has_biases,
+    int64_t num_layers,
+    double dropout,
+    bool train,
+    bool bidirectional,
+    bool batch_first) {
+  return c10::make_intrusive<VulkanOpContext>(lstm_context_create(
+      params_cpu, has_biases, num_layers, dropout, train, bidirectional, batch_first));
+}
+
+std::tuple<Tensor, Tensor, Tensor> run_lstm_context(
+    const Tensor& input_vk,      // input sequence (vulkan)
+    const Tensor& hx_vk,         // initial hidden state (vulkan)
+    const Tensor& cx_vk,         // initial cell state (vulkan)
+    const c10::intrusive_ptr<VulkanOpContext>& vulkan_context) {
+  return lstm_context_run(
+    input_vk,
+    hx_vk,
+    cx_vk,
+    vulkan_context->get_packed(),
+    vulkan_context->get_unpacked());
+}
+
 } // namespace ops
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/native/vulkan/ops/Lstm.h
+++ b/aten/src/ATen/native/vulkan/ops/Lstm.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/VulkanOpContext.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+
+//   packed
+//     std::vector<c10::intrusive_ptr<VulkanOpContext>> linear_op_contexts;  // {{ op context for b_ii, w_ii, op context for b_hi, w_hi,
+//                                                                           //    op context for b_if, w_if, op context for b_hf, w_hf,
+//                                                                           //    op context for b_ig, w_ig, op context for b_hg, w_hg,
+//                                                                           //    op context for b_io, w_io, op context for b_ho, w_ho,}, ...}
+//     bool has_biases{};
+//     int64_t num_layers{};
+//     double dropout{};
+//     bool train{};
+//     bool bidirectional{};
+//     bool batch_first{};
+
+//   unpacked
+//     std::vector<Tensor> params_cpu      // weights/biases (cpu)
+//     bool has_biases
+//     int64_t num_layers
+//     double dropout
+//     bool train
+//     bool bidirectional
+//     bool batch_first
+
+c10::intrusive_ptr<VulkanOpContext> create_lstm_context(
+    std::vector<Tensor>&& params_cpu,   // weights/biases (cpu)
+    bool has_biases,
+    int64_t num_layers,
+    double dropout,
+    bool train,
+    bool bidirectional,
+    bool batch_first);
+
+std::tuple<Tensor, Tensor, Tensor> run_lstm_context(
+    const Tensor& input_vk,      // input sequence (vulkan)
+    const Tensor& hx_vk,         // initial hidden state (vulkan)
+    const Tensor& cx_vk,         // initial cell state (vulkan)
+    const c10::intrusive_ptr<VulkanOpContext>& vulkan_context);
+
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/ops/Register.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Register.cpp
@@ -3,6 +3,7 @@
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/Convolution.h>
 #include <ATen/native/vulkan/ops/Gru.h>
+#include <ATen/native/vulkan/ops/Lstm.h>
 #include <ATen/native/vulkan/ops/TransposeConvolution2d.h>
 #include <ATen/native/vulkan/ops/Mm.h>
 #include <ATen/native/vulkan/ops/VulkanOpContext.h>
@@ -171,6 +172,20 @@ TORCH_LIBRARY(vulkan_prepack, m) {
       "vulkan_prepack::gru_run(Tensor input_vk, "
       "Tensor hx_vk, "
       "__torch__.torch.classes.vulkan.GruOpContext G_prepack) -> (Tensor next_input, Tensor hidden_layer)"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "vulkan_prepack::create_lstm_context(Tensor[] params_cpu, "
+      "bool has_biases, "
+      "int num_layers, "
+      "float dropout, "
+      "bool train, "
+      "bool bidirectional, "
+      "bool batch_first) "
+      "-> __torch__.torch.classes.vulkan.VulkanOpContext"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "vulkan_prepack::run_lstm_context(Tensor input_vk, "
+      "Tensor hx_vk, "
+      "Tensor cx_vk, "
+      "__torch__.torch.classes.vulkan.VulkanOpContext L_prepack) -> (Tensor next_input, Tensor hidden_state, Tensor cell_state)"));
 }
 
 TORCH_LIBRARY_IMPL(vulkan_prepack, CPU, m) {
@@ -182,6 +197,7 @@ TORCH_LIBRARY_IMPL(vulkan_prepack, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::linear_prepack"), TORCH_FN(linear_prepack)); // Backwards compatibility
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::create_gru_context"), TORCH_FN(create_gru_context));
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::gru_prepack"), TORCH_FN(gru_prepack)); // Backwards compatibility
+  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::create_lstm_context"), TORCH_FN(create_lstm_context));
 }
 
 TORCH_LIBRARY_IMPL(vulkan_prepack, Vulkan, m) {
@@ -193,6 +209,7 @@ TORCH_LIBRARY_IMPL(vulkan_prepack, Vulkan, m) {
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::linear_run"), TORCH_FN(linear_run)); // Backwards compatibility
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::run_gru_context"), TORCH_FN(run_gru_context));
   m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::gru_run"), TORCH_FN(gru_run)); // Backwards compatibility
+  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::run_lstm_context"), TORCH_FN(run_lstm_context));
 }
 
 Tensor convolution(

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3725,6 +3725,92 @@ TEST_F(VulkanAPITest, lstm_mclareninputs_success) {
   ASSERT_TRUE(check_cell);
 }
 
+TEST_F(VulkanAPITest, lstm_prepack_success) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const int input_size = 81;
+  const int hidden_size = 10;
+  const int num_layers = 2;
+  const int L = 1;
+  const int N = 1;
+  const double lstm_dropout = .0;
+  const bool has_biases = true;
+  const bool train = false;
+  const bool bidirectional = false;
+  const bool batch_first = true;
+  const auto in_cpu = at::rand({N, L, input_size}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto h0_cpu = at::rand({num_layers, N, hidden_size}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto c0_cpu = at::rand({num_layers, N, hidden_size}, at::device(at::kCPU).dtype(at::kFloat));
+
+  c10::List<at::Tensor> weight_ih_l; // shape (4 * hidden_size, l == 0 ? input_size : hidden_size)
+  c10::List<at::Tensor> weight_hh_l; // shape (4 * hidden_size, hidden_size)
+  c10::List<at::Tensor> bias_ih_l;   // shape (4 * hidden_size)
+  c10::List<at::Tensor> bias_hh_l;   // shape (4 * hidden_size)
+  for (int l = 0; l < num_layers; ++l) {
+    if (l == 0) {
+      weight_ih_l.emplace_back(at::rand({4 * hidden_size, input_size}, at::device(at::kCPU).dtype(at::kFloat)));
+    } else {
+      weight_ih_l.emplace_back(at::rand({4 * hidden_size, hidden_size}, at::device(at::kCPU).dtype(at::kFloat)));
+    }
+    weight_hh_l.emplace_back(at::rand({4 * hidden_size, hidden_size}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_ih_l.emplace_back(at::rand({4 * hidden_size}, at::device(at::kCPU).dtype(at::kFloat)));
+    bias_hh_l.emplace_back(at::rand({4 * hidden_size}, at::device(at::kCPU).dtype(at::kFloat)));
+  }
+
+  // put this guard here to run inference inststead of training
+  // to avoid the following error:
+  //     C++ exception with description "0INTERNAL ASSERT FAILED at "xplat/caffe2/aten/src/ATen/core/boxing/KernelFunction.cpp":31, please report a bug to PyTorch. aten::gru.input has kernels registered to both CompositeImplicitAutograd and a backend mapped to AutogradOther. This makes the backend kernel unreachable; the dispatcher will always prefer the CompositeImplicitAutograd lowering (see Note [Ambiguity in AutogradOther kernel]). If you want to override CompositeImplicitAutograd, please open an issue to request a dedicated Autograd dispatch key for the backend.
+  //     If you only want to run inference instead of training, add `c10::InferenceMode mode;` before model.forward(). Note this guard is only available in C++ but not Python at present.
+  c10::InferenceMode mode;
+
+  // Act
+  const auto out_cpu = at::lstm(in_cpu, {h0_cpu, c0_cpu},
+      { weight_ih_l[0], weight_hh_l[0], bias_ih_l[0], bias_hh_l[0],
+        weight_ih_l[1], weight_hh_l[1], bias_ih_l[1], bias_hh_l[1] },
+      has_biases, num_layers, lstm_dropout, train, bidirectional, batch_first);
+
+  auto prepack = callOpByName(
+      "vulkan_prepack::create_lstm_context",
+      "",
+      std::vector<at::Tensor>({ weight_ih_l.get(0), weight_hh_l.get(0), bias_ih_l.get(0), bias_hh_l.get(0),
+                                weight_ih_l.get(1), weight_hh_l.get(1), bias_ih_l.get(1), bias_hh_l.get(1) }),
+      has_biases, num_layers, lstm_dropout, train, bidirectional, batch_first);
+
+  auto out_vulkan = callOpByName(
+      "vulkan_prepack::run_lstm_context",
+      "",
+      in_cpu.vulkan(), h0_cpu.vulkan(), c0_cpu.vulkan(), prepack[0]);
+
+  auto cpu_output = std::get<0>(out_cpu);
+  auto cpu_hidden = std::get<1>(out_cpu);
+  auto cpu_cell = std::get<2>(out_cpu);
+  auto vulkan_output = out_vulkan[0].toTensor();
+  auto vulkan_hidden = out_vulkan[1].toTensor();
+  auto vulkan_cell = out_vulkan[2].toTensor();
+
+  // Assert
+  const auto check_output = almostEqual(cpu_output, vulkan_output.cpu());
+  if (!check_output) {
+    showRtol(cpu_output, vulkan_output.cpu());
+  }
+  ASSERT_TRUE(check_output);
+
+  const auto check_hidden = almostEqual(cpu_hidden, vulkan_hidden.cpu());
+  if (!check_hidden) {
+    showRtol(cpu_hidden, vulkan_hidden.cpu());
+  }
+  ASSERT_TRUE(check_hidden);
+
+  const auto check_cell = almostEqual(cpu_cell, vulkan_cell.cpu());
+  if (!check_cell) {
+    showRtol(cpu_cell, vulkan_cell.cpu());
+  }
+  ASSERT_TRUE(check_cell);
+}
 
 #if defined (__ANDROID__)  // to avoid `Undefined symbols for architecture arm64` error
 TEST_F(VulkanAPITest, profiling_invalideinputs_exceptions) {

--- a/torch/csrc/jit/passes/vulkan_rewrite.cpp
+++ b/torch/csrc/jit/passes/vulkan_rewrite.cpp
@@ -99,6 +99,24 @@ void insertPrePackedGruOp(std::shared_ptr<Graph>& graph) {
   gru_rewriter.runOnGraph(graph);
 }
 
+void insertPrePackedLstmOp(std::shared_ptr<Graph>& graph) {
+  std::string lstm_pattern = R"(
+      graph(%input.1, %hx:Tensor[], %params_cpu:Tensor[], %has_biases:bool, %num_layers:int, %dropout:float, %train:bool, %bidirectional:bool, %batch_first:bool):
+        %y.1 : Tensor, %hn.1 : Tensor, %cn.1 : Tensor = aten::lstm(%input.1, %hx, %params_cpu, %has_biases, %num_layers, %dropout, %train, %bidirectional, %batch_first)
+        return (%y.1, %hn.1, %cn.1) )";
+  std::string prepacked_ops_pattern = R"(
+      graph(%input.1, %hx:Tensor[], %params_cpu:Tensor[], %has_biases:bool, %num_layers:int, %dropout:float, %train:bool, %bidirectional:bool, %batch_first:bool):
+        %packed_weights_biases = vulkan_prepack::create_lstm_context(
+            %params_cpu, %has_biases, %num_layers, %dropout, %train, %bidirectional, %batch_first)
+        %hx.1 : Tensor, %cx.1 : Tensor = prim::ListUnpack(%hx)
+        %y.1 : Tensor, %hn.1 : Tensor, %cn.1 : Tensor = vulkan_prepack::run_lstm_context(%input.1, %hx.1, %cx.1, %packed_weights_biases)
+        return (%y.1, %hn.1, %cn.1) )";
+
+  SubgraphRewriter lstm_rewriter;
+  lstm_rewriter.RegisterRewritePattern(lstm_pattern, prepacked_ops_pattern);
+  lstm_rewriter.runOnGraph(graph);
+}
+
 void fuseHardtanhWithPackedOps(std::shared_ptr<Graph>& graph) {
   SubgraphRewriter rewriter;
 
@@ -188,6 +206,7 @@ void vulkanInsertPrePackedOps(std::shared_ptr<Graph>& graph) {
   insertPrePackedLinearOp(graph);
   insertPrePackedConv2dOp(graph);
   insertPrePackedGruOp(graph);
+  insertPrePackedLstmOp(graph);
 }
 
 void vulkanInsertPrePackedOps(script::Module& module) {


### PR DESCRIPTION
Summary:
Optimized LSTM operator by using pre-packing for weights and biases in the Vulkan GPU backend
- The weights and biases are always on the CPU side by design.
- The packed and unpacked data are stored in a VulkanOpContext
- Ops:
  - `at::native::vulkan::ops::create_lstm_context`: Creates a VulkanOpContext object with the packed and unpacked data, and returns a pointer to it.
  - `at::native::vulkan::ops::run_lstm_context`: Takes in the three input vulkan tensors (input sequence, initial hidden state and initial cell state) and a pointer to the context, and runs the LSTM operation.
- Registered the ops in [Register.cpp](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/vulkan/ops/Register.cpp).
- Rewrote the subgraph function of LSTM in [vulkan_rewrite.cpp](https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/passes/vulkan_rewrite.cpp) so that `create_lstm_context` and `run_lstm_context` can be executed instead in the Vulkan GPU backend.
- Added new test for the LSTM pre-packing and run ops: `lstm_prepack_success`

Test Plan: buck run //xplat/caffe2:pt_vulkan_api_test_binAppleMac

Reviewed By: SS-JIA

Differential Revision: D37052597

