### PR TITLE
Add test that all BackendComponents are covered by toString

### DIFF
--- a/c10/test/core/DispatchKeySet_test.cpp
+++ b/c10/test/core/DispatchKeySet_test.cpp
@@ -386,6 +386,17 @@ TEST(DispatchKeySet, FailAtEndIterator) {
       c10::Error);
 }
 
+TEST(DispatchKeySet, TestBackendComponentToString) {
+  std::unordered_set<std::string> seen_strings;
+  for (int i = 0; i < num_backends; i++) {
+    auto k = static_cast<BackendComponent>(i);
+    auto res = std::string(toString(k));
+    ASSERT_FALSE(res == "UNKNOWN_BACKEND_BIT");
+    ASSERT_FALSE(seen_strings.count(res) > 0);
+    seen_strings.insert(res);
+  }
+}
+
 TEST(DispatchKeySet, TestKeyOrderingInvariants) {
   for (uint8_t i = static_cast<uint8_t>(DispatchKey::StartOfDenseBackends);
        i <= static_cast<uint8_t>(DispatchKey::EndOfRuntimeBackendKeys);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #81770
* #81752
* __->__ #81713
* #81637

Signed-off-by: Edward Z. Yang <ezyang@fb.com>