### PR TITLE
SymInt revert causes backwards incompatibility

### DIFF
--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -114,6 +114,11 @@ ALLOW_LIST = [
     ("c10d::broadcast", datetime.date(2022, 6, 25)),
     ("aten::.*functional", datetime.date(2022, 8, 1)),
     ("aten::_foreach.*", datetime.date(2022, 8, 1)),
+    # verify the next 4 SymInt ones against commits BEFORE c078476eb04376c53c5008515f341fa6e81e82b6
+    ("aten::view_copy.SymInt", datetime.date(2022, 8, 15)),
+    ("aten::view.SymInt", datetime.date(2022, 8, 15)),
+    ("aten::sum.SymInt", datetime.date(2022, 8, 15)),
+    ("aten::zeros.SymInt", datetime.date(2022, 8, 15)),
     # TODO: FIXME: prims shouldn't be checked
     ("prims::.*", datetime.date(9999, 1, 1)),
 ]


### PR DESCRIPTION
Ever since https://hud.pytorch.org/pytorch/pytorch/commit/c078476eb04376c53c5008515f341fa6e81e82b6 where #81145 was reverted, our schema no longer has the following:
```
The PR is introducing backward incompatible changes to the operator library. Please contact PyTorch team to confirm whether this change is wanted or not. 
2022-07-22T12:32:01.8931944Z 
2022-07-22T12:32:01.8932069Z Broken ops: [
2022-07-22T12:32:01.8932396Z 	aten::view_copy.SymInt(Tensor self, SymInt[] size) -> Tensor
2022-07-22T12:32:01.8932578Z 	aten::view.SymInt(Tensor(a) self, SymInt[] size) -> Tensor(a)
2022-07-22T12:32:01.8932809Z 	aten::sum.SymInt(Tensor self, SymInt[1] dim, bool keepdim=False, *, int? dtype=None) -> Tensor
2022-07-22T12:32:01.8933093Z 	aten::zeros.SymInt(SymInt[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
2022-07-22T12:32:01.8933212Z ]
```

Normally, we would do a change similar to what we do in this PR where we add it to an allowlist with a date. However, I realized this allowlist is more symbolic than anything because we compare against the base commit now (and previously, the nightly commit) which both move with time. This list doesn't actually apply past the immediate present, since the check only checks against the the schema from the commit before or the day before, versus a general public schema we promise to uphold.

The allowlist is thus more of a regression list. However, there's no real mechanism to verify that these regressions no longer exist unless we keep track of the commit when the regression was introduced, which we don't do today. The regression will stop showing up on the next commit (and in the olden times, when the nightly updates) so it is more up to our integrity to ensure that when we remove things from the allowlist, the functions we've removed are now publicly exposed.

Linking @Krovatkin who will probably be trying to land SymInt to remove these entries once these functions exist again.