### PR TITLE
Fix docker build error related to libc6

### DIFF
--- a/.circleci/docker/common/install_clang.sh
+++ b/.circleci/docker/common/install_clang.sh
@@ -13,6 +13,9 @@ if [ -n "$CLANG_VERSION" ]; then
     sudo apt-get install  -y --no-install-recommends gpg-agent
     wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add  -
     apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${CLANG_VERSION} main"
+  elif [[ $UBUNTU_VERSION == 22.04 ]]; then
+    # work around ubuntu apt-get conflicts
+    sudo apt-get -y -f install
   fi
 
   sudo apt-get update


### PR DESCRIPTION
### Description
We have following failure in libc6 on postnightly builds:
https://github.com/pytorch/pytorch/runs/7579216955?check_suite_focus=true

```
The following packages have unmet dependencies:
 libc6-i386 : Depends: libc6 (= 2.35-0ubuntu3) but 2.35-0ubuntu3.1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

### Testing
In CI
