### PR TITLE
Raise warning for unpickable local function

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -755,12 +755,10 @@ class TestFunctionalIterDataPipe(TestCase):
             )
             for dps, msg in zip((datapipes_with_lambda_fn, datapipes_with_local_fn), msgs):
                 for dpipe, dp_args, dp_kwargs in dps:
-                    with warnings.catch_warnings(record=True) as wa:
+                    with self.assertWarnsRegex(UserWarning, msg):
                         datapipe = dpipe(input_dp, *dp_args, **dp_kwargs)  # type: ignore[call-arg]
-                        self.assertEqual(len(wa), 1)
-                        self.assertRegex(str(wa[0].message), msg)
-                        with self.assertRaises((pickle.PicklingError, AttributeError)):
-                            p = pickle.dumps(datapipe)
+                    with self.assertRaises((pickle.PicklingError, AttributeError)):
+                        pickle.dumps(datapipe)
 
     def test_iterable_wrapper_datapipe(self):
 
@@ -1743,12 +1741,10 @@ class TestFunctionalMapDataPipe(TestCase):
             )
             for dps, msg in zip((datapipes_with_lambda_fn, datapipes_with_local_fn), msgs):
                 for dpipe, dp_args, dp_kwargs in dps:
-                    with warnings.catch_warnings(record=True) as wa:
+                    with self.assertWarnsRegex(UserWarning, msg):
                         datapipe = dpipe(input_dp, *dp_args, **dp_kwargs)  # type: ignore[call-arg]
-                        self.assertEqual(len(wa), 1)
-                        self.assertRegex(str(wa[0].message), msg)
-                        with self.assertRaises((pickle.PicklingError, AttributeError)):
-                            p = pickle.dumps(datapipe)
+                    with self.assertRaises((pickle.PicklingError, AttributeError)):
+                        pickle.dumps(datapipe)
 
     def test_sequence_wrapper_datapipe(self):
         seq = list(range(10))

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1209,7 +1209,7 @@ class TestFunctionalIterDataPipe(TestCase):
         # Unmatched input columns with fn arguments
         _helper(None, fn_n1, 1, error=ValueError)
         _helper(None, lambda d0, d1: d0 + d1, 0, error=ValueError)
-        _helper(None, p_fn_n1, (0, 1), error=ValueError)
+        _helper(None, p_fn_n1, (0, 1, 3), error=ValueError)
 
         # Function takes fewer parameters than input col
         def zero_args():
@@ -1290,7 +1290,6 @@ class TestFunctionalIterDataPipe(TestCase):
         # Replacing with one input column and default output column
         _helper(lambda data: _dict_update(data, {"y": -data["y"]}), fn_11, "y")
         _helper(lambda data: _dict_update(data, {"y": (-data["y"], data["y"])}), fn_1n, "y")
