### PR TITLE
DDP: Get static graph to print unused parameters in debug mode.

### DIFF
--- a/torch/csrc/distributed/c10d/reducer.cpp
+++ b/torch/csrc/distributed/c10d/reducer.cpp
@@ -554,6 +554,37 @@ void Reducer::delay_all_reduce() {
     }
   }
 
+  // To avoid confusion around why static graph is picking up
+  // some parameters as unused on a rank vs not, we log
+  // unused parameter names for each rank for better
+  // debugability when TORCH_DISTRIBUTED_DEBUG is set to
+  // INFO or DETAIL
+  if (ddp_debug_level_ != c10d::DebugLevel::Off) {
+    // construct one string to output
+    std::ostringstream unused_params_stream;
+
+    for (const auto& unused_index : unused_parameters_) {
+      auto param_name = param_names_.find(unused_index);
+      TORCH_INTERNAL_ASSERT(
+          param_name != param_names_.end(),
+          "Expected to find parameter name from unused parameters map in debug mode.");
+      // Add the param_name
+      unused_params_stream << "{" << param_name->second << "," << unused_index
+                           << "}";
+    }
+
+    // Each rank prints out all the unused parameters detected
+    if (unused_parameters_.size() > 0) {
+      LOG(INFO) << "[Rank " << process_group_->getRank() << "]: "
+                << "Parameter(s) (in the format of {param_name, index}): "
+                << unused_params_stream.str()
+                << " is(are) unused during first iteration. Since"
+                << " static_graph=True is enabled for DDP, we expect"
+                << " this set of unused parameters to remain consistent"
+                << " on this rank throughout the training.";
+    }
+  }
+
   // launch all reduces for all buckets
   for (auto& bucket : buckets_) {
     all_reduce_bucket(bucket);


### PR DESCRIPTION
Fixes #68833

Test Toy Model: 
```
    class ToyModel(nn.Module):
        def __init__(self):
            super(ToyModel, self).__init__()
            # net1, bias are all unused params.
            self.net1 = nn.Linear(10, 5, bias=False)
            self.bias = nn.Parameter(torch.zeros(5))
            self.net2 = nn.Linear(10, 5)

        def forward(self, x):
            return self.net2(x).sum()
```

With this PR, the following output can be observed (using 4 Ranks, and with export TORCH_CPP_LOG_LEVEL=0 and export TORCH_DISTRIBUTED_DEBUG=INFO (or export TORCH_DISTRIBUTED_DEBUG=DETAIL), torch.nn.parallel.DistributedDataParallel with static_graph set to true): 

[I reducer.cpp:578] [Rank 0]: Parameter(s) (in the format of {param_name, index}): {.bias,0}{net1.weight,1} is(are) unused
during first iteration. Since static_graph=True is enabled for DDP, we expect this set of unused parameters to remain consi
stent on this rank throughout the training.                      
[I reducer.cpp:578] [Rank 3]: Parameter(s) (in the format of {param_name, index}): {.bias,0}{net1.weight,1} is(are) unused
during first iteration. Since static_graph=True is enabled for DDP, we expect this set of unused parameters to remain consi
stent on this rank throughout the training.                                                          
[I reducer.cpp:578] [Rank 2]: Parameter(s) (in the format of {param_name, index}): {.bias,0}{net1.weight,1} is(are) unused
during first iteration. Since static_graph=True is enabled for DDP, we expect this set of unused parameters to remain consi
stent on this rank throughout the training.                                                            
[I reducer.cpp:578] [Rank 1]: Parameter(s) (in the format of {param_name, index}): {.bias,0}{net1.weight,1} is(are) unused
during first iteration. Since static_graph=True is enabled for DDP, we expect this set of unused parameters to remain consi
stent on this rank throughout the training.
