### PR TITLE
[DataPipe] Enable profiler record context in __next__ branch

### DIFF
--- a/torch/utils/data/datapipes/_hook_iterator.py
+++ b/torch/utils/data/datapipes/_hook_iterator.py
@@ -171,7 +171,8 @@ def hook_iterator(namespace, profile_name):
             @functools.wraps(next_func)
             def wrap_next(*args, **kwargs):
                 if torch.autograd._profiler_enabled():
-                    return next_func(*args, **kwargs)
+                    with profiler_record_fn_context():
+                        return next_func(*args, **kwargs)
                 else:
                     return next_func(*args, **kwargs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #70216
* #70373
* #79658
* #79479
* #79657
* __->__ #79757
* #79656

This branch was missing the record function...