### PR TITLE
Back out "make stream version of pkl load_for_mobile shortcircuit"

### DIFF
--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -560,17 +560,11 @@ mobile::Module _load_for_mobile(
     std::istream& in,
     c10::optional<at::Device> device,
     ExtraFilesMap& extra_files) {
-  if (getFileFormat(in) == FileFormat::FlatbufferFileFormat) {
-    std::shared_ptr<char> data;
-    size_t size = 0;
-    std::tie(data, size) = get_stream_content(in);
-    return _load_mobile_from_bytes(
-        data, size, device, extra_files, kDefaultMobileLoadOptions);
-  }
-  std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
-  auto module = _load_for_mobile_impl(
-      std::move(rai), device, extra_files, kDefaultMobileLoadOptions);
-  return module;
+  std::shared_ptr<char> data;
+  size_t size = 0;
+  std::tie(data, size) = get_stream_content(in);
+  return _load_mobile_from_bytes(
+      data, size, device, extra_files, kDefaultMobileLoadOptions);
 }
 
 mobile::Module _load_for_mobile(


### PR DESCRIPTION
Summary:
Original commit changeset: b5813cd73ec2

Original Phabricator Diff: D37304855 (https://github.com/pytorch/pytorch/commit/9f866b8dbbf63c2a927ee273aa3b4285c699aa6a)

Back out to avoid conflict on S276990

Test Plan: solve  S276990

Differential Revision: D37370991

