### PR TITLE
[Vulkan] Register vulkan_prepack::run_linear_context for CPU backend

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Register.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Register.cpp
@@ -204,6 +204,9 @@ TORCH_LIBRARY_IMPL(vulkan_prepack, CPU, m) {
       TORCH_SELECTIVE_NAME("vulkan_prepack::create_linear_context"),
       TORCH_FN(create_linear_context));
   m.impl(
+      TORCH_SELECTIVE_NAME("vulkan_prepack::run_linear_context"),
+      TORCH_FN(run_linear_context));
+  m.impl(
       TORCH_SELECTIVE_NAME("vulkan_prepack::linear_prepack"),
       TORCH_FN(linear_prepack)); // Backwards compatibility
   m.impl(


### PR DESCRIPTION
Summary: Vulkan Linear op was breaking when called on a CPU tensor, because `vulkan_prepack::run_linear_context` was not registered for the CPU backend.

Test Plan:
Tested that this works using Ferraris model
```
ptbinary_build pt_benchmark
adb shell "/data/local/tmp/pt_benchmark --model=/data/local/tmp/models/ferraris/ferraris_vk.pt --use_bundled_input=0 --vulkan=true --warmup=50 --iter=500 --report_pep=true"
```

Reviewed By: SS-JIA

Differential Revision: D37889322

