### PR TITLE
`__launch_bounds__` for `torch.mode` with CUDA 11.7

### DIFF
--- a/aten/src/ATen/native/cuda/TensorModeKernel.cuh
+++ b/aten/src/ATen/native/cuda/TensorModeKernel.cuh
@@ -194,6 +194,9 @@ __device__ inline void bitonicSortKeys(
 // dimension as the innermost dim, such that we can get the particular slice for
 // a Tensor via its linear block dimension * the slice size.
 template <typename T, unsigned int Power2Size>
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11070
+__launch_bounds__(1024, 1)
+#endif
 __global__ void compute_mode(
     T* input,
     at::cuda::detail::TensorInfo<T, unsigned int> values,


### PR DESCRIPTION
This is a temporary fix for `TestReductionsCUDA.test_mode_large_cuda` which fails with CUDA 11.7 due to the following:

```
Traceback (most recent call last):
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 1805, in wrapper
    method(*args, **kwargs)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 1805, in wrapper
    method(*args, **kwargs)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_device_type.py", line 390, in instantiated_test
    raise rte
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_device_type.py", line 377, in instantiated_test
    result = test(self, **param_kwargs)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_device_type.py", line 943, in only_fn
    return fn(slf, *args, **kwargs)
  File "test_reductions.py", line 891, in test_mode_large
    testset_for_shape((10, 2048), 10)
  File "test_reductions.py", line 883, in testset_for_shape
    self._test_mode_intervals(shape, [(i, d - i)], device)
  File "test_reductions.py", line 870, in _test_mode_intervals
    values, indices = torch.mode(x, -1, False)
RuntimeError: CUDA error: too many resources requested for launch
CUDA kernel errors might be asynchronously reported at some other API call,so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
```

cc @ptrblck 