### PR TITLE
Add `-Werror=non-virtual-dtor` (reland)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -784,6 +784,11 @@ if(NOT MSVC)
   string(APPEND CMAKE_CXX_FLAGS " -Wall")
   string(APPEND CMAKE_CXX_FLAGS " -Wextra")
   string(APPEND CMAKE_CXX_FLAGS " -Werror=return-type")
+  if(NOT USE_CUDNN)
+    # Temporary fix to ignore non virtual dtor error if cudnn is used. A
+    # separate PR to cudnn_frontend is needed to address this later on
+    string(APPEND CMAKE_CXX_FLAGS " -Werror=non-virtual-dtor")
+  endif()
   string(APPEND CMAKE_CXX_FLAGS " -Wno-missing-field-initializers")
   string(APPEND CMAKE_CXX_FLAGS " -Wno-type-limits")
   string(APPEND CMAKE_CXX_FLAGS " -Wno-array-bounds")

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -566,12 +566,14 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_jit.cpp PROPERTIES COMPILE_FLAGS -Wno-noexcept-type)
     # Force -Werror on several files
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/mkldnn/Pooling.cpp PROPERTIES COMPILE_FLAGS "-Werror")
+    # Disable non-virtual-dtor error here because 3rd party (LLVM) violates that warning and fails the build
+    set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_codegen.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=non-virtual-dtor")
   endif()
   # Disable certain warnings for GCC-9.X
   if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0.0))
     # See https://github.com/pytorch/pytorch/issues/38856
     set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_jit.cpp PROPERTIES COMPILE_FLAGS "-Wno-redundant-move -Wno-noexcept-type")
-    set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_codegen.cpp PROPERTIES COMPILE_FLAGS -Wno-init-list-lifetime)
+    set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_codegen.cpp PROPERTIES COMPILE_FLAGS "-Wno-init-list-lifetime")
   endif()
 
   if(NOT INTERN_DISABLE_MOBILE_INTERP)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -566,8 +566,6 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_jit.cpp PROPERTIES COMPILE_FLAGS -Wno-noexcept-type)
     # Force -Werror on several files
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/mkldnn/Pooling.cpp PROPERTIES COMPILE_FLAGS "-Werror")
-    # Disable non-virtual-dtor error here because 3rd party (LLVM) violates that warning and fails the build
-    set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_codegen.cpp PROPERTIES COMPILE_FLAGS "-Wno-error=non-virtual-dtor")
   endif()
   # Disable certain warnings for GCC-9.X
   if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0.0))

--- a/torch/csrc/jit/codegen/cuda/transform_view.cpp
+++ b/torch/csrc/jit/codegen/cuda/transform_view.cpp
@@ -462,6 +462,9 @@ class AnalyzeViewTransformation {
   //! 2) MergeAdjacentSingletonAxes class merges or reduces any
   //!    adjacent singleton dimensions.
   class MergeAxesInterface {
+   public:
+    virtual ~MergeAxesInterface() = default;
+
    protected:
     // See addMergeTransform for "is_index_merge_rhs" and
     // "is_last_axis_rfactor" descriptions
@@ -547,6 +550,8 @@ class AnalyzeViewTransformation {
       mtsa.handle(false /* is_index_merge_rhs */, is_last_axis_rfactor);
     }
 
+    virtual ~MergeThenSplitAxes() = default;
+
    private:
     MergeThenSplitAxes(
         AnalyzeViewTransformation* avt,
@@ -593,6 +598,8 @@ class AnalyzeViewTransformation {
       masa.handle(
           true /* is_index_merge_rhs */, true /* is_last_axis_rfactor */);
     }
+
+    virtual ~MergeAdjacentSingletonAxes() = default;
 
    private:
     MergeAdjacentSingletonAxes(

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -8,8 +8,8 @@
 #include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/llvm_jit.h>
 
-//llvm::SCEVPredicate has virtual function but non-virtual destructor
-//see https://github.com/llvm/llvm-project/blob/c1a0a213378a458fbea1a5c77b315c7dce08fd05/llvm/include/llvm/Analysis/ScalarEvolution.h#L198
+// llvm::SCEVPredicate has virtual function but non-virtual destructor
+// https://github.com/llvm/llvm-project/blob/c1a0a213378a458fbea1a5c77b315c7dce08fd05/llvm/include/llvm/Analysis/ScalarEvolution.h#L198
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #include <llvm/Analysis/TargetTransformInfo.h>

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -8,7 +8,13 @@
 #include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/llvm_jit.h>
 
+//llvm::SCEVPredicate has virtual function but non-virtual destructor
+//see https://github.com/llvm/llvm-project/blob/c1a0a213378a458fbea1a5c77b315c7dce08fd05/llvm/include/llvm/Analysis/ScalarEvolution.h#L198
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #include <llvm/Analysis/TargetTransformInfo.h>
+#pragma GCC diagnostic pop
+
 #include <llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h>
 #include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
 #include <llvm/IR/IRBuilder.h>

--- a/torch/csrc/lazy/core/dynamic_ir.h
+++ b/torch/csrc/lazy/core/dynamic_ir.h
@@ -49,6 +49,7 @@ class TORCH_API DimensionNode {
   virtual int64_t getStaticValue() const {
     TORCH_CHECK(false, "NYI");
   };
+  virtual ~DimensionNode() = default;
 };
 
 } // namespace lazy

--- a/torch/csrc/lazy/core/ir_builder.h
+++ b/torch/csrc/lazy/core/ir_builder.h
@@ -130,6 +130,8 @@ struct IrBuilder {
   virtual NodePtr MakeSizeAdd(const Value& a, const Value& b) const = 0;
   virtual NodePtr MakeSizeMul(const Value& a, const Value& b) const = 0;
   virtual NodePtr MakeSizeDiv(const Value& a, const Value& b) const = 0;
+
+  virtual ~IrBuilder() = default;
 };
 
 static inline NodePtr MakeDeviceData(const std::shared_ptr<BackendData>& data) {


### PR DESCRIPTION
This PR relands #80584, but instead of adding suppression in CMakeLists.txt suppresses it directly in `llvm_codegen.cpp` and just for a single header.

In general, it's better to avoid `set_target_properties` pattern for suppressing warnings, as it makes build brittle and hard to debug/understand

Test plan: wait for `ciflow/binaries_wheel` to finish