### PR TITLE
[torchgen] Extract out schema registration logic into a function

### DIFF
--- a/tools/test/test_codegen.py
+++ b/tools/test/test_codegen.py
@@ -4,6 +4,8 @@ import unittest
 
 from tools.autograd import gen_autograd_functions
 from tools.autograd import load_derivatives
+from torchgen.gen import get_native_function_schema_registrations
+from torchgen.selective_build.selector import SelectiveBuilder
 import torchgen.model
 
 
@@ -128,6 +130,72 @@ class TestGenAutogradFunctions(unittest.TestCase):
         # (y) is not differentiable.
         assert "grad_z = grads[2]" not in definition
         assert "grad_z = grads[1]" in definition
+
+
+class TestGenSchemaRegistration(unittest.TestCase):
+    def setUp(self) -> None:
+        self.selector = SelectiveBuilder.get_nop_selector()
+        self.custom_native_function, _ = torchgen.model.NativeFunction.from_yaml(
+            {"func": "custom::func() -> bool"},
+            loc=torchgen.model.Location(__file__, 1),
+            valid_tags=set(),
+        )
+
+    def test_default_namespace_schema_registration_code_valid(self) -> None:
+        native_functions = [DEFAULT_NATIVE_FUNCTION]
+        registrations, _ = get_native_function_schema_registrations(
+            native_functions=native_functions,
+            schema_selector=self.selector,
+        )
+        self.assertEqual(registrations, ['m.def("func() -> bool", {});\n'])
+
+    def test_custom_namespace_schema_registration_code_valid(self) -> None:
+        _, registrations = get_native_function_schema_registrations(
+            native_functions=[self.custom_native_function],
+            schema_selector=self.selector,
+        )
+        self.assertEqual(
+            registrations,
+            """
+TORCH_LIBRARY(custom, m) {
+  m.def("func() -> bool", {});
+
+};""",
+        )
+
+    def test_mixed_namespace_schema_registration_code_valid(self) -> None:
+        (
+            aten_registrations,
+            custom_registrations,
+        ) = get_native_function_schema_registrations(
+            native_functions=[DEFAULT_NATIVE_FUNCTION, self.custom_native_function],
+            schema_selector=self.selector,
+        )
+        self.assertEqual(aten_registrations, ['m.def("func() -> bool", {});\n'])
+        self.assertEqual(
+            custom_registrations,
+            """
+TORCH_LIBRARY(custom, m) {
+  m.def("func() -> bool", {});
+
+};""",
+        )
+
+    def test_3_namespaces_schema_registration_code_invalid(self) -> None:
+        custom2_native_function, _ = torchgen.model.NativeFunction.from_yaml(
+            {"func": "custom2::func() -> bool"},
+            loc=torchgen.model.Location(__file__, 1),
+            valid_tags=set(),
+        )
+        with self.assertRaises(AssertionError):
+            get_native_function_schema_registrations(
+                native_functions=[
+                    DEFAULT_NATIVE_FUNCTION,
+                    self.custom_native_function,
+                    custom2_native_function,
+                ],
+                schema_selector=self.selector,
+            )
 
 
 # Represents the most basic NativeFunction. Use dataclasses.replace()

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -1392,6 +1392,41 @@ def get_native_function_declarations(
     return declarations
 
 
+# Return native function schema registration code for aten and other namespaces.
+def get_native_function_schema_registrations(
+    *,
+    native_functions: Sequence[NativeFunction],
+    schema_selector: SelectiveBuilder,
+) -> Tuple[List[str], str]:
+    ns_native_functions: Dict[str, List[NativeFunction]] = defaultdict(list)
+    for native_function in native_functions:
+        ns_native_functions[native_function.namespace].append(native_function)
+    schema_registrations = ""
+    aten_schema_registrations = []
+    custom_namespace = None
+    for namespace, funcs in ns_native_functions.items():
+
+        schema_registrations_body = list(
+            mapMaybe(RegisterSchema(schema_selector), funcs)
+        )
+        # NB: we have to separate aten namespace registration from other namespaces,
+        # because in the template we hardcoded an operator for ATen already.
+        if namespace == "aten":
+            aten_schema_registrations = schema_registrations_body
+        else:
+            assert custom_namespace is None or namespace == custom_namespace, (
+                "Only one custom namespace (other than 'aten') is currently supported, "
+                f" but getting {namespace} and {custom_namespace}"
+            )
+            custom_namespace = namespace
+            tab = "\t"
+            schema_registrations += f"""
+TORCH_LIBRARY({custom_namespace}, m) {{
+  {tab.join(schema_registrations_body)}
+}};"""
+    return (aten_schema_registrations, schema_registrations)
+
+
 def gen_aggregated_headers(
     *,
     native_functions: Sequence[NativeFunction],
@@ -2090,32 +2125,12 @@ TORCH_LIBRARY_IMPL({namespace}, {dispatch_key}, m) {{
     if force_schema_registration:
         schema_selector = SelectiveBuilder.get_nop_selector()
 
-    ns_native_functions: Dict[str, List[NativeFunction]] = defaultdict(list)
-    for native_function in native_functions:
-        ns_native_functions[native_function.namespace].append(native_function)
-    schema_registrations = ""
-    aten_schema_registrations = []
-    custom_namespace = None
-    for namespace, funcs in ns_native_functions.items():
-
-        schema_registrations_body = list(
-            mapMaybe(RegisterSchema(schema_selector), funcs)
-        )
-        # NB: we have to separate aten namespace registration from other namespaces,
-        # because in the template we hardcoded an operator for ATen already.
-        if namespace == "aten":
-            aten_schema_registrations = schema_registrations_body
-        else:
-            assert custom_namespace is None or namespace == custom_namespace, (
-                "Only one custom namespace (other than 'aten') is currently supported, "
-                f" but getting {namespace} and {custom_namespace}"
-            )
-            custom_namespace = namespace
-            tab = "\t"
-            schema_registrations += f"""
-TORCH_LIBRARY({custom_namespace}, m) {{
-  {tab.join(schema_registrations_body)}
-}};"""
+    (
+        aten_schema_registrations,
+        schema_registrations,
+    ) = get_native_function_schema_registrations(
+        native_functions=native_functions, schema_selector=schema_selector
+    )
     cpu_fm.write(
         "RegisterSchema.cpp",
         lambda: {


### PR DESCRIPTION
Summary:
A followup to  #78015 and #79733. In those PRs I introduced custom namespace support into:
* `Register<DispatchKey>.cpp`
* `RegisterSchema.cpp`
* `NativeFunctions.h`

This PR extracts out logic that generates schema registration code (used in `RegisterSchema.cpp`) into a function so that it can be easily tested and reused. Added unit test to cover the logic as well.

Test Plan: Rely on newly added unit tests.

Differential Revision: D37581186

