### PR TITLE
[MPS] Move the View ops to a separate file and reduce the number of graphs created

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -58,7 +58,7 @@ bool MPSHeapAllocatorImpl::alloc_buffer(AllocParams& p)
   TORCH_INTERNAL_ASSERT(buffer);
   // insert heap after a buffer was created on it to update the order of heap's set
   p.pool->heaps.insert(heap);
-  p.buffer_block = new BufferBlock(p.size(), buffer, heap, m_allocated_buffers.size() + 1);
+  p.buffer_block = new BufferBlock(p.size(), p.requested_size, buffer, heap, m_allocated_buffers.size() + 1);
   m_allocated_buffers[p.buffer_block->buffer] = p.buffer_block;
   m_total_allocated_memory += p.size();
 
@@ -66,7 +66,8 @@ bool MPSHeapAllocatorImpl::alloc_buffer(AllocParams& p)
     std::cerr << "Allocated "
               << (p.pool->is_shared ? "shared" : "private")
               << " buffer #" << p.buffer_block->buf_id
-              << " with aligned size " << format_size(p.size())
+              << " of size " << format_size(p.size())
+              << " at " << p.buffer_block->buffer
               << " (requested size: " << format_size(p.requested_size)
               << ", heap size: " << format_size(heap->size.available)
               << ", total allocated: " << format_size(m_total_allocated_memory) << ")\n";
@@ -92,7 +93,8 @@ bool MPSHeapAllocatorImpl::get_free_buffer(AllocParams& p)
     std::cerr << "Reusing "
               << (p.pool->is_shared ? "shared" : "private")
               << " buffer #" << p.buffer_block->buf_id
-              << " with aligned size " << format_size(p.buffer_block->size)
+              << " of size " << format_size(p.buffer_block->size)
+              << " at " << p.buffer_block->buffer
               << " (requested size: " << format_size(p.requested_size) << ")\n";
   }
   return true;
@@ -129,6 +131,7 @@ void MPSHeapAllocatorImpl::free_buffer(BufferBlock* buffer_block)
   TORCH_INTERNAL_ASSERT(buffer_block->in_use);
   trigger_memory_callbacks(buffer_block, IMpsAllocatorCallback::EventType::FREED);
   buffer_block->in_use = false;
+  buffer_block->shape.clear(); // reset shape
   BufferPool *pool = buffer_block->heap->pool;
   // Makes sure the BufferBlock* isn't already present in the pool we're freeing it back into.
   TORCH_INTERNAL_ASSERT(pool->buffers.insert(buffer_block).second);
@@ -136,8 +139,7 @@ void MPSHeapAllocatorImpl::free_buffer(BufferBlock* buffer_block)
 
 BufferBlock* MPSHeapAllocatorImpl::get_allocated_buffer_block(void* ptr)
 {
-  id<MTLBuffer> buf = __builtin_bit_cast(id<MTLBuffer>, ptr);
-  auto it = m_allocated_buffers.find(buf);
+  auto it = m_allocated_buffers.find(ptr);
   if (it == m_allocated_buffers.end())
     return nullptr;
 
@@ -157,6 +159,40 @@ bool MPSHeapAllocatorImpl::isSharedBuffer(void* ptr)
   BufferBlock *buffer_block = get_allocated_buffer_block(ptr);
   // it's OK for the buffer_block to not exist yet
   return buffer_block && buffer_block->heap->pool->is_shared;
+}
+
+ssize_t MPSHeapAllocatorImpl::getRequestedBufferSize(void* ptr)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  BufferBlock *buffer_block = get_allocated_buffer_block(ptr);
+  if (buffer_block)
+    return (ssize_t) buffer_block->requested_size;
+  // this indicates the passed buffer pointer wasn't found
+  return -1;
+}
+
+void MPSHeapAllocatorImpl::setBufferShape(void* ptr, const IntArrayRef& shape)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  BufferBlock *buffer_block = get_allocated_buffer_block(ptr);
+  TORCH_INTERNAL_ASSERT(buffer_block, "failed to find the buffer ", ptr);
+  // note that the IntArrayRef doesn't own the underlying data, and the backing
+  // memory for shape data must persist as long as the buffer is in use.
+  // So we need to copy to vector.
+  buffer_block->shape = shape.vec();
+}
+
+IntArrayRef MPSHeapAllocatorImpl::getBufferShape(void* ptr)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  BufferBlock *buffer_block = get_allocated_buffer_block(ptr);
+  if (buffer_block && buffer_block->shape.size() > 0)
+    return IntArrayRef{buffer_block->shape};
+
+  return IntArrayRef();
 }
 
 void MPSHeapAllocatorImpl::Free(void* ptr)
@@ -350,6 +386,19 @@ at::Allocator* getMPSStaticAllocator() {
   return &_getPrivateAllocator();
 }
 
+// TODO: create MPSHooks interface and move these there.
+ssize_t get_requested_buffer_size(void* ptr) {
+  return _getAllocImpl().getRequestedBufferSize(ptr);
+}
+
+void set_buffer_shape(void* ptr, const IntArrayRef& shape) {
+  _getAllocImpl().setBufferShape(ptr, shape);
+}
+
+IntArrayRef get_buffer_shape(void* ptr) {
+  return _getAllocImpl().getBufferShape(ptr);
+};
+
 } // namespace mps
 
 namespace native {
@@ -380,5 +429,4 @@ Tensor _pin_memory_mps(const Tensor& self, c10::optional<Device> device)
 }
 
 } // namespace native
-
 } // namespace at

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -37,11 +37,6 @@ private:
 
 const Generator& getDefaultMPSGenerator();
 
-enum GatherScatterViewOpType {
-  Gather,
-  Scatter,
-};
-
 void runMPSGraph(
     MPSStream* mpsStream,
     MPSGraph* mpsGraph,
@@ -55,19 +50,22 @@ std::string getMPSShapeString(MPSShape* shape);
 std::string getTensorsStringKey(const TensorList& tensors, bool use_scalar_value = true);
 double getMPSScalarValue(const Tensor& t);
 std::string getArrayRefString(const IntArrayRef s);
-std::string getStridedKey(const Tensor& self, const IntArrayRef sz,
-                          const IntArrayRef strides, int64_t offset, GatherScatterViewOpType viewOpType);
-id<MTLBuffer> gatherViewTensor(const at::Tensor& src, id<MTLBuffer> s);
-id<MTLBuffer> scatterViewTensor(at::Tensor& output, const at::Tensor src, id<MTLBuffer> updatesTensorBuffer);
+// use has_storage() on the returned tensor to determine if src actually is a view
+Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst);
+Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output);
 
 MPSShape* getMPSShape(const Tensor& t);
 MPSShape* getMPSShape(IntArrayRef sizes);
 MPSShape* getMPSShape(c10::MaybeOwned<Tensor> t);
 
+static inline id<MTLBuffer> getMTLBufferStorage(const at::Tensor& tensor) {
+  return __builtin_bit_cast(id<MTLBuffer>, tensor.storage().data());
+}
+
 class Placeholder {
  public:
-  Placeholder() : _placeholder(nullptr), _value(nullptr) {}
-  Placeholder(MPSGraphTensor* mpsGraphTensor) : _placeholder(mpsGraphTensor), _value(nullptr) {}
+  Placeholder() : _placeholder(nullptr), _value(nullptr), _tensor(Tensor()) {}
+  Placeholder(MPSGraphTensor* mpsGraphTensor) : _placeholder(mpsGraphTensor), _value(nullptr), _tensor(Tensor()) {}
   Placeholder(MPSGraphTensor* mpsGraphTensor, const Tensor& self, MPSShape *mpsShape = nullptr);
   MPSGraphTensor* getMPSGraphTensor() {
     return _placeholder;
@@ -79,22 +77,10 @@ class Placeholder {
     return _value == nullptr;
   }
 
-  void allocateViewTensor(const at::Tensor& src)
-  {
-    assert (!_viewOutput.numel());
-    _viewOutput = at::native::empty_mps(
-                  src.sizes(),
-                  src.scalar_type(),
-                  c10::nullopt,
-                  kMPS,
-                  c10::nullopt,
-                  c10::nullopt);
-  }
-
  private:
   MPSGraphTensor* _placeholder;
   MPSGraphTensorData* _value;
-  Tensor _viewOutput;
+  Tensor _tensor;
 };
 
 void resize_tensor(Tensor* output);

--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -60,18 +60,6 @@ MPSGeneratorImpl* MPSGeneratorImpl::clone_impl() const {
   return gen;
 }
 
-std::string getStridedKey(const Tensor& self, const IntArrayRef sz,
-                          const IntArrayRef strides, int64_t offset, GatherScatterViewOpType viewOpType) {
-  // TODO: move storage_offset to a PlaceholderTensor and strides to a
-  // tensor too, to avoid too many cache entries.
-  return std::to_string((uintptr_t)self.storage().data()) +
-              ":" + mps::getArrayRefString(sz) +
-              ":" + mps::getArrayRefString(strides) +
-              ":" + std::to_string(offset) +
-              ":" + getMPSTypeString(self.scalar_type()) +
-              ":" + (viewOpType == GatherScatterViewOpType::Gather ? "gather" : "scatter");
-}
-
 void runMPSGraph(
     MPSStream* mpsStream,
     MPSGraph* mpsGraph,
@@ -259,145 +247,38 @@ void printTensorNDArray(const Tensor& t) {
   auto selfDType = getMPSDataType(t.scalar_type());
 
   // Initialize data
-  id<MTLBuffer> selfBuf = __builtin_bit_cast(id<MTLBuffer>, t.storage().data());
+  id<MTLBuffer> selfBuf = getMTLBufferStorage(t);
   MPSGraphTensorData* tdata = [[[MPSGraphTensorData alloc] initWithMTLBuffer:selfBuf
                                                             shape:selfShape
                                                          dataType:selfDType] autorelease];
   [tdata printNDArray];
 }
 
-MPSCachedGraph* _getCachedGraph(const at::Tensor& src, GatherScatterViewOpType viewOpType) {
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-  string key = getStridedKey(src, src.sizes(), src.strides(), src.storage_offset(), viewOpType);
-  MPSCachedGraph* cachedGraph = cache_->LookUp(key);
-
-  return cachedGraph;
-}
-
-id<MTLBuffer> _gattherScatterViewTensor(
-  const at::Tensor& src,
-  id<MTLBuffer> sourceBuffer,
-  MPSCachedGraph* mpsCachedGraph,
-  at::Tensor& output,
-  GatherScatterViewOpType viewOpType)
+Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor, const Tensor& src, MPSShape *mpsShape) : _tensor(src)
 {
-  TORCH_CHECK(mpsCachedGraph != nil);
-  MPSStream* stream = getCurrentMPSStream();
-  bool scatterViewOp = (viewOpType == GatherScatterViewOpType::Scatter);
-  struct CachedGraph : public MPSCachedGraph
-  {
-    CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* inputTensor_ = nil;
-    MPSGraphTensor* outputTensor_ = nil;
-
-    MPSGraphTensor* scatteredTensor_ = nil;
-    MPSGraphTensor* updatesTensor_ = nil;
-  };
-
-  CachedGraph* cachedGraph = static_cast<CachedGraph *>(mpsCachedGraph);
-
-  @autoreleasepool {
-    MPSGraphTensor* inputTensor = cachedGraph->inputTensor_;
-    MPSShape *inputShape = [inputTensor shape];
-    MPSShape *resultShape = getMPSShape(src.sizes());
-    auto dataType = [inputTensor dataType];
-
-    id<MTLBuffer> dataBuffer = sourceBuffer;
-    id<MTLBuffer> resultBuffer = __builtin_bit_cast(id<MTLBuffer>, output.storage().data());
-
-    if (scatterViewOp) {
-      dataBuffer = resultBuffer;
-      resultShape = inputShape;
-    }
-
-    MPSGraphTensorData* inputTensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer: dataBuffer
-                                                                                   shape: inputShape
-                                                                                dataType: dataType] autorelease];
-    MPSGraphTensorData* updatesTensorData = nil;
-    if (scatterViewOp) {
-      updatesTensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer: sourceBuffer
-                                                                   shape: getMPSShape(src.numel())
-                                                                dataType: dataType] autorelease];
-    }
-    MPSGraphTensorData* outputTensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer: resultBuffer
-                                                                                    shape: resultShape
-                                                                                 dataType: getMPSDataType(src.scalar_type())] autorelease];
-
-    NSMutableDictionary<MPSGraphTensor*, MPSGraphTensorData*>* feeds =[NSMutableDictionary dictionary];
-    feeds[inputTensor] = inputTensorData;
-    if (scatterViewOp)
-      feeds[cachedGraph->updatesTensor_] = updatesTensorData;
-
-    NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{
-       cachedGraph->outputTensor_ : outputTensorData
-    };
-
-    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
-    return resultBuffer;
-  }
-}
-
-id<MTLBuffer> scatterViewTensor(at::Tensor& output, const at::Tensor src, id<MTLBuffer> updatesTensorBuffer) {
-  MPSCachedGraph* mpsCachedGraph = _getCachedGraph(output, GatherScatterViewOpType::Scatter);
-  if (mpsCachedGraph) {
-      _gattherScatterViewTensor(src, updatesTensorBuffer, mpsCachedGraph, output, GatherScatterViewOpType::Scatter);
-      return __builtin_bit_cast(id<MTLBuffer>, output.storage().data());
-  }
-  return nil;
-}
-
-id<MTLBuffer> gatherViewTensor(const at::Tensor& src, id<MTLBuffer> sourceBuffer) {
-  MPSCachedGraph* mpsCachedGraph = _getCachedGraph(src, GatherScatterViewOpType::Gather);
-  if (mpsCachedGraph) {
-    Tensor output = at::native::empty_mps(
-                    src.sizes(),
-                    src.scalar_type(),
-                    c10::nullopt,
-                    kMPS,
-                    c10::nullopt,
-                    c10::nullopt);
-
-    _gattherScatterViewTensor(src, sourceBuffer, mpsCachedGraph, output, GatherScatterViewOpType::Gather);
-    return __builtin_bit_cast(id<MTLBuffer>, output.storage().data());
-  }
-
-  return nil;
-}
-
-id<MTLBuffer> gatherViewTensorWithAllocatedMem(const at::Tensor& src, id<MTLBuffer> sourceBuffer, Tensor& output, MPSCachedGraph* mpsCachedGraph) {
-  TORCH_CHECK(mpsCachedGraph != nil);
-
-  _gattherScatterViewTensor(src, sourceBuffer, mpsCachedGraph, output, GatherScatterViewOpType::Gather);
-  return __builtin_bit_cast(id<MTLBuffer>, output.storage().data());
-}
-
-Placeholder::Placeholder(MPSGraphTensor* mpsGraphTensor, const Tensor& src, MPSShape *mpsShape)
-{
-  Tensor src_ = src;
-  TORCH_CHECK(src_.is_mps(), "Placeholder storage has not been allocated on MPS device!");
-    // extract the pointer to MTLBuffer from the Tensor's storage
-  id<MTLBuffer> srcBuf = __builtin_bit_cast(id<MTLBuffer>, src.storage().data());
+  TORCH_CHECK(src.is_mps(), "Placeholder storage has not been allocated on MPS device!");
+  // extract the pointer to MTLBuffer from the Tensor's storage
+  id<MTLBuffer> srcBuf = getMTLBufferStorage(src);
+  // a view tensor could be contiguous (e.g., slice ops) or non-contiguous (e.g., transpose())
   if (src.is_view() || !src.is_contiguous()) {
-    MPSCachedGraph* cachedGraph = _getCachedGraph(src, GatherScatterViewOpType::Gather);
-    if (cachedGraph) {
-      allocateViewTensor(src);
-      id<MTLBuffer> gatherTensor = gatherViewTensorWithAllocatedMem(src, srcBuf, _viewOutput, cachedGraph);
-      if (gatherTensor) {
-        srcBuf = gatherTensor;
-      }
-    } else {
-      src_ = src.contiguous();
-      srcBuf = __builtin_bit_cast(id<MTLBuffer>, src_.storage().data());
+     Tensor emptyShell = Tensor();
+    // use "_tensor" from Placeholder to retain view's output during its usage in other ops
+    _tensor = gatherViewTensor(src, emptyShell);
+    if (!_tensor.has_storage()) {
+      // if we cannot gather, we make the the tensor contiguous implicitly, and keep
+      // it in placeholder to be able to retrieve it when we return from constructor
+      _tensor = src.contiguous();
     }
+    srcBuf = getMTLBufferStorage(_tensor);
   }
   // tensor.numel() could be zero, but tensor is valid as long as the buffer size is non-zero.
   // if buffer size is zero in here, it's not a user error. It could be a missing check for
   // tensor.numel() == 0 in our internal implementations of ops.
   TORCH_INTERNAL_ASSERT([srcBuf length] > 0, "Placeholder tensor is empty!");
 
-  const MPSDataType mpsDataType = src_.dim() == 0 ? getMPSScalarType(src_.scalar_type()) : getMPSDataType(src_.scalar_type());
+  const MPSDataType mpsDataType = _tensor.dim() == 0 ? getMPSScalarType(_tensor.scalar_type()) : getMPSDataType(_tensor.scalar_type());
   if (!mpsShape)
-    mpsShape = getMPSShape(src_);
+    mpsShape = getMPSShape(_tensor);
 
   _value = [[[MPSGraphTensorData alloc] initWithMTLBuffer:srcBuf
                                                     shape:mpsShape
@@ -414,7 +295,7 @@ MPSGraphTensorData *getMPSGraphTensorData(MPSGraph* mpsGraph,
 
   MPSGraphTensorData *result = nil;
   if (tensor.numel() > 0) {
-    id<MTLBuffer> buf = __builtin_bit_cast(id<MTLBuffer>, tensor.storage().data());
+    id<MTLBuffer> buf = getMTLBufferStorage(tensor);
     result = [[[MPSGraphTensorData alloc] initWithMTLBuffer:buf
                                                     shape:mpsShape
                                                  dataType:dataType]

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -12,198 +12,9 @@
 #include <ATen/native/Resize.h>
 #include <c10/util/Optional.h>
 
+
 namespace at {
 namespace native {
-
-MPSGraphTensor* chainViewOperation(
-  MPSGraph* mpsGraph,
-  IntArrayRef size,
-  IntArrayRef stride,
-  int64_t storage_offset,
-  MPSGraphTensor* inputTensor,
-  const Tensor& self,
-  MPSGraphTensor* &updatesTensor,
-  mps::GatherScatterViewOpType viewOpType,
-  MPSShape* parentShape) {
-  using namespace mps;
-  MPSGraphTensor *outputTensor = nil;
-  const size_t shape_size = size.size();
-
-  @autoreleasepool {
-      std::vector<int32_t> sizeArray(shape_size);
-      const int64_t int_max = std::numeric_limits<int32_t>::max();
-      for (int i = 0; i < shape_size; i++) {
-        TORCH_CHECK(size[i] <= int_max);
-        sizeArray[i] = static_cast<int32_t>(size[i]);
-      }
-      NSData* shapeData = [NSData dataWithBytes: sizeArray.data()
-                                         length: shape_size * sizeof(int32_t)];
-      MPSGraphTensor* shapeTensor =  [mpsGraph constantWithData: shapeData
-                                                          shape: @[[NSNumber numberWithUnsignedInteger: shape_size]]
-                                                       dataType: MPSDataTypeInt32];
-
-      MPSGraphTensor* storageOffsetTensor = [mpsGraph constantWithScalar: storage_offset
-                                                                dataType: MPSDataTypeInt32];
-      MPSGraphTensor* strideTensor = [mpsGraph constantWithScalar: stride[shape_size - 1]
-                                                         dataType: MPSDataTypeInt32];
-      MPSGraphTensor* rangeTensor = [mpsGraph coordinateAlongAxis: -1
-                                                  withShapeTensor: shapeTensor
-                                                             name: nil];
-      MPSGraphTensor* indexTensor = [mpsGraph multiplicationWithPrimaryTensor: rangeTensor
-                                                              secondaryTensor: strideTensor
-                                                                         name: nil];
-      MPSGraphTensor* indicesTensor = indexTensor;
-      // create stride Tensors for each rank of the input tensor
-      for (int i = 1; i < shape_size; i++) {
-        strideTensor = [mpsGraph constantWithScalar: stride[shape_size - i - 1]
-                                           dataType: MPSDataTypeInt32];
-        MPSGraphTensor* rangeTensor = [mpsGraph coordinateAlongAxis: (-i - 1)
-                                                    withShapeTensor: shapeTensor
-                                                               name: nil];
-        MPSGraphTensor* indexTensor = [mpsGraph multiplicationWithPrimaryTensor: rangeTensor
-                                                                secondaryTensor: strideTensor
-                                                                           name: nil];
-        indicesTensor = [mpsGraph additionWithPrimaryTensor: indexTensor
-                                            secondaryTensor: indicesTensor
-                                                       name: nil];
-      }
-      indicesTensor = [mpsGraph additionWithPrimaryTensor: indicesTensor
-                                          secondaryTensor: storageOffsetTensor
-                                                     name: nil];
-      MPSGraphTensor *reshapedInputTensor = [mpsGraph reshapeTensor: inputTensor
-                                                          withShape: @[@-1]
-                                                               name: nil];
-      MPSGraphTensor *reshapedIndicesTensor = [mpsGraph reshapeTensor: indicesTensor
-                                                            withShape: @[@-1]
-                                                                 name: nil];
-      if (viewOpType == GatherScatterViewOpType::Scatter) {
-        updatesTensor = mps::mpsGraphUnrankedPlaceHolder(mpsGraph, mps::getMPSDataType(self.scalar_type()));
-        MPSGraphTensor* scatteredTensor = [mpsGraph scatterAlongAxis: 0
-                                                      withDataTensor: reshapedInputTensor
-                                                       updatesTensor: updatesTensor
-                                                       indicesTensor: reshapedIndicesTensor
-                                                                mode: MPSGraphScatterModeSet
-                                                                name: nil];
-        outputTensor = [mpsGraph reshapeTensor: scatteredTensor
-                                     withShape: parentShape
-                                          name: nil];
-      } else {
-        MPSGraphTensor* gatheredTensor = [mpsGraph gatherWithUpdatesTensor: reshapedInputTensor
-                                                             indicesTensor: reshapedIndicesTensor
-                                                                      axis: 0
-                                                           batchDimensions: 0
-                                                                      name: nil];
-        outputTensor = [mpsGraph reshapeTensor: gatheredTensor
-                               withShapeTensor: shapeTensor
-                                          name: nil];
-      }
-  }
-  return outputTensor;
-}
-
-
-void createCachedGraph(
-  const Tensor& self,
-  IntArrayRef size,
-  IntArrayRef stride,
-  int64_t storage_offset,
-  mps::GatherScatterViewOpType viewOpType) {
-  using namespace mps;
-  struct CachedGraph : public MPSCachedGraph
-  {
-    CachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* inputTensor_ = nil;
-    MPSGraphTensor* outputTensor_ = nil;
-    MPSGraphTensor* scatteredTensor_ = nil;
-    MPSGraphTensor* updatesTensor_ = nil;
-  };
-
-  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
-
-  @autoreleasepool {
-    string key = mps::getStridedKey(self, size, stride, storage_offset, viewOpType);
-    CachedGraph* cachedGraph = static_cast<CachedGraph *>(cache_->LookUp(key));
-    if (!cachedGraph) {
-      MPSGraphTensor *parentInputTensor = nil;
-
-      // Get parent's shape if this is a chained view
-      // Scatter will have the same hierarchy of views as gather
-      string lookup_key_parent = mps::getStridedKey(self, self.sizes(), self.strides(),
-              self.storage_offset(), mps::GatherScatterViewOpType::Gather);
-
-      CachedGraph* parentCachedGraph = static_cast<CachedGraph *>(cache_->LookUp(lookup_key_parent));
-        if (parentCachedGraph) {
-          parentInputTensor = parentCachedGraph->inputTensor_;
-        }
-
-      cache_->CreateCachedGraph(key, ^ MPSCachedGraph * () {
-        CachedGraph *newCachedGraph = nil;
-        @autoreleasepool {
-            MPSShape *shape = nil;
-            MPSGraph* mpsGraph = make_mps_graph();
-            newCachedGraph = new CachedGraph(mpsGraph);
-
-            // All chained view operations should use the shape of the first contiguous tensor from which the view was created
-            if (parentInputTensor)
-              shape = [parentInputTensor shape];
-            else
-              shape = getMPSShape(self);
-
-            // Self is the input tensor we are creating view of
-            MPSGraphTensor* inputTensor = [mpsGraph placeholderWithShape : shape
-                                                                dataType : getMPSDataType(self.scalar_type())
-                                                                    name : nil];
-            newCachedGraph->inputTensor_ = inputTensor;
-            newCachedGraph->outputTensor_ = chainViewOperation(mpsGraph, size, stride,
-                                                                storage_offset, inputTensor, self,
-                                                                newCachedGraph->updatesTensor_, viewOpType,
-                                                                viewOpType == GatherScatterViewOpType::Scatter ? shape : nil);
-        }
-        return newCachedGraph;
-      }, self.storage().data());
-    }
-  }
-}
-
-// There are few cases we need to consider:
-// Here nodes are the Tensors and the edges are the operations performed on the
-// Tensor. As a result of the operation performed we can have result as View
-// Tensor (View T) or a Non view tensor (NonView T). The difference is if its
-// mapped by the same underlying storage ptr or a new MTLBuffer was allocated.
-//                T = Tensor
-//                 ----------
-//                 | Orig T |
-//                 ----------
-//                /     |     \
-//             View T  View T  NonView T
-//             /      /    \      |
-//            View T /      \     |
-//            |     /        \    |
-//            |    /          \   |
-//            |   /            \  |
-//            NonView T         NonView T
-Tensor as_strided_tensorimpl_mps(const Tensor& self, IntArrayRef size,
-                                 IntArrayRef stride,
-                                 optional<int64_t> storage_offset_) {
-  using namespace mps;
-  // Use the size and stride to create a unique key
-  auto result = detail::make_tensor<TensorImpl>(
-      c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
-  auto storage_offset = storage_offset_.value_or(self.storage_offset());
-  setStrided(result, size, stride, storage_offset);
-
-  // 0 sizes won't result in any change in the shape of the Tensor so we can
-  // skip it. Also if the memory is contiguous we don't need to do
-  // gather-scatter operations using graph.
-  if (size.size() > 0) {
-    // If self itself was a view tensor, that means we need to chain the graphs
-    // else we will create a new entry in the cache
-    // Create a gather cached graph if there is none already in the cache
-    createCachedGraph(self, size, stride, storage_offset, GatherScatterViewOpType::Gather);
-  }
-  return result;
-}
-
 namespace mps {
 
 void* pageAlignedBlockPtr(
@@ -220,15 +31,6 @@ void* pageAlignedBlockPtr(
 
   *alignedBlockSize = alignedLength;
   return (void*)alignedAddress;
-}
-
-static bool copy_requires_temporaries(const Tensor& dst, const Tensor& src) {
-  bool same_dtype = src.dtype() == dst.dtype();
-  if (same_dtype && src.is_contiguous() && dst.is_contiguous()) {
-    return false;
-  } else {
-    return true;
-  }
 }
 
 // Copy sourceBuffer into destBuffer, casting sourceBuffer to src.scalar_type().
@@ -285,14 +87,10 @@ void copy_cast_mps(at::Tensor& dst, const at::Tensor& src,
   }
 }
 
-static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_,
-                           bool non_blocking) {
-
-  using namespace mps;
+static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_, bool non_blocking)
+{
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* stream = getCurrentMPSStream();
-  uint64_t size = src_.nbytes();
-  if (size == 0) return dst_;
   Tensor dst;
   Tensor src;
   if (!dst_.is_contiguous()) {
@@ -302,41 +100,39 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_,
   }
 
   auto storage_byte_offset = src_.storage_offset() * src_.itemsize();
-  id<MTLBuffer> sourceBuffer = __builtin_bit_cast(id<MTLBuffer>, src_.storage().data());
   if (!src_.is_contiguous()) {
-    id<MTLBuffer> gatherTensor = gatherViewTensor(src_, sourceBuffer);
-    if (gatherTensor) {
-      sourceBuffer = gatherTensor;
+    Tensor emptyShell = Tensor();
+    src = gatherViewTensor(src_, emptyShell);
+    if (src.has_storage()) {
       storage_byte_offset = 0;
     } else {
       src = src_.expand_as(dst).contiguous();
-      sourceBuffer = __builtin_bit_cast(id<MTLBuffer>, src.storage().data());
       storage_byte_offset = src.storage_offset() * src.itemsize();
     }
   } else {
     src = src_;
   }
-
-  void* host_dst = dst.storage().data();
-
-  if (sourceBuffer == nil) return dst_;
-  NSUInteger destOffset = dst.storage_offset() * dst.itemsize();
+  id<MTLBuffer> sourceBuffer = getMTLBufferStorage(src);
+  const size_t src_size = src.nbytes();
+  // if there's anything wrong with source, we shouldn't return dst_ silently and must error out.
+  TORCH_CHECK(sourceBuffer && src_size > 0);
 
   // In case of dtype change, first convert src inplace
   if (src_.dtype() != dst_.dtype()) {
-    copy_cast_mps(dst_, src_, sourceBuffer, sourceBuffer);
+    copy_cast_mps(dst, src, sourceBuffer, sourceBuffer);
   }
 
   @autoreleasepool {
     MTLResourceOptions options = MTLResourceOptionCPUCacheModeDefault | MTLResourceStorageModeShared;
     NSUInteger alignedLength = 0;
 
-    void* alignedPtr = pageAlignedBlockPtr(host_dst, (NSUInteger)size, &alignedLength);
+    void* host_dst = dst.storage().data();
+    void* alignedPtr = pageAlignedBlockPtr(host_dst, (NSUInteger)src_size, &alignedLength);
     id<MTLBuffer> destBuffer = [device newBufferWithBytesNoCopy:alignedPtr
                                                          length:alignedLength
                                                         options:options
                                                     deallocator:nil];
-    destOffset = uintptr_t(host_dst) - uintptr_t(alignedPtr);
+     NSUInteger destOffset = uintptr_t(host_dst) - uintptr_t(alignedPtr);
     // 4 bytes alignment required on macos for blits.
     TORCH_CHECK(destOffset % 4 == 0, "Unaligned blit request");
 
@@ -350,7 +146,7 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_,
                        sourceOffset:(NSUInteger)storage_byte_offset
                            toBuffer:destBuffer
                   destinationOffset:(NSUInteger)destOffset
-                               size:(NSUInteger)size];
+                               size:(NSUInteger)src_size];
         [blitEncoder endEncoding];
 
         if (non_blocking) {
@@ -369,16 +165,15 @@ static at::Tensor& copy_from_mps_(at::Tensor& dst_, const at::Tensor& src_,
   return dst_;
 }
 
-static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_,
-                         bool non_blocking) {
+static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_, bool non_blocking)
+{
   MPSStream* stream = getCurrentMPSStream();
   Tensor dst;
   Tensor src;
 
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   auto dst_byte_offset = dst_.storage_offset() * dst_.itemsize();
-  id<MTLBuffer> destBuffer = __builtin_bit_cast(id<MTLBuffer>, dst_.storage().data());
-
+  id<MTLBuffer> destBuffer = getMTLBufferStorage(dst_);
 
   if (src_.is_view()) {
     src = src_.to(dst_.dtype()).expand_as(dst_).contiguous();
@@ -453,44 +248,44 @@ void copy_blit_mps(void* dst, const void* src, size_t size) {
   });
 }
 
-
-static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_,
-                            bool non_blocking) {
-  uint64_t size = src_.nbytes();
+static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_, bool non_blocking)
+{
   auto src_byte_offset = src_.storage_offset() * src_.itemsize();
-  id<MTLBuffer> sourceBuffer = __builtin_bit_cast(id<MTLBuffer>, src_.storage().data());
+  auto dst_byte_offset = dst_.storage_offset() * dst_.itemsize();
+
+  // If dst is contiguous and there is no byte offset, we can save directly the result of
+  // gather into dst. This reduces the overhead of doing an additional blit for most cases
+  bool returnGatherOutput = (dst_.is_contiguous() && !dst_byte_offset);
   Tensor src;
+
   if (!src_.is_contiguous()) {
-    id<MTLBuffer> gatherTensor = gatherViewTensor(src_, sourceBuffer);
-    if (gatherTensor) {
-      sourceBuffer = gatherTensor;
+    Tensor emptyShell = Tensor();
+    src = gatherViewTensor(src_, returnGatherOutput ? dst_ : emptyShell);
+
+    if (src.has_storage()) {
+      if (returnGatherOutput)
+        return dst_;
+
       src_byte_offset = 0;
     } else {
       src = src_.expand_as(dst_).contiguous();
-      sourceBuffer = __builtin_bit_cast(id<MTLBuffer>, src.storage().data());
       src_byte_offset = src.storage_offset() * src.itemsize();
     }
   } else {
     src = src_;
   }
-
   // Scatter to `dst` if the memory is not contiguous
   // If the memory is not contiguous, it means that the tensor has strides and we would not be
   // able to do the copy using a single blit
   if (!dst_.is_contiguous()) {
-    // Create a scatter cached graph if there is none already in the cache
-    createCachedGraph(dst_, dst_.sizes(), dst_.strides(), dst_.storage_offset(), mps::GatherScatterViewOpType::Scatter);
-    id<MTLBuffer> scatterTensor = scatterViewTensor(dst_, src_, sourceBuffer);
-    if (scatterTensor) {
-      return dst_;
-    }
+    return scatterViewTensor(src, dst_);
   }
-
   src._set_conj(src_.is_conj());
   src._set_neg(src_.is_neg());
 
-  auto dst_byte_offset = dst_.storage_offset() * dst_.itemsize();
-  id<MTLBuffer> destBuffer = __builtin_bit_cast(id<MTLBuffer>, dst_.storage().data());
+  id<MTLBuffer> destBuffer = getMTLBufferStorage(dst_);
+  id<MTLBuffer> sourceBuffer = getMTLBufferStorage(src);
+  const size_t src_size = src.nbytes();
 
   if (src.dtype() == dst_.dtype()) {
     MPSStream* stream = getCurrentMPSStream();
@@ -499,16 +294,17 @@ static at::Tensor& copy_kernel_mps(at::Tensor& dst_, const at::Tensor& src_,
         id<MTLCommandBuffer> commandBuffer = stream->commandBuffer();
         id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer blitCommandEncoder];
         [blitEncoder copyFromBuffer:sourceBuffer
-                      sourceOffset:src_byte_offset
-                          toBuffer:destBuffer
-                 destinationOffset:dst_byte_offset
-                              size:size];
+                       sourceOffset:src_byte_offset
+                           toBuffer:destBuffer
+                  destinationOffset:dst_byte_offset
+                               size:src_size];
         [blitEncoder endEncoding];
-        stream->commitAndWait();
+        // GPU to GPU copy needs flushing only, and no synchronization with CPU is necessary
+        stream->commit(true);
       }
     });
   } else {
-    copy_cast_mps(dst_, src_, destBuffer, sourceBuffer);
+    copy_cast_mps(dst_, src, destBuffer, sourceBuffer);
   }
   return dst_;
 }

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -67,7 +67,7 @@ static Tensor& runViewGraph(ViewCachedGraph* cachedGraph, const at::Tensor& src,
     }
     MPSGraphTensorData* outputTensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer: outputBuffer
                                                                                     shape: outputShape
-                                                                                 dataType: getMPSDataType(src.scalar_type())] autorelease];
+                                                                                 dataType: getMPSDataType(output.scalar_type())] autorelease];
     NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{
       cachedGraph->outputTensor : outputTensorData
     };

--- a/aten/src/ATen/native/mps/operations/View.mm
+++ b/aten/src/ATen/native/mps/operations/View.mm
@@ -1,0 +1,259 @@
+//  Copyright © 2022 Apple Inc.
+
+#include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/Resize.h>
+
+namespace at {
+
+// these are from MPSAllocator
+namespace mps {
+  // to check the requested non-aligned size of an MTL buffer
+  ssize_t get_requested_buffer_size(void* ptr);
+  // to retrieve the shape of a base tensor from a view tensor
+  IntArrayRef get_buffer_shape(void* ptr);
+  // to set the shape of a base tensor from a view tensor
+  void set_buffer_shape(void* ptr, const IntArrayRef& shape);
+}
+
+namespace native {
+namespace mps {
+
+struct ViewCachedGraph : public MPSCachedGraph
+{
+  ViewCachedGraph(MPSGraph *graph) : MPSCachedGraph(graph) {}
+  MPSGraphTensor* inputTensor = nil;
+  MPSGraphTensor* outputTensor = nil;
+  MPSGraphTensor* updatesTensor = nil;
+  MPSGraphTensor* storageOffsetTensor = nil;
+  std::vector<MPSGraphTensor*> strideTensors;
+};
+
+static std::string getStridedKey(const ScalarType& dtype, const IntArrayRef& base_shape,
+                          const IntArrayRef& new_shape, bool is_scatter)
+{
+  return (is_scatter ? "scatter:" : "gather:") + getMPSTypeString(dtype) + "[" +
+         getArrayRefString(base_shape) + "]:[" + getArrayRefString(new_shape) + "]";
+}
+
+// initializes the MTLBuffers for tesnsor data and runs the MPSGraph for the view op
+static Tensor& runViewGraph(ViewCachedGraph* cachedGraph, const at::Tensor& src, Tensor& output, bool needsScatter)
+{
+  const id<MTLBuffer> sourceBuffer = getMTLBufferStorage(src);
+  const id<MTLBuffer> outputBuffer = getMTLBufferStorage(output);
+
+  const IntArrayRef& strides   = needsScatter ? output.strides() : src.strides();
+  const IntArrayRef& sizes     = needsScatter ? output.sizes() : src.sizes();
+  const int64_t storage_offset = needsScatter ? output.storage_offset() : src.storage_offset();
+  const MPSDataType inputType  = [cachedGraph->inputTensor dataType];
+
+  MPSShape *inputShape = [cachedGraph->inputTensor shape];
+  MPSShape *outputShape = needsScatter ? inputShape : getMPSShape(src);
+
+  MPSStream* stream = getCurrentMPSStream();
+  @autoreleasepool {
+    NSMutableDictionary *feeds = [[NSMutableDictionary new] autorelease];
+    // in case of scatter, we use ouput tensor as input buffer and write the results back to the source buffer
+    feeds[cachedGraph->inputTensor] = [[[MPSGraphTensorData alloc] initWithMTLBuffer: needsScatter ? outputBuffer : sourceBuffer
+                                                                               shape: inputShape
+                                                                            dataType: inputType] autorelease];
+    if (needsScatter) {
+      feeds[cachedGraph->updatesTensor] = [[[MPSGraphTensorData alloc] initWithMTLBuffer: sourceBuffer
+                                                                                   shape: getMPSShape(src.numel())
+                                                                                dataType: inputType] autorelease];
+    }
+    feeds[cachedGraph->storageOffsetTensor] = getMPSGraphTensorFromScalar(stream, Scalar(storage_offset), MPSDataTypeInt32);
+    for (int i = 0; i < sizes.size(); i++) {
+      feeds[cachedGraph->strideTensors[i]] = getMPSGraphTensorFromScalar(stream, Scalar(strides[i]), MPSDataTypeInt32);
+    }
+    MPSGraphTensorData* outputTensorData = [[[MPSGraphTensorData alloc] initWithMTLBuffer: outputBuffer
+                                                                                    shape: outputShape
+                                                                                 dataType: getMPSDataType(src.scalar_type())] autorelease];
+    NSDictionary<MPSGraphTensor*, MPSGraphTensorData*>* results = @{
+      cachedGraph->outputTensor : outputTensorData
+    };
+    runMPSGraph(stream, cachedGraph->graph(), feeds, results);
+  }
+  return output;
+}
+
+static MPSGraphTensor* chainViewOperation(ViewCachedGraph* cachedGraph, const IntArrayRef& size,
+                                          const IntArrayRef& stride, int64_t offset,
+                                          const IntArrayRef& base_shape, bool needsScatter)
+{
+  MPSGraph* mpsGraph = cachedGraph->graph();
+  MPSGraphTensor *outputTensor = nil;
+  const size_t shape_size = size.size();
+
+  @autoreleasepool {
+    std::vector<int32_t> sizeArray(shape_size);
+    const int64_t int_max = std::numeric_limits<int32_t>::max();
+    for (int i = 0; i < shape_size; i++) {
+      TORCH_CHECK(size[i] <= int_max);
+      sizeArray[i] = static_cast<int32_t>(size[i]);
+    }
+    NSData* shapeData = [NSData dataWithBytes: sizeArray.data()
+                                       length: shape_size * sizeof(int32_t)];
+    MPSGraphTensor* shapeTensor = [mpsGraph constantWithData: shapeData
+                                                       shape: @[[NSNumber numberWithUnsignedInteger: shape_size]]
+                                                    dataType: MPSDataTypeInt32];
+    MPSGraphTensor* indicesTensor = nil;
+    // create stride Tensors for each rank of the input tensor
+    for (int i = 0; i < shape_size; i++) {
+      MPSGraphTensor* rangeTensor = [mpsGraph coordinateAlongAxis: (-i - 1)
+                                                  withShapeTensor: shapeTensor
+                                                             name: nil];
+      MPSGraphTensor* strideTensor = cachedGraph->strideTensors[shape_size - i - 1];
+      MPSGraphTensor* indexTensor = [mpsGraph multiplicationWithPrimaryTensor: rangeTensor
+                                                              secondaryTensor: strideTensor
+                                                                         name: nil];
+      if (!indicesTensor) {
+        indicesTensor = indexTensor;
+      } else {
+        indicesTensor = [mpsGraph additionWithPrimaryTensor: indexTensor
+                                            secondaryTensor: indicesTensor
+                                                       name: nil];
+      }
+    }
+
+    indicesTensor = [mpsGraph additionWithPrimaryTensor: indicesTensor
+                                        secondaryTensor: cachedGraph->storageOffsetTensor
+                                                   name: nil];
+    MPSGraphTensor *reshapedInputTensor = [mpsGraph reshapeTensor: cachedGraph->inputTensor
+                                                        withShape: @[@-1]
+                                                             name: nil];
+    MPSGraphTensor *reshapedIndicesTensor = [mpsGraph reshapeTensor: indicesTensor
+                                                          withShape: @[@-1]
+                                                               name: nil];
+    if (needsScatter) {
+      MPSGraphTensor* scatteredTensor = [mpsGraph scatterAlongAxis: 0
+                                                    withDataTensor: reshapedInputTensor
+                                                     updatesTensor: cachedGraph->updatesTensor
+                                                     indicesTensor: reshapedIndicesTensor
+                                                              mode: MPSGraphScatterModeSet
+                                                              name: nil];
+      outputTensor = [mpsGraph reshapeTensor: scatteredTensor
+                                   withShape: getMPSShape(base_shape)
+                                        name: nil];
+    } else {
+      // Call gather to coalesce the needed values. Result will be of same shape as flattened indices tensor
+      MPSGraphTensor *gatheredTensor = [mpsGraph gatherWithUpdatesTensor: reshapedInputTensor
+                                                           indicesTensor: reshapedIndicesTensor
+                                                                    axis: 0
+                                                         batchDimensions: 0
+                                                                    name: nil];
+      // Reshape the data to desired size
+      outputTensor =  [mpsGraph reshapeTensor: gatheredTensor
+                              withShapeTensor: shapeTensor
+                                         name: nil];
+    }
+  }
+  return outputTensor;
+}
+
+// There are few cases we need to consider:
+// Here nodes are the Tensors and the edges are the operations performed on the
+// Tensor. As a result of the operation performed we can have result as View
+// Tensor (View T) or a Non view tensor (NonView T). The difference is if its
+// mapped by the same underlying storage ptr or a new MTLBuffer was allocated.
+//                T = Tensor
+//                 ----------
+//                 | Orig T |
+//                 ----------
+//                /     |     \
+//             View T  View T  NonView T
+//             /      /    \      |
+//            View T /      \     |
+//            |     /        \    |
+//            |    /          \   |
+//            |   /            \  |
+//            NonView T         NonView T
+static ViewCachedGraph* createViewGraph(const Tensor& self, IntArrayRef size, IntArrayRef stride, int64_t storage_offset, bool needsScatter)
+{
+  IntArrayRef base_shape = get_buffer_shape(self.storage().data());
+  if (base_shape.size() == 0) {
+    // IntArrayRef wouldn't own the data, so we use a static storage
+    static const int64_t shape_1d = 1;
+    // self.sizes().size() could be zero
+    base_shape = self.sizes().size() ? self.sizes() : IntArrayRef(&shape_1d, 1);
+    // base_shape will be retained in MPSAllocator until buffer gets recycled
+    if (self.storage().data())
+      set_buffer_shape(self.storage().data(), base_shape);
+  }
+  MPSGraphCache* cache_ = MPSGraphCache::getInstance();
+
+  @autoreleasepool {
+    string key = getStridedKey(self.scalar_type(), base_shape, size, needsScatter);
+    ViewCachedGraph* cachedGraph = static_cast<ViewCachedGraph *>(cache_->LookUp(key));
+
+    if (!cachedGraph) {
+      cachedGraph = static_cast<ViewCachedGraph *>(cache_->CreateCachedGraph(key, ^ MPSCachedGraph * () {
+        ViewCachedGraph *newCachedGraph = nil;
+        @autoreleasepool {
+            MPSGraph* mpsGraph = make_mps_graph();
+            newCachedGraph = new ViewCachedGraph(mpsGraph);
+            // Self is the input tensor we are creating view of
+            newCachedGraph->inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(self.scalar_type()), getMPSShape(base_shape));
+            newCachedGraph->storageOffsetTensor = mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[@1]);
+            for (int i = 0; i < size.size(); i++) {
+              newCachedGraph->strideTensors.push_back(mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeInt32, @[@1]));
+            }
+            if (needsScatter) {
+              newCachedGraph->updatesTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(self.scalar_type()));
+            }
+            newCachedGraph->outputTensor = chainViewOperation(newCachedGraph, size, stride, storage_offset, base_shape, needsScatter);
+        }
+        return newCachedGraph;
+      }));
+    }
+    return cachedGraph;
+  }
+}
+
+Tensor gatherViewTensor(const at::Tensor& src, at::Tensor& dst)
+{
+  ViewCachedGraph* cachedGraph = nullptr;
+
+  const IntArrayRef& base_shape = get_buffer_shape(src.storage().data());
+  if (base_shape.size() > 0) {
+    string key = getStridedKey(src.scalar_type(), base_shape, src.sizes(), /*is_scatter*/ false);
+    cachedGraph = static_cast<ViewCachedGraph *>(MPSGraphCache::getInstance()->LookUp(key));
+  }
+  // there are cases where gatherViewTensor() is called without having as_strided() called beforehand.
+  // this typically may come from copy_mps variants. In such cases, when the base_shape isn't found the
+  // callers would resort to make the tensor contiguous in an alternative code path.
+  if (!cachedGraph) {
+    return Tensor();
+  }
+
+  Tensor output;
+  if (!dst.has_storage())
+    output = at::native::empty_mps(src.sizes(), src.scalar_type(), c10::nullopt, kMPS);
+
+  return runViewGraph(cachedGraph, src, dst.has_storage() ? dst : output, /*needsScatter*/ false);
+}
+
+Tensor& scatterViewTensor(const at::Tensor& src, at::Tensor& output)
+{
+  ViewCachedGraph* cachedGraph = createViewGraph(output, output.sizes(), output.strides(),
+                                                 output.storage_offset(), /*needsScatter*/ true);
+  return runViewGraph(cachedGraph, src, output, /*needsScatter*/ true);
+}
+
+} // namespace mps
+
+// implementation of as_strided() op
+Tensor as_strided_tensorimpl_mps(const Tensor& self, IntArrayRef size, IntArrayRef stride, optional<int64_t> storage_offset_)
+{
+  auto storage_offset = storage_offset_.value_or(self.storage_offset());
+  auto result = detail::make_tensor<TensorImpl>(c10::TensorImpl::VIEW, Storage(self.storage()), self.key_set(), self.dtype());
+  setStrided(result, size, stride, storage_offset);
+
+  // 0 sizes won't result in any change in the shape of the Tensor so we can skip it.
+  if (size.size() > 0)
+    mps::createViewGraph(self, size, stride, storage_offset, /*needsScatter*/ false);
+
+  return result;
+}
+
+} // namespace native
+} // namespace at

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -9,6 +9,7 @@ import warnings
 import subprocess
 import tempfile
 import os
