### PR TITLE
script to monitor memory + cpu utilization 

### DIFF
--- a/.github/actions/upload-test-artifacts/action.yml
+++ b/.github/actions/upload-test-artifacts/action.yml
@@ -36,6 +36,20 @@ runs:
         rm -f test-reports-*.zip
         zip -r "test-reports-${FILE_SUFFIX}.zip" test -i '*.xml'
 
+    - name: Zip usage log for upload
+      if: runner.os != 'Windows' && !inputs.use-gha
+      shell: bash
+      env:
+        FILE_SUFFIX: ${{ inputs.file-suffix }}
+      run: |
+        # Remove any previous test reports if they exist
+        rm -f usage-log-*.zip
+        # this workflow is also run in bazel build test, but we dont generate usage reports for it
+        # so check to see if the file exists first
+        if [ -f 'usage_log.txt' ]; then
+            zip "usage-log-${FILE_SUFFIX}.zip" 'usage_log.txt'
+        fi
+
     # Windows zip
     - name: Zip JSONs for upload
       if: runner.os == 'Windows' && !inputs.use-gha
@@ -54,6 +68,15 @@ runs:
       run: |
         # -ir => recursive include all files in pattern
         7z a "test-reports-$Env:FILE_SUFFIX.zip" -ir'!test\*.xml'
+
+    - name: Zip usage log for upload
+      if: runner.os == 'Windows' && !inputs.use-gha
+      shell: powershell
+      env:
+        FILE_SUFFIX: ${{ inputs.file-suffix }}
+      run: |
+        # -ir => recursive include all files in pattern
+        7z a "usage-log-$Env:FILE_SUFFIX.zip" 'usage_log.txt'
 
     # S3 upload
     - name: Store Test Downloaded JSONs on S3
@@ -75,6 +98,16 @@ runs:
         retention-days: 14
         if-no-files-found: error
         path: test-reports-*.zip
+
+    - name: Store Usage Logs on S3
+      uses: seemethere/upload-artifact-s3@v5
+      if: ${{ !inputs.use-gha }}
+      with:
+        s3-prefix: |
+          ${{ github.repository }}/${{ github.run_id }}/${{ github.run_attempt }}/artifact
+        retention-days: 14
+        if-no-files-found: ignore
+        path: usage-log-*.zip
 
     # GHA upload
     - name: Store Test Downloaded JSONs on Github

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -67,6 +67,8 @@ jobs:
         id: monitor-script
         shell: bash
         run: |
+          python3 -m pip install psutil==5.9.1
+          python3 -m pip install pynvml==11.4.1
           python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "::set-output name=monitor-script-pid::${!}"
 

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -63,6 +63,13 @@ jobs:
             bash .github/scripts/install_nvidia_utils_linux.sh
             echo "GPU_FLAG=--gpus all" >> "${GITHUB_ENV}"
 
+      - name: Start monitoring script
+        id: monitor-script
+        shell: bash
+        run: |
+          python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
+          echo "::set-output name=monitor-script-pid::${!}"
+
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts
         with:
@@ -165,6 +172,14 @@ jobs:
         if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stop monitoring script
+        if: always() && ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        shell: bash
+        env:
+          MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        run: |
+          kill "$MONITOR_SCRIPT_PID"
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -59,6 +59,8 @@ jobs:
         id: monitor-script
         shell: bash
         run: |
+          python3 -m pip install psutil==5.9.1
+          python3 -m pip install pynvml==11.4.1
           python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "::set-output name=monitor-script-pid::${!}"
 

--- a/.github/workflows/_mac-test.yml
+++ b/.github/workflows/_mac-test.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Checkout PyTorch
         uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
 
+      - name: Start monitoring script
+        id: monitor-script
+        shell: bash
+        run: |
+          python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
+          echo "::set-output name=monitor-script-pid::${!}"
+
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts
         with:
@@ -104,6 +111,14 @@ jobs:
         if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stop monitoring script
+        if: always() && ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        shell: bash
+        env:
+          MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        run: |
+          kill "$MONITOR_SCRIPT_PID"
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -66,6 +66,8 @@ jobs:
         id: monitor-script
         shell: bash
         run: |
+          python3 -m pip install psutil==5.9.1
+          python3 -m pip install pynvml==11.4.1
           python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "::set-output name=monitor-script-pid::${!}"
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -62,6 +62,13 @@ jobs:
         with:
           docker-image: ${{ inputs.docker-image }}
 
+      - name: Start monitoring script
+        id: monitor-script
+        shell: bash
+        run: |
+          python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
+          echo "::set-output name=monitor-script-pid::${!}"
+
       - name: Download build artifacts
         uses: ./.github/actions/download-build-artifacts
         with:
@@ -166,6 +173,14 @@ jobs:
         if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stop monitoring script
+        if: always() && ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        shell: bash
+        env:
+          MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        run: |
+          kill "$MONITOR_SCRIPT_PID"
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -56,6 +56,8 @@ jobs:
         id: monitor-script
         shell: bash
         run: |
