### PR TITLE
Modify LinearAPoT matrix multiplication bitshift to support all k

### DIFF
--- a/test/quantization/core/experimental/test_linear.py
+++ b/test/quantization/core/experimental/test_linear.py
@@ -8,9 +8,9 @@ import unittest
 class TestNonUniformObserver(unittest.TestCase):
     """
         Test linear_APoT_fn by comparing to uniform linear
-        for 2d tensors with size (4,4)
+        for 2d tensors with size (4,4) and k=1
     """
-    def test_linear_APoT_fn(self):
+    def test_linear_APoT_k1(self):
         # weight: fp tensor
         weight = 1000 * torch.rand(4, 4)
 
@@ -19,6 +19,34 @@ class TestNonUniformObserver(unittest.TestCase):
 
         # calculate result from calling linear forward method
         apot_linear = LinearAPoT(weight, 8, 1)
+        apot_linear_result = apot_linear(activation)
+
+        # calculate expected results
+        fp_linear = Linear(4, 4, bias=False)
+
+        # set weight for fp linear
+        apot_quantized_weight_float = apot_linear.weight.type(torch.FloatTensor)
+        fp_linear_weight = torch.nn.parameter.Parameter(data=apot_quantized_weight_float)
+        fp_linear.weight = fp_linear_weight
+
+        fp_linear_result = fp_linear(activation).data
+
+        self.assertTrue(torch.equal(apot_linear_result, fp_linear_result))
+
+    """
+        Test linear_APoT_fn by comparing to uniform linear
+        for 2d tensors with size (5,3), (3, 5) and k=2
+    """
+    def test_linear_APoT_k2(self):
+        # weight: fp tensor
+        weight = 1000 * torch.rand(5, 3)
+
+        # activtion: fp32 tensor with ~ integer values
+        # note: transpose of activation matrix will have dimension (3, 5)
+        activation = torch.randint(low=0, high=255, size=(5, 3), dtype=torch.float)
+
+        # calculate result from calling linear forward method
+        apot_linear = LinearAPoT(weight, 8, 2)
         apot_linear_result = apot_linear(activation)
 
         # calculate expected results

--- a/torch/ao/quantization/experimental/linear.py
+++ b/torch/ao/quantization/experimental/linear.py
@@ -87,8 +87,6 @@ class LinearAPoT(WeightedQuantizedModule):
 
                 if int(ele):
                     curr_block_result += r << place
-                else:
-                    curr_block_result += 0
 
                 place += 1
 

--- a/torch/ao/quantization/experimental/linear.py
+++ b/torch/ao/quantization/experimental/linear.py
@@ -84,10 +84,8 @@ class LinearAPoT(WeightedQuantizedModule):
             curr_block_result = 0
 
             for ele in block:
-
                 if int(ele):
                     curr_block_result += r << place
-
                 place += 1
 
             idx -= 1

--- a/torch/ao/quantization/experimental/linear.py
+++ b/torch/ao/quantization/experimental/linear.py
@@ -72,17 +72,28 @@ class LinearAPoT(WeightedQuantizedModule):
         """
         product = 0
 
-        for idx in range(len(weight_val)):
-            ele = int(weight_val[idx])
+        idx = len(weight_val) - 1
+        place = 0
 
-            x = len(weight_val) - 1 - idx
+        while idx >= 0:
+            block = weight_val[idx]
 
-            if ele:
-                curr_result = r << x
-            else:
-                curr_result = 0
+            # reverse digits in block
+            block = block[::-1]
 
-            product += curr_result
+            curr_block_result = 0
+
+            for ele in block:
+
+                if int(ele):
+                    curr_block_result += r << place
+                else:
+                    curr_block_result += 0
+
+                place += 1
+
+            idx -= 1
+            product += curr_block_result
 
         return product
 
@@ -95,18 +106,18 @@ class LinearAPoT(WeightedQuantizedModule):
             decomposed_weight (Tensor): APoT quantized weight decomposed into binary
             activation (Tensor): uniformly quantized activation
         """
-        rows2 = activation.size(dim=0)
-        cols2 = activation.size(dim=1)
+        rows1 = activation.size(dim=0)
+        cols1 = activation.size(dim=1)
 
-        rows1 = decomposed_weight.shape[0]
-        cols1 = decomposed_weight.shape[1]
+        rows2 = decomposed_weight.shape[0]
+        cols2 = decomposed_weight.shape[1]
 
         result = torch.zeros(rows1, cols2)
 
         # compute matrix multiplication with bitshifts
-        for i in range(rows2):
+        for i in range(rows1):
             for j in range(cols2):
-                for k in range(rows1):
+                for k in range(rows2):
                     weight_val = decomposed_weight[k][j]
                     r = int(activation[i][k])
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82409

### Summary
This PR modifies the bitshift implementation of matrix multiplication for LinearAPoT in `bitshift_mul` to support all input values of k. It also fixes the row/col dimension assignment for the `mat_mul `method

### Test Plan
Run unit tests with: `python test/quantization/core/experimental/test_linear.py`