### PR TITLE
Fix typo in ChainedScheduler docstring

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -753,7 +753,7 @@ class CosineAnnealingLR(_LRScheduler):
 
 class ChainedScheduler(_LRScheduler):
     """Chains list of learning rate schedulers. It takes a list of chainable learning
-    rate schedulers and performs consecutive step() functions belong to them by just
+    rate schedulers and performs consecutive step() functions belonging to them by just
     one call.
 
     Args:


### PR DESCRIPTION
### Goal
Fixes https://github.com/pytorch/pytorch/issues/79720

### Approach 
replace `Chains list of learning rate schedulers. It takes a list of chainable learning rate schedulers and performs consecutive step() functions` **`belong`** `to them by just one call.` with `Chains list of learning rate schedulers. It takes a list of chainable learning rate schedulers and performs consecutive step() functions` **`belonging`** `to them by just one call.`
