### PR TITLE
[ci] fix bug in win build artifact uploading

### DIFF
--- a/.github/workflows/_win-build.yml
+++ b/.github/workflows/_win-build.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           retention-days: 14
           if-no-files-found: error
-          name: ${{ env.BUILD_ENVIRONMENT }}
+          name: ${{ inputs.build-environment }}
           path: C:\${{ github.run_id }}\build-results
 
       - name: Upload sccache stats

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Download PyTorch Build Artifacts
         uses: seemethere/download-artifact-s3@v4
         with:
-          name: ${{ env.BUILD_ENVIRONMENT }}
+          name: ${{ inputs.build-environment }}
           path: C:\${{ github.run_id }}\build-results
 
       - name: Check build-results folder


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #80042

We were uploading artifacts with a blank string as the name. Properly
set the name using `inputs.build-environment`.

This actually happened to work, because we only have one windows
artifact per workflow and so the name `""` never collided lol.