### PR TITLE
Store compilation os version on a per model basis

### DIFF
--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLBackend.mm
@@ -86,7 +86,7 @@ class CoreMLBackend: public torch::jit::PyTorchBackendInterface {
     const c10::Dict<IValue, IValue> model_dict = processed.toGenericDict();
     const std::string& extra = model_dict.at("extra").toStringRef();
     const std::string& model = model_dict.at("model").toStringRef();
-    const std::string& sha256 = model_dict.at("hash").toStringRef();
+    const std::string& modelID = model_dict.at("hash").toStringRef();
 
     const int32_t load_id = std::rand();
     const int32_t instance_key = std::rand();
@@ -121,14 +121,20 @@ class CoreMLBackend: public torch::jit::PyTorchBackendInterface {
       TORCH_CHECK(false, "Compiling model failed, only float type tensors supported");
     }
 
-    NSURL *modelURL = [PTMCoreMLCompiler compileModel:model modelID:sha256];
-    MLModel *cpuModel = modelURL ? [PTMCoreMLCompiler loadCPUModelAtURL:modelURL] : nil;
+    if (![PTMCoreMLCompiler compileModel:model modelID:modelID]) {
+      if (observer) {
+        observer->onExitCompileModel(instance_key, false, true);
+      }
+      TORCH_CHECK(false, "Compiling MLModel failed");
+    }
+
+    MLModel *cpuModel = [PTMCoreMLCompiler loadModel:modelID backend:"cpu" allowLowPrecision:NO];
 
     if (!cpuModel) {
       if (observer) {
         observer->onExitCompileModel(instance_key, false, true);
       }
-      TORCH_CHECK(false, "Compiling MLModel for CPU failed!");
+      TORCH_CHECK(false, "Loading MLModel failed");
     }
 
     NSMutableArray *orderedFeatures = [NSMutableArray array];
@@ -142,7 +148,7 @@ class CoreMLBackend: public torch::jit::PyTorchBackendInterface {
     [executor autorelease];
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-      MLModel *configuredModel = [PTMCoreMLCompiler loadModelAtURL:modelURL backend:config.backend allowLowPrecision:config.allow_low_precision];
+      MLModel *configuredModel = [PTMCoreMLCompiler loadModel:modelID backend:config.backend allowLowPrecision:config.allow_low_precision];
       executor.model = configuredModel ?: cpuModel;
     });
 

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.h
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.h
@@ -10,14 +10,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString*)modelCacheDirectory;
 
-+ (NSURL*)compileModel:(const std::string&)modelSpecs
-               modelID:(const std::string&)modelID;
++ (BOOL)compileModel:(const std::string&)modelSpecs
+             modelID:(const std::string&)modelID;
 
-+ (nullable MLModel*)loadCPUModelAtURL:(NSURL*)modelURL;
-
-+ (nullable MLModel*)loadModelAtURL:(NSURL*)modelURL
-                            backend:(const std::string&)backend
-                  allowLowPrecision:(BOOL)allowLowPrecision;
++ (nullable MLModel*)loadModel:(const std::string&)modelID
+                       backend:(const std::string&)backend
+             allowLowPrecision:(BOOL)allowLowPrecision;
 
 @end
 

--- a/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
+++ b/torch/csrc/jit/backends/coreml/objc/PTMCoreMLCompiler.mm
@@ -22,68 +22,54 @@ static NSString* gModelCacheDirectory = @"";
   return gModelCacheDirectory;
 }
 
