### PR TITLE
[testing only] check if TestRefsOpsInfo runs in CI

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1586,6 +1586,7 @@ class TestRefsOpsInfo(TestCase):
 
     @parametrize("op", ref_ops_names)
     def test_refs_are_in_decomp_table(self, op):
+        assert False
         path = op.split('.')
         module_path = '.'.join(path[:-1])
         op_name = path[-1]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #81420
* __->__ #81419
* #81142

Locally this test fails because refs I recently added (relu6 and prelu6) are not part of the decomp table, but CI apparently isn't.
EDIT: this is because the test only checks ops that are in __all__