### PR TITLE
shard `trunk / linux-bionic-cuda10.2-py3.9-gcc7 / test (slow` to 2

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -62,7 +62,8 @@ jobs:
         { include: [
           { config: "default", shard: 1, num_shards: 2, runner: "linux.4xlarge.nvidia.gpu" },
           { config: "default", shard: 2, num_shards: 2, runner: "linux.4xlarge.nvidia.gpu" },
-          { config: "slow", shard: 1, num_shards: 1, runner: "linux.4xlarge.nvidia.gpu" },
+          { config: "slow", shard: 1, num_shards: 2, runner: "linux.4xlarge.nvidia.gpu" },
+          { config: "slow", shard: 2, num_shards: 2, runner: "linux.4xlarge.nvidia.gpu" },
           { config: "nogpu_AVX512", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
           { config: "nogpu_NO_AVX2", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
           { config: "jit_legacy", shard: 1, num_shards: 1, runner: "linux.4xlarge.nvidia.gpu" },


### PR DESCRIPTION
`trunk / linux-bionic-cuda10.2-py3.9-gcc7 / test (slow` currently has an average TTS of 4 hrs and job duration of 3.3 hrs, so I would like to shard it in order to reduce the time.  