### PR TITLE
Add deepcopy functionality to parametrized modules

### DIFF
--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -289,7 +289,8 @@ def _inject_new_class(module: Module) -> None:
     def default_deepcopy(self, memo=None):
         # Just emulate a standard deepcopy procedure when __deepcopy__ doesn't exist in the current class.
         memo = {} if memo is None else memo
-        memo[id(self)] = replica = self.__new__(self.__class__)
+        replica = self.__new__(self.__class__)
+        memo[id(self)] = replica
         for key, value in self.__dict__.items():
             replica.__dict__[key] = deepcopy(value, memo)
         return replica

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -289,18 +289,18 @@ def _inject_new_class(module: Module) -> None:
 
     def default_deepcopy(self, memo):
         # Just emulate a standard deepcopy procedure when __deepcopy__ doesn't exist in the current class.
-        if id(self) in memo:
-            return memo[id(self)]
-        else:
-            replica = self.__new__(self.__class__)
-            memo[id(self)] = replica
-            replica.__dict__ = deepcopy(self.__dict__, memo)
-            # Also save all slots if they exist.
-            slots_to_save = copyreg._slotnames(self.__class__)  # type: ignore[attr-defined]
-            for slot in slots_to_save:
-                if hasattr(self, slot):
-                    setattr(replica, slot, deepcopy(getattr(self, slot), memo))
-            return replica
+        obj = memo.get(id(self), None)
+        if obj is not None:
+            return obj
+        replica = self.__new__(self.__class__)
+        memo[id(self)] = replica
+        replica.__dict__ = deepcopy(self.__dict__, memo)
+        # Also save all slots if they exist.
+        slots_to_save = copyreg._slotnames(self.__class__)  # type: ignore[attr-defined]
+        for slot in slots_to_save:
+            if hasattr(self, slot):
+                setattr(replica, slot, deepcopy(getattr(self, slot), memo))
+        return replica
 
     def getstate(self):
         raise RuntimeError(


### PR DESCRIPTION
Fixes #69413

After applying parametrization to any `nn.Module` we lose the ability to create a deepcopy of it e.g. it makes it impossible to wrap a module by an `AveragedModel`.
Specifically, the problem is that the `deepcopy` tries to invoke `__getstate__` if object hasn't implemented its own `__deepcopy__` magic method. But we don't allow serialization of the parametrized modules: `__getstate__` raises an error. 
My solution is just to create a default `__deepcopy__` method when it doesn't exist yet.
