### PR TITLE
[ao] Added ModelReport class outline for Fx Graph Modules

### DIFF
--- a/test/quantization/fx/test_model_report_fx.py
+++ b/test/quantization/fx/test_model_report_fx.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 from torch.ao.quantization import QConfig, QConfigMapping
 from torch.ao.quantization.fx._model_report.detector import DynamicStaticDetector, PerChannelDetector
 from torch.ao.quantization.fx._model_report.model_report_observer import ModelReportObserver
+from torch.ao.quantization.fx._model_report.model_report import ModelReport
 from torch.ao.quantization.observer import HistogramObserver, default_per_channel_weight_observer
 from torch.nn.intrinsic.modules.fused import ConvReLU2d, LinearReLU
 from torch.testing._internal.common_quantization import (
@@ -16,6 +17,7 @@ from torch.testing._internal.common_quantization import (
     TwoLayerLinearModel,
     skipIfNoFBGEMM,
     skipIfNoQNNPACK,
+    override_quantized_engine,
 )
 
 
@@ -87,32 +89,35 @@ class TestFxModelReportDetector(QuantizationTestCase):
         Output has no changes / suggestions
     """
 
+    @skipIfNoFBGEMM
     def test_simple_conv(self):
-        torch.backends.quantized.engine = "onednn"
 
-        q_config_mapping = QConfigMapping()
-        q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine))
+        with override_quantized_engine('fbgemm'):
+            torch.backends.quantized.engine = "fbgemm"
 
-        input = torch.randn(1, 3, 10, 10)
-        prepared_model = self._prepare_model_and_run_input(ConvModel(), q_config_mapping, input)
+            q_config_mapping = QConfigMapping()
+            q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine))
 
-        # run the detector
-        per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
-        optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
+            input = torch.randn(1, 3, 10, 10)
+            prepared_model = self._prepare_model_and_run_input(ConvModel(), q_config_mapping, input)
 
-        # no optims possible and there should be nothing in per_channel_status
-        self.assertEqual(
-            optims_str,
-            DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
-        )
-        self.assertEqual(per_channel_info["backend"], torch.backends.quantized.engine)
-        self.assertEqual(len(per_channel_info["per_channel_status"]), 1)
-        self.assertEqual(list(per_channel_info["per_channel_status"])[0], "conv")
-        self.assertEqual(
-            per_channel_info["per_channel_status"]["conv"]["per_channel_supported"],
-            True,
-        )
-        self.assertEqual(per_channel_info["per_channel_status"]["conv"]["per_channel_used"], True)
+            # run the detector
+            per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
+            optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
+
+            # no optims possible and there should be nothing in per_channel_status
+            self.assertEqual(
+                optims_str,
+                DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
+            )
+            self.assertEqual(per_channel_info["backend"], torch.backends.quantized.engine)
+            self.assertEqual(len(per_channel_info["per_channel_status"]), 1)
+            self.assertEqual(list(per_channel_info["per_channel_status"])[0], "conv")
+            self.assertEqual(
+                per_channel_info["per_channel_status"]["conv"]["per_channel_supported"],
+                True,
+            )
+            self.assertEqual(per_channel_info["per_channel_status"]["conv"]["per_channel_used"], True)
 
     """Case includes:
         Multiple conv or linear
@@ -125,35 +130,37 @@ class TestFxModelReportDetector(QuantizationTestCase):
 
     @skipIfNoQNNPACK
     def test_multi_linear_model_without_per_channel(self):
-        torch.backends.quantized.engine = "qnnpack"
 
-        q_config_mapping = QConfigMapping()
-        q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine))
+        with override_quantized_engine('qnnpack'):
+            torch.backends.quantized.engine = "qnnpack"
 
-        prepared_model = self._prepare_model_and_run_input(
-            TwoLayerLinearModel(),
-            q_config_mapping,
-            TwoLayerLinearModel().get_example_inputs()[0],
-        )
+            q_config_mapping = QConfigMapping()
+            q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine))
 
