### PR TITLE
[c10d] Change APIs in ProcessGroup to accept const std::vector<at::Tensor>&

### DIFF
--- a/test/cpp/c10d/ProcessGroupGlooTest.cpp
+++ b/test/cpp/c10d/ProcessGroupGlooTest.cpp
@@ -111,7 +111,7 @@ class ProcessGroupGlooDelayed : public ::c10d::ProcessGroupGloo {
       : ProcessGroupGloo(store, rank, size, options) {}
 
   c10::intrusive_ptr<::c10d::ProcessGroup::Work> send(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int dstRank,
       int tag) override {
     std::this_thread::sleep_for(kSendDelay);

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -450,7 +450,7 @@ void broadcast(
 
 void reduce(
     const std::vector<at::Tensor>& inputs,
-    at::Tensor& output,
+    const at::Tensor& output,
     int32_t root,
     int32_t op,
     const stream_list& streams,
@@ -496,7 +496,7 @@ void reduce(
 }
 
 void reduce(
-    std::vector<at::Tensor>& inputs,
+    const std::vector<at::Tensor>& inputs,
     int32_t root,
     int32_t op,
     const stream_list& streams,
@@ -506,7 +506,7 @@ void reduce(
 
 void all_reduce(
     const std::vector<at::Tensor>& inputs,
-    std::vector<at::Tensor>& outputs,
+    const std::vector<at::Tensor>& outputs,
     int32_t op,
     const stream_list& streams,
     const comm_list& user_comms) {
@@ -548,7 +548,7 @@ void all_reduce(
 
 void reduce_scatter(
     const std::vector<at::Tensor>& inputs,
-    std::vector<at::Tensor>& outputs,
+    const std::vector<at::Tensor>& outputs,
     int32_t op,
     const stream_list& streams,
     const comm_list& user_comms) {
@@ -590,7 +590,7 @@ void reduce_scatter(
 
 void all_gather(
     const std::vector<at::Tensor>& inputs,
-    std::vector<at::Tensor>& outputs,
+    const std::vector<at::Tensor>& outputs,
     const stream_list& streams,
     const comm_list& user_comms) {
 #ifdef USE_NCCL
@@ -639,8 +639,8 @@ void all_gather(
 }
 
 void all2all_single_equal_split(
-    at::Tensor& input,
-    at::Tensor& output,
+    const at::Tensor& input,
+    const at::Tensor& output,
     int size,
     ncclComm_t _comm,
     at::cuda::CUDAStream& stream) {
@@ -734,8 +734,8 @@ void all2all_single_unequal_split(
 }
 
 void all2all(
-    std::vector<at::Tensor>& outputTensors,
-    std::vector<at::Tensor>& inputTensors,
+    const std::vector<at::Tensor>& outputTensors,
+    const std::vector<at::Tensor>& inputTensors,
     ncclComm_t _comm,
     at::cuda::CUDAStream& stream) {
 #ifdef USE_NCCL
@@ -746,8 +746,8 @@ void all2all(
 
   NCCL_CHECK(ncclGroupStart());
   for (const auto r : c10::irange(outputTensors.size())) {
-    at::Tensor& input = inputTensors[r];
-    at::Tensor& output = outputTensors[r];
+    const at::Tensor& input = inputTensors[r];
+    const at::Tensor& output = outputTensors[r];
     if (input.numel() != 0) {
       NCCL_CHECK(ncclSend(
           input.data_ptr(),
@@ -801,7 +801,7 @@ void send(
 }
 
 void recv(
-    at::Tensor& output,
+    const at::Tensor& output,
     ncclComm_t comm,
     at::cuda::CUDAStream stream,
     int src) {
@@ -826,7 +826,7 @@ void recv(
 
 void gather(
     const at::Tensor& inputs,
-    std::vector<at::Tensor>& outputs,
+    const std::vector<at::Tensor>& outputs,
     ncclComm_t _comm,
     at::cuda::CUDAStream& stream,
     int32_t root) {
@@ -871,7 +871,7 @@ void gather(
 
 void scatter(
     const std::vector<at::Tensor>& inputs,
-    at::Tensor& outputs,
+    const at::Tensor& outputs,
     ncclComm_t _comm,
     at::cuda::CUDAStream& stream,
     int32_t root) {

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -122,14 +122,14 @@ size_t get_max_count();
 
 TORCH_CUDA_CPP_API void reduce(
     const std::vector<at::Tensor>& inputs,
-    at::Tensor& output,
+    const at::Tensor& output,
     int32_t root = 0,
     int32_t op = static_cast<int>(ncclRedOp::Sum),
     const stream_list& streams = {},
     const comm_list& user_comms = {});
 
 TORCH_CUDA_CPP_API void reduce(
-    std::vector<at::Tensor>& inputs,
+    const std::vector<at::Tensor>& inputs,
     int32_t root = 0,
     int32_t op = static_cast<int>(ncclRedOp::Sum),
     const stream_list& streams = {},
@@ -137,41 +137,41 @@ TORCH_CUDA_CPP_API void reduce(
 
 TORCH_CUDA_CPP_API void all_reduce(
     const std::vector<at::Tensor>& inputs,
-    std::vector<at::Tensor>& outputs,
+    const std::vector<at::Tensor>& outputs,
     int32_t op = static_cast<int>(ncclRedOp::Sum),
     const stream_list& streams = {},
     const comm_list& user_comms = {});
 
 TORCH_CUDA_CPP_API void reduce_scatter(
     const std::vector<at::Tensor>& inputs,
-    std::vector<at::Tensor>& outputs,
+    const std::vector<at::Tensor>& outputs,
     int32_t op = static_cast<int>(ncclRedOp::Sum),
     const stream_list& streams = {},
     const comm_list& user_comms = {});
 
 TORCH_CUDA_CPP_API void scatter(
     const std::vector<at::Tensor>& inputs,
-    at::Tensor& outputs,
+    const at::Tensor& outputs,
     ncclComm_t comm,
     at::cuda::CUDAStream& stream,
     int32_t root = 0);
 
 TORCH_CUDA_CPP_API void all_gather(
     const std::vector<at::Tensor>& inputs,
-    std::vector<at::Tensor>& outputs,
+    const std::vector<at::Tensor>& outputs,
     const stream_list& streams = {},
     const comm_list& user_comms = {});
 
 TORCH_CUDA_CPP_API void gather(
     const at::Tensor& inputs,
-    std::vector<at::Tensor>& outputs,
+    const std::vector<at::Tensor>& outputs,
     ncclComm_t comm,
     at::cuda::CUDAStream& stream,
     int32_t root = 0);
 
 TORCH_CUDA_CPP_API void all2all_single_equal_split(
-    at::Tensor& input,
-    at::Tensor& output,
+    const at::Tensor& input,
+    const at::Tensor& output,
     int size,
     ncclComm_t comm,
     at::cuda::CUDAStream& stream);
@@ -189,8 +189,8 @@ TORCH_CUDA_CPP_API void all2all_single_unequal_split(
     at::cuda::CUDAStream& stream);
 
 TORCH_CUDA_CPP_API void all2all(
-    std::vector<at::Tensor>& outputTensors,
-    std::vector<at::Tensor>& inputTensors,
+    const std::vector<at::Tensor>& outputTensors,
+    const std::vector<at::Tensor>& inputTensors,
     ncclComm_t _comm,
     at::cuda::CUDAStream& stream);
 
@@ -201,7 +201,7 @@ TORCH_CUDA_CPP_API void send(
     int dst);
 
 TORCH_CUDA_CPP_API void recv(
-    at::Tensor& output,
+    const at::Tensor& output,
     ncclComm_t comm,
     at::cuda::CUDAStream stream,
     int src);

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -213,7 +213,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // to the dispatcher.
   // TODO: Find a way to force the above rule programmatically.
   virtual c10::intrusive_ptr<ProcessGroup::Work> broadcast(
-      std::vector<at::Tensor>& /* tensors */,
+      const std::vector<at::Tensor>& /* tensors */,
       const BroadcastOptions& /* opts */ = BroadcastOptions()) {
     TORCH_CHECK(
         false,
@@ -222,7 +222,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> allreduce(
-      std::vector<at::Tensor>& /* tensors */,
+      const std::vector<at::Tensor>& /* tensors */,
       const AllreduceOptions& /* opts */ = AllreduceOptions()) {
     TORCH_CHECK(
         false,
@@ -231,7 +231,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> allreduce_coalesced(
-      std::vector<at::Tensor>& /* tensors */,
+      const std::vector<at::Tensor>& /* tensors */,
       const AllreduceCoalescedOptions& /* opts */ = AllreduceCoalescedOptions()) {
     TORCH_CHECK(
         false,
@@ -242,7 +242,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> reduce(
-      std::vector<at::Tensor>& /* tensors */,
+      const std::vector<at::Tensor>& /* tensors */,
       const ReduceOptions& /* opts */ = ReduceOptions()) {
     TORCH_CHECK(
         false,
@@ -250,8 +250,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> allgather(
-      std::vector<std::vector<at::Tensor>>& /* outputTensors */,
-      std::vector<at::Tensor>& /* inputTensors */,
+      const std::vector<std::vector<at::Tensor>>& /* outputTensors */,
+      const std::vector<at::Tensor>& /* inputTensors */,
       const AllgatherOptions& /* opts */ = AllgatherOptions()) {
     TORCH_CHECK(
         false,
@@ -280,8 +280,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // * do not implement it in your ProcessGroup, implement _allgather_base
   //   instead.
   virtual c10::intrusive_ptr<ProcessGroup::Work> allgather_coalesced(
-      std::vector<std::vector<at::Tensor>>& /* outputTensorLists */,
-      std::vector<at::Tensor>& /* inputTensors */,
+      const std::vector<std::vector<at::Tensor>>& /* outputTensorLists */,
+      const std::vector<at::Tensor>& /* inputTensors */,
       const AllgatherOptions& /* opts */ = AllgatherOptions()) {
     TORCH_CHECK(
         false,
@@ -292,8 +292,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> gather(
-      std::vector<std::vector<at::Tensor>>& /* outputTensors */,
-      std::vector<at::Tensor>& /* inputTensors */,
+      const std::vector<std::vector<at::Tensor>>& /* outputTensors */,
+      const std::vector<at::Tensor>& /* inputTensors */,
       const GatherOptions& /* opts */ = GatherOptions()) {
     TORCH_CHECK(
         false,
@@ -301,8 +301,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> scatter(
-      std::vector<at::Tensor>& /* outputTensors */,
-      std::vector<std::vector<at::Tensor>>& /* inputTensors */,
+      const std::vector<at::Tensor>& /* outputTensors */,
+      const std::vector<std::vector<at::Tensor>>& /* inputTensors */,
       const ScatterOptions& /* opts */ = ScatterOptions()) {
     TORCH_CHECK(
         false,
@@ -311,8 +311,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> reduce_scatter(
-      std::vector<at::Tensor>& /* outputTensors */,
-      std::vector<std::vector<at::Tensor>>& /* inputTensors */,
+      const std::vector<at::Tensor>& /* outputTensors */,
+      const std::vector<std::vector<at::Tensor>>& /* inputTensors */,
       const ReduceScatterOptions& /* opts */ = ReduceScatterOptions()) {
     TORCH_CHECK(
         false,
@@ -349,8 +349,8 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> alltoall(
-      std::vector<at::Tensor>& /* outputTensors */,
-      std::vector<at::Tensor>& /* inputTensors */,
+      const std::vector<at::Tensor>& /* outputTensors */,
+      const std::vector<at::Tensor>& /* inputTensors */,
       const AllToAllOptions& opts = AllToAllOptions()) {
     TORCH_CHECK(
         false,
@@ -397,7 +397,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> send(
-      std::vector<at::Tensor>& /* tensors */,
+      const std::vector<at::Tensor>& /* tensors */,
       int /* dstRank */,
       int /* tag */) {
     TORCH_CHECK(
@@ -406,7 +406,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> recv(
-      std::vector<at::Tensor>& /* tensors */,
+      const std::vector<at::Tensor>& /* tensors */,
       int /* srcRank */,
       int /* tag */) {
     TORCH_CHECK(
@@ -415,7 +415,7 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   }
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> recvAnysource(
-      std::vector<at::Tensor>& /* tensors */,
+      const std::vector<at::Tensor>& /* tensors */,
       int /* tag */) {
     TORCH_CHECK(
         false,

--- a/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupGloo.hpp
@@ -147,7 +147,7 @@ class TORCH_API ProcessGroupGloo : public ProcessGroup {
   class TORCH_API SendWork : public ProcessGroup::Work {
    public:
     explicit SendWork(
-        at::Tensor& tensor,
+        const at::Tensor& tensor,
         std::unique_ptr<::gloo::transport::UnboundBuffer> buffer);
 
     bool wait(std::chrono::milliseconds timeout = kNoTimeout) override;
@@ -162,7 +162,7 @@ class TORCH_API ProcessGroupGloo : public ProcessGroup {
   class TORCH_API RecvWork : public ProcessGroup::Work {
    public:
     explicit RecvWork(
-        at::Tensor& tensor,
+        const at::Tensor& tensor,
         std::unique_ptr<::gloo::transport::UnboundBuffer> buffer,
         const char* profilingTitle = nullptr);
 
@@ -227,25 +227,25 @@ class TORCH_API ProcessGroupGloo : public ProcessGroup {
   }
 
   c10::intrusive_ptr<ProcessGroup::Work> broadcast(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce_coalesced(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> reduce(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allgather(
-      std::vector<std::vector<at::Tensor>>& outputs,
-      std::vector<at::Tensor>& inputs,
+      const std::vector<std::vector<at::Tensor>>& outputs,
+      const std::vector<at::Tensor>& inputs,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> _allgather_base(
@@ -254,23 +254,23 @@ class TORCH_API ProcessGroupGloo : public ProcessGroup {
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allgather_coalesced(
-      std::vector<std::vector<at::Tensor>>& output_lists,
-      std::vector<at::Tensor>& input_list,
+      const std::vector<std::vector<at::Tensor>>& output_lists,
+      const std::vector<at::Tensor>& input_list,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> gather(
-      std::vector<std::vector<at::Tensor>>& outputs,
-      std::vector<at::Tensor>& inputs,
+      const std::vector<std::vector<at::Tensor>>& outputs,
+      const std::vector<at::Tensor>& inputs,
       const GatherOptions& opts = GatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> scatter(
-      std::vector<at::Tensor>& outputs,
-      std::vector<std::vector<at::Tensor>>& inputs,
+      const std::vector<at::Tensor>& outputs,
+      const std::vector<std::vector<at::Tensor>>& inputs,
       const ScatterOptions& opts = ScatterOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> reduce_scatter(
-      std::vector<at::Tensor>& outputs,
-      std::vector<std::vector<at::Tensor>>& inputs,
+      const std::vector<at::Tensor>& outputs,
+      const std::vector<std::vector<at::Tensor>>& inputs,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> alltoall_base(
@@ -281,17 +281,17 @@ class TORCH_API ProcessGroupGloo : public ProcessGroup {
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> send(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int dstRank,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recv(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int srcRank,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recvAnysource(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> barrier(

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -384,7 +384,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::enqueue(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::broadcast(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     const BroadcastOptions& opts) {
   checkSingleTensor(tensors);
   std::function<void(std::unique_ptr<WorkEntry>&)> runFunc =
@@ -408,7 +408,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::broadcast(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::allreduce(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts) {
   checkSingleTensor(tensors);
 
@@ -434,13 +434,13 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::allreduce(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::allreduce_coalesced(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     const AllreduceCoalescedOptions& opts) {
   TORCH_CHECK(false, "allreduce_coalesced is currently not supported with MPI");
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::reduce(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     const ReduceOptions& opts) {
   checkSingleTensor(tensors);
 
@@ -471,8 +471,8 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::reduce(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::allgather(
-    std::vector<std::vector<at::Tensor>>& outputTensors,
-    std::vector<at::Tensor>& inputTensors,
+    const std::vector<std::vector<at::Tensor>>& outputTensors,
+    const std::vector<at::Tensor>& inputTensors,
     const AllgatherOptions& opts) {
   checkSingleTensor(inputTensors);
   if (outputTensors.size() != 1) {
@@ -520,15 +520,15 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::allgather(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::allgather_coalesced(
-    std::vector<std::vector<at::Tensor>>& /* unused */,
-    std::vector<at::Tensor>& /* unused */,
+    const std::vector<std::vector<at::Tensor>>& /* unused */,
+    const std::vector<at::Tensor>& /* unused */,
     const AllgatherOptions& /* unused */) {
   TORCH_CHECK(false, "ProcessGroupMPI does not support allgather_coalesced");
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::gather(
-    std::vector<std::vector<at::Tensor>>& outputTensors,
-    std::vector<at::Tensor>& inputTensors,
+    const std::vector<std::vector<at::Tensor>>& outputTensors,
+    const std::vector<at::Tensor>& inputTensors,
     const GatherOptions& opts) {
   checkSingleTensor(inputTensors);
 
@@ -603,8 +603,8 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::gather(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::scatter(
-    std::vector<at::Tensor>& outputTensors,
-    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const std::vector<at::Tensor>& outputTensors,
+    const std::vector<std::vector<at::Tensor>>& inputTensors,
     const ScatterOptions& opts) {
   checkSingleTensor(outputTensors);
 
@@ -635,7 +635,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::scatter(
         at::Tensor flatInputTensor;
 
         if (rank_ == opts.rootRank) {
-          std::vector<at::Tensor>& inputDataVec = entry->src;
+          const std::vector<at::Tensor>& inputDataVec = entry->src;
           flatInputTensor = newLikeFlat(inputDataVec);
           sendbuf = flatInputTensor.data_ptr();
 
@@ -680,8 +680,8 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::scatter(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::reduce_scatter(
-    std::vector<at::Tensor>& outputTensors,
-    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const std::vector<at::Tensor>& outputTensors,
+    const std::vector<std::vector<at::Tensor>>& inputTensors,
     const ReduceScatterOptions& opts) {
   TORCH_CHECK(false, "ProcessGroupMPI does not support reduce_scatter");
 }
@@ -770,8 +770,8 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::alltoall_base(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::alltoall(
-    std::vector<at::Tensor>& outputTensors,
-    std::vector<at::Tensor>& inputTensors,
+    const std::vector<at::Tensor>& outputTensors,
+    const std::vector<at::Tensor>& inputTensors,
     const AllToAllOptions& opts) {
   TORCH_CHECK(
       inputTensors.size() == size_,
@@ -830,7 +830,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::alltoall(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::send(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     int dstRank,
     int tag) {
   checkSingleTensor(tensors);
@@ -859,7 +859,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::send(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::recv(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     int srcRank,
     int tag) {
   checkSingleTensor(tensors);
@@ -888,7 +888,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::recv(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::recvAnysource(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     int tag) {
   checkSingleTensor(tensors);
 

--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.hpp
@@ -30,8 +30,8 @@ constexpr const char* MPI_BACKEND_NAME = "mpi";
 // The actual run function that will operate either on src or dst or both.
 struct WorkEntry {
   explicit WorkEntry(
-      std::vector<at::Tensor>* srcPtr,
-      std::vector<at::Tensor>* dstPtr,
+      const std::vector<at::Tensor>* srcPtr,
+      const std::vector<at::Tensor>* dstPtr,
       std::function<void(std::unique_ptr<WorkEntry>&)> run)
       : dst(dstPtr ? *dstPtr : std::vector<at::Tensor>()),
         run(std::move(run)) {
@@ -154,25 +154,25 @@ class TORCH_API ProcessGroupMPI : public ProcessGroup {
   }
 
   c10::intrusive_ptr<ProcessGroup::Work> broadcast(
-      std::vector<at::Tensor>& data,
+      const std::vector<at::Tensor>& data,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce_coalesced(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> reduce(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allgather(
-      std::vector<std::vector<at::Tensor>>& outputTensors,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<std::vector<at::Tensor>>& outputTensors,
+      const std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> _allgather_base(
@@ -181,23 +181,23 @@ class TORCH_API ProcessGroupMPI : public ProcessGroup {
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allgather_coalesced(
-      std::vector<std::vector<at::Tensor>>& outputTensorLists,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<std::vector<at::Tensor>>& outputTensorLists,
+      const std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> gather(
-      std::vector<std::vector<at::Tensor>>& outputTensors,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<std::vector<at::Tensor>>& outputTensors,
+      const std::vector<at::Tensor>& inputTensors,
       const GatherOptions& opts = GatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> scatter(
-      std::vector<at::Tensor>& outputTensors,
-      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const std::vector<at::Tensor>& outputTensors,
+      const std::vector<std::vector<at::Tensor>>& inputTensors,
       const ScatterOptions& opts = ScatterOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> reduce_scatter(
-      std::vector<at::Tensor>& outputTensors,
-      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const std::vector<at::Tensor>& outputTensors,
+      const std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> alltoall_base(
@@ -208,22 +208,22 @@ class TORCH_API ProcessGroupMPI : public ProcessGroup {
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> alltoall(
-      std::vector<at::Tensor>& outputTensors,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<at::Tensor>& outputTensors,
+      const std::vector<at::Tensor>& inputTensors,
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> send(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int dstRank,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recv(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int srcRank,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recvAnysource(
-      std::vector<at::Tensor>& tensor,
+      const std::vector<at::Tensor>& tensor,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> barrier(

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -276,25 +276,25 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
   }
 
   c10::intrusive_ptr<ProcessGroup::Work> broadcast(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce_coalesced(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> reduce(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allgather(
-      std::vector<std::vector<at::Tensor>>& outputTensors,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<std::vector<at::Tensor>>& outputTensors,
+      const std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> _allgather_base(
@@ -303,13 +303,13 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allgather_coalesced(
-      std::vector<std::vector<at::Tensor>>& outputTensorLists,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<std::vector<at::Tensor>>& outputTensorLists,
+      const std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> reduce_scatter(
-      std::vector<at::Tensor>& outputTensors,
-      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const std::vector<at::Tensor>& outputTensors,
+      const std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> _reduce_scatter_base(
@@ -328,17 +328,17 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> alltoall(
-      std::vector<at::Tensor>& outputTensors,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<at::Tensor>& outputTensors,
+      const std::vector<at::Tensor>& inputTensors,
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> send(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int dstRank,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recv(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int srcRank,
       int tag) override;
 
@@ -348,17 +348,17 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
 
   // Unsupported Ops
   c10::intrusive_ptr<ProcessGroup::Work> gather(
-      std::vector<std::vector<at::Tensor>>& outputTensors,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<std::vector<at::Tensor>>& outputTensors,
+      const std::vector<at::Tensor>& inputTensors,
       const GatherOptions& opts = GatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> scatter(
-      std::vector<at::Tensor>& outputTensors,
-      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const std::vector<at::Tensor>& outputTensors,
+      const std::vector<std::vector<at::Tensor>>& inputTensors,
       const ScatterOptions& opts = ScatterOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recvAnysource(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int tag) override;
 
    // Agrees on an initial sequence number for the whole group by having rank 0
@@ -410,15 +410,15 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
   //    void {pre,post}(std::vector<at::cuda::CUDAStream&>);
   template <typename Fn>
   c10::intrusive_ptr<ProcessGroup::Work> collective(
-      std::vector<at::Tensor>& input,
-      std::vector<at::Tensor>& output,
+      const std::vector<at::Tensor>& input,
+      const std::vector<at::Tensor>& output,
       Fn fn,
       OpType opType,
       const char* profilingTitle = nullptr);
   template <typename Fn, typename PreProcess, typename PostProcess>
   c10::intrusive_ptr<ProcessGroup::Work> collective(
-      std::vector<at::Tensor>& input,
-      std::vector<at::Tensor>& output,
+      const std::vector<at::Tensor>& input,
+      const std::vector<at::Tensor>& output,
       Fn fn,
       PreProcess pre,
       PostProcess post,
@@ -430,14 +430,14 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
   // communicaiton primitives.
   template <typename Fn>
   c10::intrusive_ptr<ProcessGroup::Work> pointToPoint(
-      std::vector<at::Tensor>& tensor,
+      const std::vector<at::Tensor>& tensor,
       Fn fn,
       int peer,
       OpType opType,
       const char* profilingTitle = nullptr);
   template <typename Fn, typename PreProcess, typename PostProcess>
   c10::intrusive_ptr<ProcessGroup::Work> pointToPoint(
-      std::vector<at::Tensor>& tensor,
+      const std::vector<at::Tensor>& tensor,
       Fn fn,
       int peer,
       OpType opType,
@@ -446,7 +446,7 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
       const char* profilingTitle);
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce_impl(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions());
 
   // Checks for NCCL errors on each of the communicators and returns an

--- a/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.cpp
@@ -18,62 +18,62 @@ ProcessGroupRoundRobin::ProcessGroupRoundRobin(
 ProcessGroupRoundRobin::~ProcessGroupRoundRobin() {}
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::broadcast(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     const BroadcastOptions& opts) {
   return next()->broadcast(tensors, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::allreduce(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts) {
   return next()->allreduce(tensors, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::
     allreduce_coalesced(
-        std::vector<at::Tensor>& tensors,
+        const std::vector<at::Tensor>& tensors,
         const AllreduceCoalescedOptions& opts) {
   return next()->allreduce_coalesced(tensors, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::reduce(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     const ReduceOptions& opts) {
   return next()->reduce(tensors, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::allgather(
-    std::vector<std::vector<at::Tensor>>& outputs,
-    std::vector<at::Tensor>& inputs,
+    const std::vector<std::vector<at::Tensor>>& outputs,
+    const std::vector<at::Tensor>& inputs,
     const AllgatherOptions& opts) {
   return next()->allgather(outputs, inputs, opts);
 };
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::
     allgather_coalesced(
-        std::vector<std::vector<at::Tensor>>& outputTensorLists,
-        std::vector<at::Tensor>& inputTensors,
+        const std::vector<std::vector<at::Tensor>>& outputTensorLists,
+        const std::vector<at::Tensor>& inputTensors,
         const AllgatherOptions& opts) {
   return next()->allgather(outputTensorLists, inputTensors, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::gather(
-    std::vector<std::vector<at::Tensor>>& outputs,
-    std::vector<at::Tensor>& inputs,
+    const std::vector<std::vector<at::Tensor>>& outputs,
+    const std::vector<at::Tensor>& inputs,
     const GatherOptions& opts) {
   return next()->gather(outputs, inputs, opts);
 };
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::scatter(
-    std::vector<at::Tensor>& outputs,
-    std::vector<std::vector<at::Tensor>>& inputs,
+    const std::vector<at::Tensor>& outputs,
+    const std::vector<std::vector<at::Tensor>>& inputs,
     const ScatterOptions& opts) {
   return next()->scatter(outputs, inputs, opts);
 };
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::reduce_scatter(
-    std::vector<at::Tensor>& outputs,
-    std::vector<std::vector<at::Tensor>>& inputs,
+    const std::vector<at::Tensor>& outputs,
+    const std::vector<std::vector<at::Tensor>>& inputs,
     const ReduceScatterOptions& opts) {
   return next()->reduce_scatter(outputs, inputs, opts);
 };
@@ -89,21 +89,21 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::alltoall_base(
 };
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::send(
-    std::vector<at::Tensor>& /* unused */,
+    const std::vector<at::Tensor>& /* unused */,
     int /* unused */,
     int /* unused */) {
   TORCH_CHECK(false, "ProcessGroupRoundRobin does not support send");
 };
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::recv(
-    std::vector<at::Tensor>& /* unused */,
+    const std::vector<at::Tensor>& /* unused */,
     int /* unused */,
     int /* unused */) {
   TORCH_CHECK(false, "ProcessGroupRoundRobin does not support recv");
 };
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupRoundRobin::recvAnysource(
-    std::vector<at::Tensor>& /* unused */,
+    const std::vector<at::Tensor>& /* unused */,
     int /* unused */) {
   TORCH_CHECK(false, "ProcessGroupRoundRobin does not support recv");
 };

--- a/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupRoundRobin.hpp
@@ -32,25 +32,25 @@ class TORCH_API ProcessGroupRoundRobin final : public ProcessGroup {
   }
 
   c10::intrusive_ptr<ProcessGroup::Work> broadcast(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce_coalesced(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> reduce(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allgather(
-      std::vector<std::vector<at::Tensor>>& outputs,
-      std::vector<at::Tensor>& inputs,
+      const std::vector<std::vector<at::Tensor>>& outputs,
+      const std::vector<at::Tensor>& inputs,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> _allgather_base(
@@ -59,23 +59,23 @@ class TORCH_API ProcessGroupRoundRobin final : public ProcessGroup {
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allgather_coalesced(
-      std::vector<std::vector<at::Tensor>>& outputTensorLists,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<std::vector<at::Tensor>>& outputTensorLists,
+      const std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> gather(
-      std::vector<std::vector<at::Tensor>>& outputs,
-      std::vector<at::Tensor>& inputs,
+      const std::vector<std::vector<at::Tensor>>& outputs,
+      const std::vector<at::Tensor>& inputs,
       const GatherOptions& opts = GatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> scatter(
-      std::vector<at::Tensor>& outputs,
-      std::vector<std::vector<at::Tensor>>& inputs,
+      const std::vector<at::Tensor>& outputs,
+      const std::vector<std::vector<at::Tensor>>& inputs,
       const ScatterOptions& opts = ScatterOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> reduce_scatter(
-      std::vector<at::Tensor>& outputs,
-      std::vector<std::vector<at::Tensor>>& inputs,
+      const std::vector<at::Tensor>& outputs,
+      const std::vector<std::vector<at::Tensor>>& inputs,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> alltoall_base(
@@ -86,17 +86,17 @@ class TORCH_API ProcessGroupRoundRobin final : public ProcessGroup {
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> send(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int dstRank,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recv(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int srcRank,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recvAnysource(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> barrier(

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -128,7 +128,7 @@ struct CollectiveFingerPrint {
 
  private:
   void verify_tensors(
-      std::vector<at::Tensor>& tensors_to_verify,
+      const std::vector<at::Tensor>& tensors_to_verify,
       c10::intrusive_ptr<ProcessGroup>& pg) {
     // Create output tensor data structure to pass into allgather.
     std::vector<std::vector<at::Tensor>> output_tensors;
@@ -272,21 +272,21 @@ const std::string ProcessGroupWrapper::getBackendName() const {
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::broadcast(
-    std::vector<at::Tensor>& data,
+    const std::vector<at::Tensor>& data,
     const BroadcastOptions& opts) {
   runCollectiveChecks(OpType::BROADCAST, data);
   return pg_->broadcast(data, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::allreduce(
-    std::vector<at::Tensor>& data,
+    const std::vector<at::Tensor>& data,
     const AllreduceOptions& opts) {
   runCollectiveChecks(OpType::ALLREDUCE, data);
   return pg_->allreduce(data, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::allreduce_coalesced(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     const AllreduceCoalescedOptions& opts) {
   // NOTE: We don't enforce shape checking for allreduce_coalesced because
   // the implementation itself does not enforce it we have tests that use
@@ -297,15 +297,15 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::allreduce_coalesced(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::reduce(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     const ReduceOptions& opts) {
   runCollectiveChecks(OpType::REDUCE, tensors);
   return pg_->reduce(tensors, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::allgather(
-    std::vector<std::vector<at::Tensor>>& outputTensors,
-    std::vector<at::Tensor>& inputTensors,
+    const std::vector<std::vector<at::Tensor>>& outputTensors,
+    const std::vector<at::Tensor>& inputTensors,
     const AllgatherOptions& opts) {
   runCollectiveChecks(OpType::ALLGATHER, inputTensors);
   return pg_->allgather(outputTensors, inputTensors, opts);
@@ -321,8 +321,8 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::_allgather_base(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::allgather_coalesced(
-    std::vector<std::vector<at::Tensor>>& outputTensorLists,
-    std::vector<at::Tensor>& inputTensors,
+    const std::vector<std::vector<at::Tensor>>& outputTensorLists,
+    const std::vector<at::Tensor>& inputTensors,
     const AllgatherOptions& opts) {
   // NOTE: We don't enforce shape checking for allgather_coalesced because
   // the implementation itself does not enforce it we have tests that use
@@ -333,24 +333,24 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::allgather_coalesced(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::gather(
-    std::vector<std::vector<at::Tensor>>& outputTensors,
-    std::vector<at::Tensor>& inputTensors,
+    const std::vector<std::vector<at::Tensor>>& outputTensors,
+    const std::vector<at::Tensor>& inputTensors,
     const GatherOptions& opts) {
   runCollectiveChecks(OpType::GATHER, inputTensors);
   return pg_->gather(outputTensors, inputTensors, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::scatter(
-    std::vector<at::Tensor>& outputTensors,
-    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const std::vector<at::Tensor>& outputTensors,
+    const std::vector<std::vector<at::Tensor>>& inputTensors,
     const ScatterOptions& opts) {
   runCollectiveChecks(OpType::SCATTER, outputTensors);
   return pg_->scatter(outputTensors, inputTensors, opts);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::reduce_scatter(
-    std::vector<at::Tensor>& outputTensors,
-    std::vector<std::vector<at::Tensor>>& inputTensors,
+    const std::vector<at::Tensor>& outputTensors,
+    const std::vector<std::vector<at::Tensor>>& inputTensors,
     const ReduceScatterOptions& opts) {
   runCollectiveChecks(OpType::REDUCE_SCATTER, outputTensors);
   return pg_->reduce_scatter(outputTensors, inputTensors, opts);
@@ -369,8 +369,8 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::alltoall_base(
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::alltoall(
-    std::vector<at::Tensor>& outputTensors,
-    std::vector<at::Tensor>& inputTensors,
+    const std::vector<at::Tensor>& outputTensors,
+    const std::vector<at::Tensor>& inputTensors,
     const AllToAllOptions& opts) {
   // alltoall supports uneven split, so don't enforce shape checking.
   runCollectiveChecks(OpType::ALLTOALL, {});
@@ -396,21 +396,21 @@ uint64_t ProcessGroupWrapper::getSequenceNumberForGroup() {
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::send(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     int dstRank,
     int tag) {
   return pg_->send(tensors, dstRank, tag);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::recv(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     int srcRank,
     int tag) {
   return pg_->recv(tensors, srcRank, tag);
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupWrapper::recvAnysource(
-    std::vector<at::Tensor>& tensors,
+    const std::vector<at::Tensor>& tensors,
     int tag) {
   return pg_->recvAnysource(tensors, tag);
 }

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -18,25 +18,25 @@ class TORCH_API ProcessGroupWrapper : public ProcessGroup {
   const std::string getBackendName() const override;
 
   c10::intrusive_ptr<ProcessGroup::Work> broadcast(
-      std::vector<at::Tensor>& data,
+      const std::vector<at::Tensor>& data,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce(
-      std::vector<at::Tensor>& data,
+      const std::vector<at::Tensor>& data,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce_coalesced(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> reduce(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> allgather(
-      std::vector<std::vector<at::Tensor>>& outputTensors,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<std::vector<at::Tensor>>& outputTensors,
+      const std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> _allgather_base(
@@ -49,23 +49,23 @@ class TORCH_API ProcessGroupWrapper : public ProcessGroup {
   // * do not implement it in your ProcessGroup, implement _allgather_base
   //   instead.
   c10::intrusive_ptr<ProcessGroup::Work> allgather_coalesced(
-      std::vector<std::vector<at::Tensor>>& outputTensorLists,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<std::vector<at::Tensor>>& outputTensorLists,
+      const std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> gather(
-      std::vector<std::vector<at::Tensor>>& outputTensors,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<std::vector<at::Tensor>>& outputTensors,
+      const std::vector<at::Tensor>& inputTensors,
       const GatherOptions& opts = GatherOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> scatter(
-      std::vector<at::Tensor>& outputTensors,
-      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const std::vector<at::Tensor>& outputTensors,
+      const std::vector<std::vector<at::Tensor>>& inputTensors,
       const ScatterOptions& opts = ScatterOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> reduce_scatter(
-      std::vector<at::Tensor>& outputTensors,
-      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const std::vector<at::Tensor>& outputTensors,
+      const std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> alltoall_base(
@@ -76,8 +76,8 @@ class TORCH_API ProcessGroupWrapper : public ProcessGroup {
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> alltoall(
-      std::vector<at::Tensor>& outputTensors,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<at::Tensor>& outputTensors,
+      const std::vector<at::Tensor>& inputTensors,
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
   void monitoredBarrier(const BarrierOptions& opts, bool waitAllRanks = false)
@@ -95,17 +95,17 @@ class TORCH_API ProcessGroupWrapper : public ProcessGroup {
   uint64_t getSequenceNumberForGroup() override; // just call underlying
 
   c10::intrusive_ptr<ProcessGroup::Work> send(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int dstRank,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recv(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int srcRank,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> recvAnysource(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int tag) override;
 
   c10::intrusive_ptr<ProcessGroup::Work> barrier(

--- a/torch/csrc/distributed/c10d/PyProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/PyProcessGroup.hpp
@@ -52,8 +52,8 @@ class PyProcessGroup : public ProcessGroup {
   }
 
   c10::intrusive_ptr<ProcessGroup::Work> allgather(
-      std::vector<std::vector<at::Tensor>>& outputTensors,
-      std::vector<at::Tensor>& inputTensors,
+      const std::vector<std::vector<at::Tensor>>& outputTensors,
+      const std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override {
     PYBIND11_OVERRIDE(
         c10::intrusive_ptr<ProcessGroup::Work>, /* Return type */
@@ -65,7 +65,7 @@ class PyProcessGroup : public ProcessGroup {
   }
 
   c10::intrusive_ptr<ProcessGroup::Work> allreduce(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override {
     PYBIND11_OVERRIDE(
         c10::intrusive_ptr<ProcessGroup::Work>, /* Return type */
@@ -85,7 +85,7 @@ class PyProcessGroup : public ProcessGroup {
   }
 
   c10::intrusive_ptr<ProcessGroup::Work> broadcast(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       const BroadcastOptions& opts = BroadcastOptions()) override {
     PYBIND11_OVERRIDE(
         c10::intrusive_ptr<ProcessGroup::Work>, /* Return type */
@@ -96,8 +96,8 @@ class PyProcessGroup : public ProcessGroup {
   }
 
   c10::intrusive_ptr<ProcessGroup::Work> reduce_scatter(
-      std::vector<at::Tensor>& outputTensors,
-      std::vector<std::vector<at::Tensor>>& inputTensors,
+      const std::vector<at::Tensor>& outputTensors,
+      const std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
     PYBIND11_OVERRIDE(
         c10::intrusive_ptr<ProcessGroup::Work>, /* Return type */
@@ -109,7 +109,7 @@ class PyProcessGroup : public ProcessGroup {
   }
 
   c10::intrusive_ptr<ProcessGroup::Work> send(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int dstRank,
       int tag) override {
     PYBIND11_OVERRIDE(
@@ -122,7 +122,7 @@ class PyProcessGroup : public ProcessGroup {
   }
 
   c10::intrusive_ptr<ProcessGroup::Work> recv(
-      std::vector<at::Tensor>& tensors,
+      const std::vector<at::Tensor>& tensors,
       int srcRank,
       int tag) override {
     PYBIND11_OVERRIDE(

--- a/torch/csrc/distributed/c10d/Utils.hpp
+++ b/torch/csrc/distributed/c10d/Utils.hpp
@@ -322,7 +322,7 @@ inline at::Tensor flattenDenseTensors(at::TensorList tensors) {
 }
 
 inline at::Tensor newLikeFlat(
-    std::vector<std::vector<at::Tensor>>& tensors,
+    const std::vector<std::vector<at::Tensor>>& tensors,
     size_t deviceIdx) {
   if (tensors.size() == 0 || tensors[0].size() == 0) {
     TORCH_CHECK(false, "Received an empty list");
@@ -346,7 +346,7 @@ inline at::Tensor newLikeFlat(
       sizes, strides, t.options().memory_format(c10::nullopt));
 }
 
-inline at::Tensor newLikeFlat(std::vector<at::Tensor>& tensors) {
+inline at::Tensor newLikeFlat(const std::vector<at::Tensor>& tensors) {
   if (tensors.size() == 0) {
     TORCH_CHECK(false, "Received an empty list");
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #80996
* #80978
* #80975

Summary:
Change c10d APIs in ProcessGroup to accept const std::vector<at::Tensor>&
instead of std::vector<at::Tensor>&. The intention of the APIs is not to
update the vector. Instead it is to update the data of the held tensors.
This change makes this intention more clear.

Test Plan:
Covered by existing tests.

Fixed #80241.