### PR TITLE
Add Pull Request template for functorch

### DIFF
--- a/functorch/CONTRIBUTING.md
+++ b/functorch/CONTRIBUTING.md
@@ -1,2 +1,12 @@
 ## Contributing
 Feedback on our APIs, as well as finding bugs, would be very helpful.
+
+Please feel free to chat us up on the PyTorch Slack, or open an issue
+at https://github.com/pytorch/functorch if you're interested in
+contributing.
+
+To contribute a change to functorch, please make sure you are submitting a
+Pull Request to the functorch folder in https://github.com/pytorch/pytorch
+repository. The source of truth for functorch has moved there from
+https://github.com/pytorch/functorch ; the code in the pytorch/functorch
+repository is read-only.

--- a/functorch/pull_request_template.md
+++ b/functorch/pull_request_template.md
@@ -1,0 +1,5 @@
+To contribute a change to functorch, please make sure you are submitting a
+Pull Request to the functorch folder in https://github.com/pytorch/pytorch
+repository. The source of truth for functorch has moved there from
+https://github.com/pytorch/functorch ; the pytorch/functorch repository
+is now read-only.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #81995
* #81987
* #81990

The functorch in the pytorch/pytorch repository gets synced to the
pytorch/functorch repository.

This PR template tells people to submit PRs against the pytorch in the
pytorch/pytorch repository.

Also beef up our CONTRIBUTING.md