### PR TITLE
[ROCm] unskip external streams tests

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1351,7 +1351,6 @@ class TestCuda(TestCase):
                 out = cudart.cudaStreamDestroy(stream.value)
                 self.assertEqual(out, 0)
 
-    @skipIfRocm
     def test_external_streams(self):
         device = torch.cuda.device(0)
         with self._get_external_stream(device) as stream_v:
@@ -1359,7 +1358,6 @@ class TestCuda(TestCase):
             self.assertEqual(stream_v, ext_stream.cuda_stream)
             self.assertEqual(ext_stream.device.index, device.idx)
 
-    @skipIfRocm
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
     def test_external_streams_multi_device(self):
         device = torch.cuda.device(1)


### PR DESCRIPTION
These two tests are passing for ROCm 5.1.1 and 5.2.