### PR TITLE
Improve readability of cuda_lazy_init

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -42,7 +42,7 @@ static bool in_bad_fork = false; // True for children forked after cuda init
 // Called in the forked child if cuda has already been initialized
 static void forked_child() {
   in_bad_fork = true;
-  torch::utils::set_run_yet_variable_to_false();
+  torch::utils::set_requires_cuda_init(false);
 }
 #endif
 

--- a/torch/csrc/utils/cuda_lazy_init.cpp
+++ b/torch/csrc/utils/cuda_lazy_init.cpp
@@ -1,14 +1,16 @@
 #include <torch/csrc/utils/cuda_lazy_init.h>
 
-#include <torch/csrc/python_headers.h>
-#include <mutex>
-
 #include <torch/csrc/Exceptions.h>
+#include <torch/csrc/python_headers.h>
 #include <torch/csrc/utils/object_ptr.h>
+
 namespace torch {
 namespace utils {
+namespace {
 
-static bool run_yet = false;
+bool is_initialized = false;
+
+}
 
 void cuda_lazy_init() {
   pybind11::gil_scoped_acquire g;
@@ -16,20 +18,25 @@ void cuda_lazy_init() {
   // has a buggy implementation that deadlocks if an instance throws an
   // exception.  In any case, call_once isn't necessary, because we
   // have taken a lock.
-  if (!run_yet) {
-    auto module = THPObjectPtr(PyImport_ImportModule("torch.cuda"));
-    if (!module)
-      throw python_error();
-    auto res =
-        THPObjectPtr(PyObject_CallMethod(module.get(), "_lazy_init", ""));
-    if (!res)
-      throw python_error();
-    run_yet = true;
+  if (is_initialized) {
+    return;
   }
+
+  auto module = THPObjectPtr(PyImport_ImportModule("torch.cuda"));
+  if (!module) {
+    throw python_error();
+  }
+
+  auto res = THPObjectPtr(PyObject_CallMethod(module.get(), "_lazy_init", ""));
+  if (!res) {
+    throw python_error();
+  }
+
+  is_initialized = true;
 }
 
-void set_run_yet_variable_to_false() {
-  run_yet = false;
+void set_requires_cuda_init(bool value) {
+  is_initialized = value;
 }
 
 } // namespace utils

--- a/torch/csrc/utils/cuda_lazy_init.h
+++ b/torch/csrc/utils/cuda_lazy_init.h
@@ -21,7 +21,7 @@ namespace utils {
 // build, which is not good UX.
 //
 void cuda_lazy_init();
-void set_run_yet_variable_to_false();
+void set_requires_cuda_init(bool value);
 
 static void maybe_initialize_cuda(const at::TensorOptions& options) {
   if (options.device().is_cuda()) {


### PR DESCRIPTION
This PR cleans up the implementation of `cuda_lazy_init.cpp` and improves its readability. No behavioral changes are introduced.
