### PR TITLE
Fix is_channels_last_ issue for channels last memory format

### DIFF
--- a/aten/src/ATen/test/memory_format_test.cpp
+++ b/aten/src/ATen/test/memory_format_test.cpp
@@ -23,6 +23,10 @@ TEST(MemoryFormatTest, SetMemoryFormat) {
   // Ambiguous case where we fallback to Contiguous;
   // This should be `EXPECT_TRUE(t.suggest_memory_format() == at::MemoryFormat::ChannelsLast);`
   EXPECT_TRUE(t.suggest_memory_format() == at::MemoryFormat::Contiguous);
+  t = at::rand({1, 2, 3, 4}).to(at::MemoryFormat::ChannelsLast);
+  t = t.reshape({1, 2, 3, 4});
+  // The stride of reshaped tensor is [2, 1, 8, 2].
+  EXPECT_TRUE(t.suggest_memory_format() == at::MemoryFormat::ChannelsLast);
 }
 
 TEST(MemoryFormatTest, TransposeMemoryFormat) {

--- a/c10/core/MemoryFormat.h
+++ b/c10/core/MemoryFormat.h
@@ -128,7 +128,13 @@ inline bool is_channels_last_strides_2d_s4(
     if (sizes[d] == 0) {
       return false;
     }
-    if (strides[d] < min) {
+    // Special case for channels_last format.
+    // channels_last tensor with sizes[0] == 1 ([1,C,H,W]@[CWH,1,CW,C]).
+    // Reshape tensor to the same shape ([1,C,H,W]@[C,1,CW,C]). issue #78611
+    // Reshaped tensor will get unexpected stride and
+    // is_channels_last_contiguous_ will be set to true. It should be identified
+    // as channels_last to align with is_channels_last_contiguous_.
+    if (strides[d] < min && !(d == 0 && sizes[0] == 1)) {
       return false;
     }
     // Fallback to NCHW as default layout for ambiguous cases
@@ -168,7 +174,7 @@ inline bool is_channels_last_strides_3d_s5(
     if (sizes[d] == 0) {
       return false;
     }
-    if (strides[d] < min) {
+    if (strides[d] < min && !(d == 0 && sizes[0] == 1)) {
       return false;
     }
     if (d == 0 && min == strides[1]) {

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1101,6 +1101,14 @@ class TestOldViewOps(TestCase):
         self.assertEqual(x.data_ptr(), x.reshape_as(torch.rand(1, 9, 1)).data_ptr())
         self.assertRaises(RuntimeError, lambda: x.reshape_as(torch.rand(10, device=device)))
 
+        x = torch.rand((1, 4, 3, 5)).to(memory_format=torch.channels_last)
+        y = x.reshape(1, 4, 3, 5)
+        self.assertEqual(x, y)
+
+        x = torch.rand((1, 4, 4, 3, 5)).to(memory_format=torch.channels_last_3d)
+        y = x.reshape(1, 4, 4, 3, 5)
+        self.assertEqual(x, y)
+
     def test_flatten(self, device):
         # Test that flatten returns 1-dim tensor when given a 0-dim tensor
         zero_dim_tensor = torch.tensor(123, device=device)


### PR DESCRIPTION
Fixes #78611 Reshape tensors witch are channels_last will get unexpected stride. The corresponding flags is_channels_last_contiguous_ will be set to true and is_channels_last_ is set to false.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10