### PR TITLE
Do not use `thrust::lower_bound` on device

### DIFF
--- a/c10/cuda/CUDAAlgorithm.h
+++ b/c10/cuda/CUDAAlgorithm.h
@@ -1,0 +1,33 @@
+#ifdef THRUST_DEVICE_LOWER_BOUND_WORKS
+#include <thrust/binary_search.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+#endif
+namespace c10 {
+namespace cuda {
+#ifdef THRUST_DEVICE_LOWER_BOUND_WORKS
+template <typename Iter, typename Scalar>
+__forceinline__ __device__ Iter
+lower_bound(Iter start, Iter end, Scalar value) {
+  return thrust::lower_bound(thrust::device, start, end, value);
+}
+#else
+// thrust::lower_bound is broken on device, see
+// https://github.com/NVIDIA/thrust/issues/1734 Implementation inspired by
+// https://github.com/pytorch/pytorch/blob/805120ab572efef66425c9f595d9c6c464383336/aten/src/ATen/native/cuda/Bucketization.cu#L28
+template <typename Iter, typename Scalar>
+__device__ Iter lower_bound(Iter start, Iter end, Scalar value) {
+  while (start < end) {
+    auto mid = start + ((end - start) >> 1);
+    if (*mid < value) {
+      start = mid + 1;
+    } else {
+      end = mid;
+    }
+  }
+  return end;
+}
+#endif // THRUST_DEVICE_LOWER_BOUND_WORKS
+} // namespace cuda
+} // namespace c10

--- a/caffe2/operators/piecewise_linear_transform_op.cu
+++ b/caffe2/operators/piecewise_linear_transform_op.cu
@@ -1,14 +1,11 @@
 #include "caffe2/core/context_gpu.h"
 #include "caffe2/operators/piecewise_linear_transform_op.h"
-
-#include <thrust/binary_search.h>
-#include <thrust/device_vector.h>
-#include <thrust/execution_policy.h>
-#include <thrust/functional.h>
+#include <c10/cuda/CUDAAlgorithm.h>
 
 namespace caffe2 {
 
 namespace {
+
 __global__ void PieceWiseLinearTransformGeneralKernel(
     const int N,
     const int M,
@@ -30,8 +27,7 @@ __global__ void PieceWiseLinearTransformGeneralKernel(
       Y[i] = slopes_group[num_fnc_per_grp - 1] * bounds_group[num_fnc_per_grp] +
           intercepts_group[num_fnc_per_grp - 1];
     } else {
-      auto low_bound = thrust::lower_bound(
-          thrust::device,
+      auto low_bound = c10::cuda::lower_bound(
           bounds_group,
           bounds_group + num_fnc_per_grp + 1,
           X[i]);
@@ -59,8 +55,8 @@ __global__ void PieceWiseLinearTransformBinaryKernel1(
       Y[i] = slopes[num_fnc_per_grp - 1] * bounds[num_fnc_per_grp] +
           intercepts[num_fnc_per_grp - 1];
     } else {
-      auto low_bound = thrust::lower_bound(
-          thrust::device, bounds, bounds + num_fnc_per_grp + 1, X[i]);
+      auto low_bound = c10::cuda::lower_bound(
+          bounds, bounds + num_fnc_per_grp + 1, X[i]);
       int bounds_idx = low_bound - bounds - 1;
       Y[i] = slopes[bounds_idx] * X[i] + intercepts[bounds_idx];
     }
@@ -87,8 +83,8 @@ __global__ void PieceWiseLinearTransformBinaryKernel2(
       Y[index + 1] = slopes[num_fnc_per_grp - 1] * bounds[num_fnc_per_grp] +
           intercepts[num_fnc_per_grp - 1];
     } else {
-      auto low_bound = thrust::lower_bound(
-          thrust::device, bounds, bounds + num_fnc_per_grp + 1, X[index + 1]);
+      auto low_bound = c10::cuda::lower_bound(
+          bounds, bounds + num_fnc_per_grp + 1, X[index + 1]);
       int bounds_idx = low_bound - bounds - 1;
       Y[index + 1] = slopes[bounds_idx] * X[index + 1] + intercepts[bounds_idx];
     }

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -8188,6 +8188,7 @@ CAFFE2_SPECIFIC_MAPPINGS = collections.OrderedDict(
 C10_MAPPINGS = collections.OrderedDict(
     [
         ("cuda::compat::", ("hip::compat::", API_C10)),
+        ("c10/cuda/CUDAAlgorithm.h", ("c10/hip/HIPAlgorithm.h", API_C10)),
         ("c10/cuda/CUDAException.h", ("c10/hip/HIPException.h", API_C10)),
         ("c10/cuda/CUDAMacros.h", ("c10/hip/HIPMacros.h", API_C10)),
         ("c10/cuda/CUDAMathCompat.h", ("c10/hip/HIPMathCompat.h", API_C10)),


### PR DESCRIPTION
Summary: As it is broken, see https://github.com/NVIDIA/cccl/issues/814
Implementation of `c10::cuda::lower_bound` inspired by the one found in `aten/src/ATen/native/cuda/Bucketization.cu`

Test Plan: CI

Reviewed By: ngimel

Differential Revision: D37558845

