### PR TITLE
[composite compliance] check output of backward with subclass args against regular tensor

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15700,8 +15700,6 @@ op_db: List[OpInfo] = [
                         DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit',),
                         # TODO: FIXME tolerance is too high
                         DecorateInfo(unittest.skip('Skipped!'), 'TestGradients'),
-                        # Pre-existing condition - (nan vs nan) comparison
-                        DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_backward'),
                     ),
                     assert_autodiffed=True,
                     autodiff_nonfusible_nodes=['aten::pow'],),
@@ -17606,8 +17604,6 @@ op_db: List[OpInfo] = [
                         # nan vs nan comparisons
                         # https://github.com/pytorch/pytorch/issues/74279
                         DecorateInfo(unittest.skip("Skipped!"), 'TestGradients'),
-                        # Pre-existing condition - (nan vs nan) comparison
-                        DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_backward'),
                     )),
     OpInfo('zero_',
            op=lambda x: torch.zero_(x.clone()),
@@ -17635,8 +17631,6 @@ op_db: List[OpInfo] = [
                         # nan vs 0 comparisons
                         # https://github.com/pytorch/pytorch/issues/74279
                         DecorateInfo(unittest.skip("Skipped!"), 'TestGradients'),
-                        # Pre-existing condition - (nan vs nan) comparison
-                        DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_backward'),
                     )),
     BinaryUfuncInfo('special.zeta',
                     aten_name='special_zeta',

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -15700,6 +15700,8 @@ op_db: List[OpInfo] = [
                         DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit',),
                         # TODO: FIXME tolerance is too high
                         DecorateInfo(unittest.skip('Skipped!'), 'TestGradients'),
+                        # Pre-existing condition - (nan vs nan) comparison
+                        DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_backward'),
                     ),
                     assert_autodiffed=True,
                     autodiff_nonfusible_nodes=['aten::pow'],),
@@ -17604,6 +17606,8 @@ op_db: List[OpInfo] = [
                         # nan vs nan comparisons
                         # https://github.com/pytorch/pytorch/issues/74279
                         DecorateInfo(unittest.skip("Skipped!"), 'TestGradients'),
+                        # Pre-existing condition - (nan vs nan) comparison
+                        DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_backward'),
                     )),
     OpInfo('zero_',
            op=lambda x: torch.zero_(x.clone()),
@@ -17631,6 +17635,8 @@ op_db: List[OpInfo] = [
                         # nan vs 0 comparisons
                         # https://github.com/pytorch/pytorch/issues/74279
                         DecorateInfo(unittest.skip("Skipped!"), 'TestGradients'),
+                        # Pre-existing condition - (nan vs nan) comparison
+                        DecorateInfo(unittest.expectedFailure, 'TestCompositeCompliance', 'test_backward'),
                     )),
     BinaryUfuncInfo('special.zeta',
                     aten_name='special_zeta',

--- a/torch/testing/_internal/composite_compliance.py
+++ b/torch/testing/_internal/composite_compliance.py
@@ -413,6 +413,29 @@ def check_backward_formula(op: Callable, args, kwargs,
                            output_process_fn_grad=None,
                            gradcheck_wrapper=None):
     CCT = generate_cct()
+
+    def compute_expected_grads(args, kwargs):
+        if gradcheck_wrapper is None:
+            results = op(*args, **kwargs)
+        else:
+            results = gradcheck_wrapper(op, *args, **kwargs)
+
+        if output_process_fn_grad is not None:
+            results = output_process_fn_grad(results)
+
+        flat_results, _ = tree_flatten(results)
+        flat_diff_results = [r for r in flat_results if r.requires_grad]
+        assert len(flat_diff_results) > 0
+
+        grads = [torch.ones(r.shape, device=r.device, dtype=r.dtype)
+                 for r in flat_diff_results]
+        leaf_tensors = gather_leaf_tensors(args, kwargs)
+        assert len(leaf_tensors) > 0
+        return torch.autograd.grad(flat_diff_results, leaf_tensors,
+                                   grads, allow_unused=True, retain_graph=True)
+
+    expected = compute_expected_grads(args, kwargs)
+
     for choice in generate_subclass_choices_args_kwargs(args, kwargs, CCT):
         new_args, new_kwargs, which_args_are_wrapped, which_kwargs_are_wrapped = choice
         leaf_tensors = gather_leaf_tensors(new_args, new_kwargs)
@@ -442,8 +465,8 @@ def check_backward_formula(op: Callable, args, kwargs,
                  for r in flat_diff_results]
         for flat_new_grads, which_grad_is_batched in generate_subclass_choices(grads, CCT):
             try:
-                torch.autograd.grad(flat_diff_results, leaf_tensors, flat_new_grads,
-                                    allow_unused=True, retain_graph=True)
+                actual = torch.autograd.grad(flat_diff_results, leaf_tensors, flat_new_grads,
+                                             allow_unused=True, retain_graph=True)
             # see NOTE: [What errors are Composite Compiance trying to catch?]
             except RuntimeError as err:
                 raise_composite_compliance_error(
@@ -452,6 +475,11 @@ def check_backward_formula(op: Callable, args, kwargs,
                     f"- wrapped_kwargs: {which_kwargs_are_wrapped}\n"
                     f"- wrapped_grads: {which_grad_is_batched}\n"
                 )
+
+            def unwrap(e):
+                return e.elem if isinstance(e, CCT) else e
+
+            torch.testing.assert_close(tuple(map(unwrap, actual)), expected)
 
 # Checks if the forward AD formula is composite compliant by testing
 # all possible permutations of {primals, tangents} being

--- a/torch/testing/_internal/composite_compliance.py
+++ b/torch/testing/_internal/composite_compliance.py
@@ -479,7 +479,7 @@ def check_backward_formula(op: Callable, args, kwargs,
             def unwrap(e):
                 return e.elem if isinstance(e, CCT) else e
 
-            torch.testing.assert_close(tuple(map(unwrap, actual)), expected)
+            torch.testing.assert_close(tuple(map(unwrap, actual)), expected, equal_nan=True)
 
 # Checks if the forward AD formula is composite compliant by testing
 # all possible permutations of {primals, tangents} being


### PR DESCRIPTION
Time Before
```
= 919 passed, 12 skipped, 38374 deselected, 36 xfailed, 31 warnings in 699.56s (0:11:39) =
```

Time After
```
= 913 passed, 12 skipped, 38374 deselected, 42 xfailed, 31 warnings in 663.96s (0:11:03) =
```

Will follow-up for operator and forward-ad