### PR TITLE
[Sparse Adam] Fix error in loading serialized models due to introduction of new parameter

### DIFF
--- a/torch/optim/sparse_adam.py
+++ b/torch/optim/sparse_adam.py
@@ -75,7 +75,7 @@ class SparseAdam(Optimizer):
             eps = group['eps']
             lr = group['lr']
             beta1, beta2 = group['betas']
-            maximize = group['maximize']
+            maximize = group.get('maximize', False)
 
             for p in group['params']:
                 if p.grad is not None:


### PR DESCRIPTION
### Description
PR #80336  introduced a new parameter to the Sparse Adam optimizer. The new parameter is accessed inside the `step` method of the optimizer. If we try to deserialize and run an older version of the optimizer before this change was introduced, it fails in the step that tries to access the missing parameter. 

I have added a workaround to set a default value in case the parameter is unavailable in the optimizer. 
 
### Issue
<!-- Link to Issue ticket or RFP -->

### Testing
* Testing on PyTorch CI
* Manual validation against existing serialized models to make sure they continue to work