### PR TITLE
Revert "Revert "Remove python key when setting functional tensor metadata (#81401)""

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -29,7 +29,7 @@ void FunctionalTensorWrapper::set_constructor_metadata() {
   // All of the keys corresponding to functorch transforms should not be copied over.
   // Functorch transforms all have their own wrapper tensors (e.g. BatchedTensorImpl) which expect
   // to participate in the functorch transforms.
-  key_set_ = key_set_ - c10::functorch_transforms_ks;
+  key_set_ = key_set_ - c10::functorch_transforms_ks - c10::python_ks;
 }
 
 FunctionalTensorWrapper::FunctionalTensorWrapper(const Tensor& value)

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -110,6 +110,10 @@ class TestFunctionalization(TestCase):
             out_functional_unwrapped = torch._from_functional_tensor(out_functional_)
             self.assertEqual(out_ref_, out_functional_unwrapped)
 
+    def test_save_for_backwards_segfault(self):
+        inp = torch._to_functional_tensor(LoggingTensor(torch.randn(2, 2))).requires_grad_(True)
+        inp.exp()
+
     def test_multiple_views_of_same_base(self):
         def f(x):
             y = x.view(-1)
@@ -826,47 +830,6 @@ $3 = torch._ops.aten.add.Tensor($2, 1)""")
         # because normal_tensor would need to be "promoted" to a functional tensor.
         with self.assertRaises(RuntimeError):
             x1_not_functional.add_(x2_functional)
-
-    # This tests the behavior of functionalization with multiple layers of wrapped tensor subclasses.
-    def test_multiple_levels_of_wrapping(self):
-        def f(x):
-            # call an inplace op and have it get logged twice (by the outer + inner wrapper)
-            x.add_(1)
-
-        # Test 1: both the inner and outer wrapper are "functionalized"
-        x_inner_and_outer_functional = torch._to_functional_tensor(
-            InplaceLoggingTensor(torch._to_functional_tensor(LoggingTensor(torch.ones(4)))))
-
-        with capture_logs() as logs:
-            f(x_inner_and_outer_functional)
-
-        # Since both wrappers were unctionalized, they both log "add"
-        self.assertExpectedInline('\n'.join(logs), """\
-$1 = torch._ops.aten.add.Tensor($0, 1)
-$3 = torch._ops.aten.add.Tensor($2, 1)""")
-
-        # Test 2: only the inner wrapper is "functionalized"
-        x_only_inner_functional = InplaceLoggingTensor(torch._to_functional_tensor(LoggingTensor(torch.ones(4))))
-
-        with capture_logs() as logs:
-            f(x_only_inner_functional)
-
-        # Since only the inner wrapper is functionalized, then the inner (first) log is functionalized
-        self.assertExpectedInline('\n'.join(logs), """\
-$1 = torch._ops.aten.add.Tensor($0, 1)
-$3 = torch._ops.aten.add_.Tensor($2, 1)""")
-
-        # Test 3: only the inner wrapper is "functionalized"
-        x_only_outer_functional = torch._to_functional_tensor(InplaceLoggingTensor(LoggingTensor(torch.ones(4))))
-
-        with capture_logs() as logs:
-            f(x_only_outer_functional)
-
-        # Only the outer add_ is functionalized
-        # Since only the outer wrapper is functionalized, then the outer (second) log is functionalized
-        self.assertExpectedInline('\n'.join(logs), """\
-$1 = torch._ops.aten.add_.Tensor($0, 1)
-$3 = torch._ops.aten.add.Tensor($2, 1)""")
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #80566
* #81192
* __->__ #81456

This reverts commit f2bb25a758b358c0534aee5e103c2022afc2ffd6.

For the gory story see https://github.com/pytorch/pytorch/issues/73537