### PR TITLE
[fix] build failure in python 3.10

### DIFF
--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -271,6 +271,7 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
 
   {
     using torch::profiler::impl::Result;
+    using torch::profiler::impl::PyFrameState;
     py::enum_<EventType>(m, "_EventType")
         .value("TorchOp", EventType::TorchOp)
         .value("Backend", EventType::Backend)

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -270,8 +270,8 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .def("nbytes", [](const KinetoEvent& e) { return e.nBytes(); });
 
   {
-    using torch::profiler::impl::Result;
     using torch::profiler::impl::PyFrameState;
+    using torch::profiler::impl::Result;
     py::enum_<EventType>(m, "_EventType")
         .value("TorchOp", EventType::TorchOp)
         .value("Backend", EventType::Backend)


### PR DESCRIPTION
While building with Python 3.10, I get

```
/home/kshiteej/Pytorch/pytorch_complex_convolution.py/torch/csrc/autograd/init.cpp:296:28: error: template argument 1 is invalid
  296 |     py::class_<PyFrameState>(m, "_PyFrameState")
      |                            ^
/home/kshiteej/Pytorch/pytorch_complex_convolution.py/torch/csrc/autograd/init.cpp:297:39: error: reference to 'PyFrameState' is ambiguous
  297 |         .def_readonly("line_number", &PyFrameState::line_no_)
      |                                       ^~~~~~~~~~~~
In file included from /home/kshiteej/.conda/envs/pytorch-cuda-dev/include/python3.10/frameobject.h:13,
                 from /home/kshiteej/Pytorch/pytorch_complex_convolution.py/third_party/pybind11/include/pybind11/detail/common.h:125,
                 from /home/kshiteej/Pytorch/pytorch_complex_convolution.py/third_party/pybind11/include/pybind11/pytypes.h:12,
                 from /home/kshiteej/Pytorch/pytorch_complex_convolution.py/third_party/pybind11/include/pybind11/cast.h:13,
                 from /home/kshiteej/Pytorch/pytorch_complex_convolution.py/third_party/pybind11/include/pybind11/attr.h:13,
                 from /home/kshiteej/Pytorch/pytorch_complex_convolution.py/third_party/pybind11/include/pybind11/pybind11.h:45,
                 from /home/kshiteej/Pytorch/pytorch_complex_convolution.py/torch/csrc/Exceptions.h:13,
                 from /home/kshiteej/Pytorch/pytorch_complex_convolution.py/torch/csrc/autograd/init.cpp:10:
/home/kshiteej/.conda/envs/pytorch-cuda-dev/include/python3.10/cpython/frameobject.h:20:21: note: candidates are: 'typedef signed char PyFrameState'
   20 | typedef signed char PyFrameState;
      |                     ^~~~~~~~~~~~
In file included from /home/kshiteej/Pytorch/pytorch_complex_convolution.py/torch/csrc/autograd/init.cpp:24:
/home/kshiteej/Pytorch/pytorch_complex_convolution.py/torch/csrc/profiler/collection.h:136:8: note:                 'struct torch::profiler::impl::PyFrameState'
  136 | struct PyFrameState {
      |        ^~~~~~~~~~~~
```

The name `PyFrameState` clashes with one of the struct present from Python includes.
Ref: https://github.com/python/cpython/blob/cbe3ad51ed63e2e5afc408f0bbeb8bb0e9fb7f44/Include/cpython/frameobject.h#L20

(This probably wasn't caught as there isn't a CI running with Python 3.10)