### PR TITLE
[TorchArrow][efficiency][2/n] added inference_wrapper_run_flat_out fused version registration call

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -848,6 +848,8 @@ bool shouldNotFuseListUnpackSpecialCase(const Node* node) {
     return false;
   }
 
+
+
   // To fuse with sigrid transforms, we must be able to statically determine
   // `instance` and `use_offsets` - these two together let us statically
   // determine the types of the outputs. Rationale: it is a huge pain to write
@@ -869,6 +871,9 @@ bool shouldNotFuseListUnpackSpecialCase(const Node* node) {
 
 void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
   const FastMap<c10::Symbol, c10::Symbol> unfused_to_fused = {
+      OP_PAIR(
+          "torcharrow::inference_wrapper_run_flat",
+          "static_runtime::fused_inference_wrapper_run_flat"),
       OP_PAIR("fb::equally_split", "static_runtime::fused_equally_split"),
       OP_PAIR(
           "fb::sigrid_transforms", "static_runtime::fused_sigrid_transforms"),


### PR DESCRIPTION
Summary:
Added registration call to make pytorch runtime aware of `inference_wrapper_run_flat_out` functionality. Added fused version of op which will enable out variants when [OptimizeGraph pass](https://fburl.com/code/lsagnmge) is made.

Next: need to add variadic version of fused and unfused op.

Test Plan:
Added `TEST(StaticRuntime, InferenceWrapperRunFlat)`.
________________
# ptvsc2_predictor_bench benchmark run
```
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./buck-out/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench \
    --scripted_model=/tmp/351084031_0.predictor.disagg.local \
    --pt_inputs=/tmp/347514183_1_local.inputs.recordio \
    --input_type="recordio" \
    --pt_enable_static_runtime=1 \
    --pt_enable_out_variant=1 \
    --pt_manage_output_tensors=1 \
    --pt_enable_tensorexpr_fusion=0 \
    --compare_results=0 \
    --iters=100 \
    --warmup_iters=100 \
    --num_threads=1 \
    --do_profile=1 \
    --do_benchmark=1 \
    --pt_optimize_memory=1 \
    --set_compatibility=1 \
    --method_name=local.forward \
    --recordio_use_ivalue_format=1 \
    --repetitions=3 \
    --pt_use_maybe_copy_variants=1 \
    --pt_use_copy_variants=1

```

Full logs https://www.internalfb.com/phabricator/paste/view/P512417842

```
Input size: 178
Static runtime ms per iter: 0.652349. Iters per second: 1532.92
Time per node type:
        0.45103 ms.    69.0902%. static_runtime::fused_inference_wrapper_run_flat (1 nodes, out variant)
       0.186489 ms.    28.5669%. aten::linear (3 nodes, out variant)
     0.00729831 ms.    1.11798%. aten::layer_norm (1 nodes, out variant)
      0.0025013 ms.   0.383157%. aten::sigmoid (1 nodes, out variant)
      0.0022241 ms.   0.340694%. aten::mul (1 nodes, out variant)
    0.000916632 ms.   0.140412%. aten::clamp (1 nodes, out variant)
    0.000586544 ms.  0.0898485%. fb::unsqueeze_n_times (1 nodes, native)
     0.00045007 ms.  0.0689431%. fb::to_lengths_to_offsets (2 nodes, out variant)
    0.000358921 ms.  0.0549807%. prim::ListConstruct (1 nodes, out variant)
    0.000306619 ms.  0.0469689%. static_runtime::dict_unpack (1 nodes, native)
    0.000296009 ms.  0.0453436%. prim::TupleConstruct (1 nodes, out variant)
    0.000191065 ms.  0.0292678%. static_runtime::VarTupleUnpack (1 nodes, native)
     0.00011368 ms.  0.0174138%. static_runtime::to_maybe_copy_out (1 nodes, out variant)
    5.13338e-05 ms. 0.00786347%. static_runtime::select_tensor (1 nodes, native)
       0.652814 ms. in Total
BlockRunner setup time: 0.003054 ms
Memory allocation time: 0.00177592 ms
Memory deallocation time: 0.00356809 ms
Outputs deallocation time: 0.000151008 ms
First iter time: 0.703018 ms
Number of operators: 17
Total number of managed tensors: 8
Total number of managed output tensors: 7
Total number of unmanaged values: 10
Number of unmanaged values requiring cleanup: 9
Number of unmanaged values not requiring cleanup: 1
Total memory managed: 570304 bytes
Total number of reused tensors: 4
Total number of 'out' variant nodes/total number of nodes: 13/17 (76.4706%)
Total number of nodes not covered by SR/total number of nodes: 0/17 (0%)
Input size: 178
Static runtime ms per iter: 0.664118. Iters per second: 1505.76
Time per node type:
       0.464489 ms.    68.9413%. static_runtime::fused_inference_wrapper_run_flat (1 nodes, out variant)
        0.19341 ms.    28.7067%. aten::linear (3 nodes, out variant)
     0.00757482 ms.    1.12429%. aten::layer_norm (1 nodes, out variant)
     0.00259514 ms.   0.385181%. aten::sigmoid (1 nodes, out variant)
     0.00229993 ms.   0.341364%. aten::mul (1 nodes, out variant)
    0.000949868 ms.   0.140983%. aten::clamp (1 nodes, out variant)
    0.000608468 ms.  0.0903112%. fb::unsqueeze_n_times (1 nodes, native)
    0.000468258 ms.  0.0695007%. fb::to_lengths_to_offsets (2 nodes, out variant)
     0.00037085 ms.   0.055043%. prim::ListConstruct (1 nodes, out variant)
    0.000315018 ms.  0.0467563%. static_runtime::dict_unpack (1 nodes, native)
    0.000296411 ms.  0.0439946%. prim::TupleConstruct (1 nodes, out variant)
    0.000197077 ms.   0.029251%. static_runtime::VarTupleUnpack (1 nodes, native)
    0.000110735 ms.  0.0164357%. static_runtime::to_maybe_copy_out (1 nodes, out variant)
    6.02183e-05 ms. 0.00893785%. static_runtime::select_tensor (1 nodes, native)
       0.673746 ms. in Total
BlockRunner setup time: 0.003804 ms
Memory allocation time: 0.00183777 ms
Memory deallocation time: 0.00370404 ms
Outputs deallocation time: 0.000157145 ms
First iter time: 0.74622 ms
Number of operators: 17
Total number of managed tensors: 8
Total number of managed output tensors: 7
Total number of unmanaged values: 10
Number of unmanaged values requiring cleanup: 9
Number of unmanaged values not requiring cleanup: 1
Total memory managed: 570304 bytes
Total number of reused tensors: 4
Total number of 'out' variant nodes/total number of nodes: 13/17 (76.4706%)
Total number of nodes not covered by SR/total number of nodes: 0/17 (0%)
Input size: 178
Static runtime ms per iter: 0.702102. Iters per second: 1424.29
```

Differential Revision: D37139204

