### PR TITLE
Ensure torch._refs registrations also get triggered on import torch

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -561,3 +561,10 @@ def meta_remainder_scalar(scalar, other):
 @torch.library.impl(meta_lib, "logical_not_")
 def meta_logical_not_(self):
     return self
+
+
+# We must also trigger meta registrations from PrimTorch ref
+# decompositions
+import torch._refs
+import torch._refs.nn.functional
+import torch._refs.special


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #80270

Fixes https://github.com/pytorch/pytorch/issues/79938

Signed-off-by: Edward Z. Yang <ezyang@fb.com>