### PR TITLE
[MPS] Unary ops over empty tensors should be no-op

### DIFF
--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -19,6 +19,10 @@ void unary_op(const Tensor& self, const Tensor& output, std::string op_name, Una
   if (!output.is_same_size(self)) {
     output.resize_(self.sizes());
   }
+  // Empty tensor is noop
+  if (self.numel() == 0) {
+    return;
+  }
   MPSGraphCache* cache_ = MPSGraphCache::getInstance();
   @autoreleasepool {
     string key = op_name + getTensorsStringKey({self}, /*use_scalar_value*/ false);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1548,6 +1548,12 @@ class TestMPS(TestCase):
     def test_bool_full(self):
         x = torch.full((3, 3), True, device='mps')
 
+    # Empty unary op should return tensor of the same size
+    def test_empty_neg(self):
+        x = torch.tensor([[]], device='mps')
+        y = -x
+        self.assertEqual(x, y)
+
 
 class TestLogical(TestCase):
     def _wrap_tensor(self, x, device="cpu", dtype=None, requires_grad=False):


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/82531
