### PR TITLE
Correctly handle the error codes of hipGetDeviceCount

### DIFF
--- a/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
+++ b/aten/src/ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h
@@ -99,7 +99,14 @@ struct HIPGuardImplMasqueradingAsCUDA final : public c10::impl::DeviceGuardImplI
   }
   DeviceIndex deviceCount() const noexcept override {
     int deviceCnt;
-    C10_HIP_CHECK(hipGetDeviceCount(&deviceCnt));
+    hipError_t _err;
+    _err = hipGetDeviceCount(&deviceCnt);
+#if defined(USE_ROCM) && (ROCM_VERSION < 50201)
+    if(_err == hipErrorInvalidDevice)
+        return 0;
+#endif
+    if(_err != hipErrorNoDevice && _err != hipSuccess)
+        C10_HIP_CHECK(_err);
     return deviceCnt;
   }
 


### PR DESCRIPTION
Correcting the error code handling for `hipGetDeviceCount()` when no GPU are visible on the device/container.

The hipGetDeviceCount() API is updated NOT to return  _`hipErrorInvalidDevice`_ and will be available in later ROCm releases.
cc @jithunnair-amd 