### PR TITLE
[quant] Modify APoT qparam quantization levels calculation

### DIFF
--- a/test/quantization/core/experimental/test_nonuniform_observer.py
+++ b/test/quantization/core/experimental/test_nonuniform_observer.py
@@ -129,5 +129,41 @@ class TestNonUniformObserver(unittest.TestCase):
         level_indices_test_list = obs_result[2].tolist()
         self.assertEqual(len(level_indices_test_list), len(set(level_indices_test_list)))
 
+    """
+        Test case 5
+        Assume hardcoded parameters:
+        * b = 6 (total number of bits across all terms)
+        * k = 1 (base bitwidth, i.e. bitwidth of every term)
+        * n = 6 (number of additive terms)
+    """
+    def test_calculate_qparams_k1(self):
+        obs = APoTObserver(max_val=1.0, b=6, k=1)
+
+        obs_result = obs.calculate_qparams(signed=False)
+
+        # calculate expected gamma value
+        gamma_test = 0
+        for i in range(6):
+            gamma_test += 2**(-i)
+
+        gamma_test = 1 / gamma_test
+
+        # check gamma value
+        self.assertEqual(obs_result[0], gamma_test)
+
+        # check quantization levels size
+        quantlevels_size_test = int(len(obs_result[1]))
+        quantlevels_size = 2**6
+        self.assertEqual(quantlevels_size_test, quantlevels_size)
+
+        # check level indices size
+        levelindices_size_test = int(len(obs_result[2]))
+        level_indices_size = 2**6
+        self.assertEqual(levelindices_size_test, level_indices_size)
+
+        # check level indices unique values
+        level_indices_test_list = obs_result[2].tolist()
+        self.assertEqual(len(level_indices_test_list), len(set(level_indices_test_list)))
+
 if __name__ == '__main__':
     unittest.main()

--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -99,7 +99,7 @@ class APoTObserver(ObserverBase):
 
         # calculate sum of each row
         for row in cartesian_product:
-            sum = 0
+            sum = 0.0
             for ele in row:
                 sum += ele
             quantization_levels_list.append(sum)

--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -62,7 +62,7 @@ class APoTObserver(ObserverBase):
         for i in range(0, self.n):
             p_curr = torch.tensor([0])
 
-            for j in range(0, 2 ** (self.k - 1) + 1):
+            for j in range(0, (2 ** self.k - 2) + 1):
                 curr_ele = 2 ** (- (i + j * self.n))
                 p_append = torch.tensor([curr_ele])
                 p_curr = torch.cat((p_curr, p_append))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #79845
* #80075
* __->__ #80303

### Summary:
This PR updates an error in the the computation for APoT quantization levels to match the formula defined in the APoT paper: https://arxiv.org/pdf/1909.13144.pdf.

### Test Plan:
Run unit tests with:` python pytorch/test/quantization/core/experimental/test_nonuniform_observer.py`