### PR TITLE
[Easy][FSDP] Remove variable shadowing

### DIFF
--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -302,7 +302,7 @@ class FlatParamHandle:
             f"Expects {flat_param._unsharded_size.numel()} numel but got " \
             f"{tensor.numel()} numel"
         views = (
-            tensor.view(shape) for (tensor, shape) in
+            subtensor.view(shape) for (subtensor, shape) in
             zip(torch.split(tensor, flat_param._numels, dim=0), flat_param._shapes)  # type: ignore[arg-type]
         )
         return views


### PR DESCRIPTION
I unintentionally had the sub-tensors returned by `split()` bound to `tensor`, which shadows the original full `tensor`. This is a bad practice and is error-prone.

Test Plan: CI