### PR TITLE
[Vulkan] Implement Stack operator

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/stack_feature.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/stack_feature.glsl
@@ -1,0 +1,35 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION           image3D uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION           sampler3D uInput0;
+layout(set = 0, binding = 2)         uniform PRECISION           sampler3D uInput1;
+layout(set = 0, binding = 3)         uniform PRECISION           sampler3D uInput2;
+layout(set = 0, binding = 4)         uniform PRECISION           sampler3D uInput3;
+layout(set = 0, binding = 5)         uniform PRECISION restrict  Block {
+  ivec3 size;
+  int z;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 posIn = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(posIn, uBlock.size.xyz))) {
+    imageStore(
+        uOutput,
+        ivec3(posIn.x, posIn.y, uBlock.z),
+        vec4(
+            texelFetch(uInput0, posIn, 0).x,
+            texelFetch(uInput1, posIn, 0).x,
+            texelFetch(uInput2, posIn, 0).x,
+            texelFetch(uInput3, posIn, 0).x
+        ));
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Stack.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Stack.cpp
@@ -1,0 +1,108 @@
+#include <ATen/native/vulkan/ops/Common.h>
+#include <c10/util/irange.h>
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+Tensor stack_feature(const TensorList tensors, vTensor& v_output) {
+  api::Context* const context = api::context();
+
+  uint32_t num_tensors = tensors.size();
+  for (const auto i : c10::irange(v_output.extents().data[2])) {
+    const vTensor& v_t0 = convert(
+        tensors[4 * i].is_vulkan() ? tensors[4 * i] : tensors[4 * i].vulkan());
+    const vTensor& v_t1 = 4 * i + 1 < num_tensors
+        ? convert(
+              tensors[4 * i + 1].is_vulkan() ? tensors[4 * i + 1]
+                                             : tensors[4 * i + 1].vulkan())
+        : v_t0;
+    const vTensor& v_t2 = 4 * i + 2 < num_tensors
+        ? convert(
+              tensors[4 * i + 2].is_vulkan() ? tensors[4 * i + 2]
+                                             : tensors[4 * i + 2].vulkan())
+        : v_t0;
+    const vTensor& v_t3 = 4 * i + 3 < num_tensors
+        ? convert(
+              tensors[4 * i + 3].is_vulkan() ? tensors[4 * i + 3]
+                                             : tensors[4 * i + 3].vulkan())
+        : v_t0;
+
+    const struct Block final {
+      uvec3 size; // output texture size
+      uint32_t z; // texel along the channel-batch dimension to copy data to
+    } block{v_output.extents(), i};
+
+    api::UniformParamsBuffer params(context, block);
+    api::PipelineBarrier pipeline_barrier{};
+
+    context->submit_compute_job(
+        // shader descriptor
+        VK_KERNEL(stack_feature),
+        // pipeline barrier
+        pipeline_barrier,
+        // global work group size
+        v_t0.extents(),
+        // local work group size
+        adaptive_work_group_size(v_t0.extents()),
+        // fence handle
+        VK_NULL_HANDLE,
+        // shader arguments
+        v_output.image(
+            pipeline_barrier,
+            api::PipelineStage::COMPUTE,
+            api::MemoryAccessType::WRITE),
+        v_t0.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+        v_t1.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+        v_t2.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+        v_t3.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+        // params buffer
+        params.buffer());
+  }
+
+  return convert(v_output);
+}
+
+Tensor stack(const at::TensorList tensors, const int64_t dim) {
+  TORCH_CHECK(tensors.size() > 0, "Vulkan stack expects at least one tensor");
+  TORCH_CHECK(dim == 0, "Vulkan stack expects dim = 0");
+
+  at::Tensor tensor = tensors[0];
+
+  for (const auto& t : tensors) {
+    TORCH_CHECK(t.dim() == 2, "Vulkan stack expects 2 dimensional inputs");
+
+    for (const auto d : c10::irange(t.dim())) {
+      TORCH_CHECK(
+          t.size(d) == tensor.size(d),
+          "Vulkan stack inputs must have matching sizes");
+    }
+  }
+
+  uint32_t num_tensors = tensors.size();
+  std::vector<int64_t> output_sizes = {
+      num_tensors, tensor.size(0), tensor.size(1)};
+
+  vTensor v_output{api::context(), output_sizes, tensor.options()};
+
+  return stack_feature(tensors, v_output);
+}
+
+#ifdef USE_VULKAN_API
+
+TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
+  m.impl(TORCH_SELECTIVE_NAME("aten::stack"), TORCH_FN(stack));
+}
+
+#endif /* USE_VULKAN_API */
+
+} // namespace
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -3351,6 +3351,160 @@ TEST_F(VulkanAPITest, slice_invalidinputs_exceptions) {
   }, ::c10::Error);
 }
 
