### PR TITLE
Fix IdenticalTypesDifferentCus to check for a valid address on Windows.

### DIFF
--- a/aten/src/ATen/core/class_type.h
+++ b/aten/src/ATen/core/class_type.h
@@ -101,7 +101,11 @@ struct TORCH_API ClassType : public NamedType {
   std::string repr_str() const override {
     std::stringstream ss;
     ss << str()
-       << " (of Python compilation unit at: " << compilation_unit().get() << ")";
+       << " (of Python compilation unit at: " <<
+#ifdef _MSC_VER
+       "0x" <<
+#endif
+       compilation_unit().get() << ")";
     return ss.str();
   }
 


### PR DESCRIPTION
On Windows the address does not get printed as `0x` so this test always fails, This patch fixes this problem. 

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel