### PR TITLE
[PrimTorch] Adds bfloat16 reference

### DIFF
--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -741,7 +741,7 @@ def tanh(a):
 
 def bfloat16(a: Tensor, *, memory_format: torch.memory_format = torch.preserve_format):
     if a.dtype == torch.bfloat16:
-        return out
+        return a
     out = prims.convert_element_type(a, torch.bfloat16)
     if memory_format != torch.preserve_format:
         raise NotImplementedError

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -739,6 +739,12 @@ def tan(a):
 def tanh(a):
     return prims.tanh(a)
 
+
+@_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)
+def trunc(a):
+    return prims.trunc(a)
+
+
 def bfloat16(a: Tensor, *, memory_format: torch.memory_format = torch.preserve_format):
     if a.dtype == torch.bfloat16:
         return a
@@ -746,10 +752,6 @@ def bfloat16(a: Tensor, *, memory_format: torch.memory_format = torch.preserve_f
     if memory_format != torch.preserve_format:
         out = prims.clone(out, memory_format=memory_format)
     return out
-
-@_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)
-def trunc(a):
-    return prims.trunc(a)
 
 
 def _make_elementwise_binary_reference(

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -739,10 +739,12 @@ def tan(a):
 def tanh(a):
     return prims.tanh(a)
 
-def bfloat16(a, memory_format: torch.memory_format = torch.preserve_format):
+def bfloat16(a: Tensor, *, memory_format: torch.memory_format = torch.preserve_format):
+    if a.dtype == torch.bfloat16:
+        return out
     out = prims.convert_element_type(a, torch.bfloat16)
     if memory_format != torch.preserve_format:
-        out = prims.clone(out, memory_format=memory_format)
+        raise NotImplementedError
     return out
 
 @_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -750,7 +750,7 @@ def bfloat16(a: Tensor, *, memory_format: torch.memory_format = torch.preserve_f
         return a
     out = prims.convert_element_type(a, torch.bfloat16)
     if memory_format != torch.preserve_format:
-        out = prims.clone(out, memory_format=memory_format)
+        out = clone(out, memory_format=memory_format)
     return out
 
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -92,6 +92,8 @@ __all__ = [
     "tanh",
     "trace",
     "trunc",
+    # Conversion funcs
+    "bfloat16",
     #
     # Elementwise Binary References
     #
@@ -737,6 +739,10 @@ def tan(a):
 def tanh(a):
     return prims.tanh(a)
 
+@_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
+                                   aten_op=None)
+def bfloat16(a):
+    return prims.convert_element_type(a, torch.bfloat16)
 
 @_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)
 def trunc(a):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -739,10 +739,11 @@ def tan(a):
 def tanh(a):
     return prims.tanh(a)
 
-@_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT,
-                                   aten_op=None)
-def bfloat16(a):
-    return prims.convert_element_type(a, torch.bfloat16)
+def bfloat16(a, memory_format: torch.memory_format = torch.preserve_format):
+    out = prims.convert_element_type(a, torch.bfloat16)
+    if memory_format != torch.preserve_format:
+        out = prims.clone(out, memory_format=memory_format)
+    return out
 
 @_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)
 def trunc(a):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -744,7 +744,7 @@ def tanh(a):
 def trunc(a):
     return prims.trunc(a)
 
-
+@register_decomposition(torch.Tensor.bfloat16)
 def bfloat16(a: Tensor, *, memory_format: torch.memory_format = torch.preserve_format):
     if a.dtype == torch.bfloat16:
         return a

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -744,7 +744,7 @@ def bfloat16(a: Tensor, *, memory_format: torch.memory_format = torch.preserve_f
         return a
     out = prims.convert_element_type(a, torch.bfloat16)
     if memory_format != torch.preserve_format:
-        raise NotImplementedError
+        out = prims.clone(out, memory_format=memory_format)
     return out
 
 @_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20461,6 +20461,9 @@ python_ref_db = [
     ElementwiseUnaryPythonRefInfo(
         "_refs.trunc",
         torch_opinfo_name="trunc",
+    PythonRefInfo(
+        "_refs.bfloat16",
+        torch_opinfo_name="bfloat16",
     ),
     #
     # Elementwise Unary Special OpInfos

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20461,6 +20461,7 @@ python_ref_db = [
     ElementwiseUnaryPythonRefInfo(
         "_refs.trunc",
         torch_opinfo_name="trunc",
+    ),
     PythonRefInfo(
         "_refs.bfloat16",
         torch_opinfo_name="bfloat16",


### PR DESCRIPTION
Naive attempt at `bfloat16` which breaks, first error is about `out` working when it isn't expected:

`python test/test_ops.py -f -k test_out__refs_bfloat16_cpu_float32`

CC @mruberry 
