### PR TITLE
[ci] remove old USER_LAND code from ci scripts

### DIFF
--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -22,13 +22,6 @@ if [[ "${BUILD_ENVIRONMENT}" == *rocm* ]]; then
   export HSA_FORCE_FINE_GRAIN_PCIE=1
 fi
 
-# This token is used by a parser on Jenkins logs for determining
-# if a failure is a legitimate problem, or a problem with the build
-# system; to find out more, grep for this string in ossci-job-dsl.
-echo "ENTERED_USER_LAND"
-
-trap_add cleanup EXIT
-
 if [[ "$BUILD_ENVIRONMENT" != *win-* ]]; then
   if which sccache > /dev/null; then
     # Save sccache logs to file

--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -35,19 +35,6 @@ trap_add() {
 # inherit them unless the trace attribute is set
 declare -f -t trap_add
 
-# NB: define this function before set -x, so that we don't
-# pollute the log with a premature EXITED_USER_LAND ;)
-function cleanup {
-  # Note that if you've exited user land, then CI will conclude that
-  # any failure is the CI's fault.  So we MUST only output this
-  # string
-  retcode=$?
-  set +x
-  if [ $retcode -eq 0 ]; then
-    echo "EXITED_USER_LAND"
-  fi
-}
-
 function assert_git_not_dirty() {
     # TODO: we should add an option to `build_amd.py` that reverts the repo to
     #       an unmodified state.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #79396
* #80046
* __->__ #80045

We used to have a parser in jenkins that looked for "ENTERED USER LAND"
and "EXITED USER LAND" as a coarse way to classify failures in to infra
vs. user failures.

This is a good idea and I think we should implement it again for GHA.
But at the moment we don't have it, so remove the unused code.