### PR TITLE
[Not for Land][FSDP] Specify params to clone for state dict

### DIFF
--- a/torch/distributed/fsdp/flatten_params_wrapper.py
+++ b/torch/distributed/fsdp/flatten_params_wrapper.py
@@ -23,9 +23,7 @@ from typing import (
 import torch
 import torch.nn as nn
 from torch import Tensor
-
 from torch.distributed.utils import _replace_by_prefix
-
 
 ParamOffset = Tuple[int, int]
 SharedParamInfo = Tuple[str, str, nn.Module, str, nn.Module, str]


### PR DESCRIPTION
This specifies which tensors in the state dict to clone instead of specifying which tensors not to clone.

This solution is not satisfactory because it requires stripping `_CHECKPOINT_PREFIX` manually in FSDP from the cached prefixed parameter names.