### PR TITLE
[MPS] Fix incorrect contiguous operation before copy  

### DIFF
--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -212,6 +212,9 @@ static Tensor & copy_impl(Tensor & self, const Tensor & src, bool non_blocking) 
     return at::metal::metal_copy_(self, src);
   }
 
+  if (self.device().type() == at::kMPS || src.device().type() == at::kMPS) {
+    return at::native::mps::mps_copy_(self, src, non_blocking);
+  }
 
   auto iter = TensorIteratorConfig()
     .add_output(self)
@@ -240,11 +243,6 @@ static Tensor & copy_impl(Tensor & self, const Tensor & src, bool non_blocking) 
     return self;
   }
 
-#ifdef USE_MPS
-  if (self.device().type() == at::kMPS || src.device().type() == at::kMPS) {
-    return at::native::mps::mps_copy_(self, src, non_blocking);
-  }
-#endif
 
   if(!self.is_complex() && src.is_complex()) {
     TORCH_WARN_ONCE("Casting complex values to real discards the imaginary part");

--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -212,9 +212,11 @@ static Tensor & copy_impl(Tensor & self, const Tensor & src, bool non_blocking) 
     return at::metal::metal_copy_(self, src);
   }
 
+#ifdef USE_MPS
   if (self.device().type() == at::kMPS || src.device().type() == at::kMPS) {
     return at::native::mps::mps_copy_(self, src, non_blocking);
   }
+#endif
 
   auto iter = TensorIteratorConfig()
     .add_output(self)

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -333,6 +333,9 @@ static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_,
 
   if (src_.is_view()) {
     src = src_.to(dst_.dtype()).expand_as(dst_);
+    if (dst_.is_contiguous()) {
+      src = src.contiguous();
+    }
   } else {
     src = src_;
     if (src.dtype() != dst_.dtype()) {

--- a/aten/src/ATen/native/mps/operations/Copy.mm
+++ b/aten/src/ATen/native/mps/operations/Copy.mm
@@ -332,7 +332,7 @@ static at::Tensor& copy_to_mps_(at::Tensor& dst_, const at::Tensor& src_,
 
 
   if (src_.is_view()) {
-    src = src_.to(dst_.dtype()).expand_as(dst_).contiguous();
+    src = src_.to(dst_.dtype()).expand_as(dst_);
   } else {
     src = src_;
     if (src.dtype() != dst_.dtype()) {

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1462,7 +1462,7 @@ class TestMPS(TestCase):
         self.assertEqual(x.stride(), x_mps.stride())
 
         # test non-view and non-contiguous tensor
-        src = torch.randn(6, dtype=torch.float).reshape(3, 2)
+        src = torch.randn((3, 2), dtype=torch.float)
         index = torch.tensor([[0, 0], [1, 1], [2, 2]])
         x = torch.empty_strided((3, 2), (1, 3), dtype=torch.float).scatter_(0, index, src)
         x_mps = x.to("mps")

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1452,6 +1452,24 @@ class TestMPS(TestCase):
             x_mps = x_cpu.to('mps')
             self.assertEqual(x_mps.to(torch.float32), x_cpu.to(torch.float32))
 
+    def test_to_non_contiguous_src(self):
+        # test view and non-contiguous tensor
+        x = torch.randn((3, 2), dtype=torch.float).permute((1, 0))
+        x_mps = x.to("mps")
+        self.assertEqual(x._is_view(), True)
+        self.assertEqual(x.is_contiguous(), False)
+        self.assertEqual(x, x_mps)
+        self.assertEqual(x.stride(), x_mps.stride())
+
+        # test non-view and non-contiguous tensor
+        src = torch.randn(6, dtype=torch.float).reshape(3, 2)
+        index = torch.tensor([[0, 0], [1, 1], [2, 2]])
+        x = torch.empty_strided((3, 2), (1, 3), dtype=torch.float).scatter_(0, index, src)
+        x_mps = x.to("mps")
+        self.assertEqual(x._is_view(), False)
+        self.assertEqual(x.is_contiguous(), False)
+        self.assertEqual(x, x_mps)
+        self.assertEqual(x.stride(), x_mps.stride())
 
     def test_setitem_scalar(self) -> None:
         device = 'mps'


### PR DESCRIPTION
Currently, a contiguous operation is performed before copying a tensor from `cpu` to `mps`, which would break the default preserve memory copy strategy.

Let's create a tensor with the following data with stride `(2, 1)`:
```python
[[0., 1.],
 [2., 3.],
 [4., 5.]]
```

Then, we derive a view from the above tensor so that the stride becomes `(1, 2)`:
```python
[[0., 2., 4.],
 [1., 3., 5.]])
```

And now if we incorrectly have the view layout contiguous before copying, and the stride `(1, 2)` is still applied after the copy, the resulting tensor will become the following, which is incorrect:

```python
[[0.0000, 4.0000, 3.0000],
 [2.0000, 1.0000, 5.0000]]
```

A repro can be found [here](https://github.com/pytorch/pytorch/issues/79383#issuecomment-1173474956).


Partially `resolve` #79383

@albanD @kulinseth Could you help add trunk label?