### PR TITLE
torch.distribution examples rendering issue

### DIFF
--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -974,6 +974,7 @@ class CatTransform(Transform):
     in a way compatible with :func:`torch.cat`.
 
     Example::
+    
        x0 = torch.cat([torch.range(1, 10), torch.range(1, 10)], dim=0)
        x = torch.cat([x0, x0], dim=0)
        t0 = CatTransform([ExpTransform(), identity_transform], dim=0, lengths=[10, 10])
@@ -1076,6 +1077,7 @@ class StackTransform(Transform):
     in a way compatible with :func:`torch.stack`.
 
     Example::
+    
        x = torch.stack([torch.range(1, 10), torch.range(1, 10)], dim=1)
        t = StackTransform([ExpTransform(), identity_transform], dim=1)
        y = t(x)

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -974,7 +974,7 @@ class CatTransform(Transform):
     in a way compatible with :func:`torch.cat`.
 
     Example::
-    
+
        x0 = torch.cat([torch.range(1, 10), torch.range(1, 10)], dim=0)
        x = torch.cat([x0, x0], dim=0)
        t0 = CatTransform([ExpTransform(), identity_transform], dim=0, lengths=[10, 10])
@@ -1077,7 +1077,7 @@ class StackTransform(Transform):
     in a way compatible with :func:`torch.stack`.
 
     Example::
-    
+
        x = torch.stack([torch.range(1, 10), torch.range(1, 10)], dim=1)
        t = StackTransform([ExpTransform(), identity_transform], dim=1)
        y = t(x)


### PR DESCRIPTION
# Issue

"Example" section in the documentation is not rendering correctly for [`torch.distributions.transforms.CatTransform`](https://pytorch.org/docs/stable/distributions.html#torch.distributions.transforms.CatTransform)
and
[`torch.distributions.transforms.StackTransform`](https://pytorch.org/docs/stable/distributions.html#torch.distributions.transforms.StackTransform)

# Fix
Simply add an empty line after the `Example::` keyword to fix the issue.


