### PR TITLE
[Vulkan] Patch concat op to work with list of cpu tensors.

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -147,8 +147,15 @@ Tensor cat_height(const TensorList tensors, vTensor& v_output) {
   uvec3 src_offset{};
   uvec3 dst_offset{};
 
+  std::vector<Tensor> v_tensors;
+
   for (const auto& tensor : tensors) {
-    const vTensor& v_self = convert(tensor);
+    const Tensor v_tensor = tensor.is_vulkan() ? tensor : tensor.vulkan();
+    v_tensors.emplace_back(v_tensor);
+  }
+
+  for (const auto& v_tensor : v_tensors) {
+    const vTensor& v_self = convert(v_tensor);
 
     api::PipelineBarrier pipeline_barrier{};
 


### PR DESCRIPTION
Summary: Vulkan concat op breaks when called on list of CPU tensors. To resolve, had to create a vector of Vulkan tensors first (check if each tensor is a Vulkan tensor, and if not, then convert to Vulkan).

Test Plan:
Tested that this works using Ferraris model
```
ptbinary_build pt_benchmark
adb shell "/data/local/tmp/pt_benchmark --model=/data/local/tmp/models/ferraris/ferraris_vk.pt --use_bundled_input=0 --vulkan=true --warmup=50 --iter=500 --report_pep=true"
```

Differential Revision: D37887469

