### PR TITLE
Add more functorch shards to PR CI

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -171,7 +171,7 @@ jobs:
           { config: "default", shard: 4, num_shards: 4, runner: "linux.4xlarge.nvidia.gpu" },
           { config: "distributed", shard: 1, num_shards: 2, runner: "linux.8xlarge.nvidia.gpu" },
           { config: "distributed", shard: 2, num_shards: 2, runner: "linux.8xlarge.nvidia.gpu" },
-          { config: "functorch", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
+          { config: "functorch", shard: 1, num_shards: 1, runner: "linux.4xlarge.nvidia.gpu" },
         ]}
 
   linux-xenial-py3-clang5-mobile-build:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -37,6 +37,7 @@ jobs:
           { config: "docs_test", shard: 1, num_shards: 1,  runner: "linux.2xlarge" },
           { config: "jit_legacy", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
           { config: "backwards_compat", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
+          { config: "functorch", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
         ]}
 
   linux-docs:
@@ -170,6 +171,7 @@ jobs:
           { config: "default", shard: 4, num_shards: 4, runner: "linux.4xlarge.nvidia.gpu" },
           { config: "distributed", shard: 1, num_shards: 2, runner: "linux.8xlarge.nvidia.gpu" },
           { config: "distributed", shard: 2, num_shards: 2, runner: "linux.8xlarge.nvidia.gpu" },
+          { config: "functorch", shard: 1, num_shards: 1, runner: "linux.2xlarge" },
         ]}
 
   linux-xenial-py3-clang5-mobile-build:

--- a/functorch/test/test_ops.py
+++ b/functorch/test/test_ops.py
@@ -1293,9 +1293,11 @@ class TestOperators(TestCase):
 
         # numerical inconsistencies, look like bugs
         skip('ldexp', dtypes=(torch.float32,), device_type='cpu'),  # fails on all but mac
-        skip('__rmatmul__', dtypes=(torch.float32,), device_type='cpu'),  # fails on all but windows
-        skip('matmul', dtypes=(torch.float32,), device_type='cpu'),  # fails on all but windows
-        skip('nn.functional.conv_transpose3d', dtypes=(torch.float32,)),  # only fails on cpu only linux
+        skip('__rmatmul__', dtypes=(torch.float32,)),  # fails on all but windows
+        skip('matmul', dtypes=(torch.float32,)),  # fails on all but windows
+        skip('nn.functional.conv_transpose3d', dtypes=(torch.float32,)),
+        skip('nn.functional.conv_transpose2d', dtypes=(torch.float32,)),
+        skip('nn.functional.conv_transpose1d', dtypes=(torch.float32,)),
         skip('nn.functional.layer_norm', dtypes=(torch.float32,), device_type='cpu'),  # fails on windows
         skip('linalg.lu_factor', dtypes=(torch.float32,), device_type='cuda'),  # fails on all but windows
         skip('linalg.lu_factor_ex', dtypes=(torch.float32,), device_type='cuda'),  # fails on all but windows


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #81936
* #81925
* #81924
* __->__ #81919
* #81918

This PR adds functorch shards to some more linux configurations on Pull
Requests. What's missing so far (and coming in the near future) is:
- adding a shard for windows
- adding a shard for asan (functorch currently times out under asan)
- adding shards for things that run in trunk, like mac-os.

Test Plan:
- wait for tests