### PR TITLE
AT_DISPATCH: Expose switch-case like macro syntax

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -214,19 +214,23 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
 // but we're just being safe (and it doesn't hurt.)  Note we must
 // use it to shut up warnings about unused store.
 
-#define AT_DISPATCH_SWITCH(TYPE, NAME, ...)                                  \
-  [&] {                                                                      \
-    const auto& the_type = TYPE;                                             \
-    constexpr const char* at_dispatch_name = NAME;                           \
-    /* don't use TYPE again in case it is an expensive or side-effect op */  \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                    \
-    RECORD_KERNEL_FUNCTION_DTYPE(at_dispatch_name, _st);                     \
-    switch (_st) {                                                           \
-      __VA_ARGS__                                                            \
-      default:                                                               \
-        AT_ERROR(                                                            \
-            at_dispatch_name, " not implemented for '", toString(_st), "'"); \
-    }                                                                        \
+#define AT_DISPATCH_SWITCH(TYPE, NAME, ...)                                 \
+  [&] {                                                                     \
+    const auto& the_type = TYPE;                                            \
+    constexpr const char* at_dispatch_name = NAME;                          \
+    /* don't use TYPE again in case it is an expensive or side-effect op */ \
+    at::ScalarType _st = ::detail::scalar_type(the_type);                   \
+    RECORD_KERNEL_FUNCTION_DTYPE(at_dispatch_name, _st);                    \
+    switch (_st) {                                                          \
+      __VA_ARGS__                                                           \
+      default:                                                              \
+        AT_ERROR(                                                           \
+            '"',                                                            \
+            at_dispatch_name,                                               \
+            "\" not implemented for '",                                     \
+            toString(_st),                                                  \
+            "'");                                                           \
+    }                                                                       \
   }()
 
 #define AT_DISPATCH_CASE_FLOATING_TYPES(...)            \

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -48,32 +48,34 @@ TORCH_API void record_kernel_function_dtype(std::string name);
 #endif
 
 #if defined __cpp_if_constexpr
-#define AT_PRIVATE_CASE_TYPE_USING_HINT(NAME, enum_type, type, HINT, ...) \
-  case enum_type: {                                                       \
-    if constexpr (!at::should_include_kernel_dtype(NAME, enum_type)) {    \
-      AT_ERROR(                                                           \
-          "dtype '",                                                      \
-          toString(enum_type),                                            \
-          "' not selected for kernel tag ",                               \
-          #NAME);                                                         \
-    }                                                                     \
-    using HINT = type;                                                    \
-    return __VA_ARGS__();                                                 \
+#define AT_PRIVATE_CASE_TYPE_USING_HINT(enum_type, HINT, ...) \
+  case enum_type: {                                           \
+    if constexpr (!at::should_include_kernel_dtype(           \
+                      at_dispatch_name, enum_type)) {         \
+      AT_ERROR(                                               \
+          "dtype '",                                          \
+          toString(enum_type),                                \
+          "' not selected for kernel tag ",                   \
+          at_dispatch_name);                                  \
+    }                                                         \
+    using HINT = c10::impl::ScalarTypeToCPPTypeT<enum_type>;  \
+    return __VA_ARGS__();                                     \
   }
 #else
-#define AT_PRIVATE_CASE_TYPE_USING_HINT(NAME, enum_type, type, HINT, ...)    \
-  case enum_type: {                                                          \
-    at::guts::if_constexpr<(                                                 \
-        !at::should_include_kernel_dtype(NAME, enum_type))>([] {             \
-      AT_ERROR("dtype '" #enum_type "' not selected for kernel tag " #NAME); \
-    });                                                                      \
-    using HINT = type;                                                       \
-    return __VA_ARGS__();                                                    \
+#define AT_PRIVATE_CASE_TYPE_USING_HINT(enum_type, HINT, ...)                 \
+  case enum_type: {                                                           \
+    at::guts::if_constexpr<(                                                  \
+        !at::should_include_kernel_dtype(at_dispatch_name, enum_type))>([&] { \
+          AT_ERROR("dtype '", toString(enum_type),                            \
+                   "' not selected for kernel tag ", at_dispatch_name);       \
+    });                                                                       \
+    using HINT = c10::impl::ScalarTypeToCPPTypeT<enum_type>;                  \
+    return __VA_ARGS__();                                                     \
   }
 #endif
 
-#define AT_PRIVATE_CASE_TYPE(NAME, enum_type, type, ...) \
-  AT_PRIVATE_CASE_TYPE_USING_HINT(NAME, enum_type, type, scalar_t, __VA_ARGS__)
+#define AT_DISPATCH_CASE(enum_type, ...)                            \
+  AT_PRIVATE_CASE_TYPE_USING_HINT(enum_type, scalar_t, __VA_ARGS__)
 
 // Workaround for C10_UNUSED because CUDA 10.1 and below fails to handle unused
 // attribute in the type aliasing context. Keep name long and verbose to avoid
@@ -84,61 +86,22 @@ TORCH_API void record_kernel_function_dtype(std::string name);
 #define C10_UNUSED_DISPATCH_CUDA_WORKAROUND C10_UNUSED
 #endif // defined(__CUDACC__) && defined(CUDA_VERSION) && CUDA_VERSION <= 10010
 
-#if defined __cpp_if_constexpr
-#define AT_QINT_PRIVATE_CASE_TYPE(                                           \
-    NAME, enum_type, type, underlying_enum, underlying_type, ...)            \
-  case enum_type: {                                                          \
-    if constexpr (!at::should_include_kernel_dtype(NAME, enum_type)) {       \
-      AT_ERROR(                                                              \
-          "dtype '",                                                         \
-          toString(enum_type),                                               \
-          "' not selected for kernel tag ",                                  \
-          #NAME);                                                            \
-    }                                                                        \
-    using scalar_t = type;                                                   \
+#define AT_DISPATCH_CASE_QINT(enum_type, ...)                                \
+  AT_DISPATCH_CASE(enum_type, [&] {                                          \
     using underlying_t C10_UNUSED_DISPATCH_CUDA_WORKAROUND =                 \
-        scalar_t::underlying;                                                \
+        typename scalar_t::underlying;                                       \
     const auto& SCALAR_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND = enum_type; \
     const auto& UNDERLYING_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND =        \
         toUnderlying(enum_type);                                             \
     (void)SCALAR_TYPE; /* Suppress unused-var compiler warning */            \
-    /* TODO: Use [[maybe-unused]] when C++17 becomes the standard */         \
     return __VA_ARGS__();                                                    \
-  }
-#else
-#define AT_QINT_PRIVATE_CASE_TYPE(                                           \
-    NAME, enum_type, type, underlying_enum, underlying_type, ...)            \
-  case enum_type: {                                                          \
-    at::guts::if_constexpr<(                                                 \
-        !at::should_include_kernel_dtype(NAME, enum_type))>([] {             \
-      AT_ERROR("dtype '" #enum_type "' not selected for kernel tag " #NAME); \
-    });                                                                      \
-    using scalar_t = type;                                                   \
-    using underlying_t C10_UNUSED_DISPATCH_CUDA_WORKAROUND =                 \
-        scalar_t::underlying;                                                \
-    const auto& SCALAR_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND = enum_type; \
-    const auto& UNDERLYING_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND =        \
-        toUnderlying(enum_type);                                             \
-    (void)SCALAR_TYPE; /* Suppress unused-var compiler warning */            \
-    /* TODO: Use [[maybe-unused]] when C++17 becomes the standard */         \
-    return __VA_ARGS__();                                                    \
-  }
-#endif
+  });
 
-#if defined __cpp_if_constexpr
 #define AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                  \
-    NAME, enum_type, type, underlying_type, bitwidth, qmin, qmax, ...)       \
-  case enum_type: {                                                          \
-    if constexpr (!at::should_include_kernel_dtype(NAME, enum_type)) {       \
-      AT_ERROR(                                                              \
-          "dtype '",                                                         \
-          toString(enum_type),                                               \
-          "' not selected for kernel tag ",                                  \
-          #NAME);                                                            \
-    }                                                                        \
-    using scalar_t = type;                                                   \
+    enum_type, bitwidth, qmin, qmax, ...)                                    \
+  AT_DISPATCH_CASE(enum_type, [&] {                                          \
     using underlying_t C10_UNUSED_DISPATCH_CUDA_WORKAROUND =                 \
-        scalar_t::underlying;                                                \
+        typename scalar_t::underlying;                                       \
     const auto& SCALAR_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND = enum_type; \
     const auto& UNDERLYING_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND =        \
         toUnderlying(enum_type);                                             \
@@ -149,30 +112,7 @@ TORCH_API void record_kernel_function_dtype(std::string name);
     (void)quant_min; /* Suppress unused variable warning */                  \
     (void)quant_max; /* Suppress unused variable warning */                  \
     return __VA_ARGS__();                                                    \
-  }
-#else
-#define AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                  \
-    NAME, enum_type, type, underlying_type, bitwidth, qmin, qmax, ...)       \
-  case enum_type: {                                                          \
-    at::guts::if_constexpr<(                                                 \
-        !at::should_include_kernel_dtype(NAME, enum_type))>([] {             \
-      AT_ERROR("dtype '" #enum_type "' not selected for kernel tag " #NAME); \
-    });                                                                      \
-    using scalar_t = type;                                                   \
-    using underlying_t C10_UNUSED_DISPATCH_CUDA_WORKAROUND =                 \
-        scalar_t::underlying;                                                \
-    const auto& SCALAR_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND = enum_type; \
-    const auto& UNDERLYING_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND =        \
-        toUnderlying(enum_type);                                             \
-    int bit_width = bitwidth;                                                \
-    int64_t quant_min = qmin;                                                \
-    int64_t quant_max = qmax;                                                \
-    (void)bit_width; /* Suppress unused variable warning */                  \
-    (void)quant_min; /* Suppress unused variable warning */                  \
-    (void)quant_max; /* Suppress unused variable warning */                  \
-    return __VA_ARGS__();                                                    \
-  }
-#endif
+  });
 
 namespace detail {
 
@@ -267,715 +207,304 @@ inline void deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF_AND_COMPLEX() {}
 // but we're just being safe (and it doesn't hurt.)  Note we must
 // use it to shut up warnings about unused store.
 
-#define AT_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...)                           \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op */   \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
+#define AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                \
+  [&] {                                                                     \
+    const auto& at_dispatch_type = TYPE;                                    \
+    constexpr const char * at_dispatch_name = NAME;                         \
+    /* don't use TYPE again in case it is an expensive or side-effect op */ \
+    at::ScalarType _st = ::detail::scalar_type(at_dispatch_type);           \
+    RECORD_KERNEL_FUNCTION_DTYPE(at_dispatch_name, _st);                    \
+    switch (_st) {
+
+#define AT_DISPATCH_SWITCH_END()                                            \
+    default:                                                                \
+      AT_ERROR(at_dispatch_name, " not implemented for '",                  \
+               toString(_st), "'");                                         \
+    }                                                                       \
   }()
 
-#define AT_DISPATCH_FLOATING_TYPES_AND_HALF(TYPE, NAME, ...)                  \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op */   \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Half, at::Half, __VA_ARGS__) \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_CASE_FLOATING_TYPES(...)                            \
+  AT_DISPATCH_CASE(at::ScalarType::Double, __VA_ARGS__)                 \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)
 
-#define AT_DISPATCH_FLOATING_TYPES_AND(SCALARTYPE, TYPE, NAME, ...)           \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op */   \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE,                                                         \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE>::t),            \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");       \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)              \
+  AT_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__)      \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_FLOATING_TYPES_AND_HALF(...)               \
+  AT_DISPATCH_CASE(at::ScalarType::Double, __VA_ARGS__)             \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)              \
+  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)               \
+
+#define AT_DISPATCH_FLOATING_TYPES_AND_HALF(TYPE, NAME, ...)        \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                              \
+  AT_DISPATCH_CASE_FLOATING_TYPES_AND_HALF(__VA_ARGS__)             \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_FLOATING_TYPES_AND(SCALARTYPE, ...) \
+  AT_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__)                          \
+  AT_DISPATCH_CASE(SCALARTYPE, __VA_ARGS__)                             \
+
+#define AT_DISPATCH_FLOATING_TYPES_AND(SCALARTYPE, TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                              \
+  AT_DISPATCH_CASE_FLOATING_TYPES_AND(SCALARTYPE, __VA_ARGS__)      \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_FLOATING_TYPES_AND2(                           \
+    SCALARTYPE1, SCALARTYPE2, ...)                                      \
+  AT_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__)                          \
+  AT_DISPATCH_CASE(SCALARTYPE1, __VA_ARGS__)                            \
+  AT_DISPATCH_CASE(SCALARTYPE2, __VA_ARGS__)                            \
 
 #define AT_DISPATCH_FLOATING_TYPES_AND2(                                      \
     SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)                                \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op */   \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE1,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE2,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t),           \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");       \
-    }                                                                         \
-  }()
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                        \
+  AT_DISPATCH_CASE_FLOATING_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, __VA_ARGS__) \
+  AT_DISPATCH_SWITCH_END()
 
-#define AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(TYPE, NAME, ...)               \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op */   \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexDouble,                                      \
-          c10::complex<double>,                                               \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexFloat,                                       \
-          c10::complex<float>,                                                \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_CASE_COMPLEX_TYPES(...)                     \
+  AT_DISPATCH_CASE(at::ScalarType::ComplexDouble, __VA_ARGS__)  \
+  AT_DISPATCH_CASE(at::ScalarType::ComplexFloat, __VA_ARGS__)   \
 
-#define AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(                          \
-    SCALARTYPE, TYPE, NAME, ...)                                              \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op */   \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexDouble,                                      \
-          c10::complex<double>,                                               \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexFloat,                                       \
-          c10::complex<float>,                                                \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE,                                                         \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE>::t),            \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_COMPLEX_TYPES(TYPE, NAME, ...)  \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)              \
+  AT_DISPATCH_CASE_COMPLEX_TYPES(__VA_ARGS__)       \
+  AT_DISPATCH_SWITCH_END()
 
-#define AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(                          \
-    SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)                                \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op */   \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexDouble,                                      \
-          c10::complex<double>,                                               \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexFloat,                                       \
-          c10::complex<float>,                                                \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE1,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE2,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t),           \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_CASE_COMPLEX_TYPES_AND(SCALARTYPE, ...)     \
+  AT_DISPATCH_CASE_COMPLEX_TYPES(__VA_ARGS__)                   \
+  AT_DISPATCH_CASE(SCALARTYPE, __VA_ARGS__)
 
-#define AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND3(                          \
-    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, TYPE, NAME, ...)                   \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op */   \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexDouble,                                      \
-          c10::complex<double>,                                               \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexFloat,                                       \
-          c10::complex<float>,                                                \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE1,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE2,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE3,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE3>::t),           \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_COMPLEX_TYPES_AND(                           \
+    SCALARTYPE, TYPE, NAME, ...)                                 \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                           \
+  AT_DISPATCH_CASE_COMPLEX_TYPES_AND(SCALARTYPE, __VA_ARGS__)    \
+  AT_DISPATCH_SWITCH_END()
 
-#define AT_DISPATCH_INTEGRAL_TYPES(TYPE, NAME, ...)                           \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op */   \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_CASE_FLOATING_AND_COMPLEX_TYPES(...) \
+  AT_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__)           \
+  AT_DISPATCH_CASE_COMPLEX_TYPES(__VA_ARGS__)            \
 
-#define AT_DISPATCH_INTEGRAL_TYPES_AND(SCALARTYPE, TYPE, NAME, ...)           \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op */   \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE,                                                         \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE>::t),            \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(TYPE, NAME, ...)         \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_FLOATING_AND_COMPLEX_TYPES(__VA_ARGS__)              \
+  AT_DISPATCH_SWITCH_END()
 
-#define AT_DISPATCH_ALL_TYPES(TYPE, NAME, ...)                                \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op  */  \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_CASE_FLOATING_AND_COMPLEX_TYPES_AND1(SCALARTYPE, ...) \
+  AT_DISPATCH_CASE_FLOATING_AND_COMPLEX_TYPES(__VA_ARGS__)                \
+  AT_DISPATCH_CASE(SCALARTYPE, __VA_ARGS__)
 
-#define AT_DISPATCH_COMPLEX_TYPES(TYPE, NAME, ...)                          \
-  [&] {                                                                     \
-    const auto& the_type = TYPE;                                            \
-    /* don't use TYPE again in case it is an expensive or side-effect op */ \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                   \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                \
-    switch (_st) {                                                          \
-      AT_PRIVATE_CASE_TYPE(                                                 \
-          NAME,                                                             \
-          at::ScalarType::ComplexFloat,                                     \
-          c10::complex<float>,                                              \
-          __VA_ARGS__)                                                      \
-      AT_PRIVATE_CASE_TYPE(                                                 \
-          NAME,                                                             \
-          at::ScalarType::ComplexDouble,                                    \
-          c10::complex<double>,                                             \
-          __VA_ARGS__)                                                      \
-      default:                                                              \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");      \
-    }                                                                       \
-  }()
+#define AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(                    \
+    SCALARTYPE, TYPE, NAME, ...)                                        \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_FLOATING_AND_COMPLEX_TYPES_AND1(                     \
+      SCALARTYPE, __VA_ARGS__)                                          \
+  AT_DISPATCH_SWITCH_END()
 
-#define AT_DISPATCH_COMPLEX_TYPES_AND(SCALARTYPE, TYPE, NAME, ...)          \
-  [&] {                                                                     \
-    const auto& the_type = TYPE;                                            \
-    /* don't use TYPE again in case it is an expensive or side-effect op */ \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                   \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                \
-    switch (_st) {                                                          \
-      AT_PRIVATE_CASE_TYPE(                                                 \
-          NAME,                                                             \
-          at::ScalarType::ComplexFloat,                                     \
-          c10::complex<float>,                                              \
-          __VA_ARGS__)                                                      \
-      AT_PRIVATE_CASE_TYPE(                                                 \
-          NAME,                                                             \
-          at::ScalarType::ComplexDouble,                                    \
-          c10::complex<double>,                                             \
-          __VA_ARGS__)                                                      \
-      AT_PRIVATE_CASE_TYPE(                                                 \
-          NAME,                                                             \
-          SCALARTYPE,                                                       \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE>::t),          \
-          __VA_ARGS__)                                                      \
-      default:                                                              \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");      \
-    }                                                                       \
-  }()
+#define AT_DISPATCH_CASE_FLOATING_AND_COMPLEX_TYPES_AND2(               \
+    SCALARTYPE1, SCALARTYPE2, ...)                                      \
+  AT_DISPATCH_CASE_FLOATING_AND_COMPLEX_TYPES(__VA_ARGS__)              \
+  AT_DISPATCH_CASE(SCALARTYPE1, __VA_ARGS__)                            \
+  AT_DISPATCH_CASE(SCALARTYPE2, __VA_ARGS__)
 
-#define AT_DISPATCH_QINT_TYPES(TYPE, NAME, ...)                             \
-  [&] {                                                                     \
-    const auto& the_type = TYPE;                                            \
-    /* don't use TYPE again in case it is an expensive or side-effect op */ \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                   \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                \
-    switch (_st) {                                                          \
-      AT_QINT_PRIVATE_CASE_TYPE(                                            \
-          NAME, at::kQInt8, at::qint8, at::kChar, int8_t, __VA_ARGS__)      \
-      AT_QINT_PRIVATE_CASE_TYPE(                                            \
-          NAME, at::kQUInt8, at::quint8, at::kByte, uint8_t, __VA_ARGS__)   \
-      AT_QINT_PRIVATE_CASE_TYPE(                                            \
-          NAME, at::kQInt32, at::qint32, at::kInt, int, __VA_ARGS__)        \
-      default:                                                              \
-        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");     \
-    }                                                                       \
-  }()
+#define AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(                    \
+    SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)                          \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_FLOATING_AND_COMPLEX_TYPES_AND2(                     \
+      SCALARTYPE1, SCALARTYPE2, __VA_ARGS__)                            \
+  AT_DISPATCH_SWITCH_END()
 
-#define AT_DISPATCH_QINT_BYTE_TYPES(TYPE, NAME, ...)                        \
-  [&] {                                                                     \
-    const auto& the_type = TYPE;                                            \
-    /* don't use TYPE again in case it is an expensive or side-effect op */ \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                   \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                \
-    switch (_st) {                                                          \
-      AT_QINT_PRIVATE_CASE_TYPE(                                            \
-          NAME, at::kQInt8, at::qint8, at::kChar, int8_t, __VA_ARGS__)      \
-      AT_QINT_PRIVATE_CASE_TYPE(                                            \
-          NAME, at::kQUInt8, at::quint8, at::kByte, uint8_t, __VA_ARGS__)   \
-      default:                                                              \
-        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");     \
-    }                                                                       \
-  }()
+#define AT_DISPATCH_CASE_FLOATING_AND_COMPLEX_TYPES_AND3(   \
+    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, ...)             \
+  AT_DISPATCH_CASE_FLOATING_AND_COMPLEX_TYPES(__VA_ARGS__)  \
+  AT_DISPATCH_CASE(SCALARTYPE1, __VA_ARGS__)                \
+  AT_DISPATCH_CASE(SCALARTYPE2, __VA_ARGS__)                \
+  AT_DISPATCH_CASE(SCALARTYPE3, __VA_ARGS__)
 
-#define AT_DISPATCH_QINT_AND_SUB_BYTE_TYPES(TYPE, NAME, ...)                 \
-  [&] {                                                                      \
-    const auto& the_type = TYPE;                                             \
-    /* don't use TYPE again in case it is an expensive or side-effect op */  \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                    \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                 \
-    switch (_st) {                                                           \
-      AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                    \
-          NAME,                                                              \
-          at::kQInt8,                                                        \
-          at::qint8,                                                         \
-          int8_t,                                                            \
-          CHAR_BIT,                                                          \
-          SCHAR_MIN,                                                         \
-          SCHAR_MAX,                                                         \
-          __VA_ARGS__)                                                       \
-      AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                    \
-          NAME,                                                              \
-          at::kQUInt8,                                                       \
-          at::quint8,                                                        \
-          uint8_t,                                                           \
-          CHAR_BIT,                                                          \
-          0,                                                                 \
-          UCHAR_MAX,                                                         \
-          __VA_ARGS__)                                                       \
-      AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                    \
-          NAME,                                                              \
-          at::kQInt32,                                                       \
-          at::qint32,                                                        \
-          int,                                                               \
-          CHAR_BIT * sizeof(int),                                            \
-          INT_MIN,                                                           \
-          INT_MAX,                                                           \
-          __VA_ARGS__)                                                       \
-      AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                    \
-          NAME, at::kQUInt4x2, at::quint4x2, uint8_t, 4, 0, 15, __VA_ARGS__) \
-      AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                    \
-          NAME, at::kQUInt2x4, at::quint2x4, uint8_t, 2, 0, 3, __VA_ARGS__)  \
-      default:                                                               \
-        AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");      \
-    }                                                                        \
-  }()
+#define AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND3(                    \
+    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, TYPE, NAME, ...)             \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_FLOATING_AND_COMPLEX_TYPES_AND3(                     \
+      SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, __VA_ARGS__)               \
+  AT_DISPATCH_SWITCH_END()
 
-#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX(TYPE, NAME, ...)                    \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op*/    \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexFloat,                                       \
-          c10::complex<float>,                                                \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexDouble,                                      \
-          c10::complex<double>,                                               \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_CASE_INTEGRAL_TYPES(...)                \
+  AT_DISPATCH_CASE(at::ScalarType::Byte, __VA_ARGS__)       \
+  AT_DISPATCH_CASE(at::ScalarType::Char, __VA_ARGS__)       \
+  AT_DISPATCH_CASE(at::ScalarType::Int, __VA_ARGS__)        \
+  AT_DISPATCH_CASE(at::ScalarType::Long, __VA_ARGS__)       \
+  AT_DISPATCH_CASE(at::ScalarType::Short, __VA_ARGS__)
 
