### PR TITLE
Change ADD to COPY

### DIFF
--- a/.circleci/docker/ubuntu/Dockerfile
+++ b/.circleci/docker/ubuntu/Dockerfile
@@ -10,45 +10,45 @@ ARG CLANG_VERSION
 
 # Install common dependencies (so that this step can be cached separately)
 ARG EC2
-ADD ./common/install_base.sh install_base.sh
+COPY ./common/install_base.sh install_base.sh
 RUN bash ./install_base.sh && rm install_base.sh
 
 # Install clang
 ARG LLVMDEV
-ADD ./common/install_clang.sh install_clang.sh
+COPY ./common/install_clang.sh install_clang.sh
 RUN bash ./install_clang.sh && rm install_clang.sh
 
 # (optional) Install thrift.
 ARG THRIFT
-ADD ./common/install_thrift.sh install_thrift.sh
+COPY ./common/install_thrift.sh install_thrift.sh
 RUN if [ -n "${THRIFT}" ]; then bash ./install_thrift.sh; fi
 RUN rm install_thrift.sh
 ENV INSTALLED_THRIFT ${THRIFT}
 
 # Install user
-ADD ./common/install_user.sh install_user.sh
+COPY ./common/install_user.sh install_user.sh
 RUN bash ./install_user.sh && rm install_user.sh
 
 # Install katex
 ARG KATEX
-ADD ./common/install_docs_reqs.sh install_docs_reqs.sh
+COPY ./common/install_docs_reqs.sh install_docs_reqs.sh
 RUN bash ./install_docs_reqs.sh && rm install_docs_reqs.sh
 
 # Install conda and other packages (e.g., numpy, pytest)
 ENV PATH /opt/conda/bin:$PATH
 ARG ANACONDA_PYTHON_VERSION
-ADD requirements-ci.txt /opt/conda/requirements-ci.txt
-ADD ./common/install_conda.sh install_conda.sh
+COPY requirements-ci.txt /opt/conda/requirements-ci.txt
+COPY ./common/install_conda.sh install_conda.sh
 RUN bash ./install_conda.sh && rm install_conda.sh
 RUN rm /opt/conda/requirements-ci.txt
 
 # Install gcc
 ARG GCC_VERSION
-ADD ./common/install_gcc.sh install_gcc.sh
+COPY ./common/install_gcc.sh install_gcc.sh
 RUN bash ./install_gcc.sh && rm install_gcc.sh
 
 # Install lcov for C++ code coverage
-ADD ./common/install_lcov.sh install_lcov.sh
+COPY ./common/install_lcov.sh install_lcov.sh
 RUN  bash ./install_lcov.sh && rm install_lcov.sh
 
 # Install cuda and cudnn
@@ -60,21 +60,21 @@ ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
 
 # (optional) Install protobuf for ONNX
 ARG PROTOBUF
-ADD ./common/install_protobuf.sh install_protobuf.sh
+COPY ./common/install_protobuf.sh install_protobuf.sh
 RUN if [ -n "${PROTOBUF}" ]; then bash ./install_protobuf.sh; fi
 RUN rm install_protobuf.sh
 ENV INSTALLED_PROTOBUF ${PROTOBUF}
 
 # (optional) Install database packages like LMDB and LevelDB
 ARG DB
-ADD ./common/install_db.sh install_db.sh
+COPY ./common/install_db.sh install_db.sh
 RUN if [ -n "${DB}" ]; then bash ./install_db.sh; fi
 RUN rm install_db.sh
 ENV INSTALLED_DB ${DB}
 
 # (optional) Install vision packages like OpenCV and ffmpeg
 ARG VISION
-ADD ./common/install_vision.sh install_vision.sh
+COPY ./common/install_vision.sh install_vision.sh
 RUN if [ -n "${VISION}" ]; then bash ./install_vision.sh; fi
 RUN rm install_vision.sh
 ENV INSTALLED_VISION ${VISION}