+TEST_F(VulkanAPITest, stack_invalid_inputs) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Act: Vulkan stack expects at least one tensor
+  EXPECT_THROW({
+    at::stack({}, 0);
+  }, ::c10::Error);
+
+  // Act: Vulkan stack expects dim = 0
+  EXPECT_THROW({
+    at::stack({
+        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan()}, 1);
+  }, ::c10::Error);
+
+  // Act: Vulkan stack expects 2 dimensional inputs
+  EXPECT_THROW({
+    at::stack({
+        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+        at::rand({3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan()}, 0);
+  }, ::c10::Error);
+
+  // Act: Vulkan stack inputs must have matching sizes
+  EXPECT_THROW({
+    at::stack({
+        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+        at::rand({5, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan(),
+        at::rand({6, 7}, at::device(at::kCPU).dtype(at::kFloat)).vulkan()}, 0);
+  }, ::c10::Error);
+}
+
+TEST_F(VulkanAPITest, stack_1_tensor) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const auto in_cpu1 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::stack({in_cpu1}, 0);
+  const auto out_vulkan = at::stack({in_cpu1.vulkan()}, 0);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, stack_2_tensors) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const auto in_cpu1 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::stack({in_cpu1, in_cpu2}, 0);
+  const auto out_vulkan = at::stack({in_cpu1.vulkan(), in_cpu2.vulkan()}, 0);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, stack_3_tensors) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const auto in_cpu1 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::stack({in_cpu1, in_cpu2, in_cpu3}, 0);
+  const auto out_vulkan = at::stack({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan()}, 0);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, stack_4_tensors) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  // Arrange
+  const auto in_cpu1 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu2 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu3 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu4 = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+
+  // Act
+  const auto out_cpu = at::stack({in_cpu1, in_cpu2, in_cpu3, in_cpu4}, 0);
+  const auto out_vulkan = at::stack({in_cpu1.vulkan(), in_cpu2.vulkan(), in_cpu3.vulkan(), in_cpu4.vulkan()}, 0);
+
+  // Assert
+  const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+  if (!check) {
+    showRtol(out_cpu, out_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, stack_from_1_to_20_tensors) {
+  // Guard
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  std::vector<at::Tensor> tensors_cpu = {};
+  std::vector<at::Tensor> tensors_vulkan = {};
+
+  for (const auto i : c10::irange(20)) {
+    at::Tensor in_cpu = at::rand({221, 193}, at::device(at::kCPU).dtype(at::kFloat));
+    tensors_cpu.emplace_back(in_cpu);
+    tensors_vulkan.emplace_back(in_cpu.vulkan());
+    at::Tensor out_cpu = at::stack(tensors_cpu, 0);
+    at::Tensor out_vulkan = at::stack(tensors_vulkan, 0);
+    const auto check = almostEqual(out_cpu, out_vulkan.cpu());
+    if (!check) {
+      std::cout << "Error when stacking " << i << " tensors" << std::endl;
+      showRtol(out_cpu, out_vulkan.cpu());
+    }
+    ASSERT_TRUE(check);
+  }
+}
+
 TEST_F(VulkanAPITest, clone_success) {
   // Arrange
   std::multimap<c10::optional<c10::MemoryFormat>, std::vector<int64_t>> mem2sizes {


### PR DESCRIPTION
Summary:
Implemented Stack operator for the Vulkan backend.

Special case implementation:
- Input tensor must be 2-dim, i.e. [H, W].
- dim must be 0, i.e the output tensor will be [C, H, W]

References
- PyTorch Docs > torch > [torch.stack](https://pytorch.org/docs/stable/generated/torch.stack.html)

Test Plan:
Added test cases to `/xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp`

On Mac:
```
buck run //xplat/caffe2:pt_vulkan_api_test_binAppleMac
```
On Android:
```
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"

Differential Revision: D37699984

