### PR TITLE
only update pinned hash if new hash is newer than old hash

### DIFF
--- a/.github/scripts/update_commit_hashes.py
+++ b/.github/scripts/update_commit_hashes.py
@@ -68,8 +68,8 @@ def approve_pr(pr_number: str) -> None:
     )
 
 
-def make_comment(pr_number: str) -> None:
-    params = {"body": "@pytorchbot merge -g"}
+def make_comment(pr_number: str, msg: str) -> None:
+    params = {"body": msg}
     # comment with pytorchbot because pytorchmergebot gets ignored
     git_api(
         f"/repos/{OWNER}/{REPO}/issues/{pr_number}/comments",
@@ -89,26 +89,19 @@ def close_pr(pr_number: str) -> None:
 
 
 def is_newer_hash(new_hash: str, old_hash: str, repo_name: str) -> bool:
-    # this git command prints the unix timestamp of the hash
-    new_date = (
-        subprocess.run(
-            f"git show --no-patch --no-notes --pretty=%ct {new_hash}".split(),
-            capture_output=True,
-            cwd=f"{repo_name}",
+    def _get_date(hash: str) -> int:
+        # this git command prints the unix timestamp of the hash
+        return int(
+            subprocess.run(
+                f"git show --no-patch --no-notes --pretty=%ct {hash}".split(),
+                capture_output=True,
+                cwd=f"{repo_name}",
+            )
+            .stdout.decode("utf-8")
+            .strip()
         )
-        .stdout.decode("utf-8")
-        .strip()
-    )
-    old_date = (
-        subprocess.run(
-            f"git show --no-patch --no-notes --pretty=%ct {old_hash}".split(),
-            capture_output=True,
-            cwd=f"{repo_name}",
-        )
-        .stdout.decode("utf-8")
-        .strip()
-    )
-    return int(new_date) > int(old_date)
+
+    return _get_date(new_hash) > _get_date(old_hash)
 
 
 def main() -> None:
@@ -146,7 +139,7 @@ def main() -> None:
         f.seek(0)
         f.truncate()
         f.write(f"{hash}\n")
-    if is_newer_hash(hash.strip(), old_hash, args.repo_name):
+    if is_newer_hash(hash, old_hash, args.repo_name):
         # if there was an update, push to branch
         subprocess.run(f"git checkout -b {branch_name}".split())
         subprocess.run(f"git add .github/ci_commit_pins/{args.repo_name}.txt".split())
@@ -160,12 +153,13 @@ def main() -> None:
             pr_num = make_pr(args.repo_name, branch_name)
             approve_pr(pr_num)
         # comment to merge if all checks are green
-        make_comment(pr_num)
+        make_comment(pr_num, "@pytorchbot merge -g")
     else:
         print(
             f"tried to update from old hash: {old_hash} to new hash: {hash} but the old hash seems to be newer, not creating pr"
         )
         if pr_num is not None:
+            make_comment(pr_num, "closing pr as the current hash seems up to date")
             close_pr(pr_num)
             print(f"closing PR {pr_num}")
 

--- a/.github/workflows/_update-commit-hash.yml
+++ b/.github/workflows/_update-commit-hash.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout
         shell: bash
         run: |
-          git clone https://github.com/pytorch/${{ inputs.repo-name }}.git --depth=1 --quiet
+          git clone https://github.com/pytorch/${{ inputs.repo-name }}.git --quiet
 
       - name: Check if there already exists a PR
         shell: bash

--- a/.github/workflows/update-commit-hashes.yml
+++ b/.github/workflows/update-commit-hashes.yml
@@ -2,10 +2,10 @@ name: update-commit-hashes
 
 on:
   schedule:
-    # Every day at 12:37am
+    # Every day at 7:37am UTC = 12:27am PST
     # Choose a random time near midnight because it may be delayed if there are high loads
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
-    - cron: 37 0 * * *
+    - cron: 37 7 * * *
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-commit-hashes.yml
+++ b/.github/workflows/update-commit-hashes.yml
@@ -3,7 +3,7 @@ name: update-commit-hashes
 on:
   schedule:
     # Every day at 7:37am UTC = 12:27am PST
-    # Choose a random time near midnight because it may be delayed if there are high loads
+    # Choose a random time near midnight PST because it may be delayed if there are high loads
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     - cron: 37 7 * * *
   workflow_dispatch:


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/82033

Only update the pinned hash if the new hash is strictly newer than the old hash.  This should allow us to use commits on PRs as the pinned hash, which helps with fixes in XLA.  General hash update behavior (looking at hash on branch, trying to update + pushing, creating pr) should be unchanged.  

If the currently pinned hash is newer than the hash we are trying to update to, the existing pr will be closed if it exists.  

Also changes the hash update time to 12:37am PST (7:37am UTC).  