-        # run the detector
-        per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
-        optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
+            prepared_model = self._prepare_model_and_run_input(
+                TwoLayerLinearModel(),
+                q_config_mapping,
+                TwoLayerLinearModel().get_example_inputs()[0],
+            )
 
-        # there should be optims possible
-        self.assertNotEqual(
-            optims_str,
-            DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
-        )
-        self.assertEqual(per_channel_info["backend"], torch.backends.quantized.engine)
-        self.assertEqual(len(per_channel_info["per_channel_status"]), 2)
+            # run the detector
+            per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
+            optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
 
-        # for each linear layer, should be supported but not used
-        for linear_key in per_channel_info["per_channel_status"].keys():
-            module_entry = per_channel_info["per_channel_status"][linear_key]
+            # there should be optims possible
+            self.assertNotEqual(
+                optims_str,
+                DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
+            )
+            self.assertEqual(per_channel_info["backend"], torch.backends.quantized.engine)
+            self.assertEqual(len(per_channel_info["per_channel_status"]), 2)
 
-            self.assertEqual(module_entry["per_channel_supported"], True)
-            self.assertEqual(module_entry["per_channel_used"], False)
+            # for each linear layer, should be supported but not used
+            for linear_key in per_channel_info["per_channel_status"].keys():
+                module_entry = per_channel_info["per_channel_status"][linear_key]
+
+                self.assertEqual(module_entry["per_channel_supported"], True)
+                self.assertEqual(module_entry["per_channel_used"], False)
 
     """Case includes:
         Multiple conv or linear
@@ -166,70 +173,72 @@ class TestFxModelReportDetector(QuantizationTestCase):
 
     @skipIfNoQNNPACK
     def test_multiple_q_config_options(self):
-        torch.backends.quantized.engine = "qnnpack"
 
-        # qconfig with support for per_channel quantization
-        per_channel_qconfig = QConfig(
-            activation=HistogramObserver.with_args(reduce_range=True),
-            weight=default_per_channel_weight_observer,
-        )
+        with override_quantized_engine('qnnpack'):
+            torch.backends.quantized.engine = "qnnpack"
 
-        # we need to design the model
-        class ConvLinearModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.conv1 = torch.nn.Conv2d(3, 3, 2, 1)
-                self.fc1 = torch.nn.Linear(9, 27)
-                self.relu = torch.nn.ReLU()
-                self.fc2 = torch.nn.Linear(27, 27)
-                self.conv2 = torch.nn.Conv2d(3, 3, 2, 1)
+            # qconfig with support for per_channel quantization
+            per_channel_qconfig = QConfig(
+                activation=HistogramObserver.with_args(reduce_range=True),
+                weight=default_per_channel_weight_observer,
+            )
 
-            def forward(self, x):
-                x = self.conv1(x)
-                x = self.fc1(x)
-                x = self.relu(x)
-                x = self.fc2(x)
-                x = self.conv2(x)
-                return x
+            # we need to design the model
+            class ConvLinearModel(torch.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.conv1 = torch.nn.Conv2d(3, 3, 2, 1)
+                    self.fc1 = torch.nn.Linear(9, 27)
+                    self.relu = torch.nn.ReLU()
+                    self.fc2 = torch.nn.Linear(27, 27)
+                    self.conv2 = torch.nn.Conv2d(3, 3, 2, 1)
 
-        q_config_mapping = QConfigMapping()
-        q_config_mapping.set_global(
-            torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine)
-        ).set_object_type(torch.nn.Conv2d, per_channel_qconfig)
+                def forward(self, x):
+                    x = self.conv1(x)
+                    x = self.fc1(x)
+                    x = self.relu(x)
+                    x = self.fc2(x)
+                    x = self.conv2(x)
+                    return x
 
-        prepared_model = self._prepare_model_and_run_input(
-            ConvLinearModel(),
-            q_config_mapping,
-            torch.randn(1, 3, 10, 10),
-        )
+            q_config_mapping = QConfigMapping()
+            q_config_mapping.set_global(
+                torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine)
+            ).set_object_type(torch.nn.Conv2d, per_channel_qconfig)
 
-        # run the detector
-        per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
-        optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
+            prepared_model = self._prepare_model_and_run_input(
+                ConvLinearModel(),
+                q_config_mapping,
+                torch.randn(1, 3, 10, 10),
+            )
 
-        # the only suggestions should be to linear layers
+            # run the detector
+            per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
+            optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
 
-        # there should be optims possible
-        self.assertNotEqual(
-            optims_str,
-            DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
-        )
+            # the only suggestions should be to linear layers
 
-        # to ensure it got into the nested layer
-        self.assertEqual(len(per_channel_info["per_channel_status"]), 4)
+            # there should be optims possible
+            self.assertNotEqual(
+                optims_str,
+                DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
+            )
 
-        # for each layer, should be supported but not used
-        for key in per_channel_info["per_channel_status"].keys():
-            module_entry = per_channel_info["per_channel_status"][key]
-            self.assertEqual(module_entry["per_channel_supported"], True)
+            # to ensure it got into the nested layer
+            self.assertEqual(len(per_channel_info["per_channel_status"]), 4)
 
-            # if linear False, if conv2d true cuz it uses different config
-            if "fc" in key:
-                self.assertEqual(module_entry["per_channel_used"], False)
-            elif "conv" in key:
-                self.assertEqual(module_entry["per_channel_used"], True)
-            else:
-                raise ValueError("Should only contain conv and linear layers as key values")
+            # for each layer, should be supported but not used
+            for key in per_channel_info["per_channel_status"].keys():
+                module_entry = per_channel_info["per_channel_status"][key]
+                self.assertEqual(module_entry["per_channel_supported"], True)
+
+                # if linear False, if conv2d true cuz it uses different config
+                if "fc" in key:
+                    self.assertEqual(module_entry["per_channel_used"], False)
+                elif "conv" in key:
+                    self.assertEqual(module_entry["per_channel_used"], True)
+                else:
+                    raise ValueError("Should only contain conv and linear layers as key values")
 
     """Case includes:
         Multiple conv or linear
