### PR TITLE
Fix mypy for IterDataPipe.collate

### DIFF
--- a/torch/utils/data/datapipes/datapipe.pyi.in
+++ b/torch/utils/data/datapipes/datapipe.pyi.in
@@ -5,7 +5,7 @@
 
 from torch.utils.data.datapipes._typing import _DataPipeMeta, _IterDataPipeMeta
 from typing import Any, Callable, Dict, Generic, Iterator, List, Optional, TypeVar, Union
-from torch.utils.data import Dataset, IterableDataset
+from torch.utils.data import Dataset, IterableDataset, default_collate
 
 T_co = TypeVar('T_co', covariant=True)
 T = TypeVar('T')


### PR DESCRIPTION
Add `default_collate` to mypy stub file to make sure `default_collate` is imported for `IterDataPipe.collate`

Sister PR from TorchData: https://github.com/pytorch/data/pull/645