### PR TITLE
Remove wrong explanation about split size in CUDACachingAllocator

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -45,9 +45,6 @@ namespace CUDACachingAllocator {
 //   smallest available free block or allocate a new block using cudaMalloc.
 // - To reduce fragmentation, requests between 1MB and 10MB will allocate and
 //   split a 20MB block, if no free block of sufficient size is available.
-// - To further reduce fragmentation, blocks >= 200MB are not allowed to be
-//   split. These oversize cached blocks will still satisfy requests within
-//   20MB of the oversize cached block size.
 //
 // With this allocator, allocations and frees should logically be considered
 // "usages" of the memory segment associated with streams, just like kernel

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -463,11 +463,11 @@ class CachingAllocatorConfig {
             double val2 = stod(kv[1]);
             TORCH_CHECK(
                 val2 > 0,
-                "garbage_collect_threshold too small, set it 0.0~1.0",
+                "garbage_collection_threshold too small, set it 0.0~1.0",
                 "");
             TORCH_CHECK(
                 val2 < 1.0,
-                "garbage_collect_threshold too big, set it 0.0~1.0",
+                "garbage_collection_threshold too big, set it 0.0~1.0",
                 "");
             m_garbage_collection_threshold = val2;
           } else {


### PR DESCRIPTION
As docs explain, the default value for `max_split_size_mb` in CUDACachingAllocator is unlimited, which means any block can be split.

https://github.com/pytorch/pytorch/blob/76cff182428fbd165b5725f3de29dbd91a1512fa/docs/source/notes/cuda.rst#L361-L365

The implementation of split policy actually allows splitting blocks with `size < CachingAllocatorConfig::max_split_size()`, which is by default true.
https://github.com/pytorch/pytorch/blob/76cff182428fbd165b5725f3de29dbd91a1512fa/c10/cuda/CUDACachingAllocator.cpp#L1163-L1171

https://github.com/pytorch/pytorch/blob/76cff182428fbd165b5725f3de29dbd91a1512fa/c10/cuda/CUDACachingAllocator.cpp#L414-L415