### PR TITLE
Raise proper timeout when sharing the distributed shared seed

### DIFF
--- a/torch/utils/data/_utils/__init__.py
+++ b/torch/utils/data/_utils/__init__.py
@@ -40,6 +40,11 @@ r"""The key to share the same seed for shuffle DataPipe across distributed proce
 DATAPIPE_SHARED_SEED_COUNTER = "_dl_shared_seed_recv_cnt"
 r"""The key to count the number of distributed processes that have received the shared seed"""
 
+DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT = 30 * 60
+r"""Timeout (in seconds) sending the shared seed from Rank 0 and sending
+    the signal of the shared seed received from other Ranks.
+    It uses the same default timeout for the distributed process group"""
+
 DATAPIPE_SHARED_SEED_CHECK_INTERVAL = 0.01
 r"""Interval to check if each rank has received the shared seed"""
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -583,7 +583,8 @@ class DataLoader(Generic[T_co]):
                     while _shared_seed_recv_cnt < ws:
                         time.sleep(_utils.DATAPIPE_SHARED_SEED_CHECK_INTERVAL)
                         _shared_seed_recv_cnt = store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 0)
-                        if timedelta(seconds=(time.time() - start)) > _utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT:
+                        if timedelta(seconds=(time.time() - start)) > \
+                                timedelta(seconds=_utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT):
                             raise RuntimeError("Timed out receiving signals on Rank 0 in the distribtued "
                                                "store that all other Ranks have received the shared seed. "
                                                f"(world_size={ws}, received={_shared_seed_recv_cnt}, "
@@ -598,7 +599,8 @@ class DataLoader(Generic[T_co]):
                     while len(_shared_seed_str) == 0:
                         time.sleep(_utils.DATAPIPE_SHARED_SEED_CHECK_INTERVAL)
                         _shared_seed_str = store.get(_utils.DATAPIPE_SHARED_SEED)
-                        if timedelta(seconds=(time.time() - start)) > _utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT:
+                        if timedelta(seconds=(time.time() - start)) > \
+                                timedelta(seconds=_utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT):
                             raise RuntimeError("Timed out receiving the shared seed in the distribtued store "
                                                f"on Rank {rank}. (world_size={ws}, "
                                                f"timeout={_utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT})")

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -14,6 +14,7 @@ import threading
 import time
 import warnings
 
+from datetime import timedelta
 from typing import Any, Callable, Iterable, TypeVar, Generic, Sequence, List, Optional, Union
 
 import multiprocessing as python_multiprocessing
@@ -578,19 +579,29 @@ class DataLoader(Generic[T_co]):
                     # Use 'add' instead of 'get' since for some store implementations 'add'
                     # doesn't work well with 'get'.
                     _shared_seed_recv_cnt = store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 1)
+                    start = time.time()
                     while _shared_seed_recv_cnt < ws:
                         time.sleep(_utils.DATAPIPE_SHARED_SEED_CHECK_INTERVAL)
                         _shared_seed_recv_cnt = store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 0)
+                        if timedelta(seconds=(time.time() - start)) > _utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT:
+                            raise RuntimeError("Timed out receiving signals on Rank 0 in the distribtued "
+                                               "store that all other Ranks have received the shared seed. "
+                                               f"(world_size={ws}, received={_shared_seed_recv_cnt}, "
+                                               f"timeout={_utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT})")
                     # Reset after all distributed processes have received the shared seed
                     store.set(_utils.DATAPIPE_SHARED_SEED, "")
                     _shared_seed_recv_cnt = store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, -ws)
                     assert _shared_seed_recv_cnt == 0
                 else:
                     _shared_seed_str = ""
-                    store.wait([_utils.DATAPIPE_SHARED_SEED], _utils.MP_STATUS_CHECK_INTERVAL)
+                    start = time.time()
                     while len(_shared_seed_str) == 0:
                         time.sleep(_utils.DATAPIPE_SHARED_SEED_CHECK_INTERVAL)
                         _shared_seed_str = store.get(_utils.DATAPIPE_SHARED_SEED)
+                        if timedelta(seconds=(time.time() - start)) > _utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT:
+                            raise RuntimeError("Timed out receiving the shared seed in the distribtued store "
+                                               f"on Rank {rank}. (world_size={ws}, "
+                                               f"timeout={_utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT})")
                     logger.info(f"Shared seed ({_shared_seed_str}) received from store on rank {rank}")
                     _shared_seed_recv_cnt = store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 1)
                     # Exit only when all ranks received seed, otherwise we are at risk that current rank

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -585,8 +585,8 @@ class DataLoader(Generic[T_co]):
                         _shared_seed_recv_cnt = store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 0)
                         if timedelta(seconds=(time.time() - start)) > \
                                 timedelta(seconds=_utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT):
-                            raise RuntimeError("Timed out receiving signals on Rank 0 in the distribtued "
-                                               "store that all other Ranks have received the shared seed. "
+                            raise RuntimeError("Timed out receiving the signal from the distribtued store on "
+                                               "Rank 0 that all other Ranks have received the shared seed. "
                                                f"(world_size={ws}, received={_shared_seed_recv_cnt}, "
                                                f"timeout={_utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT})")
                     # Reset after all distributed processes have received the shared seed
@@ -601,7 +601,7 @@ class DataLoader(Generic[T_co]):
                         _shared_seed_str = store.get(_utils.DATAPIPE_SHARED_SEED)
                         if timedelta(seconds=(time.time() - start)) > \
                                 timedelta(seconds=_utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT):
-                            raise RuntimeError("Timed out receiving the shared seed in the distribtued store "
+                            raise RuntimeError("Timed out receiving the shared seed from the distribtued store "
                                                f"on Rank {rank}. (world_size={ws}, "
                                                f"timeout={_utils.DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT})")
                     logger.info(f"Shared seed ({_shared_seed_str}) received from store on rank {rank}")


### PR DESCRIPTION
Fixes https://github.com/pytorch/data/issues/659

- This would fix the problem that a slow DataLoader on rank 0 would cause TimeoutError as I have removed the `wait` operation on other Ranks.
- This PR also adds a [default timeout](https://github.com/pytorch/pytorch/blob/f6a45f79841fb7cdc4dfa294dbdd66d7e4b75c18/torch/csrc/distributed/c10d/ProcessGroup.hpp#L26-L27) as 30 * 60 seconds (taking reference from the distributed team's implementation). When the distributed seed is stuck on any rank, a proper timeout with detailed message will be raised.