@@ -242,36 +251,38 @@ class TestFxModelReportDetector(QuantizationTestCase):
 
     @skipIfNoQNNPACK
     def test_sequential_model_format(self):
-        torch.backends.quantized.engine = "qnnpack"
 
-        q_config_mapping = QConfigMapping()
-        q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine))
+        with override_quantized_engine('qnnpack'):
+            torch.backends.quantized.engine = "qnnpack"
 
-        prepared_model = self._prepare_model_and_run_input(
-            NESTED_CONV_LINEAR_EXAMPLE,
-            q_config_mapping,
-            torch.randn(1, 3, 10, 10),
-        )
+            q_config_mapping = QConfigMapping()
+            q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine))
 
-        # run the detector
-        per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
-        optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
+            prepared_model = self._prepare_model_and_run_input(
+                NESTED_CONV_LINEAR_EXAMPLE,
+                q_config_mapping,
+                torch.randn(1, 3, 10, 10),
+            )
 
-        # there should be optims possible
-        self.assertNotEqual(
-            optims_str,
-            DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
-        )
+            # run the detector
+            per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
+            optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
 
-        # to ensure it got into the nested layer
-        self.assertEqual(len(per_channel_info["per_channel_status"]), 4)
+            # there should be optims possible
+            self.assertNotEqual(
+                optims_str,
+                DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
+            )
 
-        # for each layer, should be supported but not used
-        for key in per_channel_info["per_channel_status"].keys():
-            module_entry = per_channel_info["per_channel_status"][key]
+            # to ensure it got into the nested layer
+            self.assertEqual(len(per_channel_info["per_channel_status"]), 4)
 
