### PR TITLE
ci: Move multigpu to periodic

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -106,6 +106,25 @@ jobs:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
 
+  linux-bionic-cuda10_2-py3_9-gcc7-build:
+    name: linux-bionic-cuda10.2-py3.9-gcc7
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-bionic-cuda10.2-py3.9-gcc7
+      docker-image-name: pytorch-linux-bionic-cuda10.2-cudnn7-py3.9-gcc7
+
+  linux-bionic-cuda10_2-py3_9-gcc7-test:
+    name: linux-bionic-cuda10.2-py3.9-gcc7
+    uses: ./.github/workflows/_linux-test.yml
+    needs: linux-bionic-cuda10_2-py3_9-gcc7-build
+    with:
+      build-environment: linux-bionic-cuda10.2-py3.9-gcc7
+      docker-image: ${{ needs.linux-bionic-cuda10_2-py3_9-gcc7-build.outputs.docker-image }}
+      test-matrix: |
+        { include: [
+          { config: "multigpu", shard: 1, num_shards: 1, runner: "linux.16xlarge.nvidia.gpu" },
+        ]}
+
   linux-xenial-cuda11_3-py3_7-gcc7-debug-build:
     name: linux-xenial-cuda11.3-py3.7-gcc7-debug
     uses: ./.github/workflows/_linux-build.yml

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -67,7 +67,6 @@ jobs:
           { config: "jit_legacy", shard: 1, num_shards: 1, runner: "linux.4xlarge.nvidia.gpu" },
           { config: "distributed", shard: 1, num_shards: 2, runner: "linux.8xlarge.nvidia.gpu" },
           { config: "distributed", shard: 2, num_shards: 2, runner: "linux.8xlarge.nvidia.gpu" },
-          { config: "multigpu", shard: 1, num_shards: 1, runner: "linux.16xlarge.nvidia.gpu" },
         ]}
 
   libtorch-linux-xenial-cuda10_2-py3_7-gcc7-build:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #79894

We have hard limitations on the number of linux.16xlarge.nvidia.gpu
machines we can spin up. Considering that the TTS for this specific job
has increased 2x over the past 7 days.

![image](https://user-images.githubusercontent.com/1700823/174675240-7d7e39dc-f7fb-4c93-8a7f-58876d860291.png)


Signed-off-by: Eli Uriegas <eliuriegas@fb.com>