### PR TITLE
[DRAFT] Enable use of CSC in autograd

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1153,10 +1153,13 @@ at::IntArrayRef strides_or_error(
         "Please either use a strided tensor or set requires_grad=False for '",
         input_name,
         "'");
-    if (input.is_mkldnn())
+    if (input.is_mkldnn()) {
       return IntArrayRef({});
-    if (input.is_sparse_csr())
+    }
+    if (input.layout() == c10::kSparseCsr ||
+        input.layout() == c10::kSparseCsc) {
       return IntArrayRef({});
+    }
     return input.strides();
   } else {
     return IntArrayRef({});

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -751,14 +751,16 @@ void validate_outputs(
     if (grad.layout() != metadata.layout()) {
       // TODO: Currently we only support (*, Sparse) combination for
       // (tensor.layout(), tensor.grad.layout()) In future, there will be an
-      // oppportunity to support more combinations of layouts if they are
+      // opportunity to support more combinations of layouts if they are
       // composable (example., operations like addition etc., are well defined
       // between tensors of different layouts.), as well as all parts of
       // autograd like AccumulateGrad correctly handle this. We allow grad to be
-      // Strided when metadata is SparseCsr
+      // Strided when metadata is SparseCsr or SparseCsc
       if (!grad.is_sparse() &&
-          !(grad.layout() == at::kStrided &&
-            metadata.layout() == at::kSparseCsr)) {
+          !((grad.layout() == at::kStrided &&
+             metadata.layout() == at::kSparseCsr) ||
+            (grad.layout() == at::kStrided &&
+             metadata.layout() == at::kSparseCsc))) {
         std::stringstream ss;
         ss << "invalid gradient at index " << i << " - expected layout ";
         ss << metadata.layout() << " but got " << grad.layout();


### PR DESCRIPTION
Just getting CI

Snippet

```
import torch
a = torch.randn(40, 50).relu()
a_csr = a.to_sparse_csr().requires_grad_()
torch.mm(a_csr, a_csr.transpose(0, 1)).sum().backward()
print(a_csr.grad)
```