### PR TITLE
Fix docstring on FileOpenerIterDataPipe

### DIFF
--- a/torch/utils/data/datapipes/iter/fileopener.py
+++ b/torch/utils/data/datapipes/iter/fileopener.py
@@ -20,7 +20,7 @@ class FileOpenerIterDataPipe(IterDataPipe[Tuple[str, IOBase]]):
     Args:
         datapipe: Iterable datapipe that provides pathnames
         mode: An optional string that specifies the mode in which
-            the file is opened by ``open()``. It defaults to ``r``, other options are 
+            the file is opened by ``open()``. It defaults to ``r``, other options are
             ``b`` for reading in binary mode and ``t`` for text mode.
         encoding: An optional string that specifies the encoding of the
             underlying file. It defaults to ``None`` to match the default encoding of ``open``.

--- a/torch/utils/data/datapipes/iter/fileopener.py
+++ b/torch/utils/data/datapipes/iter/fileopener.py
@@ -20,8 +20,7 @@ class FileOpenerIterDataPipe(IterDataPipe[Tuple[str, IOBase]]):
     Args:
         datapipe: Iterable datapipe that provides pathnames
         mode: An optional string that specifies the mode in which
-            the file is opened by ``open()``. It defaults to ``b`` which
-            means open for reading in binary mode. Another option is
+            the file is opened by ``open()``. It defaults to ``r``, other options are ``b`` for reading in binary mode and 
             to use ``t`` for text mode
         encoding: An optional string that specifies the encoding of the
             underlying file. It defaults to ``None`` to match the default encoding of ``open``.

--- a/torch/utils/data/datapipes/iter/fileopener.py
+++ b/torch/utils/data/datapipes/iter/fileopener.py
@@ -20,8 +20,7 @@ class FileOpenerIterDataPipe(IterDataPipe[Tuple[str, IOBase]]):
     Args:
         datapipe: Iterable datapipe that provides pathnames
         mode: An optional string that specifies the mode in which
-            the file is opened by ``open()``. It defaults to ``r``, other options are ``b`` for reading in binary mode and 
-            to use ``t`` for text mode
+            the file is opened by ``open()``. It defaults to ``r``, other options are ``b`` for reading in binary mode and ``t`` for text mode.
         encoding: An optional string that specifies the encoding of the
             underlying file. It defaults to ``None`` to match the default encoding of ``open``.
         length: Nominal length of the datapipe

--- a/torch/utils/data/datapipes/iter/fileopener.py
+++ b/torch/utils/data/datapipes/iter/fileopener.py
@@ -20,7 +20,8 @@ class FileOpenerIterDataPipe(IterDataPipe[Tuple[str, IOBase]]):
     Args:
         datapipe: Iterable datapipe that provides pathnames
         mode: An optional string that specifies the mode in which
-            the file is opened by ``open()``. It defaults to ``r``, other options are ``b`` for reading in binary mode and ``t`` for text mode.
+            the file is opened by ``open()``. It defaults to ``r``, other options are 
+            ``b`` for reading in binary mode and ``t`` for text mode.
         encoding: An optional string that specifies the encoding of the
             underlying file. It defaults to ``None`` to match the default encoding of ``open``.
         length: Nominal length of the datapipe


### PR DESCRIPTION
It said the default argument was `b` not `r`

Fixes #81406