### PR TITLE
[MPS] Handle int inputs of matmul ops by returning error for unsupported data types

### DIFF
--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -25,6 +25,10 @@ Tensor _mps_linear(
 
   using namespace mps;
 
+  TORCH_CHECK(input.scalar_type() == ScalarType::Double
+              || input.scalar_type() == ScalarType::Float
+              || input.scalar_type() == ScalarType::Half, "MPS device does not support linear for non-float inputs");
+
   // See [Note: hacky wrapper removal for optional tensor]
   auto bias = bias_opt.has_value()
     ? c10::MaybeOwned<Tensor>::borrowed(*bias_opt)
@@ -156,6 +160,10 @@ Tensor _mps_linear_backward_input(
   TORCH_CHECK(weight.device().is_mps() && weight.scalar_type() == kFloat,
       "mps_linear_backward: weight needs to be a dense tensor");
 
+  TORCH_CHECK(grad_output.scalar_type() == ScalarType::Double
+              || grad_output.scalar_type() == ScalarType::Float
+              || grad_output.scalar_type() == ScalarType::Half, "MPS device does not support linear backward for non-float inputs");  
+
   const Tensor weight_reshaped = weight.is_contiguous() ? weight : weight.contiguous();
 
    struct CachedGraph : public mps::MPSCachedGraph
@@ -231,6 +239,10 @@ std::tuple<Tensor, Tensor> _mps_linear_backward_weights(
 {
   TORCH_CHECK(grad_output.is_mps() && input.is_mps(),
       "_mps_linear_backward: grad_output and input needs to be mps layout");
+
+  TORCH_CHECK(grad_output.scalar_type() == ScalarType::Double
+              || grad_output.scalar_type() == ScalarType::Float
+              || grad_output.scalar_type() == ScalarType::Half, "MPS device does not support linear backward for non-float inputs");
 
    struct CachedGraph : public mps::MPSCachedGraph
   {

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -162,7 +162,7 @@ Tensor _mps_linear_backward_input(
 
   TORCH_CHECK(grad_output.scalar_type() == ScalarType::Double
               || grad_output.scalar_type() == ScalarType::Float
-              || grad_output.scalar_type() == ScalarType::Half, "MPS device does not support linear backward for non-float inputs");  
+              || grad_output.scalar_type() == ScalarType::Half, "MPS device does not support linear backward for non-float inputs");
 
   const Tensor weight_reshaped = weight.is_contiguous() ? weight : weight.contiguous();
 

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -100,6 +100,9 @@ Tensor& mm_out_mps_impl(
     Tensor& output) {
   using namespace mps;
   TORCH_CHECK(self.dim() == 2 && other.dim() == 2, "tensors must be 2-D");
+  TORCH_CHECK(self.scalar_type() == ScalarType::Double
+              || self.scalar_type() == ScalarType::Float
+              || self.scalar_type() == ScalarType::Half, "MPS device does not support mm for non-float inputs");
 
   TensorArg args[]{{output, "out", 0}, {self, "mat1", 1}, {other, "mat2", 2}};
   checkAllSameGPU("mm", args);
@@ -208,6 +211,9 @@ Tensor& addmm_out_mps_impl(
 
   TORCH_CHECK(output.is_mps());
   TORCH_CHECK(self.dim() == 2 && other.dim() == 2, "tensors must be 2-D");
+  TORCH_CHECK(self.scalar_type() == ScalarType::Double
+              || self.scalar_type() == ScalarType::Float
+              || self.scalar_type() == ScalarType::Half, "MPS device does not support addmm for non-float input");
 
   TensorArg args[]{{output, "out", 0}, {bias, "self", 1}, {self, "mat1", 2}, {other, "mat2", 3}};
   checkAllSameGPU(__func__, args);
@@ -366,6 +372,10 @@ Tensor& bmm_out_mps_impl(
   Tensor & result) {
   using namespace mps;
 
+  TORCH_CHECK(batch1.scalar_type() == ScalarType::Double
+              || batch1.scalar_type() == ScalarType::Float
+              || batch1.scalar_type() == ScalarType::Half, "MPS device does not support bmm for non-float inputs");
+
   if (batch1.numel() == 0 || batch2.numel() == 0) {
     return result;
   }
@@ -443,6 +453,10 @@ Tensor& addbmm_or_baddbmm_out_mps_impl(
   TORCH_CHECK(batch1.is_mps());
   TORCH_CHECK(batch2.is_mps());
   TORCH_CHECK(result.is_mps());
+
+  TORCH_CHECK(batch1.scalar_type() == ScalarType::Double
+              || batch1.scalar_type() == ScalarType::Float
+              || batch1.scalar_type() == ScalarType::Half, "MPS device does not support addbmm or baddbmm for non-float inputs");
 
   TORCH_CHECK(batch1.dim() == 3, "batch1 must be a 3D tensor");
   TORCH_CHECK(batch2.dim() == 3, "batch2 must be a 3D tensor");


### PR DESCRIPTION
This is in-continuation of fixes for TestConsistency for MPS backend. 

* Add error messages for unsupported matmul ops

* Add error handling for int inputs for linear op

### Description
<!-- What did you change and why was it needed? -->

### Issue
<!-- Link to Issue ticket or RFP -->

### Testing
<!-- How did you test your change? -->
