### PR TITLE
Implement .mean property for Relaxed distributions

### DIFF
--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -135,3 +135,7 @@ class RelaxedBernoulli(TransformedDistribution):
     @property
     def probs(self):
         return self.base_dist.probs
+
+    @property
+    def mean(self):
+        return self.probs

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -129,3 +129,7 @@ class RelaxedOneHotCategorical(TransformedDistribution):
     @property
     def probs(self):
         return self.base_dist.probs
+
+    @property
+    def mean(self):
+        return self.probs


### PR DESCRIPTION
Fixes [this issue](https://forum.pyro.ai/t/not-implemented-error-for-relaxed-bernoulli-straight-through-with-auto-hierarchical-normal-messenger/4377/5) on the Pyro forum.

## Tested
- covered by existing distribution tests