### PR TITLE
implement numel and tests for nested tensor

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -114,9 +114,32 @@ void NestedTensorImpl::refresh_dim() {
 int64_t NestedTensorImpl::dim_custom() const {
   return dim_default();
 }
+
+// Currently sizes and strides assume contiguous
 int64_t NestedTensorImpl::numel_custom() const {
-  TORCH_CHECK(false, "numel is disabled.");
+  if (nested_size_tensor_.dim() == 0) {
+    return 0;
+  }
+  constexpr auto numel_max = std::min(
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+      static_cast<uint64_t>(std::numeric_limits<size_t>::max()));
+
+  const auto nt_dim = nested_size_tensor_.size(1);
+  const int64_t* sizes_ptr = nested_size_tensor_.data_ptr<int64_t>();
+  uint64_t num_elements{0};
+
+  for (const auto i : c10::irange(nested_size_tensor_.size(0))) {
+    uint64_t n = 1;
+    const auto start{sizes_ptr + i * nt_dim};
+    const auto end{start + nt_dim};
+    bool overflows = c10::safe_multiplies_u64(start, end, &n);
+    num_elements += n;
+    overflows |= (num_elements > numel_max);
+    TORCH_CHECK(!overflows, "numel: integer multiplication overflow");
+  }
+  return static_cast<int64_t>(num_elements);
 }
+
 bool NestedTensorImpl::is_contiguous_custom(MemoryFormat) const {
   TORCH_CHECK(false, "is_contiguous is disabled.");
 }

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -136,9 +136,21 @@ class TestNestedTensor(TestCase):
     def test_numel(self):
         for constructor in _iter_constructors():
             a1 = constructor([])
-            self.assertRaisesRegex(
-                RuntimeError, "numel is disabled", lambda: a1.numel(),
-            )
+            self.assertEqual(a1.numel(), 0)
+            a1 = constructor([torch.tensor(3.0), torch.tensor(4.0)])
+            self.assertEqual(a1.numel(), 2)
+            a1 = constructor([torch.randn(2, 2, 2)])
+            self.assertEqual(a1.numel(), 8)
+            a1 = constructor([torch.randn([1, 2, 3]), torch.randn(3, 2, 1)])
+            self.assertEqual(a1.numel(), 12)
+            a1 = constructor([torch.randn([1, 1, 3]), torch.randn(3, 2, 4)])
+            self.assertEqual(a1.numel(), 27)
+            a1 = constructor([torch.randn([5, 5, 5]), torch.randn(6, 6, 6)])
+            self.assertEqual(a1.numel(), 341)
+
+            # Interesting edge case
+            a1 = constructor([torch.randn([1, 2, 3]), torch.randn(1, 2, 0)])
+            self.assertEqual(a1.numel(), 6)
 
     @torch.inference_mode()
     def test_size(self):


### PR DESCRIPTION
Add numel implementation for Nested Tensor. Currently the construction of nested size and nested_strides assume contiguous. This implementation was based off of the safe_compute_numel().  Having a TORCH_CHECK in a for loop kinda feels bad but I don't really know how performant numel needs to be.

Since nested size is stored as a tensor: `nested_size_tensor().cumprod(dim=1).sum(dim=0)[1].item() ` Would also get the job done. 