### PR TITLE
[fsdp] add ability to iterate through dataclasses in fsdp.utils

### DIFF
--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -53,13 +53,13 @@ class TestUtils(TestCase):
             nonlocal expected
             expected += t.numel()
             return t
-    
+
         @dataclass
         class SomeDataClass:
             some_key: str
             some_float: float
             some_tensor: List[torch.Tensor]
-            
+
 
 
         # create a mixed bag of data.

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     subtest,
 )
+from dataclasses import dataclass
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -51,12 +52,21 @@ class TestUtils(TestCase):
             nonlocal expected
             expected += t.numel()
             return t
+    
+        @dataclass
+        class SomeDataClass:
+            some_key: str
+            some_float: float
+            some_tensor: torch.Tensor
+            
+
 
         # create a mixed bag of data.
         data = [1, "str"]
         data.append({"key1": get_a_tensor(), "key2": {1: get_a_tensor()}, "key3": 3})
         data.insert(0, set(["x", get_a_tensor(), get_a_tensor()]))
         data.append(([1], get_a_tensor(), (1), [get_a_tensor()], set((1, 2))))
+        data.append(SomeDataClass("some_key", 1.0, get_a_tensor()))
         od = OrderedDict()
         od["k"] = "value"
         data.append(od)

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -2,6 +2,7 @@
 
 import random
 import sys
+from typing import List
 import unittest
 from collections import OrderedDict
 
@@ -57,7 +58,7 @@ class TestUtils(TestCase):
         class SomeDataClass:
             some_key: str
             some_float: float
-            some_tensor: torch.Tensor
+            some_tensor: List[torch.Tensor]
             
 
 
@@ -66,7 +67,7 @@ class TestUtils(TestCase):
         data.append({"key1": get_a_tensor(), "key2": {1: get_a_tensor()}, "key3": 3})
         data.insert(0, set(["x", get_a_tensor(), get_a_tensor()]))
         data.append(([1], get_a_tensor(), (1), [get_a_tensor()], set((1, 2))))
-        data.append(SomeDataClass("some_key", 1.0, get_a_tensor()))
+        data.append({"abc": SomeDataClass("some_key", 1.0, [get_a_tensor()])})
         od = OrderedDict()
         od["k"] = "value"
         data.append(od)

--- a/torch/distributed/fsdp/_utils.py
+++ b/torch/distributed/fsdp/_utils.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import dataclasses
 from typing import Any, Callable, Dict, List, Set, Tuple, Union
 
 import torch
@@ -26,6 +27,12 @@ def _apply_to_tensors(
     def apply(x: Union[torch.Tensor, Dict, List, Tuple, Set, OrderedDict, PackedSequence]) -> Any:
         if torch.is_tensor(x):
             return fn(x)
+        elif hasattr(x, "__dataclass_fields__"):
+            dc = dataclasses.replace(x)
+            for f in dataclasses.fields(dc):
+                name = f.name
+                setattr(dc, name, apply(getattr(dc, name)))
+            return dc
         elif isinstance(x, OrderedDict):
             od = x.__class__()
             for key, value in x.items():


### PR DESCRIPTION
### Description

previously FSDP was failing on a torchmultimodal model because `_apply_to_tensors` couldn't iterate over dataclasses.

### Issue

None

### Testing

unit test
