### PR TITLE
[JIT] Remove BatchNorm and InstanceNorm special cases from AliasDB and replace with SchemaInfo is_mutable checks

### DIFF
--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -636,10 +636,6 @@ void AliasDb::analyzeImpl(Node* node) {
     case prim::rpc_sync:
     case prim::rpc_remote:
       return analyzeRpcAsync(node);
-    case aten::batch_norm:
-      return analyzeBatchNorm(node);
-    case aten::instance_norm:
-      return analyzeInstanceNorm(node);
     case prim::GradOf:
       return analyzeGradOf(node);
     case prim::BroadcastMKLDNNTensors: {
@@ -808,13 +804,26 @@ void AliasDb::analyzeImpl(Node* node) {
       analysis == AliasAnalysisKind::FROM_SCHEMA,
       "AliasAnalysisKind::CONSERVATIVE/PURE_FUNCTION/INTERNAL_SPECIAL_CASE should already have been handled above");
   const auto& schema = node->schema();
-
+  torch::utils::SchemaInfo schema_info(schema);
+  if (!isFrozen_ && node->hasNamedInput("training")) {
+    auto value = constant_as<bool>(node->namedInput("training"));
+    schema_info.addArgumentValue("training", !value.has_value() || *value);
+  } else if (!isFrozen_ && node->hasNamedInput("use_input_stats")) {
+    auto value = constant_as<bool>(node->namedInput("use_input_stats"));
+    schema_info.addArgumentValue(
+        "use_input_stats", !value.has_value() || *value);
+  }
   // Bind the schema's "formal" alias annotation to the actual values those
   // schema arguments represent
   std::unordered_map<Symbol, Value*> formalToActual;
   for (const auto i : c10::irange(schema.arguments().size())) {
     const at::AliasInfo* formal = schema.arguments()[i].alias_info();
     const auto& actualValue = node->inputs().at(i);
+    // Record writes
+    if (schema_info.is_mutable({c10::SchemaArgType::input, i})) {
+      registerWrite(actualValue, node);
+    }
+
     // Skip if there's no alias annotation
     if (!formal) {
       continue;
@@ -843,11 +852,6 @@ void AliasDb::analyzeImpl(Node* node) {
     // Bind the formal to the actual
     formalToActual[formalAlias] = actualValue;
 
-    // Record writes
-    if (formal->isWrite()) {
-      registerWrite(actualValue, node);
-    }
-
     // Now deal with sets after the '->'
     if (formal->isWildcardAfter()) {
       TORCH_INTERNAL_ASSERT(
@@ -866,6 +870,10 @@ void AliasDb::analyzeImpl(Node* node) {
   for (const auto i : c10::irange(schema.returns().size())) {
     const auto actual = node->outputs().at(i);
     const at::AliasInfo* formal = schema.returns()[i].alias_info();
+    // Record writes
+    if (schema_info.is_mutable({c10::SchemaArgType::output, i})) {
+      registerWrite(actual, node);
+    }
     if (!formal) {
       // This is a fresh tensor
       giveFreshAlias(actual);
@@ -910,11 +918,6 @@ void AliasDb::analyzeImpl(Node* node) {
 
       auto toAlias = formalToActual.at(formalAlias);
       makePointerTo(actual, toAlias);
-    }
-
-    // Record writes
-    if (formal->isWrite()) {
-      registerWrite(actual, node);
     }
   }
 }
@@ -1069,59 +1072,6 @@ c10::optional<bool> getConstantBooleanInput(
   return constant_as<bool>(value);
 }
 } // namespace
-
-// custom behavior for batch_norm because (a!)? annotations currently
-// aren't supported, and because behavior differs depending on the value of
-// training
-void AliasDb::analyzeBatchNorm(Node* node) {
-  // we invoking freezing for inference, so we assume training will be folded to
-  // a constant false to avoid needing to invoke freezing multiple times in
-  // order to make batch norm weights constant
-  for (Value* output : node->outputs()) {
-    giveFreshAlias(output);
-  }
-
-  if (isFrozen_) {
-    return;
-  }
-
-  auto isTraining = getConstantBooleanInput(node, "training");
-
-  if (!isTraining.has_value() || *isTraining) {
-    TORCH_INTERNAL_ASSERT(
-        node->hasNamedInput("running_mean"), "running_mean input is expected");
-    auto runningMean = node->namedInput("running_mean");
-    TORCH_INTERNAL_ASSERT(
-        node->hasNamedInput("running_var"), "running_var input is expected");
-    auto runningVar = node->namedInput("running_var");
-
-    registerWrite(runningMean, node);
-    registerWrite(runningVar, node);
-  }
-}
-
-// custom behavior for instance_norm, because (a!)? annotations currently
-// aren't supported, and because behavior differs depending on the value of
-// use_input_stats
-void AliasDb::analyzeInstanceNorm(Node* node) {
-  for (Value* output : node->outputs()) {
-    giveFreshAlias(output);
-  }
-
-  auto useInputStats = getConstantBooleanInput(node, "use_input_stats");
-
-  if (!useInputStats.has_value() || *useInputStats) {
-    TORCH_INTERNAL_ASSERT(
-        node->hasNamedInput("running_mean"), "running_mean input is expected");
-    auto runningMean = node->namedInput("running_mean");
-    TORCH_INTERNAL_ASSERT(
-        node->hasNamedInput("running_var"), "running_var input is expected");
-    auto runningVar = node->namedInput("running_var");
-
-    registerWrite(runningMean, node);
-    registerWrite(runningVar, node);
-  }
-}
 
 // SetAttr: writes to the `self` field
 void AliasDb::analyzeSetAttr(Node* node) {

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -1059,20 +1059,6 @@ void AliasDb::analyzeRpcAsync(Node* node) {
   }
 }
 
-namespace {
-c10::optional<bool> getConstantBooleanInput(
-    Node* node,
-    const std::string& inputName) {
-  TORCH_INTERNAL_ASSERT(
-      node->hasNamedInput(inputName), inputName + " input is expected");
-  auto value = node->namedInput(inputName);
-  TORCH_INTERNAL_ASSERT(
-      value->type() == BoolType::get(),
-      inputName + "training input is expected to be a bool");
-  return constant_as<bool>(value);
-}
-} // namespace
-
 // SetAttr: writes to the `self` field
 void AliasDb::analyzeSetAttr(Node* node) {
   const auto self = node->inputs().at(0);

--- a/torch/csrc/jit/ir/alias_analysis.h
+++ b/torch/csrc/jit/ir/alias_analysis.h
@@ -226,8 +226,6 @@ class AliasDb {
   void analyzeFork(Node* node);
   void analyzeWait(Node* node);
   void analyzeRpcAsync(Node* node);
-  void analyzeBatchNorm(Node* node);
-  void analyzeInstanceNorm(Node* node);
   void analyzeGradOf(Node* node);
   void analyzeSetAttr(Node* node);
   void analyzeConservative(Node* node);

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -9,11 +9,11 @@
 #include <torch/csrc/Export.h>
 #include <torch/csrc/utils/disallow_copy.h>
 #include <torch/csrc/utils/python_stub.h>
+#include <torch/csrc/utils/schema_info.h>
 
 #include <ATen/core/Tensor.h>
 #include <ATen/core/dynamic_type.h>
 #include <ATen/core/enum_type.h>
-#include <ATen/core/function_schema.h>
 #include <ATen/core/functional.h>
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/ivalue.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #81655
* #81777
* __->__ #81737
* #81653
* #81562
* #81561

- Generalized AnalyzeImpl cases for batchNorm and InstanceNorm in alias_analysis.cpp using schema_info.
- Tested by ensuring all aliasDB special case checks for batchNorm and instanceNorm pass as expected.