### PR TITLE
[PyTorch Edge] Remove LinearPackedParamsBase __getstate__/__setstate__ from check_forward_backward_compatibility.py Allowlist

### DIFF
--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -102,8 +102,6 @@ ALLOW_LIST = [
     ("aten::_foreach.*", datetime.date(2022, 8, 1)),
     # TODO: FIXME: prims shouldn't be checked
     ("prims::.*", datetime.date(9999, 1, 1)),
-    (r"__getstate__\(__torch__.torch.classes.sparse.LinearPackedParamsBase", datetime.date(2022, 7, 15)),
-    (r"__setstate__\(__torch__.torch.classes.sparse.LinearPackedParamsBase", datetime.date(2022, 7, 15)),
 ]
 
 ALLOW_LIST_COMPILED = [


### PR DESCRIPTION
Summary: The changes to __getstate__ and __setstate__ have been landed so now we won't have backwards compatibility issues

Test Plan: CI Tests

Reviewed By: kimishpatel

Differential Revision: D37686915

