### PR TITLE
[vulkan] Integrate refactored memory mapping, remove Tensor Future pattern

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -42,23 +42,6 @@ void Context::flush() {
   images_to_clear_.clear();
 }
 
-void Context::wait(const at::Tensor& src) {
-  // wait only if Vulkan tensor
-  if (at::kVulkan == src.device().type()) {
-    api::Command::Pool& command_pool = command().pool;
-    api::Command::Buffer& command_buffer = command_pool.stream();
-
-    using Future = ops::vTensor::Future<const void, ops::vTensor::Access::Read>;
-    const ops::vTensor& v_src = ops::convert(src);
-    const Future v_src_future = v_src.host<const void>(command_buffer);
-
-    // This wait() is a no-op if data is not out of sync.  More often than
-    // not though, waits here are expected as the GPU catches up with
-    // compute submitted from CPU.
-    v_src_future.wait();
-  }
-}
-
 bool available() {
   return context();
 }

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -139,10 +139,6 @@ class Context final {
 
   void flush();
 
-  // Use this function only for debugging and testing when you want to make sure
-  // all GPU operations get finished before calling flush(). Otherwise, it may crash.
-  void wait(const at::Tensor& src);
-
  private:
 
   inline VkDevice device() {

--- a/aten/src/ATen/native/vulkan/ops/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Copy.cpp
@@ -46,72 +46,42 @@ Tensor& copy_(Tensor& self, const Tensor& src) {
         api::Command::Buffer& command_buffer = command_pool.stream(); // Don't collect the timestamp since the command buffer doesn't record anything
         const Tensor cpu_src = src.device().is_cpu() ? src : src.cpu();
 
-        // Requesting write-only host access to the tensor never triggers a sync
-        // as the contents will be overwritten regardless.  Having said that,
-        // appropriate barriers are inserted automatically if WAR or WAW hazards
-        // are detected.  Examples of such scenario for instance are if any of
-        // these async operations are on going in the background on 'self':
-        // - On discrete systems:
-        //      * buffer-to-staging transfers
-        //      * staging-to-buffer transfers
-        // - On UMA buffer is an alias for staging and accessible both on host
-        //    and device.  Consequently:
-        //      * buffer-to-image NHWC -> NC4HW packing
-        //      * image-to-buffer NC4HW -> NHWC unpacking
+        {
+          api::MemoryMap mapping(
+              v_self.host_buffer(command_buffer, vTensor::Access::Write),
+              api::MemoryAccessType::WRITE);
 
-        using Future = vTensor::Future<void, vTensor::Access::Write>;
-        Future v_self_future = v_self.host<void, vTensor::Access::Write>(command_buffer);
+          float* data_ptr = mapping.template data<float>();
 
-        // Ideally we would have been able to put as much distance between
-        // requesting the data - a call to host() - and accessing the data
-        // - a call to wait() - but a local view of the computation graph
-        // in eager mode makes that optimization non-trivial.
-
-        // This wait() will be a no-op if no hazards are detected, including the
-        // obvious, yet important, special case of 'self' being an empty tensor.
-
-        Future::Payload v_self_payload = v_self_future.wait();
-
-        memcpy(
-            v_self_payload.get(),
+          memcpy(
+            data_ptr,
             cpu_src.contiguous().data_ptr<float>(),
             std::min(src.nbytes(), self.nbytes()));
+        }
       }
     }
     // Vulkan -> X
     else if (at::kVulkan == src.device().type()) {
       api::Command::Buffer& command_buffer = command_pool.stream(); // Don't collect the timestamp since the command buffer doesn't record anything
-      const vTensor& v_src = convert(src);
+      vTensor& v_src = convert(src);
 
       // Vulkan -> CPU
       if (self.device().is_cpu()) {
-        // Similar notes as above applies, with the additional consideration of
-        // potential syncs on read accesses.  Namely,
-        // - on discrete systems, if the (staging, buffer, image) trio, or
-        // - on UMA, if the (buffer, image) duo
-        // have gone out of sync as a result of one processor writing to one
-        // resource which is then either accessed as an another resource type on
-        // the same or another processor.  Same considerations regarding hazard
-        // avoidance as above applies.
+        {
+          api::MemoryMap mapping(
+            v_src.host_buffer(command_buffer, vTensor::Access::Read),
+            api::MemoryAccessType::READ);
 
-        using Future = vTensor::Future<const void, vTensor::Access::Read>;
-        const Future v_src_future = v_src.host<const void>(command_buffer);
+          v_src.wait_for_fence();
+          mapping.invalidate();
 
-        // Ideally we would have been able to put as much distance between
-        // requesting the data - a call to host() - and accessing the data
-        // - a call to wait() - but a local view of the computation graph
-        // in eager mode makes that optimization non-trivial.
+          float* data_ptr = mapping.template data<float>();
 
-        // This wait() is a no-op if data is not out of sync.  More often than
-        // not though, waits here are expected as the GPU catches up with
-        // compute submitted from CPU.
-
-        const Future::Payload v_src_payload = v_src_future.wait();
-
-        memcpy(
-            self.data_ptr<float>(),
-            v_src_payload.get(),
-            std::min(src.nbytes(), self.nbytes()));
+          memcpy(
+              self.data_ptr<float>(),
+              data_ptr,
+              std::min(src.nbytes(), self.nbytes()));
+        }
       }
       else {
         TORCH_CHECK(false, "Unsupported!");

--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -419,17 +419,10 @@ vTensor::vTensor(
     }) {
 }
 
-const vTensor* vTensor::host(
-    api::Command::Buffer& command_buffer) const {
-  view_->staging(command_buffer, Stage::Host, Access::Read);
-  return this;
-}
-
-vTensor* vTensor::host(
+api::VulkanBuffer& vTensor::host_buffer(
     api::Command::Buffer& command_buffer,
-    const Access::Flags access) {
-  view_->staging(command_buffer, Stage::Host, access);
-  return this;
+    const Access::Flags access) & {
+  return view_->staging(command_buffer, Stage::Host, access);
 }
 
 api::VulkanBuffer::Package vTensor::buffer(
@@ -493,7 +486,6 @@ vTensor::View::View(
   : buffer_{},
     image_{},
     staging_{},
-    staging_memory_{},
     fence_{},
     // Context
     context_(context),
@@ -1098,17 +1090,10 @@ api::VulkanFence& vTensor::View::fence(const Access::Flags access) const {
   return fence_;
 }
 
-vTensor::Memory& vTensor::View::wait() const {
+void vTensor::View::wait_for_fence() const {
   if (fence_) {
     fence_.wait();
   }
-
-  staging_memory_ = {
-    staging().vma_allocator(),
-    staging().allocation(),
-  };
-
-  return staging_memory_;
 }
 
 void vTensor::View::verify() const {

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -95,74 +95,15 @@ class vTensor final {
   typedef api::Resource::Memory Memory;
 
   /*
-    Future
+    Host access
   */
 
-  template<typename Type, Access::Flags kAccess>
-  class Future final {
-    template<typename T, Access::Flags A>
-    using is_convertible = std::enable_if_t<
-        std::is_convertible<
-            Access::Pointer<T, A>,
-            Access::Pointer<Type, kAccess>>::value>;
 
-   public:
-    explicit Future(const vTensor* tensor);
-    Future(const Future&) = delete;
-    Future& operator=(const Future&) = delete;
-    Future(Future&&);
-    Future& operator=(Future&&) &;
-    Future& operator=(Future&&) && = delete;
-    template<typename T, Access::Flags A, typename = is_convertible<T, A>>
-    Future(Future<T, A>&&);
-    template<typename T, Access::Flags A, typename = is_convertible<T, A>>
-    Future& operator=(Future<T, A>&&) &;
-    template<typename T, Access::Flags A>
-    Future& operator=(Future<T, A>&&) && = delete;
-    ~Future();
+  inline void wait_for_fence() const {
+    view_->wait_for_fence();
+  }
 
-    typedef Memory::Handle<
-        Access::Pointer<
-            Type,
-            kAccess>> Payload;
-
-    // This is a blocking operation as the name suggests.  A call to host() will
-    // trigger an async copy if pending writes are detected.  Consequently, for
-    // optimal performance, put as much time and distance between the place
-    // where a vTensor::host() call occurs and the location where the returned
-    // future is explicitly waited on as a result of a call to this function.
-
-    Payload wait() const &;
-
-   private:
-    template<typename, Access::Flags>
-    friend class Future;
-
-    // Intentionally disabed to enforce a usage pattern wherein the Future's
-    // lifetime exceeds that of the Payload as we use the Future's destructor
-    // to eagerly (as opposed to lazily and upon first use) upload the
-    // modifications back onto the GPU in an effort to hide the upload latency.
-
-    Payload wait() const && = delete;
-
-   private:
-    const vTensor* tensor_;
-  };
-
-  /*
-    Host access - these functions will be expensive if they trigger a GPU -> CPU
-    sync due to pending writes.  A call to host() will trigger an async copy in
-    such scenarios, which is then explicitly waited on as part of Future::wait().
-    Consequently, for optimal performance, put as much time and distance between
-    the place where this function is called, and the location where the future is
-    waited on.
-  */
-
-  template<typename Type>
-  Future<Type, Access::Read> host(api::Command::Buffer&) const &;
-
-  template<typename Type, Access::Flags kAccess>
-  Future<Type, kAccess> host(api::Command::Buffer&) &;
+  api::VulkanBuffer& host_buffer(api::Command::Buffer&, const Access::Flags) &;
 
   /*
     Device access - these functions will be expensive if they trigger a buffer
@@ -198,25 +139,6 @@ class vTensor final {
   size_t nbytes() const;
 
  private:
-  // Some overloads below are intentionally disabled to enforce a usage pattern
-  // that ensures the Tensor's lifetime exceeds that of the scope in which the
-  // underlying data is accessed.  Allowing deleted overloads below to be
-  // invoked on a temporary would open the door to the possibility of accessing
-  // the underlying memory out of the expected scope.
-
-  /*
-    Host
-  */
-
-  const vTensor* host(api::Command::Buffer&) const;
-  vTensor* host(api::Command::Buffer&, Access::Flags);
-
-  template<typename Type>
-  Future<Type, Access::Read> host(api::Command::Buffer&) const && = delete;
-
-  template<typename Type, Access::Flags kAccess>
-  Future<Type, kAccess> host(api::Command::Buffer&) && = delete;
-
   /*
     Device
   */
@@ -262,7 +184,8 @@ class vTensor final {
     */
 
     api::VulkanBuffer& staging(api::Command::Buffer&, Stage::Flags, Access::Flags) const;
-    vTensor::Memory& wait() const;
+
+    void wait_for_fence() const;
 
     /*
       Metadata
@@ -355,7 +278,6 @@ class vTensor final {
     mutable api::VulkanBuffer buffer_;
     mutable api::VulkanImage image_;
     mutable api::VulkanBuffer staging_;
-    mutable Memory staging_memory_;
     mutable api::VulkanFence fence_;
 
     // Context
@@ -416,89 +338,6 @@ void verify(const TensorOptions& options);
 //
 // Impl
 //
-
-template<typename Type, vTensor::Access::Flags kAccess>
-inline vTensor::Future<Type, kAccess>::Future(
-    const vTensor* const tensor)
-  : tensor_(tensor) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      tensor_,
-      "Invalid Vulkan tensor!");
-}
-
-template<typename Type, vTensor::Access::Flags kAccess>
-inline vTensor::Future<Type, kAccess>::Future(
-    Future&& future)
-  : tensor_(std::move(future.tensor_)) {
-  future.tensor_ = nullptr;
-}
-
-template<typename Type, vTensor::Access::Flags kAccess>
-inline vTensor::Future<Type, kAccess>&
-vTensor::Future<Type, kAccess>::operator=(
-    Future&& future) & {
-  tensor_ = std::move(future.tensor_);
-  future.tensor_ = nullptr;
-  return *this;
-}
-
-template<typename Type, vTensor::Access::Flags kAccess>
-template<typename Type_, vTensor::Access::Flags kAccess_, typename>
-inline vTensor::Future<Type, kAccess>::Future(
-    Future<Type_, kAccess_>&& future)
-  : tensor_(std::move(future.tensor_)) {
-  future.tensor_ = nullptr;
-}
-
-template<typename Type, vTensor::Access::Flags kAccess>
-template<typename Type_, vTensor::Access::Flags kAccess_, typename>
-inline vTensor::Future<Type, kAccess>&
-vTensor::Future<Type, kAccess>::operator=(
-    Future<Type_, kAccess_>&& future) & {
-  tensor_ = std::move(future.tensor_);
-  future.tensor_ = nullptr;
-  return *this;
-}
-
-template<typename Type, vTensor::Access::Flags kAccess>
-inline vTensor::Future<Type, kAccess>::~Future() {
-#if VULKAN_SYNC_TENSORS_EAGERLY
-  // Sync eagerly in an effort to hide latency.
-  // Upside: Kick off the async transfer early on to keep the GPU busy.
-  // Downside: An extra CPU command submission.
-  if (tensor_ && (Access::Write & kAccess)) {
-    if (tensor_->has_image()) {
-      tensor_->image();
-    }
-    else {
-      tensor_->buffer();
-    }
-  }
-#endif
-}
-
-template<typename Type, vTensor::Access::Flags kAccess>
-inline typename vTensor::Future<Type, kAccess>::Payload
-vTensor::Future<Type, kAccess>::wait() const & {
-  TORCH_CHECK(
-      tensor_,
-      "vTensor::Future is in an invalid state!  "
-      "Potential reason: This future is moved from.");
-
-  return tensor_->view_->wait().template map<Type, kAccess>();
-}
-
-template<typename Type>
-inline vTensor::Future<Type, vTensor::Access::Read>
-vTensor::host(api::Command::Buffer& command_buffer) const & {
-  return Future<Type, vTensor::Access::Read>(host(command_buffer));
-}
-
-template<typename Type, vTensor::Access::Flags kAccess>
-inline vTensor::Future<Type, kAccess>
-vTensor::host(api::Command::Buffer& command_buffer) & {
-  return Future<Type, kAccess>(host(command_buffer, kAccess));
-}
 
 inline bool vTensor::has_image() const {
   return view_->has_image();

--- a/aten/src/ATen/native/vulkan/ops/TransposeConvolution2d.cpp
+++ b/aten/src/ATen/native/vulkan/ops/TransposeConvolution2d.cpp
@@ -47,11 +47,12 @@ vTensor pack_weights_2d_reverse(
       weight.options(),
   };
 
-  using Future = vTensor::Future<float, vTensor::Access::Write>;
-  Future v_weight_future = v_weight.host<float, vTensor::Access::Write>(command_buffer);
-  Future::Payload v_weight_payload = v_weight_future.wait();
+  api::MemoryMap mapping(
+      v_weight.host_buffer(command_buffer, vTensor::Access::Write),
+      api::MemoryAccessType::WRITE);
 
-  float* const dst_weight_ptr = v_weight_payload.get();
+  float* dst_weight_ptr = mapping.template data<float>();
+
   memset(dst_weight_ptr, 0, v_weight.nbytes());
 
   for (const auto src_oc : c10::irange(src_filter[Layout::Filter::output])) {
@@ -121,13 +122,14 @@ vTensor pack_biases(
     weight.options(),
   };
 
-  using Future = vTensor::Future<float, vTensor::Access::Write>;
-  Future v_bias_future = v_bias.host<float, vTensor::Access::Write>(command_buffer);
-  Future::Payload v_bias_payload = v_bias_future.wait();
+  api::MemoryMap mapping(
+      v_bias.host_buffer(command_buffer, vTensor::Access::Write),
+      api::MemoryAccessType::WRITE);
+
+  float* dst_bias_ptr = mapping.template data<float>();
 
   if (bias) {
     const float* const src_bias_ptr = bias->contiguous().data_ptr<float>();
-    float* const dst_bias_ptr = v_bias_payload.get();
 
     memset(dst_bias_ptr, 0, v_bias.nbytes());
     for (const auto i : c10::irange(src_w)) {
@@ -138,7 +140,7 @@ vTensor pack_biases(
   }
   else {
     memset(
-        v_bias_payload.get(),
+        dst_bias_ptr,
         // 2's complement integers and IEEE-754 floating point numbers both
         // have identical bit representations for 0, so can use memset which
         // only accepts uint8_t parameter.

--- a/aten/src/ATen/test/vulkan_perf_test.cpp
+++ b/aten/src/ATen/test/vulkan_perf_test.cpp
@@ -80,11 +80,6 @@ static void gru_op_perf(benchmark::State& state) {
 
     auto vulkan_output = std::get<0>(out_vulkan);
     auto vulkan_hidden = std::get<1>(out_vulkan);
-
-    // to avoid out-of-memory issues, release resources by waiting and flushing all GPU operations
-    at::native::vulkan::api::context()->wait(vulkan_output);
-    at::native::vulkan::api::context()->wait(vulkan_hidden);
-    at::native::vulkan::api::context()->flush();
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Part of a refactor of the Vulkan codebase.

Differential Revision: [D36863390](https://our.internmc.facebook.com/intern/diff/D36863390/)