### PR TITLE
Fix formatting on cumsum.cpp

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/cumsum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/cumsum.cpp
@@ -15,20 +15,16 @@ Tensor cumsum(
     const int64_t dim,
     const c10::optional<ScalarType> dtype) {
   TORCH_CHECK(
-    input_arg.dim() <= 4,
-    "Vulkan cumsum expects input dimension <= 4!");
+      input_arg.dim() <= 4, "Vulkan cumsum expects input dimension <= 4!");
 
   TORCH_CHECK(
-    batch_size(input_arg) == 1,
-    "Vulkan cumsum expects batch size <= 1!");
+      batch_size(input_arg) == 1, "Vulkan cumsum expects batch size <= 1!");
 
-  TORCH_CHECK(
-    dim < 4,
-    "Vulkan cumsum expects dim < 4!");
+  TORCH_CHECK(dim < 4, "Vulkan cumsum expects dim < 4!");
 
-  if(dim<=1) {
-      // TODO: dim<0, dim=0, dim=1(z axis)
-      TORCH_CHECK(false, "Not implemented!");
+  if (dim <= 1) {
+    // TODO: dim<0, dim=0, dim=1(z axis)
+    TORCH_CHECK(false, "Not implemented!");
   }
 
   api::Context* const context = api::context();
@@ -37,15 +33,15 @@ Tensor cumsum(
   const vTensor& v_input = convert(input);
 
   vTensor v_output{
-    context,
-    input_arg.sizes(),
-    input_arg.options(),
+      context,
+      input_arg.sizes(),
+      input_arg.options(),
   };
 
   const struct Block final {
     int32_t axis;
-  } block {
-    (3-safe_downcast<int32_t>(dim)),
+  } block{
+      (3 - safe_downcast<int32_t>(dim)),
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -54,9 +50,9 @@ Tensor cumsum(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       VK_KERNEL(cumsum),


### PR DESCRIPTION
Summary:
Fixed formatting using clang-format:

```clang-format -style=file cumsum.cpp```

Test Plan: Compile time change only.  Test not needed.

Reviewed By: kirklandsign

Differential Revision: D37703962

