### PR TITLE
Add python stack tracing option on on-demand flow

### DIFF
--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -18,16 +18,29 @@ class LibKinetoClient : public libkineto::ClientInterface {
     reportInputShapes_ = setupOpInputsCollection;
   }
 
+#ifdef USE_KINETO_UPDATED
+  void start(bool withStack) override {
+    ProfilerConfig cfg {
+      ProfilerState::KINETO_ONDEMAND,
+          /*report_input_shapes=*/reportInputShapes_,
+          /*profile_memory=*/false,
+          /*with_stack=*/withStack,
+#else
   void start() override {
     ProfilerConfig cfg{
         ProfilerState::KINETO_ONDEMAND,
-        reportInputShapes_,
-        false,
-        false,
-        false,
-        false};
+        /*report_input_shapes=*/reportInputShapes_,
+        /*profile_memory=*/false,
+        /*with_stack=*/false,
+#endif
+          /*with_flops=*/false,
+          /*with_modules=*/false
+    };
     std::set<ActivityType> activities{ActivityType::CPU};
-    auto scopes = {at::RecordScope::FUNCTION, at::RecordScope::USER_SCOPE};
+    std::unordered_set<at::RecordScope> scopes;
+    scopes.insert(at::RecordScope::FUNCTION);
+    scopes.insert(at::RecordScope::USER_SCOPE);
+    scopes.insert(at::RecordScope::BACKWARD_FUNCTION);
     enableProfiler(cfg, activities, scopes);
   }
 


### PR DESCRIPTION
Summary:
Changes:
1. add an option in Config; can use 'PYTHON_STACK_TRACE=true' option (via .conf)
2. deliver PYTHON_STACK_TRACE value to kineto_client_interface start()
3. abstract class also changed.

Test Plan:
1. launch a python test case with the following command for on-demand flow:
echo -e "PYTHON_STACK_TRACE=true" > /tmp/scott_kineto.conf && dyno gputrace --gputrace_duration 300ms --gpuconf /tmp/scott_kineto.conf

2. Then, we can see with_stack enabled as intended from output log:
INFO:2022-06-27 15:00:16 1009443:1011716 kineto_client_interface.cpp:22] withStack : 1

Differential Revision: D37410204

