### PR TITLE
[dist.checkpoint] Cleanup usage of collectives and introduce narrow helper

### DIFF
--- a/torch/distributed/_shard/_utils.py
+++ b/torch/distributed/_shard/_utils.py
@@ -1,21 +1,26 @@
 import torch
 from torch.distributed._shard.metadata import ShardMetadata
+from typing import Tuple
 
-def narrow_tensor(tensor: torch.Tensor, metadata: ShardMetadata):
+def narrow_tensor_by_index(tensor: torch.Tensor, offsets: Tuple[int, ...], sizes: Tuple[int, ...]) -> torch.Tensor:
     """
-    narrow the tensor according to the metadata
+    Narrow the tensor according to ``offsets`` and ``sizes``.
     """
     narrowed_tensor = tensor
-    shard_offsets = metadata.shard_offsets
-    shard_sizes = metadata.shard_sizes
-    for idx, (offset, size) in enumerate(zip(shard_offsets, shard_sizes)):
+    for idx, (offset, size) in enumerate(zip(offsets, sizes)):
         if size < tensor.size(idx):
             # Reshape to get shard for this rank and we don't want autograd
             # recording here for the narrow op and 'local_shard' should be a
             # leaf variable in the autograd graph.
             narrowed_tensor = narrowed_tensor.narrow(
                 idx,
-                shard_offsets[idx],
-                shard_sizes[idx]
+                offset,
+                size
             )
     return narrowed_tensor
+
+def narrow_tensor(tensor: torch.Tensor, metadata: ShardMetadata) -> torch.Tensor:
+    """
+    Narrow the tensor according to the metadata
+    """
+    return narrow_tensor_by_index(tensor, metadata.shard_offsets, metadata.shard_sizes)

--- a/torch/distributed/_shard/_utils.py
+++ b/torch/distributed/_shard/_utils.py
@@ -1,8 +1,8 @@
 import torch
 from torch.distributed._shard.metadata import ShardMetadata
-from typing import Tuple
+from typing import Sequence
 
-def narrow_tensor_by_index(tensor: torch.Tensor, offsets: Tuple[int, ...], sizes: Tuple[int, ...]) -> torch.Tensor:
+def narrow_tensor_by_index(tensor: torch.Tensor, offsets: Sequence[int], sizes: Sequence[int]) -> torch.Tensor:
     """
     Narrow the tensor according to ``offsets`` and ``sizes``.
     """

--- a/torch/distributed/_shard/checkpoint/filesystem.py
+++ b/torch/distributed/_shard/checkpoint/filesystem.py
@@ -16,6 +16,7 @@ from .metadata import (
     TensorWriteRequest,
 )
 from .storage import StorageReader, StorageWriter
+from .utils import tensor_narrow_n
 
 
 class FileSystemWriter(StorageWriter):
@@ -112,8 +113,7 @@ class FileSystemReader(StorageReader):
             # During load time, we will load the Tensor (with it orignal view)
             # narrow it along all dimemsions, and copy_ it to the
             # target tensor, which will be the same size.
