### PR TITLE
[foreach][mta] Inplace `maximum` and `minimum`

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -188,7 +188,7 @@ std::vector<Tensor> foreach_tensor_##NAME##_cuda(TensorList tensors1, TensorList
     tensor_lists.emplace_back(std::move(vec_res));                                                         \
                                                                                                            \
     AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, tensors1[0].scalar_type(), "foreach_maximum_minimum_op_cuda", [&]() { \
-        using opmath_t = at::opmath_type<scalar_t>;                                                 \
+        using opmath_t = at::opmath_type<scalar_t>;                                                        \
         auto op = []  GPU_LAMBDA (opmath_t a, opmath_t b) -> opmath_t {                                    \
             opmath_t c = a OP b ? a : b;                                                                   \
             if (_isnan(a)) {                                                                               \
@@ -196,11 +196,36 @@ std::vector<Tensor> foreach_tensor_##NAME##_cuda(TensorList tensors1, TensorList
             }                                                                                              \
             return c;};                                                                                    \
         multi_tensor_apply<3>(tensor_lists,                                                                \
-                              PointwiseOpListFunctor<scalar_t, 3>(),                                       \
-                              op);                                                                         \
+                              BinaryOpListAlphaFunctor<scalar_t, 3, 2, 1>(),                               \
+                              op,                                                                          \
+                              opmath_t(1));                                                                \
     });                                                                                                    \
                                                                                                            \
     return tensor_lists[2];                                                                                \
+}                                                                                                          \
+                                                                                                           \
+void foreach_tensor_##NAME##_cuda_(TensorList self, TensorList other) {                                    \
+  check_foreach_api_restrictions(self, other);                                                             \
+  if (!can_use_fast_route({self, other}) || has_bool_tensor(self)) {                                       \
+    return at::native::foreach_tensor_##NAME##_slow_(self, other);                                         \
+  }                                                                                                        \
+                                                                                                           \
+  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, self[0].scalar_type(), "foreach_maximum_minimum_op_cuda_",  \
+    [&]() {                                                                                                \
+      using opmath_t = at::opmath_type<scalar_t>;                                                          \
+      std::vector<std::vector<at::Tensor>> tensor_lists{self.vec(), other.vec()};                          \
+      auto op = [] GPU_LAMBDA (opmath_t a, opmath_t b) -> opmath_t {                                       \
+        opmath_t c = a OP b ? a : b;                                                                       \
+        if (_isnan(a)) {                                                                                   \
+          c = a;                                                                                           \
+        }                                                                                                  \
+        return c;                                                                                          \
+      };                                                                                                   \
+      multi_tensor_apply<2>(tensor_lists,                                                                  \
+                            BinaryOpListAlphaFunctor<scalar_t, 2, 2, 0>(),                                 \
+                            op,                                                                            \
+                            opmath_t(1));                                                                  \
+  });                                                                                                      \
 }                                                                                                          \
 
 FOREACH_MAXIMUM_MINIMUM_OP(maximum, >)

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -196,7 +196,7 @@ std::vector<Tensor> foreach_tensor_##NAME##_cuda(TensorList tensors1, TensorList
             }                                                                                              \
             return c;};                                                                                    \
         multi_tensor_apply<3>(tensor_lists,                                                                \
-                              BinaryOpListAlphaFunctor<scalar_t, 3, 2, 1>(),                               \
+                              BinaryOpListAlphaFunctor<scalar_t, 3, 2, 2>(),                               \
                               op,                                                                          \
                               opmath_t(1));                                                                \
     });                                                                                                    \

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9209,12 +9209,28 @@
     CPU: foreach_tensor_maximum_slow
     CUDA: foreach_tensor_maximum_cuda
 
+- func: _foreach_maximum_.List(Tensor(a!)[] self, Tensor[] other) -> ()
+  device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
+  variants: function
+  dispatch:
+    CPU: foreach_tensor_maximum_slow_
+    CUDA: foreach_tensor_maximum_cuda_
+  autogen: _foreach_maximum.List_out
+
 - func: _foreach_minimum.List(Tensor[] self, Tensor[] other) -> Tensor[]
   device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
   variants: function
   dispatch:
     CPU: foreach_tensor_minimum_slow
     CUDA: foreach_tensor_minimum_cuda
+
+- func: _foreach_minimum_.List(Tensor(a!)[] self, Tensor[] other) -> ()
+  device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices
+  variants: function
+  dispatch:
+    CPU: foreach_tensor_minimum_slow_
+    CUDA: foreach_tensor_minimum_cuda_
+  autogen: _foreach_minimum.List_out
 
 - func: _foreach_norm.Scalar(Tensor[] self, Scalar ord=2) -> Tensor[]
   device_check: NoCheck   # foreach kernels fall back to slow path when tensor are on different devices

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -44,7 +44,7 @@ def getScalarLists(N):
 
 _BOOL_SUB_ERR_MSG = "Subtraction, the `-` operator"
 
-# TODO(crcrpar): [refactoring] for inplace case, call a native function with `out` specified.
+# TODO(crcrpar): refactor for inplace case, call a native function with `out` specified.
 class RegularFuncWrapper:
 
     def __init__(self, func, arg_out_not_inplace: bool = False):

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: mta"]
 
-import copy
 import itertools
 from numbers import Number
 import random
@@ -44,41 +43,21 @@ def getScalarLists(N):
 
 _BOOL_SUB_ERR_MSG = "Subtraction, the `-` operator"
 
-# TODO(crcrpar): refactor for inplace case, call a native function with `out` specified.
 class RegularFuncWrapper:
 
-    def __init__(self, func, arg_out_not_inplace: bool = False):
+    def __init__(self, func):
         self.func = func
-        self.arg_out_not_inplace = arg_out_not_inplace
 
     def __call__(self, inputs, values=None, **kwargs):
         if values is not None:
             assert len(inputs) == 3
             if isinstance(values, Number):
                 values = [values for _ in range(len(inputs[0]))]
-            if self.arg_out_not_inplace:
-                result = []
-                for idx, i in enumerate(zip(*inputs)):
-                    cur_kwargs = copy.deepcopy(kwargs)
-                    cur_kwargs.update({"out": i[0]})
-                    self.func(*i, value=values[idx], **cur_kwargs)
-                    result.append(i[0])
-                return result
-            else:
-                return [self.func(*i, value=values[idx], **kwargs) for idx, i in enumerate(zip(*inputs))]
+            return [self.func(*i, value=values[idx], **kwargs) for idx, i in enumerate(zip(*inputs))]
         if len(inputs) == 2 and isinstance(inputs[1], Number):
             # binary op with tensorlist and scalar.
             inputs[1] = [inputs[1] for _ in range(len(inputs[0]))]
-        if self.arg_out_not_inplace:
-            result = []
-            for i in zip(*inputs):
-                cur_kwargs = copy.deepcopy(kwargs)
-                cur_kwargs.update({"out": i[0]})
-                self.func(*i, **kwargs)
-                result.append(i[0])
-            return result
-        else:
-            return [self.func(*i, **kwargs) for i in zip(*inputs)]
+        return [self.func(*i, **kwargs) for i in zip(*inputs)]
 
 
 class ForeachFuncWrapper:
@@ -118,12 +97,12 @@ class TestForeach(TestCase):
     # note(mkozuki): It might be the case that the expected number of `cudaLaunchKernel`s
     # is greater than 1 once foreach functions internally separate their input `TensorList`s by
     # devices & dtypes into vectors of tensors.
-    def _get_funcs(self, op, n_expected_cudaLaunchKernels: int, arg_out_not_inplace: bool = False):
+    def _get_funcs(self, op, n_expected_cudaLaunchKernels: int):
         return (
             ForeachFuncWrapper(op.method_variant, n_expected_cudaLaunchKernels),
-            RegularFuncWrapper(op.ref, arg_out_not_inplace=False),
+            RegularFuncWrapper(op.ref),
             ForeachFuncWrapper(op.inplace_variant, n_expected_cudaLaunchKernels),
-            RegularFuncWrapper(op.ref_inplace, arg_out_not_inplace=arg_out_not_inplace),
+            RegularFuncWrapper(op.ref_inplace),
         )
 
     def _binary_test(self, dtype, op, ref, inputs, is_fastpath, is_inplace, *, alpha=None):
@@ -391,15 +370,16 @@ class TestForeach(TestCase):
         for N in N_values:
             self._test_unary(device, dtype, op, N, is_fastpath=False)
 
+    # note(crcrpar): `torch.maximum` and `torch.minimum` support `out` arg but there seem to be no inplace versions.
+    # So, compare `inplace_op` results with `ref`'s outputs.
     def _minmax_test(self, opinfo, inputs, is_fastpath, n_expected_cudaLaunchKernels):
-        op, ref, inplace_op, inplace_ref = self._get_funcs(opinfo, n_expected_cudaLaunchKernels, True)
-        self.assertEqual(ref(inputs), op(inputs, self.is_cuda, is_fastpath))
+        op, ref, inplace_op, _ = self._get_funcs(opinfo, n_expected_cudaLaunchKernels)
+        expected = ref(inputs)
+        self.assertEqual(expected, op(inputs, self.is_cuda, is_fastpath))
 
         inplace_inputs = [[t.clone() for t in inputs[0]], inputs[1]]
-        inplace_ref_inputs = [[t.clone() for t in inputs[0]], inputs[1]]
-        inplace_ref(inplace_ref_inputs)
         inplace_op(inplace_inputs, self.is_cuda, is_fastpath)
