### PR TITLE
FSDP communication hook interface for NO_SHARD strategy

### DIFF
--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -51,7 +51,7 @@ class TestCommunicationHooks(FSDPTest):
             sharding_strategy=sharding_strategy
         ).to(self.rank)
 
-         # Check that default hook is set to `all_reduce`
+        # Check that default hook is set to `all_reduce`
         for entry in FSDP.fsdp_modules(net_default_hook):
             self.assertEqual(entry.communication_hook.__qualname__, allreduce_hook.allreduce_hook.__qualname__)
 

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -23,6 +23,53 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
+class Net(nn.Module):
+
+    def __init__(self, has_wrapping, sharding_strategy):
+        # to ensure determinism
+        torch.manual_seed(0)
+        torch.cuda.manual_seed(0)
+        super().__init__()
+
+        if has_wrapping:
+            self.net = FSDP(nn.Sequential(
+                nn.Linear(8, 16),
+                nn.ReLU(),
+                FSDP(
+                    nn.Linear(16, 8),
+                    device_id=torch.cuda.current_device(),
+                    sharding_strategy=sharding_strategy
+                )
+            ),
+                device_id=torch.cuda.current_device(),
+                sharding_strategy=sharding_strategy
+            )
+        else:
+            self.net = nn.Sequential(
+                nn.Linear(8, 16),
+                nn.ReLU(),
+                nn.Linear(16, 8)
+            )
+
+        self.out = nn.Linear(8, 4)
+
+    def forward(self, x):
+        return self.out(F.relu(self.net(x)))
+
+class DummyState(object):
+
+    __slots__ = [
+        "process_group"
+    ]
+
+    def __init__(self, process_group):
+        self.process_group = process_group
+
+class DummyHook(object):
+
+    def dummy_hook(self, state: DummyState, grad: torch.Tensor):
+        pass
+
 class TestCommunicationHooks(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
@@ -31,12 +78,12 @@ class TestCommunicationHooks(FSDPTest):
         [
             ShardingStrategy.NO_SHARD
         ])
-    def test_default_communication_hook_behaviour(
+    def test_default_communication_hook_behavior(
         self,
         sharding_strategy: Optional[ShardingStrategy]
     ):
         """
-        Tests FSDP's default communication hook's behaviour and correctness.
+        Tests FSDP's default communication hook's behavior and correctness.
         Arguments:
             sharding_strategy (Optional[ShardingStrategy]): Configures the FSDP algorithm.
         """
@@ -51,16 +98,12 @@ class TestCommunicationHooks(FSDPTest):
 
         # Check that default hook is set to `all_reduce`
         for entry in FSDP.fsdp_modules(net_default_hook):
-            self.assertEqual(entry.communication_hook.__qualname__, allreduce_hook.allreduce_hook.__qualname__)
+            self.assertEqual(entry.communication_hook, allreduce_hook.allreduce_hook)
 
         for _ in range(4):
 
-            # Clear gradients manually.
-            for entry in net_default_hook.parameters():
-                if entry.grad is not None:
-                    entry.grad.requires_grad_(False)
-                    entry.grad.zero_()
-
+            # Clear gradients
+            net_default_hook.zero_grad()
             loss = net_default_hook(inpt).sum()
             loss.backward()
 
@@ -74,6 +117,21 @@ class TestCommunicationHooks(FSDPTest):
                 grad[0].item(),
                 expected_grad,
                 msg=f"Expected hook grad of {expected_grad} but got {grad[0].item()}")
+
+    def _get_submodules(self, fsdp_net):
+        return [
+            submodule for submodule in FSDP.fsdp_modules(fsdp_net)
+            if not submodule.check_is_root()
+        ]
+
+    def _init_model(self, core, sharding_strategy):
+
+        device = torch.device("cuda")
+        return FSDP(
+            core,
+            device_id=torch.cuda.current_device(),
+            sharding_strategy=sharding_strategy
+        ).to(device)
 
     @skip_if_lt_x_gpu(2)
     @parametrize("has_wrapping", [True, False])
@@ -90,77 +148,20 @@ class TestCommunicationHooks(FSDPTest):
         sharding_strategy: Optional[ShardingStrategy]
     ):
         """
-        Tests FSDP's communication hook interface behaviour.
+        Tests FSDP's communication hook interface behavior.
         Arguments:
             has_wrapping (bool): Configures wrapping of a module.
             sharding_strategy (Optional[ShardingStrategy]): Configures the FSDP algorithm.
         """
 
-        class DummyState(object):
-
-            __slots__ = [
-                "process_group"
-            ]
-
-            def __init__(self, process_group):
-                self.process_group = process_group
-
-        def dummy_hook(state: DummyState, grad: torch.Tensor):
-            pass
-
-        class Net(nn.Module):
-
-            def __init__(self, has_wrapping):
-                # to ensure determinizm
-                torch.manual_seed(0)
-                torch.cuda.manual_seed(0)
-                super().__init__()
-
-                if has_wrapping:
-                    self.net = FSDP(nn.Sequential(
-                        nn.Linear(8, 16),
-                        nn.ReLU(),
-                        FSDP(
-                            nn.Linear(16, 8),
-                            device_id=torch.cuda.current_device(),
-                            sharding_strategy=sharding_strategy
-                        )
-                    ),
-                        device_id=torch.cuda.current_device(),
-                        sharding_strategy=sharding_strategy
-                    )
-                else:
-                    self.net = nn.Sequential(
-                        nn.Linear(8, 16),
-                        nn.ReLU(),
-                        nn.Linear(16, 8)
-                    )
-
-                self.out = nn.Linear(8, 4)
-
-            def forward(self, x):
-                return self.out(F.relu(self.net(x)))
-
-        def init_model(core, sharding_strategy=sharding_strategy):
-            return FSDP(
-                core,
-                device_id=torch.cuda.current_device(),
-                sharding_strategy=sharding_strategy
-            ).to(device)
-
-        def get_submodules(fsdp_net):
-            return [
-                submodule for submodule in FSDP.fsdp_modules(fsdp_net)
-                if not submodule.check_is_root()
-            ]
-
         # Initialize the model and inputs
-        device = torch.device("cuda")
-        fsdp_model_with_hook = init_model(Net(has_wrapping))
-
+        fsdp_model_with_hook = self._init_model(
+            Net(has_wrapping=has_wrapping, sharding_strategy=sharding_strategy),
+            sharding_strategy=sharding_strategy
+        )
         dummy_state = DummyState(process_group=None)
 
-        # FSDP currently suports communication hooks for a NO_SHARD strategy
+        # FSDP currently supports communication hooks for a NO_SHARD strategy
         # Check that a `NotImplementedError` is raised for other strategies
         if sharding_strategy != ShardingStrategy.NO_SHARD:
             # Check that default hook is set to None
@@ -172,7 +173,7 @@ class TestCommunicationHooks(FSDPTest):
                 NotImplementedError,
                 '^Communication hooks are currently only available for a NO_SHARD strategy.$'
             ):
-                fsdp_model_with_hook.register_comm_hook(dummy_state, dummy_hook)
+                fsdp_model_with_hook.register_comm_hook(dummy_state, DummyHook.dummy_hook)
 
         else:
 
@@ -182,69 +183,108 @@ class TestCommunicationHooks(FSDPTest):
 
             dummy_state = DummyState(process_group=None)
 
