### PR TITLE
[Vulkan] Implement Layernorm operator

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/layernorm.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/layernorm.glsl
@@ -1,0 +1,151 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2)         uniform PRECISION                    sampler3D uGamma;
+layout(set = 0, binding = 3)         uniform PRECISION                    sampler3D uBeta;
+layout(set = 0, binding = 4)         uniform PRECISION restrict           Block {
+  ivec3 isize;
+  int volume;
+  int offset;
+  float eps;
+} uBlock;
+
+shared float sh_mem[64];
+shared float mean;
+shared float rstd;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+// This is the simple two-pass algorithm to compute variance.
+// This implementation is not efficient when calculating mean and
+// variance since every work group will compute the mean and variance
+// for the entire tensor.
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  const ivec3 tid = ivec3(gl_LocalInvocationID);
+  const ivec3 group_size = ivec3(gl_WorkGroupSize);
+
+  // Start computing mean.
+  // Divide work among the 64 invocations in the work group
+  // and compute partial sums of texels that are "fully filled"
+  vec4 sum4d = vec4(0);
+  for (int z = tid.z; z < uBlock.isize.z - 1; z+=group_size.z) {
+    for (int y = tid.y; y < uBlock.isize.y; y+=group_size.y) {
+      for (int x = tid.x; x < uBlock.isize.x; x+=group_size.x) {
+        sum4d += texelFetch(uInput, ivec3(x, y, z), 0);
+      }
+    }
+  }
+  float sum = sum4d.x + sum4d.y + sum4d.w + sum4d.z;
+
+  // Still computing the mean, processing the last texel across the channel-batch dimension
+  if ((uBlock.isize.z - 1) % group_size.z == tid.z) {
+    for (int y = tid.y; y < uBlock.isize.y; y+=group_size.y) {
+      for (int x = tid.x; x < uBlock.isize.x; x+=group_size.x) {
+        const vec4 last_texel = texelFetch(uInput, ivec3(x, y, uBlock.isize.z - 1), 0);
+        sum += (
+          last_texel.x +
+          (uBlock.offset >= 1 ? last_texel.y : 0) +
+          (uBlock.offset >= 2 ? last_texel.z : 0) +
+          (uBlock.offset == 3 ? last_texel.w : 0)
+        );
+      }
+    }
+  }
+
+  // Shared memory (among threads in a work group) that holds partial sums
+  sh_mem[gl_LocalInvocationIndex] = sum;
+
+  memoryBarrierShared();
+  barrier();
+
+  // Only instance (0, 0, 0) will compute the sum of the 64 partial sums,
+  // and then compute the mean, dividing the total by the tensor's volume
+  if (tid == ivec3(0)) {
+    float total = 0;
+    for (int z = 0; z < group_size.z; ++z) {
+      for (int y = 0; y < group_size.y; ++y) {
+        for (int x = 0; x < group_size.x; ++x) {
+          total += sh_mem[z * group_size.y * group_size.x + y * group_size.x + x];
+        }
+      }
+    }
+    mean = total / uBlock.volume;
+  }
+
+  memoryBarrierShared();
+  barrier();
+
+  // Start computing variance (using the previously computed mean)
+  // Divide work among the 64 invocations in the work group
+  // and compute partial sums of texels that are "fully filled"
+  vec4 sqsum4d = vec4(0);
+  for (int z = tid.z; z < uBlock.isize.z - 1; z+=group_size.z) {
+    for (int y = tid.y; y < uBlock.isize.y; y+=group_size.y) {
+      for (int x = tid.x; x < uBlock.isize.x; x+=group_size.x) {
+        const vec4 val = texelFetch(uInput, ivec3(x, y, z), 0);
+        sqsum4d += (val - mean) * (val - mean);
+      }
+    }
+  }
+  float sqsum = sqsum4d.x + sqsum4d.y + sqsum4d.w + sqsum4d.z;
+
+  // Still computing the variance, processing the last texel across the channel-batch dimension
+  if ((uBlock.isize.z - 1) % group_size.z == tid.z) {
+    for (int y = tid.y; y < uBlock.isize.y; y+=group_size.y) {
+      for (int x = tid.x; x < uBlock.isize.x; x+=group_size.x) {
+        const vec4 last_texel = texelFetch(uInput, ivec3(x, y, uBlock.isize.z - 1), 0);
+        sqsum += (
+          (last_texel.x - mean) * (last_texel.x - mean) +
+          (uBlock.offset >= 1 ? (last_texel.y - mean) * (last_texel.y - mean) : 0) +
+          (uBlock.offset >= 2 ? (last_texel.z - mean) * (last_texel.z - mean) : 0) +
+          (uBlock.offset == 3 ? (last_texel.w - mean) * (last_texel.w - mean) : 0)
+        );
+      }
+    }
+  }
+
+  // Reuse shared memory to hold partial squared sums
+  sh_mem[gl_LocalInvocationIndex] = sqsum;
+
+  memoryBarrierShared();
+  barrier();
+
+  // Only instance (0, 0, 0) will compute the sum of the 64 partial sums,
+  // and then compute the squared root of the biased variance, with eps added
+  // to the denominator for numerical stabilty.
+  if (tid == ivec3(0)) {
+    float total2 = 0;
+    for (int z = 0; z < group_size.z; ++z) {
+      for (int y = 0; y < group_size.y; ++y) {
+        for (int x = 0; x < group_size.x; ++x) {
+          total2 += sh_mem[z * group_size.y * group_size.x + y * group_size.x + x];
+        }
+      }
+    }
+    rstd = sqrt(total2 / uBlock.volume + uBlock.eps);
+  }
+
+  memoryBarrierShared();
+  barrier();
+
+  // Compute layernorm using previously computed mean and rstd
+  if (all(lessThan(pos, uBlock.isize.xyz))) {
+    imageStore(
+        uOutput,
+        pos,
+        (texelFetch(uInput, pos, 0)
+            - mean)
+            / rstd
+            * texelFetch(uGamma, pos, 0)
+            + texelFetch(uBeta, pos, 0));
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Layernorm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Layernorm.cpp
@@ -1,0 +1,168 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+void _check_layer_norm_inputs(
+    const at::Tensor& input,
+    IntArrayRef normalized_shape,
+    const c10::optional<Tensor>& weight /* optional */,
+    const c10::optional<Tensor>& bias /* optional */) {
+
+  const auto normalized_ndim = normalized_shape.size();
+  TORCH_CHECK(
+      normalized_ndim >= 1,
+      "Expected normalized_shape to be at least 1-dimensional, i.e., ",
+      "containing at least one element, but got normalized_shape = ",
+      normalized_shape);
+  TORCH_CHECK(
+      !weight->defined() || weight->sizes().equals(normalized_shape),
+      "Expected weight to be of same shape as normalized_shape, but got ",
+      "weight of shape ",
+      weight->sizes(),
+      " and normalized_shape = ",
+      normalized_shape);
+  TORCH_CHECK(
+      !bias->defined() || bias->sizes().equals(normalized_shape),
+      "Expected bias to be of same shape as normalized_shape, but got ",
+      "bias of shape ",
+      bias->sizes(),
+      " and normalized_shape = ",
+      normalized_shape);
+
+  const auto input_shape = input.sizes();
+  const auto input_ndim = input.sizes().size();
+
+  if (input_ndim < normalized_ndim ||
+      !input_shape.slice(input_ndim - normalized_ndim)
+           .equals(normalized_shape)) {
+    std::stringstream ss;
+    ss << "Given normalized_shape=" << normalized_shape
+       << ", expected input with shape [*";
+    for (auto size : normalized_shape) {
+      ss << ", " << size;
+    }
+    ss << "], but got input of size" << input_shape;
+    AT_ERROR(ss.str());
+  }
+}
+
+Tensor layer_norm(
+    const at::Tensor& input_arg,
+    IntArrayRef normalized_shape,
+    const c10::optional<Tensor>& weight_opt /* optional */,
+    const c10::optional<Tensor>& bias_opt /* optional */,
+    double eps,
+    bool /* cudnn_enable, deprecated */) {
+
+  _check_layer_norm_inputs(input_arg, normalized_shape, weight_opt, bias_opt);
+
+  TORCH_CHECK(
+      input_arg.dim() == 3 || input_arg.dim() == 4,
+      "Vulkan layernorm expects 3-dim or 4-dim input!");
+
+  const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
+  const vTensor& v_input = convert(input);
+  const IntArrayRef v_input_sizes = v_input.sizes();
+
+  TORCH_CHECK(
+      input_arg.dim() == 3 || v_input_sizes[Layout::Activation4D::batch] == 1,
+      "Vulkan layernorm expects batch dim == 1 when the input is 4-dimensional!");
+
+  TORCH_CHECK(
+      normalized_shape.size() == 3,
+      "Vulkan layernorm expects normalized_shape to have length 3, i.e. [C, H, W]");
+
+  TORCH_CHECK(
+      weight_opt->defined() && bias_opt->defined(),
+      "Vulkan layernorm expects weight and bias arguments");
+
+  const auto volume = c10::multiply_integers(v_input_sizes.cbegin(), v_input_sizes.end());
+
+  const Tensor weight = weight_opt->is_vulkan() ? *weight_opt : weight_opt->vulkan();
+  const vTensor& v_weight = convert(weight);
+
+  const Tensor bias = bias_opt->is_vulkan() ? *bias_opt : bias_opt->vulkan();
+  const vTensor& v_bias = convert(bias);
+
+  api::Context* const context = api::context();
+
+  vTensor v_output{
+    context,
+    v_input_sizes,
+    v_input.options(),
+  };
+
+  const struct Block final {
+    uvec3 iextents;
+    int32_t volume;
+    int32_t last_texel_end_offset;
+    float epsilon;
+  } block {
+    v_input.extents(),
+    safe_downcast<int32_t>(volume),
+    safe_downcast<int32_t>((v_input_sizes[input_arg.dim() - 3] - 1) % 4),
+    safe_downcast<float>(eps)
+  };
+
+  api::UniformParamsBuffer params(context, block);
+  api::PipelineBarrier pipeline_barrier{};
+
+  context->submit_compute_job(
+      // shader layout signature
+      {
+        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+      },
+      // shader descriptor
+      VK_KERNEL(layernorm),
+      // pipeline barrier
+      pipeline_barrier,
+      // global work group size
+      v_input.extents(),
+      // local work group size
+      adaptive_work_group_size(v_input.extents()),
+      // fence handle
+      VK_NULL_HANDLE,
+      // shader arguments
+      v_output.image(
+          pipeline_barrier,
+          api::PipelineStage::Compute,
+          api::MemoryAccessType::WRITE),
+      v_input.image(
+          pipeline_barrier,
+          api::PipelineStage::Compute),
+      v_weight.image(
+          pipeline_barrier,
+          api::PipelineStage::Compute),
+      v_bias.image(
+          pipeline_barrier,
+          api::PipelineStage::Compute),
+      // params buffer
+      params.buffer());
+
+  return convert(v_output);
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::layer_norm"), TORCH_FN(layer_norm));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -1125,6 +1125,253 @@ TEST_F(VulkanAPITest, hardshrink_) {
   }
 }
 
+TEST_F(VulkanAPITest, layer_norm_invalid_inputs) {
+  c10::InferenceMode mode;
+
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Act: incorrect normalized shape
+  EXPECT_THROW({
+    at::layer_norm(
+      at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      {8, 5},
+      at::rand({8, 5}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      at::rand({8, 5}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      1e-05,
+      false);
+  }, ::c10::Error);
+
+  // Act: normalized shape must be [C, H, W]
+  EXPECT_THROW({
+    at::layer_norm(
+      at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      {5, 7},
+      at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      1e-05,
+      false);
+  }, ::c10::Error);
+
+  // Act: incorrect weight dimensions
+  EXPECT_THROW({
+    at::layer_norm(
+      at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      {3, 5, 7},
+      at::rand({3, 5}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      1e-05,
+      false);
+  }, ::c10::Error);
+
+  // Act: incorrect bias dimensions
+  EXPECT_THROW({
+    at::layer_norm(
+      at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      {3, 5, 7},
+      at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      1e-05,
+      false);
+  }, ::c10::Error);
+
+  // Act: batch dim must be 1
+  EXPECT_THROW({
+    at::layer_norm(
+      at::rand({2, 3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      {3, 5, 7},
+      at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      1e-05,
+      false);
+  }, ::c10::Error);
+
+  // Act: input has too many dimensions
+  EXPECT_THROW({
+    at::layer_norm(
+      at::rand({1, 2, 3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      {3, 5, 7},
+      at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      1e-05,
+      false);
+  }, ::c10::Error);
+
+  // Act: input has too few dimensions
+  EXPECT_THROW({
+    at::layer_norm(
+      at::rand({3, 5}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      {3, 5},
+      at::rand({3, 5}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      at::rand({3, 5}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+      1e-05,
+      false);
+  }, ::c10::Error);
+}
+
+TEST_F(VulkanAPITest, layer_norm_3d_small) {
+  c10::InferenceMode mode;
+
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto input_cpu = at::rand({1, 1, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto input_vulkan = input_cpu.vulkan();
+
+  const auto weight_cpu = at::rand({1, 1, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto weight_vulkan = weight_cpu.vulkan();
+
+  const auto bias_cpu = at::rand({1, 1, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto bias_vulkan = bias_cpu.vulkan();
+
+  const auto output_cpu = at::layer_norm(input_cpu, {1, 1, 1}, weight_cpu, bias_cpu, 1e-05, false);
+  const auto output_vulkan = at::layer_norm(input_vulkan, {1, 1, 1}, weight_vulkan, bias_vulkan, 1e-05, false);
+
+  const auto check = almostEqual(output_cpu, output_vulkan.cpu());
+  if (!check) {
+    showRtol(output_cpu, output_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, layer_norm_3d_medium) {
+  c10::InferenceMode mode;
+
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto input_cpu = at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto input_vulkan = input_cpu.vulkan();
+
+  const auto weight_cpu = at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto weight_vulkan = weight_cpu.vulkan();
+
+  const auto bias_cpu = at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto bias_vulkan = bias_cpu.vulkan();
+
+  const auto output_cpu = at::layer_norm(input_cpu, {3, 5, 7}, weight_cpu, bias_cpu, 1e-05, false);
+  const auto output_vulkan = at::layer_norm(input_vulkan, {3, 5, 7}, weight_vulkan, bias_vulkan, 1e-05, false);
+
+  const auto check = almostEqual(output_cpu, output_vulkan.cpu());
+  if (!check) {
+    showRtol(output_cpu, output_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, layer_norm_3d_large) {
+  c10::InferenceMode mode;
+
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto input_cpu = at::rand({53, 139, 109}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto input_vulkan = input_cpu.vulkan();
+
+  const auto weight_cpu = at::rand({53, 139, 109}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto weight_vulkan = weight_cpu.vulkan();
+
+  const auto bias_cpu = at::rand({53, 139, 109}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto bias_vulkan = bias_cpu.vulkan();
+
+  const auto output_cpu = at::layer_norm(input_cpu, {53, 139, 109}, weight_cpu, bias_cpu, 1e-05, false);
+  const auto output_vulkan = at::layer_norm(input_vulkan, {53, 139, 109}, weight_vulkan, bias_vulkan, 1e-05, false);
+
+  const auto check = almostEqual(output_cpu, output_vulkan.cpu());
+  if (!check) {
+    showRtol(output_cpu, output_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, layer_norm_4d_small) {
+  c10::InferenceMode mode;
+
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto input_cpu = at::rand({1, 1, 1, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto input_vulkan = input_cpu.vulkan();
+
+  const auto weight_cpu = at::rand({1, 1, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto weight_vulkan = weight_cpu.vulkan();
+
+  const auto bias_cpu = at::rand({1, 1, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto bias_vulkan = bias_cpu.vulkan();
+
+  const auto output_cpu = at::layer_norm(input_cpu, {1, 1, 1}, weight_cpu, bias_cpu, 1e-05, false);
+  const auto output_vulkan = at::layer_norm(input_vulkan, {1, 1, 1}, weight_vulkan, bias_vulkan, 1e-05, false);
+
+  const auto check = almostEqual(output_cpu, output_vulkan.cpu());
+  if (!check) {
+    showRtol(output_cpu, output_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, layer_norm_4d_medium) {
+  c10::InferenceMode mode;
+
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto input_cpu = at::rand({1, 3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto input_vulkan = input_cpu.vulkan();
+
+  const auto weight_cpu = at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto weight_vulkan = weight_cpu.vulkan();
+
+  const auto bias_cpu = at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto bias_vulkan = bias_cpu.vulkan();
+
+  const auto output_cpu = at::layer_norm(input_cpu, {3, 5, 7}, weight_cpu, bias_cpu, 1e-05, false);
+  const auto output_vulkan = at::layer_norm(input_vulkan, {3, 5, 7}, weight_vulkan, bias_vulkan, 1e-05, false);
+
+  const auto check = almostEqual(output_cpu, output_vulkan.cpu());
+  if (!check) {
+    showRtol(output_cpu, output_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, layer_norm_4d_large) {
+  c10::InferenceMode mode;
+
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto input_cpu = at::rand({1, 53, 139, 109}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto input_vulkan = input_cpu.vulkan();
+
+  const auto weight_cpu = at::rand({53, 139, 109}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto weight_vulkan = weight_cpu.vulkan();
+
+  const auto bias_cpu = at::rand({53, 139, 109}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto bias_vulkan = bias_cpu.vulkan();
+
+  const auto output_cpu = at::layer_norm(input_cpu, {53, 139, 109}, weight_cpu, bias_cpu, 1e-05, false);
+  const auto output_vulkan = at::layer_norm(input_vulkan, {53, 139, 109}, weight_vulkan, bias_vulkan, 1e-05, false);
+
+  const auto check = almostEqual(output_cpu, output_vulkan.cpu());
+  if (!check) {
+    showRtol(output_cpu, output_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
 TEST_F(VulkanAPITest, leaky_relu) {
   if (!at::is_vulkan_available()) {
     return;


### PR DESCRIPTION
Summary:
Implemented LayerNorm operator for the Vulkan backend.

Special case implementation:
- Input tensor must be 3-dim or 4-dim.
- If input tensor is 4-dim, then batch dim must be 1.
- `normalized_shape` must have length 3, i.e. [C, H, W]
- It expects weight and bias tensor arguments.

References
- PyTorch Docs > torch.nn > [LayerNorm](https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html)

Test Plan:
On Mac:
```
buck run //xplat/caffe2:pt_vulkan_api_test_binAppleMac
```
On Android:
```
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
```

Differential Revision: D37407311

