### PR TITLE
[_shard] Add ShardedTensorBase

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -23,7 +23,7 @@ from torch.distributed._shard.sharded_tensor import (
     pre_load_state_dict_hook,
     state_dict_hook,
     ShardedTensor,
-    Shard
+    Shard,
 )
 from torch.distributed._shard.sharding_spec import (
     ChunkShardingSpec,
@@ -31,7 +31,7 @@ from torch.distributed._shard.sharding_spec import (
     ShardMetadata,
 )
 from torch.distributed._shard.sharded_tensor.utils import (
-    _parse_and_validate_remote_device
+    _parse_and_validate_remote_device,
 )
 from torch.distributed._shard.sharded_tensor.api import (
     TensorProperties,
@@ -59,8 +59,12 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common i
 )
 
 if TEST_WITH_DEV_DBG_ASAN:
-    print("Skip dev-asan as torch + multiprocessing spawn have known issues", file=sys.stderr)
+    print(
+        "Skip dev-asan as torch + multiprocessing spawn have known issues",
+        file=sys.stderr,
+    )
     sys.exit(0)
+
 
 class TestShardedTensorMetadata(TestCase):
     def test_serialize_and_deserialize(self):
@@ -84,34 +88,59 @@ class TestShardedTensorMetadata(TestCase):
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
                 placement="rank:3/cuda:3",
-            )
+            ),
         ]
 
         dtypes = [
-            torch.float, torch.double, torch.cfloat, torch.cdouble, torch.half,
-            torch.bfloat16, torch.uint8, torch.int8, torch.short, torch.int,
-            torch.long, torch.bool]
+            torch.float,
+            torch.double,
+            torch.cfloat,
+            torch.cdouble,
+            torch.half,
+            torch.bfloat16,
+            torch.uint8,
+            torch.int8,
+            torch.short,
+            torch.int,
+            torch.long,
+            torch.bool,
+        ]
 
         layouts = [torch.strided, torch.sparse_coo]
         requires_grads = [True, False]
-        memory_formats = [torch.contiguous_format, torch.channels_last, torch.preserve_format]
+        memory_formats = [
+            torch.contiguous_format,
+            torch.channels_last,
+            torch.preserve_format,
+        ]
         pin_memories = [True, False]
 
-        for tensor_properties_input in itertools.product(dtypes, layouts, requires_grads, memory_formats, pin_memories):
-            dtype, layout, requires_grad, memory_format, pin_memory = tensor_properties_input
+        for tensor_properties_input in itertools.product(
+            dtypes, layouts, requires_grads, memory_formats, pin_memories
+        ):
+            (
+                dtype,
+                layout,
+                requires_grad,
+                memory_format,
+                pin_memory,
+            ) = tensor_properties_input
 
             expected_st_metadata = sharded_tensor.ShardedTensorMetadata(
                 shard_metadatas,
                 (10, 10),
-                TensorProperties(dtype, layout, requires_grad, memory_format, pin_memory)
+                TensorProperties(
+                    dtype, layout, requires_grad, memory_format, pin_memory
+                ),
             )
 
             pickled_obj = pickle.dumps(expected_st_metadata)
             st_metadata = pickle.loads(pickled_obj)
             self.assertEqual(expected_st_metadata, st_metadata)
 
+
 class TestCreateTensorFromParams(TestCase):
-    @sandcastle_skip_if(torch.cuda.device_count() < 1, 'CUDA GPU is needed')
+    @sandcastle_skip_if(torch.cuda.device_count() < 1, "CUDA GPU is needed")
     def test_empty(self):
         expected_dtype = torch.double
         tensor_properties = TensorProperties(
@@ -119,10 +148,12 @@ class TestCreateTensorFromParams(TestCase):
             layout=torch.strided,
             requires_grad=False,
             pin_memory=False,
-            memory_format=torch.contiguous_format)
-        local_device = torch.device('cuda:0')
+            memory_format=torch.contiguous_format,
+        )
+        local_device = torch.device("cuda:0")
         local_tensor = _create_tensor_from_params(
-            5, 10, local_device=local_device, tensor_properties=tensor_properties)
+            5, 10, local_device=local_device, tensor_properties=tensor_properties
+        )
         self.assertEqual(local_device, local_tensor.device)
         self.assertEqual(expected_dtype, local_tensor.dtype)
         self.assertEqual(torch.strided, local_tensor.layout)
@@ -146,7 +177,7 @@ class TestShardParameter(ShardedTensorTestBase):
 
         fc = torch.nn.Linear(12, 12).cuda(self.rank)
         weight_og = fc.weight.clone()
-        shard_parameter(fc, 'weight', spec)
+        shard_parameter(fc, "weight", spec)
 
         # Verify.
         self.assertTrue(isinstance(fc.weight, ShardedTensor))
@@ -155,7 +186,9 @@ class TestShardParameter(ShardedTensorTestBase):
         self.assertEqual(torch.Size([3, 12]), local_shards[0].tensor.size())
         self.assertEqual(3, local_shards[0].tensor.size(0))
         self.assertEqual(12, local_shards[0].tensor.size(1))
-        self.assertEqual(torch.narrow(weight_og, 0, 3 * self.rank, 3), local_shards[0].tensor)
+        self.assertEqual(
+            torch.narrow(weight_og, 0, 3 * self.rank, 3), local_shards[0].tensor
+        )
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
@@ -172,20 +205,22 @@ class TestShardParameter(ShardedTensorTestBase):
         )
 
         fc = torch.nn.Linear(12, 12).cuda(self.rank)
-        with self.assertRaisesRegex(ValueError, 'does not match with src_rank'):
-            shard_parameter(fc, 'weight', spec, src_rank=self.rank)
+        with self.assertRaisesRegex(ValueError, "does not match with src_rank"):
+            shard_parameter(fc, "weight", spec, src_rank=self.rank)
 
-        with self.assertRaisesRegex(AttributeError, 'has no attribute'):
-            shard_parameter(fc, 'foo', spec)
+        with self.assertRaisesRegex(AttributeError, "has no attribute"):
+            shard_parameter(fc, "foo", spec)
 
-        with self.assertRaisesRegex(ValueError, 'Expected Linear.bias to be a Tensor, but found str'):
+        with self.assertRaisesRegex(
+            ValueError, "Expected Linear.bias to be a Tensor, but found str"
+        ):
             del fc.bias
             fc.bias = "foo"
-            shard_parameter(fc, 'bias', spec)
+            shard_parameter(fc, "bias", spec)
 
-        with self.assertRaisesRegex(ValueError, 'not a contiguous Tensor'):
+        with self.assertRaisesRegex(ValueError, "not a contiguous Tensor"):
             fc.bias = torch.rand(10, 10).cuda(self.rank).t()
-            shard_parameter(fc, 'bias', spec)
+            shard_parameter(fc, "bias", spec)
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -196,23 +231,25 @@ class TestShardParameter(ShardedTensorTestBase):
                 "rank:3/cuda:3",
             ],
         )
-        with self.assertRaisesRegex(ValueError, 'does not match with sharding_spec'):
-            shard_parameter(fc, 'weight', spec)
+        with self.assertRaisesRegex(ValueError, "does not match with sharding_spec"):
+            shard_parameter(fc, "weight", spec)
 
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
-            ),
-        ])
-        with self.assertRaisesRegex(NotImplementedError, 'not implemented yet!'):
-            shard_parameter(fc, 'weight', spec)
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:1/cuda:1",
+                ),
+            ]
+        )
+        with self.assertRaisesRegex(NotImplementedError, "not implemented yet!"):
+            shard_parameter(fc, "weight", spec)
 
 
 class TestShardTensor(ShardedTensorTestBase):
@@ -254,10 +291,10 @@ class TestShardTensor(ShardedTensorTestBase):
         )
         tensor = torch.rand(12, 12).cuda(self.rank)
 
-        with self.assertRaisesRegex(ValueError, 'does not match with src_rank'):
+        with self.assertRaisesRegex(ValueError, "does not match with src_rank"):
             _shard_tensor(tensor, spec, src_rank=self.rank)
 
-        with self.assertRaisesRegex(ValueError, 'not a contiguous Tensor'):
+        with self.assertRaisesRegex(ValueError, "not a contiguous Tensor"):
             tensor_t = torch.rand(12, 12).cuda(self.rank).t()
             _shard_tensor(tensor_t, spec)
 
@@ -270,24 +307,24 @@ class TestShardTensor(ShardedTensorTestBase):
                 "rank:3/cuda:3",
             ],
         )
-        with self.assertRaisesRegex(ValueError, 'does not match with sharding_spec'):
+        with self.assertRaisesRegex(ValueError, "does not match with sharding_spec"):
             _shard_tensor(tensor, spec)
 
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
-            ),
-        ])
-        with self.assertRaisesRegex(
-            NotImplementedError, 'not implemented yet!'
-        ):
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:1/cuda:1",
+                ),
+            ]
+        )
+        with self.assertRaisesRegex(NotImplementedError, "not implemented yet!"):
             _shard_tensor(tensor, spec)
 
 
@@ -386,7 +423,6 @@ class TestLocalTensor(ShardedTensorTestBase):
 
 
 class TestShardedTensorChunked(ShardedTensorTestBase):
-
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
@@ -474,7 +510,9 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                     self.assertEqual([1, 20], shard_metadata.shard_sizes)
                 else:
                     self.assertEqual([3, 20], shard_metadata.shard_sizes)
-                self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
+                self.assertEqual(
+                    f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement)
+                )
 
             # Validate remote shards.
             remote_shards = st.remote_shards()
@@ -485,18 +523,20 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                 for remote_shard in shards:
                     self.assertEqual(rpc_rank, remote_shard.owner().id)
                     shard = remote_shard.to_here()
-                    self.assertEqual(f'rank:{rpc_rank}/cuda:{rpc_rank}', str(shard.metadata.placement))
+                    self.assertEqual(
+                        f"rank:{rpc_rank}/cuda:{rpc_rank}",
+                        str(shard.metadata.placement),
+                    )
                     if rpc_rank == 3:
                         self.assertEqual((1, 20), shard.tensor.size())
                     else:
                         self.assertEqual((3, 20), shard.tensor.size())
 
-
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_with_ones(self):
-        """ Test sharded_tensor.ones(...) """
+        """Test sharded_tensor.ones(...)"""
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -524,7 +564,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_gather_even(self) -> None:
-        """ Test _sharded_tensor.gather(...) with evenly distributed._shards"""
+        """Test _sharded_tensor.gather(...) with evenly distributed._shards"""
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -557,7 +597,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_gather_uneven(self) -> None:
-        """ Test _sharded_tensor.gather(...) with unevenly distributed._shards"""
+        """Test _sharded_tensor.gather(...) with unevenly distributed._shards"""
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -591,7 +631,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_with_zeros(self):
-        """ Test sharded_tensor.zeros(...) """
+        """Test sharded_tensor.zeros(...)"""
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -615,12 +655,11 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.assertEqual((expected_h, w), local_shard.size())
         self.assertEqual(local_shard, torch.zeros(expected_h, w))
 
-
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_with_rand(self):
-        """ Test sharded_tensor.rand(...)/randn(...) """
+        """Test sharded_tensor.rand(...)/randn(...)"""
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -671,7 +710,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_with_full(self):
-        """ Test sharded_tensor.full(...) """
+        """Test sharded_tensor.full(...)"""
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -684,7 +723,9 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         )
         h, w = 10, 20
         fill_value = 1234
-        st = sharded_tensor.full(spec, size=(h, w), fill_value=fill_value, dtype=torch.int32)
+        st = sharded_tensor.full(
+            spec, size=(h, w), fill_value=fill_value, dtype=torch.int32
+        )
 
         # Validate local shard is initialized with torch.full
         local_shards = st.local_shards()
@@ -694,14 +735,16 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         # The split: for rank!=3 ceil(h/4)=3  for rank=3 1
         expected_h = 1 if self.rank == 3 else math.ceil(h / 4)
         self.assertEqual((expected_h, w), local_shard.size())
-        self.assertEqual(local_shard,
-                         torch.full(size=(expected_h, w), fill_value=fill_value, dtype=torch.int32))
+        self.assertEqual(
+            local_shard,
+            torch.full(size=(expected_h, w), fill_value=fill_value, dtype=torch.int32),
+        )
 
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_like(self):
-        """ Test tensor like methods, i.e. torch.zeros_like(...), torch.full_like, etc. """
+        """Test tensor like methods, i.e. torch.zeros_like(...), torch.full_like, etc."""
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -724,22 +767,28 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             torch.rand_like: torch.rand,
             torch.randn_like: torch.randn,
             torch.empty_like: torch.empty,
-            torch.full_like: torch.full
+            torch.full_like: torch.full,
         }
         for op, expect_local_op in tensor_like_ops.items():
             if op == torch.full_like:
                 # special handle full/full_like as it needs to have additional fill_value arg
-                expect_tensor = expect_local_op((expected_h, w), 8.8, device=expected_device, dtype=dtype)
+                expect_tensor = expect_local_op(
+                    (expected_h, w), 8.8, device=expected_device, dtype=dtype
+                )
                 new_op_st = op(st, 8.8, dtype=dtype)
                 self.assertEqual(new_op_st.local_tensor(), expect_tensor)
             elif op == torch.empty_like:
                 # empty/empty_like we only compare the shape
-                expect_tensor = expect_local_op(expected_h, w, device=expected_device, dtype=dtype)
+                expect_tensor = expect_local_op(
+                    expected_h, w, device=expected_device, dtype=dtype
+                )
                 new_op_st = op(st, dtype=dtype)
                 self.assertEqual(new_op_st.local_tensor().shape, expect_tensor.shape)
             else:
                 torch.manual_seed(seed)
-                expect_tensor = expect_local_op(expected_h, w, device=expected_device, dtype=dtype)
+                expect_tensor = expect_local_op(
+                    expected_h, w, device=expected_device, dtype=dtype
+                )
                 torch.manual_seed(seed)
                 new_op_st = op(st, dtype=dtype)
                 self.assertEqual(new_op_st.local_tensor(), expect_tensor)
@@ -776,7 +825,10 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         for shard_rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual([shard_rank * 5, 0], shard_metadata.shard_offsets)
             self.assertEqual([5, 20], shard_metadata.shard_sizes)
-            self.assertEqual(f'rank:{shard_rank + 2}/cuda:{shard_rank + 2}', str(shard_metadata.placement))
+            self.assertEqual(
+                f"rank:{shard_rank + 2}/cuda:{shard_rank + 2}",
+                str(shard_metadata.placement),
+            )
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -790,7 +842,9 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             for remote_shard in shards:
                 self.assertEqual(rpc_rank, remote_shard.owner().id)
                 shard = remote_shard.to_here()
-                self.assertEqual(f'rank:{rpc_rank}/cuda:{rpc_rank}', str(shard.metadata.placement))
+                self.assertEqual(
+                    f"rank:{rpc_rank}/cuda:{rpc_rank}", str(shard.metadata.placement)
+                )
                 self.assertEqual((5, 20), shard.tensor.size())
 
     @with_comms
@@ -827,7 +881,10 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         for shard_rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual([shard_rank * 5, 0], shard_metadata.shard_offsets)
             self.assertEqual([5, 20], shard_metadata.shard_sizes)
-            self.assertEqual(f'rank:{shard_rank + 1}/cuda:{shard_rank + 2}', str(shard_metadata.placement))
+            self.assertEqual(
+                f"rank:{shard_rank + 1}/cuda:{shard_rank + 2}",
+                str(shard_metadata.placement),
+            )
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -841,7 +898,10 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             for remote_shard in shards:
                 shard = remote_shard.to_here()
                 self.assertEqual(rpc_rank, remote_shard.owner().id)
-                self.assertEqual(f'rank:{rpc_rank - 1}/cuda:{rpc_rank}', str(shard.metadata.placement))
+                self.assertEqual(
+                    f"rank:{rpc_rank - 1}/cuda:{rpc_rank}",
+                    str(shard.metadata.placement),
+                )
                 self.assertEqual((5, 20), shard.tensor.size())
 
     @with_comms
@@ -867,7 +927,9 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         local_shards = st.local_shards()
         self.assertEqual(2, len(local_shards))
         for local_shard in local_shards:
-            self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+            self.assertEqual(
+                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
+            )
             self.assertEqual((2, 20), local_shard.tensor.size())
 
         # Validate global metadata.
