### PR TITLE
Attach sequence number in log output / collective mismatch error

### DIFF
--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -33,6 +33,14 @@ class AbstractProcessGroupWrapperTest(MultiProcessTestCase):
 
     def _validate_error(self, exception, op_type, rank, tensor):
         err = str(exception)
+        # Test if sequence number is attached
+        seq_num_msg = "The sequence number is: "
+        seq_num_msg_index = err.find(seq_num_msg)
+        seq_num_msg_len = len(seq_num_msg)
+        self.assertTrue(seq_num_msg_index != -1, "Sequence number is missing.")
+        if seq_num_msg_index != -1:
+            self.assertTrue(err[seq_num_msg_index + seq_num_msg_len].isdigit(), "Sequence number is invalid.")
+
         self.assertTrue(
             op_type in err, f"Got {err} but expected {op_type} to be in error."
         )

--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -38,8 +38,7 @@ class AbstractProcessGroupWrapperTest(MultiProcessTestCase):
         seq_num_msg_index = err.find(seq_num_msg)
         seq_num_msg_len = len(seq_num_msg)
         self.assertTrue(seq_num_msg_index != -1, "Sequence number is missing.")
-        if seq_num_msg_index != -1:
-            self.assertTrue(err[seq_num_msg_index + seq_num_msg_len].isdigit(), "Sequence number is invalid.")
+        self.assertTrue(err[seq_num_msg_index + seq_num_msg_len].isdigit(), "Sequence number is invalid.")
 
         self.assertTrue(
             op_type in err, f"Got {err} but expected {op_type} to be in error."

--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -37,7 +37,7 @@ class AbstractProcessGroupWrapperTest(MultiProcessTestCase):
         seq_num_msg = "The sequence number is: "
         seq_num_msg_index = err.find(seq_num_msg)
         seq_num_msg_len = len(seq_num_msg)
-        self.assertTrue(seq_num_msg_index != -1, "Sequence number is missing.")
+        self.assertNotEqual(seq_num_msg_index, -1, "Sequence number is missing.")
         self.assertTrue(err[seq_num_msg_index + seq_num_msg_len].isdigit(), "Sequence number is invalid.")
 
         self.assertTrue(

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -163,6 +163,12 @@ struct CollectiveFingerPrint {
              << pg->getRank() << " is running collective: " << *this
              << ", but Rank " << rank
              << " is running collective: " << rank_fingerprint << ".";
+          // Attach sequence number in log output / collective mismatch error
+          try {
+            int SequenceNumberForGroup = pg->getSequenceNumberForGroup();
+            ss << " The sequence number is: " << SequenceNumberForGroup;
+          } catch (c10::Error) {
+          }
           TORCH_CHECK(false, ss.str());
         }
       }


### PR DESCRIPTION
Fixes 1. in #72435 by attaching sequence number in log output / collective mismatch error. 

Now the log output should look like:
"
Detected mismatch between collectives on ranks. Rank 1 is running inconsistent collective: CollectiveFingerPrint(OpType=ALLREDUCE, TensorShape=[20, 10], TensorDtypes=Float, TensorDeviceTypes=TensorOptions(dtype=float (default), device=cpu, layout=Strided (default), requires_grad=false (default), pinned_memory=false (default), memory_format=(nullopt)). The sequence number is: 0
"

If the sequence number is not supported, it will attach:
"
ProcessGroup <backend_name> does not yet support sequence numbers
"


To run test:
python test/distributed/test_pg_wrapper.py
