### PR TITLE
remove ROCm guards on jit script cuda methods

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -12,6 +12,20 @@
 
 namespace c10 {
 
+#ifdef USE_ROCM
+#define FORALL_CUDA_BASED_SYMBOLS(_) \
+_(hip, _set_device)                  \
+_(hip, set_stream)                   \
+_(hip, _current_device)
+#else
+#define FORALL_CUDA_BASED_SYMBOLS(_) \
+_(cuda, _set_device)                 \
+_(cuda, set_stream)                  \
+_(cuda, _current_device)             \
+_(cuda, synchronize)
+#endif
+
+
 #define FORALL_NS_SYMBOLS(_)         \
   _(namespaces, prim)                \
   _(namespaces, prims)               \
@@ -216,10 +230,7 @@ namespace c10 {
   _(aten, __contains__)              \
   _(prim, BailoutTemplate)           \
   _(prim, grad)                      \
-  _(cuda, _set_device)               \
-  _(cuda, set_stream)                \
-  _(cuda, _current_device)           \
-  _(cuda, synchronize)               \
+  FORALL_CUDA_BASED_SYMBOLS(_)       \
   _(aten, has_torch_function)        \
   FORALL_ATEN_BASE_SYMBOLS(_)        \
   _(onnx, Add)                       \

--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -1184,10 +1184,10 @@ bool Node::hasSideEffects() const {
     case prim::rpc_sync: // It represents RPC message sent.
     case prim::rpc_remote: // It represents RPC message sent.
     case aten::wait: // It can represent RPC message received.
-#if !defined(USE_ROCM)
     case cuda::set_stream:
     case cuda::_set_device:
     case cuda::_current_device:
+#if !defined(USE_ROCM)
     case cuda::synchronize:
 #endif
     case prim::Enter:

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -79,9 +79,7 @@ namespace aten {
 using namespace ::c10::aten;
 }
 namespace cuda {
-#if !defined(USE_ROCM)
 using namespace ::c10::cuda;
-#endif
 } // namespace cuda
 
 struct Function;

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -8245,8 +8245,11 @@ C10_MAPPINGS = collections.OrderedDict(
         # This substitution is not permissible, because there's another copy of this
         # function in torch/cuda.h
         # ("cuda::device_count", ("hip::device_count", API_C10)),
+        # ("cuda::synchronize", ("hip::synchronize", API_C10)),
         ("cuda::current_device", ("hip::current_device", API_C10)),
+        ("cuda::_current_device", ("hip::_current_device", API_C10)),
         ("cuda::set_device", ("hip::set_device", API_C10)),
+        ("cuda::_set_device", ("hip::_set_device", API_C10)),
         ("cuda::device_synchronize", ("hip::device_synchronize", API_C10)),
         ("cuda::getStreamFromPool", ("hip::getStreamFromPool", API_C10)),
         ("getStreamFromPool", ("getStreamFromPool", API_C10)),
@@ -8255,6 +8258,7 @@ C10_MAPPINGS = collections.OrderedDict(
         ("cuda::getCurrentCUDAStream", ("hip::getCurrentHIPStream", API_C10)),
         ("getCurrentCUDAStream", ("getCurrentHIPStream", API_C10)),
         ("cuda::get_cuda_check_prefix", ("hip::get_cuda_check_prefix", API_C10)),
+        ("cuda::set_stream", ("hip::set_stream", API_C10)),
         ("cuda::setCurrentCUDAStream", ("hip::setCurrentHIPStream", API_C10)),
         ("setCurrentCUDAStream", ("setCurrentHIPStream", API_C10)),
         ("cuda::CUDACachingAllocator", ("hip::HIPCachingAllocator", API_C10)),


### PR DESCRIPTION
Summary: Enables torchscripting of cuda streams on ROCm.

Test Plan: CI

Differential Revision: D37860210

