### PR TITLE
Add missing TORCH_ASSERT_*_OPERATORS defines in native/cuda

### DIFF
--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -1,3 +1,4 @@
+#define TORCH_ASSERT_NO_OPERATORS
 #include <ATen/Dispatch.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/LinearAlgebra.h>

--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -1,4 +1,4 @@
-// #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/ReduceOps.h>
@@ -20,16 +20,10 @@
 #include <ATen/ops/batch_norm_stats_native.h>
 #include <ATen/ops/batch_norm_update_stats_native.h>
 #include <ATen/ops/empty_like.h>
+#include <ATen/ops/from_blob.h>
 #include <ATen/ops/native_batch_norm_backward_native.h>
 #include <ATen/ops/native_batch_norm_native.h>
 #include <ATen/ops/scalar_tensor.h>
-#endif
-
-// TODO: Doesn't exist in this branch
-#if 0
-#include <ATen/ops/from_blob.h>
-#else
-#include <ATen/Functions.h>
 #endif
 
 namespace at { namespace native {

--- a/aten/src/ATen/native/cuda/RenormKernel.cu
+++ b/aten/src/ATen/native/cuda/RenormKernel.cu
@@ -1,3 +1,4 @@
+#define TORCH_ASSERT_NO_OPERATORS
 #include <ATen/native/Normalization.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>

--- a/aten/src/ATen/native/cuda/ReplicationPadding.cu
+++ b/aten/src/ATen/native/cuda/ReplicationPadding.cu
@@ -1,3 +1,4 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/core/Tensor.h>
 #include <ATen/ceil_div.h>
 #include <ATen/Dispatch.h>

--- a/aten/src/ATen/native/cuda/ValidateCompressedIndicesKernel.cu
+++ b/aten/src/ATen/native/cuda/ValidateCompressedIndicesKernel.cu
@@ -1,3 +1,4 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/sparse/ValidateCompressedIndicesCommon.h>
 #include <ATen/native/cuda/Loops.cuh>
 


### PR DESCRIPTION
Some minor cleanup:
- `ValidateCompressedIndicesKernel.cu` is a new file
- `LinearAlgebra.cu` had its define removed in #67833
- `Normalization.cu` was waiting on the `from_blob.h` file
- the others may have been oversights on my part
