### PR TITLE
Change cudnn incompatibility message wording

### DIFF
--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -38,24 +38,22 @@ if _cudnn is not None:
                 cudnn_compatible = runtime_minor >= compile_minor
             if not cudnn_compatible:
                 base_error_msg = (f'cuDNN version incompatibility: '
-                        f'PyTorch was compiled  against {compile_version} '
-                        f'but found runtime version {runtime_version}. '
-                        f'PyTorch already comes bundled with cuDNN. '
-                        f'One option to resolving this error is to ensure PyTorch '
-                        f'can find the bundled cuDNN.')
+                                  f'PyTorch was compiled  against {compile_version} '
+                                  f'but found runtime version {runtime_version}. '
+                                  f'PyTorch already comes bundled with cuDNN. '
+                                  f'One option to resolving this error is to ensure PyTorch '
+                                  f'can find the bundled cuDNN.')
 
                 if 'LD_LIBRARY_PATH' in os.environ:
                     ld_library_path = os.environ.get('LD_LIBRARY_PATH')
-                    if any(substring in ld_library_path for substring in ['cuda', 'cudnn']):
-                        raise RuntimeError(
-                            f'{base_error_msg}'
-                            f'Looks like your LD_LIBRARY_PATH contains incompatible version of cudnn'
-                            f'Please either remove it from the path or install cudnn {compile_version}')
+                    if 'cuda' in ld_library_path or 'cudnn' in ld_library_path:
+                        raise RuntimeError(f'{base_error_msg}'
+                                           f'Looks like your LD_LIBRARY_PATH contains incompatible version of cudnn'
+                                           f'Please either remove it from the path or install cudnn {compile_version}')
                     else:
-                        raise RuntimeError(
-                            f'{base_error_msg}'
-                            f'one possibility is that there is a '
-                            f'conflicting cuDNN in LD_LIBRARY_PATH.')
+                        raise RuntimeError(f'{base_error_msg}'
+                                           f'one possibility is that there is a '
+                                           f'conflicting cuDNN in LD_LIBRARY_PATH.')
                 else:
                     raise RuntimeError(base_error_msg)
 

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -38,7 +38,12 @@ if _cudnn is not None:
             if not cudnn_compatible:
                 raise RuntimeError(
                     'cuDNN version incompatibility: PyTorch was compiled  against {} '
-                    'but found runtime version {}. Please use cudnn version provided with pytorch.'.format(compile_version, runtime_version))
+                    'but found runtime version {}. '
+                    'PyTorch already comes bundled with cuDNN. '
+                    'One option to resolving this error is to ensure PyTorch '
+                    'can find the bundled cuDNN;'
+                    'one possibility is that there is a '
+                    'conflicting cuDNN in LD_LIBRARY_PATH.'.format(compile_version, runtime_version))
         return True
 else:
     def _init():

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -45,8 +45,8 @@ if _cudnn is not None:
                                   f'can find the bundled cuDNN.')
 
                 if 'LD_LIBRARY_PATH' in os.environ:
-                    ld_library_path = os.environ.get('LD_LIBRARY_PATH')
-                    if 'cuda' in ld_library_path or 'cudnn' in ld_library_path:
+                    ld_library_path = os.environ.get('LD_LIBRARY_PATH', '')
+                    if any(substring in ld_library_path for substring in ['cuda', 'cudnn']):
                         raise RuntimeError(f'{base_error_msg}'
                                            f'Looks like your LD_LIBRARY_PATH contains incompatible version of cudnn'
                                            f'Please either remove it from the path or install cudnn {compile_version}')

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import torch
 import warnings
 from contextlib import contextmanager
@@ -36,14 +37,28 @@ if _cudnn is not None:
             else:
                 cudnn_compatible = runtime_minor >= compile_minor
             if not cudnn_compatible:
-                raise RuntimeError(
-                    'cuDNN version incompatibility: PyTorch was compiled  against {} '
-                    'but found runtime version {}. '
-                    'PyTorch already comes bundled with cuDNN. '
-                    'One option to resolving this error is to ensure PyTorch '
-                    'can find the bundled cuDNN;'
-                    'one possibility is that there is a '
-                    'conflicting cuDNN in LD_LIBRARY_PATH.'.format(compile_version, runtime_version))
+                base_error_msg = (f'cuDNN version incompatibility: '
+                        f'PyTorch was compiled  against {compile_version} '
+                        f'but found runtime version {runtime_version}. '
+                        f'PyTorch already comes bundled with cuDNN. '
+                        f'One option to resolving this error is to ensure PyTorch '
+                        f'can find the bundled cuDNN.')
+
+                if 'LD_LIBRARY_PATH' in os.environ:
+                    ld_library_path = os.environ.get('LD_LIBRARY_PATH')
+                    if any(substring in ld_library_path for substring in ['cuda', 'cudnn']):
+                        raise RuntimeError(
+                            f'{base_error_msg}'
+                            f'Looks like your LD_LIBRARY_PATH contains incompatible version of cudnn'
+                            f'Please either remove it from the path or install cudnn {compile_version}')
+                    else:
+                        raise RuntimeError(
+                            f'{base_error_msg}'
+                            f'one possibility is that there is a '
+                            f'conflicting cuDNN in LD_LIBRARY_PATH.')
+                else:
+                    raise RuntimeError(base_error_msg)
+
         return True
 else:
     def _init():

--- a/torch/backends/cudnn/__init__.py
+++ b/torch/backends/cudnn/__init__.py
@@ -37,8 +37,8 @@ if _cudnn is not None:
                 cudnn_compatible = runtime_minor >= compile_minor
             if not cudnn_compatible:
                 raise RuntimeError(
-                    'cuDNN version incompatibility: PyTorch was compiled against {} '
-                    'but linked against {}'.format(compile_version, runtime_version))
+                    'cuDNN version incompatibility: PyTorch was compiled  against {} '
+                    'but found runtime version {}. Please use cudnn version provided with pytorch.'.format(compile_version, runtime_version))
         return True
 else:
     def _init():


### PR DESCRIPTION
Change cudnn incompatibility message wording
Please refer to: #80637 

Test:
```
 File "/home/atalman/torch/backends/cudnn/__init__.py", line 67, in version
    if not _init():
  File "/home/atalman/torch/backends/cudnn/__init__.py", line 50, in _init
    raise RuntimeError(
RuntimeError: cuDNN version incompatibility: PyTorch was compiled  against (8, 3, 2) but found runtime version (8, 0, 3). PyTorch already comes bundled with cuDNN. One option to resolving this error is to ensure PyTorch can find the bundled cuDNN.Looks like your LD_LIBRARY_PATH contains incompatible version of cudnnPlease either remove it from the path or install cudnn (8, 3, 2)
```