### PR TITLE
Fake: copy over grad attribute

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -14,8 +14,8 @@ from torch.testing import FileCheck
 from torch.utils._python_dispatch import enable_torch_dispatch_mode
 from torch import nn
 import unittest
-import contextlib
 import torch._prims as prims
+import contextlib
 import copy
 
 class FakeTensorTest(TestCase):
@@ -137,6 +137,17 @@ class FakeTensorTest(TestCase):
         with self.assertRaisesRegex(Exception, "non-Fake Tensor inputs"):
             with enable_torch_dispatch_mode(FakeTensorMode(inner=None)):
                 y = x[0]
+
+    def test_fake_grad_copy(self):
+        x = torch.rand([4, 4], requires_grad=True)
+        x.grad = torch.rand([4, 4])
+        mode = FakeTensorMode()
+        fake_x = mode.from_tensor(x)
+        self.assertEq
+        prims.utils.compare_tensor_meta(fake_x, x)
+        prims.utils.compare_tensor_meta(fake_x.grad, x.grad)
+
+        self.assertTrue(isinstance(fake_x.grad, FakeTensor))
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_like_constructor(self):

--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -143,7 +143,6 @@ class FakeTensorTest(TestCase):
         x.grad = torch.rand([4, 4])
         mode = FakeTensorMode()
         fake_x = mode.from_tensor(x)
-        self.assertEq
         prims.utils.compare_tensor_meta(fake_x, x)
         prims.utils.compare_tensor_meta(fake_x.grad, x.grad)
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -9,7 +9,7 @@ from typing import Callable, Union
 import torch
 import torch.fx.experimental.symbolic_shapes as symbolic_shapes
 from torch._ops import OpOverload
-from torch._subclasses.meta_utils import MetaConverter, WeakTensorRefKey
+from torch._subclasses.meta_utils import MetaConverter, safe_is_leaf, WeakTensorRefKey
 from torch.fx.operator_schemas import normalize_function
 from torch.overrides import TorchFunctionMode
 from torch.utils._mode_utils import no_dispatch
@@ -137,6 +137,8 @@ class FakeTensorConverter(object):
             out = FakeTensor(fake_mode, self.meta_converter(t), existing_device)
         if type(t) is torch.nn.Parameter:
             out = torch.nn.Parameter(out, requires_grad=out.requires_grad)  # type: ignore[assignment]
+        if safe_is_leaf(t) and t.grad is not None:
+            out.grad = self.from_real_tensor(fake_mode, t.grad)
         self.set_tensor_memo(t, out)
         return out
 

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -9,7 +9,7 @@ from typing import Callable, Union
 import torch
 import torch.fx.experimental.symbolic_shapes as symbolic_shapes
 from torch._ops import OpOverload
-from torch._subclasses.meta_utils import MetaConverter, safe_is_leaf, WeakTensorRefKey
+from torch._subclasses.meta_utils import MetaConverter, WeakTensorRefKey
 from torch.fx.operator_schemas import normalize_function
 from torch.overrides import TorchFunctionMode
 from torch.utils._mode_utils import no_dispatch

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -137,7 +137,7 @@ class FakeTensorConverter(object):
             out = FakeTensor(fake_mode, self.meta_converter(t), existing_device)
         if type(t) is torch.nn.Parameter:
             out = torch.nn.Parameter(out, requires_grad=out.requires_grad)  # type: ignore[assignment]
-        if safe_is_leaf(t) and t.grad is not None:
+        if t.grad is not None:
             out.grad = self.from_real_tensor(fake_mode, t.grad)
         self.set_tensor_memo(t, out)
         return out


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82593
* #82571
* #82337
* #82449

Copy over the grad attribute... let me any suggestions of other tests/opinfos/crossrefs I should be doing to make this more comprehensive. 