### PR TITLE
[TorchArrow][efficiency][3/n] variadic versions of op fused /unfused inference_wrapper_run_flat

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -167,6 +167,10 @@ void OptimizeGraph(
         graph,
         fromQualString("fb::sigrid_transforms_torch_bind"),
         fromQualString("fb::variadic_sigrid_transforms_torch_bind"));
+    UseVariadicOp(
+      graph,
+      fromQualString("torcharrow::inference_wrapper_run_flat"),
+      fromQualString("torcharrow::variadic_inference_wrapper_run_flat"));
     // These fused ops only have out variants - we can't do the fusion when
     // out variants are disabled.
     FuseSignLog1P(graph);

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -847,8 +847,17 @@ bool shouldNotFuseListUnpackSpecialCase(const Node* node) {
           node->kind()) == sigrid_transforms_symbols.end()) {
     return false;
   }
+  const static std::array<c10::Symbol, 2> torcharrow_inference_op_symbols{
+      c10::Symbol::fromQualString(
+          "torcharrow::variadic_inference_wrapper_run_flat"),
+      c10::Symbol::fromQualString("torcharrow::inference_wrapper_run_flat")};
 
-
+  if (std::find(
+          torcharrow_inference_op_symbols.begin(),
+          torcharrow_inference_op_symbols.end(),
+          node->kind()) == torcharrow_inference_op_symbols.end()) {
+    return false;
+  }
 
   // To fuse with sigrid transforms, we must be able to statically determine
   // `instance` and `use_offsets` - these two together let us statically
@@ -874,6 +883,9 @@ void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
       OP_PAIR(
           "torcharrow::inference_wrapper_run_flat",
           "static_runtime::fused_inference_wrapper_run_flat"),
+      OP_PAIR(
+          "torcharrow::variadic_inference_wrapper_run_flat",
+          "static_runtime::fused_variadic_inference_wrapper_run_flat"),
       OP_PAIR("fb::equally_split", "static_runtime::fused_equally_split"),
       OP_PAIR(
           "fb::sigrid_transforms", "static_runtime::fused_sigrid_transforms"),

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -848,6 +848,8 @@ bool shouldNotFuseListUnpackSpecialCase(const Node* node) {
     return false;
   }
 
+
+
   // To fuse with sigrid transforms, we must be able to statically determine
   // `instance` and `use_offsets` - these two together let us statically
   // determine the types of the outputs. Rationale: it is a huge pain to write
@@ -869,6 +871,9 @@ bool shouldNotFuseListUnpackSpecialCase(const Node* node) {
 
 void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
   const FastMap<c10::Symbol, c10::Symbol> unfused_to_fused = {
+      OP_PAIR(
+          "torcharrow::inference_wrapper_run_flat",
+          "static_runtime::fused_inference_wrapper_run_flat"),
       OP_PAIR("fb::equally_split", "static_runtime::fused_equally_split"),
       OP_PAIR(
           "fb::sigrid_transforms", "static_runtime::fused_sigrid_transforms"),


### PR DESCRIPTION
Summary:
Added `variadic` version (just an optimization) of the registered fused and unfused ops.

Context on variadic ops shared by Pytorch Compiler team:

 - variadics version are better than ops accepting list of tensors for reasons of static runtime memory planner implementation detail iirc (i.e. upgrading in a wrong way can degrade performance)
- lets us avoid refcount bumps as constructing and unpacking Tensor lists can be surprisingly expensive.

In case a variadic version of the op is available, optimize graph pass will default to the variadic version.

Test Plan:
# ptvsc2_predictor_bench benchmark run
```
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./buck-out/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench \
    --scripted_model=/tmp/351084031_0.predictor.disagg.local \
    --pt_inputs=/tmp/347514183_1_local.inputs.recordio \
    --input_type="recordio" \
    --pt_enable_static_runtime=1 \
    --pt_enable_out_variant=1 \
    --pt_manage_output_tensors=1 \
    --pt_enable_tensorexpr_fusion=0 \
    --compare_results=0 \
    --iters=100 \
    --warmup_iters=100 \
    --num_threads=1 \
    --do_profile=1 \
    --do_benchmark=1 \
    --pt_optimize_memory=1 \
    --set_compatibility=1 \
    --method_name=local.forward \
    --recordio_use_ivalue_format=1 \
    --repetitions=3 \
    --pt_use_maybe_copy_variants=1 \
    --pt_use_copy_variants=1
```
Full logs - https://fburl.com/phabricator/9hbex6qm

Differential Revision: D37456033

