### PR TITLE
Re-enable vulkan test

### DIFF
--- a/.circleci/docker/common/install_swiftshader.sh
+++ b/.circleci/docker/common/install_swiftshader.sh
@@ -11,7 +11,7 @@ retry () {
 _https_amazon_aws=https://ossci-android.s3.amazonaws.com
 
 # SwiftShader
-_swiftshader_dir=/var/lib/jenkins/swiftshader
+_swiftshader_dir=/tmp/jenkins/swiftshader
 _swiftshader_file_targz=swiftshader-abe07b943-prebuilt.tar.gz
 mkdir -p $_swiftshader_dir
 _tmp_swiftshader_targz="/tmp/${_swiftshader_file_targz}"

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -335,6 +335,8 @@ test_aot_compilation() {
 
 test_vulkan() {
   if [[ "$BUILD_ENVIRONMENT" == *vulkan* ]]; then
+    export SWIFTSHADER=1
+    source .circleci/docker/common/install_swiftshader.sh
     ln -sf "$TORCH_LIB_DIR"/libtorch* "$TORCH_TEST_DIR"
     ln -sf "$TORCH_LIB_DIR"/libc10* "$TORCH_TEST_DIR"
     export VK_ICD_FILENAMES=/var/lib/jenkins/swiftshader/build/Linux/vk_swiftshader_icd.json
@@ -342,7 +344,7 @@ test_vulkan() {
     # test reporting process (in print_test_stats.py) to function as expected.
     TEST_REPORTS_DIR=test/test-reports/cpp-vulkan/test_vulkan
     mkdir -p $TEST_REPORTS_DIR
-    "$TORCH_TEST_DIR"/vulkan_api_test --gtest_output=xml:$TEST_REPORTS_DIR/vulkan_test.xml
+    LD_LIBRARY_PATH=/tmp/jenkins/swiftshader/build/Linux/ "$TORCH_TEST_DIR"/vulkan_api_test --gtest_output=xml:$TEST_REPORTS_DIR/vulkan_test.xml
   fi
 }
 
@@ -657,8 +659,7 @@ elif [[ "${SHARD_NUMBER}" -gt 2 ]]; then
   install_torchdynamo
   test_python_shard "$SHARD_NUMBER"
 elif [[ "${BUILD_ENVIRONMENT}" == *vulkan* ]]; then
-  # TODO: re-enable vulkan test
-  echo "no-op at the moment"
+  test_vulkan
 elif [[ "${BUILD_ENVIRONMENT}" == *-bazel-* ]]; then
   test_bazel
 elif [[ "${BUILD_ENVIRONMENT}" == *-mobile-lightweight-dispatch* ]]; then

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -2670,7 +2670,7 @@ TEST_F(VulkanAPITest, cat_dim1_samefeature_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, cat_dim1_difffeature_success) {
+TEST_F(VulkanAPITest, DISABLED_cat_dim1_difffeature_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #81354

Summary: So that we can verify vulkan code for commits

Note that we need to set LD_LIBRARY_PATH to swiftshader path (using the same directory VK_ICD_FILENAMES) so that volk can load the swiftshader (mock vulkan implementation)

Also VulkanAPITest.cat_dim1_difffeature_success is disabled for now since it's flaky

Test Plan: if someting fails we should be blocked

Reviewers:

Subscribers:

Tasks:

Tags: