### PR TITLE
[ONNX] Fix ONNX aten::mul exporter with boolean inputs

### DIFF
--- a/test/onnx/expect/TestOperators.test_mul_bool.expect
+++ b/test/onnx/expect/TestOperators.test_mul_bool.expect
@@ -1,0 +1,55 @@
+ir_version: 7
+producer_name: "pytorch"
+producer_version: "CURRENT_VERSION"
+graph {
+  node {
+    input: "onnx::And_0"
+    input: "onnx::And_1"
+    output: "2"
+    name: "And_0"
+    op_type: "And"
+  }
+  name: "torch_jit"
+  input {
+    name: "onnx::And_0"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "onnx::And_1"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "2"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/test/onnx/expect/TestOperators.test_mul_fp_bool.expect
+++ b/test/onnx/expect/TestOperators.test_mul_fp_bool.expect
@@ -1,0 +1,66 @@
+ir_version: 7
+producer_name: "pytorch"
+producer_version: "CURRENT_VERSION"
+graph {
+  node {
+    input: "onnx::Cast_1"
+    output: "onnx::Mul_2"
+    name: "Cast_0"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 1
+      type: INT
+    }
+  }
+  node {
+    input: "onnx::Mul_0"
+    input: "onnx::Mul_2"
+    output: "3"
+    name: "Mul_1"
+    op_type: "Mul"
+  }
+  name: "torch_jit"
+  input {
+    name: "onnx::Mul_0"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "onnx::Cast_1"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "3"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 13
+}

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -195,6 +195,16 @@ class TestOperators(common_utils.TestCase):
         x = torch.randn(2, 3, requires_grad=True).double()
         self.assertONNX(lambda x: 1 - x, (x,))
 
+    def test_mul_bool(self):
+        x = torch.tensor([True, False, True, False])
+        y = torch.tensor([True, True, False, False])
+        self.assertONNX(lambda x, y: torch.mul(x, y), (x, y))
+
+    def test_mul_fp_bool(self):
+        x = torch.tensor([9.4, 1.7, 3.6])
+        y = torch.tensor([True, True, False])
+        self.assertONNX(lambda x, y: torch.mul(x, y), (x, y))
+
     def test_transpose(self):
         x = torch.tensor([[0.0, 1.0], [2.0, 3.0]], requires_grad=True)
         self.assertONNX(lambda x: x.transpose(0, 1).transpose(1, 0), x)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3100,6 +3100,18 @@ class TestONNXRuntime(onnx_test_common._TestONNXRuntime):
         self.run_test(DivModule(), (x, y))
         self.run_test(PowModule(), (x, z))
 
+    def test_mul_bool(self):
+        class MyModel(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.mul(x, y)
+
+        x_t = torch.tensor([True, False, True, False])
+        y_t = torch.tensor([True, True, False, False])
+        z_t = torch.tensor([1.0, 2.0, 3.0, 0.0])
+        self.run_test(MyModel(), (x_t, y_t))
+        self.run_test(MyModel(), (x_t, z_t))
+        self.run_test(MyModel(), (z_t, y_t))
+
     # fmod was added in version 10
     @skipIfUnsupportedMinOpsetVersion(10)
     @skipIfUnsupportedMaxOpsetVersion(13)

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -537,18 +537,20 @@ def _slice_helper(g, input, axes, starts, ends, steps=None, dynamic_slice=False)
 
 
 _ScalarAndTensorElementTypeGroup = collections.namedtuple(
-    "ScalarAndTensorElementTypeGroup", ("tensor_element_types", "scalar_types"))
+    "_ScalarAndTensorElementTypeGroup", ("tensor_element_types", "scalar_types")
+)
 _FPTypeGroup = _ScalarAndTensorElementTypeGroup(
-    (torch.float16, torch.float32, torch.float64, torch.bfloat16), ("Float", "Double", "Half", "BFloat16"))
+    (torch.float16, torch.float32, torch.float64, torch.bfloat16),
+    ("Float", "Double", "Half", "BFloat16"),
+)
 _BoolTypeGroup = _ScalarAndTensorElementTypeGroup((torch.bool,), ("Bool",))
 
 
-def _is_in_type_group(value: Union[torch.Tensor, torch._C.Value], type_set: _ScalarAndTensorElementTypeGroup):
-  if not value:
-    return False
-  if isinstance(value, torch.Tensor):
-    return value.dtype in type_set.tensor_element_types
-  else:
+def _is_in_type_group(value, type_set):
+    if not value:
+        return False
+    if isinstance(value, torch.Tensor):
+        return value.dtype in type_set.tensor_element_types
     scalar_type = value.type().scalarType()
     if scalar_type is None:
         warnings.warn(

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections
 import enum
 import functools
 import inspect
@@ -535,23 +536,33 @@ def _slice_helper(g, input, axes, starts, ends, steps=None, dynamic_slice=False)
         return _slice10(g, input, axes, starts, ends, steps, dynamic_slice)
 
 
-def _is_fp(value):
-    if value:
-        if isinstance(value, torch.Tensor):
-            return value.dtype in (
-                torch.float16,
-                torch.float32,
-                torch.float64,
-                torch.bfloat16,
-            )
-        else:
-            type = value.type().scalarType()
-            if type is None:
-                warnings.warn(
-                    "Type cannot be inferred, which might cause exported graph to produce incorrect results."
-                )
-            return type in ("Float", "Double", "Half", "BFloat16")
+_ScalarAndTensorElementTypeGroup = collections.namedtuple(
+    "ScalarAndTensorElementTypeGroup", ("tensor_element_types", "scalar_types"))
+_FPTypeGroup = _ScalarAndTensorElementTypeGroup(
+    (torch.float16, torch.float32, torch.float64, torch.bfloat16), ("Float", "Double", "Half", "BFloat16"))
+_BoolTypeGroup = _ScalarAndTensorElementTypeGroup((torch.bool,), ("Bool",))
+
+
+def _is_in_type_group(value: Union[torch.Tensor, torch._C.Value], type_set: _ScalarAndTensorElementTypeGroup):
+  if not value:
     return False
+  if isinstance(value, torch.Tensor):
+    return value.dtype in type_set.tensor_element_types
+  else:
+    scalar_type = value.type().scalarType()
+    if scalar_type is None:
+        warnings.warn(
+            "Type cannot be inferred, which might cause exported graph to produce incorrect results."
+        )
+    return scalar_type in type_set.scalar_types
+
+
+def _is_fp(value):
+    return _is_in_type_group(value, _FPTypeGroup)
+
+
+def _is_bool(value):
+    return _is_in_type_group(value, _BoolTypeGroup)
 
 
 def _generate_wrapped_number(g, scalar):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -374,6 +374,7 @@ def rsub(g, self, other, alpha=None):
 
 def mul(g, self, other):
     if symbolic_helper._is_bool(self) and symbolic_helper._is_bool(other):
+        # ONNX Mul doesn't support Boolean, so use And as an equivalent operator.
         return g.op("And", self, other)
     else:
         return g.op("Mul", self, other)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -373,7 +373,10 @@ def rsub(g, self, other, alpha=None):
 
 
 def mul(g, self, other):
-    return g.op("Mul", self, other)
+    if symbolic_helper._is_bool(self) and symbolic_helper._is_bool(other):
+        return g.op("And", self, other)
+    else:
+        return g.op("Mul", self, other)
 
 
 def div(g, self, other, *args):


### PR DESCRIPTION
Continue work left in #72102.

The current exporter always export `aten::mul` to ONNX `Mul`. However, ONNX `Mul` [doesn't support Boolean](https://github.com/onnx/onnx/blob/main/docs/Operators.md#type-constraints-92) so we need to explicitly use ONNX `And` in this case.
