### PR TITLE
[JIT] Add is_aliasing method to FunctionSchema

### DIFF
--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -369,6 +369,13 @@ struct TORCH_API FunctionSchema {
   bool is_varret() const {
     return is_varret_;
   }
+  bool is_aliasing(const c10::SchemaArgument &argument) const {
+    TORCH_INTERNAL_ASSERT(
+    argument.index < getCorrectList(argument.type).size(),
+    "Invalid index for schema.");
+    const AliasInfo* aliasInfo = getCorrectList(argument.type)[argument.index].alias_info();
+    return aliasInfo;
+  }
   bool is_mutable() const {
     return std::any_of(
         arguments_.cbegin(), arguments_.cend(), [](const Argument& arg) {

--- a/test/cpp/jit/test_schema_info.cpp
+++ b/test/cpp/jit/test_schema_info.cpp
@@ -6,6 +6,23 @@ namespace torch {
 namespace utils {
 using c10::SchemaArgType;
 
+TEST(FunctionSchemaIsAliasingTest, Basic) {
+  c10::FunctionSchema schema = torch::jit::parseSchema(
+      "aten::test.Tensor(Tensor(a) self, Tensor(b!) other, Tensor more_other) -> (Tensor(a), Tensor(b!))");
+  ASSERT_TRUE(schema.is_aliasing({SchemaArgType::output, 0}));
+  ASSERT_TRUE(schema.is_aliasing({SchemaArgType::output, 1}));
+  ASSERT_TRUE(schema.is_aliasing({SchemaArgType::input, 0}));
+  ASSERT_TRUE(schema.is_aliasing({SchemaArgType::input, 1}));
+  ASSERT_FALSE(schema.is_aliasing({SchemaArgType::input, 2}));
+}
+
+TEST(FunctionSchemaIsAliasingTest, InvalidArgument) {
+  c10::FunctionSchema schema = torch::jit::parseSchema(
+      "aten::sub_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> (Tensor(a!))");
+  ASSERT_THROW(schema.is_aliasing({SchemaArgType::input, 4}), c10::Error);
+  ASSERT_THROW(schema.is_aliasing({SchemaArgType::output, 4}), c10::Error);
+}
+
 TEST(FunctionSchemaIsMutableTest, Basic) {
   c10::FunctionSchema schema = torch::jit::parseSchema(
       "aten::sub_.Tensor(Tensor(a!) self, Tensor other, *, Scalar alpha=1) -> (Tensor(a!))");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #82257
* #82256
* __->__ #82255
* #82254
* #82253

- Add is_aliasing method in function schema to be able to indicate if an argument has an alias_set attached to it. This is utilized in the integration with autograd (see next PR)
- Tested in test_schema_info