### PR TITLE
add an env var for dispatcher debug logging

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -4,6 +4,11 @@
 
 namespace c10 {
 
+bool show_dispatch_trace() {
+    char const* temp = getenv("SHOW_DISPATCH_TRACE");
+    return temp != nullptr;
+}
+
 namespace detail {
 
 class RegistrationListenerList final {

--- a/aten/src/ATen/core/dispatch/Dispatcher.cpp
+++ b/aten/src/ATen/core/dispatch/Dispatcher.cpp
@@ -5,7 +5,7 @@
 namespace c10 {
 
 bool show_dispatch_trace() {
-    char const* temp = getenv("SHOW_DISPATCH_TRACE");
+    static char const* temp = getenv("TORCH_SHOW_DISPATCH_TRACE");
     return temp != nullptr;
 }
 


### PR DESCRIPTION
Partially addresses https://github.com/pytorch/pytorch/issues/81703

Committing a patch @zou3519 came up with a while ago - with a `DEBUG=1` build, you can now use `TORCH_SHOW_DISPATCH_TRACE=1 python script.py` to get chatty logs of all of the dispatcher calls that happened in a script.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #81890
* __->__ #81846

