### PR TITLE
[CI] Disable ios-12-5-1-x86-64 (#81612) (#81612)

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -128,6 +128,7 @@ jobs:
         ]}
 
   ios-12-5-1-x86-64:
+    if: false
     name: ios-12-5-1-x86-64
     uses: ./.github/workflows/_ios-build-test.yml
     with:


### PR DESCRIPTION
Summary:
Currently broken, but for a while it was not testing trunk, but rather some old released build, see https://github.com/pytorch/pytorch/runs/7369514831?check_suite_focus=true#step:9:147

Pull Request resolved: https://github.com/pytorch/pytorch/pull/81612
Approved by: https://github.com/kit1980

Test Plan: contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/446833d11f7a99366323bf4033a579a10a9309c6

Reviewed By: DanilBaibak

Differential Revision: D37919692

Pulled By: malfet

fbshipit-source-id: c4fb3e32ffd2ca4d9004a4ab14d651cface00c26