### PR TITLE
[BE] Rectify `C10_UNUSED_DISPATCH_CUDA_WORKAROUND`

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -82,28 +82,28 @@ TORCH_API void record_kernel_function_dtype(std::string name);
 #define AT_DISPATCH_CASE(enum_type, ...) \
   AT_PRIVATE_CASE_TYPE_USING_HINT(enum_type, scalar_t, __VA_ARGS__)
 
-#define AT_DISPATCH_CASE_QINT(enum_type, scalar_type, ...)                   \
-  case enum_type: {                                                          \
-    AT_PRIVATE_CHECK_SELECTIVE_BUILD(enum_type);                             \
-    using scalar_t = scalar_type;                                            \
-    using underlying_t C10_UNUSED = typename scalar_t::underlying;           \
-    const auto& SCALAR_TYPE C10_UNUSED = enum_type;                          \
-    const auto& UNDERLYING_TYPE C10_UNUSED = toUnderlying(enum_type);        \
-    return __VA_ARGS__();                                                    \
+#define AT_DISPATCH_CASE_QINT(enum_type, scalar_type, ...)            \
+  case enum_type: {                                                   \
+    AT_PRIVATE_CHECK_SELECTIVE_BUILD(enum_type);                      \
+    using scalar_t = scalar_type;                                     \
+    using underlying_t C10_UNUSED = typename scalar_t::underlying;    \
+    const auto& SCALAR_TYPE C10_UNUSED = enum_type;                   \
+    const auto& UNDERLYING_TYPE C10_UNUSED = toUnderlying(enum_type); \
+    return __VA_ARGS__();                                             \
   }
 
-#define AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                                  \
-    enum_type, scalar_type, bitwidth, qmin, qmax, ...)                       \
-  case enum_type: {                                                          \
-    AT_PRIVATE_CHECK_SELECTIVE_BUILD(enum_type);                             \
-    using scalar_t = scalar_type;                                            \
-    using underlying_t C10_UNUSED = typename scalar_t::underlying;           \
-    const auto& SCALAR_TYPE C10_UNUSED = enum_type;                          \
-    const auto& UNDERLYING_TYPE C10_UNUSED = toUnderlying(enum_type);        \
-    C10_UNUSED int bit_width = bitwidth;                                     \
-    C10_UNUSED int64_t quant_min = qmin;                                     \
-    C10_UNUSED int64_t quant_max = qmax;                                     \
-    return __VA_ARGS__();                                                    \
+#define AT_QINT_SUB_BYTE_PRIVATE_CASE_TYPE(                           \
+    enum_type, scalar_type, bitwidth, qmin, qmax, ...)                \
+  case enum_type: {                                                   \
+    AT_PRIVATE_CHECK_SELECTIVE_BUILD(enum_type);                      \
+    using scalar_t = scalar_type;                                     \
+    using underlying_t C10_UNUSED = typename scalar_t::underlying;    \
+    const auto& SCALAR_TYPE C10_UNUSED = enum_type;                   \
+    const auto& UNDERLYING_TYPE C10_UNUSED = toUnderlying(enum_type); \
+    C10_UNUSED int bit_width = bitwidth;                              \
+    C10_UNUSED int64_t quant_min = qmin;                              \
+    C10_UNUSED int64_t quant_max = qmax;                              \
+    return __VA_ARGS__();                                             \
   }
 
 namespace detail {

--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -82,24 +82,13 @@ TORCH_API void record_kernel_function_dtype(std::string name);
 #define AT_DISPATCH_CASE(enum_type, ...) \
   AT_PRIVATE_CASE_TYPE_USING_HINT(enum_type, scalar_t, __VA_ARGS__)
 
-// Workaround for C10_UNUSED because CUDA 10.1 and below fails to handle unused
-// attribute in the type aliasing context. Keep name long and verbose to avoid
-// macro collisions.
-#if defined(__CUDACC__) && defined(CUDA_VERSION) && CUDA_VERSION <= 10010
-#define C10_UNUSED_DISPATCH_CUDA_WORKAROUND
-#else
-#define C10_UNUSED_DISPATCH_CUDA_WORKAROUND C10_UNUSED
-#endif // defined(__CUDACC__) && defined(CUDA_VERSION) && CUDA_VERSION <= 10010
-
 #define AT_DISPATCH_CASE_QINT(enum_type, scalar_type, ...)                   \
   case enum_type: {                                                          \
     AT_PRIVATE_CHECK_SELECTIVE_BUILD(enum_type);                             \
     using scalar_t = scalar_type;                                            \
     using underlying_t C10_UNUSED = typename scalar_t::underlying;           \
-    const auto& SCALAR_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND = enum_type; \
-    const auto& UNDERLYING_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND =        \
-        toUnderlying(enum_type);                                             \
-    (void)SCALAR_TYPE; /* Suppress unused-var compiler warning */            \
+    const auto& SCALAR_TYPE C10_UNUSED = enum_type;                          \
+    const auto& UNDERLYING_TYPE C10_UNUSED = toUnderlying(enum_type);        \
     return __VA_ARGS__();                                                    \
   }
 
@@ -108,17 +97,12 @@ TORCH_API void record_kernel_function_dtype(std::string name);
   case enum_type: {                                                          \
     AT_PRIVATE_CHECK_SELECTIVE_BUILD(enum_type);                             \
     using scalar_t = scalar_type;                                            \
-    using underlying_t C10_UNUSED_DISPATCH_CUDA_WORKAROUND =                 \
-        typename scalar_t::underlying;                                       \
-    const auto& SCALAR_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND = enum_type; \
-    const auto& UNDERLYING_TYPE C10_UNUSED_DISPATCH_CUDA_WORKAROUND =        \
-        toUnderlying(enum_type);                                             \
+    using underlying_t C10_UNUSED = typename scalar_t::underlying;           \
+    const auto& SCALAR_TYPE C10_UNUSED = enum_type;                          \
+    const auto& UNDERLYING_TYPE C10_UNUSED = toUnderlying(enum_type);        \
     C10_UNUSED int bit_width = bitwidth;                                     \
     C10_UNUSED int64_t quant_min = qmin;                                     \
     C10_UNUSED int64_t quant_max = qmax;                                     \
-    (void)bit_width; /* Suppress unused variable warning */                  \
-    (void)quant_min; /* Suppress unused variable warning */                  \
-    (void)quant_max; /* Suppress unused variable warning */                  \
     return __VA_ARGS__();                                                    \
   }
 


### PR DESCRIPTION
This was a workaround for CUDA-10.1 compiler bug
Which is not super relevant when CUDA-11.7 is out
Also, delete unused vars suppressions, as `C10_UNUSED` should be enough
