### PR TITLE
Codegen: Parse deprecated signatures as a full FunctionSchema

### DIFF
--- a/tools/autograd/deprecated.yaml
+++ b/tools/autograd/deprecated.yaml
@@ -1,92 +1,92 @@
 # Deprecated function signatures. These are exposed in Python, but not included
 # in the error message suggestions.
 
-- name: add(Tensor self, Scalar alpha, Tensor other)
+- name: add(Tensor self, Scalar alpha, Tensor other) -> Tensor
   aten: add(self, other, alpha)
 
-- name: add(Tensor self, Scalar alpha, Tensor other, *, Tensor out)
+- name: add(Tensor self, Scalar alpha, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   aten: add_out(out, self, other, alpha)
 
-- name: addbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2)
+- name: addbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2) -> Tensor
   aten: addbmm(self, batch1, batch2, beta, alpha)
 
-- name: addbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2, *, Tensor out)
+- name: addbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addbmm_out(out, self, batch1, batch2, beta, alpha)
 
-- name: addbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2)
+- name: addbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2) -> Tensor
   aten: addbmm(self, batch1, batch2, beta, 1)
 
-- name: addbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2, *, Tensor out)
+- name: addbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addbmm_out(out, self, batch1, batch2, beta, 1)
 
-- name: addcdiv(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2)
+- name: addcdiv(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2) -> Tensor
   aten: addcdiv(self, tensor1, tensor2, value)
 
-- name: addcdiv(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2, *, Tensor out)
+- name: addcdiv(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addcdiv_out(out, self, tensor1, tensor2, value)
 
-- name: addcmul(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2)
+- name: addcmul(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2) -> Tensor
   aten: addcmul(self, tensor1, tensor2, value)
 
-- name: addcmul(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2, *, Tensor out)
+- name: addcmul(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addcmul_out(out, self, tensor1, tensor2, value)
 
-- name: addmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2)
+- name: addmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2) -> Tensor
   aten: addmm(self, mat1, mat2, beta, alpha)
 
-- name: addmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2, *, Tensor out)
+- name: addmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addmm_out(out, self, mat1, mat2, beta, alpha)
 
-- name: addmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2)
+- name: addmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2) -> Tensor
   aten: addmm(self, mat1, mat2, beta, 1)
 
-- name: addmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2, *, Tensor out)
+- name: addmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addmm_out(out, self, mat1, mat2, beta, 1)
 
-- name: sspaddmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2)
+- name: sspaddmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2) -> Tensor
   aten: sspaddmm(self, mat1, mat2, beta, alpha)
 
-- name: sspaddmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2)
+- name: sspaddmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2) -> Tensor
   aten: sspaddmm(self, mat1, mat2, beta, 1)
 
-- name: addmv(Scalar beta, Tensor self, Scalar alpha, Tensor mat, Tensor vec)
+- name: addmv(Scalar beta, Tensor self, Scalar alpha, Tensor mat, Tensor vec) -> Tensor
   aten: addmv(self, mat, vec, beta, alpha)
 
-- name: addmv(Scalar beta, Tensor self, Scalar alpha, Tensor mat, Tensor vec, *, Tensor out)
+- name: addmv(Scalar beta, Tensor self, Scalar alpha, Tensor mat, Tensor vec, *, Tensor(a!) out) -> Tensor(a!)
   aten: addmv_out(out, self, mat, vec, beta, alpha)
 
-- name: addmv(Scalar beta, Tensor self, Tensor mat, Tensor vec)
+- name: addmv(Scalar beta, Tensor self, Tensor mat, Tensor vec) -> Tensor
   aten: addmv(self, mat, vec, beta, 1)
 
-- name: addmv(Scalar beta, Tensor self, Tensor mat, Tensor vec, *, Tensor out)
+- name: addmv(Scalar beta, Tensor self, Tensor mat, Tensor vec, *, Tensor(a!) out) -> Tensor(a!)
   aten: addmv_out(out, self, mat, vec, beta, 1)
 
-- name: addr(Scalar beta, Tensor self, Scalar alpha, Tensor vec1, Tensor vec2)
+- name: addr(Scalar beta, Tensor self, Scalar alpha, Tensor vec1, Tensor vec2) -> Tensor
   aten: addr(self, vec1, vec2, beta, alpha)
 
