### PR TITLE
Add initial support for differentiable optimizers

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2680,7 +2680,7 @@ class TestSWAUtils(TestCase):
 
 instantiate_parametrized_tests(TestLRScheduler)
 
-def _diff_fn(p, grad, opt_differentiable_state, opt_class, kwargs):
+def _diff_fn(p, grad, opt_differentiable_state, opt_class, kwargs, *ignored):
     p = p.clone()
     p.grad = grad
     opt_differentiable_state = {k: v.clone() for k, v in opt_differentiable_state.items()}
@@ -2697,7 +2697,7 @@ class TestDifferentiableOptimizer(TestCase):
         grad = torch.rand(10, requires_grad=True, dtype=torch.float64)
         mbuff = torch.rand(10, requires_grad=True, dtype=torch.float64)
         state = {'momentum_buffer': mbuff}
-        gradcheck(_diff_fn, (p, grad, state, torch.optim.SGD, {'lr': 0.9, 'differentiable': True}))
+        gradcheck(_diff_fn, (p, grad, state, torch.optim.SGD, {'lr': 0.9, 'differentiable': True}, *state.values()))
 
 
 if __name__ == '__main__':

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2680,7 +2680,12 @@ class TestSWAUtils(TestCase):
 
 instantiate_parametrized_tests(TestLRScheduler)
 
+
 def _diff_fn(p, grad, opt_differentiable_state, opt_class, kwargs, *ignored):
+    # Ignored is the list of values in `opt_differentiable_state`, we do this
+    # for `gradcheck` to correctly track the state tensors as function inputs
+    # because otherwise it can't unpack the values in the `opt_differentiable_state`
+    # dict
     p = p.clone()
     p.grad = grad
     opt_differentiable_state = {k: v.clone() for k, v in opt_differentiable_state.items()}

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -306,7 +306,7 @@ class Optimizer(object):
             if not isinstance(param, torch.Tensor):
                 raise TypeError("optimizer can only optimize Tensors, "
                                 "but one of the params is " + torch.typename(param))
-            if not self.defaults['differentiable'] and not (param.is_leaf or param.retains_grad):
+            if not self.defaults.get('differentiable', None) and not (param.is_leaf or param.retains_grad):
                 raise ValueError("can't optimize a non-leaf Tensor")
 
         for name, default in self.defaults.items():


### PR DESCRIPTION
Adds the `differentiable` argument, a method for updating parameters in an existing optimizer, and a template for testing the differentiability of multiple optimizers.

This is all based in discussions with @albanD & @jbschlosser