### PR TITLE
Fix off by one error with EndOfBackendKeys

### DIFF
--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -66,11 +66,8 @@ enum class BackendComponent : uint8_t {
   PrivateUse1Bit,
   PrivateUse2Bit,
   PrivateUse3Bit,
-  // Define an alias to represent end of backend dispatch keys.
-  // If you add new backend keys after PrivateUse3, please also update it here.
-  // (But you shouldn't: private use keys should have higher precedence than
-  // all built-in keys)
-  EndOfBackendKeys = PrivateUse3Bit,
+  // Don't put any more keys after here
+  EndOfBackendKeys,
 };
 
 // Semantically, a dispatch key identifies a possible "level" in our


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #81713
* __->__ #81712
* #81637

It looks like the alias was cargo culted from functionality keys,
but you only need to actually do an alias if you need a break in the
middle of the sequence while keeping the numbering contiguous, which
doesn't apply here.  (It would also be necessary if we exactly filled
the representation type, but uint8_t has plenty of space.)

I audited all uses of this key and it turns out that it had committed
(harmless) off by one errors.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>