### PR TITLE
Revert D37946374: Multisect successfully blamed D37946374 for test or build failures

### DIFF
--- a/tools/target_definitions.bzl
+++ b/tools/target_definitions.bzl
@@ -154,8 +154,6 @@ def add_torch_libs():
         link_whole = True,
         include_directories = include_directories,
         propagated_pp_flags = propagated_pp_flags_cpu,
-        # Disable merged linking so deploy works with pybind.
-        supports_merged_linking = False,
         exported_deps = (
             [
                 ":ATen-cpu",


### PR DESCRIPTION
Summary:
This diff is reverting D37946374 (https://github.com/pytorch/pytorch/commit/0933c037e7e5d306d3ba537dcbe3192ccd060f34)
D37946374 (https://github.com/pytorch/pytorch/commit/0933c037e7e5d306d3ba537dcbe3192ccd060f34) has been identified to be causing the following test or build failures:
Tests affected:
- https://www.internalfb.com/intern/test/281475044433069/

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1089412
Here are the tasks that are relevant to this breakage:
T111653141: 6 tests started failing for oncall oculus_vision_face_tracking in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Test Plan: NA

Reviewed By: crassirostris

Differential Revision: D38232908

