### PR TITLE
Modify APoT dequantize method

### DIFF
--- a/torch/ao/quantization/experimental/quantizer.py
+++ b/torch/ao/quantization/experimental/quantizer.py
@@ -57,7 +57,7 @@ class APoTQuantizer():
         result: fp representation of input Tensor
     """
     def dequantize(self, apot_tensor) -> Tensor:
-        apot_tensor_data = apot_tensor.data
+        apot_tensor_data = apot_tensor.data.flatten()
 
         # map apot_to_float over tensor2quantize elements
         result_temp = np.empty(shape=apot_tensor_data.size())

--- a/torch/ao/quantization/experimental/quantizer.py
+++ b/torch/ao/quantization/experimental/quantizer.py
@@ -60,12 +60,12 @@ class APoTQuantizer():
         apot_tensor_data = apot_tensor.data
 
         # map apot_to_float over tensor2quantize elements
-        result_temp = np.empty(apot_tensor_data.size())
-        for ele in apot_tensor_data:
-            new_ele = apot_to_float(ele, self.quantization_levels, self.level_indices)
-            np.append(result_temp, new_ele)
+        result_temp = np.empty(shape=apot_tensor_data.size())
+        for i in range(len(apot_tensor_data)):
+            new_ele = apot_to_float(apot_tensor_data[i], self.quantization_levels, self.level_indices)
+            result_temp[i] = new_ele
 
-        result = torch.from_numpy(result_temp).int()
+        result = torch.from_numpy(result_temp)
 
         return result
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #82105
* __->__ #82126

### Summary
Modify APoT dequantize method to correctly add dequantized values to result numpy array and retain original tensor dimensions

### Test Plan
Run unit tests with: `python test/quantization/core/experimental/test_quantizer.py`