### PR TITLE
[BE] Use CamelCase for enum class members

### DIFF
--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -13,18 +13,18 @@ MemOverlap has_internal_overlap(TensorImpl* t) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(t->layout() == kStrided);
 
   if (t->is_non_overlapping_and_dense()) {
-    return MemOverlap::NO;
+    return MemOverlap::No;
   }
 
   auto strides = t->strides();
   auto sizes = t->sizes();
   for (const auto i : c10::irange(strides.size())) {
     if (strides[i] == 0 && sizes[i] > 1) {
-      return MemOverlap::YES;
+      return MemOverlap::Yes;
     }
   }
 
-  return MemOverlap::TOO_HARD;
+  return MemOverlap::TooHard;
 }
 
 void assert_no_internal_overlap(const TensorBase& t) {
@@ -32,7 +32,7 @@ void assert_no_internal_overlap(const TensorBase& t) {
 }
 
 void assert_no_internal_overlap(TensorImpl* t) {
-  TORCH_CHECK(has_internal_overlap(t) != MemOverlap::YES,
+  TORCH_CHECK(has_internal_overlap(t) != MemOverlap::Yes,
     "unsupported operation: more than one element of the written-to tensor "
     "refers to a single memory location. Please clone() the tensor before "
     "performing the operation.");
@@ -43,12 +43,12 @@ MemOverlapStatus get_overlap_status(const TensorBase& a, const TensorBase& b) {
 }
 
 MemOverlapStatus get_overlap_status(TensorImpl* a, TensorImpl* b) {
-  if (a == b) return MemOverlapStatus::FULL;
+  if (a == b) return MemOverlapStatus::Full;
   if (a->numel() == 0 || b->numel() == 0) {
-    return MemOverlapStatus::NO;
+    return MemOverlapStatus::No;
   }
   if (!a->is_non_overlapping_and_dense() || !b->is_non_overlapping_and_dense()) {
-    return MemOverlapStatus::TOO_HARD;
+    return MemOverlapStatus::TooHard;
   }
   // Test for storage equality, rather than pointer equality.
   // This reduces precision, but if people are aliasing the
@@ -64,13 +64,13 @@ MemOverlapStatus get_overlap_status(TensorImpl* a, TensorImpl* b) {
 
     if (a_begin == b_begin && a_end == b_end) {
       return (a->strides() == b->strides()) ?
-          MemOverlapStatus::FULL : MemOverlapStatus::PARTIAL;
+          MemOverlapStatus::Full : MemOverlapStatus::Partial;
     }
     if (a_begin < b_end && b_begin < a_end) {
-      return MemOverlapStatus::PARTIAL;
+      return MemOverlapStatus::Partial;
     }
   }
-  return MemOverlapStatus::NO;
+  return MemOverlapStatus::No;
 }
 
 void assert_no_partial_overlap(const TensorBase& a, const TensorBase& b) {
@@ -78,7 +78,7 @@ void assert_no_partial_overlap(const TensorBase& a, const TensorBase& b) {
 }
 
 void assert_no_partial_overlap(TensorImpl* a, TensorImpl* b) {
-  TORCH_CHECK(get_overlap_status(a, b) != MemOverlapStatus::PARTIAL,
+  TORCH_CHECK(get_overlap_status(a, b) != MemOverlapStatus::Partial,
     "unsupported operation: some elements of the input tensor and "
     "the written-to tensor refer to a single memory location. "
     "Please clone() the tensor before performing the operation.");
@@ -90,7 +90,7 @@ void assert_no_overlap(const TensorBase& a, const TensorBase& b) {
 
 void assert_no_overlap(TensorImpl* a, TensorImpl* b) {
   const auto lap = get_overlap_status(a, b);
-  TORCH_CHECK(lap != MemOverlapStatus::PARTIAL && lap != MemOverlapStatus::FULL,
+  TORCH_CHECK(lap != MemOverlapStatus::Partial && lap != MemOverlapStatus::Full,
     "unsupported operation: some elements of the input tensor and "
     "the written-to tensor refer to a single memory location. "
     "Please clone() the tensor before performing the operation.");

--- a/aten/src/ATen/MemoryOverlap.h
+++ b/aten/src/ATen/MemoryOverlap.h
@@ -11,14 +11,14 @@ class TensorBase;
 
 // MemOverlap: Whether or not there is memory overlap
 //
-// NO: Absolutely no memory overlap
-// YES: Absolutely yes memory overlap
-// TOO_HARD: There might be memory overlap, but it was too expensive to compute.
+// No: Absolutely no memory overlap
+// Yes: Absolutely yes memory overlap
+// TooHard: There might be memory overlap, but it was too expensive to compute.
 //
 // NB: Please update the python test for these if you renumber them.
-enum class MemOverlap { NO, YES, TOO_HARD };
+enum class MemOverlap { No, Yes, TooHard };
 
-enum class MemOverlapStatus { FULL, PARTIAL, NO, TOO_HARD };
+enum class MemOverlapStatus { Full, Partial, No, TooHard };
 
 TORCH_API MemOverlap has_internal_overlap(const TensorBase& t);
 TORCH_API MemOverlap has_internal_overlap(c10::TensorImpl* t);

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -626,7 +626,7 @@ Tensor index_put(const Tensor & self, const torch::List<c10::optional<Tensor>>& 
 
 Tensor & _index_put_impl_(Tensor & self, const torch::List<c10::optional<Tensor>>& indices, const Tensor & value, const bool accumulate, const bool unsafe) {
   TORCH_CHECK_INDEX(indices.size() <= (size_t)self.dim(), "too many indices for tensor of dimension ", self.dim(), " (got ", indices.size(), ")");
-  if (at::has_internal_overlap(self) == MemOverlap::YES) {
+  if (at::has_internal_overlap(self) == MemOverlap::Yes) {
     TORCH_WARN(
       "Use of index_put_ on expanded tensors is deprecated. "
       "Please clone() the tensor before performing this operation. "
@@ -1267,7 +1267,7 @@ Tensor & index_fill_(Tensor & self, int64_t dim, const Tensor & index, const Sca
     "index_fill_(): Expected dtype int64 for index.");
 
   at::assert_no_overlap(self, index);
-  if (at::has_internal_overlap(self) == at::MemOverlap::YES) {
+  if (at::has_internal_overlap(self) == at::MemOverlap::Yes) {
     TORCH_WARN(
       "Use of index_fill_ on expanded tensors is deprecated. "
       "Please clone() the tensor before performing this operation. "
@@ -1555,7 +1555,7 @@ static Tensor & masked_fill_impl_cpu(Tensor & self, const Tensor & mask, const S
             "please use a mask with dtype torch.bool instead.");
   }
 
-  if (at::has_internal_overlap(self) == MemOverlap::YES) {
+  if (at::has_internal_overlap(self) == MemOverlap::Yes) {
     TORCH_WARN(
       "Use of masked_fill_ on expanded tensors is deprecated. "
       "Please clone() the tensor before performing this operation. "

--- a/aten/src/ATen/native/cpu/SerialStackImpl.h
+++ b/aten/src/ATen/native/cpu/SerialStackImpl.h
@@ -124,8 +124,8 @@ struct CanUseNativeSerialStack<TensorListType, false> {
     // Inputs cannot alias the output tensor
     for (const auto i : c10::irange(tensors.size())) {
       auto lap = at::get_overlap_status(result, tensors[i]);
-      TORCH_CHECK(lap != at::MemOverlapStatus::PARTIAL &&
-          lap != at::MemOverlapStatus::FULL, 0,
+      TORCH_CHECK(lap != at::MemOverlapStatus::Partial &&
+          lap != at::MemOverlapStatus::Full, 0,
           "unsupported operation: the input tensors cannot refer to any of the "
           "output memory locations. Found overlap in input tensor ", i);
     }

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -1217,7 +1217,7 @@ Tensor & masked_fill__cuda(Tensor& self, const Tensor & mask, const Scalar& valu
   TORCH_CHECK(mask.scalar_type() == kByte || mask.scalar_type() == kBool,
     "expected mask dtype to be Bool but got ", mask.scalar_type());
   auto maybe_outnames = namedinference::broadcast_to_outnames(self, mask, "masked_fill_");
-  if (at::has_internal_overlap(self) == MemOverlap::YES) {
+  if (at::has_internal_overlap(self) == MemOverlap::Yes) {
     TORCH_WARN(
       "Use of masked_fill_ on expanded tensors is deprecated. "
       "Please clone() the tensor before performing this operation. "

--- a/aten/src/ATen/native/cuda/Sort.cpp
+++ b/aten/src/ATen/native/cuda/Sort.cpp
@@ -109,7 +109,7 @@ void sort_cuda_kernel(
   }
 
   c10::MaybeOwned<Tensor> values_tmp, indices_tmp;
-  if (values.strides() == self_.strides() && (newself || get_overlap_status(self, values) == MemOverlapStatus::NO)) {
+  if (values.strides() == self_.strides() && (newself || get_overlap_status(self, values) == MemOverlapStatus::No)) {
     values_tmp = c10::MaybeOwned<Tensor>::borrowed(values);
   } else {
     values_tmp = c10::MaybeOwned<Tensor>::owned(

--- a/aten/src/ATen/native/mps/operations/Shape.mm
+++ b/aten/src/ATen/native/mps/operations/Shape.mm
@@ -533,8 +533,8 @@ TORCH_IMPL_FUNC(cat_out_mps)
   for(const Tensor& t : materialized_inputs) {
     auto lap = at::get_overlap_status(out, t);
     TORCH_CHECK(
-        lap != at::MemOverlapStatus::PARTIAL &&
-            lap != at::MemOverlapStatus::FULL,
+        lap != at::MemOverlapStatus::Partial &&
+            lap != at::MemOverlapStatus::Full,
         "torch.cat(): unsupported operation: the input tensors cannot refer to any "
         "of the output memory locations. Found overlap in input "
         "tensor ",

--- a/aten/src/ATen/native/quantized/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/quantized/TensorAdvancedIndexing.cpp
@@ -35,7 +35,7 @@ static Tensor & masked_fill_impl_quantized_cpu(Tensor & self, const Tensor & mas
             "please use a mask with dtype torch.bool instead.");
   }
 
-  if (at::has_internal_overlap(self) == MemOverlap::YES) {
+  if (at::has_internal_overlap(self) == MemOverlap::Yes) {
     TORCH_WARN(
       "Use of masked_fill_ on expanded tensors is deprecated. "
       "Please clone() the tensor before performing this operation. "
@@ -82,7 +82,7 @@ Tensor& _index_put_impl_quantized_cpu_(Tensor & self, const torch::List<c10::opt
   TORCH_CHECK(self.qscheme() == c10::kPerTensorAffine, "index_put for quantized tensors is currently only supported for per tensor quantized tensors");
   TORCH_CHECK(!accumulate, "index_put for quantized tensors is currently only supported for accumulate=False");
 
-  if (at::has_internal_overlap(self) == MemOverlap::YES) {
+  if (at::has_internal_overlap(self) == MemOverlap::Yes) {
     TORCH_WARN(
       "Use of index_put_ on expanded tensors is deprecated. "
       "Please clone() the tensor before performing this operation. "

--- a/test/cpp/tensorexpr/test_memdependency.cpp
+++ b/test/cpp/tensorexpr/test_memdependency.cpp
@@ -64,9 +64,11 @@ TEST(MemDependency, BoundOverlap) {
   ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(2, 3), CB(0, 1)));
 
   // Partial overlap when middle bounds match.
-  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(0, 100), CB(100, 120)));
+  ASSERT_EQ(
+      OverlapKind::PartialOverlap, boundOverlap(CB(0, 100), CB(100, 120)));
   ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(0, 2), CB(2, 4)));
-  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(100, 120), CB(0, 100)));
+  ASSERT_EQ(
+      OverlapKind::PartialOverlap, boundOverlap(CB(100, 120), CB(0, 100)));
   ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(2, 3), CB(1, 2)));
 
   // Total overlap when one bound is single length over one end of the other.
@@ -220,21 +222,29 @@ TEST(MemDependency, BoundOverlapSymbolic) {
   // constant.
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(x, x), CB(x, x)));
-  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(x, x + 3), CB(x + 2, x + 5)));
+  ASSERT_EQ(
+      OverlapKind::PartialOverlap,
+      boundOverlap(CB(x, x + 3), CB(x + 2, x + 5)));
   ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(x, x), CB(x + 1, x + 1)));
 
   // We can't infer the sign of y, so cannot tell whether adding y is larger or
   // smaller than y/2.
-  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(x, x + y), CB(x, x + y / 2)));
+  ASSERT_EQ(
+      OverlapKind::PartialOverlap,
+      boundOverlap(CB(x, x + y), CB(x, x + y / 2)));
 
   // No information about this bound, have to take the most conservative option:
   // there may be an overlap.
   ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(x, y), CB(z, w)));
 
   // Math on opaque terms works.
-  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(x + w, y - z), CB(x + w, y - z)));
+  ASSERT_EQ(
+      OverlapKind::ContainedOrEqual,
+      boundOverlap(CB(x + w, y - z), CB(x + w, y - z)));
   // Even requiring simplification.
-  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(x - w - w, y), CB(x - w * 2, y)));
+  ASSERT_EQ(
+      OverlapKind::ContainedOrEqual,
+      boundOverlap(CB(x - w - w, y), CB(x - w * 2, y)));
 }
 
 // Tests the helper function for overlap of multi dimensional indices bounds.
@@ -250,7 +260,8 @@ TEST(MemDependency, BoundOverlapMultiDim) {
   // Sanity check one dimensional cases.
   ASSERT_EQ(OverlapKind::ContainedOrEqual, overlaps({CB(0, 0)}, {CB(0, 0)}));
   ASSERT_EQ(OverlapKind::NoOverlap, overlaps({CB(0, 2)}, {CB(5, 10)}));
-  ASSERT_EQ(OverlapKind::PartialOverlap, overlaps({CB(0, 100)}, {CB(100, 120)}));
+  ASSERT_EQ(
+      OverlapKind::PartialOverlap, overlaps({CB(0, 100)}, {CB(100, 120)}));
 
   // Total overlap in 3 dims.
   ASSERT_EQ(

--- a/test/cpp/tensorexpr/test_memdependency.cpp
+++ b/test/cpp/tensorexpr/test_memdependency.cpp
@@ -26,54 +26,54 @@ TEST(MemDependency, BoundOverlap) {
   };
 
   // Sanity check 3 overlap cases.
-  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(0, 0), CB(0, 0)));
-  ASSERT_EQ(PartialOverlap, boundOverlap(CB(0, 3), CB(2, 5)));
-  ASSERT_EQ(NoOverlap, boundOverlap(CB(0, 0), CB(1, 1)));
+  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(0, 0), CB(0, 0)));
+  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(0, 3), CB(2, 5)));
+  ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(0, 0), CB(1, 1)));
 
   // Partial overlap works in either order.
-  ASSERT_EQ(PartialOverlap, boundOverlap(CB(0, 10), CB(7, 14)));
-  ASSERT_EQ(PartialOverlap, boundOverlap(CB(7, 14), CB(0, 10)));
+  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(0, 10), CB(7, 14)));
+  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(7, 14), CB(0, 10)));
 
   // Total Overlap works when one bound encloses the other, and returns which.
-  ASSERT_EQ(Contains, boundOverlap(CB(2, 15), CB(7, 9)));
-  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(2, 15), CB(0, 16)));
+  ASSERT_EQ(OverlapKind::Contains, boundOverlap(CB(2, 15), CB(7, 9)));
+  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(2, 15), CB(0, 16)));
 
   // Total overlap works when the bounds are an identical range, returns
   // ContainedOrEqual.