-            self.assertEqual(module_entry["per_channel_supported"], True)
-            self.assertEqual(module_entry["per_channel_used"], False)
+            # for each layer, should be supported but not used
+            for key in per_channel_info["per_channel_status"].keys():
+                module_entry = per_channel_info["per_channel_status"][key]
+
+                self.assertEqual(module_entry["per_channel_supported"], True)
+                self.assertEqual(module_entry["per_channel_used"], False)
 
     """Case includes:
         Multiple conv or linear
@@ -284,36 +295,38 @@ class TestFxModelReportDetector(QuantizationTestCase):
 
     @skipIfNoQNNPACK
     def test_conv_sub_class_considered(self):
-        torch.backends.quantized.engine = "qnnpack"
 
-        q_config_mapping = QConfigMapping()
-        q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine))
+        with override_quantized_engine('qnnpack'):
+            torch.backends.quantized.engine = "qnnpack"
 
-        prepared_model = self._prepare_model_and_run_input(
-            LAZY_CONV_LINEAR_EXAMPLE,
-            q_config_mapping,
-            torch.randn(1, 3, 10, 10),
-        )
+            q_config_mapping = QConfigMapping()
+            q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine))
 
-        # run the detector
-        per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
-        optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
+            prepared_model = self._prepare_model_and_run_input(
+                LAZY_CONV_LINEAR_EXAMPLE,
+                q_config_mapping,
+                torch.randn(1, 3, 10, 10),
+            )
 
-        # there should be optims possible
-        self.assertNotEqual(
-            optims_str,
-            DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
-        )
+            # run the detector
+            per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
+            optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
 
-        # to ensure it got into the nested layer and it considered the lazyConv2d
-        self.assertEqual(len(per_channel_info["per_channel_status"]), 4)
+            # there should be optims possible
+            self.assertNotEqual(
+                optims_str,
+                DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
+            )
 
-        # for each layer, should be supported but not used
-        for key in per_channel_info["per_channel_status"].keys():
-            module_entry = per_channel_info["per_channel_status"][key]
+            # to ensure it got into the nested layer and it considered the lazyConv2d
+            self.assertEqual(len(per_channel_info["per_channel_status"]), 4)
 
-            self.assertEqual(module_entry["per_channel_supported"], True)
-            self.assertEqual(module_entry["per_channel_used"], False)
+            # for each layer, should be supported but not used
+            for key in per_channel_info["per_channel_status"].keys():
+                module_entry = per_channel_info["per_channel_status"][key]
+
+                self.assertEqual(module_entry["per_channel_supported"], True)
+                self.assertEqual(module_entry["per_channel_used"], False)
 
     """Case includes:
         Multiple conv or linear
@@ -326,35 +339,37 @@ class TestFxModelReportDetector(QuantizationTestCase):
 
     @skipIfNoFBGEMM
     def test_fusion_layer_in_sequential(self):
-        torch.backends.quantized.engine = "fbgemm"
 
-        q_config_mapping = QConfigMapping()
-        q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine))
+        with override_quantized_engine('fbgemm'):
+            torch.backends.quantized.engine = "fbgemm"
 
-        prepared_model = self._prepare_model_and_run_input(
-            FUSION_CONV_LINEAR_EXAMPLE,
-            q_config_mapping,
-            torch.randn(1, 3, 10, 10),
-        )
+            q_config_mapping = QConfigMapping()
+            q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine))
 
-        # run the detector
-        per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
-        optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
+            prepared_model = self._prepare_model_and_run_input(
+                FUSION_CONV_LINEAR_EXAMPLE,
+                q_config_mapping,
+                torch.randn(1, 3, 10, 10),
+            )
 
-        # no optims possible and there should be nothing in per_channel_status
-        self.assertEqual(
-            optims_str,
-            DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
-        )
+            # run the detector
+            per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
+            optims_str, per_channel_info = per_channel_detector.generate_detector_report(prepared_model)
 
-        # to ensure it got into the nested layer and it considered all the nested fusion components
-        self.assertEqual(len(per_channel_info["per_channel_status"]), 4)
+            # no optims possible and there should be nothing in per_channel_status
+            self.assertEqual(
+                optims_str,
+                DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
+            )
 
