### PR TITLE
Support variable arguments for refs.reshape and refs.view

### DIFF
--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -391,6 +391,19 @@ class TestPrims(TestCase):
                 actual = refs.contiguous(a, memory_format=memory_format)
                 self.assertEqual(expected.stride(), actual.stride())
 
+    @dtypes(torch.float32)
+    def test_reshape_view_method(self, device, dtype):
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+        a = make_arg((5, 5))
+        new_shape = 1, 5, 1, 5
+        result_eager = a.reshape(*new_shape)
+        result_refs = refs.reshape(a, *new_shape)
+        self.assertEqual(result_eager, result_refs)
+
+        result_eager = a.view(*new_shape)
+        result_refs = refs.view(a, *new_shape)
+        self.assertEqual(result_eager, result_refs)
+
 
 class TestPrimsBasic(TestCase):
     def test_torch_ops(self):

--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -619,7 +619,8 @@ def extract_shape(*args, allow_cpu_scalar_tensors: bool) -> Optional[ShapeType]:
 
 
 def extract_shape_from_varargs(
-    shape: Union[ShapeType, Tuple[ShapeType]]
+    shape: Union[ShapeType, Tuple[ShapeType]],
+    validate=True,
 ) -> Tuple[int, ...]:
     """
     Returns a shape from varargs.
@@ -643,7 +644,8 @@ def extract_shape_from_varargs(
     if len(shape) == 1 and isinstance(shape[0], Sequence):
         shape = shape[0]
 
-    validate_shape(shape)  # type: ignore[arg-type]
+    if validate:
+        validate_shape(shape)  # type: ignore[arg-type]
     return shape  # type: ignore[return-value]
 
 


### PR DESCRIPTION
### Description
In PyTorch, it's possible to pass unpacked shape to Tensor.view/reshape, and when this call is translated to use refs it caused an error.
Now `refs.reshape` and `refs.view` support passing variable arguments for the shape.

### Testing
Added a simple test `test_reshape_view_method` that compares Tensor.reshape/view to torch._refs.reshape/view result.
