### PR TITLE
[_shard] only check shard metadata for copy_

### DIFF
--- a/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
@@ -62,6 +62,14 @@ class TestTensorOps(ShardedTensorTestBase):
         st.copy_(ones_st)
         self.assertTrue(torch.equal(st, ones_st))
 
+        # no grad inplace_copy should work between two with different requires_grad
+        st_with_grad = sharded_tensor.rand(spec, (12, 5), requires_grad=True)
+        self.assertTrue(st_with_grad.requires_grad)
+        self.assertFalse(ones_st.requires_grad)
+        with torch.no_grad():
+            st_with_grad.copy_(ones_st)
+            self.assertTrue(torch.equal(st_with_grad, ones_st))
+
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)
     @requires_nccl()

--- a/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
+++ b/test/distributed/_shard/sharded_tensor/ops/test_tensor_ops.py
@@ -68,7 +68,7 @@ class TestTensorOps(ShardedTensorTestBase):
         self.assertFalse(ones_st.requires_grad)
         with torch.no_grad():
             st_with_grad.copy_(ones_st)
-            self.assertTrue(torch.equal(st_with_grad, ones_st))
+            self.assertEqual(st_with_grad.local_tensor(), ones_st.local_tensor())
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(TEST_GPU_NUM)

--- a/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
@@ -36,6 +36,10 @@ def binary_cmp(cmp_fun, types, args, kwargs=None, process_group=None):
     if distributed_c10d._rank_not_in_group(st1._process_group) or distributed_c10d._rank_not_in_group(st2._process_group):
         return distributed_c10d._rank_not_in_group(st1._process_group) == distributed_c10d._rank_not_in_group(st2._process_group)
 
+    # Verify metadata
+    if st1.metadata() != st2.metadata():
+        return _communicate_result(False, st1._process_group)
+
     # Verify number of local shards
     st1_local_shards = st1.local_shards()
     st2_local_shards = st2.local_shards()

--- a/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py
@@ -36,10 +36,6 @@ def binary_cmp(cmp_fun, types, args, kwargs=None, process_group=None):
     if distributed_c10d._rank_not_in_group(st1._process_group) or distributed_c10d._rank_not_in_group(st2._process_group):
         return distributed_c10d._rank_not_in_group(st1._process_group) == distributed_c10d._rank_not_in_group(st2._process_group)
 
-    # Verify metadata
-    if st1.metadata() != st2.metadata():
-        return _communicate_result(False, st1._process_group)
-
     # Verify number of local shards
     st1_local_shards = st1.local_shards()
     st2_local_shards = st2.local_shards()

--- a/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
@@ -126,13 +126,11 @@ def sharded_inplace_copy(types, args, kwargs, pg):
     self_st = args[0]
     new_st = args[1]
     nonblocking = kwargs.get("non_blocking", False)
-    self_meta = self_st.metadata()
-    new_meta = new_st.metadata()
-    if self_meta != new_meta:
-        raise RuntimeError(
-            "inplace copy can only happen between two ShardedTensor with same metadata!"
-        )
     for local_shard, new_shard in zip(self_st.local_shards(), new_st.local_shards()):
+        if local_shard.metadata != new_shard.metadata:
+            raise RuntimeError(
+                "inplace copy can only happen between two ShardedTensor with same metadata!"
+            )
         local_shard.tensor.copy_(new_shard.tensor, nonblocking)
 
     return self_st

--- a/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
+++ b/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py
@@ -131,6 +131,7 @@ def sharded_inplace_copy(types, args, kwargs, pg):
             raise RuntimeError(
                 "inplace copy can only happen between two ShardedTensor with same metadata!"
             )
+    for local_shard, new_shard in zip(self_st.local_shards(), new_st.local_shards()):
         local_shard.tensor.copy_(new_shard.tensor, nonblocking)
 
     return self_st


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82655

copy_ does not restrict on tensor properites, it does not check things like requires_grad or dtype, so only check if the shard metadata are the same

Differential Revision: [D38359176](https://our.internmc.facebook.com/intern/diff/D38359176/)