### PR TITLE
Modify float_to_apot helper function for mapping negative values

### DIFF
--- a/torch/ao/quantization/experimental/apot_utils.py
+++ b/torch/ao/quantization/experimental/apot_utils.py
@@ -22,7 +22,7 @@ def float_to_apot(x, levels, indices, alpha):
     best_idx = 0
 
     for level, idx in zip(levels_lst, indices_lst):
-        cur_delta = abs(level - x)
+        cur_delta = abs(abs(level) - abs(x))
         if cur_delta < min_delta:
             min_delta = cur_delta
             best_idx = idx


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82024

### Summary
This PR modifies the `float_to_apot` helper function to correctly map negative values from the input fp tensor to their closest corresponding quantization level.