### PR TITLE
[vulkan] Fix GenericList constructor

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/VulkanOpContext.cpp
+++ b/aten/src/ATen/native/vulkan/ops/VulkanOpContext.cpp
@@ -8,7 +8,7 @@ namespace ops {
 VulkanOpContext::VulkanOpContext(
     c10::impl::GenericList packed_context,
     c10::impl::GenericList unpacked_context)
-    : packed_{packed_context}, unpacked_{unpacked_context} {}
+    : packed_(packed_context), unpacked_(unpacked_context) {}
 
 VulkanOpContext VulkanOpContext::create(
     c10::impl::GenericList packed_context,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#82365 [vulkan] Fix GenericList constructor**

Summary:
In some configurations, this was using the initializer_list constructor
of List, which is not valid for GenericList.  Using parens forces the
copy constructor to be used instead.  (This is a pointer copy, not a
full content copy.)

Test Plan:
CI.  Built locally.