### PR TITLE
[caffe2] Fix CAFFE2_USE_ITT default true in bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -463,6 +463,7 @@ header_template_rule(
         "#define CAFFE2_USE_EIGEN_FOR_BLAS": "/* #undef CAFFE2_USE_EIGEN_FOR_BLAS */",
         "#define CAFFE2_USE_FBCODE": "/* #undef CAFFE2_USE_FBCODE */",
         "#define CAFFE2_USE_GOOGLE_GLOG": "/* #undef CAFFE2_USE_GOOGLE_GLOG */",
+        "#define CAFFE2_USE_ITT": "/* #undef CAFFE2_USE_ITT */",
         "#define CAFFE2_USE_LITE_PROTO": "/* #undef CAFFE2_USE_LITE_PROTO */",
         "#define CAFFE2_USE_MKL\n": "/* #undef CAFFE2_USE_MKL */\n",
         "#define CAFFE2_USE_NVTX": "/* #undef CAFFE2_USE_NVTX */",


### PR DESCRIPTION
Summary: A diff introduced a new cmakedefines called CAFFE2_USE_ITT. However, this does not seem to get substitued properly during header generation and thus leaves "#cmakedefine" in the generated header, thus failing builds:

Test Plan: Running a build that triggers the generation. And verifies the generated macro.h no longer has a cmakedefine in it.

Reviewed By: jdonald

Differential Revision: D37862676

