### PR TITLE
move run_android_tests.yaml to a reusable workflow

### DIFF
--- a/.github/workflows/_run_android_tests.yml
+++ b/.github/workflows/_run_android_tests.yml
@@ -2,11 +2,6 @@ name: android-tests
 
 on:
   workflow_call:
-    inputs:
-      job-base-name:
-        required: true
-        type: string
-        description: the base name of the job calling this workflow
 
 concurrency:
   group: run-android-tests-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
@@ -19,8 +14,6 @@ defaults:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    env:
-      JOB_BASE_NAME: ${{ inputs.job-base-name }}
     steps:
       - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/_run_android_tests.yml
+++ b/.github/workflows/_run_android_tests.yml
@@ -1,18 +1,11 @@
 name: android-tests
 
 on:
-  push:
-    tags:
-      # Trigger on release candidate builds
-      # Release candidate tags look like: v1.11.0-rc1
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
-      - 'ciflow/trunk/*'
-      - 'ciflow/android/*'
-    branches:
-      - master
-      - main
-      - release/*
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      job-base-name:
+        required: true
+        type: string
 
 concurrency:
   group: run-android-tests-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
@@ -23,9 +16,10 @@ defaults:
     shell: bash -e -l {0}
 
 jobs:
-
   build-and-test:
     runs-on: ubuntu-latest
+    env:
+      JOB_BASE_NAME: ${{ inputs.job-base-name }}
     steps:
       - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v2
@@ -59,10 +53,10 @@ jobs:
           ANDROID_ROOT="/usr/local/lib/android"
           ANDROID_SDK_ROOT="${ANDROID_ROOT}/sdk"
           SDKMANAGER="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager"
-          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+          echo "y" | ${SDKMANAGER} "ndk;21.4.7075529"
 
           export ANDROID_NDK="${ANDROID_SDK_ROOT}/ndk-bundle"
-          ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 $ANDROID_NDK
+          ln -sfn ${ANDROID_SDK_ROOT}/ndk/21.4.7075529 ${ANDROID_NDK}
 
           echo "CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname "$(which conda)")/../"}" >> "${GITHUB_ENV}"
           ./scripts/build_pytorch_android.sh x86

--- a/.github/workflows/_run_android_tests.yml
+++ b/.github/workflows/_run_android_tests.yml
@@ -6,6 +6,7 @@ on:
       job-base-name:
         required: true
         type: string
+        description: the base name of the job calling this workflow
 
 concurrency:
   group: run-android-tests-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/_run_android_tests.yml
+++ b/.github/workflows/_run_android_tests.yml
@@ -3,10 +3,6 @@ name: android-tests
 on:
   workflow_call:
 
-concurrency:
-  group: run-android-tests-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
-  cancel-in-progress: true
-
 defaults:
   run:
     shell: bash -e -l {0}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -261,5 +261,3 @@ jobs:
   android-emulator-build-test:
     name: android-emulator-build-test
     uses: ./.github/workflows/_run_android_tests.yml
-    with:
-      job-base-name: android-emulator-build-test

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -257,3 +257,9 @@ jobs:
     secrets:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
+
+  android-emulator-build-test:
+    name: android-emulator-build-test
+    uses: ./.github/workflows/_run_android_tests.yml
+    with:
+      job-base-name: android-emulator-build-test


### PR DESCRIPTION
Fixes #[79182](https://github.com/pytorch/pytorch/issues/79182)

Makes workflow run_android_tests.yaml reusable and append it as a job to trunk.yaml