### PR TITLE
functionalization: fix for mutable ops with different type promotion rules

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -190,6 +190,8 @@ void FunctionalTensorWrapper::replace_(const Tensor& other) {
     set_storage_offset(value_.storage_offset());
   }
   if (dtype() != value_.unsafeGetTensorImpl()->dtype() || layout() != value_.unsafeGetTensorImpl()->layout()) {
+    // .to() should not re-entrantly go through functionalization.
+    at::AutoDispatchSkipFunctionalize guard;
     value_ = value_.to(c10::TensorOptions().dtype(dtype()).layout(layout()));
   }
 }


### PR DESCRIPTION
fixes https://github.com/pytorch/pytorch/issues/81618

At some point it looks like this became broken (you can see the updated expect test looks better now, and the original was just returning a constant).

I also got a repro that was failing with an assert, that I confirmed now passes:

```
def foo(t, y):
    out_1 = torch.ones(1)
    return torch.add(t, y, out=out_1)

g = make_fx(functionalize(foo))(torch.tensor([1]), torch.tensor([1]))
print(g.code)
out1 = functionalize(foo)(torch.tensor([1]), torch.tensor([1]))
out2 = foo(torch.tensor([1]), torch.tensor([1]))
print(out1 == out2)
```

Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #81702

