### PR TITLE
Update backends.rst

### DIFF
--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -11,6 +11,7 @@ These backends include:
 
 - ``torch.backends.cuda``
 - ``torch.backends.cudnn``
+- ``torch.backends.mps``
 - ``torch.backends.mkl``
 - ``torch.backends.mkldnn``
 - ``torch.backends.openmp``


### PR DESCRIPTION
### Description
Added `torch.backends.mps` to list of avaiable torch.backends at the top, it was missing.