-
         _helper(lambda data: _dict_update(data, {"z": data["x"] + data["y"]}),
                 lambda x, y: x + y, ("x", "y"), "z")
         _helper(lambda data: _dict_update(data, {"x": 1 + data["y"]}), fn_n1_def, "y",
@@ -1303,7 +1302,7 @@ class TestFunctionalIterDataPipe(TestCase):
         # Unmatched input columns with fn arguments
         _helper(None, fn_n1, "y", error=ValueError)
         _helper(None, lambda x, y: x + y, "x", error=ValueError)
-        _helper(None, p_fn_n1, ("x", "y"), error=ValueError)
+        _helper(None, p_fn_n1, ("x", "y", "z"), error=ValueError)
 
         # Function takes fewer parameters than input col
         def zero_args():

--- a/torch/utils/data/datapipes/iter/callable.py
+++ b/torch/utils/data/datapipes/iter/callable.py
@@ -4,8 +4,9 @@ from torch.utils.data.datapipes._decorator import functional_datapipe
 from torch.utils.data._utils.collate import default_collate
 from torch.utils.data.datapipes.datapipe import IterDataPipe
 from torch.utils.data.datapipes.utils.common import (
-    _check_lambda_fn,
-    validate_input_col)
+    _check_unpickable_fn,
+    validate_input_col
+)
 
 __all__ = [
     "CollatorIterDataPipe",
@@ -66,7 +67,7 @@ class MapperIterDataPipe(IterDataPipe[T_co]):
         super().__init__()
         self.datapipe = datapipe
 
-        _check_lambda_fn(fn)
+        _check_unpickable_fn(fn)
         self.fn = fn  # type: ignore[assignment]
 
         self.input_col = input_col

--- a/torch/utils/data/datapipes/iter/combining.py
+++ b/torch/utils/data/datapipes/iter/combining.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Iterator, List, Optional, Sized, Tuple, TypeVa
 
 from torch.utils.data.datapipes._decorator import functional_datapipe
 from torch.utils.data.datapipes.datapipe import IterDataPipe
-from torch.utils.data.datapipes.utils.common import _check_lambda_fn
+from torch.utils.data.datapipes.utils.common import _check_unpickable_fn
 
 __all__ = [
     "ConcaterIterDataPipe",
@@ -300,7 +300,7 @@ class DemultiplexerIterDataPipe(IterDataPipe):
         if num_instances < 1:
             raise ValueError(f"Expected `num_instaces` larger than 0, but {num_instances} is found")
 
-        _check_lambda_fn(classifier_fn)
+        _check_unpickable_fn(classifier_fn)
 
         # When num_instances == 1, demux can be replaced by filter,
         # but keep it as Demultiplexer for the sake of consistency

--- a/torch/utils/data/datapipes/iter/grouping.py
+++ b/torch/utils/data/datapipes/iter/grouping.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from torch.utils.data.datapipes._decorator import functional_datapipe
 from torch.utils.data.datapipes.datapipe import IterDataPipe, DataChunk
-from torch.utils.data.datapipes.utils.common import _check_lambda_fn
+from torch.utils.data.datapipes.utils.common import _check_unpickable_fn
 from typing import Any, Callable, DefaultDict, Iterator, List, Optional, Sized, TypeVar
 
 __all__ = [
@@ -215,7 +215,7 @@ class GrouperIterDataPipe(IterDataPipe[DataChunk]):
                  group_size: Optional[int] = None,
                  guaranteed_group_size: Optional[int] = None,
                  drop_remaining: bool = False):
-        _check_lambda_fn(group_key_fn)
+        _check_unpickable_fn(group_key_fn)
         self.datapipe = datapipe
         self.group_key_fn = group_key_fn
 

--- a/torch/utils/data/datapipes/iter/selecting.py
+++ b/torch/utils/data/datapipes/iter/selecting.py
@@ -4,9 +4,10 @@ from torch.utils.data.datapipes._decorator import functional_datapipe
 from torch.utils.data.datapipes.datapipe import IterDataPipe
 from torch.utils.data.datapipes.dataframe import dataframe_wrapper as df_wrapper
 from torch.utils.data.datapipes.utils.common import (
-    _check_lambda_fn,
+    _check_unpickable_fn,
     _deprecation_warning,
-    validate_input_col)
+    validate_input_col
+)
 
 __all__ = ["FilterIterDataPipe", ]
 
@@ -51,7 +52,7 @@ class FilterIterDataPipe(IterDataPipe[T_co]):
         super().__init__()
         self.datapipe = datapipe
 
-        _check_lambda_fn(filter_fn)
+        _check_unpickable_fn(filter_fn)
         self.filter_fn = filter_fn  # type: ignore[assignment]
 
         if drop_empty_batches is None:

--- a/torch/utils/data/datapipes/map/callable.py
+++ b/torch/utils/data/datapipes/map/callable.py
@@ -1,4 +1,4 @@
-from torch.utils.data.datapipes.utils.common import _check_lambda_fn
+from torch.utils.data.datapipes.utils.common import _check_unpickable_fn
 from typing import Callable, TypeVar
 from torch.utils.data.datapipes._decorator import functional_datapipe
 from torch.utils.data.datapipes.datapipe import MapDataPipe
@@ -48,7 +48,7 @@ class MapperMapDataPipe(MapDataPipe[T_co]):
     ) -> None:
         super().__init__()
         self.datapipe = datapipe
