### PR TITLE
[caffe2/perfkernels] Avoid `native.host_info()` in build files

### DIFF
--- a/tools/perf_kernel_defs.bzl
+++ b/tools/perf_kernel_defs.bzl
@@ -3,7 +3,14 @@ load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 is_dbg_build = native.read_config("fbcode", "build_mode", "").find("dbg") != -1
 is_sanitizer = native.read_config("fbcode", "sanitizer", "") != ""
 
-def define_perf_kernels(prefix, levels_and_flags, compiler_common_flags, dependencies, external_deps):
+def define_perf_kernels(
+        prefix,
+        levels_and_flags,
+        compiler_common_flags = [],
+        arch_compiler_common_flags = {},
+        dependencies = [],
+        arch_dependencies = [],
+        external_deps = []):
     vectorize_flags = ([
         # "-Rpass=loop-vectorize", # Add vectorization information to output
         "-DENABLE_VECTORIZATION=1",
@@ -30,25 +37,30 @@ def define_perf_kernels(prefix, levels_and_flags, compiler_common_flags, depende
         ["**/*.h"],
     )
 
-    kernel_targets = []
-    for level, flags in levels_and_flags:
-        cpp_library(
-            name = prefix + "perfkernels_" + level,
-            srcs = native.glob(["**/*_" + level + ".cc"]),
-            headers = cpp_headers,
-            compiler_flags = compiler_common_flags + flags,
-            compiler_specific_flags = compiler_specific_flags,
-            exported_deps = dependencies,
-            exported_external_deps = external_deps,
-        )
-        kernel_targets.append(":" + prefix + "perfkernels_" + level)
+    kernel_targets = {}
+    for arch, levels_and_flags in levels_and_flags.items():
+        for level, flags in levels_and_flags:
+            cpp_library(
+                name = prefix + "perfkernels_" + level,
+                srcs = native.glob(["**/*_" + level + ".cc"]),
+                headers = cpp_headers,
+                compiler_flags = compiler_common_flags + flags,
+                arch_compiler_flags = arch_compiler_common_flags,
+                compiler_specific_flags = compiler_specific_flags,
+                exported_deps = dependencies,
+                exported_arch_deps = arch_dependencies,
+                exported_external_deps = external_deps,
+            )
+            kernel_targets.setdefault(arch, []).append(":" + prefix + "perfkernels_" + level)
 
     cpp_library(
         name = prefix + "perfkernels",
         srcs = common_srcs,
         headers = cpp_headers,
         compiler_flags = compiler_common_flags,
+        arch_compiler_flags = arch_compiler_common_flags,
         compiler_specific_flags = compiler_specific_flags,
         link_whole = True,
-        exported_deps = kernel_targets + dependencies,
+        exported_arch_deps = kernel_targets.items() + arch_dependencies,
+        exported_deps = dependencies,
     )

--- a/tools/sgx_caffe2_target_definitions.bzl
+++ b/tools/sgx_caffe2_target_definitions.bzl
@@ -225,24 +225,26 @@ def add_sgx_perf_kernel_libs():
 
     # these are esentially disabled for hte sgx build but we still need them
     # to avoid linking issues
-    levels_and_flags = ([
-        (
-            "avx2",
-            [
-                "-mavx2",
-                "-mfma",
-                "-mavx",
-                "-mf16c",
-            ],
-        ),
-        (
-            "avx",
-            [
-                "-mavx",
-                "-mf16c",
-            ],
-        ),
-    ])
+    levels_and_flags = {
+        "x86_64": [
+            (
+                "avx2",
+                [
+                    "-mavx2",
+                    "-mfma",
+                    "-mavx",
+                    "-mf16c",
+                ],
+            ),
+            (
+                "avx",
+                [
+                    "-mavx",
+                    "-mf16c",
+                ],
+            ),
+        ],
+    }
 
     define_perf_kernels(
         prefix = "sgx_",


### PR DESCRIPTION
Summary:
This refactors to avoid `native.host_info()` in build files.

Test Plan: CI

Reviewed By: psaab

Differential Revision: D37588036

topic: not user facing

