### PR TITLE
[ci] temporarily disable ROCm distributed tests

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -65,6 +65,7 @@ jobs:
       docker-image-name: pytorch-linux-bionic-rocm5.1-py3.7
 
   linux-bionic-rocm5_1-py3_7-distributed-test:
+    if: false # https://github.com/pytorch/pytorch/issues/80529
     name: linux-bionic-rocm5.1-py3.7-distributed
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-bionic-rocm5_1-py3_7-distributed-build


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #80530

They are timing out so disabling to restore CI as it is investigated.
see: https://github.com/pytorch/pytorch/issues/80529