### PR TITLE
[ao] Added insertion of observer capability to ModelReport class

### DIFF
--- a/test/quantization/fx/test_model_report_fx.py
+++ b/test/quantization/fx/test_model_report_fx.py
@@ -2,6 +2,7 @@
 # Owner(s): ["oncall: quantization"]
 
 import torch
+import torch.nn as nn
 import torch.ao.quantization.quantize_fx as quantize_fx
 import torch.nn.functional as F
 from torch.ao.quantization import QConfig, QConfigMapping
@@ -859,3 +860,101 @@ class TestFxModelReportClass(QuantizationTestCase):
 
             for value in model_report.get_observers_of_interest().values():
                 self.assertEqual(len(value), 0)
+
+    @skipIfNoFBGEMM
+    def test_prepare_model_callibration(self):
+        """
+        Tests model_report.prepare_detailed_calibration that prepares the model for callibration
+        Specifically looks at:
+        - Whether observers are properly inserted into regular nn.Module
+        - Whether the target and the arguments of the observers are proper
+        - Whether the internal representation of observers of interest is updated
+        """
+
+        # example model to use for tests
+        class ThreeOps(nn.Module):
+            def __init__(self):
+                super(ThreeOps, self).__init__()
+                self.linear = nn.Linear(3, 3)
+                self.bn = nn.BatchNorm2d(3)
+                self.relu = nn.ReLU()
+
+            def forward(self, x):
+                x = self.linear(x)
+                x = self.bn(x)
+                x = self.relu(x)
+                return x
+
+        class TwoThreeOps(nn.Module):
+            def __init__(self):
+                super(TwoThreeOps, self).__init__()
+                self.block1 = ThreeOps()
+                self.block2 = ThreeOps()
+
+            def forward(self, x):
+                x = self.block1(x)
+                y = self.block2(x)
+                z = x + y
+                z = F.relu(z)
+                return z
+
+        with override_quantized_engine('fbgemm'):
+            # create model report object
+            # make an example set of detectors
+            torch.backends.quantized.engine = "fbgemm"
+            backend = torch.backends.quantized.engine
+            test_detector_set = set([DynamicStaticDetector(), PerChannelDetector(backend)])
+            # initialize with an empty detector
+            model_report = ModelReport(test_detector_set)
+
+            # prepare the model
+            model = TwoThreeOps()
+            example_input = torch.randn(1, 3, 3, 3)
+            current_backend = torch.backends.quantized.engine
+            q_config_mapping = QConfigMapping()
+            q_config_mapping.set_global(torch.ao.quantization.get_default_qconfig(torch.backends.quantized.engine))
+
+            model_prep = quantize_fx.prepare_fx(model, q_config_mapping, example_input)
+
+            # prepare the model for callibration
+            prepared_for_callibrate_model = model_report.prepare_detailed_calibration(model_prep)
+
+            # see whether observers properly in regular nn.Module
+            # there should be 4 observers present in this case
+            modules_observer_cnt = 0
+            for fqn, module in prepared_for_callibrate_model.named_modules():
+                if isinstance(module, ModelReportObserver):
+                    modules_observer_cnt += 1
+
+            self.assertEqual(modules_observer_cnt, 4)
+
+            model_report_str_check = "model_report"
+            # also make sure arguments for observers in the graph are proper
+            for node in prepared_for_callibrate_model.graph.nodes:
+                # not all node targets are strings, so check
+                if isinstance(node.target, str) and model_report_str_check in node.target:
+                    # if pre-observer has same args as the linear (next node)
+                    if "pre_observer" in node.target:
+                        self.assertEqual(node.args, node.next.args)
+                    # if post-observer, args are the target linear (previous node)
+                    if "post_observer" in node.target:
+                        self.assertEqual(node.args, (node.prev,))
+
+            # ensure model_report observers of interest updated
+            # there should be two entries
+            self.assertEqual(len(model_report.get_observers_of_interest()), 2)
+            for detector in test_detector_set:
+                self.assertTrue(detector.get_detector_name() in model_report.get_observers_of_interest().keys())
+
+                # get number of entries for this detector
+                detector_obs_of_interest_fqns = model_report.get_observers_of_interest()[detector.get_detector_name()]
+
+                # assert that the per channel detector has 0 and the dynamic static has 4
+                if isinstance(detector, PerChannelDetector):
+                    self.assertEqual(len(detector_obs_of_interest_fqns), 0)
+                elif isinstance(detector, DynamicStaticDetector):
+                    self.assertEqual(len(detector_obs_of_interest_fqns), 4)
+
+            # ensure that we can prepare for callibration only once
+            with self.assertRaises(ValueError):
+                prepared_for_callibrate_model = model_report.prepare_detailed_calibration(model_prep)

