### PR TITLE
ci: Fix mac names, bump builds to bigger runner

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -134,7 +134,7 @@ jobs:
       IOS_SIGN_KEY_2022: ${{ secrets.IOS_SIGN_KEY_2022 }}
 
   macos-12-py3-x86-64-build:
-    name: macos-12-py3-x86-64-build
+    name: macos-12-py3-x86-64
     uses: ./.github/workflows/_mac-build.yml
     with:
       build-environment: macos-12-py3-x86-64
@@ -146,7 +146,7 @@ jobs:
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
   macos-12-py3-x86-64-test:
-    name: macos-12-py3-x86-64-test
+    name: macos-12-py3-x86-64
     uses: ./.github/workflows/_mac-test.yml
     needs: macos-12-py3-x86-64-build
     with:
@@ -160,8 +160,8 @@ jobs:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
 
-  macos-10-py3-x86-64-lite-interpreter-build:
-    name: macos-10-py3-x86-64-lite-interpreter-build
+  macos-10-py3-x86-64-lite-interpreter-build-test:
+    name: macos-10-py3-x86-64-lite-interpreter
     uses: ./.github/workflows/_mac-build.yml
     with:
       build-environment: macos-10-py3-lite-interpreter-x86-64
@@ -173,7 +173,7 @@ jobs:
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
   macos-12-py3-arm64-build:
-    name: macos-12-py3-arm64-build
+    name: macos-12-py3-arm64
     uses: ./.github/workflows/_mac-build.yml
     with:
       build-environment: macos-12-py3-arm64
@@ -185,7 +185,7 @@ jobs:
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
   macos-12-py3-arm64-mps-test:
-    name: macos-12-py3-arm64-mps-test
+    name: macos-12-py3-arm64
     uses: ./.github/workflows/_mac-test-arm64.yml
     needs: macos-12-py3-arm64-build
     with:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -133,24 +133,24 @@ jobs:
       IOS_DEV_TEAM_ID: ${{ secrets.IOS_DEV_TEAM_ID}}
       IOS_SIGN_KEY_2022: ${{ secrets.IOS_SIGN_KEY_2022 }}
 
-  macos-11-py3-x86-64-build:
-    name: macos-11-py3-x86-64
+  macos-12-py3-x86-64-build:
+    name: macos-12-py3-x86-64-build
     uses: ./.github/workflows/_mac-build.yml
     with:
-      build-environment: macos-11-py3-x86-64
+      build-environment: macos-12-py3-x86-64
       xcode-version: "13.3.1"
-      runner-type: macos-12
+      runner-type: macos-12-xl
       build-generates-artifacts: true
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
-  macos-11-py3-x86-64-test:
-    name: macos-11-py3-x86-64
+  macos-12-py3-x86-64-test:
+    name: macos-12-py3-x86-64-test
     uses: ./.github/workflows/_mac-test.yml
-    needs: macos-11-py3-x86-64-build
+    needs: macos-12-py3-x86-64-build
     with:
-      build-environment: macos-11-py3-x86-64
+      build-environment: macos-12-py3-x86-64
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 2, runner: "macos-12" },
@@ -160,11 +160,11 @@ jobs:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
 
-  macos-10-15-py3-lite-interpreter-x86-64:
-    name: macos-10-15-py3-lite-interpreter-x86-64
+  macos-10-py3-x86-64-lite-interpreter-build:
+    name: macos-10-py3-x86-64-lite-interpreter-build
     uses: ./.github/workflows/_mac-build.yml
     with:
-      build-environment: macos-10-15-py3-lite-interpreter-x86-64
+      build-environment: macos-10-py3-lite-interpreter-x86-64
       xcode-version: "12"
       runner-type: macos-10.15
       build-generates-artifacts: false
@@ -172,24 +172,24 @@ jobs:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
-  macos-10-15-py3-arm64:
-    name: macos-10-15-py3-arm64
+  macos-12-py3-arm64-build:
+    name: macos-12-py3-arm64-build
     uses: ./.github/workflows/_mac-build.yml
     with:
-      build-environment: macos-10-15-py3-arm64
+      build-environment: macos-12-py3-arm64
       xcode-version: "13.3.1"
-      runner-type: macos-12
+      runner-type: macos-12-xl
       build-generates-artifacts: true
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
       MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
 
-  macos-12-3-py38-arm64-test:
-    name: macos-12.3-py3.8-arm64-test
+  macos-12-py3-arm64-mps-test:
+    name: macos-12-py3-arm64-mps-test
     uses: ./.github/workflows/_mac-test-arm64.yml
-    needs: macos-10-15-py3-arm64
+    needs: macos-12-py3-arm64-build
     with:
-      build-environment: macos-10-15-py3-arm64
+      build-environment: macos-12-py3-arm64
 
   win-vs2019-cuda11_6-py3-build:
     name: win-vs2019-cuda11.6-py3


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #81882
* __->__ #81874

Mac names were inconsistent so I changed them to be more reflective of
what they're actually testing. As well wanted to update the builders for
the build portions to run on more powerful runners to reduce tts

Some data:
* Cuts build time by 2/3 for `arm64` cross builds:
  * [Trunk](https://github.com/pytorch/pytorch/runs/7447691552?check_suite_focus=true): 1h 22min
  * [This PR](https://github.com/pytorch/pytorch/runs/7449648493?check_suite_focus=true): 30 min
* Similar speed ups for `x86`:
  * [Trunk](https://github.com/pytorch/pytorch/runs/7447691171?check_suite_focus=true): 1h 47min
  * [This PR](https://github.com/pytorch/pytorch/runs/7449647307?check_suite_focus=true): 41min

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>