### PR TITLE
Modify quantizer test for k=1 to use uniform observer for scale, zero point

### DIFF
--- a/test/quantization/core/experimental/test_quantizer.py
+++ b/test/quantization/core/experimental/test_quantizer.py
@@ -2,6 +2,7 @@
 
 import torch
 from torch import quantize_per_tensor
+from torch.ao.quantization.observer import MinMaxObserver
 from torch.ao.quantization.experimental.observer import APoTObserver
 from torch.ao.quantization.experimental.quantizer import APoTQuantizer, quantize_APoT, dequantize_APoT
 import unittest
@@ -13,7 +14,7 @@ class TestQuantizer(unittest.TestCase):
         (non-uniform quantization reduces to uniform for k = 1)
         quantized tensor (https://pytorch.org/docs/stable/generated/torch.quantize_per_tensor.html)
         * tensor2quantize: Tensor
-        * b: 4
+        * b: 8
         * k: 1
     """
     def test_quantize_APoT_rand_k1(self):
@@ -24,9 +25,7 @@ class TestQuantizer(unittest.TestCase):
         tensor2quantize = 1000 * torch.rand(size, dtype=torch.float)
 
         observer = APoTObserver(b=8, k=1)
-        observer.forward(tensor2quantize)
-        observer.min_val = torch.tensor([0])
-        observer.max_val = torch.tensor([255])
+        observer(tensor2quantize)
         alpha, gamma, quantization_levels, level_indices = observer.calculate_qparams(signed=False)
 
         # get apot quantized tensor result
@@ -37,7 +36,14 @@ class TestQuantizer(unittest.TestCase):
                                 level_indices=level_indices)
 
         # get uniform quantization quantized tensor result
-        uniform_quantized = quantize_per_tensor(input=tensor2quantize, scale=1.0, zero_point=0, dtype=torch.quint8).int_repr()
+        uniform_observer = MinMaxObserver()
+        uniform_observer(tensor2quantize)
+        scale, zero_point = uniform_observer.calculate_qparams()
+
+        uniform_quantized = quantize_per_tensor(input=tensor2quantize,
+                                                scale=scale,
+                                                zero_point=zero_point,
+                                                dtype=torch.quint8).int_repr()
 
         qtensor_data = qtensor.data.int()
         uniform_quantized_tensor = uniform_quantized.data.int()

--- a/test/quantization/core/experimental/test_quantizer.py
+++ b/test/quantization/core/experimental/test_quantizer.py
@@ -24,9 +24,9 @@ class TestQuantizer(unittest.TestCase):
         # generate tensor with random fp values between 0 -> 1000
         tensor2quantize = 1000 * torch.rand(size, dtype=torch.float)
 
-        observer = APoTObserver(b=8, k=1)
-        observer(tensor2quantize)
-        alpha, gamma, quantization_levels, level_indices = observer.calculate_qparams(signed=False)
+        apot_observer = APoTObserver(b=8, k=1)
+        apot_observer(tensor2quantize)
+        alpha, gamma, quantization_levels, level_indices = apot_observer.calculate_qparams(signed=False)
 
         # get apot quantized tensor result
         qtensor = quantize_APoT(tensor2quantize=tensor2quantize,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #81696

### Summary
This PR modifies the first test in `test/quantization/core/experimental/test_quantizer.py` to use uniform observers to observe the calculate the scale and zero point qparams rather than hard-coding the values.

### Test Plan
Run unit tests with: `python test/quantization/core/experimental/test_quantizer.py`