### PR TITLE
[docs] Include `batch_isend_irecv` and `P2POp` of `torch.distributed`

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -350,6 +350,10 @@ as they should never be created manually, but they are guaranteed to support two
 
 .. autofunction:: irecv
 
+.. autofunction:: batch_isend_irecv
+
+.. autoclass:: P2POp
+
 Synchronous and asynchronous collective operations
 --------------------------------------------------
 Every collective operation function supports the following two kinds of operations,


### PR DESCRIPTION
It'd be helpful for the docs to render `torch.distributed.batch_isend_irecv` and `torch.distributed.P2POp`.

cc @ptrblck 