### PR TITLE
[BE][TryMerge] Do not re-import trymerge multiple times

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -11,7 +11,13 @@ import json
 import os
 from hashlib import sha256
 
-from trymerge import find_matching_merge_rule, gh_graphql, gh_get_team_members, GitHubPR, MergeRule, MandatoryChecksMissingError
+from trymerge import (find_matching_merge_rule,
+                      gh_graphql,
+                      gh_get_team_members,
+                      GitHubPR,
+                      MergeRule,
+                      MandatoryChecksMissingError,
+                      main as trymerge_main)
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from typing import cast, Any, List, Optional
 from unittest import TestCase, main, mock
@@ -239,16 +245,14 @@ class TestGitHubPR(TestCase):
     @mock.patch('trymerge.parse_args', return_value=mock_parse_args(True, False))
     @mock.patch('trymerge.try_revert', side_effect=mock_revert)
     def test_main_revert(self, mock_revert: Any, mock_parse_args: Any, gh_get_pr_info: Any) -> None:
-        import trymerge
-        trymerge.main()
+        trymerge_main()
         mock_revert.assert_called_once()
 
     @mock.patch('trymerge.gh_get_pr_info', return_value=mock_gh_get_info())
     @mock.patch('trymerge.parse_args', return_value=mock_parse_args(False, True))
     @mock.patch('trymerge.merge', side_effect=mock_merge)
     def test_main_force(self, mock_merge: Any, mock_parse_args: Any, mock_gh_get_info: Any) -> None:
-        import trymerge
-        trymerge.main()
+        trymerge_main()
         mock_merge.assert_called_once_with(mock.ANY,
                                            mock.ANY,
                                            dry_run=mock.ANY,
@@ -261,8 +265,7 @@ class TestGitHubPR(TestCase):
     @mock.patch('trymerge.parse_args', return_value=mock_parse_args(False, False))
     @mock.patch('trymerge.merge', side_effect=mock_merge)
     def test_main_merge(self, mock_merge: Any, mock_parse_args: Any, mock_gh_get_info: Any) -> None:
-        import trymerge
-        trymerge.main()
+        trymerge_main()
         mock_merge.assert_called_once_with(mock.ANY,
                                            mock.ANY,
                                            dry_run=mock.ANY,


### PR DESCRIPTION
Just import `main` as `trymerge_main` in first import statement

