### PR TITLE
Revert "Revert "Enabling SymInt in autograd; take 3 (#81145)"" ; make sure is_intlist checks for symintnodes

### DIFF
--- a/aten/src/ATen/FunctionalInverses.cpp
+++ b/aten/src/ATen/FunctionalInverses.cpp
@@ -299,6 +299,14 @@ Tensor FunctionalInverses::view_copy_inverse(const Tensor& base, const Tensor& m
     }
 }
 
+Tensor FunctionalInverses::view_copy_SymInt_inverse(const Tensor& base, const Tensor& mutated_view, bool reapply_views, c10::SymIntArrayRef size) {
+    if (reapply_views) {
+      return mutated_view.view_symint(base.sym_sizes());
+    } else {
+      return at::view_copy_symint(mutated_view, base.sym_sizes());
+    }
+}
+
 Tensor FunctionalInverses::view_copy_dtype_inverse(const Tensor& base, const Tensor& mutated_view, bool reapply_views, at::ScalarType dtype) {
     if (reapply_views) {
       return mutated_view.view(base.scalar_type());

--- a/aten/src/ATen/core/NamedRegistrations.cpp
+++ b/aten/src/ATen/core/NamedRegistrations.cpp
@@ -467,6 +467,7 @@ TORCH_LIBRARY_IMPL(aten, Named, m) {
   m.impl("sum.IntList_out", CppFunction::makeFallthrough());
   m.impl("sum.dim_DimnameList", CppFunction::makeFallthrough());
   m.impl("sum.dim_IntList", CppFunction::makeFallthrough());
+  m.impl("sum.SymInt", CppFunction::makeFallthrough());
   m.impl("t", CppFunction::makeFallthrough());
   m.impl("tan", CppFunction::makeFallthrough());
   m.impl("tan.out", CppFunction::makeFallthrough());

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1079,6 +1079,10 @@ Tensor sum(const Tensor& self, DimnameList dim, bool keepdim, c10::optional<Scal
   return at::sum(self, dimnames_to_positions(self, dim), keepdim, dtype);
 }
 
+Tensor sum_symint(const Tensor& input_t, c10::SymIntArrayRef dim, bool keepdim, optional<ScalarType> opt_dtype) {
+  return at::sum(input_t, c10::asIntArrayRefSlow(dim), keepdim, opt_dtype);
+}
+
 Tensor& sum_out(const Tensor& self, DimnameList dim,
                 bool keepdim, optional<ScalarType> opt_dtype, Tensor& result) {
   return at::sum_out(result, self, dimnames_to_positions(self, dim), keepdim, opt_dtype);

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -1078,6 +1078,14 @@ Tensor zeros(IntArrayRef size,
   return result.zero_();
 }
 
+Tensor zeros_symint(c10::SymIntArrayRef size,
+    c10::optional<ScalarType> dtype,
+    c10::optional<Layout> layout,
+    c10::optional<Device> device,
+    c10::optional<bool> pin_memory) {
+    return zeros(asIntArrayRefSlow(size), dtype, layout, device, pin_memory);
+}
+
 Tensor _efficientzerotensor(IntArrayRef size,
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <vector>
+#include <c10/util/StringUtil.h>
 
 namespace at {
 namespace meta {
@@ -3103,6 +3104,11 @@ Tensor adjoint(const Tensor &self) {
 Tensor view(const Tensor& self,
             IntArrayRef size) {
   return view_impl(self, size);
+}
+
+Tensor view_symint(const Tensor& self,
+            c10::SymIntArrayRef size) {
+  return self.view(c10::asIntArrayRefSlow(size));
 }
 
 Tensor alias(const Tensor& self) {

--- a/aten/src/ATen/native/mkldnn/TensorShape.cpp
+++ b/aten/src/ATen/native/mkldnn/TensorShape.cpp
@@ -2,6 +2,7 @@
 #include <ATen/Config.h>
 #include <ATen/InferSize.h>
 #include <ATen/NativeFunctions.h>
+#include <c10/core/SymIntArrayRef.h>
 
 #if !AT_MKLDNN_ENABLED()
 
@@ -86,3 +87,15 @@ Tensor& mkldnn_transpose_(Tensor& self, int64_t dim0, int64_t dim1) {
 } // namespace at
 
 #endif // AT_MKLDNN_ENABLED
+
+
+namespace at {
+namespace native {
+
+
+Tensor mkldnn_view_symint(const Tensor& self, c10::SymIntArrayRef size) {
+  return mkldnn_view(self, c10::asIntArrayRefSlow(size));
+}
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/mkldnn/TensorShape.h
+++ b/aten/src/ATen/native/mkldnn/TensorShape.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <c10/core/SymIntArrayRef.h>
 
 namespace at {
 namespace native {
 
 Tensor mkldnn_view(const Tensor& self, IntArrayRef size);
+
+Tensor mkldnn_view_symint(const Tensor& self, c10::SymIntArrayRef size);
 
 Tensor mkldnn_clone(const Tensor& self);
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4581,6 +4581,12 @@
     CompositeExplicitAutograd: sum
     SparseCsrCPU, SparseCsrCUDA: sum_csr
 
+- func: sum.SymInt(Tensor self, SymInt[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
+  device_check: NoCheck   # TensorIterator
+  variants: function, method
+  dispatch:
+    CompositeExplicitAutograd: sum_symint
+
 - func: sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   structured_delegate: sum.IntList_out
   device_check: NoCheck   # TensorIterator
@@ -5189,6 +5195,8 @@
     CUDA: _efficientzerotensor_cuda
 
 - func: zeros(int[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+
+- func: zeros.SymInt(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
 - func: zeros.out(int[] size, *, Tensor(a!) out) -> Tensor(a!)
 
@@ -6440,6 +6448,14 @@
   dispatch:
     CUDA: masked_softmax_backward_cuda
     CPU: masked_softmax_backward_cpu
+
+- func: view.SymInt(Tensor(a) self, SymInt[] size) -> Tensor(a)
+  variants: method
+  device_check: NoCheck
+  device_guard: False
+  dispatch:
+    CompositeExplicitAutograd: view_symint
+    MkldnnCPU: mkldnn_view_symint
 
 - func: view(Tensor(a) self, int[] size) -> Tensor(a)
   variants: method
@@ -12326,6 +12342,13 @@
   variants: function
   dispatch:
     CompositeExplicitAutograd: _neg_view_copy_out
+
+
+- func: view_copy.SymInt(Tensor self, SymInt[] size) -> Tensor
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: view_copy_SymInt
+  tags: view_copy
 
 
 - func: as_strided_copy.out(Tensor self, int[] size, int[] stride, int? storage_offset=None, *, Tensor(a!) out) -> Tensor(a!)

--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -25,6 +25,56 @@ SymInt SymInt::operator+(SymInt sci) const {
   return SymInt(data_ + sci.data_);
 }
 
+bool SymInt::operator!=(SymInt sci) const {
+  if (!is_symbolic() && !sci.is_symbolic()) {
+    return data_ != sci.data_;
+  }
+  // TODO: This is way to much boilerplate
+  std::shared_ptr<SymbolicIntNode> a =
+      is_symbolic() ? toSymbolicIntNode() : nullptr;
+  std::shared_ptr<SymbolicIntNode> b =
+      sci.is_symbolic() ? sci.toSymbolicIntNode() : nullptr;
+
+  SymbolicIntNode* common = a ? a.get() : b.get();
+  // TODO: technically we need to check that the classes match
+  if (!a) {
+    a = common->wrap(data_);
+    toSymInt(a); //
+  }
+  if (!b) {
+    b = common->wrap(sci.data_);
+    toSymInt(b);
+  }
+
+  auto c = a->ne(b);
+  return c->bool_();
+}
+
+bool SymInt::operator==(SymInt sci) const {
+  if (!is_symbolic() && !sci.is_symbolic()) {
+    return data_ == sci.data_;
+  }
+  // TODO: This is way to much boilerplate
+  std::shared_ptr<SymbolicIntNode> a =
+      is_symbolic() ? toSymbolicIntNode() : nullptr;
+  std::shared_ptr<SymbolicIntNode> b =
+      sci.is_symbolic() ? sci.toSymbolicIntNode() : nullptr;
+
+  SymbolicIntNode* common = a ? a.get() : b.get();
+  // TODO: technically we need to check that the classes match
+  if (!a) {
+    a = common->wrap(data_);
+    toSymInt(a); //
+  }
+  if (!b) {
+    b = common->wrap(sci.data_);
+    toSymInt(b);
+  }
+
+  auto c = a->eq(b);
+  return c->bool_();
+}
+
 SymInt SymInt::operator*(SymInt sci) const {
   if (!is_symbolic() && !sci.is_symbolic()) {
     return SymInt(data_ * sci.data_);
@@ -68,13 +118,11 @@ bool SymInt::operator<(int64_t sci) const {
 }
 
 bool SymInt::operator==(int64_t sci) const {
-  TORCH_CHECK(!this->is_symbolic(), "Symbolic eq isn't supported yet");
-  return data_ == sci;
+  return *this == c10::SymInt(sci);
 }
 
 bool SymInt::operator!=(int64_t sci) const {
-  TORCH_CHECK(!this->is_symbolic(), "Symbolic neq isn't supported yet");
-  return data_ != sci;
+  return *this != c10::SymInt(sci);
 }
 
 SymInt SymInt::operator*(int64_t sci) const {

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -39,16 +39,10 @@ class C10_API SymInt {
     return (MASK & static_cast<uint64_t>(this->data_)) == IS_SYM;
   }
 
-  bool operator==(const SymInt& p2) const {
-    return data_ == p2.data_;
-  }
-
-  bool operator!=(const SymInt& p2) const {
-    return data_ != p2.data_;
-  }
-
   SymInt operator+(SymInt sci) const;
   SymInt operator*(SymInt sci) const;
+  bool operator==(SymInt sci) const;
+  bool operator!=(SymInt p2) const;
   bool operator<(SymInt sci) const;
   void operator*=(SymInt sci);
 

--- a/c10/core/SymIntArrayRef.cpp
+++ b/c10/core/SymIntArrayRef.cpp
@@ -31,8 +31,4 @@ std::ostream& operator<<(std::ostream& os, SymInt s) {
   return os;
 }
 
-std::ostream& operator<<(std::ostream& out, const c10::SymIntArrayRef& list) {
-  return out << list.wrapped_symint_array_ref;
-}
-
 } // namespace c10

--- a/c10/core/SymIntArrayRef.h
+++ b/c10/core/SymIntArrayRef.h
@@ -63,6 +63,11 @@ class SymIntArrayRef final {
       size_t length)
       : wrapped_symint_array_ref(data, length) {}
 
+  template <typename U>
+  /* implicit */ SymIntArrayRef(
+      const SmallVectorTemplateCommon<c10::SymInt, U>& Vec)
+      : wrapped_symint_array_ref(Vec) {}
+
   /// Construct an SymIntArrayRef from a range.
   C10_HOST_CONSTEXPR_EXCEPT_WIN_CUDA SymIntArrayRef(
       const c10::SymInt* begin,
@@ -193,6 +198,10 @@ TORCH_API at::IntArrayRef asIntArrayRefUnchecked(c10::SymIntArrayRef ar);
 TORCH_API c10::optional<at::IntArrayRef> asIntArrayRefSlowOpt(
     c10::SymIntArrayRef ar);
 
-std::ostream& operator<<(std::ostream& out, const c10::SymIntArrayRef& list);
+inline std::ostream& operator<<(
+    std::ostream& out,
+    const c10::SymIntArrayRef& list) {
+  return out << list.wrapped_symint_array_ref;
+}
 
 } // namespace c10

--- a/c10/core/SymbolicIntNode.h
+++ b/c10/core/SymbolicIntNode.h
@@ -38,6 +38,10 @@ class C10_API SymbolicIntNode
       const std::shared_ptr<SymbolicIntNode>& other) {
     TORCH_CHECK(false, "NYI");
   };
+  virtual std::shared_ptr<SymbolicIntNode> ne(
+      const std::shared_ptr<SymbolicIntNode>& other) {
+    TORCH_CHECK(false, "NYI");
+  };
   virtual std::shared_ptr<SymbolicIntNode> gt(
       const std::shared_ptr<SymbolicIntNode>& other) {
     TORCH_CHECK(false, "NYI");

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -230,6 +230,9 @@ class TestPySymInt(TestCase):
         self.assertTrue(z.shape[1] == 4)
         self.assertTrue(z.shape[2] == 3)
 
+        z = y.expand((y.shape[1],))
+        z = y.expand(y.shape[1])
+
     @skipIfNoSympy
     def test_size_expressions(self):
         shape_env = ShapeEnv()

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -104,10 +104,10 @@ class TestFunctionalization(TestCase):
 def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([4, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
-    view_copy_default = torch.ops.aten.view_copy.default(a_1, [4, 2]);  a_1 = None
-    add_tensor = torch.ops.aten.add.Tensor(view_copy_default, fill_scalar);  view_copy_default = fill_scalar = None
-    view_copy_default_1 = torch.ops.aten.view_copy.default(add_tensor, [4, 2])
-    mul_tensor = torch.ops.aten.mul.Tensor(view_copy_default_1, view_copy_default_1);  view_copy_default_1 = None
+    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [4, 2]);  a_1 = None
+    add_tensor = torch.ops.aten.add.Tensor(view_copy_sym_int, fill_scalar);  view_copy_sym_int = fill_scalar = None
+    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(add_tensor, [4, 2])
+    mul_tensor = torch.ops.aten.mul.Tensor(view_copy_sym_int_1, view_copy_sym_int_1);  view_copy_sym_int_1 = None
     return add_tensor
     """)
 
@@ -129,9 +129,9 @@ def forward(self, a_1):
 def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([4, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
-    view_copy_default = torch.ops.aten.view_copy.default(a_1, [4, 2]);  a_1 = None
+    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [4, 2]);  a_1 = None
     empty_1 = torch.ops.aten.empty.SymInt([], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
-    add_tensor = torch.ops.aten.add.Tensor(view_copy_default, fill_scalar);  view_copy_default = fill_scalar = None
+    add_tensor = torch.ops.aten.add.Tensor(view_copy_sym_int, fill_scalar);  view_copy_sym_int = fill_scalar = None
     mul_tensor = torch.ops.aten.mul.Tensor(add_tensor, add_tensor);  add_tensor = None
     return mul_tensor
     """)
@@ -184,10 +184,10 @@ def forward(self, a_1):
 def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([4, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
-    view_copy_default = torch.ops.aten.view_copy.default(a_1, [4, 2])
+    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [4, 2])
     add_tensor = torch.ops.aten.add.Tensor(a_1, fill_scalar);  a_1 = fill_scalar = None
-    view_copy_default_1 = torch.ops.aten.view_copy.default(add_tensor, [4, 2]);  add_tensor = None
-    return view_copy_default_1
+    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(add_tensor, [4, 2]);  add_tensor = None
+    return view_copy_sym_int_1
     """)
 
     # Some ops that are mutable are neither inplace nor out= ops.
@@ -372,13 +372,13 @@ def forward(self, a_1):
 
 
 def forward(self, a_1):
-    view_copy_default = torch.ops.aten.view_copy.default(a_1, [8]);  a_1 = None
+    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [8]);  a_1 = None
     empty = torch.ops.aten.empty.memory_format([0], dtype = torch.int64, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
     arange = torch.ops.aten.arange.start_step(0, 4, 1, dtype = torch.int64, layout = torch.strided, device = device(type='cpu'))
     empty_1 = torch.ops.aten.empty.memory_format([0], dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
     arange_1 = torch.ops.aten.arange.start_step(0, 4, 1, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'))
-    index_put_default = torch.ops.aten.index_put.default(view_copy_default, [arange], arange_1);  view_copy_default = arange = arange_1 = None
-    view_copy_default_1 = torch.ops.aten.view_copy.default(index_put_default, [4, 2])
+    index_put_default = torch.ops.aten.index_put.default(view_copy_sym_int, [arange], arange_1);  view_copy_sym_int = arange = arange_1 = None
+    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(index_put_default, [4, 2])
     return index_put_default
     """)  # noqa: B950
 
@@ -400,11 +400,11 @@ def forward(self, a_1):
 def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([4, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
-    view_copy_default = torch.ops.aten.view_copy.default(a_1, [4, 2]);  a_1 = None
-    add_tensor = torch.ops.aten.add.Tensor(view_copy_default, 1);  view_copy_default = None
+    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [4, 2]);  a_1 = None
+    add_tensor = torch.ops.aten.add.Tensor(view_copy_sym_int, 1);  view_copy_sym_int = None
     mul_tensor = torch.ops.aten.mul.Tensor(add_tensor, 2)
     div_tensor = torch.ops.aten.div.Tensor(mul_tensor, 1);  mul_tensor = None
-    view_copy_default_1 = torch.ops.aten.view_copy.default(add_tensor, [4, 2]);  add_tensor = None
+    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(add_tensor, [4, 2]);  add_tensor = None
     return div_tensor
     """)
 
@@ -456,8 +456,8 @@ def forward(self, a_1):
 
 
 def forward(self, a_1):
-    view_copy_default = torch.ops.aten.view_copy.default(a_1, [4, 2]);  a_1 = None
-    return view_copy_default
+    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [4, 2]);  a_1 = None
+    return view_copy_sym_int
     """)
 
     def test_everything(self):
@@ -484,8 +484,8 @@ def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([2, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
     add_tensor = torch.ops.aten.add.Tensor(a_1, a_1);  a_1 = None
-    view_copy_default = torch.ops.aten.view_copy.default(add_tensor, [8])
-    _reshape_alias_copy_default = torch.ops.aten._reshape_alias_copy.default(view_copy_default, [2, 4], [4, 1]);  view_copy_default = None
+    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(add_tensor, [8])
+    _reshape_alias_copy_default = torch.ops.aten._reshape_alias_copy.default(view_copy_sym_int, [2, 4], [4, 1]);  view_copy_sym_int = None
     transpose_copy_int = torch.ops.aten.transpose_copy.int(_reshape_alias_copy_default, 1, 0)
     unsqueeze_copy_default = torch.ops.aten.unsqueeze_copy.default(transpose_copy_int, 0);  transpose_copy_int = None
     squeeze_copy_default = torch.ops.aten.squeeze_copy.default(unsqueeze_copy_default);  unsqueeze_copy_default = None
@@ -496,8 +496,8 @@ def forward(self, a_1):
     select_copy_int = torch.ops.aten.select_copy.int(_reshape_alias_copy_default, 0, 0);  _reshape_alias_copy_default = None
     clone_default = torch.ops.aten.clone.default(add_tensor_1, memory_format = torch.contiguous_format)
     _unsafe_view_default = torch.ops.aten._unsafe_view.default(clone_default, [4]);  clone_default = None
-    view_copy_default_1 = torch.ops.aten.view_copy.default(add_tensor, [8]);  add_tensor = None
-    _reshape_alias_copy_default_1 = torch.ops.aten._reshape_alias_copy.default(view_copy_default_1, [2, 4], [4, 1]);  view_copy_default_1 = None
+    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(add_tensor, [8]);  add_tensor = None
+    _reshape_alias_copy_default_1 = torch.ops.aten._reshape_alias_copy.default(view_copy_sym_int_1, [2, 4], [4, 1]);  view_copy_sym_int_1 = None
     transpose_copy_int_1 = torch.ops.aten.transpose_copy.int(_reshape_alias_copy_default_1, 1, 0);  _reshape_alias_copy_default_1 = None
     unsqueeze_copy_default_1 = torch.ops.aten.unsqueeze_copy.default(transpose_copy_int_1, 0);  transpose_copy_int_1 = None
     squeeze_copy_default_1 = torch.ops.aten.squeeze_copy.default(unsqueeze_copy_default_1);  unsqueeze_copy_default_1 = None
@@ -506,9 +506,9 @@ def forward(self, a_1):
     squeeze_copy_dim = torch.ops.aten.squeeze_copy.dim(unsqueeze_copy_default_2, 0);  unsqueeze_copy_default_2 = None
     transpose_copy_int_2 = torch.ops.aten.transpose_copy.int(squeeze_copy_dim, 1, 0);  squeeze_copy_dim = None
     _reshape_alias_copy_default_2 = torch.ops.aten._reshape_alias_copy.default(transpose_copy_int_2, [8], [1]);  transpose_copy_int_2 = None
-    view_copy_default_2 = torch.ops.aten.view_copy.default(_reshape_alias_copy_default_2, [4, 2]);  _reshape_alias_copy_default_2 = None
-    view_copy_default_3 = torch.ops.aten.view_copy.default(view_copy_default_2, [8]);  view_copy_default_2 = None
-    _reshape_alias_copy_default_3 = torch.ops.aten._reshape_alias_copy.default(view_copy_default_3, [2, 4], [4, 1]);  view_copy_default_3 = None
+    view_copy_sym_int_2 = torch.ops.aten.view_copy.SymInt(_reshape_alias_copy_default_2, [4, 2]);  _reshape_alias_copy_default_2 = None
+    view_copy_sym_int_3 = torch.ops.aten.view_copy.SymInt(view_copy_sym_int_2, [8]);  view_copy_sym_int_2 = None
+    _reshape_alias_copy_default_3 = torch.ops.aten._reshape_alias_copy.default(view_copy_sym_int_3, [2, 4], [4, 1]);  view_copy_sym_int_3 = None
     select_copy_int_1 = torch.ops.aten.select_copy.int(_reshape_alias_copy_default_3, 0, 0);  _reshape_alias_copy_default_3 = None
     add_tensor_2 = torch.ops.aten.add.Tensor(select_copy_int_1, _unsafe_view_default);  select_copy_int_1 = _unsafe_view_default = None
     return add_tensor_1
@@ -530,10 +530,10 @@ def forward(self, a_1):
 def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([4, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
-    view_default = torch.ops.aten.view.default(a_1, [4, 2]);  a_1 = None
-    add_tensor = torch.ops.aten.add.Tensor(view_default, fill_scalar);  view_default = fill_scalar = None
-    view_default_1 = torch.ops.aten.view.default(add_tensor, [4, 2])
-    mul_tensor = torch.ops.aten.mul.Tensor(view_default_1, view_default_1);  view_default_1 = None
+    view_sym_int = torch.ops.aten.view.SymInt(a_1, [4, 2]);  a_1 = None
+    add_tensor = torch.ops.aten.add.Tensor(view_sym_int, fill_scalar);  view_sym_int = fill_scalar = None
+    view_sym_int_1 = torch.ops.aten.view.SymInt(add_tensor, [4, 2])
+    mul_tensor = torch.ops.aten.mul.Tensor(view_sym_int_1, view_sym_int_1);  view_sym_int_1 = None
     return add_tensor
     """)
 
@@ -697,18 +697,18 @@ def forward(self, a_1):
 
 def forward(self, a_1):
     add_tensor = torch.ops.aten.add.Tensor(a_1, 1);  a_1 = None
-    view_copy_default = torch.ops.aten.view_copy.default(add_tensor, [4, 4])
-    resize_default = torch.ops.aten.resize.default(view_copy_default, [3, 3])
-    as_strided_copy_default = torch.ops.aten.as_strided_copy.default(view_copy_default, [3, 3], [3, 1]);  view_copy_default = None
-    view_copy_default_1 = torch.ops.aten.view_copy.default(as_strided_copy_default, [-1]);  as_strided_copy_default = None
-    add_tensor_1 = torch.ops.aten.add.Tensor(view_copy_default_1, 1);  view_copy_default_1 = None
-    view_copy_default_2 = torch.ops.aten.view_copy.default(add_tensor, [4, 4]);  add_tensor = None
-    as_strided_copy_default_1 = torch.ops.aten.as_strided_copy.default(view_copy_default_2, [3, 3], [3, 1])
-    view_copy_default_3 = torch.ops.aten.view_copy.default(add_tensor_1, [3, 3]);  add_tensor_1 = None
-    as_strided_scatter_default = torch.ops.aten.as_strided_scatter.default(view_copy_default_2, view_copy_default_3, [3, 3], [3, 1]);  view_copy_default_2 = view_copy_default_3 = None
-    view_copy_default_4 = torch.ops.aten.view_copy.default(as_strided_scatter_default, [8, 2]);  as_strided_scatter_default = None
-    view_copy_default_5 = torch.ops.aten.view_copy.default(view_copy_default_4, [4, 4]);  view_copy_default_4 = None
-    as_strided_copy_default_2 = torch.ops.aten.as_strided_copy.default(view_copy_default_5, [3, 3], [3, 1]);  view_copy_default_5 = None
+    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(add_tensor, [4, 4])
+    resize_default = torch.ops.aten.resize.default(view_copy_sym_int, [3, 3])
+    as_strided_copy_default = torch.ops.aten.as_strided_copy.default(view_copy_sym_int, [3, 3], [3, 1]);  view_copy_sym_int = None
+    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(as_strided_copy_default, [-1]);  as_strided_copy_default = None
+    add_tensor_1 = torch.ops.aten.add.Tensor(view_copy_sym_int_1, 1);  view_copy_sym_int_1 = None
+    view_copy_sym_int_2 = torch.ops.aten.view_copy.SymInt(add_tensor, [4, 4]);  add_tensor = None
+    as_strided_copy_default_1 = torch.ops.aten.as_strided_copy.default(view_copy_sym_int_2, [3, 3], [3, 1])
+    view_copy_sym_int_3 = torch.ops.aten.view_copy.SymInt(add_tensor_1, [3, 3]);  add_tensor_1 = None
+    as_strided_scatter_default = torch.ops.aten.as_strided_scatter.default(view_copy_sym_int_2, view_copy_sym_int_3, [3, 3], [3, 1]);  view_copy_sym_int_2 = view_copy_sym_int_3 = None
+    view_copy_sym_int_4 = torch.ops.aten.view_copy.SymInt(as_strided_scatter_default, [8, 2]);  as_strided_scatter_default = None
+    view_copy_sym_int_5 = torch.ops.aten.view_copy.SymInt(view_copy_sym_int_4, [4, 4]);  view_copy_sym_int_4 = None
+    as_strided_copy_default_2 = torch.ops.aten.as_strided_copy.default(view_copy_sym_int_5, [3, 3], [3, 1]);  view_copy_sym_int_5 = None
     add_tensor_2 = torch.ops.aten.add.Tensor(as_strided_copy_default_2, 1);  as_strided_copy_default_2 = None
     return add_tensor_2
     """)  # noqa: B950
@@ -739,11 +739,11 @@ def forward(self, a_1):
 def forward(self, a_1):
     add_tensor = torch.ops.aten.add.Tensor(a_1, 1);  a_1 = None
     resize_default = torch.ops.aten.resize.default(add_tensor, [5, 5]);  add_tensor = None
-    view_copy_default = torch.ops.aten.view_copy.default(resize_default, [25]);  resize_default = None
-    fill_scalar = torch.ops.aten.fill.Scalar(view_copy_default, 1);  view_copy_default = None
-    view_copy_default_1 = torch.ops.aten.view_copy.default(fill_scalar, [5, 5]);  fill_scalar = None
-    add_tensor_1 = torch.ops.aten.add.Tensor(view_copy_default_1, 1)
-    return (view_copy_default_1, add_tensor_1)
+    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(resize_default, [25]);  resize_default = None
+    fill_scalar = torch.ops.aten.fill.Scalar(view_copy_sym_int, 1);  view_copy_sym_int = None
+    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(fill_scalar, [5, 5]);  fill_scalar = None
+    add_tensor_1 = torch.ops.aten.add.Tensor(view_copy_sym_int_1, 1)
+    return (view_copy_sym_int_1, add_tensor_1)
     """)
 
     def test_resize_larger_invalid(self):

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -104,10 +104,10 @@ class TestFunctionalization(TestCase):
 def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([4, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
-    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [4, 2]);  a_1 = None
-    add_tensor = torch.ops.aten.add.Tensor(view_copy_sym_int, fill_scalar);  view_copy_sym_int = fill_scalar = None
-    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(add_tensor, [4, 2])
-    mul_tensor = torch.ops.aten.mul.Tensor(view_copy_sym_int_1, view_copy_sym_int_1);  view_copy_sym_int_1 = None
+    view_copy_default = torch.ops.aten.view_copy.default(a_1, [4, 2]);  a_1 = None
+    add_tensor = torch.ops.aten.add.Tensor(view_copy_default, fill_scalar);  view_copy_default = fill_scalar = None
+    view_copy_default_1 = torch.ops.aten.view_copy.default(add_tensor, [4, 2])
+    mul_tensor = torch.ops.aten.mul.Tensor(view_copy_default_1, view_copy_default_1);  view_copy_default_1 = None
     return add_tensor
     """)
 
@@ -129,9 +129,9 @@ def forward(self, a_1):
 def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([4, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
-    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [4, 2]);  a_1 = None
-    empty_1 = torch.ops.aten.empty.SymInt([], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
-    add_tensor = torch.ops.aten.add.Tensor(view_copy_sym_int, fill_scalar);  view_copy_sym_int = fill_scalar = None
+    view_copy_default = torch.ops.aten.view_copy.default(a_1, [4, 2]);  a_1 = None
+    empty_1 = torch.ops.aten.empty.memory_format([], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
+    add_tensor = torch.ops.aten.add.Tensor(view_copy_default, fill_scalar);  view_copy_default = fill_scalar = None
     mul_tensor = torch.ops.aten.mul.Tensor(add_tensor, add_tensor);  add_tensor = None
     return mul_tensor
     """)
@@ -151,8 +151,8 @@ def forward(self, a_1):
 
 
 def forward(self, a_1):
-    empty = torch.ops.aten.empty.SymInt([4], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
-    empty_1 = torch.ops.aten.empty.SymInt([4], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
+    empty = torch.ops.aten.empty.memory_format([4], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
+    empty_1 = torch.ops.aten.empty.memory_format([4], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     aminmax_default = torch.ops.aten.aminmax.default(a_1, dim = 0);  a_1 = None
     getitem = aminmax_default[0]
     getitem_1 = aminmax_default[1];  aminmax_default = None
@@ -184,10 +184,10 @@ def forward(self, a_1):
 def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([4, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
-    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [4, 2])
+    view_copy_default = torch.ops.aten.view_copy.default(a_1, [4, 2])
     add_tensor = torch.ops.aten.add.Tensor(a_1, fill_scalar);  a_1 = fill_scalar = None
-    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(add_tensor, [4, 2]);  add_tensor = None
-    return view_copy_sym_int_1
+    view_copy_default_1 = torch.ops.aten.view_copy.default(add_tensor, [4, 2]);  add_tensor = None
+    return view_copy_default_1
     """)
 
     # Some ops that are mutable are neither inplace nor out= ops.
@@ -258,7 +258,7 @@ def forward(self, a_1):
 
 
 def forward(self, a_1):
-    empty = torch.ops.aten.empty.SymInt([0], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
+    empty = torch.ops.aten.empty.memory_format([0], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     cat_default = torch.ops.aten.cat.default([a_1]);  a_1 = None
     return cat_default
     """)
@@ -372,13 +372,13 @@ def forward(self, a_1):
 
 
 def forward(self, a_1):
-    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [8]);  a_1 = None
+    view_copy_default = torch.ops.aten.view_copy.default(a_1, [8]);  a_1 = None
     empty = torch.ops.aten.empty.memory_format([0], dtype = torch.int64, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
     arange = torch.ops.aten.arange.start_step(0, 4, 1, dtype = torch.int64, layout = torch.strided, device = device(type='cpu'))
     empty_1 = torch.ops.aten.empty.memory_format([0], dtype = torch.float32, layout = torch.strided, device = device(type='cpu'), pin_memory = False)
     arange_1 = torch.ops.aten.arange.start_step(0, 4, 1, dtype = torch.float32, layout = torch.strided, device = device(type='cpu'))
-    index_put_default = torch.ops.aten.index_put.default(view_copy_sym_int, [arange], arange_1);  view_copy_sym_int = arange = arange_1 = None
-    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(index_put_default, [4, 2])
+    index_put_default = torch.ops.aten.index_put.default(view_copy_default, [arange], arange_1);  view_copy_default = arange = arange_1 = None
+    view_copy_default_1 = torch.ops.aten.view_copy.default(index_put_default, [4, 2])
     return index_put_default
     """)  # noqa: B950
 
@@ -400,11 +400,11 @@ def forward(self, a_1):
 def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([4, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
-    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [4, 2]);  a_1 = None
-    add_tensor = torch.ops.aten.add.Tensor(view_copy_sym_int, 1);  view_copy_sym_int = None
+    view_copy_default = torch.ops.aten.view_copy.default(a_1, [4, 2]);  a_1 = None
+    add_tensor = torch.ops.aten.add.Tensor(view_copy_default, 1);  view_copy_default = None
     mul_tensor = torch.ops.aten.mul.Tensor(add_tensor, 2)
     div_tensor = torch.ops.aten.div.Tensor(mul_tensor, 1);  mul_tensor = None
-    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(add_tensor, [4, 2]);  add_tensor = None
+    view_copy_default_1 = torch.ops.aten.view_copy.default(add_tensor, [4, 2]);  add_tensor = None
     return div_tensor
     """)
 
@@ -456,8 +456,8 @@ def forward(self, a_1):
 
 
 def forward(self, a_1):
-    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(a_1, [4, 2]);  a_1 = None
-    return view_copy_sym_int
+    view_copy_default = torch.ops.aten.view_copy.default(a_1, [4, 2]);  a_1 = None
+    return view_copy_default
     """)
 
     def test_everything(self):
@@ -484,8 +484,8 @@ def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([2, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
     add_tensor = torch.ops.aten.add.Tensor(a_1, a_1);  a_1 = None
-    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(add_tensor, [8])
-    _reshape_alias_copy_default = torch.ops.aten._reshape_alias_copy.default(view_copy_sym_int, [2, 4], [4, 1]);  view_copy_sym_int = None
+    view_copy_default = torch.ops.aten.view_copy.default(add_tensor, [8])
+    _reshape_alias_copy_default = torch.ops.aten._reshape_alias_copy.default(view_copy_default, [2, 4], [4, 1]);  view_copy_default = None
     transpose_copy_int = torch.ops.aten.transpose_copy.int(_reshape_alias_copy_default, 1, 0)
     unsqueeze_copy_default = torch.ops.aten.unsqueeze_copy.default(transpose_copy_int, 0);  transpose_copy_int = None
     squeeze_copy_default = torch.ops.aten.squeeze_copy.default(unsqueeze_copy_default);  unsqueeze_copy_default = None
@@ -496,8 +496,8 @@ def forward(self, a_1):
     select_copy_int = torch.ops.aten.select_copy.int(_reshape_alias_copy_default, 0, 0);  _reshape_alias_copy_default = None
     clone_default = torch.ops.aten.clone.default(add_tensor_1, memory_format = torch.contiguous_format)
     _unsafe_view_default = torch.ops.aten._unsafe_view.default(clone_default, [4]);  clone_default = None
-    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(add_tensor, [8]);  add_tensor = None
-    _reshape_alias_copy_default_1 = torch.ops.aten._reshape_alias_copy.default(view_copy_sym_int_1, [2, 4], [4, 1]);  view_copy_sym_int_1 = None
+    view_copy_default_1 = torch.ops.aten.view_copy.default(add_tensor, [8]);  add_tensor = None
+    _reshape_alias_copy_default_1 = torch.ops.aten._reshape_alias_copy.default(view_copy_default_1, [2, 4], [4, 1]);  view_copy_default_1 = None
     transpose_copy_int_1 = torch.ops.aten.transpose_copy.int(_reshape_alias_copy_default_1, 1, 0);  _reshape_alias_copy_default_1 = None
     unsqueeze_copy_default_1 = torch.ops.aten.unsqueeze_copy.default(transpose_copy_int_1, 0);  transpose_copy_int_1 = None
     squeeze_copy_default_1 = torch.ops.aten.squeeze_copy.default(unsqueeze_copy_default_1);  unsqueeze_copy_default_1 = None
@@ -506,9 +506,9 @@ def forward(self, a_1):
     squeeze_copy_dim = torch.ops.aten.squeeze_copy.dim(unsqueeze_copy_default_2, 0);  unsqueeze_copy_default_2 = None
     transpose_copy_int_2 = torch.ops.aten.transpose_copy.int(squeeze_copy_dim, 1, 0);  squeeze_copy_dim = None
     _reshape_alias_copy_default_2 = torch.ops.aten._reshape_alias_copy.default(transpose_copy_int_2, [8], [1]);  transpose_copy_int_2 = None
-    view_copy_sym_int_2 = torch.ops.aten.view_copy.SymInt(_reshape_alias_copy_default_2, [4, 2]);  _reshape_alias_copy_default_2 = None
-    view_copy_sym_int_3 = torch.ops.aten.view_copy.SymInt(view_copy_sym_int_2, [8]);  view_copy_sym_int_2 = None
-    _reshape_alias_copy_default_3 = torch.ops.aten._reshape_alias_copy.default(view_copy_sym_int_3, [2, 4], [4, 1]);  view_copy_sym_int_3 = None
+    view_copy_default_2 = torch.ops.aten.view_copy.default(_reshape_alias_copy_default_2, [4, 2]);  _reshape_alias_copy_default_2 = None
+    view_copy_default_3 = torch.ops.aten.view_copy.default(view_copy_default_2, [8]);  view_copy_default_2 = None
+    _reshape_alias_copy_default_3 = torch.ops.aten._reshape_alias_copy.default(view_copy_default_3, [2, 4], [4, 1]);  view_copy_default_3 = None
     select_copy_int_1 = torch.ops.aten.select_copy.int(_reshape_alias_copy_default_3, 0, 0);  _reshape_alias_copy_default_3 = None
     add_tensor_2 = torch.ops.aten.add.Tensor(select_copy_int_1, _unsafe_view_default);  select_copy_int_1 = _unsafe_view_default = None
     return add_tensor_1
@@ -530,10 +530,10 @@ def forward(self, a_1):
 def forward(self, a_1):
     empty = torch.ops.aten.empty.memory_format([4, 2], dtype = torch.float32, device = device(type='cpu'), pin_memory = False)
     fill_scalar = torch.ops.aten.fill.Scalar(empty, 1.0);  empty = None
-    view_sym_int = torch.ops.aten.view.SymInt(a_1, [4, 2]);  a_1 = None
-    add_tensor = torch.ops.aten.add.Tensor(view_sym_int, fill_scalar);  view_sym_int = fill_scalar = None
-    view_sym_int_1 = torch.ops.aten.view.SymInt(add_tensor, [4, 2])
-    mul_tensor = torch.ops.aten.mul.Tensor(view_sym_int_1, view_sym_int_1);  view_sym_int_1 = None
+    view_default = torch.ops.aten.view.default(a_1, [4, 2]);  a_1 = None
+    add_tensor = torch.ops.aten.add.Tensor(view_default, fill_scalar);  view_default = fill_scalar = None
+    view_default_1 = torch.ops.aten.view.default(add_tensor, [4, 2])
+    mul_tensor = torch.ops.aten.mul.Tensor(view_default_1, view_default_1);  view_default_1 = None
     return add_tensor
     """)
 
@@ -653,8 +653,8 @@ def forward(self, a_1):
 
 
 def forward(self, a_1):
-    expand_copy_sym_int = torch.ops.aten.expand_copy.SymInt(a_1, [2, 2]);  a_1 = None
-    return expand_copy_sym_int
+    expand_copy_default = torch.ops.aten.expand_copy.default(a_1, [2, 2]);  a_1 = None
+    return expand_copy_default
     """)
 
     def test_fill_(self):
@@ -697,18 +697,18 @@ def forward(self, a_1):
 
 def forward(self, a_1):
     add_tensor = torch.ops.aten.add.Tensor(a_1, 1);  a_1 = None
-    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(add_tensor, [4, 4])
-    resize_default = torch.ops.aten.resize.default(view_copy_sym_int, [3, 3])
-    as_strided_copy_default = torch.ops.aten.as_strided_copy.default(view_copy_sym_int, [3, 3], [3, 1]);  view_copy_sym_int = None
-    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(as_strided_copy_default, [-1]);  as_strided_copy_default = None
-    add_tensor_1 = torch.ops.aten.add.Tensor(view_copy_sym_int_1, 1);  view_copy_sym_int_1 = None
-    view_copy_sym_int_2 = torch.ops.aten.view_copy.SymInt(add_tensor, [4, 4]);  add_tensor = None
-    as_strided_copy_default_1 = torch.ops.aten.as_strided_copy.default(view_copy_sym_int_2, [3, 3], [3, 1])
-    view_copy_sym_int_3 = torch.ops.aten.view_copy.SymInt(add_tensor_1, [3, 3]);  add_tensor_1 = None
-    as_strided_scatter_default = torch.ops.aten.as_strided_scatter.default(view_copy_sym_int_2, view_copy_sym_int_3, [3, 3], [3, 1]);  view_copy_sym_int_2 = view_copy_sym_int_3 = None
-    view_copy_sym_int_4 = torch.ops.aten.view_copy.SymInt(as_strided_scatter_default, [8, 2]);  as_strided_scatter_default = None
-    view_copy_sym_int_5 = torch.ops.aten.view_copy.SymInt(view_copy_sym_int_4, [4, 4]);  view_copy_sym_int_4 = None
-    as_strided_copy_default_2 = torch.ops.aten.as_strided_copy.default(view_copy_sym_int_5, [3, 3], [3, 1]);  view_copy_sym_int_5 = None
+    view_copy_default = torch.ops.aten.view_copy.default(add_tensor, [4, 4])
+    resize_default = torch.ops.aten.resize.default(view_copy_default, [3, 3])
+    as_strided_copy_default = torch.ops.aten.as_strided_copy.default(view_copy_default, [3, 3], [3, 1]);  view_copy_default = None
+    view_copy_default_1 = torch.ops.aten.view_copy.default(as_strided_copy_default, [-1]);  as_strided_copy_default = None
+    add_tensor_1 = torch.ops.aten.add.Tensor(view_copy_default_1, 1);  view_copy_default_1 = None
+    view_copy_default_2 = torch.ops.aten.view_copy.default(add_tensor, [4, 4]);  add_tensor = None
+    as_strided_copy_default_1 = torch.ops.aten.as_strided_copy.default(view_copy_default_2, [3, 3], [3, 1])
+    view_copy_default_3 = torch.ops.aten.view_copy.default(add_tensor_1, [3, 3]);  add_tensor_1 = None
+    as_strided_scatter_default = torch.ops.aten.as_strided_scatter.default(view_copy_default_2, view_copy_default_3, [3, 3], [3, 1]);  view_copy_default_2 = view_copy_default_3 = None
+    view_copy_default_4 = torch.ops.aten.view_copy.default(as_strided_scatter_default, [8, 2]);  as_strided_scatter_default = None
+    view_copy_default_5 = torch.ops.aten.view_copy.default(view_copy_default_4, [4, 4]);  view_copy_default_4 = None
+    as_strided_copy_default_2 = torch.ops.aten.as_strided_copy.default(view_copy_default_5, [3, 3], [3, 1]);  view_copy_default_5 = None
     add_tensor_2 = torch.ops.aten.add.Tensor(as_strided_copy_default_2, 1);  as_strided_copy_default_2 = None
     return add_tensor_2
     """)  # noqa: B950
@@ -739,11 +739,11 @@ def forward(self, a_1):
 def forward(self, a_1):
     add_tensor = torch.ops.aten.add.Tensor(a_1, 1);  a_1 = None
     resize_default = torch.ops.aten.resize.default(add_tensor, [5, 5]);  add_tensor = None
-    view_copy_sym_int = torch.ops.aten.view_copy.SymInt(resize_default, [25]);  resize_default = None
-    fill_scalar = torch.ops.aten.fill.Scalar(view_copy_sym_int, 1);  view_copy_sym_int = None
-    view_copy_sym_int_1 = torch.ops.aten.view_copy.SymInt(fill_scalar, [5, 5]);  fill_scalar = None
-    add_tensor_1 = torch.ops.aten.add.Tensor(view_copy_sym_int_1, 1)
-    return (view_copy_sym_int_1, add_tensor_1)
+    view_copy_default = torch.ops.aten.view_copy.default(resize_default, [25]);  resize_default = None
+    fill_scalar = torch.ops.aten.fill.Scalar(view_copy_default, 1);  view_copy_default = None
+    view_copy_default_1 = torch.ops.aten.view_copy.default(fill_scalar, [5, 5]);  fill_scalar = None
+    add_tensor_1 = torch.ops.aten.add.Tensor(view_copy_default_1, 1)
+    return (view_copy_default_1, add_tensor_1)
     """)
 
     def test_resize_larger_invalid(self):

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -746,7 +746,8 @@ $6 = torch._ops.aten.add_.Tensor($1, $5)''')
         with capture_logs(is_mode=True) as logs:
             with enable_torch_dispatch_mode(LoggingTensorMode()):
                 torch.empty([])
-        self.assertExpectedInline('\n'.join(logs), ("$0 = torch._ops.aten.empty.SymInt([], dtype=torch.float32," +
+
+        self.assertExpectedInline('\n'.join(logs), ("$0 = torch._ops.aten.empty.memory_format([], dtype=torch.float32," +
                                                     " device=device(type='cpu'), pin_memory=False)"))
 
     def test_enable_torch_dispatch_mode_unrelated_tensors(self) -> None:
@@ -774,8 +775,8 @@ $2 = torch._ops.aten.add.Tensor($0, $1)""")
                     x + y
 
         self.assertExpectedInline('\n'.join(logs), """\
-$0 = torch._ops.aten.empty.SymInt([], dtype=torch.float32, device=device(type='cpu'), pin_memory=False)
-$0 = torch._ops.aten.empty.SymInt([], dtype=torch.float32, device=device(type='cpu'), pin_memory=False)
+$0 = torch._ops.aten.empty.memory_format([], dtype=torch.float32, device=device(type='cpu'), pin_memory=False)
+$0 = torch._ops.aten.empty.memory_format([], dtype=torch.float32, device=device(type='cpu'), pin_memory=False)
 $3 = torch._ops.aten.add.Tensor($1, $2)
 $3 = torch._ops.aten.add.Tensor($1, $2)""")
 
@@ -786,7 +787,7 @@ $3 = torch._ops.aten.add.Tensor($1, $2)""")
             torch.empty([])
             x + y
         self.assertExpectedInline('\n'.join(logs), """\
-$0 = torch._ops.aten.empty.SymInt([], dtype=torch.float32, device=device(type='cpu'), pin_memory=False)
+$0 = torch._ops.aten.empty.memory_format([], dtype=torch.float32, device=device(type='cpu'), pin_memory=False)
 $3 = torch._ops.aten.add.Tensor($1, $2)""")
 
         x = torch.randn([])
@@ -798,8 +799,8 @@ $3 = torch._ops.aten.add.Tensor($1, $2)""")
                 x + y
 
         self.assertExpectedInline('\n'.join(logs2), """\
-$0 = torch._ops.aten.empty.SymInt([], dtype=torch.float32, device=device(type='cpu'), pin_memory=False)
-$0 = torch._ops.aten.empty.SymInt([], dtype=torch.float32, device=device(type='cpu'), pin_memory=False)
+$0 = torch._ops.aten.empty.memory_format([], dtype=torch.float32, device=device(type='cpu'), pin_memory=False)
+$0 = torch._ops.aten.empty.memory_format([], dtype=torch.float32, device=device(type='cpu'), pin_memory=False)
 $3 = torch._ops.aten.add.Tensor($1, $2)
 $3 = torch._ops.aten.add.Tensor($1, $2)""")
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1522,6 +1522,10 @@
   self: grad.expand(self.sizes())
   result: auto_linear
 
+- name: sum.SymInt(Tensor self, SymInt[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
+  self: sum_backward(grad, self.sym_sizes(), dim, keepdim)
+  result: auto_linear
+
 - name: sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
   self: sum_backward(grad, self.sizes(), dim, keepdim)
   result: auto_linear
@@ -1706,6 +1710,12 @@
 
 - name: view(Tensor(a) self, int[] size) -> Tensor(a)
   self: grad.reshape(self.sizes())
+  result: auto_linear
+
+- name: view.SymInt(Tensor(a) self, SymInt[] size) -> Tensor(a)
+  # TODO: add proper double backward for view.SymInt
+  # by SymIntizing `reshape`
+  self: grad.reshape(c10::asIntArrayRefSlow(self.sym_sizes()))
   result: auto_linear
 
 - name: view.dtype(Tensor(a) self, ScalarType dtype) -> Tensor(a)

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -27,6 +27,7 @@ from torchgen.api.types import (
     optionalIntArrayRefT,
     scalarT,
     stringT,
+    symIntArrayRefT,
     tensorListT,
     tensorT,
 )
@@ -281,6 +282,20 @@ for (auto i : c10::irange(prop.size())) {
 return tup;
 """
 
+GETTER_BODY_ARRAYREF_SYMINT = """\
+PyObject* tup = PyTuple_New((Py_ssize_t) prop.size());
+for (auto i : c10::irange(prop.size())) {
+    auto si = prop[i];
+    if (si.is_symbolic()) {
+      auto py_symint = py::cast(si.toSymbolicIntNode()).release().ptr();
+      PyTuple_SetItem(tup, (Py_ssize_t) i, py_symint);
+    } else {
+       PyTuple_SetItem(tup, (Py_ssize_t) i, PyLong_FromUnsignedLong(si.data()));
+    }
+}
+return tup;
+"""
+
 GETTER_BODY_ARRAYREF_DOUBLE = """\
 PyObject* tup = PyTuple_New((Py_ssize_t) prop.size());
 for (auto i : c10::irange(prop.size())) {
@@ -518,6 +533,13 @@ def process_function(info: DifferentiabilityInfo, template: CodeTemplate) -> str
             getter_definitions.append(
                 GETTER_DEFINITION.substitute(
                     op=info.op, name=name, body=GETTER_BODY_ARRAYREF_LONG
+                )
+            )
+        elif type == BaseCType(symIntArrayRefT):
+            saved_variables.append(f"std::vector<c10::SymInt> {name};")
+            getter_definitions.append(
+                GETTER_DEFINITION.substitute(
+                    op=info.op, name=name, body=GETTER_BODY_ARRAYREF_SYMINT
                 )
             )
         elif type == BaseCType(optionalIntArrayRefT):

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -1123,9 +1123,9 @@ def sort_overloads(
             str(t1) == "Tensor[]"
             and str(t2).find("[]") != -1
             or
-            # Prioritize SymIntArrayRef overload over IntArrayRef
-            str(t1) == "int[]"
-            and str(t2) == "SymInt[]"
+            # Prioritize IntArrayRef overload over SymIntArrayRef
+            str(t1) == "SymInt[]"
+            and str(t2) == "int[]"
         )
 
     def is_smaller(s1: PythonSignature, s2: PythonSignature) -> bool:

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -48,6 +48,7 @@ from torchgen.api.types import (
     scalarT,
     SpecialArgName,
     stringT,
+    symIntArrayRefT,
     tensorListT,
     tensorT,
     TupleCType,
@@ -1090,6 +1091,8 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
                 expr = f"make_saved_variable_list({name})"
                 name += "_"
             elif type == BaseCType(intArrayRefT):
+                expr = expr + ".vec()"
+            elif type == BaseCType(symIntArrayRefT):
                 expr = expr + ".vec()"
             elif type == BaseCType(stringT):
                 expr = f"std::string({expr})"

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -28,6 +28,7 @@ from torchgen.api.types import (
     scalarTypeT,
     SpecialArgName,
     stringT,
+    symIntArrayRefT,
     tensorGeometryT,
     tensorOptionsT,
     typeAndSizeT,
@@ -694,6 +695,14 @@ def saved_variables(
             {
                 "suffix": "_sizes",
                 "nctype": lambda name: NamedCType(name, BaseCType(intArrayRefT)),
+            },
+        ),
+        # replace self.sym_sizes() with self_sym_sizes
+        (
+            r"{}.sym_sizes\(\)",
+            {
+                "suffix": "_sym_sizes",
+                "nctype": lambda name: NamedCType(name, BaseCType(symIntArrayRefT)),
             },
         ),
         # replace self->sizes() with self_sizes_opt

--- a/tools/autograd/templates/python_functions.cpp
+++ b/tools/autograd/templates/python_functions.cpp
@@ -5,6 +5,7 @@
 #include <Python.h>
 #include <ATen/ATen.h>
 
+#include <c10/core/SymbolicIntNode.h>
 #include "torch/csrc/autograd/generated/Functions.h"
 #include "torch/csrc/autograd/python_cpp_function.h"
 #include <torch/csrc/autograd/python_variable.h>

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -595,6 +595,21 @@ Tensor sum_backward(
   return grad.expand(sizes);
 }
 
+Tensor sum_backward(
+    const Tensor& grad,
+    c10::SymIntArrayRef sizes,
+    c10::SymIntArrayRef dims,
+    bool keepdim) {
+  if (!keepdim && sizes.size() > 0 && dims.size() > 0) {
+    // we are only using `keepdim=true` path for SymInts for now
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        false,
+        "Only the keepdim=true path is implemented to support symints in autograd");
+  } else {
+    return grad.expand_symint(sizes);
+  }
+}
+
 Tensor nansum_backward(
     const Tensor& grad,
     const Tensor& self,

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -157,6 +157,11 @@ at::Tensor sum_backward(
     at::IntArrayRef sizes,
     at::OptionalIntArrayRef opt_dims,
     bool keepdim);
+at::Tensor sum_backward(
+    const at::Tensor& grad,
+    c10::SymIntArrayRef sizes,
+    c10::SymIntArrayRef dims,
+    bool keepdim);
 at::Tensor nansum_backward(
     const at::Tensor& grad,
     const at::Tensor& self,

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -186,11 +186,11 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
   /// of the new input.
   uint32_t add_input_metadata(
       const at::TensorOptions& options,
-      at::IntArrayRef shape,
+      c10::SymIntArrayRef shape,
       bool is_tensor_subclass) noexcept {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     uint32_t input_nr = input_metadata_.size();
-    auto meta_shape = MetadataShape{c10::in_place_type<at::DimVector>, shape};
+    auto meta_shape = MetadataShape{c10::in_place_type<SymIntSmallVec>, shape};
     input_metadata_.emplace_back(options, meta_shape, is_tensor_subclass);
     return input_nr;
   }

--- a/torch/csrc/autograd/input_metadata.h
+++ b/torch/csrc/autograd/input_metadata.h
@@ -6,9 +6,12 @@
 #include <c10/core/Device.h>
 #include <c10/core/DeviceType.h>
 #include <c10/core/Stream.h>
+#include <c10/core/SymIntArrayRef.h>
 #include <c10/core/TensorImpl.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
+#include <c10/util/DimVector.h>
 #include <c10/util/Exception.h>
+#include <c10/util/SmallVector.h>
 #include <c10/util/variant.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -23,7 +26,8 @@
 namespace torch {
 namespace autograd {
 
-using MetadataShape = c10::variant<at::DimVector, at::Tensor>;
+using SymIntSmallVec = c10::SmallVector<c10::SymInt, c10::kDimVectorStaticSize>;
+using MetadataShape = c10::variant<SymIntSmallVec, at::Tensor>;
 
 /**
  * Records TensorOptions, shape of the tensor, whether or not the Python
@@ -81,7 +85,7 @@ struct InputMetadata {
     TORCH_CHECK(
         !is_nested_tensor(),
         "Zeros is not currently supported for nested tensors.")
-    return at::zeros(shape_as_dim_vector(), options_);
+    return at::zeros_symint(shape_as_dim_vector(), options_);
   }
 
   bool is_same_shape(const at::Tensor& grad) const {
@@ -92,7 +96,7 @@ struct InputMetadata {
       return at::native::get_nested_size_tensor(grad).is_same_size(
           shape_as_tensor());
     }
-    return grad.sizes().equals(shape_as_dim_vector());
+    return grad.sym_sizes().equals(shape_as_dim_vector());
   }
   bool is_expandable_to_shape(const at::Tensor& grad) const {
     // Currently NestedTensors are not expandable. If this support is added then
@@ -102,7 +106,7 @@ struct InputMetadata {
         "Both grad and InputMetadata need to be either nested or non nested tensors.")
     return grad.is_nested()
         ? false
-        : at::is_expandable_to(shape_as_dim_vector(), grad.sizes());
+        : at::is_expandable_to(shape_as_dim_vector(), grad.sym_sizes());
   }
 
   at::Tensor reduce_grad(at::Tensor& grad) const {
@@ -127,7 +131,7 @@ struct InputMetadata {
     if (is_nested_tensor()) {
       ss << shape_as_tensor();
     } else {
-      ss << shape_as_dim_vector();
+      ss << c10::asIntArrayRefSlow(shape_as_dim_vector());
     }
     return ss;
   }
@@ -141,12 +145,14 @@ struct InputMetadata {
       auto nested_size = at::native::get_nested_size_tensor(input);
       return MetadataShape{c10::in_place_type<at::Tensor>, nested_size};
     }
-    return MetadataShape{c10::in_place_type<at::DimVector>, input.sizes()};
+    return MetadataShape{c10::in_place_type<SymIntSmallVec>, input.sym_sizes()};
   }
 
-  at::DimVector shape_as_dim_vector() const {
-    return c10::get<at::DimVector>(shape_);
+  c10::SymIntArrayRef shape_as_dim_vector() const {
+    const auto& dim_shape = c10::get<SymIntSmallVec>(shape_);
+    return c10::SymIntArrayRef(dim_shape.data(), dim_shape.size());
   }
+
   at::Tensor shape_as_tensor() const {
     return c10::get<at::Tensor>(shape_);
   }

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -692,7 +692,8 @@ const std::shared_ptr<torch::autograd::Node>& VariableHooks::grad_fn(
             torch::autograd::collect_next_edges(view_info.base_));
         fn->add_input_metadata(
             view_info.base_.options(),
-            self.sizes(), // Note: sizes(), not base_.sizes(), is intentional
+            self.sym_sizes(), // Note: sizes(), not base_.sizes(), is
+                              // intentional
             self.unsafeGetTensorImpl()->is_python_dispatch());
         diff_view_meta->grad_fn_ = std::move(fn);
       }

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -143,9 +143,13 @@ void LTCTensorImpl::shallow_copy_from(
 }
 
 c10::SymIntArrayRef LTCTensorImpl::sym_sizes_custom() const {
-  return FLAGS_ltc_enable_symbolic_shapes
-      ? c10::SymIntArrayRef(sym_sizes_.data(), sym_sizes_.size())
-      : TensorImpl::sym_sizes_default();
+  if (FLAGS_ltc_enable_symbolic_shapes) {
+    return c10::SymIntArrayRef(sym_sizes_.data(), sym_sizes_.size());
+  }
+
+  // return upper bound
+  const_cast<LTCTensorImpl*>(this)->setup_size_properties();
+  return TensorImpl::sym_sizes_default();
 }
 
 c10::SymIntArrayRef LTCTensorImpl::sym_sizes() const {

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -1237,10 +1237,14 @@ bool FunctionSignature::parse(
   // if there is a single positional IntArrayRef argument, i.e. expand(..),
   // view(...), allow a var-args style IntArrayRef, so expand(5,3) behaves as
   // expand((5,3))
+  int int_list_overload = false;
   if (max_pos_args == 1 &&
       (params[0].type_ == ParameterType::INT_LIST ||
        params[0].type_ == ParameterType::SYM_INT_LIST)) {
     allow_varargs_intlist = true;
+    if (params[0].type_ == ParameterType::INT_LIST) {
+      int_list_overload = true;
+    }
   }
 
   if (nargs > max_pos_args && !allow_varargs_intlist) {
@@ -1297,7 +1301,7 @@ bool FunctionSignature::parse(
       // should avoid having complex signatures that make use of it...
     } else if (
         allow_varargs_intlist && arg_pos == 0 && !is_kwd &&
-        is_int_or_symint(obj)) {
+        ((int_list_overload && is_int_list(args, param.size)) || is_int_or_symint_list(args, param.size))) {
       // take all positional arguments as this parameter
       // e.g. permute(1, 2, 3) -> permute((1, 2, 3))
       dst[i++] = args;

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -2302,8 +2302,13 @@ TORCH_LIBRARY_IMPL({namespace}, {dispatch_key}, m) {{
             if g1.view_copy is None or g2.view_copy is None:
                 continue
             # TODO: make this more first class in the data model
-            same_base_op = str(g1.view_copy.func.name.name) == str(
-                g2.view_copy.func.name.name
+            g1_base_name = str(g1.view_copy.func.name.name)
+            g2_base_name = str(g2.view_copy.func.name.name)
+
+            same_base_op = (
+                g1_base_name == g2_base_name
+                and g1.view_copy.func.arguments.symints_to_ints()
+                == g2.view_copy.func.arguments.symints_to_ints()
             )
             op1_not_symint = "SymInt" not in str(g1.view_copy.func.name.overload_name)
             op2_symint = "SymInt" in str(g2.view_copy.func.name.overload_name)

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -791,6 +791,9 @@ class NativeFunction:
             backend_metadata,
         )
 
+    def symints_to_ints(self) -> "NativeFunction":
+        return dataclasses.replace(self, func=self.func.symints_to_ints())
+
     def validate_unstructured(self) -> None:
         # TODO: probably better to accumulate these errors and report them all
         # at once
@@ -1183,6 +1186,9 @@ class FunctionSchema:
         )
 
     decl_re = re.compile(r"(?P<name>[^\(]+)\((?P<args>.*)\) -> (?P<returns>.*)")
+
+    def symints_to_ints(self) -> "FunctionSchema":
+        return dataclasses.replace(self, arguments=self.arguments.symints_to_ints())
 
     @staticmethod
     def parse(func: str) -> "FunctionSchema":
@@ -1623,6 +1629,9 @@ class Type:
     def is_list_like(self) -> Optional["ListType"]:
         raise NotImplementedError
 
+    def symint_to_int(self) -> "Type":
+        raise NotImplementedError
+
 
 # Base types are simple, atomic types with no further structure
 BaseTy = Enum(
@@ -1663,6 +1672,11 @@ class BaseType(Type):
     def is_nullable(self) -> bool:
         return False
 
+    def symint_to_int(self) -> "BaseType":
+        if self.name == BaseTy.SymInt:
+            return BaseType(BaseTy.int)
+        return self
+
     def is_list_like(self) -> Optional["ListType"]:
         return None
 
@@ -1680,6 +1694,9 @@ class OptionalType(Type):
 
     def is_nullable(self) -> bool:
         return True
+
+    def symint_to_int(self) -> "Type":
+        return dataclasses.replace(self, elem=self.elem.symint_to_int())
 
     def is_list_like(self) -> Optional["ListType"]:
         return self.elem.is_list_like()
@@ -1706,6 +1723,9 @@ class ListType(Type):
 
     def is_nullable(self) -> bool:
         return self.elem.is_nullable()
+
+    def symint_to_int(self) -> "ListType":
+        return ListType(self.elem.symint_to_int(), self.size)
 
     def is_list_like(self) -> Optional["ListType"]:
         return self
@@ -1779,6 +1799,9 @@ class Argument:
     @property
     def is_write(self) -> bool:
         return self.annotation is not None and self.annotation.is_write
+
+    def symint_to_int(self) -> "Argument":
+        return dataclasses.replace(self, type=self.type.symint_to_int())
 
     def __str__(self) -> str:
         type = f"{self.type}"
@@ -1968,6 +1991,37 @@ class Arguments:
             for a in self.flat_all
             if a.annotation is not None and a.annotation.is_write
         ]
+
+    def symints_to_ints(self) -> "Arguments":
+        arguments = self
+
+        if arguments.self_arg:
+            arguments = dataclasses.replace(
+                arguments,
+                pre_self_positional=[
+                    x.symint_to_int() for x in arguments.pre_self_positional
+                ],
+            )
+
+        if self.tensor_options:
+            arguments = dataclasses.replace(
+                arguments,
+                post_tensor_options_kwarg_only=[
+                    x.symint_to_int() for x in arguments.post_tensor_options_kwarg_only
+                ],
+            )
+
+        arguments = dataclasses.replace(
+            arguments,
+            post_self_positional=[
+                x.symint_to_int() for x in arguments.post_self_positional
+            ],
+            pre_tensor_options_kwarg_only=[
+                x.symint_to_int() for x in arguments.pre_tensor_options_kwarg_only
+            ],
+        )
+
+        return arguments
 
     def signature(self, *, strip_default: bool = False) -> "Arguments":
         # dataclasses.replace could be used here, but it is less


### PR DESCRIPTION
### Description
This is a reland of #81145 with the following changes:

* redispatching from python to int overloads as long as none of the arguments or varargs are symintnodes.



### Testing
CI 
