### PR TITLE
Simplify torch.nn.grad by calling into aten::convolution_backward

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11771,7 +11771,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         output = F.conv1d(input, weight, dilation=2)
         grad_output = torch.randn(output.shape)
 
-        (grad_input_autograd, grad_weight_autograd) = torch.autograd.grad(output, (input, weight), grad_output)
+        grad_input_autograd, grad_weight_autograd = torch.autograd.grad(output, (input, weight), grad_output)
 
         grad_input_functional = torch.nn.grad.conv1d_input(input.shape, weight, grad_output, dilation=2)
         self.assertEqual(grad_input_functional, grad_input_autograd)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11771,13 +11771,11 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         output = F.conv1d(input, weight, dilation=2)
         grad_output = torch.randn(output.shape)
 
-        grad_autograd = torch.autograd.grad(output, (input, weight), grad_output)
+        (grad_input_autograd, grad_weight_autograd) = torch.autograd.grad(output, (input, weight), grad_output)
 
-        grad_input_autograd = grad_autograd[0]
         grad_input_functional = torch.nn.grad.conv1d_input(input.shape, weight, grad_output, dilation=2)
         self.assertEqual(grad_input_functional, grad_input_autograd)
 
-        grad_weight_autograd = grad_autograd[1]
         grad_weight_functional = torch.nn.grad.conv1d_weight(input, weight.shape, grad_output, dilation=2)
         self.assertEqual(grad_weight_functional, grad_weight_autograd)
 
@@ -11787,13 +11785,11 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         output = F.conv2d(input, weight, dilation=2)
         grad_output = torch.randn(output.shape)
 
-        grad_autograd = torch.autograd.grad(output, (input, weight), grad_output)
+        (grad_input_autograd, grad_weight_autograd) = torch.autograd.grad(output, (input, weight), grad_output)
 
-        grad_input_autograd = grad_autograd[0]
         grad_input_functional = torch.nn.grad.conv2d_input(input.shape, weight, grad_output, dilation=2)
         self.assertEqual(grad_input_functional, grad_input_autograd)
 
-        grad_weight_autograd = grad_autograd[1]
         grad_weight_functional = torch.nn.grad.conv2d_weight(input, weight.shape, grad_output, dilation=2)
         self.assertEqual(grad_weight_functional, grad_weight_autograd)
 
@@ -11803,13 +11799,11 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         output = F.conv3d(input, weight, dilation=2)
         grad_output = torch.randn(output.shape)
 
-        grad_autograd = torch.autograd.grad(output, (input, weight), grad_output)
+        (grad_input_autograd, grad_weight_autograd) = torch.autograd.grad(output, (input, weight), grad_output)
 
-        grad_input_autograd = grad_autograd[0]
         grad_input_functional = torch.nn.grad.conv3d_input(input.shape, weight, grad_output, dilation=2)
         self.assertEqual(grad_input_functional, grad_input_autograd)
 
-        grad_weight_autograd = grad_autograd[1]
         grad_weight_functional = torch.nn.grad.conv3d_weight(input, weight.shape, grad_output, dilation=2)
         self.assertEqual(grad_weight_functional, grad_weight_autograd)
 
@@ -11831,14 +11825,12 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
             grad_output = torch.randn(output.shape)
 
-            grad_autograd = torch.autograd.grad(output, (input, weight), grad_output)
+            (grad_input_autograd, grad_weight_autograd) = torch.autograd.grad(output, (input, weight), grad_output)
 
-            grad_input_autograd = grad_autograd[0]
             grad_input_functional = torch.nn.grad.conv2d_input(input.shape, weight, grad_output,
                                                                stride=stride, padding=padding, dilation=dilation, groups=groups)
             self.assertEqual(grad_input_functional, grad_input_autograd)
 
-            grad_weight_autograd = grad_autograd[1]
             grad_weight_functional = torch.nn.grad.conv2d_weight(input, weight.shape, grad_output,
                                                                  stride=stride, padding=padding, dilation=dilation, groups=groups)
             self.assertEqual(grad_weight_functional, grad_weight_autograd)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11771,9 +11771,15 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         output = F.conv1d(input, weight, dilation=2)
         grad_output = torch.randn(output.shape)
 
