### PR TITLE
Partially enabling debug mode for ROCm backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,6 +671,11 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build from: Debug Release RelWithDebInfo MinSizeRel Coverage." FORCE)
 endif()
 
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -mcmodel=large")
+#set(CMAKE_HIP_FLAGS_DEBUG "${CMAKE_HIP_FLAGS_DEBUG} -mcmodel=large")
+set(CMAKE_HIP_FLAGS_DEBUG "${CMAKE_HIP_FLAGS_RELEASE}")
+set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS} -mcmodel=large")
+
 # The below means we are cross compiling for arm64 or x86_64 on MacOSX
 if(NOT IOS AND CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_OSX_ARCHITECTURES MATCHES "^(x86_64|arm64)$")
   set(CROSS_COMPILING_MACOSX TRUE)

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -6,7 +6,12 @@ if(NOT MSVC)
   string(APPEND CMAKE_C_FLAGS " -Wno-ignored-qualifiers")
   string(APPEND CMAKE_CXX_FLAGS " -Wno-absolute-value")
   string(APPEND CMAKE_C_FLAGS " -Wno-absolute-value")
+  string(APPEND CMAKE_CXX_FLAGS_DEBUG " -mcmodel=large")
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS_DEBUG " -mcmodel=large")
 endif(NOT MSVC)
+
+#string(APPEND CMAKE_HIP_FLAGS_DEBUG " -mcmodel=large")
+set(CMAKE_HIP_FLAGS_DEBUG "${CMAKE_HIP_FLAGS_RELEASE}")
 
 # Can be compiled standalone
 if(NOT AT_INSTALL_BIN_DIR OR NOT AT_INSTALL_LIB_DIR OR NOT AT_INSTALL_INCLUDE_DIR OR NOT AT_INSTALL_SHARE_DIR)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1302,9 +1302,12 @@ if(USE_ROCM)
     message("TORCH_HIP_VERSION=${TORCH_HIP_VERSION} is added as a compiler defines")
 
     if(CMAKE_BUILD_TYPE MATCHES Debug)
-       list(APPEND HIP_CXX_FLAGS -g2)
-       list(APPEND HIP_CXX_FLAGS -O0)
+       # XXX Disabling device code debugging for now, to workaround https://github.com/RadeonOpenCompute/ROCm/issues/1765
+       #list(APPEND HIP_CXX_FLAGS -g2)
+       #list(APPEND HIP_CXX_FLAGS -O0)
+       list(APPEND HIP_CXX_FLAGS -mcmodel=large)
        list(APPEND HIP_HIPCC_FLAGS -fdebug-info-for-profiling)
+       list(APPEND HIP_HIPCC_FLAGS -mcmodel=large)
     endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
     set(HIP_CLANG_FLAGS ${HIP_CXX_FLAGS})


### PR DESCRIPTION
Getting debug mode compilation of PyTorch with ROCm backend possible (and usable!), given that for now we disable GPU debugging due to https://github.com/RadeonOpenCompute/ROCm/issues/1765

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport