### PR TITLE
patch code for Flatbuffers v206

### DIFF
--- a/torch/csrc/jit/mobile/flatbuffer_loader.cpp
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.cpp
@@ -124,29 +124,29 @@ FlatbufferLoader::FlatbufferLoader()
     : mcu_(std::make_shared<mobile::CompilationUnit>()),
       cu_(std::make_shared<CompilationUnit>()),
       ivalue_parsers_{nullptr} {
-  registerIValueParser(mobile::serialization::IValueUnion::NONE, &parseBasic);
-  registerIValueParser(mobile::serialization::IValueUnion::Int, &parseBasic);
-  registerIValueParser(mobile::serialization::IValueUnion::Bool, &parseBasic);
-  registerIValueParser(mobile::serialization::IValueUnion::Double, &parseBasic);
+  registerIValueParser(mobile::serialization::IValueUnion::IValueUnion_NONE, &parseBasic);
+  registerIValueParser(mobile::serialization::IValueUnion::IValueUnion_Int, &parseBasic);
+  registerIValueParser(mobile::serialization::IValueUnion::IValueUnion_Bool, &parseBasic);
+  registerIValueParser(mobile::serialization::IValueUnion::IValueUnion_Double, &parseBasic);
   registerIValueParser(
-      mobile::serialization::IValueUnion::ComplexDouble, &parseBasic);
+      mobile::serialization::IValueUnion::IValueUnion_ComplexDouble, &parseBasic);
   registerIValueParser(
-      mobile::serialization::IValueUnion::TensorMetadata, &parseTensor);
-  registerIValueParser(mobile::serialization::IValueUnion::String, &parseBasic);
-  registerIValueParser(mobile::serialization::IValueUnion::List, &parseList);
+      mobile::serialization::IValueUnion::IValueUnion_TensorMetadata, &parseTensor);
+  registerIValueParser(mobile::serialization::IValueUnion::IValueUnion_String, &parseBasic);
+  registerIValueParser(mobile::serialization::IValueUnion::IValueUnion_List, &parseList);
   registerIValueParser(
-      mobile::serialization::IValueUnion::IntList, &parseIntList);
+      mobile::serialization::IValueUnion::IValueUnion_IntList, &parseIntList);
   registerIValueParser(
-      mobile::serialization::IValueUnion::DoubleList, &parseDoubleList);
+      mobile::serialization::IValueUnion::IValueUnion_DoubleList, &parseDoubleList);
   registerIValueParser(
-      mobile::serialization::IValueUnion::BoolList, &parseBoolList);
-  registerIValueParser(mobile::serialization::IValueUnion::Tuple, &parseTuple);
-  registerIValueParser(mobile::serialization::IValueUnion::Dict, &parseDict);
+      mobile::serialization::IValueUnion::IValueUnion_BoolList, &parseBoolList);
+  registerIValueParser(mobile::serialization::IValueUnion::IValueUnion_Tuple, &parseTuple);
+  registerIValueParser(mobile::serialization::IValueUnion::IValueUnion_Dict, &parseDict);
   registerIValueParser(
-      mobile::serialization::IValueUnion::Object, &parseObject);
-  registerIValueParser(mobile::serialization::IValueUnion::Device, &parseBasic);
+      mobile::serialization::IValueUnion::IValueUnion_Object, &parseObject);
+  registerIValueParser(mobile::serialization::IValueUnion::IValueUnion_Device, &parseBasic);
   registerIValueParser(
-      mobile::serialization::IValueUnion::EnumValue, &parseEnum);
+      mobile::serialization::IValueUnion::IValueUnion_EnumValue, &parseEnum);
   internal_registerTypeResolver(&resolveType);
 }
 
@@ -346,21 +346,21 @@ IValue parseBasic(
     FlatbufferLoader&,
     const mobile::serialization::IValue& ivalue) {
   switch (ivalue.val_type()) {
-    case mobile::serialization::IValueUnion::NONE:
+    case mobile::serialization::IValueUnion::IValueUnion_NONE:
       return {};
-    case mobile::serialization::IValueUnion::Int:
+    case mobile::serialization::IValueUnion::IValueUnion_Int:
       return ivalue.val_as_Int()->int_val();
-    case mobile::serialization::IValueUnion::Bool:
+    case mobile::serialization::IValueUnion::IValueUnion_Bool:
       return ivalue.val_as_Bool()->bool_val();
-    case mobile::serialization::IValueUnion::Double:
+    case mobile::serialization::IValueUnion::IValueUnion_Double:
       return ivalue.val_as_Double()->double_val();
-    case mobile::serialization::IValueUnion::ComplexDouble: {
+    case mobile::serialization::IValueUnion::IValueUnion_ComplexDouble: {
       const auto* comp = ivalue.val_as_ComplexDouble();
       return c10::complex<double>(comp->real(), comp->imag());
     }
-    case mobile::serialization::IValueUnion::String:
+    case mobile::serialization::IValueUnion::IValueUnion_String:
       return ivalue.val_as_String()->data()->str();
-    case mobile::serialization::IValueUnion::Device: {
+    case mobile::serialization::IValueUnion::IValueUnion_Device: {
       return c10::Device(ivalue.val_as_Device()->str()->str());
     }
     default:
@@ -516,7 +516,7 @@ ClassTypePtr FlatbufferLoader::getOrCreateClassTypeForObject(
     TORCH_CHECK(object->type_index() < all_ivalues_.size());
     all_types_[object->type_index()] = cls;
 
-    if (obj_type->type() == mobile::serialization::TypeType::CLASS_WITH_FIELD) {
+    if (obj_type->type() == mobile::serialization::TypeType::TypeType_CLASS_WITH_FIELD) {
       for (uint32_t i = 0; i < object->attrs()->size(); i++) {
         IValue val = getIValue(object->attrs()->Get(i));
         // Need to use concrete object's field's type to set type of field.
@@ -541,7 +541,7 @@ IValue parseObject(
   auto cls = loader.getOrCreateClassTypeForObject(object);
   Stack stack;
   switch (obj_type->type()) {
-    case mobile::serialization::TypeType::CLASS_WITH_FIELD: {
+    case mobile::serialization::TypeType::TypeType_CLASS_WITH_FIELD: {
       auto obj = c10::ivalue::Object::create(
           at::StrongTypePtr(loader.cu_, cls), object->attrs()->size());
       for (uint32_t i = 0; i < object->attrs()->size(); i++) {
@@ -550,7 +550,7 @@ IValue parseObject(
       }
       return obj;
     }
-    case mobile::serialization::TypeType::CLASS_WITH_SETSTATE: {
+    case mobile::serialization::TypeType::TypeType_CLASS_WITH_SETSTATE: {
       IValue input = loader.getIValue(object->state());
       mobile::Function* setstate = loader.getFunction(object->setstate_func());
       auto obj =
@@ -560,7 +560,7 @@ IValue parseObject(
       setstate->run(stack);
       return obj;
     }
-    case mobile::serialization::TypeType::CUSTOM_CLASS: {
+    case mobile::serialization::TypeType::TypeType_CUSTOM_CLASS: {
       auto custom_class_type =
           torch::jit::getCustomClass(cls->name()->qualifiedName());
       IValue input = loader.getIValue(object->state());

--- a/torch/csrc/jit/mobile/flatbuffer_loader.h
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.h
@@ -164,7 +164,7 @@ class TORCH_API FlatbufferLoader {
   std::vector<IValue> all_ivalues_;
   std::array<
       IValueParser,
-      static_cast<uint8_t>(mobile::serialization::IValueUnion::MAX) + 1>
+      static_cast<uint8_t>(mobile::serialization::IValueUnion::IValueUnion_MAX) + 1>
       ivalue_parsers_;
   TypeResolver type_resolver_ = nullptr;
   mobile::serialization::Module* module_ = nullptr;

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -338,7 +338,7 @@ flatbuffers::DetachedBuffer FlatbufferSerializer::serializeModule(
   mcu_ = &module.compilation_unit();
 
   // first element is None.
-  insertIValue(CreateIValue(fbb, mobile::serialization::IValueUnion::NONE, 0));
+  insertIValue(CreateIValue(fbb, mobile::serialization::IValueUnion::IValueUnion_NONE, 0));
 
   auto methods = module.get_methods();
   std::vector<uint32_t> functions_index;
@@ -464,7 +464,7 @@ flatbuffers::Offset<mobile::serialization::Dict> FlatbufferSerializer::dictToFB(
 flatbuffers::Offset<mobile::serialization::ObjectType> FlatbufferSerializer::
     classTypeToFB(FlatBufferBuilder& fbb, ClassTypePtr class_ptr) {
   mobile::serialization::TypeType typetype =
-      mobile::serialization::TypeType::UNSET;
+      mobile::serialization::TypeType::TypeType_UNSET;
 
   flatbuffers::Offset<
       flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
@@ -474,11 +474,11 @@ flatbuffers::Offset<mobile::serialization::ObjectType> FlatbufferSerializer::
   const mobile::Function* setstate = mcu_->find_function(setstate_name);
   const mobile::Function* getstate = mcu_->find_function(getstate_name);
   if (setstate != nullptr && getstate != nullptr) {
-    typetype = mobile::serialization::TypeType::CLASS_WITH_SETSTATE;
+    typetype = mobile::serialization::TypeType::TypeType_CLASS_WITH_SETSTATE;
   } else if (
       class_ptr->findMethod("__setstate__") &&
       class_ptr->findMethod("__getstate__")) {
-    typetype = mobile::serialization::TypeType::CUSTOM_CLASS;
+    typetype = mobile::serialization::TypeType::TypeType_CUSTOM_CLASS;
   } else {
     size_t num_attr = class_ptr->numAttributes();
     std::vector<flatbuffers::Offset<flatbuffers::String>> names;
@@ -487,7 +487,7 @@ flatbuffers::Offset<mobile::serialization::ObjectType> FlatbufferSerializer::
       names.push_back(fbb.CreateSharedString(class_ptr->getAttributeName(i)));
     }
     names_offset = fbb.CreateVector(names);
-    typetype = mobile::serialization::TypeType::CLASS_WITH_FIELD;
+    typetype = mobile::serialization::TypeType::TypeType_CLASS_WITH_FIELD;
   }
 
   auto name_offset = fbb.CreateString(class_ptr->name()->qualifiedName());
@@ -505,7 +505,7 @@ uint32_t FlatbufferSerializer::storeFunctionAndGetIndex(
 
   auto offset = CreateIValue(
       fbb,
-      mobile::serialization::IValueUnion::Function,
+      mobile::serialization::IValueUnion::IValueUnion_Function,
       functionToFB(fbb, qn, function).Union());
 
   uint32_t index = insertIValue(offset);
@@ -667,68 +667,68 @@ flatbuffers::Offset<mobile::serialization::IValue> FlatbufferSerializer::
     iValueToFB(flatbuffers::FlatBufferBuilder& fbb, const IValue& ivalue) {
   using mobile::serialization::IValueUnion;
 
-  IValueUnion ivalue_type = IValueUnion::NONE;
+  IValueUnion ivalue_type = IValueUnion::IValueUnion_NONE;
   flatbuffers::Offset<void> offset = 0;
 
   if (ivalue.isTensor()) {
-    ivalue_type = IValueUnion::TensorMetadata;
+    ivalue_type = IValueUnion::IValueUnion_TensorMetadata;
     offset = tensorToFB(fbb, ivalue).Union();
   } else if (ivalue.isTuple()) {
-    ivalue_type = IValueUnion::Tuple;
+    ivalue_type = IValueUnion::IValueUnion_Tuple;
     offset = tupleToFB(fbb, ivalue).Union();
   } else if (ivalue.isDouble()) {
-    ivalue_type = IValueUnion::Double;
+    ivalue_type = IValueUnion::IValueUnion_Double;
     offset = fbb.CreateStruct(mobile::serialization::Double(ivalue.toDouble()))
                  .Union();
   } else if (ivalue.isComplexDouble()) {
     auto comp = ivalue.toComplexDouble();
-    ivalue_type = IValueUnion::ComplexDouble;
+    ivalue_type = IValueUnion::IValueUnion_ComplexDouble;
     offset = fbb.CreateStruct(mobile::serialization::ComplexDouble(
                                   comp.real(), comp.imag()))
                  .Union();
   } else if (ivalue.isInt()) {
-    ivalue_type = IValueUnion::Int;
+    ivalue_type = IValueUnion::IValueUnion_Int;
     offset =
         fbb.CreateStruct(mobile::serialization::Int(ivalue.toInt())).Union();
   } else if (ivalue.isBool()) {
-    ivalue_type = IValueUnion::Bool;
+    ivalue_type = IValueUnion::IValueUnion_Bool;
     offset =
         fbb.CreateStruct(mobile::serialization::Bool(ivalue.toBool())).Union();
   } else if (ivalue.isString()) {
-    ivalue_type = IValueUnion::String;
+    ivalue_type = IValueUnion::IValueUnion_String;
     offset = mobile::serialization::CreateString(
                  fbb, fbb.CreateSharedString(ivalue.toString()->string()))
                  .Union();
   } else if (ivalue.isGenericDict()) {
-    ivalue_type = IValueUnion::Dict;
+    ivalue_type = IValueUnion::IValueUnion_Dict;
     offset = dictToFB(fbb, ivalue).Union();
   } else if (ivalue.isNone()) {
-    ivalue_type = IValueUnion::NONE;
+    ivalue_type = IValueUnion::IValueUnion_NONE;
     offset = 0;
   } else if (ivalue.isIntList()) {
-    ivalue_type = IValueUnion::IntList;
+    ivalue_type = IValueUnion::IValueUnion_IntList;
     offset = mobile::serialization::CreateIntList(
                  fbb, fbb.CreateVector(ivalue.toIntVector()))
                  .Union();
   } else if (ivalue.isDoubleList()) {
-    ivalue_type = IValueUnion::DoubleList;
+    ivalue_type = IValueUnion::IValueUnion_DoubleList;
     offset = mobile::serialization::CreateDoubleList(
                  fbb, fbb.CreateVector(ivalue.toDoubleVector()))
                  .Union();
   } else if (ivalue.isBoolList()) {
-    ivalue_type = IValueUnion::BoolList;
+    ivalue_type = IValueUnion::IValueUnion_BoolList;
     auto boollist = ivalue.toBoolList();
     std::vector<uint8_t> bool_vec(boollist.begin(), boollist.end());
     offset =
         mobile::serialization::CreateBoolListDirect(fbb, &bool_vec).Union();
   } else if (ivalue.isList()) {
-    ivalue_type = IValueUnion::List;
+    ivalue_type = IValueUnion::IValueUnion_List;
     offset = listToFB(fbb, ivalue).Union();
   } else if (ivalue.isObject()) {
-    ivalue_type = IValueUnion::Object;
+    ivalue_type = IValueUnion::IValueUnion_Object;
     offset = objectToFB(fbb, ivalue).Union();
   } else if (ivalue.isDevice()) {
-    ivalue_type = IValueUnion::Device;
+    ivalue_type = IValueUnion::IValueUnion_Device;
     offset = mobile::serialization::CreateDevice(
                  fbb, fbb.CreateSharedString(ivalue.toDevice().str()))
                  .Union();
@@ -737,7 +737,7 @@ flatbuffers::Offset<mobile::serialization::IValue> FlatbufferSerializer::
     const auto& qualified_class_name =
         enum_holder->type()->qualifiedClassName();
     uint32_t ival_pos = storeIValueAndGetIndex(fbb, enum_holder->value());
-    ivalue_type = IValueUnion::EnumValue;
+    ivalue_type = IValueUnion::IValueUnion_EnumValue;
     offset = mobile::serialization::CreateEnumValue(
                  fbb,
                  fbb.CreateSharedString(qualified_class_name.qualifiedName()),

--- a/torch/csrc/jit/serialization/mobile_bytecode_generated.h
+++ b/torch/csrc/jit/serialization/mobile_bytecode_generated.h
@@ -89,23 +89,23 @@ struct ExtraFileBuilder;
 struct Module;
 struct ModuleBuilder;
 
-enum class TypeType : uint8_t {
-  UNSET = 0,
-  CLASS_WITH_FIELD = 1,
-  CUSTOM_CLASS = 2,
-  CLASS_WITH_SETSTATE = 3,
-  NON_OBJ = 4,
-  MIN = UNSET,
-  MAX = NON_OBJ
+enum TypeType : uint8_t {
+  TypeType_UNSET = 0,
+  TypeType_CLASS_WITH_FIELD = 1,
+  TypeType_CUSTOM_CLASS = 2,
+  TypeType_CLASS_WITH_SETSTATE = 3,
+  TypeType_NON_OBJ = 4,
+  TypeType_MIN = TypeType_UNSET,
+  TypeType_MAX = TypeType_NON_OBJ
 };
 
 inline const TypeType (&EnumValuesTypeType())[5] {
   static const TypeType values[] = {
-    TypeType::UNSET,
-    TypeType::CLASS_WITH_FIELD,
-    TypeType::CUSTOM_CLASS,
-    TypeType::CLASS_WITH_SETSTATE,
-    TypeType::NON_OBJ
+    TypeType_UNSET,
+    TypeType_CLASS_WITH_FIELD,
+    TypeType_CUSTOM_CLASS,
+    TypeType_CLASS_WITH_SETSTATE,
+    TypeType_NON_OBJ
   };
   return values;
 }
@@ -123,52 +123,52 @@ inline const char * const *EnumNamesTypeType() {
 }
 
 inline const char *EnumNameTypeType(TypeType e) {
-  if (flatbuffers::IsOutRange(e, TypeType::UNSET, TypeType::NON_OBJ)) return "";
+  if (flatbuffers::IsOutRange(e, TypeType_UNSET, TypeType_NON_OBJ)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesTypeType()[index];
 }
 
-enum class IValueUnion : uint8_t {
-  NONE = 0,
-  Int = 1,
-  Bool = 2,
-  Double = 3,
-  ComplexDouble = 4,
-  TensorMetadata = 5,
-  String = 6,
-  List = 7,
-  Tuple = 8,
-  Dict = 9,
-  Object = 10,
-  IntList = 11,
-  DoubleList = 12,
-  BoolList = 13,
-  Device = 14,
-  EnumValue = 15,
-  Function = 16,
-  MIN = NONE,
-  MAX = Function
+enum IValueUnion : uint8_t {
+  IValueUnion_NONE = 0,
+  IValueUnion_Int = 1,
+  IValueUnion_Bool = 2,
+  IValueUnion_Double = 3,
+  IValueUnion_ComplexDouble = 4,
+  IValueUnion_TensorMetadata = 5,
+  IValueUnion_String = 6,
+  IValueUnion_List = 7,
+  IValueUnion_Tuple = 8,
+  IValueUnion_Dict = 9,
+  IValueUnion_Object = 10,
+  IValueUnion_IntList = 11,
+  IValueUnion_DoubleList = 12,
+  IValueUnion_BoolList = 13,
+  IValueUnion_Device = 14,
+  IValueUnion_EnumValue = 15,
+  IValueUnion_Function = 16,
+  IValueUnion_MIN = IValueUnion_NONE,
+  IValueUnion_MAX = IValueUnion_Function
 };
 
 inline const IValueUnion (&EnumValuesIValueUnion())[17] {
   static const IValueUnion values[] = {
-    IValueUnion::NONE,
-    IValueUnion::Int,
-    IValueUnion::Bool,
-    IValueUnion::Double,
-    IValueUnion::ComplexDouble,
-    IValueUnion::TensorMetadata,
-    IValueUnion::String,
-    IValueUnion::List,
-    IValueUnion::Tuple,
-    IValueUnion::Dict,
-    IValueUnion::Object,
-    IValueUnion::IntList,
-    IValueUnion::DoubleList,
-    IValueUnion::BoolList,
-    IValueUnion::Device,
-    IValueUnion::EnumValue,
-    IValueUnion::Function
+    IValueUnion_NONE,
+    IValueUnion_Int,
+    IValueUnion_Bool,
+    IValueUnion_Double,
+    IValueUnion_ComplexDouble,
+    IValueUnion_TensorMetadata,
+    IValueUnion_String,
+    IValueUnion_List,
+    IValueUnion_Tuple,
+    IValueUnion_Dict,
+    IValueUnion_Object,
+    IValueUnion_IntList,
+    IValueUnion_DoubleList,
+    IValueUnion_BoolList,
+    IValueUnion_Device,
+    IValueUnion_EnumValue,
+    IValueUnion_Function
   };
   return values;
 }
@@ -198,81 +198,81 @@ inline const char * const *EnumNamesIValueUnion() {
 }
 
 inline const char *EnumNameIValueUnion(IValueUnion e) {
-  if (flatbuffers::IsOutRange(e, IValueUnion::NONE, IValueUnion::Function)) return "";
+  if (flatbuffers::IsOutRange(e, IValueUnion_NONE, IValueUnion_Function)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesIValueUnion()[index];
 }
 
 template<typename T> struct IValueUnionTraits {
-  static const IValueUnion enum_value = IValueUnion::NONE;
+  static const IValueUnion enum_value = IValueUnion_NONE;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::Int> {
-  static const IValueUnion enum_value = IValueUnion::Int;
+  static const IValueUnion enum_value = IValueUnion_Int;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::Bool> {
-  static const IValueUnion enum_value = IValueUnion::Bool;
+  static const IValueUnion enum_value = IValueUnion_Bool;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::Double> {
-  static const IValueUnion enum_value = IValueUnion::Double;
+  static const IValueUnion enum_value = IValueUnion_Double;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::ComplexDouble> {
-  static const IValueUnion enum_value = IValueUnion::ComplexDouble;
+  static const IValueUnion enum_value = IValueUnion_ComplexDouble;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::TensorMetadata> {
-  static const IValueUnion enum_value = IValueUnion::TensorMetadata;
+  static const IValueUnion enum_value = IValueUnion_TensorMetadata;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::String> {
-  static const IValueUnion enum_value = IValueUnion::String;
+  static const IValueUnion enum_value = IValueUnion_String;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::List> {
-  static const IValueUnion enum_value = IValueUnion::List;
+  static const IValueUnion enum_value = IValueUnion_List;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::Tuple> {
-  static const IValueUnion enum_value = IValueUnion::Tuple;
+  static const IValueUnion enum_value = IValueUnion_Tuple;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::Dict> {
-  static const IValueUnion enum_value = IValueUnion::Dict;
+  static const IValueUnion enum_value = IValueUnion_Dict;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::Object> {
-  static const IValueUnion enum_value = IValueUnion::Object;
+  static const IValueUnion enum_value = IValueUnion_Object;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::IntList> {
-  static const IValueUnion enum_value = IValueUnion::IntList;
+  static const IValueUnion enum_value = IValueUnion_IntList;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::DoubleList> {
-  static const IValueUnion enum_value = IValueUnion::DoubleList;
+  static const IValueUnion enum_value = IValueUnion_DoubleList;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::BoolList> {
-  static const IValueUnion enum_value = IValueUnion::BoolList;
+  static const IValueUnion enum_value = IValueUnion_BoolList;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::Device> {
-  static const IValueUnion enum_value = IValueUnion::Device;
+  static const IValueUnion enum_value = IValueUnion_Device;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::EnumValue> {
-  static const IValueUnion enum_value = IValueUnion::EnumValue;
+  static const IValueUnion enum_value = IValueUnion_EnumValue;
 };
 
 template<> struct IValueUnionTraits<torch::jit::mobile::serialization::Function> {
-  static const IValueUnion enum_value = IValueUnion::Function;
+  static const IValueUnion enum_value = IValueUnion_Function;
 };
 
 bool VerifyIValueUnion(flatbuffers::Verifier &verifier, const void *obj, IValueUnion type);
-bool VerifyIValueUnionVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<IValueUnion> *types);
+bool VerifyIValueUnionVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<uint8_t> *types);
 
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Int FLATBUFFERS_FINAL_CLASS {
  private:
@@ -488,14 +488,14 @@ struct QuantizedSchema FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<int8_t>(verifier, VT_QSCHEME) &&
-           VerifyField<double>(verifier, VT_SCALE) &&
-           VerifyField<int32_t>(verifier, VT_ZERO_POINT) &&
+           VerifyField<int8_t>(verifier, VT_QSCHEME, 1) &&
+           VerifyField<double>(verifier, VT_SCALE, 8) &&
+           VerifyField<int32_t>(verifier, VT_ZERO_POINT, 4) &&
            VerifyOffset(verifier, VT_SCALES) &&
            verifier.VerifyTable(scales()) &&
            VerifyOffset(verifier, VT_ZERO_POINTS) &&
            verifier.VerifyTable(zero_points()) &&
-           VerifyField<int32_t>(verifier, VT_AXIS) &&
+           VerifyField<int32_t>(verifier, VT_AXIS, 4) &&
            verifier.EndTable();
   }
 };
@@ -606,14 +606,14 @@ struct TensorMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint32_t>(verifier, VT_STORAGE_LOCATION_INDEX) &&
-           VerifyField<int8_t>(verifier, VT_SCALAR_TYPE) &&
-           VerifyField<int32_t>(verifier, VT_STORAGE_OFFSET) &&
+           VerifyField<uint32_t>(verifier, VT_STORAGE_LOCATION_INDEX, 4) &&
+           VerifyField<int8_t>(verifier, VT_SCALAR_TYPE, 1) &&
+           VerifyField<int32_t>(verifier, VT_STORAGE_OFFSET, 4) &&
            VerifyOffset(verifier, VT_SIZES) &&
            verifier.VerifyVector(sizes()) &&
            VerifyOffset(verifier, VT_STRIDES) &&
            verifier.VerifyVector(strides()) &&
-           VerifyField<uint8_t>(verifier, VT_REQUIRES_GRAD) &&
+           VerifyField<uint8_t>(verifier, VT_REQUIRES_GRAD, 1) &&
            VerifyOffset(verifier, VT_QUANTIZED_SCHEMA) &&
            verifier.VerifyTable(quantized_schema()) &&
            verifier.EndTable();
@@ -1210,7 +1210,7 @@ struct ObjectType FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_TYPE_NAME) &&
            verifier.VerifyString(type_name()) &&
-           VerifyField<uint8_t>(verifier, VT_TYPE) &&
+           VerifyField<uint8_t>(verifier, VT_TYPE, 1) &&
            VerifyOffset(verifier, VT_ATTR_NAMES) &&
            verifier.VerifyVector(attr_names()) &&
            verifier.VerifyVectorOfStrings(attr_names()) &&
@@ -1245,7 +1245,7 @@ struct ObjectTypeBuilder {
 inline flatbuffers::Offset<ObjectType> CreateObjectType(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> type_name = 0,
-    torch::jit::mobile::serialization::TypeType type = torch::jit::mobile::serialization::TypeType::UNSET,
+    torch::jit::mobile::serialization::TypeType type = torch::jit::mobile::serialization::TypeType_UNSET,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> attr_names = 0) {
   ObjectTypeBuilder builder_(_fbb);
   builder_.add_attr_names(attr_names);
@@ -1257,7 +1257,7 @@ inline flatbuffers::Offset<ObjectType> CreateObjectType(
 inline flatbuffers::Offset<ObjectType> CreateObjectTypeDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *type_name = nullptr,
-    torch::jit::mobile::serialization::TypeType type = torch::jit::mobile::serialization::TypeType::UNSET,
+    torch::jit::mobile::serialization::TypeType type = torch::jit::mobile::serialization::TypeType_UNSET,
     const std::vector<flatbuffers::Offset<flatbuffers::String>> *attr_names = nullptr) {
   auto type_name__ = type_name ? _fbb.CreateString(type_name) : 0;
   auto attr_names__ = attr_names ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*attr_names) : 0;
@@ -1302,11 +1302,11 @@ struct Object FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint32_t>(verifier, VT_TYPE_INDEX) &&
-           VerifyField<uint32_t>(verifier, VT_STATE) &&
+           VerifyField<uint32_t>(verifier, VT_TYPE_INDEX, 4) &&
+           VerifyField<uint32_t>(verifier, VT_STATE, 4) &&
            VerifyOffset(verifier, VT_ATTRS) &&
            verifier.VerifyVector(attrs()) &&
-           VerifyField<uint32_t>(verifier, VT_SETSTATE_FUNC) &&
+           VerifyField<uint32_t>(verifier, VT_SETSTATE_FUNC, 4) &&
            verifier.EndTable();
   }
 };
@@ -1389,7 +1389,7 @@ struct EnumValue FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_TYPE_NAME) &&
            verifier.VerifyString(type_name()) &&
-           VerifyField<uint32_t>(verifier, VT_VALUE) &&
+           VerifyField<uint32_t>(verifier, VT_VALUE, 4) &&
            verifier.EndTable();
   }
 };
@@ -1467,7 +1467,7 @@ struct Operator FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyString(name()) &&
            VerifyOffset(verifier, VT_OVERLOAD_NAME) &&
            verifier.VerifyString(overload_name()) &&
-           VerifyField<int32_t>(verifier, VT_NUM_ARGS_SERIALIZED) &&
+           VerifyField<int32_t>(verifier, VT_NUM_ARGS_SERIALIZED, 4) &&
            verifier.EndTable();
   }
 };
@@ -1553,7 +1553,7 @@ struct Arg FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyString(name()) &&
            VerifyOffset(verifier, VT_TYPE) &&
            verifier.VerifyString(type()) &&
-           VerifyField<uint32_t>(verifier, VT_DEFAULT_VALUE) &&
+           VerifyField<uint32_t>(verifier, VT_DEFAULT_VALUE, 4) &&
            verifier.EndTable();
   }
 };
@@ -1816,12 +1816,12 @@ struct Function FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyOffset(verifier, VT_TYPE_ANNOTATIONS) &&
            verifier.VerifyVector(type_annotations()) &&
            verifier.VerifyVectorOfStrings(type_annotations()) &&
-           VerifyField<int32_t>(verifier, VT_REGISTER_SIZE) &&
+           VerifyField<int32_t>(verifier, VT_REGISTER_SIZE, 4) &&
            VerifyOffset(verifier, VT_SCHEMA) &&
            verifier.VerifyTable(schema()) &&
            VerifyOffset(verifier, VT_DEBUG_INFO) &&
            verifier.VerifyTable(debug_info()) &&
-           VerifyField<uint32_t>(verifier, VT_CLASS_TYPE) &&
+           VerifyField<uint32_t>(verifier, VT_CLASS_TYPE, 4) &&
            verifier.EndTable();
   }
 };
@@ -1990,59 +1990,59 @@ struct IValue FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   template<typename T> const T *val_as() const;
   const torch::jit::mobile::serialization::Int *val_as_Int() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::Int ? static_cast<const torch::jit::mobile::serialization::Int *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_Int ? static_cast<const torch::jit::mobile::serialization::Int *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::Bool *val_as_Bool() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::Bool ? static_cast<const torch::jit::mobile::serialization::Bool *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_Bool ? static_cast<const torch::jit::mobile::serialization::Bool *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::Double *val_as_Double() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::Double ? static_cast<const torch::jit::mobile::serialization::Double *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_Double ? static_cast<const torch::jit::mobile::serialization::Double *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::ComplexDouble *val_as_ComplexDouble() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::ComplexDouble ? static_cast<const torch::jit::mobile::serialization::ComplexDouble *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_ComplexDouble ? static_cast<const torch::jit::mobile::serialization::ComplexDouble *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::TensorMetadata *val_as_TensorMetadata() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::TensorMetadata ? static_cast<const torch::jit::mobile::serialization::TensorMetadata *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_TensorMetadata ? static_cast<const torch::jit::mobile::serialization::TensorMetadata *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::String *val_as_String() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::String ? static_cast<const torch::jit::mobile::serialization::String *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_String ? static_cast<const torch::jit::mobile::serialization::String *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::List *val_as_List() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::List ? static_cast<const torch::jit::mobile::serialization::List *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_List ? static_cast<const torch::jit::mobile::serialization::List *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::Tuple *val_as_Tuple() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::Tuple ? static_cast<const torch::jit::mobile::serialization::Tuple *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_Tuple ? static_cast<const torch::jit::mobile::serialization::Tuple *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::Dict *val_as_Dict() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::Dict ? static_cast<const torch::jit::mobile::serialization::Dict *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_Dict ? static_cast<const torch::jit::mobile::serialization::Dict *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::Object *val_as_Object() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::Object ? static_cast<const torch::jit::mobile::serialization::Object *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_Object ? static_cast<const torch::jit::mobile::serialization::Object *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::IntList *val_as_IntList() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::IntList ? static_cast<const torch::jit::mobile::serialization::IntList *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_IntList ? static_cast<const torch::jit::mobile::serialization::IntList *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::DoubleList *val_as_DoubleList() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::DoubleList ? static_cast<const torch::jit::mobile::serialization::DoubleList *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_DoubleList ? static_cast<const torch::jit::mobile::serialization::DoubleList *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::BoolList *val_as_BoolList() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::BoolList ? static_cast<const torch::jit::mobile::serialization::BoolList *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_BoolList ? static_cast<const torch::jit::mobile::serialization::BoolList *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::Device *val_as_Device() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::Device ? static_cast<const torch::jit::mobile::serialization::Device *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_Device ? static_cast<const torch::jit::mobile::serialization::Device *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::EnumValue *val_as_EnumValue() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::EnumValue ? static_cast<const torch::jit::mobile::serialization::EnumValue *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_EnumValue ? static_cast<const torch::jit::mobile::serialization::EnumValue *>(val()) : nullptr;
   }
   const torch::jit::mobile::serialization::Function *val_as_Function() const {
-    return val_type() == torch::jit::mobile::serialization::IValueUnion::Function ? static_cast<const torch::jit::mobile::serialization::Function *>(val()) : nullptr;
+    return val_type() == torch::jit::mobile::serialization::IValueUnion_Function ? static_cast<const torch::jit::mobile::serialization::Function *>(val()) : nullptr;
   }
   void *mutable_val() {
     return GetPointer<void *>(VT_VAL);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint8_t>(verifier, VT_VAL_TYPE) &&
+           VerifyField<uint8_t>(verifier, VT_VAL_TYPE, 1) &&
            VerifyOffset(verifier, VT_VAL) &&
            VerifyIValueUnion(verifier, val(), val_type()) &&
            verifier.EndTable();
@@ -2136,7 +2136,7 @@ struct IValueBuilder {
 
 inline flatbuffers::Offset<IValue> CreateIValue(
     flatbuffers::FlatBufferBuilder &_fbb,
-    torch::jit::mobile::serialization::IValueUnion val_type = torch::jit::mobile::serialization::IValueUnion::NONE,
+    torch::jit::mobile::serialization::IValueUnion val_type = torch::jit::mobile::serialization::IValueUnion_NONE,
     flatbuffers::Offset<void> val = 0) {
   IValueBuilder builder_(_fbb);
   builder_.add_val(val);
@@ -2305,17 +2305,17 @@ struct Module FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint32_t>(verifier, VT_BYTECODE_VERSION) &&
+           VerifyField<uint32_t>(verifier, VT_BYTECODE_VERSION, 4) &&
            VerifyOffset(verifier, VT_EXTRA_FILES) &&
            verifier.VerifyVector(extra_files()) &&
            verifier.VerifyVectorOfTables(extra_files()) &&
            VerifyOffset(verifier, VT_METHODS) &&
            verifier.VerifyVector(methods()) &&
-           VerifyField<uint32_t>(verifier, VT_STATE_OBJ) &&
+           VerifyField<uint32_t>(verifier, VT_STATE_OBJ, 4) &&
            VerifyOffset(verifier, VT_IVALUES) &&
            verifier.VerifyVector(ivalues()) &&
            verifier.VerifyVectorOfTables(ivalues()) &&
-           VerifyField<int32_t>(verifier, VT_STORAGE_DATA_SIZE) &&
+           VerifyField<int32_t>(verifier, VT_STORAGE_DATA_SIZE, 4) &&
            VerifyOffset(verifier, VT_STORAGE_DATA) &&
            verifier.VerifyVector(storage_data()) &&
            verifier.VerifyVectorOfTables(storage_data()) &&
@@ -2327,8 +2327,8 @@ struct Module FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVectorOfTables(jit_sources()) &&
            VerifyOffset(verifier, VT_JIT_CONSTANTS) &&
            verifier.VerifyVector(jit_constants()) &&
-           VerifyField<uint32_t>(verifier, VT_OPERATOR_VERSION) &&
-           VerifyField<uint32_t>(verifier, VT_MOBILE_IVALUE_SIZE) &&
+           VerifyField<uint32_t>(verifier, VT_OPERATOR_VERSION, 4) &&
+           VerifyField<uint32_t>(verifier, VT_MOBILE_IVALUE_SIZE, 4) &&
            verifier.EndTable();
   }
 };
@@ -2453,66 +2453,66 @@ inline flatbuffers::Offset<Module> CreateModuleDirect(
 
 inline bool VerifyIValueUnion(flatbuffers::Verifier &verifier, const void *obj, IValueUnion type) {
   switch (type) {
-    case IValueUnion::NONE: {
+    case IValueUnion_NONE: {
       return true;
     }
-    case IValueUnion::Int: {
-      return verifier.Verify<torch::jit::mobile::serialization::Int>(static_cast<const uint8_t *>(obj), 0);
+    case IValueUnion_Int: {
+      return verifier.VerifyField<torch::jit::mobile::serialization::Int>(static_cast<const uint8_t *>(obj), 0, 8);
     }
-    case IValueUnion::Bool: {
-      return verifier.Verify<torch::jit::mobile::serialization::Bool>(static_cast<const uint8_t *>(obj), 0);
+    case IValueUnion_Bool: {
+      return verifier.VerifyField<torch::jit::mobile::serialization::Bool>(static_cast<const uint8_t *>(obj), 0, 1);
     }
-    case IValueUnion::Double: {
-      return verifier.Verify<torch::jit::mobile::serialization::Double>(static_cast<const uint8_t *>(obj), 0);
+    case IValueUnion_Double: {
+      return verifier.VerifyField<torch::jit::mobile::serialization::Double>(static_cast<const uint8_t *>(obj), 0, 8);
     }
-    case IValueUnion::ComplexDouble: {
-      return verifier.Verify<torch::jit::mobile::serialization::ComplexDouble>(static_cast<const uint8_t *>(obj), 0);
+    case IValueUnion_ComplexDouble: {
+      return verifier.VerifyField<torch::jit::mobile::serialization::ComplexDouble>(static_cast<const uint8_t *>(obj), 0, 8);
     }
-    case IValueUnion::TensorMetadata: {
+    case IValueUnion_TensorMetadata: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::TensorMetadata *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case IValueUnion::String: {
+    case IValueUnion_String: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::String *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case IValueUnion::List: {
+    case IValueUnion_List: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::List *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case IValueUnion::Tuple: {
+    case IValueUnion_Tuple: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::Tuple *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case IValueUnion::Dict: {
+    case IValueUnion_Dict: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::Dict *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case IValueUnion::Object: {
+    case IValueUnion_Object: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::Object *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case IValueUnion::IntList: {
+    case IValueUnion_IntList: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::IntList *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case IValueUnion::DoubleList: {
+    case IValueUnion_DoubleList: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::DoubleList *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case IValueUnion::BoolList: {
+    case IValueUnion_BoolList: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::BoolList *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case IValueUnion::Device: {
+    case IValueUnion_Device: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::Device *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case IValueUnion::EnumValue: {
+    case IValueUnion_EnumValue: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::EnumValue *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case IValueUnion::Function: {
+    case IValueUnion_Function: {
       auto ptr = reinterpret_cast<const torch::jit::mobile::serialization::Function *>(obj);
       return verifier.VerifyTable(ptr);
     }
@@ -2520,7 +2520,7 @@ inline bool VerifyIValueUnion(flatbuffers::Verifier &verifier, const void *obj, 
   }
 }
 
-inline bool VerifyIValueUnionVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<IValueUnion> *types) {
+inline bool VerifyIValueUnionVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<uint8_t> *types) {
   if (!values || !types) return !values && !types;
   if (values->size() != types->size()) return false;
   for (flatbuffers::uoffset_t i = 0; i < values->size(); ++i) {
@@ -2557,6 +2557,11 @@ inline bool ModuleBufferHasIdentifier(const void *buf) {
       buf, ModuleIdentifier());
 }
 
+inline bool SizePrefixedModuleBufferHasIdentifier(const void *buf) {
+  return flatbuffers::BufferHasIdentifier(
+      buf, ModuleIdentifier(), true);
+}
+
 inline bool VerifyModuleBuffer(
     flatbuffers::Verifier &verifier) {
   return verifier.VerifyBuffer<torch::jit::mobile::serialization::Module>(ModuleIdentifier());
@@ -2585,4 +2590,3 @@ inline void FinishSizePrefixedModuleBuffer(
 }  // namespace torch
 
 #endif  // FLATBUFFERS_GENERATED_MOBILEBYTECODE_TORCH_JIT_MOBILE_SERIALIZATION_H_
-// @generated


### PR DESCRIPTION
When trying to build pytorch `1.12~rc1` with system flatbuffers (v2.0.6) instead of the third party submodule (v2.0.5), the source fails to build due to API mismatch. So I patched the source and let it build against flatbuffers v2.0.6 .
The patch is directly rebased from `1.12~rc1` to master branch. I did not double check because I have no idea when the flatbuffers submodule will be bumped.