-        grad_input_autograd = torch.autograd.grad(output, input, grad_output)[0]
+        grad_autograd = torch.autograd.grad(output, (input, weight), grad_output)
+
+        grad_input_autograd = grad_autograd[0]
         grad_input_functional = torch.nn.grad.conv1d_input(input.shape, weight, grad_output, dilation=2)
         self.assertEqual(grad_input_functional, grad_input_autograd)
+
+        grad_weight_autograd = grad_autograd[1]
+        grad_weight_functional = torch.nn.grad.conv1d_weight(input, weight.shape, grad_output, dilation=2)
+        self.assertEqual(grad_weight_functional, grad_weight_autograd)
 
         # Conv 2D
         input = torch.randn(1, 1, 5, 5, requires_grad=True)
@@ -11781,9 +11787,15 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         output = F.conv2d(input, weight, dilation=2)
         grad_output = torch.randn(output.shape)
 
-        grad_input_autograd = torch.autograd.grad(output, input, grad_output)[0]
+        grad_autograd = torch.autograd.grad(output, (input, weight), grad_output)
+
+        grad_input_autograd = grad_autograd[0]
         grad_input_functional = torch.nn.grad.conv2d_input(input.shape, weight, grad_output, dilation=2)
         self.assertEqual(grad_input_functional, grad_input_autograd)
+
+        grad_weight_autograd = grad_autograd[1]
+        grad_weight_functional = torch.nn.grad.conv2d_weight(input, weight.shape, grad_output, dilation=2)
+        self.assertEqual(grad_weight_functional, grad_weight_autograd)
 
         # Conv 3D
         input = torch.randn(1, 1, 5, 5, 5, requires_grad=True)
@@ -11791,14 +11803,15 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         output = F.conv3d(input, weight, dilation=2)
         grad_output = torch.randn(output.shape)
 
-        grad_input_autograd = torch.autograd.grad(output, input, grad_output)[0]
+        grad_autograd = torch.autograd.grad(output, (input, weight), grad_output)
+
+        grad_input_autograd = grad_autograd[0]
         grad_input_functional = torch.nn.grad.conv3d_input(input.shape, weight, grad_output, dilation=2)
         self.assertEqual(grad_input_functional, grad_input_autograd)
 
-        # Warning for _grad_input_padding
-        with warnings.catch_warnings(record=True) as w:
-            torch.nn.grad._grad_input_padding(torch.rand(1, 2, 3), [1, 2, 5], (1,), (0,), (3,))
-        self.assertEqual(len(w), 1)
+        grad_weight_autograd = grad_autograd[1]
+        grad_weight_functional = torch.nn.grad.conv3d_weight(input, weight.shape, grad_output, dilation=2)
+        self.assertEqual(grad_weight_functional, grad_weight_autograd)
 
     def test_flatten(self):
         tensor_input = torch.randn(2, 1, 2, 3)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11822,11 +11822,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         def _test_conv2d(stride, kernel_size, groups, dilation):
             padding = kernel_size // 2
 
-            input = torch.empty(BATCH_SIZE, IN_CH, SPATIAL, SPATIAL)\
-                    .uniform_(-8.0, 8.0).requires_grad_(True)
+            input = torch.empty(BATCH_SIZE, IN_CH, SPATIAL, SPATIAL).uniform_(-8.0, 8.0).requires_grad_(True)
 