-            for dim, (start, length) in enumerate(zip(req.offsets, req.lengths)):
-                view_to_copy = torch.narrow(view_to_copy, dim, start, length)
+            view_to_copy = tensor_narrow_n(view_to_copy, req.offsets, req.lengths)
 
             assert (
                 view_to_copy.size() == req.tensor.size()

--- a/torch/distributed/_shard/checkpoint/filesystem.py
+++ b/torch/distributed/_shard/checkpoint/filesystem.py
@@ -113,7 +113,7 @@ class FileSystemReader(StorageReader):
             # During load time, we will load the Tensor (with it orignal view)
             # narrow it along all dimemsions, and copy_ it to the
             # target tensor, which will be the same size.
-            view_to_copy = tensor_narrow_n(view_to_copy, req.offsets, req.lengths)
+            view_to_copy = narrow_tensor_by_index(view_to_copy, req.offsets, req.lengths)
 
             assert (
                 view_to_copy.size() == req.tensor.size()

--- a/torch/distributed/_shard/checkpoint/filesystem.py
+++ b/torch/distributed/_shard/checkpoint/filesystem.py
@@ -16,7 +16,7 @@ from .metadata import (
     TensorWriteRequest,
 )
 from .storage import StorageReader, StorageWriter
-from .utils import tensor_narrow_n
+from torch.distributed._shard._utils import narrow_tensor_by_index
 
 
 class FileSystemWriter(StorageWriter):

--- a/torch/distributed/_shard/checkpoint/utils.py
+++ b/torch/distributed/_shard/checkpoint/utils.py
@@ -60,7 +60,6 @@ class _DistWrapper:
                 dst=self.coordinator_rank,
                 group=self.group
             )
-            # technically the type is shou
             result = gather_objs
         else:
             result = [object]

--- a/torch/distributed/_shard/checkpoint/utils.py
+++ b/torch/distributed/_shard/checkpoint/utils.py
@@ -1,0 +1,193 @@
+from typing import Any, List, Union, Callable, Tuple, Optional
+import torch.distributed as dist
+from .api import CheckpointException
+import torch
+
+def tensor_narrow_n(tensor: torch.Tensor, offsets: Tuple[int, ...], lengths: Tuple[int, ...]) -> torch.Tensor:
+    for dim, (start, length) in enumerate(zip(offsets, lengths)):
+        tensor = torch.narrow(tensor, dim, start, length)
+    return tensor
+
+class _DistWrapper:
+    """
+    This is a wrapper around PG that provides a series of features around object collectives.
+
+    It works without distributed initialized, where most collectives turns into nops.
+
+    All variants that take functions are exception robust, meaning that if one or more
+    ranks raise errors, all ranks will observe those.
+    """
+    def __init__(self, group: Optional[dist.ProcessGroup], use_dist: bool, coordinator_rank: int):
+        self.group = group
+        self.use_dist = use_dist
+        self.coordinator_rank = coordinator_rank
+        if self.use_dist:
+            self.rank = dist.get_rank(group)
+            self.is_coordinator = self.rank == coordinator_rank
+        else:
+            self.rank = 0
+            self.is_coordinator = True
+
+    def get_rank(self) -> int:
+        return self.rank
+
+    def get_world_size(self) -> int:
+        if self.use_dist:
+            return dist.get_world_size(self.group)
+        return 1
+
+    def broadcast_object(self, object: Any) -> Any:
+        object_list = [object]
+        if self.use_dist:
+            dist.broadcast_object_list(
+                object_list=object_list,
+                group=self.group,
+                src=self.coordinator_rank)
+        return object_list[0]
+
+    def gather_object(self, object: Any) -> Union[List[Any], None]:
+        if self.use_dist:
+            gather_objs = [None] * dist.get_world_size(self.group) if self.is_coordinator else None
+
+            dist.gather_object(
+                obj=object,
+                object_gather_list=gather_objs if self.is_coordinator else None,
+                dst=self.coordinator_rank,
+                group=self.group
+            )
+            result = gather_objs
+        else:
+            result = [object]
+        return result
+
+    def all_gather_object(self, object: Any) -> List[Any]:
+        if self.use_dist:
+            gather_objs = [None] * dist.get_world_size(self.group)
+
+            dist.all_gather_object(
+                object_list=gather_objs,
+                obj=object,
+                group=self.group
+            )
+        else:
+            gather_objs = [object]
+        return gather_objs
+
+    def scatter_object(self, object_list: List[Any]) -> Any:
+        if self.use_dist:
+            gather_result = [None]
+            dist.scatter_object_list(
+                scatter_object_output_list=gather_result,
+                scatter_object_input_list=object_list if self.is_coordinator else None,
+                src=self.coordinator_rank,
+                group=self.group
+            )
+
+            local_reply = gather_result[0]
+        else:
+            local_reply = object_list[0]
+        return local_reply
+
+    def reduce_scatter(self,
+        step: str,
+        map_fun: Callable[[], Any],
+        reduce_fun: Callable[[List[Any]], List[Any]]
+    ) -> Any:
+        try:
+            local_data = map_fun()
+        except BaseException as e:
+            local_data = e
+
+        all_data = self.gather_object(local_data)
+        all_results = None
+        if self.is_coordinator:
+            node_failures = {i: err for i, err in enumerate(all_data) if isinstance(err, BaseException)}
+
+            if len(node_failures) == 0:
+                try:
+                    all_results = reduce_fun(all_data)
+                except BaseException as e:
+                    node_failures[self.rank] = e
+
+            if len(node_failures) > 0:
+                all_results = [CheckpointException(step, node_failures)] * self.get_world_size()
+
+        result = self.scatter_object(all_results)
+        if isinstance(result, CheckpointException):
+            raise result
+        return result
+
+    def all_reduce(self,
+        step: str,
+        map_cb: Callable[[], Any],
+        reduce_cb: Callable[[List[Any]], Any]
+    ) -> Tuple[Any, Any]:
+        try:
+            local_data = map_cb()
+        except BaseException as e:
+            local_data = e
+
+        all_data = self.gather_object(local_data)
+        result = None
+        if self.is_coordinator:
+            node_failures = {i: err for i, err in enumerate(all_data) if isinstance(err, BaseException)}
+
+            if len(node_failures) == 0:
+                try:
+                    result = reduce_cb(all_data)
+                except BaseException as e:
+                    node_failures[self.rank] = e
+
+            if len(node_failures) > 0:
+                result = CheckpointException(step, node_failures)
+
+        result = self.broadcast_object(result)
+        if isinstance(result, CheckpointException):
+            raise result
+        return result
+
+    def all_gather(self,
+        step: str,
+        map_fun: Callable[[], Any],
+    ) -> Tuple[Any, Any]:
+        try:
+            result = map_fun()
+        except BaseException as e:
+            result = e
+
+        all_results = self.all_gather_object(result)
+
+        node_failures = {i: err for i, err in enumerate(all_results) if isinstance(err, BaseException)}
+        if len(node_failures) > 0:
+            raise CheckpointException(step, node_failures)
+        return all_results
+
+    def broadcast(self,
+        step: str,
+        map_cb: Callable[[], Any],
+    ) -> Any:
+        result = None
+        if self.is_coordinator:
+            try:
+                result = map_cb()
+            except BaseException as e:
+                result = CheckpointException(step, { self.rank: e })
+        result = self.broadcast_object(result)
+        if isinstance(result, CheckpointException):
+            raise result
+        return result
+
+    def all_to_all(self,
+        step: str,
+        map_cb: Callable[[], Any],
+    ) -> Any:
+        result = None
+        if self.is_coordinator:
+            try:
+                result = map_cb()
+            except BaseException as e:
+                result = CheckpointException(step, { self.rank: e })
+        result = self.broadcast_object(result)
+        if isinstance(result, CheckpointException):
+            raise result
+        return result

--- a/torch/distributed/_shard/checkpoint/utils.py
+++ b/torch/distributed/_shard/checkpoint/utils.py
@@ -1,8 +1,6 @@
-from typing import List, Callable, Tuple, Optional, Union, TypeVar, cast
+from typing import List, Callable, Optional, Union, TypeVar, cast
 import torch.distributed as dist
 from .api import CheckpointException
-import torch
-
 
 T = TypeVar('T')
 R = TypeVar('R')


### PR DESCRIPTION
Introduce _DistWrapper class that wraps a process group and provides functional
variants of collectives. It works without c10d enabled and is exception
robust.

Introduce tensor_narrow_n that handle narrowing over multiple dimentions.

Fixes #ISSUE_NUMBER
