### PR TITLE
Disable functorch modes in testing's freeze_rng_state(), part 2

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1231,7 +1231,7 @@ def freeze_rng_state():
     # Some OpInfos use freeze_rng_state for rng determinism, but
     # test_composite_compliance overrides dispatch for all torch functions
     # which we need to disable to get and set rng state
-    with no_dispatch():
+    with no_dispatch(), disable_functorch():
         rng_state = torch.get_rng_state()
         if torch.cuda.is_available():
             cuda_rng_state = torch.cuda.get_rng_state()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #81109

I forgot to update one line in
https://github.com/pytorch/pytorch/pull/81006. torch.get_rng_state()
returns a Tensor that can also be affected by modes so it also needs a
no_functorch() context manager.

Test Plan:
- tested with functorch tests on CUDA (that's how I discovered this
problem)