### PR TITLE
[Vulkan] Generalize GLU along channel dim to support input of any even channel size.

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/glu_channel.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/glu_channel.glsl
@@ -1,0 +1,52 @@
+#version 450 core
+#define PRECISION $precision
+#define FORMAT    $format
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
+  ivec3 size;  // output size
+  int ch;   // channel size of the output
+} uBlock;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (all(lessThan(pos, uBlock.size.xyz))) {
+    const int z0a = 2 * ((4 * pos.z) / uBlock.ch) * uBlock.ch + ((4 * pos.z) % uBlock.ch);
+    const int z1a = 2 * ((4 * pos.z + 1) / uBlock.ch) * uBlock.ch + ((4 * pos.z + 1) % uBlock.ch);
+    const int z2a = 2 * ((4 * pos.z + 2) / uBlock.ch) * uBlock.ch + ((4 * pos.z + 2) % uBlock.ch);
+    const int z3a = 2 * ((4 * pos.z + 3) / uBlock.ch) * uBlock.ch + ((4 * pos.z + 3) % uBlock.ch);
+
+    const int z0b = z0a + uBlock.ch;
+    const int z1b = z1a + uBlock.ch;
+    const int z2b = z2a + uBlock.ch;
+    const int z3b = z3a + uBlock.ch;
+
+    const float v0a = texelFetch(uInput, ivec3(pos.x, pos.y, z0a / 4), 0)[z0a % 4];
+    const float v0b = texelFetch(uInput, ivec3(pos.x, pos.y, z0b / 4), 0)[z0b % 4];
+    const float v1a = texelFetch(uInput, ivec3(pos.x, pos.y, z1a / 4), 0)[z1a % 4];
+    const float v1b = texelFetch(uInput, ivec3(pos.x, pos.y, z1b / 4), 0)[z1b % 4];
+    const float v2a = texelFetch(uInput, ivec3(pos.x, pos.y, z2a / 4), 0)[z2a % 4];
+    const float v2b = texelFetch(uInput, ivec3(pos.x, pos.y, z2b / 4), 0)[z2b % 4];
+    const float v3a = texelFetch(uInput, ivec3(pos.x, pos.y, z3a / 4), 0)[z3a % 4];
+    const float v3b = texelFetch(uInput, ivec3(pos.x, pos.y, z3b / 4), 0)[z3b % 4];
+
+    imageStore(
+        uOutput,
+        pos,
+        vec4(
+            v0a * (1 / (1 + exp(-1 * v0b))),
+            v1a * (1 / (1 + exp(-1 * v1b))),
+            v2a * (1 / (1 + exp(-1 * v2b))),
+            v3a * (1 / (1 + exp(-1 * v3b)))
+        )
+    );
+  }
+}