--- a/torch/ao/quantization/fx/_model_report/detector.py
+++ b/torch/ao/quantization/fx/_model_report/detector.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Set, Tuple, Union
+from typing import Any, Dict, Set, Tuple
 
 import torch
 import torch.nn as nn
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from torch.ao.quantization.fake_quantize import FakeQuantize
 from torch.ao.quantization.fx.graph_module import GraphModule
 from torch.ao.quantization.observer import ObserverBase
+from torch.ao.quantization.fx._model_report.model_report_observer import ModelReportObserver
 from torch.ao.quantization.qconfig import QConfig
 
 # Adding base class for detectors
@@ -25,7 +26,7 @@ class DetectorBase(ABC):
         super().__init__()
 
     @abstractmethod
-    def determine_observer_insert_points(self, model) -> Union[None, Tuple[Set[str], Any]]:
+    def determine_observer_insert_points(self, model) -> Dict:
         r"""
         Args
             model (nn.Module or subclass): model to find observer insertion points
@@ -87,11 +88,13 @@ class PerChannelDetector(DetectorBase):
         r""" returns the string name of this detector"""
         return "per_channel_detector"
 
-    def determine_observer_insert_points(self, model):
+    def determine_observer_insert_points(self, model: nn.Module) -> Dict:
         r"""
-        There is no observers inserted for the PerChannelDetector
+        There is no observers inserted for the PerChannelDetector.
+
+        Returns an empty dictionary since no observers are added or needed
         """
-        raise NotImplementedError("No observers are inserted in the PerChannelDetector.")
+        return {}
 
 
     def _detect_per_channel_helper(self, model: nn.Module, per_channel_info: Dict):
@@ -244,9 +247,77 @@ class DynamicStaticDetector(DetectorBase):
         self.tolerance = tolerance
         self.useful_observer_fqns: Set[str] = set([])
 
-    def determine_observer_insert_points(self, model) -> Tuple[Set[str], Any]:
+    def determine_observer_insert_points(self, prepared_fx_model: GraphModule) -> Dict[str, Dict[str, Any]]:
+        r"""
+        Determines where observers need to be inserted for the Dynamic vs Static detector.
+        For this detector, we want to place observers on either side of linear layers in the model.
 
