### PR TITLE
Disable nnc/test_aot_compile.sh

### DIFF
--- a/test/mobile/nnc/test_aot_compile.sh
+++ b/test/mobile/nnc/test_aot_compile.sh
@@ -23,4 +23,5 @@ test_aot_model_compiler() {
   popd
 }
 
-test_aot_model_compiler
+# Temporarily disable the test since NNC backend is no longer available.
+# test_aot_model_compiler


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #81196

Deprecation: NNC backend for mobile is not being worked upon actively. It is slated to be deprecated.


@bypass-github-export-checks

Differential Revision: [D37746019](https://our.internmc.facebook.com/intern/diff/D37746019)