-            weight = torch.empty(OUT_CH, IN_CH // groups, kernel_size, kernel_size)\
-                    .uniform_(-4.0, 4.0).requires_grad_(True)
+            weight = torch.empty(OUT_CH, IN_CH // groups, kernel_size, kernel_size).uniform_(-4.0, 4.0).requires_grad_(True)
 
             output = F.conv2d(input, weight,
                               stride=stride, padding=padding, dilation=dilation, groups=groups)

--- a/torch/nn/grad.py
+++ b/torch/nn/grad.py
@@ -2,7 +2,6 @@
 
 import torch
 from .modules.utils import _single, _pair, _triple
-import warnings
 
 
 def conv1d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=1, groups=1):

--- a/torch/nn/grad.py
+++ b/torch/nn/grad.py
@@ -5,38 +5,6 @@ from .modules.utils import _single, _pair, _triple
 import warnings
 
 
-def _grad_input_padding(grad_output, input_size, stride, padding, kernel_size, dilation=None):
-    if dilation is None:
-        # For backward compatibility
-        warnings.warn("_grad_input_padding 'dilation' argument not provided. Default of 1 is used.")
-        dilation = [1] * len(stride)
-
-    input_size = list(input_size)
-    k = grad_output.dim() - 2
-
-    if len(input_size) == k + 2:
-        input_size = input_size[-k:]
-    if len(input_size) != k:
-        raise ValueError("input_size must have {} elements (got {})"
-                         .format(k + 2, len(input_size)))
-
-    def dim_size(d):
-        return ((grad_output.size(d + 2) - 1) * stride[d] - 2 * padding[d] + 1
-                + dilation[d] * (kernel_size[d] - 1))
-
-    min_sizes = [dim_size(d) for d in range(k)]
-    max_sizes = [min_sizes[d] + stride[d] - 1 for d in range(k)]
-    for size, min_size, max_size in zip(input_size, min_sizes, max_sizes):
-        if size < min_size or size > max_size:
-            raise ValueError(
-                ("requested an input grad size of {}, but valid sizes range "
-                 "from {} to {} (for a grad_output of {})").format(
-                     input_size, min_sizes, max_sizes,
-                     grad_output.size()[2:]))
-
-    return tuple(input_size[d] - min_sizes[d] for d in range(k))
-
-
 def conv1d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=1, groups=1):
     r"""
     Computes the gradient of conv1d with respect to the input of the convolution.
@@ -62,20 +30,11 @@ def conv1d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         >>> F.grad.conv1d_input(input.shape, weight, grad_output)
 
     """
-    stride = _single(stride)
-    padding = _single(padding)
-    dilation = _single(dilation)
-    kernel_size = [weight.shape[2]]
+    input = grad_output.new_empty(input_size)
 
-    if input_size is None:
-        raise ValueError("grad.conv1d_input requires specifying an input_size")
-
-    grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
-                                             padding, kernel_size, dilation)
-
-    return torch.conv_transpose1d(
-        grad_output, weight, None, stride, padding, grad_input_padding, groups,
-        dilation)
+    return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
+                                               _single(stride), _single(padding), _single(dilation),
+                                               False, [0], groups, (True, False, False))[0]
 
 
 def conv1d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation=1, groups=1):
@@ -101,29 +60,11 @@ def conv1d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation
         >>> F.grad.conv1d_weight(input, weight.shape, grad_output)
 
     """
-    stride = _single(stride)
-    padding = _single(padding)
-    dilation = _single(dilation)
-    in_channels = input.shape[1]
-    out_channels = grad_output.shape[1]
-    min_batch = input.shape[0]
+    weight = grad_output.new_empty(weight_size)
 
-    grad_output = grad_output.contiguous().repeat(1, in_channels // groups, 1)
-    grad_output = grad_output.contiguous().view(
-        grad_output.shape[0] * grad_output.shape[1], 1, grad_output.shape[2])
-
-    input = input.contiguous().view(1, input.shape[0] * input.shape[1],
-                                    input.shape[2])
-
-    grad_weight = torch.conv1d(input, grad_output, None, dilation, padding,
-                               stride, in_channels * min_batch)
-
-    grad_weight = grad_weight.contiguous().view(
-        min_batch, grad_weight.shape[1] // min_batch, grad_weight.shape[2])
-
-    return grad_weight.sum(dim=0).view(
-        in_channels // groups, out_channels, grad_weight.shape[2]).transpose(
-            0, 1).narrow(2, 0, weight_size[2])
+    return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
+                                               _single(stride), _single(padding), _single(dilation),
+                                               False, [0], groups, (False, True, False))[1]
 
 
 def conv2d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=1, groups=1):
@@ -151,20 +92,11 @@ def conv2d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         >>> F.grad.conv2d_input(input.shape, weight, grad_output)
 
     """
