### PR TITLE
Weak-ref-ify MetaConverter and FakeTensorConverter

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -30,6 +30,8 @@ import re
 from collections import defaultdict
 import unittest
 import warnings
+import weakref
+
 
 bf16 = torch.bfloat16
 f64 = torch.float64
@@ -166,6 +168,35 @@ class TestMetaConverter(TestCase):
         self.assertEqual(m.stride(), y.stride())
         self.assertEqual(m.storage_offset(), y.storage_offset())
 
+    def test_weakref(self):
+        x = torch.randn(4, 4, 4)
+        m = MetaConverter()
+        y = m(x)
+        z = m(x)
+        self.assertIs(y, z)
+        self.assertEqual(len(m.tensor_memo), 1)
+        self.assertEqual(len(m.storage_memo), 1)
+        del x
+        self.assertEqual(len(m.tensor_memo), 0)
+        m.check_for_expired_weak_storages()
+        self.assertEqual(len(m.storage_memo), 0)
+        li = []
+        for i in range(4):
+            li.append(torch.rand([i]))
+            m(li[-1])
+        self.assertEqual(len(m.tensor_memo), 4)
+        del li
+        self.assertEqual(len(m.tensor_memo), 0)
+        m.check_for_expired_weak_storages()
+        self.assertEqual(len(m.storage_memo), 0)
+
+    def test_tensor_outlives_converter(self):
+        m = MetaConverter()
+        ref = weakref.ref(m)
+        x = torch.randn([4, 4])
+        y = m(x)
+        del m
+        self.assertIs(ref(), None)
 
 def assert_ref_meta_equal(test_case, meta_rs, rs, msg_callable):
     flat_meta_rs, _ = tree_flatten(meta_rs)

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -4,7 +4,7 @@ from torch.utils._pytree import tree_map, tree_flatten
 from functools import partial
 from torch.fx.operator_schemas import normalize_function
 from torch.utils._mode_utils import no_dispatch
-from torch._subclasses.meta_utils import MetaConverter
+from torch._subclasses.meta_utils import MetaConverter, WeakTensorRefKey
 from typing import Union, Callable
 from torch._ops import OpOverload
 from torch.overrides import TorchFunctionMode
@@ -83,8 +83,8 @@ def _is_tensor_constructor(func: OpOverload):
 
 # Similar to `MetaConverter`, this is a class for converting
 # multiple tensors into fake tensors which share the same view/storage
-# structure. Like `MetaConverter`, it will keep alive all
-# tensors that are converted to FakeTensors.
+# structure. Like `MetaConverter`, it uses `WeakTensorRefKey` to
+# hold a weak reference for all memoized tensors.
 class FakeTensorConverter(object):
     tensor_memo: weakref.WeakValueDictionary
     meta_converter: MetaConverter
@@ -97,11 +97,28 @@ class FakeTensorConverter(object):
         self.meta_converter = MetaConverter()
 
     def _get_memo(self, t):
-        if t in self.tensor_memo:
-            out = self.tensor_memo[t]
+        if WeakTensorRefKey(t) in self.tensor_memo:
+            out = self.tensor_memo[WeakTensorRefKey(t)]
             out._fix_weakref()
             return out
         return None
+
+    def set_tensor_memo(self, t, v):
+        th = WeakTensorRefKey(t)
+
+        # hold a weak ref to self, otherwise it will be kept alive
+        # by the del_ten closure
+        self_weak_ref = weakref.ref(self)
+
+        def del_ten():
+            self_ref = self_weak_ref()
+            if self_ref is None:
+                return
+            # on shutdown, th may not be in memo
+            self_ref.tensor_memo.pop(th, None)
+
+        weakref.finalize(t, del_ten)
+        self.tensor_memo[th] = v
 
     def from_real_tensor(self, fake_mode, t):
         maybe_memo = self._get_memo(t)
@@ -119,7 +136,7 @@ class FakeTensorConverter(object):
             out = FakeTensor(fake_mode, self.meta_converter(t), existing_device)
         if type(t) is torch.nn.Parameter:
             out = torch.nn.Parameter(out, requires_grad=out.requires_grad)  # type: ignore[assignment]
-        self.tensor_memo[t] = out
+        self.set_tensor_memo(t, out)
         return out
 
     def from_meta_and_device(self, fake_mode, t, device):
@@ -127,7 +144,7 @@ class FakeTensorConverter(object):
         if maybe_memo is not None:
             return maybe_memo
         out = FakeTensor(fake_mode, t, device)