+          python3 -m pip install psutil==5.9.1
+          python3 -m pip install pynvml==11.4.1
           python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
           echo "::set-output name=monitor-script-pid::${!}"
 

--- a/.github/workflows/_win-test.yml
+++ b/.github/workflows/_win-test.yml
@@ -52,6 +52,13 @@ jobs:
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Start monitoring script
+        id: monitor-script
+        shell: bash
+        run: |
+          python3 -m tools.stats.monitor > usage_log.txt 2>&1 &
+          echo "::set-output name=monitor-script-pid::${!}"
+
       - name: Download PyTorch Build Artifacts
         uses: seemethere/download-artifact-s3@v4
         with:
@@ -111,6 +118,14 @@ jobs:
         if: always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stop monitoring script
+        if: always() && ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        shell: bash
+        env:
+          MONITOR_SCRIPT_PID: ${{ steps.monitor-script.outputs.monitor-script-pid }}
+        run: |
+          kill "$MONITOR_SCRIPT_PID"
 
       - name: Upload test artifacts
         uses: ./.github/actions/upload-test-artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ docs/cpp/source/html/
 docs/cpp/source/latex/
 docs/source/generated/
 log
+usage_log.txt
 test-reports/
 test/.coverage
 test/.hypothesis/

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -1,77 +1,54 @@
 #!/usr/bin/env python3
 import datetime
-import importlib.util
 import json
-import subprocess
-import sys
+import signal
 import time
 from typing import Any, Dict, List
 
-
-def pip_install(package_name: str) -> None:
-    if importlib.util.find_spec(package_name) is None:
-        output = subprocess.run(
-            [sys.executable, "-m", "pip", "install", package_name],
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-        )
-        if output.returncode != 0:
-            print(output.stderr.decode("utf-8"))
-            print(output.stdout.decode("utf-8"))
-    # when running this script in the background, pip installs the packages to
-    # a location that is not in a path python uses to look for modules, so we
-    # manually add the location to the path
-    location = subprocess.run(
-        [sys.executable, "-m", "pip", "show", package_name],
-        stderr=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-    )
-    for s in location.stdout.decode("utf-8").splitlines():
-        if "Location:" in s:
-            sys.path.append(s.split(" ")[1])
+import psutil  # type: ignore[import]
+import pynvml  # type: ignore[import]
 
 
-def main() -> None:
-    pip_install("psutil")
-    pip_install("pynvml")
-    import psutil  # type: ignore[import]
-    import pynvml  # type: ignore[import]
+def get_processes_running_python_tests() -> List[Any]:
+    python_processes = []
+    for process in psutil.process_iter():
+        try:
+            if "python" in process.name() and process.cmdline():
+                python_processes.append(process)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            # access denied or the process died
+            pass
+    return python_processes
 
-    def get_processes_running_python_tests() -> List[Any]:
-        python_processes = []
-        for process in psutil.process_iter():
-            try:
-                if "python" in process.name() and process.cmdline():
-                    python_processes.append(process)
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                # access denied or the process died
-                pass
-        return python_processes
 
-    def get_per_process_cpu_info() -> List[Dict[str, Any]]:
-        processes = get_processes_running_python_tests()
-        per_process_info = []
-        for p in processes:
-            info = {
-                "pid": p.pid,
-                "cmd": " ".join(p.cmdline()),
-                "cpu_percent": p.cpu_percent(),
-                "rss_memory": p.memory_info().rss,
-                "uss_memory": p.memory_full_info().uss,
-            }
-            if "pss" in p.memory_full_info():
-                # only availiable in linux
-                info["pss_memory"] = p.memory_full_info().pss
-            per_process_info.append(info)
-        return per_process_info
+def get_per_process_cpu_info() -> List[Dict[str, Any]]:
+    processes = get_processes_running_python_tests()
+    per_process_info = []
+    for p in processes:
+        info = {
+            "pid": p.pid,
+            "cmd": " ".join(p.cmdline()),
+            "cpu_percent": p.cpu_percent(),
+            "rss_memory": p.memory_info().rss,
+            "uss_memory": p.memory_full_info().uss,
+        }
+        if "pss" in p.memory_full_info():
+            # only availiable in linux
+            info["pss_memory"] = p.memory_full_info().pss
+        per_process_info.append(info)
+    return per_process_info
 
-    def get_per_process_gpu_info(handle: Any) -> List[Dict[str, Any]]:
-        processes = pynvml.nvmlDeviceGetComputeRunningProcesses(handle)
-        per_process_info = []
-        for p in processes:
-            info = {"pid": p.pid, "gpu_memory": p.usedGpuMemory}
-            per_process_info.append(info)
-        return per_process_info
+
+def get_per_process_gpu_info(handle: Any) -> List[Dict[str, Any]]:
+    processes = pynvml.nvmlDeviceGetComputeRunningProcesses(handle)
+    per_process_info = []
+    for p in processes:
+        info = {"pid": p.pid, "gpu_memory": p.usedGpuMemory}
+        per_process_info.append(info)
+    return per_process_info
+
+
+if __name__ == "__main__":
 
     handle = None
     try:
