### PR TITLE
Load CPU MLModel first, and configured MLModel async

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.h
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.h
@@ -10,8 +10,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString*)modelCacheDirectory;
 
-+ (nullable MLModel*)compileMLModel:(const std::string&)modelSpecs
-                         identifier:(const std::string&)identifier
++ (NSURL*)compileModel:(const std::string&)modelSpecs
+               modelID:(const std::string&)modelID;
+
++ (nullable MLModel*)loadCPUModelAtURL:(NSURL*)modelURL;
+
++ (nullable MLModel*)loadModelAtURL:(NSURL*)modelURL
                             backend:(const std::string&)backend
                   allowLowPrecision:(BOOL)allowLowPrecision;
 

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.h
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.h
@@ -6,8 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PTMCoreMLExecutor : NSObject
 
-- (instancetype)initWithModel:(MLModel*)model
-                 featureNames:(NSArray<NSString*>*)featureNames;
+@property(atomic, strong) MLModel* model;
+
+- (instancetype)initWithFeatureNames:(NSArray<NSString*>*)featureNames;
 
 - (void)setInputs:(c10::impl::GenericList)inputs;
 

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLExecutor.mm
@@ -3,16 +3,13 @@
 #import <CoreML/CoreML.h>
 
 @implementation PTMCoreMLExecutor {
-  MLModel *_model;
   NSArray *_featureNames;
   PTMCoreMLFeatureProvider *_inputProvider;
 }
 
-- (instancetype)initWithModel:(MLModel *)model featureNames:(NSArray<NSString *> *)featureNames {
+- (instancetype)initWithFeatureNames:(NSArray<NSString *> *)featureNames {
   if (self = [super init]) {
-    _model = model;
     _featureNames = featureNames;
-
     NSSet<NSString *> *featureNamesSet = [NSSet setWithArray:featureNames];
     _inputProvider = [[PTMCoreMLFeatureProvider alloc] initWithFeatureNames:featureNamesSet];
   }
@@ -41,7 +38,7 @@
 - (id<MLFeatureProvider>)forward {
   NSError *error;
   MLPredictionOptions *options = [[MLPredictionOptions alloc] init];
-  id<MLFeatureProvider> outputs = [_model predictionFromFeatures:_inputProvider options:options error:&error];
+  id<MLFeatureProvider> outputs = [self.model predictionFromFeatures:_inputProvider options:options error:&error];
   if (error) {
     NSLog(@"Prediction failed with error %@", error);
     return nil;


### PR DESCRIPTION
Summary:
MLModel loads much faster when compute units are set to CPU only. It seems when loading with compute units set to all a large amount of preprocessing work is done during init.

So, in order to speed up our effect load time, load a cpu MLModel synchronously, and a configured MLModel asyncronously. When the second model finishes loading about 600 ms later, swap the models out.

So, for about half a second inference will occur on the cpu, but after that will kick over to gpu or npu.

On iPhone 12 I'm seeing a > 10x improvement in load time as recorded by RenderTimeLogger.cpp

Test Plan:
- Add an override to https://www.internalfb.com/intern/qe2/ig_ios_person_segmentation_universe to opt into the coreml segmentation model
- Launch IG camera and apply an effect that uses segmentation, such as green screen
- Confirm that segmentation works.

https://pxl.cl/277JL

Reviewed By: kimishpatel

Differential Revision: D37597965

