### PR TITLE
[vulkan] Refactor Shader and Pipeline

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Adapter.h
+++ b/aten/src/ATen/native/vulkan/api/Adapter.h
@@ -4,7 +4,7 @@
 
 #include <ATen/native/vulkan/api/Common.h>
 #include <ATen/native/vulkan/api/Runtime.h>
-#include <ATen/native/vulkan/api/Shader.h>
+#include <ATen/native/vulkan/api/Utils.h>
 #include <ostream>
 #include <iostream>
 
@@ -105,7 +105,7 @@ class Adapter final {
   Queue request_queue();
   void return_queue(Queue& compute_queue);
 
-  inline Shader::WorkGroup local_work_group_size() const {
+  inline utils::uvec3 local_work_group_size() const {
     return { 4u, 4u, 4u, };
   }
 

--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -36,11 +36,14 @@ struct Command final {
     void begin();
     void end();
 
-    void barrier(const Pipeline::Barrier& barrier);
-    void bind(const Pipeline::Object& pipeline);
+    void barrier(const PipelineBarrier& barrier);
+    void bind(
+        const VkPipeline pipeline,
+        VkPipelineLayout pipeline_layout,
+        utils::uvec3 local_work_group);
     void bind(const Descriptor::Set& set);
     void copy(Resource::Buffer::Object source, Resource::Buffer::Object destination);
-    void dispatch(const Shader::WorkGroup& global_work_group);
+    void dispatch(const utils::uvec3& global_work_group);
 
    private:
     friend class Pool;
@@ -52,7 +55,9 @@ struct Command final {
     VkCommandBuffer command_buffer_;
 
     struct Bound final {
-      Pipeline::Object pipeline;
+      VkPipeline pipeline;
+      VkPipelineLayout pipeline_layout;
+      utils::uvec3 local_work_group;
       VkDescriptorSet descriptor_set;
 
       void reset();

--- a/aten/src/ATen/native/vulkan/api/Common.h
+++ b/aten/src/ATen/native/vulkan/api/Common.h
@@ -7,13 +7,13 @@
 #ifdef USE_VULKAN_SHADERC_RUNTIME
 #include <ATen/native/vulkan/glsl.h>
 #define VK_KERNEL(name)                          \
-  ::at::native::vulkan::api::Shader::Descriptor{ \
+  ::at::native::vulkan::api::ShaderSource{ \
     name##_glsl,                                 \
   }
 #else
 #include <ATen/native/vulkan/spv.h>
 #define VK_KERNEL(name)                          \
-  ::at::native::vulkan::api::Shader::Descriptor{ \
+  ::at::native::vulkan::api::ShaderSource{ \
     name##_spv,                                  \
     name##_spv_len,                              \
   }
@@ -72,7 +72,6 @@ struct Descriptor;
 struct Pipeline;
 struct Resource;
 class Runtime;
-struct Shader;
 
 struct GPU final {
   VkInstance instance;

--- a/aten/src/ATen/native/vulkan/api/Descriptor.h
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.h
@@ -61,7 +61,7 @@ struct Descriptor final {
     Set(
         VkDevice device,
         VkDescriptorSet descriptor_set,
-        const Shader::Layout::Signature& shader_layout_signature);
+        ShaderLayout::Signature shader_layout_signature);
     Set(const Set&) = delete;
     Set& operator=(const Set&) = delete;
     Set(Set&&);
@@ -92,7 +92,7 @@ struct Descriptor final {
    private:
     VkDevice device_;
     VkDescriptorSet descriptor_set_;
-    Shader::Layout::Signature shader_layout_signature_;
+    ShaderLayout::Signature shader_layout_signature_;
 
     struct {
       c10::SmallVector<Item, 6u> items;
@@ -113,7 +113,9 @@ struct Descriptor final {
     Pool& operator=(Pool&&);
     ~Pool();
 
-    Set allocate(const Shader::Layout::Object& shader_layout);
+    Set allocate(
+        const VkDescriptorSetLayout handle,
+        const ShaderLayout::Signature& signature);
     void purge();
 
    private:

--- a/aten/src/ATen/native/vulkan/api/Pipeline.cpp
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.cpp
@@ -5,172 +5,257 @@ namespace native {
 namespace vulkan {
 namespace api {
 
-Pipeline::Layout::Factory::Factory(const GPU& gpu)
- : device_(gpu.device) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      device_,
-      "Invalid Vulkan device!");
-}
+//
+// PipelineLayout
+//
 
-typename Pipeline::Layout::Factory::Handle Pipeline::Layout::Factory::operator()(
-    const Descriptor& descriptor) const {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      descriptor.descriptor_set_layout,
-      "Invalid Vulkan descriptor set layout!");
-
+PipelineLayout::PipelineLayout(
+    const VkDevice device,
+    const VkDescriptorSetLayout descriptor_layout)
+  : device_(device),
+    handle_{VK_NULL_HANDLE} {
+  // TODO: Enable push constants
   const VkPipelineLayoutCreateInfo pipeline_layout_create_info{
-    VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
-    nullptr,
-    0u,
-    1u,
-    &descriptor.descriptor_set_layout,
-    0u,
-    nullptr,
+    VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,  // sType
+    nullptr,  // pNext
+    0u,  // flags
+    1u,  // setLayoutCount
+    &descriptor_layout,  // pSetLayouts
+    0u,  // pushConstantRangeCount
+    nullptr,  // pPushConstantRanges
   };
 
-  VkPipelineLayout pipeline_layout{};
   VK_CHECK(vkCreatePipelineLayout(
       device_,
       &pipeline_layout_create_info,
       nullptr,
-      &pipeline_layout));
-
-  TORCH_CHECK(
-      pipeline_layout,
-      "Invalid Vulkan pipeline layout!");
-
-  return Handle{
-    pipeline_layout,
-    Deleter(device_),
-  };
+      &handle_));
 }
 
-namespace {
-
-VkPipelineCache create_pipeline_cache(const VkDevice device) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      device,
-      "Invalid Vulkan device!");
-
-  const VkPipelineCacheCreateInfo pipeline_cache_create_info{
-    VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,
-    nullptr,
-    0u,
-    0u,
-    nullptr,
-  };
-
-  VkPipelineCache pipeline_cache{};
-  VK_CHECK(vkCreatePipelineCache(
-      device,
-      &pipeline_cache_create_info,
-      nullptr,
-      &pipeline_cache));
-
-  TORCH_CHECK(
-      pipeline_cache,
-      "Invalid Vulkan pipeline cache!");
-
-  return pipeline_cache;
+PipelineLayout::PipelineLayout(PipelineLayout&& other) noexcept
+  : device_(other.device_),
+    handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
 }
 
-} // namespace
-
-Pipeline::Factory::Factory(const GPU& gpu)
- : device_(gpu.device),
-   pipeline_cache_(
-      create_pipeline_cache(device_),
-      VK_DELETER(PipelineCache)(device_)) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      device_,
-      "Invalid Vulkan device!");
-
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      pipeline_cache_,
-      "Invalid Vulkan pipeline cache!");
+PipelineLayout::~PipelineLayout() {
+  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroyPipelineLayout(device_, handle_, nullptr);
+  handle_ = VK_NULL_HANDLE;
 }
 
-typename Pipeline::Factory::Handle Pipeline::Factory::operator()(
-    const Descriptor& descriptor) const {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      descriptor.pipeline_layout,
-      "Invalid Vulkan pipeline layout!");
+void swap(PipelineLayout& lhs, PipelineLayout& rhs) noexcept {
+  VkDevice tmp_device = lhs.device_;
+  VkPipelineLayout tmp_handle = lhs.handle_;
 
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      descriptor.shader_module,
-      "Invalid Vulkan shader module!");
+  lhs.device_ = rhs.device_;
+  lhs.handle_ = rhs.handle_;
 
+  rhs.device_ = tmp_device;
+  rhs.handle_ = tmp_handle;
+}
+
+//
+// ComputePipeline
+//
+
+ComputePipeline::ComputePipeline(
+    const VkDevice device,
+    const ComputePipeline::Descriptor& descriptor,
+    const VkPipelineCache pipeline_cache)
+  : device_(device),
+    handle_{VK_NULL_HANDLE} {
   constexpr VkSpecializationMapEntry specialization_map_entires[3]{
     // X
     {
       0u,
-      offsetof(Shader::WorkGroup, data[0u]),
-      sizeof(Shader::WorkGroup::data[0u]),
+      offsetof(utils::uvec3, data[0u]),
+      sizeof(utils::uvec3::data[0u]),
     },
     // Y
     {
       1u,
-      offsetof(Shader::WorkGroup, data[1u]),
-      sizeof(Shader::WorkGroup::data[1u]),
+      offsetof(utils::uvec3, data[1u]),
+      sizeof(utils::uvec3::data[1u]),
     },
     // Z
     {
       2u,
-      offsetof(Shader::WorkGroup, data[2u]),
-      sizeof(Shader::WorkGroup::data[2u]),
+      offsetof(utils::uvec3, data[2u]),
+      sizeof(utils::uvec3::data[2u]),
     },
   };
 
   const VkSpecializationInfo specialization_info{
-    3u,
-    specialization_map_entires,
-    sizeof(descriptor.local_work_group),
-    &descriptor.local_work_group,
+    3u,  // mapEntryCount
+    specialization_map_entires,  // pMapEntries
+    sizeof(descriptor.local_work_group),  // dataSize
+    &descriptor.local_work_group,  // pData
+  };
+
+  const VkPipelineShaderStageCreateInfo shader_stage_create_info{
+    VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,  // sType
+    nullptr,  // pNext
+    0u,  // flags
+    VK_SHADER_STAGE_COMPUTE_BIT,  // stage
+    descriptor.shader_module,  // module
+    "main",  // pName
+    &specialization_info,  // pSpecializationInfo
   };
 
   const VkComputePipelineCreateInfo compute_pipeline_create_info{
-    VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
-    nullptr,
-    0u,
-    VkPipelineShaderStageCreateInfo{
-      VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
-      nullptr,
-      0u,
-      VK_SHADER_STAGE_COMPUTE_BIT,
-      descriptor.shader_module,
-      "main",
-      &specialization_info,
-    },
-    descriptor.pipeline_layout,
-    VK_NULL_HANDLE,
-    0u,
+    VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,  // sType
+    nullptr,  // pNext
+    0u,  // flags
+    shader_stage_create_info,  // stage
+    descriptor.pipeline_layout,  // layout
+    VK_NULL_HANDLE,  // basePipelineHandle
+    0u,  // basePipelineIndex
   };
 
-  VkPipeline pipeline{};
   VK_CHECK(vkCreateComputePipelines(
       device_,
-      pipeline_cache_.get(),
+      pipeline_cache,
       1u,
       &compute_pipeline_create_info,
       nullptr,
-      &pipeline));
+      &handle_));
+}
 
-  TORCH_CHECK(
-      pipeline,
-      "Invalid Vulkan pipeline!");
+ComputePipeline::ComputePipeline(ComputePipeline&& other) noexcept
+  : device_(other.device_),
+    handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
+}
 
-  return Handle{
-    pipeline,
-    Deleter(device_),
+ComputePipeline::~ComputePipeline() {
+  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroyPipeline(device_, handle_, nullptr);
+  handle_ = VK_NULL_HANDLE;
+}
+
+void swap(ComputePipeline& lhs, ComputePipeline& rhs) noexcept {
+  VkDevice tmp_device = lhs.device_;
+  VkPipeline tmp_handle = lhs.handle_;
+
+  lhs.device_ = rhs.device_;
+  lhs.handle_ = rhs.handle_;
+
+  rhs.device_ = tmp_device;
+  rhs.handle_ = tmp_handle;
+}
+
+bool operator==(
+    const ComputePipeline::Descriptor& _1,
+    const ComputePipeline::Descriptor& _2) {
+
+  return (_1.pipeline_layout == _2.pipeline_layout && \
+          _1.shader_module == _2.shader_module && \
+          _1.local_work_group == _2.local_work_group);
+}
+
+//
+// PipelineLayoutCache
+//
+
+PipelineLayoutCache::PipelineLayoutCache(const VkDevice device)
+  : cache_mutex_{},
+    device_(device),
+    cache_{} {
+}
+
+PipelineLayoutCache::PipelineLayoutCache(PipelineLayoutCache&& other) noexcept
+  : cache_mutex_{},
+    device_(other.device_) {
+  std::lock_guard<std::mutex> lock(other.cache_mutex_);
+  cache_ = std::move(other.cache_);
+}
+
+PipelineLayoutCache::~PipelineLayoutCache() {
+  purge();
+}
+
+VkPipelineLayout PipelineLayoutCache::retrieve(
+    const PipelineLayoutCache::Key& key) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  auto it = cache_.find(key);
+  if C10_UNLIKELY(cache_.cend() == it) {
+    it = cache_.insert({key, PipelineLayoutCache::Value(device_, key)}).first;
+  }
+
+  return it->second.handle();
+}
+
+void PipelineLayoutCache::purge() {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  cache_.clear();
+}
+
+//
+// ComputePipelineCache
+//
+
+ComputePipelineCache::ComputePipelineCache(const VkDevice device)
+  : cache_mutex_{},
+    device_(device),
+    pipeline_cache_{VK_NULL_HANDLE},
+    cache_{} {
+  const VkPipelineCacheCreateInfo pipeline_cache_create_info{
+    VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,  // sType
+    nullptr,  // pNext
+    0u,  // flags
+    0u,  // initialDataSize
+    nullptr,  // pInitialData
   };
+
+  VK_CHECK(vkCreatePipelineCache(
+      device,
+      &pipeline_cache_create_info,
+      nullptr,
+      &pipeline_cache_));
 }
 
-Pipeline::Cache::Cache(Factory factory)
-  : cache_(std::move(factory)) {
+ComputePipelineCache::ComputePipelineCache(
+    ComputePipelineCache&& other) noexcept
+  : cache_mutex_{},
+    device_(other.device_),
+    pipeline_cache_(other.pipeline_cache_) {
+  std::lock_guard<std::mutex> lock(other.cache_mutex_);
+  cache_ = std::move(other.cache_);
+
+  other.pipeline_cache_ = VK_NULL_HANDLE;
 }
 
-void Pipeline::Cache::purge() {
-  cache_.purge();
+ComputePipelineCache::~ComputePipelineCache() {
+  purge();
+
+  if C10_LIKELY(VK_NULL_HANDLE == pipeline_cache_) {
+    return;
+  }
+  vkDestroyPipelineCache(device_, pipeline_cache_, nullptr);
+  pipeline_cache_ = VK_NULL_HANDLE;
+}
+
+VkPipeline ComputePipelineCache::retrieve(
+    const ComputePipelineCache::Key& key) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  auto it = cache_.find(key);
+  if C10_UNLIKELY(cache_.cend() == it) {
+    it = cache_.insert(
+        {key, ComputePipelineCache::Value(device_, key, pipeline_cache_)}).first;
+  }
+
+  return it->second.handle();
+}
+
+void ComputePipelineCache::purge() {
+  cache_.clear();
 }
 
 } // namespace api

--- a/aten/src/ATen/native/vulkan/api/Pipeline.h
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.h
@@ -3,7 +3,6 @@
 #ifdef USE_VULKAN_API
 
 #include <ATen/native/vulkan/api/Common.h>
-#include <ATen/native/vulkan/api/Cache.h>
 #include <ATen/native/vulkan/api/Resource.h>
 #include <ATen/native/vulkan/api/Shader.h>
 #include <c10/util/hash.h>
@@ -13,230 +12,176 @@ namespace native {
 namespace vulkan {
 namespace api {
 
-//
-// This struct defines pipeline, and pipeline layout, caches intended to minimize
-// redundant object reconstructions at the cost of extra memory consumption.
-//
-// A Vulkan pipeline contains the entirety of states, as one coherent monolithic
-// bundle, required to configure the GPU's execution pipeline.  This usage
-// pattern minimizes driver overhead, promotes pipeline state reuse, and is a
-// departure from, and in direct contrast with, OpenGL's individually confiurable
-// state machine.
-//
-// A Vulkan pipeline layout represents a sequence of Vulkan descriptor sets each
-// having a specific layout, and deterimines the interface between all shader
-// stages and shader resources.  For more information on shaders and shader
-// layouts check the description of at::navie::vulkan::api::Shader.
-//
-// This struct defines the facilities required to create, reuse, and destruct
-// these Vulkan objects.
-//
-
-struct Pipeline final {
-  //
-  // Barrier
-  //
-
-  struct Barrier final {
-    struct Stage final {
-      VkPipelineStageFlags src;
-      VkPipelineStageFlags dst;
-    } stage;
-
-    c10::SmallVector<Resource::Buffer::Barrier, 4u> buffers;
-    c10::SmallVector<Resource::Image::Barrier, 4u> images;
-
-    operator bool() const;
-  };
-
-  //
-  // Layout
-  //
-
-  struct Layout final {
-    /*
-      Descriptor
-    */
-
-    struct Descriptor final {
-      VkDescriptorSetLayout descriptor_set_layout;
-    };
-
-    /*
-      Factory
-    */
-
-    class Factory final {
-     public:
-      explicit Factory(const GPU& gpu);
-
-      typedef Layout::Descriptor Descriptor;
-      typedef VK_DELETER(PipelineLayout) Deleter;
-      typedef api::Handle<VkPipelineLayout, Deleter> Handle;
-
-      struct Hasher {
-        size_t operator()(const Descriptor& descriptor) const;
-      };
-
-      Handle operator()(const Descriptor& descriptor) const;
-
-     private:
-      VkDevice device_;
-    };
-
-    /*
-      Cache
-    */
-
-    typedef api::Cache<Factory> Cache;
-    Cache cache;
-
-    explicit Layout(const GPU& gpu)
-      : cache(Factory(gpu)) {
-    }
-  } layout;
-
-  //
-  // Stage
-  //
-
+struct PipelineBarrier final {
   struct Stage final {
-    typedef uint8_t Flags;
+    VkPipelineStageFlags src;
+    VkPipelineStageFlags dst;
+  } stage;
 
-    enum Type : Flags {
-      None = 0u << 0u,
-      Compute = 1u << 0u,
-      Host = 1u << 1u,
-      Transfer = 1u << 2u,
-    };
+  c10::SmallVector<Resource::Buffer::Barrier, 4u> buffers;
+  c10::SmallVector<Resource::Image::Barrier, 4u> images;
+
+  inline operator bool() const {
+    return (0u != stage.src) ||
+           (0u != stage.dst) ||
+           !buffers.empty() ||
+           !images.empty();
+  }
+};
+
+struct PipelineStage final {
+  using Flags = uint8_t;
+
+  enum Type : Flags {
+    None = 0u << 0u,
+    Compute = 1u << 0u,
+    Host = 1u << 1u,
+    Transfer = 1u << 2u,
   };
+};
 
-  /*
-    Descriptor
-  */
+class PipelineLayout final {
+ public:
+  explicit PipelineLayout(const VkDevice, const VkDescriptorSetLayout);
 
+  PipelineLayout(const PipelineLayout&) = delete;
+  PipelineLayout& operator=(const PipelineLayout&) = delete;
+
+  PipelineLayout(PipelineLayout&&) noexcept;
+  PipelineLayout& operator=(PipelineLayout&&) = delete;
+
+  ~PipelineLayout();
+
+ private:
+  VkDevice device_;
+  VkPipelineLayout handle_;
+
+ public:
+  VkPipelineLayout handle() const {
+    return handle_;
+  }
+
+  // We need to define a custom swap function since this class
+  // does not allow for move assignment. The swap function will
+  // be used in the hash map.
+  friend void swap(PipelineLayout& lhs, PipelineLayout& rhs) noexcept;
+};
+
+class ComputePipeline final {
+ public:
   struct Descriptor final {
     VkPipelineLayout pipeline_layout;
     VkShaderModule shader_module;
-    Shader::WorkGroup local_work_group;
+    utils::uvec3 local_work_group;
   };
 
-  /*
-    Factory
-  */
+  explicit ComputePipeline(
+      const VkDevice device,
+      const Descriptor& descriptor,
+      const VkPipelineCache pipeline_cache);
 
-  class Factory final {
-   public:
-    explicit Factory(const GPU& gpu);
+  ComputePipeline(const ComputePipeline&) = delete;
+  ComputePipeline& operator=(const ComputePipeline&) = delete;
 
-    typedef Pipeline::Descriptor Descriptor;
-    typedef VK_DELETER(Pipeline) Deleter;
-    typedef api::Handle<VkPipeline, Deleter> Handle;
+  ComputePipeline(ComputePipeline&&) noexcept;
+  ComputePipeline& operator=(ComputePipeline&&) = delete;
 
-    struct Hasher {
-      size_t operator()(const Descriptor& descriptor) const;
-    };
+  ~ComputePipeline();
 
-    Handle operator()(const Descriptor& descriptor) const;
+ private:
+  VkDevice device_;
+  VkPipeline handle_;
 
-   private:
-    VkDevice device_;
-    api::Handle<VkPipelineCache, VK_DELETER(PipelineCache)> pipeline_cache_;
-  };
-
-  /*
-    Object
-  */
-
-  struct Object final {
-    VkPipeline handle;
-    VkPipelineLayout layout;
-    Shader::WorkGroup local_work_group;
-
-    operator bool() const;
-  };
-
-  /*
-    Cache
-  */
-
-  class Cache final {
-   public:
-    explicit Cache(Factory factory);
-    Cache(const Cache&) = delete;
-    Cache& operator=(const Cache&) = delete;
-    Cache(Cache&&) = default;
-    Cache& operator=(Cache&&) = default;
-    ~Cache() = default;
-
-    Object retrieve(const Descriptor& descriptor);
-    void purge();
-
-   private:
-    api::Cache<Factory> cache_;
-  } cache;
-
-  explicit Pipeline(const GPU& gpu)
-    : layout(gpu),
-      cache(Factory(gpu)) {
+ public:
+  inline VkPipeline handle() const {
+    return handle_;
   }
+
+  // We need to define a custom swap function since this class
+  // does not allow for move assignment. The swap function will
+  // be used in the hash map.
+  friend void swap(ComputePipeline& lhs, ComputePipeline& rhs) noexcept;
+};
+
+class PipelineLayoutCache final {
+ public:
+  explicit PipelineLayoutCache(const VkDevice device);
+
+  PipelineLayoutCache(const PipelineLayoutCache&) = delete;
+  PipelineLayoutCache& operator=(const PipelineLayoutCache&) = delete;
+
+  PipelineLayoutCache(PipelineLayoutCache&&) noexcept;
+  PipelineLayoutCache& operator=(PipelineLayoutCache&&) = delete;
+
+  ~PipelineLayoutCache();
+
+  using Key = VkDescriptorSetLayout;
+  using Value = PipelineLayout;
+
+  struct Hasher {
+    inline size_t operator()(
+        const VkDescriptorSetLayout descriptor_layout) const {
+      return c10::get_hash(descriptor_layout);
+    }
+  };
+
+ private:
+  // Multiple threads could potentially be adding entries into the cache, so use
+  // a mutex to manage access
+  std::mutex cache_mutex_;
+
+  VkDevice device_;
+  ska::flat_hash_map<Key, Value, Hasher> cache_;
+
+ public:
+  VkPipelineLayout retrieve(const Key&);
+  void purge();
+};
+
+class ComputePipelineCache final {
+ public:
+  explicit ComputePipelineCache(const VkDevice device);
+
+  ComputePipelineCache(const ComputePipelineCache&) = delete;
+  ComputePipelineCache& operator=(const ComputePipelineCache&) = delete;
+
+  ComputePipelineCache(ComputePipelineCache&&) noexcept;
+  ComputePipelineCache& operator=(ComputePipelineCache&&) = delete;
+
+  ~ComputePipelineCache();
+
+  using Key = ComputePipeline::Descriptor;
+  using Value = ComputePipeline;
+
+  struct Hasher {
+    inline size_t operator()(
+        const ComputePipeline::Descriptor& descriptor) const {
+      return c10::get_hash(
+          descriptor.pipeline_layout,
+          descriptor.shader_module,
+          descriptor.local_work_group.data[0u],
+          descriptor.local_work_group.data[1u],
+          descriptor.local_work_group.data[2u]);
+    };
+  };
+
+ private:
+  // Multiple threads could potentially be adding entries into the cache, so use
+  // a mutex to manage access
+  std::mutex cache_mutex_;
+
+  VkDevice device_;
+  VkPipelineCache pipeline_cache_;
+  ska::flat_hash_map<Key, Value, Hasher> cache_;
+
+ public:
+  VkPipeline retrieve(const Key&);
+  void purge();
 };
 
 //
 // Impl
 //
-
-inline Pipeline::Barrier::operator bool() const {
-  return (0u != stage.src) ||
-         (0u != stage.dst) ||
-         !buffers.empty() ||
-         !images.empty();
-}
-
-inline bool operator==(
-    const Pipeline::Layout::Descriptor& _1,
-    const Pipeline::Layout::Descriptor& _2) {
-
-  return (_1.descriptor_set_layout == _2.descriptor_set_layout);
-}
-
-inline size_t Pipeline::Layout::Factory::Hasher::operator()(
-    const Descriptor& descriptor) const {
-  return c10::get_hash(descriptor.descriptor_set_layout);
-}
-
-inline bool operator==(
-    const Pipeline::Descriptor& _1,
-    const Pipeline::Descriptor& _2) {
-
-  return (_1.pipeline_layout == _2.pipeline_layout && \
-          _1.shader_module == _2.shader_module && \
-          _1.local_work_group == _2.local_work_group);
-}
-
-inline size_t Pipeline::Factory::Hasher::operator()(
-    const Descriptor& descriptor) const {
-  return c10::get_hash(
-      descriptor.pipeline_layout,
-      descriptor.shader_module,
-      descriptor.local_work_group.data[0u],
-      descriptor.local_work_group.data[1u],
-      descriptor.local_work_group.data[2u]);
-}
-
-inline Pipeline::Object::operator bool() const {
-  return (VK_NULL_HANDLE != handle) &&
-         (VK_NULL_HANDLE != layout);
-}
-
-inline Pipeline::Object Pipeline::Cache::retrieve(
-    const Descriptor& descriptor) {
-  return {
-    cache_.retrieve(descriptor),
-    descriptor.pipeline_layout,
-    descriptor.local_work_group,
-  };
-}
 
 } // namespace api
 } // namespace vulkan

--- a/aten/src/ATen/native/vulkan/api/Shader.cpp
+++ b/aten/src/ATen/native/vulkan/api/Shader.cpp
@@ -9,167 +9,233 @@ namespace native {
 namespace vulkan {
 namespace api {
 
-Shader::Layout::Factory::Factory(const GPU& gpu)
-  : device_(gpu.device) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      device_,
-      "Invalid Vulkan device!");
+//
+// ShaderSource
+//
+
+ShaderSource::ShaderSource(const char* const glsl_src)
+  : type(ShaderSource::Type::GLSL),
+    src_code{
+     .glsl = {
+       glsl_src,
+       0u,
+     },
+    } {
 }
 
-Shader::Layout::Factory::Handle Shader::Layout::Factory::operator()(
-    const Descriptor& descriptor) const {
+ShaderSource::ShaderSource(
+    const uint32_t* const spirv_bin,
+    const uint32_t size)
+  : type(Type::SPIRV),
+    src_code{
+     .spirv = {
+       spirv_bin,
+       size,
+     },
+    } {
+}
+
+bool operator==(
+    const ShaderSource& _1,
+    const ShaderSource& _2) {
+
+  if (_1.type != _2.type) {
+    return false;
+  }
+
+  if (_1.type == ShaderSource::Type::SPIRV) {
+    return (_1.src_code.spirv.bin == _2.src_code.spirv.bin && \
+            _1.src_code.spirv.size == _2.src_code.spirv.size);
+  }
+  else {
+    return (_1.src_code.glsl.src == _2.src_code.glsl.src);
+  }
+}
+
+//
+// ShaderLayout
+//
+
+ShaderLayout::ShaderLayout(
+    const VkDevice device,
+    const ShaderLayout::Signature& signature)
+  : device_(device),
+    handle_{VK_NULL_HANDLE} {
   c10::SmallVector<VkDescriptorSetLayoutBinding, 6u> bindings;
 
-  uint32_t binding = 0u;
-  for (const VkDescriptorType type : descriptor.signature) {
+  uint32_t binding_num = 0u;
+  for (const VkDescriptorType type : signature) {
     bindings.push_back({
-      binding++,
-      type,
-      1u,
-      VK_SHADER_STAGE_COMPUTE_BIT,
-      nullptr,
+      binding_num++,  // binding
+      type,  // descriptorType
+      1u,  // descriptorCount
+      VK_SHADER_STAGE_COMPUTE_BIT,  // stageFlags
+      nullptr,  // pImmutableSamplers
     });
   }
 
   const VkDescriptorSetLayoutCreateInfo descriptor_set_layout_create_info{
-    VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
-    nullptr,
-    0u,
-    static_cast<uint32_t>(bindings.size()),
-    bindings.data(),
+    VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,  // sType
+    nullptr,  // pNext
+    0u,  // flags
+    static_cast<uint32_t>(bindings.size()),  // bindingCount
+    bindings.data(),  // pBindings
   };
 
-  VkDescriptorSetLayout descriptor_set_layout{};
   VK_CHECK(vkCreateDescriptorSetLayout(
       device_,
       &descriptor_set_layout_create_info,
       nullptr,
-      &descriptor_set_layout));
-
-  TORCH_CHECK(
-      descriptor_set_layout,
-      "Invalid Vulkan descriptor set layout!");
-
-  return Handle{
-    descriptor_set_layout,
-    Deleter(device_),
-  };
+      &handle_));
 }
 
-Shader::Layout::Cache::Cache(Factory factory)
-  : cache_(std::move(factory)) {
+ShaderLayout::ShaderLayout(ShaderLayout&& other) noexcept
+  : device_(other.device_),
+    handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
 }
 
-void Shader::Layout::Cache::purge() {
-  cache_.purge();
+ShaderLayout::~ShaderLayout() {
+  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroyDescriptorSetLayout(device_, handle_, nullptr);
+  handle_ = VK_NULL_HANDLE;
 }
 
-#ifdef USE_VULKAN_SHADERC_RUNTIME
+void swap(ShaderLayout& lhs, ShaderLayout& rhs) noexcept {
+  VkDevice tmp_device = lhs.device_;
+  VkDescriptorSetLayout tmp_handle = lhs.handle_;
 
-struct Shader::Factory::Compiler final {
-  shaderc::Compiler context;
-  shaderc::CompileOptions options;
+  lhs.device_ = rhs.device_;
+  lhs.handle_ = rhs.handle_;
 
-  Compiler() {
-    options.SetNanClamp(/*enable =*/ true);
-    options.SetSourceLanguage(shaderc_source_language_glsl);
-    options.SetTargetEnvironment(shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_0);
-    options.SetWarningsAsErrors();
-  #ifdef DEBUG
-    options.SetGenerateDebugInfo();
-  #endif /* DEBUG */
-    options.SetOptimizationLevel(shaderc_optimization_level_zero);
-  }
-
-  std::vector<uint32_t> compile(const char* const source) const {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-        source,
-        "Invalid shader source code!");
-
-    const shaderc::SpvCompilationResult result = context.CompileGlslToSpv(
-        source,
-        ::strlen(source),
-        shaderc_compute_shader,
-        "vulkan_shader.comp",
-        options);
-
-    const shaderc_compilation_status status = result.GetCompilationStatus();
-    TORCH_INTERNAL_ASSERT(
-        shaderc_compilation_status_success == status,
-        "Shader compilation error: ",
-        result.GetErrorMessage());
-
-    return std::vector<uint32_t>(result.cbegin(), result.cend());
-  }
-};
-
-#else
-
-struct Shader::Factory::Compiler final {
-  std::vector<uint32_t> compile(const char* const /* source */) const {
-    return std::vector<uint32_t>{};
-  }
-};
-
-#endif /* USE_VULKAN_SHADERC_RUNTIME */
-
-Shader::Factory::Factory(const GPU& gpu)
- : device_(gpu.device),
-   compiler_(new Compiler) {
+  rhs.device_ = tmp_device;
+  rhs.handle_ = tmp_handle;
 }
 
-// std::unique_ptr requires its template parameter to be fully defined.
-// For that reason pimpl through unique_ptr requires the definition of
-// the [default] constructor and move assignment operator to appear after
-// impl is fully defined.
+//
+// ShaderModule
+//
 
-Shader::Factory::Factory(Factory&&) = default;
-Shader::Factory& Shader::Factory::Factory::operator=(Factory&&) = default;
-Shader::Factory::~Factory() = default;
-
-typename Shader::Factory::Handle Shader::Factory::operator()(
-    const Descriptor& descriptor) const {
-  std::vector<uint32_t> binary;
-
-  const uint32_t* code = nullptr;
-  uint32_t size = 0u;
-
-  if (Descriptor::Type::Source == descriptor.type) {
-    binary = compiler_->compile(descriptor.shader.source.glsl);
-    code = binary.data();
-    size = sizeof(uint32_t) * static_cast<uint32_t>(binary.size());
-  }
-  else if (Descriptor::Type::Binary == descriptor.type) {
-    code = descriptor.shader.binary.spirv;
-    size = descriptor.shader.binary.size;
-  }
-  else {
-    TORCH_INTERNAL_ASSERT(false, "Invalid descriptor type!");
-  }
+ShaderModule::ShaderModule(const VkDevice device, const ShaderSource& source)
+  : device_(device),
+    handle_{VK_NULL_HANDLE} {
+  const uint32_t* code = source.src_code.spirv.bin;
+  uint32_t size = source.src_code.spirv.size;
 
   const VkShaderModuleCreateInfo shader_module_create_info{
-    VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
-    nullptr,
-    0u,
-    size,
-    code,
+    VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,  // sType
+    nullptr,  // pNext
+    0u,  // flags
+    size,  // codeSize
+    code,  // pCode
   };
 
-  VkShaderModule shader_module{};
   VK_CHECK(vkCreateShaderModule(
       device_,
       &shader_module_create_info,
       nullptr,
-      &shader_module));
+      &handle_));
+}
 
-  TORCH_CHECK(
-      shader_module,
-      "Invalid Vulkan shader module!");
+ShaderModule::ShaderModule(ShaderModule&& other) noexcept
+  : device_(other.device_),
+    handle_(other.handle_) {
+  other.handle_ = VK_NULL_HANDLE;
+}
 
-  return Handle{
-    shader_module,
-    Deleter(device_),
-  };
+ShaderModule::~ShaderModule() {
+  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+    return;
+  }
+  vkDestroyShaderModule(device_, handle_, nullptr);
+  handle_ = VK_NULL_HANDLE;
+}
+
+void swap(ShaderModule& lhs, ShaderModule& rhs) noexcept {
+  VkDevice tmp_device = lhs.device_;
+  VkShaderModule tmp_handle = lhs.handle_;
+
+  lhs.device_ = rhs.device_;
+  lhs.handle_ = rhs.handle_;
+
+  rhs.device_ = tmp_device;
+  rhs.handle_ = tmp_handle;
+}
+
+//
+// ShaderLayoutCache
+//
+
+ShaderLayoutCache::ShaderLayoutCache(const VkDevice device)
+  : cache_mutex_{},
+    device_(device),
+    cache_{} {
+}
+
+ShaderLayoutCache::ShaderLayoutCache(ShaderLayoutCache&& other) noexcept
+  : cache_mutex_{},
+    device_(other.device_) {
+  std::lock_guard<std::mutex> lock(other.cache_mutex_);
+  cache_ = std::move(other.cache_);
+}
+
+ShaderLayoutCache::~ShaderLayoutCache() {
+  purge();
+}
+
+VkDescriptorSetLayout ShaderLayoutCache::retrieve(
+    const ShaderLayoutCache::Key& key) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  auto it = cache_.find(key);
+  if C10_UNLIKELY(cache_.cend() == it) {
+    it = cache_.insert({key, ShaderLayoutCache::Value(device_, key)}).first;
+  }
+
+  return it->second.handle();
+}
+
+void ShaderLayoutCache::purge() {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  cache_.clear();
+}
+
+//
+// ShaderCache
+//
+
+ShaderCache::ShaderCache(const VkDevice device)
+  : cache_mutex_{},
+    device_(device),
+    cache_{} {
+}
+
+ShaderCache::ShaderCache(ShaderCache&& other) noexcept
+  : cache_mutex_{},
+    device_(other.device_) {
+  std::lock_guard<std::mutex> lock(other.cache_mutex_);
+  cache_ = std::move(other.cache_);
+}
+
+ShaderCache::~ShaderCache() {
+  purge();
+}
+
+VkShaderModule ShaderCache::retrieve(const ShaderCache::Key& key) {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  auto it = cache_.find(key);
+  if C10_UNLIKELY(cache_.cend() == it) {
+    it = cache_.insert({key, ShaderCache::Value(device_, key)}).first;
+  }
+
+  return it->second.handle();
+}
+
+void ShaderCache::purge() {
+  cache_.clear();
 }
 
 } // namespace api

--- a/aten/src/ATen/native/vulkan/api/Shader.h
+++ b/aten/src/ATen/native/vulkan/api/Shader.h
@@ -3,7 +3,6 @@
 #ifdef USE_VULKAN_API
 
 #include <ATen/native/vulkan/api/Common.h>
-#include <ATen/native/vulkan/api/Cache.h>
 #include <ATen/native/vulkan/api/Utils.h>
 #include <c10/util/hash.h>
 
@@ -12,274 +11,163 @@ namespace native {
 namespace vulkan {
 namespace api {
 
-//
-// This struct defines shader, and shader layout, caches intended to minimize
-// redundant object reconstructions at the cost of extra memory consumption.
-//
-// A shader is a small, usually simple, program that typically runs on a GPU as
-// part of the graphics or compute pipelines.  The shader layout defines the
-// interface between that program and the outside world, namely what the host
-// (i.e. CPU) sees as configurable parameters of the said shader per dispatch.
-// If the shader was a regular function, the shader layout would have been its
-// function prototype declaring the number and type of its arguments.
-//
-// Furthermore, shader layouts, or as Vulkan calls them descriptor set layouts,
-// define the blueprint out of which descriptor sets are instantiated.  Descriptor
-// sets themselves, bundle the input to and output from a shader and contain
-// pointers to GPU, and GPU accessible system, memory locations where the actual
-// resources reside.  Shader layouts are also used in creation of Vulkan pipeline
-// layouts, while multiple shaders are bundled together to form a portion of the
-// the monolithic state objects that are Vulkan pipelines.
-//
-// This struct defines the facilities required to create, compile, reuse,
-// and destruct the aforementioned Vulkan objects.
-//
+struct ShaderSource final {
+  enum class Type {
+    GLSL,
+    SPIRV
+  } type;
 
-struct Shader final {
-  //
-  // Layout
-  //
+  union {
+    struct {
+      const char* src; // Null-terminated
+      uint32_t unused; // padding
+    } glsl;
+    struct {
+      const uint32_t* bin;
+      uint32_t size;
+    } spirv;
+  } src_code;
 
-  struct Layout final {
-    /*
-      Signature
-    */
-
-    typedef c10::SmallVector<VkDescriptorType, 6u> Signature;
-
-    /*
-      Descriptor
-    */
-
-    struct Descriptor final {
-      Signature signature;
-    };
-
-    /*
-      Factory
-    */
-
-    class Factory final {
-     public:
-      explicit Factory(const GPU& gpu);
-
-      typedef Layout::Descriptor Descriptor;
-      typedef VK_DELETER(DescriptorSetLayout) Deleter;
-      typedef api::Handle<VkDescriptorSetLayout, Deleter> Handle;
-
-      struct Hasher {
-        size_t operator()(const Descriptor& descriptor) const;
-      };
-
-      Handle operator()(const Descriptor& descriptor) const;
-
-     private:
-      VkDevice device_;
-    };
-
-    struct Object final {
-      VkDescriptorSetLayout handle;
-      Signature signature;
-
-      operator bool() const;
-    };
-
-    /*
-      Cache
-    */
-
-    class Cache final {
-     public:
-      explicit Cache(Factory factory);
-      Cache(const Cache&) = delete;
-      Cache& operator=(const Cache&) = delete;
-      Cache(Cache&&) = default;
-      Cache& operator=(Cache&&) = default;
-      ~Cache() = default;
-
-      Object retrieve(const Descriptor& descriptor);
-      void purge();
-
-     private:
-      api::Cache<Factory> cache_;
-    } cache;
-
-    explicit Layout(const GPU& gpu)
-      : cache(Factory(gpu)) {
-    }
-  } layout;
-
-  //
-  // Work Group
-  //
-
-  typedef utils::uvec3 WorkGroup;
-
-  /*
-    Descriptor
-  */
-
-  struct Descriptor final {
-    enum class Type {
-      Source,
-      Binary,
-    } type;
-
-    union {
-      struct {
-        const char* glsl; // Null-terminated
-        uint32_t unused;  // Padding
-      } source;
-
-      struct {
-        const uint32_t* spirv;
-        uint32_t size;    // Bytes
-      } binary;
-    } shader;
-
-    Descriptor(const char* glsl);
-    Descriptor(const uint32_t* spirv, uint32_t bytes);
-  };
-
-  /*
-    Factory
-  */
-
-  class Factory final {
-   public:
-    explicit Factory(const GPU& gpu);
-    Factory(const Factory&) = delete;
-    Factory& operator=(const Factory&) = delete;
-    Factory(Factory&&);
-    Factory& operator=(Factory&&);
-    ~Factory();
-
-    typedef Shader::Descriptor Descriptor;
-    typedef VK_DELETER(ShaderModule) Deleter;
-    typedef api::Handle<VkShaderModule, Deleter> Handle;
-
-    struct Hasher {
-      size_t operator()(const Descriptor& descriptor) const;
-    };
-
-    Handle operator()(const Descriptor& descriptor) const;
-
-   private:
-    VkDevice device_;
-    struct Compiler;
-    std::unique_ptr<Compiler> compiler_;
-  };
-
-  /*
-    Cache
-  */
-
-  typedef api::Cache<Factory> Cache;
-  Cache cache;
-
-  explicit Shader(const GPU& gpu)
-    : layout(gpu),
-      cache(Factory(gpu)) {
-  }
+  explicit ShaderSource(const char* glsl);
+  explicit ShaderSource(const uint32_t* spirv, uint32_t bytes);
 };
 
-//
-// Impl
-//
+class ShaderLayout final {
+ public:
+  using Signature = c10::SmallVector<VkDescriptorType, 6u>;
 
-inline bool operator==(
-    const Shader::Layout::Descriptor& _1,
-    const Shader::Layout::Descriptor& _2) {
-  return _1.signature == _2.signature;
-}
+  explicit ShaderLayout(const VkDevice, const Signature&);
 
-inline size_t Shader::Layout::Factory::Hasher::operator()(
-    const Descriptor& descriptor) const {
-  size_t hash = 0u;
+  ShaderLayout(const ShaderLayout&) = delete;
+  ShaderLayout& operator=(const ShaderLayout&) = delete;
 
-  for (const VkDescriptorType type : descriptor.signature) {
-    hash = c10::hash_combine(
-        hash,
-        c10::get_hash(type));
+  ShaderLayout(ShaderLayout&&) noexcept;
+  ShaderLayout& operator=(ShaderLayout&&) = delete;
+
+  ~ShaderLayout();
+
+ private:
+  VkDevice device_;
+  VkDescriptorSetLayout handle_;
+
+ public:
+  VkDescriptorSetLayout handle() const {
+    return handle_;
   }
 
-  return hash;
-}
+  // We need to define a custom swap function since this class
+  // does not allow for move assignment. The swap function will
+  // be used in the hash map.
+  friend void swap(ShaderLayout& lhs, ShaderLayout& rhs) noexcept;
+};
 
-inline Shader::Layout::Object::operator bool() const {
-  return VK_NULL_HANDLE != handle;
-}
+class ShaderModule final {
+ public:
+  explicit ShaderModule(const VkDevice device, const ShaderSource& source);
 
-inline Shader::Layout::Object Shader::Layout::Cache::retrieve(
-    const Descriptor& descriptor) {
-  return {
-    cache_.retrieve(descriptor),
-    descriptor.signature,
+  ShaderModule(const ShaderModule&) = delete;
+  ShaderModule& operator=(const ShaderModule&) = delete;
+
+  ShaderModule(ShaderModule&&) noexcept;
+  ShaderModule& operator=(ShaderModule&&) = delete;
+
+  ~ShaderModule();
+
+ private:
+  VkDevice device_;
+  VkShaderModule handle_;
+
+ public:
+  inline VkShaderModule handle() const {
+    return handle_;
+  }
+
+  // We need to define a custom swap function since this class
+  // does not allow for move assignment. The swap function will
+  // be used in the hash map.
+  friend void swap(ShaderModule& lhs, ShaderModule& rhs) noexcept;
+};
+
+class ShaderLayoutCache final {
+ public:
+  explicit ShaderLayoutCache(const VkDevice device);
+
+  ShaderLayoutCache(const ShaderLayoutCache&) = delete;
+  ShaderLayoutCache& operator=(const ShaderLayoutCache&) = delete;
+
+  ShaderLayoutCache(ShaderLayoutCache&&) noexcept;
+  ShaderLayoutCache& operator=(ShaderLayoutCache&&) = delete;
+
+  ~ShaderLayoutCache();
+
+  using Key = ShaderLayout::Signature;
+  using Value = ShaderLayout;
+
+  struct Hasher {
+    inline size_t operator()(const ShaderLayout::Signature& signature) const {
+      size_t hashed = 0u;
+
+      for (const VkDescriptorType type : signature) {
+        hashed = c10::hash_combine(
+            hashed,
+            c10::get_hash(type));
+      }
+
+      return hashed;
+    }
   };
-}
 
-inline bool operator==(
-    const Shader::WorkGroup& _1,
-    const Shader::WorkGroup& _2) {
+ private:
+  // Multiple threads could potentially be adding entries into the cache, so use
+  // a mutex to manage access
+  std::mutex cache_mutex_;
 
-  return (_1.data[0u] == _2.data[0u] && _1.data[1u] == _2.data[1u] && _1.data[2u] == _2.data[2u]);
-}
+  VkDevice device_;
+  ska::flat_hash_map<Key, Value, Hasher> cache_;
 
-inline Shader::Descriptor::Descriptor(const char* const glsl)
- : type(Type::Source),
-   shader{
-    .source = {
-      glsl,
-      0u,
-    },
-   } {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      glsl,
-      "Invalid shader source code!");
-}
+ public:
+  VkDescriptorSetLayout retrieve(const Key&);
+  void purge();
 
-inline Shader::Descriptor::Descriptor(
-    const uint32_t* const code,
-    const uint32_t size)
- : type(Type::Binary),
-   shader{
-    .binary = {
-      code,
-      size,
-    },
-   } {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      code && (0u != size),
-      "Invalid shader binary!");
-}
+};
 
-inline bool operator==(
-    const Shader::Descriptor& _1,
-    const Shader::Descriptor& _2) {
+class ShaderCache final {
+ public:
+  explicit ShaderCache(const VkDevice device);
 
-  if (_1.type != _2.type)
-    return false;
+  ShaderCache(const ShaderCache&) = delete;
+  ShaderCache& operator=(const ShaderCache&) = delete;
 
-  if (_1.type == Shader::Descriptor::Type::Binary) {
-    return (_1.shader.binary.spirv == _2.shader.binary.spirv && \
-            _1.shader.binary.size == _2.shader.binary.size);
-  }
-  else {
-    return (_1.shader.source.glsl == _2.shader.source.glsl);
-  }
-}
+  ShaderCache(ShaderCache&&) noexcept;
+  ShaderCache& operator=(ShaderCache&&) = delete;
 
-inline size_t Shader::Factory::Hasher::operator()(
-    const Descriptor& descriptor) const {
-  static_assert(
-      sizeof(Descriptor::shader.source) == sizeof(Descriptor::shader.binary),
-      "This implementation requires sizeof(Source) to be equal to sizeof(Binary).");
+  ~ShaderCache();
 
-  return c10::get_hash(
-      descriptor.type,
-      descriptor.shader.binary.spirv,
-      descriptor.shader.binary.size);
-}
+  using Key = ShaderSource;
+  using Value = ShaderModule;
+
+  struct Hasher {
+    inline size_t operator()(const ShaderSource& source) const {
+      return c10::get_hash(
+          source.type,
+          source.src_code.spirv.bin,
+          source.src_code.spirv.size);
+    }
+  };
+
+
+ private:
+  // Multiple threads could potentially be adding entries into the cache, so use
+  // a mutex to manage access
+  std::mutex cache_mutex_;
+
+  VkDevice device_;
+  ska::flat_hash_map<Key, Value, Hasher> cache_;
+
+ public:
+  VkShaderModule retrieve(const Key&);
+  void purge();
+};
 
 } // namespace api
 } // namespace vulkan

--- a/aten/src/ATen/native/vulkan/api/Utils.h
+++ b/aten/src/ATen/native/vulkan/api/Utils.h
@@ -102,6 +102,16 @@ using vec3 = vec<3u>;
 using vec4 = vec<4u>;
 
 } // namespace utils
+
+inline bool operator==(
+    const utils::uvec3& _1,
+    const utils::uvec3& _2) {
+
+  return (_1.data[0u] == _2.data[0u] && \
+          _1.data[1u] == _2.data[1u] && \
+          _1.data[2u] == _2.data[2u]);
+}
+
 } // namespace api
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -55,7 +55,7 @@ Tensor arithmetic_scalar(
     const Tensor& self_arg,
     const Scalar& other,
     const c10::optional<Scalar>& alpha_arg,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   api::Context* const context = api::context();
 
@@ -118,7 +118,7 @@ Tensor& arithmetic_scalar_(
     Tensor& self,
     const Scalar& other,
     const c10::optional<Scalar>& alpha_arg,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   api::Context* const context = api::context();
 
@@ -176,7 +176,7 @@ Tensor arithmetic_tensor(
     const Tensor& self_arg,
     const Tensor& other_arg,
     const c10::optional<Scalar>& alpha_arg,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   check_inputs(self_arg, other_arg);
   api::Context* const context = api::context();
@@ -253,7 +253,7 @@ Tensor& arithmetic_tensor_(
     Tensor& self,
     const Tensor& other_arg,
     const c10::optional<Scalar>& alpha_arg,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   check_inputs(self, other_arg);
   api::Context* const context = api::context();

--- a/aten/src/ATen/native/vulkan/ops/Clamp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clamp.cpp
@@ -14,7 +14,7 @@ Tensor _clamp(
     const Tensor& self_arg,
     const c10::optional<Scalar>& min,
     const c10::optional<Scalar>& max,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   TORCH_CHECK(
       min || max,
@@ -95,7 +95,7 @@ Tensor& _clamp_(
     Tensor& self,
     const c10::optional<Scalar>& min,
     const c10::optional<Scalar>& max,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   api::Context* const context = api::context();
 
@@ -172,7 +172,7 @@ Tensor& clamp_(
 
 Tensor activation(
     const Tensor& self_arg,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   api::Context* const context = api::context();
 
@@ -235,7 +235,7 @@ Tensor activation(
 
 Tensor& activation_(
     Tensor& self,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   api::Context* const context = api::context();
 
@@ -328,7 +328,7 @@ Tensor& hardsigmoid_(Tensor& self) {
 Tensor activation_scalar(
     const Tensor& self_arg,
     const Scalar& scalar_arg,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   api::Context* const context = api::context();
 
@@ -394,7 +394,7 @@ Tensor activation_scalar(
 Tensor& activation_scalar_(
     Tensor& self,
     const Scalar& scalar_arg,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   api::Context* const context = api::context();
 

--- a/aten/src/ATen/native/vulkan/ops/Common.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Common.cpp
@@ -41,8 +41,8 @@ uint32_t width_size(const Tensor& tensor) {
   return sizes[dims - 1];
 }
 
-api::Shader::WorkGroup adaptive_work_group_size(const api::Shader::WorkGroup& global_work_group) {
-  api::Shader::WorkGroup local_group_size = {4, 4, 4};
+api::utils::uvec3 adaptive_work_group_size(const api::utils::uvec3& global_work_group) {
+  api::utils::uvec3 local_group_size = {4, 4, 4};
   if (global_work_group.data[2u] == 1) {
     if (global_work_group.data[1u] < 8) {
       local_group_size.data[0u] = 16;

--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -48,7 +48,7 @@ uint32_t channels_size(const Tensor& tensor);
 uint32_t height_size(const Tensor& tensor);
 uint32_t width_size(const Tensor& tensor);
 
-api::Shader::WorkGroup adaptive_work_group_size(const api::Shader::WorkGroup& global_work_group);
+api::utils::uvec3 adaptive_work_group_size(const api::utils::uvec3& global_work_group);
 
 } // namespace ops
 } // namespace vulkan

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -418,7 +418,7 @@ VulkanOpContext conv2d_context_create(
 }
 
 void conv2d_sliding_window(
-    const api::Shader::Descriptor& shader,
+    const api::ShaderSource& shader,
     vTensor& v_output,
     const vTensor& v_input,
     const vTensor& packed_v_weight,

--- a/aten/src/ATen/native/vulkan/ops/Padding.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Padding.cpp
@@ -11,7 +11,9 @@ namespace {
 
 using namespace api::utils;
 
-Tensor pad2d(const Tensor& self_arg, IntArrayRef padding, const api::Shader::Descriptor& shader_descriptor,
+Tensor pad2d(
+    const Tensor& self_arg, IntArrayRef padding,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   const int pad_dim = padding.size();
   const IntArrayRef input_size = self_arg.sizes();

--- a/aten/src/ATen/native/vulkan/ops/Pool.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Pool.cpp
@@ -104,7 +104,7 @@ Tensor pool2d(
     const IntArrayRef padding_arg,
     const IntArrayRef dilation_arg,
     const bool ceil_mode,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   if (stride_arg.empty()) {
     stride_arg = kernel_arg;

--- a/aten/src/ATen/native/vulkan/ops/Softmax.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Softmax.cpp
@@ -15,7 +15,7 @@ Tensor softmax_internal(
     const at::Tensor& input_arg,
     const int64_t dim,
     const bool half_to_float,
-    const api::Shader::Descriptor& shader_descriptor,
+    const api::ShaderSource& shader_descriptor,
     const std::string& op_name) {
   TORCH_CHECK(
       input_arg.dim() == 4,
@@ -48,12 +48,12 @@ Tensor softmax_internal(
     v_input.options(),
   };
 
-  const api::Shader::WorkGroup global_work_group_size = {
+  const api::utils::uvec3 global_work_group_size = {
     safe_downcast<uint32_t>(v_input_sizes[Layout::Activation4D::width]),
     safe_downcast<uint32_t>(v_input_sizes[Layout::Activation4D::height]),
     1,
   };
-  const api::Shader::WorkGroup local_work_group_size = {8, 8, 1};
+  const api::utils::uvec3 local_work_group_size = {8, 8, 1};
 
   api::Command::Pool& command_pool = context->command().pool;
   api::Command::Buffer& command_buffer = command_pool.stream();

--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -599,7 +599,7 @@ void vTensor::View::CMD::barrier(State::Transition transition) {
   filter_access(transition.first.buffer.access);
   filter_access(transition.first.staging.access);
 
-  api::Pipeline::Barrier barrier{};
+  api::PipelineBarrier barrier{};
 
   if (transition.second.staging) {
     const State::Bundle::Buffer from = transition.first.staging;

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -87,7 +87,7 @@ class vTensor final {
     Types
   */
 
-  typedef api::Pipeline::Stage Stage;
+  typedef api::PipelineStage Stage;
   typedef api::Resource::Memory::Access Access;
   typedef api::Resource::Buffer Buffer;
   typedef api::Resource::Fence Fence;

--- a/aten/src/ATen/native/vulkan/ops/TransposeConvolution2d.cpp
+++ b/aten/src/ATen/native/vulkan/ops/TransposeConvolution2d.cpp
@@ -324,7 +324,7 @@ VulkanOpContext conv2d_transpose_context_create(
 }
 
 void conv2d_transpose_sliding_window(
-    const api::Shader::Descriptor& shader,
+    const api::ShaderSource& shader,
     vTensor& v_output,
     const vTensor& v_input,
     const vTensor& packed_v_weight,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

## Context

This PR refactors the Shader and Pipeline files to improve code readability and organization. The outcomes of this refactor are:

- Reduced nesting in classes. For instance, Shader layout objects previously had to be accessed via `Shader::Layout::Object`, but after this refactor can be accessed by simply `ShaderLayout`
- Removal of the `Cache` class. This class is simply a wrapper around `ska::flat_hash_map`, but usage requires the definition of several helper classes (such as `Factory`, `Descriptor`, and `Hasher` classes, not to mention the definition of another `Cache` class to wrap `api/Cache`) that bloats the codebase and makes it difficult to understand what's going on. After this refactor, `ska::flat_hash_map` is a direct member of the classes that use them.
- Further removal of usage of the `Handle` class which was started in https://github.com/pytorch/pytorch/pull/74698. This class standardizes the management of Vulkan handles via templates, but is ultimately hard to understand and adds an unnecessary layer of complexity when working with Vulkan handles.

This PR should not change any behaviour, it simply re-organizes these classes and improves readability of the code-base.

Differential Revision: [D36493832](https://our.internmc.facebook.com/intern/diff/D36493832/)