### PR TITLE
Upgrade pytorch nightly docker python version to 3.8

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -18,7 +18,7 @@ CUDA_CHANNEL              = nvidia
 # The conda channel to use to install pytorch / torchvision
 INSTALL_CHANNEL           = pytorch
 
-PYTHON_VERSION            = 3.7
+PYTHON_VERSION            = 3.8
 PYTORCH_VERSION           = $(shell git describe --tags --always)
 # Can be either official / dev
 BUILD_TYPE                = dev


### PR DESCRIPTION
We are planning to use nightly docker as a base to build torchbench nightly docker. Torchbench is using Python 3.8, so we would like PyTorch nightly docker to use 3.8 by default as well.