-- name: addr(Scalar beta, Tensor self, Scalar alpha, Tensor vec1, Tensor vec2, *, Tensor out)
+- name: addr(Scalar beta, Tensor self, Scalar alpha, Tensor vec1, Tensor vec2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addr_out(out, self, vec1, vec2, beta, alpha)
 
-- name: addr(Scalar beta, Tensor self, Tensor vec1, Tensor vec2)
+- name: addr(Scalar beta, Tensor self, Tensor vec1, Tensor vec2) -> Tensor
   aten: addr(self, vec1, vec2, beta, 1)
 
-- name: addr(Scalar beta, Tensor self, Tensor vec1, Tensor vec2, *, Tensor out)
+- name: addr(Scalar beta, Tensor self, Tensor vec1, Tensor vec2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addr_out(out, self, vec1, vec2, beta, 1)
 
-- name: baddbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2)
+- name: baddbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2) -> Tensor
   aten: baddbmm(self, batch1, batch2, beta, alpha)
 
-- name: baddbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2, *, Tensor out)
+- name: baddbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2, *, Tensor(a!) out) -> Tensor(a!)
   aten: baddbmm_out(out, self, batch1, batch2, beta, alpha)
 
-- name: baddbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2)
+- name: baddbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2) -> Tensor
   aten: baddbmm(self, batch1, batch2, beta, 1)
 
-- name: baddbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2, *, Tensor out)
+- name: baddbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2, *, Tensor(a!) out) -> Tensor(a!)
   aten: baddbmm_out(out, self, batch1, batch2, beta, 1)
 
-- name: sub(Tensor self, Scalar alpha, Tensor other)
+- name: sub(Tensor self, Scalar alpha, Tensor other) -> Tensor
   aten: sub(self, other, alpha)
 
-- name: sub(Tensor self, Scalar alpha, Tensor other, *, Tensor out)
+- name: sub(Tensor self, Scalar alpha, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   aten: sub_out(out, self, other, alpha)

--- a/tools/autograd/deprecated.yaml
+++ b/tools/autograd/deprecated.yaml
@@ -4,11 +4,17 @@
 - name: add(Tensor self, Scalar alpha, Tensor other) -> Tensor
   aten: add(self, other, alpha)
 
+- name: add_(Tensor(a!) self, Scalar alpha, Tensor other) -> Tensor(a!)
+  aten: add_(self, other, alpha)
+
 - name: add(Tensor self, Scalar alpha, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   aten: add_out(out, self, other, alpha)
 
 - name: addbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2) -> Tensor
   aten: addbmm(self, batch1, batch2, beta, alpha)
+
+- name: addbmm_(Scalar beta, Tensor(a!) self, Scalar alpha, Tensor batch1, Tensor batch2) -> Tensor(a!)
+  aten: addbmm_(self, batch1, batch2, beta, alpha)
 
 - name: addbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addbmm_out(out, self, batch1, batch2, beta, alpha)
@@ -16,11 +22,17 @@
 - name: addbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2) -> Tensor
   aten: addbmm(self, batch1, batch2, beta, 1)
 
+- name: addbmm_(Scalar beta, Tensor(a!) self, Tensor batch1, Tensor batch2) -> Tensor(a!)
+  aten: addbmm_(self, batch1, batch2, beta, 1)
+
 - name: addbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addbmm_out(out, self, batch1, batch2, beta, 1)
 
 - name: addcdiv(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2) -> Tensor
   aten: addcdiv(self, tensor1, tensor2, value)
