### PR TITLE
[WIP] Allow FileBaton to recover from killed processes

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -21,6 +21,7 @@ import torch.utils.cpp_extension
 from torch.autograd._functions.utils import check_onnx_broadcast
 from torch.onnx.symbolic_opset9 import _prepare_onnx_paddings
 from torch.testing._internal.common_utils import load_tests, IS_SANDCASTLE, IS_WINDOWS
+from typing import List, Any
 
 # load_tests from torch.testing._internal.common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
@@ -743,7 +744,7 @@ class TestCppExtensionUtils(TestCase):
             to_kill = [1, 4, 5, 7]
 
             with multiprocessing.Manager() as manager:
-                global_list = manager.list()
+                global_list: List[Any] = manager.list()
                 ps = []
                 for i in range(nb_processes):
                     ps.append(multiprocessing.Process(target=_file_baton_test_fn, args=(i, global_list, to_kill, test_lock_file)))

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1260,6 +1260,9 @@ class Def(TreeView):
 class Decl(TreeView):
     ...
 
+class _THManagedFile():
+    def __init__(self, filename: str) -> None: ...
+
 # Defined in torch/csrc/distributed/rpc/init.cpp
 def _rpc_init() -> _bool: ...
 

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1127,6 +1127,9 @@ Call this whenever a new thread is created in order to propagate values from
       }))
       .def("expired", &WeakTensorRef::expired);
 
+  py::class_<THManagedFile>(py_module, "_THManagedFile")
+    .def(py::init<std::string>());
+
   py::enum_<at::native::ConvBackend>(py_module, "_ConvBackend")
       .value("CudaDepthwise2d", at::native::ConvBackend::CudaDepthwise2d)
       .value("CudaDepthwise3d", at::native::ConvBackend::CudaDepthwise3d)

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -1128,7 +1128,7 @@ Call this whenever a new thread is created in order to propagate values from
       .def("expired", &WeakTensorRef::expired);
 
   py::class_<THManagedFile>(py_module, "_THManagedFile")
-    .def(py::init<std::string>());
+      .def(py::init<std::string>());
 
   py::enum_<at::native::ConvBackend>(py_module, "_ConvBackend")
       .value("CudaDepthwise2d", at::native::ConvBackend::CudaDepthwise2d)

--- a/torch/lib/libshm/alloc_info.h
+++ b/torch/lib/libshm/alloc_info.h
@@ -5,5 +5,6 @@
 struct AllocInfo {
   pid_t pid;
   char free;
+  char shm;
   char filename[60];
 };

--- a/torch/lib/libshm/libshm.h
+++ b/torch/lib/libshm/libshm.h
@@ -9,7 +9,7 @@ void libshm_init(const char* manager_exec_path);
 // Superclass to run a constructor before at::RefcountedMapAllocator
 class THManagedMapAllocatorInit {
  protected:
-  THManagedMapAllocatorInit(const char* manager_handle, const char* filename);
+  THManagedMapAllocatorInit(const char* manager_handle, const char* filename, bool shm);
   std::string manager_handle_;
 };
 
@@ -41,6 +41,16 @@ class THManagedMapAllocator : private THManagedMapAllocatorInit,
   const char* manager_handle() const {
     return manager_handle_.c_str();
   }
+};
+
+// To allow general files to be managed by the shm manager
+class THManagedFile : private THManagedMapAllocatorInit {
+ public:
+  THManagedFile(const std::string& filename);
+  ~THManagedFile();
+
+ private:
+  std::string filename_;
 };
 
 #endif

--- a/torch/utils/file_baton.py
+++ b/torch/utils/file_baton.py
@@ -1,9 +1,11 @@
 import os
 import time
+import psutil
 
 
 class FileBaton:
     '''A primitive, file-based synchronization utility.'''
+    _FILE_CONTENT_HEADER = b"PID:"
 
     def __init__(self, lock_file_path, wait_seconds=0.1):
         '''
@@ -25,8 +27,11 @@ class FileBaton:
         Returns:
             True if the file could be created, else False.
         '''
+        self._try_clear_old_lock_file()
         try:
