### PR TITLE
ci: Remove extra docker pull

### DIFF
--- a/.github/workflows/_android-build-test.yml
+++ b/.github/workflows/_android-build-test.yml
@@ -73,9 +73,6 @@ jobs:
           # 1) Not shareable: it's custom selective build, which is different from default libtorch mobile build;
           # 2) Not parallelizable by architecture: it only builds libtorch for one architecture;
 
-          echo "DOCKER_IMAGE: ${DOCKER_IMAGE}"
-          time docker pull "${DOCKER_IMAGE}" >/dev/null
-
           export BUILD_LITE_INTERPRETER
           BUILD_LITE_INTERPRETER="1"
           if [[ "${BUILD_ENVIRONMENT}" == *"full-jit" ]]; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #81038

Removes an extra docker pull from the android job that was causing tests
to fail if the docker image existed locally but didn't exist within the
registry.

This should fix issues like https://github.com/pytorch/pytorch/runs/7231969184?check_suite_focus=true

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>