### PR TITLE
[merge bot] Early Quit if Checks Will Never Run

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -93,6 +93,7 @@ def mock_merge(pr_num: int, repo: GitRepo,
                on_green: bool = False,
                land_checks: bool = False,
                timeout_minutes: int = 400,
+               queue_timeout_minutes: int = 20,
                stale_pr_days: int = 3) -> None:
     pass
 

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -17,7 +17,7 @@ from trymerge import (find_matching_merge_rule,
                       read_merge_rules,
                       GitHubPR,
                       MergeRule,
-                      MandatoryChecksMissingError,
+                      MandatoryChecksNotRunError,
                       main as trymerge_main)
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from typing import Any, List, Optional
@@ -235,8 +235,8 @@ class TestGitHubPR(TestCase):
         """
         pr = GitHubPR("pytorch", "pytorch", 76118)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        self.assertRaisesRegex(MandatoryChecksMissingError,
-                               ".*are pending/not yet run.*",
+        self.assertRaisesRegex(MandatoryChecksNotRunError,
+                               ".*are not yet run.*",
                                lambda: find_matching_merge_rule(pr, repo))
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1079,8 +1079,10 @@ def merge(pr_num: int, repo: GitRepo,
 
             return pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)
         except MandatoryChecksNotRunError as ex:
+            last_exception = str(ex)
             if elapsed_time > queue_timeout_minutes * 60:
                 raise RuntimeError(f"Merge failed due to {ex} after waiting {queue_timeout_minutes} minutes.")
+            time.sleep(5 * 60)
         except MandatoryChecksPendingError as ex:
             last_exception = str(ex)
             print(f"Merge of https://github.com/{org}/{project}/pull/{pr_num} failed due to: {ex}. Retrying in 5 min")

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1023,7 +1023,7 @@ def categorize_checks(check_runs: Dict[str, Tuple[str, str]],
         if checkname not in check_runs:
             not_run_checks.append((checkname, None))
         elif check_runs[checkname][0] is None:
-            pending_checks.append((chfeckname, check_runs[checkname][1]))
+            pending_checks.append((checkname, check_runs[checkname][1]))
         elif check_runs[checkname][0].upper() != 'SUCCESS' and check_runs[checkname][0].upper() != 'SKIPPED':
             failed_checks.append((checkname, check_runs[checkname][1]))
     return (not_run_checks, pending_checks, failed_checks)


### PR DESCRIPTION
Currently, when a PR is trying to land without the mandatory checks, the trymerge script will keep spinning until it times out. This is pretty annoying and so if the job hasn't been queued for 20 minutes, then we will stop and throw an error. 

An example of this is in: https://github.com/pytorch/pytorch/pull/79679 

Test Plan:
Tested it locally and modified tests to check for this scenario