### PR TITLE
[Vulkan] Implement GLU operator

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/glu.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/glu.glsl
@@ -1,0 +1,30 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
+  ivec3 size;  // output size
+  int chext;   // channel extent of the output
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const int z0 = 2 * (pos.z / uBlock.chext) * uBlock.chext + (pos.z % uBlock.chext);
+    const int z1 = z0 + uBlock.chext;
+    imageStore(
+        uOutput,
+        pos,
+        texelFetch(uInput, ivec3(pos.x, pos.y, z0), 0)
+            * 1 / (1 + exp(-1 * texelFetch(uInput, ivec3(pos.x, pos.y, z1), 0))));
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Glu.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Glu.cpp
@@ -1,0 +1,95 @@
+#include <ATen/native/vulkan/api/OpProfiler.h>
+#include <ATen/native/vulkan/ops/Common.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor glu(
+    const at::Tensor& input_arg,
+    const int64_t dim = -1) {
+
+  TORCH_CHECK(
+      input_arg.dim() == 4,
+      "Vulkan glu only supports 4-dim input!");
+  TORCH_CHECK(
+      dim == 1,
+      "Vulkan glu only supports GLU for dim = 1, but got dim = ", dim);
+  TORCH_CHECK(
+      channels_size(input_arg) % 8 == 0,
+      "Vulkan glu expects channel dim to be multiple of 8!");
+
+  const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
+  const vTensor& v_input = convert(input);
+  const IntArrayRef v_input_sizes = v_input.sizes();
+
+  auto output_ch_ext = v_input.sizes()[1] / 8;
+
+  api::Context* const context = api::context();
+
+  vTensor v_output{
+    context,
+    {v_input_sizes[0], v_input_sizes[1] / 2, v_input_sizes[2], v_input_sizes[3]},
+    v_input.options(),
+  };
+
+  const struct Block final {
+    uvec3 extents;
+    int32_t chext;
+  } block {
+    v_output.extents(),
+    safe_downcast<int32_t>(output_ch_ext)
+  };
+
+  api::UniformParamsBuffer params(context, block);
+  api::PipelineBarrier pipeline_barrier{};
+
+  context->submit_compute_job(
+      // shader layout signature
+      {
+        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+      },
+      // shader descriptor
+      VK_KERNEL(glu),
+      // pipeline barrier
+      pipeline_barrier,
+      // global work group size
+      v_output.extents(),
+      // local work group size
+      adaptive_work_group_size(v_output.extents()),
+      // fence handle
+      VK_NULL_HANDLE,
+      // shader arguments
+      v_output.image(
+          pipeline_barrier,
+          api::PipelineStage::Compute,
+          api::MemoryAccessType::WRITE),
+      v_input.image(
+          pipeline_barrier,
+          api::PipelineStage::Compute),
+      // params buffer
+      params.buffer());
+
+  return convert(v_output);
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::glu"), TORCH_FN(glu));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -968,6 +968,25 @@ TEST_F(VulkanAPITest, empty) {
   ASSERT_NO_THROW(at::empty({1, 17, 41, 53}, at::device(at::kVulkan).dtype(at::kFloat)));
 }
 
+TEST_F(VulkanAPITest, glu) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto in_cpu = at::rand({17, 200, 302, 5}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_vulkan = in_cpu.vulkan();
+
+  const auto out_cpu = at::glu(in_cpu, 1);
+  const auto out_vulkan = at::glu(in_vulkan, 1);
+
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
 TEST_F(VulkanAPITest, hardsigmoid) {
   if (!at::is_vulkan_available()) {
     return;


### PR DESCRIPTION
Summary:
Implemented GLU operator for the Vulkan backend.

Special case implementation:
- Input tensor must be 4-dim, i.e. [N, C, H, W].
- C must be a multiple of 8 (number of channels of output tensor must be a multiple of 4).
- dim must be 1.

References
- PyTorch Docs > torch.nn > [GLU](https://pytorch.org/docs/stable/generated/torch.nn.GLU.html)

Test Plan:
Added test case to `/xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp`

On Mac:
```
buck run //xplat/caffe2:pt_vulkan_api_test_binAppleMac
```
On Android:
```
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
```

Differential Revision: D37625389