-        # for each layer, should be supported but not used
-        for key in per_channel_info["per_channel_status"].keys():
-            module_entry = per_channel_info["per_channel_status"][key]
-            self.assertEqual(module_entry["per_channel_supported"], True)
-            self.assertEqual(module_entry["per_channel_used"], True)
+            # to ensure it got into the nested layer and it considered all the nested fusion components
+            self.assertEqual(len(per_channel_info["per_channel_status"]), 4)
+
+            # for each layer, should be supported but not used
+            for key in per_channel_info["per_channel_status"].keys():
+                module_entry = per_channel_info["per_channel_status"][key]
+                self.assertEqual(module_entry["per_channel_supported"], True)
+                self.assertEqual(module_entry["per_channel_used"], True)
 
     """Case includes:
         Multiple conv or linear
@@ -388,39 +403,40 @@ class TestFxModelReportDetector(QuantizationTestCase):
                 x = self.dequant(x)
                 return x
 
-        # create a model instance
-        model_fp32 = QATConvLinearReluModel()
+        with override_quantized_engine('qnnpack'):
+            # create a model instance
+            model_fp32 = QATConvLinearReluModel()
 
-        model_fp32.qconfig = torch.quantization.get_default_qat_qconfig("qnnpack")
+            model_fp32.qconfig = torch.quantization.get_default_qat_qconfig("qnnpack")
 
-        # model must be in eval mode for fusion
-        model_fp32.eval()
-        model_fp32_fused = torch.quantization.fuse_modules(model_fp32, [["conv", "bn", "relu"]])
+            # model must be in eval mode for fusion
+            model_fp32.eval()
+            model_fp32_fused = torch.quantization.fuse_modules(model_fp32, [["conv", "bn", "relu"]])
 
-        # model must be set to train mode for QAT logic to work
-        model_fp32_fused.train()
+            # model must be set to train mode for QAT logic to work
+            model_fp32_fused.train()
 
-        # prepare the model for QAT, different than for post training quantization
-        model_fp32_prepared = torch.quantization.prepare_qat(model_fp32_fused)
+            # prepare the model for QAT, different than for post training quantization
+            model_fp32_prepared = torch.quantization.prepare_qat(model_fp32_fused)
 
-        # run the detector
-        per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
-        optims_str, per_channel_info = per_channel_detector.generate_detector_report(model_fp32_prepared)
+            # run the detector
+            per_channel_detector = PerChannelDetector(torch.backends.quantized.engine)
+            optims_str, per_channel_info = per_channel_detector.generate_detector_report(model_fp32_prepared)
 
-        # there should be optims possible
-        self.assertNotEqual(
-            optims_str,
-            DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
-        )
+            # there should be optims possible
+            self.assertNotEqual(
+                optims_str,
+                DEFAULT_NO_OPTIMS_ANSWER_STRING.format(torch.backends.quantized.engine),
+            )
 
-        # make sure it was able to find the single conv in the fused model
-        self.assertEqual(len(per_channel_info["per_channel_status"]), 1)
+            # make sure it was able to find the single conv in the fused model
+            self.assertEqual(len(per_channel_info["per_channel_status"]), 1)
 
-        # for the one conv, it should still give advice to use different qconfig
-        for key in per_channel_info["per_channel_status"].keys():
-            module_entry = per_channel_info["per_channel_status"][key]
-            self.assertEqual(module_entry["per_channel_supported"], True)
-            self.assertEqual(module_entry["per_channel_used"], False)
+            # for the one conv, it should still give advice to use different qconfig
+            for key in per_channel_info["per_channel_status"].keys():
+                module_entry = per_channel_info["per_channel_status"][key]
+                self.assertEqual(module_entry["per_channel_supported"], True)
+                self.assertEqual(module_entry["per_channel_used"], False)
 
 
 """
@@ -743,65 +759,103 @@ class TestFxModelReportDetectDynamicStatic(QuantizationTestCase):
                 z = F.relu(z)
                 return z
 
-        # create model, example input, and qconfig mapping
-        torch.backends.quantized.engine = "fbgemm"
-        model = TwoBlockNet()
-        example_input = torch.randint(-10, 0, (1, 3, 3, 3))
-        example_input = example_input.to(torch.float)
-        q_config_mapping = QConfigMapping()
-        q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig("fbgemm"))
 
