### PR TITLE
Switched to tracing overloads by default

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -150,8 +150,6 @@ make_fx_failures = {
     skip('nn.functional.max_unpool2d', '', device_type='cpu'),
     skip('nn.functional.max_unpool3d', '', device_type='cpu'),
     skip('linalg.lstsq'),  # flaky, probably just a precision issue
-    xfail('histogram'),
-    xfail('scatter'),
     # data-dependent control flow
     xfail('cov'),
     xfail('istft'),

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -75,7 +75,7 @@ def proxy_call(func_overload, args, kwargs=None):
     proxy_args = pytree.tree_map(unwrap_proxy, args)
     proxy_kwargs = pytree.tree_map(unwrap_proxy, kwargs)
 
-    proxy_out = func(*proxy_args, **proxy_kwargs)
+    proxy_out = func_overload(*proxy_args, **proxy_kwargs)
 
     # Kind of a hacky way to test if an op is in-place or not
     if func.__name__[-1] == "_" and func.__name__[0] != "_":


### PR DESCRIPTION
There are many cases where it's more convenient to use overloads, but we've hesitated in doing so since we can't torchscript it directly.

Luckily, it's pretty easy to strip overloads. See https://github.com/pytorch/functorch/pull/899