### PR TITLE
[jiterator] De-template launch_jitted_reduce_kernel

### DIFF
--- a/aten/src/ATen/native/cuda/CUDAJitLoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDAJitLoops.cuh
@@ -270,8 +270,11 @@ static void jitted_gpu_kernel_impl(
   //   the same compute capability
   static std::mutex jiterator_mutex;
   static std::vector<JittedKernelVariantCache> device_caches(c10::cuda::device_count());
+
+  constexpr int nInputs = arity;
+  constexpr int nOutputs = 1;  // TODO: Support more than 1 output
   static const auto desc = at::cuda::jit::make_kernel_descriptor<
-    result_type, f_inputs_type, arity, ExtraArgs...>(name, f);
+    result_type, f_inputs_type, ExtraArgs...>(name, f, nInputs, nOutputs);
 
   auto &cache = device_caches[iter.device().index()];
   auto extra_args_array = tuple_to_array(extra_args);

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -69,6 +69,10 @@ struct mnt_wrapper <c10::complex<double>>{
   static constexpr int MAX_NUM_THREADS = 256;
 };
 
+constexpr int max_reduce_threads(c10::ScalarType type) {
+  return type == kComplexDouble ? 256 : 512;
+}
+
 struct ReduceConfig {
   static constexpr int BLOCK_X = 0;
   static constexpr int BLOCK_Y = 1;
@@ -896,43 +900,37 @@ static void launch_reduce_kernel(const ReduceConfig& config, const R& reduction)
   }
 }
 
-template<char const *name, typename scalar_t, typename out_scalar_t,
-int vt0, typename R>
-static void launch_jitted_reduce_kernel(DeviceIndex idx, const ReduceConfig& config,
-R& reduction, const std::string& func) {
-  constexpr int max_threads = mnt_wrapper<scalar_t>::MAX_NUM_THREADS;
+inline void launch_jitted_reduce_kernel(
+    std::mutex &jiterator_mutex,
+    std::array<at::cuda::jit::NvrtcFunction, 3> &fn_cache,
+    const at::cuda::jit::KernelDescriptor &desc,
+    int vt0, const ReduceConfig& config, void *reduction) {
   dim3 block = config.block();
   dim3 grid = config.grid();
 
-  static std::mutex _jiterator_mutex;
-  static std::vector<std::array<at::cuda::jit::NvrtcFunction, 3>> fns(c10::cuda::device_count());
   int shared_memory = config.shared_memory_size();
   at::cuda::jit::NvrtcFunction* fn_ptr;
   switch(config.output_vec_size) {
   case 4:
-    fn_ptr = &fns[idx][0];
+    fn_ptr = &fn_cache[0];
     break;
   case 2:
-    fn_ptr = &fns[idx][1];
+    fn_ptr = &fn_cache[1];
     break;
   default:
-    fn_ptr = &fns[idx][2];
+    fn_ptr = &fn_cache[2];
   }
   if (!fn_ptr->function) {
-    std::string f_inputs_type_str = at::cuda::jit::typeName<scalar_t>();
-    std::string accum_type_str = at::cuda::jit::typeName<at::opmath_type<scalar_t>>();
-    std::string result_type_str = at::cuda::jit::typeName<out_scalar_t>();
-    int max_threads_codegen = max_threads/config.output_vec_size;
-    auto code = at::cuda::jit::generate_reduction_code(1, func, name, vt0,
-                                               f_inputs_type_str, accum_type_str, result_type_str,
-                                               true, false, config.output_vec_size, max_threads_codegen);
+    int max_threads_codegen =
+        max_reduce_threads(desc.f_inputs_type) / config.output_vec_size;
+    auto code = at::cuda::jit::generate_reduction_code(
+        desc, vt0, true, false, config.output_vec_size, max_threads_codegen);
 
-    *fn_ptr = at::cuda::jit::jit_pwise_function(code, "reduction_"+std::string(name));
-
+    *fn_ptr = at::cuda::jit::jit_pwise_function(code, "reduction_" + desc.name);
   }
   constexpr int kernel_args = 1;
   void* args[kernel_args];
-  args[0] = static_cast<void*>(&reduction);
+  args[0] = reduction;
   at::cuda::jit::launch_jitted_pwise_function(*fn_ptr, args, grid, block, shared_memory);
 }
 
@@ -1311,9 +1309,17 @@ inline void jitted_gpu_reduce_kernel(TensorIterator& iter, const std::string& fu
   reduce.accumulate = iter.should_accumulate();
   reduce.final_output = iter.is_final_output();
 
-  launch_jitted_reduce_kernel<name, scalar_t,
-  out_scalar_t, vt0>(iter.device().index(),
-  config, reduce, func);
+  constexpr int nInputs = 1;
+  constexpr int nOutputs = 1;
+  static auto desc = at::cuda::jit::make_kernel_descriptor<
+    out_scalar_t, scalar_t>(name, func, nInputs, nOutputs);
+
+  static std::mutex jiterator_mutex;
+  static std::vector<std::array<at::cuda::jit::NvrtcFunction, 3>> fn_cache(c10::cuda::device_count());
+  auto &cache = fn_cache[iter.device().index()];
+
+  launch_jitted_reduce_kernel(
+      jiterator_mutex, cache, desc, vt0, config, &reduce);
 }
 
 }} // namespace at::native

