### PR TITLE
Ship `ATen/native/utils/*.h` as `package_data` for nvFuser in custom CUDAExtension

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -123,6 +123,7 @@ file(GLOB native_ao_sparse_h
             "native/ao_sparse/quantized/cpu/*.h")
 file(GLOB native_quantized_h "native/quantized/*.h" "native/quantized/cpu/*.h", "native/quantized/cudnn/*.h")
 file(GLOB native_cpu_h "native/cpu/*.h")
+file(GLOB native_utils_h "native/utils/*.h")
 
 file(GLOB native_cuda_cu "native/cuda/*.cu")
 file(GLOB native_cuda_cpp "native/cuda/*.cpp")
@@ -513,7 +514,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake-exports/ATenConfig.cmake"
 
 set(INSTALL_HEADERS ${base_h} ${ATen_CORE_HEADERS})
 if(NOT INTERN_BUILD_MOBILE)
-  list(APPEND INSTALL_HEADERS ${native_h} ${native_cpu_h} ${native_ao_sparse_h} ${native_quantized_h} ${cuda_h} ${native_cuda_h} ${native_hip_h} ${cudnn_h} ${hip_h} ${miopen_h})
+  list(APPEND INSTALL_HEADERS ${native_h} ${native_cpu_h} ${native_ao_sparse_h} ${native_quantized_h} ${native_utils_h} ${cuda_h} ${native_cuda_h} ${native_hip_h} ${cudnn_h} ${hip_h} ${miopen_h})
   # Metal
   if(USE_PYTORCH_METAL_EXPORT)
     # Add files needed from exporting metal models(optimized_for_mobile)

--- a/setup.py
+++ b/setup.py
@@ -1012,6 +1012,7 @@ if __name__ == '__main__':
                 'include/ATen/native/hip/*.cuh',
                 'include/ATen/native/quantized/*.h',
                 'include/ATen/native/quantized/cpu/*.h',
+                'include/ATen/native/utils/*.h',
                 'include/ATen/quantized/*.h',
                 'include/caffe2/utils/*.h',
                 'include/caffe2/utils/**/*.h',


### PR DESCRIPTION
Related
- https://github.com/NVIDIA/apex/pull/1309
- https://github.com/pytorch/pytorch/pull/78281-- this was closed in favor of https://github.com/pytorch/pytorch/pull/79406, more specifically, https://github.com/pytorch/pytorch/commit/c9c402eae9e0d64bb346d9e47ed1bf019b4368b5#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7.

cc @ptrblck @eqy 