-+ (NSURL*)compileModel:(const std::string&)modelSpecs modelID:(const std::string&)modelID {
++ (BOOL)compileModel:(const std::string&)modelSpecs modelID:(const std::string&)modelID {
   NSString* modelName = [NSString stringWithCString:modelID.c_str() encoding:NSUTF8StringEncoding];
   NSURL* modelPath = [PTMCoreMLCompiler _cacheFilePath:modelName];
-  NSURL* compiledModelPath = [PTMCoreMLCompiler _compiledModelFilePath:modelPath.path];
+  NSURL* compiledModelPath = [modelPath URLByAppendingPathExtension:@"mlmodelc"];
 
-  BOOL modelCached = [[NSFileManager defaultManager] fileExistsAtPath:modelPath.path];
-  BOOL compiledModelCached = [[NSFileManager defaultManager] fileExistsAtPath:compiledModelPath.path];
-  BOOL shouldRecompile = [self _shouldRecompileModel:compiledModelPath];
+  BOOL modelIsCached = [[NSFileManager defaultManager] fileExistsAtPath:modelPath.path];
+  BOOL compiledModelIsCached = [[NSFileManager defaultManager] fileExistsAtPath:compiledModelPath.path];
 
-  if (modelCached != compiledModelCached) {
-    modelCached = NO;
-    compiledModelCached = NO;
-    [PTMCoreMLCompiler _cleanupModel:modelPath compiledModel:compiledModelPath];
+#if TARGET_OS_IPHONE
+  NSError *error = nil;
+  NSURL *compilationOSPath = [modelPath URLByAppendingPathExtension:@"version"];
+  NSString *compilationOS = [NSString stringWithContentsOfFile:compilationOSPath.path encoding:NSUTF8StringEncoding error:&error];
+  NSString *currentOS = [UIDevice currentDevice].systemVersion;
+  BOOL wasCachedOnThisOS = [currentOS isEqualToString:compilationOS];
+#else
+  BOOL wasCachedOnThisOS = NO;
+#endif
+
+  if (modelIsCached != compiledModelIsCached || !wasCachedOnThisOS) {
+    modelIsCached = NO;
+    compiledModelIsCached = NO;
+    [PTMCoreMLCompiler _cleanupCachedModel:modelID];
   }
 
-  if (!modelCached) {
+  if (!modelIsCached) {
     // Note that the serialized protobuf binary contains bytes not text.
     // https://developers.google.com/protocol-buffers/docs/pythontutorial#parsing-and-serialization
     NSData* data = [NSData dataWithBytes:modelSpecs.c_str() length:modelSpecs.length()];
     if (![data writeToFile:modelPath.path atomically:YES]) {
-        // If the model cannot be persisted on disk then compilation cannot proceed.
-        NSLog(@"Failed to save specs for MLModel!");
-        [PTMCoreMLCompiler _cleanupModel:modelPath compiledModel:compiledModelPath];
-        return nil;
+      // If the model cannot be persisted on disk then compilation cannot proceed.
+      NSLog(@"Failed to save specs for MLModel!");
+      [PTMCoreMLCompiler _cleanupCachedModel:modelID];
+      return NO;
     }
   }
 
-  if (shouldRecompile || !compiledModelCached) {
-    NSError *error;
-    NSURL *temporaryURL = [MLModel compileModelAtURL:modelPath error:&error];
-    if (!error) {
-      [PTMCoreMLCompiler _moveFileToCache:temporaryURL cacheURL:compiledModelPath error:&error];
-    }
-    if (error) {
-      NSLog(@"Failed to compile MLModel!");
-      [PTMCoreMLCompiler _cleanupModel:modelPath compiledModel:compiledModelPath];
-      return nil;
-    }
+  if (compiledModelIsCached) {
+    return YES;
   }
 
-  return compiledModelPath;
+  return [PTMCoreMLCompiler _compileModel:modelID atPath:modelPath andCache:compiledModelPath];
 }
 
-+ (nullable MLModel*)loadCPUModelAtURL:(NSURL*)modelURL {
-  NSError *error;
-  MLModel *model;
-  if (@available(iOS 12.0, macOS 10.14, *)) {
-    MLModelConfiguration* config = [[MLModelConfiguration alloc] init];
-    config.computeUnits = MLComputeUnitsCPUOnly;
-    model = [MLModel modelWithContentsOfURL:modelURL configuration:config error:&error];
-  } else {
-    model = [MLModel modelWithContentsOfURL:modelURL error:&error];
-  }
-  if (error) {
-    NSLog(@"Failed to initialize MLModel!");
-    [PTMCoreMLCompiler _cleanupModel:nil compiledModel:modelURL];
-    return nil;
-  }
-  return model;
-}
++ (nullable MLModel*)loadModel:(const std::string&)modelID backend:(const std::string&)backend allowLowPrecision:(BOOL)allowLowPrecision {
+  NSString* modelName = [NSString stringWithCString:modelID.c_str() encoding:NSUTF8StringEncoding];
+  NSURL* modelPath = [PTMCoreMLCompiler _cacheFilePath:modelName];
+  NSURL* compiledModelPath = [modelPath URLByAppendingPathExtension:@"mlmodelc"];
 
-+ (nullable MLModel*)loadModelAtURL:(NSURL*)modelURL backend:(const std::string&)backend allowLowPrecision:(BOOL)allowLowPrecision {
   NSError *error;
   MLModel *model;
   if (@available(iOS 12.0, macOS 10.14, *)) {
@@ -96,64 +82,59 @@ static NSString* gModelCacheDirectory = @"";
     }
     config.computeUnits = computeUnits;
     config.allowLowPrecisionAccumulationOnGPU = allowLowPrecision;
-    model = [MLModel modelWithContentsOfURL:modelURL configuration:config error:&error];
+    model = [MLModel modelWithContentsOfURL:compiledModelPath configuration:config error:&error];
   } else {
-    model = [MLModel modelWithContentsOfURL:modelURL error:&error];
+    model = [MLModel modelWithContentsOfURL:compiledModelPath error:&error];
   }
+
   if (error) {
     NSLog(@"Failed to initialize MLModel!");
-    [PTMCoreMLCompiler _cleanupModel:nil compiledModel:modelURL];
+    [PTMCoreMLCompiler _cleanupCachedModel:modelID];
     return nil;
   }
+
   return model;
 }
 
-+ (void)_cleanupModel:(NSURL*)modelPath compiledModel:(NSURL*)compiledModelPath {
-  NSFileManager* fileManager = [NSFileManager defaultManager];
++ (BOOL)_compileModel:(const std::string&)modelID atPath:(NSURL *)modelPath andCache:(NSURL *)cachePath {
+  NSError *error;
+  NSURL *temporaryURL = [MLModel compileModelAtURL:modelPath error:&error];
+  if (!error) {
+#if TARGET_OS_IPHONE
+    NSURL *compilationOSPath = [modelPath URLByAppendingPathExtension:@"version"];
+    NSString *currentOSVer = [UIDevice currentDevice].systemVersion;
+    [currentOSVer writeToFile:compilationOSPath.path atomically:YES];
+#endif
+    [PTMCoreMLCompiler _moveFileToCache:temporaryURL cacheURL:cachePath error:&error];
+  }
+  if (error) {
+    NSLog(@"Failed to compile MLModel!");
+    [PTMCoreMLCompiler _cleanupCachedModel:modelID];
+  }
+  return !error;
+}
+
++ (void)_cleanupCachedModel:(const std::string&)modelID {
+  NSString* modelName = [NSString stringWithCString:modelID.c_str() encoding:NSUTF8StringEncoding];
+  NSURL* modelPath = [PTMCoreMLCompiler _cacheFilePath:modelName];
+  NSURL* compiledModelPath = [modelPath URLByAppendingPathExtension:@"mlmodelc"];
+  NSURL* compilationOSPath = [modelPath URLByAppendingPathExtension:@"version"];
   NSError* error = nil;
-  if (modelPath && [fileManager fileExistsAtPath:modelPath.path]) {
-    [fileManager removeItemAtPath:modelPath.path error:&error];
-  }
-  if (compiledModelPath && [fileManager fileExistsAtPath:compiledModelPath.path]) {
-    [fileManager removeItemAtPath:compiledModelPath.path error:&error];
-  }
+  [[NSFileManager defaultManager] removeItemAtPath:modelPath.path error:&error];
+  [[NSFileManager defaultManager] removeItemAtPath:compiledModelPath.path error:&error];
+  [[NSFileManager defaultManager] removeItemAtPath:compilationOSPath.path error:&error];
 }
 
 + (void)_moveFileToCache:(NSURL *)fileURL cacheURL:(NSURL *)cacheURL error:(NSError **)error {
   if ([fileURL isEqual:cacheURL]) {
     return;
   }
-  NSFileManager *fileManager = [NSFileManager defaultManager];
-  if ([fileManager fileExistsAtPath:cacheURL.path]) {
-    [fileManager removeItemAtURL:cacheURL error:error];
-  }
-  [fileManager moveItemAtURL:fileURL toURL:cacheURL error:error];
-}
-
-+ (BOOL)_shouldRecompileModel:(NSURL *)compiledModelPath {
-#if TARGET_OS_IPHONE
-  NSString *versionPath = [PTMCoreMLCompiler _cacheFilePath:@"version"].path;
-  NSString *cachedOSVer = nil;
-  if ([[NSFileManager defaultManager] fileExistsAtPath:versionPath]) {
-    NSError *error = nil;
-    cachedOSVer = [NSString stringWithContentsOfFile:versionPath encoding:NSUTF8StringEncoding error:&error];
-  }
-  // Compile the model when OS version changes
-  NSString *currentOSVer = [UIDevice currentDevice].systemVersion;
-  [currentOSVer writeToFile:versionPath atomically:YES];
-  return ![currentOSVer isEqualToString:cachedOSVer];
-#else
-  return YES;
-#endif
+  [[NSFileManager defaultManager] removeItemAtURL:cacheURL error:nil];
+  [[NSFileManager defaultManager] moveItemAtURL:fileURL toURL:cacheURL error:error];
 }
 
 + (NSURL *)_cacheFilePath:(NSString *)fileName {
   NSString *filePath = [[PTMCoreMLCompiler modelCacheDirectory] stringByAppendingPathComponent:fileName];
-  return [NSURL fileURLWithPath:filePath];
-}
-
-+ (NSURL *)_compiledModelFilePath:(NSString *)modelPath {
-  NSString *filePath = [modelPath stringByAppendingString:@".mlmodelc"];
   return [NSURL fileURLWithPath:filePath];
 }
 


### PR DESCRIPTION
Summary: Ensure that all models are recompiled when OS updates, instead of just the first model loaded after the OS update. To do this we need to save the compilation os version for each model.

Test Plan: Build and run IG, launch a segmentation effect, confirm it renders correctly. To test the OS upgrade flow you could manually change '[UIDevice currentDevice].systemVersion' to a different string and launch again, and confirm you can still access effects.

Differential Revision: D38361641

