### PR TITLE
[GH1] replace globs with patterns that mergebot can process

### DIFF
--- a/.github/merge_rules.json
+++ b/.github/merge_rules.json
@@ -99,12 +99,12 @@
       "patterns": [
          "aten/src/ATen/native/cuda/linalg/**",
          "aten/src/ATen/LinalgBackend.h",
-         "aten/src/ATen/native/**/*LinearAlgebra*",
+         "aten/src/ATen/native/**LinearAlgebra*",
          "docs/source/linalg.rst",
          "torch/linalg/**",
          "torch/_linalg_utils.py",
-         "torch/**/python_linalg_functions.*",
-         "torch/**/linalg.h",
+         "torch/**python_linalg_functions.*",
+         "torch/**linalg.h",
          "tools/autograd/templates/python_linalg_functions.cpp",
          "test/test_linalg.py"
       ],
@@ -125,7 +125,7 @@
          "docs/source/fft.rst",
          "torch/fft/**",
          "torch/csrc/api/include/torch/fft.h",
-         "torch/**/python_fft_functions.*",
+         "torch/**python_fft_functions.*",
          "tools/autograd/templates/python_fft_functions.cpp",
          "test/cpp/api/fft.cpp"
       ],
@@ -142,18 +142,18 @@
          "benchmarks/sparse",
          "c10/util/sparse_bitset.h",
          "docs/source/sparse.rst",
-         "torch/**/sparse/**",
-         "torch/**/*sparse*",
+         "torch/**sparse/**",
+         "torch/**sparse*",
          "torch/optim/sparse*",
          "torch/ao/nn/sparse/**",
-         "torch/utils/benchmark/**/*sparse*",
+         "torch/utils/benchmark/**sparse*",
          "aten/src/ATen/native/ao_sparse/**",
          "aten/src/ATen/native/sparse/**",
-         "aten/src/ATen/**/*Sparse*",
+         "aten/src/ATen/**Sparse*",
          "aten/src/ATen/*Sparse*",
          "torch/_masked/**",
          "test/*_masked*",
-         "test/**/*sparse*"
+         "test/**sparse*"
       ],
       "approved_by": ["nikitaved", "cpuhrsch", "pearu", "IvanYashchuk"],
       "mandatory_checks_name": [

--- a/.github/scripts/gitutils.py
+++ b/.github/scripts/gitutils.py
@@ -305,8 +305,8 @@ def patterns_to_regex(allowed_patterns: List[str]) -> Any:
     """
     pattern is glob-like, i.e. the only special sequences it has are:
       - ? - matches single character
-      - * - matches any non-folder separator characters
-      - ** - matches any characters
+      - * - matches any non-folder separator characters or no character
+      - ** - matches any characters or no character
       Assuming that patterns are free of braces and backslashes
       the only character that needs to be escaped are dot and plus
     """
@@ -324,9 +324,9 @@ def patterns_to_regex(allowed_patterns: List[str]) -> Any:
             elif c == "*":
                 if pattern_.peek() == "*":
                     next(pattern_)
-                    rc += ".+"
+                    rc += ".*"
                 else:
-                    rc += "[^/]+"
+                    rc += "[^/]*"
             else:
                 rc += c
     rc += ")"

--- a/.github/scripts/test_gitutils.py
+++ b/.github/scripts/test_gitutils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from gitutils import PeekableIterator
+from gitutils import PeekableIterator, patterns_to_regex
 from unittest import TestCase, main
 
 class TestPeekableIterator(TestCase):
@@ -21,6 +21,18 @@ class TestPeekableIterator(TestCase):
             else:
                 self.assertTrue(iter_.peek() is None)
 
+
+class TestPattern(TestCase):
+    def test_double_asterisks(self) -> None:
+        allowed_patterns = [
+            "aten/src/ATen/native/**LinearAlgebra*",
+        ]
+        patterns_re = patterns_to_regex(allowed_patterns)
+        fnames = [
+            "aten/src/ATen/native/LinearAlgebra.cpp",
+            "aten/src/ATen/native/cpu/LinearAlgebraKernel.cpp"]
+        for filename in fnames:
+            self.assertTrue(patterns_re.match(filename))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/81330#issuecomment-1182345751 shouldn't have happened and should have matched the linalg rule.

The reason it happened is cuz we don't treat the patterns like globs.

We may follow this up with a BE change to make the patterns be treated more like globs, which I expected originally.