### PR TITLE
fix weight norm backward bug on CPU when OMP_NUM_THREADS <= 2 (#80930…

### DIFF
--- a/aten/src/ATen/native/cpu/WeightNormKernel.cpp
+++ b/aten/src/ATen/native/cpu/WeightNormKernel.cpp
@@ -328,8 +328,14 @@ void weight_norm_backward_last_dim_kernel(
   auto grad_v_data = grad_v.data_ptr<scalar_t>();
   auto grad_g_data = grad_g.data_ptr<scalar_t>();
 
+  // the temp buffer will be used twice:
+  // 1. vertical reduction from [M, N] to [T, N]
+  // 2. store the intermediate data of `sum`, `a` and `b`,
+  //    so need to make sure it has at least 3 rows
+  //
   int num_threads = at::get_num_threads();
-  Tensor buffer = at::empty({num_threads, N}, saved_norm.options()).zero_();
+  int K = std::max(3, num_threads);
+  Tensor buffer = at::empty({K, N}, saved_norm.options()).zero_();
   auto buffer_data = buffer.data_ptr<accscalar_t>();
 
   // vertical parallel reduction
@@ -351,6 +357,9 @@ void weight_norm_backward_last_dim_kernel(
     buffer_data[j] = sum;
   }
 
+  // reuse the 1st row of buffer to store the sum
+  // 2nd row to store coefficient a
+  // 3rd row to store coefficient b
   accscalar_t* per_dim_sum = buffer_data;
   accscalar_t* a = buffer_data + N;
   accscalar_t* b = buffer_data + 2 * N;


### PR DESCRIPTION
…) (#80930)

Summary:
fix https://github.com/pytorch/pytorch/issues/80569
root cause: `weight_norm_backward_last_dim_kernel` will create a temp buffer to
do vertical reduction, size of [num_threads, N] (N is the size of last dimension of v)

to save additional memory allocation, the original kernel reuse the buffer after
the vertical sum:
  1st row stores the final result of sum
  2nd row stores coefficient a
  3rd row stores coefficient b

when OMP_NUM_THREADS <=2, this will cause illegal memory access since the buffer size
will be only 1*N or 2*N;

the fix is use a separate buffer (`a_b`) to store the coefficients of a and b.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/80930
Approved by: https://github.com/frank-wei, https://github.com/malfet

Test Plan: contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/6ee54a878081f4ebde074dfc028ae181be70f290

Reviewed By: mehtanirav

Differential Revision: D37687546

Pulled By: mehtanirav

fbshipit-source-id: 5df39c9584f310722ae6901044f35c44d2c7c091