-  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(2, 15), CB(2, 15)));
+  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(2, 15), CB(2, 15)));
 
   // Total overlap when only one end of the bound matches.
-  ASSERT_EQ(Contains, boundOverlap(CB(2, 15), CB(2, 10)));
-  ASSERT_EQ(Contains, boundOverlap(CB(2, 15), CB(3, 15)));
-  ASSERT_EQ(Contains, boundOverlap(CB(0, 10), CB(0, 9)));
-  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(2, 10), CB(2, 15)));
-  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(3, 15), CB(2, 15)));
+  ASSERT_EQ(OverlapKind::Contains, boundOverlap(CB(2, 15), CB(2, 10)));
+  ASSERT_EQ(OverlapKind::Contains, boundOverlap(CB(2, 15), CB(3, 15)));
+  ASSERT_EQ(OverlapKind::Contains, boundOverlap(CB(0, 10), CB(0, 9)));
+  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(2, 10), CB(2, 15)));
+  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(3, 15), CB(2, 15)));
 
   // No overlap when a < b.
-  ASSERT_EQ(NoOverlap, boundOverlap(CB(0, 2), CB(5, 10)));
-  ASSERT_EQ(NoOverlap, boundOverlap(CB(2, 2), CB(3, 3)));
-  ASSERT_EQ(NoOverlap, boundOverlap(CB(100, 120), CB(130, 130)));
+  ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(0, 2), CB(5, 10)));
+  ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(2, 2), CB(3, 3)));
+  ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(100, 120), CB(130, 130)));
 
   // No overlap when a > b.
