### PR TITLE
[Bootcamp][lint] Add usort to the lintrunner linters list

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -579,3 +579,20 @@ init_command = [
     'black==22.3.0',
 ]
 is_formatter = true
+
+[[linter]]
+code = 'USORT'
+include_patterns = ['**/*.py']
+command = [
+    'python3',
+    'tools/linter/adapters/usort_linter.py',
+    '--',
+    '@{{PATHSFILE}}'
+]
+init_command = [
+    'python3',
+    'tools/linter/adapters/pip_init.py',
+    '--dry-run={{DRYRUN}}',
+    'usort==1.0.2',
+]
+is_formatter = true

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -64,3 +64,6 @@ ignore_missing_imports = True
 
 [mypy-mypy.*]
 ignore_missing_imports = True
+
+[mypy-usort.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -281,3 +281,6 @@ ignore_missing_imports = True
 
 [mypy-dill.*]
 ignore_missing_imports = True
+
+[mypy-usort.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires = [
     "six",
     "requests",
     "dataclasses",
+    "usort",
 ]
 # Use legacy backend to import local packages in setup.py
 build-backend = "setuptools.build_meta:__legacy__"
@@ -23,3 +24,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 # Uncomment if pyproject.toml worked fine to ensure consistency with flake8
 # line-length = 120
 target-version = ["py37", "py38", "py39", "py310"]
+
+
+[tool.usort]
+first_party_detection = false

--- a/tools/linter/adapters/usort_linter.py
+++ b/tools/linter/adapters/usort_linter.py
@@ -1,0 +1,161 @@
+import argparse
+import concurrent.futures
+import json
+import os
+import subprocess
+from enum import Enum
+from typing import List, NamedTuple, Optional
+
+from usort import config as usort_config, usort
+
+
+class LintSeverity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    ADVICE = "advice"
+    DISABLED = "disabled"
+
+
+class LintMessage(NamedTuple):
+    path: Optional[str]
+    line: Optional[int]
+    char: Optional[int]
+    code: str
+    severity: LintSeverity
+    name: str
+    original: Optional[str]
+    replacement: Optional[str]
+    description: Optional[str]
+
+
+IS_WINDOWS: bool = os.name == "nt"
+
+
+def as_posix(name: str) -> str:
+    return name.replace("\\", "/") if IS_WINDOWS else name
+
+
+def check_file(
+    filename: str,
+) -> List[LintMessage]:
+    try:
+        top_of_file_cat = usort_config.Category("top_of_file")
+        known = usort_config.known_factory()
+        # cinder magic imports must be on top (after future imports)
+        known["__strict__"] = top_of_file_cat
+        known["__static__"] = top_of_file_cat
+
+        config = usort_config.Config(
+            categories=(
+                (
+                    usort_config.CAT_FUTURE,
+                    top_of_file_cat,
+                    usort_config.CAT_STANDARD_LIBRARY,
+                    usort_config.CAT_THIRD_PARTY,
+                    usort_config.CAT_FIRST_PARTY,
+                )
+            ),
+            known=known,
+        )
+
+        with open(filename, mode="rb") as f:
+            original = f.read()
+            result = usort(original, config)
+            if result.error:
+                raise result.error
+
+    except subprocess.TimeoutExpired:
+        return [
+            LintMessage(
+                path=filename,
+                line=None,
+                char=None,
+                code="USORT",
+                severity=LintSeverity.ERROR,
+                name="timeout",
+                original=None,
+                replacement=None,
+                description=(
+                    "usort timed out while trying to process a file. "
+                    "Please report an issue in pytorch/torchrec."
+                ),
+            )
+        ]
+    except (OSError, subprocess.CalledProcessError) as err:
+        return [
+            LintMessage(
+                path=filename,
+                line=None,
+                char=None,
+                code="USORT",
+                severity=LintSeverity.ADVICE,
+                name="command-failed",
+                original=None,
+                replacement=None,
+                description=(
+                    f"Failed due to {err.__class__.__name__}:\n{err}"
+                    if not isinstance(err, subprocess.CalledProcessError)
+                    else (
+                        "COMMAND (exit code {returncode})\n"
+                        "{command}\n\n"
+                        "STDERR\n{stderr}\n\n"
+                        "STDOUT\n{stdout}"
+                    ).format(
+                        returncode=err.returncode,
+                        command=" ".join(as_posix(x) for x in err.cmd),
+                        stderr=err.stderr.decode("utf-8").strip() or "(empty)",
+                        stdout=err.stdout.decode("utf-8").strip() or "(empty)",
+                    )
+                ),
+            )
+        ]
+
+    replacement = result.output
+    if original == replacement:
+        return []
+
+    return [
+        LintMessage(
+            path=filename,
+            line=None,
+            char=None,
+            code="USORT",
+            severity=LintSeverity.WARNING,
+            name="format",
+            original=original.decode("utf-8"),
+            replacement=replacement.decode("utf-8"),
+            description="Run `lintrunner -a` to apply this patch.",
+        )
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Format files with usort.",
+        fromfile_prefix_chars="@",
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="+",
+        help="paths to lint",
+    )
+    args = parser.parse_args()
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=os.cpu_count(),
+        thread_name_prefix="Thread",
+    ) as executor:
+        futures = {
+            executor.submit(check_file, filename): filename
+            for filename in args.filenames
+        }
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                for lint_message in future.result():
+                    print(json.dumps(lint_message._asdict()), flush=True)
+            except Exception:
+                raise RuntimeError(f"Failed at {futures[future]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:
Adding [usort](https://pypi.org/project/usort/) linter to lintrunner to ensure the imports are sorted consistently. Using https://github.com/pytorch/torchrec as the reference for the linter integration.

Test Plan:
    lintrunner init
    lintrunner
    lintrunner f
    lintrunner -a
    lintrunner torch/jit/_script.py torch/jit/_trace.py

<img width="930" alt="Lintrunner results screenshot" src="https://user-images.githubusercontent.com/108101595/175748204-0f675c99-6122-4ace-be1d-075ab9142a82.png">

Reviewers: osalpekar, suo
Subscribers: osalpekar, suo
Tasks: T123437457
Tags: lint, usort, bootcamp