### PR TITLE
[ONNX] extend add and sub exporter to cover graph non-tensor inputs

### DIFF
--- a/test/onnx/test_pytorch_jit_onnx.py
+++ b/test/onnx/test_pytorch_jit_onnx.py
@@ -79,7 +79,7 @@ class _TestJITIRToONNX:
         self.run_test(graph_ir, (a, b))
 
     def test_add_sub_with_graph_inputs(self):
-        for op in ['add', 'sub', 'rsub']:
+        for op in ["add", "sub", "rsub"]:
             graph_ir = f"""
             graph(%1 : Float(2, 3),
                   %2 : Float(2, 3),

--- a/test/onnx/test_pytorch_jit_onnx.py
+++ b/test/onnx/test_pytorch_jit_onnx.py
@@ -78,6 +78,19 @@ class _TestJITIRToONNX:
         b = torch.randn(2, 3)
         self.run_test(graph_ir, (a, b))
 
+    def test_add_sub_with_graph_inputs(self):
+        for op in ['add', 'sub', 'rsub']:
+            graph_ir = f"""
+            graph(%1 : Float(2, 3),
+                  %2 : Float(2, 3),
+                  %3 : int):
+              %4 : Float(2, 3) = aten::{op}(%1, %2, %3)
+              return (%4)
+            """
+            a = torch.randn(2, 3)
+            b = torch.randn(2, 3)
+            self.run_test(graph_ir, (a, b, 2))
+
     def test_convolution(self):
         graph_ir = """
         graph(%1 : Tensor,

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -143,6 +143,34 @@ static c10::optional<c10::ScalarType> InferExpectedScalarType(const Node* n) {
     }
     return c10::nullopt;
   };
