### PR TITLE
[JIT] Imbue stringbuf with C locale (#79929)

### DIFF
--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <locale>
 #include <memory>
 #include <set>
 #include <sstream>
@@ -891,6 +892,13 @@ Value* Value::setDebugName(const std::string& name) {
     std::string replacement_name;
     do {
       std::stringstream ss;
+#ifndef _WIN32
+      // Protect 12345 integer from becoming "1,2345" if some other process sets
+      // global locale For more details see
+      // https://github.com/pytorch/pytorch/issues/79583#issuecomment-1161260061
+      static std::locale c_locale("C");
+      ss.imbue(c_locale);
+#endif
       ss << name_base << "." << suffix++;
       replacement_name = ss.str();
     } while (names.count(replacement_name) > 0);


### PR DESCRIPTION
To prevent 12345 become "12,345" if locale is not "C", as shown in the
following example:
```cpp

int main() {
  std::locale::global(std::locale("en_US.utf-8"));
  std::stringstream ss;
  ss << "12345 in " << std::locale().name()  << " locale is " << 12345 ;
  ss.imbue(std::locale("C"));
  ss << " but in C locale is " << 12345;
  std::cout << ss.str() << std::endl;
}

```

Fixes #79583

Pull Request resolved: https://github.com/pytorch/pytorch/pull/79929
Approved by: https://github.com/davidberard98