--- a/aten/src/ATen/native/cuda/jit_utils.cpp
+++ b/aten/src/ATen/native/cuda/jit_utils.cpp
@@ -1088,6 +1088,31 @@ std::string load_code_template(const std::string& path) {
 }
 
 std::string generate_reduction_code(
+    const KernelDescriptor &desc,
+    int vt0,
+    bool contiguous,
+    bool vectorized,
+    int vec_size,
+    int max_threads_codegen) {
+  TORCH_INTERNAL_ASSERT(desc.nInputs == 1);
+  TORCH_INTERNAL_ASSERT(desc.extra_args_types.size() == 0);
+
+  return generate_reduction_code(
+      desc.nOutputs,
+      desc.f,
+      desc.name,
+      vt0,
+      typeName(desc.f_inputs_type),
+      typeName(toOpMathType(desc.f_inputs_type)),
+      typeName(desc.result_type),
+      contiguous,
+      vectorized,
+      vec_size,
+      max_threads_codegen
+    );
+}
+
+std::string generate_reduction_code(
     int nOutputs,
     const std::string& func,
     const std::string& name,

--- a/aten/src/ATen/native/cuda/jit_utils.h
+++ b/aten/src/ATen/native/cuda/jit_utils.h
@@ -38,17 +38,20 @@ c10::SmallVector<at::ScalarType> get_extra_args_types() {
 template <
   typename result_type,
   typename f_inputs_type,
-  int arity,
   typename... ExtraArgs>
-KernelDescriptor make_kernel_descriptor(std::string name, std::string f) {
+KernelDescriptor make_kernel_descriptor(
+    std::string name,
+    std::string f,
+    int nInputs,
+    int nOutputs) {
   KernelDescriptor ret;
   ret.name = std::move(name);
   ret.f = std::move(f);
   ret.f_inputs_type = c10::CppTypeToScalarType<f_inputs_type>::value;
   ret.result_type = c10::CppTypeToScalarType<result_type>::value;
   ret.extra_args_types = get_extra_args_types<ExtraArgs...>();
-  ret.nInputs = arity;
-  ret.nOutputs = 1;  // TODO: Support more than 1 output
+  ret.nInputs = nInputs;
+  ret.nOutputs = nOutputs;
   return ret;
 }
 
@@ -113,6 +116,14 @@ std::string generate_reduction_code(
     const std::string& f_inputs_type,
     const std::string& reduction_accum_type,
     const std::string& result_type,
+    bool contiguous,
+    bool vectorized,
+    int vec_size,
+    int max_threads_codegen);
+
+std::string generate_reduction_code(
+    const KernelDescriptor &desc,
+    const int vt0,
     bool contiguous,
     bool vectorized,
     int vec_size,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #80968
* #80967

As with `jitted_gpu_kernel_impl`, this
1. Hoists static variables out and into a parent funciton
2. Moves template arguments into the `jit::KernelDescriptor` struct,
   as well as changing `vt0` to just be a runtime argument
3. Changes the types of pass-through arguments to `void*`