### PR TITLE
[ONNX] Add quantized model tests to CI

### DIFF
--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -66,6 +66,7 @@ if [[ "${SHARD_NUMBER}" == "1" ]]; then
     --ignore "$top_dir/test/onnx/test_custom_ops.py" \
     --ignore "$top_dir/test/onnx/test_utility_funs.py" \
     --ignore "$top_dir/test/onnx/test_models.py" \
+    --ignore "$top_dir/test/onnx/test_models_quantized_onnxruntime.py" \
     "${test_paths[@]}"
 
   # Heavy memory usage tests that cannot run in parallel.
@@ -80,6 +81,7 @@ if [[ "${SHARD_NUMBER}" == "2" ]]; then
   # TODO(#79802): Parameterize test_models.py
   pytest "${args[@]}" \
     "$top_dir/test/onnx/test_models.py" \
+    "$top_dir/test/onnx/test_models_quantized_onnxruntime.py" \
     "$top_dir/test/onnx/test_models_onnxruntime.py" "-k" "TestModelsONNXRuntime"
 
   pytest "${args[@]}" "${args_parallel[@]}" \

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -8,9 +8,13 @@ from typing import List, Mapping, Tuple
 import onnx_test_common
 import parameterized
 import PIL
+
+import torch
 import torchvision
 from pytorch_test_common import skipIfUnsupportedMinOpsetVersion, skipScriptTest
 from test_models import TestModels
+from torch import nn
+from torch.testing._internal import common_utils
 from torchvision import ops
 from torchvision.models.detection import (
     faster_rcnn,
@@ -21,10 +25,6 @@ from torchvision.models.detection import (
     rpn,
     transform,
 )
-
-import torch
-from torch import nn
-from torch.testing._internal import common_utils
 
 
 def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7, opset_versions=None):

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -8,13 +8,9 @@ from typing import List, Mapping, Tuple
 import onnx_test_common
 import parameterized
 import PIL
-
-import torch
 import torchvision
 from pytorch_test_common import skipIfUnsupportedMinOpsetVersion, skipScriptTest
 from test_models import TestModels
-from torch import nn
-from torch.testing._internal import common_utils
 from torchvision import ops
 from torchvision.models.detection import (
     faster_rcnn,
@@ -25,6 +21,10 @@ from torchvision.models.detection import (
     rpn,
     transform,
 )
+
+import torch
+from torch import nn
+from torch.testing._internal import common_utils
 
 
 def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7, opset_versions=None):
@@ -180,7 +180,7 @@ def _init_test_roi_heads_faster_rcnn():
 
 @parameterized.parameterized_class(
     ("is_script",),
-    ([True, False],),
+    [(True,), (False,)],
     class_name_func=onnx_test_common.parameterize_class_name,
 )
 class TestModelsONNXRuntime(onnx_test_common._TestONNXRuntime):

--- a/test/onnx/test_models_quantized_onnxruntime.py
+++ b/test/onnx/test_models_quantized_onnxruntime.py
@@ -3,9 +3,9 @@
 import os
 import unittest
 
+import onnx_test_common
 import parameterized
 import PIL
-import test_onnx_common
 
 import torch
 import torchvision
@@ -48,9 +48,9 @@ class _TopPredictor(nn.Module):
 @parameterized.parameterized_class(
     ("is_script",),
     [(True,), (False,)],
-    class_name_func=test_onnx_common.parameterize_class_name,
+    class_name_func=onnx_test_common.parameterize_class_name,
 )
-class TestQuantizedModelsONNXRuntime(test_onnx_common._TestONNXRuntime):
+class TestQuantizedModelsONNXRuntime(onnx_test_common._TestONNXRuntime):
     def run_test(self, model, inputs, *args, **kwargs):
         model = _TopPredictor(model)
         return super().run_test(model, inputs, *args, **kwargs)

--- a/test/onnx/test_models_quantized_onnxruntime.py
+++ b/test/onnx/test_models_quantized_onnxruntime.py
@@ -6,9 +6,9 @@ import unittest
 import parameterized
 import PIL
 import test_onnx_common
-import torchvision
 
 import torch
+import torchvision
 from torch import nn
 
 

--- a/test/onnx/test_models_quantized_onnxruntime.py
+++ b/test/onnx/test_models_quantized_onnxruntime.py
@@ -9,7 +9,6 @@ import test_onnx_common
 import torchvision
 
 import torch
-import torch.testing._internal.common_utils
 from torch import nn
 
 

