### PR TITLE
[MPS]  Perf fixes.

### DIFF
--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -38,17 +38,18 @@ namespace mps {
 //  MPSStream
 //-----------------------------------------------------------------
 
+enum class SyncType {
+  NONE,               // no commit to command buffer
+  COMMIT,             // commit and flush the command buffer
+  COMMIT_AND_WAIT,    // flush and wait for command buffer execution to finish
+  COMMIT_AND_CONTINUE,// commit and continue with a new underlying command buffer
+};
+
 class TORCH_API MPSStream
 {
 public:
   enum Unchecked { UNCHECKED };
 
-  enum class SyncType {
-    NONE,               // no commit to command buffer
-    COMMIT,             // commit and flush the command buffer
-    COMMIT_AND_WAIT,    // flush and wait for command buffer execution to finish
-    COMMIT_AND_CONTINUE,// commit and continue with a new underlying command buffer
-  };
   /// Construct a MPSStream from a Stream.  This construction is checked,
   /// and will raise an error if the Stream is not, in fact, a MPS stream.
   explicit MPSStream(Stream stream);
@@ -57,17 +58,18 @@ public:
   MTLCommandQueue_t commandQueue() const { return _commandQueue; };
   dispatch_queue_t queue() const { return _serialQueue; }
 
-  MTLCommandBuffer_t commandBuffer();
+  MPSCommandBuffer* commandBuffer();
   void commit(bool flush);
   void commitAndWait();
   void commitAndContinue();
-  void synchronize();
+  void synchronize(SyncType syncType);
+  void fill(id<MTLBuffer> buffer, uint8_t value, size_t length, size_t offset, SyncType syncType = SyncType::NONE);
   void copy(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer,
             size_t length, size_t srcOffset, size_t dstOffset, SyncType syncType = SyncType::NONE);
   void copy_and_sync(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer,
                      size_t length, size_t srcOffset, size_t dstOffset, bool non_blocking);
   void flush();
-  void executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results);
+  void executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results, SyncType syncType = SyncType::NONE);
 
   /// Get the MPS device index that this stream is associated with.
   c10::DeviceIndex device_index() const { return _stream.device_index(); }

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -14,7 +14,7 @@ namespace mps {
 MPSStream::MPSStream(Stream stream) : _stream(stream) {
   _commandQueue = [MPSDevice::getInstance()->device() newCommandQueue];
   TORCH_CHECK(_stream.device_type() == DeviceType::MPS);
-  _serialQueue = dispatch_queue_create("metal gpu stream", NULL);
+  _serialQueue = dispatch_queue_create("metal gpu stream", nullptr);
   _executionDescriptor = [MPSGraphExecutionDescriptor new];
   _executionDescriptor.completionHandler = ^(NSDictionary<MPSGraphTensor *,
                                              MPSGraphTensorData *> * resultsDictionary,
@@ -29,22 +29,31 @@ MPSStream::~MPSStream() {
   assert(_commandBuffer == nil);
 }
 
-id<MTLCommandBuffer> MPSStream::commandBuffer() {
+MPSCommandBuffer* MPSStream::commandBuffer() {
   if (!_commandBuffer) {
-    _commandBuffer =
-        [MPSCommandBuffer commandBufferFromCommandQueue:_commandQueue].retain;
+    _commandBuffer = [MPSCommandBuffer commandBufferFromCommandQueue:_commandQueue].retain;
   }
 
   return _commandBuffer;
 }
 
-void MPSStream::synchronize() {
-  dispatch_sync(queue(), ^() {
-    @autoreleasepool {
-      commandBuffer();
+void MPSStream::synchronize(SyncType syncType) {
+  if (!_commandBuffer)
+    return;
+  switch(syncType) {
+    case SyncType::NONE:
+      // typically in GPU to GPU copies we won't commit explicitly
+      break;
+    case SyncType::COMMIT:
+      flush();
+      break;
+    case SyncType::COMMIT_AND_WAIT:
       commitAndWait();
-    }
-  });
+      break;
+    case SyncType::COMMIT_AND_CONTINUE:
+      commitAndContinue();
+      break;
+  }
 }
 
 void MPSStream::commit(bool doFlush) {
@@ -87,6 +96,23 @@ void MPSStream::_flush(bool commitAndWait) const {
   [_commandBuffer release];
 }
 
+void MPSStream::fill(id<MTLBuffer> buffer, uint8_t value, size_t length, size_t offset, SyncType syncType)
+{
+  TORCH_INTERNAL_ASSERT(length >= offset);
+  if (length == 0) return;
+  dispatch_sync(_serialQueue, ^() {
+    @autoreleasepool {
+      id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer() blitCommandEncoder];
+
+      [blitEncoder fillBuffer:buffer
+                        range:NSMakeRange(offset, length)
+                        value:value];
+      [blitEncoder endEncoding];
+      synchronize(syncType);
+    }
+  });
+}
+
 void MPSStream::copy(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer,
                     size_t length, size_t srcOffset, size_t dstOffset, SyncType syncType) {
   dispatch_sync(_serialQueue, ^() {
@@ -99,20 +125,7 @@ void MPSStream::copy(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer,
                 destinationOffset:(NSUInteger)dstOffset
                              size:(NSUInteger)length];
       [blitEncoder endEncoding];
-      switch(syncType) {
-        case SyncType::NONE:
-          // typically in GPU to GPU copies we won't commit explicitly
-          break;
-        case SyncType::COMMIT:
-          commit(true);
-          break;
-        case SyncType::COMMIT_AND_WAIT:
-          commitAndWait();
-          break;
-        case SyncType::COMMIT_AND_CONTINUE:
-          commitAndContinue();
-          break;
-      }
+      synchronize(syncType);
     }
   });
 }
@@ -123,7 +136,7 @@ void MPSStream::copy_and_sync(id<MTLBuffer> srcBuffer, id<MTLBuffer> dstBuffer, 
        !non_blocking ? SyncType::COMMIT_AND_WAIT : SyncType::COMMIT);
 }
 
-void MPSStream::executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results) {
+void MPSStream::executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDictionary* results, SyncType syncType) {
   dispatch_sync(_serialQueue, ^() {
 #if USE_MPSCOMMANDBUFFER
     [mpsGraph encodeToCommandBuffer:commandBuffer()
@@ -131,6 +144,8 @@ void MPSStream::executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDicti
                    targetOperations:nil
                   resultsDictionary:results
                 executionDescriptor:_executionDescriptor];
+    // mostly the syncType is NONE, but in some cases we may want to sync and wait (e.g., gatherViewTensor)
+    synchronize(syncType);
 #else
     commit(true);
     [mpsGraph runAsyncWithMTLCommandQueue:_commandQueue

--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -47,7 +47,7 @@ MPSDataType getMPSDataType(ScalarType scalar_type);
 MPSDataType getMPSScalarType(ScalarType scalar_type);
 std::string getMPSTypeString(ScalarType scalar_type);
 std::string getMPSShapeString(MPSShape* shape);
-std::string getTensorsStringKey(const TensorList& tensors, bool use_scalar_value = true);
+std::string getTensorsStringKey(const TensorList& tensors, bool use_scalar_value = false);
 double getMPSScalarValue(const Tensor& t);
 std::string getArrayRefString(const IntArrayRef s);
 // use has_storage() on the returned tensor to determine if src actually is a view

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -153,8 +153,10 @@ void div_mode_template(const Tensor& self, const Tensor& other,
 
 void add_sub_template(const Tensor& self, const Tensor& other, const Scalar& alpha, const Tensor& output, std::string op_name)
 {
-  if (alpha.toDouble() == 0.0)
+  if (alpha.toDouble() == 0.0) {
     const_cast<Tensor&>(output) = self.clone();
+    return;
+  }
 
   const bool alpha_has_value = alpha.toDouble() != 1.0;
   if (alpha_has_value) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/81610
* Use fillBuffer() for zero_mps()
Fix minor bug in add_sub_template() with value=0.0
Change default value of use_scalar_value to false in getTensorsStringKey()

* Fallback to fill_scalar_mps() if buffer isn't contiguous.

* Fix high memory consumption in view ops

* Change commitAndWait to Commit in View Ops