-        self.assertEqual(inplace_ref_inputs[0], inplace_inputs[0])
+        self.assertEqual(expected, inplace_inputs[0])
 
     @ops(foreach_minmax_op_db)
     def test_minmax_fastpath(self, device, dtype, op):

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -393,7 +393,7 @@ def _multi_tensor_adam(params: List[Tensor],
 
         if amsgrad:
             # Maintains the maximum of all 2nd moment running avg. till now
-            max_exp_avg_sqs = torch._foreach_maximum(max_exp_avg_sqs, exp_avg_sqs)  # type: ignore[assignment]
+            torch._foreach_maximum_(max_exp_avg_sqs, exp_avg_sqs)
 
             # Use the max. for normalizing running avg. of gradient
             max_exp_avg_sq_sqrt = torch._foreach_sqrt(max_exp_avg_sqs)

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -365,7 +365,7 @@ def _multi_tensor_adam(params: List[Tensor],
 
         if amsgrad:
             # Maintains the maximum of all 2nd moment running avg. till now
-            max_exp_avg_sqs = torch._foreach_maximum(max_exp_avg_sqs, exp_avg_sqs)  # type: ignore[assignment]
+            torch._foreach_maximum_(max_exp_avg_sqs, exp_avg_sqs)  # type: ignore[assignment]
 
             # Use the max. for normalizing running avg. of gradient
             max_exp_avg_sq_sqrt = torch._foreach_sqrt(max_exp_avg_sqs)

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -369,7 +369,7 @@ def _multi_tensor_adamw(params: List[Tensor],
 
         if amsgrad:
             # Maintains the maximum of all 2nd moment running avg. till now
-            max_exp_avg_sqs = torch._foreach_maximum(max_exp_avg_sqs, exp_avg_sqs)  # type: ignore[assignment]
+            torch._foreach_maximum_(max_exp_avg_sqs, exp_avg_sqs)
 
             # Use the max. for normalizing running avg. of gradient
             max_exp_avg_sq_sqrt = torch._foreach_sqrt(max_exp_avg_sqs)
@@ -397,7 +397,7 @@ def _multi_tensor_adamw(params: List[Tensor],
 
         if amsgrad:
             # Maintains the maximum of all 2nd moment running avg. till now
-            max_exp_avg_sqs = torch._foreach_maximum(max_exp_avg_sqs, exp_avg_sqs)  # type: ignore[assignment]
+            torch._foreach_maximum_(max_exp_avg_sqs, exp_avg_sqs)
 
             # Use the max. for normalizing running avg. of gradient
             max_exp_avg_sq_sqrt = torch._foreach_sqrt(max_exp_avg_sqs)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6623,16 +6623,13 @@ def sample_inputs_foreach(self, device, dtype, N, *, noncontiguous=False, same_s
 def get_foreach_method_names(name):
     # get torch inplace reference function
     op_name = "_foreach_" + name
+    inplace_op_name = op_name + "_"
 
     op = getattr(torch, op_name, None)
-    inplace_op = getattr(torch, op_name + "_", None)
+    inplace_op = getattr(torch, inplace_op_name, None)
 
     ref = getattr(torch, name, None)
-    if name in ("maximum", "minimum"):
-        ref_inplace = ref
-    else:
-        ref_inplace = getattr(torch.Tensor, name + "_", None)
-
+    ref_inplace = getattr(torch.Tensor, name + "_", None)
     return op, inplace_op, ref, ref_inplace
 
 class ForeachFuncInfo(OpInfo):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6623,13 +6623,16 @@ def sample_inputs_foreach(self, device, dtype, N, *, noncontiguous=False, same_s
 def get_foreach_method_names(name):
     # get torch inplace reference function
     op_name = "_foreach_" + name
-    inplace_op_name = "_foreach_" + name + "_"
 
     op = getattr(torch, op_name, None)
-    inplace_op = getattr(torch, inplace_op_name, None)
+    inplace_op = getattr(torch, op_name + "_", None)
 
     ref = getattr(torch, name, None)
-    ref_inplace = getattr(torch.Tensor, name + "_", None)
+    if name in ("maximum", "minimum"):
+        ref_inplace = ref
+    else:
+        ref_inplace = getattr(torch.Tensor, name + "_", None)
+
     return op, inplace_op, ref, ref_inplace
 
 class ForeachFuncInfo(OpInfo):


### PR DESCRIPTION
### Description
<!-- What did you change and why was it needed? -->
Implement `torch._foreach_maximum_` and `torch._foreach_minimum_` mainly for `_multi_tensor_adam` and `_multi_tensor_adamw` with `amsgrad=True` to correctly update their `max_exp_avg_sqs`.

### Issue
<!-- Link to Issue ticket or RFP -->
- https://github.com/pytorch/pytorch/issues/78807
- https://github.com/pytorch/pytorch/pull/81894
- https://github.com/pytorch/pytorch/pull/81348
- https://github.com/pytorch/pytorch/pull/81705
- https://github.com/pytorch/pytorch/issues/58833
- https://github.com/pytorch/pytorch/issues/68041

### Testing
<!-- How did you test your change? -->
Updated `test_foreach.py::TestForeach::_minmax_test` to compare the outputs of `_foreach_maximum_` (and `_foreach_minimum_`) against those of `[torch.maximum(a, b) for a, b in zip(tensors1, tensors2)]`

cc @ngimel @albanD @mikaylagawarecki 