### PR TITLE
Directly allocate eye to correct size

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -427,7 +427,7 @@ Tensor eye(int64_t n, int64_t m,
   // See [Note: hacky wrapper removal for TensorOptions]
   TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
 
-  auto tensor = at::empty({0}, options); // to be resized
+  auto tensor = at::empty({n, m}, options);
   return at::eye_out(tensor, n, m);
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82115

Signed-off-by: Edward Z. Yang <ezyang@fb.com>