### PR TITLE
Disable XLA builds (#80099) (#80099)

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -235,6 +235,7 @@ jobs:
       build-generates-artifacts: false
 
   pytorch-xla-linux-bionic-py3_7-clang8-build:
+    if: false
     name: pytorch-xla-linux-bionic-py3.7-clang8
     uses: ./.github/workflows/_linux-build.yml
     with:


### PR DESCRIPTION
Summary:
As they are constantly failing to download llvm release from https://storage.googleapis.com:
```
Error in download_and_extract: java.io.IOException: Error downloading [https://storage.googleapis.com/mirror.tensorflow.org/github.com/llvm/llvm-project/archive/9c6a2f29660b886044a267bb4de662cd801079bc.tar.gz, https://github.com/llvm/llvm-project/archive/9c6a2f29660b886044a267bb4de662cd801079bc.tar.gz] to /home/jenkins/.cache/bazel/_bazel_jenkins/b463291cb8b07b4bfde1e3a43733cd1a/external/llvm-raw/temp10926951092717297163/9c6a2f29660b886044a267bb4de662cd801079bc.tar.gz: Read timed out
Loading: 0 packages loaded
```

GitHub CC:
JackCaoG

Pull Request resolved: https://github.com/pytorch/pytorch/pull/80099
Approved by: https://github.com/janeyx99

Test Plan: contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/afdd83efcbb44fdbf270dc2000e66d9b6e2ce144

Reviewed By: atalman

Differential Revision: D37381940

Pulled By: malfet

fbshipit-source-id: 90e5e1a1dfed8dc19a6dddcbf5a4b2097755a25f