### PR TITLE
Add dump function for all Vectorized specializations

### DIFF
--- a/aten/src/ATen/cpu/vec/vec_base.h
+++ b/aten/src/ATen/cpu/vec/vec_base.h
@@ -691,6 +691,16 @@ Vectorized<T> inline clamp_min(const Vectorized<T> &a, const Vectorized<T> &min_
   return c;
 }
 
+template <class T>
+static void dump(const Vectorized<T>& a) {
+  __at_align32__ T tmp_values[a.size()];
+  a.store(tmp_values);
+  for (size_t i = 0; i < a.size(); ++i) {
+      std::cout << tmp_values[i] << " ";
+  }
+  std::cout << std::endl;
+}
+
 struct Vectorizedi;
 
 #if defined(CPU_CAPABILITY_AVX2) || defined(CPU_CAPABILITY_AVX512)


### PR DESCRIPTION
This really helps when debugging issues hence introduce a generic function instead of the per-instantiation dump member function so it can be used consistently.

I needed this for my work on the POWER issues and noticed only some classes/specializations of the `vec.dump()` function, hence the added `dump(vec)` free function which avoids the need to add one for each new specialization.

I'm sure this can be helpful to others too and would even suggest to dump the `dump` member functions (Pun intended ;-) )

CC @VitalyFedyunin after #59443