### PR TITLE
[JIT] Modify SchemaCheckMode to utilize SchemaInfo and fix training op tests accordingly

### DIFF
--- a/test/jit/test_schema_check.py
+++ b/test/jit/test_schema_check.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
 class IncorrectAliasTensor(torch.Tensor):
     ALIAS_ARG_OUT = {"aten::add"}
     ALIAS_OUT_OUT = {"aten::aminmax"}
-
+    MUTATE_ARGS_OUT = {"aten::sub"}
 
     elem: torch.Tensor
 
@@ -62,6 +62,8 @@ class IncorrectAliasTensor(torch.Tensor):
         out = func(*unwrapped_args, **tree_map(unwrap, kwargs))
         if func._schema.name in IncorrectAliasTensor.ALIAS_ARG_OUT:
             args[0].elem = out
+        if func._schema.name in IncorrectAliasTensor.MUTATE_ARGS_OUT:
+            args[0].elem = torch.rand(args[0].elem.shape)
         if func._schema.name in IncorrectAliasTensor.ALIAS_OUT_OUT:
             incorrect_out = list(out)
             incorrect_out[0] = incorrect_out[1]
@@ -77,7 +79,7 @@ class TestSchemaCheck(JitTestCase):
         with enable_torch_dispatch_mode(schema_check):
             x = torch.rand((3, 3), requires_grad=True)
             x.relu().sin()
-            self.assertEqual(["aten::rand", "aten::relu", "aten::sin"], schema_check.ops)
+        self.assertEqual(["aten::rand", "aten::relu", "aten::sin"], schema_check.ops)
 
     # Tests that SchemaCheckMode records operator order without grad
     def test_schema_check_mode_operator_order_without_grad(self):
@@ -85,7 +87,7 @@ class TestSchemaCheck(JitTestCase):
         with enable_torch_dispatch_mode(schema_check):
             x = torch.rand((3, 3), requires_grad=False)
             x.relu().sin()
-            self.assertEqual(["aten::rand", "aten::relu", "aten::sin"], schema_check.ops)
+        self.assertEqual(["aten::rand", "aten::relu", "aten::sin"], schema_check.ops)
 
     # Tests that SchemaCheckMode records mutations and aliases with none expected
     def test_schema_check_mode_mutated_aliasing_none(self):
@@ -284,30 +286,60 @@ class TestSchemaCheck(JitTestCase):
             torch.aminmax(x, dim=0, out=[actual, actual])
         self.assertEqual(torch.amax(x, dim=0), actual)
 
+    # Tests that SchemaCheckMode wraps Torch.tensor in ops with real Device input
+    def test_schema_check_mode_functionality_device_input(self):
+        with enable_torch_dispatch_mode(SchemaCheckMode()):
+            x = torch.rand((3, 3), device="cpu", dtype=torch.double)
+            y = x + x
+        self.assertEqual(x + x, y)
+
+    # Tests that SchemaCheckMode wraps Torch.tensor in special training op edge case
+    def test_schema_check_mode_functionality_training_op(self):
+        x = torch.rand((3, 3), requires_grad=True)
+        batch = torch.nn.BatchNorm1d(3, track_running_stats=True)
+        expected = batch(x)
+        with enable_torch_dispatch_mode(SchemaCheckMode()):
+            actual = batch(x)
+        self.assertEqual(expected, actual)
+
+    # Tests that SchemaCheckMode wraps Torch.tensor with nested training op edge case
+    def test_schema_check_mode_functionality_nested_training_op(self):
+        actual = torch.rand((3, 3))
+        batch = torch.nn.BatchNorm1d(3, track_running_stats=True)
+        expected = torch.clone(actual)
+        expected.sinh_()
+        expected.tanh_()
+        expected.relu_()
+        expected = batch(expected)
+
+        with enable_torch_dispatch_mode(SchemaCheckMode()):
+            actual.sinh_()
+            actual.tanh_()
+            actual.relu_()
+            actual = batch(actual)
+        self.assertEqual(expected, actual)
+
     # Tests that an exception is raised for a mismatching mutation
     def test_mutation_check_fail(self):
-        with self.assertRaisesRegex(RuntimeError, "Argument running_mean is not defined as mutable but was mutated"):
-            x = torch.rand((3, 3), requires_grad=True)
-            batch = torch.nn.BatchNorm1d(3, track_running_stats=True)
+        with self.assertRaisesRegex(RuntimeError, "Argument input is not defined as mutable but was mutated"):
+            x = torch.rand((3, 3))
+            y = torch.rand((3, 3))
             with enable_torch_dispatch_mode(SchemaCheckMode()):
-                batch(x)
+                IncorrectAliasTensor(x).sub(IncorrectAliasTensor(y))
 
-    # Tests that an exception is raised for a mismatching mutation over multiple ops
+    # # Tests that an exception is raised for a mismatching mutation over multiple ops
     def test_mutation_check_fail_multiple_operators(self):
