### PR TITLE
Make codegen to canonicalize dimensions for given ops

### DIFF
--- a/torch/csrc/lazy/core/helpers.cpp
+++ b/torch/csrc/lazy/core/helpers.cpp
@@ -53,6 +53,15 @@ std::vector<int64_t> GetCanonicalDimensionIndices(
   return canonical_dim_indices;
 }
 
+c10::optional<std::vector<int64_t>> GetCanonicalDimensionIndices(
+    at::OptionalIntArrayRef dim,
+    int64_t rank) {
+  if (dim) {
+    return {GetCanonicalDimensionIndices(*dim, rank)};
+  }
+  return c10::nullopt;
+}
+
 int64_t GetCanonicalPosition(
     c10::ArrayRef<int64_t> dimensions,
     int64_t dim,

--- a/torch/csrc/lazy/core/helpers.h
+++ b/torch/csrc/lazy/core/helpers.h
@@ -38,6 +38,10 @@ TORCH_API std::vector<int64_t> GetCanonicalDimensionIndices(
     c10::ArrayRef<int64_t> dimensions,
     int64_t rank);
 
+TORCH_API c10::optional<std::vector<int64_t>> GetCanonicalDimensionIndices(
+    at::OptionalIntArrayRef dim,
+    int64_t rank);
+
 // Returns the canonical position in the dim dimension, handling negative
 // values for the position.
 TORCH_API int64_t GetCanonicalPosition(

--- a/torchgen/gen_lazy_tensor.py
+++ b/torchgen/gen_lazy_tensor.py
@@ -484,6 +484,7 @@ def run_gen_lazy_tensor(
                     "torch/csrc/lazy/core/lazy_graph_executor.h",
                     "torch/csrc/lazy/core/metrics.h",
                     "torch/csrc/lazy/core/shape.h",
+                    "torch/csrc/lazy/core/helpers.h",
                     f"{output_dir}/{backend_key}NativeFunctions.h",
                     f"{output_dir}/LazyIr.h",
                 ]


### PR DESCRIPTION
### Description
This PR adds a codegen switch to canonicalize dimensions for dims args for the set of hardcoded ops for now.
We need to get rid of the hardcoded table in favour of specifying these attributes in the yaml file.


### Issue
(https://github.com/pytorch/pytorch/issues/82286 )

### Testing
<!-- How did you test your change? -->
