### PR TITLE
Add CPP stacktrace on CUDA OOM

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1,6 +1,7 @@
 
 #include <c10/cuda/CUDACachingAllocator.h>
 
+#include <c10/util/Exception.h>
 #include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/cuda/CUDAGuard.h>

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -11,10 +11,6 @@
 
 namespace c10 {
 
-class C10_CUDA_API CUDAOutOfMemoryError : public c10::Error {
-  using Error::Error;
-};
-
 // Caching allocator will execute every registered callback if it unable to find
 // block inside of already allocated area.
 class C10_CUDA_API FreeMemoryCallback {

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -235,6 +235,11 @@ class C10_API LinAlgError : public Error {
   using Error::Error;
 };
 
+// Used for CUDA out of memory errors
+class C10_API CUDAOutOfMemoryError : public c10::Error {
+  using Error::Error;
+};
+
 // A utility function to return an exception std::string by prepending its
 // exception type before its what() content
 C10_API std::string GetExceptionString(const std::exception& e);

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -92,6 +92,11 @@ static inline void PyErr_SetString(PyObject* type, const std::string& message) {
     PyErr_SetString(THPException_LinAlgError, torch::processErrorMsg(msg));  \
     retstmnt;                                                                \
   }                                                                          \
+  catch (const c10::CUDAOutOfMemoryError& e) {                               \
+    auto msg = e.what();                                                     \
+    PyErr_SetString(THPException_LinAlgError, torch::processErrorMsg(msg));  \
+    retstmnt;                                                                \
+  }                                                                          \
   catch (const c10::Error& e) {                                              \
     auto msg = torch::get_cpp_stacktraces_enabled()                          \
         ? e.what()                                                           \

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -97,11 +97,11 @@ static inline void PyErr_SetString(PyObject* type, const std::string& message) {
       PyErr_SetString(THPException_LinAlgError, torch::processErrorMsg(msg));  \
       retstmnt;                                                                \
     }                                                                          \
-    catch (const c10::CUDAOutOfMemoryError& e) { \
-      auto msg = e.what(); \
-      PyErr_SetString(PyExc_RuntimeError, torch::processErrorMsg(msg)); \
-      retstmnt; \
-    } \
+    catch (const c10::CUDAOutOfMemoryError& e) {                               \
+      auto msg = e.what();                                                     \
+      PyErr_SetString(PyExc_RuntimeError, torch::processErrorMsg(msg));        \
+      retstmnt;                                                                \
+    }                                                                          \
     catch (const c10::Error& e) {                                              \
       auto msg = torch::get_cpp_stacktraces_enabled()                          \
           ? e.what()                                                           \

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -20,6 +20,10 @@
 #include <torch/csrc/distributed/c10d/exception.h>
 #endif
 
+#if defined(USE_CUDA)
+#include <c10/cuda/CUDACachingAllocator.h>
+#endif
+
 static inline void PyErr_SetString(PyObject* type, const std::string& message) {
   PyErr_SetString(type, message.c_str());
 }
@@ -52,58 +56,118 @@ static inline void PyErr_SetString(PyObject* type, const std::string& message) {
     torch::PyWarningHandler __enforce_warning_buffer; \
     try {
 // Only catch torch-specific exceptions
-#define CATCH_CORE_ERRORS(retstmnt)                                          \
-  catch (python_error & e) {                                                 \
-    e.restore();                                                             \
-    retstmnt;                                                                \
-  }                                                                          \
-  catch (const c10::IndexError& e) {                                         \
-    auto msg = torch::get_cpp_stacktraces_enabled()                          \
-        ? e.what()                                                           \
-        : e.what_without_backtrace();                                        \
-    PyErr_SetString(PyExc_IndexError, torch::processErrorMsg(msg));          \
-    retstmnt;                                                                \
-  }                                                                          \
-  catch (const c10::ValueError& e) {                                         \
-    auto msg = torch::get_cpp_stacktraces_enabled()                          \
-        ? e.what()                                                           \
-        : e.what_without_backtrace();                                        \
-    PyErr_SetString(PyExc_ValueError, torch::processErrorMsg(msg));          \
-    retstmnt;                                                                \
-  }                                                                          \
-  catch (const c10::TypeError& e) {                                          \
-    auto msg = torch::get_cpp_stacktraces_enabled()                          \
-        ? e.what()                                                           \
-        : e.what_without_backtrace();                                        \
-    PyErr_SetString(PyExc_TypeError, torch::processErrorMsg(msg));           \
-    retstmnt;                                                                \
-  }                                                                          \
-  catch (const c10::NotImplementedError& e) {                                \
-    auto msg = torch::get_cpp_stacktraces_enabled()                          \
-        ? e.what()                                                           \
-        : e.what_without_backtrace();                                        \
-    PyErr_SetString(PyExc_NotImplementedError, torch::processErrorMsg(msg)); \
-    retstmnt;                                                                \
-  }                                                                          \
-  catch (const c10::LinAlgError& e) {                                        \
-    auto msg = torch::get_cpp_stacktraces_enabled()                          \
-        ? e.what()                                                           \
-        : e.what_without_backtrace();                                        \
-    PyErr_SetString(THPException_LinAlgError, torch::processErrorMsg(msg));  \
-    retstmnt;                                                                \
-  }                                                                          \
-  catch (const c10::Error& e) {                                              \
-    auto msg = torch::get_cpp_stacktraces_enabled()                          \
-        ? e.what()                                                           \
-        : e.what_without_backtrace();                                        \
-    PyErr_SetString(PyExc_RuntimeError, torch::processErrorMsg(msg));        \
-    retstmnt;                                                                \
-  }                                                                          \
-  catch (torch::PyTorchError & e) {                                          \
-    auto msg = torch::processErrorMsg(e.what());                             \
-    PyErr_SetString(e.python_type(), msg);                                   \
-    retstmnt;                                                                \
-  }
+#if defined(USE_CUDA)
+  #define CATCH_CORE_ERRORS(retstmnt)                                          \
+    catch (python_error & e) {                                                 \
+      e.restore();                                                             \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::IndexError& e) {                                         \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(PyExc_IndexError, torch::processErrorMsg(msg));          \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::ValueError& e) {                                         \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(PyExc_ValueError, torch::processErrorMsg(msg));          \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::TypeError& e) {                                          \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(PyExc_TypeError, torch::processErrorMsg(msg));           \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::NotImplementedError& e) {                                \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(PyExc_NotImplementedError, torch::processErrorMsg(msg)); \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::LinAlgError& e) {                                        \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(THPException_LinAlgError, torch::processErrorMsg(msg));  \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::CUDAOutOfMemoryError& e) { \
+      auto msg = e.what(); \
+      PyErr_SetString(PyExc_RuntimeError, torch::processErrorMsg(msg)); \
+      retstmnt; \
+    } \
+    catch (const c10::Error& e) {                                              \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(PyExc_RuntimeError, torch::processErrorMsg(msg));        \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (torch::PyTorchError & e) {                                          \
+      auto msg = torch::processErrorMsg(e.what());                             \
+      PyErr_SetString(e.python_type(), msg);                                   \
+      retstmnt;                                                                \
+    }
+#else
+  #define CATCH_CORE_ERRORS(retstmnt)                                          \
+    catch (python_error & e) {                                                 \
+      e.restore();                                                             \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::IndexError& e) {                                         \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(PyExc_IndexError, torch::processErrorMsg(msg));          \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::ValueError& e) {                                         \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(PyExc_ValueError, torch::processErrorMsg(msg));          \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::TypeError& e) {                                          \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(PyExc_TypeError, torch::processErrorMsg(msg));           \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::NotImplementedError& e) {                                \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(PyExc_NotImplementedError, torch::processErrorMsg(msg)); \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::LinAlgError& e) {                                        \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(THPException_LinAlgError, torch::processErrorMsg(msg));  \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (const c10::Error& e) {                                              \
+      auto msg = torch::get_cpp_stacktraces_enabled()                          \
+          ? e.what()                                                           \
+          : e.what_without_backtrace();                                        \
+      PyErr_SetString(PyExc_RuntimeError, torch::processErrorMsg(msg));        \
+      retstmnt;                                                                \
+    }                                                                          \
+    catch (torch::PyTorchError & e) {                                          \
+      auto msg = torch::processErrorMsg(e.what());                             \
+      PyErr_SetString(e.python_type(), msg);                                   \
+      retstmnt;                                                                \
+    }
+#endif
 
 #if defined(USE_DISTRIBUTED) && defined(USE_C10D)
 #define CATCH_C10D_ERRORS(retstmnt)              \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82665

When reporting CUDA OOM error, defaults to showing the C++ stacktrace to help with debugability in terms of when this happened / which operator caused it. 

Had to make separate macros for handling the torch errors based on whether CUDA is available or not, because you cannot have a define directive within another directive: https://stackoverflow.com/questions/10074520/why-compiler-complain-about-this-macro-declaration. Feel free to suggest better alternatives!