### PR TITLE
fix functionalization handling for mixed functional/nonfunctional tensorlists

### DIFF
--- a/aten/src/ATen/FunctionalTensorWrapper.cpp
+++ b/aten/src/ATen/FunctionalTensorWrapper.cpp
@@ -515,60 +515,42 @@ bool isFunctionalTensor(const c10::optional<Tensor>& t) {
   }
 }
 
+// For lists that have a mix of functional and nonfunctional tensors,
+// functionalization machinery should just unwrap the functional wrappers
+// and leave the ordinary tensors alone.
 bool isFunctionalTensor(const c10::List<Tensor>& t_list) {
   if (t_list.size() == 0) return false;
   auto functional_count = 0;
-  auto nonfunctional_count = 0;
   for (const auto i : c10::irange(t_list.size())) {
     if (!t_list[i].defined()) continue;
     if (isFunctionalTensor(t_list[i])) {
       ++functional_count;
-    } else {
-      ++nonfunctional_count;
     }
   }
-  TORCH_INTERNAL_ASSERT(
-       functional_count == 0 || nonfunctional_count == 0,
-      "Functionalization encountered a list of tensors where some are functional",
-      "and some are not, which is not currently unsupported.");
   return functional_count > 0;
 }
 
 bool isFunctionalTensor(const c10::List<c10::optional<Tensor>>& t_list) {
   if (t_list.size() == 0) return false;
   auto functional_count = 0;
-  auto nonfunctional_count = 0;
   for (const auto i : c10::irange(t_list.size())) {
     if (!t_list[i].has_value() || !t_list[i]->defined()) continue;
     if (isFunctionalTensor(t_list[i])) {
       ++functional_count;
-    } else {
-      ++nonfunctional_count;
     }
   }
-  TORCH_INTERNAL_ASSERT(
-       functional_count == 0 || nonfunctional_count == 0,
-      "Functionalization encountered a list of tensors where some are functional",
-      "and some are not, which is not currently unsupported.");
   return functional_count > 0;
 }
 
 bool isFunctionalTensor(const c10::ArrayRef<Tensor> t_list) {
   if (t_list.size() == 0) return false;
   auto functional_count = 0;
-  auto nonfunctional_count = 0;
   for (const auto i : c10::irange(t_list.size())) {
     if (!t_list[i].defined()) continue;
     if (isFunctionalTensor(t_list[i])) {
       ++functional_count;
-    } else {
-      ++nonfunctional_count;
     }
   }
-  TORCH_INTERNAL_ASSERT(
-       functional_count == 0 || nonfunctional_count == 0,
-      "Functionalization encountered a list of tensors where some are functional",
-      "and some are not, which is not currently unsupported.");
   return functional_count > 0;
 }
 

--- a/test/test_functionalization.py
+++ b/test/test_functionalization.py
@@ -167,6 +167,16 @@ def forward(self, a_1):
             return y
         self.assert_functionalization(f, torch.arange(3, dtype=torch.float32))
 
+    def test_tensor_list_mixed_functional_nonfunctional(self):
+        nonfunctional_tensor = torch.ones(2, dtype=torch.long)
+
+        def f(x):
+            # simple test: 1 view op, 1 inplace op
+            functional_tensor = torch.ones(2, dtype=torch.long)
+            out = x[functional_tensor, nonfunctional_tensor]
+            return out
+        self.assert_functionalization(f, torch.ones(2, 2))
+
     def test_inplace_on_non_view(self):
         def f(x):
             # test for the case where we functionalize an inplace op on the other tensor - not a view.


### PR DESCRIPTION
There's an existing assert in functionalization that's probably too restrictive - when you pass a list of tensors to an op that has a mix of functional and nonfunctional tensors, we should just selectively unwrap the functional tensors and call the op rather than erroring.

I added a test for it in `test_functionalization.py` - it looks like this behavior can also show up when tracing with `make_fx()`, when constants get baked in as module properties, which don't get wrapped up when you try to functionalize the module's forward function.

Should fix the last of https://github.com/pytorch/torchdynamo/issues/88#issuecomment-1193059940

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #82358
* __->__ #82326

