### PR TITLE
[FSDP] Fix `full_optim_state_dict()` hang

### DIFF
--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -155,6 +155,7 @@ def _communicate_optim_state(
                 buffer_size = flat_param._full_param_padded.size()  # type: ignore[attr-defined]
                 tensor_buffer = value.new_zeros(*buffer_size)
             dist._all_gather_base(tensor_buffer, value, group=group)
+            torch.cuda.synchronize()
             if to_save:
                 assert hasattr(flat_param, "_orig_size"), \
                     "Sharded flattened parameter should have `_orig_size` set"


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/80581.

Context:
https://github.com/pytorch/pytorch/blob/1f08c1d3d61d1baa43f7862c3c4489487c8635d3/torch/distributed/fsdp/_optim_utils.py#L152-L163

To-Do:
I do not understand why inserting this `torch.cuda.synchronize()` prevents the `.cpu()` call from hanging and why in particular, this `torch.cuda.synchronize()` must be called on **all ranks**. If it is only called on the saving ranks (i.e. rank 0), then the hang persists.