-#define AT_DISPATCH_ALL_TYPES_AND(SCALARTYPE, TYPE, NAME, ...)                \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op*/    \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE,                                                         \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE>::t),            \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_INTEGRAL_TYPES(TYPE, NAME, ...)         \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                      \
+  AT_DISPATCH_CASE_INTEGRAL_TYPES(__VA_ARGS__)              \
+  AT_DISPATCH_SWITCH_END()
 
-#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(SCALARTYPE, TYPE, NAME, ...)    \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op*/    \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexFloat,                                       \
-          c10::complex<float>,                                                \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexDouble,                                      \
-          c10::complex<double>,                                               \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE,                                                         \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE>::t),            \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_CASE_INTEGRAL_TYPES_AND(SCALARTYPE, ...)    \
+  AT_DISPATCH_CASE_INTEGRAL_TYPES(__VA_ARGS__)                  \
+  AT_DISPATCH_CASE(SCALARTYPE, __VA_ARGS__)
 
-#define AT_DISPATCH_ALL_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...) \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op*/    \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE1,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE2,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t),           \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_INTEGRAL_TYPES_AND(SCALARTYPE, TYPE, NAME, ...)     \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_INTEGRAL_TYPES_AND(SCALARTYPE, __VA_ARGS__)          \
+  AT_DISPATCH_SWITCH_END()
 
-#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(                               \
-    SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)                                \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op*/    \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexFloat,                                       \
-          c10::complex<float>,                                                \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexDouble,                                      \
-          c10::complex<double>,                                               \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE1,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE2,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t),           \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_CASE_ALL_TYPES(...)         \
+  AT_DISPATCH_CASE_INTEGRAL_TYPES(__VA_ARGS__)  \
+  AT_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__)
 
-#define AT_DISPATCH_ALL_TYPES_AND3(                                           \
-    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, TYPE, NAME, ...)                   \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op*/    \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE1,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE2,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE3,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE3>::t),           \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_ALL_TYPES(TYPE, NAME, ...)                          \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_ALL_TYPES(__VA_ARGS__)                               \
+  AT_DISPATCH_SWITCH_END()
 
-#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(                               \
-    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, TYPE, NAME, ...)                   \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op*/    \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexFloat,                                       \
-          c10::complex<float>,                                                \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexDouble,                                      \
-          c10::complex<double>,                                               \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE1,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE2,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE3,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE3>::t),           \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_CASE_QINT_TYPES(...)           \
+  AT_DISPATCH_CASE_QINT(at::kQInt8, __VA_ARGS__)   \
+  AT_DISPATCH_CASE_QINT(at::kQUInt8, __VA_ARGS__)  \
+  AT_DISPATCH_CASE_QINT(at::kQInt32, __VA_ARGS__)
 
-#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(                               \
-    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, SCALARTYPE4, TYPE, NAME, ...)      \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op*/    \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexFloat,                                       \
-          c10::complex<float>,                                                \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          at::ScalarType::ComplexDouble,                                      \
-          c10::complex<double>,                                               \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE1,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE1>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE2,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE2>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE3,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE3>::t),           \
-          __VA_ARGS__)                                                        \
-      AT_PRIVATE_CASE_TYPE(                                                   \
-          NAME,                                                               \
-          SCALARTYPE4,                                                        \
-          decltype(c10::impl::ScalarTypeToCPPType<SCALARTYPE4>::t),           \
-          __VA_ARGS__)                                                        \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_QINT_TYPES(TYPE, NAME, ...)                         \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_QINT_TYPES(__VA_ARGS__)                              \
+  AT_DISPATCH_SWITCH_END()
 
