### PR TITLE
[CI] Disable ios-12-5-1-x86-64

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -119,6 +119,7 @@ jobs:
         ]}
 
   ios-12-5-1-x86-64:
+    if: false
     name: ios-12-5-1-x86-64
     uses: ./.github/workflows/_ios-build-test.yml
     with:


### PR DESCRIPTION
Currently broken, but for a while it was not testing trunk, but rather some old released build, see https://github.com/pytorch/pytorch/runs/7369514831?check_suite_focus=true#step:9:147

