### PR TITLE
[bazel] fix integration test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1750,7 +1750,26 @@ cc_library(
 # imethod.cpp is excluded since torch/csrc/deploy* build is not yet supported.
 cpp_api_tests = glob(
     ["test/cpp/api/*.cpp"],
-    exclude = ["test/cpp/api/imethod.cpp"],
+    exclude = [
+        "test/cpp/api/imethod.cpp",
+        "test/cpp/api/integration.cpp",
+    ],
+)
+
+cc_test(
+      name = "integration_test",
+      size = "medium",
+      srcs = ["test/cpp/api/integration.cpp"],
+      deps = [
+          ":test_support",
+          "@com_google_googletest//:gtest_main",
+      ],
+      tags = [
+        "gpu-required",
+      ],
+      data = [
+        ":download_mnist",
+      ],
 )
 
 [
@@ -1892,3 +1911,15 @@ test_suite(
         "torch/csrc/lazy/ts_backend/ts_native_functions.cpp",
     ]
 ]
+
+genrule(
+    name = "download_mnist",
+    srcs = ["//:tools/download_mnist.py"],
+    outs = [
+        "mnist/train-images-idx3-ubyte",
+        "mnist/train-labels-idx1-ubyte",
+        "mnist/t10k-images-idx3-ubyte",
+        "mnist/t10k-labels-idx1-ubyte",
+    ],
+    cmd = "python3 tools/download_mnist.py -d $(RULEDIR)/mnist",
+)


### PR DESCRIPTION
Fixes broken bazel `bazel test //:integration_test`

Bazel needs a way to download the mnist dataset that's used in the integration test.
This patch does it through a genrule.
