### PR TITLE
Do not bind `c10::irange` output by reference

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -518,7 +518,7 @@ inline std::ostream& operator<<(std::ostream& out, const Argument& arg) {
       auto default_val = arg.default_value().value().toIntList();
       if (default_val.size() > 1) {
         auto all_defaults_the_same = true;
-        for (const auto& i : c10::irange(1, default_val.size())) {
+        for (const auto i : c10::irange(1, default_val.size())) {
           if (default_val[0] != default_val[i]) all_defaults_the_same = false;
         }
         if (all_defaults_the_same) {


### PR DESCRIPTION
First of all, binding integers by reference is slower than by value
Also, it makes no sense as `c10::irange` output does not have permanent storage and results in following compiler warning:
```
aten/src/ATen/core/function_schema.h:521:26: error: loop variable 'i' binds to a temporary value produced by a range of type 'integer_range<unsigned long>' [-Werror,-Wrange-loop-bind-reference]
        for (const auto& i : c10::irange(1, default_val.size())) {
```
