### PR TITLE
Switch to clang for OSS BUCK build

### DIFF
--- a/.buckconfig.oss
+++ b/.buckconfig.oss
@@ -15,6 +15,8 @@
 [cxx]
   cxxflags = -std=c++17
   should_remap_host_platform = true
+  cpp = /usr/bin/clang++
+  cc = /usr/bin/clang
 
 [project]
   default_flavors_mode=all

--- a/.buckconfig.oss
+++ b/.buckconfig.oss
@@ -15,8 +15,11 @@
 [cxx]
   cxxflags = -std=c++17
   should_remap_host_platform = true
-  cpp = /usr/bin/clang++
+  cpp = /usr/bin/clang
   cc = /usr/bin/clang
+  cxx = /usr/bin/clang++
+  cxxpp = /usr/bin/clang++
+  ld = /usr/bin/clang++
 
 [project]
   default_flavors_mode=all


### PR DESCRIPTION
Use clang compiler for OSS BUCK build. Some flags are only for clang not gcc.