### PR TITLE
optimize softmax backward and logsoftmax backward

### DIFF
--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -337,13 +337,7 @@ TORCH_IMPL_FUNC(log_softmax_cpu_out)
   if (input_.ndimension() > 0 && dim_ == input_.ndimension() - 1) {
     log_softmax_lastdim_kernel(kCPU, output, input_);
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND(
-        at::ScalarType::BFloat16, input_.scalar_type(), "log_softmax", [&] {
-          host_softmax<
-              scalar_t,
-              true /* LogSoftMax */,
-              false /* MaskedSoftMax */>(output, input_, dim_);
-        });
+    log_softmax_kernel(kCPU, output, input_, dim_);
   }
 }
 
@@ -372,13 +366,7 @@ TORCH_IMPL_FUNC(softmax_backward_cpu_out)
   if (grad_.ndimension() > 0 && dim_ == grad_.ndimension() - 1) {
     softmax_backward_lastdim_kernel(kCPU, grad_input, grad_, output);
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND(
-        at::ScalarType::BFloat16, grad.scalar_type(), "softmax_backward", [&] {
-          host_softmax_backward<
-              scalar_t,
-              false /* LogSoftMax */,
-              false /* MaskedSoftmax */>(grad_input, grad_, output, dim_);
-        });
+    softmax_backward_kernel(kCPU, grad_input, grad_, output, dim_);
   }
 }
 
@@ -401,16 +389,7 @@ TORCH_IMPL_FUNC(log_softmax_backward_cpu_out) (
     if (grad_.ndimension() > 0 && dim_ == grad_.ndimension() - 1) {
       log_softmax_backward_lastdim_kernel(kCPU, grad_input, grad_, output_);
     } else {
-      AT_DISPATCH_FLOATING_TYPES_AND(
-          at::ScalarType::BFloat16,
-          grad.scalar_type(),
-          "log_softmax_backward",
-          [&] {
-            host_softmax_backward<
-                scalar_t,
-                true /* LogSoftMax */,
-                false /* MaskedSoftMax */>(grad_input, grad_, output_, dim_);
-          });
+      log_softmax_backward_kernel(kCPU, grad_input, grad_, output_, dim_);
     }
   }
 }
@@ -551,6 +530,8 @@ DEFINE_DISPATCH(log_softmax_backward_lastdim_kernel);
 
 DEFINE_DISPATCH(softmax_kernel);
 DEFINE_DISPATCH(log_softmax_kernel);
+DEFINE_DISPATCH(softmax_backward_kernel);
+DEFINE_DISPATCH(log_softmax_backward_kernel);
 
 Tensor softmax(const Tensor& self, Dimname dim, optional<ScalarType> dtype) {
   return at::softmax(self, dimname_to_position(self, dim), dtype);

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -250,6 +250,413 @@ inline void _vec_host_softmax_backward_lastdim(
       });
 }
 
