### PR TITLE
[ONNX][BugFix] prelu(scalar) should output scalar value in onnx

### DIFF
--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1063,6 +1063,7 @@ def squeeze(g, self, dim=None):
 
 def prelu(g, self, weight):
     self_rank = symbolic_helper._get_tensor_rank(self)
+    original_self_rank = self_rank
     if self_rank is not None:
         if self_rank > 2:
             # make weight unidirectional broadcastable
@@ -1081,7 +1082,11 @@ def prelu(g, self, weight):
         assert (
             self_rank >= weight_rank
         ), f"rank(x) should be >= rank(slope) but got {self_rank} < {weight_rank}"
-    return g.op("PRelu", self, weight)
+    
+    ret = g.op("PRelu", self, weight)
+    if original_self_rank == 0:
+         ret = g.op("Squeeze", ret)
+    return ret
 
 
 def silu(g, input):


### PR DESCRIPTION
Exported `PReLU` (scalar input) returns mismatched output.

```python
import torch


class Net(torch.nn.Module):
    def forward(self, x):
        return torch.nn.PReLU()(x)


net = Net().eval()

x = torch.zeros((), dtype=torch.float32)

with torch.no_grad():
    y_trh = net(x)
    torch.onnx.export(net, x, "output.onnx", input_names=['inp'], output_names=[
                      'out'], verbose=True, opset_version=14)

import onnxruntime as ort
sess = ort.InferenceSession(
    "output.onnx", providers=['CPUExecutionProvider'])
y_ort = sess.run(['out'], {'inp': x.numpy()})[0]
assert y_ort.shape == y_trh.shape, 'shape mismatch, ORT is `{}` but PyTorch is `{}`'.format(
    y_ort.shape, y_trh.shape)
```

Log:

```
Exported graph: graph(%inp : Float(requires_grad=0, device=cpu)):
  %onnx::PRelu_1 : Float(1, strides=[1], requires_grad=0, device=cpu) = onnx::Constant[value={0.25}, onnx_name="Constant_0"]() # /home/ganler/miniconda3/lib/python3.8/site-packages/torch/nn/modules/activation.py:1221:0
  %onnx::Unsqueeze_2 : Long(1, strides=[1], device=cpu) = onnx::Constant[value={0}, onnx_name="Constant_1"]() # /home/ganler/miniconda3/lib/python3.8/site-packages/torch/nn/modules/activation.py:1224:0
  %onnx::PRelu_3 : Float(1, strides=[1], device=cpu) = onnx::Unsqueeze[onnx_name="Unsqueeze_2"](%inp, %onnx::Unsqueeze_2) # /home/ganler/miniconda3/lib/python3.8/site-packages/torch/nn/modules/activation.py:1224:0
  %out : Float(1, requires_grad=0, device=cpu) = onnx::PRelu[onnx_name="PRelu_3"](%onnx::PRelu_3, %onnx::PRelu_1) # /home/ganler/miniconda3/lib/python3.8/site-packages/torch/nn/modules/activation.py:1224:0
  return (%out)

Traceback (most recent call last):
  File "test.py", line 81, in <module>
    assert y_ort.shape == y_trh.shape, 'shape mismatch, ORT is `{}` but PyTorch is `{}`'.format(
AssertionError: shape mismatch, ORT is `(1,)` but PyTorch is `torch.Size([])`
```

The issue is similar to https://github.com/pytorch/pytorch/pull/78701

I did not add a test because there is one there:

https://github.com/pytorch/pytorch/blob/master/test/onnx/test_pytorch_onnx_onnxruntime.py#L6805

Not sure why it can pass the test.

cc: @justinchuby @BowenBao 