### PR TITLE
[JIT] Modify is_mutable in FunctionSchema and SchemaInfo to have SchemaArgument parameter instead of index

### DIFF
--- a/aten/src/ATen/core/function_schema.cpp
+++ b/aten/src/ATen/core/function_schema.cpp
@@ -9,7 +9,7 @@ void FunctionSchema::dump() const {
   std::cout << *this << "\n";
 }
 
-std::vector<Argument> FunctionSchema::getCorrectList(SchemaArgType type) const {
+const std::vector<Argument>& FunctionSchema::getCorrectList(SchemaArgType type) const {
   if (type == SchemaArgType::input) {
     return arguments();
   } else {

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -376,11 +376,11 @@ struct TORCH_API FunctionSchema {
           return aliasInfo && aliasInfo->isWrite();
         });
   }
-  bool is_mutable(size_t index) const {
+  bool is_mutable(const c10::SchemaArgument &argument) const {
     TORCH_INTERNAL_ASSERT(
-        index < arguments().size(),
+        argument.index < getCorrectList(argument.type).size(),
         "Invalid index for schema.");
-    const AliasInfo* aliasInfo = arguments()[index].alias_info();
+    const AliasInfo* aliasInfo = getCorrectList(argument.type)[argument.index].alias_info();
     return aliasInfo && aliasInfo->isWrite();
   }
   bool is_mutable(c10::string_view name) const {
@@ -388,7 +388,7 @@ struct TORCH_API FunctionSchema {
     TORCH_INTERNAL_ASSERT(
         index != c10::nullopt, "Schema has no argument named ", name);
 
-    return is_mutable(*index);
+    return is_mutable({c10::SchemaArgType::input, static_cast<size_t>(*index)});
   }
 
   // Returns whether lhs and rhs may alias directly.
@@ -418,7 +418,7 @@ struct TORCH_API FunctionSchema {
 
   // Returns either arguments() or returns() depending on the SchemaArgType
   // output => returns(), input => arguments()
-  std::vector<Argument> getCorrectList(SchemaArgType type) const;
+  const std::vector<Argument>& getCorrectList(SchemaArgType type) const;
 
   c10::optional<int> argumentIndexWithName(c10::string_view name) const {
     for (const auto i : c10::irange(arguments().size())) {

--- a/test/cpp/jit/test_schema_info.cpp
+++ b/test/cpp/jit/test_schema_info.cpp
@@ -9,50 +9,55 @@ using c10::SchemaArgType;
 TEST(FunctionSchemaIsMutableTest, Basic) {
   c10::FunctionSchema schema = torch::jit::parseSchema(
       "aten::sub_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> (Tensor(a!))");
-  ASSERT_TRUE(schema.is_mutable(0));
+  ASSERT_TRUE(schema.is_mutable({SchemaArgType::output, 0}));
+  ASSERT_TRUE(schema.is_mutable({SchemaArgType::input, 0}));
   ASSERT_TRUE(schema.is_mutable("self"));
-  ASSERT_FALSE(schema.is_mutable(1));
+  ASSERT_FALSE(schema.is_mutable({SchemaArgType::input, 1}));
   ASSERT_FALSE(schema.is_mutable("other"));
-  ASSERT_FALSE(schema.is_mutable(2));
+  ASSERT_FALSE(schema.is_mutable({SchemaArgType::input, 2}));
   ASSERT_FALSE(schema.is_mutable("alpha"));
 }
 
 TEST(FunctionSchemaIsMutableTest, InvalidArgument) {
   c10::FunctionSchema schema = torch::jit::parseSchema(
       "aten::sub_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> (Tensor(a!))");
-  ASSERT_THROW(schema.is_mutable(4), c10::Error);
+  ASSERT_THROW(schema.is_mutable({SchemaArgType::input, 4}), c10::Error);
+  ASSERT_THROW(schema.is_mutable({SchemaArgType::output, 4}), c10::Error);
   ASSERT_THROW(schema.is_mutable("named_argument"), c10::Error);
 }
 
 TEST(SchemaInfoIsMutableTest, Basic) {
   SchemaInfo schema(
       "aten::sub_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> (Tensor(a!))");
-  ASSERT_TRUE(schema.is_mutable(0));
+  ASSERT_TRUE(schema.is_mutable({SchemaArgType::input, 0}));
   ASSERT_TRUE(schema.is_mutable("self"));
-  ASSERT_FALSE(schema.is_mutable(1));
+  ASSERT_FALSE(schema.is_mutable({SchemaArgType::input, 1}));
   ASSERT_FALSE(schema.is_mutable("other"));
-  ASSERT_FALSE(schema.is_mutable(2));
+  ASSERT_FALSE(schema.is_mutable({SchemaArgType::input, 2}));
   ASSERT_FALSE(schema.is_mutable("alpha"));
 }
 
 TEST(SchemaInfoIsMutableTest, InvalidArgument) {
   SchemaInfo schema(
       "aten::sub_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> (Tensor(a!))");
-  ASSERT_THROW(schema.is_mutable(4), c10::Error);
+  ASSERT_THROW(schema.is_mutable({SchemaArgType::input, 4}), c10::Error);
   ASSERT_THROW(schema.is_mutable("named_argument"), c10::Error);
 }
 
 TEST(SchemaInfoIsMutableTest, AliasingInputs) {
   SchemaInfo schema(
-      "aten::sub_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> (Tensor(a!))");
-  ASSERT_TRUE(schema.is_mutable(0));
+      "aten::test.Tensor(Tensor(a!) self, Tensor(b) other, *, Scalar alpha=1) -> (Tensor(a!), Tensor(b))");
+  ASSERT_TRUE(schema.is_mutable({SchemaArgType::input, 0}));
+  ASSERT_TRUE(schema.is_mutable({SchemaArgType::output, 0}));
   ASSERT_TRUE(schema.is_mutable("self"));
-  ASSERT_FALSE(schema.is_mutable(1));
+  ASSERT_FALSE(schema.is_mutable({SchemaArgType::input, 1}));
+  ASSERT_FALSE(schema.is_mutable({SchemaArgType::output, 1}));
   ASSERT_FALSE(schema.is_mutable("other"));
   at::Tensor input = at::randn({3, 3});
   schema.addArgumentValue("self", input);
   schema.addArgumentValue("other", input);
-  ASSERT_TRUE(schema.is_mutable(1));
+  ASSERT_TRUE(schema.is_mutable({SchemaArgType::input, 1}));
+  ASSERT_TRUE(schema.is_mutable({SchemaArgType::output, 1}));
   ASSERT_TRUE(schema.is_mutable("other"));
 }
 

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1676,7 +1676,9 @@ void initJITBindings(PyObject* module) {
       .def("is_mutable", [](SchemaInfo& self) { return self.is_mutable(); })
       .def(
           "is_mutable",
-          [](SchemaInfo& self, size_t index) { return self.is_mutable(index); })
+          [](SchemaInfo& self, const SchemaArgument& argument) {
+            return self.is_mutable(argument);
+          })
       .def(
           "is_mutable",
           [](SchemaInfo& self, const std::string& name) {

--- a/torch/csrc/utils/schema_info.h
+++ b/torch/csrc/utils/schema_info.h
@@ -27,7 +27,7 @@ struct TORCH_API SchemaInfo {
 
   bool is_mutable();
 
-  bool is_mutable(size_t index);
+  bool is_mutable(const c10::SchemaArgument& argument);
 
   bool is_mutable(c10::string_view name);
 

--- a/torch/testing/_internal/schema_check_mode.py
+++ b/torch/testing/_internal/schema_check_mode.py
@@ -120,7 +120,7 @@ class SchemaCheckMode(TorchDispatchMode):
                         else:
                             self.aliasing.append(Aliasing(func._schema.name, name, f"output_{j}"))
                 if any(has_mutated(a, b, c) for a, b, c in zip(tree_flatten(before)[0], tree_flatten(after)[0], md)):
-                    if not schema_info.is_mutable(i):
+                    if not schema_info.is_mutable(SchemaArgument(SchemaArgType.input, i)):
                         raise RuntimeError(f"Argument {name} is not defined as mutable but was mutated")
                     else:
                         self.mutated.append(Mutation(func._schema.name, name))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #81787
* #81786
* #81785
* __->__ #81784
* #81783
* #81782

- Modify the is_mutable(size_t index) overload to become is_mutable(const SchemaArgument& argument) due to cases where one might want to check the mutability of either input or output arguments. 
- Refactored all calls to the function to use this new overload
- Tested through is_mutable() tests in test_schema_info.cpp