### PR TITLE
Update shallow_copy_and_detach for nested tensor impls to enable nested tensor softmax backward

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -108,41 +108,60 @@ c10::DispatchKeySet generate_nested_key_set(at::Tensor buffer) {
 }
 
 NestedTensorImpl::NestedTensorImpl(
-    at::Tensor buffer,
+    int64_t buffer_size,
+    Storage storage,
+    c10::DispatchKeySet key_set,
+    const caffe2::TypeMeta data_type,
     at::Tensor nested_size_tensor,
     at::Tensor nested_stride_tensor,
     std::vector<int64_t> offsets)
-    : TensorImpl(
-          Storage(buffer.storage()),
-          generate_nested_key_set(buffer),
-          buffer.dtype()),
+    : TensorImpl(std::move(storage), key_set, data_type),
+      buffer_size_(buffer_size),
       nested_size_tensor_(std::move(nested_size_tensor)),
       nested_stride_tensor_(std::move(nested_stride_tensor)),
       offsets_(std::move(offsets)),
-      opt_sizes_(construct_opt_sizes(nested_size_tensor_))
-{
-  auto buffer_size_vec{buffer.unsafeGetTensorImpl()->sizes()};
-  TORCH_INTERNAL_ASSERT(
-      buffer_size_vec.size() == 1,
-      "NestedTensorImpl buffer is required to be 1 dimensional but got a buffer with ",
-      buffer.dim(),
-      " dimensions.");
-  buffer_size_ = buffer_size_vec[0];
-
+      opt_sizes_(construct_opt_sizes(nested_size_tensor_)) {
   TORCH_WARN_ONCE(
       "The PyTorch API of nested tensors is in prototype stage and will change "
       "in the near future.");
-  TORCH_INTERNAL_ASSERT(buffer.is_cuda() || buffer.is_cpu(), "NestedTensorImpl buffer must be either CUDA or CPU but got ", buffer.device());
   TORCH_INTERNAL_ASSERT(nested_size_tensor_.is_contiguous());
   int64_t size_dim = nested_size_tensor_.dim();
   TORCH_INTERNAL_ASSERT(size_dim == 0 || size_dim == 2);
   TORCH_INTERNAL_ASSERT(nested_stride_tensor_.is_contiguous());
   TORCH_INTERNAL_ASSERT(nested_stride_tensor_.dim() == size_dim);
-  TORCH_INTERNAL_ASSERT(nested_stride_tensor_.sizes() == nested_size_tensor_.sizes());
-  TORCH_INTERNAL_ASSERT((size_dim == 0 && (int64_t)offsets_.empty())
-      || (size_dim == 2 && nested_size_tensor_.size(0) == (int64_t)offsets_.size()));
+  TORCH_INTERNAL_ASSERT(
+      nested_stride_tensor_.sizes() == nested_size_tensor_.sizes());
+  TORCH_INTERNAL_ASSERT(
+      (size_dim == 0 && (int64_t)offsets_.empty()) ||
+      (size_dim == 2 &&
+       nested_size_tensor_.size(0) == (int64_t)offsets_.size()));
   refresh_dim();
   set_sizes_strides_policy(c10::TensorImpl::SizesStridesPolicy::CustomSizes);
+}
+
+NestedTensorImpl::NestedTensorImpl(
+    at::Tensor buffer,
+    at::Tensor nested_size_tensor,
+    at::Tensor nested_stride_tensor,
+    std::vector<int64_t> offsets)
+    : NestedTensorImpl(
+          buffer.sizes()[0],
+          buffer.storage(),
+          generate_nested_key_set(buffer),
+          buffer.dtype(),
+          nested_size_tensor,
+          nested_stride_tensor,
+          offsets) {
+
+  TORCH_INTERNAL_ASSERT(
+      buffer.dim() == 1,
+      "NestedTensorImpl buffer is required to be 1 dimensional but got a buffer with ",
+      buffer.dim(),
+      " dimensions.");
+  TORCH_INTERNAL_ASSERT(
+      buffer.is_cuda() || buffer.is_cpu(),
+      "NestedTensorImpl buffer must be either CUDA or CPU but got ",
+      buffer.device());
 }
 
 // assume contiguous, `nested_stride_tensor` and `offsets`
@@ -235,12 +254,20 @@ c10::intrusive_ptr<TensorImpl> NestedTensorImpl::shallow_copy_and_detach_core(
     // otherwise just copy the TensorImpl and not the PyObject.  Since
     // the interpreter is dead no one can call us out on it
   }
-  auto impl = c10::make_intrusive<NestedTensorImpl>(this -> buffer_, this -> nested_size_tensor_);
-  copy_tensor_metadata(
-      /*src_impl=*/this,
-      /*dest_impl=*/impl.get(),
-      /*version_counter=*/std::forward<VariableVersion>(version_counter),
-      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
+  auto impl = c10::make_intrusive<NestedTensorImpl>(
+      buffer_size_,
+      storage_,
+      key_set_,
+      data_type_,
+      nested_size_tensor_,
+      nested_stride_tensor_,
+      offsets_);
+
+      copy_tensor_metadata(
+          /*src_impl=*/this,
+          /*dest_impl=*/impl.get(),
+          /*version_counter=*/std::forward<VariableVersion>(version_counter),
+          /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
   return impl;
 }
 

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -219,5 +219,44 @@ const char* NestedTensorImpl::tensorimpl_type_name() const {
   return "NestedTensorImpl";
 }
 
+
+template <typename VariableVersion>
+c10::intrusive_ptr<TensorImpl> NestedTensorImpl::shallow_copy_and_detach_core(
+    VariableVersion&& version_counter,
+    bool allow_tensor_metadata_change) const {
+  if (key_set_.has(DispatchKey::Python) &&
+      !c10::impl::tls_is_dispatch_key_excluded(DispatchKey::Python)) {
+    auto r = pyobj_interpreter_.load(std::memory_order_acquire)->detach(this);
+    if (r) {
+      r->set_version_counter(std::forward<VariableVersion>(version_counter));
+      r->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
+      return r;
+    }
+    // otherwise just copy the TensorImpl and not the PyObject.  Since
+    // the interpreter is dead no one can call us out on it
+  }
+  auto impl = c10::make_intrusive<NestedTensorImpl>(this -> buffer_, this -> nested_size_tensor_);
+  copy_tensor_metadata(
+      /*src_impl=*/this,
+      /*dest_impl=*/impl.get(),
+      /*version_counter=*/std::forward<VariableVersion>(version_counter),
+      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
+  return impl;
+}
+
+c10::intrusive_ptr<TensorImpl> NestedTensorImpl::shallow_copy_and_detach(
+    const c10::VariableVersion& version_counter,
+    bool allow_tensor_metadata_change) const {
+  return shallow_copy_and_detach_core(
+      version_counter, allow_tensor_metadata_change);
+}
+
+c10::intrusive_ptr<TensorImpl> NestedTensorImpl::shallow_copy_and_detach(
+    c10::VariableVersion&& version_counter,
+    bool allow_tensor_metadata_change) const {
+  return shallow_copy_and_detach_core(
+      std::move(version_counter), allow_tensor_metadata_change);
+}
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -13,6 +13,15 @@ namespace native {
 
 struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   explicit NestedTensorImpl(
+      int64_t buffer_size,
+      Storage storage,
+      c10::DispatchKeySet key_set,
+      const caffe2::TypeMeta data_type,
+      at::Tensor nested_size_tensor,
+      at::Tensor nested_stride_tensor,
+      std::vector<int64_t> offsets);
+
+  explicit NestedTensorImpl(
       at::Tensor buffer,
       at::Tensor nested_size_tensor,
       at::Tensor nested_stride_tensor,

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -90,11 +90,11 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
       const c10::VariableVersion& version_counter,
       bool allow_tensor_metadata_change) const override;
 
-   c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
       c10::VariableVersion&& version_counter,
       bool allow_tensor_metadata_change) const override;
 
-   void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override {
+  void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override {
     copy_tensor_metadata(
         /*src_impl=*/impl.get(),
         /*dest_impl=*/this,
@@ -134,7 +134,6 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
       VariableVersion&& version_counter,
       bool allow_tensor_metadata_change) const;
 };
-
 
 inline NestedTensorImpl* get_nested_tensor_impl_or_null(
     const at::Tensor& tensor) {

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -86,6 +86,22 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   // this one is real
   int64_t dim_custom() const override;
 
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
+      const c10::VariableVersion& version_counter,
+      bool allow_tensor_metadata_change) const override;
+
+   c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
+      c10::VariableVersion&& version_counter,
+      bool allow_tensor_metadata_change) const override;
+
+   void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override {
+    copy_tensor_metadata(
+        /*src_impl=*/impl.get(),
+        /*dest_impl=*/this,
+        /*version_counter=*/version_counter(),
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change());
+  }
+
  private:
   // Must be called after any changes to our dim() to sync the state
   // to TensorImpl.
@@ -112,7 +128,13 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   // TODO: maybe we can remove this metadata since
   //       we can compute it from `nested_size_tensor_`
   std::vector<int64_t> opt_sizes_;
+
+  template <typename VariableVersion>
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach_core(
+      VariableVersion&& version_counter,
+      bool allow_tensor_metadata_change) const;
 };
+
 
 inline NestedTensorImpl* get_nested_tensor_impl_or_null(
     const at::Tensor& tensor) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4548,9 +4548,6 @@
 # softmax allows positional dtype, unlike most operators, because kwonly is BC-breaking when loading jit models.
 - func: softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor
   variants: function, method
-  dispatch:
-    CompositeImplicitAutograd: softmax
-    NestedTensorCPU, NestedTensorCUDA: softmax
 
 - func: softmax.int_out(Tensor self, int dim, ScalarType? dtype=None, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
@@ -4575,6 +4572,8 @@
 
 - func: _softmax_backward_data(Tensor grad_output, Tensor output, int dim, ScalarType input_dtype) -> Tensor
   structured_delegate: _softmax_backward_data.out
+  dispatch:
+    NestedTensorCPU, NestedTensorCUDA: nested_softmax_backward
 
 - func: _softmax_backward_data.out(Tensor grad_output, Tensor output, int dim, ScalarType input_dtype, *, Tensor(a!) grad_input) -> Tensor(a!)
   structured: True

--- a/aten/src/ATen/native/nested/NestedTensorBackward.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBackward.cpp
@@ -13,6 +13,7 @@
 namespace at {
 namespace native {
 
+
 std::tuple<Tensor, Tensor, Tensor> nested_linear_backward(
     const Tensor& input,
     const Tensor& grad_output,
@@ -63,6 +64,57 @@ Tensor _reshape_nested_backward(const Tensor& self, const Tensor& grad) {
   }
   return grad.reshape(sizes);
 }
+
+Tensor nested_softmax_backward(
+    const Tensor& grad,
+    const Tensor& output,
+    int64_t dim,
+    ScalarType input_dtype) {
+  TORCH_INTERNAL_ASSERT(grad.is_nested(), "Should be nested grad")
+  TORCH_INTERNAL_ASSERT(output.is_nested(), "Should be nested output")
+
+  auto output_ptr = get_nested_tensor_impl(output);
+  auto grad_ptr = get_nested_tensor_impl(grad);
+  int64_t ntensors = output_ptr->size(0);
+  if (ntensors == 0) {
+    return grad.clone();
+  }
+
+  int64_t positive_dim = at::maybe_wrap_dim(dim, output_ptr->dim());
+
+  //  Get the info about the output
+  const Tensor &output_buffer = output_ptr->get_buffer(),
+               &output_sizemat = output_ptr->get_nested_size_tensor();
+
+  //  Get the info about the grad
+  const Tensor &grad_buffer = grad_ptr->get_buffer(),
+               &grad_sizemat = grad_ptr->get_nested_size_tensor();
+
+  TORCH_INTERNAL_ASSERT(output_sizemat.equal(grad_sizemat));
+
+  Tensor grad_output_buffer = at::empty_like(output_buffer);
+  // split buffer into original tensors
+  std::vector<int64_t> offsets = NestedTensor_get_offsets(output_ptr);
+  std::vector<IntArrayRef> shapes = NestedTensor_get_shapes(output_ptr);
+
+  for(const int64_t i: c10::irange(ntensors)){
+    auto grad_ouput_buffer_slice =
+        grad_output_buffer.slice(0, offsets[i], offsets[i + 1]).view(shapes[i]);
+    auto grad_buffer_slice =
+        grad_buffer.slice(0, offsets[i], offsets[i + 1]).view(shapes[i]);
+    auto output_buffer_slice =
+        output_buffer.slice(0, offsets[i], offsets[i + 1]).view(shapes[i]);
+    at::_softmax_backward_data_out(
+        grad_ouput_buffer_slice,
+        grad_buffer_slice,
+        output_buffer_slice,
+        positive_dim - 1,
+        input_dtype);
+  }
+  return wrap_buffer(grad_output_buffer, grad_sizemat.clone());
+}
+
+
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/nested/NestedTensorBackward.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBackward.cpp
@@ -92,10 +92,6 @@ Tensor nested_softmax_backward(
   Tensor grad_output =
       wrap_buffer(at::empty_like(output_buffer), output_sizemat.clone());
 
-  // split buffer into original tensors
-  std::vector<int64_t> offsets = NestedTensor_get_offsets(output_ptr);
-  std::vector<IntArrayRef> shapes = NestedTensor_get_shapes(output_ptr);
-
   // Unbind nt into individual tensor slices for calculating the derivative
   std::vector<Tensor> grad_output_unbind{grad_output.unbind()},
       grad_unbind{grad.unbind()}, output_unbind{output.unbind()};

--- a/aten/src/ATen/native/nested/NestedTensorBackward.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorBackward.cpp
@@ -96,11 +96,11 @@ Tensor nested_softmax_backward(
   std::vector<int64_t> offsets = NestedTensor_get_offsets(output_ptr);
   std::vector<IntArrayRef> shapes = NestedTensor_get_shapes(output_ptr);
 
-  // switch to unbind
+  // Unbind nt into individual tensor slices for calculating the derivative
   std::vector<Tensor> grad_output_unbind{grad_output.unbind()},
       grad_unbind{grad.unbind()}, output_unbind{output.unbind()};
 
-  for (const int64_t i: c10::irange(ntensors)) {
+  for(const auto i: c10::irange(ntensors)) {
     at::_softmax_backward_data_out(
         grad_output_unbind[i],
         grad_unbind[i],

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -1097,7 +1097,7 @@ inline void NestedTensor_reshape_copy(
           buffer.as_strided(sizes[i], strides[i], offsets[i]).reshape(sizes_reshaped[i]));
     }
 }
-}
+} // namespace
 
 // Special rules for reshape(nested tensor):
 // 1. Only 1 regular dimension can be collapsed with

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -730,7 +730,7 @@ Tensor softmax_nested(
   auto input_ptr = get_nested_tensor_impl(input);
   int64_t ntensors = input_ptr->size(0);
   if (ntensors == 0) {
-    return input;
+    return input.clone();
   }
   int64_t positive_dim = at::maybe_wrap_dim(dim, input_ptr->dim());
   TORCH_CHECK(

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -46,7 +46,8 @@ inline std::vector<IntArrayRef> NestedTensor_get_sizes(const NestedTensorImpl* s
     return sizes;
   }
   const int64_t* sizemat_ptr = sizemat.data_ptr<int64_t>();
-  for (int64_t i = 0; i < ntensors; i++) {
+
+  for(const auto i: c10::irange(ntensors)){
     sizes[i] = IntArrayRef(sizemat_ptr, sizemat_ptr + orig_dim);
     sizemat_ptr += orig_dim;
   }
@@ -72,7 +73,7 @@ inline std::vector<IntArrayRef> NestedTensor_get_strides(const NestedTensorImpl*
     return strides;
   }
   const int64_t* stridemat_ptr = stridemat.data_ptr<int64_t>();
-  for (int64_t i = 0; i < ntensors; i++) {
+  for(const auto i: c10::irange(ntensors)) {
     strides[i] = IntArrayRef(stridemat_ptr, stridemat_ptr + orig_dim);
     stridemat_ptr += orig_dim;
   }

--- a/c10/core/DispatchKeySet.cpp
+++ b/c10/core/DispatchKeySet.cpp
@@ -1,7 +1,6 @@
 #include <c10/core/DispatchKeySet.h>
 #include <c10/util/irange.h>
 #include <iostream>
-#include "c10/core/DispatchKey.h"
 
 namespace c10 {
 

--- a/c10/core/DispatchKeySet.cpp
+++ b/c10/core/DispatchKeySet.cpp
@@ -1,6 +1,7 @@
 #include <c10/core/DispatchKeySet.h>
 #include <c10/util/irange.h>
 #include <iostream>
+#include "c10/core/DispatchKey.h"
 
 namespace c10 {
 

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -476,6 +476,7 @@ class TestNestedTensorDeviceType(TestCase):
         self.assertEqual(nt.is_cuda, is_cuda)
 
     @dtypes(torch.float, torch.float16, torch.double)
+    @torch.inference_mode()
     def test_nested_tensor_indexing(self, device, dtype):
         # edge case: empty nested tensor
         nt0 = torch.nested_tensor([])


### PR DESCRIPTION
# Summary
This change fixes a bug that was encountered when trying to add more backward formulas for nested tensor ops.  If a derivative is defined that stores the "result" for use in the backward the output of the forward op is saved using:
```
 if (grad_fn) {
    grad_fn->result_ = SavedVariable(result, true);
  }
```

SavedVariable calls a series of functions which in turn calls shallow_copy_and_detach and when https://github.com/pytorch/pytorch/blob/c179597753f20089056115542d3b9c74ab8b864c/c10/core/TensorImpl.cpp#L533 is hit this calls sizes_custom() which is not implemented and errors.  I also noticed that since the storage format is different for nested_tensor not `storage_ ` but instead two tensors that the we should actually be calling the NestedTensorImpl constructor.

This PR overrides shallow_copy_and_detach from the derived class and ensures that shallow copy works correctly.

## Update
- Added the softmax derivative in this PR because that is a direct use case that was blocked by not having shallow_copy_and_detach work correctly.