### PR TITLE
[vulkan] add support for quantized tensors

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Resource.cpp
+++ b/aten/src/ATen/native/vulkan/api/Resource.cpp
@@ -19,11 +19,14 @@ VkFormat vk_format(const caffe2::TypeMeta dtype) {
       return VK_FORMAT_R32G32B32A32_SFLOAT;
 #endif /* USE_VULKAN_FP16_INFERENCE */
 
-    default:
-      return VK_FORMAT_UNDEFINED;
-  }
-}
+    case c10::kQUInt8:
+      return VK_FORMAT_R8G8B8A8_UINT;
 
+    default:
+      TORCH_CHECK(false, "Vulkan tensor format not supported!");
+  }
+  return VK_FORMAT_UNDEFINED;
+}
 //
 // MemoryBarrier
 //
@@ -528,10 +531,11 @@ MemoryAllocator::~MemoryAllocator() {
   vmaDestroyAllocator(allocator_);
 }
 
-VulkanImage MemoryAllocator::create_image3d_fp(
+VulkanImage MemoryAllocator::create_image3d(
     const VkExtent3D& extents,
     const VulkanImage::SamplerProperties& sampler_props,
     const VkSampler sampler,
+    const caffe2::TypeMeta dtype,
     bool allow_transfer) {
   VkImageUsageFlags usage =
       VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
@@ -540,18 +544,14 @@ VulkanImage MemoryAllocator::create_image3d_fp(
         (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
   }
 
+  const VkFormat image_format = vk_format(dtype);
+
   const VulkanImage::MemoryProperties mem_props{
       VMA_MEMORY_USAGE_GPU_ONLY,
       0u,
       0u,
       usage,
   };
-
-#ifdef USE_VULKAN_FP16_INFERENCE
-  const VkFormat image_format = VK_FORMAT_R16G16B16A16_SFLOAT;
-#else
-  const VkFormat image_format = VK_FORMAT_R32G32B32A32_SFLOAT;
-#endif /* USE_VULKAN_FP16_INFERENCE */
 
   const VulkanImage::ImageProperties image_props{
       VK_IMAGE_TYPE_3D,

--- a/aten/src/ATen/native/vulkan/api/Resource.h
+++ b/aten/src/ATen/native/vulkan/api/Resource.h
@@ -360,10 +360,11 @@ class MemoryAllocator final {
   VmaAllocator allocator_;
 
  public:
-  VulkanImage create_image3d_fp(
+  VulkanImage create_image3d(
       const VkExtent3D&,
       const VulkanImage::SamplerProperties&,
       const VkSampler,
+      const caffe2::TypeMeta dtype,
       const bool allow_transfer = false);
 
   VulkanBuffer create_storage_buffer(

--- a/aten/src/ATen/native/vulkan/glsl/image_to_nchw_quantized.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/image_to_nchw_quantized.glsl
@@ -1,0 +1,65 @@
+#version 450 core
+#define PRECISION $precision
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0) uniform PRECISION                    isampler3D uImage;
+layout(set = 0, binding = 1) buffer  PRECISION                    Buffer {
+  uint data[];
+} uBuffer;
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
+  ivec4 size;
+  ivec4 offset;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  if (pos.y == 0 && pos.z == 0) {
+      ivec4 texture_pos = ivec4(0,1,2,3) + 4 * pos.x;
+
+      ivec4 last_eight;
+      last_eight.z = texture_pos.x / (uBlock.size.x * uBlock.size.y);
+      last_eight.w = texture_pos.x % (uBlock.size.x * uBlock.size.y);
+      last_eight.y = last_eight.w / uBlock.size.x;
+      last_eight.x = last_eight.w % uBlock.size.x;
+
+      ivec4 sec_last_eight;
+      sec_last_eight.z = texture_pos.y / (uBlock.size.x * uBlock.size.y);
+      sec_last_eight.w = texture_pos.y % (uBlock.size.x * uBlock.size.y);
+      sec_last_eight.y = sec_last_eight.w / uBlock.size.x;
+      sec_last_eight.x = sec_last_eight.w % uBlock.size.x;
+
+      ivec4 thr_last_eight;
+      thr_last_eight.z = texture_pos.z / (uBlock.size.x * uBlock.size.y);
+      thr_last_eight.w = texture_pos.z % (uBlock.size.x * uBlock.size.y);
+      thr_last_eight.y = thr_last_eight.w / uBlock.size.x;
+      thr_last_eight.x = thr_last_eight.w % uBlock.size.x;
+
+      ivec4 four_last_eight;
+      four_last_eight.z = texture_pos.w / (uBlock.size.x * uBlock.size.y);
+      four_last_eight.w = texture_pos.w % (uBlock.size.x * uBlock.size.y);
+      four_last_eight.y = four_last_eight.w / uBlock.size.x;
+      four_last_eight.x = four_last_eight.w % uBlock.size.x;
+
+      ivec3 last_eight_pos = ivec3(last_eight.x, last_eight.y, last_eight.z / 4);
+      ivec3 sec_last_eight_pos = ivec3(sec_last_eight.x, sec_last_eight.y, sec_last_eight.z / 4);
+      ivec3 thr_last_eight_pos = ivec3(thr_last_eight.x, thr_last_eight.y, thr_last_eight.z / 4);
+      ivec3 four_last_eight_pos = ivec3(four_last_eight.x, four_last_eight.y, four_last_eight.z / 4);
+
+      int texel_1 = texelFetch(uImage, last_eight_pos, 0)[last_eight.z];
+      int texel_2 = texelFetch(uImage, sec_last_eight_pos, 0)[sec_last_eight.z];
+      int texel_3 = texelFetch(uImage, thr_last_eight_pos, 0)[thr_last_eight.z];
+      int texel_4 = texelFetch(uImage, four_last_eight_pos, 0)[four_last_eight.z];
+
+      uint ui32 = (uint(texel_4 & 0xFF) << 24)
+            | (uint(texel_3 & 0xFF) << 16)
+            | (uint(texel_2 & 0xFF) << 8)
+            | (uint(texel_1 & 0xFF));
+
+      uBuffer.data[texture_pos.x / 4] = ui32;
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/nchw_to_image_quantized.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/nchw_to_image_quantized.glsl
@@ -1,0 +1,52 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, rgba8ui) uniform PRECISION restrict writeonly uimage3D uImage;
+layout(set = 0, binding = 1)         buffer  PRECISION restrict readonly  Buffer {
+  uint data[];
+} uBuffer;
+layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
+  ivec4 size;
+  ivec4 offset;
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const int base = pos.x + uBlock.size.x * pos.y + uBlock.size.w * pos.z;
+    const ivec4 index = base + uBlock.offset;
+
+    int shift = (1 << 8) - 1;
+    ivec4 masks;
+    masks.x = shift << 8 * (index.x % 4);
+    masks.y = shift << 8 * (index.y % 4);
+    masks.z = shift << 8 * (index.z % 4);
+    masks.w = shift << 8 * (index.w % 4);
+
+    uint buf_in_1 = uBuffer.data[index.x / 4];
+    uint a_v = (buf_in_1 & masks.x) >> 8 * (index.x % 4);
+
+    uint buf_in_2 = uBuffer.data[index.y / 4];
+    uint b_v = (buf_in_2 & masks.y) >> 8 * (index.y % 4);
+
+    uint buf_in_3 = uBuffer.data[index.z / 4];
+    uint g_v = (buf_in_3 & masks.z) >> 8 * (index.z % 4);
+
+    uint buf_in_4 = uBuffer.data[index.w / 4];
+    uint r_v = (buf_in_4 & masks.w) >> 8 * (index.w % 4);
+
+    uvec4 texel = uvec4(a_v, b_v, g_v, r_v);
+
+    imageStore(
+        uImage,
+        pos,
+        texel);
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Copy.cpp
@@ -35,12 +35,19 @@ void copy_cpu_to_vulkan(const Tensor& src, vTensor& dst) {
   {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 
-    float* data_ptr = mapping.template data<float>();
-
-    memcpy(
-        data_ptr,
-        src.contiguous().data_ptr<float>(),
-        std::min(src.nbytes(), src.nbytes()));
+    if (src.dtype() == c10::kQUInt8) {
+      c10::quint8* data_ptr = mapping.template data<c10::quint8>();
+      memcpy(
+          data_ptr,
+          src.contiguous().data_ptr<c10::quint8>(),
+          std::min(src.nbytes(), src.nbytes()));
+    } else {
+      float* data_ptr = mapping.template data<float>();
+      memcpy(
+          data_ptr,
+          src.contiguous().data_ptr<float>(),
+          std::min(src.nbytes(), src.nbytes()));
+    }
   }
   utils::pack_staging_to_vtensor(staging.buffer(), dst);
 }
@@ -73,10 +80,19 @@ void copy_vulkan_to_cpu(vTensor& src, Tensor& dst) {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::READ);
     mapping.invalidate();
 
-    float* data_ptr = mapping.template data<float>();
-
-    memcpy(
-        dst.data_ptr<float>(), data_ptr, std::min(src.nbytes(), dst.nbytes()));
+    if (dst.is_quantized()) {
+      c10::quint8* data_ptr = mapping.template data<c10::quint8>();
+      memcpy(
+          dst.data_ptr<c10::quint8>(),
+          data_ptr,
+          std::min(src.nbytes(), dst.nbytes()));
+    } else {
+      float* data_ptr = mapping.template data<float>();
+      memcpy(
+          dst.data_ptr<float>(),
+          data_ptr,
+          std::min(src.nbytes(), dst.nbytes()));
+    }
   }
 
   context->fences().return_fence(fence);
@@ -99,6 +115,10 @@ Tensor& copy_(Tensor& self, const Tensor& src) {
     }
     // CPU -> Vulkan
     else {
+      TORCH_CHECK(
+          src.dtype() == c10::kQUInt8 || src.dtype() == at::kFloat,
+          "Invalid Data Type: expected QUint8 or Float but got ",
+          src.dtype());
       copy_cpu_to_vulkan(src, v_self);
     }
   }
@@ -108,6 +128,10 @@ Tensor& copy_(Tensor& self, const Tensor& src) {
 
     // Vulkan -> CPU
     if (self.device().is_cpu()) {
+      TORCH_CHECK(
+          self.dtype() == c10::kQUInt8 || self.dtype() == at::kFloat,
+          "Invalid Data Type: expected QUint8 or Float but got ",
+          self.dtype());
       copy_vulkan_to_cpu(v_src, self);
     } else {
       TORCH_CHECK(false, "Unsupported!");

--- a/aten/src/ATen/native/vulkan/ops/Factory.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Factory.cpp
@@ -1,11 +1,32 @@
-#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Factory.h>
 #include <torch/library.h>
 
 namespace at {
 namespace native {
 namespace vulkan {
 namespace ops {
-namespace {
+
+Tensor _empty_affine_quantized(
+    const IntArrayRef sizes,
+    const c10::optional<ScalarType> dtype,
+    const c10::optional<c10::Layout> layout,
+    const c10::optional<Device> device,
+    const c10::optional<bool> pin_memory,
+    const double scale,
+    const int64_t zero_point,
+    const optional<MemoryFormat> memory_format) {
+  return convert_quantized(vTensor{
+      api::context(),
+      sizes,
+      TensorOptions()
+          .dtype(dtype)
+          .layout(layout)
+          .device(device)
+          .pinned_memory(pin_memory)
+          .memory_format(memory_format),
+      scale,
+      zero_point});
+}
 
 Tensor empty_memory_format(
     const IntArrayRef sizes,
@@ -44,13 +65,15 @@ TORCH_LIBRARY_IMPL(aten, Vulkan, m) {
       TORCH_SELECTIVE_NAME("aten::empty.memory_format"),
       at::native::vulkan::ops::empty_memory_format);
   m.impl(
+      TORCH_SELECTIVE_NAME("aten::_empty_affine_quantized"),
+      at::native::vulkan::ops::_empty_affine_quantized);
+  m.impl(
       TORCH_SELECTIVE_NAME("aten::empty_strided"),
       TORCH_FN(at::native::vulkan::ops::empty_strided));
 }
 
 #endif /* USE_VULKAN_API */
 
-} // namespace
 } // namespace ops
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/native/vulkan/ops/Factory.h
+++ b/aten/src/ATen/native/vulkan/ops/Factory.h
@@ -1,0 +1,21 @@
+#include <ATen/native/vulkan/ops/Common.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+
+Tensor _empty_affine_quantized(
+    const IntArrayRef sizes,
+    const c10::optional<ScalarType> dtype,
+    const c10::optional<c10::Layout> layout,
+    const c10::optional<Device> device,
+    const c10::optional<bool> pin_memory,
+    const double scale,
+    const int64_t zero_point,
+    const optional<MemoryFormat> memory_format);
+
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/ops/Tensor.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.cpp
@@ -66,6 +66,15 @@ vTensor::vTensor(
           options,
       }) {}
 
+vTensor::vTensor(
+    api::Context* const context,
+    const IntArrayRef sizes,
+    const TensorOptions& options,
+    double q_scale,
+    int64_t q_zero_point)
+    : view_(
+          new vTensorStorage{context, sizes, options, q_scale, q_zero_point}) {}
+
 api::VulkanImage& vTensor::image(
     api::PipelineBarrier& pipeline_barrier,
     const api::PipelineStageFlags stage) const& {
@@ -89,7 +98,8 @@ api::VulkanImage& vTensor::image(
 
 api::VulkanImage allocate_image(
     api::Context* const context_ptr,
-    api::utils::uvec3& extents) {
+    api::utils::uvec3& extents,
+    const caffe2::TypeMeta dtype) {
   api::Adapter* adapter_ptr = context_ptr->adapter_ptr();
 
   api::ImageSampler::Properties sampler_props{
@@ -101,8 +111,8 @@ api::VulkanImage allocate_image(
 
   VkSampler sampler = adapter_ptr->sampler_cache().retrieve(sampler_props);
 
-  return adapter_ptr->vma().create_image3d_fp(
-      api::create_extent3d(extents), sampler_props, sampler, true);
+  return adapter_ptr->vma().create_image3d(
+      api::create_extent3d(extents), sampler_props, sampler, dtype, true);
 }
 
 vTensorStorage::vTensorStorage(
@@ -114,7 +124,26 @@ vTensorStorage::vTensorStorage(
       options_(options),
       sizes_(sizes),
       strides_(sizes.size()),
-      image_(allocate_image(context_, extents_)),
+      image_(allocate_image(context_, extents_, options_.dtype())),
+      last_access_{} {
+  ops::verify(options);
+}
+
+vTensorStorage::vTensorStorage(
+    api::Context* const context,
+    const IntArrayRef sizes,
+    const TensorOptions& options,
+    double q_scale_in,
+    int64_t q_zero_point_in)
+    : context_(context),
+      extents_(image_extents(sizes)),
+      options_(options),
+      sizes_(sizes),
+      strides_(sizes.size()),
+      is_quantized_{true},
+      q_scale{q_scale_in},
+      q_zero_point{q_zero_point_in},
+      image_(allocate_image(context_, extents_, options_.dtype())),
       last_access_{} {
   ops::verify(options);
 }

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -35,6 +35,12 @@ class vTensorStorage final {
       api::Context* context,
       IntArrayRef sizes,
       const TensorOptions& options);
+  vTensorStorage(
+      api::Context* context,
+      IntArrayRef sizes,
+      const TensorOptions& options,
+      double q_scale,
+      int64_t q_zero_point);
 
   vTensorStorage(const vTensorStorage&) = delete;
   vTensorStorage& operator=(const vTensorStorage&) = delete;
@@ -55,6 +61,9 @@ class vTensorStorage final {
   TensorOptions options_;
   c10::SmallVector<int64_t, 6u> sizes_;
   c10::SmallVector<int64_t, 6u> strides_;
+  bool is_quantized_{false};
+  double q_scale{1.0f};
+  int64_t q_zero_point{0u};
 
   // Image Texture
   mutable api::VulkanImage image_;
@@ -82,6 +91,12 @@ class vTensor final {
       api::Context* context,
       IntArrayRef sizes,
       const TensorOptions& options);
+  vTensor(
+      api::Context* const context,
+      const IntArrayRef sizes,
+      const TensorOptions& options,
+      double q_scale,
+      int64_t q_zero_point);
 
  private:
   // Even at the cost of a heap allocation plus the resulting negative impact
@@ -136,6 +151,10 @@ class vTensor final {
     return view_->strides_;
   }
 
+  inline bool is_quantized() const {
+    return view_->is_quantized_;
+  }
+
   inline size_t nbytes() const {
     return c10::elementSize(c10::typeMetaToScalarType(options().dtype())) *
         c10::multiply_integers(sizes());
@@ -178,6 +197,16 @@ inline Tensor convert(const vTensor& tensor) {
       tensor.strides());
 }
 
+inline Tensor convert_quantized(const vTensor& tensor) {
+  TORCH_CHECK(tensor.is_quantized(), "Not a Quantized Tensor");
+  return at::detail::make_tensor<vTensorImpl>(
+      DispatchKeySet(DispatchKey::Vulkan),
+      tensor.options().dtype(),
+      at::Device(at::kVulkan),
+      tensor,
+      tensor.sizes(),
+      tensor.strides());
+}
 } // namespace ops
 } // namespace vulkan
 } // namespace native

--- a/aten/src/ATen/test/vulkan_quantized_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_quantized_api_test.cpp
@@ -1,0 +1,172 @@
+#ifdef USE_VULKAN_API
+
+#include <ATen/ATen.h>
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <ATen/native/vulkan/api/api.h>
+#include <gtest/gtest.h>
+
+#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Copy.h>
+#include <ATen/native/vulkan/ops/Factory.h>
+
+#include <c10/util/irange.h>
+
+namespace {
+
+bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor>& inputs) {
+  float maxValue = 0.0f;
+
+  for (const auto& tensor : inputs) {
+    maxValue = fmax(tensor.abs().max().item<float>(), maxValue);
+  }
+
+#ifdef USE_VULKAN_FP16_INFERENCE
+  constexpr float tolerance = 1e-2;
+#else
+  constexpr float tolerance = 1e-5;
+#endif
+
+  return diff.abs().max().item<float>() <= (tolerance * maxValue);
+}
+
+bool almostEqual(const at::Tensor& a, const at::Tensor& b) {
+  return checkRtol(a - b, {a, b});
+}
+
+bool exactlyEqual(const at::Tensor& a, const at::Tensor& b) {
+  return (a - b).abs().max().item<float>() == 0.0f;
+}
+
+void showRtol(const at::Tensor& a, const at::Tensor& b) {
+  const auto diff = (a - b).abs();
+
+  float maxValue = a.abs().max().item<float>();
+  maxValue = fmax(b.abs().max().item<float>(), maxValue);
+
+#ifdef USE_VULKAN_FP16_INFERENCE
+  constexpr float tolerance = 1e-2;
+#else
+  constexpr float tolerance = 1e-5;
+#endif
+
+  const float maxDiff = maxValue * tolerance;
+  std::cout << "Max Diff allowed: " << maxDiff << std::endl;
+  if (diff.sizes().size() == 2) {
+    for (const auto y : c10::irange(diff.sizes()[0])) {
+      std::cout << y << ":";
+      for (const auto x : c10::irange(diff.sizes()[1])) {
+        float diff_xy = diff[y][x].item<float>();
+        if (diff_xy > maxDiff) {
+          std::cout << std::setw(5) << x;
+        } else {
+          std::cout << std::setw(5) << " ";
+        }
+      }
+      std::cout << std::endl;
+    }
+  }
+}
+} // namespace
+
+namespace {
+
+class VulkanAPITest : public ::testing::Test {
+ public:
+#if defined(__ANDROID__) // to avoid `Undefined symbols for architecture arm64`
+                         // error
+  static void SetUpTestSuite() {
+    at::native::vulkan::api::context()->querypool().enable();
+  }
+
+  static void TearDownTestSuite() {
+    at::native::vulkan::api::context()->querypool().disable(false);
+  }
+#endif
+};
+
+at::Tensor cpu_to_vulkan(at::Tensor in_cpu) {
+  auto options = in_cpu.options();
+  if (options.dtype().toScalarType() == c10::ScalarType::QUInt8) {
+    auto ret = at::native::vulkan::ops::_empty_affine_quantized(
+        in_cpu.sizes(),
+        c10::ScalarType::QUInt8,
+        options.layout(),
+        options.device(),
+        options.pinned_memory(),
+        in_cpu.q_scale(),
+        in_cpu.q_zero_point(),
+        c10::MemoryFormat::Contiguous);
+    at::native::vulkan::ops::copy_(ret, in_cpu);
+    return ret;
+  } else {
+    auto ret = at::empty(in_cpu.sizes(), options);
+    at::native::vulkan::ops::copy_(ret, in_cpu);
+    return ret;
+  }
+}
+
+at::Tensor vulkan_to_cpu(at::Tensor vulkan, at::Tensor in_cpu) {
+  auto q_options = in_cpu.options();
+  if (q_options.dtype().toScalarType() == c10::ScalarType::QUInt8) {
+    auto output = at::native::empty_affine_quantized(
+        in_cpu.sizes(),
+        q_options.dtype().toScalarType(),
+        q_options.layout(),
+        q_options.device(),
+        q_options.pinned_memory(),
+        in_cpu.q_scale(),
+        in_cpu.q_zero_point());
+    at::native::vulkan::ops::copy_(output, vulkan);
+    return output;
+  } else {
+    auto output = at::empty(in_cpu.sizes(), q_options);
+    at::native::vulkan::ops::copy_(output, vulkan);
+    return output;
+  }
+}
+
+TEST_F(VulkanAPITest, support_vulkan) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const double scale = 0.1;
+  const int64_t zero_point = 10;
+
+  auto in_cpu =
+      at::rand({2, 13, 32, 27}, at::device(at::kCPU).dtype(at::kFloat)) * 12 -
+      6;
+  auto in_cpu_quantized = at::quantize_per_tensor(
+      in_cpu, scale, zero_point, c10::ScalarType::QUInt8);
+
+  auto in_vulkan_quantized = cpu_to_vulkan(in_cpu_quantized);
+  at::native::vulkan::api::PipelineBarrier pipeline_barrier{};
+  at::native::vulkan::ops::vTensor& v_self =
+      at::native::vulkan::ops::convert(in_vulkan_quantized);
+  if (in_cpu.dtype() == c10::kQUInt8) {
+    v_self.image(
+        pipeline_barrier,
+        at::native::vulkan::api::PipelineStage::COMPUTE,
+        at::native::vulkan::api::MemoryAccessType::READ);
+    v_self.image(
+        pipeline_barrier,
+        at::native::vulkan::api::PipelineStage::COMPUTE,
+        at::native::vulkan::api::MemoryAccessType::WRITE);
+  }
+  auto output = vulkan_to_cpu(in_vulkan_quantized, in_cpu_quantized);
+  const auto check = almostEqual(
+      at::native::int_repr_quantized_cpu(in_cpu_quantized),
+      at::native::int_repr_quantized_cpu(output));
+
+  if (!check) {
+    showRtol(
+        at::native::int_repr_quantized_cpu(in_cpu_quantized),
+        at::native::int_repr_quantized_cpu(output));
+  }
+
+  ASSERT_TRUE(check);
+}
+
+} // namespace
+
+#endif /* USE_VULKAN_API */


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

for T121381630
added support for int textures/quantized tensors
wrote shaders for the above and had to modify certain files in the pytorch codebase to allow for vulkan tensors

Differential Revision: [D37314225](https://our.internmc.facebook.com/intern/diff/D37314225/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D37314225/)!