### PR TITLE
[TorchArrow][efficiency][2/n] added inference_wrapper_run_flat_out fused version registration call

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -869,6 +869,9 @@ bool shouldNotFuseListUnpackSpecialCase(const Node* node) {
 
 void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
   const FastMap<c10::Symbol, c10::Symbol> unfused_to_fused = {
+      OP_PAIR(
+          "torcharrow::inference_wrapper_run_flat",
+          "static_runtime::fused_inference_wrapper_run_flat"),
       OP_PAIR("fb::equally_split", "static_runtime::fused_equally_split"),
       OP_PAIR(
           "fb::sigrid_transforms", "static_runtime::fused_sigrid_transforms"),


### PR DESCRIPTION
Summary:
Added registration call to make pytorch runtime aware of `inference_wrapper_run_flat_out` functionality. Added fused version of op which will enable out variants when [OptimizeGraph pass](https://fburl.com/code/lsagnmge) is made.

Next: need to add variadic version of fused and unfused op.

Reviewed By: tgalkovskyi

Differential Revision: D37139204

