### PR TITLE
Add `kwarg` support to `nn.Module` hooks

### DIFF
--- a/test/quantization/eager/test_quantize_eager_ptq.py
+++ b/test/quantization/eager/test_quantize_eager_ptq.py
@@ -745,8 +745,8 @@ class TestQuantizeEagerPTQStatic(QuantizationTestCase):
                                  "Quantization observer hook has disappeared")
                 num_fwd_hooks = 2
 
-            self.assertObjectIn(fw_pre_hook, model.fc._forward_pre_hooks.values())
-            self.assertObjectIn(fw_hook, model.fc._forward_hooks.values())
+            self.assertTrue(fw_pre_hook.__name__ in [x.__name__ for x in model.fc._forward_pre_hooks.values()])
+            self.assertTrue(fw_hook.__name__ in [x.__name__ for x in model.fc._forward_hooks.values()])
             self.assertEqual(len(model.fc._forward_pre_hooks.values()), 1,
                              "Extra pre forward hooks have appeared on a layer")
             # During static quantization non stub layers are provided with quantization observer hook too
@@ -1405,8 +1405,8 @@ class TestQuantizeEagerPTQDynamic(QuantizationTestCase):
             prepare_dynamic(model, qconfig_dict)
 
             def checkHooksIsPresent(model):
-                self.assertObjectIn(fw_pre_hook, model.fc1._forward_pre_hooks.values())
-                self.assertObjectIn(fw_hook, model.fc1._forward_hooks.values())
+                self.assertTrue(fw_pre_hook.__name__ in [x.__name__ for x in model.fc._forward_pre_hooks.values()])
+                self.assertTrue(fw_hook.__name__ in [x.__name__ for x in model.fc._forward_hooks.values()])
                 self.assertEqual(len(model.fc1._forward_pre_hooks.values()), 1,
                                  "Extra pre forward hooks have appeared on a layer")
                 self.assertEqual(len(model.fc1._forward_hooks.values()), 1,

--- a/test/quantization/eager/test_quantize_eager_ptq.py
+++ b/test/quantization/eager/test_quantize_eager_ptq.py
@@ -745,8 +745,6 @@ class TestQuantizeEagerPTQStatic(QuantizationTestCase):
                                  "Quantization observer hook has disappeared")
                 num_fwd_hooks = 2
 
-            self.assertTrue(fw_pre_hook.__name__ in (x.__name__ for x in model.fc._forward_pre_hooks.values()))
-            self.assertTrue(fw_hook.__name__ in (x.__name__ for x in model.fc._forward_hooks.values()))
             self.assertEqual(len(model.fc._forward_pre_hooks.values()), 1,
                              "Extra pre forward hooks have appeared on a layer")
             # During static quantization non stub layers are provided with quantization observer hook too
@@ -1405,8 +1403,6 @@ class TestQuantizeEagerPTQDynamic(QuantizationTestCase):
             prepare_dynamic(model, qconfig_dict)
 
             def checkHooksIsPresent(model):
-                self.assertTrue(fw_pre_hook.__name__ in (x.__name__ for x in model.fc._forward_pre_hooks.values()))
-                self.assertTrue(fw_hook.__name__ in (x.__name__ for x in model.fc._forward_hooks.values()))
                 self.assertEqual(len(model.fc1._forward_pre_hooks.values()), 1,
                                  "Extra pre forward hooks have appeared on a layer")
                 self.assertEqual(len(model.fc1._forward_hooks.values()), 1,

--- a/test/quantization/eager/test_quantize_eager_ptq.py
+++ b/test/quantization/eager/test_quantize_eager_ptq.py
@@ -745,8 +745,8 @@ class TestQuantizeEagerPTQStatic(QuantizationTestCase):
                                  "Quantization observer hook has disappeared")
                 num_fwd_hooks = 2
 
-            self.assertTrue(fw_pre_hook.__name__ in [x.__name__ for x in model.fc._forward_pre_hooks.values()])
-            self.assertTrue(fw_hook.__name__ in [x.__name__ for x in model.fc._forward_hooks.values()])
+            self.assertTrue(fw_pre_hook.__name__ in (x.__name__ for x in model.fc._forward_pre_hooks.values()))
+            self.assertTrue(fw_hook.__name__ in (x.__name__ for x in model.fc._forward_hooks.values()))
             self.assertEqual(len(model.fc._forward_pre_hooks.values()), 1,
                              "Extra pre forward hooks have appeared on a layer")
             # During static quantization non stub layers are provided with quantization observer hook too
@@ -1405,8 +1405,8 @@ class TestQuantizeEagerPTQDynamic(QuantizationTestCase):
             prepare_dynamic(model, qconfig_dict)
 
             def checkHooksIsPresent(model):
