### PR TITLE
Move away from deprecated 10.15 runners for ios tests

### DIFF
--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -48,7 +48,7 @@ jobs:
     # NOTE: These builds will not run successfully without running on `pytorch/pytorch` due to the limitations
     #       of accessing secrets from forked pull requests and IOS' dependency on secrets for their build/test
     if: github.repository_owner == 'pytorch'
-    runs-on: macos-10.15
+    runs-on: macos-12
     timeout-minutes: 240
     env:
       IOS_CERT_KEY_2022: ${{ secrets.IOS_CERT_KEY_2022 }}


### PR DESCRIPTION
GH is deprecating these and failing a bunch of workflows today: https://hud.pytorch.org/pytorch/pytorch/commit/8d0cbce0696e76c9e4c929c24c0331df25125b40