### PR TITLE
update sccache_bucket in binary build

### DIFF
--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -6,7 +6,7 @@ mkdir -p "$PYTORCH_FINAL_PACKAGE_DIR"
 
 export CUDA_VERSION="${DESIRED_CUDA/cu/}"
 export USE_SCCACHE=1
-export SCCACHE_BUCKET=ossci-compiler-cache-windows
+export SCCACHE_BUCKET=ossci-compiler-cache
 export SCCACHE_IGNORE_SERVER_IO_ERROR=1
 export VC_YEAR=2019
 


### PR DESCRIPTION
Fixes #76838

Changed `SCCACHE_BUCKET,` we could see Cache hits changes in [Windows binary wheel build](https://github.com/pytorch/pytorch/runs/6999041728?check_suite_focus=true)
```
2022-06-22T06:33:53.3118307Z Compile requests                   5750
2022-06-22T06:33:53.3125700Z Compile requests executed          5738
2022-06-22T06:33:53.3125926Z Cache hits                         5691
2022-06-22T06:33:53.3126134Z Cache hits (C/C++)                 5691
2022-06-22T06:33:53.3126321Z Cache misses                         37
```



It's an old [Windows binary wheel build](https://github.com/pytorch/pytorch/runs/6921337789?check_suite_focus=true) . We could find there was very few Cache hits.



I don't know the difference between `ossci-compiler-cache-windows` and `ossci-compiler-cache`
But it's inconsistent with yml files.
(https://github.com/pytorch/pytorch/search?q=ossci-compiler-cache)
https://github.com/pytorch/pytorch/blob/bc82a5f79ca056c0f9e5b72f41c07a3387812ac6/.github/workflows/_win-build.yml#L69
