### PR TITLE
Fix multiple docstring type mistakes

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8614,7 +8614,7 @@ Returns a view of the original tensor :attr:`input` with its dimensions permuted
 
 Args:
     {input}
-    dims (tuple of ints): The desired ordering of dimensions
+    dims (tuple of int): The desired ordering of dimensions
 
 Example:
     >>> x = torch.randn(2, 3, 5)
@@ -9574,7 +9574,7 @@ dimensions and the number of elements in :attr:`input`.
 
 Args:
     input (Tensor): the tensor to be reshaped
-    shape (tuple of ints): the new shape
+    shape (tuple of int): the new shape
 
 Example::
 
@@ -12354,8 +12354,8 @@ Creates a tensor with the specified :attr:`size` and :attr:`stride` and filled w
     in memory) its behavior is undefined.
 
 Args:
-    size (tuple of ints): the shape of the output tensor
-    stride (tuple of ints): the strides of the output tensor
+    size (tuple of int): the shape of the output tensor
+    stride (tuple of int): the strides of the output tensor
 
 Keyword args:
     {dtype}

--- a/torch/amp/autocast_mode.py
+++ b/torch/amp/autocast_mode.py
@@ -171,9 +171,11 @@ class autocast(object):
 
     Args:
         device_type(str, required):  Whether to use 'cuda' or 'cpu' device
-        enabled(bool, optional, default=True):  Whether autocasting should be enabled in the region.
+        enabled(bool, optional):  Whether autocasting should be enabled in the region.
+            Default: ``True``
         dtype(torch_dtype, optional):  Whether to use torch.float16 or torch.bfloat16.
