### PR TITLE
[c10] move fexceptions to compiler_flags

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -156,6 +156,7 @@ def get_pt_compiler_flags():
     })
 
 _PT_COMPILER_FLAGS = [
+    "-fexceptions",
     "-frtti",
     "-Os",
     "-Wno-unknown-pragmas",
@@ -1116,6 +1117,7 @@ def define_buck_targets(
         deps = [
             C10,
         ],
+        compiler_flags = ["-fexceptions"],
     )
 
     # Base library shared by lite-interpreter and full-jit.
@@ -1844,6 +1846,7 @@ def define_buck_targets(
             ":torch_core",
             C10,
         ],
+        compiler_flags = ["-fexceptions"],
     )
 
     # aten_cpu and aten_native_cpu

--- a/build.bzl
+++ b/build.bzl
@@ -27,6 +27,7 @@ def define_targets(rules):
             "//c10",
             "//third_party/miniz-2.1.0:miniz",
         ],
+        copts = ["-fexceptions"],
     )
 
     #


### PR DESCRIPTION
Summary: Move `-fexceptions` out of the exported preprocessor flags and in to the libraries compiler flags. Apply the same changes to all rdeps of this library in the caffe2 subtree.

Test Plan:
Verify no rdeps are missing `-fexceptions` that have cpp sources:
```
% buck uquery 'kind(cxx*, rdeps(//xplat/caffe2/..., //xplat/caffe2/c10:c10, 1))' > /tmp/rdeps
% buck uquery '%Ss - attrfilter(preprocessor_flags, "-fexceptions", %Ss) - attrfilter(compiler_flags, "-fexceptions", %Ss)' @/tmp/rdeps
//xplat/pytorch_models/build/pytorch_dev_mobilenetv3/v1/nnc:asm
//xplat/pytorch_models/build/aot_test_model/v1/nnc:asm
//xplat/pytorch_models/build/pytorch_dev_linear/v1/nnc:asm
//xplat/pytorch_models/build/bi_bytedoc_nnc/v1/nnc:asm
//xplat/pytorch_models/build/bi_bytedoc_nnc/v2/nnc:asm
```

Differential Revision: D37386802

