### PR TITLE
Fixing AO tests

### DIFF
--- a/test/ao/sparsity/test_data_sparsifier.py
+++ b/test/ao/sparsity/test_data_sparsifier.py
@@ -43,13 +43,6 @@ class _BaseDataSparsiferTestRunner:
         # This will be rewritten as soon as possible
         self._test_case = TestCase()
 
-    def run_tests(self):
-        self._run_constructor_test()
-        self._run_squash_mask_test()
-        self._run_add_data_test()
-        self._run_step_test()
-        self._run_state_dict_test()
-
     def _get_name_data_config(self, some_data):
         if isinstance(some_data, Tuple):
             # dealing with data_list
@@ -139,6 +132,13 @@ class _BaseDataSparsiferTestRunner:
             data2 = sparsifier._extract_weight(data2)
             sparsifier.add_data(name=name1, data=data2)
             assert torch.all(data2 == sparsifier.get_data(name=name1))
+
+    def run_tests(self):
+        self._run_constructor_test()
+        self._run_squash_mask_test()
+        self._run_add_data_test()
+        self._run_step_test()
+        self._run_state_dict_test()
 
     def _run_state_dict_test(self):
         sparsifier1 = self._get_sparsifier()

--- a/test/ao/sparsity/test_data_sparsifier.py
+++ b/test/ao/sparsity/test_data_sparsifier.py
@@ -26,7 +26,7 @@ class ImplementedSparsifier(BaseDataSparsifier):
         linear_state['step_count'] = linear_state.get('step_count', 0) + 1
 
 
