### PR TITLE
Make nn.stateless correctly reset parameters if the forward pass fails

### DIFF
--- a/torch/nn/utils/stateless.py
+++ b/torch/nn/utils/stateless.py
@@ -64,11 +64,13 @@ def _reparametrize_module(
         _apply_func_submodules(
             _create_swap_params(parameters_and_buffers),
             module, name.split("."), name, (tensor,))
-    yield
-    for name in parameters_and_buffers:
-        _apply_func_submodules(
-            _remove_swap,
-            module, name.split("."), name, ())
+    try:
+        yield
+    finally:
+        for name in parameters_and_buffers:
+            _apply_func_submodules(
+                _remove_swap,
+                module, name.split("."), name, ())
 
 
 def _apply_func_submodules(


### PR DESCRIPTION
This bug came up as I was adding new tests for ExpandedWeights

If the forwards pass errors when the `_reparametrize_module` context manager is still on, the values from reparameterization will remain on the module outside of the context manager, where it should be the original values. This fixes that by putting a try/finally block around the forward call and call to reset the parameters