### PR TITLE
Run mask test with and without nested tensor

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8072,7 +8072,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
             torch.testing.assert_close(result, ref_output, rtol=1e-7, atol=1e-5)
 
-            model = nn.TransformerEncoder(encoder_layer, 6, norm=norm, enable_nested_tensor=False).to(device)
+            model = nn.TransformerEncoder(encoder_layer, 6, norm=norm, enable_nested_tensor=enable_nested_tensor).to(device)
             if not training:
                 model = model.eval()
             result = model(encoder_input, src_key_padding_mask=mask)


### PR DESCRIPTION
Summary: Run mask test with and without nested tensor

Test Plan: sandcastle

Differential Revision: D37665532