-class TestBaseDataSparsiferRunner(TestCase):
+class _BaseDataSparsiferTestRunner:
     r"""This helper test class takes in any supported type of and runs some tests.
         The user is required to pass in the data that needs to sparsified and the
         runner will run some tests that needs to be passed in order for the data
@@ -39,7 +39,18 @@ class TestBaseDataSparsiferRunner(TestCase):
         self.defaults = defaults
         self.data_with_config = data_with_config
 
-    def get_name_data_config(self, some_data):
+        # Temporary hack to quickly fix failing tests.
+        # This will be rewritten as soon as possible
+        self._test_case = TestCase()
+
+    def run_tests(self):
+        self._run_constructor_test()
+        self._run_squash_mask_test()
+        self._run_add_data_test()
+        self._run_step_test()
+        self._run_state_dict_test()
+
+    def _get_name_data_config(self, some_data):
         if isinstance(some_data, Tuple):
             # dealing with data_list
             name, data = some_data
@@ -49,7 +60,7 @@ class TestBaseDataSparsiferRunner(TestCase):
             name, data, config = some_data['name'], some_data['data'], some_data['config']
         return name, data, config
 
-    def get_sparsifier(self):
+    def _get_sparsifier(self):
         sparsifier = ImplementedSparsifier(data_list=self.data_list, **self.defaults)
         assert len(sparsifier.data_groups) == len(self.data_list)
         for data_config_dict in self.data_with_config:
@@ -57,24 +68,24 @@ class TestBaseDataSparsiferRunner(TestCase):
             sparsifier.add_data(name=name, data=data, **config)
         return sparsifier
 
-    def test_constructor(self):
-        sparsifier = self.get_sparsifier()
+    def _run_constructor_test(self):
+        sparsifier = self._get_sparsifier()
         assert len(sparsifier.data_groups) == len(self.data_list) + len(self.data_with_config)
 
         all_data = self.data_list + self.data_with_config
 
         for some_data in all_data:
-            name, _, config = self.get_name_data_config(some_data)
+            name, _, config = self._get_name_data_config(some_data)
             assert name in sparsifier.data_groups
             assert sparsifier.data_groups[name] == config
 
-    def test_step(self):
-        sparsifier = self.get_sparsifier()
+    def _run_step_test(self):
+        sparsifier = self._get_sparsifier()
         all_data = self.data_list + self.data_with_config
 
         # Check data and mask before doing the step
         for some_data in all_data:
-            name, data, _ = self.get_name_data_config(some_data)
+            name, data, _ = self._get_name_data_config(some_data)
             data = sparsifier._extract_weight(data)
             sparsified_data = sparsifier.get_data(name=name, return_original=False)
             original_data = sparsifier.get_data(name=name, return_original=True)
@@ -88,7 +99,7 @@ class TestBaseDataSparsiferRunner(TestCase):
         for _ in range(0, step_count):
             sparsifier.step()
         for some_data in all_data:
-            name, data, _ = self.get_name_data_config(some_data)
+            name, data, _ = self._get_name_data_config(some_data)
             data = sparsifier._extract_weight(data)
             sparsified_data = sparsifier.get_data(name=name, return_original=False)
             original_data = sparsifier.get_data(name=name, return_original=True)
@@ -99,53 +110,46 @@ class TestBaseDataSparsiferRunner(TestCase):
             assert 'step_count' in sparsifier.state[name]
             assert sparsifier.state[name]['step_count'] == 3
 
-    def test_squash_mask(self):
-        sparsifier = self.get_sparsifier()
+    def _run_squash_mask_test(self):
+        sparsifier = self._get_sparsifier()
         all_data = self.data_list + self.data_with_config
         for some_data in all_data:
-            name, _, _ = self.get_name_data_config(some_data)
+            name, _, _ = self._get_name_data_config(some_data)
             assert hasattr(sparsifier._container, name)
             assert is_parametrized(sparsifier._container, name)
         sparsifier.step()
         sparsifier.squash_mask()
 
         for some_data in all_data:
-            name, _, _ = self.get_name_data_config(some_data)
+            name, _, _ = self._get_name_data_config(some_data)
             assert not is_parametrized(sparsifier._container, name)  # not parametrized anymore
-            with self.assertRaises(ValueError):
+            with self._test_case.assertRaises(ValueError):
                 sparsifier.get_data(name, return_original=True)
 
-    def test_add_data(self):
-        sparsifier = self.get_sparsifier()
+    def _run_add_data_test(self):
+        sparsifier = self._get_sparsifier()
         all_data = self.data_list + self.data_with_config
         for some_data in all_data:
-            name1, data1, _ = self.get_name_data_config(some_data)
+            name1, data1, _ = self._get_name_data_config(some_data)
             data1 = sparsifier._extract_weight(data1)
             assert torch.all(data1 == sparsifier.get_data(name=name1))
             # get some other data at random and with the same name
             rand_idx = random.randint(0, len(all_data) - 1)
-            _, data2, _ = self.get_name_data_config(all_data[rand_idx])
+            _, data2, _ = self._get_name_data_config(all_data[rand_idx])
             data2 = sparsifier._extract_weight(data2)
             sparsifier.add_data(name=name1, data=data2)
             assert torch.all(data2 == sparsifier.get_data(name=name1))
 
-    def run_tests(self):
-        self.test_constructor()
-        self.test_squash_mask()
-        self.test_add_data()
-        self.test_step()
-        self.test_state_dict()
-
-    def test_state_dict(self):
-        sparsifier1 = self.get_sparsifier()
+    def _run_state_dict_test(self):
+        sparsifier1 = self._get_sparsifier()
         sparsifier2 = ImplementedSparsifier(data_list=[self.data_list[0]])
         sparsifier1.step()
 
         state_dict1 = sparsifier1.state_dict()
 
         assert sparsifier1.state != sparsifier2.state
-        name, _, _ = self.get_name_data_config(self.data_list[0])
-        self.assertNotEqual(sparsifier1.get_mask(name), sparsifier2.get_mask(name))
+        name, _, _ = self._get_name_data_config(self.data_list[0])
+        self._test_case.assertNotEqual(sparsifier1.get_mask(name), sparsifier2.get_mask(name))
 
         sparsifier2.load_state_dict(state_dict1)
         assert len(sparsifier1.state) == len(sparsifier2.state)
@@ -173,7 +177,7 @@ class TestBaseDataSparsiferRunner(TestCase):
                 param2 = getattr(container2.parametrizations, name)[0]
                 assert hasattr(param1, 'mask')
                 assert hasattr(param2, 'mask')
-                self.assertEqual(param1.__dict__, param2.__dict__)
+                self._test_case.assertEqual(param1.__dict__, param2.__dict__)
 
 
 class TestBaseDataSparsifier(TestCase):
@@ -198,8 +202,8 @@ class TestBaseDataSparsifier(TestCase):
                 'name': 'tensor5', 'data': tensor5, 'config': {'test': 8}
             },
         ]
-        tensor_test = TestBaseDataSparsiferRunner(data_list=data_list, defaults=defaults,
-                                                  data_with_config=data_with_config)
+        tensor_test = _BaseDataSparsiferTestRunner(data_list=data_list, defaults=defaults,
+                                                   data_with_config=data_with_config)
         tensor_test.run_tests()
 
     def test_nn_parameters(self):
@@ -216,8 +220,8 @@ class TestBaseDataSparsifier(TestCase):
                 'name': 'param5', 'data': param5, 'config': {'test': 8}
             },
         ]
-        param_test = TestBaseDataSparsiferRunner(data_list=data_list, defaults=defaults,
-                                                 data_with_config=data_with_config)
+        param_test = _BaseDataSparsiferTestRunner(data_list=data_list, defaults=defaults,
+                                                  data_with_config=data_with_config)
         param_test.run_tests()
 
     def test_nn_embeddings(self):
@@ -236,12 +240,12 @@ class TestBaseDataSparsifier(TestCase):
                 'name': 'emb3_bag', 'data': emb3_bag, 'config': {'test': 8}
             },
         ]
-        emb_test = TestBaseDataSparsiferRunner(data_list=data_list, defaults=defaults,
-                                               data_with_config=data_with_config)
+        emb_test = _BaseDataSparsiferTestRunner(data_list=data_list, defaults=defaults,
+                                                data_with_config=data_with_config)
         emb_test.run_tests()
 
 
-class TestNormDataSparsifierRunner(TestBaseDataSparsiferRunner):
+class _NormDataSparsifierTestRunner(_BaseDataSparsiferTestRunner):
     r"""This helper test class takes in any supported type of and runs some tests.
         This inherits the TestBaseDataSparsifierRuner wherein some functions are
         over-ridden to take accomodate the specific sparsifier.
