### PR TITLE
Prevent out of bounds access to null LTC operands

### DIFF
--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -142,9 +142,7 @@ const Output& Node::operand(size_t i) const {
   return operands_as_outputs_.at(i);
 }
 const Output& Node::nullable_operand(size_t i) const {
-  return i < operands_as_outputs_.size()
-    ? operand(i)
-    : torch::lazy::Value();
+    return i < operands_as_outputs_.size() ? operand(i) : torch::lazy::Value();
 }
 
 std::string Node::ToString() const {

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -142,7 +142,7 @@ const Output& Node::operand(size_t i) const {
   return operands_as_outputs_.at(i);
 }
 const Output& Node::nullable_operand(size_t i) const {
-    return i < operands_as_outputs_.size() ? operand(i) : torch::lazy::Value();
+  return i < operands_as_outputs_.size() ? operand(i) : torch::lazy::Value();
 }
 
 std::string Node::ToString() const {

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -143,7 +143,7 @@ const Output& Node::operand(size_t i) const {
 }
 const Output& Node::nullable_operand(size_t i) const {
   return i < operands_as_outputs_.size()
-    ? operands_as_outputs_.at(i)
+    ? operand(i)
     : torch::lazy::Value();
 }
 

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -141,6 +141,11 @@ const std::vector<Output>& Node::operands() const {
 const Output& Node::operand(size_t i) const {
   return operands_as_outputs_.at(i);
 }
+const Output& Node::nullable_operand(size_t i) const {
+  return i < operands_as_outputs_.size()
+    ? operands_as_outputs_.at(i)
+    : torch::lazy::Value();
+}
 
 std::string Node::ToString() const {
   std::stringstream ss;

--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -13,6 +13,8 @@ C10_DEFINE_bool(
 namespace torch {
 namespace lazy {
 
+static const torch::lazy::Output kNullOutput = torch::lazy::Output();
+
 size_t Output::Hasher::operator()(const Output& output) const {
   return StdHashCombine(
       reinterpret_cast<std::ptrdiff_t>(output.node), output.index);
@@ -142,7 +144,9 @@ const Output& Node::operand(size_t i) const {
   return operands_as_outputs_.at(i);
 }
 const Output& Node::nullable_operand(size_t i) const {
-  return i < operands_as_outputs_.size() ? operand(i) : torch::lazy::Value();
+  // We use kNullOutput instead of kNullValue here to avoid implicit casting,
+  // which would prevent this method from returning a reference.
+  return i < operands_as_outputs_.size() ? operand(i) : kNullOutput;
 }
 
 std::string Node::ToString() const {

--- a/torch/csrc/lazy/core/ir.h
+++ b/torch/csrc/lazy/core/ir.h
@@ -134,6 +134,9 @@ class TORCH_API Node {
 
   virtual const Output& operand(size_t i) const;
 
+  // Gets operand at index i if index is valid, or a null lazy::Value otherwise.
+  virtual const Output& nullable_operand(size_t i) const;
+
   // Returns the hash of the dag used to look up the compiled graph
   virtual hash_t hash() const = 0;
 

--- a/torch/csrc/lazy/core/ir.h
+++ b/torch/csrc/lazy/core/ir.h
@@ -134,7 +134,7 @@ class TORCH_API Node {
 
   virtual const Output& operand(size_t i) const;
 
-  // Gets operand at index i if index is valid, or a null lazy::Value otherwise.
+  // Gets operand at index i if index is valid, or kNullOutput otherwise.
   virtual const Output& nullable_operand(size_t i) const;
 
   // Returns the hash of the dag used to look up the compiled graph

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13486,8 +13486,6 @@ op_db: List[OpInfo] = [
                DecorateInfo(unittest.expectedFailure, 'TestGradients', 'test_fn_gradgrad'),
                # JIT test also tries to compute double backward, which fails
                DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit'),
-               # RuntimeError: vector::_M_range_check: __n (which is 2) >= this->size() (which is 2)
-               DecorateInfo(unittest.expectedFailure, 'TestLazyOpInfo', 'test_correctness_with_reusing_ir'),
            )),
     OpInfo('nn.functional.cosine_similarity',
            aten_name="cosine_similarity",

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -175,7 +175,7 @@ class GenLazyIR(ABC):
             shape_args.extend(a.name for a in scalar_args)
             shape_ctor_arg = f"compute_shape_{schema.name}({', '.join(shape_args)}),"
         elif schema.properties.ShapeCache:
-            shape_args = [f"operand({i})" for i in range(len(value_args))]
+            shape_args = [f"nullable_operand({i})" for i in range(len(value_args))]
             shape_args.extend(a.name for a in scalar_args)
             shape_ctor_arg = f"[&](){{ return compute_shape_{schema.name}({', '.join(shape_args)})[0]; }},"
         else:
@@ -317,14 +317,14 @@ class GenTSLazyIR(GenLazyIR):
         for arg in schema.positional_values:
             if isinstance(arg.lazy_type, OptionalCType):
                 value_comparison.append(
-                    f"operand(i++) == {arg.name}.value_or(kNullValue)"
+                    f"nullable_operand(i++) == {arg.name}.value_or(kNullValue)"
                 )
             else:
-                value_comparison.append(f"operand(i++) == {arg.name}")
+                value_comparison.append(f"nullable_operand(i++) == {arg.name}")
         for arg in schema.positional_scalars:
             value_comparison.append(f"this->{arg.name} == {arg.name}")
         for arg in schema.keyword_values:
-            value_comparison.append(f"operand(i++) == {arg.name}")
+            value_comparison.append(f"nullable_operand(i++) == {arg.name}")
         for arg in schema.keyword_scalars:
             value_comparison.append(f"this->{arg.name} == {arg.name}")
         value_comparison_str = " &&\n        ".join(value_comparison)

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -175,7 +175,7 @@ class GenLazyIR(ABC):
             shape_args.extend(a.name for a in scalar_args)
             shape_ctor_arg = f"compute_shape_{schema.name}({', '.join(shape_args)}),"
         elif schema.properties.ShapeCache:
-            shape_args = [f"nullable_operand({i})" for i in range(len(value_args))]
+            shape_args = [f"operand({i})" for i in range(len(value_args))]
             shape_args.extend(a.name for a in scalar_args)
             shape_ctor_arg = f"[&](){{ return compute_shape_{schema.name}({', '.join(shape_args)})[0]; }},"
         else:
@@ -320,11 +320,11 @@ class GenTSLazyIR(GenLazyIR):
                     f"nullable_operand(i++) == {arg.name}.value_or(kNullValue)"
                 )
             else:
-                value_comparison.append(f"nullable_operand(i++) == {arg.name}")
+                value_comparison.append(f"operand(i++) == {arg.name}")
         for arg in schema.positional_scalars:
             value_comparison.append(f"this->{arg.name} == {arg.name}")
         for arg in schema.keyword_values:
-            value_comparison.append(f"nullable_operand(i++) == {arg.name}")
+            value_comparison.append(f"operand(i++) == {arg.name}")
         for arg in schema.keyword_scalars:
             value_comparison.append(f"this->{arg.name} == {arg.name}")
         value_comparison_str = " &&\n        ".join(value_comparison)


### PR DESCRIPTION
When constructing a lazy::Node, [null operands (optional values that aren't included) are dropped](https://github.com/pytorch/pytorch/blob/30fb2c4abaaaa966999eab11674f25b18460e609/torch/csrc/lazy/core/ir.cpp#L82-L84), so it’s possible for the stored operand list to be a different length than the one that was passed into the constructor.

This can become a problem during the call to `CanBeReused` in the autogen `LazyIr.h` code. For example:

```
  bool CanBeReused(const torch::lazy::Value& input, const c10::optional<torch::lazy::Value>& weight, const c10::optional<torch::lazy::Value>& bias, const c10::optional<torch::lazy::Value>& running_mean, const c10::optional<torch::lazy::Value>& running_var, const bool& training, const double& momentum, const double& eps) const {
    size_t i = 0;
    std::cout << "Num operands: " << operands().size() << std::endl;
    return (operand(i++) == input &&
        operand(i++) == weight.value_or(kNullValue) &&
        operand(i++) == bias.value_or(kNullValue) &&
        operand(i++) == running_mean.value_or(kNullValue) &&
        operand(i++) == running_var.value_or(kNullValue) &&
        this->training == training &&
        this->momentum == momentum &&
        this->eps == eps);
  }
```

Here we operate under the assumption that the number of operands stored in the `lazy::Node` is equal to the number of operands originally passed into the constructor. Recall that we drop any null operands though, so it’s possible to inadvertently access an invalid index at this point.

This PR addresses this issue by adding a new nullable_operand method which falls back to a null value instead of producing an index error when going out of bounds.

This should solve the issue found at https://github.com/pytorch/pytorch/pull/79637#issuecomment-1162044545

cc: @antoniojkim @ke1337 @wconstab @desertfire 