### PR TITLE
Modules under migration in the public binding test

### DIFF
--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -1,4 +1,5 @@
 {
+  "being_migrated": {},
   "torch.ao.quantization": [
     "ABC",
     "ABCMeta",

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -295,7 +295,8 @@ class TestPublicBindings(TestCase):
                 if elem_module is None:
                     why_not_looks_public = "because it does not have a `__module__` attribute"
                 elem_modname_starts_with_mod = elem_module is not None and \
-                    elem_module.startswith(modname) and '._' not in elem_module
+                    elem_module.startswith(allow_dict["being_migrated"].get(modname, modname)) and \
+                    '._' not in elem_module
                 if not why_not_looks_public and not elem_modname_starts_with_mod:
                     why_not_looks_public = f"because its `__module__` attribute (`{elem_module}`) is not within the " \
                         f"torch library or does not start with the submodule where it is defined (`{modname}`)"


### PR DESCRIPTION
If a module is being migrated, a common practice is to temporarily support
the old location. That might break the assertion that the `__module__`
of a function is pointing to the same location as where it is created.

 ## Example

1. Assume there is `torch/nn/quantized/functional.py`
2. The file is copied to `torch/ao/nn/quantzied/functional.py`
3. The old location is changed to have `from torch.ao.nn.quantized.functional import *`

In such a situation, importing from the old location will have `__module__`
pointing to the new `torch/ao/nn/...` location. This will break the
current test.

 ## What changed

This PR adds the following:

1. Added a key `"being_migrated"` to the `allowlist_for_publicAPI.json`
2. Added a check in the `test_public_bindings.py` to check if the JSON file has the `"being_migrated"` key.

 ## How to add migration entries

1. Add an entry to the `"being_migrated"`
   For the example above, add `"torch.nn.quantized.functional": "torch.ao.nn.quantized.functional"`
2. Change any existing keys for the old location
   For example, if there is an existing entry `"torch.nn.quantized.functional": [...]`
   outside the `"being_migrated"`.
   Change it to `"torch.ao.nn.quantized.functional": [...]`

Fixes #ISSUE_NUMBER
