### PR TITLE
add kineto and flatbuffers to OSS BUCK

### DIFF
--- a/third_party/BUCK.oss
+++ b/third_party/BUCK.oss
@@ -1,9 +1,12 @@
 load("//third_party:glog.buck.bzl", "define_glog")
 load("//third_party:xnnpack.buck.bzl", "define_xnnpack")
+load("//third_party:kineto.buck.bzl", "define_kineto")
 
 define_glog()
 
 define_xnnpack()
+
+define_kineto()
 
 cxx_library(
     name = "fmt",
@@ -218,4 +221,97 @@ cxx_library(
     visibility = [
         "PUBLIC",
     ],
+)
+
+cxx_library(
+    name = "flatbuffers-api",
+    public_include_directories = ["flatbuffers/include"],
+    raw_headers = [
+        "flatbuffers/include/flatbuffers/base.h",
+        "flatbuffers/include/flatbuffers/flatbuffers.h",
+        "flatbuffers/include/flatbuffers/stl_emulation.h",
+    ],
+    preferred_linkage = "static",
+    visibility = ["PUBLIC"],
+)
+
+cxx_library(
+    name = "flatc_library",
+    srcs = [
+        "flatbuffers/src/code_generators.cpp",
+        "flatbuffers/src/flatc.cpp",
+        "flatbuffers/src/idl_gen_fbs.cpp",
+        "flatbuffers/src/idl_gen_text.cpp",
+        "flatbuffers/src/idl_parser.cpp",
+        "flatbuffers/src/reflection.cpp",
+        "flatbuffers/src/util.cpp",
+    ],
+    public_include_directories = [
+        "flatbuffers/grpc",
+        "flatbuffers/include",
+    ],
+    raw_headers = [
+        "flatbuffers/include/flatbuffers/flatc.h",
+        "flatbuffers/include/flatbuffers/base.h",
+        "flatbuffers/include/flatbuffers/flatbuffers.h",
+        "flatbuffers/include/flatbuffers/stl_emulation.h",
+        "flatbuffers/include/flatbuffers/code_generators.h",
+        "flatbuffers/include/flatbuffers/flexbuffers.h",
+        "flatbuffers/include/flatbuffers/hash.h",
+        "flatbuffers/include/flatbuffers/idl.h",
+        "flatbuffers/include/flatbuffers/minireflect.h",
+        "flatbuffers/include/flatbuffers/reflection.h",
+        "flatbuffers/include/flatbuffers/reflection_generated.h",
+        "flatbuffers/include/flatbuffers/util.h",
+    ],
+    preferred_linkage = "static",
+    visibility = ["PUBLIC"],
+)
+
+cxx_binary(
+    name = "flatc",
+    srcs = [
+        "flatbuffers/grpc/src/compiler/cpp_generator.cc",
+        "flatbuffers/grpc/src/compiler/go_generator.cc",
+        "flatbuffers/grpc/src/compiler/java_generator.cc",
+        "flatbuffers/grpc/src/compiler/python_generator.cc",
+        "flatbuffers/grpc/src/compiler/swift_generator.cc",
+        "flatbuffers/grpc/src/compiler/ts_generator.cc",
+        "flatbuffers/src/bfbs_gen_lua.cpp",
+        "flatbuffers/src/flatc_main.cpp",
+        "flatbuffers/src/idl_gen_cpp.cpp",
+        "flatbuffers/src/idl_gen_csharp.cpp",
+        "flatbuffers/src/idl_gen_dart.cpp",
+        "flatbuffers/src/idl_gen_go.cpp",
+        "flatbuffers/src/idl_gen_grpc.cpp",
+        "flatbuffers/src/idl_gen_java.cpp",
+        "flatbuffers/src/idl_gen_ts.cpp", # idl_gen_js_ts.cpp in fbsource
+        "flatbuffers/src/idl_gen_json_schema.cpp",
+        "flatbuffers/src/idl_gen_kotlin.cpp",
+        "flatbuffers/src/idl_gen_lobster.cpp",
+        "flatbuffers/src/idl_gen_lua.cpp",
+        "flatbuffers/src/idl_gen_php.cpp",
+        "flatbuffers/src/idl_gen_python.cpp",
+        "flatbuffers/src/idl_gen_rust.cpp",
+        "flatbuffers/src/idl_gen_swift.cpp",
+        "flatbuffers/src/idl_gen_text.cpp",
+        "flatbuffers/src/util.cpp",
+    ],
+    include_directories = [
+        "flatbuffers/grpc",
+        "flatbuffers/include",
+    ],
+    raw_headers = [
+        "flatbuffers/grpc/src/compiler/config.h",
+        "flatbuffers/grpc/src/compiler/cpp_generator.h",
+        "flatbuffers/grpc/src/compiler/go_generator.h",
+        "flatbuffers/grpc/src/compiler/java_generator.h",
+        "flatbuffers/grpc/src/compiler/python_generator.h",
+        # "flatbuffers/grpc/src/compiler/python_private_generator.h",
+        "flatbuffers/grpc/src/compiler/schema_interface.h",
+        "flatbuffers/grpc/src/compiler/swift_generator.h",
+        "flatbuffers/grpc/src/compiler/ts_generator.h",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [":flatc_library"],
 )

--- a/third_party/kineto.buck.bzl
+++ b/third_party/kineto.buck.bzl
@@ -1,0 +1,170 @@
+load("//tools/build_defs:glob_defs.bzl", "subdir_glob")
+
+# kineto code should be updated to not have to
+# suppress these warnings.
+KINETO_COMPILER_FLAGS = [
+    "-fexceptions",
+    "-Wno-deprecated-declarations",
+    "-Wno-unused-function",
+    "-Wno-unused-private-field",
+]
+
+def define_kineto():
+    cxx_library(
+        name = "libkineto",
+        srcs = [
+            "kineto/libkineto/src/ActivityProfilerController.cpp",
+            "kineto/libkineto/src/ActivityProfilerProxy.cpp",
+            "kineto/libkineto/src/CuptiActivityApi.cpp",
+            "kineto/libkineto/src/CuptiActivityProfiler.cpp",
+            "kineto/libkineto/src/CuptiRangeProfilerApi.cpp",
+            "kineto/libkineto/src/Demangle.cpp",
+            "kineto/libkineto/src/init.cpp",
+            "kineto/libkineto/src/output_csv.cpp",
+            "kineto/libkineto/src/output_json.cpp",
+        ],
+        headers = subdir_glob(
+            [
+                ("kineto/libkineto/include", "*.h"),
+                ("kineto/libkineto/src", "*.h"),
+            ],
+        ),
+        compiler_flags = KINETO_COMPILER_FLAGS,
+        # @lint-ignore BUCKLINT
+        link_whole = True,
+        visibility = ["PUBLIC"],
+        exported_deps = [
+            ":base_logger",
+            ":libkineto_api",
+            ":thread_util",
+            ":fmt",
+        ],
+    )
+
+    cxx_library(
+        name = "libkineto_api",
+        srcs = [
+            "kineto/libkineto/src/libkineto_api.cpp",
+        ],
+        headers = subdir_glob(
+            [
+                ("kineto/libkineto/include", "*.h"),
+                ("kineto/libkineto/src", "*.h"),
+            ],
+        ),
+        compiler_flags = KINETO_COMPILER_FLAGS,
+        # @lint-ignore BUCKLINT
+        link_whole = True,
+        visibility = ["PUBLIC"],
+        exported_deps = [
+            ":base_logger",
+            ":config_loader",
+            ":thread_util",
+            ":fmt",
+        ],
+    )
+
+    cxx_library(
+        name = "config_loader",
+        srcs = [
+            "kineto/libkineto/src/ConfigLoader.cpp",
+        ],
+        headers = subdir_glob(
+            [
+                ("kineto/libkineto/include", "ActivityType.h"),
+                ("kineto/libkineto/src", "*.h"),
+            ],
+        ),
+        compiler_flags = KINETO_COMPILER_FLAGS,
+        exported_deps = [
+            ":config",
+            ":thread_util",
+        ],
+    )
+
+    cxx_library(
+        name = "config",
+        srcs = [
+            "kineto/libkineto/src/AbstractConfig.cpp",
+            "kineto/libkineto/src/ActivityType.cpp",
+            "kineto/libkineto/src/Config.cpp",
+        ],
+        compiler_flags = KINETO_COMPILER_FLAGS,
+        public_include_directories = [
+            "kineto/libkineto/include",
+            "kineto/libkineto/src",
+        ],
+        # @lint-ignore BUCKRESTRICTEDSYNTAX
+        raw_headers = glob([
+            "kineto/libkineto/include/*.h",
+            "kineto/libkineto/src/*.h",
+        ]),
+        exported_deps = [
+            ":logger",
+            ":thread_util",
+            ":fmt",
+        ],
+    )
+
+    cxx_library(
+        name = "logger",
+        srcs = [
+            "kineto/libkineto/src/ILoggerObserver.cpp",
+            "kineto/libkineto/src/Logger.cpp",
+        ],
+        compiler_flags = KINETO_COMPILER_FLAGS,
+        public_include_directories = [
+            "kineto/libkineto/include",
+            "kineto/libkineto/src",
+        ],
+        raw_headers = [
+            "kineto/libkineto/include/ILoggerObserver.h",
+            "kineto/libkineto/include/ThreadUtil.h",
+            "kineto/libkineto/src/Logger.h",
+            "kineto/libkineto/src/LoggerCollector.h",
+        ],
+        exported_deps = [
+            ":thread_util",
+            ":fmt",
+        ],
+    )
+
+    cxx_library(
+        name = "base_logger",
+        srcs = [
+            "kineto/libkineto/src/GenericTraceActivity.cpp",
+        ],
+        public_include_directories = [
+            "kineto/libkineto/include",
+            "kineto/libkineto/src",
+        ],
+        # @lint-ignore BUCKRESTRICTEDSYNTAX
+        raw_headers = glob([
+            "kineto/libkineto/include/*.h",
+            "kineto/libkineto/src/*.h",
+            "kineto/libkineto/src/*.tpp",
+        ]),
+        exported_deps = [
+            ":thread_util",
+        ],
+    )
+
+    cxx_library(
+        name = "thread_util",
+        srcs = [
+            "kineto/libkineto/src/ThreadUtil.cpp",
+        ],
+        compiler_flags = KINETO_COMPILER_FLAGS,
+        exported_preprocessor_flags = [
+            "-DKINETO_NAMESPACE=libkineto",
+        ],
+        public_include_directories = [
+            "kineto/libkineto/include",
+        ],
+        raw_headers = [
+            "kineto/libkineto/include/ThreadUtil.h",
+        ],
+        exported_deps = [
+            ":fmt",
+        ],
+    )


### PR DESCRIPTION
Summary: add two third-party libraries kineto and flatbuffers to OSS BUCK build

Test Plan:
local test.
CI

Differential Revision: D37273088

