### PR TITLE
Add support for _addcarry_u64 with MSVC on ARM64 toolchain.

### DIFF
--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -10,7 +10,15 @@
 #ifdef _MSC_VER
 #define C10_HAS_BUILTIN_OVERFLOW() (0)
 #include <c10/util/llvmMathExtras.h>
+#if !defined(_M_ARM64)
 #include <intrin.h>
+#else
+inline uint64_t _addcarry_u64(const uint64_t carry, const uint64_t a, const uint64_t b, uint64_t* sum)
+{
+    *sum = a + b + carry;
+    return a > UINT32_MAX - b;
+}
+#endif
 #else
 #define C10_HAS_BUILTIN_OVERFLOW() (1)
 #endif


### PR DESCRIPTION
Currently PyTorch fails to build on MSVC with ARM64 toolchain as `_addcarry_u64` is not available for that platform. Unfortunately MSVC does not support inline asm for 64-bit platforms so the only alternative is to implement it directly in C. 
