### PR TITLE
GIL acquire needed in ValueCache::trimPrefixes

### DIFF
--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -298,9 +298,12 @@ ExtraFields<EventType::PyCCall>::args_t ValueCache::load<CallType::PyCCall>(
 
 // TODO: Use re2.
 void ValueCache::trimPrefixes() {
-  static auto prefixes = py::module::import("torch.profiler.python_tracer")
-                             .attr("_prefix_regex")()
-                             .cast<std::vector<std::string>>();
+  static const auto prefixes = []() {
+    pybind11::gil_scoped_acquire gil;
+    return py::module::import("torch.profiler.python_tracer")
+        .attr("_prefix_regex")()
+        .cast<std::vector<std::string>>();
+  }();
 
   for (auto& it : std::get<CallType::PyCall>(state_)) {
     std::string filename = it.second.filename_.str();


### PR DESCRIPTION
Summary: Dubugged a segfault issue in Ondemand python tracing. Committing as a a separate diff from D37410204.

Test Plan:
- run a python test case with the following command for on-demand flow:
echo -e "PYTHON_STACK_TRACE=true" > /tmp/scott_kineto.conf && dyno gputrace --gputrace_duration 300ms --gpuconf /tmp/scott_kineto.conf

Reviewed By: chaekit

Differential Revision: D37662988

