### PR TITLE
Correctly unpack constants when used in multi-return output

### DIFF
--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -239,6 +239,15 @@ class TestProxyTensor(TestCase):
         # In case we mutated shared state in the g graph!
         self.assertEqual(g(), f())
 
+    def test_constant_unbind(self):
+        def f():
+            val = torch.tensor([2])
+            r, = torch.unbind(val, 0)
+            return r.item()
+
+        g = make_fx(f)()
+        self.assertEqual(g(), f())
+
     def test_use_fake_and_tensor(self):
         def f(x, y):
             z = torch.tensor([2.0, 3.0])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #82587
* #82574
* __->__ #82568

Partial fix for https://github.com/pytorch/pytorch/issues/82547

Signed-off-by: Edward Z. Yang <ezyang@fb.com>