### PR TITLE
Extend fake tensor tests to cuda, add support for index put

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1676,14 +1676,14 @@ sometimes_dynamic_output_op_test = (
 
 @skipIfSlowGradcheckEnv
 class TestFakeTensorNonErroring(TestCase):
-    @onlyCPU
     @ops(op_db, dtypes=OpDTypes.any_one)
     def test_fake(self, device, dtype, op):
         name = op.name
         if op.variant_test_name:
             name += "." + op.variant_test_name
-        if name in fake_skips or "sparse" in name:
+        if name in fake_skips or "sparse" in name or "jiterator" in name:
             self.skipTest("Skip failing test")
+
         samples = op.sample_inputs(device, dtype, requires_grad=False)
         for sample in samples:
             try:

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1622,6 +1622,7 @@ class TestRefsOpsInfo(TestCase):
 
 
 fake_skips = (
+    "aminmax",  # failing input
     "cholesky",  # Could not run 'aten::cholesky' with arguments from the 'Meta' backend
     "cholesky_inverse",  # Could not run 'aten::cholesky' with arguments from the 'Meta' backend
     "cov",  # aweights cannot be negtaive

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -257,6 +257,7 @@ def check_no_bool_index_tensors(func, self, indices):
         if index is not None and index.dtype in (torch.bool, torch.uint8):
             raise DynamicOutputShapeException(func)
 
+
 def run_and_return_new_tensor_of_input_device(fake_mode, func, args, kwargs):
     _, new_kwargs = normalize_function(
         func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
@@ -268,6 +269,7 @@ def run_and_return_new_tensor_of_input_device(fake_mode, func, args, kwargs):
 
     return FakeTensor(fake_mode, out, out_device)
 
+
 # Dont default to default device handling,
 # Since op can take in non-zero sized cpu
 # index tensors with cuda self
@@ -278,10 +280,12 @@ def index_tensor(fake_mode, func, *args, **kwargs):
 
     return run_and_return_new_tensor_of_input_device(fake_mode, func, args, kwargs)
 
+
 # takes in multiple-devices, dont default to default device handling
 @register_op_impl(aten.index_put.default)
 def index_put(fake_mode, func, *args, **kwargs):
     return run_and_return_new_tensor_of_input_device(fake_mode, func, args, kwargs)
+
 
 # same with index_put, but return the input
 @register_op_impl(aten.index_put_.default)
@@ -290,9 +294,11 @@ def index_put_(fake_mode, func, *args, **kwargs):
         out = func(*args, **kwargs)
 
     _, new_kwargs = normalize_function(
-        func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True)
+        func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
+    )
 
     return new_kwargs["input"]
+
 
 # Meta tensors give you the ability to run PyTorch code without having to
 # actually do computation through tensors allocated on a `meta` device.

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -13750,8 +13750,6 @@ op_db: List[OpInfo] = [
            skips=(
                # AssertionError: Resizing an out= argument with no elements threw a resize warning!
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='cpu'),
-               # AssertionError: Shapes torch.Size([]) and torch.Size([1]) are not equal!
-               DecorateInfo(unittest.expectedFailure, 'TestFakeTensorNonErroring', 'test_fake'),
            )),
     OpInfo('as_strided',
            op=lambda x, size, stride, storage_offset=0:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82281

Testing CUDA exposes some failures, such as `index_put` with CUDA self tensor and cpu value tensors