### PR TITLE
[LT] fix lazy tensor tutorial and test for cpu only run

### DIFF
--- a/torch/csrc/lazy/test_mnist.py
+++ b/torch/csrc/lazy/test_mnist.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
                        'pin_memory': True,
                        'shuffle': True,
                        'batch_size': bsz}
-    train_kwargs.update(cuda_kwargs)
+        train_kwargs.update(cuda_kwargs)
 
     transform = transforms.Compose([
         transforms.ToTensor(),

--- a/torch/csrc/lazy/tutorial.md
+++ b/torch/csrc/lazy/tutorial.md
@@ -195,7 +195,7 @@ if __name__  == '__main__':
                        'pin_memory': True,
                        'shuffle': True,
                        'batch_size': bsz}
-    train_kwargs.update(cuda_kwargs)
+        train_kwargs.update(cuda_kwargs)
 
     transform=transforms.Compose([
         transforms.ToTensor(),


### PR DESCRIPTION
`cuda_kwargs` is undefined when LTC_TS_CUDA is not used. This fixed the issue. 