-  ASSERT_EQ(NoOverlap, boundOverlap(CB(5, 10), CB(0, 2)));
-  ASSERT_EQ(NoOverlap, boundOverlap(CB(3, 3), CB(2, 2)));
-  ASSERT_EQ(NoOverlap, boundOverlap(CB(130, 130), CB(100, 120)));
+  ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(5, 10), CB(0, 2)));
+  ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(3, 3), CB(2, 2)));
+  ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(130, 130), CB(100, 120)));
 
   // No overlap when adjacent.
-  ASSERT_EQ(NoOverlap, boundOverlap(CB(0, 100), CB(101, 120)));
-  ASSERT_EQ(NoOverlap, boundOverlap(CB(2, 3), CB(0, 1)));
+  ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(0, 100), CB(101, 120)));
+  ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(2, 3), CB(0, 1)));
 
   // Partial overlap when middle bounds match.
-  ASSERT_EQ(PartialOverlap, boundOverlap(CB(0, 100), CB(100, 120)));
-  ASSERT_EQ(PartialOverlap, boundOverlap(CB(0, 2), CB(2, 4)));
-  ASSERT_EQ(PartialOverlap, boundOverlap(CB(100, 120), CB(0, 100)));
-  ASSERT_EQ(PartialOverlap, boundOverlap(CB(2, 3), CB(1, 2)));
+  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(0, 100), CB(100, 120)));
+  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(0, 2), CB(2, 4)));
+  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(100, 120), CB(0, 100)));
+  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(2, 3), CB(1, 2)));
 
   // Total overlap when one bound is single length over one end of the other.
