### PR TITLE
[caffe2] Use `arch_deps` instead of host info for arch-specific deps

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -1,19 +1,20 @@
-def get_sleef_deps():
-    return [("sleef", None, "sleef")] if not (host_info().arch.is_aarch64) else []
+def get_sleef_arch_deps():
+    return [
+        ("x86_64", [
+            "third-party//sleef:sleef",
+        ]),
+    ]
 
-def get_blas_gomp_deps():
-    if host_info().arch.is_x86_64:
-        return [(
-            "IntelComposerXE",
-            None,
-            native.read_config("fbcode", "mkl_lp64", "mkl_lp64_omp"),
-        )]
-    if host_info().arch.is_aarch64:
-        return [
-            ("OpenBLAS", None, "OpenBLAS"),
-            ("openmp", None, "omp"),
-        ]
-    fail("Unsupported architecture")
+def get_blas_gomp_arch_deps():
+    return [
+        ("x86_64", [
+            "third-party//IntelComposerXE:{}".format(native.read_config("fbcode", "mkl_lp64", "mkl_lp64_omp")),
+        ]),
+        ("aarch64", [
+            "third-party//OpenBLAS:OpenBLAS",
+            "third-party//openmp:omp",
+        ]),
+    ]
 
 default_compiler_flags = [
     "-Wall",

--- a/tools/perf_kernel_defs.bzl
+++ b/tools/perf_kernel_defs.bzl
@@ -3,7 +3,14 @@ load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 is_dbg_build = native.read_config("fbcode", "build_mode", "").find("dbg") != -1
 is_sanitizer = native.read_config("fbcode", "sanitizer", "") != ""
 
-def define_perf_kernels(prefix, levels_and_flags, compiler_common_flags, dependencies, external_deps):
+def define_perf_kernels(
+        prefix,
+        levels_and_flags,
+        compiler_common_flags = [],
+        arch_compiler_common_flags = {},
+        dependencies = [],
+        arch_dependencies = [],
+        external_deps = []):
     vectorize_flags = ([
         # "-Rpass=loop-vectorize", # Add vectorization information to output
         "-DENABLE_VECTORIZATION=1",
@@ -30,25 +37,30 @@ def define_perf_kernels(prefix, levels_and_flags, compiler_common_flags, depende
         ["**/*.h"],
     )
 
-    kernel_targets = []
-    for level, flags in levels_and_flags:
-        cpp_library(
-            name = prefix + "perfkernels_" + level,
-            srcs = native.glob(["**/*_" + level + ".cc"]),
-            headers = cpp_headers,
-            compiler_flags = compiler_common_flags + flags,
-            compiler_specific_flags = compiler_specific_flags,
-            exported_deps = dependencies,
-            exported_external_deps = external_deps,
-        )
-        kernel_targets.append(":" + prefix + "perfkernels_" + level)
+    kernel_targets = {}
+    for arch, levels_and_flags in levels_and_flags.items():
+        for level, flags in levels_and_flags:
+            cpp_library(
+                name = prefix + "perfkernels_" + level,
+                srcs = native.glob(["**/*_" + level + ".cc"]),
+                headers = cpp_headers,
+                compiler_flags = compiler_common_flags + flags,
+                arch_compiler_flags = arch_compiler_common_flags,
+                compiler_specific_flags = compiler_specific_flags,
+                exported_deps = dependencies,
+                exported_arch_deps = arch_dependencies,
+                exported_external_deps = external_deps,
+            )
+            kernel_targets.setdefault(arch, []).append(":" + prefix + "perfkernels_" + level)
 
     cpp_library(
         name = prefix + "perfkernels",
         srcs = common_srcs,
         headers = cpp_headers,
         compiler_flags = compiler_common_flags,
+        arch_compiler_flags = arch_compiler_common_flags,
         compiler_specific_flags = compiler_specific_flags,
         link_whole = True,
-        exported_deps = kernel_targets + dependencies,
+        exported_arch_deps = kernel_targets.items() + arch_dependencies,
+        exported_deps = dependencies,
     )

--- a/tools/sgx_caffe2_target_definitions.bzl
+++ b/tools/sgx_caffe2_target_definitions.bzl
@@ -225,24 +225,26 @@ def add_sgx_perf_kernel_libs():
 
     # these are esentially disabled for hte sgx build but we still need them
     # to avoid linking issues
-    levels_and_flags = ([
-        (
-            "avx2",
-            [
-                "-mavx2",
-                "-mfma",
-                "-mavx",
-                "-mf16c",
-            ],
-        ),
-        (
-            "avx",
-            [
-                "-mavx",
-                "-mf16c",
-            ],
-        ),
-    ])
+    levels_and_flags = {
+        "x86_64": [
+            (
+                "avx2",
+                [
+                    "-mavx2",
+                    "-mfma",
+                    "-mavx",
+                    "-mf16c",
+                ],
+            ),
+            (
+                "avx",
+                [
+                    "-mavx",
+                    "-mf16c",
+                ],
+            ),
+        ],
+    }
 
     define_perf_kernels(
         prefix = "sgx_",


### PR DESCRIPTION
Test Plan: CI

Reviewed By: psaab

Differential Revision: D37588154

topic: not user facing
