### PR TITLE
[test_shape_ops] Increase system memory requirement

### DIFF
--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -475,6 +475,7 @@ class TestShapeOps(TestCase):
 
     @onlyCUDA  # CPU is too slow
     @largeTensorTest('17GB')  # 4 tensors of 4GB (in, out) x (torch, numpy) + 1GB
+    @largeTensorTest("81GB", "cpu") # even for CUDA test, sufficient system memory is required
     def test_flip_large_tensor(self, device):
         t_in = torch.empty(2**32 + 1, dtype=torch.uint8).random_()
         torch_fn = partial(torch.flip, dims=(0,))

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -475,7 +475,7 @@ class TestShapeOps(TestCase):
 
     @onlyCUDA  # CPU is too slow
     @largeTensorTest('17GB')  # 4 tensors of 4GB (in, out) x (torch, numpy) + 1GB
-    @largeTensorTest("81GB", "cpu") # even for CUDA test, sufficient system memory is required
+    @largeTensorTest("81GB", "cpu")  # even for CUDA test, sufficient system memory is required
     def test_flip_large_tensor(self, device):
         t_in = torch.empty(2**32 + 1, dtype=torch.uint8).random_()
         torch_fn = partial(torch.flip, dims=(0,))


### PR DESCRIPTION
Increase system memory requirement for TestShapeOpsCUDA.test_flip_large_tensor_cuda

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>

Fixes https://github.com/pytorch/pytorch/issues/80373