+  auto emplace_type_from_scalar = [&typesFromTensors, &typesFromScalars](at::ScalarType scalar_type) {
+    // Mimic PyTorch scalar type promotion logic
+    // from https://github.com/pytorch/pytorch/issues/9515
+    // Quoting:
+    //    A Tensor is a considered a "wrapped number" if it is
+    //    auto-wrapped from a C++ or Python number type. Integer types are
+    //    wrapped as 0-dim int64 tensors and floating-point types are
+    //    wrapped as 0-dim double tensors.
+    auto default_scalar_type =
+        at::typeMetaToScalarType(at::get_default_dtype());
+    switch (scalar_type) {
+      case at::kDouble:
+        // floating-point numbers wrapped as double tensors are
+        // considered to have default type, instead of double.
+        typesFromScalars.emplace_back(default_scalar_type);
+        break;
+      case at::kLong:
+      case at::kBool:
+        // bool and integer numbers remain the same type.
+        typesFromScalars.emplace_back(scalar_type);
+        break;
+      default:
+        // other types are not from wrapped numbers,
+        // track them as types from tensors.
+        typesFromTensors.emplace_back(scalar_type);
+        break;
+    }
+  };
 
   std::for_each(
       n->inputs().begin(), n->inputs().end(), [&](const Value* input) {
@@ -162,35 +190,21 @@ static c10::optional<c10::ScalarType> InferExpectedScalarType(const Node* n) {
           auto tensor = input->node()->t(attr::value);
           auto rank = tensor.dim();
           auto scalar_type = tensor.scalar_type();
-          // Mimic PyTorch scalar type promotion logic
-          // from https://github.com/pytorch/pytorch/issues/9515
-          // Quoting:
-          //    A Tensor is a considered a "wrapped number" if it is
-          //    auto-wrapped from a C++ or Python number type. Integer types are
-          //    wrapped as 0-dim int64 tensors and floating-point types are
-          //    wrapped as 0-dim double tensors.
+
           if (rank == 0) {
-            auto default_scalar_type =
-                at::typeMetaToScalarType(at::get_default_dtype());
-            switch (scalar_type) {
-              case at::kDouble:
-                // floating-point numbers wrapped as double tensors are
-                // considered to have default type, instead of double.
-                typesFromScalars.emplace_back(default_scalar_type);
-                break;
-              case at::kLong:
-              case at::kBool:
-                // bool and integer numbers remain the same type.
-                typesFromScalars.emplace_back(scalar_type);
-                break;
-              default:
-                // other types are not from wrapped numbers,
-                // track them as types from tensors.
-                typesFromTensors.emplace_back(scalar_type);
-                break;
-            }
+            emplace_type_from_scalar(scalar_type);
           } else {
             typesFromTensors.emplace_back(scalar_type);
+          }
+        } else if (nkind == prim::Param) {
+          if (auto scalar_type = get_scalar_type(input)) {
+            auto tensor_type = input->type()->castRaw<TensorType>();
+            auto rank = tensor_type->dim();
+            if (rank && rank.value() == 0) {
+              emplace_type_from_scalar(scalar_type.value());
+            } else {
+              typesFromTensors.emplace_back(scalar_type.value());
+            }
           }
         } else if (auto scalar_type = get_scalar_type(input)) {
           typesFromTensors.emplace_back(*scalar_type);
@@ -404,6 +418,7 @@ void ScalarTypeAnalysisForONNX(
     const std::shared_ptr<Graph>& graph,
     bool lowprecision_cast,
     int opset_version) {
+  GRAPH_DUMP("Before ScalarTypeAnalysisForONNX: ", graph);
   ImplicitCastForONNX(graph->block());
   if (lowprecision_cast) {
     LowPrecisionCastForStandardOpsONNX(graph->block(), opset_version);

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -143,34 +143,35 @@ static c10::optional<c10::ScalarType> InferExpectedScalarType(const Node* n) {
     }
     return c10::nullopt;
   };
-  auto emplace_type_from_scalar = [&typesFromTensors, &typesFromScalars](at::ScalarType scalar_type) {
-    // Mimic PyTorch scalar type promotion logic
-    // from https://github.com/pytorch/pytorch/issues/9515
-    // Quoting:
-    //    A Tensor is a considered a "wrapped number" if it is
-    //    auto-wrapped from a C++ or Python number type. Integer types are
-    //    wrapped as 0-dim int64 tensors and floating-point types are
-    //    wrapped as 0-dim double tensors.
-    auto default_scalar_type =
-        at::typeMetaToScalarType(at::get_default_dtype());
-    switch (scalar_type) {
-      case at::kDouble:
-        // floating-point numbers wrapped as double tensors are
-        // considered to have default type, instead of double.
-        typesFromScalars.emplace_back(default_scalar_type);
-        break;
-      case at::kLong:
-      case at::kBool:
-        // bool and integer numbers remain the same type.
-        typesFromScalars.emplace_back(scalar_type);
-        break;
-      default:
-        // other types are not from wrapped numbers,
-        // track them as types from tensors.
-        typesFromTensors.emplace_back(scalar_type);
-        break;
-    }
-  };
+  auto emplace_type_from_scalar =
+      [&typesFromTensors, &typesFromScalars](at::ScalarType scalar_type) {
+        // Mimic PyTorch scalar type promotion logic
+        // from https://github.com/pytorch/pytorch/issues/9515
+        // Quoting:
+        //    A Tensor is a considered a "wrapped number" if it is
+        //    auto-wrapped from a C++ or Python number type. Integer types are
+        //    wrapped as 0-dim int64 tensors and floating-point types are
+        //    wrapped as 0-dim double tensors.
+        auto default_scalar_type =
+            at::typeMetaToScalarType(at::get_default_dtype());
+        switch (scalar_type) {
+          case at::kDouble:
+            // floating-point numbers wrapped as double tensors are
+            // considered to have default type, instead of double.
+            typesFromScalars.emplace_back(default_scalar_type);
+            break;
+          case at::kLong:
+          case at::kBool:
+            // bool and integer numbers remain the same type.
+            typesFromScalars.emplace_back(scalar_type);
+            break;
+          default:
+            // other types are not from wrapped numbers,
+            // track them as types from tensors.
+            typesFromTensors.emplace_back(scalar_type);
+            break;
+        }
+      };
 
   std::for_each(
       n->inputs().begin(), n->inputs().end(), [&](const Value* input) {

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -198,8 +198,13 @@ static c10::optional<c10::ScalarType> InferExpectedScalarType(const Node* n) {
             typesFromTensors.emplace_back(scalar_type);
           }
         } else if (nkind == prim::Param) {
+          // ONNX doesn't support scalar as graph input. When
+          // seeing a scalar input, we convert its expected type to tensor.
           if (auto scalar_type = get_scalar_type(input)) {
             auto tensor_type = input->type()->castRaw<TensorType>();
+            // get_scalar_type returns non-null value already guranatees
+            // that the input has a valid tensor_type.
+            TORCH_INTERNAL_ASSERT(nullptr != tensor_type);
             auto rank = tensor_type->dim();
             if (rank && rank.value() == 0) {
               emplace_type_from_scalar(scalar_type.value());

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -346,8 +346,9 @@ def quantized_args(
 
 def _scalar(x):
     """Convert a scalar tensor into a Python value."""
-    assert x.numel() == 1
-    return x.item()
+    if isinstance(x, torch.Tensor) and x.shape == ():
+        return x.item()
+    return None
 
 
 def _if_scalar_type_as(g: _C.Graph, self, tensor):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -355,37 +355,14 @@ def add(g, self, other, alpha=None):
         return symbolic_helper._onnx_opset_unsupported_detailed(
             "Add", 9, 11, "Add between list of tensors not supported"
         )
-
-    if alpha:
-        is_scalar_one = (
-            symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) == 1
-        )
-        is_value = symbolic_helper._is_value(alpha)
-        if is_value and not is_scalar_one:
-            # If alpha=1, we don't need to add "Mul" because "Mul(x, 1) = x".
-            other = g.op("Mul", other, alpha)
-        elif not is_value and not is_scalar_one:
-            return symbolic_helper._unimplemented(
-                "add", "alpha must be either torch._C.Value or constant scalar 1."
-            )
-
+    if alpha and symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) != 1:
+        other = g.op("Mul", other, alpha)
     return g.op("Add", self, other)
 
 
 def sub(g, self, other, alpha=None):
-    # default alpha arg is to allow no-alpha sub (aten sub st overload no alpha)
-    if alpha:
-        is_value = symbolic_helper._is_value(alpha)
-        is_scalar_one = (
-            symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) == 1
-        )
-        if is_value and not is_scalar_one:
-            # If alpha=1, we don't need to add "Mul" because "Mul(x, 1) = x".
-            other = g.op("Mul", other, alpha)
-        elif not is_value and not is_scalar_one:
-            return symbolic_helper._unimplemented(
-                "sub", "alpha must be either torch._C.Value or constant scalar 1."
-            )
+    if alpha and symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) != 1:
+        other = g.op("Mul", other, alpha)
     return g.op("Sub", self, other)
 
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -357,13 +357,17 @@ def add(g, self, other, alpha=None):
         )
 
     if alpha:
-        is_scalar_one = symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) == 1
+        is_scalar_one = (
+            symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) == 1
+        )
         is_value = symbolic_helper._is_value(alpha)
         if is_value and not is_scalar_one:
-            # If alpha=1, we don't need to add "Mul" because "Mul(x, 1) = x"". 
+            # If alpha=1, we don't need to add "Mul" because "Mul(x, 1) = x".
             other = g.op("Mul", other, alpha)
         elif not is_value and not is_scalar_one:
-            return symbolic_helper._unimplemented("add", "alpha must be either torch._C.Value or constant scalar 1.")
+            return symbolic_helper._unimplemented(
+                "add", "alpha must be either torch._C.Value or constant scalar 1."
+            )
 
     return g.op("Add", self, other)
 
@@ -372,12 +376,16 @@ def sub(g, self, other, alpha=None):
     # default alpha arg is to allow no-alpha sub (aten sub st overload no alpha)
     if alpha:
         is_value = symbolic_helper._is_value(alpha)
-        is_scalar_one = symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) == 1
+        is_scalar_one = (
+            symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) == 1
+        )
         if is_value and not is_scalar_one:
