### PR TITLE
Disable some flaky vulkan_api_test

### DIFF
--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -2646,7 +2646,7 @@ TEST_F(VulkanAPITest, upsample_nearest2d) {
 }
 
 #if !defined(__APPLE__)
-TEST_F(VulkanAPITest, cat_dim1_samefeature_success) {
+TEST_F(VulkanAPITest, DISABLED_cat_dim1_samefeature_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;
@@ -2765,7 +2765,7 @@ TEST_F(VulkanAPITest, cat_dim1_singletensor_success) {
   ASSERT_TRUE(check);
 }
 
-TEST_F(VulkanAPITest, cat_dim1_twotensors_success) {
+TEST_F(VulkanAPITest, DISABLED_cat_dim1_twotensors_success) {
   // Guard
   if (!at::is_vulkan_available()) {
     return;


### PR DESCRIPTION
Summary:
VulkanAPITest.cat_dim1_twotensors_success and VulkanAPITest.cat_dim1_samefeature_success seem to be a bit flaky on master

minihud link to view the errors: https://hud.pytorch.org/minihud?name_filter=vulkan

Test Plan: github ci

Differential Revision: D37868476

