### PR TITLE
[Composite compliance testing] Refactor check_forward_ad_formula to accept Callable

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1251,7 +1251,8 @@ class TestCompositeCompliance(TestCase):
         for sample in samples:
             args = [sample.input] + list(sample.args)
             kwargs = sample.kwargs
-            composite_compliance.check_forward_ad_formula(op, args, kwargs)
+            composite_compliance.check_forward_ad_formula(
+                op.get_op(), args, kwargs, op.gradcheck_wrapper)
 
 
 class TestMathBits(TestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #81239
* #81060
* #81059
* #81057

Like https://github.com/pytorch/pytorch/pull/81059; this PR addresses
the review comments.

Test Plan:
- run tests