### PR TITLE
[quant] Modify APoT utility function comments

### DIFF
--- a/torch/ao/quantization/experimental/apot_utils.py
+++ b/torch/ao/quantization/experimental/apot_utils.py
@@ -5,7 +5,7 @@ using APoT nonuniform quantization methods.
 
 import math
 
-r"""Converts floating point input into int4 APoT2 number
+r"""Converts floating point input into APoT2 number
     based on quantization levels
 """
 def float_to_apot(x, levels, indices):
@@ -42,7 +42,7 @@ def float_to_reduced_precision(x, levels, indices):
 
     return best_fp
 
-r"""Converts int4 APoT2 input into floating point number
+r"""Converts APoT2 input into floating point number
 based on quantization levels
 """
 def apot_to_float(x_apot, levels, indices):

--- a/torch/ao/quantization/experimental/apot_utils.py
+++ b/torch/ao/quantization/experimental/apot_utils.py
@@ -5,7 +5,7 @@ using APoT nonuniform quantization methods.
 
 import math
 
-r"""Converts floating point input into APoT2 number
+r"""Converts floating point input into APoT number
     based on quantization levels
 """
 def float_to_apot(x, levels, indices):
@@ -42,7 +42,7 @@ def float_to_reduced_precision(x, levels, indices):
 
     return best_fp
 
-r"""Converts APoT2 input into floating point number
+r"""Converts APoT input into floating point number
 based on quantization levels
 """
 def apot_to_float(x_apot, levels, indices):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #80028

### Summary
This PR modifies comments for APoT utility functions `float_to_apot` and `apot_to_float` for accuracy by removing the word "int4" and changing APoT2 to APoT

### Test Plan
APoT utility functions are used in the file `quantizer.py` which can be tested with unit tests using: `python pytorch/test/quantization/core/experimental/test_quantizer.py`