@@ -253,7 +257,7 @@ class TestNormDataSparsifierRunner(TestBaseDataSparsiferRunner):
         assert norm_type in ['L1', 'L2']
         self.norm_type = norm_type
 
-    def get_bounds_on_actual_sparsity(self, config, tensor_shape):
+    def _get_bounds_on_actual_sparsity(self, config, tensor_shape):
         r"""This function gets the bounds on actual sparsity.
             Note::
                 Although we specify the sparsity_level parameter, this does not mean that
@@ -282,7 +286,7 @@ class TestNormDataSparsifierRunner(TestBaseDataSparsiferRunner):
             lower_bound, upper_bound = round(lower_bound, 3), round(upper_bound, 3)
             return lower_bound, upper_bound
 
-    def get_sparsifier(self):
+    def _get_sparsifier(self):
         sparsifier = DataNormSparsifier(data_list=self.data_list, norm=self.norm_type, **self.defaults)
         assert len(sparsifier.data_groups) == len(self.data_list)
         for data_config_dict in self.data_with_config:
@@ -290,23 +294,23 @@ class TestNormDataSparsifierRunner(TestBaseDataSparsiferRunner):
             sparsifier.add_data(name=name, data=data, **config)
         return sparsifier
 
-    def test_step(self):
-        sparsifier = self.get_sparsifier()
+    def _run_step_test(self):
+        sparsifier = self._get_sparsifier()
         all_data = self.data_list + self.data_with_config
 
         # mask before step() should not be sparsified
         for some_data in all_data:
-            name, _, _ = self.get_name_data_config(some_data)
+            name, _, _ = self._get_name_data_config(some_data)
             mask = sparsifier.get_mask(name=name)
             assert (1.0 - mask.mean()) == 0  # checking sparsity level is 0
 
         sparsifier.step()
 
         for some_data in all_data:
-            name, _, _ = self.get_name_data_config(some_data)
+            name, _, _ = self._get_name_data_config(some_data)
             mask = sparsifier.get_mask(name=name)
             config = sparsifier.data_groups[name]
-            lb, ub = self.get_bounds_on_actual_sparsity(config, mask.shape)
+            lb, ub = self._get_bounds_on_actual_sparsity(config, mask.shape)
             mask = mask.to(torch.float)
             actual_sparsity = round(1 - mask.mean().item(), 3)
             assert actual_sparsity >= lb and actual_sparsity <= ub
@@ -324,7 +328,7 @@ class TestNormDataSparsifierRunner(TestBaseDataSparsiferRunner):
             mask = mask.to(torch.float)
             assert (1.0 - mask.mean().item()) > 0  # some sparsity achieved
 
-    def test_step_2_of_4(self):
+    def _run_step_2_of_4_test(self):
         # overriding default config for test purposes
         default_config = {'sparsity_level': 1.0, 'zeros_per_block': 2, 'sparse_block_shape': (1, 4)}
         data_list = [('test_data', torch.randn(4, 4))]
@@ -336,7 +340,7 @@ class TestNormDataSparsifierRunner(TestBaseDataSparsiferRunner):
             name, _ = some_data
             mask = sparsifier.get_mask(name=name)
             mask = mask.to(torch.float)
-            self.assertAlmostEqual(1.0 - mask.mean().item(), 0.5, places=2)
+            self._test_case.assertAlmostEqual(1.0 - mask.mean().item(), 0.5, places=2)
             for row in mask:
                 for idx in range(0, len(row), 4):
                     block = row[idx:idx + 4]
@@ -344,11 +348,11 @@ class TestNormDataSparsifierRunner(TestBaseDataSparsiferRunner):
                     assert (block[:2] == 0).all()
                     assert (block[2:] != 0).all()
 
-    def test_sparsity_level(self):
+    def _run_sparsity_level_test(self):
         sparsity_levels = [-1.0, 0.0, 0.5, 1.0, 2.0]
         sparse_block_shapes = [(1, 1), (1, 4), (2, 2), (4, 1)]
         zeros_per_blocks = [0, 1, 2, 3, 4]
-        sparsifier = self.get_sparsifier()
+        sparsifier = self._get_sparsifier()
         testcases = itertools.tee(itertools.product(sparsity_levels,
                                                     sparse_block_shapes,
                                                     zeros_per_blocks))
@@ -378,12 +382,12 @@ class TestNormDataSparsifierRunner(TestBaseDataSparsiferRunner):
                 assert sparse_mask.mean() == true_sl
 
     def run_tests(self):
-        self.test_constructor()
-        self.test_squash_mask()
-        self.test_add_data()
-        self.test_state_dict()
-        self.test_step()
-        self.test_step_2_of_4()
+        self._run_constructor_test()
+        self._run_squash_mask_test()
+        self._run_add_data_test()
+        self._run_state_dict_test()
+        self._run_step_test()
+        self._run_step_2_of_4_test()
 
 
 class TestNormDataSparsifiers(TestCase):
@@ -392,7 +396,7 @@ class TestNormDataSparsifiers(TestCase):
         defaults: default config for the above data in data_list
         data_with_config: list of dictionaries defining name, data and config (look test_tensors())
 
-        Once the above is done, create an instance of TestNormDataSparsifierRunner and call run_tests()
+        Once the above is done, create an instance of _NormDataSparsifierTestRunner and call run_tests()
     """
     def test_tensors(self):
         tensor1, tensor2, tensor3 = torch.randn(3, 3), torch.randn(4, 4), torch.randn(5, 5)
