### PR TITLE
Add a small fastpath test for native mha

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -20881,6 +20881,13 @@ torch.cuda.synchronize()
 
     @dtypes(torch.double)
     @torch.no_grad()
+    def test_multihead_attn_fast_path_small_test(self, device, dtype):
+        mha = torch.nn.MultiheadAttention(3, 3, batch_first=True, dtype=dtype, device=device).eval()
+        query = torch.randn(3, 3, 3, dtype=dtype, device=device)
+        mha(query, query, query)
+
+    @dtypes(torch.double)
+    @torch.no_grad()
     def test_multihead_attn_in_proj_bias_none(self, device, dtype):
         mha = torch.nn.MultiheadAttention(1, 1, bias=False, dtype=dtype, device=device)
         query = torch.rand(3, 2, 1, dtype=dtype, device=device)


### PR DESCRIPTION
Summary: We dont have a small fast path passing test for mha before, this diff added one for better testing

Test Plan: buck build mode/dev-nosan -c fbcode.platform=platform009 -c fbcode.enable_gpu_sections=true caffe2/test:nn && buck-out/dev/gen/caffe2/test/nn\#binary.par -r test_multihead_attn_fast_path_small_test

Differential Revision: D37834319