-        _check_lambda_fn(fn)
+        _check_unpickable_fn(fn)
         self.fn = fn  # type: ignore[assignment]
 
     def __len__(self) -> int:

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -1,8 +1,7 @@
+import fnmatch
 import inspect
 import os
-import fnmatch
 import warnings
-import inspect
 
 from io import IOBase
 from functools import partial

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -40,14 +40,16 @@ def validate_input_col(fn: Callable, input_col: Optional[Union[int, tuple, list]
     if len(sig.parameters) > sz:
         non_default_params = [p for p in sig.parameters.values() if p.default is p.empty]
         if len(non_default_params) > sz:
+            fn_name = fn.__name__ if hasattr(fn, "__name__") else str(fn)
             raise ValueError(
-                f"The function {fn.__name__} takes {len(non_default_params)} "
+                f"The function {fn_name} takes {len(non_default_params)} "
                 f"non-default parameters, but {sz} are required for the given `input_col`."
             )
 
     if len(sig.parameters) < sz:
+        fn_name = fn.__name__ if hasattr(fn, "__name__") else str(fn)
         raise ValueError(
-            f"The function {fn.__name__} takes {len(sig.parameters)} "
+            f"The function {fn_name} takes {len(sig.parameters)} "
             f"parameters, but {sz} are required for the given `input_col`."
         )
 

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import fnmatch
 import warnings
@@ -52,6 +53,10 @@ def validate_input_col(fn: Callable, input_col: Optional[Union[int, tuple, list]
         )
 
 
+def _is_local_fn(fn):
+    return fn.__code__.co_flags & inspect.CO_NESTED
+
+
 def _check_unpickable_fn(fn: Callable):
     if not callable(fn):
         raise TypeError(f"A callable function is expected, but {type(fn)} is provided.")
@@ -62,7 +67,7 @@ def _check_unpickable_fn(fn: Callable):
         fn = fn.func
 
     # Local function
-    if hasattr(fn, "__qualname__") and "<locals>" in fn.__qualname__ and not DILL_AVAILABLE:
+    if _is_local_fn(fn) and not DILL_AVAILABLE:
         warnings.warn(
             "Local function is not supported by pickle, please use "
             "regular python function or functools.partial instead."

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -29,7 +29,7 @@ def validate_input_col(fn: Callable, input_col: Optional[Union[int, tuple, list]
     Returns:
         None.
     Raises:
-        TypeError: If the function is not compatible with the input column.
+        ValueError: If the function is not compatible with the input column.
     """
     sig = inspect.signature(fn)
     if isinstance(input_col, (list, tuple)):
@@ -59,6 +59,10 @@ def _is_local_fn(fn):
 
 
 def _check_unpickable_fn(fn: Callable):
+    """
+    Checks function is pickable or not. If it is a lambda or local function, a UserWarning
+    will be raised. If it's not a callable function, a TypeError will be raised.
+    """
     if not callable(fn):
         raise TypeError(f"A callable function is expected, but {type(fn)} is provided.")
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/data/issues/538

- Improve the validation function to raise warning about unpickable function when either lambda or local function is provided to `DataPipe`.
- The inner function from `functools.partial` object is extracted as well for validation
- Mimic the behavior of `pickle` module for local lambda function: It would only raise Error for the local function rather than `lambda` function. So, we will raise warning about local function not lambda function.
```py
>>> import pickle
>>> def fn():
...     lf = lambda x: x
...     pickle.dumps(lf)
>>> pickle.dumps(fn)
AttributeError: Can't pickle local object 'fn.<locals>.<lambda>'
```