### PR TITLE
[Vulkan] Fix view op to infer dim size when -1 is given

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Shape.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Shape.cpp
@@ -1,3 +1,4 @@
+#include <ATen/InferSize.h>
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/Utils.h>
 #include <torch/library.h>
@@ -13,9 +14,11 @@ Tensor view_internal(const Tensor& self_arg, const IntArrayRef shape) {
   Tensor self = self_arg.is_vulkan() ? self_arg : self_arg.vulkan();
   vTensor& v_self = convert(self);
 
+  at::DimVector inferred_size = at::infer_size_dv(shape, self.numel());
+
   vTensor v_output{
       context,
-      shape,
+      inferred_size,
       self.options(),
   };
 


### PR DESCRIPTION
Summary:
Fixed view op, so that when one of the sizes in shape is -1, it is able to infer the size, instead of throwing an error.
To do this, reused `infer_size_impl` method from `ATen/InferSize.h`, which also checks that the shape argument is valid and compatible with input tensor.
Added tests cases in `vulkan_api_test.cpp`, to check the explicit and inferred cases, as well as tests to check that invalid inputs are caught.

References
- PyTorch Docs > torch.Tensor > [view](https://pytorch.org/docs/stable/generated/torch.Tensor.view.html)

Test Plan:
Added test cases to `/xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp`

On Mac:
```
buck run //xplat/caffe2:pt_vulkan_api_test_binAppleMac
```
On Android:
```
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
```

Reviewed By: kirklandsign

Differential Revision: D37887535