@@ -81,7 +58,15 @@ def main() -> None:
         # no pynvml avaliable, probably because not cuda
         pass
 
-    while True:
+    kill_now = False
+
+    def exit_gracefully(*args: Any) -> None:
+        global kill_now
+        kill_now = True
+
+    signal.signal(signal.SIGTERM, exit_gracefully)
+
+    while not kill_now:
         try:
             stats = {
                 "time": datetime.datetime.utcnow().isoformat("T") + "Z",
@@ -90,6 +75,9 @@ def main() -> None:
             }
             if handle is not None:
                 stats["per_process_gpu_info"] = get_per_process_gpu_info(handle)
+                stats["total_gpu_utilizaiton"] = pynvml.nvmlDeviceGetUtilizationRates(
+                    handle
+                ).gpu
         except Exception as e:
             stats = {
                 "time": datetime.datetime.utcnow().isoformat("T") + "Z",
@@ -98,7 +86,3 @@ def main() -> None:
         finally:
             print(json.dumps(stats))
             time.sleep(1)
-
-
-if __name__ == "__main__":
-    main()

--- a/tools/stats/monitor.py
+++ b/tools/stats/monitor.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+import datetime
+import importlib.util
+import json
+import subprocess
+import sys
+import time
+from typing import Any, Dict, List
+
+
+def pip_install(package_name: str) -> None:
+    if importlib.util.find_spec(package_name) is None:
+        output = subprocess.run(
+            [sys.executable, "-m", "pip", "install", package_name],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+        if output.returncode != 0:
+            print(output.stderr.decode("utf-8"))
+            print(output.stdout.decode("utf-8"))
+    # when running this script in the background, pip installs the packages to
+    # a location that is not in a path python uses to look for modules, so we
+    # manually add the location to the path
+    location = subprocess.run(
+        [sys.executable, "-m", "pip", "show", package_name],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    for s in location.stdout.decode("utf-8").splitlines():
+        if "Location:" in s:
+            sys.path.append(s.split(" ")[1])
+
+
+def main() -> None:
+    pip_install("psutil")
+    pip_install("pynvml")
+    import psutil  # type: ignore[import]
+    import pynvml  # type: ignore[import]
+
+    def get_processes_running_python_tests() -> List[Any]:
+        python_processes = []
+        for process in psutil.process_iter():
+            try:
+                if "python" in process.name() and process.cmdline():
+                    python_processes.append(process)
+            except Exception:
+                # access denied
+                pass
+        return python_processes
+
+    def get_per_process_cpu_info() -> List[Dict[str, Any]]:
+        processes = get_processes_running_python_tests()
+        per_process_info = []
+        for p in processes:
+            info = {
+                "pid": p.pid,
+                "cmd": " ".join(p.cmdline()),
+                "cpu_percent": p.cpu_percent(),
+                "rss_memory": p.memory_info().rss,
+                "uss_memory": p.memory_full_info().uss,
+            }
+            try:
+                info["pss_memory"] = p.memory_full_info().pss
+            except Exception:
+                pass
+            per_process_info.append(info)
+        return per_process_info
+
+    def get_per_process_gpu_info(handle: Any) -> List[Dict[str, Any]]:
+        processes = pynvml.nvmlDeviceGetComputeRunningProcesses(handle)
+        per_process_info = []
+        for p in processes:
+            info = {"pid": p.pid, "gpu_memory": p.usedGpuMemory}
+            per_process_info.append(info)
+        return per_process_info
+
+    handle = None
+    try:
+        pynvml.nvmlInit()
+        handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+    except Exception:
+        pass
+
+    while True:
+        try:
+            stats = {
+                "time": datetime.datetime.utcnow().isoformat("T") + "Z",
+                "total_cpu_percent": psutil.cpu_percent(),
+                "per_process_cpu_info": get_per_process_cpu_info(),
+            }
+            if handle is not None:
+                stats["per_process_gpu_info"] = get_per_process_gpu_info(handle)
+        except Exception as e:
+            stats = {
+                "time": datetime.datetime.utcnow().isoformat("T") + "Z",
+                "error": str(e),
+            }
+        finally:
+            print(json.dumps(stats))
+            time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a python script that runs in the background during test jobs to log cpu + gpu memory usage and cpu utilization of python tests (really any python process) to a file and upload the file as an artifact.  

I plan on using the the gpu memory usage stats to better understand how to parallelize them, but it is easy to add on other stats if people want them.

In the future, we want to add the ability to track network usage to see if we can decrease it.  GPU utilization will also likely need to be improved.

Click the hud link to see uploaded usage log artifacts
