### PR TITLE
[onnx] Add argsort support

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -6465,6 +6465,15 @@ class TestONNXRuntime(test_onnx_common._TestONNXRuntime):
         x = torch.randn(3, 4)
         self.run_test(SortModel(), x)
 
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_argsort(self):
+        class ArgSortModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.argsort(x, dim=1, descending=False)
+
+        x = torch.randn(3, 4)
+        self.run_test(ArgSortModel(), x)
+
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_masked_fill(self):
         class MaskedFillModel(torch.nn.Module):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -487,6 +487,12 @@ def sort(g, self, dim, decending, out=None):
     return symbolic_helper._sort_helper(g, self, dim, decending=decending, out=out)
 
 
+@symbolic_helper.parse_args("v", "i", "i", "none")
+def argsort(g, self, dim, decending, out=None):
+    values, indices = symbolic_helper._sort_helper(g, self, dim, decending=decending, out=out)
+    return indices
+
+
 def round(g, self):
     return g.op("Round", self)
 

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -489,7 +489,9 @@ def sort(g, self, dim, decending, out=None):
 
 @symbolic_helper.parse_args("v", "i", "i", "none")
 def argsort(g, self, dim, decending, out=None):
-    values, indices = symbolic_helper._sort_helper(g, self, dim, decending=decending, out=out)
+    _, indices = symbolic_helper._sort_helper(
+        g, self, dim, decending=decending, out=out
+    )
     return indices
 
 


### PR DESCRIPTION
Fixes #79859 where exporting the operator '::argsort' to ONNX opset version 16 is not supported.
