### PR TITLE
[LTC] Add `Use` struct

### DIFF
--- a/torch/csrc/lazy/core/ir.cpp
+++ b/torch/csrc/lazy/core/ir.cpp
@@ -166,6 +166,7 @@ std::string Node::ToString() const {
 
 void Node::AddOperand(NodePtr node, size_t index) {
   CHECK_LT(index, node->num_outputs());
+  node->AddUse(Use(this, operands_.size(), index));
   operands_.push_back(node);
   operands_as_outputs_.emplace_back(operands_.back().get(), index);
 }

--- a/torch/csrc/lazy/core/ir.h
+++ b/torch/csrc/lazy/core/ir.h
@@ -137,6 +137,10 @@ class TORCH_API Node {
   // Gets operand at index i if index is valid, or kNullOutput otherwise.
   virtual const Output& nullable_operand(size_t i) const;
 
+  const std::set<Use>& uses() const {
+    return uses_;
+  }
+
   // Returns the hash of the dag used to look up the compiled graph
   virtual hash_t hash() const = 0;
 
@@ -174,12 +178,18 @@ class TORCH_API Node {
   // Adds node's index output number as operand.
   void AddOperand(NodePtr node, size_t index = 0);
 
+  void AddUse(Use use) {
+    uses_.insert(std::move(use));
+  }
+
   std::vector<Shape> shapes_;
   // A node holds a real reference to its operands.
   std::vector<NodePtr> operands_;
   // Outputs do not hold references on the nodes, and neither do the uses, since
   // otherwise we get into circular reference counting.
   std::vector<Output> operands_as_outputs_;
+  // We use a set for uses, as we want deterministic use sequencing.
+  std::set<Use> uses_;
 };
 
 inline std::ostream& operator<<(std::ostream& stream, const Node& node) {

--- a/torch/csrc/lazy/core/ir_metadata.cpp
+++ b/torch/csrc/lazy/core/ir_metadata.cpp
@@ -33,6 +33,23 @@ std::ostream& operator<<(
   return stream;
 }
 
+bool Use::operator<(const Use& rhs) const {
+  if (node->op() != rhs.node->op()) {
+    return node->op() < rhs.node->op();
+  }
+  if (operand_index != rhs.operand_index) {
+    return operand_index < rhs.operand_index;
+  }
+  return index < rhs.index;
+}
+
+std::string Use::ToString() const {
+  std::stringstream ss;
+  ss << node->ToString() << ", operand_index=" << operand_index
+     << ", index=" << index;
+  return ss.str();
+}
+
 namespace {
 
 struct ScopeEntry {

--- a/torch/csrc/lazy/core/ir_metadata.h
+++ b/torch/csrc/lazy/core/ir_metadata.h
@@ -7,6 +7,9 @@
 
 namespace torch {
 namespace lazy {
+
+struct Node;
+
 struct SourceLocation {
   std::string file;
   std::string function;
@@ -30,6 +33,25 @@ struct TORCH_API UserMetaData {
 struct TORCH_API MetaData {
   std::string scope;
   std::vector<SourceLocation> frame_info;
+};
+
+// Represents a use of the output of a given node.
+// If use U is within node N, it means that node U.node is using the output
+// U.index of the node N.
+struct TORCH_API Use {
+  Use(torch::lazy::Node* node, size_t operand_index, size_t index)
+      : node(node), operand_index(operand_index), index(index) {}
+
+  bool operator<(const Use& rhs) const;
+
+  std::string ToString() const;
+
+  // The node using the output of the node this use belongs to.
+  torch::lazy::Node* node = nullptr;
+  // The operand index, within node's operands, which this use refers to.
+  size_t operand_index = 0;
+  // The index within output the user node refers to.
+  size_t index = 0;
 };
 
 // TODO(whc) is this going to be used outside of in IR decompositions?

--- a/torch/csrc/lazy/core/ir_metadata.h
+++ b/torch/csrc/lazy/core/ir_metadata.h
@@ -8,7 +8,7 @@
 namespace torch {
 namespace lazy {
 
-struct Node;
+class Node;
 
 struct SourceLocation {
   std::string file;


### PR DESCRIPTION
Add `Use` struct to be able to track how many other nodes are "using" a particular `Node`. This is useful to know when pruning unnecessary model outputs in certain vendor backends.

Fixes #80527

CC: @wconstab @desertfire @JackCaoG 
