### PR TITLE
Re-enable some functionalize tests

### DIFF
--- a/functorch/test/test_eager_transforms.py
+++ b/functorch/test/test_eager_transforms.py
@@ -3044,7 +3044,6 @@ def forward(self, x_1, indices_1) -> torch.Tensor:
         out2 = vmap(functionalize(jvp_wrapper))(x, t)
         self.assertEqual(out1, out2)
 
-    @unittest.skip("Disabling to land #81145")
     def test_functionalize_fx_simple(self, device):
 
         def f(x: torch.Tensor) -> torch.Tensor:
@@ -3084,7 +3083,6 @@ def forward(self, x_1) -> torch.Tensor:
     return transpose_copy_int
     """)
 
-    @unittest.skip("Disabling to land #81145")
     def test_functionalize_fx_out_op(self, device):
 
         def f(inpt: torch.Tensor) -> torch.Tensor:
@@ -3109,7 +3107,6 @@ def forward(self, inpt_1) -> torch.Tensor:
     return view_copy_default_2
     """)
 
-    @unittest.skip("Disabling to land #81145")
     def test_functionalize_fx_multi_out_op(self, device):
 
         def f(inpt: torch.Tensor) -> torch.Tensor:
@@ -3135,7 +3132,6 @@ def forward(self, inpt_1) -> torch.Tensor:
     return (view_copy_default_1, getitem)
     """)
 
-    @unittest.skip("Disabling to land #81145")
     def test_functionalize_fx_reapply_views_simple(self, device):
 
         def f(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #82363

As far as I can tell, #81145 got merged (
https://github.com/pytorch/pytorch/pull/81145 was reverted, but the
revert was reverted https://github.com/pytorch/pytorch/pull/82189)

These tests were originally disabled to coordinate a merge across
pytorch/pytorch and pytorch/functorch repos, since the PR got merged we
can reenable these tests.

It is a little fishy that nothing had to change, but all the tests seem
to pass.

Fixes https://github.com/pytorch/functorch/issues/974