### PR TITLE
Mark underlying type as C10_UNUSED

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -95,7 +95,7 @@ TORCH_API void record_kernel_function_dtype(std::string name);
   case enum_type: {                                                          \
     AT_PRIVATE_CHECK_SELECTIVE_BUILD(enum_type);                             \
     using scalar_t = scalar_type;                                            \
-    using underlying_t = typename scalar_t::underlying;                      \
+    using underlying_t C10_UNUSED = typename scalar_t::underlying;           \
     const auto& SCALAR_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND = enum_type; \
     const auto& UNDERLYING_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND =        \
         toUnderlying(enum_type);                                             \


### PR DESCRIPTION
Fixes regression detected in https://github.com/pytorch/pytorch/pull/79978

As result some of the internal workflows fail as follows:
```
aten/src/ATen/native/cpu/CopyKernel.cpp:28:5: error: unused type alias 'underlying_t' [-Werror,-Wunused-local-typedef]
    AT_DISPATCH_QINT_TYPES(dtype, "copy_kernel", [&] {
    ^
src/ATen/native/cpu/CopyKernel.cpp:28:5: error: unused type alias 'underlying_t' [-Werror,-Wunused-local-typedef]
aten/src/ATen/Dispatch.h:393:34: note: expanded from macro 'AT_DISPATCH_QINT_TYPES'
  AT_DISPATCH_SWITCH(TYPE, NAME, AT_DISPATCH_CASE_QINT_TYPES(__VA_ARGS__))
```
