### PR TITLE
In order to make pytorch headers consumable from cpp20 code bases, …

### DIFF
--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <type_traits>
+
 #include <c10/core/Device.h>
 #include <c10/core/Layout.h>
 #include <c10/core/MemoryFormat.h>
@@ -721,10 +723,17 @@ class TORCH_API TensorBase {
   // Hooks
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
+  template <typename T>
+  using hook_return_void_t = std::enable_if_t<std::is_void<std::invoke_result<T&(TensorBase)>::type>::value, unsigned>;
+  template <typename T>
+  using hook_return_var_t = std::enable_if_t<std::is_same<std::invoke_result<T&(TensorBase)>::type, TensorBase>::value, unsigned>;
+#else
   template <typename T>
   using hook_return_void_t = std::enable_if_t<std::is_void<typename std::result_of<T&(TensorBase)>::type>::value, unsigned>;
   template <typename T>
   using hook_return_var_t = std::enable_if_t<std::is_same<typename std::result_of<T&(TensorBase)>::type, TensorBase>::value, unsigned>;
+#endif
 
   /// Registers a backward hook.
   ///

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <type_traits>
-
 #include <c10/core/Device.h>
 #include <c10/core/Layout.h>
 #include <c10/core/MemoryFormat.h>
@@ -723,17 +721,10 @@ class TORCH_API TensorBase {
   // Hooks
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
   template <typename T>
-  using hook_return_void_t = std::enable_if_t<std::is_void<std::invoke_result<T&(TensorBase)>::type>::value, unsigned>;
+  using hook_return_void_t = std::enable_if_t<std::is_void<typename c10::invoke_result_t<T&, TensorBase>>::value, unsigned>;
   template <typename T>
-  using hook_return_var_t = std::enable_if_t<std::is_same<std::invoke_result<T&(TensorBase)>::type, TensorBase>::value, unsigned>;
-#else
-  template <typename T>
-  using hook_return_void_t = std::enable_if_t<std::is_void<typename std::result_of<T&(TensorBase)>::type>::value, unsigned>;
-  template <typename T>
-  using hook_return_var_t = std::enable_if_t<std::is_same<typename std::result_of<T&(TensorBase)>::type, TensorBase>::value, unsigned>;
-#endif
+  using hook_return_var_t = std::enable_if_t<std::is_same<typename c10::invoke_result_t<T&, TensorBase>, TensorBase>::value, unsigned>;
 
   /// Registers a backward hook.
   ///

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -991,7 +991,11 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
                  cb = std::move(callback)](Future& parentFut) mutable {
       try {
         guts::if_constexpr<std::is_convertible<
+#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
+            std::invoke_result<T && (Future&)>::type,
+#else
             typename std::result_of<T && (Future&)>::type,
+#endif
             IValueWithStorages>::value>(
             [&](auto identity) {
               IValue value;

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -991,11 +991,7 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
                  cb = std::move(callback)](Future& parentFut) mutable {
       try {
         guts::if_constexpr<std::is_convertible<
-#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
-            std::invoke_result<T && (Future&)>::type,
-#else
-            typename std::result_of<T && (Future&)>::type,
-#endif
+            typename c10::invoke_result_t<T &&, Future&>,
             IValueWithStorages>::value>(
             [&](auto identity) {
               IValue value;

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -8,6 +8,8 @@
   See NOTE: [Tensor vs. TensorBase]
 #endif
 
+#include <type_traits>
+
 #include <c10/core/Device.h>
 #include <c10/core/Layout.h>
 #include <c10/core/MemoryFormat.h>
@@ -568,10 +570,17 @@ class TORCH_API Tensor: public TensorBase {
   // Hooks
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
+  template <typename T>
+  using hook_return_void_t = std::enable_if_t<std::is_void<std::invoke_result<T&(Tensor)>::type>::value, unsigned>;
+  template <typename T>
+  using hook_return_var_t = std::enable_if_t<std::is_same<std::invoke_result<T&(Tensor)>::type, Tensor>::value, unsigned>;
+#else
   template <typename T>
   using hook_return_void_t = std::enable_if_t<std::is_void<typename std::result_of<T&(Tensor)>::type>::value, unsigned>;
   template <typename T>
   using hook_return_var_t = std::enable_if_t<std::is_same<typename std::result_of<T&(Tensor)>::type, Tensor>::value, unsigned>;
+#endif
 
   /// Registers a backward hook.
   ///

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -8,8 +8,6 @@
   See NOTE: [Tensor vs. TensorBase]
 #endif
 
-#include <type_traits>
-
 #include <c10/core/Device.h>
 #include <c10/core/Layout.h>
 #include <c10/core/MemoryFormat.h>
@@ -570,17 +568,10 @@ class TORCH_API Tensor: public TensorBase {
   // Hooks
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
   template <typename T>
-  using hook_return_void_t = std::enable_if_t<std::is_void<std::invoke_result<T&(Tensor)>::type>::value, unsigned>;
+  using hook_return_void_t = std::enable_if_t<std::is_void<typename c10::invoke_result_t<T&, Tensor>>::value, unsigned>;
   template <typename T>
-  using hook_return_var_t = std::enable_if_t<std::is_same<std::invoke_result<T&(Tensor)>::type, Tensor>::value, unsigned>;
-#else
-  template <typename T>
-  using hook_return_void_t = std::enable_if_t<std::is_void<typename std::result_of<T&(Tensor)>::type>::value, unsigned>;
-  template <typename T>
-  using hook_return_var_t = std::enable_if_t<std::is_same<typename std::result_of<T&(Tensor)>::type, Tensor>::value, unsigned>;
-#endif
+  using hook_return_var_t = std::enable_if_t<std::is_same<typename c10::invoke_result_t<T&, Tensor>, Tensor>::value, unsigned>;
 
   /// Registers a backward hook.
   ///

--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -36,6 +36,19 @@
  */
 
 namespace c10 {
+
+// in c++17 std::result_of has been superceded by std::invoke_result.  Since
+// c++20, std::result_of is removed.
+template <typename F, typename... args>
+#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
+using invoke_result = typename std::invoke_result<F, args...>;
+#else
+using invoke_result = typename std::result_of<F && (args && ...)>;
+#endif
+
+template <typename F, typename... args>
+using invoke_result_t = typename invoke_result<F, args...>::type;
+
 namespace guts {
 
 template <typename Base, typename Child, typename... Args>
@@ -161,11 +174,10 @@ CUDA_HOST_DEVICE constexpr decltype(auto) apply(F&& f, Tuple&& t) {
 
 #undef CUDA_HOST_DEVICE
 
-#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
 template <typename Functor, typename... Args>
 typename std::enable_if<
     std::is_member_pointer<typename std::decay<Functor>::type>::value,
-    typename std::invoke_result<Functor && (Args && ...)>::type>::type
+    typename c10::invoke_result_t<Functor, Args...>>::type
 invoke(Functor&& f, Args&&... args) {
   return std::mem_fn(std::forward<Functor>(f))(std::forward<Args>(args)...);
 }
@@ -173,27 +185,10 @@ invoke(Functor&& f, Args&&... args) {
 template <typename Functor, typename... Args>
 typename std::enable_if<
     !std::is_member_pointer<typename std::decay<Functor>::type>::value,
-    typename std::invoke_result<Functor && (Args && ...)>::type>::type
+    typename c10::invoke_result_t<Functor, Args...>>::type
 invoke(Functor&& f, Args&&... args) {
   return std::forward<Functor>(f)(std::forward<Args>(args)...);
 }
-#else
-template <typename Functor, typename... Args>
-typename std::enable_if<
-    std::is_member_pointer<typename std::decay<Functor>::type>::value,
-    typename std::result_of<Functor && (Args && ...)>::type>::type
-invoke(Functor&& f, Args&&... args) {
-  return std::mem_fn(std::forward<Functor>(f))(std::forward<Args>(args)...);
-}
-
-template <typename Functor, typename... Args>
-typename std::enable_if<
-    !std::is_member_pointer<typename std::decay<Functor>::type>::value,
-    typename std::result_of<Functor && (Args && ...)>::type>::type
-invoke(Functor&& f, Args&&... args) {
-  return std::forward<Functor>(f)(std::forward<Args>(args)...);
-}
-#endif
 
 namespace detail {
 struct _identity final {

--- a/c10/util/C++17.h
+++ b/c10/util/C++17.h
@@ -161,7 +161,6 @@ CUDA_HOST_DEVICE constexpr decltype(auto) apply(F&& f, Tuple&& t) {
 
 #undef CUDA_HOST_DEVICE
 
-
 #if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
 template <typename Functor, typename... Args>
 typename std::enable_if<

--- a/c10/util/LeftRight.h
+++ b/c10/util/LeftRight.h
@@ -80,7 +80,8 @@ class LeftRight final {
 
   template <typename F>
 #if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
-  auto read(F&& readFunc) const -> typename std::invoke_result<F(const T&)>::type {
+  auto read(F&& readFunc) const ->
+      typename std::invoke_result<F(const T&)>::type {
 #else
   auto read(F&& readFunc) const -> typename std::result_of<F(const T&)>::type {
 #endif
@@ -225,7 +226,8 @@ class RWSafeLeftRightWrapper final {
 
   template <typename F>
 #if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
-  auto read(F&& readFunc) const -> typename std::invoke_result<F(const T&)>::type {
+  auto read(F&& readFunc) const ->
+      typename std::invoke_result<F(const T&)>::type {
 #else
   auto read(F&& readFunc) const -> typename std::result_of<F(const T&)>::type {
 #endif

--- a/c10/util/Synchronized.h
+++ b/c10/util/Synchronized.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <mutex>
-#include <type_traits>
 
 namespace c10 {
 
@@ -43,11 +42,7 @@ class Synchronized final {
    * provided callback safely.
    */
   template <typename CB>
-#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
-  std::invoke_result<CB(T&)>::type withLock(CB cb) {
-#else
-  typename std::result_of<CB(T&)>::type withLock(CB cb) {
-#endif
+  typename c10::invoke_result_t<CB, T&> withLock(CB cb) {
     std::lock_guard<std::mutex> guard(this->mutex_);
     return cb(this->data_);
   }
@@ -58,11 +53,7 @@ class Synchronized final {
    * the provided callback safely.
    */
   template <typename CB>
-#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
-  std::invoke_result<CB(T const&)>::type withLock(CB cb) const {
-#else
-  typename std::result_of<CB(T const&)>::type withLock(CB cb) const {
-#endif
+  typename c10::invoke_result_t<CB, T const&> withLock(CB cb) const {
     std::lock_guard<std::mutex> guard(this->mutex_);
     return cb(this->data_);
   }

--- a/c10/util/Synchronized.h
+++ b/c10/util/Synchronized.h
@@ -2,6 +2,8 @@
 
 #include <mutex>
 
+#include <c10/util/C++17.h>
+
 namespace c10 {
 
 /**

--- a/c10/util/Synchronized.h
+++ b/c10/util/Synchronized.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mutex>
+#include <type_traits>
 
 namespace c10 {
 
@@ -42,7 +43,11 @@ class Synchronized final {
    * provided callback safely.
    */
   template <typename CB>
+#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
+  std::invoke_result<CB(T&)>::type withLock(CB cb) {
+#else
   typename std::result_of<CB(T&)>::type withLock(CB cb) {
+#endif
     std::lock_guard<std::mutex> guard(this->mutex_);
     return cb(this->data_);
   }
@@ -53,7 +58,11 @@ class Synchronized final {
    * the provided callback safely.
    */
   template <typename CB>
+#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
+  std::invoke_result<CB(T const&)>::type withLock(CB cb) const {
+#else
   typename std::result_of<CB(T const&)>::type withLock(CB cb) const {
+#endif
     std::lock_guard<std::mutex> guard(this->mutex_);
     return cb(this->data_);
   }

--- a/c10/util/TypeList.h
+++ b/c10/util/TypeList.h
@@ -502,7 +502,8 @@ struct map_types_to_values final {
 template <class... Types>
 struct map_types_to_values<typelist<Types...>> final {
   template <class Func>
-  static std::tuple<std::invoke_result_t<Func(type_<Types>)>...> call(Func&& func) {
+  static std::tuple<std::invoke_result_t<Func(type_<Types>)>...> call(
+      Func&& func) {
     return std::tuple<std::invoke_result_t<Func(type_<Types>)>...>{
         std::forward<Func>(func)(type_<Types>())...};
   }

--- a/c10/util/TypeList.h
+++ b/c10/util/TypeList.h
@@ -3,8 +3,6 @@
 #include <c10/util/C++17.h>
 #include <c10/util/TypeTraits.h>
 
-#include <type_traits>
-
 namespace c10 {
 namespace guts {
 
@@ -498,26 +496,15 @@ struct map_types_to_values final {
       false_t<TypeList>::value,
       "In typelist::map_types_to_values<T>, the T argument must be typelist<...>.");
 };
-#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
 template <class... Types>
 struct map_types_to_values<typelist<Types...>> final {
   template <class Func>
-  static std::tuple<std::invoke_result_t<Func(type_<Types>)>...> call(
+  static std::tuple<c10::invoke_result_t<Func, type_<Types>>...> call(
       Func&& func) {
-    return std::tuple<std::invoke_result_t<Func(type_<Types>)>...>{
+    return std::tuple<c10::invoke_result_t<Func, type_<Types>>...>{
         std::forward<Func>(func)(type_<Types>())...};
   }
 };
-#else
-template <class... Types>
-struct map_types_to_values<typelist<Types...>> final {
-  template <class Func>
-  static std::tuple<std::result_of_t<Func(type_<Types>)>...> call(Func&& func) {
-    return std::tuple<std::result_of_t<Func(type_<Types>)>...>{
-        std::forward<Func>(func)(type_<Types>())...};
-  }
-};
-#endif
 } // namespace detail
 
 template <class TypeList, class Func>

--- a/torch/csrc/distributed/c10d/FileStore.cpp
+++ b/torch/csrc/distributed/c10d/FileStore.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <system_error>
 #include <thread>
+#include <typetraits>
 
 #include <c10/util/Exception.h>
 
@@ -69,7 +70,11 @@ namespace c10d {
 namespace {
 
 template <typename F>
+#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
+typename std::invoke_result<F()>::type syscall(F fn) {
+#else
 typename std::result_of<F()>::type syscall(F fn) {
+#endif
   while (true) {
     auto rv = fn();
     if (rv == -1) {

--- a/torch/csrc/distributed/c10d/FileStore.cpp
+++ b/torch/csrc/distributed/c10d/FileStore.cpp
@@ -22,7 +22,7 @@
 #include <sstream>
 #include <system_error>
 #include <thread>
-#include <typetraits>
+#include <type_traits>
 
 #include <c10/util/Exception.h>
 

--- a/torch/csrc/distributed/c10d/FileStore.cpp
+++ b/torch/csrc/distributed/c10d/FileStore.cpp
@@ -22,7 +22,6 @@
 #include <sstream>
 #include <system_error>
 #include <thread>
-#include <type_traits>
 
 #include <c10/util/Exception.h>
 
@@ -70,11 +69,7 @@ namespace c10d {
 namespace {
 
 template <typename F>
-#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L
-typename std::invoke_result<F()>::type syscall(F fn) {
-#else
-typename std::result_of<F()>::type syscall(F fn) {
-#endif
+typename c10::invoke_result_t<F> syscall(F fn) {
   while (true) {
     auto rv = fn();
     if (rv == -1) {


### PR DESCRIPTION
… all instances of std::result_of and std:result_of_t are conditionally replaced by std::invoke_result and std::invoke_result_t if __cpp_lib_is_invocable >= 201703L.  std::invoke_result was only introduced in c++17, so it should probably not be required yet.

Fixes #71657  and a small part of #69290

Tested on Centos 7 / gcc11 + a private project that requires cpp20.

I think the main questions to check by a maintainer are, 
- whether my choices of preprocessor blocks are appropriate 
- whether there are any very subtle differences between std::result_of and std::invoke_result that I have missed
- whether in any of the replacements  the 'new' side can/should be simplified further
