### PR TITLE
Update is_nhwc & is_ndhwc in ideep, to remove conv check in use_mkldnn

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -243,63 +243,9 @@ auto ConvParams::use_miopen(const at::Tensor& input, const at::Tensor& weight, b
          ;
 }
 
-bool mkldnn_conv_contiguous_check(const at::Tensor& input) {
-  if (input.is_mkldnn()) {
-    return true;
-  }
-  auto input_dim = input.dim();
-  bool is_contiguous = input.is_contiguous(at::MemoryFormat::Contiguous);
-  bool is_channels_last = (input_dim == 4)
-      ? input.is_contiguous(at::MemoryFormat::ChannelsLast)
-      : input.is_contiguous(at::MemoryFormat::ChannelsLast3d);
-  if (!(is_contiguous || is_channels_last)) {
-    return true;
-  }
-
-  auto dims = input.sizes();
-  auto strides = input.strides();
-  bool mkldnn_conv_is_contiguous = true, mkldnn_conv_is_channels_last = true;
-  if (input_dim == 4) {
-    const auto n = 0, c = 1, h = 2, w = 3;
-    mkldnn_conv_is_contiguous =
-        (strides[n] == dims[c] * dims[h] * dims[w] &&
-         strides[c] == dims[h] * dims[w] && strides[h] == dims[w] &&
-         strides[w] == 1);
-    mkldnn_conv_is_channels_last =
-        (strides[n] == dims[h] * dims[w] * dims[c] &&
-         strides[h] == dims[w] * dims[c] && strides[w] == dims[c] &&
-         strides[c] == 1);
-  } else {
-    const auto n = 0, c = 1, d = 2, h = 3, w = 4;
-    mkldnn_conv_is_contiguous =
-        (strides[n] == dims[c] * dims[d] * dims[h] * dims[w] &&
-         strides[c] == dims[d] * dims[h] * dims[w] &&
-         strides[d] == dims[h] * dims[w] && strides[h] == dims[w] &&
-         strides[w] == 1);
-    mkldnn_conv_is_channels_last =
-        (strides[n] == dims[d] * dims[h] * dims[w] * dims[c] &&
-         strides[d] == dims[h] * dims[w] * dims[c] &&
-         strides[h] == dims[w] * dims[c] && strides[w] == dims[c] &&
-         strides[c] == 1);
-  }
-  if (is_channels_last && is_contiguous) {
-    return (mkldnn_conv_is_contiguous || mkldnn_conv_is_channels_last);
-  } else if (is_channels_last) {
-    return mkldnn_conv_is_channels_last;
-  } else if (is_contiguous) {
-    return mkldnn_conv_is_contiguous;
-  }
-  return true;
-}
-
 auto ConvParams::use_mkldnn(const at::Tensor& input, const at::Tensor& weight) const -> bool {
 #if AT_MKLDNN_ENABLED()
   if (!at::globalContext().userEnabledMkldnn()) {
-    return false;
-  }
-  if (!mkldnn_conv_contiguous_check(
-          input)) { // check whether current ATen input is contiguous based on
-                    // oneDNN requirements.
     return false;
   }
   if (input.device().is_cpu() && input.scalar_type() == kBFloat16 && mkldnn_bf16_device_check()) {

--- a/caffe2/ideep/operators/order_switch_ops.cc
+++ b/caffe2/ideep/operators/order_switch_ops.cc
@@ -13,7 +13,7 @@ class IDEEPNHWC2NCHWOp final : public IDEEPOperator {
   bool RunOnDevice() override {
     const auto& X = Input(0);
     CAFFE_ENFORCE_EQ(X.ndims(), 4);
-    CAFFE_ENFORCE(X.get_desc().is_nhwc());
+    CAFFE_ENFORCE(X.get_desc().is_nhwc(true));
 
     auto *Y = Output(OUTPUT);
     CAFFE_ENFORCE(Y != &X);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14255,7 +14255,7 @@ class TestNNDeviceType(NNTestCase):
             x2 = x[..., 0]
             inputs = [x2, conv.weight, conv.bias, (2, 1), (0, 1), (1, 1), False, (0, 1), 1]
             backend_actual = torch._C._select_conv_backend(*inputs)
-            backend_expected = torch._C._ConvBackend.Slow2d
+            backend_expected = torch._C._ConvBackend.Mkldnn
             y = conv(x2)
             self.assertEqual(backend_actual, backend_expected)
 


### PR DESCRIPTION
oneDNN can support arbitrary strides as PyTorch. This PR is to update is_nhwc and is_ndhwc in ideep, in order to remove conv check in use_mkldnn.