### PR TITLE
Fix view issue in embedding_dense_backward decomp

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -763,7 +763,7 @@ def embedding_dense_backward(
     numel = indices.numel()
     grad = grad_output.view(numel, grad_output.size(-1))
     grad_weight = grad_output.new_zeros((num_weights, grad_output.shape[-1]))
-    indices_rank1 = indices.view(numel)
+    indices_rank1 = indices.reshape(numel)
     if scale_grad_by_freq:
         counts = indices.new_zeros((num_weights,))
         ones = indices.new_ones((numel,))


### PR DESCRIPTION
I was hitting:
```
  File "/home/jansel/pytorch/torch/fx/experimental/proxy_tensor.py", line 66, in proxy_call
    return CURRENT_DECOMPOSITION_TABLE[func_overload](*args, **kwargs)
  File "/home/jansel/pytorch/torch/_decomp/decompositions.py", line 801, in embedding_dense_backward
    indices_rank1 = indices.view(numel)
  File "/home/jansel/pytorch/torch/fx/experimental/proxy_tensor.py", line 122, in __torch_dispatch__
    return proxy_call(func_overload, args, kwargs)
  File "/home/jansel/pytorch/torch/fx/experimental/proxy_tensor.py", line 86, in proxy_call
    real_out = func_overload(*args, **kwargs)
  File "/home/jansel/pytorch/torch/_ops.py", line 49, in __call__
    return self._op(*args, **kwargs or {})
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```