### PR TITLE
Don't error if _warned_capturable_if_run_uncaptured not set (#80345) …

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -90,7 +90,11 @@ class Optimizer(object):
                                    self.__class__.__name__ +
                                    " but this instance was constructed with capturable=False.")
 
-            if (not self._warned_capturable_if_run_uncaptured) and self.defaults['capturable'] and (not capturing):
+            if (
+                (not getattr(self, "_warned_capturable_if_run_uncaptured", False))
+                and self.defaults["capturable"]
+                and (not capturing)
+            ):
                 print("Warning: This instance was constructed with capturable=True, but step() " +
                       "is running without CUDA graph capture. If you never intend to graph-capture this " +
                       "instance, capturable=True can impair performance, and you should set capturable=False.")


### PR DESCRIPTION
…(#80345)

Summary:
This can happen if an optimizer was pickled.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Pull Request resolved: https://github.com/pytorch/pytorch/pull/80345
Approved by: https://github.com/malfet, https://github.com/albanD

Test Plan: contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/57f001f35a22952d4f39a33c739b447c10136a7f

Reviewed By: b0noI

Differential Revision: D37523001

Pulled By: ezyang

fbshipit-source-id: 750884421d3f398695c24c351d8d6b26a501045a

