### PR TITLE
Allow register float16 weight_norm on cpu and speed up test (#80600) …

### DIFF
--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -82,7 +82,10 @@ Tensor _weight_norm
   auto v = v_in.contiguous();
   auto g = g_in.contiguous();
 
-  bool can_use_fused = (dim == 0) || (dim == v.dim() - 1);
+  auto has_half_dtype = v.scalar_type() == at::ScalarType::Half
+    || g.scalar_type() == at::ScalarType::Half;
+
+  bool can_use_fused = !has_half_dtype && ((dim == 0) || (dim == v.dim() - 1));
 
   if (can_use_fused) {
     // weight_norm does not have a derivative defined for it, so this will route back through

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4420,14 +4420,14 @@ class TestNN(NNTestCase):
 
     def test_weight_norm(self):
         for dtype in [torch.float, torch.bfloat16]:
-            input = torch.randn(3, 40, dtype=dtype)
-            m = nn.Linear(40, 50).to(dtype=dtype)
+            input = torch.randn(3, 4, dtype=dtype)
+            m = nn.Linear(4, 5).to(dtype=dtype)
             expected_output = m(input)
 
             # add weight normalization
             m = torch.nn.utils.weight_norm(m)
             self.assertEqual(m.weight_v.size(), m.weight.size())
-            self.assertEqual(m.weight_g.size(), (50, 1))
+            self.assertEqual(m.weight_g.size(), (5, 1))
             self.assertEqual(m(input), expected_output, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
             # remove weight norm
@@ -4439,11 +4439,11 @@ class TestNN(NNTestCase):
             # test with dim=1
             m = torch.nn.utils.weight_norm(m, dim=1)
             self.assertEqual(m.weight_v.size(), m.weight.size())
-            self.assertEqual(m.weight_g.size(), (1, 40))
+            self.assertEqual(m.weight_g.size(), (1, 4))
             self.assertEqual(m(input), expected_output, atol=dtype2prec_DONTUSE[dtype], rtol=0)
 
             # test with dim=None
-            m = nn.Linear(40, 50).to(dtype=dtype)
+            m = nn.Linear(4, 5).to(dtype=dtype)
             expected_output = m(input)
             m = torch.nn.utils.weight_norm(m, dim=None)
             self.assertEqual(m(input), expected_output)
@@ -4451,6 +4451,12 @@ class TestNN(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, 'register two weight_norm hooks'):
                 m = torch.nn.utils.weight_norm(m)
                 m = torch.nn.utils.weight_norm(m)
+
+        # For float16, the forward of the Module doesn't work but we must still be able
+        # to register the weight norm as this is often done before sending the Module to
+        # CUDA.
+        m = nn.Linear(4, 5, dtype=torch.float16)
+        m = torch.nn.utils.weight_norm(m)
 
     def test_parameterlistdict_setting_attributes(self):
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
…(#80600)

Summary:
Fixes https://github.com/pytorch/pytorch/issues/80599

Pull Request resolved: https://github.com/pytorch/pytorch/pull/80600
Approved by: https://github.com/malfet

Test Plan: contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/c8d64ba5ec7ee4fb2594b00e022de611bc8f2ac4

Reviewed By: seemethere

Differential Revision: D37559049

Pulled By: albanD

fbshipit-source-id: 6a44fa9c8b898e2065cdb6b160b7279466f0dc7e

