### PR TITLE
Add subset sampling support for distributed settings.

### DIFF
--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -5,7 +5,7 @@ import torch
 from . import Sampler, Dataset
 import torch.distributed as dist
 
-__all__ = ["DistributedSampler", ]
+__all__ = ["DistributedSampler", "DistributedSubsetSampler"]
 
 T_co = TypeVar('T_co', covariant=True)
 


### PR DESCRIPTION
This is useful for training on a subset of data or splitting validation
sets. The subset sampling only exists for non-distributed settings in
torch.utils.data.sampler.SubsetRandomSampler before this code.

### Description
<!-- What did you change and why was it needed? -->

I have added subset sampling support to the 'torch.utils.data.distributed.DistributedSampler' class. Before this code, subset sampling was only possible in non-distributed settings. 

This is useful for training on a subset of data or splitting validation sets. Since the DataLoader class only accept one sampler, this code is necessary for splitting data in distributed settings (among GPUs and using a subset of data rather than the whole data). 

### Issue
<!-- Link to Issue ticket or RFP -->

I did not submit any issues. But I needed this code for splitting my training data into the validation set. It was easy in non-distributed settings with 'torch.utils.data.sampler.SubsetRandomSampler'. But the only option for distributed settings was 'torch.utils.data.distributed.DistributedSampler', which is not supporting subsets. 

### Testing
<!-- How did you test your change? -->

The code was inherited from a tested class that existed before. The rest of the code is tested with training a model on cifar100. I also tested different corner cases to make sure that the code always has expected behavior and in case of bad usage, it has asserts and provides explanatory exceptions. 

cc @SsnL @VitalyFedyunin @ejguan @NivekT