### PR TITLE
[FX] Fix typo in user stack walk

### DIFF
--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -95,7 +95,7 @@ class TracerBase:
         # the user code during tracing.
         frame = inspect.currentframe()
 
-        fx_files = ['torch/fx/proxy.py', 'torch/fx/symbolic_trace.py']
+        fx_files = ['torch/fx/proxy.py', 'torch/fx/_symbolic_trace.py']
         while frame:
             frame = frame.f_back
             if frame and all(not frame.f_code.co_filename.endswith(file) for file in fx_files):


### PR DESCRIPTION
Summary: We used to have `torch/fx/symbolic_trace.py` and it was changed to `torch/fx/_symbolic_trace.py`. This part of the code was not updated.

Test Plan: ci

Differential Revision: D37595542

