### PR TITLE
Add shape inference methods for bitwise_and, bitwise_or, and bitwise_xor

### DIFF
--- a/torch/csrc/lazy/core/shape_inference.cpp
+++ b/torch/csrc/lazy/core/shape_inference.cpp
@@ -208,6 +208,24 @@ std::vector<Shape> compute_shape_binary_cross_entropy_backward(
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 
+std::vector<Shape> compute_shape_bitwise_and(
+    const at::Tensor& self,
+    const at::Scalar& other) {
+  return {Shape(self.scalar_type(), self.sizes().vec())};
+}
+
+std::vector<Shape> compute_shape_bitwise_or(
+    const at::Tensor& self,
+    const at::Scalar& other) {
+  return {Shape(self.scalar_type(), self.sizes().vec())};
+}
+
+std::vector<Shape> compute_shape_bitwise_xor(
+    const at::Tensor& self,
+    const at::Scalar& other) {
+  return {Shape(self.scalar_type(), self.sizes().vec())};
+}
+
 std::vector<Shape> compute_shape_constant_pad_nd(
     const at::Tensor& self,
     at::IntArrayRef pad,
@@ -704,12 +722,6 @@ std::vector<Shape> compute_shape_random(
 }
 
 std::vector<Shape> compute_shape_relu(const at::Tensor& self) {
-  return {Shape(self.scalar_type(), self.sizes().vec())};
-}
-
-std::vector<Shape> compute_shape_bitwise_and(
-    const at::Tensor& self,
-    const at::Scalar& other) {
   return {Shape(self.scalar_type(), self.sizes().vec())};
 }
 

--- a/torch/csrc/lazy/core/shape_inference.h
+++ b/torch/csrc/lazy/core/shape_inference.h
@@ -28,6 +28,9 @@ TORCH_API std::vector<torch::lazy::Shape> compute_shape_bernoulli(const at::Tens
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_bernoulli(const at::Tensor & self, double p, c10::optional<at::Generator> generator);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_binary_cross_entropy(const at::Tensor & self, const at::Tensor & target, const c10::optional<at::Tensor> & weight, int64_t reduction);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_binary_cross_entropy_backward(const at::Tensor & grad_output, const at::Tensor & self, const at::Tensor & target, const c10::optional<at::Tensor> & weight, int64_t reduction);
+TORCH_API std::vector<torch::lazy::Shape> compute_shape_bitwise_and(const at::Tensor & self, const at::Scalar & other);
+TORCH_API std::vector<torch::lazy::Shape> compute_shape_bitwise_or(const at::Tensor & self, const at::Scalar & other);
+TORCH_API std::vector<torch::lazy::Shape> compute_shape_bitwise_xor(const at::Tensor & self, const at::Scalar & other);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_cat(at::TensorList tensors, int64_t dim);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_clamp_min(const at::Tensor & self, const at::Scalar & min);
 TORCH_API std::vector<torch::lazy::Shape> compute_shape_clone(const at::Tensor & self, c10::optional<at::MemoryFormat> memory_format);


### PR DESCRIPTION
### Description
Add shape inference methods for bitwise_and, bitwise_or, and bitwise_xor

### Issue
This is for PyTorch/XLA Lazy code gen

### Testing

```>>> torch.bitwise_and(torch.tensor([-1, -2, 3], dtype=torch.int8), torch.tensor([1, 0, 3], dtype=torch.int8))
tensor([1, 0, 3], dtype=torch.int8)
>>> torch.bitwise_or(torch.tensor([-1, -2, 3], dtype=torch.int8), torch.tensor([1, 0, 3], dtype=torch.int8))
tensor([-1, -2,  3], dtype=torch.int8)
>>> torch.bitwise_xor(torch.tensor([-1, -2, 3], dtype=torch.int8), torch.tensor([1, 0, 3], dtype=torch.int8))
tensor([-2, -2,  0], dtype=torch.int8)
>>> torch.bitwise_and(torch.tensor([True, True, False]), torch.tensor([False, True, False]))
tensor([False,  True, False])
>>> torch.bitwise_or(torch.tensor([True, True, False]), torch.tensor([False, True, False]))
tensor([ True,  True, False])
>>> torch.bitwise_xor(torch.tensor([True, True, False]), torch.tensor([False, True, False]))
tensor([ True, False, False])
```