### PR TITLE
[lint] fix actionlint linter

### DIFF
--- a/.github/actions/calculate-docker-image/action.yml
+++ b/.github/actions/calculate-docker-image/action.yml
@@ -19,7 +19,8 @@ inputs:
     required: false
   skip_push:
     description: If set to true value, skip will be pushed, default is to skip so that pushing will be explicit
-    required: true
+    required: false
+    default: "true"
   force_push:
     description: If set to any value, always run the push
     required: false

--- a/tools/linter/adapters/actionlint_linter.py
+++ b/tools/linter/adapters/actionlint_linter.py
@@ -1,4 +1,5 @@
 import argparse
+import concurrent.futures
 import os
 import re
 import json
@@ -60,12 +61,12 @@ def run_command(
         logging.debug("took %dms", (end_time - start_time) * 1000)
 
 
-def check_files(
+def check_file(
     binary: str,
-    files: List[str],
+    file: str,
 ) -> List[LintMessage]:
     try:
-        proc = run_command([binary] + files)
+        proc = run_command([binary, file])
     except OSError as err:
         return [
             LintMessage(
@@ -133,6 +134,22 @@ if __name__ == "__main__":
         print(json.dumps(err_msg._asdict()), flush=True)
         exit(0)
 
-    lint_messages = check_files(args.binary, args.filenames)
-    for lint_message in lint_messages:
-        print(json.dumps(lint_message._asdict()), flush=True)
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=os.cpu_count(),
+        thread_name_prefix="Thread",
+    ) as executor:
+        futures = {
+            executor.submit(
+                check_file,
+                args.binary,
+                filename,
+            ): filename
+            for filename in args.filenames
+        }
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                for lint_message in future.result():
+                    print(json.dumps(lint_message._asdict()), flush=True)
+            except Exception:
+                logging.critical('Failed at "%s".', futures[future])
+                raise


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #81119

There seems to be a bug in actionlint when running it on multiple files
(reported here: https://github.com/rhysd/actionlint/issues/173). This
was causing CI to be green even though there are local linter failures.

This PR:
1. Changes our usage of actionlint to work around the aforementioned
bug.
2. Fixes the linter failures introduced