### PR TITLE
Governance process been actualized.

### DIFF
--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -78,6 +78,7 @@ Responsibilities of the maintainer includes:
 
 Core Maintainers
 ----------------
+
 The core maintainers are expected to have a deep understanding
 of the PyTorch code base and design philosophies. Their responsibilities
 include:

--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -62,7 +62,7 @@ future direction of the project and can participate in discussion.
 
 Within `pytorch/pytorch <https://github.com/pytorch/pytorch>`__,
 maintainer groups are defined in the
-`merge_rules.json <https://github.com/pytorch/pytorch/blob/master/.github/merge_rules.json>`__
+`CODEOWNERS <https://github.com/pytorch/pytorch/blob/master/CODEOWNERS>`__
 file in the GitHub repository. For other modules that correspond
 to repositories, membership is recorded on GitHub as access
 level to the repo (i.e. “write” permission). Module maintainers

--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -72,8 +72,8 @@ they are responsible for a folder).
 
 Responsibilities of the maintainer includes:
 * Triaging high priority issues of the module
-* Triaging and reviewing and landing high priority pull requests 
-  of the module
+* Triaging and reviewing and landing high priority pull requests
+  iof the module
 * Supporting public documentation related to the module
 * Running public developer meetings
 
@@ -141,7 +141,7 @@ The Process for Nomination
   However, if there is no process identified, you can file a request to the core maintainers
   by submitting [this form](https://forms.gle/xNeu1byGMZVHcA2q7). Core maintainers are
   meeting every three months.
-* If you are submitting a request to the core maintainers, the information in your request 
+* If you are submitting a request to the core maintainers, the information in your request
   must include the following items:
 
   * The nominees depth and breadth of code, review and design

--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -72,8 +72,7 @@ they are responsible for a folder).
 
 Responsibilities of the maintainer includes:
 * Triaging high priority issues of the module
-* Triaging and reviewing and landing high priority pull requests
-  iof the module
+* Triaging and reviewing and landing high priority pull requests of the module
 * Supporting public documentation related to the module
 * Running public developer meetings
 

--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -62,13 +62,20 @@ future direction of the project and can participate in discussion.
 
 Within `pytorch/pytorch <https://github.com/pytorch/pytorch>`__,
 maintainer groups are defined in the
-`CODEOWNERS <https://github.com/pytorch/pytorch/blob/master/CODEOWNERS>`__
+`merge_rules.json <https://github.com/pytorch/pytorch/blob/master/.github/merge_rules.json>`__
 file in the GitHub repository. For other modules that correspond
 to repositories, membership is recorded on GitHub as access
 level to the repo (i.e. “write” permission). Module maintainers
 are given privileges to administrate the repository (except for
 `pytorch/pytorch <https://github.com/pytorch/pytorch>`__ where
 they are responsible for a folder).
+
+Responsibilities of the maintainer includes:
+* Triaging high priority issues of the module
+* Triaging and reviewing and landing high priority pull requests 
+  of the module
+* Supporting public documentation related to the module
+* Running public developer meetings
 
 Core Maintainers
 ----------------
@@ -130,14 +137,12 @@ The Principles
 The Process for Nomination
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* We will have a nomination form, where anyone in the community can
-  nominate a person to a Module maintainer position
-* Every 3 months, the core maintainers go through the nominations,
-  do light filtering around spam or desk-rejection, and draw up a
-  list of potential nominees.
-* The core maintainers ask the specific module maintainers for more
-  information on the nominee. The information should include the following
-  items:
+* Each module will have it's own process, please conact module maintainers
+  however if there is no one, you can file a request to the core maintainers
+  via [this form](https://forms.gle/xNeu1byGMZVHcA2q7). Core maintainers are
+  meeting each 3 months.
+* If you using the core maintainers route the information in your reqest 
+  should include the following items:
 
   * The nominees depth and breadth of code, review and design
     contributions on the module

--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -139,7 +139,7 @@ The Process for Nomination
 
 * Each module has its own process. Please contact module maintainers for more information.
   However, if there is no process identified, you can file a request to the core maintainers
-  via [this form](https://forms.gle/xNeu1byGMZVHcA2q7). Core maintainers are
+  by submitting [this form](https://forms.gle/xNeu1byGMZVHcA2q7). Core maintainers are
   meeting each 3 months.
 * If you using the core maintainers route the information in your reqest 
   should include the following items:

--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -137,7 +137,7 @@ The Principles
 The Process for Nomination
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Each module will have it's own process, please conact module maintainers
+* Each module has its own process. Please contact module maintainers for more information.
   however if there is no one, you can file a request to the core maintainers
   via [this form](https://forms.gle/xNeu1byGMZVHcA2q7). Core maintainers are
   meeting each 3 months.

--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -142,7 +142,7 @@ The Process for Nomination
   by submitting [this form](https://forms.gle/xNeu1byGMZVHcA2q7). Core maintainers are
   meeting every three months.
 * If you are submitting a request to the core maintainers, the information in your request 
-  should include the following items:
+  must include the following items:
 
   * The nominees depth and breadth of code, review and design
     contributions on the module

--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -138,7 +138,7 @@ The Process for Nomination
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Each module has its own process. Please contact module maintainers for more information.
-  however if there is no one, you can file a request to the core maintainers
+  However, if there is no process identified, you can file a request to the core maintainers
   via [this form](https://forms.gle/xNeu1byGMZVHcA2q7). Core maintainers are
   meeting each 3 months.
 * If you using the core maintainers route the information in your reqest 

--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -141,7 +141,7 @@ The Process for Nomination
   However, if there is no process identified, you can file a request to the core maintainers
   by submitting [this form](https://forms.gle/xNeu1byGMZVHcA2q7). Core maintainers are
   meeting every three months.
-* If you using the core maintainers route the information in your reqest 
+* If you are submitting a request to the core maintainers, the information in your request 
   should include the following items:
 
   * The nominees depth and breadth of code, review and design

--- a/docs/source/community/governance.rst
+++ b/docs/source/community/governance.rst
@@ -140,7 +140,7 @@ The Process for Nomination
 * Each module has its own process. Please contact module maintainers for more information.
   However, if there is no process identified, you can file a request to the core maintainers
   by submitting [this form](https://forms.gle/xNeu1byGMZVHcA2q7). Core maintainers are
-  meeting each 3 months.
+  meeting every three months.
 * If you using the core maintainers route the information in your reqest 
   should include the following items:
 


### PR DESCRIPTION
Changes:
* form for topics proposals for Core maintainers review been added
* merge_rules.json file specified as spruce of truth for the list of maintainers (since it is the file that actually defines permissions)
* responsibilities of the module maintainers are added (as per the last core maintainers meeting)