### PR TITLE
Do not suppress fallback exception in fake tensor

### DIFF
--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -579,13 +579,10 @@ def run_fallback_kernel(func, args, kwargs, orig_not_implemented_exception):
                 return out
             return e
 
-        try:
-            args = tree_map(to_real_tensor, args)
-            kwargs = tree_map(to_real_tensor, kwargs)
+        args = tree_map(to_real_tensor, args)
+        kwargs = tree_map(to_real_tensor, kwargs)
 
-            r = func(*args, **kwargs)
-        except Exception as new_exception:
-            raise orig_not_implemented_exception from new_exception
+        r = func(*args, **kwargs)
 
         tensor_impls = set()
         storages = set()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82066

If the call is (1) not implemented in meta and (2) truly erroneous,
this will be the real error message, and we had better report it
to the user!

Signed-off-by: Edward Z. Yang <ezyang@fb.com>