@@ -878,7 +940,10 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         for shard_idx, shard_metadata in enumerate(shards_metadata):
             self.assertEqual([shard_idx * 2, 0], shard_metadata.shard_offsets)
             self.assertEqual([2, 20], shard_metadata.shard_sizes)
-            self.assertEqual(f'rank:{shard_idx % 4}/cuda:{shard_idx % 4}', str(shard_metadata.placement))
+            self.assertEqual(
+                f"rank:{shard_idx % 4}/cuda:{shard_idx % 4}",
+                str(shard_metadata.placement),
+            )
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -890,7 +955,6 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                 shard = remote_shard.to_here()
                 self.assertEqual((2, 20), shard.tensor.size())
                 self.assertEqual(rpc_rank, remote_shard.owner().id)
-
 
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
@@ -925,55 +989,72 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             for rank, shard_metadata in enumerate(shards_metadata):
                 self.assertEqual([0, rank * 8], shard_metadata.shard_offsets)
                 self.assertEqual([10, 8], shard_metadata.shard_sizes)
-                self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
+                self.assertEqual(
+                    f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement)
+                )
 
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_invalid_sharding(self):
         self.init_pg()
 
-        with self.assertRaisesRegex(NotImplementedError, 'does not support named dimension'):
-            spec = ChunkShardingSpec(dim='H', placements=["rank:1/cuda:1"])
+        with self.assertRaisesRegex(
+            NotImplementedError, "does not support named dimension"
+        ):
+            spec = ChunkShardingSpec(dim="H", placements=["rank:1/cuda:1"])
             sharded_tensor.empty(spec, 10, 20)
 
         for dim in [2, 3, 4, -3, -4, -5]:
             spec = ChunkShardingSpec(dim=dim, placements=["rank:1/cuda:1"])
-            with self.assertRaisesRegex(ValueError, 'Invalid sharding dim'):
+            with self.assertRaisesRegex(ValueError, "Invalid sharding dim"):
                 sharded_tensor.empty(spec, 10, 20)
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:5/cuda:1"])
-        with self.assertRaisesRegex(ValueError, 'Invalid rank'):
+        with self.assertRaisesRegex(ValueError, "Invalid rank"):
             sharded_tensor.empty(spec, 10, 20)
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
         st = sharded_tensor.empty(spec, 10, 20)
         tensor = torch.empty(10, 20)
-        with self.assertRaisesRegex(RuntimeError, "not supported yet for ShardedTensor!"):
+        with self.assertRaisesRegex(
+            RuntimeError, "not supported yet for ShardedTensor!"
+        ):
             torch.add(st, tensor)
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
-        with self.assertRaisesRegex(ValueError, 'Only torch.strided layout is currently supported'):
+        with self.assertRaisesRegex(
+            ValueError, "Only torch.strided layout is currently supported"
+        ):
             sharded_tensor.empty(spec, 10, 20, layout=torch.sparse_coo)
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
-        with self.assertRaisesRegex(ValueError, 'Only torch.contiguous_format memory_format is currently supported'):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Only torch.contiguous_format memory_format is currently supported",
+        ):
             sharded_tensor.empty(spec, 10, 20, memory_format=torch.channels_last)
 
         spec = ChunkShardingSpec(dim=0, placements=["worker0/cuda:1"])
-        with self.assertRaisesRegex(RuntimeError, 'RPC framework needs to be initialized'):
+        with self.assertRaisesRegex(
+            RuntimeError, "RPC framework needs to be initialized"
+        ):
             sharded_tensor.empty(spec, 10, 20)
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
-        with self.assertRaisesRegex(RuntimeError, 'RPC Framework needs to be initialized'):
+        with self.assertRaisesRegex(
+            RuntimeError, "RPC Framework needs to be initialized"
+        ):
             st = sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
-        with self.assertRaisesRegex(RuntimeError, 'ShardedTensor created with init_rrefs=False'):
+        with self.assertRaisesRegex(
+            RuntimeError, "ShardedTensor created with init_rrefs=False"
+        ):
             st = sharded_tensor.empty(spec, 10, 20)
             st.remote_shards()
 
         self.init_rpc()
         spec = ChunkShardingSpec(dim=0, placements=["workerfoo/cuda:1"])
-        with self.assertRaisesRegex(ValueError, 'Invalid worker name'):
+        with self.assertRaisesRegex(ValueError, "Invalid worker name"):
             sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
     @skip_if_lt_x_gpu(4)
@@ -982,18 +1063,22 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.init_pg()
 
         # Init RPC with different ranks.
-        rpc_backend_options = rpc.TensorPipeRpcBackendOptions(_transports=tp_transports())
+        rpc_backend_options = rpc.TensorPipeRpcBackendOptions(
+            _transports=tp_transports()
+        )
         rpc_backend_options.init_method = f"file://{self.file_name}"
         rank = (self.rank + 1) % self.world_size
         rpc.init_rpc(
-            name=f'worker{rank}',
+            name=f"worker{rank}",
             rank=rank,
             world_size=self.world_size,
             rpc_backend_options=rpc_backend_options,
         )
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:1/cuda:1"])
-        with self.assertRaisesRegex(ValueError, 'Default ProcessGroup and RPC ranks must be the same'):
+        with self.assertRaisesRegex(
+            ValueError, "Default ProcessGroup and RPC ranks must be the same"
+        ):
             sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
     @skip_if_lt_x_gpu(4)
@@ -1030,7 +1115,9 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         for shard_rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual([shard_rank, 0], shard_metadata.shard_offsets)
             self.assertEqual([1, 20], shard_metadata.shard_sizes)
-            self.assertEqual(f'rank:{shard_rank}/cuda:{shard_rank}', str(shard_metadata.placement))
+            self.assertEqual(
+                f"rank:{shard_rank}/cuda:{shard_rank}", str(shard_metadata.placement)
+            )
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -1079,13 +1166,13 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.assertEqual(st.ndim, 2)
         # Test with invalid input
         st = sharded_tensor.empty(spec, (10, 20), init_rrefs=True)
-        with self.assertRaisesRegex(IndexError, 'Dimension out of range'):
+        with self.assertRaisesRegex(IndexError, "Dimension out of range"):
             st.size(-3)
-        with self.assertRaisesRegex(IndexError, 'Dimension out of range'):
+        with self.assertRaisesRegex(IndexError, "Dimension out of range"):
             st.size(2)
 
         with self.assertRaises(TypeError):
-            st = sharded_tensor.empty(spec, 'foo')
+            st = sharded_tensor.empty(spec, "foo")
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -1126,7 +1213,11 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.assertTrue("submodule.sharded_tensor2" in loaded_dict_keys)
         # Verify after load.
         self.assertTrue(torch.equal(m.sharded_tensor1, module_load.sharded_tensor1))
-        self.assertTrue(torch.equal(m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2))
+        self.assertTrue(
+            torch.equal(
+                m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2
+            )
+        )
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -1162,7 +1253,11 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
         # Verify after load.
         self.assertTrue(torch.equal(m.sharded_tensor1, module_load.sharded_tensor1))
-        self.assertTrue(torch.equal(m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2))
+        self.assertTrue(
+            torch.equal(
+                m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2
+            )
+        )
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -1223,17 +1318,21 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
         buffer.seek(0)
         if self.rank != 0:
-            with self.assertRaisesRegex(RuntimeError, 'Local rank at save time was'):
+            with self.assertRaisesRegex(RuntimeError, "Local rank at save time was"):
                 with load_with_process_group(pg):
                     state_dict_deser = torch.load(buffer)
         else:
-            with self.assertRaisesRegex(RuntimeError, 'Local world size at save time was'):
+            with self.assertRaisesRegex(
+                RuntimeError, "Local world size at save time was"
+            ):
                 with load_with_process_group(pg):
                     state_dict_deser = torch.load(buffer)
 
         dist.destroy_process_group()
         buffer.seek(0)
-        with self.assertRaisesRegex(RuntimeError, 'Need to initialize default process group'):
+        with self.assertRaisesRegex(
+            RuntimeError, "Need to initialize default process group"
+        ):
             state_dict_deser = torch.load(buffer)
         rpc.shutdown()
 
@@ -1241,7 +1340,6 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_cleanup(self):
-
         def create_tensors():
             spec = ChunkShardingSpec(
                 dim=0,
@@ -1260,33 +1358,34 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
 
 class TestShardedTensorEnumerable(ShardedTensorTestBase):
-
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_sharded_tensor_metadata(self):
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[0, 5],
-                shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="rank:2/cuda:2",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 5],
-                shard_sizes=[5, 5],
-                placement="rank:3/cuda:3",
-            )
-        ])
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:1/cuda:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:2/cuda:2",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:3/cuda:3",
+                ),
+            ]
+        )
 
         st = sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         st_metadata = st.metadata()
@@ -1304,28 +1403,30 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         self.assertEqual(torch.double, st.dtype)
 
         # Need CPU for pin_memory
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cpu",
-            ),
-            ShardMetadata(
-                shard_offsets=[0, 5],
-                shard_sizes=[5, 5],
-                placement="rank:1/cpu",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="rank:2/cpu",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 5],
-                shard_sizes=[5, 5],
-                placement="rank:3/cpu",
-            )
-        ])
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cpu",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:1/cpu",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:2/cpu",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:3/cpu",
+                ),
+            ]
+        )
 
         st = sharded_tensor.empty(spec, 10, 10, pin_memory=True, init_rrefs=True)
         self.assertTrue(st.is_pinned())
@@ -1335,28 +1436,30 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @requires_nccl()
     def test_grid_sharding(self):
 
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[0, 5],
-                shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="rank:2/cuda:2",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 5],
-                shard_sizes=[5, 5],
-                placement="rank:3/cuda:3",
-            )
-        ])
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:1/cuda:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:2/cuda:2",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:3/cuda:3",
+                ),
+            ]
+        )
 
         st = sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         self.assertEqual((10, 10), st.size())
@@ -1364,22 +1467,29 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
+        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
         self.assertEqual((5, 5), local_shard.tensor.size())
 
         # Verify local shard metadata.
-        self.assertEqual((self.rank // 2 * 5, (self.rank % 2) * 5), local_shard.metadata.shard_offsets)
+        self.assertEqual(
+            (self.rank // 2 * 5, (self.rank % 2) * 5),
+            local_shard.metadata.shard_offsets,
+        )
         self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-        self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
+        self.assertEqual(
+            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
+        )
 
         # Verify global metadata.
         st_metadata = st.metadata()
         shards_metadata = st_metadata.shards_metadata
         self.assertEqual(4, len(shards_metadata))
         for rank, shard_metadata in enumerate(shards_metadata):
-            self.assertEqual((rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets)
+            self.assertEqual(
+                (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
+            )
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
+            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -1396,30 +1506,32 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_with_ones(self):
-        """ Test sharded_tensor.ones(...) """
+        """Test sharded_tensor.ones(...)"""
 
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[0, 5],
-                shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="rank:2/cuda:2",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 5],
-                shard_sizes=[5, 5],
-                placement="rank:3/cuda:3",
-            )
-        ])
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:1/cuda:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:2/cuda:2",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:3/cuda:3",
+                ),
+            ]
+        )
 
         st = sharded_tensor.ones(spec, 10, 10, init_rrefs=True)
         self.assertEqual((10, 10), st.size())
@@ -1427,7 +1539,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
         # Verify local shard is initialized with torch.ones
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
+        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
         self.assertEqual((5, 5), local_shard.tensor.size())
         self.assertEqual(local_shard.tensor, torch.ones(5, 5))
 
@@ -1435,30 +1547,32 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_gather_even(self) -> None:
-        """ Test _sharded_tensor.gather(...) with evenly distributed._shards"""
+        """Test _sharded_tensor.gather(...) with evenly distributed._shards"""
 
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[0, 5],
-                shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="rank:2/cuda:2",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 5],
-                shard_sizes=[5, 5],
-                placement="rank:3/cuda:3",
-            )
-        ])
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:1/cuda:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:2/cuda:2",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:3/cuda:3",
+                ),
+            ]
+        )
 
         h, w = 10, 10
         st = sharded_tensor.ones(spec, h, w, init_rrefs=True)
@@ -1466,11 +1580,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         full_tensor = None
         dst = 0
         if self.rank == dst:
-            full_tensor = torch.zeros(
-                h,
-                w,
-                device=torch.device(f"cuda:{dst}")
-            )
+            full_tensor = torch.zeros(h, w, device=torch.device(f"cuda:{dst}"))
         st.gather(dst, full_tensor)
 
         if self.rank == dst:
@@ -1482,30 +1592,32 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_gather_uneven(self) -> None:
-        """ Test _sharded_tensor.gather(...) with unevenly distributed._shards"""
+        """Test _sharded_tensor.gather(...) with unevenly distributed._shards"""
 
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[0, 5],
-                shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 5],
-                shard_sizes=[5, 5],
-                placement="rank:3/cuda:3",
-            )
-        ])
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:1/cuda:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:3/cuda:3",
+                ),
+            ]
+        )
 
         h, w = 10, 10
         st = sharded_tensor.ones(spec, h, w, init_rrefs=True)
@@ -1513,11 +1625,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         full_tensor = None
         dst = 0
         if self.rank == dst:
-            full_tensor = torch.zeros(
-                h,
-                w,
-                device=torch.device(f"cuda:{dst}")
-            )
+            full_tensor = torch.zeros(h, w, device=torch.device(f"cuda:{dst}"))
         st.gather(dst, full_tensor)
 
         if self.rank == dst:
@@ -1569,7 +1677,9 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         self.assertIsInstance(new_st._process_group, distributed_c10d.ProcessGroupGloo)
         # test specs before and after the move almost the same except placement device
         self.assertEqual(spec_before_move.dim, spec_after_move.dim)
-        self.assertEqual(len(spec_before_move.placements), len(spec_after_move.placements))
+        self.assertEqual(
+            len(spec_before_move.placements), len(spec_after_move.placements)
+        )
         for i, remote_device_after in enumerate(spec_after_move.placements):
             remote_device_before = spec_before_move.placements[i]
             self.assertEqual(remote_device_before.rank(), remote_device_after.rank())
@@ -1653,7 +1763,9 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         self.assertIsInstance(spec_after_move, ChunkShardingSpec)
         # test specs before and after the move almost the same except placement device
         self.assertEqual(spec_before_move.dim, spec_after_move.dim)
-        self.assertEqual(len(spec_before_move.placements), len(spec_after_move.placements))
+        self.assertEqual(
+            len(spec_before_move.placements), len(spec_after_move.placements)
+        )
         for i, remote_device_after in enumerate(spec_after_move.placements):
             remote_device_before = spec_before_move.placements[i]
             self.assertEqual(remote_device_before.rank(), remote_device_after.rank())
@@ -1768,28 +1880,30 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     def test_uneven_shards(self):
         self.init_pg()
 
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[2, 4],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[0, 4],
-                shard_sizes=[4, 2],
-                placement="rank:1/cuda:1",
-            ),
-            ShardMetadata(
-                shard_offsets=[2, 0],
-                shard_sizes=[4, 4],
-                placement="rank:2/cuda:2",
-            ),
-            ShardMetadata(
-                shard_offsets=[4, 4],
-                shard_sizes=[2, 2],
-                placement="rank:3/cuda:3",
-            ),
-        ])
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[2, 4],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 4],
+                    shard_sizes=[4, 2],
+                    placement="rank:1/cuda:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[2, 0],
+                    shard_sizes=[4, 4],
+                    placement="rank:2/cuda:2",
+                ),
+                ShardMetadata(
+                    shard_offsets=[4, 4],
+                    shard_sizes=[2, 2],
+                    placement="rank:3/cuda:3",
+                ),
+            ]
+        )
 
         st = sharded_tensor.empty(spec, 6, 6)
         self.assertEqual((6, 6), st.size())
@@ -1817,13 +1931,15 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
+        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
         verify_size(self.rank, local_shard.tensor.size())
 
         # Verify local shard metadata.
         verify_offsets(self.rank, local_shard.metadata.shard_offsets)
         verify_size(self.rank, local_shard.metadata.shard_sizes)
-        self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
+        self.assertEqual(
+            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
+        )
 
         # Verify global metadata.
         st_metadata = st.metadata()
@@ -1832,24 +1948,26 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         for rank, shard_metadata in enumerate(shards_metadata):
             verify_offsets(rank, shard_metadata.shard_offsets)
             verify_size(rank, shard_metadata.shard_sizes)
