### PR TITLE
ci: bump lite interpreter to macOS 12

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -165,7 +165,7 @@ jobs:
     uses: ./.github/workflows/_mac-build.yml
     with:
       build-environment: macos-12-py3-lite-interpreter-x86-64
-      xcode-version: "12"
+      xcode-version: "13.3.1"
       runner-type: macos-12-xl
       build-generates-artifacts: false
     secrets:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -160,13 +160,13 @@ jobs:
       AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_V2_ACCESS_KEY_ID }}
       AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_V2_SECRET_ACCESS_KEY }}
 
-  macos-10-py3-x86-64-lite-interpreter-build-test:
-    name: macos-10-py3-x86-64-lite-interpreter
+  macos-12-py3-x86-64-lite-interpreter-build-test:
+    name: macos-12-py3-x86-64-lite-interpreter
     uses: ./.github/workflows/_mac-build.yml
     with:
-      build-environment: macos-10-py3-lite-interpreter-x86-64
+      build-environment: macos-12-py3-lite-interpreter-x86-64
       xcode-version: "12"
-      runner-type: macos-10.15
+      runner-type: macos-12-xl
       build-generates-artifacts: false
     secrets:
       MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #81882
* #81874

Don't know if there's a reason for this to be on 10.15 but Github is
going to eventually deprecate these runners so better to just move this
up rather than suffer the wrath of using a deprecated runner

<img width="1198" alt="Screen Shot 2022-07-21 at 3 23 58 PM" src="https://user-images.githubusercontent.com/1700823/180238298-54d02954-3e7c-4e28-852c-c99203bea322.png">

Reference: https://github.com/pytorch/pytorch/actions/runs/2712176357

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>