### PR TITLE
adding a custom caster for c10::SymInt

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -2425,9 +2425,7 @@ c10::SymIntArrayRef concrete_sym_sizes_fn(
   py::list symints;
   for (auto it = out.begin(); it != out.end(); it++) {
     auto elm = *it;
-    auto si = torch::is_symint_node(elm)
-        ? elm.cast<c10::SymIntNodeImpl*>()->toSymInt()
-        : c10::SymInt{py::cast<int64_t>(elm)};
+    auto si = py::cast<c10::SymInt>(elm);
     // TODO: the buffer will need to be made owning later
     symints.append(si.as_int_unchecked());
   }

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -81,9 +81,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_t> N) {
       return static_cast<c10::complex<double>>(c_obj);
     }
     case TypeKind::SymIntType:
-      return torch::is_symint_node(obj)
-          ? obj.cast<c10::SymIntNodeImpl*>()->toSymInt()
-          : c10::SymInt{py::cast<int64_t>(obj)};
+      return py::cast<c10::SymInt>(obj);
     case TypeKind::IntType:
     // NB: Typically, these switches are completely dead, because
     // Argument::type() will always report IntType for these types.
@@ -194,9 +192,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_t> N) {
           c10::List<c10::SymInt> symints;
           for (auto it = obj.begin(); it != obj.end(); it++) {
             auto elm = *it;
-            auto si = torch::is_symint_node(elm)
-                ? elm.cast<c10::SymIntNodeImpl*>()->toSymInt()
-                : c10::SymInt{py::cast<int64_t>(elm)};
+            auto si = py::cast<c10::SymInt>(elm);
             symints.push_back(si);
           }
           return symints;

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -852,8 +852,7 @@ inline py::object toPyObject(IValue ivalue) {
 #endif
   } else if (ivalue.isSymInt()) {
     auto si = ivalue.toSymInt();
-    return si.is_symbolic() ? py::cast(si.toSymIntNodeImpl())
-                            : py::cast(si.expect_int());
+    return py::cast(si);
   } else {
     AT_ERROR(
         "Missing cases in 'toPyObject'! Can't convert ",

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -77,6 +77,51 @@
 #include <vector>
 
 namespace torch {
+inline bool is_symint_node(py::handle obj) {
+  auto static tp_symn = py::type::of<c10::SymIntNodeImpl>();
+  // TODO: switch this to `isinstance`
+  if (obj.get_type().equal(tp_symn)) {
+    TORCH_CHECK(
+        !jit::tracer::isTracing(), "JIT tracing of SymInts isn't supported!");
+    return true;
+  }
+  return false;
+}
+} // namespace torch
+
+namespace pybind11 {
+namespace detail {
+template <>
+struct type_caster<c10::SymInt> {
+ public:
+  PYBIND11_TYPE_CASTER(c10::SymInt, const_name("SymInt"));
+  bool load(py::handle src, bool) {
+    if (torch::is_symint_node(src)) {
+      auto si = src.cast<c10::SymIntNodeImpl*>()->toSymInt();
+      value = si;
+      return true;
+    }
+
+    auto raw_obj = src.ptr();
+    if (THPUtils_checkIndex(raw_obj)) {
+      value = c10::SymInt{THPUtils_unpackIndex(raw_obj)};
+      return true;
+    }
+    return false;
+  }
+
+  static py::handle cast(
+      c10::SymInt si,
+      return_value_policy /* policy */,
+      handle /* parent */) {
+    return si.is_symbolic() ? py::cast(si.toSymIntNodeImpl()).release()
+                            : py::cast(si.expect_int()).release();
+  }
+};
+} // namespace detail
+} // namespace pybind11
+
+namespace torch {
 
 bool should_allow_numbers_as_tensors(const std::string& name);
 
@@ -474,17 +519,6 @@ inline std::vector<int64_t> PythonArgs::intlist(int i) {
   return intlistWithDefault(i, signature.params[i].default_intlist);
 }
 
-inline bool is_symint_node(py::handle obj) {
-  auto static tp_symn = py::type::of<c10::SymIntNodeImpl>();
-  // TODO: switch this to `isinstance`
-  if (obj.get_type().equal(tp_symn)) {
-    TORCH_CHECK(
-        !jit::tracer::isTracing(), "JIT tracing of SymInts isn't supported!");
-    return true;
-  }
-  return false;
-}
-
 inline PyObject* toPyObject(c10::SymInt symint) {
   if (symint.is_symbolic()) {
     auto r = py::cast(symint.toSymIntNodeImpl()).release().ptr();
@@ -854,10 +888,8 @@ inline c10::SymInt PythonArgs::toSymInt(int i) {
     jit::tracer::ArgumentStash::stashValue(
         signature.params[i].name, idx, var, c10::IntType::get());
   }
-  if (torch::is_symint_node(py::handle(args[i]))) {
-    return py::handle(args[i]).cast<c10::SymIntNodeImpl*>()->toSymInt();
-  }
-  return c10::SymInt(THPUtils_unpackLong(args[i]));
+
+  return py::cast<c10::SymInt>(py::handle(args[i]));
 }
 
 inline int64_t PythonArgs::toInt64WithDefault(int i, int64_t default_int) {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -97,8 +97,7 @@ struct type_caster<c10::SymInt> {
   PYBIND11_TYPE_CASTER(c10::SymInt, const_name("SymInt"));
   bool load(py::handle src, bool) {
     if (torch::is_symint_node(src)) {
-      auto si = src.cast<c10::SymIntNodeImpl*>()->toSymInt();
-      value = si;
+      value = src.cast<c10::SymIntNodeImpl*>()->toSymInt();
       return true;
     }
 


### PR DESCRIPTION
### Description
Adding a custom caster for `c10::SymInt`. This simplifies handling of c10::SymInt on C++/Pytorch boundary. Namely, removing if statements to handle the union nature (e.g. SymIntNode, int) of c10::SymInt.

### Issue
<!-- Link to Issue ticket or RFP -->

### Testing
<!-- How did you test your change? -->