+import pprint
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -1701,18 +1702,30 @@ class TestNLLLoss(TestCase):
         self.assertEqual(input.grad, input_mps.grad.to('cpu'))
 
     def test_as_strided(self):
-        def helper(n, c):
-            values = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
-            values_1 = [[1.0, 1.0], [1.0, 1.0]]
-            cpu_x = torch.tensor(values, device='cpu')
-            ones1 = torch.tensor(values_1, device='mps')
-            x = cpu_x.detach().clone().to('mps').requires_grad_()
-            strided_cpu = torch.as_strided(cpu_x, (2, 2), (1, 2))
-            strided_mps = torch.as_strided(x, (2, 2), (1, 2))
+        values = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
+        values_1 = [[1.0, 1.0], [1.0, 1.0]]
+        cpu_x = torch.tensor(values, device='cpu')
+        ones1 = torch.tensor(values_1, device='mps')
+        x = cpu_x.detach().clone().to('mps').requires_grad_()
+        strided_cpu = torch.as_strided(cpu_x, (2, 2), (1, 2))
+        strided_mps = torch.as_strided(x, (2, 2), (1, 2))
+        self.assertEqual(strided_mps, strided_cpu)
+        strided_cpu_out = strided_cpu + ones1.to('cpu')
+        strided_mps_out = strided_mps + ones1
+        self.assertEqual(strided_cpu_out, strided_mps_out)
 
