### PR TITLE
Fix CheckOutputStreamSetting on JitLoggingTest as it failed if logging wasn't enabled.

### DIFF
--- a/test/cpp/jit/test_jit_logging_levels.cpp
+++ b/test/cpp/jit/test_jit_logging_levels.cpp
@@ -41,7 +41,15 @@ TEST(JitLoggingTest, CheckOutputStreamSetting) {
   ::torch::jit::set_jit_logging_levels("test_jit_logging_levels");
   std::ostringstream test_stream;
   ::torch::jit::set_jit_logging_output_stream(test_stream);
-  JIT_LOG(::torch::jit::JitLoggingLevels::GRAPH_DUMP, "Message");
+  /* Using JIT_LOG checks if this file has logging enabled with
+    is_enabled(__FILE__, level) making the test fail. since we are only testing
+    the OutputStreamSetting we can forcefully output to it directly.
+  */
+  ::torch::jit::get_jit_logging_output_stream() << ::torch::jit::jit_log_prefix(
+      ::torch::jit::JitLoggingLevels::GRAPH_DUMP,
+      __FILE__,
+      __LINE__,
+      ::c10::str("Message"));
   ASSERT_TRUE(test_stream.str().size() > 0);
 }
 


### PR DESCRIPTION
`JIT_LOG` checks if logging was enabled for that particular file and when it isn't it doesn't output anything. Since the test checks for the size of `test_stream` it fails. I believe forcing the file to have logging enabled to see if the stream is being correctly set during test makes no sense so this patches just forcibly outputs and checks if it worked. 

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel