### PR TITLE
[ROCm] Load ROCm if Torch is used as a dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1089,6 +1089,7 @@ if(BUILD_SHARED_LIBS)
       ${PROJECT_SOURCE_DIR}/cmake/public/protobuf.cmake
       ${PROJECT_SOURCE_DIR}/cmake/public/threads.cmake
       ${PROJECT_SOURCE_DIR}/cmake/public/utils.cmake
+      ${PROJECT_SOURCE_DIR}/cmake/public/LoadHIP.cmake
       DESTINATION share/cmake/Caffe2/public
       COMPONENT dev)
   install(DIRECTORY

--- a/cmake/Caffe2Config.cmake.in
+++ b/cmake/Caffe2Config.cmake.in
@@ -78,6 +78,10 @@ else()
   endif()
 endif()
 
+if (@USE_ROCM@)
+  include("${CMAKE_CURRENT_LIST_DIR}/public/LoadHIP.cmake")
+endif()
+
 if(@USE_CUDA@)
   # The file public/cuda.cmake exclusively uses CAFFE2_USE_*.
   # If Caffe2 was compiled with the libraries below, they must


### PR DESCRIPTION
Includes LoadHIP.cmake if pytorch is used as a dependency for another project and ROCm is enabled. This removes the need to explicitly link against ROCm libraries in extension projects.