### PR TITLE
[DataLoader] Locking lower ranks seed recepients (#81071) (#81071)

### DIFF
--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -592,7 +592,12 @@ class DataLoader(Generic[T_co]):
                         time.sleep(_utils.DATAPIPE_SHARED_SEED_CHECK_INTERVAL)
                         _shared_seed_str = store.get(_utils.DATAPIPE_SHARED_SEED)
                     logger.info(f"Shared seed ({_shared_seed_str}) received from store on rank {rank}")
-                    store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 1)
+                    _shared_seed_recv_cnt = store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 1)
+                    # Exit only when all ranks received seed, otherwise we are at risk that current rank
+                    # will reach same section of the code again while rank zero still in the previous iteration
+                    while _shared_seed_recv_cnt > 0:
+                        time.sleep(_utils.DATAPIPE_SHARED_SEED_CHECK_INTERVAL)
+                        _shared_seed_recv_cnt = store.add(_utils.DATAPIPE_SHARED_SEED_COUNTER, 0)
                     _shared_seed = int(_shared_seed_str)
             return _shared_seed
         else:


### PR DESCRIPTION
Summary:
Exit seed receiving section only when all ranks received seed, otherwise we are at risk that current rank
will reach same section of the code again while rank zero still in the previous iteration

Fixes: #80845

Pull Request resolved: https://github.com/pytorch/pytorch/pull/81071
Approved by: https://github.com/msaroufim, https://github.com/ejguan

Test Plan:
contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/e9b3bc2eadb8ffe10c002abcd5a34a5b7d36f390

Original Phabricator Test Plan:
Imported from OSS

Reviewed By: mehtanirav, ejguan

Differential Revision: D37702557

Pulled By: VitalyFedyunin

fbshipit-source-id: 51dd950e1bfc2c984a4ddbe6481e225023b0a202