### PR TITLE
Fix invalid type annotations on codegen

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -534,7 +534,7 @@ class _PyTreeCodeGen(CodeGen):
         return pytree.tree_unflatten(out, self.pytree_info.out_spec)
 
     def gen_fn_def(self, free_vars, maybe_return_annotation):
-        if self.pytree_info is None:
+        if self.pytree_info is None or hasattr(self, '_in_spec') == False:
             return super().gen_fn_def(free_vars, maybe_return_annotation)
         function_args = self.pytree_info.orig_args
         has_orig_self = (function_args[0] == 'self')
@@ -549,7 +549,7 @@ class _PyTreeCodeGen(CodeGen):
         return function_definition
 
     def generate_output(self, output_args):
-        if self.pytree_info:
+        if self.pytree_info and hasattr(self, '_out_spec'):
             return f'return pytree.tree_unflatten({repr(output_args)}, self._out_spec)'
         else:
             return super().generate_output(output_args)

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -542,8 +542,10 @@ class _PyTreeCodeGen(CodeGen):
             free_vars.insert(0, 'self')
         function_definition = super().gen_fn_def(function_args[:], maybe_return_annotation)
         if len(free_vars) > 0:  # pytree has placeholders in it
+            # Strip type annotations, if present. `name1: type1, name2: type2` style syntax is not valid.
+            free_vars = [free_var.split(":")[0] for free_var in free_vars]
             function_definition += f"""
-    {', '.join(free_vars)}, = fx_pytree.tree_flatten_spec([{', '.join(function_args)}], self._in_spec)"""
+    {', '.join(free_vars)} = fx_pytree.tree_flatten_spec([{', '.join(function_args)}], self._in_spec)"""
         return function_definition
 
     def generate_output(self, output_args):

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -534,7 +534,7 @@ class _PyTreeCodeGen(CodeGen):
         return pytree.tree_unflatten(out, self.pytree_info.out_spec)
 
     def gen_fn_def(self, free_vars, maybe_return_annotation):
-        if self.pytree_info is None or hasattr(self, '_in_spec') == False:
+        if self.pytree_info is None or hasattr(self, '_in_spec') is False:
             return super().gen_fn_def(free_vars, maybe_return_annotation)
         function_args = self.pytree_info.orig_args
         has_orig_self = (function_args[0] == 'self')


### PR DESCRIPTION
Before this change, you would get syntax like this, at times:

```
src_tokens : torch.Tensor, src_lengths : torch.Tensor, state_0_ : torch.Tensor, state_1_ : torch.Tensor, state_2_ : torch.Tensor, state_3_ : torch.Tensor, state_4_ : torch.Tensor, state_5_ : torch.Tensor, state_6_ : torch.Tensor, state_7_ : torch.Tensor, state_8_ : torch.Tensor, state_9_ : torch.Tensor, state_10_ : torch.Tensor, state_11_ : torch.Tensor, state_12_ : torch.Tensor, state_13_ : torch.Tensor, state_14_ : torch.Tensor, state_15_ : torch.Tensor, state_16_ : torch.Tensor, state_17_ : torch.Tensor, state_18_ : torch.Tensor, state_19_ : torch.Tensor, state_20_ : torch.Tensor, state_21_ : torch.Tensor, state_22_ : torch.Tensor, state_23_ : torch.Tensor, state_24_ : torch.Tensor, state_25_ : torch.Tensor, state_26_ : torch.Tensor, state_27_ : torch.Tensor, state_28_ : torch.Tensor, state_29_ : torch.Tensor, = fx_pytree.tree_flatten_spec([orig_arg_0, orig_arg_1, orig_arg_2], self._in_spec)
```