### PR TITLE
[di] avoid copying optional input for get_real_inputs_from_optional_inputs_v2 when possible

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -194,6 +194,7 @@ void OptimizeGraph(
       graph, /* custom_ops */ {fromQualString("fb::scale_gradient")});
   AddIfThenElseOp(graph);
   UseSplitAndSqueeze(graph);
+  UseInPlaceGetRealInputsFromOptionalInputsV2(graph);
   GRAPH_DUMP("Final graph after optimizations: ", graph);
 }
 

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -1352,6 +1352,34 @@ void EliminateNoOpSlice(std::shared_ptr<Graph>& graph) {
   }
 }
 
+void UseInPlaceGetRealInputsFromOptionalInputsV2(
+    std::shared_ptr<Graph>& graph) {
+#ifdef FBCODE_CAFFE2
+  const std::string original_pattern = R"IR(
+    graph(%optional_input: (Tensor, Tensor?, Tensor?)?[], %include_last_offsets: bool[]):
+        %x : (Tensor, Tensor?, Tensor?)[] = remote_collection::get_real_inputs_from_optional_inputs_v2(%optional_input, %include_last_offsets)
+        return (%x))IR";
+
+  const std::string new_pattern = R"IR(
+    graph(%optional_input: (Tensor, Tensor?, Tensor?)?[], %include_last_offsets: bool[]):
+        %x : (Tensor, Tensor?, Tensor?)[] = static_runtime::get_real_inputs_from_optional_inputs_v2_inplace(%optional_input, %include_last_offsets)
+        return (%x))IR";
+
+  auto isSingleUse = [](Value* value) { return value->uses().size() == 1; };
+
+  auto filter = [&isSingleUse](
+                    const Match& match,
+                    const std::unordered_map<std::string, Value*>& vmap) {
+    auto* real_node = match.nodes_map.at(vmap.at("x")->node());
+    return isSingleUse(real_node->input(0));
+  };
+
+  SubgraphRewriter fuse;
+  fuse.RegisterRewritePattern(original_pattern, new_pattern);
+  fuse.runOnGraph(graph, filter);
+#endif
+}
+
 void FuseClampNaNToNum(std::shared_ptr<Graph>& graph) {
 #ifdef FBCODE_CAFFE2
   std::string pattern = R"IR(

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -82,5 +82,8 @@ TORCH_API void RemoveUnnecessaryEmbeddingBagOutputs(
 
 TORCH_API void FuseClampNaNToNum(std::shared_ptr<Graph>& graph);
 
+TORCH_API void UseInPlaceGetRealInputsFromOptionalInputsV2(
+    std::shared_ptr<Graph>& graph);
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: avoid copies and casting by moving out of the inputs list

Differential Revision: D37572556

