### PR TITLE
[Static Runtime] Add Metadata to ProcessedNode depending upon the op type

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -833,6 +833,48 @@ class TORCH_API StaticNodeInfo {
   uint16_t outputs_offset_;
 };
 
+/*
+  ProcessedNodeMetadata class wraps the possible metadata
+  for ProcessedNode. Depending upon the nature of op, processedNode
+  can have one of the below possibilities of metadata:
+  - prim::If/prim::Loop ops contains block_runners_ as their metadata
+  - prim::fork op contains TaskLauncher (std::function) responsible for
+    execution of forked subgraph
+*/
+class TORCH_API ProcessedNodeMetadata {
+ public:
+  ProcessedNodeMetadata(std::vector<BlockRunner> runners, TaskLauncher launcher)
+      : block_runners_(std::move(runners)), launcher_(std::move(launcher)) {}
+
+  ProcessedNodeMetadata() : launcher_({}) {}
+
+  // deleted copy ctor/assigment as standard containers (vector) always
+  // have copy constructors, but their instantiation is not well-formed
+  // if the contained type (BlockRunner) is not copyable
+  ProcessedNodeMetadata(const ProcessedNodeMetadata&) = delete;
+  ProcessedNodeMetadata& operator=(const ProcessedNodeMetadata&) = delete;
+
+  std::vector<BlockRunner>& block_runners() {
+    return block_runners_;
+  }
+
+  void set_block_runners(std::vector<BlockRunner> runners) {
+    block_runners_ = std::move(runners);
+  }
+
+  void set_launcher(TaskLauncher launcher) {
+    launcher_ = std::move(launcher);
+  }
+
+  TaskLauncher launcher() {
+    return launcher_;
+  }
+
+ private:
+  std::vector<BlockRunner> block_runners_;
+  TaskLauncher launcher_;
+};
+
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class TORCH_API ProcessedNode {
  public:
@@ -845,9 +887,7 @@ class TORCH_API ProcessedNode {
         inputs_(other.inputs_),
         outputs_offset_(other.outputs_offset_),
         values_(values),
-        // TODO(T105178680): For this task, we should move
-        // block runners out of ProcessedNode.
-        block_runners_(nullptr) {}
+        meta_data_(nullptr) {}
 
   // These should be noexcept, but some Android build is failing
   // saying the noexcept specification doesn't match the calculated
@@ -939,13 +979,25 @@ class TORCH_API ProcessedNode {
   // used in debug mode
   bool verify_no_memory_overlap(bool force_check = false) const;
 
-  std::vector<BlockRunner>* block_runners() {
-    return block_runners_.get();
+  // returns pointer to ProcessedNodeMetadata or nullptr if no object is owned
+  ProcessedNodeMetadata* meta_data() {
+    return meta_data_.get();
   }
 
-  void set_block_runners(
-      std::unique_ptr<std::vector<BlockRunner>> block_runners) {
-    block_runners_ = std::move(block_runners);
+  // attach block_runner to metadata of ProcessedNode
+  void set_meta_data(std::vector<BlockRunner> block_runners) {
+    if (meta_data_ == nullptr) {
+      meta_data_ = std::make_unique<ProcessedNodeMetadata>();
+    }
+    meta_data_->set_block_runners(std::move(block_runners));
+  }
+
+  // attach TaskLauncher to metadata of ProcessedNode
+  void set_meta_data(TaskLauncher launcher) {
+    if (meta_data_ == nullptr) {
+      meta_data_ = std::make_unique<ProcessedNodeMetadata>();
+    }
+    meta_data_->set_launcher(std::move(launcher));
   }
 
  private:
@@ -959,9 +1011,10 @@ class TORCH_API ProcessedNode {
   uint16_t outputs_offset_;
   bool overlap_detected_{false};
   IValue* values_ = nullptr; // unowned
-  // For control flow; processed nodes may have sub-blocks which can
-  // be executed by op implementations.
-  std::unique_ptr<std::vector<BlockRunner>> block_runners_;
+  // Metadata for ProcessedNode.
+  // 1. prim::If/Loop nodes contains sub-blocks as metadata
+  // 2. prim::fork nodes contains custom executor for async execution
+  std::unique_ptr<ProcessedNodeMetadata> meta_data_;
 };
 
 // `StaticRuntime` is the owner of the array of IValues (used for constants,

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -883,10 +883,11 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         case BlockRunPlan::kRunBothBlocks:
           return [](ProcessedNode* p_node) {
             auto condition = p_node->Input(0).toBool();
-            auto* block_runners = p_node->block_runners();
-            DCHECK(block_runners);
-            DCHECK_EQ(block_runners->size(), 2);
-            auto& runner = (*block_runners)[!condition];
+            auto* meta_data = p_node->meta_data();
+            DCHECK(meta_data);
+            auto& block_runners = meta_data->block_runners();
+            DCHECK_EQ(block_runners.size(), 2);
+            auto& runner = block_runners[!condition];
 
             auto output = runner({});
             if (!output.isTuple()) {
@@ -902,22 +903,24 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         case BlockRunPlan::kRunOnlyTrueBlock:
           return [](ProcessedNode* p_node) {
             auto condition = p_node->Input(0).toBool();
-            auto* block_runners = p_node->block_runners();
-            DCHECK(block_runners);
-            DCHECK_EQ(block_runners->size(), 2);
+            auto* meta_data = p_node->meta_data();
+            DCHECK(meta_data);
+            auto& block_runners = meta_data->block_runners();
+            DCHECK_EQ(block_runners.size(), 2);
             if (condition) {
-              auto output = block_runners->front()({});
+              auto output = block_runners.front()({});
               DCHECK(output.isNone());
             }
           };
         case BlockRunPlan::kRunOnlyFalseBlock:
           return [](ProcessedNode* p_node) {
             auto condition = p_node->Input(0).toBool();
-            auto* block_runners = p_node->block_runners();
-            DCHECK(block_runners);
-            DCHECK_EQ(block_runners->size(), 2);
+            auto* meta_data = p_node->meta_data();
+            DCHECK(meta_data);
+            auto& block_runners = meta_data->block_runners();
+            DCHECK_EQ(block_runners.size(), 2);
             if (!condition) {
-              auto output = block_runners->back()({});
+              auto output = block_runners.back()({});
               DCHECK(output.isNone());
             }
           };
@@ -1037,9 +1040,10 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
             createFutureTypeFromGraphOutput(forkedGraph);
         p_node->Output(0) = future;
 
-        TaskLauncher taskLauncher_ = at::launch;
         ForkedSubgraphSRLauncher runtime_launcher(smodule, args, future);
-        taskLauncher_(std::move(runtime_launcher));
+        auto* meta_data = p_node->meta_data();
+        DCHECK(meta_data);
+        (meta_data->launcher())(std::move(runtime_launcher));
       };
     });
 /*
@@ -1082,10 +1086,11 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         const auto max_trip_count = p_node->Input(0).toInt();
         auto condition = p_node->Input(1).toBool();
 
-        auto* block_runners = p_node->block_runners();
-        DCHECK(block_runners);
-        DCHECK_EQ(block_runners->size(), 1);
-        auto& runner = (*block_runners)[0];
+        auto* meta_data = p_node->meta_data();
+        DCHECK(meta_data);
+        auto& block_runners = meta_data->block_runners();
+        DCHECK_EQ(block_runners.size(), 1);
+        auto& runner = block_runners[0];
 
         auto args = collectLoopSubBlockInputs(*p_node);
         int64_t loop_count = 0;


### PR DESCRIPTION
Summary:
- ProcessedNodeMetadata class wraps the possible metadata for ProcessedNode. Depending upon the nature of op, processedNode can have one of the below possibilities of metadata:
1. prim::If/prim::Loop ops contains block_runners_ as their metadata
2. prim::fork op contains TaskLauncher (std::function) responsible for execution of forked subgraph

Differential Revision: D37320704

