### PR TITLE
Revert "reverted diff: Add python stack tracing option on on-demand flow"

### DIFF
--- a/torch/csrc/profiler/kineto_client_interface.cpp
+++ b/torch/csrc/profiler/kineto_client_interface.cpp
@@ -18,16 +18,29 @@ class LibKinetoClient : public libkineto::ClientInterface {
     reportInputShapes_ = setupOpInputsCollection;
   }
 
+#ifdef USE_KINETO_MIN_CHANGE
+  void start(bool withStack) override {
+    ProfilerConfig cfg {
+      ProfilerState::KINETO_ONDEMAND,
+          /*report_input_shapes=*/reportInputShapes_,
+          /*profile_memory=*/false,
+          /*with_stack=*/withStack,
+#else
   void start() override {
     ProfilerConfig cfg{
         ProfilerState::KINETO_ONDEMAND,
-        reportInputShapes_,
-        false,
-        false,
-        false,
-        false};
+        /*report_input_shapes=*/reportInputShapes_,
+        /*profile_memory=*/false,
+        /*with_stack=*/false,
+#endif
+          /*with_flops=*/false,
+          /*with_modules=*/false
+    };
     std::set<ActivityType> activities{ActivityType::CPU};
-    auto scopes = {at::RecordScope::FUNCTION, at::RecordScope::USER_SCOPE};
+    std::unordered_set<at::RecordScope> scopes;
+    scopes.insert(at::RecordScope::FUNCTION);
+    scopes.insert(at::RecordScope::USER_SCOPE);
+    scopes.insert(at::RecordScope::BACKWARD_FUNCTION);
     enableProfiler(cfg, activities, scopes);
   }
 


### PR DESCRIPTION
Summary:
Changes:
add an option in Config; can use 'PYTHON_STACK_TRACE=true' option (via .conf)
deliver PYTHON_STACK_TRACE value to kineto_client_interface start()
abstract class also changed.
Trace after changes by running //kineto/libkineto/fb/integration_tests/trace_tester.cpp (requested by chaekit)
https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftraces%2Fdynocli%2F0%2F1657304871%2F127.0.0.1%2Flibkineto_activities_3502962.json.gz&bucket=gpu_traces

Test Plan:
launch a python test case with the following command for on-demand flow:
echo -e "PYTHON_STACK_TRACE=true" > /tmp/scott_kineto.conf && dyno gputrace --gputrace_duration 300ms --gpuconf /tmp/scott_kineto.conf

Reviewed By: chaekit

Differential Revision: D38220201

