### PR TITLE
support nested_tensor * scalar

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3411,6 +3411,7 @@
   dispatch:
     CompositeExplicitAutograd: mul
     SparseCsrCPU, SparseCsrCUDA: mul_scalar_sparse_csr
+    NestedTensorCPU, NestedTensorCUDA: mul_scalar_nested
 
 - func: mul_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -3418,6 +3419,7 @@
   dispatch:
     CompositeExplicitAutograd: mul_
     SparseCsrCPU, SparseCsrCUDA: mul__scalar_sparse_csr
+    NestedTensorCPU, NestedTensorCUDA: mul__scalar_nested
   autogen: mul.Scalar_out
 
 # multiply, alias for mul

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3411,7 +3411,6 @@
   dispatch:
     CompositeExplicitAutograd: mul
     SparseCsrCPU, SparseCsrCUDA: mul_scalar_sparse_csr
-    NestedTensorCPU, NestedTensorCUDA: mul_scalar_nested
 
 - func: mul_.Scalar(Tensor(a!) self, Scalar other) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
@@ -3419,7 +3418,6 @@
   dispatch:
     CompositeExplicitAutograd: mul_
     SparseCsrCPU, SparseCsrCUDA: mul__scalar_sparse_csr
-    NestedTensorCPU, NestedTensorCUDA: mul__scalar_nested
   autogen: mul.Scalar_out
 
 # multiply, alias for mul

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -560,6 +560,27 @@ Tensor NestedTensor_elementwise_Tensor(
     const Tensor& other,
     const std::string& op_name,
     Func f) {
+  // NOTE [dispatch when mixing nested and regular tensors]
+  // as of 6.24.2022, the dispatcher behaviour is:
+  // if self.is_nested() or other.is_nested() == True: dispatch to this function
+  // idk if this is the expected behaviour
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(self.is_nested() || other.is_nested());
+  // self is a scalar
+  if (!self.is_nested() && self.numel() == 1) {
+    auto other_impl = get_nested_tensor_impl(other);
+    return wrap_buffer(
+      f(self, other_impl->get_buffer()),
+      other_impl->get_nested_size_tensor().clone()
+    );
+  }
+  // other is a scalar
+  if (!other.is_nested() && other.numel() == 1) {
+    auto self_impl = get_nested_tensor_impl(self);
+    return wrap_buffer(
+      f(self_impl->get_buffer(), other),
+      self_impl->get_nested_size_tensor().clone()
+    );
+  }
   NestedTensorImpl* self_impl = nullptr;
   NestedTensorImpl* other_impl = nullptr;
   std::tie(self_impl, other_impl) =
@@ -592,12 +613,38 @@ Tensor NestedTensor_mul_Tensor(const Tensor& self, const Tensor& other) {
       });
 }
 
