### PR TITLE
[ONNX] Fix float point detection for optional tensor (with unknown rank) within a list

### DIFF
--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -611,7 +611,10 @@ def _is_in_type_group(value, scalar_types: Set[_type_utils.JitScalarType]) -> bo
     if isinstance(value, torch.Tensor):
         return _type_utils.JitScalarType.from_dtype(value.dtype) in scalar_types
     elif isinstance(value.type(), torch.ListType):
-        return _type_utils.JitScalarType.from_dtype(value.type().getElementType().dtype()) in scalar_types
+        return (
+            _type_utils.JitScalarType.from_dtype(value.type().getElementType().dtype())
+            in scalar_types
+        )
     scalar_type = value.type().scalarType()
     if scalar_type is None:
         warnings.warn(

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -12,7 +12,6 @@ from typing_extensions import Literal
 import torch
 import torch._C._onnx as _C_onnx
 from torch import _C
-
 # Monkey-patch graph manipulation methods on Graph, used for the ONNX symbolics
 from torch.onnx import _patch_torch, _type_utils, errors  # noqa: F401
 from torch.onnx._globals import GLOBALS
@@ -610,6 +609,8 @@ def _is_in_type_group(value, scalar_types: Set[_type_utils.JitScalarType]) -> bo
         return False
     if isinstance(value, torch.Tensor):
         return _type_utils.JitScalarType.from_dtype(value.dtype) in scalar_types
+    elif isinstance(value.type(), torch.ListType):
+        return _type_utils.JitScalarType.from_dtype(value.type().getElementType().dtype()) in scalar_types
     scalar_type = value.type().scalarType()
     if scalar_type is None:
         warnings.warn(

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -12,6 +12,7 @@ from typing_extensions import Literal
 import torch
 import torch._C._onnx as _C_onnx
 from torch import _C
+
 # Monkey-patch graph manipulation methods on Graph, used for the ONNX symbolics
 from torch.onnx import _patch_torch, _type_utils, errors  # noqa: F401
 from torch.onnx._globals import GLOBALS

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -821,28 +821,10 @@ def squeeze(g, self, dim=None):
     if input_rank is not None and dim < 0:
         adjusted_dim += input_rank
     dim_size = symbolic_helper._get_tensor_dim_size(self, adjusted_dim)
-    if (dim < 0 and input_rank is None) or dim_size is None:
-        # If onnx shape inference is not on, export always as dynamic.
-        # Because we cannot tell if observed static shape is also static at runtime.
-        # create "cond" node (condition is shape[i]==1)
-        dim_constant = g.op("Constant", value_t=torch.tensor([dim]))
-        size = symbolic_helper._size_helper(g, self, dim_constant)
-        const_one = g.op("Constant", value_t=torch.ones(1, dtype=torch.int64))
-        cond = g.op("Equal", size, const_one)
-        # create the "If" node and add the "then" and "else" blocks to it.
-        if_node_outputs = g.op("If", cond)
-        if_node = if_node_outputs.node()
-        if_block = utils._add_block(if_node)
-        squeeze_ = symbolic_helper._squeeze_helper(if_block, self, [dim])
-        utils._add_output_to_block(if_block, squeeze_)
-        else_block = utils._add_block(if_node)
-        identity_ = else_block.op("Identity", self)
-        utils._add_output_to_block(else_block, identity_)
-        return if_node_outputs
 
     # For static input shape
     dim = adjusted_dim
-    if dim_size > 1:
+    if dim_size is not None and dim_size > 1:
         warnings.warn(
             "This model contains a squeeze operation on dimension "
             + str(dim)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -4586,9 +4586,9 @@ def index(g, self, index):
             rank = symbolic_helper._get_tensor_rank(self)
             if rank is None:
                 raise NotImplementedError(
-                    "Unsupported aten::index operator of advanced indexing on tensor of unknown rank, "
-                    + "try turning on shape and type propagate during export: "
-                    + "torch.onnx._export(..., propagate=True)."
+                    "Unsupported aten::index operator of advanced indexing on tensor of unknown rank. "
+                    + "Try turning on shape inference during export: "
+                    + "torch.onnx._export(..., onnx_shape_inference=True)."
                 )
             # TODO: If indexing is supported natively in ONNX in future opsets,
             #       update the warning to recommend exporting with higher opset version.


### PR DESCRIPTION
In some scenarios, by combining a traced model with a scripted function in it, a `%74 : Tensor?[] = prim::ListConstruct(%35, %y_int, %x_int)` (aka List of Optional Tensor) can be generated, which will make `symbolic_helper._is_fp()` fail to read the data type of the specified input. 

In such scenario, something like `type = value.type().scalarType()` raises `RuntimeError: r INTERNAL ASSERT FAILED at "/github/pytorch/aten/src/ATen/core/jit_type_base.h":545, please report a bug to PyTorch. ` that refers to 

```
  template <typename T>
  T& expectRef() {
    auto* r = castRaw<T>();
    AT_ASSERT(r);
    return *r;
  }
```

What happens is that for `torch._C.TypeList` in this repro, `input.type()` is `torch._C.TypeList` which does not have `scalarType()` method. Instead, `value.type().getElementType().dtype()` should be used to get the underlying type.

This PR tries to use `value.type().getElementType().dtype()` when `isinstance(value.type(), torch.ListType)`. 
A unit test is proposed along with the fix.

