### PR TITLE
[GHF] Do not notify on merges

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -737,8 +737,6 @@ class GitHubPR:
             self.merge_ghstack_into(repo, force, comment_id=comment_id)
 
         repo.push(self.default_branch(), dry_run)
-        gh_post_pr_comment(self.org, self.project, self.pr_num,
-                           f"@{self.get_pr_creator_login()} your PR has been successfully merged.", dry_run)
         if not dry_run:
             gh_add_labels(self.org, self.project, self.pr_num, ["merged"])
 


### PR DESCRIPTION
When PR changes state from open to close this is a notification enough of the successful action triggered by the bot

Fixes #80062
