### PR TITLE
Wrap static initializers in ifdef

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -17,6 +17,7 @@
 #include <torch/csrc/jit/mobile/parse_operators.h>
 #include <torch/csrc/jit/mobile/upgrader_mobile.h>
 #include <torch/csrc/jit/serialization/export.h>
+#include <torch/csrc/jit/serialization/flatbuffer_serializer_jit.h>
 #include <torch/csrc/jit/serialization/import.h>
 #include <torch/custom_class.h>
 #include <torch/torch.h>
@@ -679,6 +680,7 @@ void backportAllVersionCheck(
 
 #if !defined FB_XPLAT_BUILD
 TEST(LiteInterpreterTest, BackPortByteCodeModelAllVersions) {
+  torch::jit::register_flatbuffer_all();
   torch::jit::Module module("m");
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   module.register_parameter("weight", torch::ones({20, 1, 5, 5}), false);

--- a/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer.cpp
@@ -778,7 +778,7 @@ flatbuffers::DetachedBuffer save_mobile_module_to_bytes(
       jit_constants);
 }
 
-void save_mobile_module_to_func(
+static void save_mobile_module_to_func(
     const mobile::Module& module,
     const std::function<size_t(const void*, size_t)>& writer_func) {
   auto buffer = save_mobile_module_to_bytes(module);
@@ -790,7 +790,11 @@ bool register_flatbuffer_serializer() {
   return true;
 }
 
+// iOS builds are often build with -Wglobal-constructor to minimize
+// startup time. So let them call register manually if needed.
+#if !defined(__APPLE__)
 const bool kFlatbufferSerializerRegistered = register_flatbuffer_serializer();
+#endif
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/serialization/flatbuffer_serializer_jit.cpp
+++ b/torch/csrc/jit/serialization/flatbuffer_serializer_jit.cpp
@@ -74,7 +74,7 @@ flatbuffers::DetachedBuffer save_jit_module_to_bytes(
   return save_mobile_module_to_bytes(mobilem, extra_files, jitfiles, constants);
 }
 
-void save_jit_module_to_write_func(
+static void save_jit_module_to_write_func(
     const Module& module,
     const ExtraFilesMap& extra_files,
     bool save_mobile_debug_info,
@@ -92,7 +92,9 @@ bool register_flatbuffer_all() {
   return true;
 }
 
+#if !defined(__APPLE__)
 const bool kFlatbufferSerializerJitInitialized = register_flatbuffer_all();
+#endif
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
because, on iOS some projects has -Wglobal-constructors and it won't build.

Fixes #ISSUE_NUMBER
