### PR TITLE
[vulkan] Replace `resource().pool.uniform(block).object` with `UniformParamsBuffer`

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -85,6 +85,8 @@ Tensor arithmetic_scalar(
           other_val,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -104,7 +106,7 @@ Tensor arithmetic_scalar(
           v_self.image(command_buffer, vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     } else {
       TORCH_CHECK(false, "Not implemented!");
     }
@@ -145,6 +147,8 @@ Tensor& arithmetic_scalar_(
           other_val,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -162,7 +166,7 @@ Tensor& arithmetic_scalar_(
               vTensor::Access::Read | vTensor::Access::Write),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     } else {
       TORCH_CHECK(false, "Not implemented!");
     }
@@ -289,6 +293,8 @@ Tensor& arithmetic_tensor_(
           alpha,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -310,7 +316,7 @@ Tensor& arithmetic_tensor_(
           v_other.image(command_buffer, vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     } else {
       TORCH_CHECK(false, "Not implemented!");
     }

--- a/aten/src/ATen/native/vulkan/ops/Clamp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clamp.cpp
@@ -50,6 +50,8 @@ Tensor _clamp(
         },
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -73,7 +75,7 @@ Tensor _clamp(
               vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -128,6 +130,8 @@ Tensor& _clamp_(
         },
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -145,7 +149,7 @@ Tensor& _clamp_(
               vTensor::Access::Read | vTensor::Access::Write),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -199,6 +203,8 @@ Tensor activation(
         0u,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -222,7 +228,7 @@ Tensor activation(
               vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -259,6 +265,8 @@ Tensor& activation_(
         0u,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -276,7 +284,7 @@ Tensor& activation_(
               vTensor::Access::Read | vTensor::Access::Write),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -357,6 +365,8 @@ Tensor activation_scalar(
         scalar_arg.to<float>(),
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -380,7 +390,7 @@ Tensor activation_scalar(
               vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -420,6 +430,8 @@ Tensor& activation_scalar_(
         scalar_arg.to<float>(),
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -437,7 +449,7 @@ Tensor& activation_scalar_(
               vTensor::Access::Read | vTensor::Access::Write),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -70,6 +70,8 @@ Tensor cat_feature(const TensorList tensors, vTensor& v_output) {
 
         ch_size_allprior += v_self.sizes()[1];
 
+        api::UniformParamsBuffer params(context, block);
+
         context->dispatch(
             command_buffer,
             {
@@ -88,7 +90,7 @@ Tensor cat_feature(const TensorList tensors, vTensor& v_output) {
             src_image,
             // Object lifetime is managed by the resource pool.
             // It is OK not to keep track of the handle.
-            context->resource().pool.uniform(block).object);
+            params.buffer().package());
       }
       else {
         TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -494,6 +494,8 @@ void conv2d_sliding_window(
       };
     }
 
+    api::UniformParamsBuffer params(context, block);
+
     context->dispatch(
         command_buffer,
         {
@@ -529,7 +531,7 @@ void conv2d_sliding_window(
             vTensor::Stage::Compute),
         // Object lifetime is managed by the resource pool.
         // It is OK not to keep track of the handle.
-        context->resource().pool.uniform(block).object);
+        params.buffer().package());
   }
   command_pool.submit(context->gpu().queue, command_buffer);
 }

--- a/aten/src/ATen/native/vulkan/ops/Lerp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Lerp.cpp
@@ -87,6 +87,8 @@ Tensor _lerp_scalar(
           weight,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -110,7 +112,7 @@ Tensor _lerp_scalar(
           v_end.image(command_buffer, vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     } else {
       TORCH_CHECK(false, "Not implemented!");
     }
@@ -157,6 +159,8 @@ Tensor& _lerp_scalar_(
           weight,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -178,7 +182,7 @@ Tensor& _lerp_scalar_(
           v_end.image(command_buffer, vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     } else {
       TORCH_CHECK(false, "Not implemented!");
     }
@@ -238,6 +242,8 @@ Tensor _lerp_tensor(
           0u,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -265,7 +271,7 @@ Tensor _lerp_tensor(
           v_weight.image(command_buffer, vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     } else {
       TORCH_CHECK(false, "Not implemented!");
     }
@@ -319,6 +325,8 @@ Tensor& _lerp_tensor_(
           0u,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -344,7 +352,7 @@ Tensor& _lerp_tensor_(
           v_weight.image(command_buffer, vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     } else {
       TORCH_CHECK(false, "Not implemented!");
     }

--- a/aten/src/ATen/native/vulkan/ops/Mean.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mean.cpp
@@ -71,6 +71,8 @@ Tensor mean(
         v_input.extents()
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -94,7 +96,7 @@ Tensor mean(
               vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/Mm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mm.cpp
@@ -274,6 +274,8 @@ Tensor context_run(
             },
         };
 
+        api::UniformParamsBuffer params(context, block);
+
         context->dispatch(
             command_buffer,
             {
@@ -313,7 +315,7 @@ Tensor context_run(
                 vTensor::Stage::Compute),
             // Object lifetime is managed by the resource pool.
             // It is OK not to keep track of the handle.
-            context->resource().pool.uniform(block).object);
+            params.buffer().package());
       }
       else {
         const struct {
@@ -323,6 +325,8 @@ Tensor context_run(
             v_output.extents(),
             safe_downcast<int32_t>(div_up(v_input.sizes()[Layout::Parameter::width], INT64_C(2))),
         };
+
+        api::UniformParamsBuffer params(context, block_no_bias);
 
         context->dispatch(
             command_buffer,
@@ -357,7 +361,7 @@ Tensor context_run(
                 vTensor::Stage::Compute),
             // Object lifetime is managed by the resource pool.
             // It is OK not to keep track of the handle.
-            context->resource().pool.uniform(block_no_bias).object);
+            params.buffer().package());
       }
     }
     else {

--- a/aten/src/ATen/native/vulkan/ops/Padding.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Padding.cpp
@@ -77,6 +77,8 @@ Tensor pad2d(
           },
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -96,7 +98,7 @@ Tensor pad2d(
           v_self.image(command_buffer, vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     } else {
       TORCH_CHECK(false, "Not implemented!");
     }

--- a/aten/src/ATen/native/vulkan/ops/Permute.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Permute.cpp
@@ -47,6 +47,8 @@ Tensor permute_4d(const Tensor& input, const uvec4& in_size, const uvec4& out_si
         out_dims,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -67,7 +69,7 @@ Tensor permute_4d(const Tensor& input, const uvec4& in_size, const uvec4& out_si
           src_image,
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/Pool.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Pool.cpp
@@ -63,6 +63,8 @@ Tensor adaptive_avg_pool2d(
         stride,
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -86,7 +88,7 @@ Tensor adaptive_avg_pool2d(
               vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");
@@ -214,6 +216,8 @@ Tensor pool2d(
         },
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -237,7 +241,7 @@ Tensor pool2d(
               vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/Slice.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Slice.cpp
@@ -52,6 +52,8 @@ Tensor slice_4d(const Tensor& input, const int64_t dim, const int64_t start, con
           safe_downcast<uint32_t>(step) },
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -72,7 +74,7 @@ Tensor slice_4d(const Tensor& input, const int64_t dim, const int64_t start, con
           src_image,
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/Softmax.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Softmax.cpp
@@ -71,6 +71,8 @@ Tensor softmax_internal(
         )
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -94,7 +96,7 @@ Tensor softmax_internal(
               vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/TransposeConvolution2d.cpp
+++ b/aten/src/ATen/native/vulkan/ops/TransposeConvolution2d.cpp
@@ -390,6 +390,8 @@ void conv2d_transpose_sliding_window(
 
     uvec3 global_size = v_output.extents();
 
+    api::UniformParamsBuffer params(context, block);
+
     context->dispatch(
         command_buffer,
         {
@@ -425,7 +427,7 @@ void conv2d_transpose_sliding_window(
             vTensor::Stage::Compute),
         // Object lifetime is managed by the resource pool.
         // It is OK not to keep track of the handle.
-        context->resource().pool.uniform(block).object);
+        params.buffer().package());
   }
   command_pool.submit(context->gpu().queue, command_buffer);
 }

--- a/aten/src/ATen/native/vulkan/ops/Upsample.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Upsample.cpp
@@ -67,6 +67,8 @@ Tensor upsample_nearest2d(
         },
       };
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -90,7 +92,7 @@ Tensor upsample_nearest2d(
               vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     }
     else {
       TORCH_CHECK(false, "Not implemented!");

--- a/aten/src/ATen/native/vulkan/ops/cumsum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/cumsum.cpp
@@ -54,6 +54,8 @@ Tensor cumsum(
           TORCH_CHECK(false, "Not implemented!");
       }
 
+      api::UniformParamsBuffer params(context, block);
+
       context->dispatch(
           command_buffer,
           {
@@ -77,7 +79,7 @@ Tensor cumsum(
               vTensor::Stage::Compute),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
-          context->resource().pool.uniform(block).object);
+          params.buffer().package());
     } else {
       TORCH_CHECK(false, "Not implemented!");
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Part of a refactor of the Vulkan codebase.

Differential Revision: [D36863388](https://our.internmc.facebook.com/intern/diff/D36863388/)