### PR TITLE
Properly compare floats in fully-connected-operator-tester

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-operator-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-operator-tester.h
@@ -356,7 +356,7 @@ class FullyConnectedOperatorTester {
           }
           for (size_t i = 0; i < batchSize(); i++) {
             for (size_t c = 0; c < outputChannels(); c++) {
-              ASSERT_EQ(
+              ASSERT_FLOAT_EQ(
                   output_dynamic[i * outputChannels() + c],
                   ((float)accumulators[i * outputChannels() + c] *
                   requantization_scales[c]) + float(bias[c]))


### PR DESCRIPTION
Need to use `ASSERT_FLOAT_EQ` for floats.

Right now the test often fails internally like this:

```
xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-operator-tester.h:362
Expected equality of these values:
  output_dynamic[i * outputChannels() + c]
    Which is: -601.09
  ((float)accumulators[i * outputChannels() + c] * requantization_scales[c]) + float(bias[c])
    Which is: -601.09
at 0, 18: reference = -601.0899658203125, optimized = -601.09002685546875
```

```
xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-operator-tester.h:362
Expected equality of these values:
  output_dynamic[i * outputChannels() + c]
    Which is: -65.6251
  ((float)accumulators[i * outputChannels() + c] * requantization_scales[c]) + float(bias[c])
    Which is: -65.6251
at 0, 7: reference = -65.625106811523438, optimized = -65.625099182128906
```