### PR TITLE
set grain_size for sort kernel

### DIFF
--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -60,7 +60,8 @@ void _dim_apply(
         }
       };
 
-      iter.for_each(loop);
+      int64_t grain_size = internal::GRAIN_SIZE / std::max(int64_t{1}, dim_size);
+      iter.for_each(loop, /*grain_size=*/grain_size);
     }
   );
 }


### PR DESCRIPTION
We collected the benchmark data of sort by using the operator_benchmark tool of PyTorch on the platform of Intel(R) Xeon(R) Platinum 8260L CPU @ 2.40GHz.
Number of cores: 24 cores(1 socket)

[sort_benchmark_08c32d7.log](https://github.com/pytorch/pytorch/files/9006429/sort_benchmark_08c32d7.log)
[sort_benchmark_the_pr.log](https://github.com/pytorch/pytorch/files/9006430/sort_benchmark_the_pr.log)

