### PR TITLE
Change SymIntNode into an intrusive pointer

### DIFF
--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -7,8 +7,10 @@ namespace c10 {
 
 std::array<SymIntNode, 2> normalize_symints(SymInt a_, SymInt b_) {
   SymIntNode a, b;
-  if (a_.is_symbolic()) a = a_.toSymIntNodeImpl();
-  if (b_.is_symbolic()) b = b_.toSymIntNodeImpl();
+  if (a_.is_symbolic())
+    a = a_.toSymIntNodeImpl();
+  if (b_.is_symbolic())
+    b = b_.toSymIntNodeImpl();
 
   SymIntNodeImpl* common = a ? a.get() : b.get();
   // TODO: technically we need to check that the classes match

--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -6,8 +6,9 @@
 namespace c10 {
 
 std::array<SymIntNode, 2> normalize_symints(SymInt a_, SymInt b_) {
-  SymIntNode a = a_.is_symbolic() ? a_.toSymIntNodeImpl() : nullptr;
-  SymIntNode b = b_.is_symbolic() ? b_.toSymIntNodeImpl() : nullptr;
+  SymIntNode a, b;
+  if (a_.is_symbolic()) a = a_.toSymIntNodeImpl();
+  if (b_.is_symbolic()) b = b_.toSymIntNodeImpl();
 
   SymIntNodeImpl* common = a ? a.get() : b.get();
   // TODO: technically we need to check that the classes match

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -2,13 +2,14 @@
 
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
+#include <c10/util/intrusive_ptr.h>
 
 #include <memory>
 
 namespace c10 {
 
 class SymIntNodeImpl;
-using SymIntNode = std::shared_ptr<SymIntNodeImpl>;
+using SymIntNode = c10::intrusive_ptr<SymIntNodeImpl>;
 
 // `SymInt` is a C++ wrapper class around int64_t data_ which  and is used to
 // represent concrete dimension values.

--- a/c10/core/SymIntNodeImpl.h
+++ b/c10/core/SymIntNodeImpl.h
@@ -3,6 +3,7 @@
 #include <c10/core/SymInt.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
+#include <c10/util/intrusive_ptr.h>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -10,13 +11,18 @@
 namespace c10 {
 
 class SymIntNodeImpl;
-using SymIntNode = std::shared_ptr<SymIntNodeImpl>;
+using SymIntNode = c10::intrusive_ptr<SymIntNodeImpl>;
 
-class C10_API SymIntNodeImpl
-    : public std::enable_shared_from_this<SymIntNodeImpl> {
+class C10_API SymIntNodeImpl : public c10::intrusive_ptr_target {
  public:
   c10::SymInt toSymInt();
   virtual ~SymIntNodeImpl(){};
+
+  template <typename T>
+  c10::intrusive_ptr<T> dyn_cast() const {
+    return c10::intrusive_ptr<T>::reclaim_copy(dynamic_cast<T*>(this));
+  }
+
   // these could be pure virtual when we implement LTC versions
   virtual SymIntNode add(const SymIntNode& other) {
     TORCH_CHECK(false, "NYI");

--- a/c10/core/SymIntTable.cpp
+++ b/c10/core/SymIntTable.cpp
@@ -5,7 +5,7 @@ namespace c10 {
 uint64_t SymIntTable::addNode(SymIntNode sin) {
   std::lock_guard<std::mutex> lock(mutex_);
   auto index = nodes_.size();
-  nodes_.push_back(sin);
+  nodes_.push_back(std::move(sin));
   return index;
 }
 SymIntNode SymIntTable::getNode(size_t index) {
@@ -17,7 +17,7 @@ SymIntNode SymIntTable::getNode(size_t index) {
 c10::SymInt SymIntNodeImpl::toSymInt() {
   // We will need to figure out a way
   // to dedup nodes
-  auto sit_sp = this->shared_from_this();
+  auto sit_sp = SymIntNode::reclaim_copy(this);
   return SymInt::toSymInt(sit_sp);
 }
 

--- a/c10/test/core/SymInt_test.cpp
+++ b/c10/test/core/SymInt_test.cpp
@@ -21,7 +21,7 @@ TEST(SymIntTest, ConcreteInts) {
 }
 
 TEST(SymIntTest, AddNode) {
-  auto n = std::make_shared<SymIntNodeImpl>();
+  auto n = c10::make_intrusive<SymIntNodeImpl>();
   auto i = n->toSymInt();
   EXPECT_TRUE(i.is_symbolic());
 }

--- a/test/cpp/lazy/test_lazy_ops.cpp
+++ b/test/cpp/lazy/test_lazy_ops.cpp
@@ -91,7 +91,7 @@ TEST(LazyDynamicOpsTest, NarrowCopy) {
   auto y = torch::rand({Y_DIM}).to(kLazy);
   auto ly = torch::lazy::TryGetLtcTensor(y);
   auto dim_node = MakeNode<SizeNode>(ly->GetIrValue(), 0);
-  auto lmn = std::make_shared<torch::lazy::SymIntNodeImpl>(dim_node);
+  auto lmn = c10::make_intrusive<torch::lazy::SymIntNodeImpl>(dim_node);
   auto z = x.narrow_copy_symint(X_DIM_INDEX, 0, lmn->toSymInt());
   AllClose(z.cpu(), x.cpu().narrow_copy(X_DIM_INDEX, 0, Y_DIM));
 }

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -452,7 +452,8 @@ std::vector<Shape> compute_shape_expand(
   for (const auto idx : c10::irange(_sizes.size())) {
     if (_sizes[idx].is_symbolic()) {
       c10::SymIntNode symbolicIntNode = _sizes[idx].toSymIntNodeImpl();
-      auto* lazySymIntNode = dynamic_cast<torch::lazy::SymIntNodeImpl*>(symbolicIntNode.get());
+      auto* lazySymIntNode =
+          dynamic_cast<torch::lazy::SymIntNodeImpl*>(symbolicIntNode.get());
       auto size_node = lazySymIntNode->node_;
       auto static_value =
           std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node)

--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -452,9 +452,7 @@ std::vector<Shape> compute_shape_expand(
   for (const auto idx : c10::irange(_sizes.size())) {
     if (_sizes[idx].is_symbolic()) {
       c10::SymIntNode symbolicIntNode = _sizes[idx].toSymIntNodeImpl();
-      auto lazySymIntNode =
-          std::dynamic_pointer_cast<torch::lazy::SymIntNodeImpl>(
-              symbolicIntNode);
+      auto* lazySymIntNode = dynamic_cast<torch::lazy::SymIntNodeImpl*>(symbolicIntNode.get());
       auto size_node = lazySymIntNode->node_;
       auto static_value =
           std::dynamic_pointer_cast<torch::lazy::DimensionNode>(size_node)

--- a/torch/csrc/lazy/core/tensor_impl.cpp
+++ b/torch/csrc/lazy/core/tensor_impl.cpp
@@ -95,7 +95,7 @@ LTCTensorImpl::LTCTensorImpl(LazyTensor&& tensor)
   for (auto i : c10::irange(rank)) {
     auto dim_node = getBackend()->GetIrBuilder()->MakeSizeNode(
         this->tensor_->GetIrValue(), i);
-    auto sn = std::make_shared<torch::lazy::SymIntNodeImpl>(dim_node);
+    auto sn = c10::make_intrusive<torch::lazy::SymIntNodeImpl>(dim_node);
     sym_sizes_.push_back(sn->toSymInt());
   }
 }

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -48,9 +48,7 @@ def node_ctor_arg_rvalue_string(arg: LazyArgument) -> str:
                 return f"lazy_{arg.name}_tensorlist"
             elif arg.is_symint_or_list:
                 cpp_type = arg.lazy_type.cpp_type()
-                return (
-                    f"{cpp_type}(dynamic_cast<torch::lazy::SymIntNodeImpl*>({arg.name}.toSymIntNodeImpl().get())->node_, 0)"
-                )
+                return f"{cpp_type}(dynamic_cast<torch::lazy::SymIntNodeImpl*>({arg.name}.toSymIntNodeImpl().get())->node_, 0)"
             return f"lazy_{arg.name}->GetIrValue()"
         elif isinstance(arg.lazy_type, OptionalCType):
             if arg.is_wrapped_scalar:

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -49,8 +49,7 @@ def node_ctor_arg_rvalue_string(arg: LazyArgument) -> str:
             elif arg.is_symint_or_list:
                 cpp_type = arg.lazy_type.cpp_type()
                 return (
-                    f"{cpp_type}(std::dynamic_pointer_cast<torch::lazy::SymIntNodeImpl>"
-                    f"({arg.name}.toSymIntNodeImpl())->node_, 0)"
+                    f"{cpp_type}(dynamic_cast<torch::lazy::SymIntNodeImpl*>({arg.name}.toSymIntNodeImpl().get())->node_, 0)"
                 )
             return f"lazy_{arg.name}->GetIrValue()"
         elif isinstance(arg.lazy_type, OptionalCType):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #82467
* #82477
* __->__ #82432

This will make the pointer type a single word, which is important
for packing it into an int64_t

Signed-off-by: Edward Z. Yang <ezyang@fb.com>