### PR TITLE
[PyTorch][Kineto] add ActivityType.h when USE_KINETO is not set

### DIFF
--- a/tools/target_definitions.bzl
+++ b/tools/target_definitions.bzl
@@ -168,7 +168,7 @@ def add_torch_libs():
                 "//gloo/fb/transport/tls:tls",
                 "//gloo/transport/tcp:tcp",
                 "//tensorpipe:tensorpipe_cpu",
-            ] + (["//kineto/libkineto:kineto"] if use_kineto() else []) +
+            ] + (["//kineto/libkineto:kineto"] if use_kineto() else ["//kineto/libkineto:kineto_activity_header"]) +
             (["//caffe2:mobile_bytecode"] if enable_flatbuffer else [])
         ),
         exported_external_deps = [


### PR DESCRIPTION
Summary:
This patch fixes an error "'ActivityType.h' file not found" when `use_kineto()` is false.

## Problem
Even when `use_kineto()` is not set (i.e., `-DUSE_KINETO` is not passed), `ActivityType.h` is required for PyTorch compilation:
https://github.com/pytorch/pytorch/blob/master/torch/csrc/profiler/kineto_shim.h#L15

## Solution
Add `ActivitiyType.h` dependency even when `use_kineto() == False`.

Test Plan: PyTorch internal and external CI tests.

Differential Revision: D38090153

