### PR TITLE
Fix bc test for sym_numel

### DIFF
--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -115,6 +115,7 @@ ALLOW_LIST = [
     ("aten::.*functional", datetime.date(2022, 8, 1)),
     ("aten::_foreach.*", datetime.date(2022, 8, 1)),
     ("aten::unflatten", datetime.date(2022, 8, 10)),
+    ("aten::sym_numel", datetime.date(2022, 8, 10)),
     # TODO: FIXME: prims shouldn't be checked
     ("prims::.*", datetime.date(9999, 1, 1)),
 ]


### PR DESCRIPTION
Didn't wait for signal and accidentally broke BC in #82726 when reverting #82374.

Test Plan:
Wait for BC test to pass

```
2022-08-03T16:09:56.9629918Z processing existing schema:  disable(__torch__.torch.classes.profiling._ScriptProfile _0) -> NoneType _0
2022-08-03T16:09:56.9632953Z processing existing schema:  _dump_stats(__torch__.torch.classes.profiling._ScriptProfile _0) -> __torch__.torch.classes.profiling.SourceStats[] _0
2022-08-03T16:09:56.9634191Z processing existing schema:  __init__(__torch__.torch.classes.c10d.ProcessGroup _0, int _1, int _2) -> NoneType _0
2022-08-03T16:09:56.9636416Z processing existing schema:  __init__(__torch__.torch.classes.c10d.Work _0) -> NoneType _0
2022-08-03T16:09:56.9637951Z processing existing schema:  __init__(__torch__.torch.classes.dist_rpc.WorkerInfo _0, str _1, int _2) -> NoneType _0
2022-08-03T16:09:56.9638408Z The PR is introducing backward incompatible changes to the operator library. Please contact PyTorch team to confirm whether this change is wanted or not. 
2022-08-03T16:09:56.9638430Z 
2022-08-03T16:09:56.9638565Z Broken ops: [
2022-08-03T16:09:56.9638749Z 	aten::sym_numel(Tensor self) -> SymInt
2022-08-03T16:09:56.9638860Z ]
2022-08-03T16:09:57.1406777Z + sccache_epilogue
2022-08-03T16:09:57.1407466Z + echo '::group::Sccache Compilation Log'
<probably uninteresting folded group, click to show>
2022-08-03T16:09:57.1676461Z ##[error]Process completed with exit code 1.
2022-08-03T16:09:57.1715241Z Prepare all required actions
```