### PR TITLE
[GHA] Re-enable backwards compatibility test!

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -29,7 +29,6 @@ jobs:
     with:
       build-environment: linux-focal-py3.7-gcc7
       docker-image: ${{ needs.linux-focal-py3_7-gcc7-build.outputs.docker-image }}
-      # add backwards_compat test back when fixed from https://github.com/pytorch/pytorch/pull/81160
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 2, runner: "linux.2xlarge" },
@@ -37,6 +36,7 @@ jobs:
           { config: "distributed", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
           { config: "docs_test", shard: 1, num_shards: 1,  runner: "linux.2xlarge" },
           { config: "jit_legacy", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
+          { config: "backwards_compat", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
         ]}
 
   linux-docs:


### PR DESCRIPTION
We should be safe to re-enable the backwards compatibility. We had previously disabled it when it failed due to @ZolotukhinM's removal of the NNC backend as these functions were no longer available.

```
        is_available(Any self) -> bool available
	compile(Any self, Any processed, Dict(str, Any) method_compile_spec) -> Dict(str, Any) handles
	execute(Any self, Any handle, Any[] input) -> Any[] output
```
https://github.com/pytorch/pytorch/runs/7274319318?check_suite_focus=true

However, these functions were accidentally exposed and should never have been in the public schema anyway, according to a discussion with @ZolotukhinM, so we should be good to re-enable. I will run a test comparing the latest master to the commit of #81246 to ensure nothing else regressed.