-    stride = _pair(stride)
-    padding = _pair(padding)
-    dilation = _pair(dilation)
-    kernel_size = (weight.shape[2], weight.shape[3])
+    input = grad_output.new_empty(input_size)
 
-    if input_size is None:
-        raise ValueError("grad.conv2d_input requires specifying an input_size")
-
-    grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
-                                             padding, kernel_size, dilation)
-
-    return torch.conv_transpose2d(
-        grad_output, weight, None, stride, padding, grad_input_padding, groups,
-        dilation)
+    return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
+                                               _pair(stride), _pair(padding), _pair(dilation),
+                                               False, [0], groups, (True, False, False))[0]
 
 
 def conv2d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation=1, groups=1):
@@ -190,33 +122,11 @@ def conv2d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation
         >>> F.grad.conv2d_weight(input, weight.shape, grad_output)
 
     """
-    stride = _pair(stride)
-    padding = _pair(padding)
-    dilation = _pair(dilation)
-    in_channels = input.shape[1]
-    out_channels = grad_output.shape[1]
-    min_batch = input.shape[0]
+    weight = grad_output.new_empty(weight_size)
 
-    grad_output = grad_output.contiguous().repeat(1, in_channels // groups, 1,
-                                                  1)
-    grad_output = grad_output.contiguous().view(
-        grad_output.shape[0] * grad_output.shape[1], 1, grad_output.shape[2],
-        grad_output.shape[3])
-
-    input = input.contiguous().view(1, input.shape[0] * input.shape[1],
-                                    input.shape[2], input.shape[3])
-
-    grad_weight = torch.conv2d(input, grad_output, None, dilation, padding,
-                               stride, in_channels * min_batch)
-
-    grad_weight = grad_weight.contiguous().view(
-        min_batch, grad_weight.shape[1] // min_batch, grad_weight.shape[2],
-        grad_weight.shape[3])
-
-    return grad_weight.sum(dim=0).view(
-        in_channels // groups, out_channels,
-        grad_weight.shape[2], grad_weight.shape[3]).transpose(0, 1).narrow(
-            2, 0, weight_size[2]).narrow(3, 0, weight_size[3])
+    return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
+                                               _pair(stride), _pair(padding), _pair(dilation),
+                                               False, [0], groups, (False, True, False))[1]
 
 
 def conv3d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=1, groups=1):
@@ -244,20 +154,11 @@ def conv3d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         >>> F.grad.conv3d_input(input.shape, weight, grad_output)
 
     """
-    stride = _triple(stride)
-    padding = _triple(padding)
-    dilation = _triple(dilation)
-    kernel_size = (weight.shape[2], weight.shape[3], weight.shape[4])
+    input = grad_output.new_empty(input_size)
 
-    if input_size is None:
-        raise ValueError("grad.conv3d_input requires specifying an input_size")
-
-    grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
-                                             padding, kernel_size, dilation)
-
-    return torch.conv_transpose3d(
-        grad_output, weight, None, stride, padding, grad_input_padding, groups,
-        dilation)
+    return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
+                                               _triple(stride), _triple(padding), _triple(dilation),
+                                               False, [0], groups, (True, False, False))[0]
 
 
 def conv3d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation=1, groups=1):
