### PR TITLE
all_gather supporting single tensor output

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2050,6 +2050,7 @@ def all_gather(output, tensor, group=None, async_op=False):
             dimension, see ``torch.cat()``;
             (ii) a stack of the input tensors along the primary dimension,
             see ``torch.stack()``.
+            Examples below may better explain the supported output forms.
         tensor (Tensor): Tensor to be broadcast from current process.
         group (ProcessGroup, optional): The process group to work on. If None,
             the default process group will be used.

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2082,6 +2082,8 @@ def all_gather(tensor_list, tensor, group=None, async_op=False):
         [tensor([1.+1.j, 2.+2.j]), tensor([3.+3.j, 4.+4.j])] # Rank 1
 
     """
+    # `tensor_list` would be understood as "tensor or list."
+    # If it is a single tensor, we would route it to the _all_gather_base implementation.
     if isinstance(tensor_list, torch.Tensor):
         return _all_gather_base(tensor_list, tensor, group, async_op)
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2082,6 +2082,9 @@ def all_gather(tensor_list, tensor, group=None, async_op=False):
         [tensor([1.+1.j, 2.+2.j]), tensor([3.+3.j, 4.+4.j])] # Rank 1
 
     """
+    if isinstance(tensor_list, torch.Tensor):
+        return _all_gather_base(tensor_list, tensor, group, async_op)
+
     _check_tensor_list(tensor_list, "tensor_list")
     _check_single_tensor(tensor, "tensor")
     if _rank_not_in_group(group):

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -3069,6 +3069,7 @@ class DistributedTest:
             group, group_id, rank = self._init_full_group_test()
             self._test_all_gather_helper(group, group_id, rank)
 
+        # Test all_gather accepting single tensor as output
         def _test_all_gather_single_output_tensor_helper(
             self, group, group_id, rank, cuda=False, rank_to_GPU=None, dtype=torch.float
         ):


### PR DESCRIPTION
### Description
This PR unifies the `all_gather` API and the `_all_gather_base` API by having the former support both single tensor and list of tensor as output. 

### Issue
Following the request of avoiding unnecessary flattening in #33924, `_all_gather_base` was implemented. That API, however, has never been productized, due to the concern of creating multiple all-gather variants. Thus, instead of productizing `_all_gather_base`, this PR uses `all_gather` to cover both, because in traditional sense (as in MPI or NCCL), `all_gather` can indeed stand for gathering multiple small buffers into a single big buffer.

### Testing
Added tests:
`test_all_gather_single_output_tensor_cuda`

### Context:

In recent discussion with @ptrblck @crcrpar regarding use of the base feature in Megatron, it was identified that unifying the two APIs was preferred to productizing _all_gather_base. Also per the initial idea to unify them as mentioned by @zhaojuanmao when _all_gather_base was first implemented https://github.com/pytorch/pytorch/pull/56315#pullrequestreview-639152513

There are two ways to unifying the two APIs.
Method 1: have all_gather accept a single tensor
Method 2: have all_gather accept a list, the list containing a single tensor
It appears to me that Method 1 is cleaner in semantics -- when user passes in a single tensor, it is explicit that they ask for merging the input tensors into a (larger) output tensor. Also, since this is something user passes in rather than a return of the function, there is no need for user to figure out what the return is (a list or a tensor).

Regarding why a single function name:
I want to give user an experience that they only need to think about what output format they want, and not having to additionally think about which function to call (especially when there are already several all_gather_* APIs there). In retrospective, it may also seem that the list implementation "hijacked" the all_gather name, whereas the single tensor implementation can be more natural, smoother in application use flow maybe, and more performant. Hence my thought of giving the tensor output the "first-class" name of all_gather.