-#define AT_DISPATCH_INDEX_TYPES(TYPE, NAME, ...)                            \
-  [&] {                                                                     \
-    const auto& the_index_type = TYPE;                                      \
-    /* don't use TYPE again in case it is an expensive or side-effect op */ \
-    at::ScalarType _it = ::detail::scalar_type(the_index_type);             \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _it)                                 \
-    switch (_it) {                                                          \
-      AT_PRIVATE_CASE_TYPE_USING_HINT(                                      \
-          NAME, at::ScalarType::Int, int32_t, index_t, __VA_ARGS__)         \
-      AT_PRIVATE_CASE_TYPE_USING_HINT(                                      \
-          NAME, at::ScalarType::Long, int64_t, index_t, __VA_ARGS__)        \
-      default:                                                              \
-        AT_ERROR(#NAME, " not implemented for '", toString(_it), "'");      \
-    }                                                                       \
-  }()
+#define AT_DISPATCH_CASE_QINT_BYTE_TYPES(...)       \
+  AT_DISPATCH_CASE_QINT(at::kQInt8, __VA_ARGS__)    \
+  AT_DISPATCH_CASE_QINT(at::kQUInt8, __VA_ARGS__)
+
+#define AT_DISPATCH_QINT_BYTE_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)               \
+  AT_DISPATCH_CASE_QINT_BYTE_TYPES(__VA_ARGS__)      \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_QINT_AND_SUB_BYTE_TYPES(...)                     \
+  AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                   \
+      at::kQInt8, CHAR_BIT, SCHAR_MIN, SCHAR_MAX, __VA_ARGS__)            \
+  AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                   \
+      at::kQUInt8, CHAR_BIT, 0, UCHAR_MAX, __VA_ARGS__)                   \
+  AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                   \
+      at::kQInt32, CHAR_BIT * sizeof(int), INT_MIN, INT_MAX, __VA_ARGS__) \
+  AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                     \
+      at::kQUInt4x2, 4, 0, 15, __VA_ARGS__)                               \
+  AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                     \
+      at::kQUInt2x4, 2, 0, 3, __VA_ARGS__)                                \
+
+#define AT_DISPATCH_QINT_AND_SUB_BYTE_TYPES(TYPE, NAME, ...)            \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_QINT_AND_SUB_BYTE_TYPES(__VA_ARGS__)                 \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX(...) \
+  AT_DISPATCH_CASE_ALL_TYPES(__VA_ARGS__)           \
+  AT_DISPATCH_CASE_COMPLEX_TYPES(__VA_ARGS__)
+
+#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX(TYPE, NAME, ...)              \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX(__VA_ARGS__)                   \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_ALL_TYPES_AND(SCALARTYPE, ...)          \
+  AT_DISPATCH_CASE_ALL_TYPES(__VA_ARGS__)                        \
+  AT_DISPATCH_CASE(SCALARTYPE, __VA_ARGS__)                      \
+
+
+#define AT_DISPATCH_ALL_TYPES_AND(SCALARTYPE, TYPE, NAME, ...)          \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_ALL_TYPES_AND(SCALARTYPE, __VA_ARGS__)               \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND(SCALARTYPE, ...) \
+  AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX(__VA_ARGS__)               \
+  AT_DISPATCH_CASE(SCALARTYPE, __VA_ARGS__)
+
+#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(SCALARTYPE, TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND(SCALARTYPE, __VA_ARGS__)   \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_ALL_TYPES_AND2(SCALARTYPE1, SCALARTYPE2, ...)  \
+  AT_DISPATCH_CASE_ALL_TYPES(__VA_ARGS__)                               \
+  AT_DISPATCH_CASE(SCALARTYPE1, __VA_ARGS__)                            \
+  AT_DISPATCH_CASE(SCALARTYPE2, __VA_ARGS__)
+
+#define AT_DISPATCH_ALL_TYPES_AND2(                                     \
+    SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)                          \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_ALL_TYPES_AND2(                                      \
+      SCALARTYPE1, SCALARTYPE2, __VA_ARGS__)                            \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND2(                    \
+    SCALARTYPE1, SCALARTYPE2, ...)                                      \
+  AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX(__VA_ARGS__)                   \
+  AT_DISPATCH_CASE(SCALARTYPE1, __VA_ARGS__)                            \
+  AT_DISPATCH_CASE(SCALARTYPE2, __VA_ARGS__)
+
+#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(                         \
+    SCALARTYPE1, SCALARTYPE2, TYPE, NAME, ...)                          \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND2(                          \
+      SCALARTYPE1, SCALARTYPE2, __VA_ARGS__)                            \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_ALL_TYPES_AND3(                \
+    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, ...)         \
+  AT_DISPATCH_CASE_ALL_TYPES(__VA_ARGS__)               \
+  AT_DISPATCH_CASE(SCALARTYPE1, __VA_ARGS__)            \
+  AT_DISPATCH_CASE(SCALARTYPE2, __VA_ARGS__)            \
+  AT_DISPATCH_CASE(SCALARTYPE3, __VA_ARGS__)
+
+#define AT_DISPATCH_ALL_TYPES_AND3(                          \
+    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, TYPE, NAME, ...)  \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                       \
+  AT_DISPATCH_CASE_ALL_TYPES_AND3(                           \
+      SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, __VA_ARGS__)    \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND3(    \
+    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, ...)         \
+  AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX(__VA_ARGS__)   \
+  AT_DISPATCH_CASE(SCALARTYPE1, __VA_ARGS__)            \
+  AT_DISPATCH_CASE(SCALARTYPE2, __VA_ARGS__)            \
+  AT_DISPATCH_CASE(SCALARTYPE3, __VA_ARGS__)
+
+#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(             \
+    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                      \
+  AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND3(              \
+      SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, __VA_ARGS__)   \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND4(         \
+    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, SCALARTYPE4, ...) \
+  AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX(__VA_ARGS__)        \
+  AT_DISPATCH_CASE(SCALARTYPE1, __VA_ARGS__)                 \
+  AT_DISPATCH_CASE(SCALARTYPE2, __VA_ARGS__)                 \
+  AT_DISPATCH_CASE(SCALARTYPE3, __VA_ARGS__)                 \
+  AT_DISPATCH_CASE(SCALARTYPE4, __VA_ARGS__)
+
+#define AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND4(             \
+    SCALARTYPE1, SCALARTYPE2, SCALARTYPE3, SCALARTYPE4,     \
+    TYPE, NAME, ...)                                        \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                      \
+  AT_DISPATCH_CASE_ALL_TYPES_AND_COMPLEX_AND4(              \
+      SCALARTYPE1, SCALARTYPE2, SCALARTYPE3,                \
+      SCALARTYPE4, __VA_ARGS__)                             \
+  AT_DISPATCH_SWITCH_END()
+
+#define AT_DISPATCH_INDEX_TYPES(TYPE, NAME, ...)                              \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                        \
+  AT_PRIVATE_CASE_TYPE_USING_HINT(at::ScalarType::Int, index_t, __VA_ARGS__)  \
+  AT_PRIVATE_CASE_TYPE_USING_HINT(at::ScalarType::Long, index_t, __VA_ARGS__) \
+  AT_DISPATCH_SWITCH_END()
 
 // ----------------------------------------------------------------------------
 // DEPRECATED MACROS, DON'T USE THESE
 // ----------------------------------------------------------------------------
 
