### PR TITLE
Fix embedding quantization issue when memory format is not `contiguous `

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
@@ -139,7 +139,8 @@ namespace native {
 //
 // Python example examining a packed 8bit zero_point and scale:
 //
-// >> x = torch.from_numpy(np.array([[[10, 20], [30, 40]],[[50, 60], [70, 80]]], dtype=np.float32))
+// >> x = torch.from_numpy(np.array([[[10, 20], [30, 40]],[[50, 60], [70, 80]]],
+// dtype=np.float32))
 // >> x_packed = torch.ops.quantized.embedding_bag_byte_prepack(x)
 //
 // # Pull out and examine packed scales, zero_points and values
@@ -228,8 +229,9 @@ Tensor& qembeddingbag_byte_prepack_out(Tensor& output, const Tensor& weight) {
   auto* output_data = output.data_ptr<uint8_t>();
 
 #ifdef USE_FBGEMM
-  if (weight.scalar_type() == at::ScalarType::Half) {
-    const auto weight_data = static_cast<fbgemm::float16*>(weight.data_ptr());
+  if (weight_contig->scalar_type() == at::ScalarType::Half) {
+    const auto weight_data =
+        static_cast<fbgemm::float16*>(weight_contig->data_ptr());
     at::parallel_for(
         0, embedding_rows, 1, [&](int64_t start_idx, int64_t end_idx) {
           fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<
@@ -240,7 +242,7 @@ Tensor& qembeddingbag_byte_prepack_out(Tensor& output, const Tensor& weight) {
               output_data + start_idx * output_columns);
         });
   } else {
-    const auto weight_data = weight.data_ptr<float>();
+    const auto weight_data = weight_contig->data_ptr<float>();
     at::parallel_for(
         0, embedding_rows, 1, [&](int64_t start_idx, int64_t end_idx) {
           fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<float>(
@@ -346,8 +348,9 @@ Tensor _qembeddingbag_nbit_prepack_helper(
 
 #ifdef USE_FBGEMM
   if (!optimized_qparams) {
-    if (weight.scalar_type() == at::ScalarType::Half) {
-      const auto weight_data = static_cast<fbgemm::float16*>(weight.data_ptr());
+    if (weight_contig.scalar_type() == at::ScalarType::Half) {
+      const auto weight_data =
+          static_cast<fbgemm::float16*>(weight_contig.data_ptr());
       at::parallel_for(
           0, embedding_rows, 1, [&](int64_t start_idx, int64_t end_idx) {
             fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<
@@ -359,7 +362,7 @@ Tensor _qembeddingbag_nbit_prepack_helper(
                 output_data + start_idx * output_shape[1]);
           });
     } else {
-      const auto weight_data = weight.data_ptr<float>();
+      const auto weight_data = weight_contig.data_ptr<float>();
       at::parallel_for(
           0, embedding_rows, 1, [&](int64_t start_idx, int64_t end_idx) {
             fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<float>(


### PR DESCRIPTION
Summary:
The current implementation of embedding quantization has the assumption that the memory address must be `contiguous` for the input `Tensor`

To guarantee that, we cast the input `weight` to be `contiguous` format, by

```
  const auto weight_contig =
      weight.expect_contiguous(weight.suggest_memory_format());
```
or
```
  Tensor weight_contig = weight.contiguous(weight.suggest_memory_format());
```

However, in the branch `USE_FBGEMM = true`, it doesn't use `weight_contig`, which gives a wrong result when the input data is not `contiguous`

Example: N2297477

Test Plan:
```
buck1 test mode/dev //caffe2/test:quantization -- --exact 'caffe2/test:quantization - test_embedding_bag_byte_unpack (quantization.core.test_quantized_op.TestQuantizedEmbeddingOps)'

buck1 test mode/dev //caffe2/test:quantization -- --exact 'caffe2/test:quantization - test_embedding_bag_2bit_unpack (quantization.core.test_quantized_op.TestQuantizedEmbeddingOps)'

buck1 test mode/dev //caffe2/test:quantization -- --exact 'caffe2/test:quantization - test_embedding_bag_4bit_unpack (quantization.core.test_quantized_op.TestQuantizedEmbeddingOps)'
```

Differential Revision: D38302116

