### PR TITLE
directly init a zero immediate buffer to reduce overhead for batch_norm cpu path

### DIFF
--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -234,7 +234,7 @@ void batch_norm_cpu_collect_stats_channels_last_impl(
   // Normal size of C should fit in L1, otherwise consider blocking on C.
   //
   int num_threads = at::get_num_threads();
-  Tensor buffer = at::empty({num_threads, n_channel}, input.options()).zero_();
+  Tensor buffer = at::zeros({num_threads, n_channel}, input.options());
   scalar_t* buffer_data = buffer.data_ptr<scalar_t>();
 
   // compute mean per input
@@ -464,7 +464,7 @@ void batch_norm_cpu_backward_channels_last_impl(Tensor& grad_input, Tensor& grad
   // Second path: parallel along dim1 of the immediate buffer.
   //
   int num_threads = at::get_num_threads();
-  Tensor buffer = at::empty({2, num_threads, n_channel}, input.options()).zero_();
+  Tensor buffer = at::zeros({2, num_threads, n_channel}, input.options());
   scalar_t* sum_data = buffer.data_ptr<scalar_t>();
   scalar_t* dotp_data = sum_data + num_threads * n_channel;
 
@@ -811,7 +811,7 @@ inline void batch_norm_cpu_collect_stats_channels_last_internal(
   param_t* var_sum_data = var_sum.data_ptr<param_t>();
 
   int num_threads = at::get_num_threads();
-  Tensor buffer = at::empty({num_threads, n_channel}, input.options().dtype(kFloat)).zero_();
+  Tensor buffer = at::zeros({num_threads, n_channel}, input.options().dtype(kFloat));
   float* buffer_data = buffer.data_ptr<float>();
 
   at::parallel_for(0, N, 1, [&](int64_t begin, int64_t end) {
@@ -1064,7 +1064,7 @@ void batch_norm_cpu_backward_channels_last_internal(Tensor& grad_input, Tensor& 
   }
 
   int num_threads = at::get_num_threads();
-  Tensor buffer = at::empty({2, num_threads, n_channel}, input.options().dtype(kFloat)).zero_();
+  Tensor buffer = at::zeros({2, num_threads, n_channel}, input.options().dtype(kFloat));
   float* sum_data = buffer.data_ptr<float>();
   float* dotp_data = sum_data + num_threads * n_channel;
 

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -18,6 +18,7 @@
 #else
 #include <ATen/ops/empty.h>
 #include <ATen/ops/ones.h>
+#include <ATen/ops/zeros.h>
 #endif
 
 namespace at { namespace native {


### PR DESCRIPTION
For batch_norm cpu path, the immediate buffer is firstly inited an empty buffer and then set the buffer value to zero again, there are two dispatches, **empty** and **zeros_**, but we can directly init a zero buffer to reduce the dispatch overhead.

see the following profiler for batch_norm backward:

![image](https://user-images.githubusercontent.com/16217777/182063350-a6680a06-6901-4e12-8207-93517c3c4529.png)

the **at::native_batch_norm_backward** time is 0.173 ms, and the **aten::zeros_** consume 0.019 ms.