### PR TITLE
[MPS] Fix scatter for bool type

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1548,6 +1548,12 @@ class TestMPS(TestCase):
     def test_bool_full(self):
         x = torch.full((3, 3), True, device='mps')
 
+    # See https://github.com/pytorch/pytorch/issues/82663
+    def test_bool_expand(self):
+        x=torch.tensor([[1], [0]], dtype=torch.bool, device='mps')
+        y=torch.tensor([0, 1], dtype=torch.bool, device='mps')
+        self.assertFalse(torch.equal(x.expand(2, 2), y.expand(2, 2)))
+
     # Empty unary op should return tensor of the same size
     def test_empty_neg(self):
         x = torch.tensor([[]], device='mps')

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1550,8 +1550,8 @@ class TestMPS(TestCase):
 
     # See https://github.com/pytorch/pytorch/issues/82663
     def test_bool_expand(self):
-        x=torch.tensor([[1], [0]], dtype=torch.bool, device='mps')
-        y=torch.tensor([0, 1], dtype=torch.bool, device='mps')
+        x = torch.tensor([[1], [0]], dtype=torch.bool, device='mps')
+        y = torch.tensor([0, 1], dtype=torch.bool, device='mps')
         self.assertFalse(torch.equal(x.expand(2, 2), y.expand(2, 2)))
 
     # Empty unary op should return tensor of the same size


### PR DESCRIPTION
By typecasting bool tensors to int8 before scattering

See https://github.com/pytorch/pytorch/issues/82663
