### PR TITLE
[JIT] Tweak annotation extraction for py3.10

### DIFF
--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -5,6 +5,7 @@ import collections
 import textwrap
 import functools
 import warnings
+import sys
 from typing import Dict, List, Set, Type
 
 import torch._jit_internal as _jit_internal
@@ -136,7 +137,22 @@ def infer_concrete_type_builder(nn_module, share_types=True):
     if isinstance(nn_module, (torch.nn.ParameterDict)):
         concrete_type_builder.set_parameter_dict()
 
-    class_annotations = getattr(nn_module, '__annotations__', {})
+    def get_annotations(obj):
+        if sys.version_info < (3, 10):
+            return getattr(obj, '__annotations__', {})
+        # In Python-3.10+ it is recommended to use inspect.get_annotations
+        # See https://docs.python.org/3.10/howto/annotations.html
+        # But also, in 3.10 annotations from base class are not inherited
+        # by unannotated derived one, so they must be manually extracted
+        annotations = inspect.get_annotations(obj)
+        if len(annotations) > 0:
+            return annotations
+        cls = obj if isinstance(obj, type) else type(obj)
+        if len(cls.__bases__) == 0:
+            return {}
+        return inspect.get_annotations(cls.__bases__[0])
+
+    class_annotations = get_annotations(nn_module)
     if isinstance(nn_module, (torch.ao.quantization.QuantWrapper)):
         class_annotations = {}
 


### PR DESCRIPTION
The way Python-3.10+ deals with annotations has changed, see
https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-10-and-newer

In particular, derived classes would not inherit parent annotations as
following example clearly demonstrates:
```
class Base:
    a: int = 3
    b: str = 'abc'

class Derived(Base):
    pass

print(Derived.__annotations__)
```

if executed by 3.10 runtime, it will return an empty dict, while older
ones return annotations of the base class

Fix that by implementing this difference in `get_annotations` function

I wonder if in general, we should do it even for older versions of Python runtime
