### PR TITLE
grammatically updated the tech docs

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1,7 +1,7 @@
 
 r"""
 The torch package contains data structures for multi-dimensional
-tensors and defines mathematical operations over these tensors.
+tensors. It also defines mathematical operations that can be performed over these tensors.
 Additionally, it provides many utilities for efficient serializing of
 Tensors and arbitrary types, and other useful utilities.
 


### PR DESCRIPTION
A small grammatical update to the torch tech docs.

![pytorchchange1](https://user-images.githubusercontent.com/88293763/174892943-7f6d320f-59af-4816-972a-d3281df82b4c.png)


