### PR TITLE
Abstract away git repo during tests

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -127,11 +127,22 @@ def mocked_read_merge_rules(repo: Any, org: str, project: str) -> List[MergeRule
                   ),
     ]
 
+class DummyGitRepo(GitRepo):
+    def __init__(self, path: str = "", remote: str = "", debug: bool = False) -> None:
+        path = path or get_git_repo_dir()
+        remote = remote or get_git_remote_name()
+        super().__init__(path, remote, debug)
+
+    def commits_resolving_gh_pr(self, pr_num: int):
+        return [1111]
+
+    def commit_message(self, ref: str) -> str:
+        return "super awsome commit message"
 
 class TestGitHubPR(TestCase):
     def test_merge_rules_valid(self) -> None:
         "Test that merge_rules.json can be parsed"
-        repo = GitRepo(get_git_repo_dir(), get_git_repo_dir())
+        repo = DummyGitRepo()
         self.assertGreater(len(read_merge_rules(repo, "pytorch", "pytorch")), 1)
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
@@ -139,7 +150,7 @@ class TestGitHubPR(TestCase):
     def test_match_rules(self, mocked_gql: Any, mocked_rmr: Any) -> None:
         "Tests that PR passes merge rules"
         pr = GitHubPR("pytorch", "pytorch", 77700)
-        repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
+        repo = DummyGitRepo()
         self.assertTrue(find_matching_merge_rule(pr, repo) is not None)
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
@@ -147,7 +158,7 @@ class TestGitHubPR(TestCase):
     def test_lint_fails(self, mocked_gql: Any, mocked_rmr: Any) -> None:
         "Tests that PR fails mandatory lint check"
         pr = GitHubPR("pytorch", "pytorch", 74649)
-        repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
+        repo = DummyGitRepo()
         self.assertRaises(RuntimeError, lambda: find_matching_merge_rule(pr, repo))
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
@@ -237,7 +248,7 @@ class TestGitHubPR(TestCase):
         """ Tests that PR with nonexistent/pending status checks fails with the right reason.
         """
         pr = GitHubPR("pytorch", "pytorch", 76118)
-        repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
+        repo = DummyGitRepo()
         self.assertRaisesRegex(MandatoryChecksMissingError,
                                ".*are pending/not yet run.*",
                                lambda: find_matching_merge_rule(pr, repo))
@@ -325,7 +336,7 @@ class TestGitHubPR(TestCase):
     def test_revert_rules(self, mock_gql: Any) -> None:
         """ Tests that reverts from collaborators are allowed """
         pr = GitHubPR("pytorch", "pytorch", 79694)
-        repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
+        repo = DummyGitRepo()
         self.assertIsNotNone(validate_revert(repo, pr, comment_id=1189459845))
 
 if __name__ == "__main__":

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -129,7 +129,7 @@ def mocked_read_merge_rules(repo: Any, org: str, project: str) -> List[MergeRule
 
 class DummyGitRepo(GitRepo):
     def __init__(self) -> None:
-        super().__init__(get_git_repo_dir(), get_git_remote_name(), debug)
+        super().__init__(get_git_repo_dir(), get_git_remote_name())
 
     def commits_resolving_gh_pr(self, pr_num: int) -> List[str]:
         return ["FakeCommitSha"]

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -133,8 +133,8 @@ class DummyGitRepo(GitRepo):
         remote = remote or get_git_remote_name()
         super().__init__(path, remote, debug)
 
-    def commits_resolving_gh_pr(self, pr_num: int):
-        return [1111]
+    def commits_resolving_gh_pr(self, pr_num: int) -> List[str]:
+        return ["FakeCommitSha"]
 
     def commit_message(self, ref: str) -> str:
         return "super awsome commit message"

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -128,10 +128,8 @@ def mocked_read_merge_rules(repo: Any, org: str, project: str) -> List[MergeRule
     ]
 
 class DummyGitRepo(GitRepo):
-    def __init__(self, path: str = "", remote: str = "", debug: bool = False) -> None:
-        path = path or get_git_repo_dir()
-        remote = remote or get_git_remote_name()
-        super().__init__(path, remote, debug)
+    def __init__(self) -> None:
+        super().__init__(get_git_repo_dir(), get_git_remote_name(), debug)
 
     def commits_resolving_gh_pr(self, pr_num: int) -> List[str]:
         return ["FakeCommitSha"]


### PR DESCRIPTION
### Description
During unit tests we want to return fake data for any methods that rely on a local git repository. Otherwise those tests will fail when run in an environment that doesn't have the pytorch repo checked out (such as fbinternal or a tarball download)

Also refactored existing tests to use the new DummyGitRepo

### Issue
N/A

### Testing
Validating old behavior:
Removed the `.git` folder locally to effectively delete the git repository. Then ran `python3 .github/scripts/test_trymerge.py` to ensure the test failed

Validating fix:
Ran `python3 .github/scripts/test_trymerge.py` both with and without the `.git` folder