### PR TITLE
Error if trying to enable_reentrant_dispatch but no TorchDispatchMode is set

### DIFF
--- a/aten/src/ATen/core/PythonFallbackKernel.cpp
+++ b/aten/src/ATen/core/PythonFallbackKernel.cpp
@@ -103,6 +103,10 @@ namespace at {
 namespace impl {
 
 RestorePythonTLSSnapshot::RestorePythonTLSSnapshot() : saved_(safe_get_tls_on_entry()), guard_(safe_get_tls_on_entry()) {
+  if (tls_on_entry->included_.has(DispatchKey::Python)) {
+    TORCH_INTERNAL_ASSERT(at::impl::TorchDispatchModeTLS::get_state(),
+        "Tried to enable reentrant dispatch but no TorchDispatchMode was set.");
+  }
   tls_on_entry = c10::nullopt;
 }
 

--- a/test/test_dispatch.py
+++ b/test/test_dispatch.py
@@ -950,5 +950,6 @@ CompositeImplicitAutograd[alias] fn_CompositeImplicitAutograd
             lambda: torch.bmm(qx, qy)
         )
 
+
 if __name__ == '__main__':
     run_tests()

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -1583,7 +1583,7 @@ class TestTorchFunctionMode(TestCase):
 
             @classmethod
             def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
-                if kwargs == None:
+                if kwargs is None:
                     kwargs = {}
 
                 def unwrap(x):

--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -1566,7 +1566,7 @@ class TestTorchFunctionMode(TestCase):
         self.assertTrue(called)
 
     def test_reentrant_dispatch_subclass(self):
-        def norm_decomp(x, p = 2.0):
+        def norm_decomp(x, p=2.0):
             return torch.sqrt(torch.sum(torch.square(x)))
 
         oplist = []
@@ -1613,7 +1613,7 @@ class TestTorchFunctionMode(TestCase):
 
 
     def test_reentrant_dispatch_mode(self):
-        def norm_decomp(x, p = 2.0):
+        def norm_decomp(x, p=2.0):
             return torch.sqrt(torch.sum(torch.square(x)))
 
         class TestMode(TorchDispatchMode):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #81677
* #81598

If you enable_reentrant_dispatch when TorchDispatchMode is not set, and
then dispatch again, then torch dispatch will fail because no mode can
be found. This throws a warning that should be easier to debug.