### PR TITLE
ci: Move buck-build-test to periodic

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -201,3 +201,7 @@ jobs:
       IOS_CERT_SECRET: ${{ secrets.IOS_CERT_SECRET}}
       IOS_DEV_TEAM_ID: ${{ secrets.IOS_DEV_TEAM_ID}}
       IOS_SIGN_KEY_2022: ${{ secrets.IOS_SIGN_KEY_2022 }}
+
+  buck-build-test:
+    name: buck-build-test
+    uses: ./.github/workflows/_buck-build-test.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -257,7 +257,3 @@ jobs:
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
-
-  buck-build-test:
-    name: buck-build-test
-    uses: ./.github/workflows/_buck-build-test.yml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #79797

Moves the buck-build-test to periodic, and moves it outside of the
revert criteria for the pytorch_oss_ci oncall

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>