### PR TITLE
[AI Accelerators] softmax kernel for Nested Tensor (CPU)

### DIFF
--- a/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.h
+++ b/aten/src/ATen/native/nested/NestedTensorTransformerFunctions.h
@@ -50,6 +50,8 @@ Tensor NestedTensor_from_padded_tensor_cpu(
     const Tensor& padded,
     const NestedTensorImpl& nt);
 
+void NestedTensor_softmax_dropout(const Tensor& query, Tensor& attn_scores);
+
 Tensor NestedTensor_to_mask(const Tensor& nt, c10::optional<int64_t> mask_dim, c10::optional<int64_t> mask_dim_length);
 
 template <typename T>


### PR DESCRIPTION
Summary: Impl better softmax kernel for Nested Tensor CPU.

Test Plan:
Benchmark results:

On CPU (command: buck run mode/opt -c fbcode.platform=platform009 //pytext/fb/tools:benchmark_transformers  -- transformer --large --use-trt-kernel False --batch-size 16 --avg-sequence-length 64 --max-sequence-length 256 --iters 10 --use-real-data-distribution --module native --use-nt True --use-cpu True

With mask (previous impl):
NT: 4573.14 ms/iter, 0.14 TFLOP/s, Speedup: 2.33x;

Without mask:

NT: 3530.55 ms/iter, 0.18 TFLOP/s, Speedup: 1.51x

Reviewed By: mikekgfb

Differential Revision: D35679352

