### PR TITLE
Do not assume what is in  `os.environ`

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -868,14 +868,15 @@ def get_selected_tests(options):
                 test_file_times = cast(Dict[str, Any], json.load(f))
         else:
             test_file_times = {}
-        if os.environ["TEST_CONFIG"] not in test_file_times:
+        test_config = os.environ.get("TEST_CONFIG")
+        if test_config not in test_file_times:
             print(
                 "::warning:: Gathered no stats from artifacts. Proceeding with default sharding plan."
             )
             selected_tests = selected_tests[which_shard - 1 :: num_shards]
         else:
             print("Found test time stats from artifacts")
-            test_file_times_config = test_file_times[os.environ["TEST_CONFIG"]]
+            test_file_times_config = test_file_times[test_config]
             shards = calculate_shards(num_shards, selected_tests, test_file_times_config)
             _, tests_from_shard = shards[which_shard - 1]
             selected_tests = tests_from_shard

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -712,8 +712,9 @@ def run_tests(argv=UNITTEST_ARGS):
         test_filename = sanitize_test_filename(test_filename)
         test_report_path = TEST_SAVE_XML + LOG_SUFFIX
         test_report_path = os.path.join(test_report_path, test_filename)
-        if test_filename in PYTEST_FILES and not IS_SANDCASTLE and not (
-            "cuda" in os.environ["BUILD_ENVIRONMENT"] and "linux" in os.environ["BUILD_ENVIRONMENT"]
+        build_environment = os.environ.get("BUILD_ENVIRONMENT", "")
+        if test_filename in PYTEST_FILES and not IS_SANDCASTLE and any(
+            "cuda" in build_environment and "linux" in build_environment
         ):
             # exclude linux cuda tests because we run into memory issues when running in parallel
             import pytest
@@ -725,7 +726,7 @@ def run_tests(argv=UNITTEST_ARGS):
             pytest_report_path = os.path.join(pytest_report_path, f"{test_filename}.xml")
             print(f'Test results will be stored in {pytest_report_path}')
             # mac slower on 4 proc than 3
-            num_procs = 3 if "macos" in os.environ["BUILD_ENVIRONMENT"] else 4
+            num_procs = 3 if "macos" in build_environment else 4
             # f = failed
             # E = error
             # X = unexpected success

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -713,7 +713,7 @@ def run_tests(argv=UNITTEST_ARGS):
         test_report_path = TEST_SAVE_XML + LOG_SUFFIX
         test_report_path = os.path.join(test_report_path, test_filename)
         build_environment = os.environ.get("BUILD_ENVIRONMENT", "")
-        if test_filename in PYTEST_FILES and not IS_SANDCASTLE and (
+        if test_filename in PYTEST_FILES and not IS_SANDCASTLE and not (
             "cuda" in build_environment and "linux" in build_environment
         ):
             # exclude linux cuda tests because we run into memory issues when running in parallel

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -713,7 +713,7 @@ def run_tests(argv=UNITTEST_ARGS):
         test_report_path = TEST_SAVE_XML + LOG_SUFFIX
         test_report_path = os.path.join(test_report_path, test_filename)
         build_environment = os.environ.get("BUILD_ENVIRONMENT", "")
-        if test_filename in PYTEST_FILES and not IS_SANDCASTLE and any(
+        if test_filename in PYTEST_FILES and not IS_SANDCASTLE and (
             "cuda" in build_environment and "linux" in build_environment
         ):
             # exclude linux cuda tests because we run into memory issues when running in parallel


### PR DESCRIPTION
`os.environ['FOO']` will raise `IndexError` if `FOO` is not found, while `os.environ.get('FOO')` would simply return `None`

Fixes https://github.com/pytorch/pytorch/issues/82492

