### PR TITLE
[MPS] Add equal operator

### DIFF
--- a/aten/src/ATen/native/mps/operations/Equal.cpp
+++ b/aten/src/ATen/native/mps/operations/Equal.cpp
@@ -1,0 +1,37 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/core/Tensor.h>
+#include <ATen/NamedTensorUtils.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/NativeFunctions.h>
+#include <ATen/MPSFunctions.h>
+#else
+#include <ATen/ops/eq_mps_dispatch.h>
+#include <ATen/ops/equal_native.h>
+#endif
+
+namespace at {
+namespace mps {
+TORCH_API at::Tensor eq(const at::Tensor & self, const at::Tensor & other);
+} // namespace
+namespace native {
+
+bool mps_equal(const Tensor& self, const Tensor &src) {
+  if (!at::namedinference::are_names_equal(
+          self.unsafeGetTensorImpl(), src.unsafeGetTensorImpl())) {
+    return false;
+  }
+  at::NoNamesGuard guard;
+  TORCH_CHECK(self.device() == src.device(), "Cannot compare two tensors on "
+              "different devices. Got: ", self.device(), " and ", src.device());
+  if (self.sizes() != src.sizes()) {
+    return false;
+  }
+  if (self.numel() == 0) {
+    return true;
+  }
+  return at::mps::eq(self, src).all().item().to<bool>();
+}
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8297,6 +8297,7 @@
   dispatch:
     CPU: cpu_equal
     CUDA: cuda_equal
+    MPS: mps_equal
     QuantizedCPU: equal_quantized_cpu
 
 - func: pow.Tensor_Tensor_out(Tensor self, Tensor exponent, *, Tensor(a!) out) -> Tensor(a!)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -4296,7 +4296,7 @@ class TestNLLLoss(TestCase):
         # see https://github.com/pytorch/pytorch/issues/79835#issuecomment-1164984534
         x = torch.ones(4, dtype=torch.int32, device='mps')
         self.assertEqual(x + 1, torch.full((4,), 2, dtype=torch.int32, device='mps'))
-        self.assertEqual(x + 1.5, torch.full((4,), 2.5, device='mps'))
+        self.assertTrue(torch.equal(x + 1.5, torch.full((4,), 2.5, device='mps')))
 
     def test_types_binary_op(self):
         # Float * Bool

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2525,6 +2525,9 @@ def main() -> None:
         DispatchKey.CompositeExplicitAutogradNonFunctional,
         DispatchKey.Meta,
     }
+    if options.mps:
+        functions_keys.add(DispatchKey.MPS)
+
     if options.backend_whitelist:
         dispatch_keys = [
             k


### PR DESCRIPTION
Which is, in essence is composite of `eq`->`all`->`item` 
`native/mps/operators/Equal.cpp` is an almost verbatim copy of `native/cuda/Equal.cpp`

Fix codegen by generating MPSFunctions headers