+
+- name: addcdiv_(Tensor(a!) self, Scalar value, Tensor tensor1, Tensor tensor2) -> Tensor(a!)
+  aten: addcdiv_(self, tensor1, tensor2, value)
 
 - name: addcdiv(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addcdiv_out(out, self, tensor1, tensor2, value)
@@ -28,17 +40,26 @@
 - name: addcmul(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2) -> Tensor
   aten: addcmul(self, tensor1, tensor2, value)
 
+- name: addcmul_(Tensor(a!) self, Scalar value, Tensor tensor1, Tensor tensor2) -> Tensor(a!)
+  aten: addcmul_(self, tensor1, tensor2, value)
+
 - name: addcmul(Tensor self, Scalar value, Tensor tensor1, Tensor tensor2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addcmul_out(out, self, tensor1, tensor2, value)
 
 - name: addmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2) -> Tensor
   aten: addmm(self, mat1, mat2, beta, alpha)
 
+- name: addmm_(Scalar beta, Tensor(a!) self, Scalar alpha, Tensor mat1, Tensor mat2) -> Tensor(a!)
+  aten: addmm_(self, mat1, mat2, beta, alpha)
+
 - name: addmm(Scalar beta, Tensor self, Scalar alpha, Tensor mat1, Tensor mat2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addmm_out(out, self, mat1, mat2, beta, alpha)
 
 - name: addmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2) -> Tensor
   aten: addmm(self, mat1, mat2, beta, 1)
+
+- name: addmm_(Scalar beta, Tensor(a!) self, Tensor mat1, Tensor mat2) -> Tensor(a!)
+  aten: addmm_(self, mat1, mat2, beta, 1)
 
 - name: addmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addmm_out(out, self, mat1, mat2, beta, 1)
@@ -52,11 +73,17 @@
 - name: addmv(Scalar beta, Tensor self, Scalar alpha, Tensor mat, Tensor vec) -> Tensor
   aten: addmv(self, mat, vec, beta, alpha)
 
+- name: addmv_(Scalar beta, Tensor(a!) self, Scalar alpha, Tensor mat, Tensor vec) -> Tensor(a!)
+  aten: addmv_(self, mat, vec, beta, alpha)
+
 - name: addmv(Scalar beta, Tensor self, Scalar alpha, Tensor mat, Tensor vec, *, Tensor(a!) out) -> Tensor(a!)
   aten: addmv_out(out, self, mat, vec, beta, alpha)
 
 - name: addmv(Scalar beta, Tensor self, Tensor mat, Tensor vec) -> Tensor
   aten: addmv(self, mat, vec, beta, 1)
+
+- name: addmv_(Scalar beta, Tensor(a!) self, Tensor mat, Tensor vec) -> Tensor(a!)
+  aten: addmv_(self, mat, vec, beta, 1)
 
 - name: addmv(Scalar beta, Tensor self, Tensor mat, Tensor vec, *, Tensor(a!) out) -> Tensor(a!)
   aten: addmv_out(out, self, mat, vec, beta, 1)
@@ -64,11 +91,17 @@
 - name: addr(Scalar beta, Tensor self, Scalar alpha, Tensor vec1, Tensor vec2) -> Tensor
   aten: addr(self, vec1, vec2, beta, alpha)
 
+- name: addr_(Scalar beta, Tensor(a!) self, Scalar alpha, Tensor vec1, Tensor vec2) -> Tensor(a!)
+  aten: addr_(self, vec1, vec2, beta, alpha)
+
 - name: addr(Scalar beta, Tensor self, Scalar alpha, Tensor vec1, Tensor vec2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addr_out(out, self, vec1, vec2, beta, alpha)
 
 - name: addr(Scalar beta, Tensor self, Tensor vec1, Tensor vec2) -> Tensor
   aten: addr(self, vec1, vec2, beta, 1)
+
+- name: addr_(Scalar beta, Tensor(a!) self, Tensor vec1, Tensor vec2) -> Tensor(a!)
+  aten: addr_(self, vec1, vec2, beta, 1)
 
 - name: addr(Scalar beta, Tensor self, Tensor vec1, Tensor vec2, *, Tensor(a!) out) -> Tensor(a!)
   aten: addr_out(out, self, vec1, vec2, beta, 1)
@@ -76,17 +109,26 @@
 - name: baddbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2) -> Tensor
   aten: baddbmm(self, batch1, batch2, beta, alpha)
 
+- name: baddbmm_(Scalar beta, Tensor(a!) self, Scalar alpha, Tensor batch1, Tensor batch2) -> Tensor(a!)
+  aten: baddbmm_(self, batch1, batch2, beta, alpha)
+
 - name: baddbmm(Scalar beta, Tensor self, Scalar alpha, Tensor batch1, Tensor batch2, *, Tensor(a!) out) -> Tensor(a!)
   aten: baddbmm_out(out, self, batch1, batch2, beta, alpha)
 
 - name: baddbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2) -> Tensor
   aten: baddbmm(self, batch1, batch2, beta, 1)
 
+- name: baddbmm_(Scalar beta, Tensor(a!) self, Tensor batch1, Tensor batch2) -> Tensor(a!)
+  aten: baddbmm_(self, batch1, batch2, beta, 1)
+
 - name: baddbmm(Scalar beta, Tensor self, Tensor batch1, Tensor batch2, *, Tensor(a!) out) -> Tensor(a!)
   aten: baddbmm_out(out, self, batch1, batch2, beta, 1)
 
 - name: sub(Tensor self, Scalar alpha, Tensor other) -> Tensor
   aten: sub(self, other, alpha)