-            self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
+            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
 
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_partial_world_size(self):
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
-            ),
-        ])
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:1/cuda:1",
+                ),
+            ]
+        )
 
         st = sharded_tensor.empty(spec, 10, 5, init_rrefs=True)
         self.assertEqual((10, 5), st.size())
@@ -1861,13 +1979,18 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         if self.rank <= 1:
             # Verify local shard.
             local_shard = st.local_shards()[0]
-            self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
+            self.assertEqual(
+                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
+            )
             self.assertEqual((5, 5), local_shard.tensor.size())
 
             # Verify local shard metadata.
             self.assertEqual((self.rank * 5, 0), local_shard.metadata.shard_offsets)
             self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-            self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
+            self.assertEqual(
+                f"rank:{self.rank}/cuda:{self.rank}",
+                str(local_shard.metadata.placement),
+            )
 
         # Verify global metadata.
         st_metadata = st.metadata()
@@ -1876,7 +1999,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         for rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual((rank * 5, 0), shard_metadata.shard_offsets)
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
+            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -1897,18 +2020,20 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_new_group(self):
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:1",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="rank:2/cuda:3",
-            ),
-        ])
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:2/cuda:3",
+                ),
+            ]
+        )
 
         pg = dist.new_group(ranks=[1, 2, 3])
 
@@ -1917,13 +2042,20 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         if self.rank == 1 or self.rank == 3:
             # Verify local shard.
             local_shard = st.local_shards()[0]
-            self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
+            self.assertEqual(
+                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
+            )
             self.assertEqual((5, 5), local_shard.tensor.size())
 
             # Verify local shard metadata.
-            self.assertEqual((self.rank // 2 * 5, 0), local_shard.metadata.shard_offsets)
+            self.assertEqual(
+                (self.rank // 2 * 5, 0), local_shard.metadata.shard_offsets
+            )
             self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-            self.assertEqual(f'rank:{self.rank - 1}/cuda:{self.rank}', str(local_shard.metadata.placement))
+            self.assertEqual(
+                f"rank:{self.rank - 1}/cuda:{self.rank}",
+                str(local_shard.metadata.placement),
+            )
 
         # Verify global metadata.
         st_metadata = st.metadata()
@@ -1932,7 +2064,9 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         for rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual((rank * 5, 0), shard_metadata.shard_offsets)
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f'rank:{rank * 2}/cuda:{rank * 2 + 1}', str(shard_metadata.placement))
+            self.assertEqual(
+                f"rank:{rank * 2}/cuda:{rank * 2 + 1}", str(shard_metadata.placement)
+            )
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -1954,28 +2088,30 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_multiple_local_shards(self):
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[0, 5],
-                shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 5],
-                shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
-            )
-        ])
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:1/cuda:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="rank:0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 5],
+                    shard_sizes=[5, 5],
+                    placement="rank:1/cuda:1",
+                ),
+            ]
+        )
 
         st = sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         self.assertEqual((10, 10), st.size())
@@ -1985,13 +2121,20 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
             # Verify local shards.
             for idx, local_shard in enumerate(st.local_shards()):
-                self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
+                self.assertEqual(
+                    torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
+                )
                 self.assertEqual((5, 5), local_shard.tensor.size())
 
                 # Verify local shard metadata.
-                self.assertEqual((idx * 5, self.rank * 5), local_shard.metadata.shard_offsets)
+                self.assertEqual(
+                    (idx * 5, self.rank * 5), local_shard.metadata.shard_offsets
+                )
                 self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-                self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
+                self.assertEqual(
+                    f"rank:{self.rank}/cuda:{self.rank}",
+                    str(local_shard.metadata.placement),
+                )
         else:
             self.assertEqual(0, len(st.local_shards()))
 
@@ -2000,9 +2143,15 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         shards_metadata = st_metadata.shards_metadata
         self.assertEqual(4, len(shards_metadata))
         for shard_rank, shard_metadata in enumerate(shards_metadata):
-            self.assertEqual((shard_rank // 2 * 5, (shard_rank % 2) * 5), shard_metadata.shard_offsets)
+            self.assertEqual(
+                (shard_rank // 2 * 5, (shard_rank % 2) * 5),
+                shard_metadata.shard_offsets,
+            )
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f'rank:{shard_rank % 2}/cuda:{shard_rank % 2}', str(shard_metadata.placement))
+            self.assertEqual(
+                f"rank:{shard_rank % 2}/cuda:{shard_rank % 2}",
+                str(shard_metadata.placement),
+            )
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2023,28 +2172,30 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_with_rpc_names(self):
-        spec = EnumerableShardingSpec([
-            ShardMetadata(
-                shard_offsets=[0, 0],
-                shard_sizes=[5, 5],
-                placement="worker0/cuda:0",
-            ),
-            ShardMetadata(
-                shard_offsets=[0, 5],
-                shard_sizes=[5, 5],
-                placement="worker1/cuda:1",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 0],
-                shard_sizes=[5, 5],
-                placement="worker2/cuda:2",
-            ),
-            ShardMetadata(
-                shard_offsets=[5, 5],
-                shard_sizes=[5, 5],
-                placement="worker3/cuda:3",
-            )
-        ])
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement="worker0/cuda:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 5],
+                    shard_sizes=[5, 5],
+                    placement="worker1/cuda:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement="worker2/cuda:2",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 5],
+                    shard_sizes=[5, 5],
+                    placement="worker3/cuda:3",
+                ),
+            ]
+        )
 
         st = sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         self.assertEqual((10, 10), st.size())
@@ -2052,22 +2203,29 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
+        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
         self.assertEqual((5, 5), local_shard.tensor.size())
 
         # Verify local shard metadata.
-        self.assertEqual((self.rank // 2 * 5, (self.rank % 2) * 5), local_shard.metadata.shard_offsets)
+        self.assertEqual(
+            (self.rank // 2 * 5, (self.rank % 2) * 5),
+            local_shard.metadata.shard_offsets,
+        )
         self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-        self.assertEqual(f'worker{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
+        self.assertEqual(
+            f"worker{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
+        )
 
         # Verify global metadata.
         st_metadata = st.metadata()
         shards_metadata = st_metadata.shards_metadata
         self.assertEqual(4, len(shards_metadata))
         for rank, shard_metadata in enumerate(shards_metadata):
-            self.assertEqual((rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets)
+            self.assertEqual(
+                (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
+            )
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f'worker{rank}/cuda:{rank}', str(shard_metadata.placement))
+            self.assertEqual(f"worker{rank}/cuda:{rank}", str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2090,7 +2248,9 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
         local_shard_metadata = None
         rank_to_metadata = {}
         for shard_metadata in tensor_meta.shards_metadata:
-            rank, device = _parse_and_validate_remote_device(pg, shard_metadata.placement)
+            rank, device = _parse_and_validate_remote_device(
+                pg, shard_metadata.placement
+            )
             rank_to_metadata[rank] = shard_metadata
             if rank == self.rank:
                 local_tensor = torch.rand(shard_metadata.shard_sizes).cuda(device)
@@ -2172,9 +2332,7 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
         )
         st_size = [24, 12]
         local_tensor = torch.rand(*st_size).cuda(self.rank)
-        with self.assertRaisesRegex(
-            ValueError, "do not cover the entire tensor"
-        ):
+        with self.assertRaisesRegex(ValueError, "do not cover the entire tensor"):
             ShardedTensor._init_from_local_tensor(
                 local_tensor,
                 enumerable_sharding_spec,
@@ -2192,7 +2350,6 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
 
 
 class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
-
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
@@ -2201,24 +2358,22 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=shard_offsets,
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}"
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
         )
 
         local_tensor = torch.randn(5, 5, device=f"cuda:{self.rank}")
         local_shard = sharded_tensor.Shard(local_tensor, local_shard_metadata)
         local_shard_from_offsets = sharded_tensor.Shard.from_tensor_and_offsets(
-            local_tensor,
-            shard_offsets=shard_offsets,
-            rank=self.rank
+            local_tensor, shard_offsets=shard_offsets, rank=self.rank
         )
         self.assertEqual(local_shard.metadata, local_shard_from_offsets.metadata)
 
         wrong_local_shard_metadata = ShardMetadata(
             shard_offsets=shard_offsets,
             shard_sizes=[6, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}"
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
         )
-        with self.assertRaisesRegex(ValueError, 'Shard tensor size does not match'):
+        with self.assertRaisesRegex(ValueError, "Shard tensor size does not match"):
             local_shard_from_wrong_meta = sharded_tensor.Shard(
                 local_tensor,
                 metadata=wrong_local_shard_metadata,
@@ -2231,32 +2386,45 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}"
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
         )
 
-        local_shards = [sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata)]
+        local_shards = [
+            sharded_tensor.Shard(
+                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+            )
+        ]
 
-        st = sharded_tensor.init_from_local_shards(local_shards, [10, 10], init_rrefs=True)
+        st = sharded_tensor.init_from_local_shards(
+            local_shards, [10, 10], init_rrefs=True
+        )
         self.assertEqual((10, 10), st.size())
         self.assertEqual(1, len(st.local_shards()))
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
+        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
         self.assertEqual((5, 5), local_shard.tensor.size())
 
         # Verify local shard metadata.
-        self.assertEqual((self.rank // 2 * 5, (self.rank % 2) * 5), local_shard.metadata.shard_offsets)
+        self.assertEqual(
+            (self.rank // 2 * 5, (self.rank % 2) * 5),
+            local_shard.metadata.shard_offsets,
+        )
         self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-        self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
+        self.assertEqual(
+            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
+        )
 
         # Verify global metadata.
         shards_metadata = st.metadata().shards_metadata
         self.assertEqual(4, len(shards_metadata))
         for rank, shard_metadata in enumerate(shards_metadata):
-            self.assertEqual((rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets)
+            self.assertEqual(
+                (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
+            )
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
+            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2269,6 +2437,65 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
                 shard = remote_shard.to_here()
                 self.assertEqual((5, 5), shard.tensor.size())
 
+    @skip_if_lt_x_gpu(4)
+    def test_st_base_init_from_local_shards_and_global_metadata(self):
+        world_size = 4
+        shards_metadata = []
+        shards = []
+        for rank in range(world_size):
+            local_shard_metadata = ShardMetadata(
+                shard_offsets=[(rank // 2) * 5, (rank % 2) * 5],
+                shard_sizes=[5, 5],
+                placement=f"rank:{rank}/cuda:{rank}",
+            )
+            shards_metadata.append(local_shard_metadata)
+            shards.append(
+                sharded_tensor.Shard(
+                    torch.randn(5, 5, device=f"cuda:{rank}"), local_shard_metadata
+                )
+            )
+
+        tensor_properties = TensorProperties(
+            dtype=torch.get_default_dtype(),
+            layout=torch.strided,
+            requires_grad=False,
+            memory_format=torch.contiguous_format,
+            pin_memory=False,
+        )
+
+        sharded_tensor_metadata = sharded_tensor.ShardedTensorMetadata(
+            shards_metadata=shards_metadata,
+            size=torch.Size([10, 10]),
+            tensor_properties=tensor_properties,
+        )
+
+        st_base = sharded_tensor.ShardedTensorBase._init_from_local_shards_and_global_metadata(
+            shards, sharded_tensor_metadata=sharded_tensor_metadata
+        )
+        self.assertEqual(4, len(st_base.local_shards()))
+
+        # Verify local shard of st_base
+        local_shard = st_base.local_shards()[0]
+        self.assertEqual(torch.device("cuda:0"), local_shard.tensor.device)
+        self.assertEqual((5, 5), local_shard.tensor.size())
+
+        # Verify local shard metadata.
+        self.assertEqual(
+            (0, 0),
+            local_shard.metadata.shard_offsets,
+        )
+        self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
+        self.assertEqual("rank:0/cuda:0", str(local_shard.metadata.placement))
+
+        # Verify global metadata.
+        shards_metadata = st_base.metadata().shards_metadata
+        self.assertEqual(4, len(shards_metadata))
+        for rank, shard_metadata in enumerate(shards_metadata):
+            self.assertEqual(
+                (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
+            )
+            self.assertEqual((5, 5), shard_metadata.shard_sizes)
+            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -2277,7 +2504,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}"
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
         )
 
         shards_metadata = []
@@ -2285,13 +2512,19 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             if r == self.rank:
                 shards_metadata.append(local_shard_metadata)
             else:
-                shards_metadata.append(ShardMetadata(
-                    shard_offsets=[(r // 2) * 5, (r % 2) * 5],
-                    shard_sizes=[5, 5],
-                    placement=f"rank:{r}/cuda:{r}"
-                ))
+                shards_metadata.append(
+                    ShardMetadata(
+                        shard_offsets=[(r // 2) * 5, (r % 2) * 5],
+                        shard_sizes=[5, 5],
+                        placement=f"rank:{r}/cuda:{r}",
+                    )
+                )
 
-        local_shards = [sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata)]
+        local_shards = [
+            sharded_tensor.Shard(
+                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+            )
+        ]
 
         tensor_properties = TensorProperties(
             dtype=torch.get_default_dtype(),
@@ -2317,21 +2550,28 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
+        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
         self.assertEqual((5, 5), local_shard.tensor.size())
 
         # Verify local shard metadata.
-        self.assertEqual((self.rank // 2 * 5, (self.rank % 2) * 5), local_shard.metadata.shard_offsets)
+        self.assertEqual(
+            (self.rank // 2 * 5, (self.rank % 2) * 5),
+            local_shard.metadata.shard_offsets,
+        )
         self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-        self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
+        self.assertEqual(
+            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
+        )
 
         # Verify global metadata.
         shards_metadata = st.metadata().shards_metadata
         self.assertEqual(4, len(shards_metadata))
         for rank, shard_metadata in enumerate(shards_metadata):
-            self.assertEqual((rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets)
+            self.assertEqual(
+                (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
+            )
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
+            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2354,21 +2594,34 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             local_shard_metadata = ShardMetadata(
                 shard_offsets=[5 * (self.rank - 1), 0],
                 shard_sizes=[5, 5],
-                placement=f"rank:{self.rank - 1}/cuda:{self.rank}"
+                placement=f"rank:{self.rank - 1}/cuda:{self.rank}",
             )
-            local_shards = [sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata)]
+            local_shards = [
+                sharded_tensor.Shard(
+                    torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+                )
+            ]
 
-            st = sharded_tensor.init_from_local_shards(local_shards, [15, 5], process_group=new_pg)
+            st = sharded_tensor.init_from_local_shards(
+                local_shards, [15, 5], process_group=new_pg
+            )
 
             # Verify local shard.
             local_shard = st.local_shards()[0]
-            self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
+            self.assertEqual(
+                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
+            )
             self.assertEqual((5, 5), local_shard.tensor.size())
 
             # Verify local shard metadata.
-            self.assertEqual(((self.rank - 1) * 5, 0), local_shard.metadata.shard_offsets)
+            self.assertEqual(
+                ((self.rank - 1) * 5, 0), local_shard.metadata.shard_offsets
+            )
             self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-            self.assertEqual(f'rank:{self.rank - 1}/cuda:{self.rank}', str(local_shard.metadata.placement))
+            self.assertEqual(
+                f"rank:{self.rank - 1}/cuda:{self.rank}",
+                str(local_shard.metadata.placement),
+            )
 
             # Verify global metadata.
             st_metadata = st.metadata()
@@ -2377,8 +2630,9 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             for rank, shard_metadata in enumerate(shards_metadata):
                 self.assertEqual((rank * 5, 0), shard_metadata.shard_offsets)
                 self.assertEqual((5, 5), shard_metadata.shard_sizes)
-                self.assertEqual(f'rank:{rank}/cuda:{rank + 1}', str(shard_metadata.placement))
-
+                self.assertEqual(
+                    f"rank:{rank}/cuda:{rank + 1}", str(shard_metadata.placement)
+                )
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -2387,36 +2641,57 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}"
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
         )
 
         indices = [[0, 1, 1], [2, 0, 2]]
         values = [3.2, 4.5, 5.8]
-        sparse_tensor = torch.sparse_coo_tensor(indices, values, (5, 5), device=f"cuda:{self.rank}")
+        sparse_tensor = torch.sparse_coo_tensor(
+            indices, values, (5, 5), device=f"cuda:{self.rank}"
+        )
 
         empty_local_shards = []
-        with self.assertRaisesRegex(ValueError, 'have no local shards on all ranks'):
-            st = sharded_tensor.init_from_local_shards(empty_local_shards, [10, 10], init_rrefs=True)
+        with self.assertRaisesRegex(ValueError, "have no local shards on all ranks"):
+            st = sharded_tensor.init_from_local_shards(
+                empty_local_shards, [10, 10], init_rrefs=True
+            )
 
         wrong_layout_shards = [
             sharded_tensor.Shard(sparse_tensor, local_shard_metadata)
         ]
-        with self.assertRaisesRegex(ValueError, 'Only torch.strided layout is currently supported'):
+        with self.assertRaisesRegex(
+            ValueError, "Only torch.strided layout is currently supported"
+        ):
             st = sharded_tensor.init_from_local_shards(
-                wrong_layout_shards, [10, 10], init_rrefs=True)
+                wrong_layout_shards, [10, 10], init_rrefs=True
+            )
 
         wrong_memory_format_shards = [
-            sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata)
+            sharded_tensor.Shard(
+                torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata
+            )
         ]
-        with self.assertRaisesRegex(ValueError, 'Only torch.contiguous_format memory_format is currently supported'):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Only torch.contiguous_format memory_format is currently supported",
+        ):
             st = sharded_tensor.init_from_local_shards(
-                wrong_memory_format_shards, [10, 10], init_rrefs=True)
+                wrong_memory_format_shards, [10, 10], init_rrefs=True
+            )
 
-        with self.assertRaisesRegex(ValueError, 'Shard tensor size does not match'):
-            wrong_size_shards = [sharded_tensor.Shard(torch.randn(2, 3, device=f"cuda:{self.rank}"), local_shard_metadata)]
+        with self.assertRaisesRegex(ValueError, "Shard tensor size does not match"):
+            wrong_size_shards = [
+                sharded_tensor.Shard(
+                    torch.randn(2, 3, device=f"cuda:{self.rank}"), local_shard_metadata
+                )
+            ]
 
-        with self.assertRaisesRegex(ValueError, "Local shard tensor device does not match"):
-            wrong_device_shards = [sharded_tensor.Shard(torch.randn(5, 5), local_shard_metadata)]
+        with self.assertRaisesRegex(
+            ValueError, "Local shard tensor device does not match"
+        ):
+            wrong_device_shards = [
+                sharded_tensor.Shard(torch.randn(5, 5), local_shard_metadata)
+            ]
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -2425,37 +2700,58 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}"
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
         )
         tensor_overall_size = [10, 10] if self.rank == 0 else [10, 5]
         wrong_dtype_shards = [
-            sharded_tensor.Shard(torch.ones(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata)
+            sharded_tensor.Shard(
+                torch.ones(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+            )
         ]
-        with self.assertRaisesRegex(ValueError, "ShardedTensor global_size property does not match from different ranks!"):
-            st = sharded_tensor.init_from_local_shards(wrong_dtype_shards, tensor_overall_size, init_rrefs=True)
+        with self.assertRaisesRegex(
+            ValueError,
+            "ShardedTensor global_size property does not match from different ranks!",
+        ):
+            st = sharded_tensor.init_from_local_shards(
+                wrong_dtype_shards, tensor_overall_size, init_rrefs=True
+            )
 
         tensor_dtype = torch.int if self.rank == 0 else torch.float32
         wrong_dtype_shards = [
-            sharded_tensor.Shard(torch.ones(5, 5, device=f"cuda:{self.rank}", dtype=tensor_dtype), local_shard_metadata)
+            sharded_tensor.Shard(
+                torch.ones(5, 5, device=f"cuda:{self.rank}", dtype=tensor_dtype),
+                local_shard_metadata,
+            )
         ]
-        with self.assertRaisesRegex(ValueError, "ShardedTensor dtype property does not match from different ranks!"):
-            st = sharded_tensor.init_from_local_shards(wrong_dtype_shards, [10, 10], init_rrefs=True)
+        with self.assertRaisesRegex(
+            ValueError,
+            "ShardedTensor dtype property does not match from different ranks!",
+        ):
+            st = sharded_tensor.init_from_local_shards(
+                wrong_dtype_shards, [10, 10], init_rrefs=True
+            )
 
         tensor_requires_grad = True if self.rank == 0 else False
         wrong_requires_grad_shards = [
             sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}", requires_grad=tensor_requires_grad),
-                local_shard_metadata
+                torch.randn(
+                    5, 5, device=f"cuda:{self.rank}", requires_grad=tensor_requires_grad
+                ),
+                local_shard_metadata,
             )
         ]
-        with self.assertRaisesRegex(ValueError, 'ShardedTensor requires_grad property does not match from different ranks!'):
+        with self.assertRaisesRegex(
+            ValueError,
+            "ShardedTensor requires_grad property does not match from different ranks!",
+        ):
             st = sharded_tensor.init_from_local_shards(
-                wrong_requires_grad_shards, [10, 10], init_rrefs=True)
+                wrong_requires_grad_shards, [10, 10], init_rrefs=True
+            )
 
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cpu"
+            placement=f"rank:{self.rank}/cpu",
         )
 
     @with_comms(init_rpc=False, backend="gloo")
@@ -2465,24 +2761,36 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cpu"
+            placement=f"rank:{self.rank}/cpu",
         )
         wrong_pin_memory_local_shards = [
-            sharded_tensor.Shard(torch.randn(5, 5, pin_memory=True), local_shard_metadata),
-            sharded_tensor.Shard(torch.randn(5, 5, pin_memory=False), local_shard_metadata)
+            sharded_tensor.Shard(
+                torch.randn(5, 5, pin_memory=True), local_shard_metadata
+            ),
+            sharded_tensor.Shard(
+                torch.randn(5, 5, pin_memory=False), local_shard_metadata
+            ),
         ]
-        with self.assertRaisesRegex(ValueError, "Local shards' tensor pin_memory property need to be the same"):
+        with self.assertRaisesRegex(
+            ValueError, "Local shards' tensor pin_memory property need to be the same"
+        ):
             st = sharded_tensor.init_from_local_shards(
-                wrong_pin_memory_local_shards, [10, 10], init_rrefs=True)
+                wrong_pin_memory_local_shards, [10, 10], init_rrefs=True
+            )
 
         tensor_pin_memory = True if self.rank == 0 else False
         wrong_pin_memory_shards_cross_ranks = [
-            sharded_tensor.Shard(torch.randn(5, 5, pin_memory=tensor_pin_memory), local_shard_metadata)
+            sharded_tensor.Shard(
+                torch.randn(5, 5, pin_memory=tensor_pin_memory), local_shard_metadata
+            )
         ]
-        with self.assertRaisesRegex(ValueError, 'ShardedTensor pin_memory property does not match from different ranks!'):
+        with self.assertRaisesRegex(
+            ValueError,
+            "ShardedTensor pin_memory property does not match from different ranks!",
+        ):
             st = sharded_tensor.init_from_local_shards(
-                wrong_pin_memory_shards_cross_ranks, [10, 10], init_rrefs=True)
-
+                wrong_pin_memory_shards_cross_ranks, [10, 10], init_rrefs=True
+            )
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -2492,14 +2800,20 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=local_shard_size,
-            placement=f"rank:{self.rank}/cuda:{self.rank}"
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
         )
 
-        local_shards = [sharded_tensor.Shard(torch.randn(local_shard_size, device=f"cuda:{self.rank}"), local_shard_metadata)]
+        local_shards = [
+            sharded_tensor.Shard(
+                torch.randn(local_shard_size, device=f"cuda:{self.rank}"),
+                local_shard_metadata,
+            )
+        ]
 
         with self.assertRaisesRegex(ValueError, "overlap"):
-            sharded_tensor.init_from_local_shards(local_shards, [10, 10], init_rrefs=True)
-
+            sharded_tensor.init_from_local_shards(
+                local_shards, [10, 10], init_rrefs=True
+            )
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -2509,13 +2823,20 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=local_shard_size,
-            placement=f"rank:{self.rank}/cuda:{self.rank}"
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
         )
 
-        local_shards = [sharded_tensor.Shard(torch.randn(local_shard_size, device=f"cuda:{self.rank}"), local_shard_metadata)]
+        local_shards = [
+            sharded_tensor.Shard(
+                torch.randn(local_shard_size, device=f"cuda:{self.rank}"),
+                local_shard_metadata,
+            )
+        ]
 
         with self.assertRaisesRegex(ValueError, "does not match tensor volume"):
-            sharded_tensor.init_from_local_shards(local_shards, [10, 10], init_rrefs=True)
+            sharded_tensor.init_from_local_shards(
+                local_shards, [10, 10], init_rrefs=True
+            )
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -2524,7 +2845,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}"
+            placement=f"rank:{self.rank}/cuda:{self.rank}",
         )
 
         shards_metadata = []
