### PR TITLE
fix: exclude NNAPI src files if `USE_NNAPI` is disabled

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -178,8 +178,13 @@ else()
     ${native_quantized_cpp} ${native_mkl_cpp} ${native_mkldnn_cpp}
     ${native_transformers_cpp}
     ${native_utils_cpp} ${native_xnnpack} ${generated_sources} ${core_generated_sources}
-    ${ATen_CPU_SRCS} ${ATen_QUANTIZED_SRCS} ${ATen_NNAPI_SRCS} ${cpu_kernel_cpp}
+    ${ATen_CPU_SRCS} ${ATen_QUANTIZED_SRCS} ${cpu_kernel_cpp}
   )
+
+  # Add NNAPI wrapper only if NNAPI is being used.
+  if(USE_NNAPI)
+    set(all_cpu_cpp ${all_cpu_CPP} ${ATen_NNAPI_SRCS})
+  endif()
 endif()
 
 if(USE_LIGHTWEIGHT_DISPATCH)


### PR DESCRIPTION
### Description
<!-- What did you change and why was it needed? -->
- When building a static libtorch library, the inclusion of NNAPI source files require programs to link to `dl`, even if `USE_NNAPI` is disabled. This prevented building a fully static portable binary.

- This PR updates the `aten/src/Aten/CMakeLists.txt` file to include NNAPI source files only when `USE_NNAPI` is enabled and allows programs to not have to link to `dl` if *not* dynamically dispatching to `NNAPI`

### Testing
<!-- How did you test your change? -->
Built libtorch from source and linked statically