### PR TITLE
move aten.native_batch_norm_backward decomposition to core

### DIFF
--- a/functorch/functorch/_src/decompositions.py
+++ b/functorch/functorch/_src/decompositions.py
@@ -145,7 +145,7 @@ def prod(x: List[int]):
     return r
 
 
-@register_decomposition(aten.native_batch_norm_backward)  # @register_decomposition_for_jvp after in core
+@register_decomposition_for_jvp(aten.native_batch_norm_backward)  # @register_decomposition_for_jvp after in core
 def native_batch_norm_backward(
     grad_out: Tensor,
     input: Tensor,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1145,9 +1145,25 @@ def native_batch_norm_backward(
 ) -> Tuple[Tensor, Optional[Tensor], Optional[Tensor]]:
     input_dtype = input.dtype
     computation_dtype = utils.get_computation_dtype(input.dtype)
-    grad_out_cast, input_cast, weight_cast, running_mean_cast, running_var_cast, save_mean_cast, save_invstd_cast = [
+    (
+        grad_out_cast,
+        input_cast,
+        weight_cast,
+        running_mean_cast,
+        running_var_cast,
+        save_mean_cast,
+        save_invstd_cast
+    ) = [
         x.to(computation_dtype) if x is not None else x
-        for x in (grad_out, input, weight, running_mean, running_var, save_mean, save_invstd)
+        for x in (
+            grad_out,
+            input,
+            weight,
+            running_mean,
+            running_var,
+            save_mean,
+            save_invstd
+        )
     ]
     input_shape = input.shape
     input_rank = input.dim()
@@ -1158,8 +1174,7 @@ def native_batch_norm_backward(
     mean = save_mean_cast
     invstd = save_invstd_cast
     if train:
-        assert save_mean_cast is not None and save_invstd_cast is not None, \
-               "when train=True, save_mean and save_invstd are required"
+        assert save_mean_cast is not None and save_invstd_cast is not None, "when train=True, save_mean and save_invstd are required"  # noqa: E501
     else:
         assert running_mean_cast is not None and running_var_cast is not None
         mean = running_mean_cast

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1236,7 +1236,7 @@ def cudnn_batch_norm_backward(
     epsilon: float,
     reserveSpace: Tensor,
 ):
-    return native_batch_norm_backward(
+    return aten.native_batch_norm_backward(
         grad_output,
         input,
         weight,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1174,9 +1174,7 @@ def native_batch_norm_backward(
     mean = save_mean_cast
     invstd = save_invstd_cast
     if train:
-        assert (
-               save_mean_cast is not None and save_invstd_cast is not None
-               ), "when train=True, save_mean and save_invstd are required"
+        assert save_mean_cast is not None and save_invstd_cast is not None
     else:
         assert running_mean_cast is not None and running_var_cast is not None
         mean = running_mean_cast

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1130,6 +1130,80 @@ def cudnn_batch_norm(
     )
 
 
+@register_decomposition(aten.native_batch_norm_backward)  # @register_decomposition_for_jvp after in core
+def native_batch_norm_backward(
+    grad_out: Tensor,
+    input: Tensor,
+    weight: Optional[Tensor],
+    running_mean: Optional[Tensor],
+    running_var: Optional[Tensor],
+    save_mean: Optional[Tensor],
+    save_invstd: Optional[Tensor],
+    train: bool,
+    eps: float,
+    output_mask: List[bool],
+) -> Tuple[Tensor, Optional[Tensor], Optional[Tensor]]:
+    input_shape = input.shape
+    input_rank = input.dim()
+    assert input_rank >= 2, "rank of the input must be at least 2"
+
+    axis = 1
+    num_features = prod(input_shape) / input_shape[axis]
+    mean = save_mean
+    invstd = save_invstd
+    if train:
+        assert save_mean is not None and save_invstd is not None, "when train=True, save_mean and save_invstd are required"
+
+        # reduciton_dims = [0] + list(range(2, input.dim()))
+        # assert invstd is not None  # for typing
+        # mean, invstd = recompute_mean_var(input, invstd, reduciton_dims, keepdim=False)
+    else:
+        assert running_mean is not None and running_var is not None
+        mean = running_mean
+        invstd = torch.rsqrt(running_var + eps)
+
+    broadcast_mask = [1] * input_rank
+    broadcast_mask[axis] = input_shape[axis]
+
+    reduction_axes: List[int] = []
+    for i in range(input_rank):
+        if i != axis:
+            reduction_axes.append(i)
+
+    mean = torch.reshape(mean, broadcast_mask)
+    norm = 1.0 / num_features
+    grad_output_sum = torch.sum(grad_out, reduction_axes)
+    dot_p = torch.sum(grad_out * (input - mean), reduction_axes)
+
+    grad_mean = torch.reshape(grad_output_sum * norm, broadcast_mask)
+    proj_scale = torch.reshape(torch.mul(dot_p * norm, invstd * invstd), broadcast_mask)
+
+    if weight is None:
+        grad_scale = torch.reshape(invstd, broadcast_mask) * 1.0
+    else:
+        grad_scale = torch.reshape(invstd * weight, broadcast_mask)
+
+    if train:
+        proj = (input - mean) * proj_scale
+        grad_input = ((grad_out - proj) - grad_mean) * grad_scale
+    else:
+        grad_input = grad_out * grad_scale
+
+    if output_mask[1]:
+        grad_weight = dot_p * invstd
+    elif weight is not None:
+        grad_weight = torch.zeros_like(weight)  # should be None but doesn't work with vjp
+    else:
+        grad_weight = torch.zeros(())  # should be None but doesn't work with vjp
+
+    if output_mask[2]:
+        grad_bias = grad_output_sum
+    else:
+        grad_bias = torch.zeros_like(grad_output_sum)  # should be None but doesn't work with vjp
+
+    return (grad_input, grad_weight, grad_bias)
+
+
 @register_decomposition(aten.cudnn_batch_norm_backward)
 def cudnn_batch_norm_backward(
     input: Tensor,

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1152,7 +1152,7 @@ def native_batch_norm_backward(
         running_mean_cast,
         running_var_cast,
         save_mean_cast,
-        save_invstd_cast
+        save_invstd_cast,
     ) = [
         x.to(computation_dtype) if x is not None else x
         for x in (
@@ -1162,7 +1162,7 @@ def native_batch_norm_backward(
             running_mean,
             running_var,
             save_mean,
-            save_invstd
+            save_invstd,
         )
     ]
     input_shape = input.shape
@@ -1174,7 +1174,9 @@ def native_batch_norm_backward(
     mean = save_mean_cast
     invstd = save_invstd_cast
     if train:
-        assert save_mean_cast is not None and save_invstd_cast is not None, "when train=True, save_mean and save_invstd are required"  # noqa: E501
+        assert (
+               save_mean_cast is not None and save_invstd_cast is not None
+               ), "when train=True, save_mean and save_invstd are required"
     else:
         assert running_mean_cast is not None and running_var_cast is not None
         mean = running_mean_cast
@@ -1188,9 +1190,9 @@ def native_batch_norm_backward(
         if i != axis:
             reduction_axes.append(i)
 
-    mean = torch.reshape(mean, broadcast_mask)   # type: ignore[arg-type]
+    mean = torch.reshape(mean, broadcast_mask)  # type: ignore[arg-type]
     norm = 1.0 / num_features
-    grad_output_sum = torch.sum(grad_out_cast, reduction_axes)   # type: ignore[arg-type]
+    grad_output_sum = torch.sum(grad_out_cast, reduction_axes)  # type: ignore[arg-type]
     dot_p = torch.sum(grad_out_cast * (input_cast - mean), reduction_axes)
 
     grad_mean = torch.reshape(grad_output_sum * norm, broadcast_mask)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1158,7 +1158,8 @@ def native_batch_norm_backward(
     mean = save_mean_cast
     invstd = save_invstd_cast
     if train:
-        assert save_mean_cast is not None and save_invstd_cast is not None, "when train=True, save_mean and save_invstd are required"
+        assert save_mean_cast is not None and save_invstd_cast is not None, \
+               "when train=True, save_mean and save_invstd are required"
 
         # reduciton_dims = [0] + list(range(2, input.dim()))
         # assert invstd is not None  # for typing
@@ -1211,7 +1212,7 @@ def native_batch_norm_backward(
         grad_input.to(input_dtype),
         _maybe_cast(grad_weight, input_dtype),
         _maybe_cast(grad_bias, input_dtype),
-)
+    )
 
 
 @register_decomposition(aten.cudnn_batch_norm_backward)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1209,15 +1209,13 @@ def native_batch_norm_backward(
 
     if output_mask[1]:
         grad_weight = dot_p * invstd
-    elif weight is not None:
-        grad_weight = torch.zeros_like(weight_cast)  # type: ignore[arg-type]
     else:
-        grad_weight = torch.zeros(())
+        grad_weight = None  # "None" doesn't work with vjp, should use zeros for vjp
 
     if output_mask[2]:
         grad_bias = grad_output_sum
     else:
-        grad_bias = torch.zeros_like(grad_output_sum)
+        grad_bias = None  # "None" doesn't work with vjp, should use zeros for vjp
 
     return (
         grad_input.to(input_dtype),

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1160,10 +1160,6 @@ def native_batch_norm_backward(
     if train:
         assert save_mean_cast is not None and save_invstd_cast is not None, \
                "when train=True, save_mean and save_invstd are required"
-
-        # reduciton_dims = [0] + list(range(2, input.dim()))
-        # assert invstd is not None  # for typing
-        # mean, invstd = recompute_mean_var(input, invstd, reduciton_dims, keepdim=False)
     else:
         assert running_mean_cast is not None and running_var_cast is not None
         mean = running_mean_cast
@@ -1199,14 +1195,14 @@ def native_batch_norm_backward(
     if output_mask[1]:
         grad_weight = dot_p * invstd
     elif weight is not None:
-        grad_weight = torch.zeros_like(weight_cast)  # type: ignore[arg-type]  # should be None but doesn't work with vjp
+        grad_weight = torch.zeros_like(weight_cast)  # type: ignore[arg-type]
     else:
-        grad_weight = torch.zeros(())  # should be None but doesn't work with vjp
+        grad_weight = torch.zeros(())
 
     if output_mask[2]:
         grad_bias = grad_output_sum
     else:
-        grad_bias = torch.zeros_like(grad_output_sum)  # should be None but doesn't work with vjp
+        grad_bias = torch.zeros_like(grad_output_sum)
 
     return (
         grad_input.to(input_dtype),


### PR DESCRIPTION
Move  aten.native_batch_norm_backward decomposition from  https://github.com/pytorch/functorch/blob/main/functorch/_src/decompositions.py#L148.

Changed to not recompute mean and invstd, added type cast. 

In fucntorch, changed `@register_decomposition_for(aten.native_batch_norm_backward)` to `@register_decomposition_for_jvp(aten.native_batch_norm_backward)`

Passing `pytest test/test_decomp.py -k norm`

Note that when the output mask is False for grad_weight and grad_bias, we should return None to be consistent with the non-decomposed operator's behavior. But "None" doesn't work with vjp, so the version of decomposition in functorch used zeros. See https://github.com/pytorch/pytorch/blob/b33c1f7dd4a4d30ebc912f555e56d105ae66aa84/functorch/functorch/_src/decompositions.py#L210.