### PR TITLE
[PyTorch] Record Sequence Number to Match Forward and Backward Operators (2nd try)

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -209,13 +209,14 @@ class TestExecutionGraph(TestCase):
         u = torch.randn(3, 4, 5, requires_grad=True)
         with record_function("## TEST 1 ##", "1, 2, 3"):
             rf_handle = _record_function_with_args_enter("## TEST 2 ##", 1, False, 2.5, [u, u], (u, u), "hello", u)
-            x = torch.randn(10, 10)
+            x = torch.randn(10, 10, requires_grad=True)
             if use_cuda:
                 x = x.cuda()
-            y = torch.randn(10, 10)
+            y = torch.randn(10, 10, requires_grad=True)
             if use_cuda:
                 y = y.cuda()
             z = x + y + x * y + x * y
+            z.backward(z)
             if use_cuda:
                 z = z.cpu()
             _record_function_with_args_exit(rf_handle)

--- a/torch/csrc/profiler/execution_graph_observer.cpp
+++ b/torch/csrc/profiler/execution_graph_observer.cpp
@@ -245,6 +245,7 @@ void writeJsonNode(
     const uint64_t rf_id,
     const uint64_t parent,
     const uint64_t fw_parent,
+    const int64_t seq_id,
     const uint64_t scope,
     const uint64_t tid,
     const uint64_t fw_tid,
@@ -258,7 +259,7 @@ void writeJsonNode(
   out << fmt::format(
       R"JSON(
     {{
-      "name": "{}", "id": {}, "rf_id": {}, "parent": {}, "fw_parent": {}, "scope": {}, "tid": {}, "fw_tid": {}, "op_schema": "{}",
+      "name": "{}", "id": {}, "rf_id": {}, "parent": {}, "fw_parent": {}, "seq_id": {}, "scope": {}, "tid": {}, "fw_tid": {}, "op_schema": "{}",
       "inputs": {}, "input_shapes": {}, "input_types": {},
       "outputs": {}, "output_shapes": {}, "output_types": {}
     }})JSON",
@@ -267,6 +268,7 @@ void writeJsonNode(
       rf_id,
       parent,
       fw_parent,
+      seq_id,
       scope,
       tid,
       fw_tid,
@@ -322,6 +324,7 @@ void finalizeExecutionGraphOutput(ExecutionGraphObserver& ob) {
       0, // rf_id
       root_id, // parent is self
       0, // fw_parent
+      -1, // seq_id
       static_cast<std::underlying_type_t<RecordScope>>(RecordScope::USER_SCOPE),
       0, // tid
       0); // fw_tid
@@ -430,6 +433,7 @@ void recordOperatorStart(
           0, // rf_id
           root_id,
           0, // fw_parent
+          -1, // seq_id
           static_cast<std::underlying_type_t<RecordScope>>(
               RecordScope::USER_SCOPE),
           tid,
@@ -546,6 +550,7 @@ void onFunctionExit(const RecordFunction& fn, ObserverContext* ctx_ptr) {
           fn.handle(),
           fc.parent_id,
           fc.fw_parent_id,
+          fn.seqNr(),
           static_cast<std::underlying_type_t<RecordScope>>(fn.scope()),
           fn.threadId(),
           fn.forwardThreadId(),


### PR DESCRIPTION
Summary: Add sequence number to map forward and backward operators.

Test Plan:
```
buck build mode/dev-nosan cea/ml_perf_model/gpu/scripts: --show-output
buck-out/gen/caffe2/test/profiler#binary.par test_profiler.TestExecutionGraph.test_execution_graph_start_stop
```
Outputs with seq_id: P505545974

Differential Revision: D37223871

