### PR TITLE
Copy black config to ufmt and run lintrunner -a

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -689,7 +689,9 @@ code = 'UFMT'
 # currently enforced by BLACK linter
 include_patterns = [
     'test/onnx/**/*.py',
+    'test/test_dynamo_cudagraphs.py',
     'tools/**/*.py',
+    'torch/package/**/*.py',
     'torch/_decomp/**/*.py',
     'torch/_lazy/**/*.py',
     'torch/_masked/**/*.py',

--- a/test/test_dynamo_cudagraphs.py
+++ b/test/test_dynamo_cudagraphs.py
@@ -1,19 +1,17 @@
 # Owner(s): ["module: cuda graphs"]
 
+import functools
 import sys
-import torch
-from torch.testing._internal.common_utils import (
-    TestCase,
-    run_tests,
-)
 
 from unittest.mock import patch
-import functools
+
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
 
 try:
+    import functorch  # noqa: F401
     import torchdynamo
     from torch.cuda._dynamo_graphs import aot_autograd_cudagraphs
-    import functorch  # noqa: F401
 
     TEST_DYNAMO = True
 except ImportError:

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -1,5 +1,6 @@
 import builtins
 import importlib
+import importlib.machinery
 import inspect
 import io
 import linecache
@@ -21,7 +22,6 @@ from ._importlib import (
     _resolve_name,
     _sanity_check,
 )
-import importlib.machinery
 from ._mangling import demangle, PackageMangler
 from ._package_unpickler import PackageUnpickler
 from .file_structure_representation import _create_directory_from_file_list, Directory


### PR DESCRIPTION
The last entry is `torch/onnx/**/*.py` will be covered in a separated PR to onnx code owner

### Description
After ufmt (black + usort) covers the same set of files as black, when we can remove black and keep only one "true" linter for pytorch