### PR TITLE
[ci] add rocm build to pull

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -92,7 +92,6 @@ jobs:
           { config: "default", shard: 5, num_shards: 5, runner: "linux.2xlarge" },
         ]}
 
-
   linux-focal-py3_7-clang10-onnx-build:
     name: linux-focal-py3.7-clang10-onnx
     uses: ./.github/workflows/_linux-build.yml
@@ -307,3 +306,13 @@ jobs:
         { include: [
           { config: "deploy", shard: 1, num_shards: 1, runner: "linux.4xlarge.nvidia.gpu" },
         ]}
+
+  # please ensure that this and its corresponding job in trunk.yml are in sync
+  linux-bionic-rocm5_1-py3_7-build:
+    # don't run build twice on master
+    if: github.event_name == 'pull_request'
+    name: linux-bionic-rocm5.1-py3.7
+    uses: ./.github/workflows/_linux-build.yml
+    with:
+      build-environment: linux-bionic-rocm5.1-py3.7
+      docker-image-name: pytorch-linux-bionic-rocm5.1-py3.7

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -234,6 +234,7 @@ jobs:
           { config: "force_on_cpu", shard: 1, num_shards: 1, runner: "windows.4xlarge" },
         ]}
 
+  # please ensure that this and its corresponding job in pull.yml are in sync
   linux-bionic-rocm5_1-py3_7-build:
     name: linux-bionic-rocm5.1-py3.7
     uses: ./.github/workflows/_linux-build.yml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #80149

these don't use the AMD runners so we can have as many as we want
without affecting queue times. Would be good to get early signal on rocm
build failures.