### PR TITLE
Allow user to disable built-in fuser when using TorchDynamo

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -16135,6 +16135,22 @@ dedent """
 
         self.checkModule(MyModule(), (torch.ones(2, 3),))
 
+    def test_context_manager(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+
+            def forward(self, x, y):
+                p = x + y
+                q = p + 2.0
+                return q
+
+        x = torch.randn(3, 2, dtype=torch.float)
+        y = torch.randn(3, 2, dtype=torch.float)
+        for fuser_name in ['fuser0', 'fuser1', 'none']:
+            with torch.jit.fuser(fuser_name):
+                self.checkModule(MyModule(), (x, y))
+
 # known to be failing in tracer
 EXCLUDE_TRACED = {
     # The following fail due to #12024.

--- a/torch/jit/_fuser.py
+++ b/torch/jit/_fuser.py
@@ -48,6 +48,11 @@ def fuser(name):
         torch._C._jit_override_can_fuse_on_gpu(False)
         torch._C._jit_set_texpr_fuser_enabled(False)
         torch._C._jit_set_nvfuser_enabled(True)
+    elif name == 'none':  # Turn Pytorch fuser off
+        torch._C._jit_override_can_fuse_on_cpu(False)
+        torch._C._jit_override_can_fuse_on_gpu(False)
+        torch._C._jit_set_texpr_fuser_enabled(False)
+        torch._C._jit_set_nvfuser_enabled(False)
     else:
         raise Exception("unrecognized fuser option")
     try:

--- a/torch/jit/_fuser.py
+++ b/torch/jit/_fuser.py
@@ -54,7 +54,7 @@ def fuser(name):
         torch._C._jit_set_texpr_fuser_enabled(False)
         torch._C._jit_set_nvfuser_enabled(False)
     else:
-        raise Exception("unrecognized fuser option")
+        raise Exception(f"unrecognized fuser option (name: {name})")
     try:
         yield
     finally:


### PR DESCRIPTION
Pytorch's built-in fuser seems have higher priority than my fuser registered via
```cpp
  torch::jit::RegisterPass pass([accelerator_symbol](std::shared_ptr<torch::jit::Graph>& g) {
    OrtFuseGraph(g, Accelerator::Supported, accelerator_symbol);
  });
```
With this PR, I can reuse `aot_autograd` backend in TorchDynamo with my own JIT fuser. My custom context is
```python
class AOTAutogradOrtFusionWithContext:
    """Pass nvfuser context to TorchDynamo"""

    def __init__(self):
        self.backend_ctx_ctor = lambda: torch.jit.fuser("none")

    def __call__(self, gm: torch.fx.GraphModule, example_inputs):
        return AOTAutogradMemoryEfficientFusion.compile_fn(gm, example_inputs)


aot_autograd_ort_strategy = AOTAutogradOrtFusionWithContext()
```