-        raise NotImplementedError("Will be implemented in a future commit")
+        Currently inserts observers for:
+            linear layers
+
+        Args:
+            prepared_fx_model (GraphModule):  The prepared Fx GraphModule
+
+        Returns a Dict mapping from unique observer fqns (where we want to insert them) to a Dict with:
+            key "target_node" -> the node we are trying to observe with this observer (torch.fx.node.Node)
+            key "insert_observer" -> the observer we wish to insert (ObserverBase)
+            key "insert_post" -> True if this is meant to be a post-observer for target_node, False if pre-observer
+            key "observer_args" -> The arguments that are meant to be passed into the observer
+        """
+
+        # observer for this detector is ModelReportObserver
+        obs_ctr = ModelReportObserver
+
+        # return dict
+        obs_fqn_to_info: Dict[str, Dict[str, Any]] = {}
+
+        for fqn, module in prepared_fx_model.named_modules():
+            # check to see if module is of a supported type
+            is_supported_type = sum(list(map(lambda x: isinstance(module, x), self.DEFAULT_DYNAMIC_STATIC_CHECK_SUPPORTED))) > 0
+
+            if is_supported_type:
+                # if it's a supported type, we want to get node and add observer insert locations
+                targeted_node = self._get_targeting_node(prepared_fx_model, fqn)
+
+                # add entry for pre-observer
+                pre_obs_fqn = fqn + "." + self.DEFAULT_PRE_OBSERVER_NAME
+
+                obs_fqn_to_info[pre_obs_fqn] = {
+                    "target_node": targeted_node,
+                    "insert_observer": obs_ctr,
+                    "insert_post": False,
+                    "observer_args": targeted_node.args
+                }
+
+                # add entry for post-observer
+                post_obs_fqn = fqn + "." + self.DEFAULT_POST_OBSERVER_NAME
+
+                obs_fqn_to_info[post_obs_fqn] = {
+                    "target_node": targeted_node,
+                    "insert_observer": obs_ctr,
+                    "insert_post": True,
+                    "observer_args": (targeted_node,)
+                }
+
+        return obs_fqn_to_info
+
+
+    def _get_targeting_node(self, prepared_fx_model: GraphModule, target_fqn: str) -> torch.fx.node.Node:
+        r"""
+        Takes in a GraphModule and the target_fqn and finds the node object that targets this fqn
+
+        Args:
+            prepared_fx_model (GraphModule):  The prepared Fx GraphModule
+            target_fqn (str): The fqn of the layer we are trying to target
+
+        Returns the node object we are trying to add observers around
+        """
+        for node in prepared_fx_model.graph.nodes:
+            # if the node's target is our target, return it
+            if node.target == target_fqn:
+                return node
+
+        raise ValueError("passed in target_fqn not found in graph's targets.")
 
     def get_detector_name(self) -> str:
         r""" returns the string name of this detector"""

--- a/torch/ao/quantization/fx/_model_report/model_report.py
+++ b/torch/ao/quantization/fx/_model_report/model_report.py
@@ -1,23 +1,28 @@
-from typing import Dict, Set, Tuple
+from typing import Any, Dict, Set, Tuple
 
 import torch
 from torch.ao.quantization.fx._model_report.detector import DetectorBase
 from torch.ao.quantization.fx.graph_module import GraphModule
+from torch.ao.quantization.observer import ObserverBase
 
 class ModelReport:
     r"""
     Generates report and collects statistics
         Used to provide users suggestions on possible model configuration improvements
+
     Currently supports generating reports on:
     - Suggestions for dynamic vs static quantization for linear layers (Graph Modules)
+
     * :attr:`desired_report_detectors` The set of Detectors representing desired reports from the ModelReport class
         Make sure that these are all unique types of detectors [do not have more than 1 of the same class]
+
     Proper Use:
     1.) Initialize ModelReport object with reports of interest by passing in initialized detector objects
     2.) Prepare your model with prepare_fx
     3.) Call model_report.prepare_detailed_calibration on your model to add relavent observers
     4.) Callibrate your model with data
     5.) Call model_report.generate_report on your model to generate report and optionally remove added observers
+
     """
 
     def __init__(self, desired_report_detectors: Set[DetectorBase]):
@@ -38,6 +43,9 @@ class ModelReport:
         for desired_report in self._desired_reports:
             self._report_name_to_observer_fqns[desired_report] = set([])
 
+        # flags to ensure that we can only prepare once
+        self._prepared_flag = False
+
     def get_desired_reports_names(self) -> Set[str]:
         """ Returns a copy of the desired reports for viewing """
         return self._desired_reports.copy()
@@ -50,22 +58,88 @@ class ModelReport:
         r"""
         Takes in a prepared fx graph model and inserts the following observers:
         - ModelReportObserver
+
         Each observer is inserted based on the desired_reports into the relavent locations
+
         Right now, each report in self._desired_reports has independent insertions
             However, if a module already has a Observer of the same type, the insertion will not occur
             This is because all of the same type of Observer collect same information, so redundant
+
         Args:
             prepared_fx_model (GraphModule):  The prepared Fx GraphModule
