### PR TITLE
[vulkan] Update allocation parameters for uniform buffers

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Resource.cpp
+++ b/aten/src/ATen/native/vulkan/api/Resource.cpp
@@ -587,7 +587,7 @@ VulkanBuffer MemoryAllocator::create_storage_buffer(
   const VkBufferUsageFlags buffer_usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
   VmaAllocationCreateFlags create_flags = DEFAULT_ALLOCATION_STRATEGY;
-  if (gpu_only) {
+  if (!gpu_only) {
     create_flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
   }
 

--- a/aten/src/ATen/native/vulkan/api/Resource.h
+++ b/aten/src/ATen/native/vulkan/api/Resource.h
@@ -466,8 +466,9 @@ struct FencePool final {
 template <typename Block>
 inline VulkanBuffer MemoryAllocator::create_params_buffer(const Block& block) {
   const VulkanBuffer::MemoryProperties mem_props{
-      DEFAULT_ALLOCATION_STRATEGY,
-      VMA_MEMORY_USAGE_CPU_TO_GPU,
+      DEFAULT_ALLOCATION_STRATEGY |
+          VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT,
+      VMA_MEMORY_USAGE_AUTO,
       0u,
       0u,
       VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #81636

Update allocation parameters when allocating memory for uniform buffers. Allocation flags were updated when changing the VMA version to 3.0.1 but forgot to update these flags.

This fixes an error on Mac with the complaint

```
Assertion failed: (IsMappingAllowed() && "Mapping is not allowed on this allocation! Please use one of the new VMA_ALLOCATION_CREATE_HOST_ACCESS_* flags when creating it."), function BlockAllocMap, file vk_mem_alloc.h, line 12139.
```

Differential Revision: [D37925152](https://our.internmc.facebook.com/intern/diff/D37925152/)