### PR TITLE
Fix //:module_test Conversion_MultiCUDA

### DIFF
--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -353,7 +353,7 @@ TEST_F(ModuleTest, Conversion_MultiCUDA) {
 TEST_F(ModuleTest, Conversion_NoGrad_MultiCUDA) {
   Linear module(128, 64);
   for (auto& parameter : module->parameters()) {
-      parameter.requires_grad_(false);
+    parameter.requires_grad_(false);
   }
   {
     module->to(torch::kInt32);

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -343,15 +343,22 @@ TEST_F(ModuleTest, Conversion_MultiCUDA) {
     }
   }
   {
-    module->to(torch::kInt32);
-    for (auto& parameter : module->parameters()) {
-      ASSERT_EQ(parameter.dtype(), torch::kInt32);
-    }
-  }
-  {
     module->to(torch::kFloat64);
     for (auto& parameter : module->parameters()) {
       ASSERT_EQ(parameter.dtype(), torch::kFloat64);
+    }
+  }
+}
+
+TEST_F(ModuleTest, Conversion_MultiCUDA_NoGrad) {
+  Linear module(128, 64);
+  for (auto& parameter : module->parameters()) {
+      parameter.requires_grad_(false);
+  }
+  {
+    module->to(torch::kInt32);
+    for (auto& parameter : module->parameters()) {
+      ASSERT_EQ(parameter.dtype(), torch::kInt32);
     }
   }
   {

--- a/test/cpp/api/module.cpp
+++ b/test/cpp/api/module.cpp
@@ -350,7 +350,7 @@ TEST_F(ModuleTest, Conversion_MultiCUDA) {
   }
 }
 
-TEST_F(ModuleTest, Conversion_MultiCUDA_NoGrad) {
+TEST_F(ModuleTest, Conversion_NoGrad_MultiCUDA) {
   Linear module(128, 64);
   for (auto& parameter : module->parameters()) {
       parameter.requires_grad_(false);


### PR DESCRIPTION
Fixes #79871

Make `module.cpp` tests respect change that was made in #78436 (no int types in autograd).

Note that there still a gap in Cmake test -- it's unclear why it didn't fail CI before.

As far as I can tell it should be executed, because it's included here https://github.com/pytorch/pytorch/blob/79507d2a9d06d4a3fb50eb21b30e08cc044776ce/test/cpp/api/CMakeLists.txt#L17:L17


