### PR TITLE
[cuDNN] Work-around 32-bit indexing failures in cuDNN batchnorm

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -489,7 +489,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
           ||(input.size(0) <= 65535 && !training)) //spatial, eval
       && detail::getCUDAHooks().compiledWithCuDNN()
       && eps >= detail::getCUDAHooks().batchnormMinEpsilonCuDNN()
-      && cudnn_enabled && detail::getCUDAHooks().versionCuDNN() >= 5110L 
+      && cudnn_enabled && detail::getCUDAHooks().versionCuDNN() >= 5110L
       && input.numel() < 2147483648 // some cuDNN kernels have 32-bit indexing limitations
       );
 

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -490,7 +490,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
       && detail::getCUDAHooks().compiledWithCuDNN()
       && eps >= detail::getCUDAHooks().batchnormMinEpsilonCuDNN()
       && cudnn_enabled && detail::getCUDAHooks().versionCuDNN() >= 5110L
-      && input.numel() < 2147483648 // some cuDNN kernels have 32-bit indexing limitations
+      && input.numel() < std::numeric_limits<std::int32_t>::max() // some cuDNN kernels have 32-bit indexing limitations
       );
 
   if (use_cudnn) {

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -489,7 +489,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
           ||(input.size(0) <= 65535 && !training)) //spatial, eval
       && detail::getCUDAHooks().compiledWithCuDNN()
       && eps >= detail::getCUDAHooks().batchnormMinEpsilonCuDNN()
-      && cudnn_enabled && detail::getCUDAHooks().versionCuDNN() >= 5110L);
+      && cudnn_enabled && detail::getCUDAHooks().versionCuDNN() >= 5110L 
+      && input.numel() < 2147483648 // some cuDNN kernels have 32-bit indexing limitations
+      );
 
   if (use_cudnn) {
     auto input_c = input.contiguous(input.suggest_memory_format());


### PR DESCRIPTION
The following workload fails on Ampere:

```
import torch
import torch.nn as nn
bn = nn.BatchNorm2d(128).cuda()
x = torch.randn([256, 128, 294, 294], device='cuda')
x = bn(x)
print(x.shape)
```

This PR adds a magic number in the `use_cudnn` condition to avoid this failure.

CC @ptrblck 