### PR TITLE
[Vulkan] Implement arithmetic ops where one of the arguments is a tensor wrapping a scalar.

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/add.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/add.glsl
@@ -12,7 +12,7 @@ layout(set = 0, binding = 2)         uniform PRECISION                    sample
 layout(set = 0, binding = 3)         uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 isize0;
-  ivec3 isize1;
+  ivec4 isize1;
   float alpha;
 } uBlock;
 
@@ -24,9 +24,12 @@ void main() {
   if (all(lessThan(pos, uBlock.size.xyz))) {
     const ivec3 input0_pos = pos % uBlock.isize0.xyz;
     const ivec3 input1_pos = pos % uBlock.isize1.xyz;
-    imageStore(
-        uOutput,
-        pos,
-        texelFetch(uInput0, input0_pos, 0) + uBlock.alpha * texelFetch(uInput1, input1_pos, 0));
+    const vec4 v0 = uBlock.isize0.w == 1
+                      ? texelFetch(uInput0, input0_pos, 0).xxxx
+                      : texelFetch(uInput0, input0_pos, 0);
+    const vec4 v1 = uBlock.isize1.w == 1
+                      ? texelFetch(uInput1, input1_pos, 0).xxxx
+                      : texelFetch(uInput1, input1_pos, 0);
+    imageStore(uOutput, pos, v0 + uBlock.alpha * v1);
   }
 }

--- a/aten/src/ATen/native/vulkan/glsl/add_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/add_.glsl
@@ -7,10 +7,10 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict image3D   uOutput;
-layout(set = 0, binding = 1)         uniform PRECISION          sampler3D uInput0;
+layout(set = 0, binding = 1)         uniform PRECISION          sampler3D uInput;
 layout(set = 0, binding = 2)         uniform PRECISION restrict Block {
   ivec4 size;
-  ivec3 isize;
+  ivec4 isize;
   float alpha;
 } uBlock;
 
@@ -21,9 +21,12 @@ void main() {
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
     const ivec3 input_pos = pos % uBlock.isize.xyz;
+    const vec4 v = uBlock.isize.w == 1
+                     ? texelFetch(uInput, input_pos, 0).xxxx
+                     : texelFetch(uInput, input_pos, 0);
     imageStore(
         uOutput,
         pos,
-        imageLoad(uOutput, pos) + uBlock.alpha * texelFetch(uInput0, input_pos, 0));
+        imageLoad(uOutput, pos) + uBlock.alpha * v);
   }
 }

--- a/aten/src/ATen/native/vulkan/glsl/div.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/div.glsl
@@ -12,7 +12,7 @@ layout(set = 0, binding = 2)         uniform PRECISION                    sample
 layout(set = 0, binding = 3)         uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 isize0;
-  ivec3 isize1;
+  ivec4 isize1;
   float alpha;
 } uBlock;
 
@@ -24,9 +24,12 @@ void main() {
   if (all(lessThan(pos, uBlock.size.xyz))) {
     const ivec3 input0_pos = pos % uBlock.isize0.xyz;
     const ivec3 input1_pos = pos % uBlock.isize1.xyz;
-    imageStore(
-        uOutput,
-        pos,
-        texelFetch(uInput0, input0_pos, 0) / texelFetch(uInput1, input1_pos, 0));
+    const vec4 v0 = uBlock.isize0.w == 1
+                      ? texelFetch(uInput0, input0_pos, 0).xxxx
+                      : texelFetch(uInput0, input0_pos, 0);
+    const vec4 v1 = uBlock.isize1.w == 1
+                      ? texelFetch(uInput1, input1_pos, 0).xxxx
+                      : texelFetch(uInput1, input1_pos, 0);
+    imageStore(uOutput, pos, v0 / v1);
   }
 }

--- a/aten/src/ATen/native/vulkan/glsl/div_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/div_.glsl
@@ -7,10 +7,10 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict image3D   uOutput;
-layout(set = 0, binding = 1)         uniform PRECISION          sampler3D uInput0;
+layout(set = 0, binding = 1)         uniform PRECISION          sampler3D uInput;
 layout(set = 0, binding = 2)         uniform PRECISION restrict Block {
   ivec4 size;
-  ivec3 isize;
+  ivec4 isize;
   float alpha;
 } uBlock;
 
