### PR TITLE
Add ComplexDouble scalar creation bindings to nvFuser's Python API

### DIFF
--- a/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
@@ -261,6 +261,13 @@ void initNvFuserPythonBindings(PyObject* module) {
       .def(
           "define_constant",
           [](FusionDefinitionContextManager& self,
+             std::complex<double> val) -> torch::jit::fuser::cuda::Val* {
+            return IrBuilder::create<ComplexDouble>(c10::complex<double>(val));
+          },
+          py::return_value_policy::reference)
+      .def(
+          "define_constant",
+          [](FusionDefinitionContextManager& self,
              bool val) -> torch::jit::fuser::cuda::Val* {
             return IrBuilder::create<Bool>(val);
           },
@@ -280,6 +287,8 @@ void initNvFuserPythonBindings(PyObject* module) {
               -> torch::jit::fuser::cuda::Val* {
             if (dtype == torch::jit::fuser::cuda::DataType::Double) {
               return IrBuilder::create<Double>();
+            } else if (dtype == torch::jit::fuser::cuda::DataType::ComplexDouble) {
+              return IrBuilder::create<ComplexDouble>();
             } else if (dtype == torch::jit::fuser::cuda::DataType::Bool) {
               return IrBuilder::create<Bool>();
             } else if (dtype == torch::jit::fuser::cuda::DataType::Int) {

--- a/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
@@ -287,7 +287,8 @@ void initNvFuserPythonBindings(PyObject* module) {
               -> torch::jit::fuser::cuda::Val* {
             if (dtype == torch::jit::fuser::cuda::DataType::Double) {
               return IrBuilder::create<Double>();
-            } else if (dtype == torch::jit::fuser::cuda::DataType::ComplexDouble) {
+            } else if (
+                 dtype == torch::jit::fuser::cuda::DataType::ComplexDouble) {
               return IrBuilder::create<ComplexDouble>();
             } else if (dtype == torch::jit::fuser::cuda::DataType::Bool) {
               return IrBuilder::create<Bool>();

--- a/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
+++ b/torch/csrc/jit/codegen/cuda/python_frontend/python_bindings.cpp
@@ -288,7 +288,7 @@ void initNvFuserPythonBindings(PyObject* module) {
             if (dtype == torch::jit::fuser::cuda::DataType::Double) {
               return IrBuilder::create<Double>();
             } else if (
-                 dtype == torch::jit::fuser::cuda::DataType::ComplexDouble) {
+                dtype == torch::jit::fuser::cuda::DataType::ComplexDouble) {
               return IrBuilder::create<ComplexDouble>();
             } else if (dtype == torch::jit::fuser::cuda::DataType::Bool) {
               return IrBuilder::create<Bool>();

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8910,7 +8910,7 @@ def reference_inputs_where(op, device, dtype, requires_grad, **kwargs):
         yield SampleInput(a, args=(c, b))
 
     # Python scalars type promotion
-    for scalar in (0, 0.0, 0j, False):
+    for scalar in (0, 0.0, 2j, False):
         yield SampleInput(scalar, args=(c, b))
         yield SampleInput(a, args=(c, scalar))
 


### PR DESCRIPTION
There is a problem that pybind11 silently converts Python's complex scalar to `bool` and uses `define_constant<bool>` overload. It was unnoticed because `0j` corresponds to `False` and tests passed, with `2j` scalar tests for `_refs.where` would fail without proper bindings.