### PR TITLE
Remove native weight norm cpu kernel

### DIFF
--- a/aten/src/ATen/native/WeightNorm.cpp
+++ b/aten/src/ATen/native/WeightNorm.cpp
@@ -82,10 +82,13 @@ Tensor _weight_norm
   auto v = v_in.contiguous();
   auto g = g_in.contiguous();
 
-  auto has_half_dtype = v.scalar_type() == at::ScalarType::Half
-    || g.scalar_type() == at::ScalarType::Half;
+  // Disable changes from #73845 (disable custom CPU kernel) since it causes
+  // many issues, including #80599, #80569 and #81195
+  // auto has_half_dtype = v.scalar_type() == at::ScalarType::Half
+  //   || g.scalar_type() == at::ScalarType::Half;
 
-  bool can_use_fused = !has_half_dtype && ((dim == 0) || (dim == v.dim() - 1));
+  // bool can_use_fused = !has_half_dtype && ((dim == 0) || (dim == v.dim() - 1));
+  bool can_use_fused = v.is_cuda() && (dim == 0 || dim == v.dim() - 1);
 
   if (can_use_fused) {
     // weight_norm does not have a derivative defined for it, so this will route back through

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4634,6 +4634,11 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         m = nn.Linear(4, 5, dtype=torch.float16)
         m = torch.nn.utils.weight_norm(m)
 
+        # Check that the computed result is correct for at least a very simple sample
+        a = torch.Tensor([[1,2],[3,4]])
+        b = torch.Tensor([[5],[6]])
+        self.assertEqual(torch._weight_norm(a,b,dim=1), a * b / a.norm(dim=0))
+
     def test_parameterlistdict_setting_attributes(self):
         with warnings.catch_warnings(record=True) as w:
             mod = nn.ParameterList(map(nn.Parameter, [torch.rand(2), torch.rand(2)]))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4635,9 +4635,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         m = torch.nn.utils.weight_norm(m)
 
         # Check that the computed result is correct for at least a very simple sample
-        a = torch.Tensor([[1,2],[3,4]])
-        b = torch.Tensor([[5],[6]])
-        self.assertEqual(torch._weight_norm(a,b,dim=1), a * b / a.norm(dim=0))
+        a = torch.Tensor([[1, 2], [3, 4]])
+        b = torch.Tensor([[5], [6]])
+        self.assertEqual(torch._weight_norm(a, b, dim=1), a * b / a.norm(dim=0))
 
     def test_parameterlistdict_setting_attributes(self):
         with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
Disable the implementation from #73845 to avoid more issues.

Fix https://github.com/pytorch/pytorch/issues/81195 