### PR TITLE
Improve wrapper subclass detection for serialization

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -898,6 +898,10 @@ class TestGetStateSubclass(torch.Tensor):
         self.reloaded = True
 
 
+class TestEmptySubclass(torch.Tensor):
+    ...
+
+
 class TestSubclassSerialization(TestCase):
     def test_tensor_subclass_wrapper_serialization(self):
         wrapped_tensor = torch.rand(2)
@@ -956,6 +960,25 @@ class TestSubclassSerialization(TestCase):
 
         self.assertEqual(new_tensor.requires_grad, my_tensor.requires_grad)
 
+    def test_empty_class_serialization(self):
+        tensor = TestEmptySubclass([1.])
+        # Ensures it runs fine
+        tensor2 = copy.copy(tensor)
+
+        with BytesIOContext() as f:
+            torch.save(tensor, f)
+            f.seek(0)
+            tensor2 = torch.load(f)
+
+        tensor = TestEmptySubclass()
+        # Ensures it runs fine
+        # Note that tensor.data_ptr() == 0 here
+        tensor2 = copy.copy(tensor)
+
+        with BytesIOContext() as f:
+            torch.save(tensor, f)
+            f.seek(0)
+            tensor2 = torch.load(f)
 
 
 instantiate_device_type_tests(TestBothSerialization, globals())

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -290,7 +290,8 @@ class Tensor(torch._C._TensorBase):
                 raise NotImplementedError(
                     'sparse csr tensor __reduce_ex__ for layout `%s`' % (self.layout))
             return (torch._utils._rebuild_sparse_csr_tensor, args_sparse_csr)
-        elif self.data_ptr() == 0 and type(self) is not torch.Tensor:
+        elif self.data_ptr() == 0 and type(self) is not torch.Tensor and \
+                type(self).__torch_dispatch__ is not torch.Tensor.__torch_dispatch__:
             arg_wrapper_subclass = (
                 type(self),
                 self.dtype,

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1339,6 +1339,10 @@ void initJITBindings(PyObject* module) {
       .def(py::init<std::string>())
       .def(py::init([](const py::object& buffer) {
         auto writer_func = [=](const void* data, size_t size) {
+          // Writting an empty file is a noop
+          if (size == 0) {
+            return size;
+          }
           auto memory_view = py::memoryview::from_memory(
               reinterpret_cast<const char*>(data), size);
           buffer.attr("write")(std::move(memory_view));


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/80983

Also fix a small bug uncovered by the new test where creating memory_view for 0-sized inputs is not valid and is now skipped
