### PR TITLE
Change functorch pin mechanism to test functorch in pytorch/pytorch

### DIFF
--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -139,15 +139,9 @@ function checkout_install_torchdynamo() {
   popd
 }
 
-function checkout_install_functorch() {
-  local commit
-  commit=$(get_pinned_commit functorch)
-  pushd ..
-  git clone https://github.com/pytorch/functorch
+function install_functorch() {
   pushd functorch
-  git checkout "${commit}"
   time python setup.py develop
-  popd
   popd
 }
 

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -603,7 +603,7 @@ test_dynamo() {
 }
 
 test_functorch() {
-  pushd ../functorch
+  pushd functorch
   pytest test
   popd
 }
@@ -688,7 +688,7 @@ elif [[ "${BUILD_ENVIRONMENT}" == *-mobile-lightweight-dispatch* ]]; then
 elif [[ "${TEST_CONFIG}" = docs_test ]]; then
   test_docs_test
 elif [[ "${TEST_CONFIG}" == *functorch* ]]; then
-  checkout_install_functorch
+  install_functorch
   test_functorch
 else
   install_torchvision


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #81936
* #81925
* #81924
* #81919
* __->__ #81918

We've moved functorch into pytorch/pytorch. Previously, there was a pin
mechanism that tested pytorch/pytorch against a specific commit in the
pytorch/functorch repository.

This PR changes it so that PyTorch CI tests the functorch inside
pytorch/pytorch instead of the functorch in pytorch/functorch.

Test Plan:
- wait for the functorch build+test job (there is only one)