### PR TITLE
Rematerialization on arbitrary graphs, mincut

### DIFF
--- a/functorch/functorch/_src/partitioners.py
+++ b/functorch/functorch/_src/partitioners.py
@@ -8,7 +8,7 @@ import os
 from torch.fx.passes import graph_drawer
 from typing import Tuple
 from .compile_utils import fx_graph_cse, get_aten_target
-
+from .utilities import _size_of, ban_recomputation, fusible_ops
 
 class InvalidNodeBase(object):
     def __repr__(self):
@@ -159,38 +159,6 @@ def default_partition(
     return _extract_fwd_bwd_modules(joint_module, saved_values)
 
 
-def _prod(x):
-    s = 1
-    for i in x:
-        s *= i
-    return s
-
-
-def _size_of(metadata):
-    sizes = {
-        torch.float: 4,
-        torch.float16: 2,
-        torch.bfloat16: 2,
-        torch.float32: 4,
-        torch.float64: 8,
-        torch.int: 4,
-        torch.int8: 1,
-        torch.int16: 2,
-        torch.int32: 4,
-        torch.int64: 8,
-        torch.uint8: 1,
-        torch.bool: 1,
-    }
-
-    numel = _prod(metadata.shape)
-    dtype = metadata.dtype
-
-    if dtype not in sizes:
-        raise NotImplementedError("Don't know the size of dtype ", dtype)
-
-    return numel * sizes[dtype]
-
-
 # Used for some investigative purposes
 def _count_ops(graph):
     from collections import defaultdict
@@ -266,51 +234,6 @@ def min_cut_rematerialization_partition(
             node.dist_from_bw = int(1e9)
             for user in node.users:
                 node.dist_from_bw = min(node.dist_from_bw, user.dist_from_bw + 1)
-
-    aten = torch.ops.aten
-
-    pointwise_ops = [aten.add, aten.sub, aten.div, aten.atan2, aten.mul, aten.max, aten.min, aten.pow, aten.remainder, aten.fmod, aten.__and__, aten.__or__, aten.__xor__, aten.__lshift__, aten.__rshift__, aten.eq, aten.ne, aten.ge, aten.gt, aten.le, aten.lt, aten.abs, aten.bitwise_not, aten.ceil, aten.floor, aten.frac, aten.neg, aten.relu, aten.round, aten.silu, aten.trunc, aten.log, aten.log10, aten.log1p, aten.log2, aten.lgamma, aten.exp, aten.expm1, aten.erf, aten.erfc, aten.cos, aten.acos, aten.cosh, aten.sin, aten.asin, aten.sinh, aten.tan, aten.atan, aten.tanh, aten.atanh, aten.sqrt, aten.rsqrt, aten.reciprocal, aten.sigmoid, aten.softplus, aten.threshold, aten.threshold_backward, aten.clamp, aten.where, aten.lerp, aten.addcmul, aten.gelu, aten.gelu_backward]  # noqa: E501
-    misc_ops = [aten.to, aten.type_as, operator.getitem]
-
-    reduction_ops = [aten.softmax, aten._softmax, aten._softmax_backward_data, aten.sum, aten.mean, aten._grad_sum_to_size, aten.sum_to_size, aten.amax]  # noqa: E501
-
-    # not recomputed by default since these are kinda expensive/hard to fuse into
-    # norm_ops = [aten.instance_norm, aten._batch_norm_impl_index, aten.native_batch_norm, aten.batch_norm, aten._batch_norm_impl_index_backward, aten.native_layer_norm, aten.layer_norm, aten.native_layer_norm_backward]  # noqa: E501
-
-    # Not used by default since NVFuser can't fuse view ops
-    # view_ops = [aten.expand, aten.clone, aten.transpose, aten.t, aten.view, aten._unsafe_view, aten.permute, aten.transpose, aten.t, aten._reshape_alias, aten.squeeze, aten.unsqueeze, aten.reshape, aten.cat, aten.slice, aten.split, aten.select, aten.repeat]  # noqa: E501
-
-    # These are the view ops that NVFuser can fuse
-    view_ops = [aten.squeeze, aten.unsqueeze]
-    random_ops = [aten.native_dropout, aten.rand_like, aten.randn_like]
-    compute_intensive_ops = [aten.mm, aten.convolution, aten.convolution_backward, aten.bmm, aten.addmm, aten.upsample_bilinear2d]  # noqa: E501
-    unrecomputable_ops = random_ops + compute_intensive_ops
-
-    recomputable_ops = set(
-        pointwise_ops
-        + misc_ops
-        + reduction_ops
-        + view_ops
-    )
-    fusible_ops = recomputable_ops | set(random_ops)
-
-    AGGRESSIVE_RECOMPUTATION = False
-
-    def ban_recomputation(node):
-        if AGGRESSIVE_RECOMPUTATION:
-            return (node.op == 'call_function' and get_aten_target(node) in unrecomputable_ops)
-        else:
-            if node.op != 'call_function':
-                return False
-            if get_aten_target(node) not in recomputable_ops:
-                return True
-            # If the output of the reduction is 4x smaller (arbitrary choice),
-            # then we don't allow recomputation.
-            if get_aten_target(node) in reduction_ops:
-                input_tensors_size = sum(_size_of(i.meta['tensor_meta']) for i in node.args if isinstance(i, fx.Node))
-                output_size = _size_of(node.meta['tensor_meta'])
-                return (output_size * 4 < input_tensors_size)
-            return False
 
     def is_fusible(a, b):
         return get_aten_target(a) in fusible_ops and get_aten_target(b) in fusible_ops

--- a/functorch/functorch/_src/remat_utils_mincut.py
+++ b/functorch/functorch/_src/remat_utils_mincut.py
@@ -1,15 +1,18 @@
+import operator
+import math
+import copy
+import os
 from typing import List, Tuple, Dict, Set
+
 import torch
 import torch.fx as fx
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
 from torch.fx.passes.backends.nvfuser import NvFuserOperatorSupport
 from torch.fx.passes.tools_common import legalize_graph
-import operator
-import math
-import copy
 
 from .utilities import _size_of, ban_recomputation
 
+REMATERIALIZATION_DEBUG = bool(os.environ.get("REMATERIALIZATION_DEBUG", False))
 
 num_group_remat = 0  # used for analytical purpose
 memory_reduced = 0
@@ -244,7 +247,8 @@ def get_node_to_copy(non_reachable: Set[str], cut_nodes: Set[str]) -> Set[str]:
         node_name = get_nx_node_name(node_name)
         node_to_copy.add(node_name)
     node_to_copy = node_to_copy.difference(cut_nodes)  # cut nodes are handeled separately as placeholders
-
+    if REMATERIALIZATION_DEBUG:
+        print(node_to_copy)
     return node_to_copy
 
 

--- a/functorch/functorch/_src/remat_utils_mincut.py
+++ b/functorch/functorch/_src/remat_utils_mincut.py
@@ -297,14 +297,14 @@ def copy_nodes(node_pair, fused_graph, name_to_node, partition, cut_nodes):
 
 def find_min_cut(node_pair: Tuple[fx.Node, fx.Node], node_users_map: Dict[str, Set[fx.Node]], fused_graph: fx.GraphModule):
     """
-    Use a min-cut algorithm to determine whether rematerialization between the ```node_pair``` 
-    is needed and which nodes should be rematerialized. 
-    This algorithm minimizes the memory reading/writing cost of computing the outputs of these two fusion groups. 
+    Use a min-cut algorithm to determine whether rematerialization between the ```node_pair```
+    is needed and which nodes should be rematerialized.
+    This algorithm minimizes the memory reading/writing cost of computing the outputs of these two fusion groups.
     The mincut value is the cost of reading/writing between the two fusion groups.
 
     Args:
-        node_pair (Tuple[fx.Node, fx.Node]): a pair of nodes in the fusion graph. We want to find the mincut between them. 
-            The first node is the origin node and the second node is the destination node. They should be "touching", 
+        node_pair (Tuple[fx.Node, fx.Node]): a pair of nodes in the fusion graph. We want to find the mincut between them.
+            The first node is the origin node and the second node is the destination node. They should be "touching",
             meaning the destination node should use the outputs of the origin node, either directly or through a getitem node.
         node_users_map (Dict[str, Set[fx.Node]]): map from a node's name its users in the original graph G
         fused_graph (fx.GraphModule): the fused graph (of some FX graph G) where each fusion group is a submodule

--- a/functorch/functorch/_src/remat_utils_mincut.py
+++ b/functorch/functorch/_src/remat_utils_mincut.py
@@ -1,0 +1,489 @@
+import torch
+from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
+from torch.fx.passes.backends.nvfuser import NvFuserOperatorSupport
+from torch.fx.passes.tools_common import legalize_graph
+import torch.fx as fx
+import operator
+import math
+import copy
+
+from .utilities import _size_of
+
+
+num_group_remat = 0  # used for analytical purpose
+memory_reduced = 0
+num_node_pairs = 0
+
+
+aten = torch.ops.aten
+
+pointwise_ops = [aten.add, aten.sub, aten.div, aten.atan2, aten.mul, aten.max, aten.min, aten.pow, aten.remainder, aten.fmod, aten.__and__, aten.__or__, aten.__xor__, aten.__lshift__, aten.__rshift__, aten.eq, aten.ne, aten.ge, aten.gt, aten.le, aten.lt, aten.abs, aten.bitwise_not, aten.ceil, aten.floor, aten.frac, aten.neg, aten.relu, aten.round, aten.silu, aten.trunc, aten.log, aten.log10, aten.log1p, aten.log2, aten.lgamma, aten.exp, aten.expm1, aten.erf, aten.erfc, aten.cos, aten.acos, aten.cosh, aten.sin, aten.asin, aten.sinh, aten.tan, aten.atan, aten.tanh, aten.atanh, aten.sqrt, aten.rsqrt,  aten.reciprocal, aten.sigmoid, aten.softplus, aten.threshold, aten.threshold_backward, aten.clamp, aten.where, aten.lerp, aten.addcmul, aten.gelu, aten.gelu_backward]  # noqa: E501
+misc_ops = [aten.to, aten.type_as, operator.getitem]
+reduction_ops = [aten.softmax, aten._softmax, aten._softmax_backward_data, aten.sum, aten.mean, aten._grad_sum_to_size, aten.sum_to_size, aten.amax]  # noqa: E501
+
+
+norm_ops = [aten.instance_norm, aten._batch_norm_impl_index, aten.native_batch_norm, aten.batch_norm, aten._batch_norm_impl_index_backward, aten.native_layer_norm, aten.layer_norm, aten.native_layer_norm_backward]  # noqa: E501
+view_ops = [aten.squeeze, aten.unsqueeze]
+random_ops = [aten.native_dropout, aten.rand_like, aten.randn_like]
+compute_intensive_ops = [aten.mm, aten.convolution, aten.convolution_backward, aten.bmm, aten.addmm, aten.upsample_bilinear2d]  # noqa: E501
+unrecomputable_ops = random_ops + compute_intensive_ops + norm_ops
+
+recomputable_ops = set(
+    pointwise_ops
+    + misc_ops
+    + reduction_ops
+    + view_ops
+)
+fusible_ops = recomputable_ops | set(random_ops)
+
+AGGRESSIVE_RECOMPUTATION = False
+
+
+def ban_recomputation(node):
+    if AGGRESSIVE_RECOMPUTATION:
+        return (node.op == 'call_function' and node.target in unrecomputable_ops)
+    else:
+        if node.op != 'call_function':
+            return False
+        if node.target not in recomputable_ops:
+            return True
+        # If the output of the reduction is 4x smaller (arbitrary choice),
+        # then we don't allow recomputation.
+        if node.target in reduction_ops:
+            input_tensors_size = sum(_size_of(i.meta['tensor_meta']) for i in node.args if isinstance(i, fx.Node))
+            output_size = _size_of(node.meta['tensor_meta'])
+            return (output_size * 4 < input_tensors_size)
+        return False
+
+
+def is_fused_node(node):
+    return node.op == "call_module" and "fused_" in node.target
+
+
+def has_remat_node(node, fused_graph):
+    module = getattr(fused_graph, node.name)
+    try_remat = False
+    for node in module.graph.nodes:
+        if node.target != operator.getitem and node.op == "call_function" and not ban_recomputation(node):
+            try_remat = True
+            break
+    return try_remat
+
+
+def try_remat(node, fused_graph):
+    return is_fused_node(node) and has_remat_node(node, fused_graph)
+
+
+def get_users(node):
+    # get the users of a node in fused graph
+    # the user might use the output of node through getitem
+    users = set()
+    for user_node in node.users:
+        if user_node.target == operator.getitem:
+            users = users.union(set(user_node.users.keys()))
+        elif user_node.op != 'output':
+            users.add(user_node)
+    return users
+
+
+def get_fused_node_pairs(fused_graph):
+    # get pairs of fused node that are (parent, children) relationship in graph
+    # the two (parent, children) nodes might have an getitem node between them
+    fused_node_pairs = []
+    for node in fused_graph.graph.nodes:
+        if(try_remat(node, fused_graph)):
+            users = get_users(node)
+            pairs = [(node, user_node) for user_node in users if (try_remat(user_node, fused_graph))]
+            fused_node_pairs.extend(pairs)
+    return fused_node_pairs
+
+
+def get_weight(node):
+    weight = 0
+    if 'tensor_meta' in node.meta:
+        weight = _size_of(node.meta['tensor_meta'])
+    return weight
+
+
+def get_name_to_args_map(node_orig, gm):
+    """
+    map from placeholder name in gm to node_orig.args
+    """
+    placeholder_map = {}
+    loc = 0
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            placeholder_map[node.name] = node_orig.args[loc]
+            loc += 1
+    return placeholder_map
+
+
+def get_nx_node_name(node_name):
+    if node_name.endswith("_in"):
+        return node_name[:-3]
+    elif node_name.endswith("_out"):
+        return node_name[:-4]
+    raise Exception("node name is not _in or _out, " + node_name)
+
+
+def get_cut_nodes_from_partition(partition, nx_graph):
+    reachable, non_reachable = partition
+    cutset = set()
+    for u, nbrs in ((n, nx_graph[n]) for n in reachable):
+        cutset.update((u, v) for v in nbrs if v in non_reachable)
+
+    cut_nodes = set()
+    for node_in, _ in cutset:
+        cut_nodes.add(get_nx_node_name(node_in))
+    return cut_nodes
+
+
+def order_topologically(nodes, gm):
+    node_order_dict = {}
+    rank = 0
+    for n in gm.graph.nodes:
+        node_order_dict[n.name] = rank
+        rank += 1
+
+    nodes = sorted(nodes, key=lambda x: node_order_dict[x])
+    return nodes
+
+
+def get_output_node_args(node):
+    if type(node.args[0]) is not tuple:
+        return node.args
+    return node.args[0]
+
+
+def get_user_name_to_user_map(output_node_in_module, fused_node):
+
+    user_name_to_user_map = {}
+    output_args = get_output_node_args(output_node_in_module)
+    for user in fused_node.users:
+        # can only do this for getitem users. might have a single add node that have two users
+        if user.target != operator.getitem:
+            break
+        loc = user.args[1]
+        if isinstance(output_args[loc], torch.fx.node.Node):
+            user_name = output_args[loc].name
+            user_name_to_user_map[user_name] = user
+    return user_name_to_user_map
+
+
+def add_new_outputs(node_pair, fused_graph, name_to_node, module_origin, cut_nodes, name_to_node_origin):
+    # modify the outputs of module_origin to contain new outputs
+
+    origin_placeholders = set(node for node in module_origin.graph.nodes if node.op == "placeholder")
+    module_origin_new_outputs = {name_to_node_origin[name] for name in cut_nodes}
+    for node in module_origin.graph.nodes:
+        if node.op == "output":
+            old_args = get_output_node_args(node)
+            module_origin_new_outputs = list(module_origin_new_outputs.difference(set(old_args)).difference(origin_placeholders))
+
+            # need to change the user to use getitem if origin only has 1 output but now has more
+            if(len(old_args) == 1 and len(module_origin_new_outputs) > 0):
+                with fused_graph.graph.inserting_after(node_pair[0]):
+                    new_node = fused_graph.graph.call_function(operator.getitem, args=(node_pair[0], 0, ))
+                node_pair[0].replace_all_uses_with(new_node)
+                new_node.args = (node_pair[0], 0, )
+                name_to_node[node_pair[0].name] = new_node  # add new arg to dest placeholder map
+
+            if len(module_origin_new_outputs) > 0:
+                # need to add new ouputs to module_origin and new inputs to module_dest
+                with fused_graph.graph.inserting_after(node_pair[0]):
+                    for i in range(len(module_origin_new_outputs)):
+                        new_node = fused_graph.graph.call_function(
+                            operator.getitem, args=(node_pair[0], i + len(old_args), ))
+                new_args = list(old_args) + module_origin_new_outputs
+                module_origin.graph.erase_node(node)
+                module_origin.graph.output(new_args[0] if len(new_args) == 1 else tuple(new_args))       
+            break
+    module_origin.recompile()
+    fused_graph.recompile()
+
+
+def remove_unused_output(fused_graph, module_origin):
+    # remove the unused output to write less
+    # Use None instead of remove entirely because getitem will index into the outputs
+    # Need to do this after fused_graph.graph.eliminate_dead_code() such that
+    # extra getitem operators are removed.
+    used_inds = set()
+
+    # need to modify the node in fused_graph, not the node passed in pairs
+    for node in fused_graph.graph.nodes:
+        if(node.name == module_origin._get_name()):
+            for node_user in node.users:
+                if node_user.target == operator.getitem:
+                    used_inds.add(node_user.args[1])
+            break
+
+    for node in module_origin.graph.nodes:
+        if node.op == "output":
+            if (len(used_inds) == 0 and type(node.args[0] is not tuple)):  # only has a single output
+                break
+            new_args = []
+            for i in range(len(node.args[0])):
+                if i in used_inds:
+                    new_args.append(node.args[0][i])  # still useful
+                else:
+                    new_args.append(None)  # no need to write out
+            node.args = (tuple(new_args), )
+            break
+    module_origin.recompile()
+    fused_graph.recompile()
+
+
+def get_node_to_copy(non_reachable, cut_nodes):
+    node_to_copy = set()
+    for node_name in non_reachable:
+        if node_name == "sink":
+            continue
+        node_name = get_nx_node_name(node_name)
+        node_to_copy.add(node_name)
+    node_to_copy = node_to_copy.difference(cut_nodes)  # cut nodes are handeled separately as placeholders
+
+    return node_to_copy
+
+
+def copy_nodes(node_pair, fused_graph, name_to_node, partition, cut_nodes):
+    """
+    copy nodes in the non_reachable partition to module of node_pair[1]
+
+    name_to_node is a mapping from name to nodes in fused graph
+    """
+    # breakpoint()
+    reachable, non_reachable = partition
+    module_origin = getattr(fused_graph, node_pair[0].name)
+    module_dest = getattr(fused_graph, node_pair[1].name)
+
+    # map from placeholder name in modules_dest to node_pair[1]'s args
+    placeholder_map = get_name_to_args_map(node_pair[1], module_dest)
+
+    name_to_node_origin = {node.name: node for node in module_origin.graph.nodes}
+    name_to_node_dest = {node.name: node for node in module_dest.graph.nodes}
+
+    # modify the outputs of module_origin to contain new outputs
+    add_new_outputs(node_pair, fused_graph, name_to_node, module_origin, cut_nodes, name_to_node_origin)
+
+    first_node_dest = None
+    for node in module_dest.graph.nodes:
+        first_node_dest = node
+        break
+
+    env = {}  # map from node in origin to node in dest
+    # create new placeholders in module_dest
+    for node_name in cut_nodes:
+        node = name_to_node_origin[node_name]
+        if node_name in name_to_node_dest:
+            # already has a placeholder for it in dest
+            env[node] = name_to_node_dest[node_name]
+            continue
+        with module_dest.graph.inserting_before(first_node_dest):
+            new_node = module_dest.graph.placeholder(node.name, type_expr=node.type)
+            new_node.meta = copy.copy(node.meta)
+            env[node] = new_node
+
+    # copy internal nodes
+    node_to_copy = get_node_to_copy(non_reachable, cut_nodes)
+    node_to_copy = order_topologically(node_to_copy, module_origin)
+    for node_name in node_to_copy:
+        node = name_to_node_origin[node_name]
+        with module_dest.graph.inserting_before(first_node_dest):
+            new_node = module_dest.graph.node_copy(node, lambda x: env[x])
+            new_node.name = node.name  # use the same name such that node can be referenced back to original graph
+            env[node] = new_node
+            # change the args of nodes in dest to use the new node
+            # e.g. a placeholder is now a node to recompute
+            if node.name in name_to_node_dest:
+                name_to_node_dest[node.name].replace_all_uses_with(new_node)
+
+    # erase unused placeholder nodes and record current active placeholders
+    active_placeholders = []
+    for node in module_dest.graph.nodes:
+        if node.op == "placeholder":
+            if len(node.users) == 0:
+                module_dest.graph.erase_node(node)
+            else:
+                active_placeholders.append(node.name)
+
+    legalize_graph(module_dest)
+    module_dest.graph.eliminate_dead_code()
+    module_dest.graph.lint()
+
+    # change the args of node_pair[1] to match the new placeholders of module_dest
+    origin_placeholder_map = get_name_to_args_map(node_pair[0], module_origin)
+    placeholder_map.update(origin_placeholder_map)
+    for node in module_origin.graph.nodes:
+        if node.op == "output":
+            user_name_to_user_map = get_user_name_to_user_map(node, node_pair[0])
+            placeholder_map.update(user_name_to_user_map)
+
+    new_args = []
+    for name in active_placeholders:
+        if name in name_to_node:  # name is a node in fused graph
+            new_args.append(name_to_node[name])
+        else:  # name is a placeholder in origin's module or dest's module or a newly added input
+            new_args.append(placeholder_map[name])
+    node_pair[1].args = tuple(new_args)
+    fused_graph.recompile()
+
+    fused_graph.graph.eliminate_dead_code()
+    fused_graph.graph.lint()
+    module_dest.recompile()
+
+    # remove the unused output to write less
+    remove_unused_output(fused_graph, module_origin)
+
+
+def find_min_cut(node_pair, node_users_map, fused_graph):
+    """
+        The mincut value is the cost of reading/writing between the two fusion groups
+    """
+
+    try:
+        import networkx as nx
+    except ImportError:
+        raise RuntimeError("Need networkx installed to perform smart recomputation heuristics")
+    nx_graph = nx.DiGraph()
+    node_origin = node_pair[0]
+    node_dest = node_pair[1]
+    module_origin = getattr(fused_graph, node_origin.name)
+    module_dest = getattr(fused_graph, node_dest.name)
+
+    dest_placeholder_names = {node.name for node in module_dest.graph.nodes if node.op == "placeholder"}
+    # used to check if a node has users in dest.
+    # The user node in the original graph has the same name as the call_func nodes in dest.
+    dest_node_names = {node.name for node in module_dest.graph.nodes if node.op != "placeholder" and node.op != "output"}  # noqa: E501
+    orig_node_names = {node.name for node in module_origin.graph.nodes if node.op != "placeholder" and node.op != "output"}  # noqa: E501
+
+    # track the users of each node in traced_graph
+    getitem_users = {}
+    for node in module_origin.graph.nodes:
+        if node.op == "output":
+            output_args = get_output_node_args(node)
+    loc = 0
+    for user in node_origin.users:
+        # can only do this for getitem users. might have a single add node that have two users
+        if user.target != operator.getitem:
+            break
+        if isinstance(output_args[loc], torch.fx.node.Node):
+            user_name = output_args[loc].name
+            getitem_users[user_name] = user.name  # add new arg to dest placeholder map
+        loc += 1
+
+    def get_capacity(node):
+        # if rematerialize an internal node, need to read and write
+        # might not need to add the write cost, because it might be read by other
+        # might not need to add the read cost, if already reading it - no need the cost
+        user_names_set = set({n.name for n in node_users_map[node.name]})
+        user_names_outside_set = user_names_set.difference(orig_node_names)
+        write_cost = 0  # cost for both read and write because only dest_module is using it
+        if weight and user_names_outside_set.issubset(set(dest_node_names)):
+            write_cost = weight
+
+        read_cost = weight
+
+        capacity = write_cost+read_cost
+        return capacity
+
+    for node in module_origin.graph.nodes:
+        if node.op == 'output':
+            continue
+
+        weight = get_weight(node)
+
+        if ban_recomputation(node):
+            nx_graph.add_edge("source",  node.name+"_out", capacity=math.inf)
+
+        # some ops like cuda_batch_norm return tuples, and they cannot be returned as output
+        # because torch.jit.script does not accept
+        # need to return getitem, these getitems might already in the graph
+        # neeed to change the capacity between _in and _out of these ndoes to inf
+        for user in node.users:
+            if user.target == operator.getitem:
+                weight = math.inf
+            break
+
+        if node.op == 'placeholder':
+            capacity = weight
+            nx_graph.add_edge("source", node.name+"_in", capacity=math.inf)
+        elif node.op == 'call_function':
+            capacity = get_capacity(node)
+
+        if (node.name in dest_placeholder_names or
+           (node.name in getitem_users and getitem_users[node.name] in dest_placeholder_names)):
+            nx_graph.add_edge(node.name+"_out", 'sink', capacity=capacity)
+
+        nx_graph.add_edge(node.name+"_in", node.name+"_out", capacity=capacity)
+        for user in node.users:
+            if user.op != "output":
+                nx_graph.add_edge(node.name+"_out", user.name+"_in", capacity=math.inf)
+
+    cut_value, partition = nx.minimum_cut(nx_graph, "source", "sink")
+
+    cut_at_sink = 0
+    for e in nx_graph.edges.data():
+        if e[1] == "sink":
+            cut_at_sink += e[2]["capacity"]
+
+    local_memory_reduced = cut_at_sink - cut_value
+    cut_nodes = get_cut_nodes_from_partition(partition, nx_graph)
+
+    return partition, cut_nodes, local_memory_reduced
+
+
+def check_remat(partition):
+    _, non_reachable = partition
+    return non_reachable != {"sink"}
+
+
+def get_fused_graph(traced_graph):
+    supported_ops = NvFuserOperatorSupport()
+    partitioner = CapabilityBasedPartitioner(traced_graph, supported_ops)
+    fused_graph = partitioner.partition_and_fuse()
+    return fused_graph
+
+
+def rematerialize_fused_graph(fused_graph, node_users_map):
+    global num_group_remat, num_node_pairs, memory_reduced
+    name_to_node = {node.name: node for node in fused_graph.graph.nodes}
+
+    fused_node_pairs = get_fused_node_pairs(fused_graph)
+    num_node_pairs = len(fused_node_pairs)
+    for node_pair in fused_node_pairs:
+        partition, cut_nodes, local_memory_reduced = find_min_cut(node_pair, node_users_map, fused_graph)
+        if local_memory_reduced > 0:
+            num_group_remat += 1
+            memory_reduced += local_memory_reduced
+            copy_nodes(node_pair, fused_graph, name_to_node, partition, cut_nodes)
+    return fused_graph
+
+
+def rematerialize(traced_graph):
+    traced_graph.graph.eliminate_dead_code()
+    traced_graph.recompile()
+    node_users_map = {node.name: set(node.users.keys()) for node in traced_graph.graph.nodes}
+
+    fused_graph = get_fused_graph(traced_graph)
+    return rematerialize_fused_graph(fused_graph, node_users_map)
+
+
+def rematerialize_stat(traced_graph, stat):
+    """
+    Modify traced_graph to a graph with rematerialization.
+    ``stat`` is a dictionary and the stats of rematerialization will be stored in it.
+    """
+    global num_group_remat, memory_reduced, num_node_pairs
+    num_group_remat = 0
+    memory_reduced = 0
+    traced_graph.graph.eliminate_dead_code()
+    traced_graph.recompile()
+    node_users_map = {node.name: set(node.users.keys()) for node in traced_graph.graph.nodes}
+
+    fused_graph = get_fused_graph(traced_graph)
+    fused_graph = rematerialize_fused_graph(fused_graph, node_users_map)
+
+    stat["num_group_remat"] = num_group_remat
+    stat["memory_reduced"] = memory_reduced
+    stat["num_node_pairs"] = num_node_pairs
+    return fused_graph

--- a/functorch/functorch/_src/utilities.py
+++ b/functorch/functorch/_src/utilities.py
@@ -74,7 +74,7 @@ def ban_recomputation(node):
         # If the output of the reduction is 4x smaller (arbitrary choice),
         # then we don't allow recomputation.
         if get_aten_target(node) in reduction_ops:
-            input_tensors_size = sum(_size_of(i.meta['tensor_meta']) for i in node.args if isinstance(i, fx.Node))
+            input_tensors_size = sum(_size_of(i.meta['tensor_meta']) for i in node.args if isinstance(i, torch.fx.Node))
             output_size = _size_of(node.meta['tensor_meta'])
             return (output_size * 4 < input_tensors_size)
         return False

--- a/functorch/functorch/_src/utilities.py
+++ b/functorch/functorch/_src/utilities.py
@@ -1,4 +1,6 @@
 import torch
+import operator
+
 
 def _prod(x):
     s = 1
@@ -31,12 +33,42 @@ def _size_of(metadata):
 
     return numel * sizes[dtype]
 
+aten = torch.ops.aten
 
-def draw_nx_graph(nx_graph, filename = "fig.svg"):
-    import matplotlib.pyplot as pyplot  # pylint: disable=import-error
-    import networkx as nx 
-    labels = nx.get_edge_attributes(nx_graph,'capacity')
-    pos=nx.planar_layout(nx_graph)
-    nx.draw(nx_graph, pos, with_labels = True)
-    nx.draw_networkx_edge_labels(nx_graph,pos,edge_labels=labels)
-    pyplot.savefig(filename)    
+pointwise_ops = [aten.add, aten.sub, aten.div, aten.atan2, aten.mul, aten.max, aten.min, aten.pow, aten.remainder, aten.fmod, aten.__and__, aten.__or__, aten.__xor__, aten.__lshift__, aten.__rshift__, aten.eq, aten.ne, aten.ge, aten.gt, aten.le, aten.lt, aten.abs, aten.bitwise_not, aten.ceil, aten.floor, aten.frac, aten.neg, aten.relu, aten.round, aten.silu, aten.trunc, aten.log, aten.log10, aten.log1p, aten.log2, aten.lgamma, aten.exp, aten.expm1, aten.erf, aten.erfc, aten.cos, aten.acos, aten.cosh, aten.sin, aten.asin, aten.sinh, aten.tan, aten.atan, aten.tanh, aten.atanh, aten.sqrt, aten.rsqrt, aten.reciprocal, aten.sigmoid, aten.softplus, aten.threshold, aten.threshold_backward, aten.clamp, aten.where, aten.lerp, aten.addcmul, aten.gelu, aten.gelu_backward]  # noqa: E501
+misc_ops = [aten.to, aten.type_as, operator.getitem]
+reduction_ops = [aten.softmax, aten._softmax, aten._softmax_backward_data, aten.sum, aten.mean, aten._grad_sum_to_size, aten.sum_to_size, aten.amax]  # noqa: E501
+
+
+norm_ops = [aten.instance_norm, aten._batch_norm_impl_index, aten.native_batch_norm, aten.batch_norm, aten._batch_norm_impl_index_backward, aten.native_layer_norm, aten.layer_norm, aten.native_layer_norm_backward]  # noqa: E501
+view_ops = [aten.squeeze, aten.unsqueeze]
+random_ops = [aten.native_dropout, aten.rand_like, aten.randn_like]
+compute_intensive_ops = [aten.mm, aten.convolution, aten.convolution_backward, aten.bmm, aten.addmm, aten.upsample_bilinear2d]  # noqa: E501
+unrecomputable_ops = random_ops + compute_intensive_ops + norm_ops
+
+recomputable_ops = set(
+    pointwise_ops
+    + misc_ops
+    + reduction_ops
+    + view_ops
+)
+fusible_ops = recomputable_ops | set(random_ops)
+
+AGGRESSIVE_RECOMPUTATION = False
+
+
+def ban_recomputation(node):
+    if AGGRESSIVE_RECOMPUTATION:
+        return (node.op == 'call_function' and node.target in unrecomputable_ops)
+    else:
+        if node.op != 'call_function':
+            return False
+        if node.target not in recomputable_ops:
+            return True
+        # If the output of the reduction is 4x smaller (arbitrary choice),
+        # then we don't allow recomputation.
+        if node.target in reduction_ops:
+            input_tensors_size = sum(_size_of(i.meta['tensor_meta']) for i in node.args if isinstance(i, fx.Node))
+            output_size = _size_of(node.meta['tensor_meta'])
+            return (output_size * 4 < input_tensors_size)
+        return False

--- a/functorch/functorch/_src/utilities.py
+++ b/functorch/functorch/_src/utilities.py
@@ -1,0 +1,42 @@
+import torch
+
+def _prod(x):
+    s = 1
+    for i in x:
+        s *= i
+    return s
+
+
+def _size_of(metadata):
+    sizes = {
+        torch.float: 4,
+        torch.float16: 2,
+        torch.bfloat16: 2,
+        torch.float32: 4,
+        torch.float64: 8,
+        torch.int: 4,
+        torch.int8: 1,
+        torch.int16: 2,
+        torch.int32: 4,
+        torch.int64: 8,
+        torch.uint8: 1,
+        torch.bool: 1,
+    }
+
+    numel = _prod(metadata.shape)
+    dtype = metadata.dtype
+
+    if dtype not in sizes:
+        raise NotImplementedError("Don't know the size of dtype ", dtype)
+
+    return numel * sizes[dtype]
+
+
+def draw_nx_graph(nx_graph, filename = "fig.svg"):
+    import matplotlib.pyplot as pyplot  # pylint: disable=import-error
+    import networkx as nx 
+    labels = nx.get_edge_attributes(nx_graph,'capacity')
+    pos=nx.planar_layout(nx_graph)
+    nx.draw(nx_graph, pos, with_labels = True)
+    nx.draw_networkx_edge_labels(nx_graph,pos,edge_labels=labels)
+    pyplot.savefig(filename)    

--- a/functorch/functorch/_src/utilities.py
+++ b/functorch/functorch/_src/utilities.py
@@ -1,6 +1,6 @@
 import torch
 import operator
-
+from .compile_utils import get_aten_target
 
 def _prod(x):
     s = 1
@@ -37,14 +37,20 @@ aten = torch.ops.aten
 
 pointwise_ops = [aten.add, aten.sub, aten.div, aten.atan2, aten.mul, aten.max, aten.min, aten.pow, aten.remainder, aten.fmod, aten.__and__, aten.__or__, aten.__xor__, aten.__lshift__, aten.__rshift__, aten.eq, aten.ne, aten.ge, aten.gt, aten.le, aten.lt, aten.abs, aten.bitwise_not, aten.ceil, aten.floor, aten.frac, aten.neg, aten.relu, aten.round, aten.silu, aten.trunc, aten.log, aten.log10, aten.log1p, aten.log2, aten.lgamma, aten.exp, aten.expm1, aten.erf, aten.erfc, aten.cos, aten.acos, aten.cosh, aten.sin, aten.asin, aten.sinh, aten.tan, aten.atan, aten.tanh, aten.atanh, aten.sqrt, aten.rsqrt, aten.reciprocal, aten.sigmoid, aten.softplus, aten.threshold, aten.threshold_backward, aten.clamp, aten.where, aten.lerp, aten.addcmul, aten.gelu, aten.gelu_backward]  # noqa: E501
 misc_ops = [aten.to, aten.type_as, operator.getitem]
+
 reduction_ops = [aten.softmax, aten._softmax, aten._softmax_backward_data, aten.sum, aten.mean, aten._grad_sum_to_size, aten.sum_to_size, aten.amax]  # noqa: E501
 
+# not recomputed by default since these are kinda expensive/hard to fuse into
+# norm_ops = [aten.instance_norm, aten._batch_norm_impl_index, aten.native_batch_norm, aten.batch_norm, aten._batch_norm_impl_index_backward, aten.native_layer_norm, aten.layer_norm, aten.native_layer_norm_backward]  # noqa: E501
 
-norm_ops = [aten.instance_norm, aten._batch_norm_impl_index, aten.native_batch_norm, aten.batch_norm, aten._batch_norm_impl_index_backward, aten.native_layer_norm, aten.layer_norm, aten.native_layer_norm_backward]  # noqa: E501
+# Not used by default since NVFuser can't fuse view ops
+# view_ops = [aten.expand, aten.clone, aten.transpose, aten.t, aten.view, aten._unsafe_view, aten.permute, aten.transpose, aten.t, aten._reshape_alias, aten.squeeze, aten.unsqueeze, aten.reshape, aten.cat, aten.slice, aten.split, aten.select, aten.repeat]  # noqa: E501
+
+# These are the view ops that NVFuser can fuse
 view_ops = [aten.squeeze, aten.unsqueeze]
 random_ops = [aten.native_dropout, aten.rand_like, aten.randn_like]
 compute_intensive_ops = [aten.mm, aten.convolution, aten.convolution_backward, aten.bmm, aten.addmm, aten.upsample_bilinear2d]  # noqa: E501
-unrecomputable_ops = random_ops + compute_intensive_ops + norm_ops
+unrecomputable_ops = random_ops + compute_intensive_ops
 
 recomputable_ops = set(
     pointwise_ops
@@ -59,15 +65,15 @@ AGGRESSIVE_RECOMPUTATION = False
 
 def ban_recomputation(node):
     if AGGRESSIVE_RECOMPUTATION:
-        return (node.op == 'call_function' and node.target in unrecomputable_ops)
+        return (node.op == 'call_function' and get_aten_target(node) in unrecomputable_ops)
     else:
         if node.op != 'call_function':
             return False
-        if node.target not in recomputable_ops:
+        if get_aten_target(node) not in recomputable_ops:
             return True
         # If the output of the reduction is 4x smaller (arbitrary choice),
         # then we don't allow recomputation.
-        if node.target in reduction_ops:
+        if get_aten_target(node) in reduction_ops:
             input_tensors_size = sum(_size_of(i.meta['tensor_meta']) for i in node.args if isinstance(i, fx.Node))
             output_size = _size_of(node.meta['tensor_meta'])
             return (output_size * 4 < input_tensors_size)

--- a/functorch/test/test_remat_mincut.py
+++ b/functorch/test/test_remat_mincut.py
@@ -1,0 +1,523 @@
+import random
+
+from functorch import make_fx
+import torch
+
+from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
+from torch.fx.passes.backends.nvfuser import NvFuserOperatorSupport
+from torch.fx.passes.graph_drawer import FxGraphDrawer
+from torch.fx.passes.tools_common import NodeList, NodeSet, legalize_graph
+
+from torch.testing._internal.common_utils import TestCase, run_tests
+from functorch._src.remat_utils_mincut import get_users, get_fused_node_pairs, find_min_cut, rematerialize, copy_nodes
+
+
+def f(a):
+    b = a.cos()
+    c = torch.relu(b)
+    d = torch.clone(c)
+    e = torch.relu(d)
+    f = torch.relu(e)
+    return b + c + e + f
+# === fused graph graph():
+#     %a_1 : [#users=1] = placeholder[target=a_1]
+#     %fused_1 : [#users=2] = call_module[target=fused_1](args = (%a_1,), kwargs = {})
+#     %getitem : [#users=1] = call_function[target=operator.getitem](args = (%fused_1, 0), kwargs = {})
+#     %getitem_1 : [#users=2] = call_function[target=operator.getitem](args = (%fused_1, 1), kwargs = {})
+#     %clone : [#users=1] = call_function[target=torch.ops.aten.clone](args = (%getitem_1,), kwargs = {})
+#     %fused_0 : [#users=1] = call_module[target=fused_0](args = (%clone, %getitem, %getitem_1), kwargs = {})
+#     return fused_0
+
+def f1(a):
+    b = a.cos()
+    c = torch.relu(b)
+    d = torch.clone(c)
+    e = torch.relu(d)
+    f = torch.relu(e)
+    return b + e + f
+# === fused graph graph():
+#     %a_1 : [#users=1] = placeholder[target=a_1]
+#     %fused_1 : [#users=2] = call_module[target=fused_1](args = (%a_1,), kwargs = {})
+#     %getitem : [#users=1] = call_function[target=operator.getitem](args = (%fused_1, 0), kwargs = {})
+#     %getitem_1 : [#users=1] = call_function[target=operator.getitem](args = (%fused_1, 1), kwargs = {})
+#     %clone : [#users=1] = call_function[target=torch.ops.aten.clone](args = (%getitem_1,), kwargs = {})
+#     %fused_0 : [#users=1] = call_module[target=fused_0](args = (%clone, %getitem), kwargs = {})
+#     return fused_0
+
+def f2(a):
+    b = a.cos()
+    c = torch.relu(b)
+    d = torch.clone(c)
+    e = torch.relu(d)
+    f = torch.relu(e)
+    return e + f
+# === fused graph graph():
+#     %a_1 : [#users=1] = placeholder[target=a_1]
+#     %fused_1 : [#users=2] = call_module[target=fused_1](args = (%a_1,), kwargs = {})
+#     %clone : [#users=1] = call_function[target=torch.ops.aten.clone](args = (%fused_1,), kwargs = {})
+#     %fused_0 : [#users=1] = call_module[target=fused_0](args = (%clone, %fused_1), kwargs = {})
+#     return fused_0
+
+# three fused groups
+def f3(a):
+    b = a.cos()
+    c = torch.relu(b)
+    d = torch.clone(c)
+    e = torch.clone(b)
+    h = e + d + b + c
+    i = h.clone()
+    j = i.relu()
+    return j + h
+
+# assignment {add_3: 0, relu_1: 0, add_2: 1, add_1: 1, add: 1, relu: 2, cos: 2}
+# === fused graph graph():
+#     %a_1 : [#users=1] = placeholder[target=a_1]
+#     %fused_2 : [#users=2] = call_module[target=fused_2](args = (%a_1,), kwargs = {})
+#     %getitem : [#users=2] = call_function[target=operator.getitem](args = (%fused_2, 0), kwargs = {})
+#     %getitem_1 : [#users=2] = call_function[target=operator.getitem](args = (%fused_2, 1), kwargs = {})
+#     %clone : [#users=1] = call_function[target=torch.ops.aten.clone](args = (%getitem_1,), kwargs = {})
+#     %clone_1 : [#users=1] = call_function[target=torch.ops.aten.clone](args = (%getitem,), kwargs = {})
+#     %fused_1 : [#users=2] = call_module[target=fused_1](args = (%clone_1, %clone, %getitem, %getitem_1), kwargs = {})
+#     %clone_2 : [#users=1] = call_function[target=torch.ops.aten.clone](args = (%fused_1,), kwargs = {})
+#     %fused_0 : [#users=1] = call_module[target=fused_0](args = (%clone_2, %fused_1), kwargs = {})
+#     return fused_0
+
+# three fused groups
+def f4(a):
+    b = a.cos()
+    c = torch.relu(b)
+    d = torch.clone(c)
+    e = torch.clone(b)
+    h = e + d + b + c
+    i = h.clone()
+    j = i.relu()
+    return j + h + b
+
+
+# three fused groups
+def f5(a):
+    b = a.cos()
+    c = torch.relu(b)
+    d = torch.clone(c)
+    h = d + b + c
+    i = h.clone()
+    j = i.relu()
+    return j + h + b
+
+
+def f6(a):
+    b = a.relu()
+    c = a.cos()
+    d = b + c
+    e = b.relu()
+    f = e + b
+    g = f.clone()
+    h = g + b
+    return h + d
+# assignment {add_3: 0, add_2: 0, add_1: 1, relu_1: 1, add: 0, cos: 0, relu: 1}
+# === fused graph graph():
+#     %a_1 : [#users=2] = placeholder[target=a_1]
+#     %fused_1 : [#users=2] = call_module[target=fused_1](args = (%a_1,), kwargs = {})
+#     %getitem : [#users=1] = call_function[target=operator.getitem](args = (%fused_1, 0), kwargs = {})
+#     %getitem_1 : [#users=1] = call_function[target=operator.getitem](args = (%fused_1, 1), kwargs = {})
+#     %clone : [#users=1] = call_function[target=torch.ops.aten.clone](args = (%getitem_1,), kwargs = {})
+#     %fused_0 : [#users=1] = call_module[target=fused_0](args = (%clone, %getitem, %a_1), kwargs = {})
+#     return fused_0
+
+def f7(a):
+    b = a.relu()
+    c = b.clone()
+    return b + c
+
+
+def f10(a):
+    b = a.max()
+    c = b.relu()
+    d = c.clone()
+    e = d.relu()
+    return b + c + e
+
+def strip_overloads(gm):
+    """
+    Modifies the target of graph nodes in :attr:`gm` to strip overloads.
+    Args:
+        gm(fx.GraphModule): The input Fx graph module to be modified
+    """
+    for node in gm.graph.nodes:
+        if isinstance(node.target, torch._ops.OpOverload):
+            node.target = node.target.overloadpacket
+    gm.recompile()
+
+def get_fused_graph(f):
+    traced_graph = make_fx(f, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(torch.randn(2).to(torch.float))
+    strip_overloads(traced_graph)
+    supported_ops = NvFuserOperatorSupport()
+    partitioner = CapabilityBasedPartitioner(traced_graph, supported_ops)
+    fused_graph = partitioner.partition_and_fuse()
+    return fused_graph
+
+
+def get_fused_graph_for_num_changes(f, input_size = 2):
+    traced_graph = make_fx(f, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(torch.randn(input_size).to(torch.float))
+    strip_overloads(traced_graph)
+    node_users_map = {node.name: set(node.users.keys()) for node in traced_graph.graph.nodes }
+    supported_ops = NvFuserOperatorSupport()
+    partitioner = CapabilityBasedPartitioner(traced_graph, supported_ops)
+    fused_graph = partitioner.partition_and_fuse()
+    return node_users_map, fused_graph
+
+
+class GetUsersTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        fused_graph = get_fused_graph(f)
+        cls.name_to_node = {node.name:node for node in fused_graph.graph.nodes}
+        fused_graph_1 = get_fused_graph(f1)
+        cls.name_to_node_1 = {node.name:node for node in fused_graph_1.graph.nodes}
+        fused_graph_2 = get_fused_graph(f2)
+        cls.name_to_node_2 = {node.name:node for node in fused_graph_2.graph.nodes}
+        
+
+    def test_two_getitem_user(self):
+        users = get_users(self.name_to_node["fused_1"])
+        users_by_name = set([n.name for n in users])
+        expected_users = set(["clone_default", "fused_0"])
+        self.assertEqual(users_by_name, expected_users)
+
+    def test_output_not_in_users(self):
+        users = get_users(self.name_to_node["fused_0"])
+        users_by_name = set([n.name for n in users])
+        expected_users = set([])
+        self.assertEqual(users_by_name, expected_users)
+
+    def test_one_getitem_user(self):
+        users = get_users(self.name_to_node_1["fused_1"])
+        users_by_name = set([n.name for n in users])
+        expected_users = set(["clone_default", "fused_0"])
+        self.assertEqual(users_by_name, expected_users)
+    
+    def test_no_getitem_user(self):
+        users = get_users(self.name_to_node_2["fused_1"])
+        users_by_name = set([n.name for n in users])
+        expected_users = set(["clone_default"])
+        self.assertEqual(users_by_name, expected_users)
+
+class GetFusedNodePairsTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fused_graph = get_fused_graph(f)
+        cls.fused_graph_1 = get_fused_graph(f1)
+        cls.fused_graph_2 = get_fused_graph(f2)
+        cls.fused_graph_3 = get_fused_graph(f3)
+        cls.fused_graph_4 = get_fused_graph(f4)
+
+    def test_only_one_pair(self):
+        pairs = get_fused_node_pairs(self.fused_graph)
+        pair_names = [(pair[0].name, pair[1].name) for pair in pairs]
+        expected_pairs = [["fused_1", "fused_0"]]
+        self.assertEqual(pair_names, expected_pairs)
+    
+        pairs = get_fused_node_pairs(self.fused_graph_1)
+        pair_names = [(pair[0].name, pair[1].name) for pair in pairs]
+        self.assertEqual(pair_names, expected_pairs)
+
+    def test_no_pair(self):
+        pairs = get_fused_node_pairs(self.fused_graph_2)
+        pair_names = [(pair[0].name, pair[1].name) for pair in pairs]
+        expected_pairs = []
+        self.assertEqual(pair_names, expected_pairs)
+
+    def test_two_pairs(self):
+        pairs = get_fused_node_pairs(self.fused_graph_3)
+        pair_names = set([(pair[0].name, pair[1].name) for pair in pairs])
+        expected_pairs = set([("fused_2", "fused_1"), ("fused_1", "fused_0")])
+        self.assertEqual(pair_names, expected_pairs)
+
+    def test_multiple_pairs(self):
+        pairs = get_fused_node_pairs(self.fused_graph_4)
+        pair_names = set([(pair[0].name, pair[1].name) for pair in pairs])
+        expected_pairs = set([("fused_2", "fused_1"), ("fused_2", "fused_0"), ("fused_1", "fused_0")])
+        self.assertEqual(pair_names, expected_pairs)
+
+
+class GetCutNodesPointwiseTestCase(TestCase):
+    # the expected size is the number of placeholders time 8 because tensor has default size 2 and each is a size 4 float32
+
+    def test_user_within_origin_module(self):
+        node_users_map, fused_graph = get_fused_graph_for_num_changes(f)
+        name_to_node = {node.name:node for node in fused_graph.graph.nodes}
+        node_pair = (name_to_node["fused_1"], name_to_node["fused_0"])
+        _, cut_nodes, _ = find_min_cut(node_pair, node_users_map, fused_graph)
+        self.assertEqual(cut_nodes, {"a_1"}, f"cut_nodes is {cut_nodes}")  
+
+    def test_multiple_fused_groups(self):
+        node_users_map, fused_graph = get_fused_graph_for_num_changes(f3)
+        name_to_node = {node.name:node for node in fused_graph.graph.nodes}
+        node_pair = (name_to_node["fused_1"], name_to_node["fused_0"])
+        _, cut_nodes, _  = find_min_cut(node_pair, node_users_map, fused_graph)
+        self.assertEqual(cut_nodes, {"add_tensor_2"}, f"cut_nodes is {cut_nodes}")  
+
+    def test_share_placeholders(self):
+        node_users_map, fused_graph = get_fused_graph_for_num_changes(f4)
+        name_to_node = {node.name:node for node in fused_graph.graph.nodes}
+        node_pair = (name_to_node["fused_1"], name_to_node["fused_0"])
+        _, cut_nodes, _  = find_min_cut(node_pair, node_users_map, fused_graph)
+        self.assertEqual(cut_nodes, {"add_tensor_2", "cos_default"}, f"cut_nodes is {cut_nodes}")  
+
+    def test_write_to_non_fusable_and_other_groups(self):
+        node_users_map, fused_graph = get_fused_graph_for_num_changes(f4)
+        name_to_node = {node.name:node for node in fused_graph.graph.nodes}
+        node_pair = (name_to_node["fused_2"], name_to_node["fused_1"])
+        _, cut_nodes, _  = find_min_cut(node_pair, node_users_map, fused_graph)
+        self.assertTrue(cut_nodes == {"a_1"} or cut_nodes == {"cos_default"}, f"cut_nodes is {cut_nodes}")  
+
+    def test_write_to_other_groups(self):
+        node_users_map, fused_graph = get_fused_graph_for_num_changes(f5)
+        name_to_node = {node.name:node for node in fused_graph.graph.nodes}
+        node_pair = (name_to_node["fused_2"], name_to_node["fused_1"])
+        _, cut_nodes, _  = find_min_cut(node_pair, node_users_map, fused_graph)
+        self.assertTrue(cut_nodes == {"a_1"} or cut_nodes == {"cos_default"}, f"cut_nodes is {cut_nodes}")  
+
+    def test_multiple_users_in_origin_group(self):
+        node_users_map, fused_graph = get_fused_graph_for_num_changes(f6)
+        name_to_node = {node.name:node for node in fused_graph.graph.nodes}
+        node_pair = (name_to_node["fused_1"], name_to_node["fused_0"])
+        _, cut_nodes, _  = find_min_cut(node_pair, node_users_map, fused_graph)
+        self.assertEqual(cut_nodes, {"a_1"}, f"cut_nodes is {cut_nodes}")  
+
+
+class GetCutNodesTestCase(TestCase):
+
+    def test_reduction_ops(self):
+        node_users_map, fused_graph = get_fused_graph_for_num_changes(f10, 3)
+        name_to_node = {node.name:node for node in fused_graph.graph.nodes}
+        node_pair = (name_to_node["fused_1"], name_to_node["fused_0"])
+        _, cut_nodes, _  = find_min_cut(node_pair, node_users_map, fused_graph)
+        self.assertEqual(cut_nodes, {"max_default"}, f"cut_nodes is {cut_nodes}")  
+
+
+def get_num_input_outpus(gm):
+    count_inp = 0
+    count_out = 0
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            count_inp += 1
+        elif node.op == "output":
+            if count_out > 0:
+                assert False, "multiple output nodes"
+            if type(node.args[0]) is not tuple:
+                count_out = 1 
+            else:
+                count_out = len(node.args[0]) - node.args[0].count(None)
+
+    return count_inp, count_out
+
+# check same result before and after
+# check if the number of placeholders and outputs are as expected
+class CopyNodesTestCase(TestCase):
+    def test(self):
+        a = torch.rand(5)
+        traced_graph = make_fx(f, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(a)
+        strip_overloads(traced_graph)
+        fused_graph = rematerialize(traced_graph)
+
+        expected = f(a)
+        result = fused_graph(a)
+        self.assertEqual(expected, result, "result is not correct")
+        
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_0)
+        self.assertEqual(count_inp, 2, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_1)
+        self.assertEqual(count_inp, 1, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+    def test_1(self):
+        traced_graph = make_fx(f1, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(torch.randn(2))
+        strip_overloads(traced_graph)
+        fused_graph = rematerialize(traced_graph)
+
+        a = torch.rand(5)
+        expected = f1(a)
+        result = fused_graph(a)
+        self.assertEqual(expected, result, "result is not correct")
+        
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_0)
+        self.assertEqual(count_inp, 2, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_1)
+        self.assertEqual(count_inp, 1, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+    def test_2_nochange(self):
+        traced_graph = make_fx(f2, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(torch.randn(2))
+        strip_overloads(traced_graph)
+        fused_graph = rematerialize(traced_graph)
+
+        a = torch.rand(5)
+        expected = f2(a)
+        result = fused_graph(a)
+        self.assertEqual(expected, result, "result is not correct")
+        
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_0)
+        self.assertEqual(count_inp, 1, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_1)
+        self.assertEqual(count_inp, 1, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+    def test_one_merge_one_skip(self):
+        traced_graph = make_fx(f3, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(torch.randn(2))
+        strip_overloads(traced_graph)
+        fused_graph = rematerialize(traced_graph)
+
+        a = torch.rand(5)
+        expected = f3(a)
+        result = fused_graph(a)
+        self.assertEqual(expected, result, "result is not correct")
+        
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_0)
+        self.assertEqual(count_inp, 2, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_1)
+        self.assertEqual(count_inp, 3, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_2)
+        self.assertEqual(count_inp, 1, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 2, f"count_out is {count_out}")
+
+    def test_one_merge_two_skip(self):
+        traced_graph = make_fx(f4, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(torch.randn(2))
+        strip_overloads(traced_graph)
+        fused_graph = rematerialize(traced_graph)
+
+        a = torch.rand(5)
+        expected = f4(a)
+        result = fused_graph(a)
+        self.assertEqual(expected, result, "result is not correct")
+        
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_0)
+        self.assertEqual(count_inp, 3, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_1)
+        self.assertEqual(count_inp, 3, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_2)
+        self.assertEqual(count_inp, 1, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 2, f"count_out is {count_out}")
+
+    def test_6(self):
+        traced_graph = make_fx(f6, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(torch.randn(2))
+        strip_overloads(traced_graph)
+        fused_graph = rematerialize(traced_graph)
+
+        a = torch.rand(5)
+        expected = f6(a)
+        result = fused_graph(a)
+        self.assertEqual(expected, result, "result is not correct")
+        
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_0)
+        self.assertEqual(count_inp, 2, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+        count_inp, count_out = get_num_input_outpus(fused_graph.fused_1)
+        self.assertEqual(count_inp, 1, f"count_inp is {count_inp}")
+        self.assertEqual(count_out, 1, f"count_out is {count_out}")
+
+    def test_no_fuse_group(self):
+        traced_graph = make_fx(f7, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(torch.randn(2))
+        strip_overloads(traced_graph)
+        fused_graph = rematerialize(traced_graph)
+
+        a = torch.rand(5)
+        expected = f7(a)
+        result = fused_graph(a)
+        self.assertEqual(expected, result, "result is not correct")
+
+    def test_single_fused_group(self):
+        def f8(a):
+            b = torch.sin(a)
+            c = torch.tanh(b)
+            d = torch.tanh(c)
+            e = torch.relu(d)
+            return e
+        traced_graph = make_fx(f8, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(torch.randn(2))
+        strip_overloads(traced_graph)
+        fused_graph = rematerialize(traced_graph)
+
+        a = torch.rand(5)
+        expected = f8(a)
+        result = fused_graph(a)
+        self.assertEqual(expected, result, "result is not correct")
+
+    def test_dest_arg_not_in_origin(self):
+        def f9(a):
+            b = a.relu()
+            c = b.relu()
+            d = c.clone()
+            e = d + b
+            f = e.clone()
+            g = f + e
+            h = g + c
+            return h
+
+        a = torch.rand(5)
+        expected = f9(a)
+        node_users_map, fused_graph = get_fused_graph_for_num_changes(f9)
+        name_to_node = {node.name:node for node in fused_graph.graph.nodes}
+        node_pair = (name_to_node["fused_1"], name_to_node["fused_0"])
+        partition, cut_nodes, _  = find_min_cut(node_pair, node_users_map, fused_graph)
+        copy_nodes(node_pair, fused_graph, name_to_node, partition, cut_nodes)
+        result = fused_graph(a)
+        self.assertEqual(expected, result, f"result is not correct, {expected}, {result}")
+
+    def test_create_new_output_arg(self):
+        def f11(a):
+            b = a.max()
+            c = b.relu()
+            d = b.cos()
+            e = c + d
+            f = e.clone()
+            return f * d + c
+        a = torch.rand(5)
+        traced_graph = make_fx(f11, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(a)
+        strip_overloads(traced_graph)
+        fused_graph = rematerialize(traced_graph)
+
+        expected = f11(a)
+        result = fused_graph(a)
+        self.assertEqual(expected, result, "result is not correct, {expected}, {result}")
+
+
+class RandomOpTestCase(TestCase):
+    def test_random(self):
+        def frandom(x):
+            vals = [x]
+            ops = [torch.clone, torch.cos, torch.sin, torch.relu, torch.tanh, torch.nn.functional.gelu]
+            for _ in range(100):
+                new_val = random.choice(ops)(random.choice(vals))
+                vals.append(new_val)
+            return vals[-1]
+
+        a = torch.rand(5, device='cuda')
+
+        for _ in range(30):
+            traced_graph = make_fx(frandom, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(a)
+            expected = traced_graph(a)
+
+            fused_graph = rematerialize(traced_graph)
+            result = fused_graph(a)
+
+            self.assertEqual(expected, result, f"result is not correct, {expected}, {result}")
+
+if __name__ == "__main__":
+    run_tests()

--- a/functorch/test/test_remat_mincut.py
+++ b/functorch/test/test_remat_mincut.py
@@ -508,7 +508,7 @@ class RandomOpTestCase(TestCase):
                 vals.append(new_val)
             return vals[-1]
 
-        a = torch.rand(5, device='cuda')
+        a = torch.rand(5)
 
         for _ in range(30):
             traced_graph = make_fx(frandom, decomposition_table={torch.ops.aten.detach.default: lambda x: x})(a)

--- a/torch/fx/passes/backends/nvfuser.py
+++ b/torch/fx/passes/backends/nvfuser.py
@@ -79,7 +79,7 @@ class NvFuserOperatorSupport(OperatorSupport):
             # TODO: might need to update according to supported input types
             "torch.ops.aten.add": None,
             "torch.ops.aten.sub": None,
-            # "torch.ops.aten.rsub": None,    # rsub decomp is supported at aten2aten level
+            "torch.ops.aten.rsub": None,    # rsub decomp is supported at aten2aten level
             "torch.ops.aten.div": None,
             "torch.ops.aten.atan2": None,
             "torch.ops.aten.mul": None,
@@ -143,7 +143,7 @@ class NvFuserOperatorSupport(OperatorSupport):
             "torch.ops.aten.isneginf": None,
             "torch.ops.aten.isposinf": None,
             "torch.ops.aten.isreal": None,
-            # "torch.ops.aten.rand_like": None,  # causing Node empty_like_default does not support nvfuser
+            "torch.ops.aten.rand_like": None,  # causing Node empty_like_default does not support nvfuser
             "torch.ops.aten.softplus": None,
             "torch.ops.aten.threshold": None,
             # relying on aten->aten->prim decomp, aten2aten is using unsupported aten.new_zero op
@@ -153,25 +153,25 @@ class NvFuserOperatorSupport(OperatorSupport):
             # Failing with where(): incompatible function arguments: \
             # [<torch._C._nvfuser.TensorView, tensor, <torch._C._nvfuser.TensorView]
             # failing with BERT_pytorch_forward_0, which has aten.where.ScalarSelf in the decomps
-            # "torch.ops.aten.where": None,
+            "torch.ops.aten.where": None,
             # However, aten.where.self overload is fully supported
             "torch.ops.aten.where.self": None,
             "torch.ops.aten.lerp": None,
             "torch.ops.aten.addcmul": None,
-            # "torch.ops.aten.native_dropout": None,    # missing refs for aten.rank_like
+            "torch.ops.aten.native_dropout": None,    # missing refs for aten.rank_like
             "torch.ops.aten.dropout": None,
-            # "torch.ops.aten.native_dropout_backward": None,   # missing refs for aten.type_as
+            "torch.ops.aten.native_dropout_backward": None,   # missing refs for aten.type_as
             "torch.ops.aten.instance_norm": None,
             "torch.ops.aten._batch_norm_impl_index": None,
-            # "torch.ops.aten.native_batch_norm": None,     # missing refs for aten.var
+            "torch.ops.aten.native_batch_norm": None,     # missing refs for aten.var
             "torch.ops.aten.batch_norm": None,
             "torch.ops.aten.cudnn_batch_norm": None,
             "torch.ops.aten._batch_norm_impl_index_backward": None,
-            # "torch.ops.aten.native_batch_norm_backward": None,    # should have been handled at aten2aten decomp
+            "torch.ops.aten.native_batch_norm_backward": None,    # should have been handled at aten2aten decomp
             "torch.ops.aten.native_layer_norm": None,
             "torch.ops.aten.layer_norm": None,
             # relying on aten->aten->prim decomp, aten2aten is using unsupported aten.div
-            # "torch.ops.aten.native_layer_norm_backward": None,
+            "torch.ops.aten.native_layer_norm_backward": None,
             "torch.ops.aten.softmax.int": None,
             "torch.ops.aten.log_softmax.int": None,
             # relying on aten->aten->prim decomp, aten2aten is using unsupported aten.amax
@@ -181,27 +181,27 @@ class NvFuserOperatorSupport(OperatorSupport):
             "torch.ops.aten.to": None,
             "torch.ops.aten._log_softmax_backward_data": None,
             # "torch.ops.aten._softmax_backward_data": None,  # Node _softmax_backward_data_default does not support nvfuser
-            # "torch.ops.aten.var.dim": None,       # missing refs
+            "torch.ops.aten.var.dim": None,       # missing refs
             "torch.ops.aten.std.dim": None,
             "torch.ops.aten.sum": None,
-            # "torch.ops.aten.mean.dim": None,      # missing refs
+            "torch.ops.aten.mean.dim": None,      # missing refs
             "torch.ops.aten._grad_sum_to_size": None,
             "torch.ops.aten.sum_to_size": None,
             "torch.ops.aten._autocast_to_reduced_precision": None,
             "torch.ops.aten._autocast_to_full_precision": None,
-            # "torch.ops.aten.to.dtype": None,      # causing segfault
-            # "torch.ops.aten.type_as": None,       # missing refs
+            "torch.ops.aten.to.dtype": None,      # causing segfault
+            "torch.ops.aten.type_as": None,       # missing refs
             "torch.ops.aten.linear": None,
             "torch.ops.aten.gelu": None,
-            # "torch.ops.aten.gelu_backward": None,       # gelu_backward is handled at aten2aten decomp
+            "torch.ops.aten.gelu_backward": None,       # gelu_backward is handled at aten2aten decomp
             # "torch.ops.aten.hardtanh": None,        # has functional ref, using unsupported aten.clamp
             "torch.ops.aten.leaky_relu": None,
             "torch.ops.aten.square": None,
             # relying on aten->aten->prim decomp, aten2aten is using unsupported aten.conj_physical
             "torch.ops.aten.tanh_backward": None,
-            # "torch.ops.aten.amax": None,      # missing prim decomp
-            # "torch.ops.aten.amin": None,      # missing prim decomp
-            # "torch.ops.aten.reshape": None,
+            "torch.ops.aten.amax": None,      # missing prim decomp
+            "torch.ops.aten.amin": None,      # missing prim decomp
+            "torch.ops.aten.reshape": None,
             # "torch.ops.aten.view": None,      # missing prim decomp
             "torch.ops.aten.flatten.using_ints": None,
 

--- a/torch/fx/passes/backends/nvfuser.py
+++ b/torch/fx/passes/backends/nvfuser.py
@@ -175,7 +175,10 @@ class NvFuserOperatorSupport(OperatorSupport):
             "torch.ops.aten.softmax.int": None,
             "torch.ops.aten.log_softmax.int": None,
             # relying on aten->aten->prim decomp, aten2aten is using unsupported aten.amax
-            # "torch.ops.aten._softmax": None,
+            "torch.ops.aten._softmax": None,
+            "torch.ops.aten._log_softmax": None,
+            "torch.ops.aten.relu_": None,
+            "torch.ops.aten.to": None,
             "torch.ops.aten._log_softmax_backward_data": None,
             # "torch.ops.aten._softmax_backward_data": None,  # Node _softmax_backward_data_default does not support nvfuser
             # "torch.ops.aten.var.dim": None,       # missing refs


### PR DESCRIPTION
### Description
Add a rematerialization algorithm that analyze an fx graph and modify it to rematerialize some nodes such that the memory reads and writes between fusion groups are reduced. In this implementation, the fusion groups are NVFuser fusion groups, but it can be easily changed to support other fusion groups. 

Refactored partitioners.py to use the common functions in utitlities.py. The functions are just moved, they are not changed.

### Issue
<!-- Link to Issue ticket or RFP -->

### Testing
There's a unittest file included in this PR. 

`pytest functorch/test/test_remat_mincut.py`

More tests and benchmarks on torchbench graphs in https://github.com/pytorch/functorch/pull/925 

Passing ` pytest functorch/test/test_pythonkey.py -k TestPartitioning`

cc @ezyang @SherlockNoMad @soumith @EikanWang @jgong5 @wenzhe-nrv