### PR TITLE
Add a miniature backend select implementation for prims

### DIFF
--- a/torch/_prims/__init__.py
+++ b/torch/_prims/__init__.py
@@ -31,6 +31,7 @@ from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten
 
 prim = torch.library.Library("prims", "DEF")
 prim_impl = torch.library.Library("prims", "IMPL", "CompositeExplicitAutograd")
+prim_backend_select_impl = torch.library.Library("prims", "IMPL", "BackendSelect")
 prim_autograd_impl = torch.library.Library("prims", "IMPL", "Autograd")
 prim_meta_impl = torch.library.Library("prims", "IMPL", "Meta")
 
@@ -453,13 +454,25 @@ def _make_prim(
         flat_args, args_spec = tree_flatten((args, kwargs))
         return BackwardsNotSupported.apply(args_spec, *flat_args)
 
+    _meta_impl = _wrap_tensor_meta(meta)
+
+    def _backend_select_impl(*args, **kwargs):
+        if kwargs.get("device") and kwargs["device"].type == "meta":
+            return _meta_impl(*args, **kwargs)
+        else:
+            return _prim_impl(*args, **kwargs)
+
     name = schema.split("(")[0]
     prim_impl.impl(name, _prim_impl)
     prim_autograd_impl.impl(name, _autograd_impl)
-    prim_meta_impl.impl(name, _wrap_tensor_meta(meta))
+    prim_meta_impl.impl(name, _meta_impl)
 
     _prim_packet = getattr(torch.ops.prims, name)
     _prim = _prim_packet.default
+
+    from torch._subclasses.fake_tensor import contains_tensor_types
+    if not any(contains_tensor_types(a.type) for a in _prim._schema.arguments):
+        prim_backend_select_impl.impl(name, _backend_select_impl)
 
     for p in (_prim_packet, _prim):
         p.__doc__ = doc


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #82333
* #82251
* __->__ #82311
* #82238

It turns out that for factory function prims (prims with no Tensor
arguments), we were always going to the ATen implementation of
the operator.

Prior to the next PR in this stack, the change is a bit hard to
test, but you can indirectly observe the impact by running arange
with trace dispatching on (well, you need
https://github.com/pytorch/pytorch/pull/82277 patched in too.)

```
$ TORCH_SHOW_DISPATCH_TRACE=1 python -c "import torch._refs; torch._refs.arange(4, device='meta')"
[callBoxed] op=[prims::arange], key=[BackendSelect]
[call] op=[aten::empty_strided], key=[BackendSelect]
[redispatch] op=[aten::empty_strided], key=[Meta]
```

Previously, the prims::arange call was dispatching to Undefined.

For maximum fidelity, technically we're supposed to redispatch to a
specific dispatch key, but the Python bindings to do this don't exist
and it was easy to route to the implementations which we already
intended to go to.  We would have to fix this if we wanted external
backends to register custom implementations to OTHER dispatch keys
via Python op registration.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>