### PR TITLE
Enforce linter in vulkan code

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -43,6 +43,8 @@ init_command = [
 code = 'CLANGFORMAT'
 include_patterns = [
     'aten/src/ATen/*.h',
+    'aten/src/ATen/native/vulkan/**/*.h',
+    'aten/src/ATen/native/vulkan/**/*.cpp',
     'c10/**/*.h',
     'c10/**/*.cpp',
     'torch/csrc/**/*.h',
@@ -51,6 +53,7 @@ include_patterns = [
     'test/cpp/**/*.cpp',
 ]
 exclude_patterns = [
+    'aten/src/ATen/native/vulkan/api/vk_mem_alloc.h',
     'c10/util/strong_type.h',
     'torch/csrc/jit/serialization/mobile_bytecode_generated.h',
 ]

--- a/aten/src/ATen/native/vulkan/VulkanGuardImpl.cpp
+++ b/aten/src/ATen/native/vulkan/VulkanGuardImpl.cpp
@@ -54,8 +54,8 @@ struct VulkanGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   bool queryEvent(void* event) const override {
     TORCH_CHECK(false, "VULKAN backend doesn't support events.")
   }
-  void destroyEvent(void* event, const DeviceIndex device_index) const
-      noexcept override {}
+  void destroyEvent(void* event, const DeviceIndex device_index)
+      const noexcept override {}
 };
 
 C10_REGISTER_GUARD_IMPL(Vulkan, VulkanGuardImpl);

--- a/aten/src/ATen/native/vulkan/VulkanOpaqueTensorImpl.h
+++ b/aten/src/ATen/native/vulkan/VulkanOpaqueTensorImpl.h
@@ -23,8 +23,7 @@ struct VulkanOpaqueTensorImpl : public OpaqueTensorImpl<OpaqueHandle> {
             opaque_handle,
             sizes,
             false),
-        strides_(strides.vec()) {
-  }
+        strides_(strides.vec()) {}
 
   IntArrayRef strides_custom() const override {
     return strides_;

--- a/aten/src/ATen/native/vulkan/api/Adapter.cpp
+++ b/aten/src/ATen/native/vulkan/api/Adapter.cpp
@@ -9,14 +9,14 @@ namespace vulkan {
 namespace api {
 
 PhysicalDevice::PhysicalDevice(const VkPhysicalDevice physical_device_handle)
-  : handle(physical_device_handle),
-    properties{},
-    memory_properties{},
-    queue_families{},
-    num_compute_queues(0),
-    has_unified_memory(false),
-    has_timestamps(false),
-    timestamp_period(0) {
+    : handle(physical_device_handle),
+      properties{},
+      memory_properties{},
+      queue_families{},
+      num_compute_queues(0),
+      has_unified_memory(false),
+      has_timestamps(false),
+      timestamp_period(0) {
   // Extract physical device properties
   vkGetPhysicalDeviceProperties(handle, &properties);
   vkGetPhysicalDeviceMemoryProperties(handle, &memory_properties);
@@ -27,7 +27,7 @@ PhysicalDevice::PhysicalDevice(const VkPhysicalDevice physical_device_handle)
   // Check if there are any memory types have both the HOST_VISIBLE and the
   // DEVICE_LOCAL property flags
   const VkMemoryPropertyFlags unified_memory_flags =
-    VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+      VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
   for (const uint32_t i : c10::irange(memory_properties.memoryTypeCount)) {
     if (memory_properties.memoryTypes[i].propertyFlags | unified_memory_flags) {
       has_unified_memory = true;
@@ -96,23 +96,23 @@ VkDevice create_logical_device(
   queues_to_get.reserve(num_queues_to_create);
 
   uint32_t remaining_queues = num_queues_to_create;
-  for (const uint32_t family_i \
-       : c10::irange(physical_device.queue_families.size())) {
-    const VkQueueFamilyProperties& queue_properties = \
+  for (const uint32_t family_i :
+       c10::irange(physical_device.queue_families.size())) {
+    const VkQueueFamilyProperties& queue_properties =
         physical_device.queue_families[family_i];
     // Check if this family has compute capability
     if (queue_properties.queueFlags & VK_QUEUE_COMPUTE_BIT) {
-      const uint32_t queues_to_init = std::min(
-          remaining_queues, queue_properties.queueCount);
+      const uint32_t queues_to_init =
+          std::min(remaining_queues, queue_properties.queueCount);
 
       const std::vector<float> queue_priorities(queues_to_init, 1.0f);
       queue_create_infos.push_back({
-        VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,  // sType
-        nullptr,  // pNext
-        0u,  // flags
-        family_i,  // queueFamilyIndex
-        queues_to_init,  // queueCount
-        queue_priorities.data(),  // pQueuePriorities
+          VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO, // sType
+          nullptr, // pNext
+          0u, // flags
+          family_i, // queueFamilyIndex
+          queues_to_init, // queueCount
+          queue_priorities.data(), // pQueuePriorities
       });
 
       for (const uint32_t queue_i : c10::irange(queues_to_init)) {
@@ -131,27 +131,30 @@ VkDevice create_logical_device(
 
   // Create the VkDevice
 
-  std::vector<const char*> requested_device_extensions {
-  #ifdef VK_KHR_portability_subset
-    VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME,
-  #endif /* VK_KHR_portability_subset */
+  std::vector<const char*> requested_device_extensions{
+#ifdef VK_KHR_portability_subset
+      VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME,
+#endif /* VK_KHR_portability_subset */
   };
 
   std::vector<const char*> enabled_device_extensions;
   find_requested_device_extensions(
-      physical_device.handle, enabled_device_extensions, requested_device_extensions);
+      physical_device.handle,
+      enabled_device_extensions,
+      requested_device_extensions);
 
   const VkDeviceCreateInfo device_create_info{
-    VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    static_cast<uint32_t>(queue_create_infos.size()),  // queueCreateInfoCount
-    queue_create_infos.data(),  // pQueueCreateInfos
-    0u,  // enabledLayerCount
-    nullptr,  // ppEnabledLayerNames
-    static_cast<uint32_t>(enabled_device_extensions.size()),  // enabledExtensionCount
-    enabled_device_extensions.data(),  // ppEnabledExtensionNames
-    nullptr,  // pEnabledFeatures
+      VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      static_cast<uint32_t>(queue_create_infos.size()), // queueCreateInfoCount
+      queue_create_infos.data(), // pQueueCreateInfos
+      0u, // enabledLayerCount
+      nullptr, // ppEnabledLayerNames
+      static_cast<uint32_t>(
+          enabled_device_extensions.size()), // enabledExtensionCount
+      enabled_device_extensions.data(), // ppEnabledExtensionNames
+      nullptr, // pEnabledFeatures
   };
 
   VkDevice handle;
@@ -166,9 +169,9 @@ VkDevice create_logical_device(
 
   for (const std::pair<uint32_t, uint32_t>& queue_idx : queues_to_get) {
     VkQueue queue_handle = VK_NULL_HANDLE;
-    VkQueueFlags flags = physical_device.queue_families[queue_idx.first].queueFlags;
-    vkGetDeviceQueue(
-        handle, queue_idx.first, queue_idx.second, &queue_handle);
+    VkQueueFlags flags =
+        physical_device.queue_families[queue_idx.first].queueFlags;
+    vkGetDeviceQueue(handle, queue_idx.first, queue_idx.second, &queue_handle);
     queues.push_back({queue_idx.first, queue_idx.second, flags, queue_handle});
     // Initial usage value
     queue_usage.push_back(0);
@@ -180,7 +183,7 @@ VkDevice create_logical_device(
 // Print utils
 
 std::string get_device_type_str(const VkPhysicalDeviceType type) {
-  switch(type) {
+  switch (type) {
     case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
       return "INTEGRATED_GPU";
     case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
@@ -238,17 +241,15 @@ std::string get_queue_family_properties_str(const VkQueueFlags flags) {
 // DeviceHandle
 //
 
-DeviceHandle::DeviceHandle(const VkDevice device)
-  : handle_(device) {
-}
+DeviceHandle::DeviceHandle(const VkDevice device) : handle_(device) {}
 
 DeviceHandle::DeviceHandle(DeviceHandle&& other) noexcept
-  : handle_(other.handle_) {
+    : handle_(other.handle_) {
   other.handle_ = VK_NULL_HANDLE;
 }
 
 DeviceHandle::~DeviceHandle() {
-  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyDevice(handle_, nullptr);
@@ -262,21 +263,23 @@ Adapter::Adapter(
     const VkInstance instance,
     const PhysicalDevice& physical_device,
     const uint32_t num_queues)
-  : queue_usage_mutex_{},
-    physical_device_(physical_device),
-    queues_{},
-    queue_usage_{},
-    queue_mutexes_{},
-    instance_(instance),
-    device_(create_logical_device(
-        physical_device_, num_queues, queues_, queue_usage_)),
-    shader_layout_cache_(device_.handle_),
-    shader_cache_(device_.handle_),
-    pipeline_layout_cache_(device_.handle_),
-    compute_pipeline_cache_(device_.handle_),
-    sampler_cache_(device_.handle_),
-    vma_(instance_, physical_device_.handle, device_.handle_) {
-}
+    : queue_usage_mutex_{},
+      physical_device_(physical_device),
+      queues_{},
+      queue_usage_{},
+      queue_mutexes_{},
+      instance_(instance),
+      device_(create_logical_device(
+          physical_device_,
+          num_queues,
+          queues_,
+          queue_usage_)),
+      shader_layout_cache_(device_.handle_),
+      shader_cache_(device_.handle_),
+      pipeline_layout_cache_(device_.handle_),
+      compute_pipeline_cache_(device_.handle_),
+      sampler_cache_(device_.handle_),
+      vma_(instance_, physical_device_.handle, device_.handle_) {}
 
 Adapter::Queue Adapter::request_queue() {
   // Lock the mutex as multiple threads can request a queue at the same time
@@ -311,15 +314,15 @@ void Adapter::submit_cmd(
     const VkCommandBuffer cmd,
     const VkFence fence) {
   const VkSubmitInfo submit_info{
-    VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // waitSemaphoreCount
-    nullptr,  // pWaitSemaphores
-    nullptr,  // pWaitDstStageMask
-    1u,  // commandBufferCount
-    &cmd,  // pCommandBuffers
-    0u,  // signalSemaphoreCount
-    nullptr,  // pSignalSemaphores
+      VK_STRUCTURE_TYPE_SUBMIT_INFO, // sType
+      nullptr, // pNext
+      0u, // waitSemaphoreCount
+      nullptr, // pWaitSemaphores
+      nullptr, // pWaitDstStageMask
+      1u, // commandBufferCount
+      &cmd, // pCommandBuffers
+      0u, // signalSemaphoreCount
+      nullptr, // pSignalSemaphores
   };
 
   std::lock_guard<std::mutex> queue_lock(
@@ -333,15 +336,15 @@ void Adapter::submit_cmds(
     const std::vector<VkCommandBuffer>& cmds,
     const VkFence fence) {
   const VkSubmitInfo submit_info{
-    VK_STRUCTURE_TYPE_SUBMIT_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // waitSemaphoreCount
-    nullptr,  // pWaitSemaphores
-    nullptr,  // pWaitDstStageMask
-    utils::safe_downcast<uint32_t>(cmds.size()),  // commandBufferCount
-    cmds.data(),  // pCommandBuffers
-    0u,  // signalSemaphoreCount
-    nullptr,  // pSignalSemaphores
+      VK_STRUCTURE_TYPE_SUBMIT_INFO, // sType
+      nullptr, // pNext
+      0u, // waitSemaphoreCount
+      nullptr, // pWaitSemaphores
+      nullptr, // pWaitDstStageMask
+      utils::safe_downcast<uint32_t>(cmds.size()), // commandBufferCount
+      cmds.data(), // pCommandBuffers
+      0u, // signalSemaphoreCount
+      nullptr, // pSignalSemaphores
   };
 
   VK_CHECK(vkQueueSubmit(device_queue.handle, 1u, &submit_info, fence));
@@ -363,14 +366,13 @@ std::string Adapter::stringize() const {
   ss << "    deviceType:    " << device_type << std::endl;
   ss << "    deviceName:    " << properties.deviceName << std::endl;
 
-#define PRINT_LIMIT_PROP(name) \
-  ss << "      " << std::left << std::setw(36) << #name << limits.name << std::endl;
+#define PRINT_LIMIT_PROP(name)                                         \
+  ss << "      " << std::left << std::setw(36) << #name << limits.name \
+     << std::endl;
 
-#define PRINT_LIMIT_PROP_VEC3(name) \
-  ss << "      " << std::left << std::setw(36) << #name \
-  << limits.name[0] << "," \
-  << limits.name[1] << "," \
-  << limits.name[2] << std::endl;
+#define PRINT_LIMIT_PROP_VEC3(name)                                       \
+  ss << "      " << std::left << std::setw(36) << #name << limits.name[0] \
+     << "," << limits.name[1] << "," << limits.name[2] << std::endl;
 
   ss << "    Physical Device Limits {" << std::endl;
   PRINT_LIMIT_PROP(maxImageDimension1D);
@@ -385,39 +387,43 @@ std::string Adapter::stringize() const {
   PRINT_LIMIT_PROP(maxComputeWorkGroupInvocations);
   PRINT_LIMIT_PROP_VEC3(maxComputeWorkGroupSize);
   ss << "    }" << std::endl;
-  ss << "  }" << std::endl;;
+  ss << "  }" << std::endl;
+  ;
 
-  const VkPhysicalDeviceMemoryProperties& mem_props = \
+  const VkPhysicalDeviceMemoryProperties& mem_props =
       physical_device_.memory_properties;
 
   ss << "  Memory Info {" << std::endl;
   ss << "    Memory Types [" << std::endl;
   for (const auto i : c10::irange(mem_props.memoryTypeCount)) {
-  ss << "      " << " [Heap " << mem_props.memoryTypes[i].heapIndex << "] "
-               << get_memory_properties_str(mem_props.memoryTypes[i].propertyFlags)
-               << std::endl;
+    ss << "      "
+       << " [Heap " << mem_props.memoryTypes[i].heapIndex << "] "
+       << get_memory_properties_str(mem_props.memoryTypes[i].propertyFlags)
+       << std::endl;
   }
   ss << "    ]" << std::endl;
   ss << "    Memory Heaps [" << std::endl;
   for (const auto i : c10::irange(mem_props.memoryHeapCount)) {
-  ss << "      " << mem_props.memoryHeaps[i].size << std::endl;
+    ss << "      " << mem_props.memoryHeaps[i].size << std::endl;
   }
   ss << "    ]" << std::endl;
   ss << "  }" << std::endl;
 
   ss << "  Queue Families {" << std::endl;
-  for (const VkQueueFamilyProperties& queue_family_props \
-       : physical_device_.queue_families) {
-  ss << "    (" << queue_family_props.queueCount << " Queues) "
-     << get_queue_family_properties_str(queue_family_props.queueFlags) << std::endl;
+  for (const VkQueueFamilyProperties& queue_family_props :
+       physical_device_.queue_families) {
+    ss << "    (" << queue_family_props.queueCount << " Queues) "
+       << get_queue_family_properties_str(queue_family_props.queueFlags)
+       << std::endl;
   }
   ss << "  }" << std::endl;
   ss << "  VkDevice: " << device_.handle_ << std::endl;
   ss << "  Compute Queues [" << std::endl;
   for (const Adapter::Queue& compute_queue : queues_) {
-  ss << "    Family " << compute_queue.family_index
-     << ", Queue " << compute_queue.queue_index
-     << ": " << compute_queue.handle << std::endl;;
+    ss << "    Family " << compute_queue.family_index << ", Queue "
+       << compute_queue.queue_index << ": " << compute_queue.handle
+       << std::endl;
+    ;
   }
   ss << "  ]" << std::endl;
   ss << "}";

--- a/aten/src/ATen/native/vulkan/api/Adapter.h
+++ b/aten/src/ATen/native/vulkan/api/Adapter.h
@@ -3,8 +3,8 @@
 #ifdef USE_VULKAN_API
 
 #include <ATen/native/vulkan/api/Common.h>
-#include <ATen/native/vulkan/api/Shader.h>
 #include <ATen/native/vulkan/api/Pipeline.h>
+#include <ATen/native/vulkan/api/Shader.h>
 #include <ATen/native/vulkan/api/Utils.h>
 #include <ostream>
 
@@ -57,9 +57,10 @@ class DeviceHandle final {
 // which points to the logical device object on the GPU.
 //
 // This class is primarily used by the Runtime class, which holds one Adapter
-// instance for each physical device visible to the VkInstance. Upon construction,
-// this class will populate the physical device properties, but will not create
-// the logical device until specifically requested via the init_device() funtion.
+// instance for each physical device visible to the VkInstance. Upon
+// construction, this class will populate the physical device properties, but
+// will not create the logical device until specifically requested via the
+// init_device() funtion.
 //
 // init_device() will create the logical device and obtain the VkDevice handle
 // for it. It will also create a number of compute queues up to the amount
@@ -119,7 +120,6 @@ class Adapter final {
   MemoryAllocator vma_;
 
  public:
-
   // Physical Device metadata
 
   inline VkPhysicalDevice physical_handle() const {
@@ -194,7 +194,11 @@ class Adapter final {
   // Miscellaneous
 
   inline utils::uvec3 local_work_group_size() const {
-    return { 4u, 4u, 4u, };
+    return {
+        4u,
+        4u,
+        4u,
+    };
   }
 
   std::string stringize() const;

--- a/aten/src/ATen/native/vulkan/api/Allocator.h
+++ b/aten/src/ATen/native/vulkan/api/Allocator.h
@@ -12,43 +12,43 @@
 #define VMA_VULKAN_VERSION 1000000
 
 #ifdef USE_VULKAN_WRAPPER
-  #define VMA_STATIC_VULKAN_FUNCTIONS 0
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
 #else
-  #define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
 #endif /* USE_VULKAN_WRAPPER */
 
 #define VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE (32ull * 1024 * 1024)
 #define VMA_SMALL_HEAP_MAX_SIZE (256ull * 1024 * 1024)
 
 #ifdef DEBUG
-  #define VMA_DEBUG_ALIGNMENT 4096
-  #define VMA_DEBUG_ALWAYS_DEDICATED_MEMORY 0
-  #define VMA_DEBUG_DETECT_CORRUPTION 1
-  #define VMA_DEBUG_GLOBAL_MUTEX 1
-  #define VMA_DEBUG_INITIALIZE_ALLOCATIONS 1
-  #define VMA_DEBUG_MARGIN 64
-  #define VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY 256
-  #define VMA_RECORDING_ENABLED 1
+#define VMA_DEBUG_ALIGNMENT 4096
+#define VMA_DEBUG_ALWAYS_DEDICATED_MEMORY 0
+#define VMA_DEBUG_DETECT_CORRUPTION 1
+#define VMA_DEBUG_GLOBAL_MUTEX 1
+#define VMA_DEBUG_INITIALIZE_ALLOCATIONS 1
+#define VMA_DEBUG_MARGIN 64
+#define VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY 256
+#define VMA_RECORDING_ENABLED 1
 
-  #define VMA_DEBUG_LOG(format, ...)
-  /*
-  #define VMA_DEBUG_LOG(format, ...) do { \
-      printf(format, __VA_ARGS__); \
-      printf("\n"); \
-  } while(false)
-  */
+#define VMA_DEBUG_LOG(format, ...)
+/*
+#define VMA_DEBUG_LOG(format, ...) do { \
+    printf(format, __VA_ARGS__); \
+    printf("\n"); \
+} while(false)
+*/
 #endif /* DEBUG */
 
 #ifdef __clang__
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wnullability-completeness"
-  #pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+#pragma clang diagnostic ignored "-Wunused-variable"
 #endif /* __clang__ */
 
 #include <ATen/native/vulkan/api/vk_mem_alloc.h>
 
 #ifdef __clang__
-  #pragma clang diagnostic pop
+#pragma clang diagnostic pop
 #endif /* __clang__ */
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -18,7 +18,8 @@ class CommandBuffer final {
  public:
   explicit CommandBuffer(
       const VkCommandBuffer,
-      const VkCommandBufferUsageFlags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+      const VkCommandBufferUsageFlags =
+          VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
   CommandBuffer(const CommandBuffer&) = delete;
   CommandBuffer& operator=(const CommandBuffer&) = delete;
@@ -30,14 +31,15 @@ class CommandBuffer final {
 
   // The lifecycle of a command buffer is as follows:
   enum State {
-    INVALID,  // Used to indicate the command buffer is moved from
-    NEW,  // Set during constructor
-    RECORDING,  // Set during call to begin(), dispatch(), and copy_texture_to_texture()
-    PIPELINE_BOUND,  // Set during call to  bind_pipeline()
-    DESCRIPTORS_BOUND,  // Set during call to bind_descriptors()
-    BARRIERS_INSERTED,  // Set during call to insert_barrier()
-    READY,  //  Set during call to end()
-    SUBMITTED,  // Set during call to get_submit_handle()
+    INVALID, // Used to indicate the command buffer is moved from
+    NEW, // Set during constructor
+    RECORDING, // Set during call to begin(), dispatch(), and
+               // copy_texture_to_texture()
+    PIPELINE_BOUND, // Set during call to  bind_pipeline()
+    DESCRIPTORS_BOUND, // Set during call to bind_descriptors()
+    BARRIERS_INSERTED, // Set during call to insert_barrier()
+    READY, //  Set during call to end()
+    SUBMITTED, // Set during call to get_submit_handle()
   };
 
   struct Bound {
@@ -47,11 +49,10 @@ class CommandBuffer final {
     VkDescriptorSet descriptors;
 
     explicit Bound()
-      : pipeline{VK_NULL_HANDLE},
-        pipeline_layout{VK_NULL_HANDLE},
-        local_workgroup_size{0u, 0u, 0u},
-        descriptors{VK_NULL_HANDLE} {
-    }
+        : pipeline{VK_NULL_HANDLE},
+          pipeline_layout{VK_NULL_HANDLE},
+          local_workgroup_size{0u, 0u, 0u},
+          descriptors{VK_NULL_HANDLE} {}
 
     inline void reset() {
       pipeline = VK_NULL_HANDLE;
@@ -88,8 +89,7 @@ class CommandBuffer final {
       const api::utils::uvec3&);
 
   void write_timestamp(const VkQueryPool, const uint32_t) const;
-  void reset_querypool(
-      const VkQueryPool, const uint32_t, const uint32_t) const;
+  void reset_querypool(const VkQueryPool, const uint32_t, const uint32_t) const;
 
   VkCommandBuffer get_submit_handle();
 
@@ -106,7 +106,9 @@ struct CommandPoolConfig final {
 class CommandPool final {
  public:
   explicit CommandPool(
-      const VkDevice, const uint32_t, const CommandPoolConfig&);
+      const VkDevice,
+      const uint32_t,
+      const CommandPoolConfig&);
 
   CommandPool(const CommandPool&) = delete;
   CommandPool& operator=(const CommandPool&) = delete;

--- a/aten/src/ATen/native/vulkan/api/Common.h
+++ b/aten/src/ATen/native/vulkan/api/Common.h
@@ -6,19 +6,16 @@
 
 #ifdef USE_VULKAN_SHADERC_RUNTIME
 #include <ATen/native/vulkan/glsl.h>
-#define VK_KERNEL(name)                          \
-    ::at::native::vulkan::api::ShaderSource{     \
-        #name,                                   \
-        name##_glsl,                             \
-      }
+#define VK_KERNEL(name)                     \
+  ::at::native::vulkan::api::ShaderSource { \
+#name, name##_glsl,                     \
+  }
 #else
 #include <ATen/native/vulkan/spv.h>
-#define VK_KERNEL(name)                          \
-    ::at::native::vulkan::api::ShaderSource{     \
-        #name,                                   \
-        name##_spv,                              \
-        name##_spv_len,                          \
-      }
+#define VK_KERNEL(name)                     \
+  ::at::native::vulkan::api::ShaderSource { \
+#name, name##_spv, name##_spv_len,      \
+  }
 #endif /* USE_VULKAN_SHADERC_RUNTIME */
 
 #ifdef USE_VULKAN_WRAPPER
@@ -31,14 +28,17 @@
 #include <vulkan/vulkan.h>
 #endif /* USE_VULKAN_WRAPPER */
 
-#define VK_CHECK(function)                                  \
-  do {                                                      \
-    const VkResult result = (function);                     \
-    TORCH_CHECK(                                            \
-        VK_SUCCESS == result,                               \
-        C10_STRINGIZE(__FILE__), " [",                      \
-        C10_STRINGIZE(__LINE__), "] "                       \
-        "VkResult:", result);                               \
+#define VK_CHECK(function)              \
+  do {                                  \
+    const VkResult result = (function); \
+    TORCH_CHECK(                        \
+        VK_SUCCESS == result,           \
+        C10_STRINGIZE(__FILE__),        \
+        " [",                           \
+        C10_STRINGIZE(__LINE__),        \
+        "] "                            \
+        "VkResult:",                    \
+        result);                        \
   } while (false)
 
 #define VK_CHECK_RELAXED(function)                          \

--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -19,11 +19,9 @@ Context::Context(size_t adapter_i, const ContextConfig& config)
       command_pool_(device_, queue_.family_index, config_.cmdPoolConfig),
       descriptor_pool_(device_, config_.descriptorPoolConfig),
       fences_(device_),
-      // Diagnostics
+// Diagnostics
 #ifdef USE_VULKAN_GPU_DIAGNOSTICS
-      querypool_(
-        device_,
-        config_.queryPoolConfig),
+      querypool_(device_, config_.queryPoolConfig),
 #endif /* USE_VULKAN_GPU_DIAGNOSTICS */
       // Command buffer submission
       cmd_mutex_{},
@@ -47,20 +45,18 @@ DescriptorSet Context::submit_compute_prologue(
     const ShaderLayout::Signature& shader_layout_signature,
     const ShaderSource& shader_descriptor,
     const utils::uvec3& local_workgroup_size) {
-
-  const VkDescriptorSetLayout shader_layout = \
+  const VkDescriptorSetLayout shader_layout =
       shader_layout_cache().retrieve(shader_layout_signature);
 
-  const VkPipelineLayout pipeline_layout = \
+  const VkPipelineLayout pipeline_layout =
       pipeline_layout_cache().retrieve(shader_layout);
 
-  const VkPipeline pipeline = pipeline_cache().retrieve({
-      pipeline_layout_cache().retrieve(shader_layout),
-      shader_cache().retrieve(shader_descriptor),
-      local_workgroup_size});
+  const VkPipeline pipeline = pipeline_cache().retrieve(
+      {pipeline_layout_cache().retrieve(shader_layout),
+       shader_cache().retrieve(shader_descriptor),
+       local_workgroup_size});
 
-  command_buffer.bind_pipeline(
-      pipeline, pipeline_layout, local_workgroup_size);
+  command_buffer.bind_pipeline(pipeline, pipeline_layout, local_workgroup_size);
 
   return descriptor_pool().get_descriptor_set(
       shader_layout, shader_layout_signature);
@@ -150,46 +146,44 @@ Context* context() {
       const uint32_t submit_frequency = 16u;
 
       const CommandPoolConfig cmd_config{
-        32u,  // cmdPoolInitialSize
-        8u,  // cmdPoolBatchSize
+          32u, // cmdPoolInitialSize
+          8u, // cmdPoolBatchSize
       };
 
       const DescriptorPoolConfig descriptor_pool_config{
-        1024u,  // descriptorPoolMaxSets
-        1024u,  // descriptorUniformBufferCount
-        1024u,  // descriptorStorageBufferCount
-        1024u,  // descriptorCombinedSamplerCount
-        1024u,  // descriptorStorageImageCount
-        32u,  // descriptorPileSizes
+          1024u, // descriptorPoolMaxSets
+          1024u, // descriptorUniformBufferCount
+          1024u, // descriptorStorageBufferCount
+          1024u, // descriptorCombinedSamplerCount
+          1024u, // descriptorStorageImageCount
+          32u, // descriptorPileSizes
       };
 
       const QueryPoolConfig query_pool_config{
-        4096u,  // maxQueryCount
-        256u,  //initialReserveSize
+          4096u, // maxQueryCount
+          256u, // initialReserveSize
       };
 
       const ContextConfig config{
-        submit_frequency,  // cmdSubmitFrequency
-        cmd_config,  // cmdPoolConfig
-        descriptor_pool_config,  // descriptorPoolConfig
-        query_pool_config,  // queryPoolConfig
+          submit_frequency, // cmdSubmitFrequency
+          cmd_config, // cmdPoolConfig
+          descriptor_pool_config, // descriptorPoolConfig
+          query_pool_config, // queryPoolConfig
       };
 
       return new Context(runtime()->default_adapter_i(), config);
-    }
-    catch (const std::exception& e) {
-      TORCH_CHECK(false, "Vulkan: Failed to initialize context! Error: ", e.what());
-    }
-    catch (...) {
-      TORCH_CHECK(false, "Vulkan: Failed to initialize context! Error: Unknown");
+    } catch (const std::exception& e) {
+      TORCH_CHECK(
+          false, "Vulkan: Failed to initialize context! Error: ", e.what());
+    } catch (...) {
+      TORCH_CHECK(
+          false, "Vulkan: Failed to initialize context! Error: Unknown");
     }
 
     return nullptr;
   }());
 
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
-      context,
-      "Invalid Vulkan context!");
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(context, "Invalid Vulkan context!");
 
   return context.get();
 }

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -2,9 +2,9 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/Common.h>
 #include <ATen/native/vulkan/api/Adapter.h>
 #include <ATen/native/vulkan/api/Command.h>
+#include <ATen/native/vulkan/api/Common.h>
 #include <ATen/native/vulkan/api/Descriptor.h>
 #include <ATen/native/vulkan/api/Pipeline.h>
 #include <ATen/native/vulkan/api/QueryPool.h>
@@ -59,7 +59,7 @@ class Context final {
   // Diagnostics
 #ifdef USE_VULKAN_GPU_DIAGNOSTICS
   QueryPool querypool_;
-#endif  /* USE_VULKAN_GPU_DIAGNOSTICS */
+#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
   // Command buffers submission
   std::mutex cmd_mutex_;
   CommandBuffer cmd_;
@@ -71,7 +71,6 @@ class Context final {
   std::vector<VulkanImage> images_to_clear_;
 
  public:
-
   // Adapter access
 
   inline Adapter* adapter_ptr() {
@@ -85,7 +84,6 @@ class Context final {
   inline VkQueue queue() {
     return queue_.handle;
   }
-
 
   // Device Caches
 
@@ -126,7 +124,7 @@ class Context final {
     set_cmd();
     querypool_.reset(cmd_);
   }
-#endif  /* USE_VULKAN_GPU_DIAGNOSTICS */
+#endif /* USE_VULKAN_GPU_DIAGNOSTICS */
 
   // Memory Management
   void register_buffer_cleanup(VulkanBuffer& buffer) {
@@ -146,7 +144,6 @@ class Context final {
   }
 
  private:
-
   inline void set_cmd() {
     if (!cmd_) {
       cmd_ = command_pool_.get_new_cmd();
@@ -167,8 +164,7 @@ class Context final {
       const utils::uvec3&);
 
  public:
-
-  template<typename... Arguments>
+  template <typename... Arguments>
   void submit_compute_job(
       const ShaderLayout::Signature&,
       const ShaderSource&,
@@ -188,11 +184,9 @@ class Context final {
       const VkFence fence_handle);
 
  private:
-
   void submit_cmd_to_gpu(const VkFence fence_handle = VK_NULL_HANDLE);
 
  public:
-
   void flush();
 };
 
@@ -200,13 +194,13 @@ class UniformParamsBuffer final {
  private:
   Context* context_p_;
   VulkanBuffer vulkan_buffer_;
+
  public:
-  template<typename Block>
+  template <typename Block>
   UniformParamsBuffer(Context* context_p, const Block& block)
-    : context_p_(context_p),
-      vulkan_buffer_(
-          context_p_->adapter_ptr()->vma().create_params_buffer(block)) {
-  }
+      : context_p_(context_p),
+        vulkan_buffer_(
+            context_p_->adapter_ptr()->vma().create_params_buffer(block)) {}
 
   UniformParamsBuffer(const UniformParamsBuffer&) = delete;
   UniformParamsBuffer& operator=(const UniformParamsBuffer&) = delete;
@@ -227,13 +221,16 @@ class StagingBuffer final {
  private:
   Context* context_p_;
   VulkanBuffer vulkan_buffer_;
+
  public:
   StagingBuffer(
-      Context* context_p, const VkDeviceSize size, const bool gpuonly = false)
-    : context_p_(context_p),
-      vulkan_buffer_(
-          context_p_->adapter_ptr()->vma().create_storage_buffer(size, gpuonly)) {
-  }
+      Context* context_p,
+      const VkDeviceSize size,
+      const bool gpuonly = false)
+      : context_p_(context_p),
+        vulkan_buffer_(context_p_->adapter_ptr()->vma().create_storage_buffer(
+            size,
+            gpuonly)) {}
 
   StagingBuffer(const StagingBuffer&) = delete;
   StagingBuffer& operator=(const StagingBuffer&) = delete;
@@ -258,22 +255,20 @@ Context* context();
 
 namespace detail {
 
-template<
-    size_t...Indices,
-    typename ...Arguments>
+template <size_t... Indices, typename... Arguments>
 inline void bind(
     DescriptorSet& descriptor_set,
     const std::index_sequence<Indices...>,
-    Arguments&&...arguments) {
+    Arguments&&... arguments) {
   C10_UNUSED const int _[]{
-    0,
-    (descriptor_set.bind(Indices, std::forward<Arguments>(arguments)), 0)...,
+      0,
+      (descriptor_set.bind(Indices, std::forward<Arguments>(arguments)), 0)...,
   };
 }
 
 } // namespace detail
 
-template<typename... Arguments>
+template <typename... Arguments>
 inline void Context::submit_compute_job(
     const ShaderLayout::Signature& shader_layout_signature,
     const ShaderSource& shader_descriptor,
@@ -289,8 +284,9 @@ inline void Context::submit_compute_job(
   // the GPU, implying there will be imminent calls to fence.wait() and flush().
   // We therefore assume the mutex is externally managed in this case, and the
   // calling thread has already locked the mutex prior to calling the function,
-  // and will release the mutex manually after calling flush(). This will prevent
-  // more dispatches from being recorded until we have flushed the Context.
+  // and will release the mutex manually after calling flush(). This will
+  // prevent more dispatches from being recorded until we have flushed the
+  // Context.
   if (fence_handle == VK_NULL_HANDLE) {
     cmd_lock = std::unique_lock<std::mutex>(cmd_mutex_);
   }
@@ -307,10 +303,7 @@ inline void Context::submit_compute_job(
 
   // Factor out template parameter independent code to minimize code bloat.
   DescriptorSet descriptor_set = submit_compute_prologue(
-      cmd_,
-      shader_layout_signature,
-      shader_descriptor,
-      local_work_group_size);
+      cmd_, shader_layout_signature, shader_descriptor, local_work_group_size);
 
   detail::bind(
       descriptor_set,
@@ -319,10 +312,7 @@ inline void Context::submit_compute_job(
 
   // Factor out template parameter independent code to minimize code bloat.
   submit_compute_epilogue(
-      cmd_,
-      descriptor_set,
-      pipeline_barrier,
-      global_work_group);
+      cmd_, descriptor_set, pipeline_barrier, global_work_group);
 
 #ifdef USE_VULKAN_GPU_DIAGNOSTICS
   querypool_.shader_profile_end(cmd_, log_idx);

--- a/aten/src/ATen/native/vulkan/api/Descriptor.h
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.h
@@ -98,8 +98,7 @@ struct DescriptorPoolConfig final {
 
 class DescriptorPool final {
  public:
-  explicit DescriptorPool(
-      const VkDevice, const DescriptorPoolConfig&);
+  explicit DescriptorPool(const VkDevice, const DescriptorPoolConfig&);
 
   DescriptorPool(const DescriptorPool&) = delete;
   DescriptorPool& operator=(const DescriptorPool&) = delete;

--- a/aten/src/ATen/native/vulkan/api/Pipeline.cpp
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.cpp
@@ -67,14 +67,14 @@ VkImageLayout vk_layout(
     const PipelineStageFlags stage,
     const MemoryAccessFlags access) {
   switch (stage) {
-
     case PipelineStage::COMPUTE:
       switch (access) {
         case MemoryAccessType::READ:
           return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
         default:
           return VK_IMAGE_LAYOUT_GENERAL;
-      } break;
+      }
+      break;
 
     case PipelineStage::TRANSFER:
       switch (access) {
@@ -86,7 +86,8 @@ VkImageLayout vk_layout(
 
         default:
           TORCH_INTERNAL_ASSERT(false, "Invalid!");
-      } break;
+      }
+      break;
 
     default:
       TORCH_INTERNAL_ASSERT(false, "Invalid!");
@@ -102,34 +103,29 @@ VkImageLayout vk_layout(
 PipelineLayout::PipelineLayout(
     const VkDevice device,
     const VkDescriptorSetLayout descriptor_layout)
-  : device_(device),
-    handle_{VK_NULL_HANDLE} {
+    : device_(device), handle_{VK_NULL_HANDLE} {
   // TODO: Enable push constants
   const VkPipelineLayoutCreateInfo pipeline_layout_create_info{
-    VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    1u,  // setLayoutCount
-    &descriptor_layout,  // pSetLayouts
-    0u,  // pushConstantRangeCount
-    nullptr,  // pPushConstantRanges
+      VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      1u, // setLayoutCount
+      &descriptor_layout, // pSetLayouts
+      0u, // pushConstantRangeCount
+      nullptr, // pPushConstantRanges
   };
 
   VK_CHECK(vkCreatePipelineLayout(
-      device_,
-      &pipeline_layout_create_info,
-      nullptr,
-      &handle_));
+      device_, &pipeline_layout_create_info, nullptr, &handle_));
 }
 
 PipelineLayout::PipelineLayout(PipelineLayout&& other) noexcept
-  : device_(other.device_),
-    handle_(other.handle_) {
+    : device_(other.device_), handle_(other.handle_) {
   other.handle_ = VK_NULL_HANDLE;
 }
 
 PipelineLayout::~PipelineLayout() {
-  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyPipelineLayout(device_, handle_, nullptr);
@@ -155,54 +151,53 @@ ComputePipeline::ComputePipeline(
     const VkDevice device,
     const ComputePipeline::Descriptor& descriptor,
     const VkPipelineCache pipeline_cache)
-  : device_(device),
-    handle_{VK_NULL_HANDLE} {
+    : device_(device), handle_{VK_NULL_HANDLE} {
   constexpr VkSpecializationMapEntry specialization_map_entires[3]{
-    // X
-    {
-      0u,
-      offsetof(utils::uvec3, data[0u]),
-      sizeof(utils::uvec3::data[0u]),
-    },
-    // Y
-    {
-      1u,
-      offsetof(utils::uvec3, data[1u]),
-      sizeof(utils::uvec3::data[1u]),
-    },
-    // Z
-    {
-      2u,
-      offsetof(utils::uvec3, data[2u]),
-      sizeof(utils::uvec3::data[2u]),
-    },
+      // X
+      {
+          0u,
+          offsetof(utils::uvec3, data[0u]),
+          sizeof(utils::uvec3::data[0u]),
+      },
+      // Y
+      {
+          1u,
+          offsetof(utils::uvec3, data[1u]),
+          sizeof(utils::uvec3::data[1u]),
+      },
+      // Z
+      {
+          2u,
+          offsetof(utils::uvec3, data[2u]),
+          sizeof(utils::uvec3::data[2u]),
+      },
   };
 
   const VkSpecializationInfo specialization_info{
-    3u,  // mapEntryCount
-    specialization_map_entires,  // pMapEntries
-    sizeof(descriptor.local_work_group),  // dataSize
-    &descriptor.local_work_group,  // pData
+      3u, // mapEntryCount
+      specialization_map_entires, // pMapEntries
+      sizeof(descriptor.local_work_group), // dataSize
+      &descriptor.local_work_group, // pData
   };
 
   const VkPipelineShaderStageCreateInfo shader_stage_create_info{
-    VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    VK_SHADER_STAGE_COMPUTE_BIT,  // stage
-    descriptor.shader_module,  // module
-    "main",  // pName
-    &specialization_info,  // pSpecializationInfo
+      VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      VK_SHADER_STAGE_COMPUTE_BIT, // stage
+      descriptor.shader_module, // module
+      "main", // pName
+      &specialization_info, // pSpecializationInfo
   };
 
   const VkComputePipelineCreateInfo compute_pipeline_create_info{
-    VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    shader_stage_create_info,  // stage
-    descriptor.pipeline_layout,  // layout
-    VK_NULL_HANDLE,  // basePipelineHandle
-    0u,  // basePipelineIndex
+      VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      shader_stage_create_info, // stage
+      descriptor.pipeline_layout, // layout
+      VK_NULL_HANDLE, // basePipelineHandle
+      0u, // basePipelineIndex
   };
 
   VK_CHECK(vkCreateComputePipelines(
@@ -215,13 +210,12 @@ ComputePipeline::ComputePipeline(
 }
 
 ComputePipeline::ComputePipeline(ComputePipeline&& other) noexcept
-  : device_(other.device_),
-    handle_(other.handle_) {
+    : device_(other.device_), handle_(other.handle_) {
   other.handle_ = VK_NULL_HANDLE;
 }
 
 ComputePipeline::~ComputePipeline() {
-  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyPipeline(device_, handle_, nullptr);
@@ -242,10 +236,10 @@ void swap(ComputePipeline& lhs, ComputePipeline& rhs) noexcept {
 bool operator==(
     const ComputePipeline::Descriptor& _1,
     const ComputePipeline::Descriptor& _2) {
-
-  return (_1.pipeline_layout == _2.pipeline_layout && \
-          _1.shader_module == _2.shader_module && \
-          _1.local_work_group == _2.local_work_group);
+  return (
+      _1.pipeline_layout == _2.pipeline_layout &&
+      _1.shader_module == _2.shader_module &&
+      _1.local_work_group == _2.local_work_group);
 }
 
 //
@@ -253,14 +247,10 @@ bool operator==(
 //
 
 PipelineLayoutCache::PipelineLayoutCache(const VkDevice device)
-  : cache_mutex_{},
-    device_(device),
-    cache_{} {
-}
+    : cache_mutex_{}, device_(device), cache_{} {}
 
 PipelineLayoutCache::PipelineLayoutCache(PipelineLayoutCache&& other) noexcept
-  : cache_mutex_{},
-    device_(other.device_) {
+    : cache_mutex_{}, device_(other.device_) {
   std::lock_guard<std::mutex> lock(other.cache_mutex_);
   cache_ = std::move(other.cache_);
 }
@@ -274,7 +264,7 @@ VkPipelineLayout PipelineLayoutCache::retrieve(
   std::lock_guard<std::mutex> lock(cache_mutex_);
 
   auto it = cache_.find(key);
-  if C10_UNLIKELY(cache_.cend() == it) {
+  if C10_UNLIKELY (cache_.cend() == it) {
     it = cache_.insert({key, PipelineLayoutCache::Value(device_, key)}).first;
   }
 
@@ -291,30 +281,27 @@ void PipelineLayoutCache::purge() {
 //
 
 ComputePipelineCache::ComputePipelineCache(const VkDevice device)
-  : cache_mutex_{},
-    device_(device),
-    pipeline_cache_{VK_NULL_HANDLE},
-    cache_{} {
+    : cache_mutex_{},
+      device_(device),
+      pipeline_cache_{VK_NULL_HANDLE},
+      cache_{} {
   const VkPipelineCacheCreateInfo pipeline_cache_create_info{
-    VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    0u,  // initialDataSize
-    nullptr,  // pInitialData
+      VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      0u, // initialDataSize
+      nullptr, // pInitialData
   };
 
   VK_CHECK(vkCreatePipelineCache(
-      device,
-      &pipeline_cache_create_info,
-      nullptr,
-      &pipeline_cache_));
+      device, &pipeline_cache_create_info, nullptr, &pipeline_cache_));
 }
 
 ComputePipelineCache::ComputePipelineCache(
     ComputePipelineCache&& other) noexcept
-  : cache_mutex_{},
-    device_(other.device_),
-    pipeline_cache_(other.pipeline_cache_) {
+    : cache_mutex_{},
+      device_(other.device_),
+      pipeline_cache_(other.pipeline_cache_) {
   std::lock_guard<std::mutex> lock(other.cache_mutex_);
   cache_ = std::move(other.cache_);
 
@@ -324,7 +311,7 @@ ComputePipelineCache::ComputePipelineCache(
 ComputePipelineCache::~ComputePipelineCache() {
   purge();
 
-  if C10_LIKELY(VK_NULL_HANDLE == pipeline_cache_) {
+  if C10_LIKELY (VK_NULL_HANDLE == pipeline_cache_) {
     return;
   }
   vkDestroyPipelineCache(device_, pipeline_cache_, nullptr);
@@ -336,9 +323,12 @@ VkPipeline ComputePipelineCache::retrieve(
   std::lock_guard<std::mutex> lock(cache_mutex_);
 
   auto it = cache_.find(key);
-  if C10_UNLIKELY(cache_.cend() == it) {
-    it = cache_.insert(
-        {key, ComputePipelineCache::Value(device_, key, pipeline_cache_)}).first;
+  if C10_UNLIKELY (cache_.cend() == it) {
+    it = cache_
+             .insert(
+                 {key,
+                  ComputePipelineCache::Value(device_, key, pipeline_cache_)})
+             .first;
   }
 
   return it->second.handle();

--- a/aten/src/ATen/native/vulkan/api/Pipeline.h
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.h
@@ -22,10 +22,8 @@ struct PipelineBarrier final {
   c10::SmallVector<ImageMemoryBarrier, 4u> images;
 
   inline operator bool() const {
-    return (0u != stage.src) ||
-           (0u != stage.dst) ||
-           !buffers.empty() ||
-           !images.empty();
+    return (0u != stage.src) || (0u != stage.dst) || !buffers.empty() ||
+        !images.empty();
   }
 };
 

--- a/aten/src/ATen/native/vulkan/api/QueryPool.cpp
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.cpp
@@ -9,22 +9,20 @@ namespace native {
 namespace vulkan {
 namespace api {
 
-QueryPool::QueryPool(
-    const VkDevice device,
-    const QueryPoolConfig& config)
-  : mutex_{},
-    device_(device),
-    config_(config),
-    querypool_(VK_NULL_HANDLE),
-    shader_log_{},
-    in_use_(0u) {
+QueryPool::QueryPool(const VkDevice device, const QueryPoolConfig& config)
+    : mutex_{},
+      device_(device),
+      config_(config),
+      querypool_(VK_NULL_HANDLE),
+      shader_log_{},
+      in_use_(0u) {
   const VkQueryPoolCreateInfo info{
-    VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    VK_QUERY_TYPE_TIMESTAMP,  // queryType
-    config_.maxQueryCount,  // queryCount
-    0u,  // pipelineStatistics
+      VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      VK_QUERY_TYPE_TIMESTAMP, // queryType
+      config_.maxQueryCount, // queryCount
+      0u, // pipelineStatistics
   };
 
   VK_CHECK(vkCreateQueryPool(device_, &info, nullptr, &querypool_));
@@ -51,7 +49,9 @@ uint32_t QueryPool::write_timestamp(const CommandBuffer& cmd) {
   TORCH_CHECK(
       in_use_ < config_.maxQueryCount,
       "Vulkan QueryPool: Exceeded the maximum number of queries "
-      "allowed by the queryPool (", config_.maxQueryCount, ")!");
+      "allowed by the queryPool (",
+      config_.maxQueryCount,
+      ")!");
 
   cmd.write_timestamp(querypool_, in_use_);
 
@@ -69,18 +69,18 @@ uint32_t QueryPool::shader_profile_begin(
 
   uint32_t log_idx = shader_log_.size();
   ShaderDuration log_entry{
-    log_idx,
-    // Execution Properties
-    kernel_name,
-    global_workgroup_size,
-    local_workgroup_size,
-    // Query indexes
-    query_idx,  // start query idx
-    UINT32_MAX,  // end query idx
-    // Timings
-    0u,  // start time
-    0u,  // end time
-    0u,  // duration
+      log_idx,
+      // Execution Properties
+      kernel_name,
+      global_workgroup_size,
+      local_workgroup_size,
+      // Query indexes
+      query_idx, // start query idx
+      UINT32_MAX, // end query idx
+      // Timings
+      0u, // start time
+      0u, // end time
+      0u, // duration
   };
 
   shader_log_.emplace_back(log_entry);
@@ -89,7 +89,8 @@ uint32_t QueryPool::shader_profile_begin(
 }
 
 void QueryPool::shader_profile_end(
-    const CommandBuffer& cmd, const uint32_t log_idx) {
+    const CommandBuffer& cmd,
+    const uint32_t log_idx) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   uint32_t query_idx = write_timestamp(cmd);
@@ -108,12 +109,12 @@ void QueryPool::extract_results() {
   VK_CHECK(vkGetQueryPoolResults(
       device_,
       querypool_,
-      0u,  // firstQuery
-      in_use_,  // queryCount
-      sizeof(uint64_t) * in_use_,  // dataSize
-      query_data.data(),  // pData
-      sizeof(uint64_t),  // stride
-      flags));  // flags
+      0u, // firstQuery
+      in_use_, // queryCount
+      sizeof(uint64_t) * in_use_, // dataSize
+      query_data.data(), // pData
+      sizeof(uint64_t), // stride
+      flags)); // flags
 
   for (ShaderDuration& entry : shader_log_) {
     entry.start_time_ns = query_data.at(entry.start_query_idx);
@@ -124,19 +125,15 @@ void QueryPool::extract_results() {
 }
 
 std::ostream& operator<<(std::ostream& os, const VkExtent3D& extents) {
-  os << "{"
-     << extents.width << ", "
-     << extents.height << ", "
-     << extents.depth << "}";
+  os << "{" << extents.width << ", " << extents.height << ", " << extents.depth
+     << "}";
   return os;
 }
 
 std::string stringize(const VkExtent3D& extents) {
   std::stringstream ss;
-  ss << "{"
-     << extents.width << ", "
-     << extents.height << ", "
-     << extents.depth << "}";
+  ss << "{" << extents.width << ", " << extents.height << ", " << extents.depth
+     << "}";
   return ss.str();
 }
 

--- a/aten/src/ATen/native/vulkan/api/QueryPool.h
+++ b/aten/src/ATen/native/vulkan/api/QueryPool.h
@@ -37,9 +37,7 @@ struct ShaderDuration final {
 
 class QueryPool final {
  public:
-  explicit QueryPool(
-      const VkDevice,
-      const QueryPoolConfig&);
+  explicit QueryPool(const VkDevice, const QueryPoolConfig&);
 
   QueryPool(const QueryPool&) = delete;
   QueryPool& operator=(const QueryPool&) = delete;
@@ -81,7 +79,6 @@ class QueryPool final {
 
   void extract_results();
   void print_results();
-
 };
 
 } // namespace api

--- a/aten/src/ATen/native/vulkan/api/Resource.cpp
+++ b/aten/src/ATen/native/vulkan/api/Resource.cpp
@@ -1,5 +1,5 @@
-#include <ATen/native/vulkan/api/Resource.h>
 #include <ATen/native/vulkan/api/Adapter.h>
+#include <ATen/native/vulkan/api/Resource.h>
 
 namespace at {
 namespace native {
@@ -13,11 +13,11 @@ namespace api {
 VkFormat vk_format(const caffe2::TypeMeta dtype) {
   switch (c10::typeMetaToScalarType(dtype)) {
     case kFloat:
-    #ifdef USE_VULKAN_FP16_INFERENCE
+#ifdef USE_VULKAN_FP16_INFERENCE
       return VK_FORMAT_R16G16B16A16_SFLOAT;
-    #else
+#else
       return VK_FORMAT_R32G32B32A32_SFLOAT;
-    #endif /* USE_VULKAN_FP16_INFERENCE */
+#endif /* USE_VULKAN_FP16_INFERENCE */
 
     default:
       return VK_FORMAT_UNDEFINED;
@@ -31,73 +31,75 @@ VkFormat vk_format(const caffe2::TypeMeta dtype) {
 MemoryBarrier::MemoryBarrier(
     const VkAccessFlags src_access_flags,
     const VkAccessFlags dst_access_flags)
-  : handle{
-      VK_STRUCTURE_TYPE_MEMORY_BARRIER,  // sType
-      nullptr,  // pNext
-      src_access_flags,  // srcAccessMask
-      dst_access_flags,  // dstAccessMask
-    } {
-}
+    : handle{
+          VK_STRUCTURE_TYPE_MEMORY_BARRIER, // sType
+          nullptr, // pNext
+          src_access_flags, // srcAccessMask
+          dst_access_flags, // dstAccessMask
+      } {}
 
 //
 // VulkanBuffer
 //
 
 VulkanBuffer::VulkanBuffer()
-  : memory_properties_{},
-    buffer_properties_{},
-    allocator_(VK_NULL_HANDLE),
-    allocation_(VK_NULL_HANDLE),
-    handle_(VK_NULL_HANDLE) {
-}
+    : memory_properties_{},
+      buffer_properties_{},
+      allocator_(VK_NULL_HANDLE),
+      allocation_(VK_NULL_HANDLE),
+      handle_(VK_NULL_HANDLE) {}
 
 VulkanBuffer::VulkanBuffer(
     const VmaAllocator vma_allocator,
     const VkDeviceSize size,
     const VulkanBuffer::MemoryProperties& mem_props)
-  : memory_properties_(mem_props),
-    buffer_properties_({
-      size,
-      0u,
-      size,
-    }),
-    allocator_(vma_allocator),
-    allocation_(VK_NULL_HANDLE),
-    handle_(VK_NULL_HANDLE) {
+    : memory_properties_(mem_props),
+      buffer_properties_({
+          size,
+          0u,
+          size,
+      }),
+      allocator_(vma_allocator),
+      allocation_(VK_NULL_HANDLE),
+      handle_(VK_NULL_HANDLE) {
   const VkBufferCreateInfo buffer_create_info{
-    VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    size,  // size
-    memory_properties_.buffer_usage,  // usage
-    VK_SHARING_MODE_EXCLUSIVE,  // sharingMode
-    0u,  // queueFamilyIndexCount
-    nullptr,  // pQueueFamilyIndices
+      VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      size, // size
+      memory_properties_.buffer_usage, // usage
+      VK_SHARING_MODE_EXCLUSIVE, // sharingMode
+      0u, // queueFamilyIndexCount
+      nullptr, // pQueueFamilyIndices
   };
 
   // TODO: enable creation with a custom pool
-  VmaAllocationCreateInfo alloc_create_info {
-    VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT, // flags
-    memory_properties_.memory_usage,  // usage
-    memory_properties_.required_mem_flags,  // requiredFlags
-    memory_properties_.preferred_mem_flags,  // preferredFlags
-    0u,  // memoryTypeBits
-    VK_NULL_HANDLE,  // pool
-    nullptr,  // pUserData
-    0.5f,  // priority
+  VmaAllocationCreateInfo alloc_create_info{
+      VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT, // flags
+      memory_properties_.memory_usage, // usage
+      memory_properties_.required_mem_flags, // requiredFlags
+      memory_properties_.preferred_mem_flags, // preferredFlags
+      0u, // memoryTypeBits
+      VK_NULL_HANDLE, // pool
+      nullptr, // pUserData
+      0.5f, // priority
   };
 
   VK_CHECK(vmaCreateBuffer(
-      allocator_, &buffer_create_info, &alloc_create_info,
-      &handle_, &allocation_, nullptr));
+      allocator_,
+      &buffer_create_info,
+      &alloc_create_info,
+      &handle_,
+      &allocation_,
+      nullptr));
 }
 
 VulkanBuffer::VulkanBuffer(VulkanBuffer&& other) noexcept
-  : memory_properties_(other.memory_properties_),
-    buffer_properties_(other.buffer_properties_),
-    allocator_(other.allocator_),
-    allocation_(other.allocation_),
-    handle_(other.handle_) {
+    : memory_properties_(other.memory_properties_),
+      buffer_properties_(other.buffer_properties_),
+      allocator_(other.allocator_),
+      allocation_(other.allocation_),
+      handle_(other.handle_) {
   other.allocation_ = VK_NULL_HANDLE;
   other.handle_ = VK_NULL_HANDLE;
 }
@@ -129,18 +131,18 @@ VulkanBuffer::~VulkanBuffer() {
 //
 
 MemoryMap::MemoryMap(const VulkanBuffer& buffer, const uint8_t access)
-  : access_(access),
-    allocator_(buffer.vma_allocator()),
-    allocation_(buffer.allocation()),
-    data_(nullptr) {
+    : access_(access),
+      allocator_(buffer.vma_allocator()),
+      allocation_(buffer.allocation()),
+      data_(nullptr) {
   VK_CHECK(vmaMapMemory(allocator_, allocation_, &data_));
 }
 
 MemoryMap::MemoryMap(MemoryMap&& other) noexcept
-  : access_(other.access_),
-    allocator_(other.allocator_),
-    allocation_(other.allocation_),
-    data_(other.data_) {
+    : access_(other.access_),
+      allocator_(other.allocator_),
+      allocation_(other.allocation_),
+      data_(other.data_) {
   other.allocation_ = VK_NULL_HANDLE;
   other.data_ = nullptr;
 }
@@ -165,8 +167,8 @@ void MemoryMap::invalidate() {
     // Call will be ignored by implementation if the memory type this allocation
     // belongs to is not HOST_VISIBLE or is HOST_COHERENT, which is the behavior
     // we want.
-    VK_CHECK(vmaInvalidateAllocation(
-        allocator_, allocation_, 0u, VK_WHOLE_SIZE));
+    VK_CHECK(
+        vmaInvalidateAllocation(allocator_, allocation_, 0u, VK_WHOLE_SIZE));
   }
 }
 
@@ -178,18 +180,17 @@ BufferMemoryBarrier::BufferMemoryBarrier(
     const VkAccessFlags src_access_flags,
     const VkAccessFlags dst_access_flags,
     const VulkanBuffer& buffer)
-  : handle{
-      VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,  // sType
-      nullptr,  // pNext
-      src_access_flags,  // srcAccessMask
-      dst_access_flags,  // dstAccessMask
-      VK_QUEUE_FAMILY_IGNORED,  // srcQueueFamilyIndex
-      VK_QUEUE_FAMILY_IGNORED,  // dstQueueFamilyIndex
-      buffer.handle_,  // buffer
-      buffer.buffer_properties_.mem_offset,  // offset
-      buffer.buffer_properties_.mem_range,  // size
-    } {
-}
+    : handle{
+          VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, // sType
+          nullptr, // pNext
+          src_access_flags, // srcAccessMask
+          dst_access_flags, // dstAccessMask
+          VK_QUEUE_FAMILY_IGNORED, // srcQueueFamilyIndex
+          VK_QUEUE_FAMILY_IGNORED, // dstQueueFamilyIndex
+          buffer.handle_, // buffer
+          buffer.buffer_properties_.mem_offset, // offset
+          buffer.buffer_properties_.mem_range, // size
+      } {}
 
 //
 // ImageSampler
@@ -198,50 +199,46 @@ BufferMemoryBarrier::BufferMemoryBarrier(
 bool operator==(
     const ImageSampler::Properties& _1,
     const ImageSampler::Properties& _2) {
-  return (_1.filter == _2.filter && \
-          _1.mipmap_mode == _2.mipmap_mode && \
-          _1.address_mode == _2.address_mode && \
-          _1.border_color == _2.border_color);
+  return (
+      _1.filter == _2.filter && _1.mipmap_mode == _2.mipmap_mode &&
+      _1.address_mode == _2.address_mode && _1.border_color == _2.border_color);
 }
 
 ImageSampler::ImageSampler(
     const VkDevice device,
     const ImageSampler::Properties& props)
-  : device_(device),
-    handle_(VK_NULL_HANDLE) {
+    : device_(device), handle_(VK_NULL_HANDLE) {
   const VkSamplerCreateInfo sampler_create_info{
-    VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    props.filter,  // magFilter
-    props.filter,  // minFilter
-    props.mipmap_mode,  // mipmapMode
-    props.address_mode,  // addressModeU
-    props.address_mode,  // addressModeV
-    props.address_mode,  // addressModeW
-    0.0f,  // mipLodBias
-    VK_FALSE,  // anisotropyEnable
-    1.0f,  // maxAnisotropy,
-    VK_FALSE,  // compareEnable
-    VK_COMPARE_OP_NEVER,  // compareOp
-    0.0f,  // minLod
-    VK_LOD_CLAMP_NONE,  // maxLod
-    props.border_color,  // borderColor
-    VK_FALSE,  // unnormalizedCoordinates
+      VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      props.filter, // magFilter
+      props.filter, // minFilter
+      props.mipmap_mode, // mipmapMode
+      props.address_mode, // addressModeU
+      props.address_mode, // addressModeV
+      props.address_mode, // addressModeW
+      0.0f, // mipLodBias
+      VK_FALSE, // anisotropyEnable
+      1.0f, // maxAnisotropy,
+      VK_FALSE, // compareEnable
+      VK_COMPARE_OP_NEVER, // compareOp
+      0.0f, // minLod
+      VK_LOD_CLAMP_NONE, // maxLod
+      props.border_color, // borderColor
+      VK_FALSE, // unnormalizedCoordinates
   };
 
-  VK_CHECK(vkCreateSampler(
-      device_, &sampler_create_info, nullptr, &handle_));
+  VK_CHECK(vkCreateSampler(device_, &sampler_create_info, nullptr, &handle_));
 }
 
 ImageSampler::ImageSampler(ImageSampler&& other) noexcept
-  : device_(other.device_),
-    handle_(other.handle_) {
+    : device_(other.device_), handle_(other.handle_) {
   other.handle_ = VK_NULL_HANDLE;
 }
 
 ImageSampler::~ImageSampler() {
-  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroySampler(device_, handle_, nullptr);
@@ -250,10 +247,7 @@ ImageSampler::~ImageSampler() {
 size_t ImageSampler::Hasher::operator()(
     const ImageSampler::Properties& props) const {
   return c10::get_hash(
-      props.filter,
-      props.mipmap_mode,
-      props.address_mode,
-      props.border_color);
+      props.filter, props.mipmap_mode, props.address_mode, props.border_color);
 }
 
 void swap(ImageSampler& lhs, ImageSampler& rhs) noexcept {
@@ -272,19 +266,18 @@ void swap(ImageSampler& lhs, ImageSampler& rhs) noexcept {
 //
 
 VulkanImage::VulkanImage()
-  : memory_properties_{},
-    image_properties_{},
-    view_properties_{},
-    sampler_properties_{},
-    allocator_(VK_NULL_HANDLE),
-    allocation_(VK_NULL_HANDLE),
-    handles_{
-        VK_NULL_HANDLE,
-        VK_NULL_HANDLE,
-        VK_NULL_HANDLE,
-    },
-    layout_{} {
-}
+    : memory_properties_{},
+      image_properties_{},
+      view_properties_{},
+      sampler_properties_{},
+      allocator_(VK_NULL_HANDLE),
+      allocation_(VK_NULL_HANDLE),
+      handles_{
+          VK_NULL_HANDLE,
+          VK_NULL_HANDLE,
+          VK_NULL_HANDLE,
+      },
+      layout_{} {}
 
 VulkanImage::VulkanImage(
     const VmaAllocator vma_allocator,
@@ -295,78 +288,82 @@ VulkanImage::VulkanImage(
     const SamplerProperties& sampler_props,
     const VkImageLayout layout,
     const VkSampler sampler)
-  : memory_properties_(mem_props),
-    image_properties_(image_props),
-    view_properties_(view_props),
-    sampler_properties_(sampler_props),
-    allocator_(vma_allocator),
-    allocation_(VK_NULL_HANDLE),
-    handles_{
-        VK_NULL_HANDLE,
-        VK_NULL_HANDLE,
-        sampler,
-    },
-    layout_(layout) {
+    : memory_properties_(mem_props),
+      image_properties_(image_props),
+      view_properties_(view_props),
+      sampler_properties_(sampler_props),
+      allocator_(vma_allocator),
+      allocation_(VK_NULL_HANDLE),
+      handles_{
+          VK_NULL_HANDLE,
+          VK_NULL_HANDLE,
+          sampler,
+      },
+      layout_(layout) {
   const VkImageCreateInfo image_create_info{
-    VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    image_properties_.image_type,  // imageType
-    image_properties_.image_format,  // format
-    image_properties_.image_extents,  // extents
-    1u,  // mipLevels
-    1u,  // arrayLayers
-    VK_SAMPLE_COUNT_1_BIT,  // samples
-    VK_IMAGE_TILING_OPTIMAL,  // tiling
-    memory_properties_.image_usage,  // usage
-    VK_SHARING_MODE_EXCLUSIVE,  // sharingMode
-    0u,  // queueFamilyIndexCount
-    nullptr,  // pQueueFamilyIndices
-    layout_,  // initialLayout
+      VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      image_properties_.image_type, // imageType
+      image_properties_.image_format, // format
+      image_properties_.image_extents, // extents
+      1u, // mipLevels
+      1u, // arrayLayers
+      VK_SAMPLE_COUNT_1_BIT, // samples
+      VK_IMAGE_TILING_OPTIMAL, // tiling
+      memory_properties_.image_usage, // usage
+      VK_SHARING_MODE_EXCLUSIVE, // sharingMode
+      0u, // queueFamilyIndexCount
+      nullptr, // pQueueFamilyIndices
+      layout_, // initialLayout
   };
 
   // TODO: enable creation with a custom pool
   const VmaAllocationCreateInfo alloc_create_info{
-    VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT, // flags
-    memory_properties_.memory_usage,  // usage
-    memory_properties_.required_mem_flags,  // requiredFlags
-    memory_properties_.preferred_mem_flags,  // preferredFlags
-    0u,  // memoryTypeBits
-    VK_NULL_HANDLE,  // pool
-    nullptr,  // pUserData
-    0.5f,  // priority
+      VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT, // flags
+      memory_properties_.memory_usage, // usage
+      memory_properties_.required_mem_flags, // requiredFlags
+      memory_properties_.preferred_mem_flags, // preferredFlags
+      0u, // memoryTypeBits
+      VK_NULL_HANDLE, // pool
+      nullptr, // pUserData
+      0.5f, // priority
   };
 
   VK_CHECK(vmaCreateImage(
-      allocator_, &image_create_info, &alloc_create_info,
-      &(handles_.image), &allocation_, nullptr));
+      allocator_,
+      &image_create_info,
+      &alloc_create_info,
+      &(handles_.image),
+      &allocation_,
+      nullptr));
 
   // Image View
 
   const VkComponentMapping component_mapping{
-    VK_COMPONENT_SWIZZLE_IDENTITY,  // r
-    VK_COMPONENT_SWIZZLE_IDENTITY,  // g
-    VK_COMPONENT_SWIZZLE_IDENTITY,  // b
-    VK_COMPONENT_SWIZZLE_IDENTITY,  // a
+      VK_COMPONENT_SWIZZLE_IDENTITY, // r
+      VK_COMPONENT_SWIZZLE_IDENTITY, // g
+      VK_COMPONENT_SWIZZLE_IDENTITY, // b
+      VK_COMPONENT_SWIZZLE_IDENTITY, // a
   };
 
   const VkImageSubresourceRange subresource_range{
-    VK_IMAGE_ASPECT_COLOR_BIT,  // aspectMask
-    0u,  // baseMipLevel
-    VK_REMAINING_MIP_LEVELS,  // levelCount
-    0u,  // baseArrayLayer
-    VK_REMAINING_ARRAY_LAYERS,  // layerCount
+      VK_IMAGE_ASPECT_COLOR_BIT, // aspectMask
+      0u, // baseMipLevel
+      VK_REMAINING_MIP_LEVELS, // levelCount
+      0u, // baseArrayLayer
+      VK_REMAINING_ARRAY_LAYERS, // layerCount
   };
 
   const VkImageViewCreateInfo image_view_create_info{
-    VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    handles_.image,  // image
-    view_properties_.view_type,  // viewType
-    view_properties_.view_format,  // format
-    component_mapping,  // components
-    subresource_range,  // subresourceRange
+      VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      handles_.image, // image
+      view_properties_.view_type, // viewType
+      view_properties_.view_format, // format
+      component_mapping, // components
+      subresource_range, // subresourceRange
   };
 
   VK_CHECK(vkCreateImageView(
@@ -374,14 +371,14 @@ VulkanImage::VulkanImage(
 }
 
 VulkanImage::VulkanImage(VulkanImage&& other) noexcept
-  : memory_properties_(other.memory_properties_),
-    image_properties_(other.image_properties_),
-    view_properties_(other.view_properties_),
-    sampler_properties_(other.sampler_properties_),
-    allocator_(other.allocator_),
-    allocation_(other.allocation_),
-    handles_(other.handles_),
-    layout_(other.layout_) {
+    : memory_properties_(other.memory_properties_),
+      image_properties_(other.image_properties_),
+      view_properties_(other.view_properties_),
+      sampler_properties_(other.sampler_properties_),
+      allocator_(other.allocator_),
+      allocation_(other.allocation_),
+      handles_(other.handles_),
+      layout_(other.layout_) {
   other.allocation_ = VK_NULL_HANDLE;
   other.handles_.image = VK_NULL_HANDLE;
   other.handles_.image_view = VK_NULL_HANDLE;
@@ -426,44 +423,40 @@ VulkanImage::~VulkanImage() {
 //
 
 ImageMemoryBarrier::ImageMemoryBarrier(
-      const VkAccessFlags src_access_flags,
-      const VkAccessFlags dst_access_flags,
-      const VkImageLayout src_layout_flags,
-      const VkImageLayout dst_layout_flags,
-      const VulkanImage& image)
-  : handle{
-      VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,  // sType
-      nullptr,  // pNext
-      src_access_flags,  // srcAccessMask
-      dst_access_flags,  // dstAccessMask
-      src_layout_flags,  // oldLayout
-      dst_layout_flags,  // newLayout
-      VK_QUEUE_FAMILY_IGNORED,  // srcQueueFamilyIndex
-      VK_QUEUE_FAMILY_IGNORED,  // dstQueueFamilyIndex
-      image.handles_.image,  // image
-      {  // subresourceRange
-        VK_IMAGE_ASPECT_COLOR_BIT,  // aspectMask
-        0u,  // baseMipLevel
-        VK_REMAINING_MIP_LEVELS,  // levelCount
-        0u,  // baseArrayLayer
-        VK_REMAINING_ARRAY_LAYERS,  // layerCount
-      },
-    } {
-}
+    const VkAccessFlags src_access_flags,
+    const VkAccessFlags dst_access_flags,
+    const VkImageLayout src_layout_flags,
+    const VkImageLayout dst_layout_flags,
+    const VulkanImage& image)
+    : handle{
+          VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, // sType
+          nullptr, // pNext
+          src_access_flags, // srcAccessMask
+          dst_access_flags, // dstAccessMask
+          src_layout_flags, // oldLayout
+          dst_layout_flags, // newLayout
+          VK_QUEUE_FAMILY_IGNORED, // srcQueueFamilyIndex
+          VK_QUEUE_FAMILY_IGNORED, // dstQueueFamilyIndex
+          image.handles_.image, // image
+          {
+              // subresourceRange
+              VK_IMAGE_ASPECT_COLOR_BIT, // aspectMask
+              0u, // baseMipLevel
+              VK_REMAINING_MIP_LEVELS, // levelCount
+              0u, // baseArrayLayer
+              VK_REMAINING_ARRAY_LAYERS, // layerCount
+          },
+      } {}
 
 //
 // SamplerCache
 //
 
 SamplerCache::SamplerCache(const VkDevice device)
-  : cache_mutex_{},
-    device_(device),
-    cache_{} {
-}
+    : cache_mutex_{}, device_(device), cache_{} {}
 
 SamplerCache::SamplerCache(SamplerCache&& other) noexcept
-  : cache_mutex_{},
-    device_(other.device_) {
+    : cache_mutex_{}, device_(other.device_) {
   std::lock_guard<std::mutex> lock(other.cache_mutex_);
   cache_ = std::move(other.cache_);
 }
@@ -476,7 +469,7 @@ VkSampler SamplerCache::retrieve(const SamplerCache::Key& key) {
   std::lock_guard<std::mutex> lock(cache_mutex_);
 
   auto it = cache_.find(key);
-  if C10_UNLIKELY(cache_.cend() == it) {
+  if C10_UNLIKELY (cache_.cend() == it) {
     it = cache_.insert({key, SamplerCache::Value(device_, key)}).first;
   }
 
@@ -495,33 +488,33 @@ MemoryAllocator::MemoryAllocator(
     const VkInstance instance,
     const VkPhysicalDevice physical_device,
     const VkDevice device)
-  : instance_{},
-    physical_device_(physical_device),
-    device_(device),
-    allocator_{VK_NULL_HANDLE} {
+    : instance_{},
+      physical_device_(physical_device),
+      device_(device),
+      allocator_{VK_NULL_HANDLE} {
   const VmaAllocatorCreateInfo allocator_create_info{
-    0u,  // flags
-    physical_device_,  // physicalDevice
-    device_,  // device
-    0u,  // preferredLargeHeapBlockSize
-    nullptr,  // pAllocationCallbacks
-    nullptr,  // pDeviceMemoryCallbacks
-    1u,  // frameinUseCount
-    nullptr,  // pHeapSizeLimit
-    nullptr,  // pVulkanFunctions
-    nullptr,  // pRecordSettings
-    instance,  // instance
-    VK_API_VERSION_1_0,  // vulkanApiVersion
+      0u, // flags
+      physical_device_, // physicalDevice
+      device_, // device
+      0u, // preferredLargeHeapBlockSize
+      nullptr, // pAllocationCallbacks
+      nullptr, // pDeviceMemoryCallbacks
+      1u, // frameinUseCount
+      nullptr, // pHeapSizeLimit
+      nullptr, // pVulkanFunctions
+      nullptr, // pRecordSettings
+      instance, // instance
+      VK_API_VERSION_1_0, // vulkanApiVersion
   };
 
   VK_CHECK(vmaCreateAllocator(&allocator_create_info, &allocator_));
 }
 
 MemoryAllocator::MemoryAllocator(MemoryAllocator&& other) noexcept
-  : instance_(other.instance_),
-    physical_device_(other.physical_device_),
-    device_(other.device_),
-    allocator_(other.allocator_) {
+    : instance_(other.instance_),
+      physical_device_(other.physical_device_),
+      device_(other.device_),
+      allocator_(other.allocator_) {
   other.allocator_ = VK_NULL_HANDLE;
   other.device_ = VK_NULL_HANDLE;
   other.physical_device_ = VK_NULL_HANDLE;
@@ -529,72 +522,78 @@ MemoryAllocator::MemoryAllocator(MemoryAllocator&& other) noexcept
 }
 
 MemoryAllocator::~MemoryAllocator() {
-  if C10_LIKELY(VK_NULL_HANDLE == allocator_) {
+  if C10_LIKELY (VK_NULL_HANDLE == allocator_) {
     return;
   }
   vmaDestroyAllocator(allocator_);
 }
 
 VulkanImage MemoryAllocator::create_image3d_fp(
-      const VkExtent3D& extents,
-      const VulkanImage::SamplerProperties& sampler_props,
-      const VkSampler sampler,
-      bool allow_transfer) {
-  VkImageUsageFlags usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+    const VkExtent3D& extents,
+    const VulkanImage::SamplerProperties& sampler_props,
+    const VkSampler sampler,
+    bool allow_transfer) {
+  VkImageUsageFlags usage =
+      VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
   if (allow_transfer) {
-    usage |= (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    usage |=
+        (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
   }
 
   const VulkanImage::MemoryProperties mem_props{
-    VMA_MEMORY_USAGE_GPU_ONLY,
-    0u,
-    0u,
-    usage,
+      VMA_MEMORY_USAGE_GPU_ONLY,
+      0u,
+      0u,
+      usage,
   };
 
 #ifdef USE_VULKAN_FP16_INFERENCE
-    const VkFormat image_format = VK_FORMAT_R16G16B16A16_SFLOAT;
+  const VkFormat image_format = VK_FORMAT_R16G16B16A16_SFLOAT;
 #else
-    const VkFormat image_format = VK_FORMAT_R32G32B32A32_SFLOAT;
+  const VkFormat image_format = VK_FORMAT_R32G32B32A32_SFLOAT;
 #endif /* USE_VULKAN_FP16_INFERENCE */
 
   const VulkanImage::ImageProperties image_props{
-    VK_IMAGE_TYPE_3D,
-    image_format,
-    extents,
+      VK_IMAGE_TYPE_3D,
+      image_format,
+      extents,
   };
 
   const VulkanImage::ViewProperties view_props{
-    VK_IMAGE_VIEW_TYPE_3D,
-    image_format,
+      VK_IMAGE_VIEW_TYPE_3D,
+      image_format,
   };
 
   const VkImageLayout initial_layout = VK_IMAGE_LAYOUT_UNDEFINED;
 
   return VulkanImage(
-      allocator_, device_,
-      mem_props, image_props, view_props, sampler_props,
-      initial_layout, sampler);
+      allocator_,
+      device_,
+      mem_props,
+      image_props,
+      view_props,
+      sampler_props,
+      initial_layout,
+      sampler);
 }
 
 VulkanBuffer MemoryAllocator::create_storage_buffer(
-    const VkDeviceSize size, const bool gpu_only) {
-  const VkBufferUsageFlags buffer_usage = \
-      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
-      VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
-      VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    const VkDeviceSize size,
+    const bool gpu_only) {
+  const VkBufferUsageFlags buffer_usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+      VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
-  const VmaMemoryUsage vma_usage = \
+  const VmaMemoryUsage vma_usage =
       gpu_only ? VMA_MEMORY_USAGE_GPU_ONLY : VMA_MEMORY_USAGE_GPU_TO_CPU;
 
-  const VkMemoryPropertyFlags preferred_mem_props = \
+  const VkMemoryPropertyFlags preferred_mem_props =
       gpu_only ? 0u : VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
 
   const VulkanBuffer::MemoryProperties mem_props{
-    vma_usage,
-    0u,
-    preferred_mem_props,
-    buffer_usage,
+      vma_usage,
+      0u,
+      preferred_mem_props,
+      buffer_usage,
   };
 
   return VulkanBuffer(allocator_, size, mem_props);
@@ -602,10 +601,10 @@ VulkanBuffer MemoryAllocator::create_storage_buffer(
 
 VulkanBuffer MemoryAllocator::create_staging_buffer(const VkDeviceSize size) {
   const VulkanBuffer::MemoryProperties mem_props{
-    VMA_MEMORY_USAGE_CPU_COPY,
-    0u,
-    0u,
-    VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+      VMA_MEMORY_USAGE_CPU_COPY,
+      0u,
+      0u,
+      VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
   };
 
   return VulkanBuffer(allocator_, size, mem_props);
@@ -616,32 +615,21 @@ VulkanBuffer MemoryAllocator::create_staging_buffer(const VkDeviceSize size) {
 //
 
 VulkanFence::VulkanFence()
-  : device_(VK_NULL_HANDLE),
-    handle_(VK_NULL_HANDLE),
-    waiting_(false) {
-}
+    : device_(VK_NULL_HANDLE), handle_(VK_NULL_HANDLE), waiting_(false) {}
 
 VulkanFence::VulkanFence(const VkDevice device)
-  : device_(device),
-    handle_(VK_NULL_HANDLE),
-    waiting_(VK_NULL_HANDLE) {
+    : device_(device), handle_(VK_NULL_HANDLE), waiting_(VK_NULL_HANDLE) {
   const VkFenceCreateInfo fence_create_info{
-    VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
+      VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
   };
 
-  VK_CHECK(vkCreateFence(
-      device_,
-      &fence_create_info,
-      nullptr,
-      &handle_));
+  VK_CHECK(vkCreateFence(device_, &fence_create_info, nullptr, &handle_));
 }
 
 VulkanFence::VulkanFence(VulkanFence&& other) noexcept
-  : device_(other.device_),
-    handle_(other.handle_),
-    waiting_(other.waiting_) {
+    : device_(other.device_), handle_(other.handle_), waiting_(other.waiting_) {
   other.handle_ = VK_NULL_HANDLE;
   other.waiting_ = false;
 }
@@ -659,7 +647,7 @@ VulkanFence& VulkanFence::operator=(VulkanFence&& other) noexcept {
 }
 
 VulkanFence::~VulkanFence() {
-  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyFence(device_, handle_, nullptr);
@@ -668,17 +656,9 @@ VulkanFence::~VulkanFence() {
 void VulkanFence::wait() {
   // if get_submit_handle() has not been called, then this will no-op
   if (waiting_) {
-    VK_CHECK(vkWaitForFences(
-        device_,
-        1u,
-        &handle_,
-        VK_TRUE,
-        UINT64_MAX));
+    VK_CHECK(vkWaitForFences(device_, 1u, &handle_, VK_TRUE, UINT64_MAX));
 
-    VK_CHECK(vkResetFences(
-        device_,
-        1u,
-        &handle_));
+    VK_CHECK(vkResetFences(device_, 1u, &handle_));
 
     waiting_ = false;
   }

--- a/aten/src/ATen/native/vulkan/api/Resource.h
+++ b/aten/src/ATen/native/vulkan/api/Resource.h
@@ -49,7 +49,9 @@ class VulkanBuffer final {
   explicit VulkanBuffer();
 
   explicit VulkanBuffer(
-      const VmaAllocator, const VkDeviceSize, const MemoryProperties&);
+      const VmaAllocator,
+      const VkDeviceSize,
+      const MemoryProperties&);
 
   VulkanBuffer(const VulkanBuffer&) = delete;
   VulkanBuffer& operator=(const VulkanBuffer&) = delete;
@@ -104,7 +106,9 @@ class VulkanBuffer final {
 
 class MemoryMap final {
  public:
-  explicit MemoryMap(const VulkanBuffer& buffer, const MemoryAccessFlags access);
+  explicit MemoryMap(
+      const VulkanBuffer& buffer,
+      const MemoryAccessFlags access);
 
   MemoryMap(const MemoryMap&) = delete;
   MemoryMap& operator=(const MemoryMap&) = delete;
@@ -121,7 +125,7 @@ class MemoryMap final {
   void* data_;
 
  public:
-  template<typename T>
+  template <typename T>
   T* data() {
     return reinterpret_cast<T*>(data_);
   }
@@ -274,10 +278,10 @@ class VulkanImage final {
 
   Package package() const {
     return {
-      handles_.image,
-      layout_,
-      handles_.image_view,
-      handles_.sampler,
+        handles_.image,
+        layout_,
+        handles_.image_view,
+        handles_.sampler,
     };
   }
 
@@ -363,11 +367,12 @@ class MemoryAllocator final {
       const bool allow_transfer = false);
 
   VulkanBuffer create_storage_buffer(
-      const VkDeviceSize, const bool gpu_only = true);
+      const VkDeviceSize,
+      const bool gpu_only = true);
 
   VulkanBuffer create_staging_buffer(const VkDeviceSize);
 
-  template<typename Block>
+  template <typename Block>
   VulkanBuffer create_params_buffer(const Block& block);
 };
 
@@ -425,10 +430,7 @@ struct FencePool final {
 
   std::stack<VulkanFence> pool_;
 
-  explicit FencePool(const VkDevice device)
-    : device_(device),
-      pool_{} {
-  }
+  explicit FencePool(const VkDevice device) : device_(device), pool_{} {}
 
   // Returns an rvalue reference to a fence, so that it can be moved
   inline VulkanFence get_fence() {
@@ -453,13 +455,13 @@ struct FencePool final {
 // Impl
 //
 
-template<typename Block>
+template <typename Block>
 inline VulkanBuffer MemoryAllocator::create_params_buffer(const Block& block) {
   const VulkanBuffer::MemoryProperties mem_props{
-    VMA_MEMORY_USAGE_CPU_TO_GPU,
-    0u,
-    0u,
-    VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+      VMA_MEMORY_USAGE_CPU_TO_GPU,
+      0u,
+      0u,
+      VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
   };
 
   VulkanBuffer uniform_buffer(allocator_, sizeof(Block), mem_props);

--- a/aten/src/ATen/native/vulkan/api/Runtime.cpp
+++ b/aten/src/ATen/native/vulkan/api/Runtime.cpp
@@ -12,7 +12,6 @@ void find_requested_layers_and_extensions(
     std::vector<const char*>& enabled_extensions,
     const std::vector<const char*>& requested_layers,
     const std::vector<const char*>& requested_extensions) {
-
   // Get supported instance layers
   uint32_t layer_count = 0;
   VK_CHECK(vkEnumerateInstanceLayerProperties(&layer_count, nullptr));
@@ -53,27 +52,27 @@ void find_requested_layers_and_extensions(
 
 VkInstance create_instance(const RuntimeConfiguration& config) {
   const VkApplicationInfo application_info{
-    VK_STRUCTURE_TYPE_APPLICATION_INFO,  // sType
-    nullptr,  // pNext
-    "PyTorch Vulkan Backend",  // pApplicationName
-    0,  // applicationVersion
-    nullptr, // pEngineName
-    0,  // engineVersion
-    VK_API_VERSION_1_0,  // apiVersion
+      VK_STRUCTURE_TYPE_APPLICATION_INFO, // sType
+      nullptr, // pNext
+      "PyTorch Vulkan Backend", // pApplicationName
+      0, // applicationVersion
+      nullptr, // pEngineName
+      0, // engineVersion
+      VK_API_VERSION_1_0, // apiVersion
   };
 
   std::vector<const char*> enabled_layers;
   std::vector<const char*> enabled_extensions;
 
   if (config.enableValidationMessages) {
-    std::vector<const char*> requested_layers {
-      // "VK_LAYER_LUNARG_api_dump",
-      "VK_LAYER_KHRONOS_validation",
+    std::vector<const char*> requested_layers{
+        // "VK_LAYER_LUNARG_api_dump",
+        "VK_LAYER_KHRONOS_validation",
     };
-    std::vector<const char*> requested_extensions {
-      #ifdef VK_EXT_debug_report
-      VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
-      #endif /* VK_EXT_debug_report */
+    std::vector<const char*> requested_extensions{
+#ifdef VK_EXT_debug_report
+        VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
+#endif /* VK_EXT_debug_report */
     };
 
     find_requested_layers_and_extensions(
@@ -84,14 +83,14 @@ VkInstance create_instance(const RuntimeConfiguration& config) {
   }
 
   const VkInstanceCreateInfo instance_create_info{
-    VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    &application_info,  // pApplicationInfo
-    static_cast<uint32_t>(enabled_layers.size()),  // enabledLayerCount
-    enabled_layers.data(),  // ppEnabledLayerNames
-    static_cast<uint32_t>(enabled_extensions.size()),  // enabledExtensionCount
-    enabled_extensions.data(),  // ppEnabledExtensionNames
+      VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      &application_info, // pApplicationInfo
+      static_cast<uint32_t>(enabled_layers.size()), // enabledLayerCount
+      enabled_layers.data(), // ppEnabledLayerNames
+      static_cast<uint32_t>(enabled_extensions.size()), // enabledExtensionCount
+      enabled_extensions.data(), // ppEnabledExtensionNames
   };
 
   VkInstance instance{};
@@ -105,7 +104,8 @@ VkInstance create_instance(const RuntimeConfiguration& config) {
   return instance;
 }
 
-std::vector<Runtime::DeviceMapping> create_physical_devices(const VkInstance instance) {
+std::vector<Runtime::DeviceMapping> create_physical_devices(
+    const VkInstance instance) {
   if (VK_NULL_HANDLE == instance) {
     return std::vector<Runtime::DeviceMapping>();
   }
@@ -154,21 +154,21 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debug_report_callback_fn(
 }
 
 VkDebugReportCallbackEXT create_debug_report_callback(
-    const VkInstance instance, const RuntimeConfiguration config) {
+    const VkInstance instance,
+    const RuntimeConfiguration config) {
   if (VK_NULL_HANDLE == instance || !config.enableValidationMessages) {
     return VkDebugReportCallbackEXT{};
   }
 
   const VkDebugReportCallbackCreateInfoEXT debugReportCallbackCreateInfo{
-    VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,  // sType
-    nullptr,  // pNext
-    VK_DEBUG_REPORT_INFORMATION_BIT_EXT |
-      VK_DEBUG_REPORT_WARNING_BIT_EXT |
-      VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT |
-      VK_DEBUG_REPORT_ERROR_BIT_EXT |
-      VK_DEBUG_REPORT_DEBUG_BIT_EXT,  // flags
-    debug_report_callback_fn,  // pfnCallback
-    nullptr,  // pUserData
+      VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT, // sType
+      nullptr, // pNext
+      VK_DEBUG_REPORT_INFORMATION_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT |
+          VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT |
+          VK_DEBUG_REPORT_ERROR_BIT_EXT |
+          VK_DEBUG_REPORT_DEBUG_BIT_EXT, // flags
+      debug_report_callback_fn, // pfnCallback
+      nullptr, // pUserData
   };
 
   const auto vkCreateDebugReportCallbackEXT =
@@ -186,9 +186,7 @@ VkDebugReportCallbackEXT create_debug_report_callback(
       nullptr,
       &debug_report_callback));
 
-  TORCH_CHECK(
-      debug_report_callback,
-      "Invalid Vulkan debug report callback!");
+  TORCH_CHECK(debug_report_callback, "Invalid Vulkan debug report callback!");
 
   return debug_report_callback;
 }
@@ -199,7 +197,8 @@ VkDebugReportCallbackEXT create_debug_report_callback(
 
 uint32_t select_first(const std::vector<Runtime::DeviceMapping>& devices) {
   if (devices.size() == 0) {
-    TORCH_WARN("Pytorch Vulkan Runtime: no device devices are available for selection!");
+    TORCH_WARN(
+        "Pytorch Vulkan Runtime: no device devices are available for selection!");
     return devices.size() + 1; // return out of range to signal invalidity
   }
 
@@ -238,30 +237,28 @@ std::unique_ptr<Runtime> init_global_vulkan_runtime() {
 
   const bool enableValidationMessages =
 #if defined(DEBUG)
-    true;
+      true;
 #else
-    false;
+      false;
 #endif /* DEBUG */
   const bool initDefaultDevice = true;
   const uint32_t numRequestedQueues = 1; // TODO: raise this value
 
-  const RuntimeConfiguration default_config {
-    enableValidationMessages,
-    initDefaultDevice,
-    AdapterSelector::First,
-    numRequestedQueues,
+  const RuntimeConfiguration default_config{
+      enableValidationMessages,
+      initDefaultDevice,
+      AdapterSelector::First,
+      numRequestedQueues,
   };
 
   try {
     return std::make_unique<Runtime>(Runtime(default_config));
-  }
-  catch (const std::exception& e) {
+  } catch (const std::exception& e) {
     TORCH_WARN(
         "Pytorch Vulkan Runtime: Failed to initialize the global vulkan runtime! "
         "The global vulkan runtime is invalid. Error: ",
         e.what());
-  }
-  catch (...) {
+  } catch (...) {
     TORCH_WARN(
         "Pytorch Vulkan Runtime: Failed to initialize the global vulkan runtime! "
         "The global vulkan runtime is invalid. "
@@ -274,28 +271,26 @@ std::unique_ptr<Runtime> init_global_vulkan_runtime() {
 } // namespace
 
 Runtime::Runtime(const RuntimeConfiguration config)
-  : config_(config),
-    instance_(create_instance(config_)),
-    device_mappings_(create_physical_devices(instance_)),
-    adapters_{},
-    default_adapter_i_(UINT32_MAX),
-    debug_report_callback_(create_debug_report_callback(instance_, config_)) {
+    : config_(config),
+      instance_(create_instance(config_)),
+      device_mappings_(create_physical_devices(instance_)),
+      adapters_{},
+      default_adapter_i_(UINT32_MAX),
+      debug_report_callback_(create_debug_report_callback(instance_, config_)) {
   // List of adapters will never exceed the number of physical devices
   adapters_.reserve(device_mappings_.size());
 
   if (config.initDefaultDevice) {
     try {
-      switch(config.defaultSelector) {
+      switch (config.defaultSelector) {
         case AdapterSelector::First:
           default_adapter_i_ = create_adapter(select_first);
       }
-    }
-    catch (const std::exception& e) {
+    } catch (const std::exception& e) {
       TORCH_WARN(
           "Pytorch Vulkan Runtime: Could not initialize default device! Error: ",
           e.what());
-    }
-    catch (...) {
+    } catch (...) {
       TORCH_WARN(
           "Pytorch Vulkan Runtime: Could not initialize default device! Error: "
           "Unknown.");
@@ -304,26 +299,27 @@ Runtime::Runtime(const RuntimeConfiguration config)
 }
 
 Runtime::~Runtime() {
-  if C10_LIKELY(VK_NULL_HANDLE == instance_) {
+  if C10_LIKELY (VK_NULL_HANDLE == instance_) {
     return;
   }
 
-  // Clear adapters list to trigger device destruction before destroying VkInstance
+  // Clear adapters list to trigger device destruction before destroying
+  // VkInstance
   adapters_.clear();
 
-  // Instance must be destroyed last as its used to destroy the debug report callback.
+  // Instance must be destroyed last as its used to destroy the debug report
+  // callback.
   if (debug_report_callback_) {
     const auto vkDestroyDebugReportCallbackEXT =
-      (PFN_vkDestroyDebugReportCallbackEXT)vkGetInstanceProcAddr(
-          instance_, "vkDestroyDebugReportCallbackEXT");
+        (PFN_vkDestroyDebugReportCallbackEXT)vkGetInstanceProcAddr(
+            instance_, "vkDestroyDebugReportCallbackEXT");
 
-      TORCH_CHECK(
-          vkDestroyDebugReportCallbackEXT,
-          "Pytorch Vulkan Runtime: Could not load vkDestroyDebugReportCallbackEXT "
-          "when destroying debug_report_callback_");
+    TORCH_CHECK(
+        vkDestroyDebugReportCallbackEXT,
+        "Pytorch Vulkan Runtime: Could not load vkDestroyDebugReportCallbackEXT "
+        "when destroying debug_report_callback_");
 
-      vkDestroyDebugReportCallbackEXT(
-          instance_, debug_report_callback_, nullptr);
+    vkDestroyDebugReportCallbackEXT(instance_, debug_report_callback_, nullptr);
 
     debug_report_callback_ = {};
   }
@@ -333,11 +329,11 @@ Runtime::~Runtime() {
 }
 
 Runtime::Runtime(Runtime&& other) noexcept
-  : config_(other.config_),
-    instance_(other.instance_),
-    adapters_(std::move(other.adapters_)),
-    default_adapter_i_(other.default_adapter_i_),
-    debug_report_callback_(other.debug_report_callback_) {
+    : config_(other.config_),
+      instance_(other.instance_),
+      adapters_(std::move(other.adapters_)),
+      default_adapter_i_(other.default_adapter_i_),
+      debug_report_callback_(other.debug_report_callback_) {
   other.instance_ = VK_NULL_HANDLE;
   other.debug_report_callback_ = {};
 }
@@ -374,7 +370,8 @@ Runtime* runtime() {
   // non-static function to ensure it has external linkage. If it were a global
   // static variable there would be one copy per translation unit that includes
   // Runtime.h as it would have internal linkage.
-  static const std::unique_ptr<Runtime> p_runtime = init_global_vulkan_runtime();
+  static const std::unique_ptr<Runtime> p_runtime =
+      init_global_vulkan_runtime();
   TORCH_CHECK(
       p_runtime,
       "Pytorch Vulkan Runtime: The global runtime could not be retrieved "

--- a/aten/src/ATen/native/vulkan/api/Runtime.h
+++ b/aten/src/ATen/native/vulkan/api/Runtime.h
@@ -2,8 +2,8 @@
 
 #ifdef USE_VULKAN_API
 
-#include <ATen/native/vulkan/api/Common.h>
 #include <ATen/native/vulkan/api/Adapter.h>
+#include <ATen/native/vulkan/api/Common.h>
 
 namespace at {
 namespace native {
@@ -35,7 +35,8 @@ class Runtime final {
  public:
   explicit Runtime(const RuntimeConfiguration);
 
-  // Do not allow copying. There should be only one global instance of this class.
+  // Do not allow copying. There should be only one global instance of this
+  // class.
   Runtime(const Runtime&) = delete;
   Runtime& operator=(const Runtime&) = delete;
 
@@ -73,7 +74,9 @@ class Runtime final {
   inline Adapter* get_adapter_p(uint32_t i) {
     TORCH_CHECK(
         i >= 0 && i < adapters_.size(),
-        "Pytorch Vulkan Runtime: Adapter at index ", i, " is not available!");
+        "Pytorch Vulkan Runtime: Adapter at index ",
+        i,
+        " is not available!");
     return adapters_[i].get();
   }
 
@@ -81,7 +84,8 @@ class Runtime final {
     return default_adapter_i_;
   }
 
-  using Selector = std::function<uint32_t (const std::vector<Runtime::DeviceMapping>&)>;
+  using Selector =
+      std::function<uint32_t(const std::vector<Runtime::DeviceMapping>&)>;
   uint32_t create_adapter(const Selector&);
 };
 

--- a/aten/src/ATen/native/vulkan/api/Shader.cpp
+++ b/aten/src/ATen/native/vulkan/api/Shader.cpp
@@ -14,43 +14,40 @@ namespace api {
 //
 
 ShaderSource::ShaderSource(std::string name, const char* const glsl_src)
-  : type(ShaderSource::Type::GLSL),
-    src_code{
-     .glsl = {
-       glsl_src,
-       0u,
-     },
-    },
-    kernel_name{std::move(name)} {
-}
+    : type(ShaderSource::Type::GLSL),
+      src_code{
+          .glsl =
+              {
+                  glsl_src,
+                  0u,
+              },
+      },
+      kernel_name{std::move(name)} {}
 
 ShaderSource::ShaderSource(
     std::string name,
     const uint32_t* const spirv_bin,
     const uint32_t size)
-  : type(Type::SPIRV),
-    src_code{
-     .spirv = {
-       spirv_bin,
-       size,
-     },
-    },
-    kernel_name{std::move(name)} {
-}
+    : type(Type::SPIRV),
+      src_code{
+          .spirv =
+              {
+                  spirv_bin,
+                  size,
+              },
+      },
+      kernel_name{std::move(name)} {}
 
-bool operator==(
-    const ShaderSource& _1,
-    const ShaderSource& _2) {
-
+bool operator==(const ShaderSource& _1, const ShaderSource& _2) {
   if (_1.type != _2.type) {
     return false;
   }
 
   if (_1.type == ShaderSource::Type::SPIRV) {
-    return (_1.src_code.spirv.bin == _2.src_code.spirv.bin && \
-            _1.src_code.spirv.size == _2.src_code.spirv.size);
-  }
-  else {
+    return (
+        _1.src_code.spirv.bin == _2.src_code.spirv.bin &&
+        _1.src_code.spirv.size == _2.src_code.spirv.size);
+  } else {
     return (_1.src_code.glsl.src == _2.src_code.glsl.src);
   }
 }
@@ -62,44 +59,39 @@ bool operator==(
 ShaderLayout::ShaderLayout(
     const VkDevice device,
     const ShaderLayout::Signature& signature)
-  : device_(device),
-    handle_{VK_NULL_HANDLE} {
+    : device_(device), handle_{VK_NULL_HANDLE} {
   c10::SmallVector<VkDescriptorSetLayoutBinding, 6u> bindings;
 
   uint32_t binding_num = 0u;
   for (const VkDescriptorType type : signature) {
     bindings.push_back({
-      binding_num++,  // binding
-      type,  // descriptorType
-      1u,  // descriptorCount
-      VK_SHADER_STAGE_COMPUTE_BIT,  // stageFlags
-      nullptr,  // pImmutableSamplers
+        binding_num++, // binding
+        type, // descriptorType
+        1u, // descriptorCount
+        VK_SHADER_STAGE_COMPUTE_BIT, // stageFlags
+        nullptr, // pImmutableSamplers
     });
   }
 
   const VkDescriptorSetLayoutCreateInfo descriptor_set_layout_create_info{
-    VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    static_cast<uint32_t>(bindings.size()),  // bindingCount
-    bindings.data(),  // pBindings
+      VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      static_cast<uint32_t>(bindings.size()), // bindingCount
+      bindings.data(), // pBindings
   };
 
   VK_CHECK(vkCreateDescriptorSetLayout(
-      device_,
-      &descriptor_set_layout_create_info,
-      nullptr,
-      &handle_));
+      device_, &descriptor_set_layout_create_info, nullptr, &handle_));
 }
 
 ShaderLayout::ShaderLayout(ShaderLayout&& other) noexcept
-  : device_(other.device_),
-    handle_(other.handle_) {
+    : device_(other.device_), handle_(other.handle_) {
   other.handle_ = VK_NULL_HANDLE;
 }
 
 ShaderLayout::~ShaderLayout() {
-  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyDescriptorSetLayout(device_, handle_, nullptr);
@@ -122,34 +114,29 @@ void swap(ShaderLayout& lhs, ShaderLayout& rhs) noexcept {
 //
 
 ShaderModule::ShaderModule(const VkDevice device, const ShaderSource& source)
-  : device_(device),
-    handle_{VK_NULL_HANDLE} {
+    : device_(device), handle_{VK_NULL_HANDLE} {
   const uint32_t* code = source.src_code.spirv.bin;
   uint32_t size = source.src_code.spirv.size;
 
   const VkShaderModuleCreateInfo shader_module_create_info{
-    VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,  // sType
-    nullptr,  // pNext
-    0u,  // flags
-    size,  // codeSize
-    code,  // pCode
+      VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      size, // codeSize
+      code, // pCode
   };
 
   VK_CHECK(vkCreateShaderModule(
-      device_,
-      &shader_module_create_info,
-      nullptr,
-      &handle_));
+      device_, &shader_module_create_info, nullptr, &handle_));
 }
 
 ShaderModule::ShaderModule(ShaderModule&& other) noexcept
-  : device_(other.device_),
-    handle_(other.handle_) {
+    : device_(other.device_), handle_(other.handle_) {
   other.handle_ = VK_NULL_HANDLE;
 }
 
 ShaderModule::~ShaderModule() {
-  if C10_LIKELY(VK_NULL_HANDLE == handle_) {
+  if C10_LIKELY (VK_NULL_HANDLE == handle_) {
     return;
   }
   vkDestroyShaderModule(device_, handle_, nullptr);
@@ -172,14 +159,10 @@ void swap(ShaderModule& lhs, ShaderModule& rhs) noexcept {
 //
 
 ShaderLayoutCache::ShaderLayoutCache(const VkDevice device)
-  : cache_mutex_{},
-    device_(device),
-    cache_{} {
-}
+    : cache_mutex_{}, device_(device), cache_{} {}
 
 ShaderLayoutCache::ShaderLayoutCache(ShaderLayoutCache&& other) noexcept
-  : cache_mutex_{},
-    device_(other.device_) {
+    : cache_mutex_{}, device_(other.device_) {
   std::lock_guard<std::mutex> lock(other.cache_mutex_);
   cache_ = std::move(other.cache_);
 }
@@ -193,7 +176,7 @@ VkDescriptorSetLayout ShaderLayoutCache::retrieve(
   std::lock_guard<std::mutex> lock(cache_mutex_);
 
   auto it = cache_.find(key);
-  if C10_UNLIKELY(cache_.cend() == it) {
+  if C10_UNLIKELY (cache_.cend() == it) {
     it = cache_.insert({key, ShaderLayoutCache::Value(device_, key)}).first;
   }
 
@@ -210,14 +193,10 @@ void ShaderLayoutCache::purge() {
 //
 
 ShaderCache::ShaderCache(const VkDevice device)
-  : cache_mutex_{},
-    device_(device),
-    cache_{} {
-}
+    : cache_mutex_{}, device_(device), cache_{} {}
 
 ShaderCache::ShaderCache(ShaderCache&& other) noexcept
-  : cache_mutex_{},
-    device_(other.device_) {
+    : cache_mutex_{}, device_(other.device_) {
   std::lock_guard<std::mutex> lock(other.cache_mutex_);
   cache_ = std::move(other.cache_);
 }
@@ -230,7 +209,7 @@ VkShaderModule ShaderCache::retrieve(const ShaderCache::Key& key) {
   std::lock_guard<std::mutex> lock(cache_mutex_);
 
   auto it = cache_.find(key);
-  if C10_UNLIKELY(cache_.cend() == it) {
+  if C10_UNLIKELY (cache_.cend() == it) {
     it = cache_.insert({key, ShaderCache::Value(device_, key)}).first;
   }
 

--- a/aten/src/ATen/native/vulkan/api/Shader.h
+++ b/aten/src/ATen/native/vulkan/api/Shader.h
@@ -12,10 +12,7 @@ namespace vulkan {
 namespace api {
 
 struct ShaderSource final {
-  enum class Type {
-    GLSL,
-    SPIRV
-  } type;
+  enum class Type { GLSL, SPIRV } type;
 
   union {
     struct {
@@ -31,7 +28,9 @@ struct ShaderSource final {
   std::string kernel_name;
   explicit ShaderSource(std::string name, const char* glsl);
   explicit ShaderSource(
-      std::string name, const uint32_t* spirv, uint32_t bytes);
+      std::string name,
+      const uint32_t* spirv,
+      uint32_t bytes);
 };
 
 class ShaderLayout final {
@@ -110,9 +109,7 @@ class ShaderLayoutCache final {
       size_t hashed = 0u;
 
       for (const VkDescriptorType type : signature) {
-        hashed = c10::hash_combine(
-            hashed,
-            c10::get_hash(type));
+        hashed = c10::hash_combine(hashed, c10::get_hash(type));
       }
 
       return hashed;
@@ -130,7 +127,6 @@ class ShaderLayoutCache final {
  public:
   VkDescriptorSetLayout retrieve(const Key&);
   void purge();
-
 };
 
 class ShaderCache final {
@@ -151,12 +147,9 @@ class ShaderCache final {
   struct Hasher {
     inline size_t operator()(const ShaderSource& source) const {
       return c10::get_hash(
-          source.type,
-          source.src_code.spirv.bin,
-          source.src_code.spirv.size);
+          source.type, source.src_code.spirv.bin, source.src_code.spirv.size);
     }
   };
-
 
  private:
   // Multiple threads could potentially be adding entries into the cache, so use
@@ -179,12 +172,11 @@ class ShaderCache final {
 inline bool operator==(
     const VkDescriptorSetLayoutBinding& _1,
     const VkDescriptorSetLayoutBinding& _2) {
-
-  return (_1.binding == _2.binding && \
-          _1.descriptorType == _2.descriptorType && \
-          _1.descriptorCount == _2.descriptorCount && \
-          _1.stageFlags == _2.stageFlags && \
-          _1.pImmutableSamplers == _2.pImmutableSamplers);
+  return (
+      _1.binding == _2.binding && _1.descriptorType == _2.descriptorType &&
+      _1.descriptorCount == _2.descriptorCount &&
+      _1.stageFlags == _2.stageFlags &&
+      _1.pImmutableSamplers == _2.pImmutableSamplers);
 }
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/api/Utils.h
+++ b/aten/src/ATen/native/vulkan/api/Utils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <c10/util/Half.h>  // For c10::overflows
+#include <c10/util/Half.h> // For c10::overflows
 
 #include <ATen/native/vulkan/api/Common.h>
 
@@ -16,24 +16,18 @@ namespace utils {
 // Alignment
 //
 
-template<typename Type>
-inline constexpr Type align_down(
-    const Type number,
-    const Type multiple) {
+template <typename Type>
+inline constexpr Type align_down(const Type number, const Type multiple) {
   return (number / multiple) * multiple;
 }
 
-template<typename Type>
-inline constexpr Type align_up(
-    const Type number,
-    const Type multiple) {
+template <typename Type>
+inline constexpr Type align_up(const Type number, const Type multiple) {
   return align_down(number + multiple - 1, multiple);
 }
 
-template<typename Type>
-inline constexpr Type div_up(
-    const Type numerator,
-    const Type denominator) {
+template <typename Type>
+inline constexpr Type div_up(const Type numerator, const Type denominator) {
   return (numerator + denominator - 1) / denominator;
 }
 
@@ -79,26 +73,26 @@ inline constexpr To safe_downcast(const From v) {
 
 namespace detail {
 
-template<typename Type, uint32_t N>
+template <typename Type, uint32_t N>
 struct vec final {
   Type data[N];
 };
 
 } // namespace detail
 
-template<uint32_t N>
+template <uint32_t N>
 using ivec = detail::vec<int32_t, N>;
 using ivec2 = ivec<2u>;
 using ivec3 = ivec<3u>;
 using ivec4 = ivec<4u>;
 
-template<uint32_t N>
+template <uint32_t N>
 using uvec = detail::vec<uint32_t, N>;
 using uvec2 = uvec<2u>;
 using uvec3 = uvec<3u>;
 using uvec4 = uvec<4u>;
 
-template<uint32_t N>
+template <uint32_t N>
 using vec = detail::vec<float, N>;
 using vec2 = vec<2u>;
 using vec3 = vec<3u>;
@@ -106,20 +100,17 @@ using vec4 = vec<4u>;
 
 } // namespace utils
 
-inline bool operator==(
-    const utils::uvec3& _1,
-    const utils::uvec3& _2) {
-
-  return (_1.data[0u] == _2.data[0u] && \
-          _1.data[1u] == _2.data[1u] && \
-          _1.data[2u] == _2.data[2u]);
+inline bool operator==(const utils::uvec3& _1, const utils::uvec3& _2) {
+  return (
+      _1.data[0u] == _2.data[0u] && _1.data[1u] == _2.data[1u] &&
+      _1.data[2u] == _2.data[2u]);
 }
 
 inline VkOffset3D create_offset3d(const utils::uvec3& offsets) {
   return VkOffset3D{
-    static_cast<int32_t>(offsets.data[0u]),
-    static_cast<int32_t>(offsets.data[1u]),
-    static_cast<int32_t>(offsets.data[2u])};
+      static_cast<int32_t>(offsets.data[0u]),
+      static_cast<int32_t>(offsets.data[1u]),
+      static_cast<int32_t>(offsets.data[2u])};
 }
 
 inline VkExtent3D create_extent3d(const utils::uvec3& extents) {

--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -66,9 +66,8 @@ Tensor arithmetic_scalar(
       v_self.options(),
   };
 
-  const float other_val = alpha_arg
-      ? other.to<float>() * alpha_arg->to<float>()
-      : other.to<float>();
+  const float other_val = alpha_arg ? other.to<float>() * alpha_arg->to<float>()
+                                    : other.to<float>();
   const struct Block final {
     uvec3 extents;
     float other;
@@ -102,9 +101,7 @@ Tensor arithmetic_scalar(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -124,9 +121,8 @@ Tensor& arithmetic_scalar_(
 
   vTensor& v_self = convert(self_arg);
 
-  const float other_val = alpha_arg
-      ? other.to<float>() * alpha_arg->to<float>()
-      : other.to<float>();
+  const float other_val = alpha_arg ? other.to<float>() * alpha_arg->to<float>()
+                                    : other.to<float>();
   const struct Block final {
     uvec3 extents;
     float other;
@@ -228,12 +224,8 @@ Tensor arithmetic_tensor(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      v_other.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_other.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -296,9 +288,7 @@ Tensor& arithmetic_tensor_(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
-      v_other.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_other.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -333,7 +323,10 @@ Tensor add_tensor(
       self_arg, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(add));
 }
 
-Tensor& add_tensor_(Tensor& self, const Tensor& other_arg, const Scalar& alpha) {
+Tensor& add_tensor_(
+    Tensor& self,
+    const Tensor& other_arg,
+    const Scalar& alpha) {
   return arithmetic_tensor_(
       self, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(add_));
 }
@@ -372,7 +365,10 @@ Tensor sub_tensor(
       self_arg, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(sub));
 }
 
-Tensor& sub_tensor_(Tensor& self, const Tensor& other_arg, const Scalar& alpha) {
+Tensor& sub_tensor_(
+    Tensor& self,
+    const Tensor& other_arg,
+    const Scalar& alpha) {
   return arithmetic_tensor_(
       self, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(sub_));
 }

--- a/aten/src/ATen/native/vulkan/ops/Batchnorm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Batchnorm.cpp
@@ -19,10 +19,7 @@ Tensor batch_norm(
     double /* momentum, not used in eval mode */,
     double eps,
     bool /* cudnn_enable, deprecated */) {
-
-  TORCH_CHECK(
-      !training,
-      "Vulkan batchnorm only supports evaluation mode.");
+  TORCH_CHECK(!training, "Vulkan batchnorm only supports evaluation mode.");
   TORCH_CHECK(
       weight_opt && weight_opt->defined() && bias_opt && bias_opt->defined(),
       "Vulkan batchnorm expects weight and bias arguments to be defined");
@@ -32,9 +29,7 @@ Tensor batch_norm(
   TORCH_CHECK(
       running_var_opt && running_var_opt->defined(),
       "running_var must be defined in evaluation mode.");
-  TORCH_CHECK(
-      input_arg.dim() == 4,
-      "Vulkan batchnorm expects 4-dim input!");
+  TORCH_CHECK(input_arg.dim() == 4, "Vulkan batchnorm expects 4-dim input!");
   TORCH_CHECK(
       channels_size(input_arg) % 4 == 0,
       "Vulkan batchnorm expects channel dim to be multiple of 4!");
@@ -47,50 +42,65 @@ Tensor batch_norm(
   auto channels_ext = num_features / 4;
 
   const Tensor weight_opt_3d = weight_opt->reshape({num_features, 1, 1});
-  const Tensor weight = weight_opt_3d.is_vulkan() ? weight_opt_3d : weight_opt_3d.vulkan();
+  const Tensor weight =
+      weight_opt_3d.is_vulkan() ? weight_opt_3d : weight_opt_3d.vulkan();
   const vTensor& v_weight = convert(weight);
   TORCH_CHECK(
       weight.numel() == num_features,
-      "weight tensor should contain ", num_features, " elements!");
+      "weight tensor should contain ",
+      num_features,
+      " elements!");
 
   const Tensor bias_opt_3d = bias_opt->reshape({num_features, 1, 1});
-  const Tensor bias = bias_opt_3d.is_vulkan() ? bias_opt_3d : bias_opt_3d.vulkan();
+  const Tensor bias =
+      bias_opt_3d.is_vulkan() ? bias_opt_3d : bias_opt_3d.vulkan();
   const vTensor& v_bias = convert(bias);
   TORCH_CHECK(
       bias.numel() == num_features,
-      "bias tensor should contain ", num_features, " elements!");
+      "bias tensor should contain ",
+      num_features,
+      " elements!");
 
-  const Tensor running_mean_opt_3d = running_mean_opt->reshape({num_features, 1, 1});
-  const Tensor running_mean = running_mean_opt_3d.is_vulkan() ? running_mean_opt_3d : running_mean_opt_3d.vulkan();
+  const Tensor running_mean_opt_3d =
+      running_mean_opt->reshape({num_features, 1, 1});
+  const Tensor running_mean = running_mean_opt_3d.is_vulkan()
+      ? running_mean_opt_3d
+      : running_mean_opt_3d.vulkan();
   const vTensor& v_running_mean = convert(running_mean);
   TORCH_CHECK(
       running_mean.numel() == num_features,
-      "running mean tensor should contain ", num_features, " elements!");
+      "running mean tensor should contain ",
+      num_features,
+      " elements!");
 
-  const Tensor running_var_opt_3d = running_var_opt->reshape({num_features, 1, 1});
-  const Tensor running_var = running_var_opt_3d.is_vulkan() ? running_var_opt_3d : running_var_opt_3d.vulkan();
+  const Tensor running_var_opt_3d =
+      running_var_opt->reshape({num_features, 1, 1});
+  const Tensor running_var = running_var_opt_3d.is_vulkan()
+      ? running_var_opt_3d
+      : running_var_opt_3d.vulkan();
   const vTensor& v_running_var = convert(running_var);
   TORCH_CHECK(
       running_var.numel() == num_features,
-      "running var tensor should contain ", num_features, " elements!");
+      "running var tensor should contain ",
+      num_features,
+      " elements!");
 
   api::Context* const context = api::context();
 
   vTensor v_output{
-    context,
-    v_input_sizes,
-    v_input.options(),
+      context,
+      v_input_sizes,
+      v_input.options(),
   };
 
   const struct Block final {
     uvec3 iextents;
     int32_t channels_ext;
     float epsilon;
-  } block {
-    v_output.extents(),
-    safe_downcast<int32_t>(channels_ext),
-    safe_downcast<float>(eps)
-  };
+  } block{
+      v_output.extents(),
+      safe_downcast<int32_t>(channels_ext),
+      safe_downcast<float>(eps)};
 
   api::UniformParamsBuffer params(context, block);
   api::PipelineBarrier pipeline_barrier{};
@@ -98,13 +108,13 @@ Tensor batch_norm(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       VK_KERNEL(batchnorm),
@@ -121,21 +131,11 @@ Tensor batch_norm(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_input.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      v_weight.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      v_bias.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      v_running_mean.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      v_running_var.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_weight.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_bias.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_running_mean.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_running_var.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 

--- a/aten/src/ATen/native/vulkan/ops/Clamp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clamp.cpp
@@ -14,9 +14,7 @@ Tensor _clamp(
     const c10::optional<Scalar>& min,
     const c10::optional<Scalar>& max,
     const api::ShaderSource& shader_descriptor) {
-  TORCH_CHECK(
-      min || max,
-      "At least one of 'min' or 'max' must not be None");
+  TORCH_CHECK(min || max, "At least one of 'min' or 'max' must not be None");
 
   api::Context* const context = api::context();
 
@@ -24,22 +22,22 @@ Tensor _clamp(
   const vTensor& v_self = convert(self_arg);
 
   vTensor v_output{
-    context,
-    v_self.sizes(),
-    v_self.options(),
+      context,
+      v_self.sizes(),
+      v_self.options(),
   };
 
   const struct Block final {
     uvec3 extents;
     uint32_t _;
     vec2 clamp;
-  } block {
-    v_output.extents(),
-    0u,
-    {
-      min ? min->to<float>() : -std::numeric_limits<float>::infinity(),
-      max ? max->to<float>() : std::numeric_limits<float>::infinity(),
-    },
+  } block{
+      v_output.extents(),
+      0u,
+      {
+          min ? min->to<float>() : -std::numeric_limits<float>::infinity(),
+          max ? max->to<float>() : std::numeric_limits<float>::infinity(),
+      },
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -48,9 +46,9 @@ Tensor _clamp(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       shader_descriptor,
@@ -67,9 +65,7 @@ Tensor _clamp(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -88,9 +84,7 @@ Tensor& _clamp_(
     const c10::optional<Scalar>& min,
     const c10::optional<Scalar>& max,
     const api::ShaderSource& shader_descriptor) {
-  TORCH_CHECK(
-      min || max,
-      "At least one of 'min' or 'max' must not be None");
+  TORCH_CHECK(min || max, "At least one of 'min' or 'max' must not be None");
 
   TORCH_CHECK(
       self_arg.is_vulkan(),
@@ -105,13 +99,13 @@ Tensor& _clamp_(
     uvec3 extents;
     uint32_t _;
     vec2 clamp;
-  } block {
-    v_self.extents(),
-    0u,
-    {
-      min ? min->to<float>() : -std::numeric_limits<float>::infinity(),
-      max ? max->to<float>() : std::numeric_limits<float>::infinity(),
-    },
+  } block{
+      v_self.extents(),
+      0u,
+      {
+          min ? min->to<float>() : -std::numeric_limits<float>::infinity(),
+          max ? max->to<float>() : std::numeric_limits<float>::infinity(),
+      },
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -120,8 +114,8 @@ Tensor& _clamp_(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       shader_descriptor,
@@ -167,17 +161,17 @@ Tensor activation(
   const vTensor& v_self = convert(self);
 
   vTensor v_output{
-    context,
-    v_self.sizes(),
-    v_self.options(),
+      context,
+      v_self.sizes(),
+      v_self.options(),
   };
 
   const struct Block final {
     uvec3 extents;
     uint32_t _;
-  } block {
-    v_output.extents(),
-    0u,
+  } block{
+      v_output.extents(),
+      0u,
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -186,9 +180,9 @@ Tensor activation(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       shader_descriptor,
@@ -205,9 +199,7 @@ Tensor activation(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -228,9 +220,9 @@ Tensor& activation_(
   const struct Block final {
     uvec3 extents;
     uint32_t _;
-  } block {
-    v_self.extents(),
-    0u,
+  } block{
+      v_self.extents(),
+      0u,
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -239,8 +231,8 @@ Tensor& activation_(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       shader_descriptor,
@@ -263,17 +255,11 @@ Tensor& activation_(
   return self_arg;
 }
 
-Tensor hardtanh(
-    const Tensor& self,
-    const Scalar& min,
-    const Scalar& max) {
+Tensor hardtanh(const Tensor& self, const Scalar& min, const Scalar& max) {
   return ops::_clamp(self, min, max, VK_KERNEL(clamp));
 }
 
-Tensor& hardtanh_(
-    Tensor& self,
-    const Scalar& min,
-    const Scalar& max) {
+Tensor& hardtanh_(Tensor& self, const Scalar& min, const Scalar& max) {
   return ops::_clamp_(self, min, max, VK_KERNEL(clamp_));
 }
 
@@ -311,19 +297,19 @@ Tensor activation_scalar(
   const vTensor& v_self = convert(self);
 
   vTensor v_output{
-    context,
-    v_self.sizes(),
-    v_self.options(),
+      context,
+      v_self.sizes(),
+      v_self.options(),
   };
 
   const struct Block final {
     uvec3 extents;
     uint32_t _;
     float scalar_value;
-  } block {
-    v_output.extents(),
-    0u,
-    scalar_arg.to<float>(),
+  } block{
+      v_output.extents(),
+      0u,
+      scalar_arg.to<float>(),
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -332,9 +318,9 @@ Tensor activation_scalar(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       shader_descriptor,
@@ -351,9 +337,7 @@ Tensor activation_scalar(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -376,10 +360,10 @@ Tensor& activation_scalar_(
     uvec3 extents;
     uint32_t _;
     float scalar_value;
-  } block {
-    v_self.extents(),
-    0u,
-    scalar_arg.to<float>(),
+  } block{
+      v_self.extents(),
+      0u,
+      scalar_arg.to<float>(),
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -388,8 +372,8 @@ Tensor& activation_scalar_(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       shader_descriptor,
@@ -412,29 +396,22 @@ Tensor& activation_scalar_(
   return self_arg;
 }
 
-Tensor hardshrink(
-    const Tensor& self_arg,
-    const Scalar& lambd) {
+Tensor hardshrink(const Tensor& self_arg, const Scalar& lambd) {
   float abs_lambd = std::abs(lambd.to<float>());
   return ops::activation_scalar(self_arg, abs_lambd, VK_KERNEL(hardshrink));
 }
 
-Tensor& hardshrink_(
-    Tensor& self,
-    const Scalar& lambd) {
+Tensor& hardshrink_(Tensor& self, const Scalar& lambd) {
   float abs_lambd = std::abs(lambd.to<float>());
   return ops::activation_scalar_(self, abs_lambd, VK_KERNEL(hardshrink_));
 }
 
-Tensor leaky_relu(
-    const Tensor& self_arg,
-    const Scalar& negative_slope) {
-  return ops::activation_scalar(self_arg, negative_slope, VK_KERNEL(leaky_relu));
+Tensor leaky_relu(const Tensor& self_arg, const Scalar& negative_slope) {
+  return ops::activation_scalar(
+      self_arg, negative_slope, VK_KERNEL(leaky_relu));
 }
 
-Tensor& leaky_relu_(
-    Tensor& self,
-    const Scalar& negative_slope) {
+Tensor& leaky_relu_(Tensor& self, const Scalar& negative_slope) {
   return ops::activation_scalar_(self, negative_slope, VK_KERNEL(leaky_relu_));
 }
 

--- a/aten/src/ATen/native/vulkan/ops/Clone.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Clone.cpp
@@ -7,11 +7,12 @@ namespace vulkan {
 namespace ops {
 namespace {
 
-Tensor clone(const Tensor& src, c10::optional<c10::MemoryFormat> optional_memory_format) {
-  auto memory_format =
-      optional_memory_format.value_or(MemoryFormat::Preserve);
+Tensor clone(
+    const Tensor& src,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  auto memory_format = optional_memory_format.value_or(MemoryFormat::Preserve);
   TORCH_CHECK(
-        (c10::MemoryFormat::Preserve == memory_format) ||
+      (c10::MemoryFormat::Preserve == memory_format) ||
           (c10::MemoryFormat::Contiguous == memory_format),
       "Vulkan supports Preserve and Contiguous memory foramts");
 

--- a/aten/src/ATen/native/vulkan/ops/Common.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Common.cpp
@@ -41,15 +41,15 @@ uint32_t width_size(const Tensor& tensor) {
   return sizes[dims - 1];
 }
 
-api::utils::uvec3 adaptive_work_group_size(const api::utils::uvec3& global_work_group) {
+api::utils::uvec3 adaptive_work_group_size(
+    const api::utils::uvec3& global_work_group) {
   api::utils::uvec3 local_group_size = {4, 4, 4};
   if (global_work_group.data[2u] == 1) {
     if (global_work_group.data[1u] < 8) {
       local_group_size.data[0u] = 16;
       local_group_size.data[1u] = 4;
       local_group_size.data[2u] = 1;
-    }
-    else {
+    } else {
       local_group_size.data[0u] = 8;
       local_group_size.data[1u] = 8;
       local_group_size.data[2u] = 1;

--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -48,7 +48,8 @@ uint32_t channels_size(const Tensor& tensor);
 uint32_t height_size(const Tensor& tensor);
 uint32_t width_size(const Tensor& tensor);
 
-api::utils::uvec3 adaptive_work_group_size(const api::utils::uvec3& global_work_group);
+api::utils::uvec3 adaptive_work_group_size(
+    const api::utils::uvec3& global_work_group);
 
 } // namespace ops
 } // namespace vulkan

--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -34,23 +34,25 @@ Tensor cat_feature(const TensorList tensors, vTensor& v_output) {
     const vTensor& v_self = convert(self);
 
     const struct Block final {
-      uvec3 size;                // output texture size
-      uint32_t fill_0;           // dummy
-      uvec3 isize;               // input texture size
-      uint32_t fill_1;           // dummy
-      uint32_t batch_size;       // input tensor's batch size
-      uint32_t ch_size;          // input tensor's channel size
-      uint32_t ch_interval;      // channel interval (total # of channels for all tensors)
-      uint32_t ch_size_allprior; // # of channels for tensor 0 to i-1 at ith tensor
-    } block {
-      v_output.extents(),
-      0u,
-      v_self.extents(),
-      0u,
-      safe_downcast<uint32_t>(v_self.sizes()[0]),
-      safe_downcast<uint32_t>(v_self.sizes()[1]),
-      safe_downcast<uint32_t>(ch_interval),
-      safe_downcast<uint32_t>(ch_size_allprior),
+      uvec3 size; // output texture size
+      uint32_t fill_0; // dummy
+      uvec3 isize; // input texture size
+      uint32_t fill_1; // dummy
+      uint32_t batch_size; // input tensor's batch size
+      uint32_t ch_size; // input tensor's channel size
+      uint32_t
+          ch_interval; // channel interval (total # of channels for all tensors)
+      uint32_t
+          ch_size_allprior; // # of channels for tensor 0 to i-1 at ith tensor
+    } block{
+        v_output.extents(),
+        0u,
+        v_self.extents(),
+        0u,
+        safe_downcast<uint32_t>(v_self.sizes()[0]),
+        safe_downcast<uint32_t>(v_self.sizes()[1]),
+        safe_downcast<uint32_t>(ch_interval),
+        safe_downcast<uint32_t>(ch_size_allprior),
     };
 
     ch_size_allprior += v_self.sizes()[1];
@@ -61,9 +63,9 @@ Tensor cat_feature(const TensorList tensors, vTensor& v_output) {
     context->submit_compute_job(
         // shader layout signature
         {
-          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+            VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+            VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+            VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
         },
         // shader descriptor
         VK_KERNEL(cat_feature),
@@ -80,9 +82,7 @@ Tensor cat_feature(const TensorList tensors, vTensor& v_output) {
             pipeline_barrier,
             api::PipelineStage::COMPUTE,
             api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
-        v_self.image(
-            pipeline_barrier,
-            api::PipelineStage::COMPUTE),
+        v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
         // params buffer
         params.buffer());
   }
@@ -104,42 +104,37 @@ Tensor cat_feature_mult4ch(const TensorList tensors, vTensor& v_output) {
   uvec3 dst_offset{};
 
   for (const auto& tensor_arg : tensors) {
-    const Tensor tensor = tensor_arg.is_vulkan()
-                          ? tensor_arg : tensor_arg.vulkan();
+    const Tensor tensor =
+        tensor_arg.is_vulkan() ? tensor_arg : tensor_arg.vulkan();
     const vTensor& v_self = convert(tensor);
 
     const uint32_t depth_slice = safe_downcast<uint32_t>(tensor.sizes()[1] / 4);
 
-    uvec3 copy_extents {
-      v_self.extents().data[0u],
-      v_self.extents().data[1u],
-      depth_slice
-    };
+    uvec3 copy_extents{
+        v_self.extents().data[0u], v_self.extents().data[1u], depth_slice};
 
     for (const auto b : c10::irange(tensor.sizes()[0])) {
       src_offset.data[2u] = safe_downcast<uint32_t>(depth_slice * b);
-      dst_offset.data[2u] = depth_size_allprior +
-                            safe_downcast<uint32_t>(depth_interval * b);
+      dst_offset.data[2u] =
+          depth_size_allprior + safe_downcast<uint32_t>(depth_interval * b);
 
-    api::PipelineBarrier pipeline_barrier{};
+      api::PipelineBarrier pipeline_barrier{};
 
-    context->submit_texture_copy(
-        // pipeline barrier
-        pipeline_barrier,
-        // images
-        v_self.image(
-            pipeline_barrier,
-            api::PipelineStage::TRANSFER),
-        v_output.image(
-            pipeline_barrier,
-            api::PipelineStage::TRANSFER,
-            api::MemoryAccessType::WRITE),
-        // copy details
-        copy_extents,
-        src_offset,
-        dst_offset,
-        // fence handle
-        VK_NULL_HANDLE);
+      context->submit_texture_copy(
+          // pipeline barrier
+          pipeline_barrier,
+          // images
+          v_self.image(pipeline_barrier, api::PipelineStage::TRANSFER),
+          v_output.image(
+              pipeline_barrier,
+              api::PipelineStage::TRANSFER,
+              api::MemoryAccessType::WRITE),
+          // copy details
+          copy_extents,
+          src_offset,
+          dst_offset,
+          // fence handle
+          VK_NULL_HANDLE);
     }
 
     depth_size_allprior += depth_slice;
@@ -167,9 +162,7 @@ Tensor cat_height(const TensorList tensors, vTensor& v_output) {
         // pipeline barrier
         pipeline_barrier,
         // images
-        v_self.image(
-            pipeline_barrier,
-            api::PipelineStage::TRANSFER),
+        v_self.image(pipeline_barrier, api::PipelineStage::TRANSFER),
         v_output.image(
             pipeline_barrier,
             api::PipelineStage::TRANSFER,
@@ -188,20 +181,16 @@ Tensor cat_height(const TensorList tensors, vTensor& v_output) {
   return convert(v_output);
 }
 
-Tensor cat(
-  const at::TensorList tensors,
-  const int64_t dim) {
-  TORCH_CHECK(
-    tensors.size() > 0,
-    "Vulkan cat expects at least one tensor");
+Tensor cat(const at::TensorList tensors, const int64_t dim) {
+  TORCH_CHECK(tensors.size() > 0, "Vulkan cat expects at least one tensor");
 
   at::Tensor tensor = tensors[0];
   int64_t cat_dim_size = 0;
   bool is_mult4ch = true;
 
-  for (const auto & t : tensors) {
-     TORCH_INTERNAL_ASSERT(
-      t.dim() == 4, "Vulkan cat expects 4 dimensional inputs");
+  for (const auto& t : tensors) {
+    TORCH_INTERNAL_ASSERT(
+        t.dim() == 4, "Vulkan cat expects 4 dimensional inputs");
 
     if (t.sizes()[1] % 4 != 0) {
       is_mult4ch = false;
@@ -212,8 +201,8 @@ Tensor cat(
         continue;
       }
       TORCH_INTERNAL_ASSERT(
-        t.size(d) == tensor.size(d),
-        "Vulkan cat inputs must have matching sizes except concatenated dimension");
+          t.size(d) == tensor.size(d),
+          "Vulkan cat inputs must have matching sizes except concatenated dimension");
     }
     cat_dim_size += t.size(dim);
   }
@@ -221,18 +210,14 @@ Tensor cat(
   auto result_size = tensor.sizes().vec();
   result_size[dim] = cat_dim_size;
 
-  vTensor v_output{
-    api::context(),
-    result_size,
-    tensor.options()};
+  vTensor v_output{api::context(), result_size, tensor.options()};
 
   if (dim == 3) {
     return cat_width(tensors, v_output);
   }
   if (dim == 2) {
     return cat_height(tensors, v_output);
-  }
-  else if (dim == 1) {
+  } else if (dim == 1) {
     if (is_mult4ch) {
       return cat_feature_mult4ch(tensors, v_output);
     }

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -4,8 +4,8 @@
 #include <ATen/native/vulkan/api/Utils.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/Convolution.h>
-#include <ATen/native/vulkan/ops/VulkanOpContext.h>
 #include <ATen/native/vulkan/ops/Utils.h>
+#include <ATen/native/vulkan/ops/VulkanOpContext.h>
 #include <c10/util/irange.h>
 
 namespace at {
@@ -17,19 +17,16 @@ namespace {
 using namespace api::utils;
 using namespace at::native::vulkan::ops;
 
-inline bool is_depthwise(
-    const IntArrayRef filter,
-    const int64_t groups) {
+inline bool is_depthwise(const IntArrayRef filter, const int64_t groups) {
   return (filter[Layout::Filter::output] == groups) &&
-         // Only K == 1 supported.
-         (filter[Layout::Filter::input] == 1);
+      // Only K == 1 supported.
+      (filter[Layout::Filter::input] == 1);
 }
 
 inline bool is_pointwise(const IntArrayRef filter) {
   return (1 == filter[Layout::Filter::height]) &&
-         (1 == filter[Layout::Filter::width]);
+      (1 == filter[Layout::Filter::width]);
 }
-
 
 bool all_lessthan(const IntArrayRef arr, const int t) {
   bool retval = true;
@@ -52,9 +49,7 @@ Conv2dMethod determine_method(
   return Conv2dSlidingWindow;
 }
 
-vTensor pack_weights_dw(
-    api::Context* const context,
-    const Tensor& weight) {
+vTensor pack_weights_dw(api::Context* const context, const Tensor& weight) {
   /* Source */
   const IntArrayRef src_filter = weight.sizes();
   const float* const src_weight_ptr = weight.data_ptr<float>();
@@ -62,8 +57,10 @@ vTensor pack_weights_dw(
   const int64_t src_kw_sz = src_filter[Layout::Filter::width];
   const int64_t src_kh_sz = src_filter[Layout::Filter::height];
   const int64_t src_kernel_sz = src_kw_sz * src_kh_sz;
-  const int64_t src_block_sz = src_kernel_sz * src_filter[Layout::Filter::input];
-  const int64_t num_stacks = div_up(src_filter[Layout::Filter::output], INT64_C(4));
+  const int64_t src_block_sz =
+      src_kernel_sz * src_filter[Layout::Filter::input];
+  const int64_t num_stacks =
+      div_up(src_filter[Layout::Filter::output], INT64_C(4));
 
   /* Destination */
   const int64_t dst_kw_sz = src_kernel_sz;
@@ -90,17 +87,18 @@ vTensor pack_weights_dw(
 
     for (const auto src_oc : c10::irange(src_filter[Layout::Filter::output])) {
       /* Source */
-      const float* const src_weight_oc_ptr = src_weight_ptr + src_oc * src_block_sz;
+      const float* const src_weight_oc_ptr =
+          src_weight_ptr + src_oc * src_block_sz;
 
       /* Destination */
       const int64_t dst_oh = src_oc / 4;
       const int64_t dst_c = src_oc % 4;
 
-      float* const dst_weight_c_ptr = dst_weight_ptr +
-                                      dst_c * dst_kernel_sz +
-                                      dst_oh * dst_kw_sz;
+      float* const dst_weight_c_ptr =
+          dst_weight_ptr + dst_c * dst_kernel_sz + dst_oh * dst_kw_sz;
 
-      for (const auto src_ih : c10::irange(src_filter[Layout::Filter::height])) {
+      for (const auto src_ih :
+           c10::irange(src_filter[Layout::Filter::height])) {
         memcpy(
             dst_weight_c_ptr + src_ih * src_kw_sz,
             src_weight_oc_ptr + src_ih * src_kw_sz,
@@ -113,9 +111,7 @@ vTensor pack_weights_dw(
   return v_weight;
 }
 
-vTensor pack_weights_2d(
-    api::Context* const context,
-    const Tensor& weight) {
+vTensor pack_weights_2d(api::Context* const context, const Tensor& weight) {
   /* Source */
   const IntArrayRef src_filter = weight.sizes();
   const float* const src_weight_ptr = weight.data_ptr<float>();
@@ -123,10 +119,13 @@ vTensor pack_weights_2d(
   const int64_t src_kw_sz = src_filter[Layout::Filter::width];
   const int64_t src_kh_sz = src_filter[Layout::Filter::height];
   const int64_t src_kernel_sz = src_kw_sz * src_kh_sz;
-  const int64_t src_block_sz = src_kernel_sz * src_filter[Layout::Filter::input];
+  const int64_t src_block_sz =
+      src_kernel_sz * src_filter[Layout::Filter::input];
 
-  const int64_t num_stacks = div_up(src_filter[Layout::Filter::output], INT64_C(4));
-  const int64_t stack_depth = api::utils::align_up(src_filter[Layout::Filter::input], INT64_C(4));
+  const int64_t num_stacks =
+      div_up(src_filter[Layout::Filter::output], INT64_C(4));
+  const int64_t stack_depth =
+      api::utils::align_up(src_filter[Layout::Filter::input], INT64_C(4));
 
   /* Destination */
   const int64_t dst_kw_sz = src_kw_sz * stack_depth;
@@ -153,7 +152,8 @@ vTensor pack_weights_2d(
 
     for (const auto src_oc : c10::irange(src_filter[Layout::Filter::output])) {
       /* Source */
-      const float* const src_weight_oc_ptr = src_weight_ptr + src_oc * src_block_sz;
+      const float* const src_weight_oc_ptr =
+          src_weight_ptr + src_oc * src_block_sz;
 
       /* Destination */
       const int64_t dst_oh = src_oc / 4;
@@ -168,8 +168,9 @@ vTensor pack_weights_2d(
           for (const auto src_iw : c10::irange(src_kw_sz)) {
             memcpy(
                 dst_weight_c_ptr + (dst_oh * src_kh_sz + src_ih) * dst_kw_sz +
-                  dst_ic4 * src_kw_sz * 4 + src_iw * 4 + src_ic % 4,
-                src_weight_oc_ptr + src_ic * src_kernel_sz + src_ih * src_kw_sz + src_iw,
+                    dst_ic4 * src_kw_sz * 4 + src_iw * 4 + src_ic % 4,
+                src_weight_oc_ptr + src_ic * src_kernel_sz +
+                    src_ih * src_kw_sz + src_iw,
                 sizeof(float));
           }
         }
@@ -181,9 +182,7 @@ vTensor pack_weights_2d(
   return v_weight;
 }
 
-vTensor pack_weights(
-    const Tensor& weight_arg,
-    const Conv2dMethod conv_method) {
+vTensor pack_weights(const Tensor& weight_arg, const Conv2dMethod conv_method) {
   if (weight_arg.is_vulkan()) {
     return convert(weight_arg);
   }
@@ -193,19 +192,13 @@ vTensor pack_weights(
   const Tensor weight = weight_arg.contiguous();
 
   if (conv_method == Conv2dDepthwise) {
-    return pack_weights_dw(
-        context,
-        weight);
+    return pack_weights_dw(context, weight);
   }
 
-  return pack_weights_2d(
-      context,
-      weight);
+  return pack_weights_2d(context, weight);
 }
 
-vTensor pack_biases(
-    const c10::optional<Tensor>& bias,
-    const Tensor& weight) {
+vTensor pack_biases(const c10::optional<Tensor>& bias, const Tensor& weight) {
   if (bias && bias->is_vulkan()) {
     return convert(*bias);
   }
@@ -215,13 +208,13 @@ vTensor pack_biases(
   const int64_t src_w = weight.size(Layout::Filter::output);
   const int64_t packed_w = div_up(src_w, INT64_C(4));
   vTensor v_bias{
-    context,
-    {
-      4,
-      1,
-      packed_w,
-    },
-    weight.options(),
+      context,
+      {
+          4,
+          1,
+          packed_w,
+      },
+      weight.options(),
   };
 
   api::StagingBuffer staging(context, v_bias.buffer_bytes());
@@ -239,8 +232,7 @@ vTensor pack_biases(
         const int64_t x = i / 4;
         dst_bias_ptr[c * packed_w + x] = src_bias_ptr[i];
       }
-    }
-    else {
+    } else {
       memset(
           dst_bias_ptr,
           // 2's complement integers and IEEE-754 floating point numbers both
@@ -265,14 +257,12 @@ std::array<int64_t, 4> pack_filter(
   };
 
   return {
-    align_up(filter[Layout::Filter::output], INT64_C(4)),
-    align_up(filter[Layout::Filter::input], INT64_C(4)),
-    effective(
-        filter[Layout::Filter::height],
-        dilation[Layout::Parameter::height]),
-    effective(
-        filter[Layout::Filter::width],
-        dilation[Layout::Parameter::width]),
+      align_up(filter[Layout::Filter::output], INT64_C(4)),
+      align_up(filter[Layout::Filter::input], INT64_C(4)),
+      effective(
+          filter[Layout::Filter::height], dilation[Layout::Parameter::height]),
+      effective(
+          filter[Layout::Filter::width], dilation[Layout::Parameter::width]),
   };
 }
 
@@ -280,8 +270,8 @@ std::array<int64_t, 2> pack_params(const std::vector<int64_t>& vector) {
   TORCH_INTERNAL_ASSERT(2u == vector.size(), "Invalid usage!");
 
   return {
-    vector[0],
-    vector[1],
+      vector[0],
+      vector[1],
   };
 }
 
@@ -297,56 +287,54 @@ bool available(
     const c10::optional<Scalar>& output_min,
     const c10::optional<Scalar>& output_max) {
   return api::available() &&
-         // Weight
-         (4 == weight.ndimension()) &&
-         (weight.size(Layout::Filter::height) > 0) &&
-         (weight.size(Layout::Filter::width) > 0) &&
-         ((weight.device().is_cpu()) ||
-          (c10::DeviceType::Vulkan == weight.device().type())) &&
-         (kFloat == weight.scalar_type()) &&
-         // Bias
-         ((bias && bias->defined()) ? ((1 == bias->ndimension()) &&
-                                       ((bias->device().is_cpu()) ||
-                                        (c10::DeviceType::Vulkan == bias->device().type())) &&
-                                       (kFloat == bias->scalar_type()) &&
-                                       (transposed ? false /* to be addded in the future */
-                                                   : (weight.size(Layout::Filter::output) ==
-                                                          bias->size(Layout::Filter::output))))
-                                    : true) &&
-         // Stride
-         (stride[Layout::Parameter::height] > 0) &&
-         (stride[Layout::Parameter::width] > 0) &&
-         // Padding
-         (padding[Layout::Parameter::height] >= 0) &&
-         (padding[Layout::Parameter::width] >= 0) &&
-         // Dilation
-         (dilation[Layout::Parameter::height] > 0) &&
-         (dilation[Layout::Parameter::width] > 0) &&
-         // Groups
-         (groups > 0) &&
-         // Input
-         (weight.size(Layout::Filter::input) > 0) &&
-         // Output
-         (weight.size(Layout::Filter::output) > 0) &&
-         // Output - Groups
-         ((weight.size(Layout::Filter::output) % groups) == 0) &&
-         // Output Min / Max
-         (!output_min || output_min->isFloatingPoint()) &&
-         (!output_max || output_max->isFloatingPoint()) &&
-         true;
+      // Weight
+      (4 == weight.ndimension()) && (weight.size(Layout::Filter::height) > 0) &&
+      (weight.size(Layout::Filter::width) > 0) &&
+      ((weight.device().is_cpu()) ||
+       (c10::DeviceType::Vulkan == weight.device().type())) &&
+      (kFloat == weight.scalar_type()) &&
+      // Bias
+      ((bias && bias->defined())
+           ? ((1 == bias->ndimension()) &&
+              ((bias->device().is_cpu()) ||
+               (c10::DeviceType::Vulkan == bias->device().type())) &&
+              (kFloat == bias->scalar_type()) &&
+              (transposed ? false /* to be addded in the future */
+                          : (weight.size(Layout::Filter::output) ==
+                             bias->size(Layout::Filter::output))))
+           : true) &&
+      // Stride
+      (stride[Layout::Parameter::height] > 0) &&
+      (stride[Layout::Parameter::width] > 0) &&
+      // Padding
+      (padding[Layout::Parameter::height] >= 0) &&
+      (padding[Layout::Parameter::width] >= 0) &&
+      // Dilation
+      (dilation[Layout::Parameter::height] > 0) &&
+      (dilation[Layout::Parameter::width] > 0) &&
+      // Groups
+      (groups > 0) &&
+      // Input
+      (weight.size(Layout::Filter::input) > 0) &&
+      // Output
+      (weight.size(Layout::Filter::output) > 0) &&
+      // Output - Groups
+      ((weight.size(Layout::Filter::output) % groups) == 0) &&
+      // Output Min / Max
+      (!output_min || output_min->isFloatingPoint()) &&
+      (!output_max || output_max->isFloatingPoint()) && true;
 }
 
 bool usable(const Tensor& input) {
-         // Input
+  // Input
   return (4 == input.ndimension()) &&
-         (c10::DeviceType::Vulkan == input.device().type()) &&
-         (kFloat == input.scalar_type()) &&
-         (input.size(Layout::Activation4D::batch) >= 0) &&
-         (input.size(Layout::Activation4D::channels) > 0) &&
-         (input.size(Layout::Activation4D::height) > 0) &&
-         (input.size(Layout::Activation4D::width) > 0) &&
-         !input.requires_grad() &&
-         true;
+      (c10::DeviceType::Vulkan == input.device().type()) &&
+      (kFloat == input.scalar_type()) &&
+      (input.size(Layout::Activation4D::batch) >= 0) &&
+      (input.size(Layout::Activation4D::channels) > 0) &&
+      (input.size(Layout::Activation4D::height) > 0) &&
+      (input.size(Layout::Activation4D::width) > 0) && !input.requires_grad() &&
+      true;
 }
 
 } // namespace
@@ -384,12 +372,8 @@ VulkanOpContext conv2d_context_create(
       "transposed, output_padding, output_min, output_max) parameters are either "
       "invalid individually or their combination is not supported by Vulkan impl.");
 
-  const auto method = determine_method(
-      weight.sizes(),
-      stride,
-      padding,
-      dilation,
-      groups);
+  const auto method =
+      determine_method(weight.sizes(), stride, padding, dilation, groups);
 
   c10::impl::GenericList packed_context{c10::AnyType::get()};
   packed_context.reserve(10);
@@ -401,8 +385,12 @@ VulkanOpContext conv2d_context_create(
   packed_context.emplace_back(output_padding);
   packed_context.emplace_back(pack_params(dilation));
   packed_context.emplace_back(safe_downcast<int32_t>(groups));
-  packed_context.emplace_back(output_min ? output_min->template to<float>() : -std::numeric_limits<float>::infinity());
-  packed_context.emplace_back(output_max ? output_max->template to<float>() : +std::numeric_limits<float>::infinity());
+  packed_context.emplace_back(
+      output_min ? output_min->template to<float>()
+                 : -std::numeric_limits<float>::infinity());
+  packed_context.emplace_back(
+      output_max ? output_max->template to<float>()
+                 : +std::numeric_limits<float>::infinity());
   packed_context.emplace_back(method);
 
   c10::impl::GenericList unpacked_context{c10::AnyType::get()};
@@ -448,44 +436,45 @@ void conv2d_sliding_window(
     ivec2 dilate;
     vec2 clamp;
     ivec4 src_filter;
-  } block {
-    v_output.extents(),
-    safe_downcast<int32_t>(packed_filter[Layout::Filter::input]),
-    {
-      safe_downcast<int32_t>(packed_filter[Layout::Filter::width]),
-      safe_downcast<int32_t>(packed_filter[Layout::Filter::height]),
-      safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::width]),
-      safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::height]),
-    },
-    {
-      safe_downcast<int32_t>(unpacked_filter[Layout::Filter::width]),
-      safe_downcast<int32_t>(unpacked_filter[Layout::Filter::height]),
-    },
-    {
-      safe_downcast<int32_t>(packed_stride[Layout::Parameter::width]),
-      safe_downcast<int32_t>(packed_stride[Layout::Parameter::height]),
-    },
-    {
-      safe_downcast<int32_t>(packed_padding[Layout::Parameter::width]),
-      safe_downcast<int32_t>(packed_padding[Layout::Parameter::height]),
-    },
-    {
-      safe_downcast<int32_t>(packed_dilation[Layout::Parameter::width]),
-      safe_downcast<int32_t>(packed_dilation[Layout::Parameter::height]),
-    },
-    {
-      packed_output_min,
-      packed_output_max,
-    },
+  } block{
+      v_output.extents(),
+      safe_downcast<int32_t>(packed_filter[Layout::Filter::input]),
+      {
+          safe_downcast<int32_t>(packed_filter[Layout::Filter::width]),
+          safe_downcast<int32_t>(packed_filter[Layout::Filter::height]),
+          safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::width]),
+          safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::height]),
+      },
+      {
+          safe_downcast<int32_t>(unpacked_filter[Layout::Filter::width]),
+          safe_downcast<int32_t>(unpacked_filter[Layout::Filter::height]),
+      },
+      {
+          safe_downcast<int32_t>(packed_stride[Layout::Parameter::width]),
+          safe_downcast<int32_t>(packed_stride[Layout::Parameter::height]),
+      },
+      {
+          safe_downcast<int32_t>(packed_padding[Layout::Parameter::width]),
+          safe_downcast<int32_t>(packed_padding[Layout::Parameter::height]),
+      },
+      {
+          safe_downcast<int32_t>(packed_dilation[Layout::Parameter::width]),
+          safe_downcast<int32_t>(packed_dilation[Layout::Parameter::height]),
+      },
+      {
+          packed_output_min,
+          packed_output_max,
+      },
   };
 
   uvec3 global_size = v_output.extents();
   if (method_ == Conv2dPointwise) {
     global_size = {
-      safe_downcast<uint32_t>(div_up(v_output.sizes()[Layout::Filter::width], INT64_C(2))),
-      safe_downcast<uint32_t>(div_up(v_output.sizes()[Layout::Filter::height], INT64_C(2))),
-      v_output.extents().data[2u]
-    };
+        safe_downcast<uint32_t>(
+            div_up(v_output.sizes()[Layout::Filter::width], INT64_C(2))),
+        safe_downcast<uint32_t>(
+            div_up(v_output.sizes()[Layout::Filter::height], INT64_C(2))),
+        v_output.extents().data[2u]};
   }
 
   api::UniformParamsBuffer params(context, block);
@@ -494,11 +483,11 @@ void conv2d_sliding_window(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       shader,
@@ -515,15 +504,9 @@ void conv2d_sliding_window(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_input.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      packed_v_weight.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      packed_v_bias.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      packed_v_weight.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      packed_v_bias.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 }
@@ -555,64 +538,64 @@ Tensor conv2d_context_run(
       "Reason: The provided input tensor is either invalid or unsupported by Vulkan impl.");
 
   vTensor v_output{
-    context,
-    conv_output_size(
-        v_input.sizes(),
-        unpacked_filter,
-        packed_padding,
-        packed_stride,
-        packed_dilation),
-    input.options(),
+      context,
+      conv_output_size(
+          v_input.sizes(),
+          unpacked_filter,
+          packed_padding,
+          packed_stride,
+          packed_dilation),
+      input.options(),
   };
 
-  switch(method_) {
+  switch (method_) {
     case Conv2dDepthwise:
       conv2d_sliding_window(
-        VK_KERNEL(conv2d_dw),
-        v_output,
-        v_input,
-        packed_v_weight,
-        packed_v_bias,
-        packed_filter,
-        packed_stride,
-        packed_padding,
-        packed_dilation,
-        packed_output_min,
-        packed_output_max,
-        unpacked_filter,
-        method_);
+          VK_KERNEL(conv2d_dw),
+          v_output,
+          v_input,
+          packed_v_weight,
+          packed_v_bias,
+          packed_filter,
+          packed_stride,
+          packed_padding,
+          packed_dilation,
+          packed_output_min,
+          packed_output_max,
+          unpacked_filter,
+          method_);
       break;
     case Conv2dPointwise:
       conv2d_sliding_window(
-        VK_KERNEL(conv2d_pw_2x2),
-        v_output,
-        v_input,
-        packed_v_weight,
-        packed_v_bias,
-        packed_filter,
-        packed_stride,
-        packed_padding,
-        packed_dilation,
-        packed_output_min,
-        packed_output_max,
-        unpacked_filter,
-        method_);
+          VK_KERNEL(conv2d_pw_2x2),
+          v_output,
+          v_input,
+          packed_v_weight,
+          packed_v_bias,
+          packed_filter,
+          packed_stride,
+          packed_padding,
+          packed_dilation,
+          packed_output_min,
+          packed_output_max,
+          unpacked_filter,
+          method_);
       break;
     default:
       conv2d_sliding_window(
-        VK_KERNEL(conv2d),
-        v_output,
-        v_input,
-        packed_v_weight,
-        packed_v_bias,
-        packed_filter,
-        packed_stride,
-        packed_padding,
-        packed_dilation,
-        packed_output_min,
-        packed_output_max,
-        unpacked_filter,
-        method_);
+          VK_KERNEL(conv2d),
+          v_output,
+          v_input,
+          packed_v_weight,
+          packed_v_bias,
+          packed_filter,
+          packed_stride,
+          packed_padding,
+          packed_dilation,
+          packed_output_min,
+          packed_output_max,
+          unpacked_filter,
+          method_);
       break;
   }
 
@@ -628,33 +611,29 @@ c10::intrusive_ptr<VulkanOpContext> create_conv2d_clamp_context(
     const int64_t groups,
     const c10::optional<Scalar>& output_min,
     const c10::optional<Scalar>& output_max) {
-  return c10::make_intrusive<VulkanOpContext>(
-      conv2d_context_create(
-          weight,
-          bias,
-          stride,
-          padding,
-          dilation,
-          /* transposed = */ false,
-          /* output_padding_arg = */ {},
-          groups,
-          output_min,
-          output_max));
+  return c10::make_intrusive<VulkanOpContext>(conv2d_context_create(
+      weight,
+      bias,
+      stride,
+      padding,
+      dilation,
+      /* transposed = */ false,
+      /* output_padding_arg = */ {},
+      groups,
+      output_min,
+      output_max));
 }
 
 Tensor run_conv2d_clamp_context(
     const Tensor& input,
     const c10::intrusive_ptr<VulkanOpContext>& vulkan_context) {
   return conv2d_context_run(
-    input,
-    vulkan_context->get_packed(),
-    vulkan_context->get_unpacked());
+      input, vulkan_context->get_packed(), vulkan_context->get_unpacked());
 }
 
 /* Backwards compatibility */
 Conv2dOpContext::Conv2dOpContext(VulkanOpContext vulkan_context)
-  : vulkan_context_{std::move(vulkan_context)} {
-}
+    : vulkan_context_{std::move(vulkan_context)} {}
 
 Conv2dOpContext Conv2dOpContext::create(
     const Tensor& weight,
@@ -667,51 +646,50 @@ Conv2dOpContext Conv2dOpContext::create(
     const int64_t groups,
     const c10::optional<Scalar>& output_min,
     const c10::optional<Scalar>& output_max) {
-  return Conv2dOpContext {
-      conv2d_context_create(
-        weight,
-        bias,
-        stride_arg,
-        padding_arg,
-        dilation_arg,
-        transposed,
-        output_padding_arg,
-        groups,
-        output_min,
-        output_max)
-  };
+  return Conv2dOpContext{conv2d_context_create(
+      weight,
+      bias,
+      stride_arg,
+      padding_arg,
+      dilation_arg,
+      transposed,
+      output_padding_arg,
+      groups,
+      output_min,
+      output_max)};
 }
 
 Tensor Conv2dOpContext::run(const Tensor& input_arg) const {
   return conv2d_context_run(
-    input_arg,
-    vulkan_context_.get_packed(),
-    vulkan_context_.get_unpacked());
+      input_arg, vulkan_context_.get_packed(), vulkan_context_.get_unpacked());
 }
 
 Conv2dOpContext::State Conv2dOpContext::unpack() const {
-  const c10::impl::GenericList unpacked_ = std::get<1>(vulkan_context_.get_state());
+  const c10::impl::GenericList unpacked_ =
+      std::get<1>(vulkan_context_.get_state());
   const Tensor unpacked_weight = unpacked_.get(0).toTensor();
-  const c10::optional<Tensor> unpacked_bias
-   = unpacked_.get(1).isTensor() ? unpacked_.get(1).toTensor() : (c10::optional<Tensor>&) c10::nullopt;
+  const c10::optional<Tensor> unpacked_bias = unpacked_.get(1).isTensor()
+      ? unpacked_.get(1).toTensor()
+      : (c10::optional<Tensor>&)c10::nullopt;
   const std::vector<int64_t> unpacked_stride = unpacked_.get(2).toIntVector();
   const std::vector<int64_t> unpacked_padding = unpacked_.get(3).toIntVector();
   const std::vector<int64_t> unpacked_dilation = unpacked_.get(4).toIntVector();
   const int64_t unpacked_groups = unpacked_.get(5).toInt();
-  const c10::optional<Scalar> unpacked_output_min
-   = unpacked_.get(6).isScalar() ? unpacked_.get(6).toScalar() : (c10::optional<Scalar>) c10::nullopt;
-  const c10::optional<Scalar> unpacked_output_max
-   = unpacked_.get(6).isScalar() ? unpacked_.get(7).toScalar() : (c10::optional<Scalar>) c10::nullopt;
+  const c10::optional<Scalar> unpacked_output_min = unpacked_.get(6).isScalar()
+      ? unpacked_.get(6).toScalar()
+      : (c10::optional<Scalar>)c10::nullopt;
+  const c10::optional<Scalar> unpacked_output_max = unpacked_.get(6).isScalar()
+      ? unpacked_.get(7).toScalar()
+      : (c10::optional<Scalar>)c10::nullopt;
   return Conv2dOpContext::State{
-    unpacked_weight,
-    unpacked_bias,
-    unpacked_stride,
-    unpacked_padding,
-    unpacked_dilation,
-    unpacked_groups,
-    unpacked_output_min,
-    unpacked_output_max
-  };
+      unpacked_weight,
+      unpacked_bias,
+      unpacked_stride,
+      unpacked_padding,
+      unpacked_dilation,
+      unpacked_groups,
+      unpacked_output_min,
+      unpacked_output_max};
 }
 
 c10::intrusive_ptr<Conv2dOpContext> conv2d_clamp_prepack(
@@ -723,18 +701,17 @@ c10::intrusive_ptr<Conv2dOpContext> conv2d_clamp_prepack(
     const int64_t groups,
     const c10::optional<Scalar>& output_min,
     const c10::optional<Scalar>& output_max) {
-  return c10::make_intrusive<Conv2dOpContext>(
-      Conv2dOpContext::create(
-          std::move(weight),
-          std::move(bias),
-          std::move(stride),
-          std::move(padding),
-          std::move(dilation),
-          /* transposed = */ false,
-          /* output_padding = */ {},
-          groups,
-          output_min,
-          output_max));
+  return c10::make_intrusive<Conv2dOpContext>(Conv2dOpContext::create(
+      std::move(weight),
+      std::move(bias),
+      std::move(stride),
+      std::move(padding),
+      std::move(dilation),
+      /* transposed = */ false,
+      /* output_padding = */ {},
+      groups,
+      output_min,
+      output_max));
 }
 
 Tensor conv2d_clamp_run(

--- a/aten/src/ATen/native/vulkan/ops/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Copy.cpp
@@ -15,9 +15,7 @@ void copy_vulkan_to_vulkan(vTensor& src, vTensor& dst) {
       // pipeline barrier
       pipeline_barrier,
       // images
-      src.image(
-          pipeline_barrier,
-          api::PipelineStage::TRANSFER),
+      src.image(pipeline_barrier, api::PipelineStage::TRANSFER),
       dst.image(
           pipeline_barrier,
           api::PipelineStage::TRANSFER,
@@ -40,9 +38,9 @@ void copy_cpu_to_vulkan(const Tensor& src, vTensor& dst) {
     float* data_ptr = mapping.template data<float>();
 
     memcpy(
-      data_ptr,
-      src.contiguous().data_ptr<float>(),
-      std::min(src.nbytes(), src.nbytes()));
+        data_ptr,
+        src.contiguous().data_ptr<float>(),
+        std::min(src.nbytes(), src.nbytes()));
   }
   utils::pack_staging_to_vtensor(staging.buffer(), dst);
 }
@@ -78,9 +76,7 @@ void copy_vulkan_to_cpu(vTensor& src, Tensor& dst) {
     float* data_ptr = mapping.template data<float>();
 
     memcpy(
-        dst.data_ptr<float>(),
-        data_ptr,
-        std::min(src.nbytes(), dst.nbytes()));
+        dst.data_ptr<float>(), data_ptr, std::min(src.nbytes(), dst.nbytes()));
   }
 
   context->fences().return_fence(fence);
@@ -113,12 +109,10 @@ Tensor& copy_(Tensor& self, const Tensor& src) {
     // Vulkan -> CPU
     if (self.device().is_cpu()) {
       copy_vulkan_to_cpu(v_src, self);
-    }
-    else {
+    } else {
       TORCH_CHECK(false, "Unsupported!");
     }
-  }
-  else {
+  } else {
     TORCH_INTERNAL_ASSERT(
         false,
         "Invalid code path taken! Either the source or the destination tensor "

--- a/aten/src/ATen/native/vulkan/ops/Factory.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Factory.cpp
@@ -23,7 +23,7 @@ Tensor empty_memory_format(
           .device(device)
           .pinned_memory(pin_memory)
           .memory_format(memory_format),
-    });
+  });
 }
 
 Tensor empty_strided(
@@ -34,19 +34,18 @@ Tensor empty_strided(
     const optional<Device> device,
     const optional<bool> pin_memory) {
   return empty_memory_format(
-      sizes,
-      dtype,
-      layout,
-      device,
-      pin_memory,
-      c10::MemoryFormat::Contiguous);
+      sizes, dtype, layout, device, pin_memory, c10::MemoryFormat::Contiguous);
 }
 
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
-  m.impl(TORCH_SELECTIVE_NAME("aten::empty.memory_format"), at::native::vulkan::ops::empty_memory_format);
-  m.impl(TORCH_SELECTIVE_NAME("aten::empty_strided"), TORCH_FN(at::native::vulkan::ops::empty_strided));
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::empty.memory_format"),
+      at::native::vulkan::ops::empty_memory_format);
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::empty_strided"),
+      TORCH_FN(at::native::vulkan::ops::empty_strided));
 }
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/ops/Glu.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Glu.cpp
@@ -9,16 +9,12 @@ namespace {
 
 using namespace api::utils;
 
-Tensor glu(
-    const at::Tensor& input_arg,
-    const int64_t dim = -1) {
-
-  TORCH_CHECK(
-      input_arg.dim() == 4,
-      "Vulkan glu only supports 4-dim input!");
+Tensor glu(const at::Tensor& input_arg, const int64_t dim = -1) {
+  TORCH_CHECK(input_arg.dim() == 4, "Vulkan glu only supports 4-dim input!");
   TORCH_CHECK(
       dim == 1,
-      "Vulkan glu only supports GLU for dim = 1, but got dim = ", dim);
+      "Vulkan glu only supports GLU for dim = 1, but got dim = ",
+      dim);
   TORCH_CHECK(
       channels_size(input_arg) % 8 == 0,
       "Vulkan glu expects channel dim to be multiple of 8!");
@@ -32,18 +28,18 @@ Tensor glu(
   api::Context* const context = api::context();
 
   vTensor v_output{
-    context,
-    {v_input_sizes[0], v_input_sizes[1] / 2, v_input_sizes[2], v_input_sizes[3]},
-    v_input.options(),
+      context,
+      {v_input_sizes[0],
+       v_input_sizes[1] / 2,
+       v_input_sizes[2],
+       v_input_sizes[3]},
+      v_input.options(),
   };
 
   const struct Block final {
     uvec3 extents;
     int32_t chext;
-  } block {
-    v_output.extents(),
-    safe_downcast<int32_t>(output_ch_ext)
-  };
+  } block{v_output.extents(), safe_downcast<int32_t>(output_ch_ext)};
 
   api::UniformParamsBuffer params(context, block);
   api::PipelineBarrier pipeline_barrier{};
@@ -51,9 +47,9 @@ Tensor glu(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       VK_KERNEL(glu),
@@ -70,9 +66,7 @@ Tensor glu(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_input.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 

--- a/aten/src/ATen/native/vulkan/ops/Gru.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Gru.cpp
@@ -10,10 +10,11 @@ namespace ops {
 namespace {
 //
 // input_vk: input tensor of shape (L, N, H_in) when batch_first=False
-//                                 (N, L, H_in) when batch_first=True containing the features of the input sequence
-// hx_vk: initial hidden state for each element in the batch. tensor of shape (D * num_layers, N, H_out)
-// output: tensor of shape (N, L, D * H_out)) when batch_first=True
-// h_n: tensor of shape (D * num_layers, N, H_out)
+//                                 (N, L, H_in) when batch_first=True containing
+//                                 the features of the input sequence
+// hx_vk: initial hidden state for each element in the batch. tensor of shape (D
+// * num_layers, N, H_out) output: tensor of shape (N, L, D * H_out)) when
+// batch_first=True h_n: tensor of shape (D * num_layers, N, H_out)
 //
 //  where
 //    L = sequence length
@@ -23,30 +24,40 @@ namespace {
 //    H_out = hidden_size (# of features in the hidden state h)
 //
 std::tuple<Tensor, Tensor> gru_input(
-  const Tensor & input_vk,  // input sequence (vulkan)
-  const Tensor & hx_vk,     // initial hidden state (vulkan)
-  TensorList params_cpu,    // weights/biases (cpu)
-  bool has_biases,
-  int64_t num_layers,
-  double dropout,
-  bool train,
-  bool bidirectional,
-  bool batch_first) {
-  TORCH_CHECK(static_cast<int64_t>(params_cpu.size()) == 4 * num_layers,
-              "Vulkan gru expects 'params_cpu' size to be 4 * 'num_layers'.");
-  TORCH_INTERNAL_ASSERT(input_vk.sizes().size() == 3, "Vulkan gru expects 'input_vk' dims to be 3.");
-  TORCH_INTERNAL_ASSERT(hx_vk.sizes().size() == 3, "Vulkan gru expects 'hx_vk' dims to be 3.");
-  TORCH_INTERNAL_ASSERT(has_biases, "Vulkan gru expects 'has_biases' to be true.");
+    const Tensor& input_vk, // input sequence (vulkan)
+    const Tensor& hx_vk, // initial hidden state (vulkan)
+    TensorList params_cpu, // weights/biases (cpu)
+    bool has_biases,
+    int64_t num_layers,
+    double dropout,
+    bool train,
+    bool bidirectional,
+    bool batch_first) {
+  TORCH_CHECK(
+      static_cast<int64_t>(params_cpu.size()) == 4 * num_layers,
+      "Vulkan gru expects 'params_cpu' size to be 4 * 'num_layers'.");
+  TORCH_INTERNAL_ASSERT(
+      input_vk.sizes().size() == 3,
+      "Vulkan gru expects 'input_vk' dims to be 3.");
+  TORCH_INTERNAL_ASSERT(
+      hx_vk.sizes().size() == 3, "Vulkan gru expects 'hx_vk' dims to be 3.");
+  TORCH_INTERNAL_ASSERT(
+      has_biases, "Vulkan gru expects 'has_biases' to be true.");
   TORCH_INTERNAL_ASSERT(!train, "Vulkan gru expects 'train' to be false.");
-  TORCH_INTERNAL_ASSERT(!bidirectional, "Vulkan gru expects 'bidirectional' to be false.");
-  TORCH_INTERNAL_ASSERT(batch_first, "Vulkan gru expects 'batch_first' to be true.");
-  TORCH_INTERNAL_ASSERT(dropout < std::numeric_limits<double>::epsilon()*1000, "Vulkan gru expects 'dropout' to be 0.0.");
+  TORCH_INTERNAL_ASSERT(
+      !bidirectional, "Vulkan gru expects 'bidirectional' to be false.");
+  TORCH_INTERNAL_ASSERT(
+      batch_first, "Vulkan gru expects 'batch_first' to be true.");
+  TORCH_INTERNAL_ASSERT(
+      dropout < std::numeric_limits<double>::epsilon() * 1000,
+      "Vulkan gru expects 'dropout' to be 0.0.");
 
   const auto hidden_size = hx_vk.size(2);
-  std::vector<at::Tensor> h_n_list;  // hidden output
+  std::vector<at::Tensor> h_n_list; // hidden output
 
   // reshape to 2D due to Vulkan at::mm op accepts only 2D
-  auto x = input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
+  auto x =
+      input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
 
   for (int64_t i = 0; i < num_layers; ++i) {
     // extract each hidden state and squeeze into 2D dim
@@ -58,30 +69,34 @@ std::tuple<Tensor, Tensor> gru_input(
     const auto& b_ih = params_cpu[i * 4 + 2];
     const auto& b_hh = params_cpu[i * 4 + 3];
 
-    const auto&  w_i_rzn = w_ih.split(hidden_size);
-    const auto&  w_h_rzn = w_hh.split(hidden_size);
-    const auto&  b_i_rzn = b_ih.split(hidden_size);
-    const auto&  b_h_rzn = b_hh.split(hidden_size);
+    const auto& w_i_rzn = w_ih.split(hidden_size);
+    const auto& w_h_rzn = w_hh.split(hidden_size);
+    const auto& b_i_rzn = b_ih.split(hidden_size);
+    const auto& b_h_rzn = b_hh.split(hidden_size);
 
-    const auto&  w_ir = w_i_rzn[0];
-    const auto&  w_iz = w_i_rzn[1];
-    const auto&  w_in = w_i_rzn[2];
-    const auto&  w_hr = w_h_rzn[0];
-    const auto&  w_hz = w_h_rzn[1];
-    const auto&  w_hn = w_h_rzn[2];
-    const auto&  b_ir = b_i_rzn[0];
-    const auto&  b_iz = b_i_rzn[1];
-    const auto&  b_in = b_i_rzn[2];
-    const auto&  b_hr = b_h_rzn[0];
-    const auto&  b_hz = b_h_rzn[1];
-    const auto&  b_hn = b_h_rzn[2];
+    const auto& w_ir = w_i_rzn[0];
+    const auto& w_iz = w_i_rzn[1];
+    const auto& w_in = w_i_rzn[2];
+    const auto& w_hr = w_h_rzn[0];
+    const auto& w_hz = w_h_rzn[1];
+    const auto& w_hn = w_h_rzn[2];
+    const auto& b_ir = b_i_rzn[0];
+    const auto& b_iz = b_i_rzn[1];
+    const auto& b_in = b_i_rzn[2];
+    const auto& b_hr = b_h_rzn[0];
+    const auto& b_hz = b_h_rzn[1];
+    const auto& b_hn = b_h_rzn[2];
 
-    const auto&  r = at::sigmoid(at::addmm(b_ir, x, w_ir.t()) + at::addmm(b_hr, h, w_hr.t()));
-    const auto&  z = at::sigmoid(at::addmm(b_iz, x, w_iz.t()) + at::addmm(b_hz, h, w_hz.t()));
-    const auto&  n = at::tanh(at::addmm(b_in, x, w_in.t()) + r * (at::addmm(b_hn, h, w_hn.t())));
+    const auto& r = at::sigmoid(
+        at::addmm(b_ir, x, w_ir.t()) + at::addmm(b_hr, h, w_hr.t()));
+    const auto& z = at::sigmoid(
+        at::addmm(b_iz, x, w_iz.t()) + at::addmm(b_hz, h, w_hz.t()));
+    const auto& n = at::tanh(
+        at::addmm(b_in, x, w_in.t()) + r * (at::addmm(b_hn, h, w_hn.t())));
     h = (z * (-1) + 1) * n + z * h;
-    x = h;  // next input
-    h_n_list.emplace_back(h.reshape({1, 1, h.size(0), h.size(1)}));  // 2D to 4D for cat op
+    x = h; // next input
+    h_n_list.emplace_back(
+        h.reshape({1, 1, h.size(0), h.size(1)})); // 2D to 4D for cat op
   }
 
   auto h_n = at::cat(h_n_list, 1);
@@ -102,8 +117,9 @@ TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
 std::vector<c10::intrusive_ptr<VulkanOpContext>> pack_linear_op_contexts(
     const std::vector<Tensor>& params_cpu,
     int64_t num_layers) {
-  TORCH_CHECK(static_cast<int64_t>(params_cpu.size()) == 4 * num_layers,
-              "Vulkan gru expects 'params_cpu' size to be 4 * 'num_layers'.");
+  TORCH_CHECK(
+      static_cast<int64_t>(params_cpu.size()) == 4 * num_layers,
+      "Vulkan gru expects 'params_cpu' size to be 4 * 'num_layers'.");
   std::vector<c10::intrusive_ptr<VulkanOpContext>> linear_op_contexts;
   for (int64_t i = 0; i < num_layers; ++i) {
     const auto& w_ih = params_cpu.at(i * 4);
@@ -112,23 +128,23 @@ std::vector<c10::intrusive_ptr<VulkanOpContext>> pack_linear_op_contexts(
     const auto& b_hh = params_cpu.at(i * 4 + 3);
     const auto& hidden_size = w_ih.size(0) / 3;
 
-    const auto&  w_i_rzn = w_ih.split(hidden_size);
-    const auto&  w_h_rzn = w_hh.split(hidden_size);
-    const auto&  b_i_rzn = b_ih.split(hidden_size);
-    const auto&  b_h_rzn = b_hh.split(hidden_size);
+    const auto& w_i_rzn = w_ih.split(hidden_size);
+    const auto& w_h_rzn = w_hh.split(hidden_size);
+    const auto& b_i_rzn = b_ih.split(hidden_size);
+    const auto& b_h_rzn = b_hh.split(hidden_size);
 
-    const auto&  w_ir = w_i_rzn[0];
-    const auto&  w_iz = w_i_rzn[1];
-    const auto&  w_in = w_i_rzn[2];
-    const auto&  w_hr = w_h_rzn[0];
-    const auto&  w_hz = w_h_rzn[1];
-    const auto&  w_hn = w_h_rzn[2];
-    const auto&  b_ir = b_i_rzn[0];
-    const auto&  b_iz = b_i_rzn[1];
-    const auto&  b_in = b_i_rzn[2];
-    const auto&  b_hr = b_h_rzn[0];
-    const auto&  b_hz = b_h_rzn[1];
-    const auto&  b_hn = b_h_rzn[2];
+    const auto& w_ir = w_i_rzn[0];
+    const auto& w_iz = w_i_rzn[1];
+    const auto& w_in = w_i_rzn[2];
+    const auto& w_hr = w_h_rzn[0];
+    const auto& w_hz = w_h_rzn[1];
+    const auto& w_hn = w_h_rzn[2];
+    const auto& b_ir = b_i_rzn[0];
+    const auto& b_iz = b_i_rzn[1];
+    const auto& b_in = b_i_rzn[2];
+    const auto& b_hr = b_h_rzn[0];
+    const auto& b_hz = b_h_rzn[1];
+    const auto& b_hn = b_h_rzn[2];
 
     linear_op_contexts.emplace_back(create_linear_context(w_ir.t(), b_ir));
     linear_op_contexts.emplace_back(create_linear_context(w_hr.t(), b_hr));
@@ -148,12 +164,16 @@ VulkanOpContext gru_context_create(
     bool train,
     bool bidirectional,
     bool batch_first) {
-
-  TORCH_INTERNAL_ASSERT(has_biases, "Vulkan gru expects 'has_biases' to be true.");
+  TORCH_INTERNAL_ASSERT(
+      has_biases, "Vulkan gru expects 'has_biases' to be true.");
   TORCH_INTERNAL_ASSERT(!train, "Vulkan gru expects 'train' to be false.");
-  TORCH_INTERNAL_ASSERT(!bidirectional, "Vulkan gru expects 'bidirectional' to be false.");
-  TORCH_INTERNAL_ASSERT(batch_first, "Vulkan gru expects 'batch_first' to be true.");
-  TORCH_INTERNAL_ASSERT(dropout < std::numeric_limits<double>::epsilon()*1000, "Vulkan gru expects 'dropout' to be 0.0.");
+  TORCH_INTERNAL_ASSERT(
+      !bidirectional, "Vulkan gru expects 'bidirectional' to be false.");
+  TORCH_INTERNAL_ASSERT(
+      batch_first, "Vulkan gru expects 'batch_first' to be true.");
+  TORCH_INTERNAL_ASSERT(
+      dropout < std::numeric_limits<double>::epsilon() * 1000,
+      "Vulkan gru expects 'dropout' to be 0.0.");
 
   c10::impl::GenericList packed_context{c10::AnyType::get()};
   packed_context.reserve(7);
@@ -179,46 +199,73 @@ VulkanOpContext gru_context_create(
 }
 
 std::tuple<Tensor, Tensor> gru_context_run(
-    const Tensor & input_vk,      // input sequence (vulkan)
-    const Tensor & hx_vk,         // initial hidden state (vulkan)
+    const Tensor& input_vk, // input sequence (vulkan)
+    const Tensor& hx_vk, // initial hidden state (vulkan)
     const c10::impl::GenericList& packed_context,
     const c10::impl::GenericList& unpacked_context) {
-  TORCH_INTERNAL_ASSERT(input_vk.sizes().size() == 3, "Vulkan gru expects 'input_vk' dims to be 3.");
-  TORCH_INTERNAL_ASSERT(hx_vk.sizes().size() == 3, "Vulkan gru expects 'hx_vk' dims to be 3.");
+  TORCH_INTERNAL_ASSERT(
+      input_vk.sizes().size() == 3,
+      "Vulkan gru expects 'input_vk' dims to be 3.");
+  TORCH_INTERNAL_ASSERT(
+      hx_vk.sizes().size() == 3, "Vulkan gru expects 'hx_vk' dims to be 3.");
 
-  const c10::List<c10::IValue> packed_linear_op_contexts = packed_context.get(0).toList();
+  const c10::List<c10::IValue> packed_linear_op_contexts =
+      packed_context.get(0).toList();
   const int64_t packed_num_layers = packed_context.get(2).toInt();
 
-  const int64_t linear_op_contexts_per_layer = 6;   // (b_ir, w_ir), (b_hr, w_hr), (b_iz, w_iz), (b_hz, w_hz), (b_in, w_in), (b_hn, w_hn)
-  std::vector<at::Tensor> h_n_list;  // hidden output
+  const int64_t linear_op_contexts_per_layer =
+      6; // (b_ir, w_ir), (b_hr, w_hr), (b_iz, w_iz), (b_hz, w_hz), (b_in,
+         // w_in), (b_hn, w_hn)
+  std::vector<at::Tensor> h_n_list; // hidden output
 
   // reshape to 2D due to Vulkan at::mm op accepts only 2D
-  auto x = input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
+  auto x =
+      input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
 
   for (int64_t i = 0; i < packed_num_layers; ++i) {
     // extract each hidden state and squeeze into 2D dim
     auto h = at::slice(hx_vk, 0, i, i + 1, 1);
     h = h.reshape({h.size(0) * h.size(1), h.size(2)});
 
-    const auto&  cxt_ir = packed_linear_op_contexts[i * linear_op_contexts_per_layer + 0].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_hr = packed_linear_op_contexts[i * linear_op_contexts_per_layer + 1].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_iz = packed_linear_op_contexts[i * linear_op_contexts_per_layer + 2].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_hz = packed_linear_op_contexts[i * linear_op_contexts_per_layer + 3].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_in = packed_linear_op_contexts[i * linear_op_contexts_per_layer + 4].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_hn = packed_linear_op_contexts[i * linear_op_contexts_per_layer + 5].toCustomClass<VulkanOpContext>();
+    const auto& cxt_ir =
+        packed_linear_op_contexts[i * linear_op_contexts_per_layer + 0]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_hr =
+        packed_linear_op_contexts[i * linear_op_contexts_per_layer + 1]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_iz =
+        packed_linear_op_contexts[i * linear_op_contexts_per_layer + 2]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_hz =
+        packed_linear_op_contexts[i * linear_op_contexts_per_layer + 3]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_in =
+        packed_linear_op_contexts[i * linear_op_contexts_per_layer + 4]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_hn =
+        packed_linear_op_contexts[i * linear_op_contexts_per_layer + 5]
+            .toCustomClass<VulkanOpContext>();
 
-    const auto&  r = at::sigmoid(
-      linear_context_run(x, cxt_ir->get_packed(), cxt_ir->get_unpacked(), 1.0f, 1.0f)
-       + linear_context_run(h, cxt_hr->get_packed(), cxt_hr->get_unpacked(), 1.0f, 1.0f));
-    const auto&  z = at::sigmoid(
-      linear_context_run(x, cxt_iz->get_packed(), cxt_iz->get_unpacked(), 1.0f, 1.0f)
-       + linear_context_run(h, cxt_hz->get_packed(), cxt_hz->get_unpacked(), 1.0f, 1.0f));
-    const auto&  n = at::tanh(
-      linear_context_run(x, cxt_in->get_packed(), cxt_in->get_unpacked(), 1.0f, 1.0f)
-       + r * (linear_context_run(h, cxt_hn->get_packed(), cxt_hn->get_unpacked(), 1.0f, 1.0f)));
+    const auto& r = at::sigmoid(
+        linear_context_run(
+            x, cxt_ir->get_packed(), cxt_ir->get_unpacked(), 1.0f, 1.0f) +
+        linear_context_run(
+            h, cxt_hr->get_packed(), cxt_hr->get_unpacked(), 1.0f, 1.0f));
+    const auto& z = at::sigmoid(
+        linear_context_run(
+            x, cxt_iz->get_packed(), cxt_iz->get_unpacked(), 1.0f, 1.0f) +
+        linear_context_run(
+            h, cxt_hz->get_packed(), cxt_hz->get_unpacked(), 1.0f, 1.0f));
+    const auto& n = at::tanh(
+        linear_context_run(
+            x, cxt_in->get_packed(), cxt_in->get_unpacked(), 1.0f, 1.0f) +
+        r *
+            (linear_context_run(
+                h, cxt_hn->get_packed(), cxt_hn->get_unpacked(), 1.0f, 1.0f)));
     h = (z * (-1) + 1) * n + z * h;
-    x = h;  // next input
-    h_n_list.emplace_back(h.reshape({1, 1, h.size(0), h.size(1)}));  // 2D to 4D for cat op
+    x = h; // next input
+    h_n_list.emplace_back(
+        h.reshape({1, 1, h.size(0), h.size(1)})); // 2D to 4D for cat op
   }
 
   auto h_n = at::cat(h_n_list, 1);
@@ -235,7 +282,13 @@ c10::intrusive_ptr<VulkanOpContext> create_gru_context(
     bool bidirectional,
     bool batch_first) {
   return c10::make_intrusive<VulkanOpContext>(gru_context_create(
-      params_cpu, has_biases, num_layers, dropout, train, bidirectional, batch_first));
+      params_cpu,
+      has_biases,
+      num_layers,
+      dropout,
+      train,
+      bidirectional,
+      batch_first));
 }
 
 std::tuple<Tensor, Tensor> run_gru_context(
@@ -243,16 +296,15 @@ std::tuple<Tensor, Tensor> run_gru_context(
     const Tensor& hx_vk,
     const c10::intrusive_ptr<VulkanOpContext>& vulkan_context) {
   return gru_context_run(
-    input_vk,
-    hx_vk,
-    vulkan_context->get_packed(),
-    vulkan_context->get_unpacked());
+      input_vk,
+      hx_vk,
+      vulkan_context->get_packed(),
+      vulkan_context->get_unpacked());
 }
 
 /* Backwards compatibility */
 GruOpContext::GruOpContext(VulkanOpContext vulkan_context)
-  : vulkan_context_{std::move(vulkan_context)} {
-}
+    : vulkan_context_{std::move(vulkan_context)} {}
 
 GruOpContext GruOpContext::create(
     const std::vector<Tensor>& params_cpu, // weights/biases (cpu)
@@ -262,31 +314,31 @@ GruOpContext GruOpContext::create(
     bool train,
     bool bidirectional,
     bool batch_first) {
-  return GruOpContext {
-      gru_context_create(
-        params_cpu,
-        has_biases,
-        num_layers,
-        dropout,
-        train,
-        bidirectional,
-        batch_first)
-  };
+  return GruOpContext{gru_context_create(
+      params_cpu,
+      has_biases,
+      num_layers,
+      dropout,
+      train,
+      bidirectional,
+      batch_first)};
 }
 
 std::tuple<Tensor, Tensor> GruOpContext::run(
-    const Tensor & input_vk,      // input sequence (vulkan)
-    const Tensor & hx_vk) const { // initial hidden state (vulkan)
+    const Tensor& input_vk, // input sequence (vulkan)
+    const Tensor& hx_vk) const { // initial hidden state (vulkan)
   return gru_context_run(
-    input_vk,
-    hx_vk,
-    vulkan_context_.get_packed(),
-    vulkan_context_.get_unpacked());
+      input_vk,
+      hx_vk,
+      vulkan_context_.get_packed(),
+      vulkan_context_.get_unpacked());
 }
 
 GruOpContext::State GruOpContext::unpack() const {
-  const c10::impl::GenericList unpacked_ = std::get<1>(vulkan_context_.get_state());
-  const std::vector<Tensor> unpacked_params_cpu = unpacked_.get(0).toTensorVector();
+  const c10::impl::GenericList unpacked_ =
+      std::get<1>(vulkan_context_.get_state());
+  const std::vector<Tensor> unpacked_params_cpu =
+      unpacked_.get(0).toTensorVector();
   const bool unpacked_has_biases = unpacked_.get(1).toBool();
   const int64_t unpacked_num_layers = unpacked_.get(2).toInt();
   const double unpacked_dropout = unpacked_.get(3).toDouble();
@@ -294,13 +346,13 @@ GruOpContext::State GruOpContext::unpack() const {
   const bool unpacked_bidirectional = unpacked_.get(5).toBool();
   const bool unpacked_batch_first = unpacked_.get(6).toBool();
   return GruOpContext::State{
-    unpacked_params_cpu,
-    unpacked_has_biases,
-    unpacked_num_layers,
-    unpacked_dropout,
-    unpacked_train,
-    unpacked_bidirectional,
-    unpacked_batch_first,
+      unpacked_params_cpu,
+      unpacked_has_biases,
+      unpacked_num_layers,
+      unpacked_dropout,
+      unpacked_train,
+      unpacked_bidirectional,
+      unpacked_batch_first,
   };
 }
 
@@ -313,7 +365,13 @@ c10::intrusive_ptr<GruOpContext> gru_prepack(
     bool bidirectional,
     bool batch_first) {
   return c10::make_intrusive<GruOpContext>(GruOpContext::create(
-      params_cpu, has_biases, num_layers, dropout, train, bidirectional, batch_first));
+      params_cpu,
+      has_biases,
+      num_layers,
+      dropout,
+      train,
+      bidirectional,
+      batch_first));
 }
 
 std::tuple<Tensor, Tensor> gru_run(

--- a/aten/src/ATen/native/vulkan/ops/Gru.h
+++ b/aten/src/ATen/native/vulkan/ops/Gru.h
@@ -12,9 +12,31 @@ namespace vulkan {
 namespace ops {
 
 //   packed
-//     std::vector<c10::intrusive_ptr<VulkanOpContext>> linear_op_contexts;  // {{ op context for b_ir, w_ir, op context for b_hr, w_hr,
-//                                                                           //    op context for b_iz, w_iz, op context for b_hz, w_hz,
-//                                                                           //    op context for b_in, w_in, op context for b_hn, w_hn,}, ...}
+//     std::vector<c10::intrusive_ptr<VulkanOpContext>> linear_op_contexts;  //
+//     {{ op context for b_ir, w_ir, op context for b_hr, w_hr,
+//                                                                           //
+//                                                                           op
+//                                                                           context
+//                                                                           for
+//                                                                           b_iz,
+//                                                                           w_iz,
+//                                                                           op
+//                                                                           context
+//                                                                           for
+//                                                                           b_hz,
+//                                                                           w_hz,
+//                                                                           //
+//                                                                           op
+//                                                                           context
+//                                                                           for
+//                                                                           b_in,
+//                                                                           w_in,
+//                                                                           op
+//                                                                           context
+//                                                                           for
+//                                                                           b_hn,
+//                                                                           w_hn,},
+//                                                                           ...}
 //     bool has_biases{};
 //     int64_t num_layers{};
 //     double dropout{};
@@ -41,13 +63,13 @@ VulkanOpContext gru_context_create(
     bool batch_first);
 
 std::tuple<Tensor, Tensor> gru_context_run(
-    const Tensor & input_vk,      // input sequence (vulkan)
-    const Tensor & hx_vk,         // initial hidden state (vulkan)
+    const Tensor& input_vk, // input sequence (vulkan)
+    const Tensor& hx_vk, // initial hidden state (vulkan)
     const c10::impl::GenericList& packed_context,
     const c10::impl::GenericList& unpacked_context);
 
 c10::intrusive_ptr<VulkanOpContext> create_gru_context(
-    std::vector<Tensor>&& params_cpu,   // weights/biases (cpu)
+    std::vector<Tensor>&& params_cpu, // weights/biases (cpu)
     bool has_biases,
     int64_t num_layers,
     double dropout,
@@ -57,7 +79,7 @@ c10::intrusive_ptr<VulkanOpContext> create_gru_context(
 
 std::tuple<Tensor, Tensor> run_gru_context(
     const Tensor& input_vk,
-    const Tensor & hx_vk,
+    const Tensor& hx_vk,
     const c10::intrusive_ptr<VulkanOpContext>& vulkan_context);
 
 // Backwards compatibility
@@ -72,11 +94,11 @@ class GruOpContext final : public torch::jit::CustomClassHolder {
       bool bidirectional,
       bool batch_first);
 
-  using State = std::tuple<std::vector<Tensor>, bool, int64_t, double, bool, bool, bool>;
+  using State =
+      std::tuple<std::vector<Tensor>, bool, int64_t, double, bool, bool, bool>;
 
-  std::tuple<Tensor, Tensor> run(
-      const Tensor& input_vk,
-      const Tensor & hx_vk) const;
+  std::tuple<Tensor, Tensor> run(const Tensor& input_vk, const Tensor& hx_vk)
+      const;
   State unpack() const;
 
  private:
@@ -85,7 +107,7 @@ class GruOpContext final : public torch::jit::CustomClassHolder {
 };
 
 c10::intrusive_ptr<GruOpContext> gru_prepack(
-    std::vector<Tensor>&& params_cpu,   // weights/biases (cpu)
+    std::vector<Tensor>&& params_cpu, // weights/biases (cpu)
     bool has_biases,
     int64_t num_layers,
     double dropout,
@@ -95,7 +117,7 @@ c10::intrusive_ptr<GruOpContext> gru_prepack(
 
 std::tuple<Tensor, Tensor> gru_run(
     const Tensor& input_vk,
-    const Tensor & hx_vk,
+    const Tensor& hx_vk,
     const c10::intrusive_ptr<GruOpContext>& context);
 
 } // namespace ops

--- a/aten/src/ATen/native/vulkan/ops/Layernorm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Layernorm.cpp
@@ -14,7 +14,6 @@ void _check_layer_norm_inputs(
     IntArrayRef normalized_shape,
     const c10::optional<Tensor>& weight /* optional */,
     const c10::optional<Tensor>& bias /* optional */) {
-
   const auto normalized_ndim = normalized_shape.size();
   TORCH_CHECK(
       normalized_ndim >= 1,
@@ -60,7 +59,6 @@ Tensor layer_norm(
     const c10::optional<Tensor>& bias_opt /* optional */,
     double eps,
     bool /* cudnn_enable, deprecated */) {
-
   _check_layer_norm_inputs(input_arg, normalized_shape, weight_opt, bias_opt);
 
   TORCH_CHECK(
@@ -83,9 +81,11 @@ Tensor layer_norm(
       weight_opt->defined() && bias_opt->defined(),
       "Vulkan layernorm expects weight and bias arguments");
 
-  const auto volume = c10::multiply_integers(v_input_sizes.cbegin(), v_input_sizes.end());
+  const auto volume =
+      c10::multiply_integers(v_input_sizes.cbegin(), v_input_sizes.end());
 
-  const Tensor weight = weight_opt->is_vulkan() ? *weight_opt : weight_opt->vulkan();
+  const Tensor weight =
+      weight_opt->is_vulkan() ? *weight_opt : weight_opt->vulkan();
   const vTensor& v_weight = convert(weight);
 
   const Tensor bias = bias_opt->is_vulkan() ? *bias_opt : bias_opt->vulkan();
@@ -94,9 +94,9 @@ Tensor layer_norm(
   api::Context* const context = api::context();
 
   vTensor v_output{
-    context,
-    v_input_sizes,
-    v_input.options(),
+      context,
+      v_input_sizes,
+      v_input.options(),
   };
 
   const struct Block final {
@@ -104,12 +104,11 @@ Tensor layer_norm(
     int32_t volume;
     int32_t last_texel_end_offset;
     float epsilon;
-  } block {
-    v_input.extents(),
-    safe_downcast<int32_t>(volume),
-    safe_downcast<int32_t>((v_input_sizes[input_arg.dim() - 3] - 1) % 4),
-    safe_downcast<float>(eps)
-  };
+  } block{
+      v_input.extents(),
+      safe_downcast<int32_t>(volume),
+      safe_downcast<int32_t>((v_input_sizes[input_arg.dim() - 3] - 1) % 4),
+      safe_downcast<float>(eps)};
 
   api::UniformParamsBuffer params(context, block);
   api::PipelineBarrier pipeline_barrier{};
@@ -117,11 +116,11 @@ Tensor layer_norm(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       VK_KERNEL(layernorm),
@@ -138,15 +137,9 @@ Tensor layer_norm(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_input.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      v_weight.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      v_bias.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_weight.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_bias.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 

--- a/aten/src/ATen/native/vulkan/ops/Lerp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Lerp.cpp
@@ -57,9 +57,9 @@ Tensor _lerp_scalar(
   const vTensor& v_end = convert(end);
 
   vTensor v_output{
-    context,
-    v_start.sizes(),
-    v_start.options(),
+      context,
+      v_start.sizes(),
+      v_start.options(),
   };
 
   const float weight = weight_arg.to<float>();
@@ -105,12 +105,8 @@ Tensor _lerp_scalar(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_start.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      v_end.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_start.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_end.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -172,9 +168,7 @@ Tensor& _lerp_scalar_(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
-      v_end.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_end.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -196,13 +190,14 @@ Tensor _lerp_tensor(
   const Tensor end = end_arg.is_vulkan() ? end_arg : end_arg.vulkan();
   const vTensor& v_end = convert(end);
 
-  const Tensor weight = weight_arg.is_vulkan() ? weight_arg : weight_arg.vulkan();
+  const Tensor weight =
+      weight_arg.is_vulkan() ? weight_arg : weight_arg.vulkan();
   const vTensor& v_weight = convert(weight_arg);
 
   vTensor v_output{
-    context,
-    v_start.sizes(),
-    v_start.options(),
+      context,
+      v_start.sizes(),
+      v_start.options(),
   };
 
   const struct Block final {
@@ -252,15 +247,9 @@ Tensor _lerp_tensor(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_start.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      v_end.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      v_weight.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_start.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_end.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_weight.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -285,7 +274,8 @@ Tensor& _lerp_tensor_(
   const Tensor end = end_arg.is_vulkan() ? end_arg : end_arg.vulkan();
   const vTensor& v_end = convert(end_arg);
 
-  const Tensor weight = weight_arg.is_vulkan() ? weight_arg : weight_arg.vulkan();
+  const Tensor weight =
+      weight_arg.is_vulkan() ? weight_arg : weight_arg.vulkan();
   const vTensor& v_weight = convert(weight_arg);
 
   const struct Block final {
@@ -330,12 +320,8 @@ Tensor& _lerp_tensor_(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
-      v_end.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      v_weight.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_end.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      v_weight.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -343,25 +329,27 @@ Tensor& _lerp_tensor_(
 }
 
 Tensor lerp_scalar(
-    const Tensor& start, const Tensor& end, const Scalar& weight) {
+    const Tensor& start,
+    const Tensor& end,
+    const Scalar& weight) {
   return _lerp_scalar(start, end, weight);
 }
 
-Tensor& lerp_scalar_(
-    Tensor& self, const Tensor& end, const Scalar& weight) {
+Tensor& lerp_scalar_(Tensor& self, const Tensor& end, const Scalar& weight) {
   return _lerp_scalar_(self, end, weight);
 }
 
 Tensor lerp_tensor(
-    const Tensor& start, const Tensor& end, const Tensor& weight) {
+    const Tensor& start,
+    const Tensor& end,
+    const Tensor& weight) {
   if (weight.sizes().size() == 0) {
     return _lerp_scalar(start, end, weight.item<float>());
   }
   return _lerp_tensor(start, end, weight);
 }
 
-Tensor& lerp_tensor_(
-    Tensor& self, const Tensor& end, const Tensor& weight) {
+Tensor& lerp_tensor_(Tensor& self, const Tensor& end, const Tensor& weight) {
   if (weight.sizes().size() == 0) {
     return _lerp_scalar_(self, end, weight.item<float>());
   }

--- a/aten/src/ATen/native/vulkan/ops/Lstm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Lstm.cpp
@@ -9,14 +9,19 @@ namespace vulkan {
 namespace ops {
 namespace {
 //
-// input_vk: input tensor of shape (L, N, H_in) when batch_first=False or (N, L, H_in) when batch_first=True
+// input_vk: input tensor of shape (L, N, H_in) when batch_first=False or (N, L,
+// H_in) when batch_first=True
 //           containing the features of the input sequence
-// hx_vk: tensor of shape (D * num_layers, N, H_out) containing the initial hidden state for each element in the input sequence.
-// cx_vk: tensor of shape (D * num_layers, N, H_cell) containing the initial cell state for each element in the input sequence.
-// output: tensor of shape (L, N, D * H_out) when batch_first=False or (N, L, D * H_out) when batch_first=True
-//         containing the output features (h_t) from the last layer of the LSTM, for each t
-// h_n: tensor of shape (D * num_layers, N, H_out) containing the final hidden state for each element in the sequence.
-// c_n: tensor of shape (D * num_layers, N, H_cell) containing the final cell state for each element in the sequence.
+// hx_vk: tensor of shape (D * num_layers, N, H_out) containing the initial
+// hidden state for each element in the input sequence. cx_vk: tensor of shape
+// (D * num_layers, N, H_cell) containing the initial cell state for each
+// element in the input sequence. output: tensor of shape (L, N, D * H_out) when
+// batch_first=False or (N, L, D * H_out) when batch_first=True
+//         containing the output features (h_t) from the last layer of the LSTM,
+//         for each t
+// h_n: tensor of shape (D * num_layers, N, H_out) containing the final hidden
+// state for each element in the sequence. c_n: tensor of shape (D * num_layers,
+// N, H_cell) containing the final cell state for each element in the sequence.
 //
 //  where
 //    L = sequence length
@@ -27,35 +32,51 @@ namespace {
 //    H_out = hidden_size
 //
 std::tuple<Tensor, Tensor, Tensor> lstm_input(
-  const Tensor & input_vk,  // input sequence (vulkan)
-  TensorList hx,    // initial hidden state (vulkan) & initial cell state (vulkan)
-  TensorList params_cpu,    // weights/biases (cpu)
-  bool has_biases,
-  int64_t num_layers,
-  double dropout,
-  bool train,
-  bool bidirectional,
-  bool batch_first) {
-  TORCH_CHECK(hx[0].size(2) == hx[1].size(2), "Vulkan LSTM with projections is not supported");
-  TORCH_CHECK(static_cast<int64_t>(params_cpu.size()), "Vulkan LSTM expects 'params_cpu' size to be 4 * 'num_layers'.");
-  TORCH_INTERNAL_ASSERT(input_vk.sizes().size() == 3, "Vulkan LSTM expects input dims to be 3.");
-  TORCH_INTERNAL_ASSERT(hx[0].sizes().size() == 3, "Vulkan LSTM expects hidden state dims to be 3.");
-  TORCH_INTERNAL_ASSERT(hx[1].sizes().size() == 3, "Vulkan LSTM expects cell state dims to be 3.");
-  TORCH_INTERNAL_ASSERT(has_biases, "Vulkan LSTM expects 'has_biases' to be true.");
+    const Tensor& input_vk, // input sequence (vulkan)
+    TensorList
+        hx, // initial hidden state (vulkan) & initial cell state (vulkan)
+    TensorList params_cpu, // weights/biases (cpu)
+    bool has_biases,
+    int64_t num_layers,
+    double dropout,
+    bool train,
+    bool bidirectional,
+    bool batch_first) {
+  TORCH_CHECK(
+      hx[0].size(2) == hx[1].size(2),
+      "Vulkan LSTM with projections is not supported");
+  TORCH_CHECK(
+      static_cast<int64_t>(params_cpu.size()),
+      "Vulkan LSTM expects 'params_cpu' size to be 4 * 'num_layers'.");
+  TORCH_INTERNAL_ASSERT(
+      input_vk.sizes().size() == 3, "Vulkan LSTM expects input dims to be 3.");
+  TORCH_INTERNAL_ASSERT(
+      hx[0].sizes().size() == 3,
+      "Vulkan LSTM expects hidden state dims to be 3.");
+  TORCH_INTERNAL_ASSERT(
+      hx[1].sizes().size() == 3,
+      "Vulkan LSTM expects cell state dims to be 3.");
+  TORCH_INTERNAL_ASSERT(
+      has_biases, "Vulkan LSTM expects 'has_biases' to be true.");
   TORCH_INTERNAL_ASSERT(!train, "Vulkan LSTM expects 'train' to be false.");
-  TORCH_INTERNAL_ASSERT(!bidirectional, "Vulkan LSTM expects 'bidirectional' to be false.");
-  TORCH_INTERNAL_ASSERT(batch_first, "Vulkan LSTM expects 'batch_first' to be true.");
-  TORCH_INTERNAL_ASSERT(dropout < std::numeric_limits<double>::epsilon()*1000, "Vulkan LSTM expects 'dropout' to be 0.0.");
+  TORCH_INTERNAL_ASSERT(
+      !bidirectional, "Vulkan LSTM expects 'bidirectional' to be false.");
+  TORCH_INTERNAL_ASSERT(
+      batch_first, "Vulkan LSTM expects 'batch_first' to be true.");
+  TORCH_INTERNAL_ASSERT(
+      dropout < std::numeric_limits<double>::epsilon() * 1000,
+      "Vulkan LSTM expects 'dropout' to be 0.0.");
 
   const Tensor& hx_vk = hx[0];
   const Tensor& cx_vk = hx[1];
 
   const auto hidden_size = hx_vk.size(2);
-  std::vector<at::Tensor> h_n_list;  // hidden state output
-  std::vector<at::Tensor> c_n_list;  // cell state output
+  std::vector<at::Tensor> h_n_list; // hidden state output
+  std::vector<at::Tensor> c_n_list; // cell state output
 
   // reshape to 2D due to Vulkan at::mm op accepts only 2D
-  auto x = input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
+  auto x =
+      input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
 
   h_n_list.reserve(num_layers);
   c_n_list.reserve(num_layers);
@@ -95,15 +116,21 @@ std::tuple<Tensor, Tensor, Tensor> lstm_input(
     const auto& b_hg = b_h_ifgo[2];
     const auto& b_ho = b_h_ifgo[3];
 
-    const auto& i = at::sigmoid(at::addmm(b_ii, x, w_ii.t()) + at::addmm(b_hi, h, w_hi.t()));
-    const auto& f = at::sigmoid(at::addmm(b_if, x, w_if.t()) + at::addmm(b_hf, h, w_hf.t()));
-    const auto& g = at::tanh(at::addmm(b_ig, x, w_ig.t()) + at::addmm(b_hg, h, w_hg.t()));
-    const auto& o = at::sigmoid(at::addmm(b_io, x, w_io.t()) + at::addmm(b_ho, h, w_ho.t()));
+    const auto& i = at::sigmoid(
+        at::addmm(b_ii, x, w_ii.t()) + at::addmm(b_hi, h, w_hi.t()));
+    const auto& f = at::sigmoid(
+        at::addmm(b_if, x, w_if.t()) + at::addmm(b_hf, h, w_hf.t()));
+    const auto& g =
+        at::tanh(at::addmm(b_ig, x, w_ig.t()) + at::addmm(b_hg, h, w_hg.t()));
+    const auto& o = at::sigmoid(
+        at::addmm(b_io, x, w_io.t()) + at::addmm(b_ho, h, w_ho.t()));
     c = f * c + i * g;
     h = o * at::tanh(c);
-    x = h;  // next input
-    h_n_list.emplace_back(h.reshape({1, 1, h.size(0), h.size(1)}));  // 2D to 4D for cat op
-    c_n_list.emplace_back(c.reshape({1, 1, c.size(0), c.size(1)}));  // 2D to 4D for cat op
+    x = h; // next input
+    h_n_list.emplace_back(
+        h.reshape({1, 1, h.size(0), h.size(1)})); // 2D to 4D for cat op
+    c_n_list.emplace_back(
+        c.reshape({1, 1, c.size(0), c.size(1)})); // 2D to 4D for cat op
   }
 
   auto h_n = at::cat(h_n_list, 1);
@@ -126,13 +153,13 @@ TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
 std::vector<c10::intrusive_ptr<VulkanOpContext>> pack_lstm_linear_op_contexts(
     const std::vector<Tensor>& params_cpu,
     int64_t num_layers) {
-  TORCH_CHECK(static_cast<int64_t>(params_cpu.size()) == 4 * num_layers,
-              "Vulkan LSTM expects 'params_cpu' size to be 4 * 'num_layers'.");
+  TORCH_CHECK(
+      static_cast<int64_t>(params_cpu.size()) == 4 * num_layers,
+      "Vulkan LSTM expects 'params_cpu' size to be 4 * 'num_layers'.");
   std::vector<c10::intrusive_ptr<VulkanOpContext>> linear_op_contexts;
   linear_op_contexts.reserve(num_layers * 8);
 
   for (int64_t l = 0; l < num_layers; ++l) {
-
     const auto& w_ih = params_cpu[l * 4];
     const auto& w_hh = params_cpu[l * 4 + 1];
     const auto& b_ih = params_cpu[l * 4 + 2];
@@ -181,16 +208,21 @@ VulkanOpContext lstm_context_create(
     bool train,
     bool bidirectional,
     bool batch_first) {
-
-  TORCH_INTERNAL_ASSERT(has_biases, "Vulkan LSTM expects 'has_biases' to be true.");
+  TORCH_INTERNAL_ASSERT(
+      has_biases, "Vulkan LSTM expects 'has_biases' to be true.");
   TORCH_INTERNAL_ASSERT(!train, "Vulkan LSTM expects 'train' to be false.");
-  TORCH_INTERNAL_ASSERT(!bidirectional, "Vulkan LSTM expects 'bidirectional' to be false.");
-  TORCH_INTERNAL_ASSERT(batch_first, "Vulkan LSTM expects 'batch_first' to be true.");
-  TORCH_INTERNAL_ASSERT(dropout < std::numeric_limits<double>::epsilon()*1000, "Vulkan LSTM expects 'dropout' to be 0.0.");
+  TORCH_INTERNAL_ASSERT(
+      !bidirectional, "Vulkan LSTM expects 'bidirectional' to be false.");
+  TORCH_INTERNAL_ASSERT(
+      batch_first, "Vulkan LSTM expects 'batch_first' to be true.");
+  TORCH_INTERNAL_ASSERT(
+      dropout < std::numeric_limits<double>::epsilon() * 1000,
+      "Vulkan LSTM expects 'dropout' to be 0.0.");
 
   c10::impl::GenericList packed_context{c10::AnyType::get()};
   packed_context.reserve(7);
-  packed_context.emplace_back(pack_lstm_linear_op_contexts(params_cpu, num_layers));
+  packed_context.emplace_back(
+      pack_lstm_linear_op_contexts(params_cpu, num_layers));
   packed_context.emplace_back(has_biases);
   packed_context.emplace_back(num_layers);
   packed_context.emplace_back(dropout);
@@ -212,24 +244,33 @@ VulkanOpContext lstm_context_create(
 }
 
 std::tuple<Tensor, Tensor, Tensor> lstm_context_run(
-    const Tensor& input_vk,      // input sequence (vulkan)
-    const Tensor& hx_vk,         // initial hidden state (vulkan)
-    const Tensor& cx_vk,         // initial cell state (vulkan)
+    const Tensor& input_vk, // input sequence (vulkan)
+    const Tensor& hx_vk, // initial hidden state (vulkan)
+    const Tensor& cx_vk, // initial cell state (vulkan)
     const c10::impl::GenericList& packed_context,
     const c10::impl::GenericList& unpacked_context) {
-  TORCH_INTERNAL_ASSERT(input_vk.sizes().size() == 3, "Vulkan LSTM expects input dims to be 3.");
-  TORCH_INTERNAL_ASSERT(hx_vk.sizes().size() == 3, "Vulkan LSTM expects hidden state dims to be 3.");
-  TORCH_INTERNAL_ASSERT(cx_vk.sizes().size() == 3, "Vulkan LSTM expects cell state dims to be 3.");
+  TORCH_INTERNAL_ASSERT(
+      input_vk.sizes().size() == 3, "Vulkan LSTM expects input dims to be 3.");
+  TORCH_INTERNAL_ASSERT(
+      hx_vk.sizes().size() == 3,
+      "Vulkan LSTM expects hidden state dims to be 3.");
+  TORCH_INTERNAL_ASSERT(
+      cx_vk.sizes().size() == 3,
+      "Vulkan LSTM expects cell state dims to be 3.");
 
-  const c10::List<c10::IValue> packed_linear_op_contexts = packed_context.get(0).toList();
+  const c10::List<c10::IValue> packed_linear_op_contexts =
+      packed_context.get(0).toList();
   const int64_t packed_num_layers = packed_context.get(2).toInt();
 
-  const int64_t linear_op_contexts_per_layer = 8;   // (b_ii, w_ii), (b_hi, w_hi), (b_if, w_if), (b_hf, w_hf), (b_ig, w_ig), (b_hg, w_hg), (b_io, w_io), (b_ho, w_ho)
-  std::vector<at::Tensor> h_n_list;  // hidden state output
-  std::vector<at::Tensor> c_n_list;  // cell state output
+  const int64_t linear_op_contexts_per_layer =
+      8; // (b_ii, w_ii), (b_hi, w_hi), (b_if, w_if), (b_hf, w_hf), (b_ig,
+         // w_ig), (b_hg, w_hg), (b_io, w_io), (b_ho, w_ho)
+  std::vector<at::Tensor> h_n_list; // hidden state output
+  std::vector<at::Tensor> c_n_list; // cell state output
 
   // reshape to 2D due to Vulkan at::mm op accepts only 2D
-  auto x = input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
+  auto x =
+      input_vk.reshape({input_vk.size(0) * input_vk.size(1), input_vk.size(2)});
 
   h_n_list.reserve(packed_num_layers);
   c_n_list.reserve(packed_num_layers);
@@ -242,32 +283,58 @@ std::tuple<Tensor, Tensor, Tensor> lstm_context_run(
     auto c = at::slice(cx_vk, 0, l, l + 1, 1);
     c = c.reshape({c.size(0) * c.size(1), c.size(2)});
 
-    const auto&  cxt_ii = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 0].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_hi = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 1].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_if = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 2].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_hf = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 3].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_ig = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 4].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_hg = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 5].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_io = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 6].toCustomClass<VulkanOpContext>();
-    const auto&  cxt_ho = packed_linear_op_contexts[l * linear_op_contexts_per_layer + 7].toCustomClass<VulkanOpContext>();
+    const auto& cxt_ii =
+        packed_linear_op_contexts[l * linear_op_contexts_per_layer + 0]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_hi =
+        packed_linear_op_contexts[l * linear_op_contexts_per_layer + 1]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_if =
+        packed_linear_op_contexts[l * linear_op_contexts_per_layer + 2]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_hf =
+        packed_linear_op_contexts[l * linear_op_contexts_per_layer + 3]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_ig =
+        packed_linear_op_contexts[l * linear_op_contexts_per_layer + 4]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_hg =
+        packed_linear_op_contexts[l * linear_op_contexts_per_layer + 5]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_io =
+        packed_linear_op_contexts[l * linear_op_contexts_per_layer + 6]
+            .toCustomClass<VulkanOpContext>();
+    const auto& cxt_ho =
+        packed_linear_op_contexts[l * linear_op_contexts_per_layer + 7]
+            .toCustomClass<VulkanOpContext>();
 
-    const auto&  i = at::sigmoid(
-      linear_context_run(x, cxt_ii->get_packed(), cxt_ii->get_unpacked(), 1.0f, 1.0f)
-       + linear_context_run(h, cxt_hi->get_packed(), cxt_hi->get_unpacked(), 1.0f, 1.0f));
-    const auto&  f = at::sigmoid(
-      linear_context_run(x, cxt_if->get_packed(), cxt_if->get_unpacked(), 1.0f, 1.0f)
-       + linear_context_run(h, cxt_hf->get_packed(), cxt_hf->get_unpacked(), 1.0f, 1.0f));
-    const auto&  g = at::tanh(
-      linear_context_run(x, cxt_ig->get_packed(), cxt_ig->get_unpacked(), 1.0f, 1.0f)
-       + linear_context_run(h, cxt_hg->get_packed(), cxt_hg->get_unpacked(), 1.0f, 1.0f));
-    const auto&  o = at::sigmoid(
-      linear_context_run(x, cxt_io->get_packed(), cxt_io->get_unpacked(), 1.0f, 1.0f)
-       + linear_context_run(h, cxt_ho->get_packed(), cxt_ho->get_unpacked(), 1.0f, 1.0f));
+    const auto& i = at::sigmoid(
+        linear_context_run(
+            x, cxt_ii->get_packed(), cxt_ii->get_unpacked(), 1.0f, 1.0f) +
+        linear_context_run(
+            h, cxt_hi->get_packed(), cxt_hi->get_unpacked(), 1.0f, 1.0f));
+    const auto& f = at::sigmoid(
+        linear_context_run(
+            x, cxt_if->get_packed(), cxt_if->get_unpacked(), 1.0f, 1.0f) +
+        linear_context_run(
+            h, cxt_hf->get_packed(), cxt_hf->get_unpacked(), 1.0f, 1.0f));
+    const auto& g = at::tanh(
+        linear_context_run(
+            x, cxt_ig->get_packed(), cxt_ig->get_unpacked(), 1.0f, 1.0f) +
+        linear_context_run(
+            h, cxt_hg->get_packed(), cxt_hg->get_unpacked(), 1.0f, 1.0f));
+    const auto& o = at::sigmoid(
+        linear_context_run(
+            x, cxt_io->get_packed(), cxt_io->get_unpacked(), 1.0f, 1.0f) +
+        linear_context_run(
+            h, cxt_ho->get_packed(), cxt_ho->get_unpacked(), 1.0f, 1.0f));
     c = f * c + i * g;
     h = o * at::tanh(c);
-    x = h;  // next input
-    h_n_list.emplace_back(h.reshape({1, 1, h.size(0), h.size(1)}));  // 2D to 4D for cat op
-    c_n_list.emplace_back(c.reshape({1, 1, c.size(0), c.size(1)}));  // 2D to 4D for cat op
+    x = h; // next input
+    h_n_list.emplace_back(
+        h.reshape({1, 1, h.size(0), h.size(1)})); // 2D to 4D for cat op
+    c_n_list.emplace_back(
+        c.reshape({1, 1, c.size(0), c.size(1)})); // 2D to 4D for cat op
   }
 
   auto h_n = at::cat(h_n_list, 1);
@@ -286,20 +353,26 @@ c10::intrusive_ptr<VulkanOpContext> create_lstm_context(
     bool bidirectional,
     bool batch_first) {
   return c10::make_intrusive<VulkanOpContext>(lstm_context_create(
-      params_cpu, has_biases, num_layers, dropout, train, bidirectional, batch_first));
+      params_cpu,
+      has_biases,
+      num_layers,
+      dropout,
+      train,
+      bidirectional,
+      batch_first));
 }
 
 std::tuple<Tensor, Tensor, Tensor> run_lstm_context(
-    const Tensor& input_vk,      // input sequence (vulkan)
-    const Tensor& hx_vk,         // initial hidden state (vulkan)
-    const Tensor& cx_vk,         // initial cell state (vulkan)
+    const Tensor& input_vk, // input sequence (vulkan)
+    const Tensor& hx_vk, // initial hidden state (vulkan)
+    const Tensor& cx_vk, // initial cell state (vulkan)
     const c10::intrusive_ptr<VulkanOpContext>& vulkan_context) {
   return lstm_context_run(
-    input_vk,
-    hx_vk,
-    cx_vk,
-    vulkan_context->get_packed(),
-    vulkan_context->get_unpacked());
+      input_vk,
+      hx_vk,
+      cx_vk,
+      vulkan_context->get_packed(),
+      vulkan_context->get_unpacked());
 }
 
 } // namespace ops

--- a/aten/src/ATen/native/vulkan/ops/Lstm.h
+++ b/aten/src/ATen/native/vulkan/ops/Lstm.h
@@ -12,10 +12,42 @@ namespace vulkan {
 namespace ops {
 
 //   packed
-//     std::vector<c10::intrusive_ptr<VulkanOpContext>> linear_op_contexts;  // {{ op context for b_ii, w_ii, op context for b_hi, w_hi,
-//                                                                           //    op context for b_if, w_if, op context for b_hf, w_hf,
-//                                                                           //    op context for b_ig, w_ig, op context for b_hg, w_hg,
-//                                                                           //    op context for b_io, w_io, op context for b_ho, w_ho,}, ...}
+//     std::vector<c10::intrusive_ptr<VulkanOpContext>> linear_op_contexts;  //
+//     {{ op context for b_ii, w_ii, op context for b_hi, w_hi,
+//                                                                           //
+//                                                                           op
+//                                                                           context
+//                                                                           for
+//                                                                           b_if,
+//                                                                           w_if,
+//                                                                           op
+//                                                                           context
+//                                                                           for
+//                                                                           b_hf,
+//                                                                           w_hf,
+//                                                                           //
+//                                                                           op
+//                                                                           context
+//                                                                           for
+//                                                                           b_ig,
+//                                                                           w_ig,
+//                                                                           op
+//                                                                           context
+//                                                                           for
+//                                                                           b_hg,
+//                                                                           w_hg,
+//                                                                           //
+//                                                                           op
+//                                                                           context
+//                                                                           for
+//                                                                           b_io,
+//                                                                           w_io,
+//                                                                           op
+//                                                                           context
+//                                                                           for
+//                                                                           b_ho,
+//                                                                           w_ho,},
+//                                                                           ...}
 //     bool has_biases{};
 //     int64_t num_layers{};
 //     double dropout{};
@@ -33,7 +65,7 @@ namespace ops {
 //     bool batch_first
 
 c10::intrusive_ptr<VulkanOpContext> create_lstm_context(
-    std::vector<Tensor>&& params_cpu,   // weights/biases (cpu)
+    std::vector<Tensor>&& params_cpu, // weights/biases (cpu)
     bool has_biases,
     int64_t num_layers,
     double dropout,
@@ -42,9 +74,9 @@ c10::intrusive_ptr<VulkanOpContext> create_lstm_context(
     bool batch_first);
 
 std::tuple<Tensor, Tensor, Tensor> run_lstm_context(
-    const Tensor& input_vk,      // input sequence (vulkan)
-    const Tensor& hx_vk,         // initial hidden state (vulkan)
-    const Tensor& cx_vk,         // initial cell state (vulkan)
+    const Tensor& input_vk, // input sequence (vulkan)
+    const Tensor& hx_vk, // initial hidden state (vulkan)
+    const Tensor& cx_vk, // initial cell state (vulkan)
     const c10::intrusive_ptr<VulkanOpContext>& vulkan_context);
 
 } // namespace ops

--- a/aten/src/ATen/native/vulkan/ops/Mean.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mean.cpp
@@ -15,9 +15,7 @@ Tensor mean(
     const IntArrayRef dim,
     const bool keepdim,
     const optional<ScalarType> dtype) {
-  TORCH_CHECK(
-      input_arg.dim() == 4,
-      "Vulkan mean expects 4-dimensional input!");
+  TORCH_CHECK(input_arg.dim() == 4, "Vulkan mean expects 4-dimensional input!");
 
   static const std::unordered_set<int64_t> expected_dims_set({2, 3});
   std::unordered_set<int64_t> dims_set;
@@ -38,8 +36,8 @@ Tensor mean(
   const IntArrayRef v_input_sizes = v_input.sizes();
 
   c10::SmallVector<int64_t, 4u> output_sizes{
-    v_input_sizes[Layout::Activation4D::batch],
-    v_input_sizes[Layout::Activation4D::channels],
+      v_input_sizes[Layout::Activation4D::batch],
+      v_input_sizes[Layout::Activation4D::channels],
   };
 
   if (keepdim) {
@@ -48,22 +46,21 @@ Tensor mean(
   }
 
   vTensor v_output{
-    context,
-    output_sizes,
-    v_input.options(),
+      context,
+      output_sizes,
+      v_input.options(),
   };
 
   const struct Block final {
     uvec3 extents;
     int32_t range;
     uvec3 iextents;
-  } block {
-    v_output.extents(),
-    safe_downcast<int32_t>(
-        v_input_sizes[Layout::Activation4D::width] *
-        v_input_sizes[Layout::Activation4D::height]),
-    v_input.extents()
-  };
+  } block{
+      v_output.extents(),
+      safe_downcast<int32_t>(
+          v_input_sizes[Layout::Activation4D::width] *
+          v_input_sizes[Layout::Activation4D::height]),
+      v_input.extents()};
 
   api::UniformParamsBuffer params(context, block);
   api::PipelineBarrier pipeline_barrier{};
@@ -71,9 +68,9 @@ Tensor mean(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       keepdim ? VK_KERNEL(mean) : VK_KERNEL(mean2d),
@@ -90,9 +87,7 @@ Tensor mean(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_input.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 

--- a/aten/src/ATen/native/vulkan/ops/Mm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mm.cpp
@@ -1,6 +1,6 @@
 #include <ATen/native/vulkan/ops/Mm.h>
-#include <ATen/native/vulkan/ops/VulkanOpContext.h>
 #include <ATen/native/vulkan/ops/Utils.h>
+#include <ATen/native/vulkan/ops/VulkanOpContext.h>
 #include <c10/util/irange.h>
 
 namespace at {
@@ -12,8 +12,7 @@ namespace {
 using namespace api::utils;
 using namespace at::native::vulkan::ops;
 
-vTensor pack_weights(
-    const Tensor& weight_arg) {
+vTensor pack_weights(const Tensor& weight_arg) {
   if (weight_arg.is_vulkan()) {
     return convert(weight_arg);
   }
@@ -36,9 +35,9 @@ vTensor pack_weights(
   vTensor v_weight{
       context,
       {
-        4,
-        dst_kh_sz,
-        dst_kw_sz,
+          4,
+          dst_kh_sz,
+          dst_kw_sz,
       },
       weight.options(),
   };
@@ -53,8 +52,8 @@ vTensor pack_weights(
 
     for (const auto src_h : c10::irange(src_kh_sz)) {
       for (const auto src_w : c10::irange(src_kw_sz)) {
-        int64_t dst_plane = 2*(src_h%2) + (src_w%2);
-        int64_t dst_index = (src_h/2)*dst_kw_sz + (src_w/2);
+        int64_t dst_plane = 2 * (src_h % 2) + (src_w % 2);
+        int64_t dst_index = (src_h / 2) * dst_kw_sz + (src_w / 2);
         memcpy(
             dst_weight_ptr + dst_plane * dst_plane_sz + dst_index,
             src_weight_ptr + src_h * src_kw_sz + src_w,
@@ -86,8 +85,7 @@ vTensor pack_biases(
     if (bias.sizes().size() == 2) {
       src_kw_sz = b_sizes[Layout::Parameter::width];
       src_kh_sz = b_sizes[Layout::Parameter::height];
-    }
-    else {
+    } else {
       src_kw_sz = b_sizes[Layout::Parameter::height];
       src_kh_sz = 1;
     }
@@ -100,9 +98,9 @@ vTensor pack_biases(
     vTensor v_bias{
         context,
         {
-          4,
-          dst_kh_sz,
-          dst_kw_sz,
+            4,
+            dst_kh_sz,
+            dst_kw_sz,
         },
         bias_arg->options(),
     };
@@ -117,8 +115,8 @@ vTensor pack_biases(
 
       for (const auto src_h : c10::irange(src_kh_sz)) {
         for (const auto src_w : c10::irange(src_kw_sz)) {
-          int64_t dst_plane = 2*(src_h%2) + (src_w%2);
-          int64_t dst_index = (src_h/2)*dst_kw_sz + (src_w/2);
+          int64_t dst_plane = 2 * (src_h % 2) + (src_w % 2);
+          int64_t dst_index = (src_h / 2) * dst_kw_sz + (src_w / 2);
           memcpy(
               dst_bias_ptr + dst_plane * dst_plane_sz + dst_index,
               src_bias_ptr + src_h * src_kw_sz + src_w,
@@ -129,8 +127,7 @@ vTensor pack_biases(
     utils::pack_staging_to_vtensor(staging.buffer(), v_bias);
 
     return v_bias;
-  }
-  else {
+  } else {
     vTensor v_bias{
         api::context(),
         {1},
@@ -157,30 +154,28 @@ vTensor pack_biases(
   }
 }
 
-bool available(
-    const Tensor& weight,
-    const c10::optional<Tensor>& bias) {
+bool available(const Tensor& weight, const c10::optional<Tensor>& bias) {
   return api::available() &&
-         // Weight
-         (2 == weight.ndimension()) &&
-         (weight.size(Layout::Parameter::height) > 0) &&
-         (weight.size(Layout::Parameter::width) > 0) &&
-         ((weight.device().is_cpu()) ||
-          (c10::DeviceType::Vulkan == weight.device().type())) &&
-         (kFloat == weight.scalar_type()) &&
-         !weight.requires_grad() &&
-         // Bias
-         ((bias && bias->defined()) ? ((bias->ndimension() > 0) &&
-                                       ((bias->device().is_cpu()) ||
-                                        (c10::DeviceType::Vulkan == bias->device().type())) &&
-                                       (kFloat == bias->scalar_type()) &&
-                                       ((bias->ndimension() > 1) ?
-                                            (bias->size(Layout::Parameter::width) ==
-                                                weight.size(Layout::Parameter::width))
-                                            : true) &&
-                                       !bias->requires_grad())
-                                    : true) &&
-         true;
+      // Weight
+      (2 == weight.ndimension()) &&
+      (weight.size(Layout::Parameter::height) > 0) &&
+      (weight.size(Layout::Parameter::width) > 0) &&
+      ((weight.device().is_cpu()) ||
+       (c10::DeviceType::Vulkan == weight.device().type())) &&
+      (kFloat == weight.scalar_type()) && !weight.requires_grad() &&
+      // Bias
+      ((bias && bias->defined())
+           ? ((bias->ndimension() > 0) &&
+              ((bias->device().is_cpu()) ||
+               (c10::DeviceType::Vulkan == bias->device().type())) &&
+              (kFloat == bias->scalar_type()) &&
+              ((bias->ndimension() > 1)
+                   ? (bias->size(Layout::Parameter::width) ==
+                      weight.size(Layout::Parameter::width))
+                   : true) &&
+              !bias->requires_grad())
+           : true) &&
+      true;
 }
 
 bool usable(
@@ -188,12 +183,11 @@ bool usable(
     const Tensor& weight,
     const c10::optional<Tensor>& /* bias */) {
   return (2 == input.ndimension()) &&
-         (c10::DeviceType::Vulkan == input.device().type()) &&
-         (kFloat == input.scalar_type()) &&
-         (input.size(Layout::Parameter::width) ==
-              weight.size(Layout::Parameter::height)) &&
-         !input.requires_grad() &&
-         true;
+      (c10::DeviceType::Vulkan == input.device().type()) &&
+      (kFloat == input.scalar_type()) &&
+      (input.size(Layout::Parameter::width) ==
+       weight.size(Layout::Parameter::height)) &&
+      !input.requires_grad() && true;
 }
 
 VulkanOpContext context_create(
@@ -232,8 +226,9 @@ Tensor context_run(
   const vTensor& packed_v_weight = convert(packed_context.get(0).toTensor());
   const vTensor& packed_v_bias = convert(packed_context.get(1).toTensor());
   const Tensor& unpacked_weight = unpacked_context.get(0).toTensor();
-  const c10::optional<Tensor>& unpacked_bias
-   = unpacked_context.get(1).isTensor() ? unpacked_context.get(1).toTensor() : c10::optional<Tensor>();
+  const c10::optional<Tensor>& unpacked_bias =
+      unpacked_context.get(1).isTensor() ? unpacked_context.get(1).toTensor()
+                                         : c10::optional<Tensor>();
 
   TORCH_CHECK(
       usable(input, unpacked_weight, unpacked_bias),
@@ -242,11 +237,11 @@ Tensor context_run(
       "combination with the provided weight and bias tensors are unsupported by "
       "Vulkan impl.");
 
-  vTensor v_output {
+  vTensor v_output{
       context,
       {
-        v_input.sizes()[Layout::Parameter::height],
-        unpacked_weight.sizes()[Layout::Parameter::width],
+          v_input.sizes()[Layout::Parameter::height],
+          unpacked_weight.sizes()[Layout::Parameter::width],
       },
       input.options(),
   };
@@ -256,12 +251,13 @@ Tensor context_run(
       uvec3 size;
       int32_t K;
       vec2 multiplier;
-    } block {
+    } block{
         v_output.extents(),
-        safe_downcast<int32_t>(div_up(v_input.sizes()[Layout::Parameter::width], INT64_C(2))),
+        safe_downcast<int32_t>(
+            div_up(v_input.sizes()[Layout::Parameter::width], INT64_C(2))),
         {
-          alpha,
-          beta,
+            alpha,
+            beta,
         },
     };
 
@@ -283,9 +279,11 @@ Tensor context_run(
         pipeline_barrier,
         // global work group size
         {
-          safe_downcast<uint32_t>(div_up(unpacked_weight.sizes()[Layout::Parameter::width], INT64_C(2))),
-          safe_downcast<uint32_t>(div_up(v_input.sizes()[Layout::Parameter::height], INT64_C(2))),
-          1,
+            safe_downcast<uint32_t>(div_up(
+                unpacked_weight.sizes()[Layout::Parameter::width], INT64_C(2))),
+            safe_downcast<uint32_t>(
+                div_up(v_input.sizes()[Layout::Parameter::height], INT64_C(2))),
+            1,
         },
         // local work group size
         {8, 8, 1},
@@ -296,25 +294,19 @@ Tensor context_run(
             pipeline_barrier,
             api::PipelineStage::COMPUTE,
             api::MemoryAccessType::WRITE),
-        v_input.image(
-            pipeline_barrier,
-            api::PipelineStage::COMPUTE),
-        packed_v_weight.image(
-            pipeline_barrier,
-            api::PipelineStage::COMPUTE),
-        packed_v_bias.image(
-            pipeline_barrier,
-            api::PipelineStage::COMPUTE),
+        v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+        packed_v_weight.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+        packed_v_bias.image(pipeline_barrier, api::PipelineStage::COMPUTE),
         // params buffer
         params.buffer());
-  }
-  else {
+  } else {
     const struct {
       uvec3 size;
       int32_t K;
-    } block_no_bias {
+    } block_no_bias{
         v_output.extents(),
-        safe_downcast<int32_t>(div_up(v_input.sizes()[Layout::Parameter::width], INT64_C(2))),
+        safe_downcast<int32_t>(
+            div_up(v_input.sizes()[Layout::Parameter::width], INT64_C(2))),
     };
 
     api::UniformParamsBuffer params(context, block_no_bias);
@@ -334,9 +326,11 @@ Tensor context_run(
         pipeline_barrier,
         // global work group size
         {
-          safe_downcast<uint32_t>(div_up(unpacked_weight.sizes()[Layout::Parameter::width], INT64_C(2))),
-          safe_downcast<uint32_t>(div_up(v_input.sizes()[Layout::Parameter::height], INT64_C(2))),
-          1,
+            safe_downcast<uint32_t>(div_up(
+                unpacked_weight.sizes()[Layout::Parameter::width], INT64_C(2))),
+            safe_downcast<uint32_t>(
+                div_up(v_input.sizes()[Layout::Parameter::height], INT64_C(2))),
+            1,
         },
         // local work group size
         {8, 8, 1},
@@ -347,12 +341,8 @@ Tensor context_run(
             pipeline_barrier,
             api::PipelineStage::COMPUTE,
             api::MemoryAccessType::WRITE),
-        v_input.image(
-            pipeline_barrier,
-            api::PipelineStage::COMPUTE),
-        packed_v_weight.image(
-            pipeline_barrier,
-            api::PipelineStage::COMPUTE),
+        v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+        packed_v_weight.image(pipeline_barrier, api::PipelineStage::COMPUTE),
         // params buffer
         params.buffer());
   }
@@ -366,31 +356,26 @@ Tensor addmm(
     const Tensor& weight,
     const Scalar& beta,
     const Scalar& alpha) {
-
   VulkanOpContext vulkan_context = context_create(weight, bias);
 
   return context_run(
-    input,
-    vulkan_context.get_packed(),
-    vulkan_context.get_unpacked(),
-    alpha.to<float>(),
-    beta.to<float>());
+      input,
+      vulkan_context.get_packed(),
+      vulkan_context.get_unpacked(),
+      alpha.to<float>(),
+      beta.to<float>());
 }
 
-Tensor mm(
-    const Tensor& mat1_arg,
-    const Tensor& mat2_arg) {
-
-  VulkanOpContext vulkan_context = context_create(
-    mat2_arg,
-    c10::optional<Tensor>());
+Tensor mm(const Tensor& mat1_arg, const Tensor& mat2_arg) {
+  VulkanOpContext vulkan_context =
+      context_create(mat2_arg, c10::optional<Tensor>());
 
   return context_run(
-    mat1_arg,
-    vulkan_context.get_packed(),
-    vulkan_context.get_unpacked(),
-    1.0f,
-    1.0f);
+      mat1_arg,
+      vulkan_context.get_packed(),
+      vulkan_context.get_unpacked(),
+      1.0f,
+      1.0f);
 }
 
 #ifdef USE_VULKAN_API
@@ -423,35 +408,28 @@ c10::intrusive_ptr<VulkanOpContext> create_linear_context(
     Tensor&& weight,
     c10::optional<Tensor>&& bias) {
   return c10::make_intrusive<VulkanOpContext>(
-      linear_context_create(
-          weight,
-          bias));
+      linear_context_create(weight, bias));
 }
 
 Tensor run_linear_context(
     const Tensor& input,
     const c10::intrusive_ptr<VulkanOpContext>& vulkan_context) {
   return linear_context_run(
-    input,
-    vulkan_context->get_packed(),
-    vulkan_context->get_unpacked(),
-    1.0,
-    1.0);
+      input,
+      vulkan_context->get_packed(),
+      vulkan_context->get_unpacked(),
+      1.0,
+      1.0);
 }
 
 /* Backwards compatibility */
 LinearOpContext::LinearOpContext(VulkanOpContext vulkan_context)
-  : vulkan_context_{std::move(vulkan_context)} {
-}
+    : vulkan_context_{std::move(vulkan_context)} {}
 
 LinearOpContext LinearOpContext::create(
     const Tensor& weight,
     const c10::optional<Tensor>& bias) {
-  return LinearOpContext {
-      linear_context_create(
-        weight,
-        bias)
-  };
+  return LinearOpContext{linear_context_create(weight, bias)};
 }
 
 Tensor LinearOpContext::run(
@@ -459,31 +437,28 @@ Tensor LinearOpContext::run(
     const float alpha,
     const float beta) const {
   return linear_context_run(
-    input_arg,
-    vulkan_context_.get_packed(),
-    vulkan_context_.get_unpacked(),
-    alpha,
-    beta);
+      input_arg,
+      vulkan_context_.get_packed(),
+      vulkan_context_.get_unpacked(),
+      alpha,
+      beta);
 }
 
 LinearOpContext::State LinearOpContext::unpack() const {
-  const c10::impl::GenericList unpacked_ = std::get<1>(vulkan_context_.get_state());
+  const c10::impl::GenericList unpacked_ =
+      std::get<1>(vulkan_context_.get_state());
   const Tensor unpacked_weight = unpacked_.get(0).toTensor();
-  const c10::optional<Tensor> unpacked_bias
-   = unpacked_.get(1).isTensor() ? unpacked_.get(1).toTensor() : c10::optional<Tensor>();
-  return LinearOpContext::State{
-    unpacked_weight,
-    unpacked_bias
-  };
+  const c10::optional<Tensor> unpacked_bias = unpacked_.get(1).isTensor()
+      ? unpacked_.get(1).toTensor()
+      : c10::optional<Tensor>();
+  return LinearOpContext::State{unpacked_weight, unpacked_bias};
 }
 
 c10::intrusive_ptr<LinearOpContext> linear_prepack(
     Tensor&& weight,
     c10::optional<Tensor>&& bias) {
   return c10::make_intrusive<LinearOpContext>(
-      LinearOpContext::create(
-          std::move(weight),
-          std::move(bias)));
+      LinearOpContext::create(std::move(weight), std::move(bias)));
 }
 
 Tensor linear_run(

--- a/aten/src/ATen/native/vulkan/ops/Padding.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Padding.cpp
@@ -62,12 +62,10 @@ Tensor pad2d(
   } block{
       v_output.extents(),
       0u,
-      {
-        safe_downcast<uint32_t>(pad_left),
-        safe_downcast<uint32_t>(pad_right),
-        safe_downcast<uint32_t>(pad_top),
-        safe_downcast<uint32_t>(pad_bottom)
-      },
+      {safe_downcast<uint32_t>(pad_left),
+       safe_downcast<uint32_t>(pad_right),
+       safe_downcast<uint32_t>(pad_top),
+       safe_downcast<uint32_t>(pad_bottom)},
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -95,9 +93,7 @@ Tensor pad2d(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -115,8 +111,12 @@ Tensor replication_pad2d(const Tensor& self_arg, IntArrayRef padding) {
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
-  m.impl(TORCH_SELECTIVE_NAME("aten::reflection_pad2d"), TORCH_FN(reflection_pad2d));
-  m.impl(TORCH_SELECTIVE_NAME("aten::replication_pad2d"), TORCH_FN(replication_pad2d));
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::reflection_pad2d"),
+      TORCH_FN(reflection_pad2d));
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::replication_pad2d"),
+      TORCH_FN(replication_pad2d));
 }
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/ops/Permute.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Permute.cpp
@@ -21,21 +21,21 @@ Tensor permute_4d(
   const vTensor& v_self = convert(input);
 
   const struct Block final {
-    uvec3 size;                // output texture size
-    uint32_t fill_0;           // dummy
-    uvec3 isize;               // input texture size
-    uint32_t fill_1;           // dummy
-    uvec4 tensor_size;         // output tensor size
-    uvec4 itensor_size;        // input tensor size
-    uvec4 dims;                // output dims
-  } block {
-    v_output.extents(),
-    0u,
-    v_self.extents(),
-    0u,
-    out_size,
-    in_size,
-    out_dims,
+    uvec3 size; // output texture size
+    uint32_t fill_0; // dummy
+    uvec3 isize; // input texture size
+    uint32_t fill_1; // dummy
+    uvec4 tensor_size; // output tensor size
+    uvec4 itensor_size; // input tensor size
+    uvec4 dims; // output dims
+  } block{
+      v_output.extents(),
+      0u,
+      v_self.extents(),
+      0u,
+      out_size,
+      in_size,
+      out_dims,
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -44,9 +44,9 @@ Tensor permute_4d(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       VK_KERNEL(permute_4d),
@@ -63,9 +63,7 @@ Tensor permute_4d(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::READ | api::MemoryAccessType::WRITE),
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -74,8 +72,8 @@ Tensor permute_4d(
 
 Tensor permute(const Tensor& self, IntArrayRef dims) {
   auto nDims = safe_downcast<uint32_t>(self.dim());
-  TORCH_CHECK(dims.size() == (size_t)nDims,
-           "number of dims don't match in permute");
+  TORCH_CHECK(
+      dims.size() == (size_t)nDims, "number of dims don't match in permute");
 
   uvec4 in_size{1u, 1u, 1u, 1u}, out_size{1u, 1u, 1u, 1u};
   uvec4 out_dims{0u, 1u, 2u, 3u};
@@ -86,8 +84,7 @@ Tensor permute(const Tensor& self, IntArrayRef dims) {
   std::vector<bool> seen(nDims);
   for (const auto i : c10::irange(nDims)) {
     auto dim = safe_downcast<uint32_t>(maybe_wrap_dim(dims[i], nDims));
-    TORCH_CHECK(!seen[dim],
-             "repeated dim in permute");
+    TORCH_CHECK(!seen[dim], "repeated dim in permute");
     seen[dim] = true;
     newSizes[i] = oldSizes[dim];
     if (dim != i) {
@@ -103,10 +100,7 @@ Tensor permute(const Tensor& self, IntArrayRef dims) {
     return self;
   }
 
-  vTensor v_output{
-    api::context(),
-    newSizes,
-    self.options()};
+  vTensor v_output{api::context(), newSizes, self.options()};
 
   return permute_4d(self, in_size, out_size, out_dims, v_output);
 }

--- a/aten/src/ATen/native/vulkan/ops/Pool.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Pool.cpp
@@ -1,5 +1,5 @@
-#include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/Pool.h>
+#include <ATen/native/vulkan/ops/Common.h>
 #include <torch/library.h>
 
 namespace at {
@@ -23,22 +23,22 @@ Tensor adaptive_avg_pool2d(
   const vTensor& v_self = convert(self);
 
   vTensor v_output{
-    context,
-    {
-      self_arg.size(Layout::Activation4D::batch),
-      self_arg.size(Layout::Activation4D::channels),
-      output_size[Layout::Activation4D::batch],
-      output_size[Layout::Activation4D::channels],
-    },
-    v_self.options(),
+      context,
+      {
+          self_arg.size(Layout::Activation4D::batch),
+          self_arg.size(Layout::Activation4D::channels),
+          output_size[Layout::Activation4D::batch],
+          output_size[Layout::Activation4D::channels],
+      },
+      v_self.options(),
   };
 
   const uvec3 v_output_size = v_output.extents();
   const uvec3 v_self_size = v_self.extents();
 
-  const vec2 stride {
-    static_cast<float>(v_self_size.data[0u]) / v_output_size.data[0u],
-    static_cast<float>(v_self_size.data[1u]) / v_output_size.data[1u],
+  const vec2 stride{
+      static_cast<float>(v_self_size.data[0u]) / v_output_size.data[0u],
+      static_cast<float>(v_self_size.data[1u]) / v_output_size.data[1u],
   };
 
   const struct Block final {
@@ -46,14 +46,16 @@ Tensor adaptive_avg_pool2d(
     uint32_t _;
     vec2 kernel;
     vec2 stride;
-  } block {
-    v_output.extents(),
-    0u,
-    {
-      v_self_size.data[0u] - (v_output_size.data[0u] - 1u) * stride.data[0u],
-      v_self_size.data[1u] - (v_output_size.data[1u] - 1u) * stride.data[1u],
-    },
-    stride,
+  } block{
+      v_output.extents(),
+      0u,
+      {
+          v_self_size.data[0u] -
+              (v_output_size.data[0u] - 1u) * stride.data[0u],
+          v_self_size.data[1u] -
+              (v_output_size.data[1u] - 1u) * stride.data[1u],
+      },
+      stride,
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -62,9 +64,9 @@ Tensor adaptive_avg_pool2d(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       VK_KERNEL(adaptive_avg_pool2d),
@@ -81,9 +83,7 @@ Tensor adaptive_avg_pool2d(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -108,8 +108,8 @@ Tensor pool2d(
 
   static const auto normalize = [](const IntArrayRef parameter) {
     return std::array<int64_t, 2>{
-      parameter[0],
-      (2 == parameter.size()) ? parameter[1] : parameter[0],
+        parameter[0],
+        (2 == parameter.size()) ? parameter[1] : parameter[0],
     };
   };
 
@@ -158,14 +158,14 @@ Tensor pool2d(
   const vTensor& v_self = convert(self);
 
   vTensor v_output{
-    context,
-    {
-      input_size[Layout::Activation4D::batch],
-      input_size[Layout::Activation4D::channels],
-      output_height,
-      output_width,
-    },
-    v_self.options(),
+      context,
+      {
+          input_size[Layout::Activation4D::batch],
+          input_size[Layout::Activation4D::channels],
+          output_height,
+          output_width,
+      },
+      v_self.options(),
   };
 
   const struct Block final {
@@ -175,29 +175,28 @@ Tensor pool2d(
     ivec2 stride;
     ivec2 padding;
     ivec2 dilation;
-  } block {
-    v_output.extents(),
-    safe_downcast<int32_t>(
-        kernel[Layout::Parameter::width] *
-        kernel[Layout::Parameter::height]),
-    {
-      safe_downcast<int32_t>(kernel[Layout::Parameter::width]),
-      safe_downcast<int32_t>(kernel[Layout::Parameter::height]),
-      safe_downcast<int32_t>(self_arg.size(Layout::Activation4D::width)),
-      safe_downcast<int32_t>(self_arg.size(Layout::Activation4D::height)),
-    },
-    {
-      safe_downcast<int32_t>(stride[Layout::Parameter::width]),
-      safe_downcast<int32_t>(stride[Layout::Parameter::height]),
-    },
-    {
-      safe_downcast<int32_t>(padding[Layout::Parameter::width]),
-      safe_downcast<int32_t>(padding[Layout::Parameter::height]),
-    },
-    {
-      safe_downcast<int32_t>(dilation[Layout::Parameter::width]),
-      safe_downcast<int32_t>(dilation[Layout::Parameter::height]),
-    },
+  } block{
+      v_output.extents(),
+      safe_downcast<int32_t>(
+          kernel[Layout::Parameter::width] * kernel[Layout::Parameter::height]),
+      {
+          safe_downcast<int32_t>(kernel[Layout::Parameter::width]),
+          safe_downcast<int32_t>(kernel[Layout::Parameter::height]),
+          safe_downcast<int32_t>(self_arg.size(Layout::Activation4D::width)),
+          safe_downcast<int32_t>(self_arg.size(Layout::Activation4D::height)),
+      },
+      {
+          safe_downcast<int32_t>(stride[Layout::Parameter::width]),
+          safe_downcast<int32_t>(stride[Layout::Parameter::height]),
+      },
+      {
+          safe_downcast<int32_t>(padding[Layout::Parameter::width]),
+          safe_downcast<int32_t>(padding[Layout::Parameter::height]),
+      },
+      {
+          safe_downcast<int32_t>(dilation[Layout::Parameter::width]),
+          safe_downcast<int32_t>(dilation[Layout::Parameter::height]),
+      },
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -206,9 +205,9 @@ Tensor pool2d(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       shader_descriptor,
@@ -225,9 +224,7 @@ Tensor pool2d(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -243,13 +240,13 @@ Tensor avg_pool2d(
     const bool /* count_include_pad */,
     const c10::optional<int64_t> /* divisor_override */) {
   return pool2d(
-    self_arg,
-    kernel_arg,
-    stride_arg,
-    padding_arg,
-    {1,1},
-    ceil_mode,
-    VK_KERNEL(avg_pool2d));
+      self_arg,
+      kernel_arg,
+      stride_arg,
+      padding_arg,
+      {1, 1},
+      ceil_mode,
+      VK_KERNEL(avg_pool2d));
 }
 
 Tensor max_pool2d(
@@ -260,19 +257,21 @@ Tensor max_pool2d(
     const IntArrayRef dilation_arg,
     const bool ceil_mode) {
   return pool2d(
-    self_arg,
-    kernel_arg,
-    stride_arg,
-    padding_arg,
-    dilation_arg,
-    ceil_mode,
-    VK_KERNEL(max_pool2d));
+      self_arg,
+      kernel_arg,
+      stride_arg,
+      padding_arg,
+      dilation_arg,
+      ceil_mode,
+      VK_KERNEL(max_pool2d));
 }
 
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
-  m.impl(TORCH_SELECTIVE_NAME("aten::_adaptive_avg_pool2d"), TORCH_FN(adaptive_avg_pool2d));
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::_adaptive_avg_pool2d"),
+      TORCH_FN(adaptive_avg_pool2d));
   m.impl(TORCH_SELECTIVE_NAME("aten::avg_pool2d"), TORCH_FN(avg_pool2d));
   m.impl(TORCH_SELECTIVE_NAME("aten::max_pool2d"), TORCH_FN(max_pool2d));
 }

--- a/aten/src/ATen/native/vulkan/ops/Register.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Register.cpp
@@ -4,8 +4,8 @@
 #include <ATen/native/vulkan/ops/Convolution.h>
 #include <ATen/native/vulkan/ops/Gru.h>
 #include <ATen/native/vulkan/ops/Lstm.h>
-#include <ATen/native/vulkan/ops/TransposeConvolution2d.h>
 #include <ATen/native/vulkan/ops/Mm.h>
+#include <ATen/native/vulkan/ops/TransposeConvolution2d.h>
 #include <ATen/native/vulkan/ops/VulkanOpContext.h>
 #include <torch/custom_class.h>
 #include <torch/library.h>
@@ -25,10 +25,8 @@ TORCH_LIBRARY(vulkan, m) {
           },
           // __setstate__
           [](VulkanOpContext::State state) {
-            return c10::make_intrusive<VulkanOpContext>(
-              VulkanOpContext::create(
-                std::get<0>(state),
-                std::get<1>(state)));
+            return c10::make_intrusive<VulkanOpContext>(VulkanOpContext::create(
+                std::get<0>(state), std::get<1>(state)));
           });
   // To maintain backwards compatibility.
   m.class_<Conv2dOpContext>("Conv2dOpContext")
@@ -189,27 +187,65 @@ TORCH_LIBRARY(vulkan_prepack, m) {
 }
 
 TORCH_LIBRARY_IMPL(vulkan_prepack, CPU, m) {
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::create_conv2d_clamp_context"), TORCH_FN(create_conv2d_clamp_context));
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::conv2d_clamp_prepack"), TORCH_FN(conv2d_clamp_prepack)); // Backwards compatibility
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::create_conv2d_transpose_clamp_context"), TORCH_FN(create_conv2d_transpose_clamp_context));
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::conv2d_transpose_clamp_prepack"), TORCH_FN(conv2d_transpose_clamp_prepack)); // Backwards compatibility
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::create_linear_context"), TORCH_FN(create_linear_context));
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::linear_prepack"), TORCH_FN(linear_prepack)); // Backwards compatibility
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::create_gru_context"), TORCH_FN(create_gru_context));
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::gru_prepack"), TORCH_FN(gru_prepack)); // Backwards compatibility
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::create_lstm_context"), TORCH_FN(create_lstm_context));
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::create_conv2d_clamp_context"),
+      TORCH_FN(create_conv2d_clamp_context));
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::conv2d_clamp_prepack"),
+      TORCH_FN(conv2d_clamp_prepack)); // Backwards compatibility
+  m.impl(
+      TORCH_SELECTIVE_NAME(
+          "vulkan_prepack::create_conv2d_transpose_clamp_context"),
+      TORCH_FN(create_conv2d_transpose_clamp_context));
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::conv2d_transpose_clamp_prepack"),
+      TORCH_FN(conv2d_transpose_clamp_prepack)); // Backwards compatibility
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::create_linear_context"),
+      TORCH_FN(create_linear_context));
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::linear_prepack"),
+      TORCH_FN(linear_prepack)); // Backwards compatibility
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::create_gru_context"),
+      TORCH_FN(create_gru_context));
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::gru_prepack"),
+      TORCH_FN(gru_prepack)); // Backwards compatibility
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::create_lstm_context"),
+      TORCH_FN(create_lstm_context));
 }
 
 TORCH_LIBRARY_IMPL(vulkan_prepack, Vulkan, m) {
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::run_conv2d_clamp_context"), TORCH_FN(run_conv2d_clamp_context));
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::conv2d_clamp_run"), TORCH_FN(conv2d_clamp_run)); // Backwards compatibility
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::run_conv2d_transpose_clamp_context"), TORCH_FN(run_conv2d_transpose_clamp_context));
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::conv2d_transpose_clamp_run"), TORCH_FN(conv2d_transpose_clamp_run)); // Backwards compatibility
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::run_linear_context"), TORCH_FN(run_linear_context));
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::linear_run"), TORCH_FN(linear_run)); // Backwards compatibility
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::run_gru_context"), TORCH_FN(run_gru_context));
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::gru_run"), TORCH_FN(gru_run)); // Backwards compatibility
-  m.impl(TORCH_SELECTIVE_NAME("vulkan_prepack::run_lstm_context"), TORCH_FN(run_lstm_context));
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::run_conv2d_clamp_context"),
+      TORCH_FN(run_conv2d_clamp_context));
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::conv2d_clamp_run"),
+      TORCH_FN(conv2d_clamp_run)); // Backwards compatibility
+  m.impl(
+      TORCH_SELECTIVE_NAME(
+          "vulkan_prepack::run_conv2d_transpose_clamp_context"),
+      TORCH_FN(run_conv2d_transpose_clamp_context));
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::conv2d_transpose_clamp_run"),
+      TORCH_FN(conv2d_transpose_clamp_run)); // Backwards compatibility
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::run_linear_context"),
+      TORCH_FN(run_linear_context));
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::linear_run"),
+      TORCH_FN(linear_run)); // Backwards compatibility
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::run_gru_context"),
+      TORCH_FN(run_gru_context));
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::gru_run"),
+      TORCH_FN(gru_run)); // Backwards compatibility
+  m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::run_lstm_context"),
+      TORCH_FN(run_lstm_context));
 }
 
 Tensor convolution(
@@ -224,17 +260,9 @@ Tensor convolution(
     const int64_t groups) {
   if (transposed) {
     VulkanOpContext vulkan_context = conv2d_transpose_context_create(
-        weight,
-        bias,
-        stride,
-        padding,
-        output_padding,
-        dilation,
-        groups);
+        weight, bias, stride, padding, output_padding, dilation, groups);
     return conv2d_transpose_context_run(
-      input,
-      vulkan_context.get_packed(),
-      vulkan_context.get_unpacked());
+        input, vulkan_context.get_packed(), vulkan_context.get_unpacked());
   }
   VulkanOpContext vulkan_context = conv2d_context_create(
       weight,
@@ -246,9 +274,7 @@ Tensor convolution(
       output_padding,
       groups);
   return conv2d_context_run(
-    input,
-    vulkan_context.get_packed(),
-    vulkan_context.get_unpacked());
+      input, vulkan_context.get_packed(), vulkan_context.get_unpacked());
 }
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {

--- a/aten/src/ATen/native/vulkan/ops/Shape.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Shape.cpp
@@ -7,18 +7,16 @@ namespace native {
 namespace vulkan {
 namespace ops {
 
-Tensor view_internal(
-    const Tensor& self_arg,
-    const IntArrayRef shape) {
+Tensor view_internal(const Tensor& self_arg, const IntArrayRef shape) {
   api::Context* const context = api::context();
 
   Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
   vTensor& v_self = convert(self);
 
   vTensor v_output{
-    context,
-    shape,
-    self.options(),
+      context,
+      shape,
+      self.options(),
   };
 
   api::StagingBuffer buffer(context, v_self.buffer_bytes(), true);
@@ -30,18 +28,18 @@ Tensor view_internal(
       pipeline_barrier,
       buffer.buffer(),
       // Previous access
-      api::PipelineStage::COMPUTE, api::MemoryAccessType::WRITE,
+      api::PipelineStage::COMPUTE,
+      api::MemoryAccessType::WRITE,
       // Next access
-      api::PipelineStage::COMPUTE, api::MemoryAccessType::READ);
+      api::PipelineStage::COMPUTE,
+      api::MemoryAccessType::READ);
 
   utils::pack_buffer_to_vtensor(buffer.buffer(), v_output, pipeline_barrier);
 
   return convert(v_output);
 }
 
-inline Tensor view(
-    const Tensor& self_arg,
-    const IntArrayRef shape) {
+inline Tensor view(const Tensor& self_arg, const IntArrayRef shape) {
   return view_internal(self_arg, shape);
 }
 
@@ -56,7 +54,8 @@ Tensor _reshape_alias(
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
   m.impl(TORCH_SELECTIVE_NAME("aten::view"), TORCH_FN(view));
-  m.impl(TORCH_SELECTIVE_NAME("aten::_reshape_alias"), TORCH_FN(_reshape_alias));
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::_reshape_alias"), TORCH_FN(_reshape_alias));
 }
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/ops/Slice.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Slice.cpp
@@ -25,26 +25,24 @@ Tensor slice_4d(
   const vTensor& v_self = convert(input);
 
   const struct Block final {
-    uvec3 size;                // output texture size
-    uint32_t fill_0;           // dummy
-    uvec3 isize;               // input texture size
-    uint32_t fill_1;           // dummy
-    uvec4 tensor_size;         // output tensor size
-    uvec4 itensor_size;        // input tensor size
-    uvec4 args;                // input arguments (dim, start, end, step)
-  } block {
-    v_output.extents(),
-    0u,
-    v_self.extents(),
-    0u,
-    out_tsize,
-    in_tsize,
-    {
-      safe_downcast<uint32_t>(dim),
-      safe_downcast<uint32_t>(start),
-      safe_downcast<uint32_t>(end),
-      safe_downcast<uint32_t>(step)
-    },
+    uvec3 size; // output texture size
+    uint32_t fill_0; // dummy
+    uvec3 isize; // input texture size
+    uint32_t fill_1; // dummy
+    uvec4 tensor_size; // output tensor size
+    uvec4 itensor_size; // input tensor size
+    uvec4 args; // input arguments (dim, start, end, step)
+  } block{
+      v_output.extents(),
+      0u,
+      v_self.extents(),
+      0u,
+      out_tsize,
+      in_tsize,
+      {safe_downcast<uint32_t>(dim),
+       safe_downcast<uint32_t>(start),
+       safe_downcast<uint32_t>(end),
+       safe_downcast<uint32_t>(step)},
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -53,9 +51,9 @@ Tensor slice_4d(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       VK_KERNEL(slice_4d),
@@ -72,9 +70,7 @@ Tensor slice_4d(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -99,37 +95,30 @@ Tensor slice_width(
     src_offset.data[0u] = start;
 
     uvec3 copy_extents{
-      safe_downcast<uint32_t>(end - start),
-      v_self.extents().data[1u],
-      v_self.extents().data[2u]
-    };
+        safe_downcast<uint32_t>(end - start),
+        v_self.extents().data[1u],
+        v_self.extents().data[2u]};
 
     api::PipelineBarrier pipeline_barrier{};
 
     context->submit_texture_copy(
-      // pipeline barrier
-      pipeline_barrier,
-      // images
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::TRANSFER),
-      v_output.image(
-          pipeline_barrier,
-          api::PipelineStage::TRANSFER,
-          api::MemoryAccessType::WRITE),
-      // copy details
-      copy_extents,
-      src_offset,
-      dst_offset,
-      // fence handle
-      VK_NULL_HANDLE);
-  }
-  else {
-    uvec3 copy_extents {
-      1u,
-      v_self.extents().data[1u],
-      v_self.extents().data[2u]
-    };
+        // pipeline barrier
+        pipeline_barrier,
+        // images
+        v_self.image(pipeline_barrier, api::PipelineStage::TRANSFER),
+        v_output.image(
+            pipeline_barrier,
+            api::PipelineStage::TRANSFER,
+            api::MemoryAccessType::WRITE),
+        // copy details
+        copy_extents,
+        src_offset,
+        dst_offset,
+        // fence handle
+        VK_NULL_HANDLE);
+  } else {
+    uvec3 copy_extents{
+        1u, v_self.extents().data[1u], v_self.extents().data[2u]};
 
     const auto x_max = v_self.extents().data[0u];
 
@@ -144,22 +133,20 @@ Tensor slice_width(
       api::PipelineBarrier pipeline_barrier{};
 
       context->submit_texture_copy(
-        // pipeline barrier
-        pipeline_barrier,
-        // images
-        v_self.image(
-            pipeline_barrier,
-            api::PipelineStage::TRANSFER),
-        v_output.image(
-            pipeline_barrier,
-            api::PipelineStage::TRANSFER,
-            api::MemoryAccessType::WRITE),
-        // copy details
-        copy_extents,
-        src_offset,
-        dst_offset,
-        // fence handle
-        VK_NULL_HANDLE);
+          // pipeline barrier
+          pipeline_barrier,
+          // images
+          v_self.image(pipeline_barrier, api::PipelineStage::TRANSFER),
+          v_output.image(
+              pipeline_barrier,
+              api::PipelineStage::TRANSFER,
+              api::MemoryAccessType::WRITE),
+          // copy details
+          copy_extents,
+          src_offset,
+          dst_offset,
+          // fence handle
+          VK_NULL_HANDLE);
     }
   }
 
@@ -183,38 +170,31 @@ Tensor slice_height(
   if (step == 1) {
     src_offset.data[1u] = start;
 
-    uvec3 copy_extents {
-      v_self.extents().data[0u],
-      safe_downcast<uint32_t>(end - start),
-      v_self.extents().data[2u]
-    };
+    uvec3 copy_extents{
+        v_self.extents().data[0u],
+        safe_downcast<uint32_t>(end - start),
+        v_self.extents().data[2u]};
 
     api::PipelineBarrier pipeline_barrier{};
 
     context->submit_texture_copy(
-      // pipeline barrier
-      pipeline_barrier,
-      // images
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::TRANSFER),
-      v_output.image(
-          pipeline_barrier,
-          api::PipelineStage::TRANSFER,
-          api::MemoryAccessType::WRITE),
-      // copy details
-      copy_extents,
-      src_offset,
-      dst_offset,
-      // fence handle
-      VK_NULL_HANDLE);
-  }
-  else {
-    uvec3 copy_extents {
-      v_self.extents().data[0u],
-      1u,
-      v_self.extents().data[2u]
-    };
+        // pipeline barrier
+        pipeline_barrier,
+        // images
+        v_self.image(pipeline_barrier, api::PipelineStage::TRANSFER),
+        v_output.image(
+            pipeline_barrier,
+            api::PipelineStage::TRANSFER,
+            api::MemoryAccessType::WRITE),
+        // copy details
+        copy_extents,
+        src_offset,
+        dst_offset,
+        // fence handle
+        VK_NULL_HANDLE);
+  } else {
+    uvec3 copy_extents{
+        v_self.extents().data[0u], 1u, v_self.extents().data[2u]};
 
     const auto y_max = v_self.extents().data[1u];
     for (int64_t y = start, y_new = 0; y < end; y += step, ++y_new) {
@@ -227,22 +207,20 @@ Tensor slice_height(
       api::PipelineBarrier pipeline_barrier{};
 
       context->submit_texture_copy(
-        // pipeline barrier
-        pipeline_barrier,
-        // images
-        v_self.image(
-            pipeline_barrier,
-            api::PipelineStage::TRANSFER),
-        v_output.image(
-            pipeline_barrier,
-            api::PipelineStage::TRANSFER,
-            api::MemoryAccessType::WRITE),
-        // copy details
-        copy_extents,
-        src_offset,
-        dst_offset,
-        // fence handle
-        VK_NULL_HANDLE);
+          // pipeline barrier
+          pipeline_barrier,
+          // images
+          v_self.image(pipeline_barrier, api::PipelineStage::TRANSFER),
+          v_output.image(
+              pipeline_barrier,
+              api::PipelineStage::TRANSFER,
+              api::MemoryAccessType::WRITE),
+          // copy details
+          copy_extents,
+          src_offset,
+          dst_offset,
+          // fence handle
+          VK_NULL_HANDLE);
     }
   }
 
@@ -297,19 +275,15 @@ Tensor slice(
   }
   dim += 4 - nDims;
 
-  vTensor v_output{
-    api::context(),
-    newSizes,
-    self.options()};
+  vTensor v_output{api::context(), newSizes, self.options()};
 
   if (dim == 3) {
     slice_width(self, start_val, end_val, step, v_output);
-  }
-  else if (dim == 2) {
+  } else if (dim == 2) {
     slice_height(self, start_val, end_val, step, v_output);
-  }
-  else {
-    slice_4d(self, dim, start_val, end_val, step, in_tsize, out_tsize, v_output);
+  } else {
+    slice_4d(
+        self, dim, start_val, end_val, step, in_tsize, out_tsize, v_output);
   }
 
   auto result = convert(v_output);

--- a/aten/src/ATen/native/vulkan/ops/Softmax.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Softmax.cpp
@@ -16,12 +16,9 @@ Tensor softmax_internal(
     const bool half_to_float,
     const api::ShaderSource& shader_descriptor) {
   TORCH_CHECK(
-      input_arg.dim() == 4,
-      "Vulkan softmax expects 4-dimensional input!");
+      input_arg.dim() == 4, "Vulkan softmax expects 4-dimensional input!");
 
-  TORCH_CHECK(
-      dim == 1,
-      "Vulkan softmax expects dim == 1 (channel)");
+  TORCH_CHECK(dim == 1, "Vulkan softmax expects dim == 1 (channel)");
 
   api::Context* const context = api::context();
 
@@ -34,34 +31,32 @@ Tensor softmax_internal(
       "Vulkan softmax expects batch dim == 1");
 
   c10::SmallVector<int64_t, 4u> output_sizes{
-    v_input_sizes[Layout::Activation4D::batch],
-    v_input_sizes[Layout::Activation4D::channels],
-    v_input_sizes[Layout::Activation4D::height],
-    v_input_sizes[Layout::Activation4D::width],
+      v_input_sizes[Layout::Activation4D::batch],
+      v_input_sizes[Layout::Activation4D::channels],
+      v_input_sizes[Layout::Activation4D::height],
+      v_input_sizes[Layout::Activation4D::width],
   };
 
   vTensor v_output{
-    context,
-    output_sizes,
-    v_input.options(),
+      context,
+      output_sizes,
+      v_input.options(),
   };
 
   const api::utils::uvec3 global_work_group_size = {
-    safe_downcast<uint32_t>(v_input_sizes[Layout::Activation4D::width]),
-    safe_downcast<uint32_t>(v_input_sizes[Layout::Activation4D::height]),
-    1,
+      safe_downcast<uint32_t>(v_input_sizes[Layout::Activation4D::width]),
+      safe_downcast<uint32_t>(v_input_sizes[Layout::Activation4D::height]),
+      1,
   };
   const api::utils::uvec3 local_work_group_size = {8, 8, 1};
 
   const struct Block final {
     uvec3 iextents;
     int last_texel_end_offset;
-  } block {
-    v_input.extents(),
-    safe_downcast<int32_t>(
-        (v_input_sizes[Layout::Activation4D::channels] - 1) % 4
-    )
-  };
+  } block{
+      v_input.extents(),
+      safe_downcast<int32_t>(
+          (v_input_sizes[Layout::Activation4D::channels] - 1) % 4)};
 
   api::UniformParamsBuffer params(context, block);
   api::PipelineBarrier pipeline_barrier{};
@@ -69,9 +64,9 @@ Tensor softmax_internal(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       shader_descriptor,
@@ -88,9 +83,7 @@ Tensor softmax_internal(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_input.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -101,8 +94,7 @@ Tensor softmax(
     const at::Tensor& input_arg,
     const int64_t dim,
     const bool half_to_float) {
-  return softmax_internal(
-      input_arg, dim, half_to_float, VK_KERNEL(softmax));
+  return softmax_internal(input_arg, dim, half_to_float, VK_KERNEL(softmax));
 }
 
 Tensor log_softmax(

--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -1,5 +1,5 @@
-#include <ATen/native/vulkan/ops/Tensor.h>
 #include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Tensor.h>
 #include <c10/util/accumulate.h>
 
 namespace at {
@@ -43,9 +43,10 @@ api::utils::uvec3 image_extents(const IntArrayRef sizes) {
   }
 
   return {
-    api::utils::safe_downcast<uint32_t>(width),
-    api::utils::safe_downcast<uint32_t>(height),
-    api::utils::safe_downcast<uint32_t>(api::utils::div_up(depth, INT64_C(4))),
+      api::utils::safe_downcast<uint32_t>(width),
+      api::utils::safe_downcast<uint32_t>(height),
+      api::utils::safe_downcast<uint32_t>(
+          api::utils::div_up(depth, INT64_C(4))),
   };
 }
 
@@ -59,16 +60,15 @@ vTensor::vTensor(
     api::Context* const context,
     const IntArrayRef sizes,
     const TensorOptions& options)
-  : view_(new vTensorStorage{
-      context,
-      sizes,
-      options,
-    }) {
-}
+    : view_(new vTensorStorage{
+          context,
+          sizes,
+          options,
+      }) {}
 
 api::VulkanImage& vTensor::image(
     api::PipelineBarrier& pipeline_barrier,
-    const api::PipelineStageFlags stage) const & {
+    const api::PipelineStageFlags stage) const& {
   view_->transition(pipeline_barrier, stage, api::MemoryAccessType::READ);
 
   return view_->image_;
@@ -88,14 +88,15 @@ api::VulkanImage& vTensor::image(
 //
 
 api::VulkanImage allocate_image(
-    api::Context* const context_ptr, api::utils::uvec3& extents) {
+    api::Context* const context_ptr,
+    api::utils::uvec3& extents) {
   api::Adapter* adapter_ptr = context_ptr->adapter_ptr();
 
   api::ImageSampler::Properties sampler_props{
-    VK_FILTER_NEAREST,
-    VK_SAMPLER_MIPMAP_MODE_NEAREST,
-    VK_SAMPLER_ADDRESS_MODE_REPEAT,
-    VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
+      VK_FILTER_NEAREST,
+      VK_SAMPLER_MIPMAP_MODE_NEAREST,
+      VK_SAMPLER_ADDRESS_MODE_REPEAT,
+      VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
   };
 
   VkSampler sampler = adapter_ptr->sampler_cache().retrieve(sampler_props);
@@ -108,13 +109,13 @@ vTensorStorage::vTensorStorage(
     api::Context* const context,
     const IntArrayRef sizes,
     const TensorOptions& options)
-  : context_(context),
-    extents_(image_extents(sizes)),
-    options_(options),
-    sizes_(sizes),
-    strides_(sizes.size()),
-    image_(allocate_image(context_, extents_)),
-    last_access_{} {
+    : context_(context),
+      extents_(image_extents(sizes)),
+      options_(options),
+      sizes_(sizes),
+      strides_(sizes.size()),
+      image_(allocate_image(context_, extents_)),
+      last_access_{} {
   ops::verify(options);
 }
 

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -3,8 +3,8 @@
 #ifdef USE_VULKAN_API
 
 #include <ATen/ATen.h>
-#include <ATen/native/vulkan/api/api.h>
 #include <ATen/native/vulkan/VulkanOpaqueTensorImpl.h>
+#include <ATen/native/vulkan/api/api.h>
 #include <c10/util/accumulate.h>
 
 namespace at {
@@ -17,16 +17,13 @@ struct LastAccess {
   api::MemoryAccessFlags access;
 
   LastAccess()
-    : stage{api::PipelineStage::NO_STAGE},
-      access{api::MemoryAccessType::NONE} {
-  }
+      : stage{api::PipelineStage::NO_STAGE},
+        access{api::MemoryAccessType::NONE} {}
 
   LastAccess(
       api::PipelineStageFlags stage_flags,
       api::MemoryAccessFlags access_flags)
-    : stage{stage_flags},
-      access{access_flags} {
-  }
+      : stage{stage_flags}, access{access_flags} {}
 };
 
 class vTensorStorage final {
@@ -68,9 +65,9 @@ class vTensorStorage final {
  private:
   // Memory barrier insertion
   void transition(
-    api::PipelineBarrier&,
-    const api::PipelineStageFlags,
-    const api::MemoryAccessFlags);
+      api::PipelineBarrier&,
+      const api::PipelineStageFlags,
+      const api::MemoryAccessFlags);
 
   // Validation
   void verify() const;
@@ -96,14 +93,14 @@ class vTensor final {
   // at::TensorImpl::release_resources() to function as expected.  Now that this
   // class is made copyable though, a new door to a whole new class of bugs is
   // opened, in that there now is a chance of two [shallow] copies, have their
-  // StorageState objects go out of sync as a result of an operation being performed on
-  // one shallow copy that is not reflected in the other.  Technically, if the
-  // programmer is very careful, it is possible to avoid this trap and not pay
-  // the cost of indirection, but the resulting bugs of missing memory barriers
-  // will be so frustrating to hunt down for those unfamiliar with the internal
-  // mechanics of this class, that I decided to take the performance pentalty
-  // of this extra layer of indirection in favor of making this class easier
-  // to use.
+  // StorageState objects go out of sync as a result of an operation being
+  // performed on one shallow copy that is not reflected in the other.
+  // Technically, if the programmer is very careful, it is possible to avoid
+  // this trap and not pay the cost of indirection, but the resulting bugs of
+  // missing memory barriers will be so frustrating to hunt down for those
+  // unfamiliar with the internal mechanics of this class, that I decided to
+  // take the performance pentalty of this extra layer of indirection in favor
+  // of making this class easier to use.
   std::shared_ptr<vTensorStorage> view_;
 
  public:
@@ -111,9 +108,8 @@ class vTensor final {
    Texture Access
   */
 
-  api::VulkanImage& image(
-      api::PipelineBarrier&,
-      const api::PipelineStageFlags) const &;
+  api::VulkanImage& image(api::PipelineBarrier&, const api::PipelineStageFlags)
+      const&;
 
   api::VulkanImage& image(
       api::PipelineBarrier&,
@@ -141,14 +137,14 @@ class vTensor final {
   }
 
   inline size_t nbytes() const {
-    return c10::elementSize(c10::typeMetaToScalarType(options().dtype()))
-           * c10::multiply_integers(sizes());
+    return c10::elementSize(c10::typeMetaToScalarType(options().dtype())) *
+        c10::multiply_integers(sizes());
   }
 
   inline VkDeviceSize buffer_bytes() {
-    return c10::elementSize(c10::typeMetaToScalarType(options().dtype()))
-           * view_->extents_.data[0u] * view_->extents_.data[1u]
-           * (4u * view_->extents_.data[2u]);
+    return c10::elementSize(c10::typeMetaToScalarType(options().dtype())) *
+        view_->extents_.data[0u] * view_->extents_.data[1u] *
+        (4u * view_->extents_.data[2u]);
   }
 };
 
@@ -164,9 +160,7 @@ using vTensorImpl = VulkanOpaqueTensorImpl<vTensor>;
 void verify(const TensorOptions& options);
 
 inline vTensor& convert(const Tensor& tensor) {
-  TORCH_INTERNAL_ASSERT(
-      tensor.is_vulkan(),
-      "Vulkan tensor expected!");
+  TORCH_INTERNAL_ASSERT(tensor.is_vulkan(), "Vulkan tensor expected!");
 
   vTensorImpl* const impl =
       static_cast<vTensorImpl*>(tensor.unsafeGetTensorImpl());

--- a/aten/src/ATen/native/vulkan/ops/TransposeConvolution2d.cpp
+++ b/aten/src/ATen/native/vulkan/ops/TransposeConvolution2d.cpp
@@ -4,8 +4,8 @@
 #include <ATen/native/vulkan/api/Utils.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/TransposeConvolution2d.h>
-#include <ATen/native/vulkan/ops/VulkanOpContext.h>
 #include <ATen/native/vulkan/ops/Utils.h>
+#include <ATen/native/vulkan/ops/VulkanOpContext.h>
 #include <c10/util/irange.h>
 
 namespace at {
@@ -28,10 +28,13 @@ vTensor pack_weights_2d_reverse(
   const int64_t src_kw_sz = src_filter[Layout::Filter::width];
   const int64_t src_kh_sz = src_filter[Layout::Filter::height];
   const int64_t src_kernel_sz = src_kw_sz * src_kh_sz;
-  const int64_t src_block_sz = src_kernel_sz * src_filter[Layout::Filter::input];
+  const int64_t src_block_sz =
+      src_kernel_sz * src_filter[Layout::Filter::input];
 
-  const int64_t num_stacks = div_up(src_filter[Layout::Filter::output], INT64_C(4));
-  const int64_t stack_depth = api::utils::align_up(src_filter[Layout::Filter::input], INT64_C(4));
+  const int64_t num_stacks =
+      div_up(src_filter[Layout::Filter::output], INT64_C(4));
+  const int64_t stack_depth =
+      api::utils::align_up(src_filter[Layout::Filter::input], INT64_C(4));
 
   /* Destination */
   const int64_t dst_kw_sz = src_kw_sz * stack_depth;
@@ -58,7 +61,8 @@ vTensor pack_weights_2d_reverse(
 
     for (const auto src_oc : c10::irange(src_filter[Layout::Filter::output])) {
       /* Source */
-      const float* const src_weight_oc_ptr = src_weight_ptr + src_oc * src_block_sz;
+      const float* const src_weight_oc_ptr =
+          src_weight_ptr + src_oc * src_block_sz;
 
       /* Destination */
       const int64_t dst_oh = src_oc / 4;
@@ -73,8 +77,10 @@ vTensor pack_weights_2d_reverse(
             const int64_t dst_w = reversed ? (src_kw_sz - 1 - src_iw) : src_iw;
             const int64_t dst_w_offset = dst_w * stack_depth;
             memcpy(
-                dst_weight_c_ptr + (dst_oh * src_kh_sz + dst_h) * dst_kw_sz + src_ic + dst_w_offset,
-                src_weight_oc_ptr + src_ic * src_kernel_sz + src_ih * src_kw_sz + src_iw,
+                dst_weight_c_ptr + (dst_oh * src_kh_sz + dst_h) * dst_kw_sz +
+                    src_ic + dst_w_offset,
+                src_weight_oc_ptr + src_ic * src_kernel_sz +
+                    src_ih * src_kw_sz + src_iw,
                 sizeof(float));
           }
         }
@@ -95,15 +101,10 @@ vTensor pack_weights(const Tensor& weight_arg) {
 
   const Tensor weight = at::permute(weight_arg, {1, 0, 2, 3}).contiguous();
 
-  return pack_weights_2d_reverse(
-      context,
-      weight,
-      true);
+  return pack_weights_2d_reverse(context, weight, true);
 }
 
-vTensor pack_biases(
-    const c10::optional<Tensor>& bias,
-    const Tensor& weight) {
+vTensor pack_biases(const c10::optional<Tensor>& bias, const Tensor& weight) {
   if (bias && bias->is_vulkan()) {
     return convert(*bias);
   }
@@ -113,13 +114,13 @@ vTensor pack_biases(
   const int64_t src_w = weight.size(Layout::TransposedFilter::output);
   const int64_t packed_w = div_up(src_w, INT64_C(4));
   vTensor v_bias{
-    context,
-    {
-      4,
-      1,
-      packed_w,
-    },
-    weight.options(),
+      context,
+      {
+          4,
+          1,
+          packed_w,
+      },
+      weight.options(),
   };
 
   api::StagingBuffer staging(context, v_bias.buffer_bytes());
@@ -137,8 +138,7 @@ vTensor pack_biases(
         const int64_t x = i / 4;
         dst_bias_ptr[c * packed_w + x] = src_bias_ptr[i];
       }
-    }
-    else {
+    } else {
       memset(
           dst_bias_ptr,
           // 2's complement integers and IEEE-754 floating point numbers both
@@ -163,14 +163,12 @@ std::array<int64_t, 4> pack_filter(
   };
 
   return {
-    align_up(filter[Layout::TransposedFilter::output], INT64_C(4)),
-    align_up(filter[Layout::TransposedFilter::input], INT64_C(4)),
-    effective(
-        filter[Layout::Filter::height],
-        dilation[Layout::Parameter::height]),
-    effective(
-        filter[Layout::Filter::width],
-        dilation[Layout::Parameter::width]),
+      align_up(filter[Layout::TransposedFilter::output], INT64_C(4)),
+      align_up(filter[Layout::TransposedFilter::input], INT64_C(4)),
+      effective(
+          filter[Layout::Filter::height], dilation[Layout::Parameter::height]),
+      effective(
+          filter[Layout::Filter::width], dilation[Layout::Parameter::width]),
   };
 }
 
@@ -178,8 +176,8 @@ std::array<int64_t, 2> pack_params(const std::vector<int64_t>& vector) {
   TORCH_INTERNAL_ASSERT(2u == vector.size(), "Invalid usage!");
 
   return {
-    vector[0],
-    vector[1],
+      vector[0],
+      vector[1],
   };
 }
 
@@ -195,71 +193,73 @@ bool available(
     const c10::optional<Scalar>& output_min,
     const c10::optional<Scalar>& output_max) {
   return api::available() &&
-         // Weight
-         (4 == weight.ndimension()) &&
-         (weight.size(Layout::Filter::height) > 0) &&
-         (weight.size(Layout::Filter::width) > 0) &&
-         ((weight.device().is_cpu()) ||
-          (c10::DeviceType::Vulkan == weight.device().type())) &&
-         (kFloat == weight.scalar_type()) &&
-         // Bias
-         ((bias && bias->defined()) ? ((1 == bias->ndimension()) &&
-                                       ((bias->device().is_cpu()) ||
-                                        (c10::DeviceType::Vulkan == bias->device().type())) &&
-                                       (kFloat == bias->scalar_type()) &&
-                                       (transposed ? (weight.size(Layout::TransposedFilter::output) ==
-                                                          bias->size(Layout::Filter::output))
-                                                   : (weight.size(Layout::Filter::output) ==
-                                                          bias->size(Layout::Filter::output))))
-                                    : true) &&
-         // Stride
-         (stride[Layout::Parameter::height] > 0) &&
-         (stride[Layout::Parameter::width] > 0) &&
-         // Padding
-         (padding[Layout::Parameter::height] >= 0) &&
-         (padding[Layout::Parameter::width] >= 0) &&
-         // Dilation
-         (transposed ? (dilation[Layout::Parameter::height] == 1) &&
-                       (dilation[Layout::Parameter::width] == 1)
-                     : (dilation[Layout::Parameter::height] > 0) &&
-                       (dilation[Layout::Parameter::width] > 0)) &&
-         // Groups
-         (groups > 0) &&
-         // Input
-         (weight.size(Layout::Filter::input) > 0) &&
-         // Output
-         (weight.size(Layout::Filter::output) > 0) &&
-         // Output - Groups
-         ((weight.size(Layout::Filter::output) % groups) == 0) &&
-         // Output Min / Max
-         (!output_min || output_min->isFloatingPoint()) &&
-         (!output_max || output_max->isFloatingPoint()) &&
-         true;
+      // Weight
+      (4 == weight.ndimension()) && (weight.size(Layout::Filter::height) > 0) &&
+      (weight.size(Layout::Filter::width) > 0) &&
+      ((weight.device().is_cpu()) ||
+       (c10::DeviceType::Vulkan == weight.device().type())) &&
+      (kFloat == weight.scalar_type()) &&
+      // Bias
+      ((bias && bias->defined())
+           ? ((1 == bias->ndimension()) &&
+              ((bias->device().is_cpu()) ||
+               (c10::DeviceType::Vulkan == bias->device().type())) &&
+              (kFloat == bias->scalar_type()) &&
+              (transposed ? (weight.size(Layout::TransposedFilter::output) ==
+                             bias->size(Layout::Filter::output))
+                          : (weight.size(Layout::Filter::output) ==
+                             bias->size(Layout::Filter::output))))
+           : true) &&
+      // Stride
+      (stride[Layout::Parameter::height] > 0) &&
+      (stride[Layout::Parameter::width] > 0) &&
+      // Padding
+      (padding[Layout::Parameter::height] >= 0) &&
+      (padding[Layout::Parameter::width] >= 0) &&
+      // Dilation
+      (transposed ? (dilation[Layout::Parameter::height] == 1) &&
+               (dilation[Layout::Parameter::width] == 1)
+                  : (dilation[Layout::Parameter::height] > 0) &&
+               (dilation[Layout::Parameter::width] > 0)) &&
+      // Groups
+      (groups > 0) &&
+      // Input
+      (weight.size(Layout::Filter::input) > 0) &&
+      // Output
+      (weight.size(Layout::Filter::output) > 0) &&
+      // Output - Groups
+      ((weight.size(Layout::Filter::output) % groups) == 0) &&
+      // Output Min / Max
+      (!output_min || output_min->isFloatingPoint()) &&
+      (!output_max || output_max->isFloatingPoint()) && true;
 }
 
 bool usable(const Tensor& input) {
-         // Input
+  // Input
   return (4 == input.ndimension()) &&
-         (c10::DeviceType::Vulkan == input.device().type()) &&
-         (kFloat == input.scalar_type()) &&
-         (input.size(Layout::Activation4D::batch) >= 0) &&
-         (input.size(Layout::Activation4D::channels) > 0) &&
-         (input.size(Layout::Activation4D::height) > 0) &&
-         (input.size(Layout::Activation4D::width) > 0) &&
-         !input.requires_grad() &&
-         true;
+      (c10::DeviceType::Vulkan == input.device().type()) &&
+      (kFloat == input.scalar_type()) &&
+      (input.size(Layout::Activation4D::batch) >= 0) &&
+      (input.size(Layout::Activation4D::channels) > 0) &&
+      (input.size(Layout::Activation4D::height) > 0) &&
+      (input.size(Layout::Activation4D::width) > 0) && !input.requires_grad() &&
+      true;
 }
 
 static inline std::vector<int64_t> get_conv_transpose_output_size(
-    IntArrayRef input_size, IntArrayRef weight_size,
-    IntArrayRef padding, IntArrayRef output_padding,
-    IntArrayRef stride, IntArrayRef dilation = IntArrayRef()) {
+    IntArrayRef input_size,
+    IntArrayRef weight_size,
+    IntArrayRef padding,
+    IntArrayRef output_padding,
+    IntArrayRef stride,
+    IntArrayRef dilation = IntArrayRef()) {
   auto dim = input_size.size();
   std::vector<int64_t> output_size(dim);
   output_size[0] = input_size[input_batch_size_dim];
   output_size[1] = weight_size[weight_input_channels_dim];
   for (const auto d : c10::irange(2, dim)) {
-    output_size[d] = stride[d - 2] * (input_size[d] - 1) + weight_size[d] - 2 * padding[d - 2] + output_padding[d - 2];
+    output_size[d] = stride[d - 2] * (input_size[d] - 1) + weight_size[d] -
+        2 * padding[d - 2] + output_padding[d - 2];
   }
   return output_size;
 }
@@ -279,7 +279,8 @@ VulkanOpContext conv2d_transpose_context_create(
   const auto stride = expand_param_if_needed(stride_arg, "stride", 2);
   const auto padding = expand_param_if_needed(padding_arg, "padding", 2);
   const auto dilation = expand_param_if_needed(dilation_arg, "dilation", 2);
-  const auto output_padding = expand_param_if_needed(output_padding_arg, "output_padding", 2);
+  const auto output_padding =
+      expand_param_if_needed(output_padding_arg, "output_padding", 2);
 
   TORCH_CHECK(
       available(
@@ -308,8 +309,12 @@ VulkanOpContext conv2d_transpose_context_create(
   packed_context.emplace_back(pack_params(output_padding));
   packed_context.emplace_back(pack_params(dilation));
   packed_context.emplace_back(safe_downcast<int32_t>(groups));
-  packed_context.emplace_back(output_min ? output_min->template to<float>() : -std::numeric_limits<float>::infinity());
-  packed_context.emplace_back(output_max ? output_max->template to<float>() : +std::numeric_limits<float>::infinity());
+  packed_context.emplace_back(
+      output_min ? output_min->template to<float>()
+                 : -std::numeric_limits<float>::infinity());
+  packed_context.emplace_back(
+      output_max ? output_max->template to<float>()
+                 : +std::numeric_limits<float>::infinity());
 
   c10::impl::GenericList unpacked_context{c10::AnyType::get()};
   unpacked_context.reserve(10);
@@ -352,35 +357,36 @@ void conv2d_transpose_sliding_window(
     ivec2 dilate;
     vec2 clamp;
     ivec4 src_filter;
-  } block {
-    v_output.extents(),
-    safe_downcast<int32_t>(packed_filter[Layout::Filter::input]), /* this is aligned up */
-    {
-      safe_downcast<int32_t>(packed_filter[Layout::Filter::width]),
-      safe_downcast<int32_t>(packed_filter[Layout::Filter::height]),
-      safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::width]),
-      safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::height]),
-    },
-    {
-      safe_downcast<int32_t>(unpacked_filter[Layout::Filter::width]),
-      safe_downcast<int32_t>(unpacked_filter[Layout::Filter::height]),
-    },
-    {
-      safe_downcast<int32_t>(packed_stride[Layout::Parameter::width]),
-      safe_downcast<int32_t>(packed_stride[Layout::Parameter::height]),
-    },
-    {
-      safe_downcast<int32_t>(packed_padding[Layout::Parameter::width]),
-      safe_downcast<int32_t>(packed_padding[Layout::Parameter::height]),
-    },
-    {
-      safe_downcast<int32_t>(packed_dilation[Layout::Parameter::width]),
-      safe_downcast<int32_t>(packed_dilation[Layout::Parameter::height]),
-    },
-    {
-      packed_output_min,
-      packed_output_max,
-    },
+  } block{
+      v_output.extents(),
+      safe_downcast<int32_t>(
+          packed_filter[Layout::Filter::input]), /* this is aligned up */
+      {
+          safe_downcast<int32_t>(packed_filter[Layout::Filter::width]),
+          safe_downcast<int32_t>(packed_filter[Layout::Filter::height]),
+          safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::width]),
+          safe_downcast<int32_t>(v_input.sizes()[Layout::Activation4D::height]),
+      },
+      {
+          safe_downcast<int32_t>(unpacked_filter[Layout::Filter::width]),
+          safe_downcast<int32_t>(unpacked_filter[Layout::Filter::height]),
+      },
+      {
+          safe_downcast<int32_t>(packed_stride[Layout::Parameter::width]),
+          safe_downcast<int32_t>(packed_stride[Layout::Parameter::height]),
+      },
+      {
+          safe_downcast<int32_t>(packed_padding[Layout::Parameter::width]),
+          safe_downcast<int32_t>(packed_padding[Layout::Parameter::height]),
+      },
+      {
+          safe_downcast<int32_t>(packed_dilation[Layout::Parameter::width]),
+          safe_downcast<int32_t>(packed_dilation[Layout::Parameter::height]),
+      },
+      {
+          packed_output_min,
+          packed_output_max,
+      },
   };
 
   uvec3 global_size = v_output.extents();
@@ -391,11 +397,11 @@ void conv2d_transpose_sliding_window(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       shader,
@@ -412,15 +418,9 @@ void conv2d_transpose_sliding_window(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_input.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      packed_v_weight.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
-      packed_v_bias.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      packed_v_weight.image(pipeline_barrier, api::PipelineStage::COMPUTE),
+      packed_v_bias.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 }
@@ -452,30 +452,30 @@ Tensor conv2d_transpose_context_run(
       "Reason: The provided input tensor is either invalid or unsupported by Vulkan impl.");
 
   vTensor v_output{
-    context,
-    get_conv_transpose_output_size(
-        v_input.sizes(),
-        unpacked_filter,
-        packed_padding,
-        packed_output_padding,
-        packed_stride,
-        packed_dilation),
-    input.options(),
+      context,
+      get_conv_transpose_output_size(
+          v_input.sizes(),
+          unpacked_filter,
+          packed_padding,
+          packed_output_padding,
+          packed_stride,
+          packed_dilation),
+      input.options(),
   };
 
   conv2d_transpose_sliding_window(
-    VK_KERNEL(conv_transpose2d),
-    v_output,
-    v_input,
-    packed_v_weight,
-    packed_v_bias,
-    packed_filter,
-    packed_stride,
-    packed_padding,
-    packed_dilation,
-    packed_output_min,
-    packed_output_max,
-    unpacked_filter);
+      VK_KERNEL(conv_transpose2d),
+      v_output,
+      v_input,
+      packed_v_weight,
+      packed_v_bias,
+      packed_filter,
+      packed_stride,
+      packed_padding,
+      packed_dilation,
+      packed_output_min,
+      packed_output_max,
+      unpacked_filter);
 
   return convert(v_output);
 }
@@ -490,32 +490,29 @@ c10::intrusive_ptr<VulkanOpContext> create_conv2d_transpose_clamp_context(
     const int64_t groups,
     const c10::optional<Scalar>& output_min,
     const c10::optional<Scalar>& output_max) {
-  return c10::make_intrusive<VulkanOpContext>(
-      conv2d_transpose_context_create(
-          weight,
-          bias,
-          stride,
-          padding,
-          output_padding,
-          dilation,
-          groups,
-          output_min,
-          output_max));
+  return c10::make_intrusive<VulkanOpContext>(conv2d_transpose_context_create(
+      weight,
+      bias,
+      stride,
+      padding,
+      output_padding,
+      dilation,
+      groups,
+      output_min,
+      output_max));
 }
 
 Tensor run_conv2d_transpose_clamp_context(
     const Tensor& input,
     const c10::intrusive_ptr<VulkanOpContext>& vulkan_context) {
   return conv2d_transpose_context_run(
-    input,
-    vulkan_context->get_packed(),
-    vulkan_context->get_unpacked());
+      input, vulkan_context->get_packed(), vulkan_context->get_unpacked());
 }
 
 /* Backwards compatibility */
-TransposeConv2dOpContext::TransposeConv2dOpContext(VulkanOpContext vulkan_context)
-  : vulkan_context_{std::move(vulkan_context)} {
-}
+TransposeConv2dOpContext::TransposeConv2dOpContext(
+    VulkanOpContext vulkan_context)
+    : vulkan_context_{std::move(vulkan_context)} {}
 
 TransposeConv2dOpContext TransposeConv2dOpContext::create(
     const Tensor& weight,
@@ -527,51 +524,52 @@ TransposeConv2dOpContext TransposeConv2dOpContext::create(
     const int64_t groups,
     const c10::optional<Scalar>& output_min,
     const c10::optional<Scalar>& output_max) {
-  return TransposeConv2dOpContext {
-      conv2d_transpose_context_create(
-        weight,
-        bias,
-        stride_arg,
-        padding_arg,
-        output_padding_arg,
-        dilation_arg,
-        groups,
-        output_min,
-        output_max)
-  };
+  return TransposeConv2dOpContext{conv2d_transpose_context_create(
+      weight,
+      bias,
+      stride_arg,
+      padding_arg,
+      output_padding_arg,
+      dilation_arg,
+      groups,
+      output_min,
+      output_max)};
 }
 
 Tensor TransposeConv2dOpContext::run(const Tensor& input_arg) const {
   return conv2d_transpose_context_run(
-    input_arg,
-    vulkan_context_.get_packed(),
-    vulkan_context_.get_unpacked());
+      input_arg, vulkan_context_.get_packed(), vulkan_context_.get_unpacked());
 }
 
 TransposeConv2dOpContext::State TransposeConv2dOpContext::unpack() const {
-  const c10::impl::GenericList unpacked_ = std::get<1>(vulkan_context_.get_state());
+  const c10::impl::GenericList unpacked_ =
+      std::get<1>(vulkan_context_.get_state());
   const Tensor unpacked_weight = unpacked_.get(0).toTensor();
-  const c10::optional<Tensor> unpacked_bias
-   = unpacked_.get(1).isTensor() ? unpacked_.get(1).toTensor() : (c10::optional<Tensor>&) c10::nullopt;
+  const c10::optional<Tensor> unpacked_bias = unpacked_.get(1).isTensor()
+      ? unpacked_.get(1).toTensor()
+      : (c10::optional<Tensor>&)c10::nullopt;
   const std::vector<int64_t> unpacked_stride = unpacked_.get(3).toIntVector();
   const std::vector<int64_t> unpacked_padding = unpacked_.get(4).toIntVector();
-  const std::vector<int64_t> unpacked_output_padding = unpacked_.get(5).toIntVector();
+  const std::vector<int64_t> unpacked_output_padding =
+      unpacked_.get(5).toIntVector();
   const std::vector<int64_t> unpacked_dilation = unpacked_.get(6).toIntVector();
   const int64_t unpacked_groups = unpacked_.get(7).toInt();
-  const c10::optional<Scalar> unpacked_output_min
-   = unpacked_.get(6).isScalar() ? unpacked_.get(8).toScalar() : (c10::optional<Scalar>) c10::nullopt;
-  const c10::optional<Scalar> unpacked_output_max
-   = unpacked_.get(6).isScalar() ? unpacked_.get(9).toScalar() : (c10::optional<Scalar>) c10::nullopt;
+  const c10::optional<Scalar> unpacked_output_min = unpacked_.get(6).isScalar()
+      ? unpacked_.get(8).toScalar()
+      : (c10::optional<Scalar>)c10::nullopt;
+  const c10::optional<Scalar> unpacked_output_max = unpacked_.get(6).isScalar()
+      ? unpacked_.get(9).toScalar()
+      : (c10::optional<Scalar>)c10::nullopt;
   return TransposeConv2dOpContext::State{
-    unpacked_weight,
-    unpacked_bias,
-    unpacked_stride,
-    unpacked_padding,
-    unpacked_output_padding,
-    unpacked_dilation,
-    unpacked_groups,
-    unpacked_output_min,
-    unpacked_output_max,
+      unpacked_weight,
+      unpacked_bias,
+      unpacked_stride,
+      unpacked_padding,
+      unpacked_output_padding,
+      unpacked_dilation,
+      unpacked_groups,
+      unpacked_output_min,
+      unpacked_output_max,
   };
 }
 

--- a/aten/src/ATen/native/vulkan/ops/Upsample.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Upsample.cpp
@@ -26,14 +26,14 @@ Tensor upsample_nearest2d(
   const auto v_input_sizes = v_input.sizes();
 
   vTensor v_output{
-    context,
-    {
-      v_input_sizes[Layout::Activation4D::batch],
-      v_input_sizes[Layout::Activation4D::channels],
-      output_sizes[Layout::Parameter::height],
-      output_sizes[Layout::Parameter::width],
-    },
-    input_arg.options(),
+      context,
+      {
+          v_input_sizes[Layout::Activation4D::batch],
+          v_input_sizes[Layout::Activation4D::channels],
+          output_sizes[Layout::Parameter::height],
+          output_sizes[Layout::Parameter::width],
+      },
+      input_arg.options(),
   };
 
   const struct Block final {
@@ -41,23 +41,25 @@ Tensor upsample_nearest2d(
     uint32_t _;
     ivec2 iextents;
     vec2 scale;
-  } block {
-    v_output.extents(),
-    0u,
-    {
-      safe_downcast<int32_t>(input_arg.size(Layout::Activation4D::width) - 1),
-      safe_downcast<int32_t>(input_arg.size(Layout::Activation4D::height) - 1),
-    },
-    {
-      compute_scales_value<float>(
-          scales_w,
-          v_input_sizes[Layout::Activation4D::width],
-          output_sizes[Layout::Parameter::width]),
-      compute_scales_value<float>(
-          scales_h,
-          v_input_sizes[Layout::Activation4D::height],
-          output_sizes[Layout::Parameter::height]),
-    },
+  } block{
+      v_output.extents(),
+      0u,
+      {
+          safe_downcast<int32_t>(
+              input_arg.size(Layout::Activation4D::width) - 1),
+          safe_downcast<int32_t>(
+              input_arg.size(Layout::Activation4D::height) - 1),
+      },
+      {
+          compute_scales_value<float>(
+              scales_w,
+              v_input_sizes[Layout::Activation4D::width],
+              output_sizes[Layout::Parameter::width]),
+          compute_scales_value<float>(
+              scales_h,
+              v_input_sizes[Layout::Activation4D::height],
+              output_sizes[Layout::Parameter::height]),
+      },
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -66,9 +68,9 @@ Tensor upsample_nearest2d(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       VK_KERNEL(upsample_nearest2d),
@@ -85,9 +87,7 @@ Tensor upsample_nearest2d(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_input.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 
@@ -97,7 +97,9 @@ Tensor upsample_nearest2d(
 #ifdef USE_VULKAN_API
 
 TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
-  m.impl(TORCH_SELECTIVE_NAME("aten::upsample_nearest2d"), TORCH_FN(upsample_nearest2d));
+  m.impl(
+      TORCH_SELECTIVE_NAME("aten::upsample_nearest2d"),
+      TORCH_FN(upsample_nearest2d));
 }
 
 #endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/ops/Utils.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Utils.cpp
@@ -4,7 +4,7 @@ namespace at {
 namespace native {
 namespace vulkan {
 namespace ops {
-namespace utils{
+namespace utils {
 
 void pack_buffer_to_vtensor(
     api::VulkanBuffer& buffer,
@@ -19,15 +19,15 @@ void pack_buffer_to_vtensor(
     api::utils::uvec3 extents;
     uint32_t block;
     api::utils::uvec4 offset;
-  } block {
-    extents,
-    4u * plane,
-    {
-      0u * plane,
-      1u * plane,
-      2u * plane,
-      3u * plane,
-    },
+  } block{
+      extents,
+      4u * plane,
+      {
+          0u * plane,
+          1u * plane,
+          2u * plane,
+          3u * plane,
+      },
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -35,9 +35,9 @@ void pack_buffer_to_vtensor(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       VK_KERNEL(nchw_to_image),
@@ -65,7 +65,9 @@ void pack_staging_to_vtensor(api::VulkanBuffer& staging, vTensor& v_self) {
 }
 
 void pack_vtensor_to_staging(
-    vTensor& v_self, api::VulkanBuffer& staging, const VkFence fence_handle) {
+    vTensor& v_self,
+    api::VulkanBuffer& staging,
+    const VkFence fence_handle) {
   api::Context* const context = api::context();
 
   const api::utils::uvec3 extents = v_self.extents();
@@ -75,15 +77,15 @@ void pack_vtensor_to_staging(
     api::utils::uvec3 extents;
     uint32_t block;
     api::utils::uvec4 offset;
-  } block {
-    extents,
-    4u * plane,
-    {
-      0u * plane,
-      1u * plane,
-      2u * plane,
-      3u * plane,
-    },
+  } block{
+      extents,
+      4u * plane,
+      {
+          0u * plane,
+          1u * plane,
+          2u * plane,
+          3u * plane,
+      },
   };
 
   api::UniformParamsBuffer params(context, block);
@@ -92,9 +94,9 @@ void pack_vtensor_to_staging(
   context->submit_compute_job(
       // shader layout signature
       {
-        VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+          VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
       },
       // shader descriptor
       VK_KERNEL(image_to_nchw),
@@ -107,9 +109,7 @@ void pack_vtensor_to_staging(
       // fence handle
       fence_handle,
       // shader arguments
-      v_self.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_self.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       staging,
       // params buffer
       params.buffer());

--- a/aten/src/ATen/native/vulkan/ops/Utils.h
+++ b/aten/src/ATen/native/vulkan/ops/Utils.h
@@ -10,19 +10,21 @@ namespace vulkan {
 namespace ops {
 namespace utils {
 
-inline int64_t normalize(
-    const int64_t dimension,
-    const int64_t n) {
+inline int64_t normalize(const int64_t dimension, const int64_t n) {
   return (dimension % n + n) % n;
 }
 
 void pack_buffer_to_vtensor(
-    api::VulkanBuffer&, vTensor&, api::PipelineBarrier&);
+    api::VulkanBuffer&,
+    vTensor&,
+    api::PipelineBarrier&);
 
 void pack_staging_to_vtensor(api::VulkanBuffer&, vTensor&);
 
 void pack_vtensor_to_staging(
-    vTensor&, api::VulkanBuffer&, const VkFence fence_handle = VK_NULL_HANDLE);
+    vTensor&,
+    api::VulkanBuffer&,
+    const VkFence fence_handle = VK_NULL_HANDLE);
 
 } // namespace utils
 } // namespace ops

--- a/aten/src/ATen/native/vulkan/ops/VulkanOpContext.cpp
+++ b/aten/src/ATen/native/vulkan/ops/VulkanOpContext.cpp
@@ -8,9 +8,7 @@ namespace ops {
 VulkanOpContext::VulkanOpContext(
     c10::impl::GenericList packed_context,
     c10::impl::GenericList unpacked_context)
-  : packed_{ packed_context },
-    unpacked_{ unpacked_context } {
-}
+    : packed_{packed_context}, unpacked_{unpacked_context} {}
 
 VulkanOpContext VulkanOpContext::create(
     c10::impl::GenericList packed_context,

--- a/aten/src/ATen/native/vulkan/ops/cumsum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/cumsum.cpp
@@ -69,9 +69,7 @@ Tensor cumsum(
           pipeline_barrier,
           api::PipelineStage::COMPUTE,
           api::MemoryAccessType::WRITE),
-      v_input.image(
-          pipeline_barrier,
-          api::PipelineStage::COMPUTE),
+      v_input.image(pipeline_barrier, api::PipelineStage::COMPUTE),
       // params buffer
       params.buffer());
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #81390

Summary: Add vulkan code (aten/src/ATen/native/vulkan) to linter check path config (.lintrunner.toml) for better code readability

After this patch, we need to check for linter errors before we submit the commit
 with `lintrunner -a` or `clang-format`

Test Plan: lintrunner -a

Reviewers:

Subscribers:

Tasks:

Tags: