### PR TITLE
[pytorch] add missing -fexceptions flags

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -156,6 +156,7 @@ def get_pt_compiler_flags():
     })
 
 _PT_COMPILER_FLAGS = [
+    "-fexceptions",
     "-frtti",
     "-Os",
     "-Wno-unknown-pragmas",
@@ -1099,6 +1100,7 @@ def define_buck_targets(
         srcs = [
             "torch/csrc/jit/mobile/observer.cpp",
         ] + ([] if IS_OSS else ["torch/fb/observers/MobileObserverUtil.cpp"]),
+        compiler_flags = ["-fexceptions"],
         header_namespace = "",
         exported_headers = subdir_glob(
             [
@@ -1833,6 +1835,7 @@ def define_buck_targets(
             "torch/csrc/jit/runtime/static/passes.cpp",
             "torch/csrc/jit/runtime/static/te_wrapper.cpp",
         ],
+        compiler_flags = ["-fexceptions"],
         labels = labels,
         # @lint-ignore BUCKLINT link_whole
         link_whole = True,

--- a/build.bzl
+++ b/build.bzl
@@ -14,6 +14,7 @@ def define_targets(rules):
             "caffe2/serialize/istream_adapter.cc",
             "caffe2/serialize/read_adapter_interface.cc",
         ],
+        copts = ["-fexceptions"],
         tags = [
             "supermodule:android/default/pytorch",
             "supermodule:ios/default/public.pytorch",


### PR DESCRIPTION
Summary:
Add missing `-fexceptions` flags that are currently being passed through `exported_preprocessor_flags`. The exported preprocessor flags will be removed in a subsequent diff.

This is a rediff of D37386802 (https://github.com/pytorch/pytorch/commit/3e1ac21c3bcbc0e27dcf058900e9572d3c135a20) with the changes split out to avoid reverts.

Test Plan:
Check flag is present:
```
$ buck uquery xplat/caffe2:common_core -a 'compiler_flags'
{
  "//xplat/caffe2:common_core" : {
    "compiler_flags" : [
      "-fexceptions",
      "-frtti",
      "-Os",
      "-Wno-unknown-pragmas",
      "-Wno-write-strings",
      "-Wno-unused-variable",
      "-Wno-unused-function",
      "-Wno-deprecated-declarations",
      "-Wno-shadow",
      "-Wno-global-constructors",
      "-Wno-missing-prototypes",
      "-std=gnu++17",
      "/EHsc",
      "/GR",
      "/O1",
      "/wd4101"
    ]
  }
}
```

Differential Revision: D37813869