-        # prep model and select observer
-        model_prep = quantize_fx.prepare_fx(model, q_config_mapping, example_input)
-        obs_ctr = ModelReportObserver
+        with override_quantized_engine('fbgemm'):
+            # create model, example input, and qconfig mapping
+            torch.backends.quantized.engine = "fbgemm"
+            model = TwoBlockNet()
+            example_input = torch.randint(-10, 0, (1, 3, 3, 3))
+            example_input = example_input.to(torch.float)
+            q_config_mapping = QConfigMapping()
+            q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig("fbgemm"))
 
-        # find layer to attach to and store
-        linear_fqn = "block2.linear"  # fqn of target linear
+            # prep model and select observer
+            model_prep = quantize_fx.prepare_fx(model, q_config_mapping, example_input)
+            obs_ctr = ModelReportObserver
 
-        target_linear = None
-        for node in model_prep.graph.nodes:
-            if node.target == linear_fqn:
-                target_linear = node
-                break
+            # find layer to attach to and store
+            linear_fqn = "block2.linear"  # fqn of target linear
 
-        # insert into both module and graph pre and post
+            target_linear = None
+            for node in model_prep.graph.nodes:
+                if node.target == linear_fqn:
+                    target_linear = node
+                    break
 
-        # set up to insert before target_linear (pre_observer)
-        with model_prep.graph.inserting_before(target_linear):
-            obs_to_insert = obs_ctr()
-            pre_obs_fqn = linear_fqn + ".model_report_pre_observer"
-            model_prep.add_submodule(pre_obs_fqn, obs_to_insert)
-            model_prep.graph.create_node(op="call_module", target=pre_obs_fqn, args=target_linear.args)
+            # insert into both module and graph pre and post
 
-        # set up and insert after the target_linear (post_observer)
-        with model_prep.graph.inserting_after(target_linear):
-            obs_to_insert = obs_ctr()
-            post_obs_fqn = linear_fqn + ".model_report_post_observer"
-            model_prep.add_submodule(post_obs_fqn, obs_to_insert)
-            model_prep.graph.create_node(op="call_module", target=post_obs_fqn, args=(target_linear,))
+            # set up to insert before target_linear (pre_observer)
+            with model_prep.graph.inserting_before(target_linear):
+                obs_to_insert = obs_ctr()
+                pre_obs_fqn = linear_fqn + ".model_report_pre_observer"
+                model_prep.add_submodule(pre_obs_fqn, obs_to_insert)
+                model_prep.graph.create_node(op="call_module", target=pre_obs_fqn, args=target_linear.args)
 
-        # need to recompile module after submodule added and pass input through
-        model_prep.recompile()
+            # set up and insert after the target_linear (post_observer)
+            with model_prep.graph.inserting_after(target_linear):
+                obs_to_insert = obs_ctr()
+                post_obs_fqn = linear_fqn + ".model_report_post_observer"
+                model_prep.add_submodule(post_obs_fqn, obs_to_insert)
+                model_prep.graph.create_node(op="call_module", target=post_obs_fqn, args=(target_linear,))
 
-        num_iterations = 10
-        for i in range(num_iterations):
-            if i % 2 == 0:
-                example_input = torch.randint(-10, 0, (1, 3, 3, 3)).to(torch.float)
-            else:
-                example_input = torch.randint(0, 10, (1, 3, 3, 3)).to(torch.float)
-            model_prep(example_input)
+            # need to recompile module after submodule added and pass input through
+            model_prep.recompile()
 
-        # run it through the dynamic vs static detector
-        dynamic_vs_static_detector = DynamicStaticDetector()
-        dynam_vs_stat_str, dynam_vs_stat_dict = dynamic_vs_static_detector.generate_detector_report(model_prep)
+            num_iterations = 10
+            for i in range(num_iterations):
+                if i % 2 == 0:
+                    example_input = torch.randint(-10, 0, (1, 3, 3, 3)).to(torch.float)
+                else:
+                    example_input = torch.randint(0, 10, (1, 3, 3, 3)).to(torch.float)
+                model_prep(example_input)
 
-        # one of the stats should be stationary, and the other non-stationary
-        # as a result, dynamic should be recommended
-        data_dist_info = [
-            dynam_vs_stat_dict[linear_fqn]["pre_observer_data_dist"],
-            dynam_vs_stat_dict[linear_fqn]["post_observer_data_dist"],
-        ]
+            # run it through the dynamic vs static detector
+            dynamic_vs_static_detector = DynamicStaticDetector()
+            dynam_vs_stat_str, dynam_vs_stat_dict = dynamic_vs_static_detector.generate_detector_report(model_prep)
 
-        self.assertTrue("stationary" in data_dist_info)
-        self.assertTrue("non-stationary" in data_dist_info)
-        self.assertTrue(dynam_vs_stat_dict[linear_fqn]["dynamic_recommended"])
+            # one of the stats should be stationary, and the other non-stationary
+            # as a result, dynamic should be recommended
+            data_dist_info = [
+                dynam_vs_stat_dict[linear_fqn]["pre_observer_data_dist"],
+                dynam_vs_stat_dict[linear_fqn]["post_observer_data_dist"],
+            ]
+
+            self.assertTrue("stationary" in data_dist_info)
+            self.assertTrue("non-stationary" in data_dist_info)
+            self.assertTrue(dynam_vs_stat_dict[linear_fqn]["dynamic_recommended"])
+
+class TestFxModelReportClass(QuantizationTestCase):
+
+    @skipIfNoFBGEMM
+    def test_constructor(self):
+        """
+        Tests the constructor of the ModelReport class.
+        Specifically looks at:
+        - The desired reports
+        - Ensures that the observers of interest are properly initialized
+        """
+
+        with override_quantized_engine('fbgemm'):
+            # set the backend for this test
+            torch.backends.quantized.engine = "fbgemm"
+            backend = torch.backends.quantized.engine
+
+            # make an example set of detectors
+            test_detector_set = set([DynamicStaticDetector(), PerChannelDetector(backend)])
+            # initialize with an empty detector
+            model_report = ModelReport(test_detector_set)
+
+            # make sure internal valid reports matches
+            detector_name_set = set([detector.get_detector_name() for detector in test_detector_set])
+            self.assertEqual(model_report.get_desired_reports_names(), detector_name_set)
+
+            # now attempt with no valid reports, should raise error
+            with self.assertRaises(ValueError):
+                model_report = ModelReport(set([]))
+
+            # number of expected obs of interest entries
+            num_expected_entries = len(test_detector_set)
+            self.assertEqual(len(model_report.get_observers_of_interest()), num_expected_entries)
+
+            for value in model_report.get_observers_of_interest().values():
+                self.assertEqual(len(value), 0)

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -87,6 +87,7 @@ try:
     from quantization.fx.test_model_report_fx import TestFxModelReportDetector  # noqa: F401
     from quantization.fx.test_model_report_fx import TestFxModelReportObserver      # noqa: F401
     from quantization.fx.test_model_report_fx import TestFxModelReportDetectDynamicStatic  # noqa: F401
+    from quantization.fx.test_model_report_fx import TestFxModelReportClass  # noqa: F401
 except ImportError:
     pass
 

