### PR TITLE
[Py3.10] Allow floats to be imported as Long

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -207,11 +207,14 @@ class TestSparseCompressed(TestCase):
             # replaced with a N-list where N==len(densesize) and the
             # shape corresponds to densesize.
 
+            max_val = torch.iinfo(dtype).max if dtype in [torch.int16, torch.int8, torch.uint8] else None
+
             def list_add(lst, value):
                 # recursively add a value to lst items
                 if isinstance(lst, list):
                     return [list_add(item, value) for item in lst]
-                return lst + value
+                rc = lst + value
+                return rc if max_val is None else (rc % max_val)
 
             def stretch_values(value, bdim, values_item_shape):
                 # replace a value with a new value that extends the

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -60,6 +60,13 @@ inline int32_t THPUtils_unpackInt(PyObject* obj) {
 }
 
 inline int64_t THPUtils_unpackLong(PyObject* obj) {
+#if PY_VERSION_HEX >= 0x030a00f0
+  // In Python-3.10 floats can no longer be silently converted to integers
+  // Keep backward compatible behavior for now
+  if (PyFloat_Check(obj)) {
+    return static_cast<int64_t>(PyFloat_AS_DOUBLE(obj));
+  }
+#endif
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int overflow;
   long long value = PyLong_AsLongLongAndOverflow(obj, &overflow);

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -60,13 +60,6 @@ inline int32_t THPUtils_unpackInt(PyObject* obj) {
 }
 
 inline int64_t THPUtils_unpackLong(PyObject* obj) {
-#if PY_VERSION_HEX >= 0x030a00f0
-  // In Python-3.10 floats can no longer be silently converted to integers
-  // Keep backward compatible behavior for now
-  if (PyFloat_Check(obj)) {
-    return static_cast<int64_t>(PyFloat_AS_DOUBLE(obj));
-  }
-#endif
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int overflow;
   long long value = PyLong_AsLongLongAndOverflow(obj, &overflow);

--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <c10/util/TypeCast.h>
 #include <torch/csrc/python_headers.h>
 
 #include <torch/csrc/Exceptions.h>
@@ -9,22 +10,35 @@
 namespace torch {
 namespace utils {
 
+template <typename T>
+inline T unpackIntegral(PyObject* obj, const char* type) {
+#if PY_VERSION_HEX >= 0x030a00f0
+  // In Python-3.10 floats can no longer be silently converted to integers
+  // Keep backward compatible behavior for now
+  if (PyFloat_Check(obj)) {
+    return c10::checked_convert<T>(THPUtils_unpackDouble(obj), type);
+  }
+#endif
+
+  return c10::checked_convert<T>(THPUtils_unpackLong(obj), type);
+}
+
 inline void store_scalar(void* data, at::ScalarType scalarType, PyObject* obj) {
   switch (scalarType) {
     case at::kByte:
-      *(uint8_t*)data = (uint8_t)THPUtils_unpackLong(obj);
+      *(uint8_t*)data = unpackIntegral<uint8_t>(obj, "uint8");
       break;
     case at::kChar:
-      *(int8_t*)data = (int8_t)THPUtils_unpackLong(obj);
+      *(int8_t*)data = unpackIntegral<int8_t>(obj, "int8");
       break;
     case at::kShort:
-      *(int16_t*)data = (int16_t)THPUtils_unpackLong(obj);
+      *(int16_t*)data = unpackIntegral<int16_t>(obj, "int16");
       break;
     case at::kInt:
-      *(int32_t*)data = (int32_t)THPUtils_unpackLong(obj);
+      *(int32_t*)data = unpackIntegral<int32_t>(obj, "int32");
       break;
     case at::kLong:
-      *(int64_t*)data = THPUtils_unpackLong(obj);
+      *(int64_t*)data = unpackIntegral<int64_t>(obj, "int64");
       break;
     case at::kHalf:
       *(at::Half*)data =


### PR DESCRIPTION
Thus avoiding `TypeError: 'float' object cannot be interpreted as an integer` when trying to create integer tensor from floating point values

Use `c10::checked_convert` to detect overflows during tensor construction from scalars. Modify sparse_csr test that violated this rule

Fixes #69319

Tested in #81233
