### PR TITLE
Add `native_functions.yaml` to MPS rule

### DIFF
--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -166,6 +166,7 @@
       "name": "MPS",
       "patterns": [
          "test/test_mps.py",
+         "aten/src/ATen/native/native_functions.yaml",
          "aten/src/ATen/mps/**",
          "aten/src/ATen/native/mps/**"
       ],


### PR DESCRIPTION
Often PRs that add new MPS op have to edit `native_functions.yaml`, for example #81303