--- a/test/onnx/test_models_quantized_onnxruntime.py
+++ b/test/onnx/test_models_quantized_onnxruntime.py
@@ -1,0 +1,98 @@
+# Owner(s): ["module: onnx"]
+
+import os
+import unittest
+
+import parameterized
+import PIL
+import test_onnx_common
+import torchvision
+
+import torch
+import torch.testing._internal.common_utils
+from torch import nn
+
+
+def _get_test_image_tensor():
+    data_dir = os.path.join(os.path.dirname(__file__), "assets")
+    img_path = os.path.join(data_dir, "grace_hopper_517x606.jpg")
+    input_image = PIL.Image.open(img_path)
+    # Based on example from https://pytorch.org/hub/pytorch_vision_resnet/
+    preprocess = torchvision.transforms.Compose(
+        [
+            torchvision.transforms.Resize(256),
+            torchvision.transforms.CenterCrop(224),
+            torchvision.transforms.ToTensor(),
+            torchvision.transforms.Normalize(
+                mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+            ),
+        ]
+    )
+    return preprocess(input_image).unsqueeze(0)
+
+
+# Due to precision error from quantization, check only that the top prediction matches.
+class _TopPredictor(nn.Module):
+    def __init__(self, base_model):
+        super().__init__()
+        self.base_model = base_model
+
+    def forward(self, x):
+        x = self.base_model(x)
+        _, topk_id = torch.topk(x[0], 1)
+        return topk_id
+
+
+# TODO: All torchvision quantized model test can be written as single parameterized test case,
+# after per-parameter test decoration is supported via #79979, or after they are all enabled,
+# whichever is first.
+@parameterized.parameterized_class(
+    ("is_script",),
+    [(True,), (False,)],
+    class_name_func=test_onnx_common.parameterize_class_name,
+)
+class TestQuantizedModelsONNXRuntime(test_onnx_common._TestONNXRuntime):
+    def run_test(self, model, inputs, *args, **kwargs):
+        model = _TopPredictor(model)
+        return super().run_test(model, inputs, *args, **kwargs)
+
+    def test_mobilenet_v3(self):
+        model = torchvision.models.quantization.mobilenet_v3_large(
+            pretrained=True, quantize=True
+        )
+        self.run_test(model, _get_test_image_tensor())
+
+    @unittest.skip("quantized::cat not supported")
+    def test_inception_v3(self):
+        model = torchvision.models.quantization.inception_v3(
+            pretrained=True, quantize=True
+        )
+        self.run_test(model, _get_test_image_tensor())
+
+    @unittest.skip("quantized::cat not supported")
+    def test_googlenet(self):
+        model = torchvision.models.quantization.googlenet(
+            pretrained=True, quantize=True
+        )
+        self.run_test(model, _get_test_image_tensor())
+
+    @unittest.skip("quantized::cat not supported")
+    def test_shufflenet_v2_x0_5(self):
+        model = torchvision.models.quantization.shufflenet_v2_x0_5(
+            pretrained=True, quantize=True
+        )
+        self.run_test(model, _get_test_image_tensor())
+
+    def test_resnet18(self):
+        model = torchvision.models.quantization.resnet18(pretrained=True, quantize=True)
+        self.run_test(model, _get_test_image_tensor())
+
+    def test_resnet50(self):
+        model = torchvision.models.quantization.resnet50(pretrained=True, quantize=True)
+        self.run_test(model, _get_test_image_tensor())
+
+    def test_resnext101_32x8d(self):
+        model = torchvision.models.quantization.resnext101_32x8d(
+            pretrained=True, quantize=True
+        )
+        self.run_test(model, _get_test_image_tensor())

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -309,8 +309,6 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test(model, (x, model.hidden))
 
     def get_image(self, rel_path: str, size: Tuple[int, int]) -> Tensor:
-        import os
-
         from PIL import Image
         from torchvision import transforms
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -381,52 +381,6 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         assert torch.all(out2[0].eq(out_trace2[0]))
         assert torch.all(out2[1].eq(out_trace2[1]))
 
-    @unittest.skip(
-        "Unstable loading pretrained quantized mobilenet v3: https://github.com/pytorch/vision/issues/5303"
-    )
-    @skipIfUnsupportedMinOpsetVersion(10)
-    @skipScriptTest()
-    def test_mobilenet_v3_quant(self):
-        model = torchvision.models.quantization.mobilenet_v3_large(
-            pretrained=True, quantize=True
-        )
-        from PIL import Image
-        from torchvision import transforms
-
-        data_dir = os.path.join(os.path.dirname(__file__), "assets")
-        path = os.path.join(data_dir, "grace_hopper_517x606.jpg")
-        input_image = Image.open(path)
-        # Based on example from https://pytorch.org/hub/pytorch_vision_resnet/
-        preprocess = transforms.Compose(
-            [
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                ),
-            ]
-        )
-        input_tensor = preprocess(input_image).unsqueeze(0)
-
-        # Due to precision error from quantization, check only that the top prediction matches.
-        class TopPredictor(torch.nn.Module):
-            def __init__(self, mobilenet):
-                super().__init__()
-                self.mobilenet = mobilenet
-
-            def forward(self, x):
-                x = self.mobilenet(x)
-                _, topk_catid = torch.topk(x[0], 1)
-                return topk_catid
-
-        # Currently, we need convert the model to ScriptModule before export.
-        # The reason is that PackedParams contains int (not tensor).
-        # Then it fails when the exporter calls _trace_and_get_graph_from_model().
-        # TODO: https://msdata.visualstudio.com/Vienna/_workitems/edit/1547858
-        model = torch.jit.trace(TopPredictor(model), input_tensor)
-        self.run_test(model, (input_tensor,))
-
     def test_word_language_model_RNN_TANH(self):
         self.run_word_language_model("RNN_TANH")
 


### PR DESCRIPTION
In parallel to #80039, start tracking torchvision quantized model export in CI.

This PR depends on ~~#80393~~#79256, bumping torchvision version in CI, due to PyTorch not backward compatible with vision #74028.