### PR TITLE
Add reduce_scatter_v, a vector ReduceScatter for non-uniform input tensor splits

### DIFF
--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -209,6 +209,21 @@ class ProcessGroup:
         op=ReduceOp.SUM,
     ) -> Work: ...
     @overload
+    def _reduce(
+        self,
+        output_tensors: List[Tensor],
+        input_tensors: List[Tensor],
+        opts=ReduceOptions(),
+    ) -> Work: ...
+    @overload
+    def _reduce(
+        self,
+        output_tensor: Tensor,
+        input_tensor: Tensor,
+        root: int,
+        op=ReduceOp.SUM,
+    ) -> Work: ...
+    @overload
     def allgather(
         self,
         output_tensors: List[List[Tensor]],

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -16,6 +16,8 @@ std::string opTypeToString(OpType opType) {
       return "ALLREDUCE_COALESCED";
     case OpType::REDUCE:
       return "REDUCE";
+    case OpType::_REDUCE:
+      return "_REDUCE";
     case OpType::ALLGATHER:
       return "ALLGATHER";
     case OpType::_ALLGATHER_BASE:

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -48,6 +48,7 @@ enum class OpType : std::uint8_t {
   RECVANYSOURCE = 14,
   BARRIER = 15,
   _REDUCE_SCATTER_BASE = 16,
+  _REDUCE = 17,
   UNKNOWN = 100,
 };
 
@@ -243,6 +244,15 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> reduce(
       std::vector<at::Tensor>& /* tensors */,
+      const ReduceOptions& /* opts */ = ReduceOptions()) {
+    TORCH_CHECK(
+        false,
+        c10::str("ProcessGroup ", getBackendName(), "does not support reduce"));
+  }
+
+  virtual c10::intrusive_ptr<ProcessGroup::Work> _reduce(
+      std::vector<at::Tensor>& /* outputTensors */,
+      std::vector<at::Tensor>& /* inputTensors */,
       const ReduceOptions& /* opts */ = ReduceOptions()) {
     TORCH_CHECK(
         false,

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -292,6 +292,11 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
       std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override;
 
+  c10::intrusive_ptr<ProcessGroup::Work> _reduce(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const ReduceOptions& opts = ReduceOptions()) override;
+
   c10::intrusive_ptr<ProcessGroup::Work> allgather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1087,6 +1087,34 @@ Arguments:
               py::call_guard<py::gil_scoped_release>())
 
           .def(
+              "_reduce",
+              &::c10d::ProcessGroup::_reduce,
+              py::arg("output_tensors"),
+              py::arg("input_tensors"),
+              py::arg("opts") = ::c10d::ReduceOptions(),
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
+              "_reduce",
+              [](::c10d::ProcessGroup& pg,
+                 at::Tensor& y,
+                 at::Tensor& x,
+                 int rootRank,
+                 ::c10d::ReduceOp op) {
+                ::c10d::ReduceOptions opts;
+                opts.reduceOp = op;
+                opts.rootRank = rootRank;
+                std::vector<at::Tensor> ys = {y};
+                std::vector<at::Tensor> xs = {x};
+                return pg._reduce(ys, xs, opts);
+              },
+              py::arg("output_tensor"),
+              py::arg("input_tensor"),
+              py::arg("root"),
+              py::arg("op") = ::c10d::ReduceOp::SUM,
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
               "allgather",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  const std::vector<std::vector<at::Tensor>>& output_tensors,

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -2196,6 +2196,40 @@ class DistributedTest:
                 rank_to_GPU,
             )
 
+        @sandcastle_skip_if(BACKEND != "nccl", "Only Nccl supports reduce_scatter_v")
+        @sandcastle_skip_if(BACKEND in DistTestCases.skip_collective["reduce"], f"{BACKEND} does not support reduce")
+        @skip_if_no_gpu
+        def test_reduce_scatter_v_cuda(self):
+            self._barrier()
+            group, group_id, rank = self._init_global_test()
+            rank_to_GPU = init_multigpu_helper(dist.get_world_size(), BACKEND)
+            device_id = rank_to_GPU[rank][0]
+
+            input_split_sizes = []
+            for src in group:
+                input_split_sizes.append(src + 1)
+            start_len = sum(input_split_sizes[:rank])
+            end_len = start_len + input_split_sizes[rank]
+            sum_len = sum(input_split_sizes)
+            master_value = 2
+            worker_value = 10
+
+            for async_val in [True, False]:
+                tensor = _build_tensor(sum_len, worker_value, device_id=device_id)
+                tensor[start_len:end_len].fill_(master_value)
+                out_tensor = torch.empty(input_split_sizes[rank], sum_len, sum_len, dtype=torch.float).fill_(-1).cuda(device_id)
+
+                req = dist.reduce_scatter_v(out_tensor, tensor, input_split_sizes, dist.ReduceOp.SUM, group_id, async_val)
+                if async_val:
+                    req.wait()
+
+                expected_value = 2 + (10 * (len(group) - 1))
+                expected_tensor = torch.empty(input_split_sizes[rank], sum_len, sum_len, dtype=torch.float)
+                expected_tensor = expected_tensor.fill_(expected_value).cuda(device_id)
+
+                self._barrier()
+                self.assertEqual(out_tensor, expected_tensor)
+
         @skip_if_no_gpu
         @require_backend(DistTestCases.backend_feature["gpu"])
         def test_all_reduce_result_cuda(self):


### PR DESCRIPTION
Summary:
In `reduce_scatter_v`, each process reduces and scatters a flattened tensor split according to the input_split_sizes list to all processes in a group.
A `reduce_scatter_v` call internally calls a list of `_reduce`s, one for each process.
If input_split_sizes is None, `reduce_scatter_v` makes a call to `reduce_scatter` instead.

Test Plan: Added a new test `test_reduce_scatter_v_cuda` for reduce_scatter_v to `distributed_nccl_spawn`.

Differential Revision: D37508233