-  ASSERT_EQ(Contains, boundOverlap(CB(2, 15), CB(15, 15)));
-  ASSERT_EQ(Contains, boundOverlap(CB(2, 15), CB(2, 2)));
-  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(2, 2), CB(2, 15)));
-  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(15, 15), CB(2, 15)));
+  ASSERT_EQ(OverlapKind::Contains, boundOverlap(CB(2, 15), CB(15, 15)));
+  ASSERT_EQ(OverlapKind::Contains, boundOverlap(CB(2, 15), CB(2, 2)));
+  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(2, 2), CB(2, 15)));
+  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(15, 15), CB(2, 15)));
 }
 
 TEST(MemDependency, BoundComparison) {
@@ -84,123 +84,123 @@ TEST(MemDependency, BoundComparison) {
   };
 
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(10, 100), CB(10, 100), CompareSelectOperation::kEQ));
   ASSERT_EQ(
-      CmpEvalResult::TRUE,
+      CmpEvalResult::True,
       compareBound(CB(10, 10), CB(10, 10), CompareSelectOperation::kEQ));
   ASSERT_EQ(
-      CmpEvalResult::FALSE,
+      CmpEvalResult::False,
       compareBound(CB(10, 20), CB(30, 40), CompareSelectOperation::kEQ));
   ASSERT_EQ(
-      CmpEvalResult::FALSE,
+      CmpEvalResult::False,
       compareBound(CB(30, 40), CB(10, 20), CompareSelectOperation::kEQ));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 40), CB(40, 50), CompareSelectOperation::kEQ));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 40), CB(20, 30), CompareSelectOperation::kEQ));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 45), CB(40, 50), CompareSelectOperation::kEQ));
 
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(10, 100), CB(10, 100), CompareSelectOperation::kNE));
   ASSERT_EQ(
-      CmpEvalResult::FALSE,
+      CmpEvalResult::False,
       compareBound(CB(10, 10), CB(10, 10), CompareSelectOperation::kNE));
   ASSERT_EQ(
-      CmpEvalResult::TRUE,
+      CmpEvalResult::True,
       compareBound(CB(10, 20), CB(30, 40), CompareSelectOperation::kNE));
   ASSERT_EQ(
-      CmpEvalResult::TRUE,
+      CmpEvalResult::True,
       compareBound(CB(30, 40), CB(10, 20), CompareSelectOperation::kNE));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 40), CB(40, 50), CompareSelectOperation::kNE));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 40), CB(20, 30), CompareSelectOperation::kEQ));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 45), CB(40, 50), CompareSelectOperation::kNE));
 
   ASSERT_EQ(
-      CmpEvalResult::TRUE,
+      CmpEvalResult::True,
       compareBound(CB(10, 20), CB(30, 40), CompareSelectOperation::kLT));
   ASSERT_EQ(
-      CmpEvalResult::FALSE,
+      CmpEvalResult::False,
       compareBound(CB(30, 40), CB(10, 20), CompareSelectOperation::kLT));
   ASSERT_EQ(
-      CmpEvalResult::FALSE,
+      CmpEvalResult::False,
       compareBound(CB(30, 40), CB(10, 30), CompareSelectOperation::kLT));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(10, 100), CB(10, 100), CompareSelectOperation::kLT));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 40), CB(40, 50), CompareSelectOperation::kLT));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 45), CB(40, 50), CompareSelectOperation::kLT));
 
   ASSERT_EQ(
-      CmpEvalResult::FALSE,
+      CmpEvalResult::False,
       compareBound(CB(10, 20), CB(30, 40), CompareSelectOperation::kGE));
   ASSERT_EQ(
-      CmpEvalResult::TRUE,
+      CmpEvalResult::True,
       compareBound(CB(30, 40), CB(10, 20), CompareSelectOperation::kGE));
   ASSERT_EQ(
-      CmpEvalResult::TRUE,
+      CmpEvalResult::True,
       compareBound(CB(30, 40), CB(10, 30), CompareSelectOperation::kGE));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(10, 100), CB(10, 100), CompareSelectOperation::kGE));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 40), CB(40, 50), CompareSelectOperation::kGE));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 45), CB(40, 50), CompareSelectOperation::kGE));
 
   ASSERT_EQ(
-      CmpEvalResult::FALSE,
+      CmpEvalResult::False,
       compareBound(CB(10, 20), CB(30, 40), CompareSelectOperation::kGT));
   ASSERT_EQ(
-      CmpEvalResult::FALSE,
+      CmpEvalResult::False,
       compareBound(CB(30, 40), CB(40, 50), CompareSelectOperation::kGT));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(10, 100), CB(10, 100), CompareSelectOperation::kGT));
   ASSERT_EQ(
-      CmpEvalResult::TRUE,
+      CmpEvalResult::True,
       compareBound(CB(30, 40), CB(10, 20), CompareSelectOperation::kGT));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 40), CB(10, 30), CompareSelectOperation::kGT));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 45), CB(40, 50), CompareSelectOperation::kGT));
 
   ASSERT_EQ(
-      CmpEvalResult::TRUE,
+      CmpEvalResult::True,
       compareBound(CB(10, 20), CB(30, 40), CompareSelectOperation::kLE));
   ASSERT_EQ(
-      CmpEvalResult::TRUE,
+      CmpEvalResult::True,
       compareBound(CB(30, 40), CB(40, 50), CompareSelectOperation::kLE));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(10, 100), CB(10, 100), CompareSelectOperation::kLE));
   ASSERT_EQ(
-      CmpEvalResult::FALSE,
+      CmpEvalResult::False,
       compareBound(CB(30, 40), CB(10, 20), CompareSelectOperation::kLE));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 40), CB(10, 30), CompareSelectOperation::kLE));
   ASSERT_EQ(
-      CmpEvalResult::NOT_DETERMINED,
+      CmpEvalResult::NotDetermined,
       compareBound(CB(30, 45), CB(40, 50), CompareSelectOperation::kLE));
 }
 
