### PR TITLE
Enhance OneDNN PostOp Fusion for Conv2d

### DIFF
--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -171,6 +171,7 @@ class AliasDb {
   void enablePreciseTupleContainerAnalysis();
 
   friend struct MutationRemover;
+  friend class TensorExprFuser;
 
  private:
   // Helper for topologically-safe node moves.

--- a/torch/csrc/jit/passes/remove_mutation.h
+++ b/torch/csrc/jit/passes/remove_mutation.h
@@ -36,6 +36,7 @@ struct TORCH_API MutationRemover {
   static bool hasSideEffectOrAlias(Value* v, AliasDb* aliasDb);
 
  private:
+  friend class TensorExprFuser;
   Node* createSpecialMappedOp(Node* n);
   bool listMutationFollowingListConstruct(Node* n);
   bool tryMakeCreationAndMutationAtomic(

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -62,6 +62,9 @@ TORCH_API Value* broadcastSizes(at::ArrayRef<Value*> sizes, AliasDb* db);
 namespace tensorexpr {
 TORCH_API bool isSupported(Node* node);
 
+// Check whether node can be supported by onednn post-op fusion
+bool oneDNNPostopFusableWithInplaceNode(const Node* node);
+
 /// Get the modifiable custom operator set object.
 ///
 /// For static shapes, if a custom operator has been added to the custom

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -362,11 +362,13 @@ void mergeNodeIntoSubgraph(
     auto inputs = subgraphNode->inputs();
     for (size_t i = 0; i < toMerge->outputs().size(); ++i) {
       auto it = std::find(inputs.begin(), inputs.end(), toMerge->outputs()[i]);
-      if (it != inputs.end()) {
+      while (it != inputs.end()) {
         size_t p = it - inputs.begin();
         subgraphNode->removeInput(p);
         subgraph->inputs()[p]->replaceAllUsesWith(mergedNode->outputs()[i]);
         subgraph->eraseInput(p);
+        inputs = subgraphNode->inputs();
+        it = std::find(inputs.begin(), inputs.end(), toMerge->outputs()[i]);
       }
     }
   }


### PR DESCRIPTION
## Summary
This PR aims to support inplace op it TE partially. This can enable TE fusion for patterns like  "at::conv, at::relu_" with OneDNN post-op fusion.

## Options

### Option 1: Replace the in-place operator with the out-place operator
 - Pros: Easy to implement. Can re-use "RemoveTensorMutation" for replacement and the lowing function of outplace version. Will not have a performance penalty under "fusion" cases.
 - Cons: The fallback path is also outplaced version, which will have a performance penalty here. Sometimes we cannot safely replace the inplace op with its' outplace version.
 
### Option 2: Lower the body in terms of in-place directly
 - Pros: More straightforward. Can support more scenarios.
 - Cons: Hard to develop. More engineer effort.

We choose **option 1** in this PR, and we can consider option 2 if we observed that in many real-world scenarios, options1 failed.

## Implement Details
![image](https://user-images.githubusercontent.com/54701539/179939197-7c2a2e84-ddec-4b40-90ec-4e1cd2870b5b.png)

We will pull inplace ops into TE fusion groups if the ops satisfy 2 conditionals:
 - This inplace ops can be safely replaced with its outplace version at the global graph. (Re-use the ability of RemoveTensorMutation)
 - The outplace version is supported by TE.

To achieve this, we extend the behavior of **Operator supported check** and **TryMerge**.
### In **Operator supported check**. 
For example, [isSupported](https://github.com/pytorch/pytorch/blob/23bdb570cf05f0cefdacdda5cbf73f58a2e574f4/torch/csrc/jit/passes/tensorexpr_fuser.cpp#L89). If an inplace op can be safely replaced with its outplace version. We will create an outplace node and send this node to pass the TE checks. After the checks are done, destroy the outplace node.
 - We choose to make a outplace node to pass the TE checks because we do not want directly added inplace op into the supported op list. Te does not **directly** support these inplace ops.
 - We will destroy the outplace node after **Operator supported check** is done because **Operator supported check** is not all checks for TE fusion, there are many following checks later and we do not know whether all following check will pass at this stage.


### In **TryMerge**.
Here we can know all checks are passed, we will replace an inplace op with its outplace version before the moment we merge the node into fusion groups.

### Some details for safely replacement
Whether an inplace op can be replaced safely depends on the behavior of RemoveTensorMutions.
2 cases below will not be replaced.
```python
def fn(a, b):
    return a.relu_() + b.relu()
def fn(a, b):
    c = a + b
    return c.sigmoid().add(c.relu_())
```
Ops like \_\_and\_\_/\_\_or\_\_. Their inplace version are \_\_iand\_\_/\_\_ior\_\_. These ops cannot be replaced by RemoveTensorMutaion. So we do not support them yet.

## Unit test details
 - test_mkldnn_fusion.py

UT covered ops
```
relu, gelu, sigmoid, add, add+relu, tanh, hardswish, leaky_relu, hardtanh, clamp and their inplace version
```

Linear's post-op fusion and silu, elu, mish fusion for linear/conv depends on other PR. Will expand OneDNNPostopFusableWithGraph to support them after they are merged.



cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel