### PR TITLE
[GHA] Remove new lines from PR_BODY too to appease batch env var copying

### DIFF
--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -116,9 +116,11 @@ jobs:
           export SHARD_NUMBER=0
 
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
-          # trim all new lines from commit messages so we don't run into issues with batch environment
+
+          # trim all new lines from commit messages + PR_BODY so we don't run into issues with batch environment
           # variable copying. see https://github.com/pytorch/pytorch/pull/80043#issuecomment-1167796028
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[$'\n\r']}"
+          export PR_BODY="${PR_BODY//[$'\n\r']}"
 
           # TODO: Stop building test binaries as part of the build phase
           # Make sure we copy test results from bazel-testlogs symlink to

--- a/.github/workflows/_bazel-build-test.yml
+++ b/.github/workflows/_bazel-build-test.yml
@@ -117,7 +117,7 @@ jobs:
 
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
 
-          # trim all new lines from commit messages + PR_BODY so we don't run into issues with batch environment
+          # trim all new lines from commit messages + PR_BODY to avoid issues with batch environment
           # variable copying. see https://github.com/pytorch/pytorch/pull/80043#issuecomment-1167796028
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[$'\n\r']}"
           export PR_BODY="${PR_BODY//[$'\n\r']}"

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -98,7 +98,7 @@ jobs:
 
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
 
-          # trim all new lines from commit messages + PR_BODY so we don't run into issues with batch environment
+          # trim all new lines from commit messages + PR_BODY to avoid issues with batch environment
           # variable copying. see https://github.com/pytorch/pytorch/pull/80043#issuecomment-1167796028
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[$'\n\r']}"
           export PR_BODY="${PR_BODY//[$'\n\r']}"

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -97,9 +97,11 @@ jobs:
           fi
 
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
-          # trim all new lines from commit messages so we don't run into issues with batch environment
+
+          # trim all new lines from commit messages + PR_BODY so we don't run into issues with batch environment
           # variable copying. see https://github.com/pytorch/pytorch/pull/80043#issuecomment-1167796028
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[$'\n\r']}"
+          export PR_BODY="${PR_BODY//[$'\n\r']}"
 
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
 
-          # trim all new lines from commit messages + PR_BODY so we don't run into issues with batch environment
+          # trim all new lines from commit messages + PR_BODY to avoid issues with batch environment
           # variable copying. see https://github.com/pytorch/pytorch/pull/80043#issuecomment-1167796028
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[$'\n\r']}"
           export PR_BODY="${PR_BODY//[$'\n\r']}"

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -75,9 +75,11 @@ jobs:
         id: test
         run: |
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
-          # trim all new lines from commit messages so we don't run into issues with batch environment
+
+          # trim all new lines from commit messages + PR_BODY so we don't run into issues with batch environment
           # variable copying. see https://github.com/pytorch/pytorch/pull/80043#issuecomment-1167796028
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[$'\n\r']}"
+          export PR_BODY="${PR_BODY//[$'\n\r']}"
 
           python3 -mpip install dist/*.whl
           .jenkins/pytorch/macos-test.sh

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -94,7 +94,7 @@ jobs:
 
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
 
-          # trim all new lines from commit messages + PR_BODY so we don't run into issues with batch environment
+          # trim all new lines from commit messages + PR_BODY to avoid issues with batch environment
           # variable copying. see https://github.com/pytorch/pytorch/pull/80043#issuecomment-1167796028
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[$'\n\r']}"
           export PR_BODY="${PR_BODY//[$'\n\r']}"

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -93,9 +93,11 @@ jobs:
           fi
 
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
-          # trim all new lines from commit messages so we don't run into issues with batch environment
+
+          # trim all new lines from commit messages + PR_BODY so we don't run into issues with batch environment
           # variable copying. see https://github.com/pytorch/pytorch/pull/80043#issuecomment-1167796028
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[$'\n\r']}"
+          export PR_BODY="${PR_BODY//[$'\n\r']}"
 
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
 
-          # trim all new lines from commit messages + PR_BODY so we don't run into issues with batch environment
+          # trim all new lines from commit messages + PR_BODY to avoid issues with batch environment
           # variable copying. see https://github.com/pytorch/pytorch/pull/80043#issuecomment-1167796028
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[$'\n\r']}"
           export PR_BODY="${PR_BODY//[$'\n\r']}"

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -83,9 +83,11 @@ jobs:
           TORCH_CUDA_ARCH_LIST: "7.0"
         run: |
           COMMIT_MESSAGES=$(git cherry -v "origin/${GIT_DEFAULT_BRANCH:-master}")
-          # trim all new lines from commit messages so we don't run into issues with batch environment
+
+          # trim all new lines from commit messages + PR_BODY so we don't run into issues with batch environment
           # variable copying. see https://github.com/pytorch/pytorch/pull/80043#issuecomment-1167796028
           export COMMIT_MESSAGES="${COMMIT_MESSAGES//[$'\n\r']}"
+          export PR_BODY="${PR_BODY//[$'\n\r']}"
 
           .jenkins/pytorch/win-test.sh
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/80543 doesn't work in preventing batch from interpreting the multiline env vars. We will remove the lines from these env vars instead, since PR_BODY and COMMIT_MESSAGES are both used to determine what disabled tests to not skip.

Test plan is using the following below and making sure tests still pass, which they do.

Summary: previous versions of sparsity utils either allowed for a leading '.' for fqns, or would only allow for that.
Per discussion with ao team about

fqns don't have a leading '.'
fqn of root module is ''
these utilities have been updated to align with these definitions.
module_to_fqn was changed to not generate a leading '.' and output ''
for root module

fqn_to_module was changed to output the root rather than None for
path=''

get_arg_info_from_tensor_fqn had explicit handling for a leading '.'
that was removed. The previous implementation overwrote the tensor_fqn
if it had a leading '.' which resulted in undesirable behavior of
rewriting arguments provided by the user.

Also refactored utils to be simpler and added comments, formatting and
test

Test Plan:
python test/test_ao_sparsity.py
python test/test_ao_sparsity.py TestSparsityUtilFunctions

Reviewers:

Subscribers:

Tasks:

Tags: