### PR TITLE
add qscheme check for quantization observer

### DIFF
--- a/torch/ao/quantization/fx/_equalize.py
+++ b/torch/ao/quantization/fx/_equalize.py
@@ -465,7 +465,7 @@ def scale_weight_functional(
     equalization_scale: torch.Tensor,
     next_equalization_scale: Optional[torch.Tensor],
 ) -> None:
-    """ Scales the weight value for torch/ao/quantization/fx/_equalize.pyfunctional layers
+    """ Scales the weight value for functional layers
     """
     if equalization_scale is None:
         return

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -464,6 +464,11 @@ class MinMaxObserver(UniformQuantizationObserverBase):
             factory_kwargs=factory_kwargs,
             eps=eps,
         )
+        if qscheme != torch.per_tensor_symmetric and self.qscheme != torch.per_tensor_affine:
+            raise NotImplementedError(
+                "MinMaxObserver's qscheme only support torch.per_tensor_symmetric \
+                    and torch.per_tensor_affine."
+            )
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
         self.register_buffer("min_val", torch.tensor(float("inf"), **factory_kwargs))
         self.register_buffer("max_val", torch.tensor(float("-inf"), **factory_kwargs))
@@ -561,6 +566,11 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
         eps=torch.finfo(torch.float32).eps,
         **kwargs
     ) -> None:
+        if qscheme != torch.per_tensor_symmetric and self.qscheme != torch.per_tensor_affine:
+            raise NotImplementedError(
+                "MovingAverageMinMaxObserver's qscheme only support \
+                    torch.per_tensor_symmetric and torch.per_tensor_affine."
+            )
         self.averaging_constant = averaging_constant
         super(MovingAverageMinMaxObserver, self).__init__(
             dtype=dtype,
@@ -630,6 +640,11 @@ class PerChannelMinMaxObserver(UniformQuantizationObserverBase):
         factory_kwargs=None,
         eps=torch.finfo(torch.float32).eps,
     ) -> None:
+        if qscheme != torch.per_channel_symmetric and self.qscheme != torch.per_channel_affine:
+            raise NotImplementedError(
+                "PerChannelMinMaxObserver's qscheme only support \
+                    torch.per_channel_symmetric and torch.per_channel_affine."
+            )
         super(PerChannelMinMaxObserver, self).__init__(
             dtype=dtype,
             qscheme=qscheme,
@@ -814,6 +829,11 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         eps=torch.finfo(torch.float32).eps,
         **kwargs
     ) -> None:
+        if qscheme != torch.per_channel_symmetric and self.qscheme != torch.per_channel_affine:
+            raise NotImplementedError(
+                "MovingAveragePerChannelMinMaxObserver's qscheme only support \
+                    torch.per_channel_symmetric and torch.per_channel_affine."
+            )
         super(MovingAveragePerChannelMinMaxObserver, self).__init__(
             ch_axis=ch_axis,
             dtype=dtype,
@@ -894,6 +914,11 @@ class HistogramObserver(UniformQuantizationObserverBase):
         factory_kwargs=None,
         eps=torch.finfo(torch.float32).eps,
     ) -> None:
+        if qscheme != torch.per_tensor_symmetric and self.qscheme != torch.per_tensor_affine:
+            raise NotImplementedError(
+                "HistogramObserver's qscheme only support torch.per_tensor_symmetric \
+                    and torch.per_tensor_affine."
+            )
         # bins: The number of bins used for histogram calculation.
         super(HistogramObserver, self).__init__(
             dtype=dtype,

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -448,7 +448,7 @@ class MinMaxObserver(UniformQuantizationObserverBase):
         factory_kwargs=None,
         eps=torch.finfo(torch.float32).eps,
     ) -> None:
-        if not is_per_tensor(qscheme): 
+        if not is_per_tensor(qscheme):
             raise NotImplementedError(
                 "MinMaxObserver's qscheme only support torch.per_tensor_symmetric \
                     and torch.per_tensor_affine."

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -642,7 +642,7 @@ class PerChannelMinMaxObserver(UniformQuantizationObserverBase):
         if not is_per_channel(qscheme):
             raise NotImplementedError(
                 "PerChannelMinMaxObserver's qscheme only support \
-                    torch.per_channel_symmetric and torch.per_channel_affine."
+                    torch.per_channel_symmetric, torch.per_channel_affine and torch.per_channel_affine_float_qparams."
             )
         super(PerChannelMinMaxObserver, self).__init__(
             dtype=dtype,
@@ -831,7 +831,7 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         if not is_per_channel(qscheme):
             raise NotImplementedError(
                 "MovingAveragePerChannelMinMaxObserver's qscheme only support \
-                    torch.per_channel_symmetric and torch.per_channel_affine."
+                    torch.per_channel_symmetric, torch.per_channel_affine and torch.per_channel_affine_float_qparams."
             )
         super(MovingAveragePerChannelMinMaxObserver, self).__init__(
             ch_axis=ch_axis,

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -448,7 +448,11 @@ class MinMaxObserver(UniformQuantizationObserverBase):
         factory_kwargs=None,
         eps=torch.finfo(torch.float32).eps,
     ) -> None:
-
+        if qscheme != torch.per_tensor_symmetric and qscheme != torch.per_tensor_affine:
+            raise NotImplementedError(
+                "MinMaxObserver's qscheme only support torch.per_tensor_symmetric \
+                    and torch.per_tensor_affine."
+            )
         # For x86 quantized kernels, we need to ensure that the vpmaddubsw
         # instruction does not overflow. We allow for a reduce_range argument to
         # observers that reduces the quantized range to (0,127) or (-64, 63).
@@ -464,11 +468,6 @@ class MinMaxObserver(UniformQuantizationObserverBase):
             factory_kwargs=factory_kwargs,
             eps=eps,
         )
-        if qscheme != torch.per_tensor_symmetric and self.qscheme != torch.per_tensor_affine:
-            raise NotImplementedError(
-                "MinMaxObserver's qscheme only support torch.per_tensor_symmetric \
-                    and torch.per_tensor_affine."
-            )
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
         self.register_buffer("min_val", torch.tensor(float("inf"), **factory_kwargs))
         self.register_buffer("max_val", torch.tensor(float("-inf"), **factory_kwargs))
@@ -566,7 +565,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
         eps=torch.finfo(torch.float32).eps,
         **kwargs
     ) -> None:
-        if qscheme != torch.per_tensor_symmetric and self.qscheme != torch.per_tensor_affine:
+        if qscheme != torch.per_tensor_symmetric and qscheme != torch.per_tensor_affine:
             raise NotImplementedError(
                 "MovingAverageMinMaxObserver's qscheme only support \
                     torch.per_tensor_symmetric and torch.per_tensor_affine."
@@ -640,7 +639,7 @@ class PerChannelMinMaxObserver(UniformQuantizationObserverBase):
         factory_kwargs=None,
         eps=torch.finfo(torch.float32).eps,
     ) -> None:
-        if qscheme != torch.per_channel_symmetric and self.qscheme != torch.per_channel_affine:
+        if qscheme != torch.per_channel_symmetric and qscheme != torch.per_channel_affine:
             raise NotImplementedError(
                 "PerChannelMinMaxObserver's qscheme only support \
                     torch.per_channel_symmetric and torch.per_channel_affine."
@@ -829,7 +828,7 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         eps=torch.finfo(torch.float32).eps,
         **kwargs
     ) -> None:
-        if qscheme != torch.per_channel_symmetric and self.qscheme != torch.per_channel_affine:
+        if qscheme != torch.per_channel_symmetric and qscheme != torch.per_channel_affine:
             raise NotImplementedError(
                 "MovingAveragePerChannelMinMaxObserver's qscheme only support \
                     torch.per_channel_symmetric and torch.per_channel_affine."
@@ -914,7 +913,7 @@ class HistogramObserver(UniformQuantizationObserverBase):
         factory_kwargs=None,
         eps=torch.finfo(torch.float32).eps,
     ) -> None:
-        if qscheme != torch.per_tensor_symmetric and self.qscheme != torch.per_tensor_affine:
+        if qscheme != torch.per_tensor_symmetric and qscheme != torch.per_tensor_affine:
             raise NotImplementedError(
                 "HistogramObserver's qscheme only support torch.per_tensor_symmetric \
                     and torch.per_tensor_affine."

--- a/torch/ao/quantization/observer.py
+++ b/torch/ao/quantization/observer.py
@@ -12,8 +12,8 @@ from typing import Any, List, Tuple, Optional, Dict
 
 import torch
 import torch.nn as nn
-from torch.ao.quantization.utils import check_min_max_valid, calculate_qmin_qmax
-
+from torch.ao.quantization.utils import (
+    check_min_max_valid, calculate_qmin_qmax, is_per_tensor, is_per_channel)
 
 __all__ = [
     "default_affine_fixed_qparams_observer",
@@ -448,7 +448,7 @@ class MinMaxObserver(UniformQuantizationObserverBase):
         factory_kwargs=None,
         eps=torch.finfo(torch.float32).eps,
     ) -> None:
-        if qscheme != torch.per_tensor_symmetric and qscheme != torch.per_tensor_affine:
+        if not is_per_tensor(qscheme): 
             raise NotImplementedError(
                 "MinMaxObserver's qscheme only support torch.per_tensor_symmetric \
                     and torch.per_tensor_affine."
@@ -565,7 +565,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
         eps=torch.finfo(torch.float32).eps,
         **kwargs
     ) -> None:
-        if qscheme != torch.per_tensor_symmetric and qscheme != torch.per_tensor_affine:
+        if not is_per_tensor(qscheme):
             raise NotImplementedError(
                 "MovingAverageMinMaxObserver's qscheme only support \
                     torch.per_tensor_symmetric and torch.per_tensor_affine."
@@ -639,7 +639,7 @@ class PerChannelMinMaxObserver(UniformQuantizationObserverBase):
         factory_kwargs=None,
         eps=torch.finfo(torch.float32).eps,
     ) -> None:
-        if qscheme != torch.per_channel_symmetric and qscheme != torch.per_channel_affine:
+        if not is_per_channel(qscheme):
             raise NotImplementedError(
                 "PerChannelMinMaxObserver's qscheme only support \
                     torch.per_channel_symmetric and torch.per_channel_affine."
@@ -828,7 +828,7 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         eps=torch.finfo(torch.float32).eps,
         **kwargs
     ) -> None:
-        if qscheme != torch.per_channel_symmetric and qscheme != torch.per_channel_affine:
+        if not is_per_channel(qscheme):
             raise NotImplementedError(
                 "MovingAveragePerChannelMinMaxObserver's qscheme only support \
                     torch.per_channel_symmetric and torch.per_channel_affine."
@@ -913,7 +913,7 @@ class HistogramObserver(UniformQuantizationObserverBase):
         factory_kwargs=None,
         eps=torch.finfo(torch.float32).eps,
     ) -> None:
-        if qscheme != torch.per_tensor_symmetric and qscheme != torch.per_tensor_affine:
+        if not is_per_tensor(qscheme):
             raise NotImplementedError(
                 "HistogramObserver's qscheme only support torch.per_tensor_symmetric \
                     and torch.per_tensor_affine."


### PR DESCRIPTION
Motivation: each quantization observer only supports a limit qschemes, we need to do this check at the initiation step, rather than at the running step, such as MinMaxObserver with set qscheme with **torch.per_channel_affine**, there will have a runtime error at the running the calibration step:

```
AttributeError: 'MinMaxObserver' object has no attribute 'ch_axis'
```