+
         Returns the same GraphModule with the observers inserted
         """
-        pass
+
+        # if already prepared once, cannot prepare again
+        if self._prepared_flag:
+            raise ValueError("Already ran preparing detailed callibration. Run the report generation next after callibration.")
+
+        # loop through each detector, find where placements should be, and keep track
+        insert_observers_fqns: Dict[str, Any] = {}
+
+        for detector in self._desired_report_detectors:
+            # determine observer points for each detector
+            obs_fqn_to_info = detector.determine_observer_insert_points(prepared_fx_model)
+            # map each insert point to the observer to use
+            insert_observers_fqns.update(obs_fqn_to_info)
+            # update the set of observers this report cares about
+            self._report_name_to_observer_fqns[detector.get_detector_name()] = set(obs_fqn_to_info.keys())
+
+        # now insert all the observers at their desired locations
+        for observer_fqn in insert_observers_fqns:
+            target_node = insert_observers_fqns[observer_fqn]["target_node"]
+            insert_obs = insert_observers_fqns[observer_fqn]["insert_observer"]
+            insert_post = insert_observers_fqns[observer_fqn]["insert_post"]
+            observer_args = insert_observers_fqns[observer_fqn]["observer_args"]
+            self._insert_observer_around_module(
+                prepared_fx_model, observer_fqn, target_node, insert_obs, observer_args, insert_post
+            )
+
+        self._prepared_flag = True
+
+        return prepared_fx_model
+
+    def _insert_observer_around_module(
+        self,
+        prepared_fx_model: GraphModule,
+        obs_fqn: str,
+        target_node: torch.fx.node.Node,
+        obs_to_insert: ObserverBase,
+        observer_args: Tuple,
+        insert_post: bool
+    ):
+        r"""
+        Helper function that inserts the observer into both the graph structure and the module of the model
+
+        Args
+            prepared_fx_model (GraphModule):  The prepared Fx GraphModule
+            node_fqn (str): The fully qualified name of the observer we want to insert
+            target_node (torch.fx.node.Node): The node in prepared_fx_module we are inserting observers around
+            obs_to_insert (ObserverBase): The observer we are inserting around target_node
+            observer_args (Tuple): The arguments we want to pass into the observer
+            insert_post (bool): whether this is meant to be a post observer for this node
+        """
+        # if we are inserting post, then our target node is the next node
+        if insert_post:
+            target_node = target_node.next
+
+        with prepared_fx_model.graph.inserting_before(target_node):
+            obs_to_insert = obs_to_insert()
+            prepared_fx_model.add_submodule(obs_fqn, obs_to_insert)
+            prepared_fx_model.graph.create_node(op="call_module", target=obs_fqn, args=observer_args)
+
+        # recompile model after inserts are made
+        prepared_fx_model.recompile()
 
     def _get_node_from_fqn(self, fx_model: GraphModule, node_fqn: str) -> torch.fx.node.Node:
         r"""
         Takes in a graph model and returns the node based on the fqn
+
         Args
             fx_model (GraphModule): The Fx GraphModule that already contains the node with fqn node_fqn
             node_fqn (str): The fully qualified name of the node we want to find in fx_model
+
         Returns the Node object of the given node_fqn otherwise returns None
         """
         pass
@@ -76,10 +150,13 @@ class ModelReport:
         r"""
         Takes in a callibrated fx graph model and generates all the requested reports.
         The reports generated are specified by the desired_reports specified in desired_reports
+
         Can optionally remove all the observers inserted by the ModelReport instance
+
         Args:
             calibrated_fx_model (GraphModule): The Fx GraphModule that has already been callibrated by the user
             remove_inserted_observers (bool): True to remove the observers inserted by this ModelReport instance
+
         Returns a mapping of each desired report name to a tuple with:
             The textual summary of that report information
             A dictionary containing relavent statistics or information for that report


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #80054
* __->__ #80053
* #80052

Summary: The ModelReport class in model_report.py combines the
functionality of the detectors and the ModelReportObserver. It creates
an end-to-end system where a user can pass in a prepared Graph Model to
insert the ModelReportObservers, then after the user callibrates their
model, the callibrated model can then be used by the ModelReport class
to generate reports based on what the user wished to gather information
on.

This contains the implementation and tests for the
prepare_detailed_calibration method which is used on a prepared fx model
to insert the desired observers for the different detectors.

This also address and fixes a revert issue from https://github.com/pytorch/pytorch/pull/79595 where there was a test Mac regression. Specifically, there was a test failure in TestFxModelReportDetector.tset_simple_conv because it tried to use a "fbgemm" quantized engine. However there was no engine available, and I had forgotten to add the @skipIfNoFBGEMM to the test case. This commit is part of a stack starting at https://github.com/pytorch/pytorch/pull/80052 that adds this tag.

Test Plan: python test/test_quantization.py TestFxModelReportClass

Reviewers:

Subscribers:

Tasks:

Tags: