### PR TITLE
[fx2trt] fix vanilla convolution test

### DIFF
--- a/torch/testing/_internal/common_fx2trt.py
+++ b/torch/testing/_internal/common_fx2trt.py
@@ -166,7 +166,7 @@ class TRTTestCase(TestCase):
 
 
 class VanillaTestCase(TRTTestCase):
-    def run_test(self, mod, inputs, expected_ops, rtol=1e-05, atol=1e-06):
+    def run_test(self, mod, inputs, expected_ops, rtol=1e-03, atol=1e-03):
         mod = torch.fx.symbolic_trace(mod)
         shape_prop.ShapeProp(mod).propagate(*inputs)
         mod = NormalizeArgs(mod).transform()


### PR DESCRIPTION
Summary:
Fixes for failing tests for trt 8.4
- Increase error tolerance on vanilla tests to match that of acc ops converters tests
- Fix stride/padding dims for vanilla converter of conv1d

Reviewed By: mortzur

Differential Revision: D37329899

