### PR TITLE
Fix the issue of multiple instance of RegisterCodeGenList in TE codegen backend

### DIFF
--- a/torch/csrc/jit/tensorexpr/codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/codegen.cpp
@@ -22,6 +22,11 @@ CodeGen::CodeGen(
   allocIntermediateBufs();
 }
 
+RegisterCodeGenList& RegisterCodeGenList::GetInstance() {
+  static RegisterCodeGenList codegen_list;
+  return codegen_list;
+}
+
 RegisterCodeGenList::StmtFactoryMethod RegisterCodeGenList::
     FindStmtFactoryMethod(const std::string& name) {
   auto iter = stmt_factory_methods_.find(name);

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -191,10 +191,7 @@ class CodeGen::CallArg {
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class RegisterCodeGenList {
  public:
-  TORCH_API static RegisterCodeGenList& GetInstance() {
-    static RegisterCodeGenList codegen_list;
-    return codegen_list;
-  }
+  TORCH_API static RegisterCodeGenList& GetInstance();
 
   using StmtFactoryMethod = std::function<std::unique_ptr<CodeGen>(
       StmtPtr stmt,


### PR DESCRIPTION
## Motivation
External plug-in register new codegen of backend thru `RegisterCodeGen`. Hit the issue that there would be multiple global RegisterCodeGenList instance if the link is not handled carefully.
Enhance the usage of the RegisterCodeGen.

## Solution
1. By moving the definition of `RegisterCodeGenList::GetInstance` from header to cpp. To avoid multiple definition of the global RegisterCodeGenList.


