### PR TITLE
Basic support for NNC quantization

### DIFF
--- a/test/cpp/tensorexpr/test_quantization.cpp
+++ b/test/cpp/tensorexpr/test_quantization.cpp
@@ -221,6 +221,105 @@ TEST_F(Quantization, QuantAddDequantUInt8) {
   CHECK_EQ(check, 1);
 }
 
+at::Tensor quantized_add_relu(
+    at::Tensor x1,
+    at::Tensor x2,
+    double scale,
+    int64_t zero) {
+  const auto qadd_op =
+      c10::Dispatcher::singleton()
+          .findSchemaOrThrow("quantized::add_relu", "")
+          .typed<at::Tensor(at::Tensor, at::Tensor, double, int64_t)>();
+  return qadd_op.call(x1, x2, scale, zero);
+}
+
+TEST_F(Quantization, QuantAddReluDequantInt8) {
+  const auto graph_string = R"IR(
+      graph(%x1 : Float(2, 2, strides=[2, 1], device=cpu), %x2 : Float(2, 2, strides=[2, 1], device=cpu)):
+        %2 : int = prim::Constant[value=12]()
+        %qz1 : int = prim::Constant[value=13]()
+        %qs1 : float = prim::Constant[value=0.1]()
+        %qz2 : int = prim::Constant[value=13]()
+        %qs2 : float = prim::Constant[value=0.1]()
+        %qza : int = prim::Constant[value=13]()
+        %qsa : float = prim::Constant[value=0.1]()
+        %q1 : QInt8(2, 2) = aten::quantize_per_tensor(%x1, %qs1, %qz1, %2)
+        %q2 : QInt8(2, 2) = aten::quantize_per_tensor(%x2, %qs2, %qz2, %2)
+        %qa : QInt8(2, 2) = quantized::add_relu(%q1, %q2, %qsa, %qza)
+        %6 : Float(2, 2) = aten::dequantize(%qa)
+        return (%6))IR";
+  auto graph = std::make_shared<Graph>();
+  parseIR(graph_string, &*graph);
+
+  auto x1 = at::rand({2, 2}, TensorOptions(kCPU).dtype(at::kFloat));
+  auto x2 = at::rand({2, 2}, TensorOptions(kCPU).dtype(at::kFloat));
+  auto q1 = at::quantize_per_tensor(x1, 0.1f, 13, at::kQInt8);
+  auto q2 = at::quantize_per_tensor(x2, 0.1f, 13, at::kQInt8);
+  auto qa = quantized_add_relu(q1, q2, 0.1f, 13);
+  auto y_expected = at::dequantize(qa);
+  TensorExprKernel k(graph);
+  std::vector<at::Tensor> inputs = {x1, x2};
+  StmtPtr s = k.getCodeGenStmt();
+
+  std::vector<IValue> stack = fmap<IValue>(inputs);
+  k.run(stack);
+  auto y = stack[0].toTensor();
+  bool check = at::allclose(y_expected, y);
+  if (!check) {
+    std::cout << "x1:\n" << x1 << std::endl;
+    std::cout << "q1:\n" << q1 << std::endl;
+    std::cout << "x2:\n" << x2 << std::endl;
+    std::cout << "q2:\n" << q2 << std::endl;
+    std::cout << "y_expected:\n" << y_expected << std::endl;
+    std::cout << "y:\n" << y << std::endl;
+  }
+  CHECK_EQ(check, 1);
+}
+
+TEST_F(Quantization, QuantAddReluDequantUInt8) {
+  const auto graph_string = R"IR(
+      graph(%x1 : Float(2, 2, strides=[2, 1], device=cpu), %x2 : Float(2, 2, strides=[2, 1], device=cpu)):
+        %2 : int = prim::Constant[value=13]()
+        %qz1 : int = prim::Constant[value=13]()
+        %qs1 : float = prim::Constant[value=0.1]()
+        %qz2 : int = prim::Constant[value=13]()
+        %qs2 : float = prim::Constant[value=0.1]()
+        %qza : int = prim::Constant[value=13]()
+        %qsa : float = prim::Constant[value=0.1]()
+        %q1 : QUInt8(2, 2) = aten::quantize_per_tensor(%x1, %qs1, %qz1, %2)
+        %q2 : QUInt8(2, 2) = aten::quantize_per_tensor(%x2, %qs2, %qz2, %2)
+        %qa : QUInt8(2, 2) = quantized::add_relu(%q1, %q2, %qsa, %qza)
+        %6 : Float(2, 2) = aten::dequantize(%qa)
+        return (%6))IR";
+  auto graph = std::make_shared<Graph>();
+  parseIR(graph_string, &*graph);
+
+  auto x1 = at::rand({2, 2}, TensorOptions(kCPU).dtype(at::kFloat));
+  auto x2 = at::rand({2, 2}, TensorOptions(kCPU).dtype(at::kFloat));
+  auto q1 = at::quantize_per_tensor(x1, 0.1f, 13, at::kQUInt8);
+  auto q2 = at::quantize_per_tensor(x2, 0.1f, 13, at::kQUInt8);
+  auto qa = quantized_add_relu(q1, q2, 0.1f, 13);
+  auto y_expected = at::dequantize(qa);
+
+  TensorExprKernel k(graph);
+  std::vector<at::Tensor> inputs = {x1, x2};
+  StmtPtr s = k.getCodeGenStmt();
+
+  std::vector<IValue> stack = fmap<IValue>(inputs);
+  k.run(stack);
+  auto y = stack[0].toTensor();
+  bool check = at::allclose(y_expected, y);
+  if (!check) {
+    std::cout << "x1:\n" << x1 << std::endl;
+    std::cout << "q1:\n" << q1 << std::endl;
+    std::cout << "x2:\n" << x2 << std::endl;
+    std::cout << "q2:\n" << q2 << std::endl;
+    std::cout << "y_expected:\n" << y_expected << std::endl;
+    std::cout << "y:\n" << y << std::endl;
+  }
+  CHECK_EQ(check, 1);
+}
+
 TEST_F(Quantization, QuantSigmoidDequantUInt8) {
   const auto graph_string = R"IR(
       graph(%x1 : Float(2, 2, strides=[2, 1], device=cpu)):

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -40,6 +40,7 @@ namespace torch {
 namespace jit {
 
 static bool texpr_reductions_enabled = false;
+static bool texpr_quant_enabled = false;
 
 bool isSupportedForBlock(Node* node) {
   switch (node->kind()) {
@@ -75,6 +76,25 @@ OperatorSet& getCustomOperatorSet() {
   return _g_custom_operator_set;
 }
 
+OperatorSet& getQuantizationOperatorSet() {
+  // clang-format off
+  static OperatorSet _g_supported_quantization_set{
+      "aten::quantize_per_tensor.tensor_qparams(Tensor self, Tensor scale, Tensor zero_point, ScalarType dtype) -> Tensor",
+      "aten::quantize_per_tensor(Tensor self, float scale, int zero_point, ScalarType dtype) -> Tensor",
+      "aten::dequantize.self(Tensor self) -> Tensor",
+      "quantized::add(Tensor qa, Tensor qb, float scale, int zero_point) -> Tensor qc",
+      "quantized::mul(Tensor qa, Tensor qb, float scale, int zero_point)-> Tensor qc",
+      "quantized::matmul(Tensor qa, Tensor qb, float scale, int zero_point)-> Tensor qc",
+      "quantized::add_relu(Tensor qa, Tensor qb, float scale, int zero_point) -> Tensor qc",
+      "quantized::conv2d.new(Tensor qx, __torch__.torch.classes.quantized.Conv2dPackedParamsBase packed_weight, float output_scale, int output_zero_point) -> (Tensor)",
+      "quantized::conv2d_relu.new(Tensor qx, __torch__.torch.classes.quantized.Conv2dPackedParamsBase packed_weight, float output_scale, int output_zero_point) -> (Tensor)",
+      "quantized::linear(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> (Tensor Y)",
+      "quantized::linear_relu(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> (Tensor Y)",
+  };
+  // clang-format on
+  return _g_supported_quantization_set;
+};
+
 static const OperatorSet& supported_non_eltwise_set() {
   // clang-format off
   static const OperatorSet supported_non_eltwise_set{
@@ -102,12 +122,14 @@ bool isSupported(Node* node) {
       "aten::cat(Tensor[] tensors, int dim=0) -> Tensor",
       "aten::unsqueeze(Tensor(a) self, int dim) -> Tensor(a)",
   };
+
   // clang-format on
 
   if (get_tensorexpr_elementwise_set().contains(node) ||
       node->isMemberOf(supported_non_eltwise_set()) ||
       node->isMemberOf(supported_misc_set) ||
       node->isMemberOf(getCustomOperatorSet()) ||
+      (texpr_quant_enabled && node->isMemberOf(getQuantizationOperatorSet())) ||
       (texpr_reductions_enabled && node->isMemberOf(supported_reduction_set))) {
     // We only insert guards on Tensor types, so we rely on the output
     // of a node being uniquely determined by its input types.
@@ -180,8 +202,18 @@ bool setTexprReductionsEnabled(bool value) {
   return old_value;
 }
 
+bool setTexprQuantEnabled(bool value) {
+  bool old_value = texpr_quant_enabled;
+  texpr_quant_enabled = value;
+  return old_value;
+}
+
 bool texprReductionsEnabled() {
   return texpr_reductions_enabled;
+}
+
+bool texprQuantEnabled() {
+  return texpr_quant_enabled;
 }
 
 void removeProfileNodesAndSpecializeTypes(Block* b) {
@@ -489,7 +521,8 @@ class TensorExprFuser {
       // non-elementwise like batch_norm, conv, matmul, and
       // a few exceptions (e.g. prim::ConstantChunk, etc) listed above
       if (!(get_tensorexpr_elementwise_set().contains(n)) &&
-          !n->isMemberOf(tensorexpr::supported_non_eltwise_set())) {
+          !n->isMemberOf(tensorexpr::supported_non_eltwise_set()) &&
+          !n->isMemberOf(tensorexpr::getQuantizationOperatorSet())) {
         continue;
       }
 
@@ -1079,7 +1112,7 @@ class TensorExprFuser {
           // All tensor types should be known.
           return false;
         }
-        if (c10::isComplexType(*st) || c10::isQIntType(*st)) {
+        if (c10::isComplexType(*st)) {
           return false;
         }
       }

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -25,6 +25,8 @@ TORCH_API void setTensorExprDynamicShapeFusionEnabled(bool val);
 TORCH_API bool tensorExprDynamicShapeFusionEnabled();
 TORCH_API bool setTexprReductionsEnabled(bool value);
 TORCH_API bool texprReductionsEnabled();
+TORCH_API bool setTexprQuantEnabled(bool value);
+TORCH_API bool texprQuantEnabled();
 
 TORCH_API void RemoveProfileNodesAndSpecializeTypes(
     std::shared_ptr<Graph>& graph);
@@ -72,6 +74,11 @@ TORCH_API bool isSupported(Node* node);
 /// @return Reference of the custome operator set
 ///
 TORCH_API OperatorSet& getCustomOperatorSet();
+
+/// Get the modifiable quantization operator set object.
+/// @return Reference of the quantization operator set
+///
+TORCH_API OperatorSet& getQuantizationOperatorSet();
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -979,6 +979,8 @@ void initJITBindings(PyObject* module) {
           "_jit_texpr_dynamic_shape_enabled",
           &tensorExprDynamicShapeFusionEnabled)
       .def("_jit_texpr_reductions_enabled", &texprReductionsEnabled)
+      .def("_jit_set_texpr_quantization_enabled", &setTexprQuantEnabled)
+      .def("_jit_texpr_quantization_enabled", &texprQuantEnabled)
       .def(
           "_jit_set_te_generate_block_code",
           [](bool gen_block_code) {

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -91,6 +91,26 @@ class TORCH_API CodeGen {
         size, stride, dtype_opt, layout_opt, device_opt, pin_memory_opt);
   }
 
+  virtual at::Tensor empty_strided_quantized(
+      c10::IntArrayRef size,
+      c10::optional<c10::ScalarType> dtype_opt,
+      c10::optional<c10::Layout> layout_opt,
+      c10::optional<c10::Device> device_opt,
+      c10::optional<bool> pin_memory_opt,
+      double scale,
+      int64_t zero_point,
+      c10::optional<c10::MemoryFormat> memory_format_opt) {
+    return at::native::empty_affine_quantized(
+        size,
+        dtype_opt,
+        layout_opt,
+        device_opt,
+        pin_memory_opt,
+        scale,
+        zero_point,
+        memory_format_opt);
+  };
+
   const std::string& kernel_func_name() const {
     return kernel_func_name_;
   }

--- a/torch/csrc/jit/tensorexpr/graph_opt.cpp
+++ b/torch/csrc/jit/tensorexpr/graph_opt.cpp
@@ -1,6 +1,10 @@
 #include <torch/csrc/jit/tensorexpr/graph_opt.h>
 
+#include <torch/csrc/jit/ir/irparser.h>
+#include <torch/csrc/jit/ir/subgraph_matcher.h>
 #include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/common_subexpression_elimination.h>
+#include <torch/csrc/jit/passes/constant_pooling.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <torch/csrc/jit/runtime/symbolic_shape_registry_util.h>
@@ -179,6 +183,236 @@ bool OptimizeCat(const std::shared_ptr<Graph>& graph) {
     return true;
   }
   return false;
+}
+
+Node* insertDequant(Graph* graph, Value* quantized_val) {
+  Node* dequant = graph->create(Symbol::aten("dequantize"), {quantized_val});
+  auto tt = quantized_val->type()->cast<TensorType>();
+  TORCH_INTERNAL_ASSERT(
+      tt != nullptr,
+      buildErrorMessage("Value to be dequanted should be a tensortype."));
+  auto output_type = tt->withScalarType(at::ScalarType::Float);
+  dequant->output()
+      ->setDebugName(quantized_val->debugName() + ".dequant")
+      ->setType(output_type);
+
+  return graph->insertNode(dequant);
+}
+
+Node* insertQuant(
+    Graph* graph,
+    std::vector<Value*>& inputs,
+    c10::optional<c10::ScalarType> dtype) {
+  // TODO: also to deal with quantize_per_channel
+  inputs.push_back(
+      graph->insertConstant(IValue(static_cast<int64_t>(dtype.value()))));
+  Node* quant = graph->create(Symbol::aten("quantize_per_tensor"), inputs);
+
+  Value* fp32_value = inputs.at(0);
+  auto output_type =
+      fp32_value->type()->cast<TensorType>()->withScalarType(dtype);
+  quant->output()
+      ->setDebugName(fp32_value->debugName() + ".quant")
+      ->setType(output_type);
+
+  return graph->insertNode(quant);
+}
+
+void DecomposeQuantizedOp(
+    std::shared_ptr<Graph> graph,
+    Graph& pattern_graph,
+    Graph& target_graph,
+    c10::optional<Graph*>& post_op_graph) {
+  std::vector<Value*> values_to_rewrite;
+  std::unordered_map<Value*, Value*> rewrite_map;
+  std::unordered_set<Node*> nodes_to_delete_;
+
+  // Locate the pattern graph and replace with target graph
+  const auto& matches = findPatternMatches(pattern_graph, *graph);
+  for (const Match& match : matches) {
+    // Collect original inputs and insertion point for target graph
+    Node* ins_point = nullptr;
+    c10::optional<c10::ScalarType> quant_dtype = c10::nullopt;
+    std::vector<Value*> inputs, outputs;
+    std::vector<size_t> qtensor_pos_list;
+    for (const auto idx : c10::irange(pattern_graph.inputs().size())) {
+      Value* input = match.values_map.at(pattern_graph.inputs().at(idx));
+      inputs.push_back(input);
+      if (!ins_point || ins_point->isBefore(input->node())) {
+        ins_point = input->node();
+      }
+      c10::TensorTypePtr inputType = input->type()->cast<TensorType>();
+      if (inputType) {
+        auto scalarType = inputType->scalarType();
+        if (scalarType == at::ScalarType::QInt8 ||
+            scalarType == at::ScalarType::QUInt8) {
+          qtensor_pos_list.push_back(idx);
+        }
+      }
+    }
+    AT_ASSERT(ins_point);
+
+    // Prepare the outputs for target graph
+    for (Value* v : pattern_graph.outputs()) {
+      Value* output = match.values_map.at(v);
+      outputs.push_back(output);
+      if (quant_dtype == c10::nullopt) {
+        c10::TensorTypePtr outputType = output->type()->cast<TensorType>();
+        if (outputType) {
+          // Assume all the outputs have same dtype
+          quant_dtype = outputType->scalarType();
+        }
+      }
+    }
+
+    if (quant_dtype == c10::nullopt) {
+      // Can't decompose if havn't got quant dtype from any output, skip this
+      // match
+      continue;
+    }
+
+    // Insert dequant nodes and replace the outputs in the original inputs
+    ins_point = ins_point->next();
+    WithInsertPoint insert_point(ins_point);
+    for (const auto idx : c10::irange(qtensor_pos_list.size())) {
+      size_t qtensor_pos = qtensor_pos_list.at(idx);
+      ins_point = insertDequant(graph.get(), inputs.at(qtensor_pos));
+      inputs.at(qtensor_pos) = ins_point->output();
+    }
+
+    // Prepare the inputs for quantization OP (partially) and FP32 OP
+    // TODO: assume quantize_per_tensor here, need to support per_channel in
+    // future
+    std::vector<Value*> quant_inputs;
+    quant_inputs.push_back(nullptr);
+    quant_inputs.push_back(inputs.at(inputs.size() - 2));
+    quant_inputs.push_back(inputs.at(inputs.size() - 1));
+    inputs.pop_back();
+    inputs.pop_back();
+
+    // Insert the according FP32 OP
+    std::vector<Value*> new_outputs = insertGraph(*graph, target_graph, inputs);
+    AT_ASSERT(outputs.size() == new_outputs.size());
+
+    // Insert post-op nodes
+    if (post_op_graph != c10::nullopt) {
+      for (const auto idx : c10::irange(new_outputs.size())) {
+        Value* v = new_outputs.at(idx);
+        Value* v_ori = outputs.at(idx);
+        if (v->type()->cast<TensorType>()) {
+          v->setType(v_ori->type()->cast<TensorType>()->withScalarType(
+              at::ScalarType::Float));
+          std::vector<Value*> post_op_outputs =
+              insertGraph(*graph, **post_op_graph, {v});
+          new_outputs.at(idx) = post_op_outputs[0];
+        }
+      }
+    }
+
+    // Insert quant nodes
+    for (const auto idx : c10::irange(new_outputs.size())) {
+      Value* v = new_outputs.at(idx);
+      Value* v_ori = outputs.at(idx);
+      if (v->type()->cast<TensorType>()) {
+        v->setType(v_ori->type()->cast<TensorType>()->withScalarType(
+            at::ScalarType::Float));
+        quant_inputs.at(0) = v;
+        ins_point = insertQuant(graph.get(), quant_inputs, quant_dtype);
+        new_outputs.at(idx) = ins_point->output();
+      }
+    }
+
+    // Record all planned rewritings
+    AT_ASSERT(outputs.size() == new_outputs.size());
+    for (const auto idx : c10::irange(outputs.size())) {
+      values_to_rewrite.push_back(outputs[idx]);
+      rewrite_map[outputs[idx]] =
+          new_outputs[idx]->setType(outputs[idx]->type());
+    }
+    // Record all planned deletions
+    for (Node* pattern_n : pattern_graph.nodes()) {
+      if (match.nodes_map.count(pattern_n)) {
+        Node* n = match.nodes_map.at(pattern_n);
+        nodes_to_delete_.insert(n);
+      }
+    }
+  }
+
+  // Perform planned rewritings
+  for (auto v : values_to_rewrite) {
+    v->replaceAllUsesWith(rewrite_map.at(v));
+  }
+
+  // Perform planned deletions
+  for (auto n : nodes_to_delete_) {
+    n->removeAllInputs();
+  }
+  for (auto n : nodes_to_delete_) {
+    n->destroy();
+  }
+  nodes_to_delete_.clear();
+}
+
+void DecomposeQuantizedOps(std::shared_ptr<Graph> graph) {
+  std::vector<std::pair<std::string, std::string>> op_list;
+  // Only support unary OPs with shape not changed
+  std::vector<c10::optional<std::string>> post_op_list;
+
+  op_list.push_back({
+      R"(graph(%a_quant, %b_quant, %scale, %zero_point):
+         %add_out = quantized::add(%a_quant, %b_quant, %scale, %zero_point)
+         return (%add_out) )",
+      R"(graph(%a, %b):
+         %1 : int = prim::Constant[value=1]()
+         %add_out = aten::add(%a, %b, %1)
+         return (%add_out) )"});
+  post_op_list.push_back(c10::nullopt);
+
+  op_list.push_back({
+      R"(graph(%a_quant, %b_quant, %scale, %zero_point):
+         %mul_out = quantized::mul(%a_quant, %b_quant, %scale, %zero_point)
+         return (%mul_out) )",
+      R"(graph(%a, %b):
+         %mul_out = aten::mul(%a, %b)
+         return (%mul_out) )"});
+  post_op_list.push_back(c10::nullopt);
+
+  op_list.push_back({
+      R"(graph(%a_quant, %b_quant, %scale, %zero_point):
+         %add_out = quantized::add_relu(%a_quant, %b_quant, %scale, %zero_point)
+         return (%add_out) )",
+      R"(graph(%a, %b):
+         %1 : int = prim::Constant[value=1]()
+         %add_out = aten::add(%a, %b, %1)
+         return (%add_out) )"});
+  post_op_list.push_back(c10::make_optional(std::string(
+      R"(graph(%a):
+      %relu_out = aten::relu(%a)
+      return (%relu_out) )")));
+
+  for (const auto idx : c10::irange(op_list.size())) {
+    Graph pattern_graph;
+    parseIR(op_list[idx].first, &pattern_graph);
+    Graph target_graph;
+    parseIR(op_list[idx].second, &target_graph);
+    c10::optional<Graph*> post_op_graph;
+    Graph post_op_g;
+    if (post_op_list[idx] != c10::nullopt) {
+      parseIR(post_op_list[idx].value(), &post_op_g);
+      post_op_graph.emplace(&post_op_g);
+    }
+    DecomposeQuantizedOp(graph, pattern_graph, target_graph, post_op_graph);
+  }
+}
+
+bool DecomposeOps(const std::shared_ptr<Graph>& graph) {
+  DecomposeQuantizedOps(graph);
+  GRAPH_DUMP("After DecomposeQuantizedOps:", graph);
+  EliminateCommonSubexpression(graph);
+  GRAPH_DUMP("After EliminateCommonSubexpression:", graph);
+  ConstantPooling(graph);
+  GRAPH_DUMP("After ConstantPooling:", graph);
+  return true;
 }
 
 void annotateInputShapes(

--- a/torch/csrc/jit/tensorexpr/graph_opt.h
+++ b/torch/csrc/jit/tensorexpr/graph_opt.h
@@ -57,6 +57,7 @@ namespace tensorexpr {
 //     aten_cat is the output buffer here.
 
 bool OptimizeCat(const std::shared_ptr<Graph>& graph);
+bool DecomposeOps(const std::shared_ptr<Graph>& graph);
 
 TORCH_API void annotateInputShapes(
     const std::shared_ptr<Graph>& graph,

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -275,12 +275,14 @@ class TORCH_API TensorExprKernel {
     c10::optional<c10::Layout> layout;
     c10::optional<c10::Device> device;
     c10::optional<bool> pinned_memory;
+    c10::optional<c10::MemoryFormat> memory_format;
 
     UnpackedTensorOptions(const c10::TensorOptions& opts)
         : dtype(optTypeMetaToScalarType(opts.dtype_opt())),
           layout(opts.layout_opt()),
           device(opts.device_opt()),
-          pinned_memory(opts.pinned_memory_opt()) {}
+          pinned_memory(opts.pinned_memory_opt()),
+          memory_format(opts.memory_format_opt()) {}
   };
 
   ExprHandle getVarForShape(const c10::ShapeSymbol& ss);
@@ -305,8 +307,12 @@ class TORCH_API TensorExprKernel {
   std::vector<CodeGen::BufferArg> bufferArgs_;
   std::vector<std::vector<int64_t>> tensorOutputSizes_;
   std::vector<std::vector<int64_t>> tensorOutputStrides_;
+  std::vector<ExprPtr> tensorOutputQscales_;
+  std::vector<ExprPtr> tensorOutputQzeros_;
+  std::unordered_map<std::string, size_t> qtensorInputIndex_;
   std::vector<torch::jit::StrideInput> tensorOutputStrideDesc_;
   std::vector<bool> isOutputScalar_;
+  std::vector<bool> isOutputQuantized_;
   std::vector<UnpackedTensorOptions> tensorOutputTensorOptions_;
   std::unordered_set<BufPtr> bufOutputs_;
   std::unordered_map<const torch::jit::Value*, BufPtr> bufs_;

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -404,6 +404,26 @@ at::Tensor LLVMCodeGen::empty_strided(
       size, stride, dtype_opt, layout_opt, device_opt, pin_memory_opt);
 }
 
+at::Tensor LLVMCodeGen::empty_strided_quantized(
+    c10::IntArrayRef size,
+    c10::optional<c10::ScalarType> dtype_opt,
+    c10::optional<c10::Layout> layout_opt,
+    c10::optional<c10::Device> device_opt,
+    c10::optional<bool> pin_memory_opt,
+    double scale,
+    int64_t zero_point,
+    c10::optional<c10::MemoryFormat> memory_format_opt) {
+  return at::native::empty_affine_quantized(
+      size,
+      dtype_opt,
+      layout_opt,
+      device_opt,
+      pin_memory_opt,
+      scale,
+      zero_point,
+      memory_format_opt);
+}
+
 void* LLVMCodeGen::getKernelAddress(LLVMCodeGenCallee* callee) {
   return (void*)callee->getKernelAddress();
 }

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.h
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.h
@@ -53,6 +53,16 @@ class TORCH_API LLVMCodeGen : public CodeGen {
       c10::optional<c10::Device> device_opt,
       c10::optional<bool> pin_memory_opt) override;
 
+  at::Tensor empty_strided_quantized(
+      c10::IntArrayRef size,
+      c10::optional<c10::ScalarType> dtype_opt,
+      c10::optional<c10::Layout> layout_opt,
+      c10::optional<c10::Device> device_opt,
+      c10::optional<bool> pin_memory_opt,
+      double scale,
+      int64_t zero_point,
+      c10::optional<c10::MemoryFormat> memory_format_opt) override;
+
   template <typename T>
   T value() {
     return value<T>(nullptr);


### PR DESCRIPTION
This PR aims to provide basic support of quantization in NNC, including the whole path since TE fuser until OP lowering to TE IR.

The basic philosophy is to leverage FP32 path in TE as much as possible for those OPs without dedicated hardware acceleration/benefit, which can then enable pytorch to support quantization as quick/efficient as possible while keeping those hardware-beneficial OPs with dedicated TE IR implementation.

With this philosophy, OPs like Conv/Matmul should definitely be with dedicated TE IR implementation as with CPU acceleration like AVX512-VNNI, etc. And most of the other OPs should fall into the first category to leverage related FP32 OPs in TE.

The way used to leverage FP32 OP is 'Decompose' -- which means to decompose a quantized OP into an OP sequence like dequantize/FP32 OP/quantize. E.x.: quantized:mul => aten::dequantize/aten::mul/aten::quantize_per_tensor. After TE fuser gets the sub-graph, it can run this 'Decompose' pass as part of its graph optimization phase, then all the quantization OPs will be replaced with related sequences except the quantized Conv/Matmuls, which can then be lowered into TE IR accordingly.

Besides the basic philosophy, another major part for quantization support is to embed quantization information like qscale and qzero_point during TE execution both for TE kernel compiling and running. This includes both TE framework support and TE OP level support.

Below listed more details:

- Implemented quantization path in TE fuser which will accept supported quantization OPs into TE sub-group.
```
torch/csrc/jit/passes/tensorexpr_fuser.cpp
```

- Implemented quantization path in TE kernel compiling and running as to pass in/out quantization specific info like qscale/qzero_point.
```
torch/csrc/jit/tensorexpr/kernel.cpp
torch/csrc/jit/tensorexpr/kernel.h
torch/csrc/jit/tensorexpr/codegen.h
torch/csrc/jit/tensorexpr/llvm_codegen.h
torch/csrc/jit/tensorexpr/llvm_codegen.cpp
```

- Implemented a new graph optimization path inside TE fuser as to 'decompose' quantization OPs into an OP sequence like dequantize/FP32 OP/quantize. 
```
torch/csrc/jit/tensorexpr/graph_opt.cpp
torch/csrc/jit/tensorexpr/graph_opt.h
```

- Updated existing NNC quantization lowering functions to support qscale and qzero obtaining from runtime.
```
torch/csrc/jit/tensorexpr/operators/quantization.cpp
torch/csrc/jit/tensorexpr/operators/quantization.h
```

- Added a new interface(c/python) to control the enable/disable of quantization support in TE.
- Added a new interface (c) to support customization of supported quantization OP list for TE fuser.
```
torch/csrc/jit/passes/tensorexpr_fuser.cpp
torch/csrc/jit/passes/tensorexpr_fuser.h
torch/csrc/jit/python/init.cpp
```

- Added some tests regarding the new features of this commit.
```
test/cpp/tensorexpr/test_graph_opt.cpp
test/cpp/tensorexpr/test_quantization.cpp
test/cpp/tensorexpr/test_external_calls.cpp
```



