### PR TITLE
Support python 3.11 changes.

### DIFF
--- a/torch/csrc/Stream.cpp
+++ b/torch/csrc/Stream.cpp
@@ -107,7 +107,12 @@ PyTypeObject THPStreamType = {
 
 void THPStream_init(PyObject* module) {
   THPStreamClass = &THPStreamType;
-  Py_TYPE(&THPStreamType) = &PyType_Type;
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
+  static inline void _Py_SET_TYPE(PyObject * ob, PyTypeObject * type) {
+    ob->ob_type = type;
+  }
+#define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
+#endif
   if (PyType_Ready(&THPStreamType) < 0) {
     throw python_error();
   }

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -38,11 +38,18 @@ static constexpr size_t CallTypeSize = 3;
 struct CodeLocation {
   CodeLocation() = default;
   explicit CodeLocation(const PyFrameObject* frame)
+  // clang-format off
+#if PY_VERSION_HEX >= 0x030B0000
+      : code_{PyFrame_GetCode(frame)},
+        lasti_{PyFrame_GetLasti(frame)} {}
+#else
       : code_{frame->f_code}, lasti_{frame->f_lasti} {}
+#endif
 
   bool operator==(const CodeLocation& other) const {
     return code_ == other.code_ && lasti_ == other.lasti_;
   }
+  // clang-format on
 
   PyCodeObject* code_{nullptr};
   int lasti_{0};
@@ -257,7 +264,12 @@ void ValueCache::store<CallType::PyModuleCall>(const PyModuleCallKey& key) {
   if (C10_UNLIKELY(cache.modules_.find(key) == cache.modules_.end())) {
     if (C10_UNLIKELY(!cache.module_forward_.has_value())) {
       auto frame = PyEval_GetFrame();
+#if PY_VERSION_HEX >= 0x030B0000
+      TORCH_INTERNAL_ASSERT(
+          (PyObject*)(PyFrame_GetCode(frame)) == nnModuleCode());
+#else
       TORCH_INTERNAL_ASSERT((PyObject*)(frame->f_code) == nnModuleCode());
+#endif
       cache.module_forward_ = PyCallKey(frame);
       store<CallType::PyCall>(*cache.module_forward_);
     }
@@ -531,7 +543,11 @@ void PythonTracer::start(torch::profiler::impl::RecordQueue* queue) {
     size_t depth = 0; // Make sure we can't infinite loop.
     while (frame != nullptr && depth <= 128) {
       current_stack.push_back(frame);
+#if PY_VERSION_HEX >= 0x030B0000
+      frame = PyFrame_GetBack(frame);
+#else
       frame = frame->f_back;
+#endif
       depth++;
     }
     for (auto it = current_stack.rbegin(); it != current_stack.rend(); it++) {
@@ -572,7 +588,11 @@ void PythonTracer::clear() {
 void PythonTracer::recordPyCall(ThreadLocalResults& tls, PyFrameObject* frame) {
   static constexpr auto E = EventType::PyCall;
   auto get_key = [&]() -> TraceKey {
+#if PY_VERSION_HEX >= 0x030B0000
+    if ((PyObject*)(PyFrame_GetCode(frame)) == module_call_code_) {
+#else
     if ((PyObject*)(frame->f_code) == module_call_code_) {
+#endif
       // By default, CPython stores locals in a "fast" format, with an array
       // of names and an array of values. Consequently, frame->f_locals is
       // NULL since the interpreter has no need to populate it.
@@ -583,13 +603,28 @@ void PythonTracer::recordPyCall(ThreadLocalResults& tls, PyFrameObject* frame) {
       // `PyFrame_FastToLocals` which forces the interpreter to materialize
       // the full dict of locals.
       PyFrame_FastToLocals(frame);
+#if PY_VERSION_HEX >= 0x030B0000
+      auto self = PyDict_GetItemString(PyFrame_GetLocals(frame), "self");
+#else
       auto self = PyDict_GetItemString(frame->f_locals, "self");
+#endif
       PyFrame_LocalsToFast(frame, 0);
+#if PY_VERSION_HEX >= 0x030B0000
+      TORCH_INTERNAL_ASSERT(PyFrame_GetBack(frame) != nullptr);
+      return tls.intern<CallType::PyModuleCall, E>(
+          self, PyFrame_GetBack(frame));
+#else
       TORCH_INTERNAL_ASSERT(frame->f_back != nullptr);
       return tls.intern<CallType::PyModuleCall, E>(self, frame->f_back);
+#endif
 
     } else {
+#if PY_VERSION_HEX >= 0x030B0000
+      auto f_back =
+          PyFrame_GetBack(frame) != nullptr ? PyFrame_GetBack(frame) : frame;
+#else
       auto f_back = frame->f_back != nullptr ? frame->f_back : frame;
+#endif
       return tls.intern<CallType::PyCall, E>(frame, f_back);
     }
   };

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -576,6 +576,12 @@ static int THPVariable_clear(THPVariable* self) {
   return 0;
 }
 
+int THPFunction_traverse(THPFunction* self, visitproc visit, void* arg) {
+  TORCH_INTERNAL_ASSERT(
+      false, "Tensor tp_traverse function was not overriden properly");
+  return 0;
+}
+
 PyObject* THPVariable_pynew(
     PyTypeObject* type,
     PyObject* args,
@@ -1653,7 +1659,7 @@ PyTypeObject THPVariableType = {
         Py_TPFLAGS_HAVE_GC, /* tp_flags */
     nullptr, /* tp_doc */
     // Also set by metaclass
-    nullptr, /* tp_traverse */
+    (traverseproc)THPFunction_traverse, /* tp_traverse */
     (inquiry)THPVariable_clear, /* tp_clear */
     nullptr, /* tp_richcompare */
     0, /* tp_weaklistoffset */
@@ -1700,7 +1706,7 @@ static void clear_slots(PyTypeObject* type, PyObject* self) {
   PyMemberDef* mp;
 
   n = Py_SIZE(type);
-  mp = PyHeapType_GET_MEMBERS((PyHeapTypeObject*)type);
+  mp = type->tp_members;
   for (i = 0; i < n; i++, mp++) {
     if (mp->type == T_OBJECT_EX && !(mp->flags & READONLY)) {
       char* addr = (char*)self + mp->offset;
@@ -1912,7 +1918,7 @@ static int traverse_slots(
   PyMemberDef* mp;
 
   n = Py_SIZE(type);
-  mp = PyHeapType_GET_MEMBERS((PyHeapTypeObject*)type);
+  mp = type->tp_members;
   for (i = 0; i < n; i++, mp++) {
     if (mp->type == T_OBJECT_EX) {
       char* addr = (char*)self + mp->offset;

--- a/torch/csrc/lazy/python/python_util.cpp
+++ b/torch/csrc/lazy/python/python_util.cpp
@@ -19,9 +19,15 @@ c10::optional<SourceLocation> GetPythonFrameTop() {
     return c10::nullopt;
   }
   SourceLocation loc;
+#if PY_VERSION_HEX >= 0x030B0000
+  loc.line = PyCode_Addr2Line(PyFrame_GetCode(frame), PyFrame_GetLasti(frame));
+  loc.file = THPUtils_unpackString(PyFrame_GetCode(frame)->co_filename);
+  loc.function = THPUtils_unpackString(PyFrame_GetCode(frame)->co_name);
+#else
   loc.line = PyCode_Addr2Line(frame->f_code, frame->f_lasti);
   loc.file = THPUtils_unpackString(frame->f_code->co_filename);
   loc.function = THPUtils_unpackString(frame->f_code->co_name);
+#endif
   return loc;
 }
 
@@ -32,11 +38,22 @@ std::vector<SourceLocation> GetPythonFrames() {
     PyFrameObject* frame = PyEval_GetFrame();
     while (frame != nullptr) {
       SourceLocation loc;
+#if PY_VERSION_HEX >= 0x030B0000
+      loc.line =
+          PyCode_Addr2Line(PyFrame_GetCode(frame), PyFrame_GetLasti(frame));
+      loc.file = THPUtils_unpackString(PyFrame_GetCode(frame)->co_filename);
+      loc.function = THPUtils_unpackString(PyFrame_GetCode(frame)->co_name);
+#else
       loc.line = PyCode_Addr2Line(frame->f_code, frame->f_lasti);
       loc.file = THPUtils_unpackString(frame->f_code->co_filename);
       loc.function = THPUtils_unpackString(frame->f_code->co_name);
+#endif
       frames.push_back(std::move(loc));
+#if PY_VERSION_HEX >= 0x030B0000
+      frame = PyFrame_GetBack(frame);
+#else
       frame = frame->f_back;
+#endif
     }
   }
   return frames;


### PR DESCRIPTION
This PR adds support for required changes having python >= 3.11

---
* [Builds](https://copr.fedorainfracloud.org/coprs/rezso/ML/build/4584964/) on {py3.10, py3.11} x {aarch64, x86_64}.

Guided from here: https://docs.python.org/3.11/whatsnew/3.11.html#pyframeobject-3-11-hiding

Thanks,
~Cristian.

