### PR TITLE
Add a lint rule for PYBIND11_DECLARE_HOLDER_TYPE

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -421,6 +421,40 @@ command = [
 ]
 
 [[linter]]
+code = 'PYBIND11_SPECIALIZATION'
+include_patterns = [
+    '**/*.cpp',
+    '**/*.h',
+]
+exclude_patterns = [
+    # The place for all orphan specializations
+    'torch/csrc/utils/pybind.h',
+    # These specializations are non-orphan
+    'torch/csrc/distributed/c10d/init.cpp',
+    'torch/csrc/jit/python/pybind.h',
+    # These are safe to exclude as they do not have Python
+    'c10/**/*',
+]
+command = [
+    'python3',
+    'tools/linter/adapters/grep_linter.py',
+    '--pattern=PYBIND11_DECLARE_HOLDER_TYPE',
+    '--linter-name=PYBIND11_SPECIALIZATION',
+    '--error-name=pybind11 specialization in non-standard location',
+    """--error-description=\
+        This pybind11 specialization (PYBIND11_DECLARE_HOLDER_TYPE) should \
+        be placed in torch/csrc/utils/pybind.h so that it is guaranteed to be \
+        included at any site that may potentially make use of it via py::cast. \
+        If your specialization is in the same header file as the definition \
+        of the holder type, you can ignore this lint by adding your header to \
+        the exclude_patterns for this lint in .lintrunner.toml.  For more \
+        information see https://github.com/pybind/pybind11/issues/4099 \
+    """,
+    '--',
+    '@{{PATHSFILE}}'
+]
+
+[[linter]]
 code = 'PYPIDEP'
 include_patterns = ['.github/**']
 exclude_patterns = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82556
* #82552

This rule is less important, but serves the complementary purpose
of making sure people don't define PYBIND11_DECLARE_HOLDER_TYPE in
the wrong header file.  It should either be defined with the holder
type definition (in that case the file is excluded from the lint)
or in torch/csrc/utils/pybind.h)

Signed-off-by: Edward Z. Yang <ezyang@fb.com>