### PR TITLE
Store non-symbolic SymInt as int in IValue

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -555,9 +555,15 @@ public:
     payload.u.as_int = i;
   }
 
-  IValue(c10::SymInt i) : tag(Tag::SymInt) {
-    // TODO: needs to be changed when SymInt becomes owning
-    payload.u.as_int = i.as_int_unchecked();
+  IValue(c10::SymInt i) {
+    if (i.is_symbolic()) {
+      // TODO: needs to be changed when SymInt becomes owning
+      tag = Tag::SymInt;
+      payload.u.as_int = i.as_int_unchecked();
+    } else {
+      tag = Tag::Int;
+      payload.u.as_int = i.as_int_unchecked();
+    }
   }
 
   IValue(c10::SymIntArrayRef v);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #82468
* __->__ #82555
* #82467
* #82477
* #82548

When symbolic integers become intrusively refcounted, it is necessary
for IValue to reference count them correctly.  Instead of adding another
element to the union (which is possible, but I kind of would prefer not
to do it), I am instead representing non symbolic integers as just plain
integers in the IValue, which makes sense because they're
equivalent.

The main hazard for doing this is if there is logic inspecting the types
of the IValue to determine dispatch.  For single int/symint arguments,
this should be benign as we always have an eligible int overload.  For
an array of ints/symints, the list unconditionally reports as a SymInt
list, so it should be OK too.  Let's see!

Signed-off-by: Edward Z. Yang <ezyang@fb.com>