### PR TITLE
Increase atol for test_noncontiguous_samples_nn_functional_conv_transpose3d_cuda_float32

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13708,7 +13708,7 @@ op_db: List[OpInfo] = [
                    toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1.3e-06), }),
                    'TestCommon', 'test_variant_consistency_eager', device_type='cuda'),
                DecorateInfo(
-                   toleranceOverride({torch.float32: tol(atol=1e-04, rtol=1.3e-06), }),
+                   toleranceOverride({torch.float32: tol(atol=1.3e-04, rtol=1.3e-06), }),
                    'TestCommon', 'test_noncontiguous_samples', device_type='cuda')],
            skips=(
                # RuntimeError: !lhs.isAliasOf(rhs)INTERNAL ASSERT FAILED at


### PR DESCRIPTION
This test is currently flaky due to randomly generated inputs sometimes producing results very slightly outside the specified tolerance. For example:

```
Mismatched elements: 1 / 2744 (0.0%)
Greatest absolute difference: 0.0001068115234375 at index (0, 7, 2, 3, 4) (up to 0.0001 allowed)
Greatest relative difference: 3.0445612311553214e-05 at index (0, 7, 2, 3, 4) (up to 1.3e-06 allowed)
```

Fixes #79509
