### PR TITLE
Fix hostname endpoint mismatch

### DIFF
--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -164,12 +164,13 @@ def _matches_machine_hostname(host: str) -> bool:
     if host == this_host:
         return True
 
+    host_fqdn = socket.getfqdn(host)
     addr_list = socket.getaddrinfo(
         this_host, None, proto=socket.IPPROTO_TCP, flags=socket.AI_CANONNAME
     )
     for addr_info in addr_list:
         # If we have an FQDN in the addr_info, compare it to `host`.
-        if addr_info[3] and addr_info[3] == host:
+        if addr_info[3] and (addr_info[3] == host or addr_info[3] == host_fqdn):
             return True
         # Otherwise if `host` represents an IP address, compare it to our IP
         # address.
@@ -177,7 +178,10 @@ def _matches_machine_hostname(host: str) -> bool:
             return True
 
     for (nic_host, nic_addr) in nic_info():
-        if nic_host == host or addr and nic_addr == str(addr):
+        if (
+                nic_host == host or nic_host == host_fqdn
+                or addr and nic_addr == str(addr)
+        ):
             return True
 
     return False

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -4,10 +4,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import fcntl
 import ipaddress
 import random
 import re
 import socket
+import struct
 import time
 import weakref
 from datetime import timedelta
@@ -15,6 +17,37 @@ from threading import Event, Thread
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 __all__ = ['parse_rendezvous_endpoint']
+
+
+# From https://stackoverflow.com/a/27494105.
+def nic_ip_address(nic_name):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    return socket.inet_ntoa(fcntl.ioctl(
+        s.fileno(),
+        0x8915,  # SIOCGIFADDR
+        struct.pack('256s', nic_name[:15].encode("UTF-8"))
+    )[20:24])
+
+
+# Adapted from https://stackoverflow.com/a/27494105.
+def nic_info():
+    """Return a list of tuples containing each NIC's hostname and its IPv4."""
+    nics = []
+    try:
+        if_nameindex = socket.if_nameindex()
+    except OSError:
+        return nics
+
+    for (_, nic_name) in if_nameindex:
+        try:
+            ip_addr = nic_ip_address(nic_name)
+        except OSError:
+            continue
+
+        hostname = socket.gethostbyaddr(ip_addr)[0]
+        nics.append((hostname, ip_addr))
+    return nics
+
 
 def _parse_rendezvous_config(config_str: str) -> Dict[str, str]:
     """Extracts key-value pairs from a rendezvous configuration string.
@@ -141,6 +174,10 @@ def _matches_machine_hostname(host: str) -> bool:
         # Otherwise if `host` represents an IP address, compare it to our IP
         # address.
         if addr and addr_info[4][0] == str(addr):
+            return True
+
+    for (nic_host, nic_addr) in nic_info():
+        if nic_host == host or addr and nic_addr == str(addr):
             return True
 
     return False

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -32,7 +32,7 @@ def nic_ip_address(nic_name: str) -> str:
 # Adapted from https://stackoverflow.com/a/27494105.
 def nic_info() -> List[Tuple[str, str]]:
     """Return a list of tuples containing each NIC's hostname and its IPv4."""
-    nics = []
+    nics: List[Tuple[str, str]] = []
     try:
         if_nameindex = socket.if_nameindex()
     except OSError:

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -14,13 +14,13 @@ import time
 import weakref
 from datetime import timedelta
 from threading import Event, Thread
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 __all__ = ['parse_rendezvous_endpoint']
 
 
 # From https://stackoverflow.com/a/27494105.
-def nic_ip_address(nic_name):
+def nic_ip_address(nic_name: str) -> str:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     return socket.inet_ntoa(fcntl.ioctl(
         s.fileno(),
@@ -30,7 +30,7 @@ def nic_ip_address(nic_name):
 
 
 # Adapted from https://stackoverflow.com/a/27494105.
-def nic_info():
+def nic_info() -> List[Tuple[str, str]]:
     """Return a list of tuples containing each NIC's hostname and its IPv4."""
     nics = []
     try:

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -224,6 +224,7 @@ def launch_agent(
         tee=config.tee,
         master_addr=master_addr,
         master_port=master_port,
+        endpoint=rdzv_parameters.endpoint.strip(),
     )
 
     agent = LocalElasticAgent(


### PR DESCRIPTION
This fixes the issues explained in #73656, by

1. additionally comparing the IPs and hostnames of all NICs to find a matching host,
2. keeping the original `endpoint` in the `WorkerSpec` so that its information can be used to find a matching FQDN for the used NIC. (This information was previously completely discarded unless `--rdzv_backend static` was used.)

In addition, we now also check not only the given hostname but also the fully qualified version of it. This way, users are allowed to specify non-fully-qualified hostnames as well. Since this may be debatable, feel free to make me remove this commit.

If you want, I can also add checking for all hostname aliases as well. I went the same route as you by simply discarding aliases.

Fixes #73656.