--- a/torch/ao/quantization/fx/_model_report/model_report.py
+++ b/torch/ao/quantization/fx/_model_report/model_report.py
@@ -1,0 +1,87 @@
+from typing import Dict, Set, Tuple
+
+import torch
+from torch.ao.quantization.fx._model_report.detector import DetectorBase
+from torch.ao.quantization.fx.graph_module import GraphModule
+
+class ModelReport:
+    r"""
+    Generates report and collects statistics
+        Used to provide users suggestions on possible model configuration improvements
+    Currently supports generating reports on:
+    - Suggestions for dynamic vs static quantization for linear layers (Graph Modules)
+    * :attr:`desired_report_detectors` The set of Detectors representing desired reports from the ModelReport class
+        Make sure that these are all unique types of detectors [do not have more than 1 of the same class]
+    Proper Use:
+    1.) Initialize ModelReport object with reports of interest by passing in initialized detector objects
+    2.) Prepare your model with prepare_fx
+    3.) Call model_report.prepare_detailed_calibration on your model to add relavent observers
+    4.) Callibrate your model with data
+    5.) Call model_report.generate_report on your model to generate report and optionally remove added observers
+    """
+
+    def __init__(self, desired_report_detectors: Set[DetectorBase]):
+
+        if len(desired_report_detectors) == 0:
+            raise ValueError("Should include at least 1 desired report")
+
+        # keep the reports private so they can't be modified
+        self._desired_report_detectors = desired_report_detectors
+        self._desired_reports = set([detector.get_detector_name() for detector in desired_report_detectors])
+
+        # keep a mapping of desired reports to observers of interest
+        # this is to get the readings, and to remove them, can create a large set
+        # this set can then be used to traverse the graph and remove added observers
+        self._report_name_to_observer_fqns: Dict[str, Set[str]] = {}
+
+        # initialize each report to have empty set of observers of interest
+        for desired_report in self._desired_reports:
+            self._report_name_to_observer_fqns[desired_report] = set([])
+
+    def get_desired_reports_names(self) -> Set[str]:
+        """ Returns a copy of the desired reports for viewing """
+        return self._desired_reports.copy()
+
+    def get_observers_of_interest(self) -> Dict[str, Set[str]]:
+        """ Returns a copy of the observers of interest for viewing """
+        return self._report_name_to_observer_fqns.copy()
+
+    def prepare_detailed_calibration(self, prepared_fx_model: GraphModule) -> GraphModule:
+        r"""
+        Takes in a prepared fx graph model and inserts the following observers:
+        - ModelReportObserver
+        Each observer is inserted based on the desired_reports into the relavent locations
+        Right now, each report in self._desired_reports has independent insertions
+            However, if a module already has a Observer of the same type, the insertion will not occur
+            This is because all of the same type of Observer collect same information, so redundant
+        Args:
+            prepared_fx_model (GraphModule):  The prepared Fx GraphModule
+        Returns the same GraphModule with the observers inserted
+        """
+        pass
+
+    def _get_node_from_fqn(self, fx_model: GraphModule, node_fqn: str) -> torch.fx.node.Node:
+        r"""
+        Takes in a graph model and returns the node based on the fqn
+        Args
+            fx_model (GraphModule): The Fx GraphModule that already contains the node with fqn node_fqn
+            node_fqn (str): The fully qualified name of the node we want to find in fx_model
+        Returns the Node object of the given node_fqn otherwise returns None
+        """
+        pass
+
+    def generate_model_report(
+        self, calibrated_fx_model: GraphModule, remove_inserted_observers: bool
+    ) -> Dict[str, Tuple[str, Dict]]:
+        r"""
+        Takes in a callibrated fx graph model and generates all the requested reports.
+        The reports generated are specified by the desired_reports specified in desired_reports
+        Can optionally remove all the observers inserted by the ModelReport instance
+        Args:
+            calibrated_fx_model (GraphModule): The Fx GraphModule that has already been callibrated by the user
+            remove_inserted_observers (bool): True to remove the observers inserted by this ModelReport instance
+        Returns a mapping of each desired report name to a tuple with:
+            The textual summary of that report information
+            A dictionary containing relavent statistics or information for that report
+        """
+        pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #80054
* #80053
* __->__ #80052

Summary: The ModelReport class in model_report.py combines the
functionality of the detectors and the ModelReportObserver. It creates
an end-to-end system where a user can pass in a prepared Graph Model to
insert the ModelReportObservers, then after the user callibrates their
model, the callibrated model can then be used by the ModelReport class
to generate reports based on what the user wished to gather information
on.

This contains the init method and the signatures and docs for each
of the proposed helper functions.

This also address and fixes a revert issue from https://github.com/pytorch/pytorch/pull/79595 where there was a test Mac regression. Specifically, there was a test failure in TestFxModelReportDetector.tset_simple_conv because it tried to use a "fbgemm" quantized engine. However there was no engine available, and I had forgotten to add the @skipIfNoFBGEMM to the test case. This commit, and the subsequent stack, include this fix of adding this tag.

Test Plan: python test/test_quantization.py TestFxModelReportClass

Reviewers:

Subscribers:

Tasks:

Tags: