### PR TITLE
[MPS] Check grad correctness in the generic test framework in `test_mps.py`

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6660,7 +6660,10 @@ class TestConsistency(TestCase):
                 if not op.supports_autograd:
                     continue
 
-                if key in self.BACKWARD_BLOCK_LIST or str(dtype) not in MPS_DTYPES_REQ_GRAD:
+                if str(dtype) not in MPS_DTYPES_REQ_GRAD:
+                    continue
+
+                if key in self.BACKWARD_BLOCK_LIST:
                     if self.BACKWARD_BLOCK_LIST[key] is None or str(dtype) in self.BACKWARD_BLOCK_LIST[key]:
                         continue
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6608,6 +6608,7 @@ class TestConsistency(TestCase):
         'logaddexp2': None,  # `aten::pow.Scalar_out`
         'nn.functional.mse_loss': ['torch.float16'],  # `Half`
         'nn.functional.smooth_l1_loss': ['torch.float16'],  # `Half`
+        'nn.functional.embedding': None,  # #82809
     }
 
     # Used for accept mode only
@@ -6689,7 +6690,7 @@ class TestConsistency(TestCase):
 
                 if isinstance(cpu_sample.input, (list, tuple)):
                     for cpu_sample_, mps_sample_ in zip(cpu_sample.input, mps_sample.input):
-                        self.assertEqual(cpu_sample_, mps_sample_)
+                        self.assertEqual(cpu_sample_.input.grad, mps_sample_.input.grad)
                 else:
                     self.assertEqual(cpu_sample.input.grad, mps_sample.input.grad)
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6693,7 +6693,7 @@ class TestConsistency(TestCase):
 
                 if isinstance(cpu_sample.input, (list, tuple)):
                     for cpu_sample_, mps_sample_ in zip(cpu_sample.input, mps_sample.input):
-                        self.assertEqual(cpu_sample_.input.grad, mps_sample_.input.grad)
+                        self.assertEqual(cpu_sample_.grad, mps_sample_.grad)
                 else:
                     self.assertEqual(cpu_sample.input.grad, mps_sample.input.grad)
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6592,6 +6592,10 @@ class TestConsistency(TestCase):
         'take_along_dim': None,
     }
 
+    BACKWARD_BLOCK_LIST = {
+        'diff': None,
+    }
+
     # Used for accept mode only
     NEW_ALLOW_LIST = defaultdict(list)
 
@@ -6639,9 +6643,10 @@ class TestConsistency(TestCase):
                 mps_out = op(*mps_args, **mps_kwargs)
                 self.assertEqual(cpu_out, mps_out)
 
-                cpu_out.sum().backward()
-                mps_out.sum().backward()
-                self.assertEqual(cpu_sample.input.grad, mps_sample.input.grad)
+                if key not in self.BACKWARD_BLOCK_LIST:
+                    cpu_out.sum().backward()
+                    mps_out.sum().backward()
+                    self.assertEqual(cpu_sample.input.grad, mps_sample.input.grad)
 
         except Exception as e:
             if not generate_new_truth:

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6645,8 +6645,7 @@ class TestConsistency(TestCase):
                 mps_out = op(*mps_args, **mps_kwargs)
                 self.assertEqual(cpu_out, mps_out)
 
-
-                if key in self.BACKWARD_BLOCK_LIST or dtype not in ["torch.float16", "torch.float32"]:
+                if key in self.BACKWARD_BLOCK_LIST or str(dtype) not in ["torch.float16", "torch.float32"]:
                     continue
 
                 cpu_sample = cpu_sample.transform(lambda x: x.requires_grad_() if isinstance(x, torch.Tensor) else x)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6593,7 +6593,9 @@ class TestConsistency(TestCase):
     }
 
     BACKWARD_BLOCK_LIST = {
+        # Segmentation fault
         'diff': None,
+        'sub': None,
     }
 
     # Used for accept mode only
@@ -6643,6 +6645,7 @@ class TestConsistency(TestCase):
                 mps_out = op(*mps_args, **mps_kwargs)
                 self.assertEqual(cpu_out, mps_out)
 
+                print(mps_args, mps_kwargs)
                 if key not in self.BACKWARD_BLOCK_LIST:
                     cpu_out.sum().backward()
                     mps_out.sum().backward()

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6599,6 +6599,9 @@ class TestConsistency(TestCase):
         'sub': None,
         'true_divide': None,
 
+        # assertion errors
+        'index_select': ['torch.float16'],
+
         # some aten operators in the derivative definition have not been supported by MPS
         'masked_select': None,  # `aten::masked_scatter_`
         'sgn': None,  # `aten::_efficientzerotensor`

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -6596,6 +6596,7 @@ class TestConsistency(TestCase):
         # Segmentation fault
         'diff': None,
         'sub': None,
+        'true_divide': None,
     }
 
     # Used for accept mode only
@@ -6645,7 +6646,6 @@ class TestConsistency(TestCase):
                 mps_out = op(*mps_args, **mps_kwargs)
                 self.assertEqual(cpu_out, mps_out)
 
-                print(mps_args, mps_kwargs)
                 if key not in self.BACKWARD_BLOCK_LIST:
                     cpu_out.sum().backward()
                     mps_out.sum().backward()


### PR DESCRIPTION
### Description
This PR:

1. adds the grad correctness check
2. fixes the segm fault error of `prelu` backward by returning zero-element gard tensors fast.

### Issue
<!-- Link to Issue ticket or RFP -->

### Testing
<!-- How did you test your change? -->