@@ -219,22 +219,22 @@ TEST(MemDependency, BoundOverlapSymbolic) {
   // Sanity check cases where the start and end is symbolic but the diff is
   // constant.
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(x, x), CB(x, x)));
-  ASSERT_EQ(PartialOverlap, boundOverlap(CB(x, x + 3), CB(x + 2, x + 5)));
-  ASSERT_EQ(NoOverlap, boundOverlap(CB(x, x), CB(x + 1, x + 1)));
+  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(x, x), CB(x, x)));
+  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(x, x + 3), CB(x + 2, x + 5)));
+  ASSERT_EQ(OverlapKind::NoOverlap, boundOverlap(CB(x, x), CB(x + 1, x + 1)));
 
   // We can't infer the sign of y, so cannot tell whether adding y is larger or
   // smaller than y/2.
-  ASSERT_EQ(PartialOverlap, boundOverlap(CB(x, x + y), CB(x, x + y / 2)));
+  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(x, x + y), CB(x, x + y / 2)));
 
   // No information about this bound, have to take the most conservative option:
   // there may be an overlap.
-  ASSERT_EQ(PartialOverlap, boundOverlap(CB(x, y), CB(z, w)));
+  ASSERT_EQ(OverlapKind::PartialOverlap, boundOverlap(CB(x, y), CB(z, w)));
 
   // Math on opaque terms works.
-  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(x + w, y - z), CB(x + w, y - z)));
+  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(x + w, y - z), CB(x + w, y - z)));
   // Even requiring simplification.
-  ASSERT_EQ(ContainedOrEqual, boundOverlap(CB(x - w - w, y), CB(x - w * 2, y)));
+  ASSERT_EQ(OverlapKind::ContainedOrEqual, boundOverlap(CB(x - w - w, y), CB(x - w * 2, y)));
 }
 
 // Tests the helper function for overlap of multi dimensional indices bounds.
@@ -248,63 +248,63 @@ TEST(MemDependency, BoundOverlapMultiDim) {
   };
 
   // Sanity check one dimensional cases.
