### PR TITLE
[DataPipe] Fix fork/unzip with a single child

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -883,12 +883,16 @@ class TestFunctionalIterDataPipe(TestCase):
         self.assertEqual([(i, i) for i in range(10)], output)
 
         # Functional Test: one child DataPipe yields all value first, but buffer_size = 5 being too small
-        dp1, dp2 = input_dp.fork(num_instances=2, buffer_size=5)
+        dp1, dp2 = input_dp.fork(num_instances=2, buffer_size=4)
         it1 = iter(dp1)
-        for _ in range(5):
+        for _ in range(4):
             next(it1)
         with self.assertRaises(BufferError):
             next(it1)
+        with self.assertRaises(BufferError):
+            list(dp2)
+
+        dp1, dp2 = input_dp.fork(num_instances=2, buffer_size=5)
         with self.assertRaises(BufferError):
             list(dp2)
 

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -862,7 +862,7 @@ class TestFunctionalIterDataPipe(TestCase):
         with self.assertRaises(ValueError):
             input_dp.fork(num_instances=0)
 
-        dp0 = input_dp.fork(num_instances=1)
+        dp0 = input_dp.fork(num_instances=1, buffer_size=0)
         self.assertEqual(dp0, input_dp)
 
         # Functional Test: making sure all child DataPipe shares the same reference

--- a/torch/utils/data/datapipes/iter/combining.py
+++ b/torch/utils/data/datapipes/iter/combining.py
@@ -112,9 +112,9 @@ class _ForkerIterDataPipe(IterDataPipe):
                 UserWarning
             )
         self.child_pointers: List[int] = [0] * num_instances  # Indicate the indices of the next element to get
-        self.slowest_ptr = 0
-        self.leading_ptr = 0
-        self.end_ptr: Optional[int] = None
+        self.slowest_ptr = 0  # The index to read by the slowest child
+        self.leading_ptr = 0  # The index to read by the fastest child
+        self.end_ptr: Optional[int] = None  # The index to stop child
 
     def __len__(self):
         return len(self.main_datapipe)
@@ -122,36 +122,31 @@ class _ForkerIterDataPipe(IterDataPipe):
     def get_next_element_by_instance(self, instance_id: int):
         if self._datapipe_iterator is None:
             self._datapipe_iterator = iter(self.main_datapipe)
-        while self.end_ptr is None or self.child_pointers[instance_id] < self.end_ptr:
-            if not self.buffer or self.child_pointers[instance_id] > self.leading_ptr:
+        while self.end_ptr is None or self.child_pointers[instance_id] + 1 < self.end_ptr:
+            self.child_pointers[instance_id] += 1
+            # Use buffer
+            if self.buffer and self.child_pointers[instance_id] <= self.leading_ptr:
+                idx = self.child_pointers[instance_id] - self.slowest_ptr - 1
+                return_val = self.buffer[idx]
+            else:  # Retreive one element from main datapipe
                 self.leading_ptr = self.child_pointers[instance_id]
-                if self.buffer_size >= 0 and self.leading_ptr - self.slowest_ptr + 1 > self.buffer_size:
-                    raise BufferError("ForkerIterDataPipe buffer overflow," +
-                                      f"buffer size {self.buffer_size} is insufficient.")
                 try:
                     return_val = next(self._datapipe_iterator)
-                    self.child_pointers[instance_id] += 1
                     self.buffer.append(return_val)
-                    if self.child_pointers[instance_id] - 1 == self.slowest_ptr:
-                        new_min = min(self.child_pointers)  # Can optimize by avoiding the call to min()
-                        if self.slowest_ptr < new_min:
-                            self.slowest_ptr = new_min
-                            self.buffer.popleft()
-                    yield return_val
                 except StopIteration:
                     self.end_ptr = self.leading_ptr
-            else:  # Child pointer is slower than or equal to the leading_ptr
-                buffer_index = self.child_pointers[instance_id] - self.slowest_ptr
-                return_val = self.buffer[buffer_index]
-                self.child_pointers[instance_id] += 1
-                if self.child_pointers[instance_id] - 1 == self.slowest_ptr:
-                    new_min = min(self.child_pointers)  # Can optimize by avoiding the call to min()
-                    if self.slowest_ptr < new_min:
-                        self.slowest_ptr = new_min
-                        self.buffer.popleft()
-                yield return_val
-        if self.end_ptr and self.child_pointers[instance_id] == self.end_ptr and\
-           all(p == self.end_ptr for p in self.child_pointers):
+                    continue
+            if self.child_pointers[instance_id] == self.slowest_ptr + 1:
+                new_min = min(self.child_pointers)  # Can optimize by avoiding the call to min()
+                if self.slowest_ptr < new_min:
+                    self.slowest_ptr = new_min
+                    self.buffer.popleft()
+            if self.buffer_size >= 0 and self.leading_ptr > self.buffer_size + self.slowest_ptr:
+                raise BufferError("ForkerIterDataPipe buffer overflow," +
+                                  f"buffer size {self.buffer_size} is insufficient.")
+            yield return_val
+
+        if all(p + 1 == self.end_ptr for p in self.child_pointers):
             self._datapipe_iterator = None
 
     def is_every_instance_exhausted(self) -> bool:


### PR DESCRIPTION
When `Forker` or `Unzipper` only contains a single child, the buffer should be cleaned up. This is one of the root causes for the issue reported internally. See: https://fburl.com/2k0et1gv