### PR TITLE
[Quant] Add fast path of qmean/qstd for quantized CPU (reopen #70172)

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4638,6 +4638,7 @@
   dispatch:
     CPU, CUDA: std
     MPS: std_mps
+    QuantizedCPU: std_quantized_cpu
 
 - func: std_mean(Tensor self, bool unbiased=True) -> (Tensor, Tensor)
   device_check: NoCheck   # TensorIterator
@@ -4668,6 +4669,7 @@
   device_check: NoCheck   # TensorIterator
   dispatch:
     CPU, CUDA: std_out
+    QuantizedCPU: std_out_quantized_cpu
 
 - func: std.names_dim(Tensor self, Dimname[1] dim, bool unbiased=True, bool keepdim=False) -> Tensor
   device_check: NoCheck   # TensorIterator

--- a/aten/src/ATen/native/quantized/cpu/QuantizedOps.h
+++ b/aten/src/ATen/native/quantized/cpu/QuantizedOps.h
@@ -170,6 +170,13 @@ using qmean_inner_dim_fn = void (*)(
     c10::optional<ScalarType> /* opt_dtype */,
     Tensor& /* Y */);
 
+using qstd_inner_dim_fn = void (*)(
+    const Tensor& /* X */,
+    optional<IntArrayRef> /* dim */,
+    optional<int64_t> /* unbiased */,
+    bool /* keepdim */,
+    Tensor& /* Y */);
+
 DECLARE_DISPATCH(qadaptive_avg_pool2d_fn, qadaptive_avg_pool2d_nhwc_stub);
 DECLARE_DISPATCH(qadaptive_avg_pool3d_fn, qadaptive_avg_pool3d_ndhwc_stub);
 DECLARE_DISPATCH(qadd_scalar_fn, qadd_scalar_relu_stub);
@@ -202,6 +209,7 @@ DECLARE_DISPATCH(qthreshold_fn, qthreshold_stub);
 DECLARE_DISPATCH(qtopk_fn, qtopk_stub);
 DECLARE_DISPATCH(qupsample_bilinear2d_fn, qupsample_bilinear2d_nhwc_stub);
 DECLARE_DISPATCH(qmean_inner_dim_fn, qmean_inner_dim_stub);
+DECLARE_DISPATCH(qstd_inner_dim_fn, qstd_inner_dim_stub);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/cpu/QuantizedOps.h
+++ b/aten/src/ATen/native/quantized/cpu/QuantizedOps.h
@@ -163,6 +163,13 @@ using qnormalize_fn = void (*)(
     double /* eps */,
     Tensor* /* Y */);
 
+using qmean_inner_dim_fn = void (*)(
+    const Tensor& /* X */,
+    IntArrayRef /* dim */,
+    bool /* keepdim */,
+    c10::optional<ScalarType> /* opt_dtype */,
+    Tensor& /* Y */);
+
 DECLARE_DISPATCH(qadaptive_avg_pool2d_fn, qadaptive_avg_pool2d_nhwc_stub);
 DECLARE_DISPATCH(qadaptive_avg_pool3d_fn, qadaptive_avg_pool3d_ndhwc_stub);
 DECLARE_DISPATCH(qadd_scalar_fn, qadd_scalar_relu_stub);
@@ -194,6 +201,7 @@ DECLARE_DISPATCH(qtanh_fn, qtanh_stub);
 DECLARE_DISPATCH(qthreshold_fn, qthreshold_stub);
 DECLARE_DISPATCH(qtopk_fn, qtopk_stub);
 DECLARE_DISPATCH(qupsample_bilinear2d_fn, qupsample_bilinear2d_nhwc_stub);
+DECLARE_DISPATCH(qmean_inner_dim_fn, qmean_inner_dim_stub);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/quantized/cpu/QuantizedOps.h
+++ b/aten/src/ATen/native/quantized/cpu/QuantizedOps.h
@@ -172,7 +172,7 @@ using qmean_inner_dim_fn = void (*)(
 
 using qstd_inner_dim_fn = void (*)(
     const Tensor& /* X */,
-    optional<IntArrayRef> /* dim */,
+    OptionalIntArrayRef /* dim */,
     optional<int64_t> /* unbiased */,
     bool /* keepdim */,
     Tensor& /* Y */);

--- a/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
+++ b/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
@@ -21,7 +21,7 @@ inline bool is_innnermost_dim(
   maybe_wrap_dims(dims, ndim);
   std::sort(dims.begin(), dims.end(), std::greater<int64_t>());
   bool is_innermost = dims.empty() || dims[0] == ndim - 1;
-  for (int i = 1; i < dims.size(); ++i) {
+  for (size_t i = 1; i < dims.size(); ++i) {
     is_innermost = is_innermost && (dims[i] == dims[i-1] - 1);
   }
   return is_innermost;
@@ -175,7 +175,7 @@ Tensor& mean_out_quantized_cpu(
 // qstd
 inline bool is_std_inner_dim_fast_path(
     const Tensor& self,
-    optional<IntArrayRef> dim,
+    OptionalIntArrayRef dim,
     optional<int64_t> unbiased) {
   // Do not enter fast path if there are too few elements
   IntArrayRef dims = dim.has_value() ? dim.value() : IntArrayRef();
@@ -195,7 +195,7 @@ inline bool is_std_inner_dim_fast_path(
 
 Tensor& std_out_quantized_cpu(
     const Tensor& self,
-    optional<IntArrayRef> dim,
+    OptionalIntArrayRef dim,
     optional<int64_t> unbiased,
     bool keepdim,
     Tensor& result) {
@@ -219,7 +219,7 @@ Tensor& std_out_quantized_cpu(
 
 Tensor std_quantized_cpu(
     const Tensor& self,
-    optional<IntArrayRef> dim,
+    OptionalIntArrayRef dim,
     optional<int64_t> unbiased,
     bool keepdim) {
   Tensor result;

--- a/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
+++ b/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
@@ -1,7 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/NamedTensorUtils.h>
 #include <ATen/NativeFunctions.h>
-#include <ATen/native/quantized/cpu/quantized_ops.h>
+#include <ATen/native/quantized/cpu/QuantizedOps.h>
 #include <ATen/native/quantized/cpu/init_qnnpack.h>
 #include <ATen/native/quantized/cpu/QnnpackUtils.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>

--- a/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
+++ b/aten/src/ATen/native/quantized/cpu/ReduceOps.cpp
@@ -128,7 +128,8 @@ Tensor& mean_out_quantized_cpu(
 #endif
 
   // Take average in the innermost dimensions
-  if (is_mean_inner_dim_fast_path(self, dim, opt_dtype)) {
+  if (self.is_contiguous(c10::MemoryFormat::Contiguous) &&
+      is_mean_inner_dim_fast_path(self, dim, opt_dtype)) {
     qmean_inner_dim_stub(self.device().type(), self, dim, keepdim, opt_dtype, result);
     return result;
   }
@@ -199,7 +200,8 @@ Tensor& std_out_quantized_cpu(
     bool keepdim,
     Tensor& result) {
   // Fast path
-  if (is_std_inner_dim_fast_path(self, dim, unbiased)) {
+  if (self.is_contiguous(c10::MemoryFormat::Contiguous) &&
+      is_std_inner_dim_fast_path(self, dim, unbiased)) {
     qstd_inner_dim_stub(self.device().type(), self, dim, unbiased, keepdim, result);
     return result;
   }

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2737,14 +2737,14 @@ void qmean_inner_dim_kernel(
   ScalarType dtype = self.scalar_type();
   auto in_dims = self.sizes().vec();
   auto out_dims = in_dims;
-  int64_t num_dims_to_squeeze = dim.empty() ? self.dim() : dim.size();
+  size_t num_dims_to_squeeze = dim.empty() ? self.dim() : dim.size();
   int64_t M = 1; // Num of groups
   int64_t N = 1; // Num of elements to take average of in each group
   bool output_is_zero_dim = false;
-  for (int i = 0; i < in_dims.size() - num_dims_to_squeeze; ++i) {
+  for (size_t i = 0; i < in_dims.size() - num_dims_to_squeeze; ++i) {
     M *= in_dims[i];
   }
-  for (int i = 0; i < num_dims_to_squeeze; ++i) {
+  for (size_t i = 0; i < num_dims_to_squeeze; ++i) {
     auto idx = out_dims.size() - 1 - i;
     N *= out_dims[idx];
     out_dims[idx] = 1;
@@ -2779,22 +2779,22 @@ void qmean_inner_dim_kernel(
 
 void qstd_inner_dim_kernel(
     const Tensor& self,
-    optional<IntArrayRef> dim,
+    OptionalIntArrayRef dim,
     optional<int64_t> unbiased,
     bool keepdim,
     Tensor& result) {
   ScalarType dtype = self.scalar_type();
   auto in_dims = self.sizes().vec();
   auto out_dims = in_dims;
-  int64_t num_dims_to_squeeze = dim.has_value() && !dim.value().empty() ?
-                                dim.value().size() :
-                                self.dim();
+  size_t num_dims_to_squeeze = dim.has_value() && !dim.value().empty() ?
+                               dim.value().size() :
+                               self.dim();
   int64_t M = 1; // Num of groups
   int64_t N = 1; // Num of elements to take std of in each group
-  for (int i = 0; i < in_dims.size() - num_dims_to_squeeze; ++i) {
+  for (size_t i = 0; i < in_dims.size() - num_dims_to_squeeze; ++i) {
     M *= in_dims[i];
   }
-  for (int i = 0; i < num_dims_to_squeeze; ++i) {
+  for (size_t i = 0; i < num_dims_to_squeeze; ++i) {
     auto idx = out_dims.size() - 1 - i;
     N *= out_dims[idx];
     out_dims[idx] = 1;

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2727,6 +2727,55 @@ void quantized_normalize_kernel(
   });
 }
 
+void qmean_inner_dim_kernel(
+    const Tensor& self,
+    IntArrayRef dim,
+    bool keepdim,
+    c10::optional<ScalarType> opt_dtype,
+    Tensor& result) {
+  // 'opt_dtype' should be none or equal to that of input
+  ScalarType dtype = self.scalar_type();
+  auto in_dims = self.sizes().vec();
+  auto out_dims = in_dims;
+  int64_t num_dims_to_squeeze = dim.empty() ? self.dim() : dim.size();
+  int64_t M = 1; // Num of groups
+  int64_t N = 1; // Num of elements to take average of in each group
+  bool output_is_zero_dim = false;
+  for (int i = 0; i < in_dims.size() - num_dims_to_squeeze; ++i) {
+    M *= in_dims[i];
+  }
+  for (int i = 0; i < num_dims_to_squeeze; ++i) {
+    auto idx = out_dims.size() - 1 - i;
+    N *= out_dims[idx];
+    out_dims[idx] = 1;
+  }
+  if (!keepdim) {
+    out_dims.erase(out_dims.end() - num_dims_to_squeeze, out_dims.end());
+  }
+  result = at::_empty_affine_quantized(
+      out_dims,
+      at::device(kCPU).dtype(dtype).memory_format(self.suggest_memory_format()),
+      self.q_scale(),
+      self.q_zero_point(),
+      c10::nullopt);
+
+  AT_DISPATCH_QINT_TYPES(self.scalar_type(), "quantized_layer_norm_kernel_impl_cpu", [&]() {
+    scalar_t* X_data = self.data_ptr<scalar_t>();
+    scalar_t* Y_data = result.data_ptr<scalar_t>();
+
+    at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
+      for (const auto i : c10::irange(start, end)) {
+        scalar_t* X_ptr = X_data + i * N;
+        scalar_t* Y_ptr = Y_data + i;
+        scalar_t::underlying* X_ptr_underlying = reinterpret_cast<scalar_t::underlying*>(X_ptr);
+        scalar_t::underlying* Y_ptr_underlying = reinterpret_cast<scalar_t::underlying*>(Y_ptr);
+        auto x_sum = hsum(X_ptr_underlying, N);
+        *Y_ptr_underlying = x_sum / N;
+      }
+    });
+  });
+}
+
 #ifdef USE_FBGEMM
 void quantize_tensor_per_tensor_affine_cpu(
     const Tensor& rtensor,
@@ -3709,6 +3758,7 @@ REGISTER_NO_AVX512_DISPATCH(quantize_tensor_per_tensor_affine_sub_byte_stub);
 REGISTER_NO_AVX512_DISPATCH(dequantize_tensor_per_tensor_affine_sub_byte_stub);
 REGISTER_NO_AVX512_DISPATCH(masked_fill_kernel_quantized_stub);
 REGISTER_NO_AVX512_DISPATCH(index_put_kernel_quantized_stub);
+REGISTER_NO_AVX512_DISPATCH(qmean_inner_dim_stub);
 #else
 REGISTER_DISPATCH(dequantize_tensor_per_channel_affine_stub,
                   &dequantize_tensor_per_channel_affine_cpu);
@@ -3779,6 +3829,7 @@ REGISTER_DISPATCH(
 REGISTER_DISPATCH(
     index_put_kernel_quantized_stub,
     &index_put_kernel_quantized_cpu);
+REGISTER_DISPATCH(qmean_inner_dim_stub, &qmean_inner_dim_kernel);
 #endif // CPU_CAPABILITY_AVX512 && _WIN32
 
 } // namespace native

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2776,6 +2776,70 @@ void qmean_inner_dim_kernel(
   });
 }
 
+void qstd_inner_dim_kernel(
+    const Tensor& self,
+    optional<IntArrayRef> dim,
+    optional<int64_t> unbiased,
+    bool keepdim,
+    Tensor& result) {
+  ScalarType dtype = self.scalar_type();
+  auto in_dims = self.sizes().vec();
+  auto out_dims = in_dims;
+  int64_t num_dims_to_squeeze = dim.has_value() && !dim.value().empty() ?
+                                dim.value().size() :
+                                self.dim();
+  int64_t M = 1; // Num of groups
+  int64_t N = 1; // Num of elements to take std of in each group
+  for (int i = 0; i < in_dims.size() - num_dims_to_squeeze; ++i) {
+    M *= in_dims[i];
+  }
+  for (int i = 0; i < num_dims_to_squeeze; ++i) {
+    auto idx = out_dims.size() - 1 - i;
+    N *= out_dims[idx];
+    out_dims[idx] = 1;
+  }
+  if (!keepdim) {
+    out_dims.erase(out_dims.end() - num_dims_to_squeeze, out_dims.end());
+  }
+  int64_t den = N; // Denominator when computing mean and deviation
+  if (unbiased.has_value() && unbiased.value() == 1) {
+    den -= 1;
+  }
+  auto x_scale = self.q_scale();
+  auto x_zp = self.q_zero_point();
+  result = at::_empty_affine_quantized(
+      out_dims,
+      at::device(kCPU).dtype(dtype).memory_format(self.suggest_memory_format()),
+      x_scale,
+      x_zp,
+      c10::nullopt);
+
+  AT_DISPATCH_QINT_TYPES(self.scalar_type(), "quantized_layer_norm_kernel_impl_cpu", [&]() {
+    scalar_t* X_data = self.data_ptr<scalar_t>();
+    scalar_t* Y_data = result.data_ptr<scalar_t>();
+
+    at::parallel_for(0, M, 1, [&](int64_t start, int64_t end) {
+      for (const auto i : c10::irange(start, end)) {
+        scalar_t* X_ptr = X_data + i * N;
+        scalar_t* Y_ptr = Y_data + i;
+        scalar_t::underlying* X_ptr_underlying = reinterpret_cast<scalar_t::underlying*>(X_ptr);
+        scalar_t::underlying* Y_ptr_underlying = reinterpret_cast<scalar_t::underlying*>(Y_ptr);
+        auto x_sum_shifted = hsum(X_ptr_underlying, N);
+        auto x_sum_sq_shifted = hsum_sq(X_ptr_underlying, N);
+        // Mean with zero point
+        float x_mean_shifted_div_scale_x = static_cast<float>(x_sum_shifted) / N;
+        float x_mean_unbiased_shifted_div_scale_x = static_cast<float>(x_sum_shifted) / den;
+        // variance / x_scale^2
+        float x_var_div_scale_x_sq =
+            std::max(static_cast<float>(x_sum_sq_shifted) / den -
+                2 * x_mean_shifted_div_scale_x * x_mean_unbiased_shifted_div_scale_x +
+                x_mean_shifted_div_scale_x * x_mean_shifted_div_scale_x * N / den, 0.0f);
+        *Y_ptr_underlying = std::sqrt(x_var_div_scale_x_sq) * x_scale;
+      }
+    });
+  });
+}
+
 #ifdef USE_FBGEMM
 void quantize_tensor_per_tensor_affine_cpu(
     const Tensor& rtensor,
@@ -3759,6 +3823,7 @@ REGISTER_NO_AVX512_DISPATCH(dequantize_tensor_per_tensor_affine_sub_byte_stub);
 REGISTER_NO_AVX512_DISPATCH(masked_fill_kernel_quantized_stub);
 REGISTER_NO_AVX512_DISPATCH(index_put_kernel_quantized_stub);
 REGISTER_NO_AVX512_DISPATCH(qmean_inner_dim_stub);
+REGISTER_NO_AVX512_DISPATCH(qstd_inner_dim_stub);
 #else
 REGISTER_DISPATCH(dequantize_tensor_per_channel_affine_stub,
                   &dequantize_tensor_per_channel_affine_cpu);
@@ -3830,6 +3895,7 @@ REGISTER_DISPATCH(
     index_put_kernel_quantized_stub,
     &index_put_kernel_quantized_cpu);
 REGISTER_DISPATCH(qmean_inner_dim_stub, &qmean_inner_dim_kernel);
+REGISTER_DISPATCH(qstd_inner_dim_stub, &qstd_inner_dim_kernel);
 #endif // CPU_CAPABILITY_AVX512 && _WIN32
 
 } // namespace native

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2740,7 +2740,6 @@ void qmean_inner_dim_kernel(
   size_t num_dims_to_squeeze = dim.empty() ? self.dim() : dim.size();
   int64_t M = 1; // Num of groups
   int64_t N = 1; // Num of elements to take average of in each group
-  bool output_is_zero_dim = false;
   for (size_t i = 0; i < in_dims.size() - num_dims_to_squeeze; ++i) {
     M *= in_dims[i];
   }


### PR DESCRIPTION
> Note: This is a reopen of https://github.com/pytorch/pytorch/pull/70172 which was merged then reverted.

Add fast path of qmean and qstd when computation is done in innermost dimensions for quantized CPU. The fast path supports inputs in contiguous memory format.
For example:
```python
X = torch.randn((2,3,4,5), dtype=torch.float)
qX = torch.quantize_per_tensor(X, scale, zero_point, torch_type)

# dim can be: -1, (-1, -2), (-1, -2, -3), (-1, -2, -3, -4), 3, (3, 2), (3, 2, 1), (3, 2, 1, 0) or None
dim = -1
qY = torch.mean(qX, dim) # qY = torch.std(qX, dim)
```

**Performance test results**
Test Env:
- Intel® Xeon® CLX-8260
- 1 instance, 4 cores
- Using Jemalloc

Test method:
Create 4d contiguous tensors as inputs, set `dim` to the innermost two dimensions `(-1, -2)`, then do the following tests
- Quantize inputs and use the fast path
- Quantize inputs and use the reference path
- Use fp32 kernel (no quantization)

Mean: exec time (us) vs. shape
![image](https://user-images.githubusercontent.com/12522207/148152617-604f2841-cfcd-495c-ae88-c27d9165b46a.png)

Std: exec time (us) vs. shape
![image](https://user-images.githubusercontent.com/12522207/148152632-3a8dceb1-0057-42c9-af65-1e26d697ff0c.png)

