### PR TITLE
Allow torch._C to be recognized a module in torch.package

### DIFF
--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -1,4 +1,4 @@
-import _frozen_importlib_external
+import _frozen_importlib_external # type: ignore[import]
 import builtins
 import importlib
 import inspect


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #80914

This pr addresses https://github.com/pytorch/multipy/issues/82 and https://github.com/pytorch/multipy/issues/44. The changes will be copied over to [pytorch/multipy](https://github.com/pytorch/multipy) as well.

A C extension module behaves a bit differently than a normal python package as it does not contain a `__path__` attribute. However, these modules still have information about their submodules. This PR also checks if a module is a C extension module  and checks if the module we are looking for is in it's children. 

For example, if we are importing `torch._C._nn` we check if the parent `torch._C` is a C extension module if necessary, and then check if `torch._C._nn` is a proper child of `torch._C`.