### PR TITLE
Pin windows numpy

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_miniconda3.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_miniconda3.bat
@@ -19,7 +19,7 @@ if "%INSTALL_FRESH_CONDA%"=="1" (
 
 call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3
 if "%INSTALL_FRESH_CONDA%"=="1" (
-  call conda install -y -q python=%PYTHON_VERSION% numpy cffi pyyaml boto3 libuv
+  call conda install -y -q python=%PYTHON_VERSION% numpy"<1.23" cffi pyyaml boto3 libuv
   if errorlevel 1 exit /b
   if not errorlevel 0 exit /b
   call conda install -y -q -c conda-forge cmake=3.22.3


### PR DESCRIPTION
### Description
Pinned numpy for windows temporarily. Numpy shouldn't need to be pinned, but its upgrade to 1.23 has wreaked havoc on CI. Never mind about the not pinning!

### Issue
Related to https://github.com/pytorch/pytorch/issues/82653

### Testing
CI -- win cpu should pass