### PR TITLE
py::cast can fail, check for nullptr

### DIFF
--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -58,6 +58,7 @@ PyObject* THPSize_NewFromSymSizes(const at::Tensor& self_) {
           !torch::jit::tracer::isTracing(),
           "JIT Tracing of SymInts isn't supported");
       auto py_symint = py::cast(si.toSymbolicIntNode()).release().ptr();
+      if (!py_symint) throw python_error();
       PyTuple_SET_ITEM(ret.get(), i, py_symint);
     } else {
       if (torch::jit::tracer::isTracing()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82519
* #82332

This prevents a mysterious segfault on nullptr access
later in the program.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>