@@ -2532,11 +2853,13 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             if r == self.rank:
                 shards_metadata.append(local_shard_metadata)
             else:
-                shards_metadata.append(ShardMetadata(
-                    shard_offsets=[(r // 2) * 5, (r % 2) * 5],
-                    shard_sizes=[5, 5],
-                    placement=f"rank:{r}/cuda:{r}"
-                ))
+                shards_metadata.append(
+                    ShardMetadata(
+                        shard_offsets=[(r // 2) * 5, (r % 2) * 5],
+                        shard_sizes=[5, 5],
+                        placement=f"rank:{r}/cuda:{r}",
+                    )
+                )
 
         tensor_properties = TensorProperties(
             dtype=torch.get_default_dtype(),
@@ -2553,85 +2876,120 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         )
 
         empty_local_shards = []
-        with self.assertRaisesRegex(RuntimeError, 'does not match number of local shards metadata'):
+        with self.assertRaisesRegex(
+            RuntimeError, "does not match number of local shards metadata"
+        ):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                empty_local_shards,
-                sharded_tensor_metadata
+                empty_local_shards, sharded_tensor_metadata
             )
 
         wrong_num_shards = [
-            sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata),
-            sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata)
+            sharded_tensor.Shard(
+                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+            ),
+            sharded_tensor.Shard(
+                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
+            ),
         ]
-        with self.assertRaisesRegex(RuntimeError, 'does not match number of local shards metadata'):
+        with self.assertRaisesRegex(
+            RuntimeError, "does not match number of local shards metadata"
+        ):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_num_shards,
-                sharded_tensor_metadata
+                wrong_num_shards, sharded_tensor_metadata
             )
 
-        with self.assertRaisesRegex(ValueError, 'Shard tensor size does not match with metadata.shard_lengths'):
-            wrong_size_shards = [sharded_tensor.Shard(torch.randn(2, 3, device=f"cuda:{self.rank}"), local_shard_metadata)]
+        with self.assertRaisesRegex(
+            ValueError, "Shard tensor size does not match with metadata.shard_lengths"
+        ):
+            wrong_size_shards = [
+                sharded_tensor.Shard(
+                    torch.randn(2, 3, device=f"cuda:{self.rank}"), local_shard_metadata
+                )
+            ]
 
-        with self.assertRaisesRegex(ValueError, "Local shard tensor device does not match with local Shard's placement"):
-            wrong_device_shards = [sharded_tensor.Shard(torch.randn(5, 5), local_shard_metadata)]
+        with self.assertRaisesRegex(
+            ValueError,
+            "Local shard tensor device does not match with local Shard's placement",
+        ):
+            wrong_device_shards = [
+                sharded_tensor.Shard(torch.randn(5, 5), local_shard_metadata)
+            ]
 
         wrong_dtype_shards = [
-            sharded_tensor.Shard(torch.ones(5, 5, device=f"cuda:{self.rank}", dtype=torch.int), local_shard_metadata)
+            sharded_tensor.Shard(
+                torch.ones(5, 5, device=f"cuda:{self.rank}", dtype=torch.int),
+                local_shard_metadata,
+            )
         ]
-        with self.assertRaisesRegex(ValueError, "Local shards' tensor dtype property is incompatible with"):
+        with self.assertRaisesRegex(
+            ValueError, "Local shards' tensor dtype property is incompatible with"
+        ):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_dtype_shards,
-                sharded_tensor_metadata
+                wrong_dtype_shards, sharded_tensor_metadata
             )
 
         indices = [[0, 1, 1], [2, 0, 2]]
         values = [3.2, 4.5, 5.8]
-        sparse_tensor = torch.sparse_coo_tensor(indices, values, (5, 5), device=f"cuda:{self.rank}")
+        sparse_tensor = torch.sparse_coo_tensor(
+            indices, values, (5, 5), device=f"cuda:{self.rank}"
+        )
 
         wrong_layout_shards = [
             sharded_tensor.Shard(sparse_tensor, local_shard_metadata)
         ]
-        with self.assertRaisesRegex(ValueError, "Local shards' tensor layout property is incompatible with"):
+        with self.assertRaisesRegex(
+            ValueError, "Local shards' tensor layout property is incompatible with"
+        ):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_layout_shards,
-                sharded_tensor_metadata
+                wrong_layout_shards, sharded_tensor_metadata
             )
 
         wrong_requires_grad_shards = [
-            sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}", requires_grad=True), local_shard_metadata)
+            sharded_tensor.Shard(
+                torch.randn(5, 5, device=f"cuda:{self.rank}", requires_grad=True),
+                local_shard_metadata,
+            )
         ]
-        with self.assertRaisesRegex(ValueError, "Local shards' tensor requires_grad property is incompatible with"):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Local shards' tensor requires_grad property is incompatible with",
+        ):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_requires_grad_shards,
-                sharded_tensor_metadata
+                wrong_requires_grad_shards, sharded_tensor_metadata
             )
 
         wrong_memory_format_shards = [
-            sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata)
+            sharded_tensor.Shard(
+                torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata
+            )
         ]
-        with self.assertRaisesRegex(ValueError, 'Only torch.contiguous_format memory_format is currently supported'):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Only torch.contiguous_format memory_format is currently supported",
+        ):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_memory_format_shards,
-                sharded_tensor_metadata
+                wrong_memory_format_shards, sharded_tensor_metadata
             )
         # pin_memory can only be on CPU
         local_shard_metadata.placement = _remote_device(f"rank:{self.rank}/cpu")
         wrong_pin_memory_shards = [
-            sharded_tensor.Shard(torch.randn(5, 5, pin_memory=True), local_shard_metadata)
+            sharded_tensor.Shard(
+                torch.randn(5, 5, pin_memory=True), local_shard_metadata
+            )
         ]
-        with self.assertRaisesRegex(ValueError, "Local shards' tensor pin_memory property is incompatible with"):
+        with self.assertRaisesRegex(
+            ValueError, "Local shards' tensor pin_memory property is incompatible with"
+        ):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_pin_memory_shards,
-                sharded_tensor_metadata
+                wrong_pin_memory_shards, sharded_tensor_metadata
             )
 
-class TestShardedTensorCustomOps(ShardedTensorTestBase):
 
+class TestShardedTensorCustomOps(ShardedTensorTestBase):
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_custom_op(self):
-
         @custom_sharded_op_impl(torch.asin)
         def my_sharded_asin(types, args, kwargs, process_group):
             return torch.asin(args[0].local_shards()[0].tensor)
@@ -2673,7 +3031,7 @@ class TestShardedTensorCustomOps(ShardedTensorTestBase):
             ],
         )
         m = torch.nn.Linear(32, 16).cuda(self.rank)
-        shard_parameter(m, 'weight', spec)
+        shard_parameter(m, "weight", spec)
 
         result = m(torch.rand(15, 32).cuda(self.rank))
         self.assertEqual(t, result)
@@ -2683,15 +3041,18 @@ class TestShardedTensorCustomOps(ShardedTensorTestBase):
     @requires_nccl()
     def test_custom_op_errors(self):
 
-        with self.assertRaisesRegex(TypeError, 'expects signature'):
+        with self.assertRaisesRegex(TypeError, "expects signature"):
+
             @custom_sharded_op_impl(torch.nn.functional.linear)
             def my_op1(types, args, kwargs, process_group, random_param):
                 pass
 
-        with self.assertRaisesRegex(TypeError, 'expects signature'):
+        with self.assertRaisesRegex(TypeError, "expects signature"):
+
             @custom_sharded_op_impl(torch.nn.functional.linear)
             def my_op2(types):
                 pass
+
 
 class TestShardMetadata(ShardedTensorTestBase):
     @with_comms
@@ -2718,5 +3079,6 @@ class TestShardMetadata(ShardedTensorTestBase):
         shard = Shard(torch.zeros(10), md)
         self.assertIsNone(shard.metadata.placement)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -23,7 +23,7 @@ from torch.distributed._shard.sharded_tensor import (
     pre_load_state_dict_hook,
     state_dict_hook,
     ShardedTensor,
-    Shard,
+    Shard
 )
 from torch.distributed._shard.sharding_spec import (
     ChunkShardingSpec,
@@ -31,7 +31,7 @@ from torch.distributed._shard.sharding_spec import (
     ShardMetadata,
 )
 from torch.distributed._shard.sharded_tensor.utils import (
-    _parse_and_validate_remote_device,
+    _parse_and_validate_remote_device
 )
 from torch.distributed._shard.sharded_tensor.api import (
     TensorProperties,
@@ -59,12 +59,8 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common i
 )
 
 if TEST_WITH_DEV_DBG_ASAN:
-    print(
-        "Skip dev-asan as torch + multiprocessing spawn have known issues",
-        file=sys.stderr,
-    )
+    print("Skip dev-asan as torch + multiprocessing spawn have known issues", file=sys.stderr)
     sys.exit(0)
-
 
 class TestShardedTensorMetadata(TestCase):
     def test_serialize_and_deserialize(self):
@@ -88,59 +84,34 @@ class TestShardedTensorMetadata(TestCase):
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
                 placement="rank:3/cuda:3",
-            ),
+            )
         ]
 
         dtypes = [
-            torch.float,
-            torch.double,
-            torch.cfloat,
-            torch.cdouble,
-            torch.half,
-            torch.bfloat16,
-            torch.uint8,
-            torch.int8,
-            torch.short,
-            torch.int,
-            torch.long,
-            torch.bool,
-        ]
+            torch.float, torch.double, torch.cfloat, torch.cdouble, torch.half,
+            torch.bfloat16, torch.uint8, torch.int8, torch.short, torch.int,
+            torch.long, torch.bool]
 
         layouts = [torch.strided, torch.sparse_coo]
         requires_grads = [True, False]
-        memory_formats = [
-            torch.contiguous_format,
-            torch.channels_last,
-            torch.preserve_format,
-        ]
+        memory_formats = [torch.contiguous_format, torch.channels_last, torch.preserve_format]
         pin_memories = [True, False]
 
-        for tensor_properties_input in itertools.product(
-            dtypes, layouts, requires_grads, memory_formats, pin_memories
-        ):
-            (
-                dtype,
-                layout,
-                requires_grad,
-                memory_format,
-                pin_memory,
-            ) = tensor_properties_input
+        for tensor_properties_input in itertools.product(dtypes, layouts, requires_grads, memory_formats, pin_memories):
+            dtype, layout, requires_grad, memory_format, pin_memory = tensor_properties_input
 
             expected_st_metadata = sharded_tensor.ShardedTensorMetadata(
                 shard_metadatas,
                 (10, 10),
-                TensorProperties(
-                    dtype, layout, requires_grad, memory_format, pin_memory
-                ),
+                TensorProperties(dtype, layout, requires_grad, memory_format, pin_memory)
             )
 
             pickled_obj = pickle.dumps(expected_st_metadata)
             st_metadata = pickle.loads(pickled_obj)
             self.assertEqual(expected_st_metadata, st_metadata)
 
-
 class TestCreateTensorFromParams(TestCase):
-    @sandcastle_skip_if(torch.cuda.device_count() < 1, "CUDA GPU is needed")
+    @sandcastle_skip_if(torch.cuda.device_count() < 1, 'CUDA GPU is needed')
     def test_empty(self):
         expected_dtype = torch.double
         tensor_properties = TensorProperties(
@@ -148,12 +119,10 @@ class TestCreateTensorFromParams(TestCase):
             layout=torch.strided,
             requires_grad=False,
             pin_memory=False,
-            memory_format=torch.contiguous_format,
-        )
-        local_device = torch.device("cuda:0")
+            memory_format=torch.contiguous_format)
+        local_device = torch.device('cuda:0')
         local_tensor = _create_tensor_from_params(
-            5, 10, local_device=local_device, tensor_properties=tensor_properties
-        )
+            5, 10, local_device=local_device, tensor_properties=tensor_properties)
         self.assertEqual(local_device, local_tensor.device)
         self.assertEqual(expected_dtype, local_tensor.dtype)
         self.assertEqual(torch.strided, local_tensor.layout)
@@ -177,7 +146,7 @@ class TestShardParameter(ShardedTensorTestBase):
 
         fc = torch.nn.Linear(12, 12).cuda(self.rank)
         weight_og = fc.weight.clone()
-        shard_parameter(fc, "weight", spec)
+        shard_parameter(fc, 'weight', spec)
 
         # Verify.
         self.assertTrue(isinstance(fc.weight, ShardedTensor))
@@ -186,9 +155,7 @@ class TestShardParameter(ShardedTensorTestBase):
         self.assertEqual(torch.Size([3, 12]), local_shards[0].tensor.size())
         self.assertEqual(3, local_shards[0].tensor.size(0))
         self.assertEqual(12, local_shards[0].tensor.size(1))
-        self.assertEqual(
-            torch.narrow(weight_og, 0, 3 * self.rank, 3), local_shards[0].tensor
-        )
+        self.assertEqual(torch.narrow(weight_og, 0, 3 * self.rank, 3), local_shards[0].tensor)
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
@@ -205,22 +172,20 @@ class TestShardParameter(ShardedTensorTestBase):
         )
 
         fc = torch.nn.Linear(12, 12).cuda(self.rank)
-        with self.assertRaisesRegex(ValueError, "does not match with src_rank"):
-            shard_parameter(fc, "weight", spec, src_rank=self.rank)
+        with self.assertRaisesRegex(ValueError, 'does not match with src_rank'):
+            shard_parameter(fc, 'weight', spec, src_rank=self.rank)
 
-        with self.assertRaisesRegex(AttributeError, "has no attribute"):
-            shard_parameter(fc, "foo", spec)
+        with self.assertRaisesRegex(AttributeError, 'has no attribute'):
+            shard_parameter(fc, 'foo', spec)
 
-        with self.assertRaisesRegex(
-            ValueError, "Expected Linear.bias to be a Tensor, but found str"
-        ):
+        with self.assertRaisesRegex(ValueError, 'Expected Linear.bias to be a Tensor, but found str'):
             del fc.bias
             fc.bias = "foo"
-            shard_parameter(fc, "bias", spec)
+            shard_parameter(fc, 'bias', spec)
 
-        with self.assertRaisesRegex(ValueError, "not a contiguous Tensor"):
+        with self.assertRaisesRegex(ValueError, 'not a contiguous Tensor'):
             fc.bias = torch.rand(10, 10).cuda(self.rank).t()
-            shard_parameter(fc, "bias", spec)
+            shard_parameter(fc, 'bias', spec)
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -231,25 +196,23 @@ class TestShardParameter(ShardedTensorTestBase):
                 "rank:3/cuda:3",
             ],
         )
-        with self.assertRaisesRegex(ValueError, "does not match with sharding_spec"):
-            shard_parameter(fc, "weight", spec)
+        with self.assertRaisesRegex(ValueError, 'does not match with sharding_spec'):
+            shard_parameter(fc, 'weight', spec)
 
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
-                ),
-            ]
-        )
-        with self.assertRaisesRegex(NotImplementedError, "not implemented yet!"):
-            shard_parameter(fc, "weight", spec)
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="rank:1/cuda:1",
+            ),
+        ])
+        with self.assertRaisesRegex(NotImplementedError, 'not implemented yet!'):
+            shard_parameter(fc, 'weight', spec)
 
 
 class TestShardTensor(ShardedTensorTestBase):
@@ -291,10 +254,10 @@ class TestShardTensor(ShardedTensorTestBase):
         )
         tensor = torch.rand(12, 12).cuda(self.rank)
 
-        with self.assertRaisesRegex(ValueError, "does not match with src_rank"):
+        with self.assertRaisesRegex(ValueError, 'does not match with src_rank'):
             _shard_tensor(tensor, spec, src_rank=self.rank)
 
-        with self.assertRaisesRegex(ValueError, "not a contiguous Tensor"):
+        with self.assertRaisesRegex(ValueError, 'not a contiguous Tensor'):
             tensor_t = torch.rand(12, 12).cuda(self.rank).t()
             _shard_tensor(tensor_t, spec)
 
@@ -307,24 +270,24 @@ class TestShardTensor(ShardedTensorTestBase):
                 "rank:3/cuda:3",
             ],
         )
-        with self.assertRaisesRegex(ValueError, "does not match with sharding_spec"):
+        with self.assertRaisesRegex(ValueError, 'does not match with sharding_spec'):
             _shard_tensor(tensor, spec)
 
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
-                ),
-            ]
-        )
-        with self.assertRaisesRegex(NotImplementedError, "not implemented yet!"):
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="rank:1/cuda:1",
+            ),
+        ])
+        with self.assertRaisesRegex(
+            NotImplementedError, 'not implemented yet!'
+        ):
             _shard_tensor(tensor, spec)
 
 
@@ -423,6 +386,7 @@ class TestLocalTensor(ShardedTensorTestBase):
 
 
 class TestShardedTensorChunked(ShardedTensorTestBase):
+
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
@@ -510,9 +474,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                     self.assertEqual([1, 20], shard_metadata.shard_sizes)
                 else:
                     self.assertEqual([3, 20], shard_metadata.shard_sizes)
-                self.assertEqual(
-                    f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement)
-                )
+                self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
 
             # Validate remote shards.
             remote_shards = st.remote_shards()
@@ -523,20 +485,18 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                 for remote_shard in shards:
                     self.assertEqual(rpc_rank, remote_shard.owner().id)
                     shard = remote_shard.to_here()
-                    self.assertEqual(
-                        f"rank:{rpc_rank}/cuda:{rpc_rank}",
-                        str(shard.metadata.placement),
-                    )
+                    self.assertEqual(f'rank:{rpc_rank}/cuda:{rpc_rank}', str(shard.metadata.placement))
                     if rpc_rank == 3:
                         self.assertEqual((1, 20), shard.tensor.size())
                     else:
                         self.assertEqual((3, 20), shard.tensor.size())
 
+
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_with_ones(self):
-        """Test sharded_tensor.ones(...)"""
+        """ Test sharded_tensor.ones(...) """
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -564,7 +524,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_gather_even(self) -> None:
-        """Test _sharded_tensor.gather(...) with evenly distributed._shards"""
+        """ Test _sharded_tensor.gather(...) with evenly distributed._shards"""
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -597,7 +557,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_gather_uneven(self) -> None:
-        """Test _sharded_tensor.gather(...) with unevenly distributed._shards"""
+        """ Test _sharded_tensor.gather(...) with unevenly distributed._shards"""
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -631,7 +591,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_with_zeros(self):
-        """Test sharded_tensor.zeros(...)"""
+        """ Test sharded_tensor.zeros(...) """
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -655,11 +615,12 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.assertEqual((expected_h, w), local_shard.size())
         self.assertEqual(local_shard, torch.zeros(expected_h, w))
 
+
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_with_rand(self):
-        """Test sharded_tensor.rand(...)/randn(...)"""
+        """ Test sharded_tensor.rand(...)/randn(...) """
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -710,7 +671,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_with_full(self):
-        """Test sharded_tensor.full(...)"""
+        """ Test sharded_tensor.full(...) """
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -723,9 +684,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         )
         h, w = 10, 20
         fill_value = 1234
-        st = sharded_tensor.full(
-            spec, size=(h, w), fill_value=fill_value, dtype=torch.int32
-        )
+        st = sharded_tensor.full(spec, size=(h, w), fill_value=fill_value, dtype=torch.int32)
 
         # Validate local shard is initialized with torch.full
         local_shards = st.local_shards()
@@ -735,16 +694,14 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         # The split: for rank!=3 ceil(h/4)=3  for rank=3 1
         expected_h = 1 if self.rank == 3 else math.ceil(h / 4)
         self.assertEqual((expected_h, w), local_shard.size())
-        self.assertEqual(
-            local_shard,
-            torch.full(size=(expected_h, w), fill_value=fill_value, dtype=torch.int32),
-        )
+        self.assertEqual(local_shard,
+                         torch.full(size=(expected_h, w), fill_value=fill_value, dtype=torch.int32))
 
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_like(self):
-        """Test tensor like methods, i.e. torch.zeros_like(...), torch.full_like, etc."""
+        """ Test tensor like methods, i.e. torch.zeros_like(...), torch.full_like, etc. """
 
         spec = ChunkShardingSpec(
             dim=0,
@@ -767,28 +724,22 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             torch.rand_like: torch.rand,
             torch.randn_like: torch.randn,
             torch.empty_like: torch.empty,
-            torch.full_like: torch.full,
+            torch.full_like: torch.full
         }
         for op, expect_local_op in tensor_like_ops.items():
             if op == torch.full_like:
                 # special handle full/full_like as it needs to have additional fill_value arg
-                expect_tensor = expect_local_op(
-                    (expected_h, w), 8.8, device=expected_device, dtype=dtype
-                )
+                expect_tensor = expect_local_op((expected_h, w), 8.8, device=expected_device, dtype=dtype)
                 new_op_st = op(st, 8.8, dtype=dtype)
                 self.assertEqual(new_op_st.local_tensor(), expect_tensor)
             elif op == torch.empty_like:
                 # empty/empty_like we only compare the shape
-                expect_tensor = expect_local_op(
-                    expected_h, w, device=expected_device, dtype=dtype
-                )
+                expect_tensor = expect_local_op(expected_h, w, device=expected_device, dtype=dtype)
                 new_op_st = op(st, dtype=dtype)
                 self.assertEqual(new_op_st.local_tensor().shape, expect_tensor.shape)
             else:
                 torch.manual_seed(seed)
-                expect_tensor = expect_local_op(
-                    expected_h, w, device=expected_device, dtype=dtype
-                )
+                expect_tensor = expect_local_op(expected_h, w, device=expected_device, dtype=dtype)
                 torch.manual_seed(seed)
                 new_op_st = op(st, dtype=dtype)
                 self.assertEqual(new_op_st.local_tensor(), expect_tensor)
@@ -825,10 +776,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         for shard_rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual([shard_rank * 5, 0], shard_metadata.shard_offsets)
             self.assertEqual([5, 20], shard_metadata.shard_sizes)
-            self.assertEqual(
-                f"rank:{shard_rank + 2}/cuda:{shard_rank + 2}",
-                str(shard_metadata.placement),
-            )
+            self.assertEqual(f'rank:{shard_rank + 2}/cuda:{shard_rank + 2}', str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -842,9 +790,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             for remote_shard in shards:
                 self.assertEqual(rpc_rank, remote_shard.owner().id)
                 shard = remote_shard.to_here()
-                self.assertEqual(
-                    f"rank:{rpc_rank}/cuda:{rpc_rank}", str(shard.metadata.placement)
-                )
+                self.assertEqual(f'rank:{rpc_rank}/cuda:{rpc_rank}', str(shard.metadata.placement))
                 self.assertEqual((5, 20), shard.tensor.size())
 
     @with_comms
@@ -881,10 +827,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         for shard_rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual([shard_rank * 5, 0], shard_metadata.shard_offsets)
             self.assertEqual([5, 20], shard_metadata.shard_sizes)
-            self.assertEqual(
-                f"rank:{shard_rank + 1}/cuda:{shard_rank + 2}",
-                str(shard_metadata.placement),
-            )
+            self.assertEqual(f'rank:{shard_rank + 1}/cuda:{shard_rank + 2}', str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -898,10 +841,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             for remote_shard in shards:
                 shard = remote_shard.to_here()
                 self.assertEqual(rpc_rank, remote_shard.owner().id)
-                self.assertEqual(
-                    f"rank:{rpc_rank - 1}/cuda:{rpc_rank}",
-                    str(shard.metadata.placement),
-                )
+                self.assertEqual(f'rank:{rpc_rank - 1}/cuda:{rpc_rank}', str(shard.metadata.placement))
                 self.assertEqual((5, 20), shard.tensor.size())
 
     @with_comms
@@ -927,9 +867,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         local_shards = st.local_shards()
         self.assertEqual(2, len(local_shards))
         for local_shard in local_shards:
-            self.assertEqual(
-                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
-            )
+            self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
             self.assertEqual((2, 20), local_shard.tensor.size())
 
         # Validate global metadata.
@@ -940,10 +878,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         for shard_idx, shard_metadata in enumerate(shards_metadata):
             self.assertEqual([shard_idx * 2, 0], shard_metadata.shard_offsets)
             self.assertEqual([2, 20], shard_metadata.shard_sizes)
-            self.assertEqual(
-                f"rank:{shard_idx % 4}/cuda:{shard_idx % 4}",
-                str(shard_metadata.placement),
-            )
+            self.assertEqual(f'rank:{shard_idx % 4}/cuda:{shard_idx % 4}', str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -955,6 +890,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
                 shard = remote_shard.to_here()
                 self.assertEqual((2, 20), shard.tensor.size())
                 self.assertEqual(rpc_rank, remote_shard.owner().id)
+
 
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
@@ -989,72 +925,55 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
             for rank, shard_metadata in enumerate(shards_metadata):
                 self.assertEqual([0, rank * 8], shard_metadata.shard_offsets)
                 self.assertEqual([10, 8], shard_metadata.shard_sizes)
-                self.assertEqual(
-                    f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement)
-                )
+                self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
 
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_invalid_sharding(self):
         self.init_pg()
 
-        with self.assertRaisesRegex(
-            NotImplementedError, "does not support named dimension"
-        ):
-            spec = ChunkShardingSpec(dim="H", placements=["rank:1/cuda:1"])
+        with self.assertRaisesRegex(NotImplementedError, 'does not support named dimension'):
+            spec = ChunkShardingSpec(dim='H', placements=["rank:1/cuda:1"])
             sharded_tensor.empty(spec, 10, 20)
 
         for dim in [2, 3, 4, -3, -4, -5]:
             spec = ChunkShardingSpec(dim=dim, placements=["rank:1/cuda:1"])
-            with self.assertRaisesRegex(ValueError, "Invalid sharding dim"):
+            with self.assertRaisesRegex(ValueError, 'Invalid sharding dim'):
                 sharded_tensor.empty(spec, 10, 20)
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:5/cuda:1"])
-        with self.assertRaisesRegex(ValueError, "Invalid rank"):
+        with self.assertRaisesRegex(ValueError, 'Invalid rank'):
             sharded_tensor.empty(spec, 10, 20)
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
         st = sharded_tensor.empty(spec, 10, 20)
         tensor = torch.empty(10, 20)
-        with self.assertRaisesRegex(
-            RuntimeError, "not supported yet for ShardedTensor!"
-        ):
+        with self.assertRaisesRegex(RuntimeError, "not supported yet for ShardedTensor!"):
             torch.add(st, tensor)
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
-        with self.assertRaisesRegex(
-            ValueError, "Only torch.strided layout is currently supported"
-        ):
+        with self.assertRaisesRegex(ValueError, 'Only torch.strided layout is currently supported'):
             sharded_tensor.empty(spec, 10, 20, layout=torch.sparse_coo)
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
-        with self.assertRaisesRegex(
-            ValueError,
-            "Only torch.contiguous_format memory_format is currently supported",
-        ):
+        with self.assertRaisesRegex(ValueError, 'Only torch.contiguous_format memory_format is currently supported'):
             sharded_tensor.empty(spec, 10, 20, memory_format=torch.channels_last)
 
         spec = ChunkShardingSpec(dim=0, placements=["worker0/cuda:1"])
-        with self.assertRaisesRegex(
-            RuntimeError, "RPC framework needs to be initialized"
-        ):
+        with self.assertRaisesRegex(RuntimeError, 'RPC framework needs to be initialized'):
             sharded_tensor.empty(spec, 10, 20)
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:0/cuda:1"])
-        with self.assertRaisesRegex(
-            RuntimeError, "RPC Framework needs to be initialized"
-        ):
+        with self.assertRaisesRegex(RuntimeError, 'RPC Framework needs to be initialized'):
             st = sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
-        with self.assertRaisesRegex(
-            RuntimeError, "ShardedTensor created with init_rrefs=False"
-        ):
+        with self.assertRaisesRegex(RuntimeError, 'ShardedTensor created with init_rrefs=False'):
             st = sharded_tensor.empty(spec, 10, 20)
             st.remote_shards()
 
         self.init_rpc()
         spec = ChunkShardingSpec(dim=0, placements=["workerfoo/cuda:1"])
-        with self.assertRaisesRegex(ValueError, "Invalid worker name"):
+        with self.assertRaisesRegex(ValueError, 'Invalid worker name'):
             sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
     @skip_if_lt_x_gpu(4)
@@ -1063,22 +982,18 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.init_pg()
 
         # Init RPC with different ranks.
-        rpc_backend_options = rpc.TensorPipeRpcBackendOptions(
-            _transports=tp_transports()
-        )
+        rpc_backend_options = rpc.TensorPipeRpcBackendOptions(_transports=tp_transports())
         rpc_backend_options.init_method = f"file://{self.file_name}"
         rank = (self.rank + 1) % self.world_size
         rpc.init_rpc(
-            name=f"worker{rank}",
+            name=f'worker{rank}',
             rank=rank,
             world_size=self.world_size,
             rpc_backend_options=rpc_backend_options,
         )
 
         spec = ChunkShardingSpec(dim=0, placements=["rank:1/cuda:1"])
-        with self.assertRaisesRegex(
-            ValueError, "Default ProcessGroup and RPC ranks must be the same"
-        ):
+        with self.assertRaisesRegex(ValueError, 'Default ProcessGroup and RPC ranks must be the same'):
             sharded_tensor.empty(spec, 10, 20, init_rrefs=True)
 
     @skip_if_lt_x_gpu(4)
@@ -1115,9 +1030,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         for shard_rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual([shard_rank, 0], shard_metadata.shard_offsets)
             self.assertEqual([1, 20], shard_metadata.shard_sizes)
-            self.assertEqual(
-                f"rank:{shard_rank}/cuda:{shard_rank}", str(shard_metadata.placement)
-            )
+            self.assertEqual(f'rank:{shard_rank}/cuda:{shard_rank}', str(shard_metadata.placement))
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -1166,13 +1079,13 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.assertEqual(st.ndim, 2)
         # Test with invalid input
         st = sharded_tensor.empty(spec, (10, 20), init_rrefs=True)
-        with self.assertRaisesRegex(IndexError, "Dimension out of range"):
+        with self.assertRaisesRegex(IndexError, 'Dimension out of range'):
             st.size(-3)
-        with self.assertRaisesRegex(IndexError, "Dimension out of range"):
+        with self.assertRaisesRegex(IndexError, 'Dimension out of range'):
             st.size(2)
 
         with self.assertRaises(TypeError):
-            st = sharded_tensor.empty(spec, "foo")
+            st = sharded_tensor.empty(spec, 'foo')
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -1213,11 +1126,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
         self.assertTrue("submodule.sharded_tensor2" in loaded_dict_keys)
         # Verify after load.
         self.assertTrue(torch.equal(m.sharded_tensor1, module_load.sharded_tensor1))
-        self.assertTrue(
-            torch.equal(
-                m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2
-            )
-        )
+        self.assertTrue(torch.equal(m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2))
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -1253,11 +1162,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
         # Verify after load.
         self.assertTrue(torch.equal(m.sharded_tensor1, module_load.sharded_tensor1))
-        self.assertTrue(
-            torch.equal(
-                m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2
-            )
-        )
+        self.assertTrue(torch.equal(m.submodule.sharded_tensor2, module_load.submodule.sharded_tensor2))
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -1318,21 +1223,17 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
         buffer.seek(0)
         if self.rank != 0:
-            with self.assertRaisesRegex(RuntimeError, "Local rank at save time was"):
+            with self.assertRaisesRegex(RuntimeError, 'Local rank at save time was'):
                 with load_with_process_group(pg):
                     state_dict_deser = torch.load(buffer)
         else:
-            with self.assertRaisesRegex(
-                RuntimeError, "Local world size at save time was"
-            ):
+            with self.assertRaisesRegex(RuntimeError, 'Local world size at save time was'):
                 with load_with_process_group(pg):
                     state_dict_deser = torch.load(buffer)
 
         dist.destroy_process_group()
         buffer.seek(0)
-        with self.assertRaisesRegex(
-            RuntimeError, "Need to initialize default process group"
-        ):
+        with self.assertRaisesRegex(RuntimeError, 'Need to initialize default process group'):
             state_dict_deser = torch.load(buffer)
         rpc.shutdown()
 
@@ -1340,6 +1241,7 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_cleanup(self):
+
         def create_tensors():
             spec = ChunkShardingSpec(
                 dim=0,
@@ -1358,34 +1260,33 @@ class TestShardedTensorChunked(ShardedTensorTestBase):
 
 
 class TestShardedTensorEnumerable(ShardedTensorTestBase):
+
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_sharded_tensor_metadata(self):
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:2/cuda:2",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:3/cuda:3",
-                ),
-            ]
-        )
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[0, 5],
+                shard_sizes=[5, 5],
+                placement="rank:1/cuda:1",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="rank:2/cuda:2",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 5],
+                shard_sizes=[5, 5],
+                placement="rank:3/cuda:3",
+            )
+        ])
 
         st = sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         st_metadata = st.metadata()
@@ -1403,30 +1304,28 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         self.assertEqual(torch.double, st.dtype)
 
         # Need CPU for pin_memory
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cpu",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:1/cpu",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:2/cpu",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:3/cpu",
-                ),
-            ]
-        )
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cpu",
+            ),
+            ShardMetadata(
+                shard_offsets=[0, 5],
+                shard_sizes=[5, 5],
+                placement="rank:1/cpu",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="rank:2/cpu",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 5],
+                shard_sizes=[5, 5],
+                placement="rank:3/cpu",
+            )
+        ])
 
         st = sharded_tensor.empty(spec, 10, 10, pin_memory=True, init_rrefs=True)
         self.assertTrue(st.is_pinned())
@@ -1436,30 +1335,28 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @requires_nccl()
     def test_grid_sharding(self):
 
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:2/cuda:2",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:3/cuda:3",
-                ),
-            ]
-        )
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[0, 5],
+                shard_sizes=[5, 5],
+                placement="rank:1/cuda:1",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="rank:2/cuda:2",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 5],
+                shard_sizes=[5, 5],
+                placement="rank:3/cuda:3",
+            )
+        ])
 
         st = sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         self.assertEqual((10, 10), st.size())
@@ -1467,29 +1364,22 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
         self.assertEqual((5, 5), local_shard.tensor.size())
 
         # Verify local shard metadata.
-        self.assertEqual(
-            (self.rank // 2 * 5, (self.rank % 2) * 5),
-            local_shard.metadata.shard_offsets,
-        )
+        self.assertEqual((self.rank // 2 * 5, (self.rank % 2) * 5), local_shard.metadata.shard_offsets)
         self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-        self.assertEqual(
-            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
-        )
+        self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
 
         # Verify global metadata.
         st_metadata = st.metadata()
         shards_metadata = st_metadata.shards_metadata
         self.assertEqual(4, len(shards_metadata))
         for rank, shard_metadata in enumerate(shards_metadata):
-            self.assertEqual(
-                (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
-            )
+            self.assertEqual((rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets)
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
+            self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -1506,32 +1396,30 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_create_sharded_tensor_with_ones(self):
-        """Test sharded_tensor.ones(...)"""
+        """ Test sharded_tensor.ones(...) """
 
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:2/cuda:2",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:3/cuda:3",
-                ),
-            ]
-        )
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[0, 5],
+                shard_sizes=[5, 5],
+                placement="rank:1/cuda:1",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="rank:2/cuda:2",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 5],
+                shard_sizes=[5, 5],
+                placement="rank:3/cuda:3",
+            )
+        ])
 
         st = sharded_tensor.ones(spec, 10, 10, init_rrefs=True)
         self.assertEqual((10, 10), st.size())
@@ -1539,7 +1427,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
         # Verify local shard is initialized with torch.ones
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
         self.assertEqual((5, 5), local_shard.tensor.size())
         self.assertEqual(local_shard.tensor, torch.ones(5, 5))
 
@@ -1547,32 +1435,30 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_gather_even(self) -> None:
-        """Test _sharded_tensor.gather(...) with evenly distributed._shards"""
+        """ Test _sharded_tensor.gather(...) with evenly distributed._shards"""
 
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:2/cuda:2",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:3/cuda:3",
-                ),
-            ]
-        )
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[0, 5],
+                shard_sizes=[5, 5],
+                placement="rank:1/cuda:1",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="rank:2/cuda:2",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 5],
+                shard_sizes=[5, 5],
+                placement="rank:3/cuda:3",
+            )
+        ])
 
         h, w = 10, 10
         st = sharded_tensor.ones(spec, h, w, init_rrefs=True)
@@ -1580,7 +1466,11 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         full_tensor = None
         dst = 0
         if self.rank == dst:
-            full_tensor = torch.zeros(h, w, device=torch.device(f"cuda:{dst}"))
+            full_tensor = torch.zeros(
+                h,
+                w,
+                device=torch.device(f"cuda:{dst}")
+            )
         st.gather(dst, full_tensor)
 
         if self.rank == dst:
@@ -1592,32 +1482,30 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_gather_uneven(self) -> None:
-        """Test _sharded_tensor.gather(...) with unevenly distributed._shards"""
+        """ Test _sharded_tensor.gather(...) with unevenly distributed._shards"""
 
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:3/cuda:3",
-                ),
-            ]
-        )
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[0, 5],
+                shard_sizes=[5, 5],
+                placement="rank:1/cuda:1",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 5],
+                shard_sizes=[5, 5],
+                placement="rank:3/cuda:3",
+            )
+        ])
 
         h, w = 10, 10
         st = sharded_tensor.ones(spec, h, w, init_rrefs=True)
@@ -1625,7 +1513,11 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         full_tensor = None
         dst = 0
         if self.rank == dst:
-            full_tensor = torch.zeros(h, w, device=torch.device(f"cuda:{dst}"))
+            full_tensor = torch.zeros(
+                h,
+                w,
+                device=torch.device(f"cuda:{dst}")
+            )
         st.gather(dst, full_tensor)
 
         if self.rank == dst:
@@ -1677,9 +1569,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         self.assertIsInstance(new_st._process_group, distributed_c10d.ProcessGroupGloo)
         # test specs before and after the move almost the same except placement device
         self.assertEqual(spec_before_move.dim, spec_after_move.dim)
-        self.assertEqual(
-            len(spec_before_move.placements), len(spec_after_move.placements)
-        )
+        self.assertEqual(len(spec_before_move.placements), len(spec_after_move.placements))
         for i, remote_device_after in enumerate(spec_after_move.placements):
             remote_device_before = spec_before_move.placements[i]
             self.assertEqual(remote_device_before.rank(), remote_device_after.rank())
@@ -1763,9 +1653,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         self.assertIsInstance(spec_after_move, ChunkShardingSpec)
         # test specs before and after the move almost the same except placement device
         self.assertEqual(spec_before_move.dim, spec_after_move.dim)
-        self.assertEqual(
-            len(spec_before_move.placements), len(spec_after_move.placements)
-        )
+        self.assertEqual(len(spec_before_move.placements), len(spec_after_move.placements))
         for i, remote_device_after in enumerate(spec_after_move.placements):
             remote_device_before = spec_before_move.placements[i]
             self.assertEqual(remote_device_before.rank(), remote_device_after.rank())
@@ -1880,30 +1768,28 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     def test_uneven_shards(self):
         self.init_pg()
 
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[2, 4],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 4],
-                    shard_sizes=[4, 2],
-                    placement="rank:1/cuda:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[2, 0],
-                    shard_sizes=[4, 4],
-                    placement="rank:2/cuda:2",
-                ),
-                ShardMetadata(
-                    shard_offsets=[4, 4],
-                    shard_sizes=[2, 2],
-                    placement="rank:3/cuda:3",
-                ),
-            ]
-        )
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[2, 4],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[0, 4],
+                shard_sizes=[4, 2],
+                placement="rank:1/cuda:1",
+            ),
+            ShardMetadata(
+                shard_offsets=[2, 0],
+                shard_sizes=[4, 4],
+                placement="rank:2/cuda:2",
+            ),
+            ShardMetadata(
+                shard_offsets=[4, 4],
+                shard_sizes=[2, 2],
+                placement="rank:3/cuda:3",
+            ),
+        ])
 
         st = sharded_tensor.empty(spec, 6, 6)
         self.assertEqual((6, 6), st.size())
@@ -1931,15 +1817,13 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
         verify_size(self.rank, local_shard.tensor.size())
 
         # Verify local shard metadata.
         verify_offsets(self.rank, local_shard.metadata.shard_offsets)
         verify_size(self.rank, local_shard.metadata.shard_sizes)
-        self.assertEqual(
-            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
-        )
+        self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
 
         # Verify global metadata.
         st_metadata = st.metadata()
@@ -1948,26 +1832,24 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         for rank, shard_metadata in enumerate(shards_metadata):
             verify_offsets(rank, shard_metadata.shard_offsets)
             verify_size(rank, shard_metadata.shard_sizes)
-            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
+            self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
 
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_partial_world_size(self):
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
-                ),
-            ]
-        )
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="rank:1/cuda:1",
+            ),
+        ])
 
         st = sharded_tensor.empty(spec, 10, 5, init_rrefs=True)
         self.assertEqual((10, 5), st.size())
@@ -1979,18 +1861,13 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         if self.rank <= 1:
             # Verify local shard.
             local_shard = st.local_shards()[0]
-            self.assertEqual(
-                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
-            )
+            self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
             self.assertEqual((5, 5), local_shard.tensor.size())
 
             # Verify local shard metadata.
             self.assertEqual((self.rank * 5, 0), local_shard.metadata.shard_offsets)
             self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-            self.assertEqual(
-                f"rank:{self.rank}/cuda:{self.rank}",
-                str(local_shard.metadata.placement),
-            )
+            self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
 
         # Verify global metadata.
         st_metadata = st.metadata()
@@ -1999,7 +1876,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         for rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual((rank * 5, 0), shard_metadata.shard_offsets)
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
+            self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2020,20 +1897,18 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_new_group(self):
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:2/cuda:3",
-                ),
-            ]
-        )
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:1",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="rank:2/cuda:3",
+            ),
+        ])
 
         pg = dist.new_group(ranks=[1, 2, 3])
 
@@ -2042,20 +1917,13 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         if self.rank == 1 or self.rank == 3:
             # Verify local shard.
             local_shard = st.local_shards()[0]
-            self.assertEqual(
-                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
-            )
+            self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
             self.assertEqual((5, 5), local_shard.tensor.size())
 
             # Verify local shard metadata.
-            self.assertEqual(
-                (self.rank // 2 * 5, 0), local_shard.metadata.shard_offsets
-            )
+            self.assertEqual((self.rank // 2 * 5, 0), local_shard.metadata.shard_offsets)
             self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-            self.assertEqual(
-                f"rank:{self.rank - 1}/cuda:{self.rank}",
-                str(local_shard.metadata.placement),
-            )
+            self.assertEqual(f'rank:{self.rank - 1}/cuda:{self.rank}', str(local_shard.metadata.placement))
 
         # Verify global metadata.
         st_metadata = st.metadata()
@@ -2064,9 +1932,7 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         for rank, shard_metadata in enumerate(shards_metadata):
             self.assertEqual((rank * 5, 0), shard_metadata.shard_offsets)
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(
-                f"rank:{rank * 2}/cuda:{rank * 2 + 1}", str(shard_metadata.placement)
-            )
+            self.assertEqual(f'rank:{rank * 2}/cuda:{rank * 2 + 1}', str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2088,30 +1954,28 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_multiple_local_shards(self):
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="rank:0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 5],
-                    shard_sizes=[5, 5],
-                    placement="rank:1/cuda:1",
-                ),
-            ]
-        )
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[0, 5],
+                shard_sizes=[5, 5],
+                placement="rank:1/cuda:1",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="rank:0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 5],
+                shard_sizes=[5, 5],
+                placement="rank:1/cuda:1",
+            )
+        ])
 
         st = sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         self.assertEqual((10, 10), st.size())
@@ -2121,20 +1985,13 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
             # Verify local shards.
             for idx, local_shard in enumerate(st.local_shards()):
-                self.assertEqual(
-                    torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
-                )
+                self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
                 self.assertEqual((5, 5), local_shard.tensor.size())
 
                 # Verify local shard metadata.
-                self.assertEqual(
-                    (idx * 5, self.rank * 5), local_shard.metadata.shard_offsets
-                )
+                self.assertEqual((idx * 5, self.rank * 5), local_shard.metadata.shard_offsets)
                 self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-                self.assertEqual(
-                    f"rank:{self.rank}/cuda:{self.rank}",
-                    str(local_shard.metadata.placement),
-                )
+                self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
         else:
             self.assertEqual(0, len(st.local_shards()))
 
@@ -2143,15 +2000,9 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
         shards_metadata = st_metadata.shards_metadata
         self.assertEqual(4, len(shards_metadata))
         for shard_rank, shard_metadata in enumerate(shards_metadata):
-            self.assertEqual(
-                (shard_rank // 2 * 5, (shard_rank % 2) * 5),
-                shard_metadata.shard_offsets,
-            )
+            self.assertEqual((shard_rank // 2 * 5, (shard_rank % 2) * 5), shard_metadata.shard_offsets)
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(
-                f"rank:{shard_rank % 2}/cuda:{shard_rank % 2}",
-                str(shard_metadata.placement),
-            )
+            self.assertEqual(f'rank:{shard_rank % 2}/cuda:{shard_rank % 2}', str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2172,30 +2023,28 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_with_rpc_names(self):
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="worker0/cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 5],
-                    shard_sizes=[5, 5],
-                    placement="worker1/cuda:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="worker2/cuda:2",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 5],
-                    shard_sizes=[5, 5],
-                    placement="worker3/cuda:3",
-                ),
-            ]
-        )
+        spec = EnumerableShardingSpec([
+            ShardMetadata(
+                shard_offsets=[0, 0],
+                shard_sizes=[5, 5],
+                placement="worker0/cuda:0",
+            ),
+            ShardMetadata(
+                shard_offsets=[0, 5],
+                shard_sizes=[5, 5],
+                placement="worker1/cuda:1",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 0],
+                shard_sizes=[5, 5],
+                placement="worker2/cuda:2",
+            ),
+            ShardMetadata(
+                shard_offsets=[5, 5],
+                shard_sizes=[5, 5],
+                placement="worker3/cuda:3",
+            )
+        ])
 
         st = sharded_tensor.empty(spec, 10, 10, init_rrefs=True)
         self.assertEqual((10, 10), st.size())
@@ -2203,29 +2052,22 @@ class TestShardedTensorEnumerable(ShardedTensorTestBase):
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
         self.assertEqual((5, 5), local_shard.tensor.size())
 
         # Verify local shard metadata.
