### PR TITLE
TensorImpl:::size_custom to support NestedTensor.size

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -65,6 +65,9 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   // with real implementations
   int64_t numel_custom() const override;
   bool is_contiguous_custom(MemoryFormat) const override;
+  int64_t size_custom(int64_t d) const override {
+    return this->size(d);
+  }
   IntArrayRef sizes_custom() const override;
   c10::SymIntArrayRef sym_sizes_custom() const override;
   c10::SymIntArrayRef sym_sizes() const override;

--- a/aten/src/ATen/core/TensorBase.h
+++ b/aten/src/ATen/core/TensorBase.h
@@ -165,10 +165,7 @@ class TORCH_API TensorBase {
   }
 
   int64_t size(int64_t dim) const {
-    const auto sizes = this->sizes();
-    const auto ndim = static_cast<int64_t>(sizes.size());
-    // false is passed to maybe_wrap_dim so behavior is identical to array access (but with wrapping)
-    return sizes[c10::maybe_wrap_dim(dim, ndim, /*wrap_scalar=*/false)];
+    return impl_->size(dim);
   }
 
   int64_t stride(int64_t dim) const {

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -383,6 +383,13 @@ bool TensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
       " do not have is_contiguous");
 }
 
+int64_t TensorImpl::size_custom(int64_t d) const {
+  if (is_python_dispatch()) {
+    return load_pyobj_interpreter()->size(this, d);
+  }
+  TORCH_CHECK(
+      false, "Tensors of type ", tensorimpl_type_name(), " do not have a size along dimension ", d, ".");
+}
 IntArrayRef TensorImpl::sizes_custom() const {
   if (is_python_dispatch()) {
     return load_pyobj_interpreter()->sizes(this);

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -383,11 +383,6 @@ bool TensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
       " do not have is_contiguous");
 }
 
-int64_t TensorImpl::size_custom(int64_t d) const {
-  // TODO: We could add support to Python dispatch here.
-  d = maybe_wrap_dim(d, dim(), /*wrap_scalar=*/false);
-  return sizes_custom()[d]; // unchecked (maybe_wrap_dim enforces bounds)
-}
 IntArrayRef TensorImpl::sizes_custom() const {
   if (is_python_dispatch()) {
     return load_pyobj_interpreter()->sizes(this);

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -384,9 +384,7 @@ bool TensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
 }
 
 int64_t TensorImpl::size_custom(int64_t d) const {
-  if (is_python_dispatch()) {
-    return load_pyobj_interpreter()->size(this, d);
-  }
+  // TODO: Add support to python_dispatch
   TORCH_CHECK(
       false, "Tensors of type ", tensorimpl_type_name(), " do not have a size along dimension ", d, ".");
 }

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -384,9 +384,9 @@ bool TensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
 }
 
 int64_t TensorImpl::size_custom(int64_t d) const {
-  // TODO: Add support to python_dispatch
-  TORCH_CHECK(
-      false, "Tensors of type ", tensorimpl_type_name(), " do not have a size along dimension ", d, ".");
+  // TODO: We could add support to Python dispatch here.
+  d = maybe_wrap_dim(d, dim(), /*wrap_scalar=*/false);
+  return sizes_custom()[d]; // unchecked (maybe_wrap_dim enforces bounds)
 }
 IntArrayRef TensorImpl::sizes_custom() const {
   if (is_python_dispatch()) {

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -577,7 +577,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * be faster
    */
   int64_t size(int64_t d) const {
-    d = maybe_wrap_dim(d, dim(), false);
+    d = maybe_wrap_dim(d, dim(), /*wrap_scalar=*/false);
     if (C10_UNLIKELY(
             sizes_strides_policy_ >=
             static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
@@ -674,6 +674,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   virtual IntArrayRef strides_custom() const;
   virtual bool is_contiguous_custom(at::MemoryFormat memory_format) const;
   // sizes_strides_policy_ >= CustomSizes
+  virtual int64_t size_custom(int64_t d) const;
   virtual IntArrayRef sizes_custom() const;
   virtual c10::SymIntArrayRef sym_sizes_custom() const;
   virtual Device device_custom() const;

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -675,7 +675,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   virtual bool is_contiguous_custom(at::MemoryFormat memory_format) const;
   // sizes_strides_policy_ >= CustomSizes
   // Currently this method only exists to be overwritten by subclasses such as NestedTensorImpl.
-  virtual int64_t TensorImpl::size_custom(int64_t d) const {
+  virtual int64_t size_custom(int64_t d) const {
     // TODO: We could add support to Python dispatch here.
     // TODO: We could call into aten::size.int instead of
     // sizes_custom()[d] and enable use of the dispatcher.

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -581,7 +581,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     if (C10_UNLIKELY(
             sizes_strides_policy_ >=
             static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
-      return sizes_custom()[d]; // unchecked (maybe_wrap_dim enforces bounds)
+      return size_custom(d); // unchecked (maybe_wrap_dim enforces bounds)
     }
     return sizes_and_strides_.size_at_unchecked(d).as_int_unchecked();
   }

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -577,12 +577,12 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * be faster
    */
   int64_t size(int64_t d) const {
-    d = maybe_wrap_dim(d, dim(), /*wrap_scalar=*/false);
     if (C10_UNLIKELY(
             sizes_strides_policy_ >=
             static_cast<uint8_t>(SizesStridesPolicy::CustomSizes))) {
-      return size_custom(d); // unchecked (maybe_wrap_dim enforces bounds)
+      return size_custom(d);
     }
+    d = maybe_wrap_dim(d, dim(), /*wrap_scalar=*/false);
     return sizes_and_strides_.size_at_unchecked(d).as_int_unchecked();
   }
 
@@ -674,7 +674,14 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   virtual IntArrayRef strides_custom() const;
   virtual bool is_contiguous_custom(at::MemoryFormat memory_format) const;
   // sizes_strides_policy_ >= CustomSizes
-  virtual int64_t size_custom(int64_t d) const;
+  // Currently this method only exists to be overwritten by subclasses such as NestedTensorImpl.
+  virtual int64_t TensorImpl::size_custom(int64_t d) const {
+    // TODO: We could add support to Python dispatch here.
+    // TODO: We could call into aten::size.int instead of
+    // sizes_custom()[d] and enable use of the dispatcher.
+    d = maybe_wrap_dim(d, dim(), /*wrap_scalar=*/false);
+    return sizes_custom()[d]; // unchecked (maybe_wrap_dim enforces bounds)
+  }
   virtual IntArrayRef sizes_custom() const;
   virtual c10::SymIntArrayRef sym_sizes_custom() const;
   virtual Device device_custom() const;

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -674,7 +674,8 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   virtual IntArrayRef strides_custom() const;
   virtual bool is_contiguous_custom(at::MemoryFormat memory_format) const;
   // sizes_strides_policy_ >= CustomSizes
-  // Currently this method only exists to be overwritten by subclasses such as NestedTensorImpl.
+  // Currently this method only exists to be overwritten by subclasses such as
+  // NestedTensorImpl.
   virtual int64_t size_custom(int64_t d) const {
     // TODO: We could add support to Python dispatch here.
     // TODO: We could call into aten::size.int instead of

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -676,12 +676,14 @@ class TestNestedTensorAutograd(TestCase):
                                  torch.rand(1, 8)])
         self.assertEqual(a.size(0), 2)
         self.assertEqual(a.size(1), 1)
-        self.assertRaises(RuntimeError, lambda: a.size(2))
+        self.assertRaisesRegex(
+            RuntimeError, "Given dimension 2 is irregular and does not have a size", lambda: a.size(2))
 
         a = torch.nested_tensor([torch.rand(3, 4),
                                  torch.rand(5, 4)])
         self.assertEqual(a.size(0), 2)
-        self.assertRaises(RuntimeError, lambda: a.size(1))
+        self.assertRaisesRegex(
+            RuntimeError, "Given dimension 1 is irregular and does not have a size", lambda: a.size(1))
         self.assertEqual(a.size(2), 4)
 
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -662,6 +662,29 @@ class TestNestedTensorAutograd(TestCase):
         data = (a, b, c)
         assert torch.autograd.gradcheck(grad_test_func, inputs=data)
 
+    def test_size_dim(self):
+        a = torch.nested_tensor([])
+        self.assertEqual(a.size(0), 0)
+
+        a = torch.nested_tensor([torch.tensor(1)])
+        self.assertEqual(a.size(0), 1)
+
+        a = torch.nested_tensor([torch.tensor(1), torch.tensor(2)])
+        self.assertEqual(a.size(0), 2)
+
+        a = torch.nested_tensor([torch.rand(1, 2),
+                                 torch.rand(1, 8)])
+        self.assertEqual(a.size(0), 2)
+        self.assertEqual(a.size(1), 1)
+        self.assertRaises(RuntimeError, lambda: a.size(2))
+
+        a = torch.nested_tensor([torch.rand(3, 4),
+                                 torch.rand(5, 4)])
+        self.assertEqual(a.size(0), 2)
+        self.assertRaises(RuntimeError, lambda: a.size(1))
+        self.assertEqual(a.size(2), 4)
+
+
 
 instantiate_device_type_tests(TestNestedTensorDeviceType, globals())
 


### PR DESCRIPTION
This allows subclasses such as NestedTensorImpl to provide special behavior for `int64_t size(int64_t d)` that'll also be accessible by our Python frontend.

It follows the same pattern as sizes_custom.

Currently getting CI before asking for a review.