### PR TITLE
Enable distributed tests for ROCm

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -63,7 +63,6 @@ jobs:
       docker-image-name: pytorch-linux-focal-rocm5.2-py3.7
 
   linux-focal-rocm5_2-py3_7-distributed-test:
-    if: false # https://github.com/pytorch/pytorch/issues/80529
     name: linux-focal-rocm5.2-py3.7-distributed
     uses: ./.github/workflows/_rocm-test.yml
     needs: linux-focal-rocm5_2-py3_7-distributed-build


### PR DESCRIPTION
We're investigating why the distributed tests were running for >4.5hrs in CI when they were disabled: https://github.com/pytorch/pytorch/issues/80529

Our internal runs have been running within 4 hrs for distributed shard1+shard2. 

This PR enables the distributed job to see if the runtime has improved at all.