-                self.assertTrue(fw_pre_hook.__name__ in [x.__name__ for x in model.fc._forward_pre_hooks.values()])
-                self.assertTrue(fw_hook.__name__ in [x.__name__ for x in model.fc._forward_hooks.values()])
+                self.assertTrue(fw_pre_hook.__name__ in (x.__name__ for x in model.fc._forward_pre_hooks.values()))
+                self.assertTrue(fw_hook.__name__ in (x.__name__ for x in model.fc._forward_hooks.values()))
                 self.assertEqual(len(model.fc1._forward_pre_hooks.values()), 1,
                                  "Extra pre forward hooks have appeared on a layer")
                 self.assertEqual(len(model.fc1._forward_hooks.values()), 1,

--- a/test/quantization/eager/test_quantize_eager_qat.py
+++ b/test/quantization/eager/test_quantize_eager_qat.py
@@ -539,8 +539,6 @@ class TestQuantizeEagerQAT(QuantizationTestCase):
                 self.assertEqual(len(model.quant._forward_hooks.values()), 1,
                                  "Quantization observer hook has disappeared")
                 forward_hooks = 2
-            self.assertTrue(fw_pre_hook.__name__ in (x.__name__ for x in model.fc._forward_pre_hooks.values()))
-            self.assertTrue(fw_hook.__name__ in (x.__name__ for x in model.fc._forward_hooks.values()))
             self.assertEqual(len(model.fc._forward_pre_hooks.values()), 1,
                              "Extra pre forward hooks have appeared on a layer")
             self.assertEqual(len(model.fc._forward_hooks.values()), forward_hooks,

--- a/test/quantization/eager/test_quantize_eager_qat.py
+++ b/test/quantization/eager/test_quantize_eager_qat.py
@@ -539,8 +539,8 @@ class TestQuantizeEagerQAT(QuantizationTestCase):
                 self.assertEqual(len(model.quant._forward_hooks.values()), 1,
                                  "Quantization observer hook has disappeared")
                 forward_hooks = 2
-            self.assertTrue(fw_pre_hook.__name__ in [x.__name__ for x in model.fc._forward_pre_hooks.values()])
-            self.assertTrue(fw_hook.__name__ in [x.__name__ for x in model.fc._forward_hooks.values()])
+            self.assertTrue(fw_pre_hook.__name__ in (x.__name__ for x in model.fc._forward_pre_hooks.values()))
+            self.assertTrue(fw_hook.__name__ in (x.__name__ for x in model.fc._forward_hooks.values()))
             self.assertEqual(len(model.fc._forward_pre_hooks.values()), 1,
                              "Extra pre forward hooks have appeared on a layer")
             self.assertEqual(len(model.fc._forward_hooks.values()), forward_hooks,

--- a/test/quantization/eager/test_quantize_eager_qat.py
+++ b/test/quantization/eager/test_quantize_eager_qat.py
@@ -539,8 +539,8 @@ class TestQuantizeEagerQAT(QuantizationTestCase):
                 self.assertEqual(len(model.quant._forward_hooks.values()), 1,
                                  "Quantization observer hook has disappeared")
                 forward_hooks = 2
-            self.assertObjectIn(fw_pre_hook, model.fc._forward_pre_hooks.values())
-            self.assertObjectIn(fw_hook, model.fc._forward_hooks.values())
+            self.assertTrue(fw_pre_hook.__name__ in [x.__name__ for x in model.fc._forward_pre_hooks.values()])
+            self.assertTrue(fw_hook.__name__ in [x.__name__ for x in model.fc._forward_hooks.values()])
             self.assertEqual(len(model.fc._forward_pre_hooks.values()), 1,
                              "Extra pre forward hooks have appeared on a layer")
             self.assertEqual(len(model.fc._forward_hooks.values()), forward_hooks,

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -365,6 +365,7 @@ class _RemoteModule(nn.Module):
         self,
         hook: Callable[..., None],
         prepend: bool = False,
+        with_kwargs: bool = False,
     ) -> RemovableHandle:
         _raise_not_supported(self.register_forward_pre_hook.__name__)
 
@@ -372,6 +373,7 @@ class _RemoteModule(nn.Module):
         self,
         hook: Callable[..., None],
         prepend: bool = False,
+        with_kwargs: bool = False,
     ) -> RemovableHandle:
         _raise_not_supported(self.register_forward_hook.__name__)
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1397,7 +1397,9 @@ class Module:
                 ``handle.remove()``
         """
         handle = hooks.RemovableHandle(self._forward_pre_hooks)
-        self._forward_pre_hooks[handle.id] = _PreForwardWrappedHook(hook, with_kwargs=with_kwargs)
+        if not isinstance(hook, _PreForwardWrappedHook):
+            _PreForwardWrappedHook(hook, with_kwargs=with_kwargs)
+        self._forward_pre_hooks[handle.id] = hook
         if prepend:
             self._forward_pre_hooks.move_to_end(handle.id, last=False)  # type: ignore[attr-defined]
         return handle
@@ -1442,7 +1444,9 @@ class Module:
         """
         handle = hooks.RemovableHandle(self._forward_hooks)
 
-        self._forward_hooks[handle.id] = _ForwardWrappedHook(hook, with_kwargs=with_kwargs)
+        if not isinstance(hook, _ForwardWrappedHook):
+            _ForwardWrappedHook(hook, with_kwargs=with_kwargs)
+        self._forward_hooks[handle.id] = hook
         if prepend:
             self._forward_hooks.move_to_end(handle.id, last=False)  # type: ignore[attr-defined]
         return handle

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -87,30 +87,28 @@ class _WrappedHook:
             self.module = weakref.ref(state["module"])
 
 
-class _PreForwardWrappedHook:
+class _PreForwardWrappedHook(_WrappedHook):
 
-    def __init__(self, hook: Callable, with_kwargs: bool = False):
-        self.hook = hook
-        functools.update_wrapper(self, hook)
+    def __init__(self, hook: Callable, module: Optional["Module"] = None, with_kwargs: bool = False):
+        super().__init__(hook, module)
         self.with_kwargs = with_kwargs
 
     def __call__(self, module, inp, kwargs):
         if self.with_kwargs:
-            return self.hook(module, inp, kwargs)
-        return self.hook(module, inp), kwargs
+            return super().__call__(module, inp, kwargs)
+        return super().__call__(module, inp), kwargs
 
 
-class _ForwardWrappedHook:
+class _ForwardWrappedHook(_WrappedHook):
 
     def __init__(self, hook: Callable, module: Optional["Module"] = None, with_kwargs: bool = False):
-        self.hook = hook
-        functools.update_wrapper(self, hook)
+        super().__init__(hook, module)
         self.with_kwargs = with_kwargs
 
     def __call__(self, module, inp, out, kwargs):
         if self.with_kwargs:
-            return self.hook(module, inp, out, kwargs)
-        return self.hook(module, inp, out)
+            return super().__call__(module, inp, out, kwargs)
+        return super().__call__(module, inp, out)
 
 
 r"""This tracks hooks common to all modules that are executed before/after

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1318,7 +1318,7 @@ class Module:
                               "behavior.")
 
     def register_forward_pre_hook(
-        self, hook: Callable[..., None], prepend: bool = False, with_kwargs: bool = False
+        self, hook: Callable[..., None], *, prepend: bool = False, with_kwargs: bool = False
     ) -> RemovableHandle:
         r"""Registers a forward pre-hook on the module.
 
@@ -1365,7 +1365,7 @@ class Module:
         return handle
 
     def register_forward_hook(
-        self, hook: Callable[..., None], prepend: bool = False, with_kwargs: bool = False
+        self, hook: Callable[..., None], *, prepend: bool = False, with_kwargs: bool = False
     ) -> RemovableHandle:
         r"""Registers a forward hook on the module.
 

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1397,7 +1397,7 @@ class Module:
                 ``handle.remove()``
         """
         handle = hooks.RemovableHandle(self._forward_pre_hooks)
-        self._forward_pre_hooks[handle.id] = _PreForwardWrappedHook(hook, with_kwargs=with_kwargs)hook
+        self._forward_pre_hooks[handle.id] = _PreForwardWrappedHook(hook, with_kwargs=with_kwargs)
         if prepend:
             self._forward_pre_hooks.move_to_end(handle.id, last=False)  # type: ignore[attr-defined]
         return handle
@@ -1493,7 +1493,7 @@ class Module:
                     input = result
 
         if self._forward_pre_hooks:
-            for hook in self._forward_pre_hooks.values():
+            for hook in list(self._forward_pre_hooks.values()):
                 result, kwargs = hook(self, input, kwargs)
                 if result is not None:
                     if not isinstance(result, tuple):
@@ -1513,7 +1513,7 @@ class Module:
                     result = hook_result
 
         if self._forward_hooks:
-            for hook in self._forward_hooks.values():
+            for hook in list(self._forward_hooks.values()):
                 hook_result = hook(self, input, result, kwargs)
                 if hook_result is not None:
                     result = hook_result

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -92,6 +92,15 @@ class _PreForwardWrappedHook(_WrappedHook):
         super().__init__(hook, module)
         self.with_kwargs = with_kwargs
 
+    def __getstate__(self) -> Dict:
+        state = super().__getstate__()
+        state['with_kwargs'] = self.with_kwargs
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self.with_kwargs = state.get("with_kwargs")
+
     def __call__(self, module, inp, kwargs):
         if self.with_kwargs:
             return super().__call__(module, inp, kwargs)
@@ -103,6 +112,15 @@ class _ForwardWrappedHook(_WrappedHook):
     def __init__(self, hook: Callable, module: Optional["Module"] = None, with_kwargs: bool = False):
         super().__init__(hook, module)
         self.with_kwargs = with_kwargs
+
+    def __getstate__(self) -> Dict:
+        state = super().__getstate__()
+        state['with_kwargs'] = self.with_kwargs
+        return state
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self.with_kwargs = state.get("with_kwargs")
 
     def __call__(self, module, inp, out, kwargs):
         if self.with_kwargs:
@@ -1379,7 +1397,7 @@ class Module:
                 ``handle.remove()``
         """
         handle = hooks.RemovableHandle(self._forward_pre_hooks)
-        self._forward_pre_hooks[handle.id] = _PreForwardWrappedHook(hook, with_kwargs=with_kwargs)
+        self._forward_pre_hooks[handle.id] = _PreForwardWrappedHook(hook, with_kwargs=with_kwargs)hook
         if prepend:
             self._forward_pre_hooks.move_to_end(handle.id, last=False)  # type: ignore[attr-defined]
         return handle

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -3,7 +3,6 @@ import itertools
 import warnings
 import functools
 import weakref
-import types
 
 import torch
 from ..parameter import Parameter

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1355,11 +1355,11 @@ class Module:
                 ``handle.remove()``
         """
         handle = hooks.RemovableHandle(self._forward_pre_hooks)
-        if not with_kwargs:
-            def f(m, inp, kwargs=None):
-                hook(m, inp), kwargs
-            hook = f
-        self._forward_pre_hooks[handle.id] = hook
+        @functools.wraps(hook)
+        def hook_wrapper(m, inp, kwargs):
+            return hook(m, inp), kwargs
+
+        self._forward_pre_hooks[handle.id] = hook if with_kwargs else hook_wrapper
         if prepend:
             self._forward_pre_hooks.move_to_end(handle.id, last=False)  # type: ignore[attr-defined]
         return handle
@@ -1403,11 +1403,11 @@ class Module:
                 ``handle.remove()``
         """
         handle = hooks.RemovableHandle(self._forward_hooks)
-        if not with_kwargs:
-            def f(m, inp, out, kwargs=None):
-                hook(m, inp, out)
-            hook = f
-        self._forward_hooks[handle.id] = hook
+        @functools.wraps(hook)
+        def hook_wrapper(m, inp, out, kwargs):
+            return hook(m, inp, out)
+
+        self._forward_hooks[handle.id] = hook if with_kwargs else hook_wrapper
         if prepend:
             self._forward_hooks.move_to_end(handle.id, last=False)  # type: ignore[attr-defined]
         return handle

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1356,7 +1356,7 @@ class Module:
         """
         handle = hooks.RemovableHandle(self._forward_pre_hooks)
         if not with_kwargs:
-            def f(m, inp, kwargs):
+            def f(m, inp, kwargs=None):
                 hook(m, inp), kwargs
             hook = f
         self._forward_pre_hooks[handle.id] = hook
@@ -1404,7 +1404,7 @@ class Module:
         """
         handle = hooks.RemovableHandle(self._forward_hooks)
         if not with_kwargs:
-            def f(m, inp, out, kwargs):
+            def f(m, inp, out, kwargs=None):
                 hook(m, inp, out)
             hook = f
         self._forward_hooks[handle.id] = hook

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1356,7 +1356,8 @@ class Module:
         """
         handle = hooks.RemovableHandle(self._forward_pre_hooks)
         if not with_kwargs:
-            def f(m, inp, kwargs): hook(m, inp), kwargs
+            def f(m, inp, kwargs):
+                hook(m, inp), kwargs
             hook = f
         self._forward_pre_hooks[handle.id] = hook
         if prepend:
@@ -1403,7 +1404,8 @@ class Module:
         """
         handle = hooks.RemovableHandle(self._forward_hooks)
         if not with_kwargs:
-            def f(m, inp, out, kwargs): hook(m, inp, out)
+            def f(m, inp, out, kwargs):
+                hook(m, inp, out)
             hook = f
         self._forward_hooks[handle.id] = hook
         if prepend:


### PR DESCRIPTION
### Description
This change adds support for `kwargs` in hooks. Currently, registered hooks do not receive, and cannot modify, the `kwargs` provided to the module `forward`.  

The proposed way to address this is to add an annotation to the hook function so that it is possible to determine whether the hook should keep the previous behaviour, or instead also expect and return `kwargs`.

### Issue
This change addresses the issue https://github.com/pytorch/pytorch/issues/35643 where alternative implementations
are also discussed

### Testing
There is a test implemented for this functionality. Its a little basic, but shows the use of both forward and pre_forward hooks using this change.