### PR TITLE
[GH1] Relanding #80064 to erase double messaging as it was overwritten by mistake

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -748,8 +748,6 @@ class GitHubPR:
         self.merge_changes(repo, force, comment_id)
 
         repo.push(self.default_branch(), dry_run)
-        gh_post_pr_comment(self.org, self.project, self.pr_num,
-                           f"@{self.get_pr_creator_login()} your PR has been successfully merged.", dry_run)
         if not dry_run:
             gh_add_labels(self.org, self.project, self.pr_num, ["merged"])
 


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/77943 accidentally overwrote #80064. We can revert that PR and reland it later or we can land this fix PR as it is one line.