@@ -21,9 +21,12 @@ void main() {
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
     const ivec3 input_pos = pos % uBlock.isize.xyz;
+    const vec4 v = uBlock.isize.w == 1
+                     ? texelFetch(uInput, input_pos, 0).xxxx
+                     : texelFetch(uInput, input_pos, 0);
     imageStore(
         uOutput,
         pos,
-        imageLoad(uOutput, pos) / texelFetch(uInput0, input_pos, 0));
+        imageLoad(uOutput, pos) / v);
   }
 }

--- a/aten/src/ATen/native/vulkan/glsl/mul.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mul.glsl
@@ -12,7 +12,7 @@ layout(set = 0, binding = 2)         uniform PRECISION                    sample
 layout(set = 0, binding = 3)         uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 isize0;
-  ivec3 isize1;
+  ivec4 isize1;
   float alpha;
 } uBlock;
 
@@ -24,9 +24,12 @@ void main() {
   if (all(lessThan(pos, uBlock.size.xyz))) {
     const ivec3 input0_pos = pos % uBlock.isize0.xyz;
     const ivec3 input1_pos = pos % uBlock.isize1.xyz;
-    imageStore(
-        uOutput,
-        pos,
-        texelFetch(uInput0, input0_pos, 0) * texelFetch(uInput1, input1_pos, 0));
+    const vec4 v0 = uBlock.isize0.w == 1
+                      ? texelFetch(uInput0, input0_pos, 0).xxxx
+                      : texelFetch(uInput0, input0_pos, 0);
+    const vec4 v1 = uBlock.isize1.w == 1
+                      ? texelFetch(uInput1, input1_pos, 0).xxxx
+                      : texelFetch(uInput1, input1_pos, 0);
+    imageStore(uOutput, pos, v0 * v1);
   }
 }

--- a/aten/src/ATen/native/vulkan/glsl/mul_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mul_.glsl
@@ -7,10 +7,10 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict image3D   uOutput;
-layout(set = 0, binding = 1)         uniform PRECISION          sampler3D uInput0;
+layout(set = 0, binding = 1)         uniform PRECISION          sampler3D uInput;
 layout(set = 0, binding = 2)         uniform PRECISION restrict Block {
   ivec4 size;
-  ivec3 isize;
+  ivec4 isize;
   float alpha;
 } uBlock;
 
@@ -21,9 +21,12 @@ void main() {
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
     const ivec3 input_pos = pos % uBlock.isize.xyz;
+    const vec4 v = uBlock.isize.w == 1
+                     ? texelFetch(uInput, input_pos, 0).xxxx
+                     : texelFetch(uInput, input_pos, 0);
     imageStore(
         uOutput,
         pos,
-        imageLoad(uOutput, pos) * texelFetch(uInput0, input_pos, 0));
+        imageLoad(uOutput, pos) * v);
   }
 }

--- a/aten/src/ATen/native/vulkan/glsl/sub.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/sub.glsl
@@ -12,7 +12,7 @@ layout(set = 0, binding = 2)         uniform PRECISION                    sample
 layout(set = 0, binding = 3)         uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 isize0;
-  ivec3 isize1;
+  ivec4 isize1;
   float alpha;
 } uBlock;
 
@@ -24,9 +24,12 @@ void main() {
   if (all(lessThan(pos, uBlock.size.xyz))) {
     const ivec3 input0_pos = pos % uBlock.isize0.xyz;
     const ivec3 input1_pos = pos % uBlock.isize1.xyz;
-    imageStore(
-        uOutput,
-        pos,
-        texelFetch(uInput0, input0_pos, 0) - uBlock.alpha * texelFetch(uInput1, input1_pos, 0));
+    const vec4 v0 = uBlock.isize0.w == 1
+                      ? texelFetch(uInput0, input0_pos, 0).xxxx
+                      : texelFetch(uInput0, input0_pos, 0);
+    const vec4 v1 = uBlock.isize1.w == 1
+                      ? texelFetch(uInput1, input1_pos, 0).xxxx
+                      : texelFetch(uInput1, input1_pos, 0);
+    imageStore(uOutput, pos, v0 - uBlock.alpha * v1);
   }
 }

--- a/aten/src/ATen/native/vulkan/glsl/sub_.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/sub_.glsl
@@ -7,10 +7,10 @@ layout(std430) buffer;
 /* Qualifiers: layout - storage - precision - memory */
 
 layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict image3D   uOutput;
