### PR TITLE
Fix possible out-of-range error of 'as_nd' util function

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -671,21 +671,14 @@ static void qprelu_out_kernel(Tensor& out,
   int64_t input_ndim = qx.dim();
   TORCH_CHECK(input_ndim > 0, "qprelu: zero-dim input tensor is not allowed.");
 
-  // Helper to convert 1d tensors or scalar tensor to an nd tensor that broadcasts with input
+  // Weight should be a 1d or scalar tensor
+  // Reshape it to an nd tensor that broadcasts with input
   // All elements go into the channel dimension
-  DimVector sizes(input_ndim, 1), strides(input_ndim, 0);
-  auto as_nd = [&](const Tensor& t) {
-    TORCH_INTERNAL_ASSERT(t.defined() && (t.dim() == 1 || t.dim() == 0));
-    if (input_ndim > 1) {
-      // Take t's length and stride if it's 1d.
-      // Otherwise t is a scalar. Then size is 1 and stride is 0.
-      sizes[1] = t.dim() == 1 ? t.sizes()[0] : 1;
-      strides[1] = t.dim() == 1 ? t.strides()[0] : 0;
-    }
-    return t.as_strided(sizes, strides);
-  };
-
-  auto qw_nd = as_nd(qw);
+  DimVector sizes(input_ndim, 1);
+  if (input_ndim > 1) {
+    sizes[1] = qw.numel();
+  }
+  auto qw_nd = qw.reshape(sizes);
 
   auto iter = TensorIteratorConfig()
     .add_output(out)

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -676,8 +676,12 @@ static void qprelu_out_kernel(Tensor& out,
   DimVector sizes(input_ndim, 1), strides(input_ndim, 0);
   auto as_nd = [&](const Tensor& t) {
     TORCH_INTERNAL_ASSERT(t.defined() && (t.dim() == 1 || t.dim() == 0));
-    sizes[1] = t.dim() == 1 ? t.sizes()[0] : 1;
-    strides[1] = t.dim() == 1 ? t.strides()[0] : 0;
+    if (input_ndim > 1) {
+      // Take t's length and stride if it's 1d.
+      // Otherwise t is a scalar. Then size is 1 and stride is 0.
+      sizes[1] = t.dim() == 1 ? t.sizes()[0] : 1;
+      strides[1] = t.dim() == 1 ? t.strides()[0] : 0;
+    }
     return t.as_strided(sizes, strides);
   };
 


### PR DESCRIPTION
### Description
Fix a flaw in util function `as_nd` which may cause out-of-range error if input is 1-dimensional.
This util function is defined as local a lambda expression in `aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp: qprelu_out_kernel()`

### Solution
Use `reshape` instead of the lambda expression.
Check number of dims of input before assigning values.