### PR TITLE
[ONNX] exporter native_layer_norm

### DIFF
--- a/test/onnx/test_pytorch_jit_onnx.py
+++ b/test/onnx/test_pytorch_jit_onnx.py
@@ -92,6 +92,23 @@ class _TestJITIRToONNX:
             b = torch.randn(2, 3)
             self.run_test(graph_ir, (a, b, 2))
 
+    def test_native_layer_norm(self):
+        graph_ir = """
+        graph(%x : Float(2, 3, 2),
+              %w : Float(3, 2),
+              %b : Float(3, 2)):
+          %5 : int = prim::Constant[value=3]()
+          %6 : int = prim::Constant[value=2]()
+          %7 : int[] = prim::ListConstruct(%5, %6)
+          %10 : float = prim::Constant[value=1.0000000000000001e-05]()
+          %11 : Float(2, 3, 2), %12 : Float(2, 1, 1), %13 : Float(2, 1, 1) = aten::native_layer_norm(%x, %7, %w, %b, %10)
+          return (%11, %12, %13)
+        """
+        x = torch.randn(2, 3, 2)
+        w = torch.randn(3, 2)
+        b = torch.randn(3, 2)
+        self.run_test(graph_ir, (x, w, b))
+
     def test_convolution(self):
         graph_ir = """
         graph(%1 : Tensor,

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2252,7 +2252,7 @@ def native_layer_norm(g, input, normalized_shape, weight, bias, eps):
 
 @symbolic_helper.parse_args("v", "is", "v", "v", "f", "i")
 def layer_norm(g, input, normalized_shape, weight, bias, eps, cudnn_enable):
-    normalized, mean, rstd = _layer_norm_shared(
+    normalized, _, _ = _layer_norm_shared(
         g, input, normalized_shape, weight, bias, eps, cudnn_enable, False
     )
     return normalized

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -8,7 +8,7 @@ import functools
 import math
 import sys
 import warnings
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch._C._onnx as _C_onnx
@@ -2206,8 +2206,15 @@ def batch_norm(
 
 
 def _layer_norm_returns_normalized_input_mean_rstd(
-    g, input, normalized_shape, weight, bias, eps, cudnn_enable, return_mean_rstd
-):
+    g,
+    input: torch._C.Value,
+    normalized_shape: Sequence[int],
+    weight: torch._C.Value,
+    bias: torch._C.Value,
+    eps: float,
+    cudnn_enable: bool,
+    return_mean_rstd: bool,
+) -> Tuple[torch._C.Value, Optional[torch._C.Value], Optional[torch._C.Value]]:
     if symbolic_helper.is_caffe2_aten_fallback():
         return g.at(
             "layer_norm",

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2247,8 +2247,7 @@ def _layer_norm_returns_normalized_input_mean_rstd(
         # rdenominator = 1 / sqrt(variance + eps)
         rdenominator = reciprocal(g, denominator)
         return normalized, mean, rdenominator
-    else:
-        return normalized, None, None
+    return normalized, None, None
 
 
 @symbolic_helper.parse_args("v", "is", "v", "v", "f")

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2207,14 +2207,14 @@ def batch_norm(
 
 def _layer_norm_returns_normalized_input_mean_rstd(
     g,
-    input: torch._C.Value,
+    input: _C.Value,
     normalized_shape: Sequence[int],
-    weight: torch._C.Value,
-    bias: torch._C.Value,
+    weight: _C.Value,
+    bias: _C.Value,
     eps: float,
     cudnn_enable: bool,
     return_mean_rstd: bool,
-) -> Tuple[torch._C.Value, Optional[torch._C.Value], Optional[torch._C.Value]]:
+) -> Tuple[_C.Value, Optional[_C.Value], Optional[_C.Value]]:
     if symbolic_helper.is_caffe2_aten_fallback():
         return g.at(
             "layer_norm",

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -7,8 +7,8 @@ release on 01/23/19
 import functools
 import math
 import sys
-import typing
 import warnings
+from typing import List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch._C._onnx as _C_onnx
@@ -1400,9 +1400,9 @@ def _avg_pool(name, tuple_fn):
     def symbolic_fn(
         g,
         input: _C.Value,
-        kernel_size: typing.Tuple[int, ...],
-        stride: typing.Tuple[int, ...],
-        padding: typing.Union[int, typing.Tuple[int, ...]],
+        kernel_size: Tuple[int, ...],
+        stride: Tuple[int, ...],
+        padding: Union[int, Tuple[int, ...]],
         ceil_mode: int,
         count_include_pad: int,
         divisor_override=None,
@@ -2207,14 +2207,14 @@ def batch_norm(
 
 def _layer_norm_returns_normalized_input_mean_rstd(
     g,
-    input: _C.Value,
-    normalized_shape: typing.Sequence[int],
-    weight: _C.Value,
-    bias: _C.Value,
+    input: torch._C.Value,
+    normalized_shape: Sequence[int],
+    weight: torch._C.Value,
+    bias: torch._C.Value,
     eps: float,
     cudnn_enable: bool,
     return_mean_rstd: bool,
-) -> typing.Tuple[_C.Value, typing.Optional[_C.Value], typing.Optional[_C.Value]]:
+) -> Tuple[torch._C.Value, Optional[torch._C.Value], Optional[torch._C.Value]]:
     if symbolic_helper.is_caffe2_aten_fallback():
         return g.at(
             "layer_norm",
@@ -4651,7 +4651,7 @@ def linalg_norm(
     g,
     self: torch._C.Value,
     ord: torch._C.Value,
-    dim: typing.List[int],
+    dim: List[int],
     keepdim: int,
     dtype: torch._C.Value,
 ):
@@ -4683,11 +4683,11 @@ def linalg_norm(
 @symbolic_helper.parse_args("v", "f", "is", "i", "v")
 def linalg_vector_norm(
     g,
-    self: _C.Value,
+    self: torch._C.Value,
     ord: float,
-    dim: typing.List[int],
+    dim: List[int],
     keepdim: int,
-    dtype: _C.Value,
+    dtype: torch._C.Value,
 ):
     # Conditions based on https://pytorch.org/docs/stable/generated/torch.linalg.vector_norm.html
     if dim is None:
@@ -4724,7 +4724,7 @@ def linalg_matrix_norm(
     g,
     self: torch._C.Value,
     ord: torch._C.Value,
-    dim: typing.List[int],
+    dim: List[int],
     keepdim: int,
     dtype: torch._C.Value,
 ):
@@ -4827,7 +4827,7 @@ def baddbmm(g, self, batch1, batch2, beta, alpha):
 
 
 @symbolic_helper.parse_args("v", "s")
-def meshgrid(g, tensor_list, indexing: typing.Optional[str] = None):
+def meshgrid(g, tensor_list, indexing: Optional[str] = None):
     if indexing is None:
         indexing = "ij"
     elif indexing not in {"ij", "xy"}:
@@ -5047,7 +5047,7 @@ def as_strided(g, self, sizes, strides, offset=None):
     self_1d = symbolic_helper._reshape_helper(
         g, self, g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64))
     )
-    ind: typing.Optional[torch.Tensor]
+    ind: Optional[torch.Tensor]
     if not symbolic_helper._is_value(sizes):
         ind = torch.tensor([0], dtype=torch.long)
         for i, (size, stride) in enumerate(zip(sizes, strides)):
@@ -5415,7 +5415,7 @@ class Prim:
         return None
 
     @staticmethod
-    def ListUnpack(g, *inputs, **kwargs) -> typing.Optional[typing.List[_C.Value]]:
+    def ListUnpack(g, *inputs, **kwargs) -> Optional[List[_C.Value]]:
         if len(inputs) == 1 and inputs[0].node().kind() == "prim::ListConstruct":
             # Cancel the previous node if it is ListConstruct by returning its inputs
             # TODO(justinchuby): Use a public method in the helper module

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -7,8 +7,8 @@ release on 01/23/19
 import functools
 import math
 import sys
+import typing
 import warnings
-from typing import List, Optional, Sequence, Tuple, Union
 
 import torch
 import torch._C._onnx as _C_onnx
@@ -1400,9 +1400,9 @@ def _avg_pool(name, tuple_fn):
     def symbolic_fn(
         g,
         input: _C.Value,
-        kernel_size: Tuple[int, ...],
-        stride: Tuple[int, ...],
-        padding: Union[int, Tuple[int, ...]],
+        kernel_size: typing.Tuple[int, ...],
+        stride: typing.Tuple[int, ...],
+        padding: typing.Union[int, typing.Tuple[int, ...]],
         ceil_mode: int,
         count_include_pad: int,
         divisor_override=None,
@@ -2207,14 +2207,14 @@ def batch_norm(
 
 def _layer_norm_returns_normalized_input_mean_rstd(
     g,
-    input: torch._C.Value,
-    normalized_shape: Sequence[int],
-    weight: torch._C.Value,
-    bias: torch._C.Value,
+    input: _C.Value,
+    normalized_shape: typing.Sequence[int],
+    weight: _C.Value,
+    bias: _C.Value,
     eps: float,
     cudnn_enable: bool,
     return_mean_rstd: bool,
-) -> Tuple[torch._C.Value, Optional[torch._C.Value], Optional[torch._C.Value]]:
+) -> typing.Tuple[_C.Value, typing.Optional[_C.Value], typing.Optional[_C.Value]]:
     if symbolic_helper.is_caffe2_aten_fallback():
         return g.at(
             "layer_norm",
@@ -4651,7 +4651,7 @@ def linalg_norm(
     g,
     self: torch._C.Value,
     ord: torch._C.Value,
-    dim: List[int],
+    dim: typing.List[int],
     keepdim: int,
     dtype: torch._C.Value,
 ):
@@ -4683,11 +4683,11 @@ def linalg_norm(
 @symbolic_helper.parse_args("v", "f", "is", "i", "v")
 def linalg_vector_norm(
     g,
-    self: torch._C.Value,
+    self: _C.Value,
     ord: float,
-    dim: List[int],
+    dim: typing.List[int],
     keepdim: int,
-    dtype: torch._C.Value,
+    dtype: _C.Value,
 ):
     # Conditions based on https://pytorch.org/docs/stable/generated/torch.linalg.vector_norm.html
     if dim is None:
@@ -4724,7 +4724,7 @@ def linalg_matrix_norm(
     g,
     self: torch._C.Value,
     ord: torch._C.Value,
-    dim: List[int],
+    dim: typing.List[int],
     keepdim: int,
     dtype: torch._C.Value,
 ):
@@ -4827,7 +4827,7 @@ def baddbmm(g, self, batch1, batch2, beta, alpha):
 
 
 @symbolic_helper.parse_args("v", "s")
-def meshgrid(g, tensor_list, indexing: Optional[str] = None):
+def meshgrid(g, tensor_list, indexing: typing.Optional[str] = None):
     if indexing is None:
         indexing = "ij"
     elif indexing not in {"ij", "xy"}:
@@ -5047,7 +5047,7 @@ def as_strided(g, self, sizes, strides, offset=None):
     self_1d = symbolic_helper._reshape_helper(
         g, self, g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64))
     )
-    ind: Optional[torch.Tensor]
+    ind: typing.Optional[torch.Tensor]
     if not symbolic_helper._is_value(sizes):
         ind = torch.tensor([0], dtype=torch.long)
         for i, (size, stride) in enumerate(zip(sizes, strides)):
@@ -5415,7 +5415,7 @@ class Prim:
         return None
 
     @staticmethod
-    def ListUnpack(g, *inputs, **kwargs) -> Optional[List[_C.Value]]:
+    def ListUnpack(g, *inputs, **kwargs) -> typing.Optional[typing.List[_C.Value]]:
         if len(inputs) == 1 and inputs[0].node().kind() == "prim::ListConstruct":
             # Cancel the previous node if it is ListConstruct by returning its inputs
             # TODO(justinchuby): Use a public method in the helper module


### PR DESCRIPTION
Pytorch has two similar layer normalization symbols `aten::layer_norm` and `aten::native_layer_norm`. This PR reuses `aten::layer_norm`'s exporter for exporting `aten::native_layer_norm` with a small refinement. A test is also included. This PR is required because JIT graphs generated from TorchDynamo and LazyTensor (with TS backend) may contain `native_layer_norm` instead of `layer_norm`.