### PR TITLE
Use AutogradNestedTensor key for nested tensors

### DIFF
--- a/c10/core/DispatchKeySet.cpp
+++ b/c10/core/DispatchKeySet.cpp
@@ -38,8 +38,7 @@ bool isBackendDispatchKey(DispatchKey t) {
       // Note [NestedTensor Not Included in Backend Keys]
       // NestedTensor has been explicitly removed from the "backend keyset" due
       // to incompatibility with some kernels, so we don't want it to be
-      // included in CompositeImplicitAutograd or CompositeExplicitAutograd
-      // kernels.
+      // included in CompositeExplicitAutograd kernels.
       && t != DispatchKey::NestedTensor && backend_dispatch_keyset.has(t);
 }
 
@@ -76,8 +75,7 @@ bool runtimeDispatchKeySetHas(DispatchKey t, DispatchKey k) {
     case DispatchKey::Autograd:
       return autograd_dispatch_keyset.has(toFunctionalityKey(k));
     case DispatchKey::CompositeImplicitAutograd:
-      // See Note [NestedTensor Not Included in Backend Keys]
-      return k != DispatchKey::NestedTensor && math_dispatch_keyset.has(k);
+      return math_dispatch_keyset.has(k);
     case DispatchKey::CompositeExplicitAutograd:
       // See Note [NestedTensor Not Included in Backend Keys]
       return k != DispatchKey::NestedTensor && backend_dispatch_keyset.has(k);
@@ -118,6 +116,8 @@ DispatchKeySet getBackendKeySetFromAutograd(DispatchKey t) {
       return DispatchKeySet(DispatchKey::PrivateUse2);
     case DispatchKey::AutogradPrivateUse3:
       return DispatchKeySet(DispatchKey::PrivateUse3);
+    case DispatchKey::AutogradNestedTensor:
+      return DispatchKeySet({DispatchKey::NestedTensorCPU, DispatchKey::NestedTensorCUDA});
     case DispatchKey::AutogradOther:
       return autogradother_backends;
     default:

--- a/c10/core/DispatchKeySet.cpp
+++ b/c10/core/DispatchKeySet.cpp
@@ -117,7 +117,8 @@ DispatchKeySet getBackendKeySetFromAutograd(DispatchKey t) {
     case DispatchKey::AutogradPrivateUse3:
       return DispatchKeySet(DispatchKey::PrivateUse3);
     case DispatchKey::AutogradNestedTensor:
-      return DispatchKeySet({DispatchKey::NestedTensorCPU, DispatchKey::NestedTensorCUDA});
+      return DispatchKeySet(
+          {DispatchKey::NestedTensorCPU, DispatchKey::NestedTensorCUDA});
     case DispatchKey::AutogradOther:
       return autogradother_backends;
     default:

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -633,6 +633,7 @@ C10_API inline int getDispatchTableIndexForDispatchKey(DispatchKey k) {
 constexpr DispatchKeySet autograd_dispatch_keyset = DispatchKeySet({
     DispatchKey::AutogradFunctionality,
     DispatchKey::AutogradOther,
+    DispatchKey::AutogradNestedTensor,
 });
 
 constexpr DispatchKeySet autocast_dispatch_keyset = DispatchKeySet({
@@ -741,6 +742,7 @@ constexpr auto autograd_privateuse2_ks =
 constexpr auto autograd_privateuse3_ks =
     DispatchKeySet(DispatchKey::AutogradPrivateUse3);
 constexpr auto autograd_other_ks = DispatchKeySet(DispatchKey::AutogradOther);
+constexpr auto autograd_nested = DispatchKeySet(DispatchKey::AutogradNestedTensor);
 
 // keyset correpsonding to functorch keys that have their own dedicated
 // TensorImpl subclass.

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -742,7 +742,8 @@ constexpr auto autograd_privateuse2_ks =
 constexpr auto autograd_privateuse3_ks =
     DispatchKeySet(DispatchKey::AutogradPrivateUse3);
 constexpr auto autograd_other_ks = DispatchKeySet(DispatchKey::AutogradOther);
-constexpr auto autograd_nested = DispatchKeySet(DispatchKey::AutogradNestedTensor);
+constexpr auto autograd_nested =
+    DispatchKeySet(DispatchKey::AutogradNestedTensor);
 
 // keyset correpsonding to functorch keys that have their own dedicated
 // TensorImpl subclass.

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -173,13 +173,13 @@ TensorImpl::TensorImpl(
     // grad.
     //       See Note [Dream: skip VariableType kernel when requires_grad=false]
 
-    // [Note: Nested Tensor Autograd] The Nested Tensor key is a functionality key and therefore
-    // getAutogradRelatedKeySetFromBackend will return the wrong autograd key
-    // For this specific impl we make sure to register the correct Autograd key
-    if (key_set.has_any(c10::DispatchKeySet{c10::DispatchKey::NestedTensor})){
+    // [Note: Nested Tensor Autograd] The Nested Tensor key is a functionality
+    // key and therefore getAutogradRelatedKeySetFromBackend will return the
+    // wrong autograd key For this specific impl we make sure to register the
+    // correct Autograd key
+    if (key_set.has_any(c10::DispatchKeySet{c10::DispatchKey::NestedTensor})) {
       key_set_ = key_set | inplace_or_view_ks | autograd_nested;
-    }
-    else{
+    } else {
       key_set_ = key_set | getAutogradRelatedKeySetFromBackend(k);
     }
   }


### PR DESCRIPTION
This is related to this issue: #79048 and this issue: #79039

This will enable us to register autograd kernels specific to NestedTensor while also registering kernels to CompositeImplicitAutograd
