### PR TITLE
Fix interpretation torch -> torch._refs in case of nested torch calls under TorchRefsMode

### DIFF
--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -83,7 +83,9 @@ class TorchRefsMode(torch.overrides.TorchFunctionMode):
         mapping = torch_to_refs_map()
         func = mapping.get(orig_func, None)
         if func is not None:
-            return func(*args, **kwargs)
+            # torch calls inside func should be interpreted as refs calls
+            with self.push():
+                return func(*args, **kwargs)
         if self.strict:
             raise RuntimeError(
                 f"no _refs support for {torch.overrides.resolve_name(orig_func)}"

--- a/torch/_prims/context.py
+++ b/torch/_prims/context.py
@@ -84,7 +84,7 @@ class TorchRefsMode(torch.overrides.TorchFunctionMode):
         func = mapping.get(orig_func, None)
         if func is not None:
             # torch calls inside func should be interpreted as refs calls
-            with self.push():
+            with torch.overrides.enable_torch_function_mode(self, replace=self.inner):
                 return func(*args, **kwargs)
         if self.strict:
             raise RuntimeError(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20309,7 +20309,6 @@ python_ref_db = [
     PythonRefInfo(
         "_refs.nn.functional.layer_norm",
         torch_opinfo_name="nn.functional.layer_norm",
-        supports_nvfuser=False,
         skips=(
             # Reference result was farther (3.5762786809723224e-07) from the precise computation
             # than the torch result was (2.5068410824946596e-07)!
@@ -20329,7 +20328,6 @@ python_ref_db = [
     ElementwiseUnaryPythonRefInfo(
         "_refs.nn.functional.mish",
         torch_opinfo_name="nn.functional.mish",
-        supports_nvfuser=False,
     ),
     ElementwiseUnaryPythonRefInfo(
         "_refs.nn.functional.selu",


### PR DESCRIPTION
torch calls inside `TorchRefsMode.__torch_function__` dispatch should be interpreted as refs calls under `TorchRefsMode`. Fixes https://github.com/pytorch/pytorch/issues/80079.

In addition, this PR enables two more tests for the nvFuser executor.

For example here's the FX trace of `torch._refs.nn.functional.layer_norm` before the proposed change (note the mix of `aten` and `prims`):
```py
opcode         name                    target                      args                              kwargs
-------------  ----------------------  --------------------------  --------------------------------  -----------------
placeholder    a_1                     a_1                         ()                                {}
call_function  convert_element_type    prims.convert_element_type  (a_1, torch.float32)              {}
call_function  var                     prims.var                   (convert_element_type, [0, 1])    {'correction': 0}
call_function  broadcast_in_dim        prims.broadcast_in_dim      (var, [1, 1], [])                 {}
call_function  convert_element_type_1  prims.convert_element_type  (a_1, torch.float32)              {}
call_function  sum_1                   prims.sum                   (convert_element_type_1, [0, 1])  {}
call_function  broadcast_in_dim_1      prims.broadcast_in_dim      (sum_1, [1, 1], [])               {}
call_function  div                     prims.div                   (broadcast_in_dim_1, 9.0)         {}
call_function  add                     aten.add                    (broadcast_in_dim, 1e-05)         {}
call_function  rsqrt                   aten.rsqrt                  (add,)                            {}
call_function  sub                     aten.sub                    (a_1, div)                        {}
call_function  mul                     aten.mul                    (sub, rsqrt)                      {}
call_function  convert_element_type_2  prims.convert_element_type  (mul, torch.float32)              {}
output         output                  output                      (convert_element_type_2,)         {}
```
And with this PR:
```py
opcode         name                    target                      args                              kwargs
-------------  ----------------------  --------------------------  --------------------------------  -----------------
placeholder    a_1                     a_1                         ()                                {}
call_function  convert_element_type    prims.convert_element_type  (a_1, torch.float32)              {}
call_function  var                     prims.var                   (convert_element_type, [0, 1])    {'correction': 0}
call_function  broadcast_in_dim        prims.broadcast_in_dim      (var, [1, 1], [])                 {}
call_function  convert_element_type_1  prims.convert_element_type  (a_1, torch.float32)              {}
call_function  sum_1                   prims.sum                   (convert_element_type_1, [0, 1])  {}
call_function  broadcast_in_dim_1      prims.broadcast_in_dim      (sum_1, [1, 1], [])               {}
call_function  div                     prims.div                   (broadcast_in_dim_1, 9.0)         {}
call_function  add                     prims.add                   (broadcast_in_dim, 1e-05)         {}
call_function  rsqrt                   prims.rsqrt                 (add,)                            {}
call_function  broadcast_in_dim_2      prims.broadcast_in_dim      (div, [3, 3], [0, 1])             {}
call_function  sub                     prims.sub                   (a_1, broadcast_in_dim_2)         {}
call_function  broadcast_in_dim_3      prims.broadcast_in_dim      (rsqrt, [3, 3], [0, 1])           {}
call_function  mul                     prims.mul                   (sub, broadcast_in_dim_3)         {}
call_function  convert_element_type_2  prims.convert_element_type  (mul, torch.float32)              {}
output         output                  output                      (convert_element_type_2,)         {}
```