### PR TITLE
Add Custom Module Support List

### DIFF
--- a/torch/quantization/fx/_equalize.py
+++ b/torch/quantization/fx/_equalize.py
@@ -17,6 +17,7 @@ from torch.ao.quantization.fx._equalize import (
     default_equalization_qconfig,
     fused_module_supports_equalization,
     nn_module_supports_equalization,
+    custom_module_supports_equalization,
     node_supports_equalization,
     is_equalization_observer,
     get_op_node_and_weight_eq_obs,
@@ -32,5 +33,6 @@ from torch.ao.quantization.fx._equalize import (
     convert_eq_obs,
     _convert_equalization_ref,
     get_layer_sqnr_dict,
-    get_equalization_qconfig_dict
+    get_equalization_qconfig_dict,
+    CUSTOM_MODULE_SUPP_LIST,
 )


### PR DESCRIPTION
Summary:
Add a global custon module support list  for the users to specify the modules they want the equalization process support.

To use this list, import it from the _equalize.py file and append module in it.

Unittest passed to check global support list:

https://pxl.cl/28RKG

Test Plan: buck1 test mode/dev //on_device_ai/odai/tests/transforms:test_transforms -- --exact 'on_device_ai/odai/tests/transforms:test_transforms - test_custom_support_list (on_device_ai.odai.tests.transforms.test_input_weight_for_turing.TestInputWeight)'

Reviewed By: jerryzh168

Differential Revision: D38264244

