### PR TITLE
[ci] only upload summarized test stats for PRs

### DIFF
--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -34,9 +34,10 @@ jobs:
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           WORKFLOW_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           echo "${WORKFLOW_URL}"
-          python3 -m tools.stats.upload_test_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
+          python3 -m tools.stats.upload_test_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}" --head-branch "${HEAD_BRANCH}"
           python3 -m tools.stats.upload_sccache_stats --workflow-run-id "${WORKFLOW_RUN_ID}" --workflow-run-attempt "${WORKFLOW_RUN_ATTEMPT}"
 
   check-api-rate:

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -209,6 +209,6 @@ if __name__ == "__main__":
     # volume of writes we do to Rockset.
     upload_to_rockset("test_run_summary", summarize_test_cases(test_cases))
 
-    if args.head_branch != "master":
+    if args.head_branch == "master":
         # For master jobs, upload everytihng.
         upload_to_rockset("test_run", test_cases)

--- a/tools/stats/upload_test_stats.py
+++ b/tools/stats/upload_test_stats.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Dict, List, Any, Tuple, Optional
+from typing import Dict, List, Any
 from tempfile import TemporaryDirectory
 
 from tools.stats.upload_stats_lib import (
@@ -18,7 +18,6 @@ def parse_xml_report(
     report: Path,
     workflow_id: int,
     workflow_run_attempt: int,
-    skip_tag: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Convert a test report xml file into a JSON-serializable list of test cases."""
     print(f"Parsing {tag}s for test report: {report}")
@@ -34,7 +33,7 @@ def parse_xml_report(
 
     test_cases = []
     for test_case in root.iter(tag):
-        case = process_xml_element(test_case, skip_tag)
+        case = process_xml_element(test_case)
         case["workflow_id"] = workflow_id
         case["workflow_run_attempt"] = workflow_run_attempt
         case["job_id"] = job_id
@@ -43,7 +42,7 @@ def parse_xml_report(
     return test_cases
 
 
-def process_xml_element(element: ET.Element, skip_tag: Optional[str]) -> Dict[str, Any]:
+def process_xml_element(element: ET.Element) -> Dict[str, Any]:
     """Convert a test suite element into a JSON-serializable dict."""
     ret: Dict[str, Any] = {}
 
@@ -89,23 +88,18 @@ def process_xml_element(element: ET.Element, skip_tag: Optional[str]) -> Dict[st
     #       "bar": {"text": "another"}
     #    }
     for child in element:
-        if child.tag == skip_tag:
-            continue
-
         if child.tag not in ret:
-            ret[child.tag] = process_xml_element(child, skip_tag)
+            ret[child.tag] = process_xml_element(child)
         else:
             # If there are multiple tags with the same name, they should be
             # coalesced into a list.
             if not isinstance(ret[child.tag], list):
                 ret[child.tag] = [ret[child.tag]]
-            ret[child.tag].append(process_xml_element(child, skip_tag))
+            ret[child.tag].append(process_xml_element(child))
     return ret
 
 
-def get_tests(
-    workflow_run_id: int, workflow_run_attempt: int
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+def get_tests(workflow_run_id: int, workflow_run_attempt: int) -> List[Dict[str, Any]]:
     with TemporaryDirectory() as temp_dir:
         print("Using temporary directory:", temp_dir)
         os.chdir(temp_dir)
@@ -125,7 +119,6 @@ def get_tests(
 
         # Parse the reports and transform them to JSON
         test_cases = []
-        test_suites = []
         for xml_report in Path(".").glob("**/*.xml"):
             test_cases.extend(
                 parse_xml_report(
@@ -135,17 +128,59 @@ def get_tests(
                     workflow_run_attempt,
                 )
             )
-            test_suites.extend(
-                parse_xml_report(
-                    "testsuite",
-                    xml_report,
-                    workflow_run_id,
-                    workflow_run_attempt,
-                    skip_tag="testcase",
-                )
-            )
 
-        return test_cases, test_suites
+        return test_cases
+
+
+def summarize_test_cases(test_cases: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Group test cases by classname, file, and job_id. We perform the aggregation
+    manually instead of using the `test-suite` XML tag because xmlrunner does
+    not produce reliable output for it.
+    """
+
+    def get_key(test_case: Dict[str, Any]) -> Any:
+        return (
+            test_case.get("file"),
+            test_case.get("classname"),
+            test_case["job_id"],
+            test_case["workflow_id"],
+            test_case["workflow_run_attempt"],
+        )
+
+    def init_value(test_case: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "file": test_case.get("file"),
+            "classname": test_case.get("classname"),
+            "job_id": test_case["job_id"],
+            "workflow_id": test_case["workflow_id"],
+            "workflow_run_attempt": test_case["workflow_run_attempt"],
+            "tests": 0,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 0,
+            "successes": 0,
+            "time": 0.0,
+        }
+
+    ret = {}
+    for test_case in test_cases:
+        key = get_key(test_case)
+        if key not in ret:
+            ret[key] = init_value(test_case)
+
+        ret[key]["tests"] += 1
+
+        if "failure" in test_case:
+            ret[key]["failures"] += 1
+        elif "error" in test_case:
+            ret[key]["errors"] += 1
+        elif "skipped" in test_case:
+            ret[key]["skipped"] += 1
+        else:
+            ret[key]["successes"] += 1
+
+        ret[key]["time"] += test_case["time"]
+    return list(ret.values())
 
 
 if __name__ == "__main__":
@@ -162,7 +197,18 @@ if __name__ == "__main__":
         required=True,
         help="which retry of the workflow this is",
     )
+    parser.add_argument(
+        "--head-branch",
+        required=True,
+        help="Head branch of the workflow",
+    )
     args = parser.parse_args()
-    test_cases, test_suites = get_tests(args.workflow_run_id, args.workflow_run_attempt)
-    upload_to_rockset("test_run", test_cases)
-    upload_to_rockset("test_suite", test_suites)
+    test_cases = get_tests(args.workflow_run_id, args.workflow_run_attempt)
+
+    # For PRs, only upload a summary of test_runs. This helps lower the
+    # volume of writes we do to Rockset.
+    upload_to_rockset("test_run_summary", summarize_test_cases(test_cases))
+
+    if args.head_branch != "master":
+        # For master jobs, upload everytihng.
+        upload_to_rockset("test_run", test_cases)

--- a/tools/test/test_upload_test_stats.py
+++ b/tools/test/test_upload_test_stats.py
@@ -3,7 +3,7 @@ import os
 
 IN_CI = os.environ.get("CI")
 
-from tools.stats.upload_test_stats import get_tests
+from tools.stats.upload_test_stats import get_tests, summarize_test_cases
 
 
 class TestUploadTestStats(unittest.TestCase):
@@ -13,9 +13,10 @@ class TestUploadTestStats(unittest.TestCase):
     )
     def test_existing_job(self) -> None:
         """Run on a known-good job and make sure we don't error and get basically okay reults."""
-        test_cases, test_suites = get_tests(2465214458, 1)
-        self.assertEqual(len(test_cases), 731457)
-        self.assertEqual(len(test_suites), 7781)
+        test_cases = get_tests(2561394934, 1)
+        self.assertEqual(len(test_cases), 609873)
+        summary = summarize_test_cases(test_cases)
+        self.assertEqual(len(summary), 5068)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #80295

We are uploading too many tests which is stressing out Rockset. We do
not really use granular per-test statistics for PRs, so change to
uploading summary information for PRs.

We will still be uploading per-test stats from master.