### PR TITLE
Fix nondeterminism in torchgen

### DIFF
--- a/torchgen/dest/ufunc.py
+++ b/torchgen/dest/ufunc.py
@@ -286,13 +286,14 @@ def compute_ufunc_cuda(g: NativeFunctionsGroup) -> str:
 
     # Next, build the conditionals
     sig = StructuredImplSignature(g, ufunc.kernel_name(g, DispatchKey.CUDA))
+    supported_dtypes = sorted(ufunctor_sigs.keys(), key=lambda x: str(x))
     dtype_cases = []
-    for dtype, inner_ufunctor_sigs in ufunctor_sigs.items():
+    for dtype in supported_dtypes:
         dtype_cases.append(
             f"""
 AT_DISPATCH_CASE(at::ScalarType::{dtype},
   [&]() {{
-    {compute_ufunc_cuda_dtype_body(g, dtype, inner_ufunctor_sigs, sig.arguments())}
+    {compute_ufunc_cuda_dtype_body(g, dtype, ufunctor_sigs[dtype], sig.arguments())}
   }}
 )
 """
@@ -514,13 +515,14 @@ def compute_ufunc_cpu_kernel(g: NativeFunctionsGroup) -> str:
                     )
 
     # Build the conditionals
+    supported_dtypes = sorted(ufunc_sigs.keys(), key=lambda x: str(x))
     dtype_cases = []
-    for dtype, inner_ufunc_sigs in ufunc_sigs.items():
+    for dtype in supported_dtypes:
         dtype_cases.append(
             f"""
 AT_DISPATCH_CASE(at::ScalarType::{dtype},
   [&]() {{
-    {compute_ufunc_cpu_dtype_body(g, dtype, inner_ufunc_sigs, stub_sig.arguments())}
+    {compute_ufunc_cpu_dtype_body(g, dtype, ufunc_sigs[dtype], stub_sig.arguments())}
   }}
 )
 """

--- a/torchgen/gen.py
+++ b/torchgen/gen.py
@@ -1890,7 +1890,7 @@ def gen_headers(
     core_fm.write("aten_interned_strings.h", gen_aten_interned_strings)
 
     def gen_tags_enum() -> Dict[str, str]:
-        return {"enum_of_valid_tags": (",\n".join([f"{tag}" for tag in valid_tags]))}
+        return {"enum_of_valid_tags": (",\n".join(sorted(valid_tags)))}
 
     core_fm.write("enum_tag.h", gen_tags_enum)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82536

Closes #82320

The iteration order of a `set` can change from run to run, resulting
in real content changes to generated files and therefore unnecessary
rebuilding.

The fix is to use a sort to give a repeatable iteration order.