### PR TITLE
[JIT] Document runtime flags

### DIFF
--- a/torch/csrc/jit/OVERVIEW.md
+++ b/torch/csrc/jit/OVERVIEW.md
@@ -58,6 +58,8 @@ Sections start with a reference to the source file where the code related to the
     - [Derivative Preserving Optimization](#derivative-preserving-optimization)
     - [Post-derivative optimization](#post-derivative-optimization)
     - [Derivate Splitting](#derivate-splitting)
+    - [Fusers](#fusers)
+    - [Disabling Optimizations](#disabling-optimizations)
   - [JIT Logging](#jit-logging)
   - [JIT Optimization Limiter](#jit-optimization-limiter)
   - [DifferentiableGraphOp](#differentiablegraphop)
@@ -1165,6 +1167,59 @@ with prim::DifferentiableGraph_0 = graph(%13 : Float(*, *),
   %hy : Float(*, *) = aten::mul(%outgate, %4)
   return (%hy, %cy)
 ```
+
+### Fusers ###
+
+As mentioned in the [Post-derivative optimization](#post-derivative-optimization) section, one of the
+available optimizations is _fusion_, which merges operator kernels and compiles new kernels. Fusion
+has two benefits: first, it reduces dispatcher overhead by combining multiple operator calls into a
+single call to the fused kernel; and second, on GPU it can reduce the number of reads and writes to
+global GPU memory, which can be a significant portion of the runtime for pointwise operators.
+
+The current default fuser on NVIDIA GPUs is
+[NVFuser](https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/codegen/cuda/README.md), while other use cases use
+[NNC](https://github.com/pytorch/pytorch/tree/master/torch/csrc/jit/tensorexpr) as a fuser.
+
+Since fusers rely on specialized information that is only available at runtime - such as dtype,
+device, and shape - they are only applied after the first invocation of a torchscript function or
+module. As a result, the first invocation of a torchscript function can sometimes behave slightly
+differently from subsequent invocations.
+
+To enable/disable different fusers, refer to the settings below. These settings apply globally in
+the process in which they are set. Different fusers may excel in different scenarios, and disabling
+or switching the fuser could also provide a temporary fix in case of bugs.
+
+**Python APIs:**
+
+
+| Feature | Python API |
+|---|---|
+| NNC enable/disable | `torch._C._jit_set_texpr_fuser_enabled()` |
+| NNC on CPU | `torch._C._jit_override_can_fuse_on_cpu()` |
+| NNC on GPU | `torch._C._jit_override_can_fuse_on_gpu()` |
+| NNC context manager | `with torch.jit.fuser("fuser1"):` |
+| NVFuser enable/disable | `torch._C._jit_set_nvfuser_enabled()` |
+| NVFuser context manager | `with torch.jit.fuser("fuser2")` |
+
+**C++ APIs:**
+
+| Feature | C++ API | Header file |
+|---|---|---|
+| NNC enable/disable | `torch::jit::setTensorExprFuserEnabled(bool);` | [here](https://github.com/pytorch/pytorch/blob/1a7e560adecb0192f69f4d05b990800b60dc380b/torch/csrc/jit/passes/tensorexpr_fuser.h#L22) |
+| NNC on CPU | `torch::jit::overrideCanFuseOnCPU(bool);` | [here](https://github.com/pytorch/pytorch/blob/1a7e560adecb0192f69f4d05b990800b60dc380b/torch/csrc/jit/codegen/fuser/interface.h#L28-L29) |
+| NNC on GPU | `torch::jit::overrideCanFuseOnGPU(bool);` | [here](https://github.com/pytorch/pytorch/blob/1a7e560adecb0192f69f4d05b990800b60dc380b/torch/csrc/jit/codegen/fuser/interface.h#L28-L29) |
+| NVFuser enable/disable | `torch::jit::fuser::cuda::setEnabled(bool);` | [here](https://github.com/pytorch/pytorch/blob/1a7e560adecb0192f69f4d05b990800b60dc380b/torch/csrc/jit/codegen/cuda/interface.h#L56) |
+
+### Disabling Optimizations ###
+
+To completely disable the runtime optimizations and only run the minimum optimizations necessary,
+the following commands can be used to globally (in a process) disable the majority of runtime
+optimizations. This will disable JIT autodiff (instead it will rely on the default autograd
+implementation provided in eager mode) as well as the fusers and some other runtime optimizations.
+
+* Python: `torch._C._get_graph_executor_optimize(False)`
+* C++: `torch::jit::setGraphExecutorOptimize(false);`
+* C++ header: [here](https://github.com/pytorch/pytorch/blob/1a7e560adecb0192f69f4d05b990800b60dc380b/torch/csrc/jit/python/update_graph_executor_opt.h#L5)
 
 ## JIT Logging ##
 


### PR DESCRIPTION
Document flags for enabling/disabling fusers, and using the simple
executor (instead of profiling executor).