-#define AT_DISPATCH_ALL_TYPES_AND_HALF(TYPE, NAME, ...)                       \
-  [&] {                                                                       \
-    detail::deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF();                      \
-    const auto& the_type = TYPE;                                              \
-    /* don't use TYPE again in case it is an expensive or side-effect op */   \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Byte, uint8_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Char, int8_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Double, double, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Half, at::Half, __VA_ARGS__) \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_ALL_TYPES_AND_HALF(TYPE, NAME, ...)                 \
+  detail::deprecated_AT_DISPATCH_ALL_TYPES_AND_HALF();                  \
+  AT_DISPATCH_SWITCH_BEGIN(TYPE, NAME)                                  \
+  AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, __VA_ARGS__)          \
+  AT_DISPATCH_SWITCH_END()

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -300,14 +300,15 @@ void sign_kernel(TensorIteratorBase& iter){
 
 static void signbit_kernel(TensorIteratorBase& iter){
   // NOTE: signbit does not always support integral arguments.
-  if (at::isIntegralType(iter.input_dtype(), /*includeBool=*/false)) {
-    AT_DISPATCH_INTEGRAL_TYPES(iter.input_dtype(), "signbit_cpu", [&]() {
-      cpu_kernel(iter, [](scalar_t a) -> bool { return c10::is_negative(a); }); });
-  } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, ScalarType::Half, iter.input_dtype(), "signbit_cpu", [&]() {
-      using opmath_t = at::opmath_type<scalar_t>;
-     cpu_kernel(iter, [](scalar_t a) -> bool { return std::signbit(opmath_t{a}); }); });
-  }
+  AT_DISPATCH_SWITCH_BEGIN(iter.input_dtype(), "signbit_cpu")
+      AT_DISPATCH_CASE_INTEGRAL_TYPES([&] {
+        cpu_kernel(iter, [](scalar_t a) -> bool { return c10::is_negative(a); });
+      })
+      AT_DISPATCH_CASE_FLOATING_TYPES_AND2(kBFloat16, ScalarType::Half, [&] {
+        using opmath_t = at::opmath_type<scalar_t>;
+        cpu_kernel(iter, [](scalar_t a) -> bool { return std::signbit(opmath_t{a}); });
+      })
+  AT_DISPATCH_SWITCH_END();
 }
 
 static void sgn_kernel(TensorIteratorBase& iter) {

--- a/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/UnaryOpsKernel.cpp
@@ -300,7 +300,7 @@ void sign_kernel(TensorIteratorBase& iter){
 
 static void signbit_kernel(TensorIteratorBase& iter){
   // NOTE: signbit does not always support integral arguments.
-  AT_DISPATCH_SWITCH_BEGIN(iter.input_dtype(), "signbit_cpu")
+  AT_DISPATCH_SWITCH(iter.input_dtype(), "signbit_cpu",
       AT_DISPATCH_CASE_INTEGRAL_TYPES([&] {
         cpu_kernel(iter, [](scalar_t a) -> bool { return c10::is_negative(a); });
       })
@@ -308,7 +308,7 @@ static void signbit_kernel(TensorIteratorBase& iter){
         using opmath_t = at::opmath_type<scalar_t>;
         cpu_kernel(iter, [](scalar_t a) -> bool { return std::signbit(opmath_t{a}); });
       })
-  AT_DISPATCH_SWITCH_END();
+    );
 }
 
 static void sgn_kernel(TensorIteratorBase& iter) {

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -179,10 +179,9 @@ namespace {
 constexpr int NLL_LOSS_THREADS = 32;
 
 #define AT_DISPATCH_NLL_LOSS_INDEX_TYPES(TYPE, NAME, ...)                     \
-  AT_DISPATCH_SWITCH_BEGIN()                                                  \
+  AT_DISPATCH_SWITCH(TYPE, NAME,                                              \
   AT_PRIVATE_CASE_TYPE_USING_HINT(at::ScalarType::Byte, index_t, __VA_ARGS__) \
-  AT_PRIVATE_CASE_TYPE_USING_HINT(at::ScalarType::Long, index_t, __VA_ARGS__) \
-  AT_DISPATCH_SWITCH_END()
+  AT_PRIVATE_CASE_TYPE_USING_HINT(at::ScalarType::Long, index_t, __VA_ARGS__))
 
 template <typename scalar_t, typename index_t>
 __global__ void nll_loss_forward_no_reduce_cuda_kernel(

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -178,17 +178,11 @@ namespace {
 
 constexpr int NLL_LOSS_THREADS = 32;
 
-#define AT_DISPATCH_NLL_LOSS_INDEX_TYPES(TYPE, NAME, ...)                   \
-  [&] {                                                                     \
-    at::ScalarType _it = TYPE;                                              \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _it)                                 \
-    switch (_it) {                                                          \
-      AT_PRIVATE_CASE_TYPE_USING_HINT(NAME, at::ScalarType::Byte, uint8_t, index_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE_USING_HINT(NAME, at::ScalarType::Long, int64_t, index_t, __VA_ARGS__)\
-      default:                                                              \
-        AT_ERROR(#NAME, " not implemented for '", toString(_it), "'");      \
-    }                                                                       \
-  }()
+#define AT_DISPATCH_NLL_LOSS_INDEX_TYPES(TYPE, NAME, ...)                     \
+  AT_DISPATCH_SWITCH_BEGIN()                                                  \
+  AT_PRIVATE_CASE_TYPE_USING_HINT(at::ScalarType::Byte, index_t, __VA_ARGS__) \
+  AT_PRIVATE_CASE_TYPE_USING_HINT(at::ScalarType::Long, index_t, __VA_ARGS__) \
+  AT_DISPATCH_SWITCH_END()
 
 template <typename scalar_t, typename index_t>
 __global__ void nll_loss_forward_no_reduce_cuda_kernel(

--- a/aten/src/ATen/native/mps/TensorFactory.h
+++ b/aten/src/ATen/native/mps/TensorFactory.h
@@ -1,17 +1,10 @@
 //  Copyright © 2022 Apple Inc.
 
-#define AT_DISPATCH_MPS_TYPES(TYPE, NAME, ...)                                \
-  [&] {                                                                       \
-    const auto& the_type = TYPE;                                              \
-    at::ScalarType _st = ::detail::scalar_type(the_type);                     \
-    RECORD_KERNEL_FUNCTION_DTYPE(NAME, _st);                                  \
-    switch (_st) {                                                            \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Float, float, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Int, int32_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Long, int64_t, __VA_ARGS__)  \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Short, int16_t, __VA_ARGS__) \
-      AT_PRIVATE_CASE_TYPE(NAME, at::ScalarType::Half, at::Half, __VA_ARGS__) \
-      default:                                                                \
-        AT_ERROR(#NAME, " not implemented for '", toString(_st), "'");        \
-    }                                                                         \
-  }()
+#define AT_DISPATCH_MPS_TYPES(TYPE, NAME, ...)                          \
+  AT_DISPATCH_SWITCH_BEGIN()                                            \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)                  \
+  AT_DISPATCH_CASE(at::ScalarType::Int, __VA_ARGS__)                    \
+  AT_DISPATCH_CASE(at::ScalarType::Long, __VA_ARGS__)                   \
+  AT_DISPATCH_CASE(at::ScalarType::Short, __VA_ARGS__)                  \
+  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)                   \
+  AT_DISPATCH_SWITCH_END()                                              \

--- a/aten/src/ATen/native/mps/TensorFactory.h
+++ b/aten/src/ATen/native/mps/TensorFactory.h
@@ -1,10 +1,10 @@
 //  Copyright © 2022 Apple Inc.
 
 #define AT_DISPATCH_MPS_TYPES(TYPE, NAME, ...)                          \
-  AT_DISPATCH_SWITCH_BEGIN()                                            \
-  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)                  \
-  AT_DISPATCH_CASE(at::ScalarType::Int, __VA_ARGS__)                    \
-  AT_DISPATCH_CASE(at::ScalarType::Long, __VA_ARGS__)                   \
-  AT_DISPATCH_CASE(at::ScalarType::Short, __VA_ARGS__)                  \
-  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)                   \
-  AT_DISPATCH_SWITCH_END()                                              \
+  AT_DISPATCH_SWITCH(                                                   \
+      TYPE, NAME,                                                       \
+      AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)              \
+      AT_DISPATCH_CASE(at::ScalarType::Int, __VA_ARGS__)                \
+      AT_DISPATCH_CASE(at::ScalarType::Long, __VA_ARGS__)               \
+      AT_DISPATCH_CASE(at::ScalarType::Short, __VA_ARGS__)              \
+      AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__))

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -114,6 +114,9 @@ AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SPECIALIZE_ScalarTypeToCPPType)
 
 #undef SPECIALIZE_ScalarTypeToCPPType
 
+template <c10::ScalarType N>
+using ScalarTypeToCPPTypeT = typename ScalarTypeToCPPType<N>::type;
+
 } // namespace impl
 
 template <typename T>

--- a/torchgen/dest/ufunc.py
+++ b/torchgen/dest/ufunc.py
@@ -21,7 +21,6 @@ from torchgen.api.types import (
     BaseCType,
     Expr,
     NamedCType,
-    ScalarTypeToCppMapping,
     VectorizedCType,
 )
 from torchgen.context import with_native_function
@@ -309,13 +308,9 @@ AT_DISPATCH_CASE(at::ScalarType::{dtype},
 {stub_sig.dispatch_decl()};
 
 {stub_sig.kernel_defn()} {{
-  at::ScalarType st = iter.common_dtype();
-  RECORD_KERNEL_FUNCTION_DTYPE("{sig.name}", st);
-  switch (st) {{
+  AT_DISPATCH_SWITCH(iter.common_dtype(), "{sig.name}",
     {dtype_cases_str}
-    default:
-      TORCH_CHECK(false, "{sig.name}", " not implemented for '", toString(st), "'");
-  }}
+  );
 }}
 REGISTER_DISPATCH({stub_sig.name}, &{stub_sig.kernel_name});
 
@@ -535,9 +530,9 @@ AT_DISPATCH_CASE(at::ScalarType::{dtype},
 namespace {{
 
 {stub_sig.kernel_defn()} {{
-  AT_DISPATCH_SWITCH_BEGIN(iter.common_dtype(), "{stub_sig.name}")
+  AT_DISPATCH_SWITCH(iter.common_dtype(), "{stub_sig.name}",
     {dtype_cases_str}
-  AT_DISPATCH_SWITCH_END();
+  );
 }}
 
 }} // anonymous namespace

--- a/torchgen/dest/ufunc.py
+++ b/torchgen/dest/ufunc.py
@@ -290,7 +290,7 @@ def compute_ufunc_cuda(g: NativeFunctionsGroup) -> str:
     for dtype, inner_ufunctor_sigs in ufunctor_sigs.items():
         dtype_cases.append(
             f"""
-AT_PRIVATE_CASE_TYPE("{sig.name}", at::ScalarType::{dtype}, {ScalarTypeToCppMapping[dtype]},
+AT_DISPATCH_CASE(at::ScalarType::{dtype},
   [&]() {{
     {compute_ufunc_cuda_dtype_body(g, dtype, inner_ufunctor_sigs, sig.arguments())}
   }}
@@ -522,7 +522,7 @@ def compute_ufunc_cpu_kernel(g: NativeFunctionsGroup) -> str:
     for dtype, inner_ufunc_sigs in ufunc_sigs.items():
         dtype_cases.append(
             f"""
-AT_PRIVATE_CASE_TYPE("{stub_sig.name}", at::ScalarType::{dtype}, {ScalarTypeToCppMapping[dtype]},
+AT_DISPATCH_CASE(at::ScalarType::{dtype},
   [&]() {{
     {compute_ufunc_cpu_dtype_body(g, dtype, inner_ufunc_sigs, stub_sig.arguments())}
   }}
@@ -535,13 +535,9 @@ AT_PRIVATE_CASE_TYPE("{stub_sig.name}", at::ScalarType::{dtype}, {ScalarTypeToCp
 namespace {{
 
 {stub_sig.kernel_defn()} {{
-  at::ScalarType st = iter.common_dtype();
-  RECORD_KERNEL_FUNCTION_DTYPE("{stub_sig.name}", st);
-  switch (st) {{
+  AT_DISPATCH_SWITCH_BEGIN(iter.common_dtype(), "{stub_sig.name}")
     {dtype_cases_str}
-    default:
-      TORCH_CHECK(false, "{stub_sig.name}", " not implemented for '", toString(st), "'");
-  }}
+  AT_DISPATCH_SWITCH_END();
 }}
 
 }} // anonymous namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79978

This expands the `AT_DISPATCH` macros to enable writing your own
`AT_DISPATCH_SWITCH` statements with multiple `AT_DISPATCH_CASE`
labels. So, where previously you may have written:

```cpp
if (iter.common_dtype() == kBool) {
  my_bool_kernel(iter);
} else {
  AT_DISPATCH_INTEGRAL_TYPES(iter.common_dtype(), "my_kernel", [&] {
    ...
  });
}
```

You can now instead write

```cpp
AT_DISPATCH_SWITCH(iter.common_dtype(), "my_kernel",
  AT_DISPATCH_CASE(kBool, [&] { my_kernel_bool(iter); })
  AT_DISPATCH_CASE_INTEGRAL_TYPES([&] { ... })
);
```

The macro syntax is a bit ugly, however the benefits are:
- Greater flexibility, as the kernel code doesn't have to be shared
  for all dtypes.
- Selective build and RECORD_KERNEL_FUNCTION work even for single
  dtype specializations such as the bool case in the example.
- The compiler sees a single switch for all types, which should be
  easier to optimize into a jump table.
- We also now get errors if the same scalar type is handled twice.