### PR TITLE
Excluded future functorch path from linters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,6 +22,8 @@ exclude =
     ./docs/caffe2,
     ./docs/cpp/src,
     ./docs/src,
+    # See NOTE: [Impending functorch move]
+    ./functorch,
     ./scripts,
     ./test/generated_type_hints_smoketest.py,
     ./third_party,

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -9,6 +9,11 @@ exclude_patterns = [
     'docs/caffe2/**',
     'docs/cpp/src/**',
     'docs/src/**',
+    # NOTE: [Impending functorch move]
+    # In preparation for the functorch -> pytorch merge,
+    # we are adding the following excludes so that functorch passes
+    # lint when it gets merged in. Please don't delete.
+    'functorch/**',
     'scripts/**',
     'test/generated_type_hints_smoketest.py',
     'third_party/**',
@@ -220,7 +225,11 @@ command = [
 [[linter]]
 code = 'TYPEIGNORE'
 include_patterns = ['**/*.py', '**/*.pyi']
-exclude_patterns = ['test/test_jit.py']
+exclude_patterns = [
+    'test/test_jit.py',
+    # See NOTE: [Impending functorch move]
+    'functorch/**',
+]
 command = [
     'python3',
     'tools/linter/adapters/grep_linter.py',
@@ -292,6 +301,8 @@ exclude_patterns=[
     'tools/clang_format_hash/**',
     'test/cpp/jit/upgrader_models/*.ptl',
     'test/cpp/jit/upgrader_models/*.ptl.ff',
+    # See NOTE: [Impending functorch move]
+    'functorch/**',
 ]
 command = [
     'python3',
@@ -311,6 +322,8 @@ exclude_patterns = [
     'aten/src/ATen/native/vulkan/api/vk_mem_alloc.h',
     'test/cpp/jit/upgrader_models/*.ptl',
     'test/cpp/jit/upgrader_models/*.ptl.ff',
+    # See NOTE: [Impending functorch move]
+    'functorch/**',
 ]
 command = [
     'python3',
@@ -340,6 +353,8 @@ exclude_patterns = [
     'test/cpp/jit/upgrader_models/*.ptl',
     'test/cpp/jit/upgrader_models/*.ptl.ff',
     '.lintrunner.toml',
+    # See NOTE: [Impending functorch move]
+    'functorch/**',
 ]
 command = [
     'python3',
@@ -421,6 +436,8 @@ exclude_patterns = [
     '**/git-pre-commit',
     '**/git-clang-format',
     '**/gradlew',
+    # See NOTE: [Impending functorch move]
+    'functorch/**',
 ]
 command = [
     'python3',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #81563
* #81555

In preparation for the functorch->pytorch move, this PR excludes
functorch paths from lint so we avoid breaking lint when we execute the
move. We will fix and re-enable lint when we're done with the merge.

Why not add all these linters to the pytorch/functorch repo now and fix
all the lints? Because (1) it's easier to not add them, especially if
we're moving out of there soon and (2) it's difficult to reproduce the
linting setup 1:1 (I tried for a bit).

Test Plan:
- cp functorch to functorch, run `lintrunner`, observe all pass