### PR TITLE
Fix warning if backend registers timer

### DIFF
--- a/torch/csrc/distributed/c10d/logger.cpp
+++ b/torch/csrc/distributed/c10d/logger.cpp
@@ -318,7 +318,9 @@ void Logger::set_runtime_stats_and_log() {
         "Cuda time stats are not collected for multi-device modules.");
     return;
   }
-  if (!reducer_->params_[0].is_cuda() && !reducer_->params_[0].is_cpu()) {
+
+  if (!reducer_->timer_ &&
+      (!reducer_->params_[0].is_cuda() && !reducer_->params_[0].is_cpu())) {
     TORCH_WARN_ONCE(
         "Time stats are currently only collected for CPU and CUDA devices. "
         "Please refer to CpuTimer or CudaTimer for how to register timer "


### PR DESCRIPTION
if backend registers for timer, dont print the
warn msg and return.

Change-Id: I7228958b131308acce75f6d8b6259142e0d764c9
Signed-off-by: Jeeja <jeejakp@habana.ai>

Fixes #ISSUE_NUMBER
