### PR TITLE
[Prims] Unbreak CUDA lazy init (#80899) (#80899)

### DIFF
--- a/torch/_prims/utils.py
+++ b/torch/_prims/utils.py
@@ -7,8 +7,8 @@ import operator
 
 import torch
 
-# nvFuser imports are conditional on CUDA being available
-if torch.cuda.is_available():
+# nvFuser imports are conditional on being compiled with CUDA
+if hasattr(torch._C, "_nvfuser"):
     from torch._C._nvfuser import DataType  # type: ignore[import]
 
     _torch_dtype_to_nvfuser_dtype_map = {


### PR DESCRIPTION
Summary:
CUDA calls should not be made in the default codepath

Fixes https://github.com/pytorch/pytorch/issues/80876

Pull Request resolved: https://github.com/pytorch/pytorch/pull/80899
Approved by: https://github.com/ngimel

Test Plan: contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/b62209f047bddbef3c7b7ab822a70d5dd5596165

Reviewed By: mehtanirav

Differential Revision: D37648864

Pulled By: malfet

fbshipit-source-id: 9648e91cdcca96d9f76d873930e4ea2601bfb57d
