### PR TITLE
[caffe] remove some unnecessary exported_preprocessor_flags

### DIFF
--- a/c2_defs.bzl
+++ b/c2_defs.bzl
@@ -93,12 +93,6 @@ def get_c2_tvm():
     return bool(int(c2_tvm))
 
 _C2_XPLAT_NO_HPTT_PREPROCESSOR_FLAGS = [
-    "-fexceptions",
-    "-frtti",
-    "-Wno-shadow",
-    "-Wno-unknown-pragmas",
-    "-Wno-unused-variable",
-    "-Wno-sign-compare",
     "-Icaffe2",
     "-Imodules",
     "-DEIGEN_NO_DEBUG",
@@ -139,7 +133,13 @@ def get_c2_xplat_preprocessor_flags():
 def get_c2_xplat_no_hptt_compiler_flags():
     return [
         "-Os",
-    ] + get_c2_xplat_no_hptt_preprocessor_flags()
+        "-fexceptions",
+        "-frtti",
+        "-Wno-shadow",
+        "-Wno-unknown-pragmas",
+        "-Wno-unused-variable",
+        "-Wno-sign-compare",
+    ]
 
 def get_c2_xplat_compiler_flags():
     return get_c2_xplat_no_hptt_compiler_flags() + C2_XPLAT_HPTT_PREPROCESSOR_FLAGS


### PR DESCRIPTION
Summary: Move caffe2 compiler flags out of exported_preprocessor_flags, these should only contain defines and includes.

Test Plan:
Flags before: P510631359
Flags after: P510631375

Removed compiler flags are not present in exported preprocessor flags any more and exported preprocessor flags are not duplicated in compiler flags:

{F745125320}

Reviewed By: smeenai

Differential Revision: D37288331

