### PR TITLE
[WIP]Use empty_quantized when pickling non-cpu qtensor

### DIFF
--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -685,7 +685,19 @@ WriteableTensorData getWriteableTensorData(
     // NB: This new tensor is created to support cuda tensors.
     // Storages can be mutated when converting tensors from cuda to cpu,
     // and we need a cpu tensor to copy data from.
-    result.tensor_ =
+    if(tensor.is_quantized()){
+      result.tensor_ =
+        at::empty_quantized({0}, tensor)
+            .set_(
+                tensor.storage(),
+                /* storage_offset = */ 0,
+                /* size = */
+                {static_cast<int64_t>(
+                    tensor.storage().nbytes() / tensor.element_size())},
+                /* stride = */ {1})
+            .cpu();
+    }else{
+      result.tensor_ =
         at::empty({0}, tensor.options())
             .set_(
                 tensor.storage(),
@@ -695,6 +707,7 @@ WriteableTensorData getWriteableTensorData(
                     tensor.storage().nbytes() / tensor.element_size())},
                 /* stride = */ {1})
             .cpu();
+    }
     TORCH_CHECK(
         result.tensor_.storage().nbytes() == result.size_,
         "Storage tensor size did not match record size");

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -685,28 +685,28 @@ WriteableTensorData getWriteableTensorData(
     // NB: This new tensor is created to support cuda tensors.
     // Storages can be mutated when converting tensors from cuda to cpu,
     // and we need a cpu tensor to copy data from.
-    if(tensor.is_quantized()){
+    if (tensor.is_quantized()) {
       result.tensor_ =
-        at::empty_quantized({0}, tensor)
-            .set_(
-                tensor.storage(),
-                /* storage_offset = */ 0,
-                /* size = */
-                {static_cast<int64_t>(
-                    tensor.storage().nbytes() / tensor.element_size())},
-                /* stride = */ {1})
-            .cpu();
-    }else{
+          at::empty_quantized({0}, tensor)
+              .set_(
+                  tensor.storage(),
+                  /* storage_offset = */ 0,
+                  /* size = */
+                  {static_cast<int64_t>(
+                      tensor.storage().nbytes() / tensor.element_size())},
+                  /* stride = */ {1})
+              .cpu();
+    } else {
       result.tensor_ =
-        at::empty({0}, tensor.options())
-            .set_(
-                tensor.storage(),
-                /* storage_offset = */ 0,
-                /* size = */
-                {static_cast<int64_t>(
-                    tensor.storage().nbytes() / tensor.element_size())},
-                /* stride = */ {1})
-            .cpu();
+          at::empty({0}, tensor.options())
+              .set_(
+                  tensor.storage(),
+                  /* storage_offset = */ 0,
+                  /* size = */
+                  {static_cast<int64_t>(
+                      tensor.storage().nbytes() / tensor.element_size())},
+                  /* stride = */ {1})
+              .cpu();
     }
     TORCH_CHECK(
         result.tensor_.storage().nbytes() == result.size_,


### PR DESCRIPTION
# Motivation
When use `torch.jit.save` to serialize a non-cpu model, the `pickler` would move tensors(e.g. weight/bias) to CPU firstly. The new CPU tensor is created through `at::empty`, which does not fit for quantized tensor.  

# Solution
Check whether original tensor is a quantized one before creating CPU copy. If original tensor is a quantized tensor, use `at::empty_quantied` to create CPU copy instead.


cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel