### PR TITLE
[PyTorch] Reporting OOM events to the Pytorch Profiler.

### DIFF
--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -57,6 +57,25 @@ void reportMemoryUsageToProfiler(
   }
 }
 
+void reportOutOfMemoryToProfiler(
+    int64_t alloc_size,
+    int64_t total_allocated,
+    int64_t total_reserved,
+    Device device) {
+  auto* reporter_ptr = static_cast<MemoryReportingInfoBase*>(
+      ThreadLocalDebugInfo::get(DebugInfoKind::PROFILER_STATE));
+  if (reporter_ptr) {
+    reporter_ptr->reportOutOfMemory(
+        alloc_size, total_allocated, total_reserved, device);
+  }
+}
+
 MemoryReportingInfoBase::MemoryReportingInfoBase() = default;
+
+void MemoryReportingInfoBase::reportOutOfMemory(
+    int64_t /*alloc_size*/,
+    int64_t /*total_allocated*/,
+    int64_t /*total_reserved*/,
+    Device /*device*/) {}
 
 } // namespace c10

--- a/c10/core/Allocator.h
+++ b/c10/core/Allocator.h
@@ -243,12 +243,24 @@ struct C10_API MemoryReportingInfoBase : public c10::DebugInfoBase {
       int64_t total_reserved,
       Device device) = 0;
 
+  virtual void reportOutOfMemory(
+      int64_t alloc_size,
+      int64_t total_allocated,
+      int64_t total_reserved,
+      Device device);
+
   virtual bool memoryProfilingEnabled() const = 0;
 };
 
 C10_API bool memoryProfilingEnabled();
 C10_API void reportMemoryUsageToProfiler(
     void* ptr,
+    int64_t alloc_size,
+    int64_t total_allocated,
+    int64_t total_reserved,
+    Device device);
+
+C10_API void reportOutOfMemoryToProfiler(
     int64_t alloc_size,
     int64_t total_allocated,
     int64_t total_reserved,

--- a/c10/core/CPUAllocator.h
+++ b/c10/core/CPUAllocator.h
@@ -17,12 +17,13 @@ using MemoryDeleter = void (*)(void*);
 // A helper function that is basically doing nothing.
 C10_API void NoDelete(void*);
 
-// A simple struct that is used to report C10's memory allocation and
-// deallocation status to the profiler
+// A simple struct that is used to report C10's memory allocation,
+// deallocation status and out-of-memory events to the profiler
 class C10_API ProfiledCPUMemoryReporter {
  public:
   ProfiledCPUMemoryReporter() {}
   void New(void* ptr, size_t nbytes);
+  void OutOfMemory(size_t nbytes);
   void Delete(void* ptr);
 
  private:

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -611,6 +611,13 @@ class DeviceCachingAllocator {
 
       stats.num_ooms += 1;
 
+      c10::reportOutOfMemoryToProfiler(
+          size,
+          stats.allocated_bytes[static_cast<int64_t>(StatType::AGGREGATE)]
+              .current,
+          stats.reserved_bytes[static_cast<int64_t>(StatType::AGGREGATE)]
+              .current,
+          c10::Device(c10::DeviceType::CUDA, static_cast<DeviceIndex>(device)));
       // "total capacity": total global memory on GPU
       // "allowed": memory is allowed to use, which set by fraction.
       // "already allocated": memory allocated by the program using the

--- a/torch/autograd/profiler_util.py
+++ b/torch/autograd/profiler_util.py
@@ -636,11 +636,13 @@ def _filter_stack_entry(entry):
     return all([not (f[0] in entry and f[1] in entry) for f in filtered_entries])
 
 MEMORY_EVENT_NAME = "[memory]"
+OUT_OF_MEMORY_EVENT_NAME = "[OutOfMemory]"
 
 def _filter_name(name):
     # ignoring the following utility ops
     filtered_out_names = [
         MEMORY_EVENT_NAME,  # used only for the top-level memory events
+        OUT_OF_MEMORY_EVENT_NAME,
         "profiler::_record_function_enter",
         "profiler::_record_function_enter_new",
         "profiler::_record_function_exit",

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -146,6 +146,22 @@ struct EventFieldsVisitor {
     }
   }
 
+  void operator()(const ExtraFields<EventType::OutOfMemory>& alloc) {
+    kineto_event_.get()
+        .deviceIndex(alloc.device_index_)
+        .nBytes(alloc.alloc_size_);
+
+    addMetadata("Device Type", std::to_string((int8_t)alloc.device_type_));
+    addMetadata("Device Id", std::to_string(alloc.device_index_));
+    addMetadata("Bytes", std::to_string(alloc.alloc_size_));
+    if (alloc.total_allocated_ >= 0) {
+      addMetadata("Total Allocated", std::to_string(alloc.total_allocated_));
+    }
+    if (alloc.total_reserved_ >= 0) {
+      addMetadata("Total Reserved", std::to_string(alloc.total_reserved_));
+    }
+  }
+
   template <typename T>
   void handleJIT(T& fields) {
     auto& jit_stack = fields.jit_stack_;
@@ -277,6 +293,22 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalStateBase {
       record_queue_.getSubqueue()->emplace_allocation_event(
           torch::profiler::impl::getApproximateTime(),
           ptr,
+          alloc_size,
+          total_allocated,
+          total_reserved,
+          device.type(),
+          device.index());
+    }
+  }
+
+  void reportOutOfMemory(
+      int64_t alloc_size,
+      int64_t total_allocated,
+      int64_t total_reserved,
+      c10::Device device) override {
+    if (config_.profile_memory && config_.state != ProfilerState::Disabled) {
+      record_queue_.getSubqueue()->emplace_ooms_event(
+          torch::profiler::impl::getApproximateTime(),
           alloc_size,
           total_allocated,
           total_reserved,

--- a/torch/csrc/profiler/collection.h
+++ b/torch/csrc/profiler/collection.h
@@ -25,6 +25,7 @@ enum class EventType : uint8_t {
   TorchOp = 0,
   Backend,
   Allocation,
+  OutOfMemory,
   PyCall,
   PyCCall
 };
@@ -114,6 +115,21 @@ static_assert(
     std::is_pod<ExtraFields<EventType::Allocation>>::value,
     "Non-POD member of ExtraFields<EventType::Allocation>.");
 
+template <>
+struct ExtraFields<EventType::OutOfMemory> {
+  torch::profiler::impl::approx_time_t start_time_;
+  int64_t alloc_size_;
+  int64_t total_allocated_;
+  int64_t total_reserved_;
+  c10::DeviceType device_type_;
+  c10::DeviceIndex device_index_;
+};
+
+// For performance.
+static_assert(
+    std::is_pod<ExtraFields<EventType::OutOfMemory>>::value,
+    "Non-POD member of ExtraFields<EventType::OutOfMemory>.");
+
 struct PyFrameState {
   int line_no_;
   at::StringView filename_;
@@ -201,6 +217,7 @@ struct TORCH_API Result : public std::enable_shared_from_this<Result> {
       ExtraFields<EventType::TorchOp>,
       ExtraFields<EventType::Backend>,
       ExtraFields<EventType::Allocation>,
+      ExtraFields<EventType::OutOfMemory>,
       ExtraFields<EventType::PyCall>,
       ExtraFields<EventType::PyCCall>>
       extra_fields_;
@@ -339,6 +356,11 @@ class TORCH_API ThreadLocalSubqueue {
   }
 
   template <class... Args>
+  void emplace_ooms_event(Args&&... args) {
+    ooms_.emplace_back(std::forward<Args>(args)...);
+  }
+
+  template <class... Args>
   void emplace_py_call(Args&&... args) {
     py_calls_.emplace_back(std::forward<Args>(args)...);
   }
@@ -409,6 +431,9 @@ class TORCH_API ThreadLocalSubqueue {
 
   // reportMemoryUsage
   AppendOnlyList<ExtraFields<EventType::Allocation>, BlockSize> allocations_;
+
+  // reportOOMs
+  AppendOnlyList<ExtraFields<EventType::OutOfMemory>, BlockSize> ooms_;
 };
 
 class TORCH_API RecordQueue {


### PR DESCRIPTION
Summary: Similar to reporting alloc and dealloc events in the PyTorch profiler, we are now reporting Out of Memory events as well. This is useful for performance troubleshooting

Test Plan: Added test_oom_tracing to test/test_profiler.py

Differential Revision: D36268132

