### PR TITLE
[BE] Fix CMake dev warning

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -121,7 +121,7 @@ file(GLOB native_ao_sparse_h
             "native/ao_sparse/cpu/*.h"
             "native/ao_sparse/quantized/*.h"
             "native/ao_sparse/quantized/cpu/*.h")
-file(GLOB native_quantized_h "native/quantized/*.h" "native/quantized/cpu/*.h", "native/quantized/cudnn/*.h")
+file(GLOB native_quantized_h "native/quantized/*.h" "native/quantized/cpu/*.h" "native/quantized/cudnn/*.h")
 file(GLOB native_cpu_h "native/cpu/*.h")
 
 file(GLOB native_cuda_cu "native/cuda/*.cu")


### PR DESCRIPTION
Remove spurious comma to fix
```
CMake Warning (dev) at aten/src/ATen/CMakeLists.txt:124:
  Syntax Warning in cmake code at column 79

  Argument not separated from preceding token by whitespace.
```