@@ -283,31 +184,8 @@ def conv3d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation
         >>> F.grad.conv3d_weight(input, weight.shape, grad_output)
 
     """
-    stride = _triple(stride)
-    padding = _triple(padding)
-    dilation = _triple(dilation)
-    in_channels = input.shape[1]
-    out_channels = grad_output.shape[1]
-    min_batch = input.shape[0]
+    weight = grad_output.new_empty(weight_size)
 
-    grad_output = grad_output.repeat(1, in_channels // groups, 1, 1, 1)
-    grad_output = grad_output.contiguous().view(
-        grad_output.shape[0] * grad_output.shape[1], 1, grad_output.shape[2],
-        grad_output.shape[3], grad_output.shape[4])
-
-    input = input.contiguous().view(1, input.shape[0] * input.shape[1],
-                                    input.shape[2], input.shape[3],
-                                    input.shape[4])
-
-    grad_weight = torch.conv3d(input, grad_output, None, dilation, padding,
-                               stride, in_channels * min_batch)
-
-    grad_weight = grad_weight.contiguous().view(
-        min_batch, grad_weight.shape[1] // min_batch, grad_weight.shape[2],
-        grad_weight.shape[3], grad_weight.shape[4])
-
-    return grad_weight.sum(dim=0).view(
-        in_channels // groups, out_channels, grad_weight.shape[2],
-        grad_weight.shape[3], grad_weight.shape[4]).transpose(0, 1).narrow(
-            2, 0, weight_size[2]).narrow(3, 0, weight_size[3]).narrow(
-                4, 0, weight_size[4])
+    return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
+                                               _triple(stride), _triple(padding), _triple(dilation),
+                                               False, [0], groups, (False, True, False))[1]

--- a/torch/nn/grad.py
+++ b/torch/nn/grad.py
@@ -29,7 +29,7 @@ def conv1d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         >>> F.grad.conv1d_input(input.shape, weight, grad_output)
 
     """
-    input = grad_output.new_empty(input_size)
+    input = grad_output.new_empty(1).expand(input_size)
 
     return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
                                                _single(stride), _single(padding), _single(dilation),
@@ -59,7 +59,7 @@ def conv1d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation
         >>> F.grad.conv1d_weight(input, weight.shape, grad_output)
 
     """
-    weight = grad_output.new_empty(weight_size)
+    weight = grad_output.new_empty(1).expand(weight_size)
 
     return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
                                                _single(stride), _single(padding), _single(dilation),
@@ -91,7 +91,7 @@ def conv2d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         >>> F.grad.conv2d_input(input.shape, weight, grad_output)
 
     """
-    input = grad_output.new_empty(input_size)
+    input = grad_output.new_empty(1).expand(input_size)
 
     return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
                                                _pair(stride), _pair(padding), _pair(dilation),
@@ -121,7 +121,7 @@ def conv2d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation
         >>> F.grad.conv2d_weight(input, weight.shape, grad_output)
 
     """
-    weight = grad_output.new_empty(weight_size)
+    weight = grad_output.new_empty(1).expand(weight_size)
 
     return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
                                                _pair(stride), _pair(padding), _pair(dilation),
@@ -153,7 +153,7 @@ def conv3d_input(input_size, weight, grad_output, stride=1, padding=0, dilation=
         >>> F.grad.conv3d_input(input.shape, weight, grad_output)
 
     """
-    input = grad_output.new_empty(input_size)
+    input = grad_output.new_empty(1).expand(input_size)
 
     return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
                                                _triple(stride), _triple(padding), _triple(dilation),
@@ -183,7 +183,7 @@ def conv3d_weight(input, weight_size, grad_output, stride=1, padding=0, dilation
         >>> F.grad.conv3d_weight(input, weight.shape, grad_output)
 
     """
-    weight = grad_output.new_empty(weight_size)
+    weight = grad_output.new_empty(1).expand(weight_size)
 
     return torch.ops.aten.convolution_backward(grad_output, input, weight, None,
                                                _triple(stride), _triple(padding), _triple(dilation),


### PR DESCRIPTION
`torch.nn.grad` has its own implementations of gradients for conv1d, conv2d, and conv3d. This PR simplifies them by calling into the unified `aten::convolution_backward` backend instead.

The existing implementation of conv2d_weight is incorrect for some inputs (see issue #51430). This PR fixes the issue.

This PR expands coverage in test_nn to include conv1d_weight, conv2d_weight, and conv3d_weight, which were previously untested. It also expands the cases for conv2d to cover issue #51430.

Fixes #51430
