### PR TITLE
[Trivial] Delete C10_DECLARE_TLS_class_static and C10_DEFINE_TLS_class_static

### DIFF
--- a/c10/test/util/ThreadLocal_test.cpp
+++ b/c10/test/util/ThreadLocal_test.cpp
@@ -64,21 +64,6 @@ TEST(ThreadLocalTest, TestInnerScopeWithTwoVars) {
   EXPECT_EQ(*str, "");
 }
 
-struct Foo {
-  C10_DECLARE_TLS_class_static(Foo, std::string, str_);
-};
-
-C10_DEFINE_TLS_class_static(Foo, std::string, str_);
-
-TEST(ThreadLocalTest, TestClassScope) {
-  EXPECT_EQ(*Foo::str_, "");
-
-  *Foo::str_ = "abc";
-  EXPECT_EQ(*Foo::str_, "abc");
-  EXPECT_EQ(Foo::str_->length(), 3);
-  EXPECT_EQ(Foo::str_.get(), "abc");
-}
-
 C10_DEFINE_TLS_static(std::string, global_);
 C10_DEFINE_TLS_static(std::string, global2_);
 TEST(ThreadLocalTest, TestTwoGlobalScopeVars) {

--- a/c10/util/ThreadLocal.h
+++ b/c10/util/ThreadLocal.h
@@ -94,12 +94,6 @@ class ThreadLocal {
 
 #define C10_DEFINE_TLS_static(Type, Name) static ::c10::ThreadLocal<Type> Name
 
-#define C10_DECLARE_TLS_class_static(Class, Type, Name) \
-  static ::c10::ThreadLocal<Type> Name
-
-#define C10_DEFINE_TLS_class_static(Class, Type, Name) \
-  ::c10::ThreadLocal<Type> Class::Name
-
 #else // defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
 
 namespace c10 {
@@ -139,15 +133,6 @@ class ThreadLocal {
   static ::c10::ThreadLocal<Type> Name([]() { \
     static thread_local Type var;             \
     return &var;                              \
-  })
-
-#define C10_DECLARE_TLS_class_static(Class, Type, Name) \
-  static ::c10::ThreadLocal<Type> Name
-
-#define C10_DEFINE_TLS_class_static(Class, Type, Name) \
-  ::c10::ThreadLocal<Type> Class::Name([]() {          \
-    static thread_local Type var;                      \
-    return &var;                                       \
   })
 
 #endif // defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #81453
* #81452
* __->__ #81451

AFAICT only C10_DEFINE_TLS_static is actually used anywhere.

Differential Revision: [D37842248](https://our.internmc.facebook.com/intern/diff/D37842248/)