### PR TITLE
Enhance loop-carried dependence check

### DIFF
--- a/torch/csrc/jit/tensorexpr/bounds_inference.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.cpp
@@ -325,18 +325,27 @@ bool hasConflictingOverlap(
     auto bIndexBounds = bIndexBoundsInfo[bIt->first];
     auto aTABIs = aBound.second;
     auto bTABIs = bIt->second;
-    for (size_t i = 0; i < aTABIs.size(); ++i) {
-      for (size_t j = 0; j < bTABIs.size(); ++j) {
-        auto aTABI = aTABIs[i];
-        auto bTABI = bTABIs[j];
-        if (aTABI.kind == kLoad && bTABI.kind == kLoad) {
+    size_t aIndexBoundIter = 0;
+    for (const auto& aTABI: aTABIs) {
+      if (aFilter != kMutate && aTABI.kind != aFilter) {
+        continue;
+      }
+      size_t bIndexBoundIter = 0;
+      for (const auto& bTABI: bTABIs) {
+        if (bFilter != kMutate && bTABI.kind != bFilter) {
           continue;
         }
-        auto overlap = overlaps(aIndexBounds[i], bIndexBounds[j]);
+        if (aTABI.kind == kLoad && bTABI.kind == kLoad) {
+          bIndexBoundIter++;
+          continue;
+        }
+        auto overlap = overlaps(aIndexBounds[aIndexBoundIter], bIndexBounds[bIndexBoundIter]);
         if (overlap != OverlapKind::NoOverlap) {
           return true;
         }
+        bIndexBoundIter++;
       }
+      aIndexBoundIter++;
     }
   }
   return false;


### PR DESCRIPTION
### Description
Enhance the loop-carried dependence check for the case:

```
sum[0ll] = 0.f;
for (int64_t i_1 = 0ll; i_1 < 1024ll; i_1++) {
  sum[0ll] = (sum[0ll]) + ((tx[i_1]) + 1.f);
}
```

There is WriteAfterLoad in the single statement of the loop body for the reduction in TE. It is institutive a carried dependence loop. But `LoopNest::hasLoopCarriedDependence` failed to detect the dependence. To enhance the `LoopNest::hasLoopCarriedDependence` for this kind of case.

### Solution
Naively check for every store and load of same statement to the same buffer, if the index expressions are invariant to the loop var and there is an overlap in accesses, return true to indicate a loop-carried dependence.
