### PR TITLE
making sure we don't accept pointers in int64_t c-tor

### DIFF
--- a/c10/core/SymInt.cpp
+++ b/c10/core/SymInt.cpp
@@ -33,7 +33,7 @@ c10::SymInt SymInt::toSymInt(SymIntNode sin_sp) {
   auto ptr = static_cast<uint64_t>(
       reinterpret_cast<uintptr_t>(static_cast<void*>(sin_sp.release())));
   auto rep = (ptr & ~MASK) | IS_SYM;
-  return c10::SymInt(static_cast<int64_t>(rep));
+  return c10::SymInt(UNCHECKED, static_cast<int64_t>(rep));
 }
 
 SymInt SymInt::operator+(SymInt sci) const {

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -28,11 +28,9 @@ namespace c10 {
 // SymIntNodeImpl*] which will be implemented as a single packed int64_t field
 // named data_.
 class C10_API SymInt {
-  enum class CTOR_TYPE {
-    INT, /* unused */
+  enum Unchecked {
     UNCHECKED,
   };
-
 
  public:
   /*implicit*/ SymInt(int64_t d) : data_(d) {
@@ -41,7 +39,7 @@ class C10_API SymInt {
   SymInt() = default;
 
   // unchecked c-tor accepting raw `data_`
-  SymInt(int64_t d, CTOR_TYPE) : data_(d) {}
+  SymInt(Unchecked, int64_t d) : data_(d) {}
 
   // TODO: these implementations are not optimal because they allocate a
   // temporary and then use the move constructor/assignment

--- a/c10/core/SymInt.h
+++ b/c10/core/SymInt.h
@@ -28,10 +28,20 @@ namespace c10 {
 // SymIntNodeImpl*] which will be implemented as a single packed int64_t field
 // named data_.
 class C10_API SymInt {
+  enum class CTOR_TYPE {
+    INT, /* unused */
+    UNCHECKED,
+  };
+
+
  public:
-  // TODO: this needs to only accept integers, not pointers
-  /*implicit*/ SymInt(int64_t d) : data_(d){};
+  /*implicit*/ SymInt(int64_t d) : data_(d) {
+    TORCH_CHECK(!is_symbolic());
+  };
   SymInt() = default;
+
+  // unchecked c-tor accepting raw `data_`
+  SymInt(int64_t d, CTOR_TYPE) : data_(d) {}
 
   // TODO: these implementations are not optimal because they allocate a
   // temporary and then use the move constructor/assignment


### PR DESCRIPTION
### Description
This PR adds extra checking to make sure we don't accidentally pass a pointer as an int into an int64_t c-tor.

### Issue
<!-- Link to Issue ticket or RFP -->

### Testing
<!-- How did you test your change? -->
