### PR TITLE
[Nested Tensor] Created Nested Tensor to Nested Tensor Views

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -5,7 +5,25 @@
 #include <ATen/NestedTensorImpl.h>
 #include <c10/core/DispatchKey.h>
 #include <c10/util/Exception.h>
+#include <c10/core/TensorImpl.h>
 
+namespace {
+inline void validate_nested_tensor_metadata(
+    const at::Tensor& nested_sizes,
+    const at::Tensor& nested_strides,
+    const std::vector<int64_t>& offsets) {
+  TORCH_INTERNAL_ASSERT(nested_sizes.is_contiguous());
+  int64_t size_dim = nested_sizes.dim();
+  TORCH_INTERNAL_ASSERT(size_dim == 0 || size_dim == 2);
+  TORCH_INTERNAL_ASSERT(nested_strides.is_contiguous());
+  TORCH_INTERNAL_ASSERT(nested_strides.dim() == size_dim);
+  TORCH_INTERNAL_ASSERT(nested_sizes.sizes() == nested_strides.sizes());
+  TORCH_INTERNAL_ASSERT(
+      (size_dim == 0 && (int64_t)offsets.empty()) ||
+      (size_dim == 2 && nested_sizes.size(0) == (int64_t)offsets.size()));
+}
+
+} // namespace
 namespace at {
 namespace native {
 
@@ -129,17 +147,7 @@ NestedTensorImpl::NestedTensorImpl(
       storage_device.is_cpu() || storage_device.is_cuda(),
       "NestedTensorImpl storage must be either CUDA or CPU but got ",
       storage_device);
-  TORCH_INTERNAL_ASSERT(nested_size_tensor_.is_contiguous());
-  int64_t size_dim = nested_size_tensor_.dim();
-  TORCH_INTERNAL_ASSERT(size_dim == 0 || size_dim == 2);
-  TORCH_INTERNAL_ASSERT(nested_stride_tensor_.is_contiguous());
-  TORCH_INTERNAL_ASSERT(nested_stride_tensor_.dim() == size_dim);
-  TORCH_INTERNAL_ASSERT(
-      nested_stride_tensor_.sizes() == nested_size_tensor_.sizes());
-  TORCH_INTERNAL_ASSERT(
-      (size_dim == 0 && (int64_t)offsets_.empty()) ||
-      (size_dim == 2 &&
-       nested_size_tensor_.size(0) == (int64_t)offsets_.size()));
+  validate_nested_tensor_metadata(nested_size_tensor_, nested_stride_tensor_, offsets_);
   refresh_dim();
   set_sizes_strides_policy(c10::TensorImpl::SizesStridesPolicy::CustomSizes);
 }
@@ -178,29 +186,19 @@ NestedTensorImpl::NestedTensorImpl(
 {}
 
 NestedTensorImpl::NestedTensorImpl(
-    Storage storage,
+    c10::TensorImpl::ImplType impl_type,
     const at::Tensor& base_tensor,
     at::Tensor nested_size_tensor,
     at::Tensor nested_stride_tensor,
-    std::vector<int64_t> offsets)
-    : TensorImpl(c10::TensorImpl::VIEW, std::move(storage), base_tensor.key_set(), base_tensor.dtype()),
+    std::vector<int64_t>&& offsets)
+    : TensorImpl(impl_type, Storage(base_tensor.storage()), base_tensor.key_set(), base_tensor.dtype()),
       buffer_size_(get_nested_tensor_impl(base_tensor)-> get_buffer_size()),
       nested_size_tensor_(std::move(nested_size_tensor)),
       nested_stride_tensor_(std::move(nested_stride_tensor)),
       offsets_(std::move(offsets)),
       opt_sizes_(construct_opt_sizes(nested_size_tensor_)) {
   TORCH_INTERNAL_ASSERT(base_tensor.is_nested());
-  TORCH_INTERNAL_ASSERT(nested_size_tensor_.is_contiguous());
-  int64_t size_dim = nested_size_tensor_.dim();
-  TORCH_INTERNAL_ASSERT(size_dim == 0 || size_dim == 2);
-  TORCH_INTERNAL_ASSERT(nested_stride_tensor_.is_contiguous());
-  TORCH_INTERNAL_ASSERT(nested_stride_tensor_.dim() == size_dim);
-  TORCH_INTERNAL_ASSERT(
-      nested_stride_tensor_.sizes() == nested_size_tensor_.sizes());
-  TORCH_INTERNAL_ASSERT(
-      (size_dim == 0 && (int64_t)offsets_.empty()) ||
-      (size_dim == 2 &&
-       nested_size_tensor_.size(0) == (int64_t)offsets_.size()));
+  validate_nested_tensor_metadata(nested_size_tensor_, nested_stride_tensor_, offsets_);
   refresh_dim();
   set_sizes_strides_policy(c10::TensorImpl::SizesStridesPolicy::CustomSizes);
 }

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -126,7 +126,6 @@ c10::DispatchKeySet generate_nested_key_set(at::Tensor buffer) {
 }
 
 NestedTensorImpl::NestedTensorImpl(
-    int64_t buffer_size,
     Storage storage,
     c10::DispatchKeySet key_set,
     const caffe2::TypeMeta data_type,
@@ -134,7 +133,6 @@ NestedTensorImpl::NestedTensorImpl(
     at::Tensor nested_stride_tensor,
     std::vector<int64_t> offsets)
     : TensorImpl(std::move(storage), key_set, data_type),
-      buffer_size_(buffer_size),
       nested_size_tensor_(std::move(nested_size_tensor)),
       nested_stride_tensor_(std::move(nested_stride_tensor)),
       offsets_(std::move(offsets)),
@@ -158,7 +156,6 @@ NestedTensorImpl::NestedTensorImpl(
     at::Tensor nested_stride_tensor,
     std::vector<int64_t> offsets)
     : NestedTensorImpl(
-          buffer.sizes()[0],
           buffer.storage(),
           generate_nested_key_set(buffer),
           buffer.dtype(),
@@ -192,7 +189,6 @@ NestedTensorImpl::NestedTensorImpl(
     at::Tensor nested_stride_tensor,
     std::vector<int64_t>&& offsets)
     : TensorImpl(impl_type, Storage(base_tensor.storage()), base_tensor.key_set(), base_tensor.dtype()),
-      buffer_size_(get_nested_tensor_impl(base_tensor)-> get_buffer_size()),
       nested_size_tensor_(std::move(nested_size_tensor)),
       nested_stride_tensor_(std::move(nested_stride_tensor)),
       offsets_(std::move(offsets)),
@@ -282,7 +278,6 @@ c10::intrusive_ptr<TensorImpl> NestedTensorImpl::shallow_copy_and_detach_core(
     // the interpreter is dead no one can call us out on it
   }
   auto impl = c10::make_intrusive<NestedTensorImpl>(
-      buffer_size_,
       storage_,
       key_set_,
       data_type_,

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -30,6 +30,14 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   // can be infered from `nested_size_tensor`
   explicit NestedTensorImpl(at::Tensor buffer, at::Tensor nested_size_tensor);
 
+  // This constructor is used creating view tensors from nested  tensors
+  explicit NestedTensorImpl(
+      Storage storage,
+      const at::Tensor& base_tensor,
+      at::Tensor nested_size_tensor,
+      at::Tensor nested_stride_tensor,
+      std::vector<int64_t> offsets);
+
   // TODO: don't expose private implementation details like this; in
   // particular, resizing this tensor will mess up our dim() and
   // callers cannot fix it.
@@ -71,6 +79,10 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
         Storage(storage_), buffer_key_set_, data_type_);
     buffer_tensor_impl->set_sizes_contiguous(c10::makeArrayRef(buffer_size_));
     return Tensor(buffer_tensor_impl);
+  }
+
+  int64_t get_buffer_size() const {
+    return buffer_size_;
   }
 
  protected:

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -91,7 +91,6 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
 
   int64_t get_buffer_size() const {
     return storage_.nbytes() / data_type_.itemsize();
-    ;
   }
 
  protected:
@@ -174,10 +173,10 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
     auto buffer_key_set = this->key_set();
     const bool Autograd = buffer_key_set.has_any(c10::autograd_dispatch_keyset);
     // Remove nested tensor specific keys
-    buffer_key_set =
-        buffer_key_set - c10::DispatchKeySet{c10::DispatchKey::NestedTensor};
     buffer_key_set = buffer_key_set -
-        c10::DispatchKeySet{c10::DispatchKey::AutogradNestedTensor};
+        c10::DispatchKeySet{
+            c10::DispatchKey::NestedTensor,
+            c10::DispatchKey::AutogradNestedTensor};
 
     // Add dense tensor specific keys
     buffer_key_set =

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -32,13 +32,13 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   // can be infered from `nested_size_tensor`
   explicit NestedTensorImpl(at::Tensor buffer, at::Tensor nested_size_tensor);
 
-  // This constructor is used creating view tensors from nested  tensors
+  // This constructor is used creating view tensors from nested tensors
   explicit NestedTensorImpl(
-      Storage storage,
+      c10::TensorImpl::ImplType impl_type,
       const at::Tensor& base_tensor,
       at::Tensor nested_size_tensor,
       at::Tensor nested_stride_tensor,
-      std::vector<int64_t> offsets);
+      std::vector<int64_t>&& offsets);
 
   // TODO: don't expose private implementation details like this; in
   // particular, resizing this tensor will mess up our dim() and
@@ -73,7 +73,14 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
         " is irregular and does not have a size.");
     return *optional_size;
   }
-
+  /**
+   * Return a view of the nested tensor as a 1 dimensional contiguous tensor.
+   *
+   * The buffer tensor created by this function shares the same storage_impl as
+   * the original nested tensor, and therefore can be seen as a view.
+   *
+   * @return A newly constructed view tensor
+   */
   at::Tensor get_buffer() const {
     auto buffer_key_set_ = generate_buffer_key_set();
     auto buffer_tensor_impl = c10::make_intrusive<TensorImpl>(

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -1001,7 +1001,8 @@ Tensor transpose_nested(const Tensor& self, int64_t dim0, int64_t dim1) {
   // create transposed `sizemat` and `stridemat`
   Tensor sizemat_transposed = at::index_select(sizemat, 1, column_indices),
       stridemat_transposed = at::index_select(stridemat, 1, column_indices);
-  return wrap_buffer(self_ptr->get_buffer(), sizemat_transposed, stridemat_transposed, self_ptr->get_offsets());
+  return create_nested_view_tensor(
+      self, sizemat_transposed, stridemat_transposed, self_ptr->get_offsets());
 }
 
 // utilities supporting `_reshape_nested`

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -1002,7 +1002,7 @@ Tensor transpose_nested(const Tensor& self, int64_t dim0, int64_t dim1) {
   Tensor sizemat_transposed = at::index_select(sizemat, 1, column_indices),
       stridemat_transposed = at::index_select(stridemat, 1, column_indices);
   return create_nested_view_tensor(
-      self, sizemat_transposed, stridemat_transposed, self_ptr->get_offsets());
+      self, sizemat_transposed, stridemat_transposed, std::vector<int64_t>(self_ptr->get_offsets()));
 }
 
 // utilities supporting `_reshape_nested`

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -38,8 +38,12 @@ inline at::Tensor get_buffer(const at::Tensor& tensor) {
    * Create a new nested tensor that is a view of a base nested tensor
    *
    * create_view_tensor calls a specialized constructor that copys the
-   * the keys from base onto the new view tensor being created
-   * the buffer is shared between the base and the returned view tensor
+   * the keys from base onto the new view tensor being created.
+   * The storage is shared between the base and the returned view tensor
+   *
+   * All callers of this helper must:
+   * - Only return a view of the input
+   * - Must be explicit and define a derivative
    *
    * @param base Base tensor to construct view from.
    * @param nested_size_tensor View tensors' sizes.

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -4,6 +4,7 @@
 #include <c10/macros/Macros.h>
 #include <ATen/NestedTensorImpl.h>
 #include <c10/core/TensorImpl.h>
+#include <c10/util/Exception.h>
 
 #include <vector>
 
@@ -34,7 +35,7 @@ inline at::Tensor get_buffer(const at::Tensor& tensor) {
 }
 
   /**
-   * Create a new nested tensor that is a view of base
+   * Create a new nested tensor that is a view of a base nested tensor
    *
    * create_view_tensor calls a specialized constructor that copys the
    * the keys from base onto the new view tensor being created
@@ -51,7 +52,7 @@ inline at::Tensor get_buffer(const at::Tensor& tensor) {
       at::Tensor nested_size_tensor,
       at::Tensor nested_stride_tensor,
       std::vector<int64_t>&& offsets) {
-
+    TORCH_INTERNAL_ASSERT(base.is_nested(), "This function can only be used to create nested tensor views");
     return at::detail::make_tensor<NestedTensorImpl>(
         c10::TensorImpl::VIEW,
         base,

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -3,6 +3,7 @@
 #include <ATen/ATen.h>
 #include <c10/macros/Macros.h>
 #include <ATen/NestedTensorImpl.h>
+#include <c10/core/TensorImpl.h>
 
 #include <vector>
 
@@ -46,18 +47,17 @@ inline at::Tensor get_buffer(const at::Tensor& tensor) {
    * @return A newly constructed view tensor
    */
   inline at::Tensor create_nested_view_tensor(
-      at::Tensor base,
+      const at::Tensor& base,
       at::Tensor nested_size_tensor,
       at::Tensor nested_stride_tensor,
-      const std::vector<int64_t>& offsets) {
-    auto base_impl = get_nested_tensor_impl(base);
+      std::vector<int64_t>&& offsets) {
 
     return at::detail::make_tensor<NestedTensorImpl>(
-        base_impl->storage(),
+        c10::TensorImpl::VIEW,
         base,
-        std::move(nested_size_tensor),
-        std::move(nested_stride_tensor),
-        offsets);
+        nested_size_tensor,
+        nested_stride_tensor,
+        std::move(offsets));
   }
 
 // The sizes of the underlying tensors

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -32,6 +32,34 @@ inline at::Tensor get_buffer(const at::Tensor& tensor) {
   return get_nested_tensor_impl(tensor)->get_buffer();
 }
 
+  /**
+   * Create a new nested tensor that is a view of base
+   *
+   * create_view_tensor calls a specialized constructor that copys the
+   * the keys from base onto the new view tensor being created
+   * the buffer is shared between the base and the returned view tensor
+   *
+   * @param base Base tensor to construct view from.
+   * @param nested_size_tensor View tensors' sizes.
+   * @param nested_stride_tensor View tensors' strides.
+   * @param offsets View tensors' offsets.
+   * @return A newly constructed view tensor
+   */
+  inline at::Tensor create_nested_view_tensor(
+      at::Tensor base,
+      at::Tensor nested_size_tensor,
+      at::Tensor nested_stride_tensor,
+      const std::vector<int64_t>& offsets) {
+    auto base_impl = get_nested_tensor_impl(base);
+
+    return at::detail::make_tensor<NestedTensorImpl>(
+        base_impl->storage(),
+        base,
+        std::move(nested_size_tensor),
+        std::move(nested_stride_tensor),
+        offsets);
+  }
+
 // The sizes of the underlying tensors
 inline std::vector<IntArrayRef> NestedTensor_get_sizes(const NestedTensorImpl* self_ptr) {
   int64_t ntensors = self_ptr->size(0);

--- a/c10/core/DispatchKeySet.cpp
+++ b/c10/core/DispatchKeySet.cpp
@@ -50,7 +50,7 @@ constexpr DispatchKeySet math_dispatch_keyset = backend_dispatch_keyset |
     autograd_dispatch_keyset |
     // See Note [NestedTensor Not Included in Backend Keys]
     // The caveat to that note is that nested_tensor is a special case
-    // where we would like to support composite implict kernels but not
+    // where we would like to support composite implicit kernels but not
     // explicit kernels therefore we manually add the key to the
     // math_dispatch_keyset
     DispatchKeySet{DispatchKey::NestedTensor};

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -127,7 +127,7 @@ TensorImpl::TensorImpl(
     const caffe2::TypeMeta data_type,
     c10::optional<c10::Device> device_opt)
     // NOLINTNEXTLINE(performance-move-const-arg)
-    : TensorImpl({}, key_set, data_type, std::move(device_opt)) {}
+    : TensorImpl(Storage{}, key_set, data_type, std::move(device_opt)) {}
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 TensorImpl::TensorImpl(
@@ -181,7 +181,6 @@ TensorImpl::TensorImpl(
   if (!is_inference()) {
     version_counter_ = VariableVersion(/*version=*/0);
   }
-
   // we would also like to check that non-cpu devices have an index, but some
   // Caffe2 operators create Storages with default devices.
 }

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -127,7 +127,7 @@ TensorImpl::TensorImpl(
     const caffe2::TypeMeta data_type,
     c10::optional<c10::Device> device_opt)
     // NOLINTNEXTLINE(performance-move-const-arg)
-    : TensorImpl(Storage{}, key_set, data_type, std::move(device_opt)) {}
+    : TensorImpl({}, key_set, data_type, std::move(device_opt)) {}
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 TensorImpl::TensorImpl(

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1119,8 +1119,6 @@ class TestNestedTensorDeviceType(TestCase):
             ptT = pt.transpose(-1, -2)
             self.assertEqual(ptT, ptT_from_ntT)
 
-
-
     @dtypes(torch.float, torch.float16, torch.double)
     @torch.inference_mode()
     def test_reshape(self, device, dtype):

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1100,6 +1100,28 @@ class TestNestedTensorDeviceType(TestCase):
         self.assertEqual(ptT, ptT_from_ntT)
 
     @dtypes(torch.float, torch.float16, torch.double)
+    def test_transpose_inference_mode_interaction(self, device, dtype):
+        nt = self.random_nt(device, dtype, 4, (4, 4))
+        # Construct in default mode and transpose while in inference mode
+        with torch.inference_mode():
+            ntT = nt.transpose(-1, -2)
+            ptT_from_ntT = noncontiguous_to_padded_tensor(ntT)
+            pt = nt.to_padded_tensor(0.0)
+            ptT = pt.transpose(-1, -2)
+            self.assertEqual(ptT, ptT_from_ntT)
+
+        # Construct and transpose while in inference mode
+        with torch.inference_mode():
+            nt = self.random_nt(device, dtype, 4, (4, 4))
+            ntT = nt.transpose(-1, -2)
+            ptT_from_ntT = noncontiguous_to_padded_tensor(ntT)
+            pt = nt.to_padded_tensor(0.0)
+            ptT = pt.transpose(-1, -2)
+            self.assertEqual(ptT, ptT_from_ntT)
+
+
+
+    @dtypes(torch.float, torch.float16, torch.double)
     @torch.inference_mode()
     def test_reshape(self, device, dtype):
         nt = self.random_nt(device, dtype, 4, (4, 4))


### PR DESCRIPTION
# Summary
This is PR is pulling out all the changes from #81838 specific to properly creating nested_tensor views. I will update this comment with a design doc once that has been made.  This should enable proper creation of NestedTensor views, two nested_tensors sharing the same buffer_ but with different NestedTensor meta data. 

The function `create_nested_tensor_view` is a helper function for creating a new nested tensor whose storage aliases the base causing the underlying storage to be shared - and is therefore a view. 

This function by itself is not differentiable and therefore autograd does not track its uses. If a nested tensor function implementation uses this helper in its implementation the aten_op must meet two requirements:
- The function must return a view of the input
- The function must be explicit and defines its backward 

## Testing
A bug was found when creating a base tensor out of inference mode and then creating a view in inference mode. This test has been aded to this PR in order to show the effect of the change. 
