### PR TITLE
Convert toOpMathType to an inline function, to fix test breakages

### DIFF
--- a/aten/src/ATen/OpMathType.h
+++ b/aten/src/ATen/OpMathType.h
@@ -30,7 +30,7 @@ using opmath_type = typename OpMathType<T>::type;
 
 namespace {
 
-c10::ScalarType toOpMathType(const c10::ScalarType type) {
+inline c10::ScalarType toOpMathType(const c10::ScalarType type) {
   switch (type) {
 #define DEFINE_CASE(scalar_t, TypeNum) \
   case ScalarType::TypeNum:            \


### PR DESCRIPTION
Summary:
Ideally function implementations in headers should be inline, class functions, or moved into cpp files. Otherwise we'll end up with errors when these headers are imported into targets that break on unused function warnings. This header was recently imported into the PyTorchPlaygroundTests target, breaking it. Making this function inline unbreaks these tests.

Related discussion:
https://fb.workplace.com/groups/474291069286180/permalink/5228784980503408/

Test Plan: Build and run tests.

Differential Revision: D37850416

