### PR TITLE
Expose an out-of-place _reduce from ProcessGroupNCCL

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -102,6 +102,7 @@ exclude_patterns = [
     'torch/distributed/elastic/agent/server/api.py',
     'torch/testing/_internal/**',
     'torch/distributed/fsdp/fully_sharded_data_parallel.py',
+    'torch/distributed/distributed_c10d.py',
     # TODO(suo): these exclusions were added just to get lint clean on master.
     # Follow up to do more target suppressions and remove them.
     'torch/distributed/fsdp/flatten_params_wrapper.py',

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -209,6 +209,21 @@ class ProcessGroup:
         op=ReduceOp.SUM,
     ) -> Work: ...
     @overload
+    def _reduce(
+        self,
+        output_tensors: List[Tensor],
+        input_tensors: List[Tensor],
+        opts=ReduceOptions(),
+    ) -> Work: ...
+    @overload
+    def _reduce(
+        self,
+        output_tensor: Tensor,
+        input_tensor: Tensor,
+        root: int,
+        op=ReduceOp.SUM,
+    ) -> Work: ...
+    @overload
     def allgather(
         self,
         output_tensors: List[List[Tensor]],

--- a/torch/csrc/distributed/c10d/Ops.hpp
+++ b/torch/csrc/distributed/c10d/Ops.hpp
@@ -38,6 +38,12 @@ TORCH_API c10::intrusive_ptr<ProcessGroup::Work> reduce(
     at::TensorList tensors,
     const ReduceOptions& opts = {});
 
+TORCH_API c10::intrusive_ptr<ProcessGroup::Work> _reduce(
+    const c10::intrusive_ptr<ProcessGroup> &process_group,
+    const std::vector<at::Tensor> &output_tensors,
+    const std::vector<at::Tensor> &input_tensors,
+    const ReduceOptions &opts = {});
+
 TORCH_API c10::intrusive_ptr<ProcessGroup::Work> gather(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     const std::vector<std::vector<at::Tensor>>& output_tensors,

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -16,6 +16,8 @@ std::string opTypeToString(OpType opType) {
       return "ALLREDUCE_COALESCED";
     case OpType::REDUCE:
       return "REDUCE";
+    case OpType::_REDUCE:
+      return "_REDUCE";
     case OpType::ALLGATHER:
       return "ALLGATHER";
     case OpType::_ALLGATHER_BASE:

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -209,6 +209,15 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
     TORCH_INTERNAL_ASSERT(false, "getBackendName is not implemented.");
   };
 
+  virtual void startCoalescing() {
+    // no-op for backends that have not implemented startCoalescing
+  }
+
+  virtual void endCoalescing(
+      std::vector<c10::intrusive_ptr<ProcessGroup::Work>>& /* reqs */) {
+    // no-op for backends that have not implemented endCoalescing
+  }
+
   // Consider using ops in Ops.hpp instead of the below, which route things
   // to the dispatcher.
   // TODO: Find a way to force the above rule programmatically.

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -48,6 +48,7 @@ enum class OpType : std::uint8_t {
   RECVANYSOURCE = 14,
   BARRIER = 15,
   _REDUCE_SCATTER_BASE = 16,
+  _REDUCE = 17,
   UNKNOWN = 100,
 };
 
@@ -252,6 +253,15 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> reduce(
       std::vector<at::Tensor>& /* tensors */,
+      const ReduceOptions& /* opts */ = ReduceOptions()) {
+    TORCH_CHECK(
+        false,
+        c10::str("ProcessGroup ", getBackendName(), "does not support reduce"));
+  }
+
+  virtual c10::intrusive_ptr<ProcessGroup::Work> _reduce(
+      std::vector<at::Tensor>& /* outputTensors */,
+      std::vector<at::Tensor>& /* inputTensors */,
       const ReduceOptions& /* opts */ = ReduceOptions()) {
     TORCH_CHECK(
         false,

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1405,6 +1405,34 @@ ProcessGroupNCCL::Options::Options(bool is_high_priority_stream)
     : ProcessGroup::Options(NCCL_BACKEND_NAME),
       is_high_priority_stream(is_high_priority_stream) {}
 
+void ProcessGroupNCCL::startCoalescing() {
+  coalescedDevices_.clear();
+  coalescing_active_ = true;
+  groupStart();
+}
+
+void ProcessGroupNCCL::endCoalescing(
+    std::vector<c10::intrusive_ptr<ProcessGroup::Work>>& reqs) {
+  groupEnd();
+  if (reqs.size() != coalescedDevices_.size()) {
+    TORCH_CHECK(false, "Number of requests do not match number of collectives");
+  }
+
+  int batch_idx = 0;
+  for (const auto& req : reqs) {
+    auto ncclWork = dynamic_cast<ProcessGroupNCCL::WorkNCCL*>(req.get());
+    // @lint-ignore CLANGTIDY
+    std::vector<at::Device> devices = coalescedDevices_[batch_idx];
+    const auto key = getKeyFromDevices(devices);
+    auto& ncclStreams = ncclStreams_[key];
+    for (const auto i : c10::irange(devices.size())) {
+      (*ncclWork->ncclEndEvents_)[i].record(ncclStreams[i]);
+    }
+    batch_idx += 1;
+  }
+  coalescing_active_ = false;
+}
+
 template <typename Fn, typename PreProcess, typename PostProcess>
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
     std::vector<at::Tensor>& inputs,
@@ -1435,6 +1463,10 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
   const bool inputs_same_dev = (devices.size() == 1);
   const auto key = getKeyFromDevices(devices);
   auto& ncclComms = getNCCLComm(key, devices, opType);
+
+  if (coalescing_active_) {
+    coalescedDevices_.push_back(devices);
+  }
 
   // Used many times below, so we stash the unordered_map lookup
   auto& ncclStreams = ncclStreams_[key];
@@ -1497,7 +1529,9 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
   // End event should only be recorded after the ncclGroupEnd()
   for (const auto i : c10::irange(devices.size())) {
     at::cuda::CUDAStream& ncclStream = ncclStreams[i];
-    (*work->ncclEndEvents_)[i].record(ncclStream);
+    if (!coalescing_active_) {
+      (*work->ncclEndEvents_)[i].record(ncclStream);
+    }
     work->ncclComms_[i] = ncclComms[i];
   }
 
@@ -1559,6 +1593,10 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::pointToPoint(
     p2pTargetRank = isSendRecvSelf ? 0 : 1 - p2pRank;
   }
   auto& ncclComms = getNCCLComm(key, devices, opType, p2pRank, isSendRecvSelf);
+
+  if (coalescing_active_) {
+    coalescedDevices_.push_back(devices);
+  }
 
   // First let NCCL streams wait for input tensors allocation streams
   syncStreams(devices, ncclEvents_[key], ncclStreams_[key]);
@@ -1623,7 +1661,9 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::pointToPoint(
   // End event should only be recorded after the ncclGroupEnd()
   for (const auto i : c10::irange(tensors.size())) {
     at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
-    (*work->ncclEndEvents_)[i].record(ncclStream);
+    if (!coalescing_active_) {
+      (*work->ncclEndEvents_)[i].record(ncclStream);
+    }
     work->ncclComms_[i] = ncclComms[i];
     work->blockingWait_ = blockingWait_;
     work->opTimeout_ = options_->timeout;

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
@@ -1860,6 +1860,52 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce(
       "nccl:reduce");
 }
 
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::_reduce(
+    std::vector<at::Tensor>& outputTensors,
+    std::vector<at::Tensor>& inputTensors,
+    const ReduceOptions& opts) {
+  check_gpu_tensors_different_devices(outputTensors);
+  check_gpu_tensors_different_devices(inputTensors);
+  // @lint-ignore CLANGTIDY
+  auto tensor = outputTensors.back();
+  // @lint-ignore CLANGTIDY
+  auto in_tensor = inputTensors.back();
+  if (tensor.numel() != in_tensor.numel()) {
+    TORCH_CHECK(
+        false,
+        "Tensor input and output of _reduce must have the same number of elements ");
+  }
+  RECORD_PARAM_COMMS(
+      rank_, // rank
+      "_reduce", // colName
+      tensor.numel(), // inSize
+      tensor.numel(), // outSize
+      tensor.scalar_type(), // dType
+      std::vector<int64_t>(), // inSplitSizes
+      std::vector<int64_t>()); // outSplitSizes
+
+  return collective(
+      inputTensors,
+      outputTensors,
+      [&](at::Tensor& input,
+          at::Tensor& output,
+          ncclComm_t comm,
+          at::cuda::CUDAStream& stream) {
+        const auto root = opts.rootRank * inputTensors.size() + opts.rootTensor;
+        return ncclReduce(
+            input.data_ptr(),
+            output.data_ptr(),
+            input.numel(),
+            getNcclDataType(input.scalar_type()),
+            getNcclReduceOp(opts.reduceOp, input),
+            (int) root,
+            comm,
+            stream.stream());
+      },
+      OpType::_REDUCE,
+      "nccl:_reduce");
+}
+
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors,

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -272,8 +272,13 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
   }
 
   const std::string getBackendName() const override {
-      return std::string(NCCL_BACKEND_NAME);
+        return std::string(NCCL_BACKEND_NAME);
   }
+
+  void startCoalescing() override;
+
+  void endCoalescing(
+      std::vector<c10::intrusive_ptr<ProcessGroup::Work>>& reqs) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> broadcast(
       std::vector<at::Tensor>& tensors,
@@ -583,6 +588,12 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
 
   // Device Indexes used for all collectives in this group
   std::set<int> usedDeviceIdxs_;
+
+  // Flag to denote if a coalescing groupStart/groupEnd block is active
+  bool coalescing_active_ = false;
+
+  // Stores device indexes for all collectives run inside a coalescing block
+  std::vector<std::vector<at::Device>> coalescedDevices_;
 
   // map from the key: "group name + pg counter (ID)" to the
   // unique NCCL ID count. This needs to be group and pg specific

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -297,6 +297,11 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
       std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override;
 
+  c10::intrusive_ptr<ProcessGroup::Work> _reduce(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const ReduceOptions& opts = ReduceOptions()) override;
+
   c10::intrusive_ptr<ProcessGroup::Work> allgather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1353,6 +1353,15 @@ Arguments:
           .def(
               "_get_backend_name",
               &::c10d::ProcessGroup::getBackendName,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_start_coalescing",
+              &::c10d::ProcessGroup::startCoalescing,
+              py::call_guard<py::gil_scoped_release>())
+          .def(
+              "_end_coalescing",
+              &::c10d::ProcessGroup::endCoalescing,
+              py::arg("reqs"),
               py::call_guard<py::gil_scoped_release>());
 
   // base ProcessGroup::Options binding

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1091,6 +1091,39 @@ Arguments:
               py::call_guard<py::gil_scoped_release>())
 
           .def(
+              "_reduce",
+              [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+                 const std::vector<at::Tensor>& output_tensors,
+                 const std::vector<at::Tensor>& input_tensors,
+                 const ::c10d::ReduceOptions& opts) {
+                return ::c10d::ops::_reduce(self, output_tensors, input_tensors, opts);
+              },
+              py::arg("output_tensors"),
+              py::arg("input_tensors"),
+              py::arg("opts") = ::c10d::ReduceOptions(),
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "_reduce",
+              [](const c10::intrusive_ptr<::c10d::ProcessGroup>& pg,
+                 at::Tensor& y,
+                 at::Tensor& x,
+                 int rootRank,
+                 ::c10d::ReduceOp op) {
+                ::c10d::ReduceOptions opts;
+                opts.reduceOp = op;
+                opts.rootRank = rootRank;
+                std::vector<at::Tensor> ys = {y};
+                std::vector<at::Tensor> xs = {x};
+                return ::c10d::ops::_reduce(pg, ys, xs, opts);
+              },
+              py::arg("output_tensor"),
+              py::arg("input_tensor"),
+              py::arg("root"),
+              py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
               "allgather",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  const std::vector<std::vector<at::Tensor>>& output_tensors,


### PR DESCRIPTION
Summary: This change exposes an out-of-place `_reduce` API from the ProcessGroupNCCL. It allows reducing an input tensor and placing the output in a separate output tensor.

Test Plan: unittest added in a later commit

Differential Revision: D37508234

