### PR TITLE
[Static Runtime] Support Futures in Static Runtime Engine

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -842,6 +842,7 @@ BlockRunner::BlockRunner(
     const StaticModule& sm,
     IValue* values,
     Block* block,
+    torch::jit::TaskLauncher* launcher,
     bool is_root_block)
     : static_module_(sm),
       block_info_(static_module_.block_info(block)),
@@ -864,11 +865,9 @@ BlockRunner::BlockRunner(
 
   for (auto& pnode : nodes_) {
     auto* node = pnode.node();
-    // attaching default interop threadpool executor to fork nodes
-    if (node->kind() == prim::fork) {
-      TaskLauncher launcher_ = at::launch;
-      pnode.set_meta_data(std::move(launcher_));
-    }
+
+    // attach the async taskLauncher to processedNodes
+    pnode.set_metadata(launcher);
     auto blocks = node->blocks();
     const auto num_blocks = blocks.size();
     if (num_blocks == 0) {
@@ -879,9 +878,9 @@ BlockRunner::BlockRunner(
     block_runners.reserve(num_blocks);
 
     for (auto* b : blocks) {
-      block_runners.emplace_back(sm, values_, b);
+      block_runners.emplace_back(sm, values_, b, launcher);
     }
-    pnode.set_meta_data(std::move(block_runners));
+    pnode.set_metadata(std::move(block_runners));
   }
 }
 
@@ -1249,6 +1248,52 @@ c10::IValue BlockRunner::run_impl_record_functions(
   return run_impl(std::forward<IValueList>(args), kwargs);
 }
 
+template <typename IValueList>
+c10::intrusive_ptr<c10::ivalue::Future> BlockRunner::run_impl_async(
+    IValueList&& args,
+    const KeywordArgs& kwargs) {
+  // run the graph inline in the caller thread. Async ops will be
+  // executed on taskLauncher attached to the metadata of ProcessedNodes
+  c10::IValue output = run_impl(args, kwargs);
+
+  // If the output is of type future, return it
+  if (output.isFuture()) {
+    return output.toFuture();
+  }
+
+  // wrap the output into future, mark completed and return it
+  TypePtr return_type;
+  if (block_info_.num_outputs() > 1) {
+    return_type = TupleType::create(
+        fmap(outputs(), [](const IValue* v) { return v->type(); }));
+  } else {
+    return_type = outputs().at(0)->type();
+  }
+  c10::intrusive_ptr<Future> future = c10::make_intrusive<Future>(return_type);
+  future->markCompleted(output);
+  return future;
+}
+
+template <typename IValueList>
+c10::intrusive_ptr<c10::ivalue::Future> BlockRunner::
+    run_impl_record_functions_async(
+        IValueList&& args,
+        const KeywordArgs& kwargs) {
+  auto step_callbacks =
+      at::getStepCallbacksUnlessEmpty(at::RecordScope::STATIC_RUNTIME_MODEL);
+  if (C10_UNLIKELY(step_callbacks.has_value())) {
+    at::RecordFunction guard(std::move(*step_callbacks));
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(guard.isActive());
+    guard.needsInputs()
+        ? guard.before(
+              "forward", c10::ArrayRef<const IValue>(args.data(), args.size()))
+        : guard.before("forward");
+
+    return run_impl_async(std::forward<IValueList>(args), kwargs);
+  }
+  return run_impl_async(std::forward<IValueList>(args), kwargs);
+}
+
 c10::IValue BlockRunner::operator()(
     const std::vector<c10::IValue>& args,
     const KeywordArgs& kwargs) {
@@ -1266,6 +1311,26 @@ c10::IValue BlockRunner::operator()(
   return run_impl(std::move(args), kwargs);
 #else
   return run_impl_record_functions(std::move(args), kwargs);
+#endif
+}
+
+c10::intrusive_ptr<c10::ivalue::Future> BlockRunner::runAsync(
+    const std::vector<c10::IValue>& args,
+    const KeywordArgs& kwargs) {
+#ifdef PYTORCH_DISABLE_NET_PROFILING
+  return run_impl_async(args, kwargs);
+#else
+  return run_impl_record_functions_async(args, kwargs);
+#endif
+}
+
+c10::intrusive_ptr<c10::ivalue::Future> BlockRunner::runAsync(
+    std::vector<c10::IValue>&& args,
+    const KeywordArgs& kwargs) {
+#ifdef PYTORCH_DISABLE_NET_PROFILING
+  return run_impl_async(std::move(args), kwargs);
+#else
+  return run_impl_record_functions_async(std::move(args), kwargs);
 #endif
 }
 
@@ -1725,9 +1790,9 @@ bool BlockRunner::check_for_memory_leak(
         }
       }
     }
-    auto* meta_data = pnode.meta_data();
-    if (recurse_on_sub_blocks && meta_data) {
-      auto& block_runners = meta_data->block_runners();
+    auto* metadata = pnode.metadata();
+    if (recurse_on_sub_blocks && metadata) {
+      auto& block_runners = metadata->block_runners();
       for (auto& block_runner : block_runners) {
         block_runner.check_for_memory_leak(
             output_returned, recurse_on_sub_blocks);
@@ -2058,9 +2123,14 @@ void ProcessedNode::verify_and_correct_memory_overlap() {
 StaticRuntime::StaticRuntime(const StaticModule& sm)
     : values_(sm.value_buffer_size()) {
   std::copy(sm.constants().begin(), sm.constants().end(), values_.data());
+  // default task launcher set to inter-op thread pool
+  async_task_launcher_ = at::launch;
   block_ = std::make_unique<BlockRunner>(
-      sm, values_.data(), sm.root_block(), /*is_root_block*/ true);
-  ;
+      sm,
+      values_.data(),
+      sm.root_block(),
+      &async_task_launcher_,
+      true /*is_root_block*/);
 }
 
 c10::IValue StaticRuntime::operator()(
@@ -2073,6 +2143,22 @@ c10::IValue StaticRuntime::operator()(
     std::vector<c10::IValue>&& args,
     const KeywordArgs& kwargs) {
   return (*block_)(std::move(args), kwargs);
+}
+
+c10::intrusive_ptr<c10::ivalue::Future> StaticRuntime::runAsync(
+    const std::vector<c10::IValue>& args,
+    const KeywordArgs& kwargs,
+    torch::jit::TaskLauncher taskLauncher) {
+  async_task_launcher_ = std::move(taskLauncher);
+  return block_->runAsync(args, kwargs);
+}
+
+c10::intrusive_ptr<c10::ivalue::Future> StaticRuntime::runAsync(
+    std::vector<c10::IValue>&& args,
+    const KeywordArgs& kwargs,
+    torch::jit::TaskLauncher taskLauncher) {
+  async_task_launcher_ = std::move(taskLauncher);
+  return block_->runAsync(std::move(args), kwargs);
 }
 
 bool StaticRuntime::check_for_memory_leak(bool output_returned) {

--- a/torch/csrc/jit/runtime/static/native_ops.cpp
+++ b/torch/csrc/jit/runtime/static/native_ops.cpp
@@ -883,9 +883,9 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         case BlockRunPlan::kRunBothBlocks:
           return [](ProcessedNode* p_node) {
             auto condition = p_node->Input(0).toBool();
-            auto* meta_data = p_node->meta_data();
-            DCHECK(meta_data);
-            auto& block_runners = meta_data->block_runners();
+            auto* metadata = p_node->metadata();
+            DCHECK(metadata);
+            auto& block_runners = metadata->block_runners();
             DCHECK_EQ(block_runners.size(), 2);
             auto& runner = block_runners[!condition];
 
@@ -903,9 +903,9 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         case BlockRunPlan::kRunOnlyTrueBlock:
           return [](ProcessedNode* p_node) {
             auto condition = p_node->Input(0).toBool();
-            auto* meta_data = p_node->meta_data();
-            DCHECK(meta_data);
-            auto& block_runners = meta_data->block_runners();
+            auto* metadata = p_node->metadata();
+            DCHECK(metadata);
+            auto& block_runners = metadata->block_runners();
             DCHECK_EQ(block_runners.size(), 2);
             if (condition) {
               auto output = block_runners.front()({});
@@ -915,9 +915,9 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         case BlockRunPlan::kRunOnlyFalseBlock:
           return [](ProcessedNode* p_node) {
             auto condition = p_node->Input(0).toBool();
-            auto* meta_data = p_node->meta_data();
-            DCHECK(meta_data);
-            auto& block_runners = meta_data->block_runners();
+            auto* metadata = p_node->metadata();
+            DCHECK(metadata);
+            auto& block_runners = metadata->block_runners();
             DCHECK_EQ(block_runners.size(), 2);
             if (!condition) {
               auto output = block_runners.back()({});
@@ -1041,9 +1041,11 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         p_node->Output(0) = future;
 
         ForkedSubgraphSRLauncher runtime_launcher(smodule, args, future);
-        auto* meta_data = p_node->meta_data();
-        DCHECK(meta_data);
-        (meta_data->launcher())(std::move(runtime_launcher));
+        auto* metadata = p_node->metadata();
+        DCHECK(metadata);
+        auto* launcher = metadata->launcher();
+        DCHECK(launcher);
+        (*launcher)(std::move(runtime_launcher));
       };
     });
 /*
@@ -1086,9 +1088,9 @@ REGISTER_NATIVE_OPERATOR_FUNCTOR(
         const auto max_trip_count = p_node->Input(0).toInt();
         auto condition = p_node->Input(1).toBool();
 
-        auto* meta_data = p_node->meta_data();
-        DCHECK(meta_data);
-        auto& block_runners = meta_data->block_runners();
+        auto* metadata = p_node->metadata();
+        DCHECK(metadata);
+        auto& block_runners = metadata->block_runners();
         DCHECK_EQ(block_runners.size(), 1);
         auto& runner = block_runners[0];
 


### PR DESCRIPTION
Summary: - Static Runtime now exports runAsync() API which returns an intrusive_ptr to c10:Future type

Differential Revision: D37385849

