### PR TITLE
[Static Runtime] Fix precision error in test cases

### DIFF
--- a/benchmarks/static_runtime/test_static_module.cc
+++ b/benchmarks/static_runtime/test_static_module.cc
@@ -485,7 +485,7 @@ TEST(StaticRuntime, DeepWide) {
       at::Tensor output_2 = outputs[0].toTensor();
       smod.runtime().check_for_memory_leak();
       EXPECT_TRUE(
-          torch::allclose(output_1, output_2, /*rtol=*/1e-5, /*atol=*/1e-7));
+          torch::allclose(output_1, output_2, /*rtol=*/1e-5, /*atol=*/1e-5));
     }
   }
 }
@@ -513,7 +513,7 @@ TEST(StaticRuntime, KWargsAPI_1) {
 
         at::Tensor output_2 = getTensor(output_ivalue);
         EXPECT_TRUE(
-            torch::allclose(output_1, output_2, /*rtol=*/1e-5, /*atol=*/1e-7));
+            torch::allclose(output_1, output_2, /*rtol=*/1e-5, /*atol=*/1e-5));
 
         // check for output aliasing
         EXPECT_EQ(output_ivalue.use_count(), 1);
@@ -558,7 +558,7 @@ TEST(StaticRuntime, KWargsAPI_2) {
 
         at::Tensor output_2 = getTensor(output_ivalue);
         EXPECT_TRUE(
-            torch::allclose(output_1, output_2, /*rtol=*/1e-5, /*atol=*/1e-7));
+            torch::allclose(output_1, output_2, /*rtol=*/1e-5, /*atol=*/1e-5));
 
         // check for output aliasing
         EXPECT_EQ(output_ivalue.use_count(), 1);
@@ -636,7 +636,7 @@ TEST(StaticRuntime, CleanUpMemory) {
             auto output_2 = outputs[0].toTensor();
             runtime.check_for_memory_leak();
             EXPECT_TRUE(torch::allclose(
-                output_1, output_2, /*rtol=*/1e-5, /*atol=*/1e-7));
+                output_1, output_2, /*rtol=*/1e-5, /*atol=*/1e-5));
             if (manage_output_tensors) {
               runtime.deallocateOutputTensors();
               runtime.checkOutputTensorMemoryLeaks();
@@ -882,7 +882,7 @@ TEST(StaticRuntime, FusionPass) {
       EXPECT_TRUE(hit);
       auto output_2 = getTensor(module.forward(inputs));
       EXPECT_TRUE(
-          torch::allclose(output_1, output_2, /*rtol=*/1e-5, /*atol=*/1e-7));
+          torch::allclose(output_1, output_2, /*rtol=*/1e-5, /*atol=*/1e-5));
     }
   }
 }


### PR DESCRIPTION
Summary:
- Test cases related to DeepAndWideSciptModel() was crashing at random due to precision issue
- test cases related for precision: DeepWide, KWargsAPI_1, KWargsAPI_2, KWargsAPI_Optional, FusionPass
- test failure was not observed always due to random input to the model (via torch::randn)
- Increasing the absolute tolerance for test cases

Differential Revision: D37639067