-            if has_wrapping:
-                # Creating a list of non-root submodules to test
-                submodules = get_submodules(fsdp_model_with_hook)
-                # Check that assertion is raised for registering a comm hook on a non-root
-                with self.assertRaisesRegex(AssertionError, '^register_comm_hook can only be called on a root instance.$'):
-                    submodules[1].register_comm_hook(
-                        dummy_state,
-                        dummy_hook
-                    )
-
-                # Simmulate a registretion of a hook on a submodule
-                submodules[1]._hook_registered = True
-
-                # Check that an error is raised when some of submodules have a non-default hook assigned
-                with self.assertRaisesRegex(
-                    AssertionError,
-                    '^communication hook can be only registered once$'
-                ):
-                    fsdp_model_with_hook.register_comm_hook(
-                        dummy_state,
-                        dummy_hook
-                    )
-
-                # Reinitialize model to default
-                fsdp_model_with_hook = init_model(Net(has_wrapping))
-                submodules = get_submodules(fsdp_model_with_hook)
-                submodules[1].communication_hook = dummy_hook
-
-                # Check that an error is raised when some of submodules have a non-default hook assigned
-                with self.assertRaisesRegex(
-                    AssertionError,
-                    f'^communication hook should be default, but it is {submodules[1].communication_hook.__name__} instead$'
-                ):
-                    fsdp_model_with_hook.register_comm_hook(
-                        dummy_state,
-                        dummy_hook
-                    )
-
-                # Reinitialize model to default
-                fsdp_model_with_hook = init_model(Net(has_wrapping))
-
             fsdp_model_with_hook.register_comm_hook(
                 dummy_state,
-                dummy_hook
+                DummyHook.dummy_hook
             )
 
             # Check that we can't register comm hook twice
             with self.assertRaisesRegex(AssertionError, '^communication hook can be only registered once$'):
                 fsdp_model_with_hook.register_comm_hook(
                     dummy_state,
-                    dummy_hook
+                    DummyHook.dummy_hook
                 )
 
             # Check dummy hook was registered for the root and all submodules if any
             for entry in FSDP.fsdp_modules(fsdp_model_with_hook):
                 self.assertEqual(
                     entry.communication_hook,
-                    dummy_hook
+                    DummyHook.dummy_hook
                 )
                 self.assertEqual(
                     entry.communication_hook_state,
                     dummy_state
                 )
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize(
+        "sharding_strategy",
+        [
+            ShardingStrategy.NO_SHARD
+        ])
+    def test_registering_hook_non_root(
+        self,
+        sharding_strategy: Optional[ShardingStrategy]
+    ):
+        """
+        Tests FSDP's communication hook registering for submodules.
+        Make sure it can't be registered for non-root submodules.
+        Currently tests only ``NO_SHARD`` strategy.
+        Arguments:
+            sharding_strategy (Optional[ShardingStrategy]): Configures the FSDP algorithm.
+
+        """
+
+        fsdp_model_with_hook = self._init_model(
+            Net(has_wrapping=True, sharding_strategy=sharding_strategy),
+            sharding_strategy=sharding_strategy
+        )
+        dummy_state = DummyState(process_group=None)
+        # Creating a list of non-root submodules to test
+        submodules = self._get_submodules(fsdp_model_with_hook)
+        # Check that assertion is raised for registering a comm hook on a non-root
+        with self.assertRaisesRegex(AssertionError, '^register_comm_hook can only be called on a root instance.$'):
+            submodules[1].register_comm_hook(dummy_state, DummyHook.dummy_hook)
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize(
+        "sharding_strategy",
+        [
+            ShardingStrategy.NO_SHARD
+        ])
+    def test_registering_hook_submodules(
+        self,
+        sharding_strategy: Optional[ShardingStrategy]
+    ):
+        """
+        Tests FSDP's communication hook registering for submodules.
+        Checks behavior if a hook was registered for a non-root submodule
+        Currently tests only ``NO_SHARD`` strategy.
+        Arguments:
+            sharding_strategy (Optional[ShardingStrategy]): Configures the FSDP algorithm.
+
+        """
+
+        fsdp_model_with_hook = self._init_model(
+            Net(has_wrapping=True, sharding_strategy=sharding_strategy),
+            sharding_strategy=sharding_strategy
+        )
+        dummy_state = DummyState(process_group=None)
+        submodules = self._get_submodules(fsdp_model_with_hook)
+
+        # Simulate a registration of a hook on a submodule
+        submodules[1]._hook_registered = True
+        # Check that an error is raised when some of submodules have a non-default hook assigned
+        with self.assertRaisesRegex(AssertionError, '^communication hook can be only registered once$'):
+            fsdp_model_with_hook.register_comm_hook(dummy_state, DummyHook.dummy_hook)
+
+        # Reinitialize the model
+        fsdp_model_with_hook = self._init_model(
+            Net(has_wrapping=True, sharding_strategy=sharding_strategy),
+            sharding_strategy=sharding_strategy
+        )
+        submodules = self._get_submodules(fsdp_model_with_hook)
+        submodules[1].communication_hook = DummyHook.dummy_hook
+
+        # Check that an error is raised when some of submodules have a non-default hook assigned
+        with self.assertRaisesRegex(
+            AssertionError,
+            f'^communication hook should be default, but it is {submodules[1].communication_hook.__name__} instead$'
+        ):
+            fsdp_model_with_hook.register_comm_hook(
+                dummy_state,
+                DummyHook.dummy_hook
+            )
 
 
 instantiate_parametrized_tests(TestCommunicationHooks)

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -1,0 +1,206 @@
+# Owner(s): ["oncall: distributed"]
+
+import copy
+import sys
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import distributed as dist
+from torch.distributed.algorithms._comm_hooks import allreduce_hook
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.fully_sharded_data_parallel import ShardingStrategy
+
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import FSDPTest
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
+
+if not dist.is_available():
+    print("Distributed not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+class TestCommunicationHooks(FSDPTest):
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize(
+        "sharding_strategy",
+        [
+            ShardingStrategy.NO_SHARD
+        ])
+    def test_default_communication_hook_behaviour(
+        self,
+        sharding_strategy: Optional[ShardingStrategy]
+    ):
+        """
+        Tests FSDP's default communication hook's behaviour and correctness.
+        Arguments:
+            has_wrapping (bool): Configures wrapping of a module.
+            sharding_strategy (Optional[ShardingStrategy]): Configures the FSDP algorithm.
+        """
+        m = torch.nn.Linear(1, 2, bias=False)
+        inpt = torch.tensor([self.rank]).float().cuda(self.rank)
+
+        net_default_hook = FSDP(
+            copy.deepcopy(m),
+            device_id=torch.cuda.current_device(),
+            sharding_strategy=sharding_strategy
+        ).to(self.rank)
+
+         # Check that default hook is set to `all_reduce`
+        for entry in FSDP.fsdp_modules(net_default_hook):
+            self.assertEqual(entry.communication_hook.__qualname__, allreduce_hook.allreduce_hook.__qualname__)
+
+        for _ in range(4):
+
+            # Clear gradients manually.
+            for entry in net_default_hook.parameters():
+                if entry.grad is not None:
+                    entry.grad.requires_grad_(False)
+                    entry.grad.zero_()
+
+            loss = net_default_hook(inpt).sum()
+            loss.backward()
+
+            # For each worker, the gradient on the weight should be worker_rank.
+            grad = [param.grad for param in net_default_hook.parameters()]
+
+            avg = copy.deepcopy(grad[0])
+            expected_grad = (
+                sum(i for i in range(dist.get_world_size())) / dist.get_world_size()
+            )
+            # Verify default hook produces expected gradients
+            self.assertEqual(
+                avg[0].item(),
+                expected_grad,
+                msg=f"Expected hook grad of {expected_grad} but got {avg[0].item()}")
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("has_wrapping", [True, False])
+    @parametrize(
+        "sharding_strategy",
+        [
+            ShardingStrategy.NO_SHARD,
+            ShardingStrategy.FULL_SHARD,
+            ShardingStrategy.SHARD_GRAD_OP
+        ])
+    def test_default_communication_hook_initialization(
+        self,
+        has_wrapping: bool,
+        sharding_strategy: Optional[ShardingStrategy]
+    ):
+
+        """
+        Tests FSDP's communication hook interface behaviour.
+        Arguments:
+            has_wrapping (bool): Configures wrapping of a module.
+            sharding_strategy (Optional[ShardingStrategy]): Configures the FSDP algorithm.
+        """
+
+        class DummyState(object):
+
+            __slots__ = [
+                "process_group"
+            ]
+
+            def __init__(self, process_group):
+                self.process_group = process_group
+
+        def dummy_hook(state: DummyState, grad: torch.Tensor):
+            pass
+
+
+        class Net(nn.Module):
+
+            def __init__(self, has_wrapping):
+                # to ensure determinizm
+                torch.manual_seed(0)
+                torch.cuda.manual_seed(0)
+                super().__init__()
+
+                if has_wrapping:
+                    self.net = FSDP(nn.Sequential(
+                        nn.Linear(8, 16),
+                        nn.ReLU(),
+                        FSDP(
+                            nn.Linear(16, 8),
+                            device_id=torch.cuda.current_device(),
+                            sharding_strategy=sharding_strategy
+                        )
+                    ),
+                        device_id=torch.cuda.current_device(),
+                        sharding_strategy=sharding_strategy
+                    )
+                else:
+                    self.net = nn.Sequential(
+                        nn.Linear(8, 16),
+                        nn.ReLU(),
+                        nn.Linear(16, 8)
+                    )
+
+                self.out = nn.Linear(8, 4)
+
+            def forward(self, x):
+                return self.out(F.relu(self.net(x)))
+
+        # Initialize the model and inputs
+        device = torch.device("cuda")
+        fsdp_model_with_hook = FSDP(
+            Net(has_wrapping),
+            device_id=torch.cuda.current_device(),
+            sharding_strategy=sharding_strategy
+        ).to(device)
+
+        dummy_state = DummyState(process_group=None)
+
+        # FSDP currently suports communication hooks for a NO_SHARD strategy
+        # Check that a `NotImplementedError`` is raised for other strategies
+        if sharding_strategy != ShardingStrategy.NO_SHARD:
+            # Check that default hook is set to None
+            for entry in FSDP.fsdp_modules(fsdp_model_with_hook):
+                self.assertIsNone(entry.communication_hook)
+                self.assertIsNone(entry.communication_hook_state)
+
+            with self.assertRaises(
+                NotImplementedError,
+                msg="Communication hooks are currently only available for a NO_SHARD strategy."
+            ):
+                fsdp_model_with_hook.register_comm_hook(dummy_state, dummy_hook)
+
+        else:
+
+            # Check that default hook is set to `all_reduce`
+            for entry in FSDP.fsdp_modules(fsdp_model_with_hook):
+                self.assertEqual(entry.communication_hook.__qualname__, allreduce_hook.allreduce_hook.__qualname__)
+
+            dummy_state = DummyState(process_group=None)
+            fsdp_model_with_hook.register_comm_hook(
+                dummy_state,
+                dummy_hook
+            )
+            with self.assertRaises(AssertionError):
+                fsdp_model_with_hook.register_comm_hook(
+                    dummy_state,
+                    dummy_hook
+                )
+
+            # Check dummy hook was registered for the root and all submodules if any
+            for entry in FSDP.fsdp_modules(fsdp_model_with_hook):
+                self.assertEqual(
+                    entry.communication_hook.__qualname__,
+                    dummy_hook.__qualname__
+                )
+                self.assertEqual(
+                    entry.communication_hook_state,
+                    dummy_state
+                )
+
+
+instantiate_parametrized_tests(TestCommunicationHooks)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -208,7 +208,7 @@ class TestCommunicationHooks(FSDPTest):
                 dummy_hook
             )
             # Check that we can't register comm hook twice
