### PR TITLE
fix a warning uint to int changes a sign

### DIFF
--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -93,7 +93,7 @@ class C10_API SymInt {
   static constexpr uint64_t MAX_SYM_IDX = 1ULL << 62;
   // Since 0b10... is reserved for symbolic indices, any integers lower than
   // this value would collide with our representation.
-  static constexpr int64_t MIN_INT = -1LL & ~(1ULL << 62);
+  static constexpr int64_t MIN_INT = -1LL & static_cast<int64_t>(~(1ULL << 62));
   int64_t data_;
 };
 


### PR DESCRIPTION
fix a clang warning "uint to int changes a sign"
