### PR TITLE
Raise proper timeout when sharing the distributed shared seed (#81666…

### DIFF
--- a/torch/utils/data/_utils/__init__.py
+++ b/torch/utils/data/_utils/__init__.py
@@ -40,6 +40,11 @@ r"""The key to share the same seed for shuffle DataPipe across distributed proce
 DATAPIPE_SHARED_SEED_COUNTER = "_dl_shared_seed_recv_cnt"
 r"""The key to count the number of distributed processes that have received the shared seed"""
 
+DATAPIPE_SHARED_SEED_DEFAULT_TIMEOUT = 30 * 60
+r"""Timeout (in seconds) sending the shared seed from Rank 0 and sending
+    the signal of the shared seed received from other Ranks.
+    It uses the same default timeout for the distributed process group"""
+
 DATAPIPE_SHARED_SEED_CHECK_INTERVAL = 0.01
 r"""Interval to check if each rank has received the shared seed"""
 


### PR DESCRIPTION
…) (#81666)

Summary:
Fixes https://github.com/pytorch/data/issues/659

- This would fix the problem that a slow DataLoader on rank 0 would cause TimeoutError as I have removed the `wait` operation on other Ranks.
- This PR also adds a [default timeout](https://github.com/pytorch/pytorch/blob/f6a45f79841fb7cdc4dfa294dbdd66d7e4b75c18/torch/csrc/distributed/c10d/ProcessGroup.hpp#L26-L27) as 30 * 60 seconds (taking reference from the distributed team's implementation). When the distributed seed is stuck on any rank, a proper timeout with detailed message will be raised.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/81666
Approved by: https://github.com/NivekT

Test Plan: contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/aa1466d542c6addd5719f268f57ccdcbc0dbf84f

Reviewed By: jeanschmidt

Differential Revision: D37990752

Pulled By: ejguan

fbshipit-source-id: 41639341aa737ab64de1992db5ed43cbb110ec91
