### PR TITLE
[XLA] Fix performance regression due to expand.SymInt

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -844,7 +844,7 @@ Tensor diag_embed(const Tensor& self, int64_t offset, int64_t dim1_, int64_t dim
 
 Tensor expand_symint(const Tensor& self, c10::SymIntArrayRef packed_size, bool implicit) {
   auto size = asIntArrayRefSlow(packed_size);
-  return expand(self, size, implicit);
+  return self.expand(size, implicit);
 }
 
 Tensor expand(const Tensor& self, IntArrayRef size, bool /*unused*/) {


### PR DESCRIPTION
We recently found https://github.com/pytorch/pytorch/pull/79795 is causing performance regression in bert model on XLA device due to unlowered op. I suspect https://github.com/pytorch/xla/issues/3726 is due to the same issue. After some debugging, it seems the arg parser will always return the first signature in
```cpp
  static PythonArgParser parser({
    "expand(SymIntArrayRef size, *, bool implicit=False)",
    "expand(IntArrayRef size, *, bool implicit=False)",
  }, /*traceable=*/true);
```
for normal expand op. Maybe this is intentional?

Now `native::expand_symint` will be dispatched to `native::as_strided`. Op like `x = torch.rand(1,512); x.expand(24,512)` will become `x.as_strided((24,512),(0,1))` for XLA device and strides like (0,1) is not supported on XLA device according to this [function](https://github.com/pytorch/xla/blob/3d24d955b6121289a3c8bb86eda541fca7a0d69f/torch_xla/csrc/ops/as_strided.cpp#L76).

Min code to reproduce the issue:
```py
import torch
import torch_xla.core.xla_model as xm
import torch_xla.debug.metrics as met

x = torch.randint(0,10,size=(1,512), device=xm.xla_device())
y = x.expand([24, 512])
xm.mark_step()
print(met.metrics_report()
```

cc @Krovatkin @miladm