### PR TITLE
Change rocblas.h to rocblas/rocblas.h only if ROCm version >= 5.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ six
 types-dataclasses
 typing_extensions
 sympy
+packaging

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -1,4 +1,6 @@
+import os
 import collections
+from packaging import version
 
 from .constants import (API_BLAS, API_C10, API_CAFFE2, API_DRIVER, API_FFT,
                         API_PYTORCH, API_RAND, API_ROCTX, API_RTC, API_RUNTIME,
@@ -563,8 +565,8 @@ CUDA_INCLUDE_MAP = collections.OrderedDict(
             ("hip/hip_texture_types.h", CONV_INCLUDE, API_RUNTIME),
         ),
         ("vector_types.h", ("hip/hip_vector_types.h", CONV_INCLUDE, API_RUNTIME)),
-        ("cublas.h", ("rocblas/rocblas.h", CONV_INCLUDE_CUDA_MAIN_H, API_BLAS)),
-        ("cublas_v2.h", ("rocblas/rocblas.h", CONV_INCLUDE_CUDA_MAIN_H, API_BLAS)),
+        ("cublas.h", ("{}rocblas.h".format("rocblas/" if version.parse(os.environ["GPU_ARCH_VERSION"]) >= version.parse("5.2.0") else ""), CONV_INCLUDE_CUDA_MAIN_H, API_BLAS)),
+        ("cublas_v2.h", ("{}rocblas.h".format("rocblas/" if version.parse(os.environ["GPU_ARCH_VERSION"]) >= version.parse("5.2.0") else ""), CONV_INCLUDE_CUDA_MAIN_H, API_BLAS)),
         ("curand.h", ("hiprand/hiprand.h", CONV_INCLUDE_CUDA_MAIN_H, API_RAND)),
         ("curand_kernel.h", ("hiprand/hiprand_kernel.h", CONV_INCLUDE, API_RAND)),
         ("curand_discrete.h", ("hiprand/hiprand_kernel.h", CONV_INCLUDE, API_RAND)),


### PR DESCRIPTION
Change rocblas.h to rocblas/rocblas.h only if ROCm version >= 5.2.0

Let's make the fix for #80848 backwards-compatible, as it's always encouraged by large projects. This changeset moves `rocblas.h` into `rocblas` folder only if the ROCm version indicated by the environment variable is 5.2.0 or newer. Older versions are left in piece (the newest available manylinux image is still 5.1.1).

Ternary operator looks ugly, I'd be happy to follow more elegant suggestions!