### PR TITLE
a new section for ir generation

### DIFF
--- a/aten/src/ATen/native/ts_native_functions.yaml
+++ b/aten/src/ATen/native/ts_native_functions.yaml
@@ -168,6 +168,8 @@ full_codegen:
   - slice_scatter
   - diagonal_scatter
   - as_strided_scatter
+ir_gen:
+  - selu
 supported:
   - clone
   - _copy_from

--- a/tools/test/test_gen_backend_stubs.py
+++ b/tools/test/test_gen_backend_stubs.py
@@ -238,7 +238,7 @@ invalid_key: invalid_val"""
         output_error = self.get_errors_from_gen_backend_stubs(yaml_str)
         self.assertExpectedInline(
             output_error,
-            """ contains unexpected keys: invalid_key. Only the following keys are supported: backend, class_name, cpp_namespace, extra_headers, supported, autograd, full_codegen, non_native""",  # noqa: B950
+            """ contains unexpected keys: invalid_key. Only the following keys are supported: backend, class_name, cpp_namespace, extra_headers, supported, autograd, full_codegen, non_native, ir_gen""",  # noqa: B950
         )
 
     # if use_out_as_primary is provided, it must be a bool

--- a/torchgen/gen_backend_stubs.py
+++ b/torchgen/gen_backend_stubs.py
@@ -67,6 +67,7 @@ def parse_backend_yaml(
         "autograd",
         "full_codegen",
         "non_native",
+        "ir_gen",
     ]
 
     backend = yaml_values.pop("backend", None)
@@ -106,6 +107,9 @@ def parse_backend_yaml(
 
     # non_native is ignored by parse_backend_yaml, and re-parsed in gen_lazy_tensor.py
     non_native = yaml_values.pop("non_native", {})
+
+    # ir_gen is ignored by parse_backend_yaml, and re-parsed in gen_lazy_tensor.py
+    _ = yaml_values.pop("ir_gen", {})
 
     assert (
         len(yaml_values.keys()) == 0

--- a/torchgen/gen_lazy_tensor.py
+++ b/torchgen/gen_lazy_tensor.py
@@ -359,6 +359,11 @@ def run_gen_lazy_tensor(
     autograd_key = parsed_backend_yaml.autograd_key
     cpp_namespace = parsed_backend_yaml.cpp_namespace
     backend_indices = parsed_backend_yaml.backend_indices
+    # the following 3 keys are all processed differently
+    # for full_codegen, we generate IR, kernels, etc
+    # for ir_gen, we generate only IR
+    # non_native is used to register kernels not declared in
+    # native_functions.yaml
     full_codegen, non_native, ir_gen = parse_native_functions_keys(
         source_yaml, grouped_native_functions
     )

--- a/torchgen/gen_lazy_tensor.py
+++ b/torchgen/gen_lazy_tensor.py
@@ -105,7 +105,7 @@ ParsedExternalYaml = namedtuple(
 def parse_native_functions_keys(
     backend_yaml_path: str,
     grouped_native_functions: Sequence[Union[NativeFunction, NativeFunctionsGroup]],
-) -> Tuple[List[OperatorName], List[Any]]:
+) -> Tuple[List[OperatorName], List[Any], List[OperatorName]]:
 
     native_functions_map: Dict[OperatorName, NativeFunction] = {
         f.func.name: f
@@ -121,9 +121,13 @@ def parse_native_functions_keys(
 
     full_codegen = yaml_values.pop("full_codegen", [])
     non_native = yaml_values.pop("non_native", [])
+    ir_gen = yaml_values.pop("ir_gen", [])
     assert isinstance(full_codegen, list)
     assert isinstance(non_native, list)
-    return [OperatorName.parse(name) for name in full_codegen], non_native
+    assert isinstance(ir_gen, list)
+    full_codegen_opnames = [OperatorName.parse(name) for name in full_codegen]
+    ir_gen_opnames = [OperatorName.parse(name) for name in ir_gen]
+    return full_codegen_opnames, non_native, ir_gen_opnames
 
 
 def validate_shape_inference_header(
@@ -347,6 +351,7 @@ def run_gen_lazy_tensor(
     grouped_native_functions = sorted(
         grouped_native_functions, key=sort_native_function
     )
+
     parsed_backend_yaml = parse_backend_yaml(
         source_yaml, grouped_native_functions, backend_indices
     )
@@ -354,13 +359,14 @@ def run_gen_lazy_tensor(
     autograd_key = parsed_backend_yaml.autograd_key
     cpp_namespace = parsed_backend_yaml.cpp_namespace
     backend_indices = parsed_backend_yaml.backend_indices
-    full_codegen, non_native = parse_native_functions_keys(
+    full_codegen, non_native, ir_gen = parse_native_functions_keys(
         source_yaml, grouped_native_functions
     )
 
     def concat_map_codegen(
         func: Callable[[NativeFunction], Sequence[str]],
         xs: Iterable[Union[NativeFunctionsGroup, NativeFunction]],
+        ops_list: List[OperatorName] = full_codegen,
     ) -> Iterator[str]:
         """
         We code-gen for the functional variant, which is all we need for IR classes/lowerings/shape inferences, but we
@@ -370,7 +376,7 @@ def run_gen_lazy_tensor(
         for x in xs:
             fs = list(x.functions()) if isinstance(x, NativeFunctionsGroup) else [x]
             for f in fs:
-                if f.func.name in full_codegen:
+                if f.func.name in ops_list:
                     for r in func(f):
                         yield r
 
@@ -535,7 +541,9 @@ def run_gen_lazy_tensor(
             if node_base_hdr is not None
             else [],
             "ir_declarations": list(
-                concat_map_codegen(lazy_ir_obj, grouped_native_functions)
+                concat_map_codegen(
+                    lazy_ir_obj, grouped_native_functions, full_codegen + ir_gen
+                )
             ),
             "namespace_prologue": ns_helper.prologue,
             "namespace_epilogue": ns_helper.epilogue,


### PR DESCRIPTION
This is to get a conversation started.

* @JackCaoG we could add attributes to items in `ir_codegen` section to customize IR generation logic (e.g. not generating `::Lower`). Though it could be a bit tricky to thread it through.
* Adding an extra argument to `map_codegen` to filter native functions out seems like a step in the right direction. Otherwise, it's a bit confusing how do we go from a full list to a codegen list.