-            # If alpha=1, we don't need to add "Mul" because "Mul(x, 1) = x"". 
+            # If alpha=1, we don't need to add "Mul" because "Mul(x, 1) = x".
             other = g.op("Mul", other, alpha)
         elif not is_value and not is_scalar_one:
-            return symbolic_helper._unimplemented("sub", "alpha must be either torch._C.Value or constant scalar 1.")
+            return symbolic_helper._unimplemented(
+                "sub", "alpha must be either torch._C.Value or constant scalar 1."
+            )
     return g.op("Sub", self, other)
 
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -356,16 +356,28 @@ def add(g, self, other, alpha=None):
             "Add", 9, 11, "Add between list of tensors not supported"
         )
 
-    # default alpha arg is to allow no-alpha add (aten add st overload no alpha)
-    if alpha and symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) != 1:
-        return symbolic_helper._unimplemented("add", "alpha != 1")
+    if alpha:
+        is_scalar_one = symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) == 1
+        is_value = symbolic_helper._is_value(alpha)
+        if is_value and not is_scalar_one:
+            # If alpha=1, we don't need to add "Mul" because "Mul(x, 1) = x"". 
+            other = g.op("Mul", other, alpha)
+        elif not is_value and not is_scalar_one:
+            return symbolic_helper._unimplemented("add", "alpha must be either torch._C.Value or constant scalar 1.")
+
     return g.op("Add", self, other)
 
 
 def sub(g, self, other, alpha=None):
     # default alpha arg is to allow no-alpha sub (aten sub st overload no alpha)
-    if alpha and symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) != 1:
-        return symbolic_helper._unimplemented("sub", "alpha != 1")
+    if alpha:
+        is_value = symbolic_helper._is_value(alpha)
+        is_scalar_one = symbolic_helper._scalar(symbolic_helper._maybe_get_scalar(alpha)) == 1
+        if is_value and not is_scalar_one:
+            # If alpha=1, we don't need to add "Mul" because "Mul(x, 1) = x"". 
+            other = g.op("Mul", other, alpha)
+        elif not is_value and not is_scalar_one:
+            return symbolic_helper._unimplemented("sub", "alpha must be either torch._C.Value or constant scalar 1.")
     return g.op("Sub", self, other)
 
 


### PR DESCRIPTION
ONNX exporter fails when the 3rd input of `aten:add` or `aten::sub` isn't a tensor. This PR fixes this failure.