-        self.tensor_memo[t] = out
+        self.set_tensor_memo(t, out)
         return out
 
     def __call__(self, fake_mode, t, device=None):

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -1,5 +1,7 @@
 import torch
 from torch.utils._mode_utils import no_dispatch
+from torch.multiprocessing.reductions import StorageWeakRef
+import weakref
 
 def safe_is_leaf(t):
     try:
@@ -9,36 +11,133 @@ def safe_is_leaf(t):
         return False
 
 
+# torch.Tensors cannot be used as a key in a dictionary
+# because they define a custom __eq__ function which when used
+# to resolve hash collisions will throw when comparing tensors:
+# "RuntimeError: bool value of Tensor with more than one value is ambiguous."
+# To avoid that, we use an object which will hold a Tensor and use
+# its id for both hashing and equality.
+# In order to use this as a weak key reference, we cannot
+# simply use weakref.WeakKeyDictionary because the newly constructed
+# WeakTensorRefKey only use would be a dictionary so it would have no strong
+# references.
+# To get around this issue, we can use it as a normal key, and then set
+# `weakref.finalize` to delete the key when its contained tensor dies.
+
+class WeakTensorRefKey(object):
+    def __init__(self, ten):
+        self.ten = weakref.ref(ten)
+        # store id since as soon as ten is deallocated
+        # the old id will no longer be recoverable, and
+        # we need to be able to remove the WeakTensorRefKey
+        # from the dictionary by hashing it to the same
+        # value it had when ten was alive
+        self.id = id(self.ten())
+
+    def __hash__(self):
+        return self.id
+
+    def __eq__(self, other):
+        if id(self) == id(other):
+            return True
+        return self.id == other.id
+
+
 # This is a class for converting multiple tensors into meta tensors which
 # share the same view/storage structure.  The operation model is you allocate
 # one of these, and then call it repeatedly on all the tensors you want to
 # convert.  It's important to use the same object for tensors you want to
 # share storage because this is how we correlate shared storages to the same
-# meta storages; similarly, it's important NOT to use the same object for
-# unrelated groups of tensors because this class will remember all the
-# tensors/storages its seen and therefore leak memory.
+# meta storages. This class will hold weak references to cached tenosrs
+# and tensor storages.
 class MetaConverter:
     def __init__(self):
         self.storage_memo = {}
         self.tensor_memo = {}
+        self.maybe_storages_to_delete = []
+        self.check_expired_frequency = 128
+        self.check_expired_count = 0
         self.hit = 0
         self.miss = 0
+        self.del_hook = None
 
     def successful(self):
         return self.hit > 0 and self.miss == 0
+
+    def check_for_expired_weak_storages(self):
+        new_li = []
+        stor_to_delete = []
+        for obj in self.maybe_storages_to_delete:
+            if not obj.expired():
+                new_li.append(obj)
+            else:
+                stor_to_delete.append(obj)
+        for obj in stor_to_delete:
+            self.storage_memo.pop(obj, None)
+        self.maybe_storages_to_delete = new_li
+
+        # if for some reason we have aquired many storages which have not expired
+        # even though a tensor with their storage has expired (aliasing or otherwise)
+        # check for expired storages less often so as to bound the amount of work we
+        # do checking for expired storages
+        self.check_expired_frequency = max(self.check_expired_frequency, len(self.maybe_storages_to_delete))
+
+
+    def get_tensor_memo(self, t):
+        return self.tensor_memo.get(WeakTensorRefKey(t), None)
+
+    def set_tensor_memo(self, t, v):
+        # hold a weak ref to self, otherwise it will be kept alive
+        # by the del_ten closure
+        self_weak_ref = weakref.ref(self)
+        weak_st = StorageWeakRef(t.storage())
+        tensor_ref_key = WeakTensorRefKey(t)
+
+        def del_ten():
+            # tensor outlives the converter
+            self_ref = self_weak_ref()
+            if self_ref is None:
+                return
+            # on shutdown, tensor_ref_key may not be in memo
+            self_ref.tensor_memo.pop(tensor_ref_key, None)
+            if weak_st and weak_st.expired():
+                self_ref.storage_memo.pop(weak_st, None)
+            else:
+                # [expired-storages]
+                # NB: even though the tensor has died,
+                # the deallocation of its storage can take longer,
+                # even when the storage has no other uses/views.
+                # In this case, the StorageWeakRef object will be kept alive
+                # longer than it needs to be, however the storage itself
+                # will be deallocated. We retain the possibly dead storages
+                # and periodically check if any of them are expired and
+                # can be freed.
+                self_ref.maybe_storages_to_delete.append(weak_st)
+
+        weakref.finalize(t, del_ten)
+        self.tensor_memo[tensor_ref_key] = v
 
     # NB: doesn't actually return a storage, because meta storage is
     # not supported
     def meta_storage(self, s):
         # NB: TypedStorage is freshly allocated and cannot be used as hash
         # key index.
