### PR TITLE
[mergebot] combine land check and job started comments

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -782,7 +782,8 @@ class GitHubPR:
         commit = repo.get_commit('HEAD').commit_hash
         gh_post_pr_comment(self.org, self.project, self.pr_num,
                            '@pytorchbot successfully started a merge and created land time checks.' +
-                           f' See progress here: https://hud.pytorch.org/{self.org}/{self.project}/commit/{commit}')
+                           f' See merge status [here]({os.getenv("GH_RUN_URL")}) ' +
+                           'and land check progress [here](https://hud.pytorch.org/{self.org}/{self.project}/commit/{commit})')
         return commit
 
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -781,7 +781,7 @@ class GitHubPR:
         repo._run_git('push', '-u', 'origin', land_check_branch, '--force')
         commit = repo.get_commit('HEAD').commit_hash
         gh_post_pr_comment(self.org, self.project, self.pr_num,
-                           'Successfully started land time checks.' +
+                           '@pytorchbot successfully started a merge and created land time checks.' +
                            f' See progress here: https://hud.pytorch.org/{self.org}/{self.project}/commit/{commit}')
         return commit
 
@@ -1087,10 +1087,10 @@ def main() -> None:
         gh_post_pr_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)
         import traceback
         traceback.print_exc()
-
-    msg = f"@pytorchbot successfully started a {'revert' if args.revert else 'merge'} job."
-    msg += f" Check the current status [here]({os.getenv('GH_RUN_URL')})"
-    gh_post_pr_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)
+    if not args.land_checks:
+        msg = f"@pytorchbot successfully started a {'revert' if args.revert else 'merge'} job."
+        msg += f" Check the current status [here]({os.getenv('GH_RUN_URL')})"
+        gh_post_pr_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)
 
     if args.revert:
         try:


### PR DESCRIPTION
Addresses https://github.com/pytorch/pytorch/issues/80923

The alternative to this is editing the start comment to include the land checks details, but I think it might be a bit misleading because the land check branch creation might not be there when the person first clicks on it when they get a notification.  This might be a bit annoying cause then the user won't be able to look at their progress. 