### PR TITLE
[Profiler] Defer recording startup python events

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -66,6 +66,7 @@ try:
 except ImportError:
     HAS_PSUTIL = False
 import pickle
+import threading
 
 from torch._C._profiler import _ExperimentalConfig, _ExtraFields_PyCall
 
@@ -1505,23 +1506,6 @@ class TestTorchTidyProfiler(TestCase):
             lambda: torch.zeros((1,)).cos()
         )
 
-    def test_impl_reuse(self) -> None:
-        repeats = 1_000
-        with profile(profile_memory=True, record_shapes=True) as p:
-            for _ in range(repeats):
-                torch.ones((1,))
-            gc.collect()
-
-        roots = p.profiler.kineto_results.experimental_event_tree()
-        tensor_impls = tuple(
-            e.extra_fields.inputs.tensor_metadata[0].impl_ptr
-            for e in _utils.traverse_dfs(roots)
-            if e.name == "aten::fill_"
-        )
-
-        self.assertEqual(len(tensor_impls), repeats)
-        self.assertEqual(len(set(tensor_impls)), repeats)
-
     def test_extra_fields(self):
         with profile(with_stack=True, profile_memory=True) as p:
             _ = torch.ones((1,))
@@ -1652,6 +1636,73 @@ class TestTorchTidyProfiler(TestCase):
         self.assertEqual(input_info.dtypes, ['float', 'double', 'Scalar'])
         self.assertEqual(input_info.shapes, [[5, 5], [], []])
         self.assertEqual(input_info.ivalues, [None, None, alpha])
+
+    def test_startup_events(self):
+
+        def flat_out_extrafields(nodes, out=None):
+            if out is None:
+                out = []
+            for node in nodes:
+                if isinstance(node.extra_fields, _ExtraFields_PyCall):
+                    out.append(node)
+                flat_out_extrafields(node.children, out)
+            return out
+
+        class simpleNet(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fc1 = nn.Linear(1000, 500)
+                self.fc2 = nn.Linear(500, 2)
+
+            def forward(self, x):
+                return self.fc2(self.fc1(x))
+
+        # Barrier for timeout to avoid deadlock
+        num_prior_threads = 1
+        num_post_start_threads = 1
+        num_threads = num_prior_threads + num_post_start_threads + 1  # main thread
+        start_barrier = threading.Barrier(num_threads, timeout=60)
+        end_barrier = threading.Barrier(num_threads, timeout=60)
+
+        def run_simplenet():
+            def block():
+                start_barrier.wait()
+
+            block()
+            inputs = torch.rand(1000)
+            net = simpleNet()
+            out = net(inputs)
+            # end_barrier.wait()
+
+        threads = []
+        for _ in range(num_prior_threads):
+            thrd = threading.Thread(target=run_simplenet, daemon=True)
+            thrd.start()
+            threads.append(thrd)
+
+        with torch.profiler.profile(with_stack=True) as prof:
+            for _ in range(num_post_start_threads):
+                thrd = threading.Thread(target=run_simplenet)
+                threads.append(thrd)
+                thrd.start()
+
+            start_barrier.wait()
+        # end_barrier.wait()
+
+            for t in threads:
+                t.join()
+
+        nodes = flat_out_extrafields(prof.profiler.kineto_results.experimental_event_tree())
+        tid = None
+        count = {}
+        for e in nodes:
+            if e.start_tid not in count:
+                count[e.start_tid] = 0
+            count[e.start_tid] += 1
+            self.assertNotEqual(e.start_tid, 2 ** 64 - 1, "max_tid (2^64-1 from uint64_t) should not exits")
+            # self.assertLessEqual(len(count), 5, "Expect Five threads")
+        self.assertEqual(len(count), num_threads - 1, f"Expect {num_threads-1} threads {len(count)}")
+        self.assertEqual(sum(count.values()), len(nodes), "Something Wrong in tid counting")
 
     def test_nnmodule_params(self):
 


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/issues/81559
- Bypass recording startup calls, instead store their TraceKey and start_time
- Push stored startup calls into 'enters' (set_start_frames)
- Try best-effort inference of system TID for startup calls (populate())

Test Plan:
Lunch a workload that has python modules:
buck build mode/opt kineto/libkineto/fb/integration_tests:pytorch_resnet_integration_test
./buck-out/gen/kineto/libkineto/fb/integration_tests/pytorch_resnet_integration_test.par

Differential Revision: D38029112