+
+- name: sub_(Tensor(a!) self, Scalar alpha, Tensor other) -> Tensor(a!)
+  aten: sub_(self, other, alpha)
 
 - name: sub(Tensor self, Scalar alpha, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   aten: sub_out(out, self, other, alpha)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -560,7 +560,7 @@ def load_deprecated_signatures(
                         return False
 
             return len(schema.returns) == len(aten_schema.returns) and all(
-                a.type == b.type for a, b in zip(schema.returns, aten_schema.returns)
+                a == b for a, b in zip(schema.returns, aten_schema.returns)
             )
 
         any_schema_found = False

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -34,13 +34,12 @@ import itertools
 import re
 from collections import defaultdict
 
-from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import yaml
 from torchgen.api import cpp
 from torchgen.api.python import (
     arg_parser_output_exprs,
-    argument_type_str,
     cpp_dispatch_exprs,
     cpp_dispatch_target,
     dispatch_lambda_args,
@@ -48,19 +47,25 @@ from torchgen.api.python import (
     dispatch_lambda_return_str,
     has_tensor_options,
     namedtuple_fieldnames,
-    PythonArgument,
     PythonSignature,
     PythonSignatureDeprecated,
     PythonSignatureGroup,
     PythonSignatureNativeFunctionPair,
     signature,
+    signature_from_schema,
 )
-from torchgen.api.types import CppSignatureGroup
 
 from torchgen.code_template import CodeTemplate
 from torchgen.context import with_native_function
 from torchgen.gen import cpp_string, parse_native_yaml, parse_tags_yaml
-from torchgen.model import Argument, BaseOperatorName, NativeFunction, Type, Variant
+from torchgen.model import (
+    Argument,
+    BaseOperatorName,
+    FunctionSchema,
+    NativeFunction,
+    Type,
+    Variant,
+)
 from torchgen.utils import FileManager, split_name_params, YamlLoader
 
 from .gen_trace_type import should_trace
@@ -495,46 +500,10 @@ def load_deprecated_signatures(
     # the call) to generate the full python signature.
     # We join the deprecated and the original signatures using type-only form.
 
-    # native function -> type-only signature
-    @with_native_function
-    def signature_original(f: NativeFunction) -> str:
-        # remove inplace suffix but keep outplace suffix
-        opname = str(f.func.name.name.base)
-        if f.func.is_out_fn():
-            opname += "_out"
-        if f.func.name.name.inplace and pyi:
-            opname += "_"
-        args = CppSignatureGroup.from_native_function(
-            f, method=False
-        ).signature.arguments()
-        # Simply ignore TensorOptionsArguments as it does not exist in deprecated.yaml.
-        types = ", ".join(
-            argument_type_str(a.argument.type)
-            for a in args
-            if isinstance(a.argument, Argument)
-        )
-        return f"{opname}({types})"
-
-    # deprecated -> type-only native signature (according to the call order)
-    def signature_deprecated(
-        opname: str, params: List[str], call_args: List[str]
-    ) -> str:
-        # create a mapping of parameter name to parameter type
-        types: Dict[str, str] = {}
-        for param in params:
-            if param == "*":
-                continue
-            type, name = param.split(" ")
-            types[name] = type
-        # if the name in the call is not in the parameter list, assume it's
-        # a literal Scalar
-        rearranged_types = ", ".join(types.get(arg, "Scalar") for arg in call_args)
-        return f"{opname}({rearranged_types})"
-
-    # group the original ATen signatures by type-only signature
+    # group the original ATen signatures by name
     grouped: Dict[str, List[PythonSignatureNativeFunctionPair]] = defaultdict(list)
     for pair in pairs:
-        grouped[signature_original(pair.function)].append(pair)
+        grouped[pair.signature.name].append(pair)
 
     # find matching original signatures for each deprecated signature
     results: List[PythonSignatureNativeFunctionPair] = []
@@ -543,66 +512,92 @@ def load_deprecated_signatures(
         deprecated_defs = yaml.load(f, Loader=YamlLoader)
 
     for deprecated in deprecated_defs:
-        _, params = split_name_params(deprecated["name"])
+        schema = FunctionSchema.parse(deprecated["name"])
         aten_name, call_args = split_name_params(deprecated["aten"])
+        is_out = aten_name.endswith("_out")
+        if is_out:
+            aten_name = aten_name.replace("_out", "")
 
-        for pair in grouped[signature_deprecated(aten_name, params, call_args)]:
-            # It uses the types from the original ATen declaration, but the
-            # ordering and parameter names from the deprecated overload. Any
-            # default parameter values from the original ATen declaration are
-            # ignored.
-            # Deprecated signature might reorder input_args and input_kwargs,
-            # but never changes output_args nor TensorOptions (if any?),
-            # so here we only look into these two types of args.
-            python_sig = pair.signature
-            src_args: Dict[str, PythonArgument] = {
-                a.name: PythonArgument(
-                    name=a.name,
-                    type=a.type,
-                    default=None,
-                    default_init=None,
+        # HACK: these are fixed constants used to pass the the aten function.
+        # The type must be known ahead of time
+        known_constants = {
+            "1": Type.parse("Scalar"),
+        }
+        schema_args_by_name = {a.name: a for a in schema.arguments.flat_all}
+        for name in call_args:
+            assert (
+                name in schema_args_by_name or name in known_constants
+            ), f"deprecation definiton: Unrecognized value {name}"
+
+        # Map deprecated signature arguments to their aten signature name
+        def map_schema_arguments(
+            aten_schema: FunctionSchema,
+        ) -> Optional[Dict[str, str]]:
+            arguments: Iterable[Argument]
+            if is_out:
+                arguments = itertools.chain(
+                    aten_schema.arguments.out, aten_schema.arguments.flat_non_out
                 )
-                for a in itertools.chain(python_sig.input_args, python_sig.input_kwargs)
-            }
+            else:
+                arguments = aten_schema.arguments.flat_all
 
-            args: List[str] = []
-            input_args: List[PythonArgument] = []
-            input_kwargs: List[PythonArgument] = []
+            arg_mapping: Dict[str, str] = {}
+            for i, arg in enumerate(arguments):
+                if i < len(call_args):
+                    arg_name = call_args[i]
+                    if arg_name in known_constants:
+                        schema_type = known_constants[arg_name]
+                        schema_annotation = None
+                    else:
+                        arg_mapping[arg_name] = arg.name
+                        schema_arg = schema_args_by_name[arg_name]
+                        schema_type = schema_arg.type
+                        schema_annotation = schema_arg.annotation
 
-            kwarg_only = False
-            for param in params:
-                if param == "*":
-                    kwarg_only = True
-                    continue
-                _, param_name = param.split(" ")
-                args.append(param_name)
-
-                if param_name not in src_args:
-                    # output argument
-                    continue
-
-                if not kwarg_only:
-                    if not method or param_name != "self":
-                        input_args.append(src_args[param_name])
+                    if schema_type != arg.type or schema_annotation != arg.annotation:
+                        return None
                 else:
-                    input_kwargs.append(src_args[param_name])
+                    if arg.default is None:
+                        return None
+
+            returns_match = len(schema.returns) == len(aten_schema.returns) and all(
+                a.type == b.type for a, b in zip(schema.returns, aten_schema.returns)
+            )
+            return arg_mapping if returns_match else None
+
+        any_schema_found = False
+        for pair in grouped[aten_name]:
+            to_aten_name = map_schema_arguments(pair.function.func)
+            if to_aten_name is None:
+                continue
+            any_schema_found = True
+
+            python_sig = signature_from_schema(
+                schema,
+                category_override=pair.function.category_override,
+                method=method,
+                pyi=pyi,
+            )
 
             results.append(
                 PythonSignatureNativeFunctionPair(
                     signature=PythonSignatureDeprecated(
                         name=python_sig.name,
-                        input_args=tuple(input_args),
-                        input_kwargs=tuple(input_kwargs),
+                        input_args=python_sig.input_args,
+                        input_kwargs=python_sig.input_kwargs,
                         output_args=python_sig.output_args,
                         tensor_options_args=python_sig.tensor_options_args,
                         method=python_sig.method,
-                        deprecated_args_names=tuple(args),
+                        deprecated_schema=schema,
                         deprecated_args_exprs=tuple(call_args),
                         returns=python_sig.returns,
                     ),
                     function=pair.function,
                 )
             )
+        assert (
+            any_schema_found
+        ), f"No native function with name {aten_name} matched signature:\n  {str(schema)}"
 
     return results
 
@@ -1192,8 +1187,12 @@ def emit_single_dispatch(
     @with_native_function
     def go(f: NativeFunction) -> str:
         # header comments
+        if isinstance(ps, PythonSignatureDeprecated):
+            schema_comment = f"// [deprecated] aten::{ps.deprecated_schema}"
+        else:
+            schema_comment = f"// aten::{f.func}"
+
         deprecated = "[deprecated] " if ps.deprecated else ""
-        schema_comment = f"// {deprecated}aten::{f.func}"
 
         # dispatch lambda signature
         name = cpp.name(f.func)

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -533,7 +533,7 @@ def load_deprecated_signatures(
         # if the types and alias annotation match.
         def is_schema_compatible(
             aten_schema: FunctionSchema,
-        ) -> Optional[Dict[str, str]]:
+        ) -> bool:
             arguments: Iterable[Argument]
             if is_out:
                 arguments = itertools.chain(
@@ -554,10 +554,10 @@ def load_deprecated_signatures(
                         schema_annotation = schema_arg.annotation
 
                     if schema_type != arg.type or schema_annotation != arg.annotation:
-                        return None
+                        return False
                 else:
                     if arg.default is None:
-                        return None
+                        return False
 
             return len(schema.returns) == len(aten_schema.returns) and all(
                 a.type == b.type for a, b in zip(schema.returns, aten_schema.returns)

--- a/torchgen/api/python.py
+++ b/torchgen/api/python.py
@@ -9,6 +9,7 @@ from torchgen.model import (
     Argument,
     BaseTy,
     BaseType,
+    FunctionSchema,
     ListType,
     NativeFunction,
     OptionalType,
@@ -447,12 +448,8 @@ class PythonSignature:
 # dedicated data model to store these extra properties.
 @dataclass(frozen=True)
 class PythonSignatureDeprecated(PythonSignature):
-    # We need keep the order of arguments in deprecated signature.
-    # Particularly, method signature might have 'self' not at the beginning, e.g.:
-    #   addmm(Scalar beta, Tensor self, Tensor mat1, Tensor mat2)
-    # When generating lambda function signature we need follow the exact order (even for method=True):
-    #   [](Scalar beta, const Tensor & self, const Tensor & mat1, const Tensor & mat2) -> Tensor
-    deprecated_args_names: Tuple[str, ...]
+    # Schema for the deprecated function
+    deprecated_schema: FunctionSchema
 
     # The deprecated signature might miss some arguments that the corresponding
     # C++ signature expects. We need store the constant default values to pass in.
@@ -725,21 +722,33 @@ def argument(a: Argument) -> PythonArgument:
 def signature(
     f: NativeFunction, *, method: bool = False, pyi: bool = False
 ) -> PythonSignature:
+    return signature_from_schema(
+        f.func, category_override=f.category_override, method=method, pyi=pyi
+    )
+
+
+def signature_from_schema(
+    func: FunctionSchema,
+    *,
+    category_override: Optional[str],
+    method: bool = False,
+    pyi: bool = False,
+) -> PythonSignature:
     args: List[Argument] = []
-    args.extend(f.func.arguments.pre_self_positional)
+    args.extend(func.arguments.pre_self_positional)
     # Skip SelfArgument if this is method.
-    if not method and f.func.arguments.self_arg is not None:
-        args.append(f.func.arguments.self_arg.argument)
-    args.extend(f.func.arguments.post_self_positional)
-    args.extend(f.func.arguments.pre_tensor_options_kwarg_only)
+    if not method and func.arguments.self_arg is not None:
+        args.append(func.arguments.self_arg.argument)
+    args.extend(func.arguments.post_self_positional)
+    args.extend(func.arguments.pre_tensor_options_kwarg_only)
     # Skip TensorOptionsArguments. Python side TensorOptions
     # arguments are created based on different rules - see below.
-    args.extend(f.func.arguments.post_tensor_options_kwarg_only)
-    args.extend(f.func.arguments.out)
+    args.extend(func.arguments.post_tensor_options_kwarg_only)
+    args.extend(func.arguments.out)
 
-    input_arg_set = set(a.name for a in f.func.arguments.flat_positional)
-    kwarg_only_set = set(a.name for a in f.func.arguments.flat_kwarg_only)
-    out_arg_set = set(a.name for a in f.func.arguments.out)
+    input_arg_set = set(a.name for a in func.arguments.flat_positional)
+    kwarg_only_set = set(a.name for a in func.arguments.flat_kwarg_only)
+    out_arg_set = set(a.name for a in func.arguments.out)
 
     input_args = tuple(map(argument, filter(lambda a: a.name in input_arg_set, args)))
     input_kwargs = tuple(
@@ -756,23 +765,23 @@ def signature(
     # source of drift between eager and JIT. Pull this logic out to a shared place.
 
     has_tensor_input_arg = any(
-        a.type.is_tensor_like() for a in f.func.arguments.flat_non_out
+        a.type.is_tensor_like() for a in func.arguments.flat_non_out
     )
-    if any(a.name == "requires_grad" for a in f.func.schema_order_arguments()):
+    if any(a.name == "requires_grad" for a in func.schema_order_arguments()):
         raise ValueError(
             "argument named requires_grad is reserved, should not explicitly add it in the schema"
         )
 
     # [old codegen] this probably won't work if one of the returns is not a tensor,
     # but it will produce a compile-time error that is obvious.
-    has_tensor_return = any(r.type.is_tensor_like() for r in f.func.returns)
+    has_tensor_return = any(r.type.is_tensor_like() for r in func.returns)
 
-    name: str = cpp.name(f.func)
-    is_factory_function = f.category_override == "factory" or (
+    name: str = cpp.name(func)
+    is_factory_function = category_override == "factory" or (
         has_tensor_return and not has_tensor_input_arg
     )
     is_like_or_new_function = (
-        f.category_override in ("new", "like")
+        category_override in ("new", "like")
         or name.startswith("new_")
         or name.endswith("_like")
     )
@@ -781,7 +790,7 @@ def signature(
     if is_factory_function or is_like_or_new_function:
 
         def topt_default_init(name: str) -> Optional[str]:
-            topt_args = f.func.arguments.tensor_options
+            topt_args = func.arguments.tensor_options
             if topt_args is None:
                 return None
             a = getattr(topt_args, name)
@@ -842,10 +851,10 @@ def signature(
             )
         )
 
-    returns = PythonReturns(returns=f.func.returns)
+    returns = PythonReturns(returns=func.returns)
 
     return PythonSignature(
-        name=str(f.func.name.name),
+        name=str(func.name.name),
         input_args=input_args,
         input_kwargs=input_kwargs,
         output_args=PythonOutArgument.from_outputs(outputs),
@@ -1035,20 +1044,19 @@ def returns_str_pyi(signature: PythonSignature) -> str:
 def dispatch_lambda_args(
     ps: PythonSignature, f: NativeFunction
 ) -> Tuple[DispatchLambdaArgument, ...]:
-    # Start with cpp arguments - dispatch lambda signature always include 'self'
-    cpp_args: Sequence[Binding] = _cpp_signature(f, method=False).arguments()
-
-    # Special reorder logic for deprecated python signature
     if isinstance(ps, PythonSignatureDeprecated):
-        m: Dict[str, Binding] = dict((a.name, a) for a in cpp_args)
-        # reorder according to the deprecated signature
-        # ignore 'out' argument when binding to non-output function.
-        ordered_args = filter(
-            lambda n: n != "out" or f.func.is_out_fn(), ps.deprecated_args_names
-        )
-        cpp_args = list(map(lambda n: m[n], ordered_args))
+        schema = ps.deprecated_schema
+    else:
+        schema = f.func
 
-    out_args: Set[str] = set(a.name for a in f.func.arguments.out)
+    # Start with cpp arguments - dispatch lambda signature always include 'self'
+    cpp_args = cpp.arguments(
+        arguments=schema.arguments,
+        faithful=False,
+        method=False,
+        cpp_no_default_args=f.cpp_no_default_args,
+    )
+    out_args: Set[str] = set(a.name for a in schema.arguments.out)
 
     # Convert from cpp argument to lambda argument
     def dispatch_lambda_arg(cpp_arg: Binding) -> DispatchLambdaArgument:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #74728
* #74727
* __->__ #82179

Deprecated signatures are currently "parsed" manually to find the
relative order of the argument names and all other information is
inferred from the aten schema for the non-deprecated overload.
However, this leads to problems if the argument names don't match or
if there are multiple candidates that match the ATen function call.

Instead, this makes the deprecated function a full FunctionSchema and
so the entire python signature comes solely from the deprecated
schema, with the `aten:` clause only used for the dispatch lambda call.

I have confirmed locally that there is no change to
`python_torch_functionsEverything.cpp`.