### PR TITLE
Enable reentrant dispatch for decompositions

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -198,7 +198,7 @@ class TestProxyTensor(TestCase):
         def f(x):
             return torch.ops.aten.norm.Scalar(x, 2.0)
 
-        def norm_decomp(x, p = 2.0):
+        def norm_decomp(x, p=2.0):
             if p != 2.0:
                 raise RuntimeError("can't handle with p != 2")
             return torch.sqrt(torch.sum(torch.square(x)))
@@ -208,7 +208,6 @@ class TestProxyTensor(TestCase):
         traced = make_fx(f, decomposition_table=decomp)(torch.rand(3))
 
         for n in traced.graph.nodes:
-            print(n)
             self.assertTrue("square" not in str(n.target))
             self.assertTrue("norm" not in str(n.target))
 

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -194,6 +194,24 @@ class TestProxyTensor(TestCase):
 
         self.assertEqual(fx_module(x), decomposed_module(x))
 
+    def test_make_fx_reentrant_dispatch(self):
+        def f(x):
+            return torch.ops.aten.norm.Scalar(x, 2.0)
+
+        def norm_decomp(x, p = 2.0):
+            if p != 2.0:
+                raise RuntimeError("can't handle with p != 2")
+            return torch.sqrt(torch.sum(torch.square(x)))
+
+        decomp = {torch.ops.aten.norm.Scalar: norm_decomp}
+
+        traced = make_fx(f, decomposition_table=decomp)(torch.rand(3))
+
+        for n in traced.graph.nodes:
+            print(n)
+            self.assertTrue("square" not in str(n.target))
+            self.assertTrue("norm" not in str(n.target))
+
 make_fx_failures = {
     # unknown
     xfail('allclose'),

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -65,7 +65,8 @@ def proxy_call(func_overload, args, kwargs=None):
         kwargs = {}
     func = func_overload.overloadpacket
     if func_overload in CURRENT_DECOMPOSITION_TABLE:
-        return CURRENT_DECOMPOSITION_TABLE[func_overload](*args, **kwargs)
+        with torch.overrides.enable_reentrant_dispatch():
+            return CURRENT_DECOMPOSITION_TABLE[func_overload](*args, **kwargs)
     if func_overload == aten._local_scalar_dense.default:
         raise RuntimeError("It appears that you're trying to get value out of a tracing tensor - erroring out! "
                            "It's likely that this is caused by data-dependent control flow or similar."

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -15,12 +15,16 @@ from torch.utils._mode_utils import no_dispatch
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
 from contextlib import contextmanager, nullcontext
 
-from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils._python_dispatch import TorchDispatchMode, enable_torch_dispatch_mode
 
 __all__ = ["ProxyTensor", "PythonKeyTracer", "dispatch_trace", "make_fx", "enable_strict", "DecompositionInterpreter"]
 aten = torch.ops.aten
 
 CURRENT_DECOMPOSITION_TABLE: Dict[torch._ops.OpOverload, Callable] = {}
+
+# In order to use reentrant dispatch, we need to re-set the torch dispatch mode.
+# This stores the mode to be used inside proxy_call
+PROXY_DISPATCH_MODE = None
 
 
 @contextmanager
@@ -32,6 +36,17 @@ def decompose(decomposition_table):
         yield CURRENT_DECOMPOSITION_TABLE
     finally:
         CURRENT_DECOMPOSITION_TABLE = old_decomposition_table
+
+@contextmanager
+def proxy_dispatch_mode_ctx(mode):
+    global PROXY_DISPATCH_MODE
+    old_mode = PROXY_DISPATCH_MODE
+    PROXY_DISPATCH_MODE = mode
+    try:
+        yield PROXY_DISPATCH_MODE
+    finally:
+        PROXY_DISPATCH_MODE = mode
+
 
 # Checks whether we try to convert the tensor into a scalar
 IS_STRICT = True
@@ -65,7 +80,9 @@ def proxy_call(func_overload, args, kwargs=None):
         kwargs = {}
     func = func_overload.overloadpacket
     if func_overload in CURRENT_DECOMPOSITION_TABLE:
-        with torch.overrides.enable_reentrant_dispatch():
+        global PROXY_DISPATCH_MODE
+        proxy_mode = enable_torch_dispatch_mode(PROXY_DISPATCH_MODE) if PROXY_DISPATCH_MODE else nullcontext()
+        with proxy_mode, torch.overrides.enable_reentrant_dispatch():
             return CURRENT_DECOMPOSITION_TABLE[func_overload](*args, **kwargs)
     if func_overload == aten._local_scalar_dense.default:
         raise RuntimeError("It appears that you're trying to get value out of a tracing tensor - erroring out! "
@@ -282,7 +299,8 @@ def make_fx(f, decomposition_table=None, trace_factory_functions=True, use_fake=
         if use_fake:  # type: ignore[attr-defined]
             args = pytree.tree_map(wrap_fake, args)
 
-        with decompose(decomposition_table), fake_tensor_mode, proxy_mode:  # type: ignore[attr-defined]
+        with decompose(decomposition_table), fake_tensor_mode, proxy_mode, \
+                proxy_dispatch_mode_ctx(proxy_mode):  # type: ignore[attr-defined]
             t = dispatch_trace(wrap_key(f, args), tracer=fx_tracer, concrete_args=tuple(phs))
         return t
 


### PR DESCRIPTION
This allows us to avoid tracing through CompositeImplicitAutograd ops
when decomposing via make_fx or other decomposition methods that use
tracing.