### PR TITLE
Fix to preserve view relationships for Parameter.__deepcopy__()

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -489,6 +489,22 @@ class TestNN(NNTestCase):
         for b in net.buffers():
             self.assertTrue(b.storage().is_shared())
 
+    def test_param_deepcopy_preserves_view_relationships(self):
+
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                t = torch.randn(3)
+                self.p1 = torch.nn.Parameter(t)
+                self.p2 = torch.nn.Parameter(t)
+
+        net = Net()
+        self.assertTrue(net.p1.storage().data_ptr() == net.p2.storage().data_ptr())
+
+        # Copy's parameters should reference the same storage.
+        net_copy = deepcopy(net)
+        self.assertTrue(net_copy.p1.storage().data_ptr() == net_copy.p2.storage().data_ptr())
+
     def _test_hooks(self, backward_register_fn):
         module = nn.Sigmoid()
         input = torch.ones(5, 5, requires_grad=True)

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -88,7 +88,7 @@ class Tensor(torch._C._TensorBase):
         if not self.is_leaf:
             raise RuntimeError("Only Tensors created explicitly by the user "
                                "(graph leaves) support the deepcopy protocol at the moment")
-        if id(self) in memo:
+        if id(self) in memo: #and self.shape == memo[id(self)].shape:
             return memo[id(self)]
         with torch.no_grad():
             # TODO: skipping storage copy is wrong for meta, as meta

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -88,7 +88,7 @@ class Tensor(torch._C._TensorBase):
         if not self.is_leaf:
             raise RuntimeError("Only Tensors created explicitly by the user "
                                "(graph leaves) support the deepcopy protocol at the moment")
-        if id(self) in memo: #and self.shape == memo[id(self)].shape:
+        if id(self) in memo:
             return memo[id(self)]
         with torch.no_grad():
             # TODO: skipping storage copy is wrong for meta, as meta

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -53,7 +53,7 @@ class Parameter(torch.Tensor, metaclass=_ParameterMeta):
         if id(self) in memo:
             return memo[id(self)]
         else:
-            result = type(self)(self.data.clone(memory_format=torch.preserve_format), self.requires_grad)
+            result = type(self)(self.data.__deepcopy__(memo), self.requires_grad)
             memo[id(self)] = result
             return result
 

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -53,7 +53,11 @@ class Parameter(torch.Tensor, metaclass=_ParameterMeta):
         if id(self) in memo:
             return memo[id(self)]
         else:
-            result = type(self)(self.data.__deepcopy__(memo), self.requires_grad)
+            # Redispatch to Tensor.__deepcopy__() with self reinterpreted as a Tensor
+            # to get proper view handling.
+            # https://github.com/pytorch/pytorch/issues/79788
+            result = torch.Tensor._make_subclass(torch.Tensor, self, self.requires_grad)
+            result = type(self)(result.__deepcopy__(memo), self.requires_grad)
             memo[id(self)] = result
             return result
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #79799

Fixes #79788

BC-breaking notes:
* Deepcopying involving parameters now preserves view relationships, breaking anyone who relies on deepcopy producing new, independent objects.
* Callers of `Parameter.new_empty()` will now get a `Parameter` object instead of a `Tensor` object.