### PR TITLE
[DOC] fix a mistake in torch.dist document

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3835,7 +3835,7 @@ Example::
     >>> torch.dist(x, y, 3)
     tensor(1.6973)
     >>> torch.dist(x, y, 0)
-    tensor(inf)
+    tensor(4.)
     >>> torch.dist(x, y, 1)
     tensor(2.6537)
 """.format(


### PR DESCRIPTION
In document (https://pytorch.org/docs/stable/generated/torch.dist.html )the torch.dist(x, y, 0) returns inf.

However, it should return 4.0 and the pytorch (1.12)  does return 4.0