+Tensor mul_scalar_nested(const Tensor& self, const Scalar& other) {
+  auto self_ptr = get_nested_tensor_impl(self);
+  Tensor out_buffer = self_ptr->get_buffer().mul(other);
+  return wrap_buffer(out_buffer, self_ptr->get_nested_size_tensor().clone());
+}
+
+Tensor& mul__scalar_nested(Tensor& self, const Scalar& other) {
+  auto self_ptr = get_nested_tensor_impl(self);
+  self_ptr->get_buffer().mul_(other);
+  return self;
+}
+
 template <typename Func>
 Tensor& NestedTensor_elementwise__Tensor(
     Tensor& self,
     const Tensor& other,
     const std::string& op_name,
     Func f) {
+  // See NOTE [dispatch when mixing nested and regular tensors]
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(self.is_nested() || other.is_nested());
+  // self is a scalar
+  if (!self.is_nested() && self.numel() == 1) {
+    auto other_impl = get_nested_tensor_impl(other);
+    f(self, other_impl->get_buffer());
+    return self;
+  }
+  // other is a scalar
+  if (!other.is_nested() && other.numel() == 1) {
+    auto self_impl = get_nested_tensor_impl(self);
+    f(self_impl->get_buffer(), other);
+    return self;
+  }
   NestedTensorImpl* self_impl = nullptr;
   NestedTensorImpl* other_impl = nullptr;
   std::tie(self_impl, other_impl) =

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -435,10 +435,28 @@ class TestNestedTensorDeviceType(TestCase):
     @skipMeta
     @torch.inference_mode()
     def test_nested_tensor_mul(self, device, dtype):
+        # nested tensor * nested tensor
         (nt1, nt2) = self.random_nt_pair(device, dtype, 4, (4, 4))
         ref = torch.nested_tensor([t1 * t2 for (t1, t2) in zip(nt1.unbind(), nt2.unbind())])
         out = nt1 * nt2
         self.nt_equal(ref, out)
+        # nested tensor * scalar
+        number = 10.0
+        scalar = torch.tensor(number).to(dtype).to(device)
+        vector = torch.tensor([number]).to(dtype).to(device)
+        ref = torch.nested_tensor([t * number for t in nt1.unbind()])
+        out_number0 = nt1 * number
+        out_number1 = number * nt1
+        out_scalar0 = nt1 * scalar
+        out_scalar1 = scalar * nt1
+        out_vector0 = nt1 * vector
+        out_vector1 = vector * nt1
+        self.nt_equal(out_number0, ref)
+        self.nt_equal(out_number1, ref)
+        self.nt_equal(out_scalar0, ref)
+        self.nt_equal(out_scalar1, ref)
+        self.nt_equal(out_vector0, ref)
+        self.nt_equal(out_vector1, ref)
 
     @dtypes(torch.float, torch.float16)
     @skipMeta
@@ -453,10 +471,35 @@ class TestNestedTensorDeviceType(TestCase):
     @skipMeta
     @torch.inference_mode()
     def test_nested_tensor_mul_in_place(self, device, dtype):
+        # nested tensor * nested tensor
         (nt1, nt2) = self.random_nt_pair(device, dtype, 4, (4, 4))
         ref = torch.nested_tensor([t1 * t2 for (t1, t2) in zip(nt1.unbind(), nt2.unbind())])
         nt1 *= nt2
         self.nt_equal(ref, nt1)
+        # nested tensor * scalar
+        number = 10.0
+        scalar = torch.tensor(number).to(dtype).to(device)
+        vector = torch.tensor([number]).to(dtype).to(device)
+        ref = torch.nested_tensor([t * number for t in nt1.unbind()])
+        out_number = nt1.clone()
+        out_number *= number
+        out_scalar = nt1.clone()
+        out_scalar *= scalar
+        out_vector = nt1.clone()
+        out_vector *= vector
+        self.nt_equal(out_number, ref)
+        self.nt_equal(out_scalar, ref)
+        self.nt_equal(out_vector, ref)
+        self.assertRaisesRegex(
+            RuntimeError,
+            r"output with shape \[.*\] doesn't match the broadcast shape \[.*\]",
+            lambda: scalar.mul_(nt1)
+        )
+        self.assertRaisesRegex(
+            RuntimeError,
+            r"output with shape \[.*\] doesn't match the broadcast shape \[.*\]",
+            lambda: vector.mul_(nt1)
+        )
 
     @dtypes(torch.float, torch.float16)
     @skipMeta


### PR DESCRIPTION
In transformer, the scale step in attention has a `nested_tensor / scalar` operation. There are two ways to support that:
1. directly support `nested_tensor / scalar`:
* pro: straightforward, good UX
* con: is dispatching `mul(nested tensor, regular tensor)` a good practice?
2. let user manually convert `scalar` to `nested_scalar = torch.nested_tensor([broadcast_scalar])`
* pro: dispatcher only has to deal with `mul(nested tensor, nested tensor)`
* con: confusing manual conversions, bad UX