### PR TITLE
Disable XLA builds

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -209,6 +209,7 @@ jobs:
       build-generates-artifacts: false
 
   linux-bionic-py3_7-clang8-xla-build:
+    if: false
     name: linux-bionic-py3_7-clang8-xla
     uses: ./.github/workflows/_linux-build.yml
     with:


### PR DESCRIPTION
As they are constantly failing to download llvm release from https://storage.googleapis.com:
```
Error in download_and_extract: java.io.IOException: Error downloading [https://storage.googleapis.com/mirror.tensorflow.org/github.com/llvm/llvm-project/archive/9c6a2f29660b886044a267bb4de662cd801079bc.tar.gz, https://github.com/llvm/llvm-project/archive/9c6a2f29660b886044a267bb4de662cd801079bc.tar.gz] to /home/jenkins/.cache/bazel/_bazel_jenkins/b463291cb8b07b4bfde1e3a43733cd1a/external/llvm-raw/temp10926951092717297163/9c6a2f29660b886044a267bb4de662cd801079bc.tar.gz: Read timed out
Loading: 0 packages loaded
```
cc: @JackCaoG 
