### PR TITLE
Expose set GPU memory fraction per process in CPP API.

### DIFF
--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -408,6 +408,10 @@ void CUDAHooks::deviceSynchronize(int64_t device_index) const {
   c10::cuda::device_synchronize();
 }
 
+void CUDAHooks::setMemoryFraction(double fraction, int64_t device_index) const {
+  c10::cuda::CUDACachingAllocator::setMemoryFraction(fraction, int(device_index));
+}
+
 // Sigh, the registry doesn't support namespaces :(
 using at::CUDAHooksRegistry;
 using at::RegistererCUDAHooksRegistry;

--- a/aten/src/ATen/cuda/detail/CUDAHooks.h
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.h
@@ -50,6 +50,7 @@ struct CUDAHooks : public at::CUDAHooksInterface {
   void cuFFTClearPlanCache(int64_t device_index) const override;
   int getNumGPUs() const override;
   void deviceSynchronize(int64_t device_index) const override;
+  void setMemoryFraction(double fraction, int64_t device_index) const override;
 };
 
 }}} // at::cuda::detail

--- a/aten/src/ATen/detail/CUDAHooksInterface.h
+++ b/aten/src/ATen/detail/CUDAHooksInterface.h
@@ -187,6 +187,10 @@ struct TORCH_API CUDAHooksInterface {
   virtual void deviceSynchronize(int64_t /*device_index*/) const {
     TORCH_CHECK(false, "Cannot synchronize CUDA device without ATen_cuda library. ", CUDA_HELP);
   }
+
+  virtual void setMemoryFraction(double /*fraction*/, int64_t /*device_index*/) const {
+    TORCH_CHECK(false, "Cannot set CUDA device memory fraction limit without ATen_cuda library. ", CUDA_HELP);
+  }
 };
 
 // NB: dummy argument to suppress "ISO C++11 requires at least one argument

--- a/torch/csrc/api/include/torch/cuda.h
+++ b/torch/csrc/api/include/torch/cuda.h
@@ -26,5 +26,8 @@ void TORCH_API manual_seed_all(uint64_t seed);
 /// Waits for all kernels in all streams on a CUDA device to complete.
 void TORCH_API synchronize(int64_t device_index = -1);
 
+/// Sets memory fraction for a process.
+void TORCH_API set_per_process_memory_fraction(float fraction, int64_t device_index = -1);
+
 } // namespace cuda
 } // namespace torch

--- a/torch/csrc/api/include/torch/cuda.h
+++ b/torch/csrc/api/include/torch/cuda.h
@@ -28,7 +28,8 @@ void TORCH_API synchronize(int64_t device_index = -1);
 
 #ifdef USE_CUDA
 /// Sets memory fraction for a process.
-void TORCH_API set_per_process_memory_fraction(float fraction, int64_t device_index = -1);
+void TORCH_API
+set_per_process_memory_fraction(float fraction, int64_t device_index = -1);
 #endif
 
 } // namespace cuda

--- a/torch/csrc/api/include/torch/cuda.h
+++ b/torch/csrc/api/include/torch/cuda.h
@@ -26,8 +26,10 @@ void TORCH_API manual_seed_all(uint64_t seed);
 /// Waits for all kernels in all streams on a CUDA device to complete.
 void TORCH_API synchronize(int64_t device_index = -1);
 
+#ifdef USE_CUDA
 /// Sets memory fraction for a process.
 void TORCH_API set_per_process_memory_fraction(float fraction, int64_t device_index = -1);
+#endif
 
 } // namespace cuda
 } // namespace torch

--- a/torch/csrc/api/include/torch/cuda.h
+++ b/torch/csrc/api/include/torch/cuda.h
@@ -26,11 +26,9 @@ void TORCH_API manual_seed_all(uint64_t seed);
 /// Waits for all kernels in all streams on a CUDA device to complete.
 void TORCH_API synchronize(int64_t device_index = -1);
 
-#ifdef USE_CUDA
 /// Sets memory fraction for a process.
 void TORCH_API
 set_per_process_memory_fraction(float fraction, int64_t device_index = -1);
-#endif
 
 } // namespace cuda
 } // namespace torch

--- a/torch/csrc/api/src/cuda.cpp
+++ b/torch/csrc/api/src/cuda.cpp
@@ -76,9 +76,9 @@ void set_per_process_memory_fraction(float fraction, int64_t device_index) {
   TORCH_CHECK(
       fraction >= 0.0 || fraction <= 1.0,
       "Memory fraction should be between 0 and 1, got: ",
-      fraction
-      );
-  c10::cuda::CUDACachingAllocator::setMemoryFraction(fraction, int(device_index));
+      fraction);
+  c10::cuda::CUDACachingAllocator::setMemoryFraction(
+      fraction, int(device_index));
 }
 #endif
 

--- a/torch/csrc/api/src/cuda.cpp
+++ b/torch/csrc/api/src/cuda.cpp
@@ -3,7 +3,10 @@
 #include <ATen/Context.h>
 #include <c10/core/DeviceGuard.h>
 #include <c10/util/irange.h>
+
+#ifdef USE_CUDA
 #include <c10/cuda/CUDACachingAllocator.h>
+#endif
 
 #include <cstddef>
 
@@ -62,6 +65,7 @@ void synchronize(int64_t device_index) {
   at::detail::getCUDAHooks().deviceSynchronize(device_index);
 }
 
+#ifdef USE_CUDA
 void set_per_process_memory_fraction(float fraction, int64_t device_index) {
   TORCH_CHECK(is_available(), "No CUDA GPUs are available");
   int64_t num_gpus = cuda::device_count();
@@ -76,6 +80,7 @@ void set_per_process_memory_fraction(float fraction, int64_t device_index) {
       );
   c10::cuda::CUDACachingAllocator::setMemoryFraction(fraction, int(device_index));
 }
+#endif
 
 } // namespace cuda
 } // namespace torch

--- a/torch/csrc/api/src/cuda.cpp
+++ b/torch/csrc/api/src/cuda.cpp
@@ -4,10 +4,6 @@
 #include <c10/core/DeviceGuard.h>
 #include <c10/util/irange.h>
 
-#ifdef USE_CUDA
-#include <c10/cuda/CUDACachingAllocator.h>
-#endif
-
 #include <cstddef>
 
 namespace torch {
@@ -65,7 +61,6 @@ void synchronize(int64_t device_index) {
   at::detail::getCUDAHooks().deviceSynchronize(device_index);
 }
 
-#ifdef USE_CUDA
 void set_per_process_memory_fraction(float fraction, int64_t device_index) {
   TORCH_CHECK(is_available(), "No CUDA GPUs are available");
   int64_t num_gpus = cuda::device_count();
@@ -77,10 +72,8 @@ void set_per_process_memory_fraction(float fraction, int64_t device_index) {
       fraction >= 0.0 || fraction <= 1.0,
       "Memory fraction should be between 0 and 1, got: ",
       fraction);
-  c10::cuda::CUDACachingAllocator::setMemoryFraction(
-      fraction, int(device_index));
+  at::detail::getCUDAHooks().setMemoryFraction(fraction, device_index);
 }
-#endif
 
 } // namespace cuda
 } // namespace torch


### PR DESCRIPTION
This PR exposes the TORCH.CUDA.SET_PER_PROCESS_MEMORY_FRACTION function that is already exposed in python

cc @ngimel