-            self.assertEqual(strided_mps, strided_cpu)
+        # test with storage offsets
+        cpu_x = torch.rand(3, 3, device='cpu')
+        mps_x = cpu_x.to('mps')
+        strided_cpu1 = torch.as_strided(cpu_x, (2, 2), (1, 2), 0)
+        strided_mps1 = torch.as_strided(mps_x, (2, 2), (1, 2), 0)
+        strided_cpu2 = torch.as_strided(cpu_x, (2, 2), (1, 2), 1)
+        strided_mps2 = torch.as_strided(mps_x, (2, 2), (1, 2), 1)
+        strided_cpu_out = strided_cpu1 - strided_cpu2
+        strided_mps_out = strided_mps1 - strided_mps2
+        self.assertEqual(strided_cpu_out, strided_mps_out)
 
-        helper(3, 3)
+
 
     def test_sum_backward(self):
         def helper(n, c):
@@ -4810,7 +4823,7 @@ class TestGatherScatter(TestCase):
         x_mps = torch.zeros(10, dtype=torch.float32, device="mps")
         x_mps[::2] = 1.0
 
-        x_cpu = torch.zeros(10, dtype=torch.float32, device="mps")
+        x_cpu = torch.zeros(10, dtype=torch.float32, device="cpu")
         x_cpu[::2] = 1.0
 
         self.assertEqual(x_cpu, x_mps)


### PR DESCRIPTION
This is dependent on the PR to go in first: https://github.com/pytorch/pytorch/pull/79939

Remove the data_ptr from the View Graph key which reduces the number of
graphs created significantly.

Don't wait when copying from MPS to MPS tensors