-  ASSERT_EQ(ContainedOrEqual, overlaps({CB(0, 0)}, {CB(0, 0)}));
-  ASSERT_EQ(NoOverlap, overlaps({CB(0, 2)}, {CB(5, 10)}));
-  ASSERT_EQ(PartialOverlap, overlaps({CB(0, 100)}, {CB(100, 120)}));
+  ASSERT_EQ(OverlapKind::ContainedOrEqual, overlaps({CB(0, 0)}, {CB(0, 0)}));
+  ASSERT_EQ(OverlapKind::NoOverlap, overlaps({CB(0, 2)}, {CB(5, 10)}));
+  ASSERT_EQ(OverlapKind::PartialOverlap, overlaps({CB(0, 100)}, {CB(100, 120)}));
 
   // Total overlap in 3 dims.
   ASSERT_EQ(
-      ContainedOrEqual,
+      OverlapKind::ContainedOrEqual,
       overlaps({CB(0, 2), CB(0, 5), CB(0, 4)}, {CB(0, 2), CB(0, 5), CB(0, 4)}));
   ASSERT_EQ(
-      ContainedOrEqual,
+      OverlapKind::ContainedOrEqual,
       overlaps(
           {CB(0, 2), CB(0, 5), CB(0, 4)}, {CB(0, 2), CB(0, 5), CB(0, 10)}));
 
   // Total overlap in 2 dims, no overlap in another.
   ASSERT_EQ(
-      NoOverlap,
+      OverlapKind::NoOverlap,
       overlaps(
           {CB(0, 2), CB(0, 5), CB(0, 4)}, {CB(0, 2), CB(0, 5), CB(5, 10)}));
 
   // Total overlap in 2 dims, partial overlap in another.
   ASSERT_EQ(
-      PartialOverlap,
+      OverlapKind::PartialOverlap,
       overlaps(
           {CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(0, 2), CB(0, 5), CB(5, 10)}));
   // This case is most important, so verify the overlap in any dim. (dim 2)
   ASSERT_EQ(
-      PartialOverlap,
+      OverlapKind::PartialOverlap,
       overlaps({CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(0, 2), CB(2, 6), CB(0, 5)}));
   // Dim 1.
   ASSERT_EQ(
-      PartialOverlap,
+      OverlapKind::PartialOverlap,
       overlaps({CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(1, 3), CB(0, 5), CB(0, 5)}));
   // Total overlap in 1 dim, partial in 2.
   ASSERT_EQ(
-      PartialOverlap,
+      OverlapKind::PartialOverlap,
       overlaps(
           {CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(2, 6), CB(0, 5), CB(5, 10)}));
   // Total overlap, partial overlap, no overlap.
   ASSERT_EQ(
-      NoOverlap,
+      OverlapKind::NoOverlap,
       overlaps(
           {CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(2, 6), CB(11, 15), CB(0, 5)}));
 
   // Total overlap (B) in 2 dims, total overlap (A) in another.
   ASSERT_EQ(
-      Contains,
+      OverlapKind::Contains,
       overlaps({CB(0, 2), CB(0, 5), CB(0, 4)}, {CB(0, 2), CB(0, 3), CB(0, 4)}));
 
   // Total overlap (A) in 2 dims, total overlap (B) in another.
   ASSERT_EQ(
-      Contains,
+      OverlapKind::Contains,
       overlaps(
           {CB(0, 12), CB(0, 15), CB(0, 4)}, {CB(0, 2), CB(0, 3), CB(0, 14)}));
 
   // Total (B), No Overlap, Total (A).
   ASSERT_EQ(
-      NoOverlap,
+      OverlapKind::NoOverlap,
       overlaps(
           {CB(0, 2), CB(0, 5), CB(0, 5)}, {CB(0, 6), CB(11, 15), CB(1, 2)}));
 }

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1918,11 +1918,11 @@ void ProcessedNode::run() {
 
 static bool checkNoMemoryOverlap(const at::Tensor& a, const at::Tensor& b) {
   at::MemOverlapStatus status = at::get_overlap_status(a, b);
-  if (status == at::MemOverlapStatus::FULL ||
-      status == at::MemOverlapStatus::PARTIAL) {
+  if (status == at::MemOverlapStatus::Full ||
+      status == at::MemOverlapStatus::Partial) {
     return false;
   }
-  if (status == at::MemOverlapStatus::TOO_HARD) {
+  if (status == at::MemOverlapStatus::TooHard) {
     VLOG(1) << "Detected TOO_HARD memory overlap status";
   }
   return true;

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -1068,7 +1068,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::clone, aten_clone, [](Node* n) -> SROperator {
       in principle, figure out copy of strides.
     */
     if ((at::has_internal_overlap(src.unsafeGetTensorImpl()) ==
-         at::MemOverlap::YES) ||
+         at::MemOverlap::Yes) ||
         (memory_format != c10::MemoryFormat::Preserve)) {
       p_node->Output(0) = at::native::clone(src, memory_format);
       return;

--- a/torch/csrc/jit/tensorexpr/bounds_inference.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.cpp
@@ -248,7 +248,7 @@ HazardKind getPotentialHazards(
     // First, RAW.
     for (auto& bR : bReads) {
       for (auto& aW : aWrites) {
-        if (boundOverlap(bR, aW) != NoOverlap) {
+        if (boundOverlap(bR, aW) != OverlapKind::NoOverlap) {
           return HazardKind::ReadAfterWrite;
         }
       }
@@ -257,7 +257,7 @@ HazardKind getPotentialHazards(
     // Then WAR.
     for (auto& bW : bWrites) {
       for (auto& aR : aReads) {
-        if (boundOverlap(bW, aR) != NoOverlap) {
+        if (boundOverlap(bW, aR) != OverlapKind::NoOverlap) {
           return HazardKind::WriteAfterRead;
         }
       }
@@ -266,7 +266,7 @@ HazardKind getPotentialHazards(
     // Then WAW.
     for (auto& bW : bWrites) {
       for (auto& aW : aWrites) {
-        if (boundOverlap(bW, aW) != NoOverlap) {
+        if (boundOverlap(bW, aW) != OverlapKind::NoOverlap) {
           return HazardKind::WriteAfterWrite;
         }
       }
@@ -333,7 +333,7 @@ bool hasConflictingOverlap(
           continue;
         }
         auto overlap = overlaps(aIndexBounds[i], bIndexBounds[j]);
-        if (overlap != NoOverlap) {
+        if (overlap != OverlapKind::NoOverlap) {
           return true;
         }
       }

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
@@ -87,7 +87,7 @@ OverlapKind boundOverlap(Bound a, Bound b) {
   bool startEqual = exprEquals(a.start, b.start);
   bool endEqual = exprEquals(a.end, b.end);
   if (startEqual && endEqual) {
-    return ContainedOrEqual;
+    return OverlapKind::ContainedOrEqual;
   }
 
   // We have to figure out if the bounds fall under the following 2 cases:
@@ -110,10 +110,10 @@ OverlapKind boundOverlap(Bound a, Bound b) {
   ExprPtr highDiff = IRSimplifier::simplify(alloc<Sub>(b.start, a.end));
 
   if (mustBePositive(lowDiff)) {
-    return NoOverlap;
+    return OverlapKind::NoOverlap;
   }
   if (mustBePositive(highDiff)) {
-    return NoOverlap;
+    return OverlapKind::NoOverlap;
   }
 
   ExprPtr diff_start = IRSimplifier::simplify(alloc<Sub>(b.start, a.start));
@@ -125,17 +125,17 @@ OverlapKind boundOverlap(Bound a, Bound b) {
     int end = immediateAs<int>(diff_end);
     // If diff_start and diff_end have different signs they are enclosing.
     if (start <= 0 && end >= 0) {
-      return ContainedOrEqual;
+      return OverlapKind::ContainedOrEqual;
     }
 
     if (start >= 0 && end <= 0) {
-      return Contains;
+      return OverlapKind::Contains;
     }
   }
 
   // We can't be sure there's no overlap so the conservative answer is
   // partial.
-  return PartialOverlap;
+  return OverlapKind::PartialOverlap;
 }
 
 CmpEvalResult TORCH_API compareBound(
@@ -144,18 +144,18 @@ CmpEvalResult TORCH_API compareBound(
     const CompareSelectOperation& cmp_op) {
   switch (cmp_op) {
     case CompareSelectOperation::kGT:
-      return (a > b) ? TRUE : (a <= b ? FALSE : NOT_DETERMINED);
+      return (a > b) ? CmpEvalResult::True : (a <= b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
     case CompareSelectOperation::kGE:
-      return (a >= b) ? TRUE : (a < b ? FALSE : NOT_DETERMINED);
+      return (a >= b) ? CmpEvalResult::True : (a < b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
     case CompareSelectOperation::kLT:
-      return (a < b) ? TRUE : (a >= b ? FALSE : NOT_DETERMINED);
+      return (a < b) ? CmpEvalResult::True : (a >= b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
     case CompareSelectOperation::kLE:
-      return (a <= b) ? TRUE : (a > b ? FALSE : NOT_DETERMINED);
+      return (a <= b) ? CmpEvalResult::True : (a > b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
     case CompareSelectOperation::kNE:
-      return (a != b) ? TRUE : (a == b ? FALSE : NOT_DETERMINED);
+      return (a != b) ? CmpEvalResult::True : (a == b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
     default:
       TORCH_INTERNAL_ASSERT(cmp_op == CompareSelectOperation::kEQ)
-      return (a == b) ? TRUE : (a != b ? FALSE : NOT_DETERMINED);
+      return (a == b) ? CmpEvalResult::True : (a != b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
   }
 }
 
@@ -190,7 +190,7 @@ Bound flattenBounds(const IndexBounds& a) {
 
 OverlapKind overlaps(const IndexBounds& a, const IndexBounds& b) {
   if (a.empty() && b.empty()) {
-    return ContainedOrEqual;
+    return OverlapKind::ContainedOrEqual;
   }
 
   // All accesses to a buf must have the same dimensionality.
@@ -203,20 +203,20 @@ OverlapKind overlaps(const IndexBounds& a, const IndexBounds& b) {
   OverlapKind overlap = boundOverlap(a[0], b[0]);
   for (size_t i = 1; i < a.size(); ++i) {
     OverlapKind bOverlap = boundOverlap(a[i], b[i]);
-    if (bOverlap == NoOverlap) {
-      return NoOverlap;
+    if (bOverlap == OverlapKind::NoOverlap) {
+      return OverlapKind::NoOverlap;
     }
 
-    if (overlap == ContainedOrEqual && bOverlap == Contains) {
-      overlap = Contains;
+    if (overlap == OverlapKind::ContainedOrEqual && bOverlap == OverlapKind::Contains) {
+      overlap = OverlapKind::Contains;
     }
 
-    if (overlap == Contains && bOverlap == ContainedOrEqual) {
+    if (overlap == OverlapKind::Contains && bOverlap == OverlapKind::ContainedOrEqual) {
       continue;
     }
 
     if (bOverlap != overlap) {
-      overlap = PartialOverlap;
+      overlap = OverlapKind::PartialOverlap;
       break;
     }
   }
@@ -226,10 +226,10 @@ OverlapKind overlaps(const IndexBounds& a, const IndexBounds& b) {
 
 std::vector<Bound> subtractBound(Bound a, Bound b) {
   OverlapKind overlap = boundOverlap(a, b);
-  if (overlap == NoOverlap) {
+  if (overlap == OverlapKind::NoOverlap) {
     return {a};
   }
-  if (overlap == ContainedOrEqual) {
+  if (overlap == OverlapKind::ContainedOrEqual) {
     return {};
   }
 
@@ -293,11 +293,11 @@ std::vector<IndexBounds> subtractIndicesBounds(
     const IndexBounds& A,
     const IndexBounds& B,
     OverlapKind overlap) {
-  if (overlap == NoOverlap) {
+  if (overlap == OverlapKind::NoOverlap) {
     return {A};
   }
 
-  if (overlap == ContainedOrEqual) {
+  if (overlap == OverlapKind::ContainedOrEqual) {
     return {};
   }
   // All accesses to a buf must have the same dimensionality.

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
@@ -144,18 +144,30 @@ CmpEvalResult TORCH_API compareBound(
     const CompareSelectOperation& cmp_op) {
   switch (cmp_op) {
     case CompareSelectOperation::kGT:
-      return (a > b) ? CmpEvalResult::True : (a <= b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
+      return (a > b)
+          ? CmpEvalResult::True
+          : (a <= b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
     case CompareSelectOperation::kGE:
-      return (a >= b) ? CmpEvalResult::True : (a < b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
+      return (a >= b)
+          ? CmpEvalResult::True
+          : (a < b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
     case CompareSelectOperation::kLT:
-      return (a < b) ? CmpEvalResult::True : (a >= b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
+      return (a < b)
+          ? CmpEvalResult::True
+          : (a >= b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
     case CompareSelectOperation::kLE:
-      return (a <= b) ? CmpEvalResult::True : (a > b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
+      return (a <= b)
+          ? CmpEvalResult::True
+          : (a > b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
     case CompareSelectOperation::kNE:
-      return (a != b) ? CmpEvalResult::True : (a == b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
+      return (a != b)
+          ? CmpEvalResult::True
+          : (a == b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
     default:
       TORCH_INTERNAL_ASSERT(cmp_op == CompareSelectOperation::kEQ)
-      return (a == b) ? CmpEvalResult::True : (a != b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
+      return (a == b)
+          ? CmpEvalResult::True
+          : (a != b ? CmpEvalResult::False : CmpEvalResult::NotDetermined);
   }
 }
 
@@ -207,11 +219,13 @@ OverlapKind overlaps(const IndexBounds& a, const IndexBounds& b) {
       return OverlapKind::NoOverlap;
     }
 
-    if (overlap == OverlapKind::ContainedOrEqual && bOverlap == OverlapKind::Contains) {
+    if (overlap == OverlapKind::ContainedOrEqual &&
+        bOverlap == OverlapKind::Contains) {
       overlap = OverlapKind::Contains;
     }
 
-    if (overlap == OverlapKind::Contains && bOverlap == OverlapKind::ContainedOrEqual) {
+    if (overlap == OverlapKind::Contains &&
+        bOverlap == OverlapKind::ContainedOrEqual) {
       continue;
     }
 

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.h
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.h
@@ -57,7 +57,12 @@ struct BoundHash {
 //     Contains: All elements in the Bound B are in the Bound B.
 //     PartialOverlap: Any elements in the Bound B are in the Bound A.
 //     NoOverlap: No elements in the Bound A are in the bound B.
-enum class OverlapKind { ContainedOrEqual, Contains, PartialOverlap, NoOverlap };
+enum class OverlapKind {
+  ContainedOrEqual,
+  Contains,
+  PartialOverlap,
+  NoOverlap
+};
 
 // The Bound comparison result.
 //     True: Every Bound element always satisfies the given comparison operator

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.h
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.h
@@ -57,15 +57,15 @@ struct BoundHash {
 //     Contains: All elements in the Bound B are in the Bound B.
 //     PartialOverlap: Any elements in the Bound B are in the Bound A.
 //     NoOverlap: No elements in the Bound A are in the bound B.
-enum OverlapKind { ContainedOrEqual, Contains, PartialOverlap, NoOverlap };
+enum class OverlapKind { ContainedOrEqual, Contains, PartialOverlap, NoOverlap };
 
 // The Bound comparison result.
-//     TRUE: Every Bound element always satifies the given comparison operator
-//     FALSE: Every Bound element always does NOT satify the given comparison
+//     True: Every Bound element always satisfies the given comparison operator
+//     False: Every Bound element always does NOT satisfy the given comparison
 //     operator
-//     NOT_DETERMINED: Some elements satify the given comparison operator and
+//     NotDetermined: Some elements satisfy the given comparison operator and
 //     some elements not
-enum CmpEvalResult { TRUE, FALSE, NOT_DETERMINED };
+enum class CmpEvalResult { True, False, NotDetermined };
 
 // Returns the kind of overlap between Bound A and Bound A in a single
 // dimension.

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -2981,9 +2981,9 @@ ExprPtr SimplifierUnderContext::mutate(CompareSelectPtr v) {
 
   // Return the simplified ret1/ret2 if the compare result is deterministic.
   // Otherwise, return the simplified CompareSelect directly.
-  auto ret_expr = (cmp_res == analysis::CmpEvalResult::TRUE)
+  auto ret_expr = (cmp_res == analysis::CmpEvalResult::True)
       ? simplified_ret1
-      : ((cmp_res == analysis::CmpEvalResult::FALSE)
+      : ((cmp_res == analysis::CmpEvalResult::False)
              ? simplified_ret2
              : simplified_cmp_select_expr);
   GRAPH_DEBUG("(SimplifierUnderContext) Final: ", std::to_string(ret_expr));

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -866,7 +866,7 @@ void MemDependencyChecker::visit(ForPtr v) {
       std::vector<IndexBounds> newBoundSlices;
       for (auto& b : openBounds) {
         OverlapKind overlap = overlaps(b, other->bounds());
-        if (overlap == NoOverlap) {
+        if (overlap == OverlapKind::NoOverlap) {
           newBoundSlices.push_back(b);
           continue;
         }
@@ -875,7 +875,7 @@ void MemDependencyChecker::visit(ForPtr v) {
         info->addDependency(other);
         other->addDependent(info);
 
-        if (overlap == Contains) {
+        if (overlap == OverlapKind::Contains) {
           continue;
         }
 
@@ -1192,7 +1192,7 @@ void MemDependencyChecker::updateWriteHistory(
 
     OverlapKind overlap = overlaps(indexBounds, info->bounds());
 
-    if (overlap == NoOverlap) {
+    if (overlap == OverlapKind::NoOverlap) {
       ++it;
       continue;
     }
@@ -1211,7 +1211,7 @@ void MemDependencyChecker::updateWriteHistory(
       continue;
     }
 
-    if (overlap == ContainedOrEqual) {
+    if (overlap == OverlapKind::ContainedOrEqual) {
       // Total overlap is easy - the new access totally replaces the old.
       it = writeHistory.erase(it);
     } else {


### PR DESCRIPTION
Per many C++ code-style guides members(for [example](https://google.github.io/styleguide/cppguide.html#Enumerator_Names) ) members of `enum` should be CamelCased,
and only defines should be ALL_CAPS

Changes `MemOverlap`, `MemOverlapStatus` and `CmpEvalResult` enum values

Also, `YES`, `NO`, `TRUE` and `FALSE` are often system defines

Fixes among other things, current iOS build regression, see, which manifests as follows (see [this](https://hud.pytorch.org/pytorch/pytorch/commit/6e90572bb9443266e1abe5c7d737b028926d9b6b): 
```
/Users/runner/work/pytorch/pytorch/aten/src/ATen/MemoryOverlap.h:19:29: error: expected identifier
enum class MemOverlap { NO, YES, TOO_HARD };
                            ^
/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator14.4.sdk/usr/include/objc/objc.h:89:13: note: expanded from macro 'YES'
#define YES __objc_yes
```
