### PR TITLE
Use a different heuristic to parse int lists.

### DIFF
--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1123,9 +1123,9 @@ def sort_overloads(
             str(t1) == "Tensor[]"
             and str(t2).find("[]") != -1
             or
-            # Prioritize SymIntArrayRef overload over IntArrayRef
-            str(t1) == "int[]"
-            and str(t2) == "SymInt[]"
+            # Prioritize IntArrayRef overload over SymIntArrayRef
+            str(t1) == "SymInt[]"
+            and str(t2) == "int[]"
         )
 
     def is_smaller(s1: PythonSignature, s2: PythonSignature) -> bool:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82182

Previously, Krovatkin attempted to distinguish int lists from sym
int lists by requiring all arguments to the int list be integers, which
broke FX tracing.  We subsequently reordered the overloads so that SymInt
overload came first.

This reorders the overloads back to their original order, and instead
changes the algorithm to reject a list as int list if any of the arguments
IS A SymInt.  This means it is still possible to call the IntList overload
with non-int arguments (for torch function), so long as the first argument
is an int.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>