### PR TITLE
[PyTorch][ATen][AMD] always declare ROCmBackwardPassGuard

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -353,7 +353,7 @@ bool NoTF32Guard::should_disable_tf32() {
   return override_allow_tf32_flag;
 }
 
-#ifdef USE_ROCM
+#if !defined(_WIN32)
 // Ops can query this flag to know they are in the backward pass.
 // This information can be used, for example, to select implementations
 // with different numerical or performance characteristics.

--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -415,7 +415,8 @@ struct TORCH_API NoTF32Guard {
   bool changed = false;
 };
 
-#ifdef USE_ROCM
+#if !defined(_WIN32)
+// Windows does not allow TORCH_API + thread_local, so we skip it.
 struct TORCH_API ROCmBackwardPassGuard {
   ROCmBackwardPassGuard();
   ~ROCmBackwardPassGuard();


### PR DESCRIPTION
Summary:
## Problem

`ROCmBackwardPassGuard` is only defined and instantiated when `USE_ROCM` is set, which complicates our internal build system that distinguishes a CPU-only module from a GPU-aware module.

## Solution
Despite its name, `ROCmBackwardPassGuard` does not depend on ROCm features.
Regardless of its usefulness for non-ROCm code, we don't need `#ifdef USE_ROCM` for the declaration of `ROCmBackwardPassGuard` like other components like CUDA-specific `NoTF32Guard`.

Note: this patch should not have any side effects (`ROCmBackwardPassGuard` is not instantiated when `USE_ROCM` is not set) except for additional tiny compilation time for these 10 lines.

Reviewed By: minsii

Differential Revision: D36670235

