### PR TITLE
[Checkpoint Wrapper] Fix assert

### DIFF
--- a/test/distributed/fsdp/test_checkpoint_wrapper.py
+++ b/test/distributed/fsdp/test_checkpoint_wrapper.py
@@ -106,7 +106,7 @@ class CheckpointWrapperTest(TestCase):
 
         functional_reentrant = test(use_checkpointing=True, use_wrapper=False, use_reentrant=True)
         wrapper_reentrant = test(use_checkpointing=False, use_wrapper=True, use_reentrant=True)
-        self.assertEqual(functional_no_reentrant, wrapper_no_reentrant)
+        self.assertEqual(functional_reentrant, wrapper_reentrant)
 
     def test_forward_missing_attributes(self):
         lin = nn.Linear(1, 1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#80283 [Checkpoint Wrapper] Fix assert**

https://github.com/pytorch/pytorch/blob/f11cce309bf290151a21b2ac8e79bf2a24dcf2f3/test/distributed/fsdp/test_checkpoint_wrapper.py#L103-L109

The second assert is re-asserting the same thing as the first assert, so `functional_reentrant` and `wrapper_reentrant` are unused. This PR fixes the second assert to assert that `functional_reentrant` and `wrapper_reentrant` are equal.