@@ -83,9 +83,9 @@ ENV INSTALLED_VISION ${VISION}
 ARG ANDROID
 ARG ANDROID_NDK
 ARG GRADLE_VERSION
-ADD ./common/install_android.sh install_android.sh
-ADD ./android/AndroidManifest.xml AndroidManifest.xml
-ADD ./android/build.gradle build.gradle
+COPY ./common/install_android.sh install_android.sh
+COPY ./android/AndroidManifest.xml AndroidManifest.xml
+COPY ./android/build.gradle build.gradle
 RUN if [ -n "${ANDROID}" ]; then bash ./install_android.sh; fi
 RUN rm install_android.sh
 RUN rm AndroidManifest.xml
@@ -94,46 +94,46 @@ ENV INSTALLED_ANDROID ${ANDROID}
 
 # (optional) Install Vulkan SDK
 ARG VULKAN_SDK_VERSION
-ADD ./common/install_vulkan_sdk.sh install_vulkan_sdk.sh
+COPY ./common/install_vulkan_sdk.sh install_vulkan_sdk.sh
 RUN if [ -n "${VULKAN_SDK_VERSION}" ]; then bash ./install_vulkan_sdk.sh; fi
 RUN rm install_vulkan_sdk.sh
 
 # (optional) Install swiftshader
 ARG SWIFTSHADER
-ADD ./common/install_swiftshader.sh install_swiftshader.sh
+COPY ./common/install_swiftshader.sh install_swiftshader.sh
 RUN if [ -n "${SWIFTSHADER}" ]; then bash ./install_swiftshader.sh; fi
 RUN rm install_swiftshader.sh
 
 # (optional) Install non-default CMake version
 ARG CMAKE_VERSION
-ADD ./common/install_cmake.sh install_cmake.sh
+COPY ./common/install_cmake.sh install_cmake.sh
 RUN if [ -n "${CMAKE_VERSION}" ]; then bash ./install_cmake.sh; fi
 RUN rm install_cmake.sh
 
 # (optional) Install non-default Ninja version
 ARG NINJA_VERSION
-ADD ./common/install_ninja.sh install_ninja.sh
+COPY ./common/install_ninja.sh install_ninja.sh
 RUN if [ -n "${NINJA_VERSION}" ]; then bash ./install_ninja.sh; fi
 RUN rm install_ninja.sh
 
-ADD ./common/install_openssl.sh install_openssl.sh
+COPY ./common/install_openssl.sh install_openssl.sh
 RUN bash ./install_openssl.sh
 ENV OPENSSL_ROOT_DIR /opt/openssl
 ENV OPENSSL_DIR /opt/openssl
 RUN rm install_openssl.sh
 
 # Install ccache/sccache (do this last, so we get priority in PATH)
-ADD ./common/install_cache.sh install_cache.sh
+COPY ./common/install_cache.sh install_cache.sh
 ENV PATH /opt/cache/bin:$PATH
 RUN bash ./install_cache.sh && rm install_cache.sh
 
 # Add jni.h for java host build
-ADD ./common/install_jni.sh install_jni.sh
-ADD ./java/jni.h jni.h
+COPY ./common/install_jni.sh install_jni.sh
+COPY ./java/jni.h jni.h
 RUN bash ./install_jni.sh && rm install_jni.sh
 
 # Install Open MPI for CUDA
-ADD ./common/install_openmpi.sh install_openmpi.sh
+COPY ./common/install_openmpi.sh install_openmpi.sh
 RUN if [ -n "${CUDA_VERSION}" ]; then bash install_openmpi.sh; fi
 RUN rm install_openmpi.sh
 


### PR DESCRIPTION
Docker docs says "For other items (files, directories) that do not require ADD’s tar auto-extraction capability, you should always use COPY": https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy

I've found this by running https://github.com/hadolint/hadolint

If this goes well, I'll change other files too.