-            with self.assertRaises(AssertionError):
+            with self.assertRaisesRegex(AssertionError, '^communication hook can be only registered once$'):
                 fsdp_model_with_hook.register_comm_hook(
                     dummy_state,
                     dummy_hook

--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -169,7 +169,7 @@ class TestCommunicationHooks(FSDPTest):
 
             # Check that default hook is set to `all_reduce`
             for entry in FSDP.fsdp_modules(fsdp_model_with_hook):
-                self.assertEqual(entry.communication_hook.__qualname__, allreduce_hook.allreduce_hook.__qualname__)
+                self.assertEqual(entry.communication_hook, allreduce_hook.allreduce_hook)
 
             dummy_state = DummyState(process_group=None)
 

--- a/torch/distributed/algorithms/_comm_hooks/__init__.py
+++ b/torch/distributed/algorithms/_comm_hooks/__init__.py
@@ -1,0 +1,1 @@
+from . import allreduce_hook

--- a/torch/distributed/algorithms/_comm_hooks/allreduce_hook.py
+++ b/torch/distributed/algorithms/_comm_hooks/allreduce_hook.py
@@ -46,14 +46,14 @@ class AllReduceState(object):
 def allreduce_hook(state: AllReduceState, grad: torch.Tensor):
     r"""
     This FSDP communication hook implements ``all_reduce`` algorithm
-    and a neccessary pre- and post-division of gradients.
+    and a necessary pre- and post-division of gradients.
 
     Args:
         state (AllReduceState): State information, configures pre- and post-division factors
         grad (torch.Tensor): A gradient for the local batch that needs to be communicated across ranks.
     """
-    grad.div_(state.gradient_predivide_factor)
+    if state.gradient_predivide_factor > 1:
+        grad.div_(state.gradient_predivide_factor)
     dist.all_reduce(grad, group=state.process_group)
     if state.gradient_postdivide_factor > 1:
-        # Average grad by world_size for consistency with PyTorch DDP.
         grad.div_(state.gradient_postdivide_factor)

--- a/torch/distributed/algorithms/_comm_hooks/allreduce_hook.py
+++ b/torch/distributed/algorithms/_comm_hooks/allreduce_hook.py
@@ -1,0 +1,59 @@
+import torch
+import torch.distributed as dist
+from torch.distributed import distributed_c10d
+
+
+class AllReduceState(object):
+    r"""
+    Stores parameters, needed to perform ``all_reduce`` algorithm
+    within a communication hook.
+
+    Args:
+        process_group (ProcessGroup): The process group to be used for all-reduce.
+        world_size (int): The number of nodes in a process group.
+            Determined based on a ``process_group``.
+        gradient_predivide_factor (float): A factor for gradients' pre-division.
+        gradient_postdivide_factor (float): A factor for gradients' post-division.
+    """
+
+    __slots__ = [
+        "process_group",
+        "world_size",
+        "gradient_predivide_factor",
+        "gradient_postdivide_factor"
+    ]
+
+    def __init__(
+        self,
+        process_group
+    ):
+        self.process_group = process_group if process_group is not None else distributed_c10d._get_default_group()
+        self.world_size = dist.get_world_size(process_group)
+        self.gradient_predivide_factor = self._get_gradient_predivide_factor(
+            self.world_size
+        )
+        self.gradient_postdivide_factor = self.world_size / self.gradient_predivide_factor
+
+    # setting two factors 'self.gradient_predivide_factor'
+    # and 'self.gradient_postdivide_factor' to avoid underflow and overflow
+    def _get_gradient_predivide_factor(self, world_size: int) -> float:
+        factor: int = 1
+        while world_size % factor == 0 and world_size / factor > factor:
+            factor *= 2
+        return float(factor)
+
+
+def allreduce_hook(state: AllReduceState, grad: torch.Tensor):
+    r"""
+    This FSDP communication hook implements ``all_reduce`` algorithm
+    and a neccessary post-division of gradients.
+
+    Args:
+        state (AllReduceState): State information, configures pre- and post-division factors
+        grad (torch.Tensor): A gradient for the local batch that needs to be communicated across ranks.
+    """
+    # `all_reduce` is a default hook and grad is already pre-divided
+    dist.all_reduce(grad, group=state.process_group)
+    if state.gradient_postdivide_factor > 1:
+        # Average grad by world_size for consistency with PyTorch DDP.
+        grad.div_(state.gradient_postdivide_factor)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -3,7 +3,6 @@ import contextlib
 import copy
 import functools
 import itertools
-import logging
 import math
 import traceback
 import warnings
@@ -97,8 +96,6 @@ FSDP_WRAPPED_MODULE = "_fsdp_wrapped_module"
 FSDP_PREFIX = FSDP_WRAPPED_MODULE + "." + FPW_MODULE + "."
 
 _PARAM_BROADCAST_BUCKET_SIZE = int(250 * 1024 * 1024)
-
-logger = logging.getLogger(__name__)
 
 def _default_meta_device_init_fn(module):
     """
@@ -729,7 +726,6 @@ class FullyShardedDataParallel(nn.Module):
                 sync_module_states=sync_module_states,
             )
 
-        self._comm_hook_was_called = False
         self.process_group = process_group or _get_default_group()
         self.rank = self.process_group.rank()
         self.world_size = self.process_group.size()

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -4070,7 +4070,7 @@ class FullyShardedDataParallel(nn.Module):
                             the full, flattened, unsharded gradient with respect to all variables
                             corresponding to the model this FSDP unit is wrapping
                             (that are not wrapped by other FSDP sub-units).
-                            It then performs all neccessary processing and returns ``None``.
+                            It then performs all necessary processing and returns ``None``.
 
         """
         assert self.check_is_root(), "register_comm_hook can only be called on a root instance."

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -26,7 +26,6 @@ from typing import (
     Union,
     cast,
 )
-from torch.distributed.algorithms._comm_hooks import allreduce_hook
 
 import torch
 import torch.distributed as dist
@@ -932,9 +931,9 @@ class FullyShardedDataParallel(nn.Module):
         # For validating execution order across ranks
         self._exec_order_data = _ExecOrderData()
 
-         # setting communication hook to a default
-        self.communication_hook = self._get_default_comm_hook(self.sharding_strategy)
-        self.communication_hook_state = self._get_default_comm_hook_state(self.sharding_strategy, self.process_group)
+        # setting communication hook to a default
+        self.communication_hook = self._get_default_comm_hook()
+        self.communication_hook_state = self._get_default_comm_hook_state()
         self._comm_hook_was_called = False
 
     def _init_param_exec_order_wrap_policy(self, *args, **kwargs) -> None:
@@ -953,10 +952,6 @@ class FullyShardedDataParallel(nn.Module):
                 m._fsdp_params_exec_order = self._fsdp_params_exec_order
                 m._param_exec_order_policy = True
                 m._param_exec_order_prep_stage = True
-
-        # setting communication hook to a default
-        self.communication_hook = self._get_default_comm_hook()
-        self.communication_hook_state = self._get_default_comm_hook_state()
 
     def _move_module_if_needed(self, module) -> None:
         """
@@ -1176,24 +1171,6 @@ class FullyShardedDataParallel(nn.Module):
                     not hasattr(p, "_params_exec_order_hook_handle")
                 ), "When not in execution order prep stage, all _params_exec_order_hook_handle should be removed."
         return is_prep_stage
-
-    def _get_default_comm_hook(self) -> Any:
-        """
-        Sets a default communication hook based on a sharding strategy.
-        """
-        if self.sharding_strategy != ShardingStrategy.NO_SHARD:
-            return None
-        else:
-            return allreduce_hook.allreduce_hook
-
-    def _get_default_comm_hook_state(self) -> Any:
-        """
-        Sets a default communication hook state based on a sharding strategy.
-        """
-        if self.sharding_strategy != ShardingStrategy.NO_SHARD:
-            return None
-        else:
-            return allreduce_hook.AllReduceState(process_group=self.process_group)
 
     @staticmethod
     def fsdp_modules(
@@ -2928,8 +2905,8 @@ class FullyShardedDataParallel(nn.Module):
                     # reduce_dtype matches the param dtype.
                     param.grad.data = param.grad.data.to(self.mixed_precision.reduce_dtype)
 
-                if self.gradient_predivide_factor > 1 and\
-                    self.communication_hook == self._get_default_comm_hook(self.sharding_strategy):
+                if self.gradient_predivide_factor > 1 and \
+                        self.communication_hook == self._get_default_comm_hook():
                     # Average grad by world_size for consistency with PyTorch DDP.
                     param.grad.div_(self.gradient_predivide_factor)
 
@@ -3428,57 +3405,6 @@ class FullyShardedDataParallel(nn.Module):
                         f"parameters in `forward()` for {r2_param_names}"
                     )
             eod.param_order.append(param_index)
-
-    def register_comm_hook(self, state: object, hook: callable):
-        r"""
-        Registers a communication hook which is an enhancement that provides a
-        flexible hook to users where they can specify how FSDP aggregates gradients
-        across multiple workers.
-
-        This hook can be used to implement several algorithms like GossipGrad
-        and gradient compression which involve different communication strategies for
-        parameter syncs while running Fully Sharded Data Parallel training.
-
-        .. warning::
-            FSDP only support communication hooks for a ``NO_SHARD`` strategy at this time.
-            If other strategies are used, an error will be raised.
-
-        .. warning ::
-            FSDP communication hook should be registered before running an initial forward pass
-            and only once.
-
-        Args:
-            state (object): Passed to the hook to maintain any state information during the training process.
-                            Examples include error feedback in gradient compression,
-                            peers to communicate with next in `GossipGrad <https://arxiv.org/abs/1803.05880>`_, etc.
-
-                            It is locally stored by each worker
-                            and shared by all the gradient tensors on the worker.
-
-            hook (callable): Callable with the following signature:
-                             ``hook: Callable[torch.Tensor] -> None``:
-
-                             This function takes in a python tensor, which represents a gradient
-                             of a loss function with respect to variables of a model
-                             for the local batch that needs to be communicated across ranks.
-                             It then performs all neccessary processing and returns nothing.
-
-        """
-        assert self.check_is_root(), "register_comm_hook can only be called on a root instance."
-        assert not self._comm_hook_was_called, "register_comm_hook can be only called once"
-        if self.sharding_strategy != ShardingStrategy.NO_SHARD:
-            raise NotImplementedError(
-                "Communication hooks are currently only available for a NO_SHARD strategy."
-            )
-        else:
-            # register same hook for root and all submodules
-            for submodule in self.fsdp_modules(self):
-                submodule._comm_hook_was_called = True
-                # registering hook only if it hasn't been already registered
-                if submodule.communication_hook == self._get_default_comm_hook():
-                    submodule.communication_hook_state = state
-                    submodule.communication_hook = hook
-
 
 
     @torch.no_grad()
@@ -4102,23 +4028,23 @@ class FullyShardedDataParallel(nn.Module):
             return new_osd
         return new_osd  # should never reach here
 
-    def _get_default_comm_hook(self, sharding_strategy) -> Any:
-        """
+    def _get_default_comm_hook(self) -> Any:
+        r"""
         Sets a default communication hook based on a sharding strategy.
         """
-        if sharding_strategy != ShardingStrategy.NO_SHARD:
+        if self.sharding_strategy != ShardingStrategy.NO_SHARD:
             return None
         else:
             return allreduce_hook.allreduce_hook
 
-    def _get_default_comm_hook_state(self, sharding_strategy, process_group) -> Any:
-        """
+    def _get_default_comm_hook_state(self) -> Any:
+        r"""
         Sets a default communication hook state based on a sharding strategy.
         """
-        if sharding_strategy != ShardingStrategy.NO_SHARD:
+        if self.sharding_strategy != ShardingStrategy.NO_SHARD:
             return None
         else:
-            return allreduce_hook.AllReduceState(process_group=process_group)
+            return allreduce_hook.AllReduceState(process_group=self.process_group)
 
     def register_comm_hook(self, state: object, hook: callable):
         r"""
@@ -4158,7 +4084,7 @@ class FullyShardedDataParallel(nn.Module):
             for submodule in self.fsdp_modules(self):
                 submodule._comm_hook_was_called = True
                 # registering hook only if it hasn't been already registered
-                if submodule.communication_hook == self._get_default_comm_hook(self.sharding_strategy):
+                if submodule.communication_hook == self._get_default_comm_hook():
                     submodule.communication_hook_state = state
                     submodule.communication_hook = hook
 

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -4024,7 +4024,7 @@ class FullyShardedDataParallel(nn.Module):
 
     def _get_default_comm_hook(self) -> Any:
         r"""
-        Sets a default communication hook based on a sharding strategy.
+        Returns a default communication hook based on a sharding strategy.
         """
         if self.sharding_strategy != ShardingStrategy.NO_SHARD:
             return None
@@ -4033,7 +4033,7 @@ class FullyShardedDataParallel(nn.Module):
 
     def _get_default_comm_hook_state(self) -> Any:
         r"""
-        Sets a default communication hook state based on a sharding strategy.
+        Returns a default communication hook state based on a sharding strategy.
         """
         if self.sharding_strategy != ShardingStrategy.NO_SHARD:
             return None
@@ -4066,14 +4066,15 @@ class FullyShardedDataParallel(nn.Module):
                             and shared by all the gradient tensors on the worker.
             hook (callable): Callable with the following signature:
                             ``hook: Callable[torch.Tensor] -> None``:
-                            This function takes in a python tensor, which represents
+                            This function takes in a Python tensor, which represents
                             the full, flattened, unsharded gradient with respect to all variables
                             corresponding to the model this FSDP unit is wrapping
                             (that are not wrapped by other FSDP sub-units).
                             It then performs all necessary processing and returns ``None``.
 
         """
-        assert self.check_is_root(), "register_comm_hook can only be called on a root instance."
+        if not self.check_is_root():
+            raise AssertionError("register_comm_hook can only be called on a root instance.")
         if self.sharding_strategy != ShardingStrategy.NO_SHARD:
             raise NotImplementedError(
                 "Communication hooks are currently only available for a NO_SHARD strategy."

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -4043,19 +4043,22 @@ class FullyShardedDataParallel(nn.Module):
             return allreduce_hook.AllReduceState(process_group=self.process_group)
 
     def register_comm_hook(self, state: object, hook: callable):
-        r"""
+        """
         Registers a communication hook which is an enhancement that provides a
         flexible hook to users where they can specify how FSDP aggregates gradients
         across multiple workers.
         This hook can be used to implement several algorithms like GossipGrad
         and gradient compression which involve different communication strategies for
         parameter syncs while running Fully Sharded Data Parallel training.
+
         .. warning::
             FSDP only support communication hooks for a ``NO_SHARD`` strategy at this time.
             If other strategies are used, an error will be raised.
+
         .. warning ::
             FSDP communication hook should be registered before running an initial forward pass
             and only once.
+
         Args:
             state (object): Passed to the hook to maintain any state information during the training process.
                             Examples include error feedback in gradient compression,
@@ -4063,11 +4066,12 @@ class FullyShardedDataParallel(nn.Module):
                             It is locally stored by each worker
                             and shared by all the gradient tensors on the worker.
             hook (callable): Callable with the following signature:
-                             ``hook: Callable[torch.Tensor] -> None``:
-                             This function takes in a python tensor, which represents a gradient
-                             of a loss function with respect to variables of a model
-                             for the local batch that needs to be communicated across ranks.
-                             It then performs all neccessary processing and returns nothing.
+                            ``hook: Callable[torch.Tensor] -> None``:
+                            This function takes in a python tensor, which represents a gradient
+                            of a loss function with respect to variables of a model
+                            for the local batch that needs to be communicated across ranks.
+                            It then performs all neccessary processing and returns nothing.
+
         """
         assert self.check_is_root(), "register_comm_hook can only be called on a root instance."
         assert not self._comm_hook_was_called, "register_comm_hook can be only called once"

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -4081,8 +4081,8 @@ class FullyShardedDataParallel(nn.Module):
         else:
             # register same hook for root and all submodules
             for submodule in self.fsdp_modules(self):
-                assert not self.self._hook_registered, "communication hook can be only registered once"
-                submodule.self._hook_registered = True
+                assert not submodule._hook_registered, "communication hook can be only registered once"
+                submodule._hook_registered = True
                 # registering hook only if it hasn't been already registered
                 if submodule.communication_hook == self._get_default_comm_hook():
                     submodule.communication_hook_state = state


### PR DESCRIPTION
Fixes #79114

An implementation of a FSDP communication hook interface for a NO_SHARD strategy:
- `FullyShardedDataParallel.register_comm_hook(self, state: object, hook: callable)` checks current sharding strategy. If it is other that NO_SHARD, raises a runtime error. Otherwise, sets and shares a specified hook and its state with all submodules
- When FSDP is ready to communicate a gradient, checks if there is a registered hook, and calls it instead of all_reduce. Additionally, gradient pre and post devision are not performed if a hook is registered.

To test the interface, I've implemented a communication hook, that calls for `all_reduce`.

A  unittest:
- checks that is a sharding strategy is anything but NO_SHARD, a runtime error is raised
- checks that for a NO_SHARD case, model with registered all_reduce hook and without a hook work the same.
- checks for 2 types of FSDP models: with the wrapped first layer and without. (to make sure submodules have a hook registered)