### PR TITLE
[Kineto] Add header only target (and supermodules)

### DIFF
--- a/third_party/kineto.buck.bzl
+++ b/third_party/kineto.buck.bzl
@@ -168,3 +168,14 @@ def define_kineto():
             ":fmt",
         ],
     )
+
+    cxx_library(
+        name = "libkineto_headers",
+        exported_headers = native.glob([
+            "kineto/include/*.h",
+        ]),
+        public_include_directories = [
+            "kineto/include",
+        ],
+        visibility = ["PUBLIC"],
+    )


### PR DESCRIPTION
Summary:
I want PyTorch to be able to unconditionally use the Kineto enums without having to pull in the entire library.

Node: New targets run afoul of https://www.internalfb.com/intern/wiki/Supermodules/My_diff_has_Supermodule_violations/, so I have to add that as well.

Test Plan: Sandcastle

Differential Revision: D37365998