-layout(set = 0, binding = 1)         uniform PRECISION          sampler3D uInput0;
+layout(set = 0, binding = 1)         uniform PRECISION          sampler3D uInput;
 layout(set = 0, binding = 2)         uniform PRECISION restrict Block {
   ivec4 size;
-  ivec3 isize;
+  ivec4 isize;
   float alpha;
 } uBlock;
 
@@ -21,9 +21,12 @@ void main() {
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
     const ivec3 input_pos = pos % uBlock.isize.xyz;
+    const vec4 v = uBlock.isize.w == 1
+                     ? texelFetch(uInput, input_pos, 0).xxxx
+                     : texelFetch(uInput, input_pos, 0);
     imageStore(
         uOutput,
         pos,
-        imageLoad(uOutput, pos) - uBlock.alpha * texelFetch(uInput0, input_pos, 0));
+        imageLoad(uOutput, pos) - uBlock.alpha * v);
   }
 }

--- a/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Arithmetic.cpp
@@ -10,63 +10,74 @@ namespace vulkan {
 namespace ops {
 namespace {
 
-bool broadcast_input(const Tensor& input1, const Tensor& input2) {
-  return ((height_size(input1) > 1 && height_size(input2) == 1) ||
-          (height_size(input2) > 1 && height_size(input1) == 1) ||
-          (height_size(input1) == height_size(input2))) &&
-      ((width_size(input1) > 1 && width_size(input2) == 1) ||
-       (width_size(input2) > 1 && width_size(input1) == 1) ||
-       (width_size(input1) == width_size(input2)));
-}
-
 void check_inputs(const Tensor& input1, const Tensor& input2) {
-  TORCH_CHECK(
-      channels_size(input1) == channels_size(input2),
-      "Vulkan binary elementwise ops require channel dimension to be equal!");
+  const std::string broadcast_error_msg =
+      "Incompatible dimensions for broadcasting for binary elementwise op!";
   if (batch_size(input1) != batch_size(input2)) {
     TORCH_CHECK(
-        channels_size(input1) % 4 == 0,
-        "Vulkan binary elementwise ops require channel to be a multiple of 4 to broadcast along batch dimension!")
+        batch_size(input1) == 1 || batch_size(input2), broadcast_error_msg);
+    TORCH_CHECK(
+        (channels_size(input1) == channels_size(input2) &&
+         channels_size(input1) % 4 == 0) ||
+            channels_size(input1) * batch_size(input1) == 1 ||
+            channels_size(input2) * batch_size(input2) == 1,
+        "Invalid broadcasting for Vulkan binary elementwise op! "
+        "If batch dimensions aren't equal, then channel dimensions must be "
+        "equal and multiple of 4 or one of the inputs must have "
+        "channel and batch dimensions both equal to 1!");
   }
-
-  const std::string broadcast_error_msg =
-      "Incompatible input dimensions for broadcasting for Vulkan binary elementwise op!";
-
-  TORCH_CHECK(broadcast_input(input1, input2), broadcast_error_msg);
+  if (channels_size(input1) != channels_size(input2)) {
+    TORCH_CHECK(
+        channels_size(input1) == 1 || channels_size(input2),
+        broadcast_error_msg);
+    TORCH_CHECK(
+        channels_size(input1) * batch_size(input1) == 1 ||
+            channels_size(input2) * batch_size(input2) == 1,
+        "Invalid broadcasting for Vulkan binary elementwise op! "
+        "If channel dimensions aren't equal, then one of the inputs must have "
+        "channel and batch dimensions both equal to 1!");
+  }
+  if (height_size(input1) != height_size(input2)) {
+    TORCH_CHECK(
+        height_size(input1) == 1 || height_size(input2), broadcast_error_msg);
+  }
+  if (width_size(input1) != width_size(input2)) {
+    TORCH_CHECK(
+        width_size(input1) == 1 || width_size(input2), broadcast_error_msg);
+  }
 }
 
-std::vector<int64_t> broadcast_size(
-    const Tensor& input1,
-    const Tensor& input2) {
-  std::vector<int64_t> out = {};
-  int input1_size = input1.sizes().size();
-  int input2_size = input2.sizes().size();
-  if (input1_size > input2_size) {
-    for (int i = 0; i < input1_size; i++) {
-      out.push_back(input1.sizes()[i]);
+std::vector<int64_t> broadcast_size(const Tensor& t1, const Tensor& t2) {
+  int64_t t1_size = t1.dim();
+  int64_t t2_size = t2.dim();
+
+  std::vector<int64_t> out;
+  if (t1_size > t2_size) {
+    for (int64_t i = 0; i < t1_size; i++) {
+      out.push_back(t1.sizes()[i]);
     }
   } else {
-    for (int i = 0; i < input2_size; i++) {
-      out.push_back(input2.sizes()[i]);
+    for (int64_t i = 0; i < t2_size; i++) {
+      out.push_back(t2.sizes()[i]);
     }
   }
 
-  if (width_size(input1) > 1 && width_size(input2) == 1) {
-    out[out.size() - 1] = width_size(input1);
-  } else if (width_size(input2) > 1 && width_size(input1) == 1) {
-    out[out.size() - 1] = width_size(input2);
+  if (out.size() > 0) {
+    out[out.size() - 1] = std::max(width_size(t1), width_size(t2));
   }
-
   if (out.size() > 1) {
-    if (height_size(input1) > 1 && height_size(input2) == 1) {
-      out[out.size() - 2] = height_size(input1);
-    } else if (height_size(input2) > 1 && height_size(input1) == 1) {
-      out[out.size() - 2] = height_size(input2);
-    }
+    out[out.size() - 2] = std::max(height_size(t1), height_size(t2));
+  }
+  if (out.size() > 2) {
+    out[out.size() - 3] = std::max(channels_size(t1), channels_size(t2));
+  }
+  if (out.size() > 3) {
+    out[out.size() - 4] = std::max(batch_size(t1), batch_size(t2));
   }
 
   return out;
 }
+
 } // namespace
 using namespace api::utils;
 
@@ -195,15 +206,17 @@ Tensor arithmetic_tensor(
     uvec3 extents;
     uint32_t fill_0;
     uvec3 input1_extents;
-    uint32_t fill_1;
+    uint32_t channel_batch_size_1;
     uvec3 input2_extents;
+    uint32_t channel_batch_size_2;
     float alpha;
   } block{
       v_output.extents(),
       0u,
       v_self.extents(),
-      0u,
+      channels_size(self) * batch_size(self),
       v_other.extents(),
+      channels_size(other) * batch_size(other),
       alpha,
   };
 
@@ -326,6 +339,14 @@ Tensor& arithmetic_tensor_(
     const Tensor& other_arg,
     const c10::optional<Scalar>& alpha_arg,
     const api::ShaderSource& shader_descriptor) {
+  TORCH_CHECK(
+      batch_size(self_arg) >= batch_size(other_arg) &&
+          channels_size(self_arg) >= channels_size(other_arg) &&
+          height_size(self_arg) >= height_size(other_arg) &&
+          width_size(self_arg) >= width_size(other_arg),
+      "Dimensions of input tensor to Vulkan in-place binary elementwise op "
+      "must be less than or equal the dimensions of the underlying tensor.");
+
   check_inputs(self_arg, other_arg);
 
   TORCH_CHECK(
@@ -344,11 +365,13 @@ Tensor& arithmetic_tensor_(
     uvec3 extents;
     uint32_t fill_0;
     uvec3 input_extents;
+    uint32_t channel_batch_size_other;
     float alpha;
   } block{
       v_self.extents(),
       0u,
       v_other.extents(),
+      channels_size(other) * batch_size(other),
       alpha,
   };
 
@@ -431,13 +454,6 @@ Tensor add_tensor(
     const Tensor& self_arg,
     const Tensor& other_arg,
     const Scalar& alpha) {
-  if (other_arg.sizes().size() == 0) {
-    return arithmetic_scalar(
-        self_arg,
-        other_arg.item<float>(),
-        c10::optional<Scalar>(alpha.to<float>()),
-        VK_KERNEL(add_scalar));
-  }
   return arithmetic_tensor(
       self_arg, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(add));
 }
@@ -473,13 +489,6 @@ Tensor sub_tensor(
     const Tensor& self_arg,
     const Tensor& other_arg,
     const Scalar& alpha) {
-  if (other_arg.sizes().size() == 0) {
-    return arithmetic_scalar(
-        self_arg,
-        other_arg.item<float>(),
-        c10::optional<Scalar>(-1 * alpha.to<float>()),
-        VK_KERNEL(add_scalar));
-  }
   return arithmetic_tensor(
       self_arg, other_arg, c10::optional<Scalar>(alpha), VK_KERNEL(sub));
 }
@@ -503,13 +512,6 @@ Tensor& mul_scalar_(Tensor& self, const Scalar& other) {
 }
 
 Tensor mul_tensor(const Tensor& self_arg, const Tensor& other_arg) {
-  if (other_arg.sizes().size() == 0) {
-    return arithmetic_scalar(
-        self_arg,
-        other_arg.item<float>(),
-        c10::optional<Scalar>(),
-        VK_KERNEL(mul_scalar));
-  }
   return arithmetic_tensor(
       self_arg, other_arg, c10::optional<Scalar>(), VK_KERNEL(mul));
 }
@@ -536,13 +538,6 @@ Tensor& div_scalar_(Tensor& self, const Scalar& other) {
 }
 
 Tensor div_tensor(const Tensor& self_arg, const Tensor& other_arg) {
-  if (other_arg.sizes().size() == 0) {
-    return arithmetic_scalar(
-        self_arg,
-        1.0 / other_arg.item<float>(),
-        c10::optional<Scalar>(),
-        VK_KERNEL(mul_scalar));
-  }
   return arithmetic_tensor(
       self_arg, other_arg, c10::optional<Scalar>(), VK_KERNEL(div));
 }

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -336,6 +336,43 @@ TEST_F(VulkanAPITest, add_broadcast2) {
   ASSERT_TRUE(check);
 }
 
+TEST_F(VulkanAPITest, add_broadcast3) {
+
+  const auto a_cpu = at::rand({3, 4, 41, 53}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_cpu = at::rand({1, 1, 41, 53}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::add(a_cpu, b_cpu, 2.5f);
+  const auto c_vulkan = at::add(a_vulkan, b_vulkan, 2.5f);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, add_broadcast4) {
+  const auto a_cpu = at::rand({3, 4, 41, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_cpu = at::rand({1, 41, 53}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::add(a_cpu, b_cpu, 2.5f);
+  const auto c_vulkan = at::add(a_vulkan, b_vulkan, 2.5f);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
 TEST_F(VulkanAPITest, add_) {
   auto a_cpu = at::rand({61, 17, 29, 83}, at::device(at::kCPU).dtype(at::kFloat));
   auto a_vulkan = a_cpu.vulkan();
@@ -419,6 +456,69 @@ TEST_F(VulkanAPITest, add_scalar_) {
   const auto check = almostEqual(a_cpu, a_vulkan.cpu());
   if (!check) {
     showRtol(a_cpu, a_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, add_scalar_wrapped) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto a_cpu = at::rand({13, 23, 59, 73}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_scalar = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  const auto c_cpu = at::add(a_cpu, b_scalar, 2.1f);
+  const auto c_vulkan = at::add(a_vulkan, b_scalar, 2.1f);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, add_scalar_wrapped_) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  auto a_cpu = at::rand({47, 2, 23, 97}, at::device(at::kCPU).dtype(at::kFloat));
+  auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_scalar = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  a_cpu.add_(b_scalar, 2.1f);
+  a_vulkan.add_(b_scalar, 2.1f);
+
+  const auto check = almostEqual(a_cpu, a_vulkan.cpu());
+  if (!check) {
+    showRtol(a_cpu, a_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, add_to_scalar_wrapped) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto a = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  const auto b_cpu = at::rand({11, 7, 139, 109}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::add(a, b_cpu, 2.1f);
+  const auto c_vulkan = at::add(a, b_vulkan, 2.1f);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
   }
 
   ASSERT_TRUE(check);
@@ -1033,6 +1133,42 @@ TEST_F(VulkanAPITest, div_broadcast2) {
   ASSERT_TRUE(check);
 }
 
+TEST_F(VulkanAPITest, div_broadcast3) {
+  const auto a_cpu = at::rand({3, 4, 179, 221}, at::device(at::kCPU).dtype(at::kFloat))+0.01;
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_cpu = at::rand({1, 1, 179, 221}, at::device(at::kCPU).dtype(at::kFloat))+0.01;
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::div(a_cpu, b_cpu);
+  const auto c_vulkan = at::div(a_vulkan, b_vulkan);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, div_broadcast4) {
+  const auto a_cpu = at::rand({3, 4, 41, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_cpu = at::rand({1, 41, 53}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::div(a_cpu, b_cpu);
+  const auto c_vulkan = at::div(a_vulkan, b_vulkan);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
 TEST_F(VulkanAPITest, div_) {
   auto a_cpu = at::rand({61, 17, 29, 83}, at::device(at::kCPU).dtype(at::kFloat))+0.01;
   auto a_vulkan = a_cpu.vulkan();
@@ -1117,6 +1253,69 @@ TEST_F(VulkanAPITest, div_scalar_) {
   const auto check = almostEqual(a_cpu, a_vulkan.cpu());
   if (!check) {
     showRtol(a_cpu, a_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, div_scalar_wrapped) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto a_cpu = at::rand({17, 213, 213, 7}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_scalar = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  const auto c_cpu = at::div(a_cpu, b_scalar);
+  const auto c_vulkan = at::div(a_vulkan, b_scalar);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, div_scalar_wrapped_) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  auto a_cpu = at::rand({11, 7, 139, 109}, at::device(at::kCPU).dtype(at::kFloat));
+  auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_scalar = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  a_cpu.div_(b_scalar);
+  a_vulkan.div_(b_scalar);
+
+  const auto check = almostEqual(a_cpu, a_vulkan.cpu());
+  if (!check) {
+    showRtol(a_cpu, a_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, div_to_scalar_wrapped) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto a = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  const auto b_cpu = at::rand({2, 3, 5, 7}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::div(a, b_cpu);
+  const auto c_vulkan = at::div(a, b_vulkan);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
   }
 
   ASSERT_TRUE(check);
@@ -1816,6 +2015,42 @@ TEST_F(VulkanAPITest, mul_broadcast2) {
   ASSERT_TRUE(check);
 }
 
+TEST_F(VulkanAPITest, mul_broadcast3) {
+  const auto a_cpu = at::rand({3, 4, 179, 221}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_cpu = at::rand({1, 1, 179, 221}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::mul(a_cpu, b_cpu);
+  const auto c_vulkan = at::mul(a_vulkan, b_vulkan);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, mul_broadcast4) {
+  const auto a_cpu = at::rand({3, 4, 179, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_cpu = at::rand({1, 179, 221}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::mul(a_cpu, b_cpu);
+  const auto c_vulkan = at::mul(a_vulkan, b_vulkan);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
 TEST_F(VulkanAPITest, mul_) {
   auto a_cpu = at::rand({61, 17, 29, 83}, at::device(at::kCPU).dtype(at::kFloat));
   auto a_vulkan = a_cpu.vulkan();
@@ -1899,6 +2134,69 @@ TEST_F(VulkanAPITest, mul_scalar_) {
   const auto check = almostEqual(a_cpu, a_vulkan.cpu());
   if (!check) {
     showRtol(a_cpu, a_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, mul_scalar_wrapped) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto a_cpu = at::rand({17, 213, 213, 7}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_scalar = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  const auto c_cpu = at::mul(a_cpu, b_scalar);
+  const auto c_vulkan = at::mul(a_vulkan, b_scalar);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, mul_scalar_wrapped_) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  auto a_cpu = at::rand({11, 7, 139, 109}, at::device(at::kCPU).dtype(at::kFloat));
+  auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_scalar = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  a_cpu.mul_(b_scalar);
+  a_vulkan.mul_(b_scalar);
+
+  const auto check = almostEqual(a_cpu, a_vulkan.cpu());
+  if (!check) {
+    showRtol(a_cpu, a_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, mul_to_scalar_wrapped) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto a = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  const auto b_cpu = at::rand({11, 7, 139, 109}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::mul(a, b_cpu);
+  const auto c_vulkan = at::mul(a, b_vulkan);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
   }
 
   ASSERT_TRUE(check);
@@ -2182,6 +2480,42 @@ TEST_F(VulkanAPITest, sub_broadcast2) {
   ASSERT_TRUE(check);
 }
 
+TEST_F(VulkanAPITest, sub_broadcast3) {
+  const auto a_cpu = at::rand({3, 4, 179, 221}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_cpu = at::rand({1, 1, 179, 221}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::sub(a_cpu, b_cpu, 2.5f);
+  const auto c_vulkan = at::sub(a_vulkan, b_vulkan, 2.5f);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, sub_broadcast4) {
+  const auto a_cpu = at::rand({3, 4, 179, 1}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_cpu = at::rand({1, 179, 221}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::sub(a_cpu, b_cpu, 2.5f);
+  const auto c_vulkan = at::sub(a_vulkan, b_vulkan, 2.5f);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
 TEST_F(VulkanAPITest, sub_) {
   auto a_cpu = at::rand({61, 17, 29, 83}, at::device(at::kCPU).dtype(at::kFloat));
   auto a_vulkan = a_cpu.vulkan();
@@ -2231,6 +2565,111 @@ TEST_F(VulkanAPITest, sub_broadcast1_) {
   const auto check = almostEqual(a_cpu, a_vulkan.cpu());
   if (!check) {
     showRtol(b_cpu, b_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, sub_scalar) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto a_cpu = at::rand({13, 23, 59, 73}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const float b_scalar = 3.1415f;
+
+  const auto c_cpu = at::sub(a_cpu, b_scalar, 2.1f);
+  const auto c_vulkan = at::sub(a_vulkan, b_scalar, 2.1f);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, sub_scalar_) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  auto a_cpu = at::rand({47, 2, 23, 97}, at::device(at::kCPU).dtype(at::kFloat));
+  auto a_vulkan = a_cpu.vulkan();
+
+  const float b_scalar = 3.1415f;
+
+  a_cpu.sub_(b_scalar, 2.1f);
+  a_vulkan.sub_(b_scalar, 2.1f);
+
+  const auto check = almostEqual(a_cpu, a_vulkan.cpu());
+  if (!check) {
+    showRtol(a_cpu, a_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, sub_scalar_wrapped) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto a_cpu = at::rand({13, 23, 59, 73}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_scalar = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  const auto c_cpu = at::sub(a_cpu, b_scalar, 2.1f);
+  const auto c_vulkan = at::sub(a_vulkan, b_scalar, 2.1f);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, sub_scalar_wrapped_) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  auto a_cpu = at::rand({47, 2, 23, 97}, at::device(at::kCPU).dtype(at::kFloat));
+  auto a_vulkan = a_cpu.vulkan();
+
+  const auto b_scalar = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  a_cpu.sub_(b_scalar, 2.1f);
+  a_vulkan.sub_(b_scalar, 2.1f);
+
+  const auto check = almostEqual(a_cpu, a_vulkan.cpu());
+  if (!check) {
+    showRtol(a_cpu, a_vulkan.cpu());
+  }
+
+  ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, sub_to_scalar_wrapped) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto a = at::rand({1}, at::device(at::kCPU).dtype(at::kFloat));
+
+  const auto b_cpu = at::rand({11, 7, 139, 109}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto b_vulkan = b_cpu.vulkan();
+
+  const auto c_cpu = at::sub(a, b_cpu, 2.1f);
+  const auto c_vulkan = at::sub(a, b_vulkan, 2.1f);
+
+  const auto check = almostEqual(c_cpu, c_vulkan.cpu());
+  if (!check) {
+    showRtol(c_cpu, c_vulkan.cpu());
   }
 
   ASSERT_TRUE(check);


### PR DESCRIPTION
Summary:
Increased support for already existing arithmetic ops.

The first or second argument for each of the ops: `sub`, `add`, `mul` and `div` can now be a tensor that is wrapping a scalar i.e. something like `at::tensor(1.0f)`.

Added tests cases to check each of the new functionality (where `*` is either `add`, `sub`, `mul` or `div`):
- `*_scalar_wrapped`: Tests the functionality of performing an arithmetic op between a tensor (first argument) and a scalar wrapped into a tensor (second argument), i.e. something like: `at::add(x, at::tensor(1.0f))`.
- `*_scalar_wrapped_`: Tests the functionality of performing an arithmetic op that modifies a tensor by performing an arithmetic op where the argument is a scalar wrapped into a tensor, i.e something like: `x.mul(at::tensor(2.0f))`.
- `*_to_scalar`: Tests the functionality of performing an arithmetic op where the first argument is a scalar wrapped into a tensor, i.e. something like: `at::sub(at::tensor(1.0f), x)`.

Test Plan:
Added test cases to `/xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp`

On Mac:
```
buck run //xplat/caffe2:pt_vulkan_api_test_binAppleMac
```
On Android:
```
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
```

Reviewed By: SS-JIA

Differential Revision: D37932313

