### PR TITLE
libtorch: exclude from libomnibus to support multipy usage from pybind

### DIFF
--- a/tools/target_definitions.bzl
+++ b/tools/target_definitions.bzl
@@ -154,6 +154,8 @@ def add_torch_libs():
         link_whole = True,
         include_directories = include_directories,
         propagated_pp_flags = propagated_pp_flags_cpu,
+        # Disable merged linking so deploy works with pybind.
+        supports_merged_linking = False,
         exported_deps = (
             [
                 ":ATen-cpu",


### PR DESCRIPTION
Summary: When libtorch is bundled into libomnibus all of the symbols are marked as unexported which causes issues when deploy/multipy tries to link in a subinterpreter at runtime. This excludes `libtorch` and `ATen-core` from libomnibus so the symbols remain exported and available.

Test Plan:
stacked diff

```
buck2 test @//mode/opt -c python.package_style=inplace //multipy/runtime:test_deploy_from_python
```

Differential Revision: D37946374

