### PR TITLE
CoreML backend should log on failure not success

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
@@ -187,8 +187,7 @@ class CoreMLBackend: public torch::jit::PyTorchBackendInterface {
       // Check if this inference session is logged. If so, log every N inferences
       bool succeeded = outputsProvider != nil;
       bool should_log = load_id < kSampleThreshold && inferences > 1;
-      should_log = should_log && (inferences % kSampleEvery == 0);
-      should_log = should_log || succeeded;
+      should_log = !succeeded || (should_log && (inferences % kSampleEvery == 0));
       observer->onExitExecuteModel(instance_key, inferences, succeeded, should_log);
     }
 


### PR DESCRIPTION
### Description
The original intention of this code was to log whenever inference fails, not whenever it succeeds. This change updates the logic of should_log to match this intention.
