### PR TITLE
add workflow name to conclusions dictionary in trymerge

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -121,7 +121,7 @@ def mocked_read_merge_rules(repo: Any, org: str, project: str) -> List[MergeRule
                   approved_by=["pytorch/metamates"],
                   mandatory_checks_name=["Lint",
                                          "Facebook CLA Check",
-                                         "linux-xenial-cuda11.3-py3.7-gcc7 / build",
+                                         "pull / linux-xenial-cuda11.3-py3.7-gcc7 / build",
                                          ],
                   ),
     ]
@@ -257,7 +257,7 @@ class TestGitHubPR(TestCase):
         """
         pr = GitHubPR("pytorch", "pytorch", 77700)
         conclusions = pr.get_checkrun_conclusions()
-        self.assertTrue("linux-docs / build-docs (cpp)" in conclusions.keys())
+        self.assertTrue("pull / linux-docs / build-docs (cpp)" in conclusions.keys())
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
     def test_get_many_land_checks(self, mocked_gql: Any) -> None:
@@ -265,7 +265,7 @@ class TestGitHubPR(TestCase):
         """
         conclusions = get_land_checkrun_conclusions('pytorch', 'pytorch', '6882717f73deffb692219ccd1fd6db258d8ed684')
         self.assertGreater(len(conclusions), 100)
-        self.assertTrue("linux-docs / build-docs (cpp)" in conclusions.keys())
+        self.assertTrue("pull / linux-docs / build-docs (cpp)" in conclusions.keys())
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
     def test_failed_land_checks(self, mocked_gql: Any) -> None:

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -626,12 +626,15 @@ class GitHubPR:
                 checkruns = node["checkRuns"]
                 if workflow_run is not None:
                     conclusions[workflow_run["workflow"]["name"]] = (node["conclusion"], node["url"])
+                check_run_name_prefix = "" if workflow_run is None else f'{workflow_run["workflow"]["name"]} / '
                 has_failing_check = False
                 while checkruns is not None:
                     for checkrun_node in checkruns["nodes"]:
                         if checkrun_node["conclusion"] == 'FAILURE':
                             has_failing_check = True
-                        conclusions[checkrun_node["name"]] = (checkrun_node["conclusion"], checkrun_node["detailsUrl"])
+                        conclusions[f'{check_run_name_prefix}{checkrun_node["name"]}'] = (
+                            checkrun_node["conclusion"], checkrun_node["detailsUrl"]
+                        )
                     if bool(checkruns["pageInfo"]["hasNextPage"]):
                         rc = gh_graphql(GH_GET_PR_NEXT_CHECK_RUNS,
                                         name=self.project,
@@ -967,12 +970,15 @@ def get_land_checkrun_conclusions(org: str, project: str, commit: str) -> Dict[s
             checkruns = node["checkRuns"]
             if workflow_run is not None:
                 conclusions[workflow_run["workflow"]["name"]] = (node["conclusion"], node["url"])
+            check_run_name_prefix = "" if workflow_run is None else f'{workflow_run["workflow"]["name"]} / '
             has_failing_check = False
             while checkruns is not None:
                 for checkrun_node in checkruns["nodes"]:
                     if checkrun_node["conclusion"] == 'FAILURE':
                         has_failing_check = True
-                    conclusions[checkrun_node["name"]] = (checkrun_node["conclusion"], checkrun_node["detailsUrl"])
+                    conclusions[f'{check_run_name_prefix}{checkrun_node["name"]}'] = (
+                        checkrun_node["conclusion"], checkrun_node["detailsUrl"]
+                    )
                 if bool(checkruns["pageInfo"]["hasNextPage"]):
                     rc = gh_graphql(GH_GET_COMMIT_NEXT_CHECK_RUNS,
                                     name=project,

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -449,6 +449,11 @@ def gh_get_team_members(org: str, name: str) -> List[str]:
         rc += [member["login"] for member in team_members["nodes"]]
     return rc
 
+def get_check_run_name_prefix(workflow_run: Any) -> str:
+    if workflow_run is None:
+        return ""
+    else:
+        return f'{workflow_run["workflow"]["name"]} / '
 
 def parse_args() -> Any:
     from argparse import ArgumentParser
@@ -626,13 +631,12 @@ class GitHubPR:
                 checkruns = node["checkRuns"]
                 if workflow_run is not None:
                     conclusions[workflow_run["workflow"]["name"]] = (node["conclusion"], node["url"])
-                check_run_name_prefix = "" if workflow_run is None else f'{workflow_run["workflow"]["name"]} / '
                 has_failing_check = False
                 while checkruns is not None:
                     for checkrun_node in checkruns["nodes"]:
                         if checkrun_node["conclusion"] == 'FAILURE':
                             has_failing_check = True
-                        conclusions[f'{check_run_name_prefix}{checkrun_node["name"]}'] = (
+                        conclusions[f'{get_check_run_name_prefix(workflow_run)}{checkrun_node["name"]}'] = (
                             checkrun_node["conclusion"], checkrun_node["detailsUrl"]
                         )
                     if bool(checkruns["pageInfo"]["hasNextPage"]):
@@ -970,13 +974,12 @@ def get_land_checkrun_conclusions(org: str, project: str, commit: str) -> Dict[s
             checkruns = node["checkRuns"]
             if workflow_run is not None:
                 conclusions[workflow_run["workflow"]["name"]] = (node["conclusion"], node["url"])
-            check_run_name_prefix = "" if workflow_run is None else f'{workflow_run["workflow"]["name"]} / '
             has_failing_check = False
             while checkruns is not None:
                 for checkrun_node in checkruns["nodes"]:
                     if checkrun_node["conclusion"] == 'FAILURE':
                         has_failing_check = True
-                    conclusions[f'{check_run_name_prefix}{checkrun_node["name"]}'] = (
+                    conclusions[f'{get_check_run_name_prefix(workflow_run)}{checkrun_node["name"]}'] = (
                         checkrun_node["conclusion"], checkrun_node["detailsUrl"]
                     )
                 if bool(checkruns["pageInfo"]["hasNextPage"]):


### PR DESCRIPTION
Xla hash updates were failing because the merge rules json was looking for the name of the job in the format `<workflow name> / <job name>` but try merge just has `<job name>`.  

An easier solution would be to just get rid of pull in the merge rules but I think it would be better to keep to this naming convention.