### PR TITLE
Exclude Fake dispatch key during tensor construction

### DIFF
--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -336,9 +336,11 @@ Tensor internal_new_from_data(
         c10::DispatchKey::FuncTorchDynamicLayerFrontMode);
     c10::impl::ExcludeDispatchKeyGuard functorch_back_guard(
         c10::DispatchKey::FuncTorchDynamicLayerBackMode);
-    // We disable Fake and DeferredInit handlers for similar reasons as functorch.
+    // We disable Fake and DeferredInit handlers for similar reasons as
+    // functorch.
     c10::impl::ExcludeDispatchKeyGuard fake_and_deferred_init_guard(
-        c10::DispatchKeySet{c10::DispatchKey::Fake, c10::DispatchKey::DeferredInit});
+        c10::DispatchKeySet{
+            c10::DispatchKey::Fake, c10::DispatchKey::DeferredInit});
     // Note [Functionalization <> torch.Tensor constructor]
     // Functionalization "lifts" the newly constructed tensor into a wrapper
     // using aten::lift().

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -336,9 +336,9 @@ Tensor internal_new_from_data(
         c10::DispatchKey::FuncTorchDynamicLayerFrontMode);
     c10::impl::ExcludeDispatchKeyGuard functorch_back_guard(
         c10::DispatchKey::FuncTorchDynamicLayerBackMode);
-    // We disable DeferredInit handler for similar reasons as functorch.
-    c10::impl::ExcludeDispatchKeyGuard deferred_init_guard(
-        c10::DispatchKey::DeferredInit);
+    // We disable Fake and DeferredInit handlers for similar reasons as functorch.
+    c10::impl::ExcludeDispatchKeyGuard fake_and_deferred_init_guard(
+        c10::DispatchKeySet{c10::DispatchKey::Fake, c10::DispatchKey::DeferredInit});
     // Note [Functionalization <> torch.Tensor constructor]
     // Functionalization "lifts" the newly constructed tensor into a wrapper
     // using aten::lift().


### PR DESCRIPTION
This PR excludes Fake dispatch key during tensor construction in order to have consistent behavior with the DeferredInit key in torchdistX.