### PR TITLE
[PTE] Fix module level information in profiling

### DIFF
--- a/buckbuild.bzl
+++ b/buckbuild.bzl
@@ -1191,7 +1191,7 @@ def define_buck_targets(
         exported_headers = [
         ],
         compiler_flags = get_pt_compiler_flags(),
-        exported_preprocessor_flags = get_pt_preprocessor_flags(),
+        exported_preprocessor_flags = get_pt_preprocessor_flags() + (["-DSYMBOLICATE_MOBILE_DEBUG_HANDLE"] if get_enable_eager_symbolication() else []),
         extra_flags = {
             "fbandroid_compiler_flags": ["-frtti"],
         },


### PR DESCRIPTION
Summary: We lost SYMBOLICATE_MOBILE_DEBUG_HANDLE flag in some buck file refactoring, bringing it back to fetch module level information in profiling

Test Plan: Profiling output has module level information

Reviewed By: kimishpatel

Differential Revision: D37970958

