### PR TITLE
[FSDP] import ``_symbolic_trace`` only when ``torch.fx`` is enabled

### DIFF
--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -85,9 +85,7 @@ except ImportError:
     _TORCHDISTX_AVAIL = False
 
 _TORCH_FX_AVAIL = True
-try:
-    from torch import fx
-except ImportError:
+if not hasattr(torch, "fx"):
     _TORCH_FX_AVAIL = False
 if _TORCH_FX_AVAIL:
     from ._symbolic_trace import _init_execution_info, _patch_tracer, TracingConfig

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -942,7 +942,11 @@ class FullyShardedDataParallel(nn.Module):
         auto_wrap_policy = kwargs["auto_wrap_policy"]
         module = kwargs["module"]
         assert hasattr(auto_wrap_policy, "tracing_config")
-        if _TORCH_FX_AVAIL and isinstance(
+        if not _TORCH_FX_AVAIL:
+            assert (
+                auto_wrap_policy.tracing_config is None
+            ), "tracing_config should be None when torch.fx is not enabled"
+        elif isinstance(
             auto_wrap_policy.tracing_config,
             TracingConfig
         ):
@@ -966,6 +970,10 @@ class FullyShardedDataParallel(nn.Module):
                         "tracer.trace failed inside _init_param_exec_order_wrap_policy"
                         f" with the error: {e}."
                     )
+        else:
+            assert (
+                auto_wrap_policy.tracing_config is None
+            ), "tracing_config should either be an instance of TracingConfig or be None"
         # The initial FSDP wrapping is done with auto_wrap_policy.init_policy
         kwargs["auto_wrap_policy"] = auto_wrap_policy.init_policy
         self.__init__(*args, **kwargs)
@@ -991,10 +999,6 @@ class FullyShardedDataParallel(nn.Module):
                     for flat_param in module_to_fsdp[m].params:
                         self._fsdp_params_exec_order.append(flat_param)
             self._param_exec_order_prep_stage = False
-        else:
-            assert (
-                auto_wrap_policy.tracing_config is None
-            ), "tracing_config should either be an instance of TracingConfig or be None"
 
         for m in self.modules():
             if m is not self and isinstance(m, FullyShardedDataParallel):


### PR DESCRIPTION
This is used to fix internal tests where ``torch.fx`` is not available in the module.