### PR TITLE
[JIT] Enchance training ops check to be more inclusive and account for possible pybind exceptions

### DIFF
--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1679,7 +1679,7 @@ void initJITBindings(PyObject* module) {
           [](SchemaInfo& self, size_t index) { return self.is_mutable(index); })
       .def(
           "is_mutable",
-          [](SchemaInfo& self, c10::string_view name) {
+          [](SchemaInfo& self, const std::string& name) {
             return self.is_mutable(name);
           })
       .def(
@@ -1699,7 +1699,10 @@ void initJITBindings(PyObject* module) {
           [](SchemaInfo& self,
              const std::string& name,
              const py::object& value) {
-            if (name == "input") {
+            // For normalization purposes there is an inconsistency within
+            // torch.fx that turns all arguments named "self" into "input". Thus
+            // this check ensures that those arguments are checked correctly.
+            if (name == "input" && !self.hasInputArgumentNamed("input")) {
               self.addArgumentValue("self", toTypeInferredIValue(value));
             } else {
               self.addArgumentValue(name, toTypeInferredIValue(value));
@@ -1713,8 +1716,13 @@ void initJITBindings(PyObject* module) {
           TORCH_INTERNAL_ASSERT(
               key.isString(),
               "Add argument value keys types should be strings.");
-          if (key.toStringRef() == "input") {
-            value_map["self"] = value;
+          // For normalization purposes there is an inconsistency within
+          // torch.fx that
+          // turns all arguments named "self" into "input". Thus this check
+          // ensures that those arguments are checked correctly.
+          if (key.toStringRef() == "input" &&
+              !self.hasInputArgumentNamed("input")) {
+            self.addArgumentValue("self", value);
           } else {
             value_map[key.toStringRef()] = value;
           }
@@ -1887,8 +1895,11 @@ void initJITBindings(PyObject* module) {
                 return nullptr;
               }),
           py::call_guard<py::gil_scoped_release>());
-  m.def("_is_alias_of", [](const at::Tensor& self, const at::Tensor& other) {
-    return self.is_alias_of(other);
+  m.def("_is_alias_of", [](const py::object& self, const py::object& other) {
+    return toTypeInferredIValue(self).isAliasOf(toTypeInferredIValue(other));
+  });
+  m.def("_overlaps", [](const py::object& self, const py::object& other) {
+    return toTypeInferredIValue(self).overlaps(toTypeInferredIValue(other));
   });
   m.def("fork", [](const py::args& args, const py::kwargs& kwargs) {
     AT_ASSERT(args.size() >= 1);

--- a/torch/csrc/utils/schema_info.cpp
+++ b/torch/csrc/utils/schema_info.cpp
@@ -33,6 +33,13 @@ void SchemaInfo::addArgumentValues(
   }
 }
 
+bool SchemaInfo::hasInputArgumentNamed(const std::string& name) const {
+  return std::any_of(
+      schema_.arguments().begin(),
+      schema_.arguments().end(),
+      [&name](const c10::Argument& arg) { return arg.name() == name; });
+}
+
 bool SchemaInfo::is_mutable() {
   for (size_t i = 0; i < schema_.arguments().size(); i++) {
     if (is_mutable(i)) {
@@ -48,34 +55,33 @@ bool SchemaInfo::is_mutable(size_t index) {
   if (!alias_maps_current_) {
     generateAliasMaps();
   }
+  static const std::vector<c10::FunctionSchema> training_ops = getTrainingOps();
 
-  static const c10::FunctionSchema batch_norm_schema = torch::jit::parseSchema(
-      "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor");
-  static const c10::FunctionSchema instance_norm_schema = torch::jit::parseSchema(
-      "aten::instance_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool use_input_stats, float momentum, float eps, bool cudnn_enabled) -> Tensor");
-
-  // Note that the batch norm and instance norm checks depend on index because
+  // Note that the training_op checks depend on index because
   // of cases where either running_mean or running_var alias another input
   // argument causing its alias status to change.
   return std::any_of(
       input_alias_map_[index].begin(),
       input_alias_map_[index].end(),
       [this](size_t aliasing_index) {
-        if (batch_norm_schema == this->schema_ &&
+        bool special_case =
             (this->schema_.arguments()[aliasing_index].name() ==
                  "running_mean" ||
-             this->schema_.arguments()[aliasing_index].name() ==
-                 "running_var")) {
-          return value_map_.count("training") &&
+             this->schema_.arguments()[aliasing_index].name() == "running_var");
+        bool is_training_op = std::any_of(
+            training_ops.begin(),
+            training_ops.end(),
+            [this](const c10::FunctionSchema& training_op) {
+              return this->schema_ == training_op;
+            });
+        if (special_case && is_training_op) {
+          bool has_training = value_map_.count("training") &&
               value_map_.at("training").toBool();
-        } else if (
-            instance_norm_schema == this->schema_ &&
-            (this->schema_.arguments()[aliasing_index].name() ==
-                 "running_mean" ||
-             this->schema_.arguments()[aliasing_index].name() ==
-                 "running_var")) {
-          return value_map_.count("use_input_stats") &&
+          bool has_train =
+              value_map_.count("train") && value_map_.at("train").toBool();
+          bool has_use_input_stats = value_map_.count("use_input_stats") &&
               value_map_.at("use_input_stats").toBool();
+          return has_training || has_train || has_use_input_stats;
         } else {
           return this->schema_.is_mutable(aliasing_index);
         }
@@ -236,6 +242,29 @@ void SchemaInfo::ensureConservativity(
       }
     }
   }
+}
+
+std::vector<c10::FunctionSchema> SchemaInfo::getTrainingOps() {
+  // This is a list of ops where the a boolean variable (either "training",
+  // "train" or "use_input_stats") affects the mutability of running_mean and
+  // running_var
+  static const std::vector<std::string> training_op_strings = {
+      "aten::batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "aten::instance_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool use_input_stats, float momentum, float eps, bool cudnn_enabled) -> Tensor",
+      "aten::_batch_norm_impl_index(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> (Tensor, Tensor, Tensor, Tensor, int)",
+      "aten::cudnn_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor, Tensor)",
+      "aten::miopen_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor)",
+      "aten::native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)",
+      "aten::native_batch_norm.out(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, *, Tensor(a!) out, Tensor(b!) save_mean, Tensor(c!) save_invstd) -> (Tensor(a!), Tensor(b!), Tensor(c!))",
+  };
+
+  std::vector<c10::FunctionSchema> training_ops;
+  training_ops.reserve(training_op_strings.size());
+  for (const std::string& signature : training_op_strings) {
+    training_ops.push_back(torch::jit::parseSchema(signature));
+  }
+
+  return training_ops;
 }
 
 void SchemaInfo::initSchemaInfo() {

--- a/torch/csrc/utils/schema_info.h
+++ b/torch/csrc/utils/schema_info.h
@@ -63,6 +63,8 @@ struct TORCH_API SchemaInfo {
   void addArgumentValues(
       const std::unordered_map<std::string, at::IValue>& values);
 
+  bool hasInputArgumentNamed(const std::string& name) const;
+
  private:
   // This function enforces more conservative results when the TORCH_WARN is
   // triggered from above due to duplicates in an argument list
@@ -80,6 +82,8 @@ struct TORCH_API SchemaInfo {
       const c10::SchemaArgument& rhs);
 
   static std::vector<c10::FunctionSchema> getNonDeterministicOps();
+
+  static std::vector<c10::FunctionSchema> getTrainingOps();
 
   // Set of all wildcard arguments
   std::unordered_set<c10::SchemaArgument> wildcard_set_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #81787
* #81786
* #81785
* #81784
* #81783
* __->__ #81782

- Modified is_mutable python binding to accept a string instead of a string_view for better python compatibility.
- Modified argument value adding python bindings to deal with input/self edge case due to inconsistencies in how the first variable is named.
- Modified _is_alias_of and created _contains_alias_of python bindings to accurately find out if values are aliasing, or contain an alias.
- Fixed is_mutable implementation to cover all ops that have mutable optional arguments. (These are all the ops that have the optional arguments 'running_mean' and 'running_var' along with either 'train', 'training' or 'use_input_stats.'