### PR TITLE
torch.sparse.softmax avoid div by zero and invalid kernel launch parameters

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -3387,7 +3387,8 @@ class TestSparse(TestCase):
     @dtypes(torch.double)
     def test_softmax_zero_nnz(self, device, dtype):
         t = torch.sparse_coo_tensor([[]], [], (3,), device=device, dtype=dtype)
-        torch.sparse.softmax(t, 0)
+        out = torch.sparse.softmax(t, 0)
+        self.assertEqual(out.to_dense(), torch.zeros_like(t))
 
 
     # TODO: Check after why ROCm's cusparseXcsrgemm2Nnz function doesn't return the same nnz value as CUDA

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -3383,6 +3383,13 @@ class TestSparse(TestCase):
         test_op(3, 100, [3, 4, 2, 3, 5, 2], coalesced)
         test_op(4, 100, [3, 4, 2, 3, 5, 2], coalesced)
 
+
+    @dtypes(torch.double)
+    def test_softmax_zero_nnz(self, device, dtype):
+        t = torch.sparse_coo_tensor([[]], [], (3,), device=device, dtype=dtype)
+        torch.sparse.softmax(t, 0)
+
+
     # TODO: Check after why ROCm's cusparseXcsrgemm2Nnz function doesn't return the same nnz value as CUDA
     @skipIfRocm
     @coalescedonoff

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -3390,7 +3390,6 @@ class TestSparse(TestCase):
         out = torch.sparse.softmax(t, 0)
         self.assertEqual(out.to_dense(), torch.zeros_like(t))
 
-
     # TODO: Check after why ROCm's cusparseXcsrgemm2Nnz function doesn't return the same nnz value as CUDA
     @skipIfRocm
     @coalescedonoff


### PR DESCRIPTION
### Description
Small changes needed to deal with nnz 0 inputs.

### Issue
https://github.com/pytorch/pytorch/issues/82107

### Testing
Added additional test coverage to reproduce bug reported in issue. Tested resulting values by conversion `to_dense`.
