### PR TITLE
Fix code that triggers BytesWarning

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -332,7 +332,7 @@ def get_executable_command(options, allow_pytest, disable_coverage=False):
     if options.coverage and not disable_coverage:
         executable = ["coverage", "run", "--parallel-mode", "--source=torch"]
     else:
-        executable = [sys.executable]
+        executable = [sys.executable, "-bb"]
     if options.pytest:
         if allow_pytest:
             executable += ["-m", "pytest"]

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15157,9 +15157,10 @@ torch.cuda.synchronize()
                 [sys.executable, '-c', script],
                 cwd=os.path.dirname(os.path.realpath(__file__)),
                 capture_output=True,
+                text=True,
             )
 
-            output = str(p.stdout) + '\n' + str(p.stderr)
+            output = p.stdout + '\n' + p.stderr
 
             error_msg = error_msgs[module_name]
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -748,7 +748,7 @@ class TestTorchDeviceType(TestCase):
 
             # Checks for cpp context in the warning message
             escaped_warning_message = str(warning.message).encode('unicode_escape')
-            self.assertTrue(re.search(s, str(escaped_warning_message), re.IGNORECASE) is not None)
+            self.assertTrue(re.search(s, repr(escaped_warning_message), re.IGNORECASE) is not None)
 
             # Checks the Python features of the warning
             # Note: the eager mode warning refers to the line in the function
@@ -764,7 +764,7 @@ class TestTorchDeviceType(TestCase):
 
             # Checks for cpp context in the warning message
             escaped_warning_message = str(warning.message).encode('unicode_escape')
-            self.assertTrue(re.search(s, str(escaped_warning_message), re.IGNORECASE) is not None)
+            self.assertTrue(re.search(s, repr(escaped_warning_message), re.IGNORECASE) is not None)
 
             # Checks the Python features of the warning
             # Note: the jitted warning's lineno refers to the call to the jitted

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -56,7 +56,7 @@ def _is_zipfile(f) -> bool:
     start = f.tell()
 
     byte = f.read(1)
-    while byte != "":
+    while byte != b"":
         read_bytes.append(byte)
         if len(read_bytes) == 4:
             break


### PR DESCRIPTION
Fixes #74812.

I have fixed the multiple instances in the repository that trigger
`BytesWarning`, and I have enabled the `-bb` option when tests are run
to prevent regressions.