### PR TITLE
Build example_allreduce only for GLOO

### DIFF
--- a/test/cpp/c10d/CMakeLists.txt
+++ b/test/cpp/c10d/CMakeLists.txt
@@ -72,7 +72,7 @@ if(USE_MPI AND USE_C10D_MPI)
   endif()
 endif()
 
-if(LINUX)
+if(LINUX AND USE_GLOO AND USE_C10D_GLOO)
   add_executable(example_allreduce example/allreduce.cpp)
   target_include_directories(example_allreduce PRIVATE $<BUILD_INTERFACE:${TORCH_SRC_DIR}/csrc/distributed>)
   target_link_libraries(example_allreduce pthread torch_cpu)


### PR DESCRIPTION
`example/allreduce.cpp` is GLOO-specific and will not compile with USE_GLOO=0
