### PR TITLE
[torch.fx] Check node type before fetching .users

### DIFF
--- a/torch/ao/quantization/fx/match_utils.py
+++ b/torch/ao/quantization/fx/match_utils.py
@@ -52,7 +52,7 @@ def is_match(modules, node, pattern, max_uses=sys.maxsize):
     if isinstance(self_match, type) and issubclass(self_match, MatchAllNode):
         return True
 
-    if len(node.users) > max_uses:
+    if not isinstance(node, Node) or len(node.users) > max_uses:
         return False
 
     if isinstance(self_match, type) and issubclass(self_match, torch.nn.Module):


### PR DESCRIPTION
Summary:
as title
currently it fails when `node` is actually a constant instead of `fx.Node`

Test Plan: existing unit tests

Differential Revision: D37389003

