### PR TITLE
[AutoAccept][Codemod][FBSourceBuckFormatLinter] Daily `arc lint --take BUCKFORMAT`

### DIFF
--- a/pt_template_srcs.bzl
+++ b/pt_template_srcs.bzl
@@ -134,6 +134,7 @@ def get_generate_code_bin_outs():
 
     if is_arvr_mode():
         outs.update({
+            "autograd/generated/python_enum_tag.cpp": ["autograd/generated/python_enum_tag.cpp"],
             "autograd/generated/python_fft_functions.cpp": ["autograd/generated/python_fft_functions.cpp"],
             "autograd/generated/python_functions.h": ["autograd/generated/python_functions.h"],
             "autograd/generated/python_functions_0.cpp": ["autograd/generated/python_functions_0.cpp"],
@@ -150,7 +151,6 @@ def get_generate_code_bin_outs():
             "autograd/generated/python_torch_functions_1.cpp": ["autograd/generated/python_torch_functions_1.cpp"],
             "autograd/generated/python_torch_functions_2.cpp": ["autograd/generated/python_torch_functions_2.cpp"],
             "autograd/generated/python_variable_methods.cpp": ["autograd/generated/python_variable_methods.cpp"],
-            "autograd/generated/python_enum_tag.cpp": ["autograd/generated/python_enum_tag.cpp"],
         })
     return outs
 


### PR DESCRIPTION
Summary:
Meta:
**If you take no action, this diff will be automatically accepted on 2022-06-28.**
(To remove yourself from auto-accept diffs and just let them all land, add yourself to [this Butterfly rule](https://www.internalfb.com/butterfly/rule/904302247110220))

Produced by `tools/arcanist/lint/codemods/buckformat-fbsource`.

#nocancel

Rules run:
- CodemodTransformerSimpleShell

Config Oncall: [lint](https://our.intern.facebook.com/intern/oncall3/?shortname=lint)
CodemodConfig: [CodemodConfigFBSourceBuckFormatLinter](https://www.internalfb.com/code/www/flib/intern/codemod_service/config/fbsource_arc_f/CodemodConfigFBSourceBuckFormatLinter.php)
ConfigType: php
Sandcastle URL: https://www.internalfb.com/intern/sandcastle/job/9007199961796985/
This diff was automatically created with CodemodService.
To learn more about CodemodService, check out the [CodemodService wiki](https://fburl.com/CodemodService).

_____

## Questions / Comments / Feedback?

**[Click here to give feedback about this diff](https://www.internalfb.com/codemod_service/feedback?sandcastle_job_id=9007199961796985).**

* Returning back to author or abandoning this diff will only cause the diff to be regenerated in the future.
* Do **NOT** post in the CodemodService Feedback group about this specific diff.

drop-conflicts

Test Plan:
Meta:
No commands were run for this Codemod

Reviewed By: strulovich

Differential Revision: D37482777

