### PR TITLE
Change AllReduceCommHook to accept instrusive_ptr

### DIFF
--- a/torch/csrc/distributed/c10d/comm.hpp
+++ b/torch/csrc/distributed/c10d/comm.hpp
@@ -114,7 +114,7 @@ namespace detail {
 template <typename T>
 class CppCommHookInterface : public CommHookInterface {
  public:
-  explicit CppCommHookInterface(T& state) : state_(state) {}
+  explicit CppCommHookInterface(const T& state) : state_(state) {}
 
   ~CppCommHookInterface() override = default;
 

--- a/torch/csrc/distributed/c10d/default_comm_hooks.cpp
+++ b/torch/csrc/distributed/c10d/default_comm_hooks.cpp
@@ -14,11 +14,7 @@ c10::intrusive_ptr<c10::ivalue::Future> AllReduceCommHook::runHook(
   std::vector<at::Tensor> tensors = {bucket.getBufferRef()};
   // Apply the division first to avoid overflow, especially for FP16.
   tensors[0] /= state_->getSize();
-  return ops::allreduce(
-             c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(
-                 state_),
-             tensors)
-      ->getFuture();
+  return ops::allreduce(state_, tensors)->getFuture();
 }
 
 c10::intrusive_ptr<c10::ivalue::Future> FP16CompressCommHook::runHook(
@@ -28,12 +24,7 @@ c10::intrusive_ptr<c10::ivalue::Future> FP16CompressCommHook::runHook(
   compressed_tensor /= state_->getSize();
   std::vector<at::Tensor> tensors = {compressed_tensor};
 
-  auto allreduce_fut =
-      ops::allreduce(
-          c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(
-              state_),
-          tensors)
-          ->getFuture();
+  auto allreduce_fut = ops::allreduce(state_, tensors)->getFuture();
   auto decompressed_tensor = bucket.getBufferRef();
   auto decompress = [decompressed_tensor](c10::ivalue::Future& allreduce_fut) {
     auto result = allreduce_fut.value();
@@ -56,11 +47,7 @@ c10::intrusive_ptr<c10::ivalue::Future> FP16CompressCommHook::runHook(
 c10::intrusive_ptr<c10::ivalue::Future> _AllReduceBySumCommHook::runHook(
     GradBucket& bucket) {
   std::vector<at::Tensor> tensors = {bucket.getBufferRef()};
-  return ops::allreduce(
-             c10::intrusive_ptr<ProcessGroup>::unsafe_reclaim_from_nonowning(
-                 state_),
-             tensors)
-      ->getFuture();
+  return ops::allreduce(state_, tensors)->getFuture();
 }
 
 } // namespace c10d

--- a/torch/csrc/distributed/c10d/default_comm_hooks.hpp
+++ b/torch/csrc/distributed/c10d/default_comm_hooks.hpp
@@ -10,20 +10,20 @@ enum class BuiltinCommHookType {
   FP16_COMPRESS = 2,
 };
 
-class AllReduceCommHook : public CppCommHookInterface<ProcessGroup*> {
+class AllReduceCommHook : public CppCommHookInterface<c10::intrusive_ptr<ProcessGroup>> {
  public:
-  explicit AllReduceCommHook(ProcessGroup* state)
-      : CppCommHookInterface<ProcessGroup*>(state) {}
+  explicit AllReduceCommHook(const c10::intrusive_ptr<ProcessGroup>& state)
+      : CppCommHookInterface<c10::intrusive_ptr<ProcessGroup>>(state) {}
 
   ~AllReduceCommHook() override = default;
 
   c10::intrusive_ptr<c10::ivalue::Future> runHook(GradBucket& bucket) override;
 };
 
-class FP16CompressCommHook : public CppCommHookInterface<ProcessGroup*> {
+class FP16CompressCommHook : public CppCommHookInterface<c10::intrusive_ptr<ProcessGroup>> {
  public:
-  explicit FP16CompressCommHook(ProcessGroup* state)
-      : CppCommHookInterface<ProcessGroup*>(state) {}
+  explicit FP16CompressCommHook(const c10::intrusive_ptr<ProcessGroup>& state)
+      : CppCommHookInterface<c10::intrusive_ptr<ProcessGroup>>(state) {}
 
   ~FP16CompressCommHook() override = default;
 
@@ -35,10 +35,10 @@ class FP16CompressCommHook : public CppCommHookInterface<ProcessGroup*> {
 // over all the input parameters, when no communication hook is provided by the user.
 // Only used internally and not released as a public built-in communication hook.
 class _AllReduceBySumCommHook
-    : public CppCommHookInterface<ProcessGroup*> {
+    : public CppCommHookInterface<c10::intrusive_ptr<ProcessGroup>> {
  public:
-  explicit _AllReduceBySumCommHook(ProcessGroup* state)
-      : CppCommHookInterface<ProcessGroup*>(state) {}
+  explicit _AllReduceBySumCommHook(const c10::intrusive_ptr<ProcessGroup>& state)
+      : CppCommHookInterface<c10::intrusive_ptr<ProcessGroup>>(state) {}
 
   ~_AllReduceBySumCommHook() override = default;
 

--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -846,7 +846,7 @@ void Reducer::mark_variable_ready(size_t variable_index) {
 c10::intrusive_ptr<c10::ivalue::Future> Reducer::run_comm_hook(
     GradBucket& grad_bucket) {
   if (comm_hook_ == nullptr) {
-    _AllReduceBySumCommHook allreduce_hook(process_group_.get());
+    _AllReduceBySumCommHook allreduce_hook(process_group_);
     return allreduce_hook.runHook(grad_bucket);
   } else {
     return comm_hook_->runHook(grad_bucket);
@@ -1729,13 +1729,11 @@ void Reducer::register_builtin_comm_hook(
 
   switch (comm_hook_type) {
     case c10d::BuiltinCommHookType::ALLREDUCE:
-      comm_hook_ =
-          std::make_unique<c10d::AllReduceCommHook>(process_group_.get());
+      comm_hook_ = std::make_unique<c10d::AllReduceCommHook>(process_group_);
       LOG(INFO) << "Built-in communication hook ALLREDUCE is registered.";
       break;
     case c10d::BuiltinCommHookType::FP16_COMPRESS:
-      comm_hook_ =
-          std::make_unique<c10d::FP16CompressCommHook>(process_group_.get());
+      comm_hook_ = std::make_unique<c10d::FP16CompressCommHook>(process_group_);
       LOG(INFO) << "Built-in communication hook FP16_COMPRESS is registered.";
       break;
     default:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #80996
* #80978
* __->__ #80975

Summary:
Change class AllReduceCommHook : public CppCommHookInterface<ProcessGroup*>
to class AllReduceCommHook : public CppCommHookInterface<intrusive_ptr<ProcessGroup>>.
Ditto for the related classes as well.

Test Plan:
Covered by existing unit tests.

Fixed #80243