### PR TITLE
[MPS] Workaround for uint8 gather bug

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -130,9 +130,9 @@ std::string getMPSTypeString(ScalarType scalar_type) {
     case ScalarType::Short:
       return "Int16";
     case ScalarType::Char:
-      return "UInt8";
-    case ScalarType::Byte:
       return "Int8";
+    case ScalarType::Byte:
+      return "UInt8";
     case ScalarType::Bool:
       return "Bool";
     default:


### PR DESCRIPTION
Looks like MPSGraph generates a wrong shader for expanding column into a matrix, though datatype should not really matter for scatter-gather ops, should it?

Also, fix minor typo: `c10::ScalarType:Char` is signed type, whereas `c10::ScalarType::Byte` is unsigned.

Workarounds https://github.com/pytorch/pytorch/issues/82305 by aliasing tensors of `uint8` types to `int8` typed ones