--- a/aten/src/ATen/native/vulkan/glsl/glu_channel_mul4.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/glu_channel_mul4.glsl
@@ -10,7 +10,7 @@ layout(set = 0, binding = 0, FORMAT) uniform PRECISION restrict writeonly image3
 layout(set = 0, binding = 1)         uniform PRECISION                    sampler3D uInput;
 layout(set = 0, binding = 2)         uniform PRECISION restrict           Block {
   ivec3 size;  // output size
-  int chext;   // channel extent of the output
+  int ch;      // channel size of the output
 } uBlock;
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -19,8 +19,9 @@ void main() {
   const ivec3 pos = ivec3(gl_GlobalInvocationID);
 
   if (all(lessThan(pos, uBlock.size.xyz))) {
-    const int z0 = 2 * (pos.z / uBlock.chext) * uBlock.chext + (pos.z % uBlock.chext);
-    const int z1 = z0 + uBlock.chext;
+    const int chext = uBlock.ch / 4;
+    const int z0 = 2 * (pos.z / chext) * chext + (pos.z % chext);
+    const int z1 = z0 + chext;
     imageStore(
         uOutput,
         pos,

--- a/aten/src/ATen/native/vulkan/ops/Glu.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Glu.cpp
@@ -16,37 +16,35 @@ Tensor glu(const at::Tensor& input_arg, const int64_t dim = -1) {
       "Vulkan glu only supports GLU for dim = 1, but got dim = ",
       dim);
   TORCH_CHECK(
-      channels_size(input_arg) % 8 == 0,
-      "Vulkan glu expects channel dim to be multiple of 8!");
+      channels_size(input_arg) % 2 == 0,
+      "Vulkan glu expects channel dim to be multiple of 2!");
 
   const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();
   const vTensor& v_input = convert(input);
   const IntArrayRef v_input_sizes = v_input.sizes();
 
-  auto output_ch_ext = v_input.sizes()[1] / 8;
+  auto output_ch_size = v_input.sizes()[1] / 2;
 
   api::Context* const context = api::context();
 
   vTensor v_output{
       context,
-      {v_input_sizes[0],
-       v_input_sizes[1] / 2,
-       v_input_sizes[2],
-       v_input_sizes[3]},
+      {v_input_sizes[0], output_ch_size, v_input_sizes[2], v_input_sizes[3]},
       v_input.options(),
   };
 
   const struct Block final {
     uvec3 extents;
     int32_t chext;
-  } block{v_output.extents(), safe_downcast<int32_t>(output_ch_ext)};
+  } block{v_output.extents(), safe_downcast<int32_t>(output_ch_size)};
 
   api::UniformParamsBuffer params(context, block);
   api::PipelineBarrier pipeline_barrier{};
 
   context->submit_compute_job(
       // shader descriptor
-      VK_KERNEL(glu),
+      output_ch_size % 4 == 0 ? VK_KERNEL(glu_channel_mul4)
+                              : VK_KERNEL(glu_channel),
       // pipeline barrier
       pipeline_barrier,
       // global work group size

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -1283,12 +1283,12 @@ TEST_F(VulkanAPITest, empty) {
   ASSERT_NO_THROW(at::empty({1, 17, 41, 53}, at::device(at::kVulkan).dtype(at::kFloat)));
 }
 
-TEST_F(VulkanAPITest, glu) {
+void test_glu(const at::IntArrayRef input_shape) {
   if (!at::is_vulkan_available()) {
     return;
   }
 
-  const auto in_cpu = at::rand({17, 200, 302, 5}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_cpu = at::rand(input_shape, at::device(at::kCPU).dtype(at::kFloat));
   const auto in_vulkan = in_cpu.vulkan();
 
   const auto out_cpu = at::glu(in_cpu, 1);
@@ -1300,6 +1300,26 @@ TEST_F(VulkanAPITest, glu) {
   }
 
   ASSERT_TRUE(check);
+}
+
+TEST_F(VulkanAPITest, glu_ch_200) {
+  test_glu({17, 200, 302, 5});
+}
+
+TEST_F(VulkanAPITest, glu_ch_64) {
+  test_glu({1, 64, 100, 8});
+}
+
+TEST_F(VulkanAPITest, glu_ch_32) {
+  test_glu({1, 32, 100, 19});
+}
+
+TEST_F(VulkanAPITest, glu_ch_10) {
+  test_glu({17, 10, 57, 41});
+}
+
+TEST_F(VulkanAPITest, glu_ch_2) {
+  test_glu({1, 2, 100, 40});
 }
 
 TEST_F(VulkanAPITest, hardsigmoid) {


### PR DESCRIPTION
Summary:
Extended previous implementation of GLU, to support input of any even channel size (i.e. output tensor of any channel size)

This is still a special case implementation of GLU:
- Input tensor must be 4-dim, i.e. [N, C, H, W].
- dim must be 1.

References
- PyTorch Docs > torch.nn > [GLU](https://pytorch.org/docs/stable/generated/torch.nn.GLU.html)

Test Plan:
Added test cases to `/xplat/caffe2/aten/src/ATen/test/vulkan_api_test.cpp`

On Mac:
```
buck run //xplat/caffe2:pt_vulkan_api_test_binAppleMac
```
On Android:
```
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"

Reviewed By: SS-JIA

Differential Revision: D37958364