-        cache_enabled(bool, optional, default=True):  Whether the weight cache inside autocast should be enabled.
+        cache_enabled(bool, optional):  Whether the weight cache inside autocast should be enabled.
+            Default: ``True``
     """
     def __init__(self, device_type : str,
                  dtype : Optional[_dtype] = None,

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -522,9 +522,9 @@ class emit_itt(object):
         instance should be enabled at any given time.
 
     Args:
-        enabled (bool, optional, default=True): Setting ``enabled=False`` makes this context manager a no-op.
+        enabled (bool, optional): Setting ``enabled=False`` makes this context manager a no-op.
             Default: ``True``.
-        record_shapes (bool, optional, default=False): If ``record_shapes=True``, the itt range wrapping
+        record_shapes (bool, optional): If ``record_shapes=True``, the itt range wrapping
             each autograd op will append information about the sizes of Tensor arguments received
             by that op, in the following format:
             ``[[arg0.size(0), arg0.size(1), ...], [arg1.size(0), arg1.size(1), ...], ...]``
@@ -532,6 +532,7 @@ class emit_itt(object):
             Arguments will be listed in the order they are received by the backend op.
             Please note that this order may not match the order in which those arguments were passed
             on the Python side.  Also note that shape recording may increase the overhead of itt range creation.
+            Default: ``False``
 
     Example:
         >>> with torch.autograd.profiler.emit_itt():
@@ -588,9 +589,9 @@ class emit_nvtx(object):
         instance should be enabled at any given time.
 
     Args:
-        enabled (bool, optional, default=True): Setting ``enabled=False`` makes this context manager a no-op.
+        enabled (bool, optional): Setting ``enabled=False`` makes this context manager a no-op.
             Default: ``True``.
-        record_shapes (bool, optional, default=False): If ``record_shapes=True``, the nvtx range wrapping
+        record_shapes (bool, optional): If ``record_shapes=True``, the nvtx range wrapping
             each autograd op will append information about the sizes of Tensor arguments received
             by that op, in the following format:
             ``[[arg0.size(0), arg0.size(1), ...], [arg1.size(0), arg1.size(1), ...], ...]``
@@ -598,6 +599,7 @@ class emit_nvtx(object):
             Arguments will be listed in the order they are received by the backend op.
             Please note that this order may not match the order in which those arguments were passed
             on the Python side.  Also note that shape recording may increase the overhead of nvtx range creation.
+            Default: ``False``
 
     Example:
         >>> with torch.cuda.profiler.profile():

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -102,8 +102,9 @@ class GradScaler(object):
             :meth:`update` if inf/NaN gradients occur in an iteration.
         growth_interval (int, optional, default=2000):  Number of consecutive iterations without inf/NaN gradients
             that must occur for the scale to be multiplied by ``growth_factor``.
-        enabled (bool, optional, default=True):  If ``False``, disables gradient scaling. :meth:`step` simply
+        enabled (bool, optional):  If ``False``, disables gradient scaling. :meth:`step` simply
             invokes the underlying ``optimizer.step()``, and other methods become no-ops.
+            Default: ``True``
     """
     def __init__(self,
                  init_scale=2.**16,

--- a/torch/distributed/fsdp/sharded_grad_scaler.py
+++ b/torch/distributed/fsdp/sharded_grad_scaler.py
@@ -71,8 +71,9 @@ class ShardedGradScaler(GradScaler):
             :meth:`update` if inf/NaN gradients occur in an iteration.
         growth_interval (int, optional, default=2000):  Number of consecutive iterations without inf/NaN gradients
             that must occur for the scale to be multiplied by ``growth_factor``.
-        enabled (bool, optional, default=True):  If ``False``, disables gradient scaling. :meth:`step` simply
+        enabled (bool, optional):  If ``False``, disables gradient scaling. :meth:`step` simply
             invokes the underlying ``optimizer.step()``, and other methods become no-ops.
+            Default: ``True``
         process_group (ProcessGroup, optional, default=torch.distributed.group.WORLD):
             process group for sharding
     """

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -367,7 +367,7 @@ def list(github, force_reload=False, skip_validation=False, trust_repo=None):
             specified by the ``github`` argument properly belongs to the repo owner. This will make
             requests to the GitHub API; you can specify a non-default GitHub token by setting the
             ``GITHUB_TOKEN`` environment variable. Default is ``False``.
-        trust_repo (bool, string or None): ``"check"``, ``True``, ``False`` or ``None``.
+        trust_repo (bool, str or None): ``"check"``, ``True``, ``False`` or ``None``.
             This parameter was introduced in v1.12 and helps ensuring that users
             only run code from repos that they trust.
 
@@ -423,7 +423,7 @@ def help(github, model, force_reload=False, skip_validation=False, trust_repo=No
             specified by the ``github`` argument properly belongs to the repo owner. This will make
             requests to the GitHub API; you can specify a non-default GitHub token by setting the
             ``GITHUB_TOKEN`` environment variable. Default is ``False``.
-        trust_repo (bool, string or None): ``"check"``, ``True``, ``False`` or ``None``.
+        trust_repo (bool, str or None): ``"check"``, ``True``, ``False`` or ``None``.
             This parameter was introduced in v1.12 and helps ensuring that users
             only run code from repos that they trust.
 
@@ -485,7 +485,7 @@ def load(repo_or_dir, model, *args, source='github', trust_repo=None, force_relo
         *args (optional): the corresponding args for callable ``model``.
         source (str, optional): 'github' or 'local'. Specifies how
             ``repo_or_dir`` is to be interpreted. Default is 'github'.
-        trust_repo (bool, string or None): ``"check"``, ``True``, ``False`` or ``None``.
+        trust_repo (bool, str or None): ``"check"``, ``True``, ``False`` or ``None``.
             This parameter was introduced in v1.12 and helps ensuring that users
             only run code from repos that they trust.
 

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -1053,7 +1053,7 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None,
      and as a decorator ``@torch.jit.script`` for :ref:`torchscript-classes` and functions.
 
     Args:
-        obj (callable, class, or ``nn.Module``):  The ``nn.Module``, function, class type,
+        obj (callable, class, or nn.Module):  The ``nn.Module``, function, class type,
                                                   dictionary, or list to compile.
         example_inputs (Union[List[Tuple], Dict[Callable, List[Tuple]], None]): Provide example inputs
             to annotate the arguments for a function or ``nn.Module``.

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -246,7 +246,7 @@ def dirac_(tensor, groups=1):
 
     Args:
         tensor: a {3, 4, 5}-dimensional `torch.Tensor`
-        groups (optional): number of groups in the conv layer (default: 1)
+        groups (int, optional): number of groups in the conv layer (default: 1)
     Examples:
         >>> w = torch.empty(3, 16, 5, 5)
         >>> nn.init.dirac_(w)

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -222,9 +222,10 @@ def checkpoint(function, *args, use_reentrant: bool = True, **kwargs):
             passed as the tuple. For example, in LSTM, if user passes
             ``(activation, hidden)``, :attr:`function` should correctly use the
             first input as ``activation`` and the second input as ``hidden``
-        preserve_rng_state(bool, optional, default=True):  Omit stashing and restoring
+        preserve_rng_state(bool, optional):  Omit stashing and restoring
             the RNG state during each checkpoint.
-        use_reentrant(bool, optional, default=True): Use checkpointing
+            Default: ``True``
+        use_reentrant(bool, optional): Use checkpointing
             implementation that requires re-entrant autograd.
             If ``use_reentrant=False`` is specified, ``checkpoint`` will use an
             implementation that does not require re-entrant autograd. This
@@ -232,6 +233,7 @@ def checkpoint(function, *args, use_reentrant: bool = True, **kwargs):
             working as expected with ``torch.autograd.grad`` and support for
             keyword arguments input into the checkpointed function. Note that future
             versions of PyTorch will default to ``use_reentrant=False``.
+            Default: ``True``
         args: tuple containing inputs to the :attr:`function`
 
     Returns:
@@ -284,8 +286,9 @@ def checkpoint_sequential(functions, segments, input, **kwargs):
             functions (comprising the model) to run sequentially.
         segments: Number of chunks to create in the model
         input: A Tensor that is input to :attr:`functions`
-        preserve_rng_state(bool, optional, default=True):  Omit stashing and restoring
+        preserve_rng_state(bool, optional):  Omit stashing and restoring
             the RNG state during each checkpoint.
+            Default: ``True``
 
     Returns:
         Output of running :attr:`functions` sequentially on :attr:`*inputs`
@@ -326,8 +329,9 @@ def _checkpoint_without_reentrant(function, preserve_rng_state=True, *args, **kw
             passed as the tuple. For example, in LSTM, if user passes
             ``(activation, hidden)``, :attr:`function` should correctly use the
             first input as ``activation`` and the second input as ``hidden``
-        preserve_rng_state(bool, optional, default=True):  Omit stashing and restoring
+        preserve_rng_state(bool, optional):  Omit stashing and restoring
             the RNG state during each checkpoint.
+            Default: ``True``
         *args: Arguments to pass in to the given ``function``.
         **kwargs: Keyword arguments to pass into the given ``function``.
     """


### PR DESCRIPTION
### Description


* Docstrings using `(tuple of ints)` shows up as `(tuple of python:ints)`, so I fixed them by making the `int` no longer plural. Example: https://pytorch.org/docs/stable/generated/torch.permute.html#torch.permute
* A docstring type in JIT had one of its types incorrectly highlighted as code. Example: https://pytorch.org/docs/stable/generated/torch.jit.script.html#torch.jit.script
* I found some docstring type usages of `string` that had not yet been converted to `str` after #82410
* Some docstrings incorrectly listed their defaults inside the docstring types.
* I also found a docstring that was missing its type

### Testing
No testing should be required.

---

In the developer guidelines, there should probably be standards listed for the docstring types.