### PR TITLE
Remove python key when setting functional tensor metadata

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -29,7 +29,7 @@ void FunctionalTensorWrapper::set_constructor_metadata() {
   // All of the keys corresponding to functorch transforms should not be copied over.
   // Functorch transforms all have their own wrapper tensors (e.g. BatchedTensorImpl) which expect
   // to participate in the functorch transforms.
-  key_set_ = key_set_ - c10::functorch_transforms_ks;
+  key_set_ = key_set_ - c10::functorch_transforms_ks - c10::python_ks;
 }
 
 FunctionalTensorWrapper::FunctionalTensorWrapper(const Tensor& value)

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -110,6 +110,10 @@ class TestFunctionalization(TestCase):
             out_functional_unwrapped = torch._from_functional_tensor(out_functional_)
             self.assertEqual(out_ref_, out_functional_unwrapped)
 
+    def test_save_for_backwards_segfault(self):
+        inp = torch._to_functional_tensor(LoggingTensor(torch.randn(2, 2))).requires_grad_(True)
+        inp.exp()
+
     def test_multiple_views_of_same_base(self):
         def f(x):
             y = x.view(-1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #80566
* #81192
* __->__ #81401

Fixes https://github.com/pytorch/pytorch/issues/81365

Signed-off-by: Edward Z. Yang <ezyang@fb.com>