### PR TITLE
Fix release doc builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,9 @@ on:
     - cron: 0 0 * * *
   push:
     tags:
+      # NOTE: Doc build pipelines should only get triggered on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
       - ciflow/nightly/*
   workflow_dispatch:
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
     tags:
       # NOTE: Doc build pipelines should only get triggered on release candidate builds
       # Release candidate tags look like: v1.11.0-rc1
-       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
       - ciflow/nightly/*
   workflow_dispatch:
 


### PR DESCRIPTION
This logic were lost during last workflow migration and as result we do not have docs builds for 1.12 release candidate, see pytorch/pytorch.github.io/tree/site/docs 

Hattip to @brianjo for reminding me about the issue
