### PR TITLE
Check existence of the array ref when tracing resize_

### DIFF
--- a/torch/csrc/autograd/TraceTypeManual.cpp
+++ b/torch/csrc/autograd/TraceTypeManual.cpp
@@ -54,7 +54,9 @@ const Tensor& resize_(
     IntArrayRef size,
     c10::optional<MemoryFormat> optional_memory_format) {
   if (torch::jit::tracer::isTracing()) {
-    jit::tracer::ArgumentStash::popIntArrayRef("size");
+    if (jit::tracer::ArgumentStash::hasIntArrayRef("size")) {
+      jit::tracer::ArgumentStash::popIntArrayRef("size");
+    }
     jit::tracer::warn("resize_", jit::tracer::WARN_RESIZE);
     jit::tracer::delValueTrace(self);
   }

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -982,7 +982,8 @@ void ArgumentStash::stashIntArrayRefElem(
   // TODO: check type?
   if (!isTracing())
     return;
-  auto& list_trace = stash.intlists.emplace(arg_name, size).first->second;
+  IntArrayRefTrace& list_trace =
+      stash.intlists.emplace(arg_name, size).first->second;
   AT_ASSERT(size == list_trace.size());
   AT_ASSERT(idx < list_trace.size());
   AT_ASSERT(list_trace[idx] == nullptr);
@@ -1060,7 +1061,8 @@ const char* WARN_CONSTRUCTOR =
 const char* WARN_RESIZE =
     " can't be represented in the JIT at the moment, so we won't connect any uses of "
     "this value with its current trace. If you happen to use it again, it will show "
-    "up as a constant in the graph.";
+    "up as a constant in the graph. Consider using `view` or `reshape` to make "
+    "it traceable.";
 const char* STRICT_TRACER_MSG =
     " might cause the trace to be incorrect, this is only valid if the container "
     "structure does not change based on the module's inputs. Consider using a constant "


### PR DESCRIPTION
When `.resize_` takes an empty `torch.Size` or ints, tracing it would result in a `RuntimeError: _Map_base::at` (key not found in map). 

In

https://github.com/pytorch/pytorch/blob/0d124fc6961f5b39f1a46722dab2d88f23686783/torch/csrc/jit/frontend/tracer.h#L126-L129

- This change updates `TraceType::resize_` to check the mapping first.
- It also updates the warning message when tracing `resize_` to suggest using reshape or view.

Repo:

```python
import torch


class M(torch.nn.Module):
    def forward(self, x, y):
        print(y.shape)
        x = x.resize_(y.shape)
        return x, y


x = torch.tensor(1.2)
y = torch.tensor(4.2)

M()(x, y)
torch.jit.trace(M(), (x, y))
```

Related: https://github.com/pytorch/pytorch/issues/76486