### PR TITLE
Ensure `Transform` is pickleable.

### DIFF
--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -96,6 +96,11 @@ class Transform(object):
             raise ValueError('cache_size must be 0 or 1')
         super(Transform, self).__init__()
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_inv"] = None
+        return state
+
     @property
     def event_dim(self):
         if self.domain.event_dim == self.codomain.event_dim:


### PR DESCRIPTION
`Transform` is not currently pickleable if the inverse transform cache `_inv` is not `None` because `_inv` is a `weakref` which cannot be serialized by `pickle`. 

The following succeeds.

```python
>>> import torch as th
>>> import pickle

>>> dist = th.distributions.TransformedDistribution(
...     th.distributions.Normal(0, 1),
...     [th.distributions.AffineTransform(2, 3)]
... )
>>> th.save(dist, "some-file.pt")
```

But the transformed distribution can no longer be pickled after evaluating `log_prob` (which implicitly creates `_inv`).

```python
>>> dist.log_prob(th.linspace(0, 1, 10))
>>> th.save(dist, "some-file.pt")
TypeError: cannot pickle 'weakref' object
```

This PR fixes the issue by setting `_inv` to `None` in `__getstate__`. cc @fritzo, @neerajprad 