### PR TITLE
Bumping doc build instance type

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -38,7 +38,7 @@ jobs:
   build-docs:
     # Don't run on forked repos.
     if: github.repository_owner == 'pytorch'
-    runs-on: [self-hosted, linux.2xlarge]
+    runs-on: [self-hosted, linux.4xlarge]
     strategy:
       matrix:
         docs_type: [cpp, python]


### PR DESCRIPTION
### Description
Bumping doc build instance type since we have constant failures in nightly docs build, running out of memory
Example:
https://github.com/pytorch/pytorch/runs/7642875300?check_suite_focus=true#step:8:26330
```
waiting for workers...
/home/ec2-user/actions-runner/_work/_temp/318122b1-3455-4a6b-bcb0-32b541662a5e.sh: line 28: 12686 Killed                  docker exec -t "${container_name}" bash -c "sudo chown -R jenkins . && pip install dist/*.whl && ./.circleci/scripts/${DOCS_TYPE}_doc_push_script.sh"
Error: Process completed with exit code 137.
```


### Testing
In CI
