### PR TITLE
[vulkan] fixed calling of threshold op

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/threshold.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/threshold.glsl
@@ -10,8 +10,7 @@ layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3
 layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput;
 layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
   ivec4 size;
-  float threshold;
-  float value;
+  vec2 params;
 } uBlock;
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -20,9 +19,10 @@ void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
-    const vec4 inval = texelFetch(uInput, pos, 0);
-    const vec4 mask1 = vec4(lessThan(inval, vec4(threshold)));
-    const vec4 outval = mask1 * value + inval;
+    vec4 inval = texelFetch(uInput, pos, 0);
+    vec4 mask1 = vec4(lessThan(inval, vec4(uBlock.params.x)));
+    vec4 mask2 = vec4(greaterThan(inval, vec4(uBlock.params.x)));
+    vec4 outval = mask2 * inval + mask1 * uBlock.params.y;
     imageStore(uOutput, pos, outval);
   }
 }

--- a/aten/src/ATen/native/vulkan/ops/Clamp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clamp.cpp
@@ -14,6 +14,7 @@ Tensor _clamp(
     const Tensor& self_arg,
     const c10::optional<Scalar>& min,
     const c10::optional<Scalar>& max,
+    const api::Shader::Descriptor& shader_descriptor,
     const std::string& op_name) {
   TORCH_CHECK(
       min || max,
@@ -56,7 +57,7 @@ Tensor _clamp(
             VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
             VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
           },
-          VK_KERNEL(clamp),
+          shader_descriptor,
           v_output.extents(),
           context->gpu().adapter->local_work_group_size(),
           // Write-only access bypasses synchronization but inserts appropriate
@@ -87,13 +88,14 @@ Tensor clamp(
     const Tensor& self_arg,
     const c10::optional<Scalar>& min,
     const c10::optional<Scalar>& max) {
-  return _clamp(self_arg, min, max, "aten::clamp");
+  return _clamp(self_arg, min, max, VK_KERNEL(clamp), "aten::clamp");
 }
 
 Tensor& _clamp_(
     Tensor& self,
     const c10::optional<Scalar>& min,
     const c10::optional<Scalar>& max,
+    const api::Shader::Descriptor& shader_descriptor,
     const std::string& op_name) {
   api::Context* const context = api::context();
 
@@ -132,7 +134,7 @@ Tensor& _clamp_(
             VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
             VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
           },
-          VK_KERNEL(clamp_),
+          shader_descriptor,
           v_self.extents(),
           context->gpu().adapter->local_work_group_size(),
           // Read-Write access triggers an async synchronization if necessory
@@ -154,11 +156,18 @@ Tensor& _clamp_(
   return self;
 }
 
+Tensor threshold(
+    const Tensor& self,
+    const Scalar& threshold,
+    const Scalar& value) {
+  return _clamp(self, threshold, value, VK_KERNEL(threshold), "aten::threshold");
+}
+
 Tensor& clamp_(
     Tensor& self,
     const c10::optional<Scalar>& min,
     const c10::optional<Scalar>& max) {
-  return _clamp_(self, min, max, "aten::clamp_");
+  return _clamp_(self, min, max, VK_KERNEL(clamp_), "aten::clamp_");
 }
 
 Tensor activation(
@@ -282,22 +291,22 @@ Tensor hardtanh(
     const Tensor& self,
     const Scalar& min,
     const Scalar& max) {
-  return ops::_clamp(self, min, max, "aten::hardtanh");
+  return ops::_clamp(self, min, max, VK_KERNEL(clamp), "aten::hardtanh");
 }
 
 Tensor& hardtanh_(
     Tensor& self,
     const Scalar& min,
     const Scalar& max) {
-  return ops::_clamp_(self, min, max, "aten::hardtanh_");
+  return ops::_clamp_(self, min, max, VK_KERNEL(clamp_), "aten::hardtanh_");
 }
 
 Tensor relu(const Tensor& self) {
-  return ops::_clamp(self, 0, c10::nullopt, "aten::relu");
+  return ops::_clamp(self, 0, c10::nullopt, VK_KERNEL(clamp), "aten::relu");
 }
 
 Tensor& relu_(Tensor& self) {
-  return ops::_clamp_(self, 0, c10::nullopt, "aten::relu_");
+  return ops::_clamp_(self, 0, c10::nullopt, VK_KERNEL(clamp_), "aten::relu_");
 }
 
 Tensor hardswish(const Tensor& self) {
@@ -479,13 +488,6 @@ Tensor& tanh_(Tensor& self) {
   return ops::activation_(self, VK_KERNEL(tanh_), "aten::tanh_");
 }
 
-
-Tensor threshold(
-    const Tensor& self,
-    const Scalar& threshold,
-    const Scalar& value) {
-  return ops::_clamp(self, threshold, value, "aten::threshold");
-}
 
 #ifdef USE_VULKAN_API
 


### PR DESCRIPTION
Summary: implemented threshold op for vulkan (realized it was not being called and the shader was in the wrong folder so had to fix that)

Test Plan: buck run //xplat/caffe2:pt_vulkan_api_test_binAppleMac

Differential Revision: D37210717

