### PR TITLE
[DataLoader] Locking lower ranks seed recepients

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -69,6 +69,8 @@ get_worker_info = _utils.worker.get_worker_info
 logger = logging.getLogger(__name__)
 
 
+
+
 class _DatasetKind(object):
     Map = 0
     Iterable = 1
@@ -211,6 +213,7 @@ class DataLoader(Generic[T_co]):
     prefetch_factor: int
     _iterator : Optional['_BaseDataLoaderIter']
     __initialized = False
+    seeds_done = {}
 
     def __init__(self, dataset: Dataset[T_co], batch_size: Optional[int] = 1,
                  shuffle: Optional[bool] = None, sampler: Union[Sampler, Iterable, None] = None,
@@ -592,7 +595,12 @@ class DataLoader(Generic[T_co]):
                         time.sleep(_utils.DATAPIPE_SHARED_SEED_CHECK_INTERVAL)
                         _shared_seed_str = store.get(_utils.DATAPIPE_SHARED_SEED)
                     logger.info(f"Shared seed ({_shared_seed_str}) received from store on rank {rank}")
-                    store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 1)
+                    _shared_seed_recv_cnt = store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 1)
+                    # Exit only when all ranks received seed, otherwise we are at risk that current rank 
+                    # will reach same section of the code again while rank zero still in the previous iteration
+                    while _shared_seed_recv_cnt > 0:
+                        time.sleep(_utils.DATAPIPE_SHARED_SEED_CHECK_INTERVAL)
+                        _shared_seed_recv_cnt = store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 0)
                     _shared_seed = int(_shared_seed_str)
             return _shared_seed
         else:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -69,8 +69,6 @@ get_worker_info = _utils.worker.get_worker_info
 logger = logging.getLogger(__name__)
 
 
-
-
 class _DatasetKind(object):
     Map = 0
     Iterable = 1
@@ -213,7 +211,6 @@ class DataLoader(Generic[T_co]):
     prefetch_factor: int
     _iterator : Optional['_BaseDataLoaderIter']
     __initialized = False
-    seeds_done = {}
 
     def __init__(self, dataset: Dataset[T_co], batch_size: Optional[int] = 1,
                  shuffle: Optional[bool] = None, sampler: Union[Sampler, Iterable, None] = None,

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -593,7 +593,7 @@ class DataLoader(Generic[T_co]):
                         _shared_seed_str = store.get(_utils.DATAPIPE_SHARED_SEED)
                     logger.info(f"Shared seed ({_shared_seed_str}) received from store on rank {rank}")
                     _shared_seed_recv_cnt = store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 1)
-                    # Exit only when all ranks received seed, otherwise we are at risk that current rank 
+                    # Exit only when all ranks received seed, otherwise we are at risk that current rank
                     # will reach same section of the code again while rank zero still in the previous iteration
                     while _shared_seed_recv_cnt > 0:
                         time.sleep(_utils.DATAPIPE_SHARED_SEED_CHECK_INTERVAL)


### PR DESCRIPTION
Exit seed receiving section only when all ranks received seed, otherwise we are at risk that current rank 
will reach same section of the code again while rank zero still in the previous iteration

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #81071

Fixes: #80845

Differential Revision: [D37702557](https://our.internmc.facebook.com/intern/diff/D37702557)