### PR TITLE
[vulkan] Remove references to old Resource struct

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -73,8 +73,8 @@ struct Command final {
         operator bool() const;
       } stage;
 
-      c10::SmallVector<Resource::Buffer::Barrier, 4u> buffers;
-      c10::SmallVector<Resource::Image::Barrier, 4u> images;
+      c10::SmallVector<api::BufferMemoryBarrier, 4u> buffer_barriers;
+      c10::SmallVector<api::ImageMemoryBarrier, 4u> image_barriers;
 
       void reset();
     } barriers_;

--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -17,7 +17,6 @@ Context::Context(const VkInstance instance, size_t adapter_i)
       queue_(adapter_p_->request_queue()),
       command_(gpu()),
       descriptor_(gpu()),
-      resource_(gpu()),
       fences_(device_),
       querypool_(
         device_,
@@ -34,7 +33,6 @@ Context::~Context() {
 void Context::flush() {
   VK_CHECK(vkQueueWaitIdle(queue()));
 
-  resource().pool.purge();
   descriptor().pool.purge();
   command().pool.purge();
 

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -47,7 +47,6 @@ class Context final {
   // Resource Pools
   Command command_;
   Descriptor descriptor_;
-  Resource resource_;
   FencePool fences_;
   QueryPool querypool_;
   // Memory Management
@@ -99,10 +98,6 @@ class Context final {
 
   inline Descriptor& descriptor() {
     return descriptor_;
-  }
-
-  inline Resource& resource() {
-    return resource_;
   }
 
   inline FencePool& fences() {

--- a/aten/src/ATen/native/vulkan/api/Descriptor.cpp
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.cpp
@@ -154,55 +154,6 @@ Descriptor::Set& Descriptor::Set::operator=(Set&& set) {
 
 Descriptor::Set& Descriptor::Set::bind(
     const uint32_t binding,
-    const Resource::Buffer::Object& buffer) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      device_ && descriptor_set_,
-      "This descriptor set is in an invalid state! "
-      "Potential reason: This descriptor set is moved from.");
-
-  update({
-      binding,
-      shader_layout_signature_[binding],
-      {
-        .buffer = {
-          buffer.handle,
-          buffer.offset,
-          buffer.range,
-        },
-      },
-    });
-
-  return *this;
-}
-
-Descriptor::Set& Descriptor::Set::bind(
-    const uint32_t binding,
-    const Resource::Image::Object& image) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      device_ && descriptor_set_,
-      "This descriptor set is in an invalid state! "
-      "Potential reason: This descriptor set is moved from.");
-
-  update(Item{
-      binding,
-      shader_layout_signature_[binding],
-      {
-        .image = {
-          image.sampler,
-          image.view,
-          [](const VkDescriptorType type, const VkImageLayout layout) {
-            return (VK_DESCRIPTOR_TYPE_STORAGE_IMAGE == type) ?
-                    VK_IMAGE_LAYOUT_GENERAL : layout;
-          }(shader_layout_signature_[binding], image.layout),
-        },
-      },
-    });
-
-  return *this;
-}
-
-Descriptor::Set& Descriptor::Set::bind(
-    const uint32_t binding,
     const VulkanBuffer::Package& package) {
   update({
       binding,

--- a/aten/src/ATen/native/vulkan/api/Descriptor.h
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.h
@@ -68,9 +68,6 @@ struct Descriptor final {
     Set& operator=(Set&&);
     ~Set() = default;
 
-    Set& bind(uint32_t binding, const Resource::Buffer::Object& buffer);
-    Set& bind(uint32_t binding, const Resource::Image::Object& image);
-
     Set& bind(uint32_t binding, const VulkanBuffer::Package&);
     Set& bind(uint32_t binding, const VulkanImage::Package&);
 

--- a/aten/src/ATen/native/vulkan/api/Pipeline.h
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.h
@@ -18,8 +18,8 @@ struct PipelineBarrier final {
     VkPipelineStageFlags dst;
   } stage;
 
-  c10::SmallVector<Resource::Buffer::Barrier, 4u> buffers;
-  c10::SmallVector<Resource::Image::Barrier, 4u> images;
+  c10::SmallVector<api::BufferMemoryBarrier, 4u> buffers;
+  c10::SmallVector<api::ImageMemoryBarrier, 4u> images;
 
   inline operator bool() const {
     return (0u != stage.src) ||

--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -100,7 +100,7 @@ Tensor arithmetic_scalar(
           // Write-only access bypasses synchronization but inserts appropriate
           // barriers if necessary.
           v_output.image(
-              command_buffer, vTensor::Stage::Compute, vTensor::Access::Write),
+              command_buffer, vTensor::Stage::Compute, api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_self.image(command_buffer, vTensor::Stage::Compute),
@@ -163,7 +163,7 @@ Tensor& arithmetic_scalar_(
           v_self.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Read | vTensor::Access::Write),
+              api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
           params.buffer().package());
@@ -236,7 +236,7 @@ Tensor arithmetic_tensor(
           // Write-only access bypasses synchronization but inserts appropriate
           // barriers if necessary.
           v_output.image(
-              command_buffer, vTensor::Stage::Compute, vTensor::Access::Write),
+              command_buffer, vTensor::Stage::Compute, api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_self.image(command_buffer, vTensor::Stage::Compute),
@@ -310,7 +310,7 @@ Tensor& arithmetic_tensor_(
           v_self.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Read | vTensor::Access::Write),
+              api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_other.image(command_buffer, vTensor::Stage::Compute),

--- a/aten/src/ATen/native/vulkan/ops/Clamp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clamp.cpp
@@ -67,7 +67,7 @@ Tensor _clamp(
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Write),
+              api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_self.image(
@@ -146,7 +146,7 @@ Tensor& _clamp_(
           v_self.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Read | vTensor::Access::Write),
+              api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
           params.buffer().package());
@@ -220,7 +220,7 @@ Tensor activation(
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Write),
+              api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_self.image(
@@ -281,7 +281,7 @@ Tensor& activation_(
           v_self.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Read | vTensor::Access::Write),
+              api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
           params.buffer().package());
@@ -382,7 +382,7 @@ Tensor activation_scalar(
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Write),
+              api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_self.image(
@@ -446,7 +446,7 @@ Tensor& activation_scalar_(
           v_self.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Read | vTensor::Access::Write),
+              api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
           // Object lifetime is managed by the resource pool.
           // It is OK not to keep track of the handle.
           params.buffer().package());

--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -38,7 +38,7 @@ Tensor cat_feature(const TensorList tensors, vTensor& v_output) {
     auto dst_image = v_output.image(
       command_buffer,
       vTensor::Stage::Compute,
-      vTensor::Access::Read | vTensor::Access::Write);
+      api::MemoryAccessType::READ | api::MemoryAccessType::WRITE);
 
     for (const auto& tensor : tensors) {
       const Tensor self = tensor.is_vulkan() ? tensor : tensor.vulkan();
@@ -119,7 +119,7 @@ Tensor cat_feature_mult4ch(const TensorList tensors, vTensor& v_output) {
     auto dst_image = v_output.image(
       command_buffer,
       vTensor::Stage::Transfer,
-      vTensor::Access::Write);
+      api::MemoryAccessType::WRITE);
     uvec3 src_offset{};
     uvec3 dst_offset{};
 
@@ -173,7 +173,7 @@ Tensor cat_height(const TensorList tensors, vTensor& v_output) {
     auto dst_image = v_output.image(
       command_buffer,
       vTensor::Stage::Transfer,
-      vTensor::Access::Write);
+      api::MemoryAccessType::WRITE);
 
     uvec3 src_offset{};
     uvec3 dst_offset{};

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -80,7 +80,7 @@ vTensor pack_weights_dw(
   };
 
   api::MemoryMap mapping(
-      v_weight.host_buffer(command_buffer, vTensor::Access::Write),
+      v_weight.host_buffer(command_buffer, api::MemoryAccessType::WRITE),
       api::MemoryAccessType::WRITE);
 
   float* dst_weight_ptr = mapping.template data<float>();
@@ -142,7 +142,7 @@ vTensor pack_weights_2d(
   };
 
   api::MemoryMap mapping(
-      v_weight.host_buffer(command_buffer, vTensor::Access::Write),
+      v_weight.host_buffer(command_buffer, api::MemoryAccessType::WRITE),
       api::MemoryAccessType::WRITE);
 
   float* dst_weight_ptr = mapping.template data<float>();
@@ -225,7 +225,7 @@ vTensor pack_biases(
   };
 
   api::MemoryMap mapping(
-      v_bias.host_buffer(command_buffer, vTensor::Access::Write),
+      v_bias.host_buffer(command_buffer, api::MemoryAccessType::WRITE),
       api::MemoryAccessType::WRITE);
 
   float* dst_bias_ptr = mapping.template data<float>();
@@ -513,7 +513,7 @@ void conv2d_sliding_window(
         v_output.image(
             command_buffer,
             vTensor::Stage::Compute,
-            vTensor::Access::Write),
+            api::MemoryAccessType::WRITE),
         // Read-only access is implied on const tensors and triggers an async
         // synchronization if necessary.
         v_input.image(

--- a/aten/src/ATen/native/vulkan/ops/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Copy.cpp
@@ -37,7 +37,7 @@ Tensor& copy_(Tensor& self, const Tensor& src) {
               v_self.buffer(
                   command_buffer,
                   vTensor::Stage::Transfer,
-                  vTensor::Access::Write));
+                  api::MemoryAccessType::WRITE));
         }
         command_pool.submit(context->gpu().queue, command_buffer);
       }
@@ -48,7 +48,7 @@ Tensor& copy_(Tensor& self, const Tensor& src) {
 
         {
           api::MemoryMap mapping(
-              v_self.host_buffer(command_buffer, vTensor::Access::Write),
+              v_self.host_buffer(command_buffer, api::MemoryAccessType::WRITE),
               api::MemoryAccessType::WRITE);
 
           float* data_ptr = mapping.template data<float>();
@@ -69,7 +69,7 @@ Tensor& copy_(Tensor& self, const Tensor& src) {
       if (self.device().is_cpu()) {
         {
           api::MemoryMap mapping(
-            v_src.host_buffer(command_buffer, vTensor::Access::Read),
+            v_src.host_buffer(command_buffer, api::MemoryAccessType::READ),
             api::MemoryAccessType::READ);
 
           v_src.wait_for_fence();

--- a/aten/src/ATen/native/vulkan/ops/Lerp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Lerp.cpp
@@ -103,7 +103,7 @@ Tensor _lerp_scalar(
           // Write-only access bypasses synchronization but inserts appropriate
           // barriers if necessary.
           v_output.image(
-              command_buffer, vTensor::Stage::Compute, vTensor::Access::Write),
+              command_buffer, vTensor::Stage::Compute, api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_start.image(command_buffer, vTensor::Stage::Compute),
@@ -176,7 +176,7 @@ Tensor& _lerp_scalar_(
           v_self.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Read | vTensor::Access::Write),
+              api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_end.image(command_buffer, vTensor::Stage::Compute),
@@ -259,7 +259,7 @@ Tensor _lerp_tensor(
           // Write-only access bypasses synchronization but inserts appropriate
           // barriers if necessary.
           v_output.image(
-              command_buffer, vTensor::Stage::Compute, vTensor::Access::Write),
+              command_buffer, vTensor::Stage::Compute, api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_start.image(command_buffer, vTensor::Stage::Compute),
@@ -343,7 +343,7 @@ Tensor& _lerp_tensor_(
           v_self.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Read | vTensor::Access::Write),
+              api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_end.image(command_buffer, vTensor::Stage::Compute),

--- a/aten/src/ATen/native/vulkan/ops/Mean.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mean.cpp
@@ -88,7 +88,7 @@ Tensor mean(
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Write),
+              api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_input.image(

--- a/aten/src/ATen/native/vulkan/ops/Mm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mm.cpp
@@ -44,7 +44,7 @@ vTensor pack_weights(
   };
 
   api::MemoryMap mapping(
-      v_weight.host_buffer(command_buffer, vTensor::Access::Write),
+      v_weight.host_buffer(command_buffer, api::MemoryAccessType::WRITE),
       api::MemoryAccessType::WRITE);
 
   float* dst_weight_ptr = mapping.template data<float>();
@@ -107,7 +107,7 @@ vTensor pack_biases(
     };
 
     api::MemoryMap mapping(
-        v_bias.host_buffer(command_buffer, vTensor::Access::Write),
+        v_bias.host_buffer(command_buffer, api::MemoryAccessType::WRITE),
         api::MemoryAccessType::WRITE);
 
     float* dst_bias_ptr = mapping.template data<float>();
@@ -135,7 +135,7 @@ vTensor pack_biases(
     };
 
     api::MemoryMap mapping(
-        v_bias.host_buffer(command_buffer, vTensor::Access::Write),
+        v_bias.host_buffer(command_buffer, api::MemoryAccessType::WRITE),
         api::MemoryAccessType::WRITE);
 
     float* data_ptr = mapping.template data<float>();
@@ -297,7 +297,7 @@ Tensor context_run(
             v_output.image(
                 command_buffer,
                 vTensor::Stage::Compute,
-                vTensor::Access::Write),
+                api::MemoryAccessType::WRITE),
             // Read-only access is implied on const tensors and triggers an async
             // synchronization if necessary.
             v_input.image(
@@ -348,7 +348,7 @@ Tensor context_run(
             v_output.image(
                 command_buffer,
                 vTensor::Stage::Compute,
-                vTensor::Access::Write),
+                api::MemoryAccessType::WRITE),
             // Read-only access is implied on const tensors and triggers an async
             // synchronization if necessary.
             v_input.image(

--- a/aten/src/ATen/native/vulkan/ops/Padding.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Padding.cpp
@@ -92,7 +92,7 @@ Tensor pad2d(
           // Write-only access bypasses synchronization but inserts appropriate
           // barriers if necessary.
           v_output.image(
-              command_buffer, vTensor::Stage::Compute, vTensor::Access::Write),
+              command_buffer, vTensor::Stage::Compute, api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_self.image(command_buffer, vTensor::Stage::Compute),

--- a/aten/src/ATen/native/vulkan/ops/Permute.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Permute.cpp
@@ -20,7 +20,7 @@ Tensor permute_4d(const Tensor& input, const uvec4& in_size, const uvec4& out_si
     auto dst_image = v_output.image(
       command_buffer,
       vTensor::Stage::Compute,
-      vTensor::Access::Read | vTensor::Access::Write);
+      api::MemoryAccessType::READ | api::MemoryAccessType::WRITE);
 
     const Tensor self = input.is_vulkan() ? input : input.vulkan();
     const vTensor& v_self = convert(self);

--- a/aten/src/ATen/native/vulkan/ops/Pool.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Pool.cpp
@@ -80,7 +80,7 @@ Tensor adaptive_avg_pool2d(
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Write),
+              api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_self.image(
@@ -233,7 +233,7 @@ Tensor pool2d(
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Write),
+              api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_self.image(

--- a/aten/src/ATen/native/vulkan/ops/Shape.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Shape.cpp
@@ -39,7 +39,7 @@ Tensor view_internal(
         v_output.buffer(
             command_buffer,
             vTensor::Stage::Transfer,
-            vTensor::Access::Write));
+            api::MemoryAccessType::WRITE));
   }
   command_pool.submit(context->gpu().queue, command_buffer);
 

--- a/aten/src/ATen/native/vulkan/ops/Slice.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Slice.cpp
@@ -29,7 +29,7 @@ Tensor slice_4d(const Tensor& input, const int64_t dim, const int64_t start, con
       auto dst_image = v_output.image(
         command_buffer,
         vTensor::Stage::Compute,
-        vTensor::Access::Write);
+        api::MemoryAccessType::WRITE);
 
       const struct Block final {
         uvec3 size;                // output texture size
@@ -100,7 +100,7 @@ Tensor slice_width(const Tensor& input, const int64_t start, const int64_t end, 
       auto dst_image = v_output.image(
         command_buffer,
         vTensor::Stage::Transfer,
-        vTensor::Access::Write);
+        api::MemoryAccessType::WRITE);
 
       uvec3 src_offset{};
       uvec3 dst_offset{};
@@ -160,7 +160,7 @@ Tensor slice_height(const Tensor& input, const int64_t start, const int64_t end,
       auto dst_image = v_output.image(
         command_buffer,
         vTensor::Stage::Transfer,
-        vTensor::Access::Write);
+        api::MemoryAccessType::WRITE);
 
       uvec3 src_offset{};
       uvec3 dst_offset{};

--- a/aten/src/ATen/native/vulkan/ops/Softmax.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Softmax.cpp
@@ -88,7 +88,7 @@ Tensor softmax_internal(
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Write),
+              api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_input.image(

--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -41,9 +41,9 @@ VkExtent3D vk_extent(const uvec3& extent) {
   };
 }
 
-vTensor::Access::Flags access(
+api::MemoryAccessFlags access(
     const VkAccessFlags vk_access) {
-  vTensor::Access::Flags access = 0u;
+  api::MemoryAccessFlags access = 0u;
 
   constexpr VkAccessFlags kRead =
       VK_ACCESS_HOST_READ_BIT |
@@ -59,11 +59,11 @@ vTensor::Access::Flags access(
       VK_ACCESS_TRANSFER_WRITE_BIT;
 
   if (vk_access & kRead) {
-    access |= vTensor::Access::Read;
+    access |= api::MemoryAccessType::READ;
   }
 
   if (vk_access & kWrite) {
-    access |= vTensor::Access::Write;
+    access |= api::MemoryAccessType::WRITE;
   }
 
   return access;
@@ -71,10 +71,10 @@ vTensor::Access::Flags access(
 
 VkAccessFlags vk_access(
     const vTensor::Stage::Flags stage,
-    const vTensor::Access::Flags access) {
+    const api::MemoryAccessFlags access) {
   VkAccessFlags vk_access = 0u;
 
-  if (access & vTensor::Access::Read) {
+  if (access & api::MemoryAccessType::READ) {
     if (stage & vTensor::Stage::Compute) {
       vk_access |= VK_ACCESS_SHADER_READ_BIT;
     }
@@ -88,7 +88,7 @@ VkAccessFlags vk_access(
     }
   }
 
-  if (access & vTensor::Access::Write) {
+  if (access & api::MemoryAccessType::WRITE) {
     if (stage & vTensor::Stage::Compute) {
       vk_access |= VK_ACCESS_SHADER_WRITE_BIT;
     }
@@ -107,11 +107,11 @@ VkAccessFlags vk_access(
 
 VkImageLayout vk_layout(
     const vTensor::Stage::Flags stage,
-    const vTensor::Access::Flags access) {
+    const api::MemoryAccessFlags access) {
   switch (stage) {
     case vTensor::Stage::Compute:
       switch (access) {
-        case vTensor::Access::Read:
+        case api::MemoryAccessType::READ:
           return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
         default:
@@ -120,10 +120,10 @@ VkImageLayout vk_layout(
 
     case vTensor::Stage::Transfer:
       switch (access) {
-        case vTensor::Access::Read:
+        case api::MemoryAccessType::READ:
           return VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
 
-        case vTensor::Access::Write:
+        case api::MemoryAccessType::WRITE:
           return VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 
         default:
@@ -172,53 +172,6 @@ VkDeviceSize buffer_bytes(
   return size;
 }
 
-vTensor::Buffer allocate_buffer(
-    const api::Adapter* const adapter,
-    api::Resource::Pool* const pool,
-    const IntArrayRef sizes,
-    const TensorOptions& options) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      adapter,
-      "Invalid Vulkan adapter!");
-
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      pool,
-      "Invalid Vulkan resource pool!");
-
-  TORCH_CHECK(!sizes.empty(), "Invalid Vulkan tensor size!");
-  verify(options);
-
-  const VkFlags usage =
-      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
-      VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
-      VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-
-  const auto memory = [adapter]() -> api::Resource::Memory::Descriptor {
-    if (requires_staging(adapter)) {
-      return {
-        VMA_MEMORY_USAGE_GPU_ONLY,
-        0u,
-        0u,
-      };
-    }
-
-    return {
-      VMA_MEMORY_USAGE_GPU_TO_CPU,
-      0u,
-      VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-    };
-  }();
-
-  return pool->create_buffer({
-      buffer_bytes(sizes, options.dtype()),
-      // Usage
-      {
-        usage,
-        memory,
-      },
-    });
-}
-
 bool requires_image(const IntArrayRef sizes) {
   return (1u <= sizes.size()) && (sizes.size() <= 4u);
 }
@@ -263,92 +216,12 @@ uvec3 image_extents(const IntArrayRef sizes) {
   };
 }
 
-vTensor::Image allocate_image(
-    api::Resource::Pool* const pool,
-    const VkExtent3D& extents,
-    const TensorOptions& options) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      pool,
-      "Invalid Vulkan resource pool!");
-
-  verify(options);
-
-  return pool->create_image({
-      VK_IMAGE_TYPE_3D,
-      vk_format(options.dtype()),
-      extents,
-      // Usage
-      {
-        VK_IMAGE_USAGE_SAMPLED_BIT |
-            VK_IMAGE_USAGE_STORAGE_BIT |
-            VK_IMAGE_USAGE_TRANSFER_SRC_BIT | // for vkCmdCopyImage
-            VK_IMAGE_USAGE_TRANSFER_DST_BIT,  // for vkCmdCopyImage
-        {
-          VMA_MEMORY_USAGE_GPU_ONLY,
-          0u,
-          0u,
-        },
-      },
-      // View
-      {
-        VK_IMAGE_VIEW_TYPE_3D,
-        vk_format(options.dtype()),
-      },
-      // Sampler
-      {
-        VK_FILTER_NEAREST,
-        VK_SAMPLER_MIPMAP_MODE_NEAREST,
-        VK_SAMPLER_ADDRESS_MODE_REPEAT,
-        VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
-      },
-    });
-}
-
 bool requires_staging(const api::Adapter* const adapter) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       adapter,
       "Invalid Vulkan adapter!");
 
   return !adapter->has_unified_memory();
-}
-
-vTensor::Buffer allocate_staging(
-    const api::Adapter* const adapter,
-    api::Resource::Pool* const pool,
-    const IntArrayRef sizes,
-    const TensorOptions& options) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      adapter,
-      "Invalid Vulkan adapter!");
-
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      pool,
-      "Invalid Vulkan resource pool!");
-
-  TORCH_CHECK(!sizes.empty(), "Invalid Vulkan tensor size!");
-  verify(options);
-
-  return pool->create_buffer({
-      buffer_bytes(sizes, options.dtype()),
-      // Usage
-      {
-        VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
-            VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-        {
-          VMA_MEMORY_USAGE_CPU_COPY,
-          0u,
-          0u,
-        },
-      },
-    });
-}
-
-vTensor::Fence allocate_fence(api::Resource::Pool* const pool) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      pool,
-      "Invalid Vulkan resource pool!");
-
-  return pool->fence();
 }
 
 enum class Barrier {
@@ -364,11 +237,11 @@ Barrier categorize(
     return Barrier::None;
   }
 
-  const vTensor::Access::Flags src_access = access(vk_src_access);
-  const vTensor::Access::Flags dst_access = access(vk_dst_access);
+  const api::MemoryAccessFlags src_access = access(vk_src_access);
+  const api::MemoryAccessFlags dst_access = access(vk_dst_access);
 
-  if ((src_access & vTensor::Access::Read) == src_access) {
-    if ((dst_access & vTensor::Access::Read) == dst_access) {
+  if ((src_access & api::MemoryAccessType::READ) == src_access) {
+    if ((dst_access & api::MemoryAccessType::READ) == dst_access) {
       // RAR (Read after Read)
       return Barrier::None;
     }
@@ -399,21 +272,8 @@ vTensor::vTensor(
     api::Context* const context,
     const IntArrayRef sizes,
     const TensorOptions& options)
-  : vTensor(
-      context,
-      &context->resource().pool,
-      sizes,
-      options) {
-}
-
-vTensor::vTensor(
-    api::Context* const context,
-    api::Resource::Pool* const pool,
-    const IntArrayRef sizes,
-    const TensorOptions& options)
   : view_(new View{
       context,
-      pool,
       sizes,
       options,
     }) {
@@ -421,7 +281,7 @@ vTensor::vTensor(
 
 api::VulkanBuffer& vTensor::host_buffer(
     api::Command::Buffer& command_buffer,
-    const Access::Flags access) & {
+    const api::MemoryAccessFlags access) & {
   return view_->staging(command_buffer, Stage::Host, access);
 }
 
@@ -431,13 +291,13 @@ api::VulkanBuffer::Package vTensor::buffer(
   return view_->buffer(
       command_buffer,
       stage,
-      Access::Read).package();
+      api::MemoryAccessType::READ).package();
 }
 
 api::VulkanBuffer::Package vTensor::buffer(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage,
-    const Access::Flags access) & {
+    const api::MemoryAccessFlags access) & {
   return view_->buffer(
       command_buffer,
       stage,
@@ -450,13 +310,13 @@ api::VulkanImage::Package vTensor::image(
   return view_->image(
       command_buffer,
       stage,
-      Access::Read).package();
+      api::MemoryAccessType::READ).package();
 }
 
 api::VulkanImage::Package vTensor::image(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage,
-    const Access::Flags access) & {
+    const api::MemoryAccessFlags access) & {
   return view_->image(
       command_buffer,
       stage,
@@ -479,7 +339,6 @@ vTensor::View::View()
 
 vTensor::View::View(
     api::Context* const context,
-    api::Resource::Pool* const pool,
     const IntArrayRef sizes,
     const TensorOptions& options)
     // Resources
@@ -522,10 +381,6 @@ class vTensor::View::CMD final {
   CMD(CMD&&) = delete;
   CMD& operator=(CMD&&) = delete;
   ~CMD() = default;
-
-  typedef api::Resource::Buffer Buffer;
-  typedef api::Resource::Image Image;
-  typedef api::Resource::Fence Fence;
 
   void barrier(State::Transition transition);
 
@@ -603,24 +458,13 @@ void vTensor::View::CMD::barrier(State::Transition transition) {
         from.access,
         to.access);
 
-    api::VulkanBuffer::Package package = view_.staging().package();
-
     if (Barrier::None != category) {
       barrier.stage.src |= from.stage;
       barrier.stage.dst |= to.stage;
 
       if (Barrier::Memory == category) {
-        barrier.buffers.push_back({
-          {
-            package.handle,
-            package.buffer_offset,
-            package.buffer_range,
-          },
-          {
-            from.access,
-            to.access,
-          },
-        });
+        barrier.buffers.push_back(
+            api::BufferMemoryBarrier(from.access, to.access, view_.staging()));
       }
     }
   }
@@ -639,17 +483,8 @@ void vTensor::View::CMD::barrier(State::Transition transition) {
       barrier.stage.src |= from.stage;
       barrier.stage.dst |= to.stage;
       if (Barrier::Memory == category) {
-        barrier.buffers.push_back({
-          {
-            package.handle,
-            package.buffer_offset,
-            package.buffer_range,
-          },
-          {
-            from.access,
-            to.access,
-          },
-        });
+        barrier.buffers.push_back(
+            api::BufferMemoryBarrier(from.access, to.access, view_.buffer()));
       }
     }
   }
@@ -674,22 +509,13 @@ void vTensor::View::CMD::barrier(State::Transition transition) {
             "Invalid image layout!");
         api::VulkanImage::Package package = view_.image().package();
 
-        barrier.images.push_back({
-          {
-            package.handle,
-            package.image_layout,
-            package.image_view,
-            package.image_sampler,
-          },
-          {
-            from.access,
-            to.access,
-          },
-          {
-            from.layout,
-            to.layout,
-          },
-        });
+        barrier.images.push_back(
+            api::ImageMemoryBarrier(
+                from.access,
+                to.access,
+                from.layout,
+                to.layout,
+                view_.image()));
 
         view_.image().set_layout(to.layout);
       }
@@ -724,12 +550,12 @@ void vTensor::View::CMD::copy_buffer_to_staging(
           // Staging
           {
             vk_stage(Stage::Transfer),
-            vk_access(Stage::Transfer, Access::Write),
+            vk_access(Stage::Transfer, api::MemoryAccessType::WRITE),
           },
           // Buffer
           {
             vk_stage(Stage::Transfer),
-            vk_access(Stage::Transfer, Access::Read),
+            vk_access(Stage::Transfer, api::MemoryAccessType::READ),
           },
           // Image
           {},
@@ -751,12 +577,12 @@ void vTensor::View::CMD::copy_staging_to_buffer(
           // Staging
           {
             vk_stage(Stage::Transfer),
-            vk_access(Stage::Transfer, Access::Read),
+            vk_access(Stage::Transfer, api::MemoryAccessType::READ),
           },
           // Buffer
           {
             vk_stage(Stage::Transfer),
-            vk_access(Stage::Transfer, Access::Write),
+            vk_access(Stage::Transfer, api::MemoryAccessType::WRITE),
           },
           // Image
           {},
@@ -782,13 +608,13 @@ void vTensor::View::CMD::copy_buffer_to_image(
           // Buffer
           {
             vk_stage(Stage::Compute),
-            vk_access(Stage::Compute, Access::Read),
+            vk_access(Stage::Compute, api::MemoryAccessType::READ),
           },
           // Image
           {
             vk_stage(Stage::Compute),
-            vk_access(Stage::Compute, Access::Write),
-            vk_layout(Stage::Compute, Access::Write),
+            vk_access(Stage::Compute, api::MemoryAccessType::WRITE),
+            vk_layout(Stage::Compute, api::MemoryAccessType::WRITE),
           },
         }));
 
@@ -844,13 +670,13 @@ void vTensor::View::CMD::copy_image_to_buffer(
           // Buffer
           {
             vk_stage(Stage::Compute),
-            vk_access(Stage::Compute, Access::Write),
+            vk_access(Stage::Compute, api::MemoryAccessType::WRITE),
           },
           // Image
           {
             vk_stage(Stage::Compute),
-            vk_access(Stage::Compute, Access::Read),
-            vk_layout(Stage::Compute, Access::Read),
+            vk_access(Stage::Compute, api::MemoryAccessType::READ),
+            vk_layout(Stage::Compute, api::MemoryAccessType::READ),
           },
         }));
 
@@ -910,7 +736,7 @@ api::VulkanBuffer& vTensor::View::buffer() const {
 api::VulkanBuffer& vTensor::View::buffer(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage,
-    const Access::Flags access) const {
+    const api::MemoryAccessFlags access) const {
   CMD cmd(*this, command_buffer);
   return buffer(cmd, stage, access);
 }
@@ -918,18 +744,18 @@ api::VulkanBuffer& vTensor::View::buffer(
 api::VulkanBuffer& vTensor::View::buffer(
     CMD& cmd,
     const Stage::Flags stage,
-    const Access::Flags access) const {
-  if ((access & Access::Read) && state_.is_dirty(Component::Buffer)) {
+    const api::MemoryAccessFlags access) const {
+  if ((access & api::MemoryAccessType::READ) && state_.is_dirty(Component::Buffer)) {
     if (state_.is_clean(Component::Staging)) {
       cmd.copy_staging_to_buffer(
           state_,
-          staging(cmd, Stage::Transfer, Access::Read),
+          staging(cmd, Stage::Transfer, api::MemoryAccessType::READ),
           buffer());
     }
     else if (state_.is_clean(Component::Image)) {
       cmd.copy_image_to_buffer(
           state_,
-          image(cmd, Stage::Compute, Access::Read),
+          image(cmd, Stage::Compute, api::MemoryAccessType::READ),
           buffer());
     }
     else {
@@ -952,7 +778,7 @@ api::VulkanBuffer& vTensor::View::buffer(
           {},
         }));
 
-  if (access & Access::Write) {
+  if (access & api::MemoryAccessType::WRITE) {
     state_.set_dirty(Component::All);
   }
 
@@ -985,7 +811,7 @@ api::VulkanImage& vTensor::View::image() const {
 api::VulkanImage& vTensor::View::image(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage,
-    const Access::Flags access) const {
+    const api::MemoryAccessFlags access) const {
   CMD cmd(*this, command_buffer);
   return image(cmd, stage, access);
 }
@@ -993,11 +819,11 @@ api::VulkanImage& vTensor::View::image(
 api::VulkanImage& vTensor::View::image(
     CMD& cmd,
     const Stage::Flags stage,
-    const Access::Flags access) const {
-  if ((access & Access::Read) && state_.is_dirty(Component::Image)) {
+    const api::MemoryAccessFlags access) const {
+  if ((access & api::MemoryAccessType::READ) && state_.is_dirty(Component::Image)) {
     cmd.copy_buffer_to_image(
         state_,
-        buffer(cmd, stage, Access::Read),
+        buffer(cmd, stage, api::MemoryAccessType::READ),
         image());
   }
 
@@ -1015,7 +841,7 @@ api::VulkanImage& vTensor::View::image(
           },
         }));
 
-  if (access & Access::Write) {
+  if (access & api::MemoryAccessType::WRITE) {
     state_.set_dirty(Component::All);
   }
 
@@ -1041,7 +867,7 @@ api::VulkanBuffer& vTensor::View::staging() const {
 api::VulkanBuffer& vTensor::View::staging(
     api::Command::Buffer& command_buffer,
     const Stage::Flags stage,
-    const Access::Flags access) const {
+    const api::MemoryAccessFlags access) const {
   CMD cmd(*this, command_buffer);
   api::VulkanBuffer& staging = this->staging(cmd, stage, access);
   cmd.submit(fence(access));
@@ -1052,11 +878,11 @@ api::VulkanBuffer& vTensor::View::staging(
 api::VulkanBuffer& vTensor::View::staging(
     CMD& cmd,
     const Stage::Flags stage,
-    const Access::Flags access) const {
-  if ((access & Access::Read) && state_.is_dirty(Component::Staging)) {
+    const api::MemoryAccessFlags access) const {
+  if ((access & api::MemoryAccessType::READ) && state_.is_dirty(Component::Staging)) {
     cmd.copy_buffer_to_staging(
         state_,
-        buffer(cmd, Stage::Transfer, Access::Read),
+        buffer(cmd, Stage::Transfer, api::MemoryAccessType::READ),
         staging());
   }
 
@@ -1073,7 +899,7 @@ api::VulkanBuffer& vTensor::View::staging(
           {},
         }));
 
-  if (access & Access::Write) {
+  if (access & api::MemoryAccessType::WRITE) {
     state_.set_dirty(Component::All);
   }
 
@@ -1082,8 +908,9 @@ api::VulkanBuffer& vTensor::View::staging(
   return staging();
 }
 
-api::VulkanFence& vTensor::View::fence(const Access::Flags access) const {
-  if (!fence_ && access & Access::Read) {
+api::VulkanFence& vTensor::View::fence(
+    const api::MemoryAccessFlags access) const {
+  if (!fence_ && access & api::MemoryAccessType::READ) {
     fence_ = context_->fences().get_fence();
   }
 

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -77,22 +77,12 @@ class vTensor final {
       api::Context* context,
       IntArrayRef sizes,
       const TensorOptions& options);
-  vTensor(
-      api::Context* context,
-      api::Resource::Pool* pool,
-      IntArrayRef sizes,
-      const TensorOptions& options);
 
   /*
     Types
   */
 
   typedef api::PipelineStage Stage;
-  typedef api::Resource::Memory::Access Access;
-  typedef api::Resource::Buffer Buffer;
-  typedef api::Resource::Fence Fence;
-  typedef api::Resource::Image Image;
-  typedef api::Resource::Memory Memory;
 
   /*
     Host access
@@ -103,7 +93,8 @@ class vTensor final {
     view_->wait_for_fence();
   }
 
-  api::VulkanBuffer& host_buffer(api::Command::Buffer&, const Access::Flags) &;
+  api::VulkanBuffer& host_buffer(
+      api::Command::Buffer&, const api::MemoryAccessFlags) &;
 
   /*
     Device access - these functions will be expensive if they trigger a buffer
@@ -122,11 +113,14 @@ class vTensor final {
   */
 
   api::VulkanBuffer::Package buffer(api::Command::Buffer&, Stage::Flags) const &;
-  api::VulkanBuffer::Package buffer(api::Command::Buffer&, Stage::Flags, Access::Flags) &;
+  api::VulkanBuffer::Package buffer(
+      api::Command::Buffer&, Stage::Flags, api::MemoryAccessFlags) &;
 
   bool has_image() const;
+
   api::VulkanImage::Package image(api::Command::Buffer&, Stage::Flags) const &;
-  api::VulkanImage::Package image(api::Command::Buffer&, Stage::Flags, Access::Flags) &;
+  api::VulkanImage::Package image(
+      api::Command::Buffer&, Stage::Flags, api::MemoryAccessFlags) &;
 
   /*
     Metadata
@@ -143,11 +137,15 @@ class vTensor final {
     Device
   */
 
-  Buffer::Object buffer(api::Command::Buffer&, Stage::Flags) const && = delete;
-  Buffer::Object buffer(api::Command::Buffer&, Stage::Flags, Access::Flags) && = delete;
+  api::VulkanBuffer::Package buffer(
+      api::Command::Buffer&, Stage::Flags) const && = delete;
+  api::VulkanBuffer::Package buffer(
+      api::Command::Buffer&, Stage::Flags, api::MemoryAccessFlags) && = delete;
 
-  Image::Object image(api::Command::Buffer&, Stage::Flags) const && = delete;
-  Image::Object image(api::Command::Buffer&, Stage::Flags, Access::Flags) && = delete;
+  api::VulkanImage::Package image(
+      api::Command::Buffer&, Stage::Flags) const && = delete;
+  api::VulkanImage::Package image(
+      api::Command::Buffer&, Stage::Flags, api::MemoryAccessFlags) && = delete;
 
  private:
   class View final {
@@ -155,7 +153,6 @@ class vTensor final {
     View();
     View(
         api::Context* context,
-        api::Resource::Pool* pool,
         IntArrayRef sizes,
         const TensorOptions& options);
     View(const View&) = delete;
@@ -170,20 +167,23 @@ class vTensor final {
       Buffer
     */
 
-    api::VulkanBuffer& buffer(api::Command::Buffer&, Stage::Flags, Access::Flags) const;
+    api::VulkanBuffer& buffer(
+        api::Command::Buffer&, Stage::Flags, api::MemoryAccessFlags) const;
 
     /*
       Image
     */
 
     bool has_image() const;
-    api::VulkanImage& image(api::Command::Buffer&, Stage::Flags, Access::Flags) const;
+    api::VulkanImage& image(
+        api::Command::Buffer&, Stage::Flags, api::MemoryAccessFlags) const;
 
     /*
       Host
     */
 
-    api::VulkanBuffer& staging(api::Command::Buffer&, Stage::Flags, Access::Flags) const;
+    api::VulkanBuffer& staging(
+        api::Command::Buffer&, Stage::Flags, api::MemoryAccessFlags) const;
 
     void wait_for_fence() const;
 
@@ -263,12 +263,12 @@ class vTensor final {
    private:
     // Accessors / Lazy Allocation
     api::VulkanBuffer& buffer() const;
-    api::VulkanBuffer& buffer(CMD&, Stage::Flags, Access::Flags) const;
+    api::VulkanBuffer& buffer(CMD&, Stage::Flags, api::MemoryAccessFlags) const;
     api::VulkanImage& image() const;
-    api::VulkanImage& image(CMD&, Stage::Flags, Access::Flags) const;
+    api::VulkanImage& image(CMD&, Stage::Flags, api::MemoryAccessFlags) const;
     api::VulkanBuffer& staging() const;
-    api::VulkanBuffer& staging(CMD&, Stage::Flags, Access::Flags) const;
-    api::VulkanFence& fence(Access::Flags) const;
+    api::VulkanBuffer& staging(CMD&, Stage::Flags, api::MemoryAccessFlags) const;
+    api::VulkanFence& fence(api::MemoryAccessFlags) const;
 
     // Validation
     void verify() const;

--- a/aten/src/ATen/native/vulkan/ops/TransposeConvolution2d.cpp
+++ b/aten/src/ATen/native/vulkan/ops/TransposeConvolution2d.cpp
@@ -48,7 +48,7 @@ vTensor pack_weights_2d_reverse(
   };
 
   api::MemoryMap mapping(
-      v_weight.host_buffer(command_buffer, vTensor::Access::Write),
+      v_weight.host_buffer(command_buffer, api::MemoryAccessType::WRITE),
       api::MemoryAccessType::WRITE);
 
   float* dst_weight_ptr = mapping.template data<float>();
@@ -123,7 +123,7 @@ vTensor pack_biases(
   };
 
   api::MemoryMap mapping(
-      v_bias.host_buffer(command_buffer, vTensor::Access::Write),
+      v_bias.host_buffer(command_buffer, api::MemoryAccessType::WRITE),
       api::MemoryAccessType::WRITE);
 
   float* dst_bias_ptr = mapping.template data<float>();
@@ -409,7 +409,7 @@ void conv2d_transpose_sliding_window(
         v_output.image(
             command_buffer,
             vTensor::Stage::Compute,
-            vTensor::Access::Write),
+            api::MemoryAccessType::WRITE),
         // Read-only access is implied on const tensors and triggers an async
         // synchronization if necessary.
         v_input.image(

--- a/aten/src/ATen/native/vulkan/ops/Upsample.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Upsample.cpp
@@ -84,7 +84,7 @@ Tensor upsample_nearest2d(
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Write),
+              api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_input.image(

--- a/aten/src/ATen/native/vulkan/ops/cumsum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/cumsum.cpp
@@ -71,7 +71,7 @@ Tensor cumsum(
           v_output.image(
               command_buffer,
               vTensor::Stage::Compute,
-              vTensor::Access::Write),
+              api::MemoryAccessType::WRITE),
           // Read-only access is implied on const tensors and triggers an async
           // synchronization if necessary.
           v_input.image(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Part of a refactor of the Vulkan codebase.

Differential Revision: [D36863347](https://our.internmc.facebook.com/intern/diff/D36863347/)