@@ -410,11 +414,11 @@ class TestNormDataSparsifiers(TestCase):
                 'config': {'sparsity_level': 0.3, 'sparse_block_shape': (2, 3), 'zeros_per_block': 6}
             },
         ]
-        tensor_test_l1 = TestNormDataSparsifierRunner(data_list=data_list, defaults=defaults,
+        tensor_test_l1 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
                                                       data_with_config=data_with_config, norm_type='L1')
         tensor_test_l1.run_tests()
 
-        tensor_test_l2 = TestNormDataSparsifierRunner(data_list=data_list, defaults=defaults,
+        tensor_test_l2 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
                                                       data_with_config=data_with_config, norm_type='L2')
         tensor_test_l2.run_tests()
 
@@ -434,11 +438,11 @@ class TestNormDataSparsifiers(TestCase):
                 'config': {'sparsity_level': 0.3, 'sparse_block_shape': (2, 3), 'zeros_per_block': 6}
             },
         ]
-        param_test_l1 = TestNormDataSparsifierRunner(data_list=data_list, defaults=defaults,
+        param_test_l1 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
                                                      data_with_config=data_with_config, norm_type='L1')
         param_test_l1.run_tests()
 
-        param_test_l2 = TestNormDataSparsifierRunner(data_list=data_list, defaults=defaults,
+        param_test_l2 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
                                                      data_with_config=data_with_config, norm_type='L2')
         param_test_l2.run_tests()
 
@@ -460,11 +464,11 @@ class TestNormDataSparsifiers(TestCase):
                 'config': {'sparsity_level': 0.3, 'sparse_block_shape': (2, 3), 'zeros_per_block': 6}
             },
         ]
-        emb_test_l1 = TestNormDataSparsifierRunner(data_list=data_list, defaults=defaults,
+        emb_test_l1 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
                                                    data_with_config=data_with_config, norm_type='L1')
         emb_test_l1.run_tests()
 
-        emb_test_l2 = TestNormDataSparsifierRunner(data_list=data_list, defaults=defaults,
+        emb_test_l2 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
                                                    data_with_config=data_with_config, norm_type='L2')
 
         emb_test_l2.run_tests()

--- a/test/ao/sparsity/test_data_sparsifier.py
+++ b/test/ao/sparsity/test_data_sparsifier.py
@@ -415,11 +415,11 @@ class TestNormDataSparsifiers(TestCase):
             },
         ]
         tensor_test_l1 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
-                                                      data_with_config=data_with_config, norm_type='L1')
+                                                       data_with_config=data_with_config, norm_type='L1')
         tensor_test_l1.run_tests()
 
         tensor_test_l2 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
-                                                      data_with_config=data_with_config, norm_type='L2')
+                                                       data_with_config=data_with_config, norm_type='L2')
         tensor_test_l2.run_tests()
 
     def test_nn_parameters(self):
@@ -439,11 +439,11 @@ class TestNormDataSparsifiers(TestCase):
             },
         ]
         param_test_l1 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
-                                                     data_with_config=data_with_config, norm_type='L1')
+                                                      data_with_config=data_with_config, norm_type='L1')
         param_test_l1.run_tests()
 
         param_test_l2 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
-                                                     data_with_config=data_with_config, norm_type='L2')
+                                                      data_with_config=data_with_config, norm_type='L2')
         param_test_l2.run_tests()
 
     def test_nn_embeddings(self):
@@ -465,10 +465,10 @@ class TestNormDataSparsifiers(TestCase):
             },
         ]
         emb_test_l1 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
-                                                   data_with_config=data_with_config, norm_type='L1')
+                                                    data_with_config=data_with_config, norm_type='L1')
         emb_test_l1.run_tests()
 
         emb_test_l2 = _NormDataSparsifierTestRunner(data_list=data_list, defaults=defaults,
-                                                   data_with_config=data_with_config, norm_type='L2')
+                                                    data_with_config=data_with_config, norm_type='L2')
 
         emb_test_l2.run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79811

A test was introduced, that was adding a constructor with positional arguments to the instance of the `TestCase`. The intention was to add a reusable "runner" for the relevant testcases. However, this broke the unittest's ability to discover any tests defined.

The failing behavior was not caught because when running the tests using python, the unittest's is able to run the tests correctly, without trying to identify the discovery/listing of all the tests.

The immediate followup is to rewrite the tests in the `data_sparsifier` to implement proper "runner" classes / functions.

Differential Revision: [D37253508](https://our.internmc.facebook.com/intern/diff/D37253508/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D37253508/)!