-        with self.assertRaisesRegex(RuntimeError, "Argument running_mean is not defined as mutable but was mutated"):
-            x = torch.rand((3, 3), requires_grad=True)
-            batch = torch.nn.BatchNorm1d(3, track_running_stats=True)
+        with self.assertRaisesRegex(RuntimeError, "Argument input is not defined as mutable but was mutated"):
+            x = torch.rand((3, 3))
+            y = torch.rand((3, 3))
             with enable_torch_dispatch_mode(SchemaCheckMode()):
-                x = x.sinh()
-                x = x.tanh()
-                x = x.relu()
-                batch(x)
+                IncorrectAliasTensor(x).sin().cos().sub(IncorrectAliasTensor(y))
 
     # Tests that an exception is raised for a mismatching alias
     def test_alias_check_fail_simple(self):
         with self.assertRaisesRegex(RuntimeError, "Argument input is not defined to alias output but was aliasing"):
             x = torch.rand((3, 3), requires_grad=True)
-            y = torch.zeros((3, 3))
+            y = torch.rand((3, 3))
             with enable_torch_dispatch_mode(SchemaCheckMode()):
                 IncorrectAliasTensor(x).add(IncorrectAliasTensor(y), alpha=2)
 
@@ -335,13 +367,23 @@ class TestSchemaCheck(JitTestCase):
             with enable_torch_dispatch_mode(s):
                 IncorrectAliasTensor(x).aminmax(dim=0)
 
-    # Tests that isAliasOf returns as expected
+    # Tests that is_alias_of returns as expected
     def test_is_alias_of(self):
         x = torch.rand((3, 3), requires_grad=True)
         y = torch.rand((3, 3), requires_grad=True)
         y = x.add(x, alpha=2)
         self.assertTrue(torch._C._is_alias_of(x, x))
         self.assertFalse(torch._C._is_alias_of(x, y))
+
+    # Tests that overlaps returns as expected
+    def test_overlaps(self):
+        x = torch.rand((3, 3), requires_grad=True)
+        y = torch.rand((3, 3), requires_grad=True)
+        z = [x, y]
+        self.assertTrue(torch._C._overlaps(x, x))
+        self.assertFalse(torch._C._overlaps(x, y))
+        self.assertTrue(torch._C._overlaps(z, x))
+        self.assertTrue(torch._C._overlaps(z, y))
 
     # Tests that SchemaInfo Bindings work as expected
     def test_schema_info_bind(self):

--- a/torch/testing/_internal/schema_check_mode.py
+++ b/torch/testing/_internal/schema_check_mode.py
@@ -11,6 +11,11 @@ from copy import deepcopy
 Mutation = namedtuple('Mutation', ['op_name', 'arg_name'])
 Aliasing = namedtuple('Aliasing', ['op_name', 'arg_name', 'output_number'])
 
+# Simplified naming for C++ classes
+SchemaArgument = torch._C._SchemaArgument
+SchemaArgType = torch._C._SchemaArgType
+SchemaInfo = torch._C._SchemaInfo
+
 # This TorchDispatchMode Subclass is used to verify op schemas
 # This TorchDispatchMode Scubclass currently:
 #  - Records the called ops
@@ -45,36 +50,13 @@ class SchemaCheckMode(TorchDispatchMode):
             return False
 
         def has_aliased(lhs, rhs):
-            if type(lhs) == torch.Tensor and type(rhs) == torch.Tensor:
-                return torch._C._is_alias_of(lhs, rhs)
-            return False
-
-        def is_mutable(arg_alias_pairs):
-            for arg in arg_alias_pairs:
-                if arg.alias_info is not None and arg.alias_info.is_write:
-                    return True
-            return False
-
-        def is_aliasing(output, arg_alias_pairs):
-            for arg in arg_alias_pairs:
-                if arg.alias_info is not None:
-                    if '*' in arg.alias_info.after_set:
-                        same_types = output.type == arg.type
-                        elems_same_types = (isinstance(output.type, torch._C.ListType) and output.type.getElementType() == arg.type)
-                        if same_types or elems_same_types:
-                            return True
-                    elif output.alias_info is not None:
-                        share_aliasing_sets = bool(len(output.alias_info.after_set & arg.alias_info.after_set))
-                        if share_aliasing_sets:
-                            return True
-            return False
-
-        def are_args_aliasing(lhs, rhs):
-            for lhs_value in lhs:
-                for rhs_value in rhs:
-                    if (has_aliased(lhs_value, rhs_value)):
-                        return True
-            return False
+            try:
+                return torch._C._overlaps(lhs, rhs)
+            except Exception as exception:
+                if str(exception).startswith("Cannot inspect value of type "):
+                    return False
+                else:
+                    raise exception
 
         def standardize_name(name):
             return name if name != "self" else "input"
@@ -110,61 +92,45 @@ class SchemaCheckMode(TorchDispatchMode):
         ).kwargs
 
         c_p_args = dict(zip(pre_arguments.keys(), clone_inputs(pre_arguments.values())))
