### PR TITLE
[ONNX] Export aten::_log_softmax

### DIFF
--- a/test/onnx/test_pytorch_jit_onnx.py
+++ b/test/onnx/test_pytorch_jit_onnx.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: onnx"]
 import onnxruntime
+import unittest
 
 import torch
 from torch.onnx import verification
@@ -103,6 +104,20 @@ class _TestJITIRToONNX:
           return (%y)
         """
         x = torch.randn(5, 2)
+        self.run_test(graph_ir, (x,))
+
+    @unittest.skipIf(
+        not torch.cuda.is_available(), "half_to_float only on CUDA implementation"
+    )
+    def test_log_softmax_half_to_float(self):
+        graph_ir = """
+        graph(%x: Tensor):
+          %half_to_float: bool = prim::Constant[value=1]()
+          %dim: int = prim::Constant[value=1]()
+          %y = aten::_log_softmax(%x, %dim, %half_to_float)
+          return (%y)
+        """
+        x = torch.randn(5, 2).half().to("cuda")
         self.run_test(graph_ir, (x,))
 
 

--- a/test/onnx/test_pytorch_jit_onnx.py
+++ b/test/onnx/test_pytorch_jit_onnx.py
@@ -1,8 +1,8 @@
 # Owner(s): ["module: onnx"]
 import onnxruntime
-import unittest
 
 import torch
+from pytorch_test_common import skipIfNoCuda
 from torch.onnx import verification
 from torch.testing._internal import common_utils
 
@@ -106,9 +106,7 @@ class _TestJITIRToONNX:
         x = torch.randn(5, 2)
         self.run_test(graph_ir, (x,))
 
-    @unittest.skipIf(
-        not torch.cuda.is_available(), "half_to_float only on CUDA implementation"
-    )
+    @skipIfNoCuda
     def test_log_softmax_half_to_float(self):
         graph_ir = """
         graph(%x: Tensor):

--- a/test/onnx/test_pytorch_jit_onnx.py
+++ b/test/onnx/test_pytorch_jit_onnx.py
@@ -94,6 +94,17 @@ class _TestJITIRToONNX:
         w = torch.randn(4, 1, 3, 3)
         self.run_test(graph_ir, (x, w))
 
+    def test_log_softmax(self):
+        graph_ir = """
+        graph(%x: Tensor):
+          %half_to_float: bool = prim::Constant[value=0]()
+          %dim: int = prim::Constant[value=1]()
+          %y = aten::_log_softmax(%x, %dim, %half_to_float)
+          return (%y)
+        """
+        x = torch.randn(5, 2)
+        self.run_test(graph_ir, (x,))
+
 
 def MakeTestCase(opset_version: int) -> type:
     name = f"TestJITIRToONNX_opset{opset_version}"

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1922,6 +1922,12 @@ def log_softmax(g, input, dim, dtype=None):
     return return_op
 
 
+@symbolic_helper.parse_args("v", "i", "i")
+def _log_softmax(g, input, dim, half_to_float):
+    # TODO: Handle half_to_float.
+    return log_softmax(g, input, dim)
+
+
 @symbolic_helper.parse_args(
     "v", "v", "v", "is", "is", "is", "i", "is", "i", "i", "i", "i", "i"
 )

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1924,7 +1924,8 @@ def log_softmax(g, input, dim, dtype=None):
 
 @symbolic_helper.parse_args("v", "i", "i")
 def _log_softmax(g, input, dim, half_to_float):
-    # TODO: Handle half_to_float.
+    if half_to_float and input.type().scalarType() == "Half":
+        input = g.op("Cast", input, to_i=symbolic_helper.cast_pytorch_to_onnx["Float"])
     return log_softmax(g, input, dim)
 
 


### PR DESCRIPTION
As title. We are seeing more aten symbols when exporting JIT graph from TorchDynamo and LazyTensor.

Fixes #81939 