### PR TITLE
Stash torch dispatch mode in PythonTLSSnapshot

### DIFF
--- a/aten/src/ATen/core/PythonFallbackKernel.h
+++ b/aten/src/ATen/core/PythonFallbackKernel.h
@@ -1,16 +1,23 @@
 #pragma once
 
+#include <torch/csrc/utils/torch_dispatch_mode.h>
 
 namespace at {
 namespace impl {
+
+struct TORCH_API DispatchContextSnapshot {
+  c10::impl::LocalDispatchKeySet key_set_;
+  std::shared_ptr<c10::SafePyObject> dispatch_mode_;
+};
 
 struct TORCH_API RestorePythonTLSSnapshot {
   RestorePythonTLSSnapshot();
   ~RestorePythonTLSSnapshot();
 
 private:
-  c10::impl::LocalDispatchKeySet saved_;
-  c10::impl::ForceDispatchKeyGuard guard_;
+  DispatchContextSnapshot saved_;
+  c10::impl::ForceDispatchKeyGuard key_guard_;
+  torch::torch_dispatch_mode::StashTorchDispatchModeGuard mode_guard_;
 };
 
 

--- a/torch/csrc/utils/torch_dispatch_mode.h
+++ b/torch/csrc/utils/torch_dispatch_mode.h
@@ -7,9 +7,10 @@ namespace torch_dispatch_mode {
 
 struct StashTorchDispatchModeGuard {
  public:
-  StashTorchDispatchModeGuard() {
+  StashTorchDispatchModeGuard(
+      std::shared_ptr<at::SafePyObject> new_state = nullptr) {
     saved_ = at::impl::TorchDispatchModeTLS::get_state();
-    at::impl::TorchDispatchModeTLS::set_state(nullptr);
+    at::impl::TorchDispatchModeTLS::set_state(std::move(new_state));
   }
 
   ~StashTorchDispatchModeGuard() {

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -22,10 +22,6 @@ aten = torch.ops.aten
 
 CURRENT_DECOMPOSITION_TABLE: Dict[torch._ops.OpOverload, Callable] = {}
 
-# In order to use reentrant dispatch, we need to re-set the torch dispatch mode.
-# This stores the mode to be used inside proxy_call
-PROXY_DISPATCH_MODE = None
-
 
 @contextmanager
 def decompose(decomposition_table):
@@ -36,16 +32,6 @@ def decompose(decomposition_table):
         yield CURRENT_DECOMPOSITION_TABLE
     finally:
         CURRENT_DECOMPOSITION_TABLE = old_decomposition_table
-
-@contextmanager
-def proxy_dispatch_mode_ctx(mode):
-    global PROXY_DISPATCH_MODE
-    old_mode = PROXY_DISPATCH_MODE
-    PROXY_DISPATCH_MODE = mode
-    try:
-        yield PROXY_DISPATCH_MODE
-    finally:
-        PROXY_DISPATCH_MODE = mode
 
 
 # Checks whether we try to convert the tensor into a scalar
@@ -90,9 +76,7 @@ def proxy_call(func_overload, args, kwargs=None):
         kwargs = {}
     func = func_overload.overloadpacket
     if func_overload in CURRENT_DECOMPOSITION_TABLE:
-        global PROXY_DISPATCH_MODE
-        proxy_mode = enable_torch_dispatch_mode(PROXY_DISPATCH_MODE) if PROXY_DISPATCH_MODE else nullcontext()
-        with proxy_mode, torch.overrides.enable_reentrant_dispatch():
+        with torch.overrides.enable_reentrant_dispatch():
             return CURRENT_DECOMPOSITION_TABLE[func_overload](*args, **kwargs)
     if func_overload == aten._local_scalar_dense.default:
         t, = args
@@ -421,11 +405,7 @@ a bug if you need this)""")
         if use_fake:  # type: ignore[attr-defined]
             args = pytree.tree_map(wrap_fake, args)
 
-        with (  # type: ignore[attr-defined]
-                decompose(decomposition_table),
-                fake_tensor_mode,
-                proxy_mode,
-                proxy_dispatch_mode_ctx(proxy_mode)):
+        with decompose(decomposition_table), fake_tensor_mode, proxy_mode:  # type: ignore[attr-defined]
             t = dispatch_trace(wrap_key(f, args), tracer=fx_tracer, concrete_args=tuple(phs))
         return t
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #81599
* #81598

Previously PythonTLSSnapshot would record only the dispatch key set, but
not the dispatch mode callback. So when using TorchDispatchMode with
torch.override.enable_reentrant_dispatch, the following would happen:

1. Enable TorchDispatchMode, which sets the dispatch mode callback and
enables the Python/PythonTLSSnapshot keys in TLS dispatch key set.
2. Call some torch ops
3. Dispatch to PythonTLSSnapshot, which locally records the dispatch key set
4. Dispatch to Python, which unsets the callback and removes Python from
the TLS dispatch key set
5. Call into the torch_dispatch implementation in python
6. Enable torch.override.enable_reentrant_dispatch, which resets the TLS
dispatch key set that was saved in step 3 (including turning on the Python bit)
7. Dispatch to PythonTLSSnapshot
8. Dispatch to Python (because python bit was set in 6). But, because
the callback was unset in step 4, this errors out.

This will also stash the torch_dispatch callback during
PythonTLSSnapshot, so that we can automatically reset the torch_dispatch
callback when we enable reentrant dispatch.