### PR TITLE
Make maximize optional

### DIFF
--- a/torch/optim/sparse_adam.py
+++ b/torch/optim/sparse_adam.py
@@ -75,7 +75,7 @@ class SparseAdam(Optimizer):
             eps = group['eps']
             lr = group['lr']
             beta1, beta2 = group['betas']
-            maximize = group['maximize']
+            maximize = group.get('maximize', False)
 
             for p in group['params']:
                 if p.grad is not None:


### PR DESCRIPTION
### Description
Made the maximize key optional, defaulting it to False

### Issue
The `maximize` key was recently added in https://github.com/pytorch/pytorch/pull/80336.  The key seems to have been meant to be an optional one, but it would result in failures for anyone who didn't specify a value for it.

### Testing
CI

cc: @zaxtax @albanD 