### PR TITLE
Windows nvtx for CUDA 11.6 require _wgetenv decl

### DIFF
--- a/torch/csrc/cuda/shared/nvtx.cpp
+++ b/torch/csrc/cuda/shared/nvtx.cpp
@@ -1,3 +1,6 @@
+#ifdef _WIN32
+#include <wchar.h> // _wgetenv for nvtx
+#endif
 #include <nvToolsExt.h>
 #include <torch/csrc/utils/pybind.h>
 


### PR DESCRIPTION
Summary:
The include ordering modified via clang-format prevented a
declaration of _wgetenv, declared and used in nvtxInit.h, which was
previously acquired transitively through the pybind include. Provide an
explicit platform include of wchar.h which defines it on Windows, prior
to including nvToolsExt.h

Test Plan: Windows msvc cuda11 build should pass.

Differential Revision: D37244689

