### PR TITLE
Remove nested tensor dispatch key if the op is CompositeImplicit

### DIFF
--- a/aten/src/ATen/native/Dropout.cpp
+++ b/aten/src/ATen/native/Dropout.cpp
@@ -117,6 +117,9 @@ Tensor native_dropout_backward_cpu(const Tensor& grad, const Tensor& mask, doubl
 Tensor dropout(const Tensor& input, double p, bool train) {
   auto result = [&]() {
     NoNamesGuard guard;
+    if (input.is_nested()) {
+      return std::get<0>(at::native_dropout(input, p, train));
+    }
     if (train && is_fused_kernel_acceptable(input, p)) {
       return std::get<0>(at::native_dropout(input, p, train));
     }

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -18,6 +18,9 @@
 namespace at { namespace native {
 
 Tensor linear(const Tensor& input, const Tensor& weight, const c10::optional<Tensor>& bias_opt) {
+  if (input.is_nested()) {
+    return at::nested_linear(input, weight, bias_opt);
+  }
   // See [Note: hacky wrapper removal for optional tensor]
   auto bias = bias_opt.has_value()
     ? c10::MaybeOwned<Tensor>::borrowed(*bias_opt)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -222,6 +222,7 @@
   dispatch:
     CPU: native_dropout_cpu
     CUDA: native_dropout_cuda
+    NestedTensorCPU, NestedTensorCUDA: native_dropout_nested
   tags: nondeterministic_seeded
 
 - func: native_dropout_backward(Tensor grad_output, Tensor mask, float scale) -> Tensor
@@ -242,15 +243,9 @@
 - func: _shape_as_tensor(Tensor self) -> Tensor
 
 - func: dropout(Tensor input, float p, bool train) -> Tensor
-  dispatch:
-    CompositeImplicitAutograd: dropout
-    NestedTensorCPU, NestedTensorCUDA: dropout_nested
   tags: nondeterministic_seeded
 
 - func: dropout_(Tensor(a!) self, float p, bool train) -> Tensor(a!)
-  dispatch:
-    CompositeImplicitAutograd: dropout_
-    NestedTensorCPU, NestedTensorCUDA: dropout_nested_
 
 - func: feature_dropout(Tensor input, float p, bool train) -> Tensor
 
@@ -2777,11 +2772,12 @@
 
 - func: linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor
   python_module: nn
+
+- func: nested_linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor
   dispatch:
-    CompositeImplicitAutograd: linear
     NestedTensorCPU, NestedTensorCUDA: nested_linear
 
-- func: linear_backward(Tensor self, Tensor grad_output, Tensor weight, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+- func: nested_linear_backward(Tensor self, Tensor grad_output, Tensor weight, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
   dispatch:
     NestedTensorCPU, NestedTensorCUDA: nested_linear_backward
 
@@ -4435,9 +4431,6 @@
 # softmax allows positional dtype, unlike most operators, because kwonly is BC-breaking when loading jit models.
 - func: softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor
   variants: function, method
-  dispatch:
-    CompositeImplicitAutograd: softmax
-    NestedTensorCPU, NestedTensorCUDA: softmax
 
 - func: softmax.int_out(Tensor self, int dim, ScalarType? dtype=None, *, Tensor(a!) out) -> Tensor(a!)
   variants: function

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -768,10 +768,15 @@ Tensor dropout_nested(const Tensor& input, double p, bool train) {
   return wrap_buffer(output_buffer, sizemat.clone());
 }
 
-Tensor& dropout_nested_(Tensor& input, double p, bool train) {
-  Tensor input_buffer = get_buffer(input);
-  at::dropout_(input_buffer, p, train);
-  return input;
+std::tuple<Tensor,Tensor> native_dropout_nested(const Tensor& input, double p, c10::optional<bool> train) {
+  auto input_ptr = get_nested_tensor_impl(input);
+  const Tensor & input_buffer = input_ptr->get_buffer(),
+               & sizemat = input_ptr->get_nested_size_tensor();
+  Tensor output_buffer, mask_buffer;
+  std::tie(output_buffer, mask_buffer) = at::native_dropout(input_buffer, p, train);
+  Tensor output = wrap_buffer(output_buffer, sizemat.clone()),
+           mask = wrap_buffer(mask_buffer, sizemat.clone());
+  return std::make_tuple(output, mask);
 }
 
 Tensor softmax_nested(

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2150,8 +2150,8 @@
   result0: gather(self_t.flatten(-3), -1, result1.flatten(-3)).view_as(result1)
   output_differentiability: [True, False]
 
-- name: linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor
-  input, weight, bias: linear_backward(input, grad, weight, grad_input_mask)
+- name: nested_linear(Tensor input, Tensor weight, Tensor? bias=None) -> Tensor
+  input, weight, bias: nested_linear_backward(input, grad, weight, grad_input_mask)
 
 #mps
 - name: _mps_max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor


### PR DESCRIPTION
Historically, nested tensor dispatch key was left out from composite, as pointed out by issue [#79048](https://github.com/pytorch/pytorch/issues/79048). As a result, if an op is declared to be CompositeImplicit (e.g. dropout, softmax, linear), then when calling on nested tensor the dispatcher would raise "not registered" error rather than call into the CompositeImplicit op.

The hacky solution was to add "NestedTensorCPU, NestedTensorCUDA" entry to "native_functions.yaml" even if the op is CompositeImplicit. This is flaky, so it may cause some unexpected trouble.

As pull request [#80273](https://github.com/pytorch/pytorch/pull/80273) resolves the historical problem by adding AutogradNestedTensor key to CompositeImplicit, we can now remove the hacky practice.

In addition, the `torch.inference_mode()` constraint can be removed. It was flaky in the past:
* some ops could be called without `torch.inference_mode()`, but some must otherwise they would get dispatched to regular tensor kernels rather than the desired nested tensor ones
* if created a nested tensor out of a `torch.inference_mode()` scope, then passing it to an `@torch.inference_mode()` decorated function would trigger "try to set version counter in inference mode" error

Now the CompositeImplicit nested tensor dispatching behaviour under  `torch.inference_mode()` is to get "not registered" error as expected, since CompositeImplicit includes only AutogradNestedTensor key, no NestedTensorCPU nor NestedTensorCUDA. Maybe @drisspg can add them in the future.