+template <typename scalar_t>
+inline void _vec_softmax_backward(
+    scalar_t* grad_input_data_base,
+    scalar_t* grad_output_data_base,
+    scalar_t* output_data_base,
+    int64_t outer_size,
+    int64_t inner_size,
+    int64_t dim_size) {
+  using Vec = vec::Vectorized<scalar_t>;
+  int64_t outer_stride = dim_size * inner_size;
+  int64_t BLOCK_SIZE = 128 * 1024;
+  int64_t CHUNK_SIZE = std::max(
+      int64_t(BLOCK_SIZE / dim_size / sizeof(scalar_t)), (int64_t)Vec::size());
+  CHUNK_SIZE = CHUNK_SIZE / Vec::size() * Vec::size();
+  int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
+  int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
+  parallel_for(
+      0, outer_size * num_chunks, grain_size, [&](int64_t begin, int64_t end) {
+        // thread local temp buffer that holds vertical sum result
+        std::unique_ptr<scalar_t[]> buffer(new scalar_t[CHUNK_SIZE]);
+        scalar_t* tmp_sum_data = buffer.get();
+
+        for (int64_t i = begin; i < end; i++) {
+          int64_t outer_idx = i / num_chunks;
+          int64_t k = i % num_chunks;
+          int64_t inner_idx_begin = k * CHUNK_SIZE;
+          int64_t size = std::min(CHUNK_SIZE, inner_size - inner_idx_begin);
+
+          // init
+          Vec zero_vec = Vec(scalar_t(0));
+          int64_t d0 = 0;
+          for (; d0 < size - (size % Vec::size()); d0 += Vec::size()) {
+            zero_vec.store(tmp_sum_data + d0);
+          }
+          for (; d0 < size; d0++) {
+            tmp_sum_data[d0] = scalar_t(0);
+          }
+
+          // compute sum of grad_output * output
+          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+            int64_t offset = outer_idx * outer_stride + dim_idx * inner_size +
+                inner_idx_begin;
+            scalar_t* grad_output_ptr = grad_output_data_base + offset;
+            scalar_t* output_ptr = output_data_base + offset;
+
+            int64_t d1 = 0;
+            for (; d1 < size - (size % Vec::size()); d1 += Vec::size()) {
+              Vec grad_output_vec = Vec::loadu(grad_output_ptr + d1);
+              Vec output_vec = Vec::loadu(output_ptr + d1);
+              Vec sum_vec = Vec::loadu(tmp_sum_data + d1);
+              sum_vec += grad_output_vec * output_vec;
+              sum_vec.store(tmp_sum_data + d1);
+            }
+            for (; d1 < size; d1++) {
+              tmp_sum_data[d1] += grad_output_ptr[d1] * output_ptr[d1];
+            }
+          }
+
+          // compute output * (grad_output - sum)
+          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+            int64_t offset = outer_idx * outer_stride + dim_idx * inner_size +
+                inner_idx_begin;
+            scalar_t* grad_output_ptr = grad_output_data_base + offset;
+            scalar_t* output_ptr = output_data_base + offset;
+            scalar_t* grad_input_ptr = grad_input_data_base + offset;
+
+            int64_t d2 = 0;
+            for (; d2 < size - (size % Vec::size()); d2 += Vec::size()) {
+              Vec grad_output_vec = Vec::loadu(grad_output_ptr + d2);
+              Vec output_vec = Vec::loadu(output_ptr + d2);
+              Vec sum_vec = Vec::loadu(tmp_sum_data + d2);
+              Vec grad_input_vec = output_vec * (grad_output_vec - sum_vec);
+              grad_input_vec.store(grad_input_ptr + d2);
+            }
+            for (; d2 < size; d2++) {
+              grad_input_ptr[d2] = output_ptr[d2] * (grad_output_ptr[d2] - tmp_sum_data[d2]);
+            }
+          }
+        }
+      });
+}
+
+template <>
+inline void _vec_softmax_backward<BFloat16>(
+    BFloat16* grad_input_data_base,
+    BFloat16* grad_output_data_base,
+    BFloat16* output_data_base,
+    int64_t outer_size,
+    int64_t inner_size,
+    int64_t dim_size) {
+  using bVec = vec::Vectorized<BFloat16>;
+  using fVec = vec::Vectorized<float>;
+  int64_t outer_stride = dim_size * inner_size;
+  int64_t BLOCK_SIZE = 128 * 1024;
+  int64_t CHUNK_SIZE = std::max(
+      int64_t(BLOCK_SIZE / dim_size / sizeof(BFloat16)), (int64_t)bVec::size());
+  CHUNK_SIZE = CHUNK_SIZE / bVec::size() * bVec::size();
+  int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
+  int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
+  parallel_for(
+      0, outer_size * num_chunks, grain_size, [&](int64_t begin, int64_t end) {
+        // thread local temp buffer that holds vertical sum result
+        std::unique_ptr<float[]> buffer(new float[CHUNK_SIZE]);
+        float* tmp_sum_data = buffer.get();
+
+        // thread local buffer that holds grad_output and output data in float32
+        std::unique_ptr<float[]> grad_output_buffer(
+            new float[dim_size * CHUNK_SIZE]);
+        float* grad_output_buffer_data = grad_output_buffer.get();
+
+        std::unique_ptr<float[]> output_buffer(
+            new float[dim_size * CHUNK_SIZE]);
+        float* output_buffer_data = output_buffer.get();
+
+        for (int64_t i = begin; i < end; i++) {
+          int64_t outer_idx = i / num_chunks;
+          int64_t k = i % num_chunks;
+          int64_t inner_idx_begin = k * CHUNK_SIZE;
+          int64_t size = std::min(CHUNK_SIZE, inner_size - inner_idx_begin);
+
+          // init
+          fVec zero_fvec = fVec(float(0));
+          int64_t d0 = 0;
+          for (; d0 < size - (size % bVec::size()); d0 += bVec::size()) {
+            zero_fvec.store(tmp_sum_data + d0);
+            zero_fvec.store(tmp_sum_data + d0 + fVec::size());
+          }
+          for (; d0 < size; d0++) {
+            tmp_sum_data[d0] = float(0);
+          }
+
+          // compute sum of grad_output * output
+          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+            int64_t offset = outer_idx * outer_stride + dim_idx * inner_size +
+                inner_idx_begin;
+            BFloat16* grad_output_ptr = grad_output_data_base + offset;
+            BFloat16* output_ptr = output_data_base + offset;
+            float* grad_output_buffer_ptr =
+                grad_output_buffer_data + dim_idx * CHUNK_SIZE;
+            float* output_buffer_ptr =
+                output_buffer_data + dim_idx * CHUNK_SIZE;
+
+            int64_t d1 = 0;
+            for (; d1 < size - (size % bVec::size()); d1 += bVec::size()) {
+              bVec grad_output_bvec = bVec::loadu(grad_output_ptr + d1);
+              fVec grad_output_fvec0, grad_output_fvec1;
+              std::tie(grad_output_fvec0, grad_output_fvec1) =
+                  convert_bfloat16_float(grad_output_bvec);
+              bVec output_bvec = bVec::loadu(output_ptr + d1);
+              fVec output_fvec0, output_fvec1;
+              std::tie(output_fvec0, output_fvec1) =
+                  convert_bfloat16_float(output_bvec);
+              fVec sum_fvec0 = fVec::loadu(tmp_sum_data + d1);
+              fVec sum_fvec1 = fVec::loadu(tmp_sum_data + d1 + fVec::size());
+              sum_fvec0 += grad_output_fvec0 * output_fvec0;
+              sum_fvec1 += grad_output_fvec1 * output_fvec1;
+              sum_fvec0.store(tmp_sum_data + d1);
+              sum_fvec1.store(tmp_sum_data + d1 + fVec::size());
+
+              // cache the 'converted' float grad_output and output
+              grad_output_fvec0.store(grad_output_buffer_ptr + d1);
+              grad_output_fvec1.store(
+                  grad_output_buffer_ptr + d1 + fVec::size());
+              output_fvec0.store(output_buffer_ptr + d1);
+              output_fvec1.store(output_buffer_ptr + d1 + fVec::size());
+            }
+            for (; d1 < size; d1++) {
+              float grad_output_val = float(grad_output_ptr[d1]);
+              float output_val = float(output_ptr[d1]);
+              tmp_sum_data[d1] += grad_output_val * output_val;
+              grad_output_buffer_ptr[d1] = grad_output_val;
+              output_buffer_ptr[d1] = output_val;
+            }
+          }
+
+          // compute output * (grad_output - sum)
+          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+            BFloat16* grad_input_ptr = grad_input_data_base +
+                outer_idx * outer_stride + dim_idx * inner_size +
+                inner_idx_begin;
+            float* grad_output_buffer_ptr =
+                grad_output_buffer_data + dim_idx * CHUNK_SIZE;
+            float* output_buffer_ptr =
+                output_buffer_data + dim_idx * CHUNK_SIZE;
+
+            int64_t d2 = 0;
+            for (; d2 < size - (size % bVec::size()); d2 += bVec::size()) {
+              fVec sum_fvec0 = fVec::loadu(tmp_sum_data + d2);
+              fVec sum_fvec1 = fVec::loadu(tmp_sum_data + d2 + fVec::size());
+              fVec grad_output_fvec0 = fVec::loadu(grad_output_buffer_ptr + d2);
+              fVec grad_output_fvec1 =
+                  fVec::loadu(grad_output_buffer_ptr + d2 + fVec::size());
+              fVec output_fvec0 = fVec::loadu(output_buffer_ptr + d2);
+              fVec output_fvec1 =
+                  fVec::loadu(output_buffer_ptr + d2 + fVec::size());
+              fVec grad_input_fvec0 =
+                  output_fvec0 * (grad_output_fvec0 - sum_fvec0);
+              fVec grad_input_fvec1 =
+                  output_fvec1 * (grad_output_fvec1 - sum_fvec1);
+              bVec grad_input_bvec =
+                  convert_float_bfloat16(grad_input_fvec0, grad_input_fvec1);
+              grad_input_bvec.store(grad_input_ptr + d2);
+            }
+            for (; d2 < size; d2++) {
+              grad_input_ptr[d2] = output_buffer_ptr[d2] * (grad_output_buffer_ptr[d2] - tmp_sum_data[d2]);
+            }
+          }
+        }
+      });
+}
+
+template <typename scalar_t>
+inline void _vec_log_softmax_backward(
+    scalar_t* grad_input_data_base,
+    scalar_t* grad_output_data_base,
+    scalar_t* output_data_base,
+    int64_t outer_size,
+    int64_t inner_size,
+    int64_t dim_size) {
+  using Vec = vec::Vectorized<scalar_t>;
+  int64_t outer_stride = dim_size * inner_size;
+  int64_t BLOCK_SIZE = 128 * 1024;
+  int64_t CHUNK_SIZE = std::max(
+      int64_t(BLOCK_SIZE / dim_size / sizeof(scalar_t)), (int64_t)Vec::size());
+  CHUNK_SIZE = CHUNK_SIZE / Vec::size() * Vec::size();
+  int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
+  int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
+  parallel_for(
+      0, outer_size * num_chunks, grain_size, [&](int64_t begin, int64_t end) {
+        // thread local temp buffer that holds vertical sum result
+        std::unique_ptr<scalar_t[]> buffer(new scalar_t[CHUNK_SIZE]);
+        scalar_t* tmp_sum_data = buffer.get();
+
+        for (int64_t i = begin; i < end; i++) {
+          int64_t outer_idx = i / num_chunks;
+          int64_t k = i % num_chunks;
+          int64_t inner_idx_begin = k * CHUNK_SIZE;
+          int64_t size = std::min(CHUNK_SIZE, inner_size - inner_idx_begin);
+
+          // init
+          Vec zero_vec = Vec(scalar_t(0));
+          int64_t d0 = 0;
+          for (; d0 < size - (size % Vec::size()); d0 += Vec::size()) {
+            zero_vec.store(tmp_sum_data + d0);
+          }
+          for (; d0 < size; d0++) {
+            tmp_sum_data[d0] = scalar_t(0);
+          }
+
+          // compute sum of grad_output
+          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+            scalar_t* grad_output_ptr = grad_output_data_base +
+                outer_idx * outer_stride + dim_idx * inner_size +
+                inner_idx_begin;
+
+            int64_t d1 = 0;
+            for (; d1 < size - (size % Vec::size()); d1 += Vec::size()) {
+              Vec grad_output_vec = Vec::loadu(grad_output_ptr + d1);
+              Vec sum_vec = Vec::loadu(tmp_sum_data + d1);
+              sum_vec += grad_output_vec;
+              sum_vec.store(tmp_sum_data + d1);
+            }
+            for (; d1 < size; d1++) {
+              tmp_sum_data[d1] += grad_output_ptr[d1];
+            }
+          }
+
+          // compute grad_output - output.exp() * sum
+          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+            int64_t offset = outer_idx * outer_stride + dim_idx * inner_size +
+                inner_idx_begin;
+            scalar_t* grad_output_ptr = grad_output_data_base + offset;
+            scalar_t* output_ptr = output_data_base + offset;
+            scalar_t* grad_input_ptr = grad_input_data_base + offset;
+
+            int64_t d2 = 0;
+            for (; d2 < size - (size % Vec::size()); d2 += Vec::size()) {
+              Vec grad_output_vec = Vec::loadu(grad_output_ptr + d2);
+              Vec output_vec = Vec::loadu(output_ptr + d2);
+              Vec sum_vec = Vec::loadu(tmp_sum_data + d2);
+              Vec grad_input_vec = grad_output_vec - output_vec.exp() * sum_vec;
+              grad_input_vec.store(grad_input_ptr + d2);
+            }
+            for (; d2 < size; d2++) {
+              grad_input_ptr[d2] = grad_output_ptr[d2] -
+                  std::exp(output_ptr[d2]) * tmp_sum_data[d2];
+            }
+          }
+        }
+      });
+}
+
+template <>
+inline void _vec_log_softmax_backward<BFloat16>(
+    BFloat16* grad_input_data_base,
+    BFloat16* grad_output_data_base,
+    BFloat16* output_data_base,
+    int64_t outer_size,
+    int64_t inner_size,
+    int64_t dim_size) {
+  using bVec = vec::Vectorized<BFloat16>;
+  using fVec = vec::Vectorized<float>;
+  int64_t outer_stride = dim_size * inner_size;
+  int64_t BLOCK_SIZE = 128 * 1024;
+  int64_t CHUNK_SIZE = std::max(
+      int64_t(BLOCK_SIZE / dim_size / sizeof(BFloat16)), (int64_t)bVec::size());
+  CHUNK_SIZE = CHUNK_SIZE / bVec::size() * bVec::size();
+  int64_t num_chunks = divup(inner_size, CHUNK_SIZE);
+  int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size * CHUNK_SIZE);
+  parallel_for(
+      0, outer_size * num_chunks, grain_size, [&](int64_t begin, int64_t end) {
+        // thread local temp buffer that holds vertical sum result
+        std::unique_ptr<float[]> buffer(new float[CHUNK_SIZE]);
+        float* tmp_sum_data = buffer.get();
+
+        // thread local buffer that holds grad_output data in float32
+        std::unique_ptr<float[]> grad_output_buffer(
+            new float[dim_size * CHUNK_SIZE]);
+        float* grad_output_buffer_data = grad_output_buffer.get();
+
+        for (int64_t i = begin; i < end; i++) {
+          int64_t outer_idx = i / num_chunks;
+          int64_t k = i % num_chunks;
+          int64_t inner_idx_begin = k * CHUNK_SIZE;
+          int64_t size = std::min(CHUNK_SIZE, inner_size - inner_idx_begin);
+
+          // init
+          fVec zero_fvec = fVec(float(0));
+          int64_t d0 = 0;
+          for (; d0 < size - (size % bVec::size()); d0 += bVec::size()) {
+            zero_fvec.store(tmp_sum_data + d0);
+            zero_fvec.store(tmp_sum_data + d0 + fVec::size());
+          }
+          for (; d0 < size; d0++) {
+            tmp_sum_data[d0] = float(0);
+          }
+
+          // compute sum of grad_output
+          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+            BFloat16* grad_output_ptr = grad_output_data_base +
+                outer_idx * outer_stride + dim_idx * inner_size +
+                inner_idx_begin;
+            float* grad_output_buffer_ptr =
+                grad_output_buffer_data + dim_idx * CHUNK_SIZE;
+
+            int64_t d1 = 0;
+            for (; d1 < size - (size % bVec::size()); d1 += bVec::size()) {
+              bVec grad_output_bvec = bVec::loadu(grad_output_ptr + d1);
+              fVec grad_output_fvec0, grad_output_fvec1;
+              std::tie(grad_output_fvec0, grad_output_fvec1) =
+                  convert_bfloat16_float(grad_output_bvec);
+              fVec sum_fvec0 = fVec::loadu(tmp_sum_data + d1);
+              fVec sum_fvec1 = fVec::loadu(tmp_sum_data + d1 + fVec::size());
+              sum_fvec0 += grad_output_fvec0;
+              sum_fvec1 += grad_output_fvec1;
+              sum_fvec0.store(tmp_sum_data + d1);
+              sum_fvec1.store(tmp_sum_data + d1 + fVec::size());
+
+              // cache the 'converted' float grad_output
+              grad_output_fvec0.store(grad_output_buffer_ptr + d1);
+              grad_output_fvec1.store(
+                  grad_output_buffer_ptr + d1 + fVec::size());
+            }
+            for (; d1 < size; d1++) {
+              float grad_output_val = float(grad_output_ptr[d1]);
+              tmp_sum_data[d1] += grad_output_val;
+              grad_output_buffer_ptr[d1] = grad_output_val;
+            }
+          }
+
+          // compute grad_output - output.exp() * sum
+          for (int64_t dim_idx = 0; dim_idx < dim_size; dim_idx++) {
+            int64_t offset = outer_idx * outer_stride + dim_idx * inner_size +
+                inner_idx_begin;
+            BFloat16* output_ptr = output_data_base + offset;
+            BFloat16* grad_input_ptr = grad_input_data_base + offset;
+            float* grad_output_buffer_ptr =
+                grad_output_buffer_data + dim_idx * CHUNK_SIZE;
+
+            int64_t d2 = 0;
+            for (; d2 < size - (size % bVec::size()); d2 += bVec::size()) {
+              bVec output_bvec = bVec::loadu(output_ptr + d2);
+              fVec output_fvec0, output_fvec1;
+              std::tie(output_fvec0, output_fvec1) =
+                  convert_bfloat16_float(output_bvec);
+              fVec sum_fvec0 = fVec::loadu(tmp_sum_data + d2);
+              fVec sum_fvec1 = fVec::loadu(tmp_sum_data + d2 + fVec::size());
+              fVec grad_output_fvec0 = fVec::loadu(grad_output_buffer_ptr + d2);
+              fVec grad_output_fvec1 =
+                  fVec::loadu(grad_output_buffer_ptr + d2 + fVec::size());
+              fVec grad_input_fvec0 =
+                  grad_output_fvec0 - output_fvec0.exp() * sum_fvec0;
+              fVec grad_input_fvec1 =
+                  grad_output_fvec1 - output_fvec1.exp() * sum_fvec1;
+              bVec grad_input_bvec =
+                  convert_float_bfloat16(grad_input_fvec0, grad_input_fvec1);
+              grad_input_bvec.store(grad_input_ptr + d2);
+            }
+            for (; d2 < size; d2++) {
+              grad_input_ptr[d2] = grad_output_buffer_ptr[d2] -
+                  std::exp(float(output_ptr[d2])) * tmp_sum_data[d2];
+            }
+          }
+        }
+      });
+}
+
 template <typename scalar_t, bool LogSoftMax>
 struct vec_host_softmax_lastdim {
   static void apply(const Tensor& output, const Tensor& input) {
@@ -279,13 +686,13 @@ inline void _vec_softmax(
   using Vec_bf16 = vec::Vectorized<BFloat16>;
   int64_t dim_stride = inner_size;
   int64_t outer_stride = dim_size * dim_stride;
-  int64_t grain_size = std::min(internal::GRAIN_SIZE / dim_size, (int64_t)1);
+  int64_t grain_size = std::max(internal::GRAIN_SIZE / dim_size, (int64_t)1);
   int vectorized_step = Vec_bf16().size(); // Currently, we only support BFloat16 in this special implementation
   parallel_for(
       0, outer_size * inner_size, grain_size, [&](int64_t begin, int64_t end) {
         int64_t idx = begin;
-        std::unique_ptr<float[]> temp_vec_input(new float[dim_size*vectorized_step*2]());
-        std::unique_ptr<float[]> temp_vec_output(new float[dim_size*vectorized_step*2]());
+        std::unique_ptr<float[]> temp_vec_input(new float[dim_size*vectorized_step]());
+        std::unique_ptr<float[]> temp_vec_output(new float[dim_size*vectorized_step]());
         float* temp_vec_input_data = temp_vec_input.get();
         float* temp_vec_output_data = temp_vec_output.get();
         while (idx < end) {
@@ -299,37 +706,37 @@ inline void _vec_softmax(
                 output_data_base + outer_idx * outer_stride + inner_idx;
             // Step 1: Get max Score
             Vec_bf16 max_vec_bf16 = Vec_bf16::loadu(input_data);
-            std::tuple<vec::Vectorized<float>, vec::Vectorized<float>> convert_result = convert_bfloat16_float(max_vec_bf16);
+            std::tuple<Vec, Vec> convert_result = convert_bfloat16_float(max_vec_bf16);
             Vec max_vec_o1 = std::get<0>(convert_result);
             Vec max_vec_o2 = std::get<1>(convert_result);
             std::get<0>(convert_result).store(temp_vec_input_data);
-            std::get<1>(convert_result).store(temp_vec_input_data + vectorized_step);
+            std::get<1>(convert_result).store(temp_vec_input_data + Vec().size());
             for (const auto d : c10::irange(1, dim_size)) {
               Vec_bf16 input_vec_bf16 = Vec_bf16::loadu(input_data + d * dim_stride);
               convert_result = convert_bfloat16_float(input_vec_bf16);
               max_vec_o1 = vec::maximum(max_vec_o1, std::get<0>(convert_result));
               max_vec_o2 = vec::maximum(max_vec_o2, std::get<1>(convert_result));
-              std::get<0>(convert_result).store(temp_vec_input_data + d*vectorized_step*2);
-              std::get<1>(convert_result).store(temp_vec_input_data + d*vectorized_step*2 + vectorized_step);
+              std::get<0>(convert_result).store(temp_vec_input_data + d*vectorized_step);
+              std::get<1>(convert_result).store(temp_vec_input_data + d*vectorized_step + Vec().size());
             }
             // Step2: Calculate sum
             Vec sum_vec_o1 = Vec(0.0);
             Vec sum_vec_o2 = Vec(0.0);
             for (const auto d : c10::irange(dim_size)) {
-              Vec output_vec_o1 = Vec::loadu(temp_vec_input_data + d*vectorized_step*2);
-              Vec output_vec_o2 = Vec::loadu(temp_vec_input_data + d*vectorized_step*2 + vectorized_step);
+              Vec output_vec_o1 = Vec::loadu(temp_vec_input_data + d*vectorized_step);
+              Vec output_vec_o2 = Vec::loadu(temp_vec_input_data + d*vectorized_step + Vec().size());
               output_vec_o1 = (output_vec_o1 - max_vec_o1).exp();
               output_vec_o2 = (output_vec_o2 - max_vec_o2).exp();
-              output_vec_o1.store(temp_vec_output_data + d*vectorized_step*2);
-              output_vec_o2.store(temp_vec_output_data + d*vectorized_step*2 + vectorized_step);
+              output_vec_o1.store(temp_vec_output_data + d*vectorized_step);
+              output_vec_o2.store(temp_vec_output_data + d*vectorized_step + Vec().size());
 
               sum_vec_o1 = sum_vec_o1 + output_vec_o1;
               sum_vec_o2 = sum_vec_o2 + output_vec_o2;
             }
             // Step3: Unify
             for (const auto d : c10::irange(dim_size)) {
-              Vec output_vec_o1 = Vec::loadu(temp_vec_output_data + d*vectorized_step*2);
-              Vec output_vec_o2 = Vec::loadu(temp_vec_output_data + d*vectorized_step*2 + vectorized_step);
+              Vec output_vec_o1 = Vec::loadu(temp_vec_output_data + d*vectorized_step);
+              Vec output_vec_o2 = Vec::loadu(temp_vec_output_data + d*vectorized_step + Vec().size());
               output_vec_o1 = output_vec_o1/sum_vec_o1;
               output_vec_o2 = output_vec_o2/sum_vec_o2;
               Vec_bf16 output_vec_bf16 = convert_float_bfloat16(output_vec_o1, output_vec_o2);
@@ -385,7 +792,7 @@ inline void _vec_softmax(
   using Vec = vec::Vectorized<scalar_t>;
   int64_t dim_stride = inner_size;
   int64_t outer_stride = dim_size * dim_stride;
-  int64_t grain_size = std::min(internal::GRAIN_SIZE / dim_size, (int64_t)1);
+  int64_t grain_size = std::max(internal::GRAIN_SIZE / dim_size, (int64_t)1);
   int vectorized_step = Vec().size();
   parallel_for(
       0, outer_size * inner_size, grain_size, [&](int64_t begin, int64_t end) {
@@ -741,6 +1148,45 @@ struct vec_host_softmax_backward_lastdim {
   }
 };
 
+template <typename scalar_t, bool LogSoftMax>
+struct vec_host_softmax_backward {
+  static void apply(
+      const Tensor& grad_input,
+      const Tensor& grad,
+      const Tensor& output,
+      int64_t dim) {
+    int64_t outer_size = 1;
+    int64_t dim_size = grad.size(dim);
+    int64_t inner_size = 1;
+    for (const auto i : c10::irange(dim)) {
+      outer_size *= grad.size(i);
+    }
+    for (int64_t i = dim + 1; i < grad.dim(); ++i) {
+      inner_size *= grad.size(i);
+    }
+    scalar_t* grad_input_data_base = grad_input.data_ptr<scalar_t>();
+    scalar_t* grad_output_data_base = grad.data_ptr<scalar_t>();
+    scalar_t* output_data_base = output.data_ptr<scalar_t>();
+    if (LogSoftMax) {
+      _vec_log_softmax_backward<scalar_t>(
+          grad_input_data_base,
+          grad_output_data_base,
+          output_data_base,
+          outer_size,
+          inner_size,
+          dim_size);
+    } else {
+      _vec_softmax_backward<scalar_t>(
+          grad_input_data_base,
+          grad_output_data_base,
+          output_data_base,
+          outer_size,
+          inner_size,
+          dim_size);
+    }
+  }
+};
+
 static void softmax_lastdim_kernel_impl(
     const Tensor& result,
     const Tensor& self) {
@@ -795,6 +1241,36 @@ static void log_softmax_backward_lastdim_kernel_impl(
       });
 }
 
+static void softmax_backward_kernel_impl(
+    const Tensor& grad_input,
+    const Tensor& grad,
+    const Tensor& output,
+    int64_t dim) {
+  AT_DISPATCH_FLOATING_TYPES_AND(
+      at::ScalarType::BFloat16,
+      grad.scalar_type(),
+      "softmax_backward_kernel_impl",
+      [&] {
+        vec_host_softmax_backward<scalar_t, false>::apply(
+            grad_input, grad, output, dim);
+      });
+}
+
+static void log_softmax_backward_kernel_impl(
+    const Tensor& grad_input,
+    const Tensor& grad,
+    const Tensor& output,
+    int64_t dim) {
+  AT_DISPATCH_FLOATING_TYPES_AND(
+      at::ScalarType::BFloat16,
+      grad.scalar_type(),
+      "log_softmax_backward_kernel_impl",
+      [&] {
+        vec_host_softmax_backward<scalar_t, true>::apply(
+            grad_input, grad, output, dim);
+      });
+}
+
 } // anonymous namespace
 
 REGISTER_DISPATCH(softmax_lastdim_kernel, &softmax_lastdim_kernel_impl);
@@ -808,5 +1284,8 @@ REGISTER_DISPATCH(
 
 REGISTER_DISPATCH(softmax_kernel, &softmax_kernel_impl);
 REGISTER_DISPATCH(log_softmax_kernel, &log_softmax_kernel_impl);
-
+REGISTER_DISPATCH(softmax_backward_kernel, &softmax_backward_kernel_impl);
+REGISTER_DISPATCH(
+    log_softmax_backward_kernel,
+    &log_softmax_backward_kernel_impl);
 }} // namespace at::native

--- a/aten/src/ATen/native/cpu/SoftmaxKernel.h
+++ b/aten/src/ATen/native/cpu/SoftmaxKernel.h
@@ -17,8 +17,12 @@ DECLARE_DISPATCH(backward_fn, softmax_backward_lastdim_kernel);
 DECLARE_DISPATCH(backward_fn, log_softmax_backward_lastdim_kernel);
 
 using forward_fn_with_dim = void(*)(const Tensor &, const Tensor &, const int64_t);
+using backward_fn_with_dim =
+    void (*)(const Tensor&, const Tensor&, const Tensor&, const int64_t);
+
 DECLARE_DISPATCH(forward_fn_with_dim, softmax_kernel);
 DECLARE_DISPATCH(forward_fn_with_dim, log_softmax_kernel);
-
+DECLARE_DISPATCH(backward_fn_with_dim, softmax_backward_kernel);
+DECLARE_DISPATCH(backward_fn_with_dim, log_softmax_backward_kernel);
 }
 }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11582,31 +11582,33 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(F.softmin(x, 0), F.softmax(-x, 0))
 
     def test_log_softmax_cpu(self, dtype=torch.bfloat16):
-        inputf = torch.rand(32, 100, device="cpu", dtype=torch.float, requires_grad=True)
-        input = inputf.to(dtype).detach().requires_grad_(True)
-        outf = F.log_softmax(inputf, dim=-1)
-        out = F.log_softmax(input, dim=-1)
-        self.assertEqual(out.dtype, dtype)
-        # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
-        self.assertEqualIgnoreType(out, outf, atol=0.1, rtol=0)
+        for dim in [0, 1]:
+            inputf = torch.rand(200, 200, device="cpu", dtype=torch.float, requires_grad=True)
+            input = inputf.to(dtype).detach().requires_grad_(True)
+            outf = F.log_softmax(inputf, dim=dim)
+            out = F.log_softmax(input, dim=dim)
+            self.assertEqual(out.dtype, dtype)
+            # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
+            self.assertEqualIgnoreType(out, outf, atol=0.1, rtol=0)
 
-        out.sum().backward()
-        outf.sum().backward()
-        self.assertEqual(input.grad.dtype, dtype)
-        self.assertEqual(input.grad, inputf.grad.to(dtype), atol=0.1, rtol=0)
+            out.sum().backward()
+            outf.sum().backward()
+            self.assertEqual(input.grad.dtype, dtype)
+            self.assertEqual(input.grad, inputf.grad.to(dtype), atol=0.1, rtol=0)
 
     def test_softmax_cpu(self, dtype=torch.bfloat16):
-        inputf = torch.rand(32, 100, device="cpu", dtype=torch.float, requires_grad=True)
-        input = inputf.to(dtype).detach().requires_grad_(True)
-        outf = F.softmax(inputf, dim=-1)
-        out = F.softmax(input, dim=-1)
-        self.assertEqual(out.dtype, dtype)
-        self.assertEqualIgnoreType(out, outf, atol=1e-3, rtol=0)
+        for dim in [0, 1]:
+            inputf = torch.rand(200, 200, device="cpu", dtype=torch.float, requires_grad=True)
+            input = inputf.to(dtype).detach().requires_grad_(True)
+            outf = F.softmax(inputf, dim=dim)
+            out = F.softmax(input, dim=dim)
+            self.assertEqual(out.dtype, dtype)
+            self.assertEqualIgnoreType(out, outf, atol=1e-3, rtol=0)
 
-        out.sum().backward()
-        outf.sum().backward()
-        self.assertEqual(input.grad.dtype, dtype)
-        self.assertEqual(input.grad, inputf.grad.to(dtype), atol=1e-3, rtol=0)
+            out.sum().backward()
+            outf.sum().backward()
+            self.assertEqual(input.grad.dtype, dtype)
+            self.assertEqual(input.grad, inputf.grad.to(dtype), atol=1e-3, rtol=0)
 
     def test_adaptive_log_softmax(self):
         # args validation


### PR DESCRIPTION
Currently, if we run softmax_backward/logsoftmax_backward which are not along the last dim, the calculation will fall to a [scalar version](https://github.com/pytorch/pytorch/blob/32593ef2dd26e32ed44d3c03d3f5de4a42eb149a/aten/src/ATen/native/SoftMax.cpp#L220-L287). And we find actually we have the chance to vectorize the calculation along the inner_size dim.

Changes we made:

Use vectorized softmax_backward_kernel/log_softmax_backward_kernel instead of host_softmax_backward when not along the last dim.

We collected the benchmark data of softmax_backward and logsoftmax_backward for BFloat16 and Float32 data type by using the operator_benchmark tool of PyTorch on the platform of Intel(R) Xeon(R) Platinum 8260L CPU @ 2.40GHz.
Number of cores: 24 cores(1 socket)
[softmax_benchmark_32593ef.log](https://github.com/pytorch/pytorch/files/8962956/softmax_benchmark_32593ef.log)
[softmax_benchmark_the_pr.log](https://github.com/pytorch/pytorch/files/8962958/softmax_benchmark_the_pr.log)

