### PR TITLE
Introduce MetadataIndex and helper to use it.

### DIFF
--- a/test/distributed/_shard/checkpoint/test_utils.py
+++ b/test/distributed/_shard/checkpoint/test_utils.py
@@ -48,7 +48,7 @@ def create_sharded_tensor(rank, world_size, shards_per_rank):
     sharded_tensor_md = ShardedTensorMetadata(
         shards_metadata=shards_metadata,
         size=torch.Size([8 * len(shards_metadata)]),
-        tensor_properties=TensorProperties.create_for_tensor(torch.zeros(1))
+        tensor_properties=TensorProperties.create_from_tensor(torch.zeros(1))
     )
 
     return ShardedTensor._init_from_local_shards_and_global_metadata(

--- a/test/distributed/_shard/checkpoint/test_utils.py
+++ b/test/distributed/_shard/checkpoint/test_utils.py
@@ -1,0 +1,127 @@
+# Owner(s): ["oncall: distributed"]
+
+import sys
+
+import torch
+
+from torch.distributed._shard.sharded_tensor import (
+    Shard,
+    ShardMetadata,
+    ShardedTensor,
+    ShardedTensorMetadata,
+)
+from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
+
+from torch.testing._internal.common_utils import (
+    TestCase,
+    TEST_WITH_DEV_DBG_ASAN,
+    run_tests,
+)
+from torch.distributed._shard.checkpoint.utils import find_state_dict_object
+from torch.distributed._shard.checkpoint.metadata import MetadataIndex
+from torch.testing._internal.distributed.distributed_utils import (
+    with_fake_comms
+)
+
+if TEST_WITH_DEV_DBG_ASAN:
+    print(
+        "Skip dev-asan as torch + multiprocessing spawn have known issues",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+def create_sharded_tensor(rank, world_size, shards_per_rank):
+    shards_metadata = []
+    local_shards = []
+    for idx in range(0, world_size * shards_per_rank):
+        shard_rank = idx // shards_per_rank
+        shard_md = ShardMetadata(shard_offsets=[idx * 8], shard_sizes=[8], placement=f"rank:{shard_rank}/cpu")
+        shards_metadata.append(shard_md)
+        if shard_rank == rank:
+            shard = Shard.from_tensor_and_offsets(
+                torch.rand(*shard_md.shard_sizes),
+                shard_offsets=shard_md.shard_offsets,
+                rank=rank
+            )
+            local_shards.append(shard)
+
+    sharded_tensor_md = ShardedTensorMetadata(
+        shards_metadata=shards_metadata,
+        size=torch.Size([8 * len(shards_metadata)]),
+        tensor_properties=TensorProperties.create_for_tensor(torch.zeros(1))
+    )
+
+    return ShardedTensor._init_from_local_shards_and_global_metadata(
+        local_shards=local_shards,
+        sharded_tensor_metadata=sharded_tensor_md
+    )
+
+
+class TestMedatadaIndex(TestCase):
+    def test_init_convert_offset(self):
+        a = MetadataIndex("foo", [1, 2])
+        b = MetadataIndex("foo", torch.Size([1, 2]))
+        self.assertEqual(a, b)
+
+    def test_index_hint_ignored_on_equals(self):
+        a = MetadataIndex("foo")
+        b = MetadataIndex("foo", index=99)
+        self.assertEqual(a, b)
+
+    def test_index_hint_ignored_on_hash(self):
+        a = MetadataIndex("foo")
+        b = MetadataIndex("foo", index=99)
+        self.assertEqual(hash(a), hash(b))
+
+    def test_flat_data(self):
+        state_dict = {
+            "a": torch.rand(10),
+            "b": [1, 2, 3],
+        }
+
+        a = find_state_dict_object(state_dict, MetadataIndex("a"))
+        self.assertEqual(a, state_dict["a"])
+        a = find_state_dict_object(state_dict, MetadataIndex("a", index=99))
+        self.assertEqual(a, state_dict["a"])
+
+        b = find_state_dict_object(state_dict, MetadataIndex("b"))
+        self.assertEqual(b, state_dict["b"])
+        b = find_state_dict_object(state_dict, MetadataIndex("b", index=1))
+        self.assertEqual(b, state_dict["b"])
+
+        with self.assertRaisesRegex(ValueError, "FQN"):
+            find_state_dict_object(state_dict, MetadataIndex("c"))
+        with self.assertRaisesRegex(ValueError, "ShardedTensor"):
+            find_state_dict_object(state_dict, MetadataIndex("a", [0]))
+        with self.assertRaisesRegex(ValueError, "ShardedTensor"):
+            find_state_dict_object(state_dict, MetadataIndex("b", [1]))
+
+    @with_fake_comms(rank=0, world_size=2)
+    def test_sharded_tensor_lookup(self):
+        st = create_sharded_tensor(rank=0, world_size=2, shards_per_rank=3)
+        state_dict = {"st": st}
+
+        obj = find_state_dict_object(state_dict, MetadataIndex("st", [8]))
+        self.assertEqual(obj, st.local_shards()[1].tensor)
+
+        # good hint
+        obj = find_state_dict_object(state_dict, MetadataIndex("st", [8], index=1))
+        self.assertEqual(obj, st.local_shards()[1].tensor)
+
+        # bad hint
+        obj = find_state_dict_object(state_dict, MetadataIndex("st", [8], index=2))
+        self.assertEqual(obj, st.local_shards()[1].tensor)
+
+        # broken hint
+        obj = find_state_dict_object(state_dict, MetadataIndex("st", [8], index=99))
+        self.assertEqual(obj, st.local_shards()[1].tensor)
+
+        with self.assertRaisesRegex(ValueError, "no offset was provided"):
+            find_state_dict_object(state_dict, MetadataIndex("st"))
+
+        with self.assertRaisesRegex(ValueError, "Could not find shard"):
+            find_state_dict_object(state_dict, MetadataIndex("st", [1]))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/_shard/checkpoint/metadata.py
+++ b/torch/distributed/_shard/checkpoint/metadata.py
@@ -92,7 +92,16 @@ class MetadataIndex:
     """If the object is a tensor, offset into the tensor we're looking for"""
 
     index: Optional[int] = field(hash=False, compare=False, default=None)
-    """Index hint when searching for tensor chunk to speedup lookups (optional)"""
+    """
+    Index hint when searching for tensor chunk to speedup lookups (optional)
+
+    A common representation of a sharded tensor is as a list of chunks so to
+    find the index in such a list you need to linear search it.
+
+    When constructing an instance of MetadataIndex that points to that list,
+    one can provide the index as a hint and it will be probed first before
+    the linear search and thus making it significantly faster.
+    """
 
     def __init__(self, fqn: str, offset: Optional[Sequence[int]] = None, index: Optional[int] = None):
         # We must use object.__setattr__ due to frozen=True

--- a/torch/distributed/_shard/checkpoint/metadata.py
+++ b/torch/distributed/_shard/checkpoint/metadata.py
@@ -1,6 +1,6 @@
 import io
-from dataclasses import dataclass
-from typing import Dict, List, Tuple, Union
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple, Union, Optional, Sequence, Any
 
 import torch
 from torch.distributed._shard.sharded_tensor import (
@@ -10,6 +10,7 @@ from torch.distributed._shard.sharded_tensor import (
 )
 
 TENSOR_TYPE = Union[torch.Tensor, ShardedTensor]
+STATE_DICT_TYPE = Dict[str, Any]
 
 @dataclass
 class ShardStorageMetadata:
@@ -77,3 +78,25 @@ class TensorReadRequest:
     # offset and length w.r.t. to the storage identified by ``storage_key``
     offsets: Tuple[int, ...]
     lengths: Tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class MetadataIndex:
+    """
+    This class represents a lookup key for items in a state dict or Metadata.
+    """
+    fqn: str
+    """Fully Qualified Name of the object"""
+
+    offset: Optional[torch.Size] = None
+    """If the object is a tensor, offset into the tensor we're looking for"""
+
+    index: Optional[int] = field(hash=False, compare=False, default=None)
+    """Index hint when searching for tensor chunk to speedup lookups (optional)"""
+
+    def __init__(self, fqn: str, offset: Optional[Sequence[int]] = None, index: Optional[int] = None):
+        # We must use object.__setattr__ due to frozen=True
+        object.__setattr__(self, "fqn", fqn)
+        object.__setattr__(self, "index", index)
+        if offset is not None:
+            object.__setattr__(self, "offset", torch.Size(offset))

--- a/torch/distributed/_shard/sharded_tensor/metadata.py
+++ b/torch/distributed/_shard/sharded_tensor/metadata.py
@@ -59,7 +59,7 @@ class TensorProperties(object):
         self.memory_format = memory_format
 
     @staticmethod
-    def create_for_tensor(tensor: torch.Tensor) -> "TensorProperties":
+    def create_from_tensor(tensor: torch.Tensor) -> "TensorProperties":
         return TensorProperties(
             dtype=tensor.dtype,
             layout=tensor.layout,

--- a/torch/distributed/_shard/sharded_tensor/metadata.py
+++ b/torch/distributed/_shard/sharded_tensor/metadata.py
@@ -58,6 +58,15 @@ class TensorProperties(object):
 
         self.memory_format = memory_format
 
+    @staticmethod
+    def create_for_tensor(tensor: torch.Tensor) -> "TensorProperties":
+        return TensorProperties(
+            dtype=tensor.dtype,
+            layout=tensor.layout,
+            requires_grad=tensor.requires_grad,
+            memory_format=torch.contiguous_format,
+            pin_memory=tensor.is_pinned()
+        )
 @dataclass
 class ShardedTensorMetadata(object):
     """

--- a/torch/testing/_internal/distributed/distributed_utils.py
+++ b/torch/testing/_internal/distributed/distributed_utils.py
@@ -1,0 +1,62 @@
+from contextlib import contextmanager
+from datetime import timedelta
+from functools import (
+    partial,
+    wraps,
+)
+
+import torch.distributed as dist
+
+class MockProcessGroup(dist.ProcessGroup):
+
+    def __init__(self, rank, world):
+        super(MockProcessGroup, self).__init__(rank, world)
+
+    def getBackendName(self):
+        return "mock_process_group"
+
+def create_mock_pg(prefix_store, rank, world_size, timeout):
+    return MockProcessGroup(rank, world_size)
+
+dist.Backend.register_backend('mock_process_group', create_mock_pg)
+
+def mock_init_dist(rank, world_size):
+    # !!! WARNING !!!
+    # Kids don't try this at home, this is a cute pile of hacks that
+    # depends on a small mountain of c10d internals
+    assert not dist.is_initialized()
+    store = dist.HashStore()
+    # Trick _store_based_barrier into believing everyone else already checked-in
+    store.add("store_based_barrier_key:0", world_size - 1)
+    dist.init_process_group(
+        backend="mock_process_group",
+        rank=rank,
+        world_size=world_size,
+        store=store,
+        group_name="fake",
+        timeout=timedelta(seconds=1))
+
+@contextmanager
+def with_dist(rank=0, world_size=2):
+    """
+    Context manager that initializer c10d with a fake process group.
+    """
+    mock_init_dist(rank=rank, world_size=world_size)
+    try:
+        yield
+    finally:
+        dist.destroy_process_group()
+
+def with_fake_comms(func=None, rank=0, world_size=2):
+    """
+    Function wrapper that inits a fake process group designed for testing.
+    Right now only querying for world size is available
+    """
+    if func is None:
+        return partial(with_fake_comms, rank=rank, world_size=world_size)
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with with_dist(rank, world_size):
+            func(self)
+    return wrapper


### PR DESCRIPTION
MetadataIndex simplifies indexing into state dict and Metadata.

This includes a find_state_dict_object helper that searcher into a state dict.

This PR doesn't include search over Metadata at it requires changes that will land
in a subsequent PR.

