### PR TITLE
[pytorch][mergebot][EASY] Fix test case for trymerge

### DIFF
--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -322,7 +322,9 @@ class TestGitHubPR(TestCase):
                                            mandatory_only=False)
 
     @mock.patch('trymerge.gh_graphql', side_effect=mocked_gh_graphql)
-    def test_revert_rules(self, mock_gql: Any) -> None:
+    @mock.patch('gitutils.GitRepo.commits_resolving_gh_pr', return_value=["123abc"])
+    @mock.patch('gitutils.GitRepo.commit_message', return_value="hello there\nDifferential Revision: D123")
+    def test_revert_rules(self, mock_gql: Any, mock_resolving_gh_pr: Any, mock_commit_message: Any) -> None:
         """ Tests that reverts from collaborators are allowed """
         pr = GitHubPR("pytorch", "pytorch", 79694)
         repo = GitRepo(get_git_repo_dir(), get_git_remote_name())


### PR DESCRIPTION
Summary: This broke internally since the internal repo isn't git. We can just mock the parts here that are shell commands

Test Plan: contbuild

Differential Revision: D38328220

