### PR TITLE
make sym sizes be computed lazily

### DIFF
--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -89,15 +89,6 @@ LTCTensorImpl::LTCTensorImpl(LazyTensor&& tensor)
   // according to https://github.com/pytorch/xla/pull/2682.
   is_non_overlapping_and_dense_ = false;
   set_sizes_strides_policy(SizesStridesPolicy::CustomSizes);
-
-  auto rank = tensor_->shape().Get().sizes().size();
-  sym_sizes_.reserve(rank);
-  for (auto i : c10::irange(rank)) {
-    auto dim_node = getBackend()->GetIrBuilder()->MakeSizeNode(
-        this->tensor_->GetIrValue(), i);
-    auto sn = c10::make_intrusive<torch::lazy::SymIntNodeImpl>(dim_node);
-    sym_sizes_.push_back(sn->toSymInt());
-  }
 }
 
 void LTCTensorImpl::set_tensor(const LazyTensorPtr& lazy_tensor) {
@@ -142,18 +133,31 @@ void LTCTensorImpl::shallow_copy_from(
   generation_ = 0;
 }
 
-c10::SymIntArrayRef LTCTensorImpl::sym_sizes_custom() const {
-  if (FLAGS_ltc_enable_symbolic_shapes) {
-    return c10::SymIntArrayRef(sym_sizes_.data(), sym_sizes_.size());
-  }
-
-  // return upper bound
-  const_cast<LTCTensorImpl*>(this)->setup_size_properties();
-  return TensorImpl::sym_sizes_default();
-}
-
 c10::SymIntArrayRef LTCTensorImpl::sym_strides_custom() const {
   return sym_strides_default();
+}
+
+void LTCTensorImpl::setup_sym_sizes() const {
+  auto rank = tensor_->shape().Get().sizes().size();
+  std::vector<c10::SymInt> sym_sizes;
+  sym_sizes.reserve(rank);
+  for (auto i : c10::irange(rank)) {
+    auto dim_node = getBackend()->GetIrBuilder()->MakeSizeNode(
+        this->tensor_->GetIrValue(), i);
+    auto sn = c10::make_intrusive<torch::lazy::SymIntNodeImpl>(dim_node);
+    sym_sizes.push_back(sn->toSymInt());
+  }
+
+  sym_sizes_ = sym_sizes;
+}
+
+c10::SymIntArrayRef LTCTensorImpl::sym_sizes_custom() const {
+  if (FLAGS_ltc_enable_symbolic_shapes) {
+    setup_sym_sizes();
+    return c10::SymIntArrayRef(sym_sizes_->data(), sym_sizes_->size());
+  }
+
+  return c10::SymIntArrayRef::fromIntArrayRef(sizes_custom());
 }
 
 c10::SymIntArrayRef LTCTensorImpl::sym_sizes() const {

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -58,9 +58,10 @@ class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
 
  private:
   void setup_size_properties();
+  void setup_sym_sizes() const;
 
   LazyTensorPtr tensor_;
-  std::vector<c10::SymInt> sym_sizes_;
+  mutable c10::optional<std::vector<c10::SymInt>> sym_sizes_;
   size_t generation_{0};
 };
 


### PR DESCRIPTION
### Description

Creating size nodes proactively for each tensor is leading to increased memory pressure as hold strong pointers to tensor data.

### Issue
[<!-- Link to Issue ticket or RFP -->](https://github.com/pytorch/pytorch/issues/80942)

Creating 

### Testing
<!-- How did you test your change? -->
