### PR TITLE
[quant] Refactor quantize clamping into float_to_apot util function

### DIFF
--- a/torch/ao/quantization/experimental/apot_utils.py
+++ b/torch/ao/quantization/experimental/apot_utils.py
@@ -8,7 +8,13 @@ import math
 r"""Converts floating point input into APoT number
     based on quantization levels
 """
-def float_to_apot(x, levels, indices):
+def float_to_apot(x, levels, indices, alpha):
+    # clip values based on alpha
+    if x < -alpha:
+        return -alpha
+    elif x > alpha:
+        return alpha
+
     levels_lst = list(levels)
     indices_lst = list(indices)
 

--- a/torch/ao/quantization/experimental/quantizer.py
+++ b/torch/ao/quantization/experimental/quantizer.py
@@ -32,11 +32,11 @@ class APoTQuantizer():
     def quantize(self, tensor2quantize: Tensor):
         result = torch.tensor([])
 
-        # clip tensor2quantize values based on alpha qparam
-        tensor2quantize = torch.clamp(tensor2quantize, -self.alpha, self.alpha)
-
         # map float_to_apot over tensor2quantize elements
-        tensor2quantize = tensor2quantize.apply_(lambda x: float_to_apot(x, self.quantization_levels, self.level_indices))
+        tensor2quantize = tensor2quantize.apply_(lambda x: float_to_apot(x,
+                                                                         self.quantization_levels,
+                                                                         self.level_indices,
+                                                                         self.alpha))
 
         from torch.ao.quantization.experimental.APoT_tensor import TensorAPoT
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #80885

### Summary:
This PR moves the clamping functionality from `quantize` to `float_to_apot` util function to align with the uniform quantize workflow in the codebase.

### Test Plan:
Run unit tests with:
python pytorch/test/quantization/core/experimental/test_quantizer.py