### PR TITLE
[DataPipe] Correct the type of exception that is being raised by ShufflerMapDataPipe

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1793,6 +1793,16 @@ class TestFunctionalMapDataPipe(TestCase):
         with self.assertRaisesRegex(IndexError, r"out of range"):
             input_dp1.zip(input_dp2, input_dp3)[5]
 
+        # Functional Test: Ensure `zip` can combine `Shuffler` with others
+        dp1 = dp.map.SequenceWrapper(range(10))
+        shuffle_dp1 = dp1.shuffle()
+        dp2 = dp.map.SequenceWrapper(range(10))
+        shuffle_dp2 = dp2.shuffle()
+        zip_dp = shuffle_dp1.zip(shuffle_dp2)
+        self.assertEqual(10, len(list(zip_dp)))
+        zip_dp2 = shuffle_dp1.zip(dp2)
+        self.assertEqual(10, len(list(zip_dp)))
+
         # __len__ Test: returns the length of the shortest DataPipe
         zip_dp = input_dp1.zip(input_dp2, input_dp3)
         self.assertEqual(5, len(zip_dp))

--- a/torch/utils/data/datapipes/map/combinatorics.py
+++ b/torch/utils/data/datapipes/map/combinatorics.py
@@ -49,7 +49,10 @@ class ShufflerMapDataPipe(MapDataPipe[T_co]):
         random.shuffle(self.indices)
 
     def __getitem__(self, index) -> T_co:
-        old_numeric_index = self.index_map[index]
+        try:
+            old_numeric_index = self.index_map[index]
+        except KeyError:
+            raise IndexError(f"Index {index} is out of range for {self}.")
         new_index = self.indices[old_numeric_index]
         return self.datapipe[new_index]
 

--- a/torch/utils/data/datapipes/map/combining.py
+++ b/torch/utils/data/datapipes/map/combining.py
@@ -91,7 +91,7 @@ class ZipperMapDataPipe(MapDataPipe[Tuple[T_co, ...]]):
         for dp in self.datapipes:
             try:
                 res.append(dp[index])
-            except (IndexError, KeyError):
+            except IndexError:
                 raise IndexError(f"Index {index} is out of range for one of the input MapDataPipes {dp}.")
         return tuple(res)
 

--- a/torch/utils/data/datapipes/map/combining.py
+++ b/torch/utils/data/datapipes/map/combining.py
@@ -91,7 +91,7 @@ class ZipperMapDataPipe(MapDataPipe[Tuple[T_co, ...]]):
         for dp in self.datapipes:
             try:
                 res.append(dp[index])
-            except IndexError:
+            except (IndexError, KeyError):
                 raise IndexError(f"Index {index} is out of range for one of the input MapDataPipes {dp}.")
         return tuple(res)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #82666

Fixes https://github.com/pytorch/data/issues/708

The following code snippet used to fail, now it has been added as a test case:
```python
dp1 = dp.map.SequenceWrapper(range(10))
shuffle_dp1 = dp1.shuffle()
dp2 = dp.map.SequenceWrapper(range(10))
shuffle_dp2 = dp2.shuffle()
zip_dp = shuffle_dp1.zip(shuffle_dp2)
list(zip_dp)  # This used to fail
```

The issue was that `ShufflerMapDataPipe` raises a `KeyError` when an out of bound index is passed into it, but that was not handled by `zip_dp`'s `__getitem__` which only handled `IndexError`. With this change, it handles both.