-        cloned_arguments = {name : tree_map(unwrap, tree_flatten(c_p_args.get(name))[0]) for name in c_p_args}
+        cloned_arguments = {name : tree_map(unwrap, c_p_args.get(name)) for name in c_p_args}
         cloned_metadata = {name : tree_map(parse_metadata, tree_flatten(pre_arguments.get(name))[0]) for name in pre_arguments}
 
         out = func(*args, **kwargs)
-
-        arguments = {name : tree_map(unwrap, tree_flatten(pre_arguments.get(name))[0]) for name in pre_arguments}
+        arguments = {name : tree_map(unwrap, pre_arguments.get(name)) for name in pre_arguments}
         tuple_out = out if isinstance(out, tuple) else (out, )
-        u_out = [tree_map(unwrap, tree_flatten(i)[0]) for i in tuple_out]
+        tuple_out = tree_map(unwrap, tuple_out)
 
-        # Construct an aliasing map between op arguments for verifying aliasing pairs
-        # between op arguments and op outputs. This is used to allow cases where two aliasing arguments
-        # cause a non-mutable/non-aliasing argument to mutate or alias.
-        arg_alias_pairs_map = {standardize_name(arg.name) : [arg] for arg in func._schema.arguments}
-
-        # Construct an aliasing set for each output for verifying aliasing pairs
-        # between op outputs
-        out_alias_pairs_map = [set() for arg in func._schema.returns]
-
-        # Aliasing between arguments
-        for i_arg, j_arg in combinations(func._schema.arguments, 2):
-            i_values = arguments.get(standardize_name(i_arg.name))
-            j_values = arguments.get(standardize_name(j_arg.name))
-            if are_args_aliasing(i_values, j_values):
-                arg_alias_pairs_map[standardize_name(i_arg.name)].append(j_arg)
-                arg_alias_pairs_map[standardize_name(j_arg.name)].append(i_arg)
+        schema_info = SchemaInfo(func._schema)
+        schema_info.add_argument_values(pre_arguments)
 
         # Process arguments with outputs
-        for arg in func._schema.arguments:
+        for i in range(len(func._schema.arguments)):
+            arg = func._schema.arguments[i]
             name = standardize_name(arg.name)
             if arguments.get(name) is not None:
-                arg_alias_pairs = arg_alias_pairs_map[name]
                 before = cloned_arguments.get(name)
                 md = cloned_metadata.get(name)
                 after = arguments.get(name)
-                for v in after:
-                    for i in range(len(u_out)):
-                        for j in range(len(u_out[i])):
-                            if has_aliased(v, u_out[i][j]):
-                                if not is_aliasing(func._schema.returns[i], arg_alias_pairs):
-                                    raise RuntimeError(f'Argument {name} is not defined to alias output but was aliasing')
-                                else:
-                                    self.aliasing.append(Aliasing(func._schema.name, name, f"output_{i}"))
-                                    out_alias_pairs_map[i].add(name)
-                                    break
-                if any(has_mutated(i, j, k) for i, j, k in zip(before, after, md)):
-                    if not is_mutable(arg_alias_pairs):
+                for j in range(len(tuple_out)):
+                    if has_aliased(tuple_out[j], after):
+                        if not schema_info.may_contain_alias(
+                            SchemaArgument(SchemaArgType.output, j),
+                                SchemaArgument(SchemaArgType.input, i)):
+                            raise RuntimeError(f'Argument {name} is not defined to alias output but was aliasing')
+                        else:
+                            self.aliasing.append(Aliasing(func._schema.name, name, f"output_{j}"))
+                if any(has_mutated(a, b, c) for a, b, c in zip(tree_flatten(before)[0], tree_flatten(after)[0], md)):
+                    if not schema_info.is_mutable(i):
                         raise RuntimeError(f"Argument {name} is not defined as mutable but was mutated")
                     else:
                         self.mutated.append(Mutation(func._schema.name, name))
 
         # Aliasing between outputs
         for i, j in combinations(range(len(func._schema.returns)), 2):
-            if are_args_aliasing(u_out[i], u_out[j]):
-                share_aliasing_inputs = bool(len(out_alias_pairs_map[i] & out_alias_pairs_map[j]))
-                if (not share_aliasing_inputs):
+            if has_aliased(tuple_out[i], tuple_out[j]):
+                if not schema_info.may_contain_alias(
+                    SchemaArgument(SchemaArgType.output, i),
+                        SchemaArgument(SchemaArgType.output, j)):
                     raise RuntimeError(f'Outputs {i} and {j} alias unexpectedly')
 
         return out


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #81787
* #81786
* #81785
* #81784
* __->__ #81783
* #81782

- Refactored SchemaCheckMode class to depend on SchemaInfo python bindings and _contains_alias_of.
- This is tested through all existing tests and the new tests for accurate batch_norm and instance functionality,replacement mutation fail tests, and a test for specified 'device' and 'dtype' inputs.