-        if s._cdata not in self.storage_memo:
-            self.storage_memo[s._cdata] = torch.empty(s.size(), dtype=s.dtype, device='meta')
-        return self.storage_memo[s._cdata]
+
+        # Use a Weak Ref to s in order to not leak memory
+        swr = StorageWeakRef(s)
+        if swr not in self.storage_memo:
+            self.storage_memo[swr] = torch.empty(s.size(), dtype=s.dtype, device='meta')
+        return self.storage_memo[swr]
 
     # This function assumes that it's possible to do the conversion
     def meta_tensor(self, t):
-        if t not in self.tensor_memo:
+        # see expired-storages
+        self.check_expired_count += 1
+        if self.check_expired_count == self.check_expired_frequency:
+            self.check_for_expired_weak_storages()
+            self.check_expired_count = 0
+
+        if self.get_tensor_memo(t) is None:
             with torch.inference_mode(t.is_inference()):
                 if t._is_view():
                     # Construct views in two steps: recursively meta-fy their
@@ -92,9 +191,9 @@ class MetaConverter:
 
                 torch._C._set_conj(r, t.is_conj())
                 torch._C._set_neg(r, t.is_neg())
-            self.tensor_memo[t] = r
+            self.set_tensor_memo(t, r)
 
-        return self.tensor_memo[t]
+        return self.get_tensor_memo(t)
 
     def __call__(self, t):
         # TODO: zero tensors?  We appear to have eliminated them by

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -133,7 +133,7 @@ class MetaConverter:
     def meta_tensor(self, t):
         # see expired-storages
         self.check_expired_count += 1
-        if self.check_expired_count == self.check_expired_frequency:
+        if self.check_expired_count >= self.check_expired_frequency:
             self.check_for_expired_weak_storages()
             self.check_expired_count = 0
 

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -37,6 +37,14 @@ class StorageWeakRef(object):
     def __del__(self):
         self._free_weak_ref(self.cdata)
 
+    def __hash__(self):
+        return self.cdata
+
+    def __eq__(self, other):
+        if id(self) == id(other):
+            return True
+        return self.cdata == other.cdata
+
 
 class SharedCache(dict):
     """dictionary from multiprocessing handles to StorageWeakRef"""


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #80545
* __->__ #80544

Make `MetaConverter` and `FakeTensorConverter` hold weak references to their memoized tensors, and also have `MetaConverter` hold weak reference to Tensor storage. Otherwise it can be tricky for users to make sure all existing FakeTensors or FakeTensorModes are deleted which otherwise will leak memory. 

I ran into https://github.com/pytorch/pytorch/issues/7733 which I was able to get around with the following (see comment from code):

```
# torch.Tensors cannot be used as a key in a dictionary
# because they define a custom __eq__ function which when used
# to resolve hash collisions will throw when comparing tensors:
# "RuntimeError: bool value of Tensor with more than one value is ambiguous."
# To avoid that, we use an object which will hold a Tensor and use
# its id for both hashing and equality.
# In order to use this as a weak key reference, we cannot
# simply use weakref.WeakKeyDictionary because the newly constructed
# WeakTensorRefKey only use would be a dictionary so it would have no strong
# references.
# To get around this issue, we can use it as a normal key, and then set
# `weakref.finalize` to delete the key when its contained tensor dies.
``` 

While for the tensor memo we can set a `weakref.finalize` callback that will remove the corresponding `WeakTensorRefKey` from the tensor memo, at the point that this callback is invoked the tensor storage is not yet deallocated.. See comment from code:

```
# [expired-storages]
# NB: even though the tensor has died,
# the deallocation of its storage can take longer,
# even when the storage has no other uses/views.
# In this case, the StorageWeakRef object will be kept alive
# longer than it needs to be, however the storage itself
# will be deallocated. We retain the possibly dead storages
# and periodically check if any of them are expired and
# can be freed.
```


partial fix for https://github.com/pytorch/torchdynamo/issues/468