-        self.assertEqual(
-            (self.rank // 2 * 5, (self.rank % 2) * 5),
-            local_shard.metadata.shard_offsets,
-        )
+        self.assertEqual((self.rank // 2 * 5, (self.rank % 2) * 5), local_shard.metadata.shard_offsets)
         self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-        self.assertEqual(
-            f"worker{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
-        )
+        self.assertEqual(f'worker{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
 
         # Verify global metadata.
         st_metadata = st.metadata()
         shards_metadata = st_metadata.shards_metadata
         self.assertEqual(4, len(shards_metadata))
         for rank, shard_metadata in enumerate(shards_metadata):
-            self.assertEqual(
-                (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
-            )
+            self.assertEqual((rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets)
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f"worker{rank}/cuda:{rank}", str(shard_metadata.placement))
+            self.assertEqual(f'worker{rank}/cuda:{rank}', str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2248,9 +2090,7 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
         local_shard_metadata = None
         rank_to_metadata = {}
         for shard_metadata in tensor_meta.shards_metadata:
-            rank, device = _parse_and_validate_remote_device(
-                pg, shard_metadata.placement
-            )
+            rank, device = _parse_and_validate_remote_device(pg, shard_metadata.placement)
             rank_to_metadata[rank] = shard_metadata
             if rank == self.rank:
                 local_tensor = torch.rand(shard_metadata.shard_sizes).cuda(device)
@@ -2332,7 +2172,9 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
         )
         st_size = [24, 12]
         local_tensor = torch.rand(*st_size).cuda(self.rank)
-        with self.assertRaisesRegex(ValueError, "do not cover the entire tensor"):
+        with self.assertRaisesRegex(
+            ValueError, "do not cover the entire tensor"
+        ):
             ShardedTensor._init_from_local_tensor(
                 local_tensor,
                 enumerable_sharding_spec,
@@ -2350,6 +2192,7 @@ class TestShardedTensorFromLocalTensor(ShardedTensorTestBase):
 
 
 class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
+
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
@@ -2358,22 +2201,24 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=shard_offsets,
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/cuda:{self.rank}"
         )
 
         local_tensor = torch.randn(5, 5, device=f"cuda:{self.rank}")
         local_shard = sharded_tensor.Shard(local_tensor, local_shard_metadata)
         local_shard_from_offsets = sharded_tensor.Shard.from_tensor_and_offsets(
-            local_tensor, shard_offsets=shard_offsets, rank=self.rank
+            local_tensor,
+            shard_offsets=shard_offsets,
+            rank=self.rank
         )
         self.assertEqual(local_shard.metadata, local_shard_from_offsets.metadata)
 
         wrong_local_shard_metadata = ShardMetadata(
             shard_offsets=shard_offsets,
             shard_sizes=[6, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/cuda:{self.rank}"
         )
-        with self.assertRaisesRegex(ValueError, "Shard tensor size does not match"):
+        with self.assertRaisesRegex(ValueError, 'Shard tensor size does not match'):
             local_shard_from_wrong_meta = sharded_tensor.Shard(
                 local_tensor,
                 metadata=wrong_local_shard_metadata,
@@ -2386,45 +2231,32 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/cuda:{self.rank}"
         )
 
-        local_shards = [
-            sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
-            )
-        ]
+        local_shards = [sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata)]
 
-        st = sharded_tensor.init_from_local_shards(
-            local_shards, [10, 10], init_rrefs=True
-        )
+        st = sharded_tensor.init_from_local_shards(local_shards, [10, 10], init_rrefs=True)
         self.assertEqual((10, 10), st.size())
         self.assertEqual(1, len(st.local_shards()))
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
         self.assertEqual((5, 5), local_shard.tensor.size())
 
         # Verify local shard metadata.
-        self.assertEqual(
-            (self.rank // 2 * 5, (self.rank % 2) * 5),
-            local_shard.metadata.shard_offsets,
-        )
+        self.assertEqual((self.rank // 2 * 5, (self.rank % 2) * 5), local_shard.metadata.shard_offsets)
         self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-        self.assertEqual(
-            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
-        )
+        self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
 
         # Verify global metadata.
         shards_metadata = st.metadata().shards_metadata
         self.assertEqual(4, len(shards_metadata))
         for rank, shard_metadata in enumerate(shards_metadata):
-            self.assertEqual(
-                (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
-            )
+            self.assertEqual((rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets)
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
+            self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2504,7 +2336,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/cuda:{self.rank}"
         )
 
         shards_metadata = []
@@ -2512,19 +2344,13 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             if r == self.rank:
                 shards_metadata.append(local_shard_metadata)
             else:
-                shards_metadata.append(
-                    ShardMetadata(
-                        shard_offsets=[(r // 2) * 5, (r % 2) * 5],
-                        shard_sizes=[5, 5],
-                        placement=f"rank:{r}/cuda:{r}",
-                    )
-                )
+                shards_metadata.append(ShardMetadata(
+                    shard_offsets=[(r // 2) * 5, (r % 2) * 5],
+                    shard_sizes=[5, 5],
+                    placement=f"rank:{r}/cuda:{r}"
+                ))
 
-        local_shards = [
-            sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
-            )
-        ]
+        local_shards = [sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata)]
 
         tensor_properties = TensorProperties(
             dtype=torch.get_default_dtype(),
@@ -2550,28 +2376,21 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
 
         # Verify local shard.
         local_shard = st.local_shards()[0]
-        self.assertEqual(torch.device(f"cuda:{self.rank}"), local_shard.tensor.device)
+        self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
         self.assertEqual((5, 5), local_shard.tensor.size())
 
         # Verify local shard metadata.
-        self.assertEqual(
-            (self.rank // 2 * 5, (self.rank % 2) * 5),
-            local_shard.metadata.shard_offsets,
-        )
+        self.assertEqual((self.rank // 2 * 5, (self.rank % 2) * 5), local_shard.metadata.shard_offsets)
         self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-        self.assertEqual(
-            f"rank:{self.rank}/cuda:{self.rank}", str(local_shard.metadata.placement)
-        )
+        self.assertEqual(f'rank:{self.rank}/cuda:{self.rank}', str(local_shard.metadata.placement))
 
         # Verify global metadata.
         shards_metadata = st.metadata().shards_metadata
         self.assertEqual(4, len(shards_metadata))
         for rank, shard_metadata in enumerate(shards_metadata):
-            self.assertEqual(
-                (rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets
-            )
+            self.assertEqual((rank // 2 * 5, (rank % 2) * 5), shard_metadata.shard_offsets)
             self.assertEqual((5, 5), shard_metadata.shard_sizes)
-            self.assertEqual(f"rank:{rank}/cuda:{rank}", str(shard_metadata.placement))
+            self.assertEqual(f'rank:{rank}/cuda:{rank}', str(shard_metadata.placement))
 
         # Validate remote shards.
         remote_shards = st.remote_shards()
@@ -2594,34 +2413,21 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             local_shard_metadata = ShardMetadata(
                 shard_offsets=[5 * (self.rank - 1), 0],
                 shard_sizes=[5, 5],
-                placement=f"rank:{self.rank - 1}/cuda:{self.rank}",
+                placement=f"rank:{self.rank - 1}/cuda:{self.rank}"
             )
-            local_shards = [
-                sharded_tensor.Shard(
-                    torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
-                )
-            ]
+            local_shards = [sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata)]
 
-            st = sharded_tensor.init_from_local_shards(
-                local_shards, [15, 5], process_group=new_pg
-            )
+            st = sharded_tensor.init_from_local_shards(local_shards, [15, 5], process_group=new_pg)
 
             # Verify local shard.
             local_shard = st.local_shards()[0]
-            self.assertEqual(
-                torch.device(f"cuda:{self.rank}"), local_shard.tensor.device
-            )
+            self.assertEqual(torch.device(f'cuda:{self.rank}'), local_shard.tensor.device)
             self.assertEqual((5, 5), local_shard.tensor.size())
 
             # Verify local shard metadata.
-            self.assertEqual(
-                ((self.rank - 1) * 5, 0), local_shard.metadata.shard_offsets
-            )
+            self.assertEqual(((self.rank - 1) * 5, 0), local_shard.metadata.shard_offsets)
             self.assertEqual((5, 5), local_shard.metadata.shard_sizes)
-            self.assertEqual(
-                f"rank:{self.rank - 1}/cuda:{self.rank}",
-                str(local_shard.metadata.placement),
-            )
+            self.assertEqual(f'rank:{self.rank - 1}/cuda:{self.rank}', str(local_shard.metadata.placement))
 
             # Verify global metadata.
             st_metadata = st.metadata()
@@ -2630,9 +2436,8 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             for rank, shard_metadata in enumerate(shards_metadata):
                 self.assertEqual((rank * 5, 0), shard_metadata.shard_offsets)
                 self.assertEqual((5, 5), shard_metadata.shard_sizes)
-                self.assertEqual(
-                    f"rank:{rank}/cuda:{rank + 1}", str(shard_metadata.placement)
-                )
+                self.assertEqual(f'rank:{rank}/cuda:{rank + 1}', str(shard_metadata.placement))
+
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -2641,57 +2446,36 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/cuda:{self.rank}"
         )
 
         indices = [[0, 1, 1], [2, 0, 2]]
         values = [3.2, 4.5, 5.8]
-        sparse_tensor = torch.sparse_coo_tensor(
-            indices, values, (5, 5), device=f"cuda:{self.rank}"
-        )
+        sparse_tensor = torch.sparse_coo_tensor(indices, values, (5, 5), device=f"cuda:{self.rank}")
 
         empty_local_shards = []
-        with self.assertRaisesRegex(ValueError, "have no local shards on all ranks"):
-            st = sharded_tensor.init_from_local_shards(
-                empty_local_shards, [10, 10], init_rrefs=True
-            )
+        with self.assertRaisesRegex(ValueError, 'have no local shards on all ranks'):
+            st = sharded_tensor.init_from_local_shards(empty_local_shards, [10, 10], init_rrefs=True)
 
         wrong_layout_shards = [
             sharded_tensor.Shard(sparse_tensor, local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            ValueError, "Only torch.strided layout is currently supported"
-        ):
+        with self.assertRaisesRegex(ValueError, 'Only torch.strided layout is currently supported'):
             st = sharded_tensor.init_from_local_shards(
-                wrong_layout_shards, [10, 10], init_rrefs=True
-            )
+                wrong_layout_shards, [10, 10], init_rrefs=True)
 
         wrong_memory_format_shards = [
-            sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata
-            )
+            sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            ValueError,
-            "Only torch.contiguous_format memory_format is currently supported",
-        ):
+        with self.assertRaisesRegex(ValueError, 'Only torch.contiguous_format memory_format is currently supported'):
             st = sharded_tensor.init_from_local_shards(
-                wrong_memory_format_shards, [10, 10], init_rrefs=True
-            )
+                wrong_memory_format_shards, [10, 10], init_rrefs=True)
 
-        with self.assertRaisesRegex(ValueError, "Shard tensor size does not match"):
-            wrong_size_shards = [
-                sharded_tensor.Shard(
-                    torch.randn(2, 3, device=f"cuda:{self.rank}"), local_shard_metadata
-                )
-            ]
+        with self.assertRaisesRegex(ValueError, 'Shard tensor size does not match'):
+            wrong_size_shards = [sharded_tensor.Shard(torch.randn(2, 3, device=f"cuda:{self.rank}"), local_shard_metadata)]
 
-        with self.assertRaisesRegex(
-            ValueError, "Local shard tensor device does not match"
-        ):
-            wrong_device_shards = [
-                sharded_tensor.Shard(torch.randn(5, 5), local_shard_metadata)
-            ]
+        with self.assertRaisesRegex(ValueError, "Local shard tensor device does not match"):
+            wrong_device_shards = [sharded_tensor.Shard(torch.randn(5, 5), local_shard_metadata)]
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -2700,58 +2484,37 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/cuda:{self.rank}"
         )
         tensor_overall_size = [10, 10] if self.rank == 0 else [10, 5]
         wrong_dtype_shards = [
-            sharded_tensor.Shard(
-                torch.ones(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
-            )
+            sharded_tensor.Shard(torch.ones(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            ValueError,
-            "ShardedTensor global_size property does not match from different ranks!",
-        ):
-            st = sharded_tensor.init_from_local_shards(
-                wrong_dtype_shards, tensor_overall_size, init_rrefs=True
-            )
+        with self.assertRaisesRegex(ValueError, "ShardedTensor global_size property does not match from different ranks!"):
+            st = sharded_tensor.init_from_local_shards(wrong_dtype_shards, tensor_overall_size, init_rrefs=True)
 
         tensor_dtype = torch.int if self.rank == 0 else torch.float32
         wrong_dtype_shards = [
-            sharded_tensor.Shard(
-                torch.ones(5, 5, device=f"cuda:{self.rank}", dtype=tensor_dtype),
-                local_shard_metadata,
-            )
+            sharded_tensor.Shard(torch.ones(5, 5, device=f"cuda:{self.rank}", dtype=tensor_dtype), local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            ValueError,
-            "ShardedTensor dtype property does not match from different ranks!",
-        ):
-            st = sharded_tensor.init_from_local_shards(
-                wrong_dtype_shards, [10, 10], init_rrefs=True
-            )
+        with self.assertRaisesRegex(ValueError, "ShardedTensor dtype property does not match from different ranks!"):
+            st = sharded_tensor.init_from_local_shards(wrong_dtype_shards, [10, 10], init_rrefs=True)
 
         tensor_requires_grad = True if self.rank == 0 else False
         wrong_requires_grad_shards = [
             sharded_tensor.Shard(
-                torch.randn(
-                    5, 5, device=f"cuda:{self.rank}", requires_grad=tensor_requires_grad
-                ),
-                local_shard_metadata,
+                torch.randn(5, 5, device=f"cuda:{self.rank}", requires_grad=tensor_requires_grad),
+                local_shard_metadata
             )
         ]
-        with self.assertRaisesRegex(
-            ValueError,
-            "ShardedTensor requires_grad property does not match from different ranks!",
-        ):
+        with self.assertRaisesRegex(ValueError, 'ShardedTensor requires_grad property does not match from different ranks!'):
             st = sharded_tensor.init_from_local_shards(
-                wrong_requires_grad_shards, [10, 10], init_rrefs=True
-            )
+                wrong_requires_grad_shards, [10, 10], init_rrefs=True)
 
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cpu",
+            placement=f"rank:{self.rank}/cpu"
         )
 
     @with_comms(init_rpc=False, backend="gloo")
@@ -2761,36 +2524,24 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cpu",
+            placement=f"rank:{self.rank}/cpu"
         )
         wrong_pin_memory_local_shards = [
-            sharded_tensor.Shard(
-                torch.randn(5, 5, pin_memory=True), local_shard_metadata
-            ),
-            sharded_tensor.Shard(
-                torch.randn(5, 5, pin_memory=False), local_shard_metadata
-            ),
+            sharded_tensor.Shard(torch.randn(5, 5, pin_memory=True), local_shard_metadata),
+            sharded_tensor.Shard(torch.randn(5, 5, pin_memory=False), local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            ValueError, "Local shards' tensor pin_memory property need to be the same"
-        ):
+        with self.assertRaisesRegex(ValueError, "Local shards' tensor pin_memory property need to be the same"):
             st = sharded_tensor.init_from_local_shards(
-                wrong_pin_memory_local_shards, [10, 10], init_rrefs=True
-            )
+                wrong_pin_memory_local_shards, [10, 10], init_rrefs=True)
 
         tensor_pin_memory = True if self.rank == 0 else False
         wrong_pin_memory_shards_cross_ranks = [
-            sharded_tensor.Shard(
-                torch.randn(5, 5, pin_memory=tensor_pin_memory), local_shard_metadata
-            )
+            sharded_tensor.Shard(torch.randn(5, 5, pin_memory=tensor_pin_memory), local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            ValueError,
-            "ShardedTensor pin_memory property does not match from different ranks!",
-        ):
+        with self.assertRaisesRegex(ValueError, 'ShardedTensor pin_memory property does not match from different ranks!'):
             st = sharded_tensor.init_from_local_shards(
-                wrong_pin_memory_shards_cross_ranks, [10, 10], init_rrefs=True
-            )
+                wrong_pin_memory_shards_cross_ranks, [10, 10], init_rrefs=True)
+
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -2800,20 +2551,14 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=local_shard_size,
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/cuda:{self.rank}"
         )
 
-        local_shards = [
-            sharded_tensor.Shard(
-                torch.randn(local_shard_size, device=f"cuda:{self.rank}"),
-                local_shard_metadata,
-            )
-        ]
+        local_shards = [sharded_tensor.Shard(torch.randn(local_shard_size, device=f"cuda:{self.rank}"), local_shard_metadata)]
 
         with self.assertRaisesRegex(ValueError, "overlap"):
-            sharded_tensor.init_from_local_shards(
-                local_shards, [10, 10], init_rrefs=True
-            )
+            sharded_tensor.init_from_local_shards(local_shards, [10, 10], init_rrefs=True)
+
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -2823,20 +2568,13 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=local_shard_size,
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/cuda:{self.rank}"
         )
 
-        local_shards = [
-            sharded_tensor.Shard(
-                torch.randn(local_shard_size, device=f"cuda:{self.rank}"),
-                local_shard_metadata,
-            )
-        ]
+        local_shards = [sharded_tensor.Shard(torch.randn(local_shard_size, device=f"cuda:{self.rank}"), local_shard_metadata)]
 
         with self.assertRaisesRegex(ValueError, "does not match tensor volume"):
-            sharded_tensor.init_from_local_shards(
-                local_shards, [10, 10], init_rrefs=True
-            )
+            sharded_tensor.init_from_local_shards(local_shards, [10, 10], init_rrefs=True)
 
     @with_comms
     @skip_if_lt_x_gpu(4)
@@ -2845,7 +2583,7 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         local_shard_metadata = ShardMetadata(
             shard_offsets=[(self.rank // 2) * 5, (self.rank % 2) * 5],
             shard_sizes=[5, 5],
-            placement=f"rank:{self.rank}/cuda:{self.rank}",
+            placement=f"rank:{self.rank}/cuda:{self.rank}"
         )
 
         shards_metadata = []
@@ -2853,13 +2591,11 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
             if r == self.rank:
                 shards_metadata.append(local_shard_metadata)
             else:
-                shards_metadata.append(
-                    ShardMetadata(
-                        shard_offsets=[(r // 2) * 5, (r % 2) * 5],
-                        shard_sizes=[5, 5],
-                        placement=f"rank:{r}/cuda:{r}",
-                    )
-                )
+                shards_metadata.append(ShardMetadata(
+                    shard_offsets=[(r // 2) * 5, (r % 2) * 5],
+                    shard_sizes=[5, 5],
+                    placement=f"rank:{r}/cuda:{r}"
+                ))
 
         tensor_properties = TensorProperties(
             dtype=torch.get_default_dtype(),
@@ -2876,120 +2612,85 @@ class TestShardedTensorFromLocalShards(ShardedTensorTestBase):
         )
 
         empty_local_shards = []
-        with self.assertRaisesRegex(
-            RuntimeError, "does not match number of local shards metadata"
-        ):
+        with self.assertRaisesRegex(RuntimeError, 'does not match number of local shards metadata'):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                empty_local_shards, sharded_tensor_metadata
+                empty_local_shards,
+                sharded_tensor_metadata
             )
 
         wrong_num_shards = [
-            sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
-            ),
-            sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata
-            ),
+            sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata),
+            sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}"), local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            RuntimeError, "does not match number of local shards metadata"
-        ):
+        with self.assertRaisesRegex(RuntimeError, 'does not match number of local shards metadata'):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_num_shards, sharded_tensor_metadata
+                wrong_num_shards,
+                sharded_tensor_metadata
             )
 
-        with self.assertRaisesRegex(
-            ValueError, "Shard tensor size does not match with metadata.shard_lengths"
-        ):
-            wrong_size_shards = [
-                sharded_tensor.Shard(
-                    torch.randn(2, 3, device=f"cuda:{self.rank}"), local_shard_metadata
-                )
-            ]
+        with self.assertRaisesRegex(ValueError, 'Shard tensor size does not match with metadata.shard_lengths'):
+            wrong_size_shards = [sharded_tensor.Shard(torch.randn(2, 3, device=f"cuda:{self.rank}"), local_shard_metadata)]
 
-        with self.assertRaisesRegex(
-            ValueError,
-            "Local shard tensor device does not match with local Shard's placement",
-        ):
-            wrong_device_shards = [
-                sharded_tensor.Shard(torch.randn(5, 5), local_shard_metadata)
-            ]
+        with self.assertRaisesRegex(ValueError, "Local shard tensor device does not match with local Shard's placement"):
+            wrong_device_shards = [sharded_tensor.Shard(torch.randn(5, 5), local_shard_metadata)]
 
         wrong_dtype_shards = [
-            sharded_tensor.Shard(
-                torch.ones(5, 5, device=f"cuda:{self.rank}", dtype=torch.int),
-                local_shard_metadata,
-            )
+            sharded_tensor.Shard(torch.ones(5, 5, device=f"cuda:{self.rank}", dtype=torch.int), local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            ValueError, "Local shards' tensor dtype property is incompatible with"
-        ):
+        with self.assertRaisesRegex(ValueError, "Local shards' tensor dtype property is incompatible with"):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_dtype_shards, sharded_tensor_metadata
+                wrong_dtype_shards,
+                sharded_tensor_metadata
             )
 
         indices = [[0, 1, 1], [2, 0, 2]]
         values = [3.2, 4.5, 5.8]
-        sparse_tensor = torch.sparse_coo_tensor(
-            indices, values, (5, 5), device=f"cuda:{self.rank}"
-        )
+        sparse_tensor = torch.sparse_coo_tensor(indices, values, (5, 5), device=f"cuda:{self.rank}")
 
         wrong_layout_shards = [
             sharded_tensor.Shard(sparse_tensor, local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            ValueError, "Local shards' tensor layout property is incompatible with"
-        ):
+        with self.assertRaisesRegex(ValueError, "Local shards' tensor layout property is incompatible with"):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_layout_shards, sharded_tensor_metadata
+                wrong_layout_shards,
+                sharded_tensor_metadata
             )
 
         wrong_requires_grad_shards = [
-            sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}", requires_grad=True),
-                local_shard_metadata,
-            )
+            sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}", requires_grad=True), local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            ValueError,
-            "Local shards' tensor requires_grad property is incompatible with",
-        ):
+        with self.assertRaisesRegex(ValueError, "Local shards' tensor requires_grad property is incompatible with"):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_requires_grad_shards, sharded_tensor_metadata
+                wrong_requires_grad_shards,
+                sharded_tensor_metadata
             )
 
         wrong_memory_format_shards = [
-            sharded_tensor.Shard(
-                torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata
-            )
+            sharded_tensor.Shard(torch.randn(5, 5, device=f"cuda:{self.rank}").t(), local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            ValueError,
-            "Only torch.contiguous_format memory_format is currently supported",
-        ):
+        with self.assertRaisesRegex(ValueError, 'Only torch.contiguous_format memory_format is currently supported'):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_memory_format_shards, sharded_tensor_metadata
+                wrong_memory_format_shards,
+                sharded_tensor_metadata
             )
         # pin_memory can only be on CPU
         local_shard_metadata.placement = _remote_device(f"rank:{self.rank}/cpu")
         wrong_pin_memory_shards = [
-            sharded_tensor.Shard(
-                torch.randn(5, 5, pin_memory=True), local_shard_metadata
-            )
+            sharded_tensor.Shard(torch.randn(5, 5, pin_memory=True), local_shard_metadata)
         ]
-        with self.assertRaisesRegex(
-            ValueError, "Local shards' tensor pin_memory property is incompatible with"
-        ):
+        with self.assertRaisesRegex(ValueError, "Local shards' tensor pin_memory property is incompatible with"):
             ShardedTensor._init_from_local_shards_and_global_metadata(
-                wrong_pin_memory_shards, sharded_tensor_metadata
+                wrong_pin_memory_shards,
+                sharded_tensor_metadata
             )
-
 
 class TestShardedTensorCustomOps(ShardedTensorTestBase):
+
     @with_comms
     @skip_if_lt_x_gpu(4)
     @requires_nccl()
     def test_custom_op(self):
+
         @custom_sharded_op_impl(torch.asin)
         def my_sharded_asin(types, args, kwargs, process_group):
             return torch.asin(args[0].local_shards()[0].tensor)
@@ -3031,7 +2732,7 @@ class TestShardedTensorCustomOps(ShardedTensorTestBase):
             ],
         )
         m = torch.nn.Linear(32, 16).cuda(self.rank)
-        shard_parameter(m, "weight", spec)
+        shard_parameter(m, 'weight', spec)
 
         result = m(torch.rand(15, 32).cuda(self.rank))
         self.assertEqual(t, result)
@@ -3041,18 +2742,15 @@ class TestShardedTensorCustomOps(ShardedTensorTestBase):
     @requires_nccl()
     def test_custom_op_errors(self):
 
-        with self.assertRaisesRegex(TypeError, "expects signature"):
-
+        with self.assertRaisesRegex(TypeError, 'expects signature'):
             @custom_sharded_op_impl(torch.nn.functional.linear)
             def my_op1(types, args, kwargs, process_group, random_param):
                 pass
 
-        with self.assertRaisesRegex(TypeError, "expects signature"):
-
+        with self.assertRaisesRegex(TypeError, 'expects signature'):
             @custom_sharded_op_impl(torch.nn.functional.linear)
             def my_op2(types):
                 pass
-
 
 class TestShardMetadata(ShardedTensorTestBase):
     @with_comms
@@ -3079,6 +2777,5 @@ class TestShardMetadata(ShardedTensorTestBase):
         shard = Shard(torch.zeros(10), md)
         self.assertIsNone(shard.metadata.placement)
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     run_tests()

--- a/torch/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/distributed/_shard/sharded_tensor/__init__.py
@@ -12,6 +12,7 @@ from .api import (
     _CUSTOM_SHARDED_OPS,
     _SHARDED_OPS,
     Shard,
+    ShardedTensorBase,
     ShardedTensor,
     ShardedTensorMetadata,
     TensorProperties,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82291

This PR added ShardedTensorBase, which is the base class of
ShardedTensor, and only contains local shards, ShardedTensorMetadata,
and does not have any communication backend attached (i.e ProcessGroup)

Differential Revision: [D38190272](https://our.internmc.facebook.com/intern/diff/D38190272)