-            self.fd = os.open(self.lock_file_path, os.O_CREAT | os.O_EXCL)
+            self.fd = os.open(self.lock_file_path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+            os.write(self.fd, self._FILE_CONTENT_HEADER + str.encode(str(os.getpid())))
+            os.fsync(self.fd)
             return True
         except FileExistsError:
             return False
@@ -39,6 +44,7 @@ class FileBaton:
         passed to the constructor.
         '''
         while os.path.exists(self.lock_file_path):
+            self._try_clear_old_lock_file()
             time.sleep(self.wait_seconds)
 
     def release(self):
@@ -47,3 +53,47 @@ class FileBaton:
             os.close(self.fd)
 
         os.remove(self.lock_file_path)
+
+    def _try_clear_old_lock_file(self):
+        '''
+        Try to detect lingering lock files and delete them.
+        This function is NOT guaranteed to always detect them and only aims at solving
+        the most basic case: another process died while holding the baton and was not
+        able to remove the file.
+
+        This function must NEVER clear the lock while there is a change a valid owner for
+        the lock exists. In particular, it is important to keep in mind that this function
+        might race with any step of the lock acquisition step.
+        '''
+
+        if os.path.exists(self.lock_file_path):
+            remove = False
+            try:
+                with open(self.lock_file_path, 'rb') as f:
+                    data = f.read()
+                    if data.startswith(self._FILE_CONTENT_HEADER):
+                        pid = data[len(self._FILE_CONTENT_HEADER):]
+                        # If the file content is not valid, assume that it is still being written
+                        # into to avoid any race while the main process is writing into it.
+                        try:
+                            pid = int(pid.decode())
+                        except:
+                            pass
+                        else:
+                            # Check if that process is running
+                            # if any step of getting information about the process (like it died)
+                            # in between the calls, just do nothing.
+                            try:
+                                if psutil.pid_exists(pid):
+                                    p = psutil.Process(pid)
+                                    if p.status() == psutil.STATUS_ZOMBIE:
+                                        # Steal the lock from zombie processes
+                                        remove = True
+                                else:
+                                    # The process died, it is ok to unlock the file
+                                    remove = True
+                            except:
+                                pass
+            finally:
+                if remove:
+                    os.remove(self.lock_file_path)

--- a/torch/utils/file_baton.py
+++ b/torch/utils/file_baton.py
@@ -1,11 +1,9 @@
 import os
 import time
-import psutil
-
+import torch
 
 class FileBaton:
     '''A primitive, file-based synchronization utility.'''
-    _FILE_CONTENT_HEADER = b"PID:"
 
     def __init__(self, lock_file_path, wait_seconds=0.1):
         '''
@@ -19,6 +17,7 @@ class FileBaton:
         self.lock_file_path = lock_file_path
         self.wait_seconds = wait_seconds
         self.fd = None
+        self.file_deleter = None
 
     def try_acquire(self):
         '''
@@ -27,11 +26,9 @@ class FileBaton:
         Returns:
             True if the file could be created, else False.
         '''
-        self._try_clear_old_lock_file()
         try:
-            self.fd = os.open(self.lock_file_path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
-            os.write(self.fd, self._FILE_CONTENT_HEADER + str.encode(str(os.getpid())))
-            os.fsync(self.fd)
+            self.fd = os.open(self.lock_file_path, os.O_CREAT | os.O_EXCL | os.O_TRUNC)
+            self.file_deleter = torch._C._THManagedFile(self.lock_file_path)
             return True
         except FileExistsError:
             return False
@@ -44,7 +41,6 @@ class FileBaton:
         passed to the constructor.
         '''
         while os.path.exists(self.lock_file_path):
-            self._try_clear_old_lock_file()
             time.sleep(self.wait_seconds)
 
     def release(self):
@@ -53,47 +49,4 @@ class FileBaton:
             os.close(self.fd)
 
         os.remove(self.lock_file_path)
-
-    def _try_clear_old_lock_file(self):
-        '''
-        Try to detect lingering lock files and delete them.
-        This function is NOT guaranteed to always detect them and only aims at solving
-        the most basic case: another process died while holding the baton and was not
-        able to remove the file.
-
-        This function must NEVER clear the lock while there is a change a valid owner for
-        the lock exists. In particular, it is important to keep in mind that this function
-        might race with any step of the lock acquisition step.
-        '''
-
-        if os.path.exists(self.lock_file_path):
-            remove = False
-            try:
-                with open(self.lock_file_path, 'rb') as f:
-                    data = f.read()
-                    if data.startswith(self._FILE_CONTENT_HEADER):
-                        pid = data[len(self._FILE_CONTENT_HEADER):]
-                        # If the file content is not valid, assume that it is still being written
-                        # into to avoid any race while the main process is writing into it.
-                        try:
-                            pid = int(pid.decode())
-                        except:
-                            pass
-                        else:
-                            # Check if that process is running
-                            # if any step of getting information about the process (like it died)
-                            # in between the calls, just do nothing.
-                            try:
-                                if psutil.pid_exists(pid):
-                                    p = psutil.Process(pid)
-                                    if p.status() == psutil.STATUS_ZOMBIE:
-                                        # Steal the lock from zombie processes
-                                        remove = True
-                                else:
-                                    # The process died, it is ok to unlock the file
-                                    remove = True
-                            except:
-                                pass
-            finally:
-                if remove:
-                    os.remove(self.lock_file_path)
+        self.file_deleter = None


### PR DESCRIPTION
This happens regularly when multiprocessing is being used in metaseq

Note that the same race as before can happen if the process is killed in between the creation of the file and writing the header into it. That section is hopefully small enough that this won't happen too often in practice.