### PR TITLE
[primTorch] Elementary sinc,sgn

### DIFF
--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -48,7 +48,6 @@ __all__ = [
     "asinh",
     "atan",
     "atanh",
-    "copysign",
     "cos",
     "cosh",
     "bessel_i0",
@@ -549,13 +548,6 @@ atanh = _make_elementwise_unary_prim(
     "atanh",
     impl_aten=torch.atanh,
     impl_nvfuser=_atanh_nvfuser,  # type: ignore[name-defined]
-    doc="",
-    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
-)
-
-copysign = _make_elementwise_unary_prim(
-    "copysign",
-    impl_aten=torch.copysign,
     doc="",
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "asinh",
     "atan",
     "atanh",
+    "copysign",
     "cos",
     "cosh",
     "bessel_i0",
@@ -79,8 +80,10 @@ __all__ = [
     "sign",
     "signbit",
     "sin",
+    "sinc",
     "sinh",
     "sqrt",
+    "sng",
     "tan",
     "tanh",
     "trunc",
@@ -550,6 +553,13 @@ atanh = _make_elementwise_unary_prim(
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
+copysign = _make_elementwise_unary_prim(
+    "copysign",
+    impl_aten=torch.copysign,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
 cos = _make_elementwise_unary_prim(
     "cos",
     impl_aten=torch.cos,
@@ -786,6 +796,13 @@ round = _make_elementwise_unary_prim(
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
+sgn = _make_elementwise_unary_prim(
+    "sgn",
+    impl_aten=torch.sgn,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
 rsqrt = _make_elementwise_unary_prim(
     "rsqrt",
     impl_aten=torch.rsqrt,
@@ -816,6 +833,13 @@ sin = _make_elementwise_unary_prim(
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )
 
+sinc = _make_elementwise_unary_prim(
+    "sinc",
+    impl_aten=torch.sinc,
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
 sinh = _make_elementwise_unary_prim(
     "sinh",
     impl_aten=torch.sinh,
@@ -828,6 +852,13 @@ sqrt = _make_elementwise_unary_prim(
     "sqrt",
     impl_aten=torch.sqrt,
     impl_nvfuser=_sqrt_nvfuser,  # type: ignore[name-defined]
+    doc="",
+    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
+)
+
+sgn = _make_elementwise_unary_prim(
+    "sgn",
+    impl_aten=torch.sgn,
     doc="",
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )

--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -77,13 +77,13 @@ __all__ = [
     "neg",
     "reciprocal",
     "round",
+    "sgn",
     "sign",
     "signbit",
     "sin",
     "sinc",
     "sinh",
     "sqrt",
-    "sng",
     "tan",
     "tanh",
     "trunc",
@@ -852,13 +852,6 @@ sqrt = _make_elementwise_unary_prim(
     "sqrt",
     impl_aten=torch.sqrt,
     impl_nvfuser=_sqrt_nvfuser,  # type: ignore[name-defined]
-    doc="",
-    type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
-)
-
-sgn = _make_elementwise_unary_prim(
-    "sgn",
-    impl_aten=torch.sgn,
     doc="",
     type_promotion=ELEMENTWISE_PRIM_TYPE_PROMOTION_KIND.DEFAULT,
 )

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -667,9 +667,19 @@ def signbit(a):
     return prims.signbit(a)
 
 
+@_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT)
+def sgn(a):
+    return prims.sgn(a)
+
+
 @_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)
 def sin(a):
     return prims.sin(a)
+
+
+@_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)
+def sinc(a):
+    return prims.sinc(a)
 
 
 @_make_elementwise_unary_reference(ELEMENTWISE_TYPE_PROMOTION_KIND.INT_TO_FLOAT)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -20300,6 +20300,11 @@ python_ref_db = [
         handles_large_floats=False,
     ),
     ElementwiseUnaryPythonRefInfo(
+        "_refs.sgn",
+        torch_opinfo_name="sgn",
+        supports_nvfuser=False,
+    ),
+    ElementwiseUnaryPythonRefInfo(
         "_refs.sign",
         torch_opinfo_name="sign",
         supports_nvfuser=False,
@@ -20312,6 +20317,11 @@ python_ref_db = [
     ElementwiseUnaryPythonRefInfo(
         "_refs.sin",
         torch_opinfo_name="sin",
+    ),
+    ElementwiseUnaryPythonRefInfo(
+        "_refs.sinc",
+        torch_opinfo_name="sinc",
+        supports_nvfuser=False,
     ),
     ElementwiseUnaryPythonRefInfo(
         "_refs.sinh",


### PR DESCRIPTION
Adds `prims` and `refs` for basic elementary unary operations, namely:

- `sinc`
- `sgn`