### PR TITLE
Allow PR collaborators revert PRs

### DIFF
--- a/.github/scripts/gql_mocks.json
+++ b/.github/scripts/gql_mocks.json
@@ -19964,5 +19964,92 @@
         }
       }
     }
+  },
+  "query_sha=4c16925415d1fcc12ac0f5f7ce73b8e6122997d2f51c4c2757c2543e6493c60d cr_cursor=Y3Vyc29yOnYyOpHPAAAAAbqubxc= cs_cursor=Y3Vyc29yOnYyOpHPAAAAAbtMgmA= name=pytorch number=79694 owner=pytorch": {
+    "data": {
+      "repository": {
+        "pullRequest": {
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "oid": "ffe43399d6f60ef7844523a5f465c11d9a67062f",
+                  "checkSuites": {
+                    "nodes": [
+                      {
+                        "checkRuns": {
+                          "nodes": [
+                            {
+                              "name": "win-vs2019-cpu-py3 / test (default, 1, 2, windows.4xlarge)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/runs/7427036779?check_suite_focus=true"
+                            },
+                            {
+                              "name": "win-vs2019-cpu-py3 / test (default, 2, 2, windows.4xlarge)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/runs/7427036925?check_suite_focus=true"
+                            }
+                          ],
+                          "pageInfo": {
+                            "endCursor": "Y3Vyc29yOnYyOpHPAAAAAbqvlv0=",
+                            "hasNextPage": false
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "query_sha=4c16925415d1fcc12ac0f5f7ce73b8e6122997d2f51c4c2757c2543e6493c60d cr_cursor=Y3Vyc29yOnYyOpHPAAAAAbxLMxE= cs_cursor=Y3Vyc29yOnYyOpHPAAAAAbzb6nI= name=pytorch number=79694 owner=pytorch": {
+    "data": {
+      "repository": {
+        "pullRequest": {
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "oid": "ffe43399d6f60ef7844523a5f465c11d9a67062f",
+                  "checkSuites": {
+                    "nodes": [
+                      {
+                        "checkRuns": {
+                          "nodes": [
+                            {
+                              "name": "linux-xenial-cuda11_3-py3_7-gcc7-deploy / test (deploy, 1, 1, linux.4xlarge.nvidia.gpu)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/runs/7454025911?check_suite_focus=true"
+                            },
+                            {
+                              "name": "win-vs2019-cpu-py3 / test (default, 1, 2, windows.4xlarge)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/runs/7454189584?check_suite_focus=true"
+                            },
+                            {
+                              "name": "win-vs2019-cpu-py3 / test (default, 2, 2, windows.4xlarge)",
+                              "conclusion": "SUCCESS",
+                              "detailsUrl": "https://github.com/pytorch/pytorch/runs/7454189772?check_suite_focus=true"
+                            }
+                          ],
+                          "pageInfo": {
+                            "endCursor": "Y3Vyc29yOnYyOpHPAAAAAbxN6Mw=",
+                            "hasNextPage": false
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
   }
 }

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -323,12 +323,10 @@ class TestGitHubPR(TestCase):
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
     def test_revert_rules(self, mock_gql: Any) -> None:
-        """ Tests that reverts from collaborators are not allowed, Zain to change it soon """
+        """ Tests that reverts from collaborators are allowed """
         pr = GitHubPR("pytorch", "pytorch", 79694)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
-        self.assertRaisesRegex(PostCommentError,
-                               ".*is not a MEMBER, but COLLABORATOR.*",
-                               lambda: validate_revert(repo, pr, comment_id=1189459845))
+        self.assertIsNotNone(validate_revert(repo, pr, comment_id=1189459845))
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -21,7 +21,6 @@ from trymerge import (find_matching_merge_rule,
                       GitHubPR,
                       MergeRule,
                       MandatoryChecksMissingError,
-                      PostCommentError,
                       main as trymerge_main)
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 from typing import Any, List, Optional

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1061,9 +1061,12 @@ def validate_revert(repo: GitRepo, pr: GitHubPR, *,
     allowed_reverters = ["COLLABORATOR", "MEMBER", "OWNER"]
     # For some reason, one can not be a member of private repo, only CONTRIBUTOR
     if pr.is_base_repo_private():
-      allowed_reverters.append("CONTRIBUTOR")
+        allowed_reverters.append("CONTRIBUTOR")
     if author_association not in allowed_reverters:
-        raise PostCommentError(f"Will not revert as @{author_login} is not one of [{', '.join(allowed_reverters)}], but instead is {author_association}.")
+        raise PostCommentError((
+            f"Will not revert as @{author_login} is not one of "
+            f"[{', '.join(allowed_reverters)}], but instead is {author_association}."
+        ))
     skip_internal_checks = can_skip_internal_checks(pr, comment_id)
 
     # Raises exception if matching rule is not found, but ignores all status checks

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1058,10 +1058,12 @@ def validate_revert(repo: GitRepo, pr: GitHubPR, *,
         raise PostCommentError("Don't want to revert based on edited command")
     author_association = comment.author_association
     author_login = comment.author_login
+    allowed_reverters = ["COLLABORATOR", "MEMBER", "OWNER"]
     # For some reason, one can not be a member of private repo, only CONTRIBUTOR
-    expected_association = "CONTRIBUTOR" if pr.is_base_repo_private() else "MEMBER"
-    if author_association != expected_association and author_association != "OWNER":
-        raise PostCommentError(f"Will not revert as @{author_login} is not a {expected_association}, but {author_association}")
+    if pr.is_base_repo_private():
+      allowed_reverters.append("CONTRIBUTOR")  
+    if author_association not in allowed_reverters:
+        raise PostCommentError(f"Will not revert as @{author_login} is not one of [{', '.join(allowed_reverters)}], but instead is {author_association}.")
     skip_internal_checks = can_skip_internal_checks(pr, comment_id)
 
     # Raises exception if matching rule is not found, but ignores all status checks

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1061,7 +1061,7 @@ def validate_revert(repo: GitRepo, pr: GitHubPR, *,
     allowed_reverters = ["COLLABORATOR", "MEMBER", "OWNER"]
     # For some reason, one can not be a member of private repo, only CONTRIBUTOR
     if pr.is_base_repo_private():
-      allowed_reverters.append("CONTRIBUTOR")  
+      allowed_reverters.append("CONTRIBUTOR")
     if author_association not in allowed_reverters:
         raise PostCommentError(f"Will not revert as @{author_login} is not one of [{', '.join(allowed_reverters)}], but instead is {author_association}.")
     skip_internal_checks = can_skip_internal_checks(pr, comment_id)


### PR DESCRIPTION
### Description
This enables COLLABORATORS for a repository to revert PRs if they discover a problem.

The main difference between a COLLABORATOR and a MEMBER is that a MEMBER has access to the entire pytorch organization, while a COLLABORATOR's access is limited to a specific repository.  But within that repository, granting them both revert rights seems quite reasonable

### Issue
This request originated from pytorchbot's refusal to revert this pr: https://github.com/pytorch/pytorch/pull/79694#issuecomment-1189460942

### Testing
CI