### PR TITLE
automate hash updates - remove vision hash update

### DIFF
--- a/.github/workflows/update-commit-hashes.yml
+++ b/.github/workflows/update-commit-hashes.yml
@@ -26,12 +26,3 @@ jobs:
     secrets:
       MERGEBOT_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
       PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
-
-  update-vision-commit-hash:
-    uses: ./.github/workflows/_update-commit-hash.yml
-    with:
-      repo-name: vision
-      branch: main
-    secrets:
-      MERGEBOT_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
-      PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/update-commit-hashes.yml
+++ b/.github/workflows/update-commit-hashes.yml
@@ -26,3 +26,13 @@ jobs:
     secrets:
       MERGEBOT_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
       PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+
+  # keeps failing, issue at https://github.com/pytorch/pytorch/issues/80745
+  # update-vision-commit-hash:
+  #   uses: ./.github/workflows/_update-commit-hash.yml
+  #   with:
+  #     repo-name: vision
+  #     branch: main
+  #   secrets:
+  #     MERGEBOT_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+  #     PYTORCHBOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}


### PR DESCRIPTION
vision hash update hasnt been updated since a long time and keeps failing when we try to do it now, so i want to remove the hash update until it gets fixed

issue at #80745