### PR TITLE
[ROCM] Enable Sparse Pickle Test

### DIFF
--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -3019,7 +3019,6 @@ class TestSparse(TestSparseBase):
         self.assertEqual(list(t.coalesce().indices().size()), [2, 1])
         self.assertEqual(list(t.coalesce().values().size()), [1, 3])
 
-    @skipIfRocm
     @coalescedonoff
     @dtypes(torch.double)
     def test_pickle(self, device, dtype, coalesced):

--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -233,7 +233,17 @@ void THPStorage_writeFileRaw(
   int64_t numel = size_bytes / element_size;
   if (self->device_type() == at::kCPU) {
     data = self->data<uint8_t>();
-#ifdef USE_CUDA
+#if defined(USE_CUDA) && defined(TORCH_HIP_VERSION) && (TORCH_HIP_VERSION >= 301)
+  } else if (self->device_type() == at::kCUDA) {
+    cpu_data = std::unique_ptr<char[]>(new char[size_bytes]);
+    data = (uint8_t*)cpu_data.get();
+    C10_CUDA_CHECK(hipMemcpyWithStream(
+        data,
+        self->data<uint8_t>(),
+        size_bytes,
+        cudaMemcpyDeviceToHost,
+        c10::hip::getCurrentHIPStreamMasqueradingAsCUDA()));
+#elif defined(USE_CUDA)
   } else if (self->device_type() == at::kCUDA) {
     cpu_data = std::unique_ptr<char[]>(new char[size_bytes]);
     data = (uint8_t*)cpu_data.get();
@@ -398,7 +408,15 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
     }
   }
 
-#ifdef USE_CUDA
+#if defined(USE_CUDA) && defined(TORCH_HIP_VERSION) && (TORCH_HIP_VERSION >= 301)
+  if (storage->device_type() == at::kCUDA) {
+    C10_CUDA_CHECK(hipMemcpyWithStream(storage->data<uint8_t>(),
+          data,
+          nbytes,
+          cudaMemcpyHostToDevice,
+          c10::hip::getCurrentHIPStreamMasqueradingAsCUDA()));
+  }
+#elif defined(USE_CUDA)
   if (storage->device_type() == at::kCUDA) {
     C10_CUDA_CHECK(cudaMemcpy(
         storage->data<uint8_t>(), data, nbytes, cudaMemcpyHostToDevice));

--- a/torch/csrc/serialization.cpp
+++ b/torch/csrc/serialization.cpp
@@ -233,7 +233,8 @@ void THPStorage_writeFileRaw(
   int64_t numel = size_bytes / element_size;
   if (self->device_type() == at::kCPU) {
     data = self->data<uint8_t>();
-#if defined(USE_CUDA) && defined(TORCH_HIP_VERSION) && (TORCH_HIP_VERSION >= 301)
+#if defined(USE_CUDA) && defined(TORCH_HIP_VERSION) && \
+    (TORCH_HIP_VERSION >= 301)
   } else if (self->device_type() == at::kCUDA) {
     cpu_data = std::unique_ptr<char[]>(new char[size_bytes]);
     data = (uint8_t*)cpu_data.get();
@@ -408,13 +409,15 @@ c10::intrusive_ptr<c10::StorageImpl> THPStorage_readFileRaw(
     }
   }
 
-#if defined(USE_CUDA) && defined(TORCH_HIP_VERSION) && (TORCH_HIP_VERSION >= 301)
+#if defined(USE_CUDA) && defined(TORCH_HIP_VERSION) && \
+    (TORCH_HIP_VERSION >= 301)
   if (storage->device_type() == at::kCUDA) {
-    C10_CUDA_CHECK(hipMemcpyWithStream(storage->data<uint8_t>(),
-          data,
-          nbytes,
-          cudaMemcpyHostToDevice,
-          c10::hip::getCurrentHIPStreamMasqueradingAsCUDA()));
+    C10_CUDA_CHECK(hipMemcpyWithStream(
+        storage->data<uint8_t>(),
+        data,
+        nbytes,
+        cudaMemcpyHostToDevice,
+        c10::hip::getCurrentHIPStreamMasqueradingAsCUDA()));
   }
 #elif defined(USE_CUDA)
   if (storage->device_type() == at::kCUDA) {


### PR DESCRIPTION
Missed stream context for serialization

### Description
Missing ROCm stream context on memory operations for serialization 

### Testing
Ran the sparse pickle test


cc @jeffdaily @sunway513 @jithunnair-amd @ROCmSupport