### PR TITLE
[mergebot] Post PR Comment on cancel

### DIFF
--- a/.github/scripts/comment_on_pr.py
+++ b/.github/scripts/comment_on_pr.py
@@ -1,6 +1,7 @@
 from typing import Any
-from trymerge import gh_post_pr_comment, BOT_COMMANDS_WIKI
+from trymerge import gh_post_pr_comment
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
+from trymerge_explainer import BOT_COMMANDS_WIKI
 import os
 
 

--- a/.github/scripts/comment_on_pr.py
+++ b/.github/scripts/comment_on_pr.py
@@ -1,5 +1,5 @@
-from expecttest import Any
-from trymerge import gh_post_pr_comment
+from typing import Any
+from trymerge import gh_post_pr_comment, BOT_COMMANDS_WIKI
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
 import os
 
@@ -17,12 +17,13 @@ def main() -> None:
     args = parse_args()
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name(), debug=True)
     org, project = repo.gh_owner_and_name()
-    sender = os.environ.get("GH_SENDER")
     run_url = os.environ.get("GH_RUN_URL")
 
-    author_mention_prefix = f"@{sender}" if sender is not None else "The"
     job_link = f"[job]({run_url})" if run_url is not None else "job"
-    msg = f"{author_mention_prefix} {args.action} {job_link} was canceled."
+    msg = (
+        f"The {args.action} {job_link} was canceled. If you believe this is a mistake,"
+        + f"then you can re trigger it through [pytorch-bot]({BOT_COMMANDS_WIKI})."
+    )
 
     gh_post_pr_comment(org, project, args.pr_num, msg)
     print(org, project, args.pr_num, msg)

--- a/.github/scripts/comment_on_pr.py
+++ b/.github/scripts/comment_on_pr.py
@@ -1,0 +1,32 @@
+from expecttest import Any
+from trymerge import gh_post_pr_comment
+from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
+import os
+
+
+def parse_args() -> Any:
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser("Comment on a PR")
+    parser.add_argument("pr_num", type=int)
+    parser.add_argument("action", type=str)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    repo = GitRepo(get_git_repo_dir(), get_git_remote_name(), debug=True)
+    org, project = repo.gh_owner_and_name()
+    sender = os.environ.get("GH_SENDER")
+    run_url = os.environ.get("GH_RUN_URL")
+
+    author_mention_prefix = f"@{sender}" if sender is not None else "The"
+    job_link = f"[job]({run_url})" if run_url is not None else "job"
+    msg = f"{author_mention_prefix} {args.action} {job_link} was canceled."
+
+    gh_post_pr_comment(org, project, args.pr_num, msg)
+    print(org, project, args.pr_num, msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -46,5 +46,14 @@ jobs:
               python3 .github/scripts/trymerge.py --revert "${PR_NUM}"
             fi
           fi
-
+      - name: Comment on Canceled
+        if: ${{ cancelled() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+          PR_NUM: ${{ github.event.client_payload.pr_num }}
+          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_SENDER: ${{ github.event.sender.login }}
+        run: |
+          set -ex
+          python3 .github/scripts/trymerge.py "${PR_NUM}" "merge"
 concurrency: try-revert

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -54,7 +54,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
           GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_SENDER: ${{ github.event.sender.login }}
         run: |
           set -ex
           python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "merge"

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -56,6 +56,6 @@ jobs:
           GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -ex
-          python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "merge"
+          python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "revert"
 
 concurrency: try-revert

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -8,6 +8,8 @@ jobs:
   do_revert:
     name: try_revert_pr_${{ github.event.client_payload.pr_num }}
     runs-on: linux.20_04.4x
+    env:
+        GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -31,7 +33,6 @@ jobs:
           PR_NUM: ${{ github.event.client_payload.pr_num }}
           COMMENT_ID: ${{ github.event.client_payload.comment_id }}
           REASON: ${{ github.event.client_payload.reason }}
-          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -ex
           if [ -n "${COMMENT_ID}" ]; then
@@ -53,7 +54,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
-          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -ex
           python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "revert"

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -16,6 +16,7 @@ jobs:
           architecture: x64
       - name: Checkout repo
         uses: actions/checkout@v2
+        id: checkout
         with:
           fetch-depth: 0
           token: ${{ secrets.MERGEBOT_TOKEN }}
@@ -47,7 +48,8 @@ jobs:
             fi
           fi
       - name: Comment on Canceled
-        if: ${{ cancelled() }}
+        if: ${{ cancelled() && steps.checkout.outcome == 'success' }}
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
@@ -55,5 +57,6 @@ jobs:
           GH_SENDER: ${{ github.event.sender.login }}
         run: |
           set -ex
-          python3 .github/scripts/trymerge.py "${PR_NUM}" "merge"
+          python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "merge"
+
 concurrency: try-revert

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -50,6 +50,16 @@ jobs:
           else
             python3 .github/scripts/trymerge.py "${PR_NUM}"
           fi
+      - name: Comment on Canceled
+        if: ${{ cancelled() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+          PR_NUM: ${{ github.event.client_payload.pr_num }}
+          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_SENDER: ${{ github.event.sender.login }}
+        run: |
+          set -ex
+          python3 .github/scripts/trymerge.py "${PR_NUM}" "merge"
 
 # We want newer merge commands to supercede old ones
 concurrency:

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -15,6 +15,7 @@ jobs:
           python-version: 3.8
           architecture: x64
       - name: Checkout repo
+        id: checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -51,7 +52,8 @@ jobs:
             python3 .github/scripts/trymerge.py "${PR_NUM}"
           fi
       - name: Comment on Canceled
-        if: ${{ cancelled() }}
+        if: ${{ cancelled() && steps.checkout.outcome == 'success' }}
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
@@ -59,7 +61,7 @@ jobs:
           GH_SENDER: ${{ github.event.sender.login }}
         run: |
           set -ex
-          python3 .github/scripts/trymerge.py "${PR_NUM}" "merge"
+          python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "merge"
 
 # We want newer merge commands to supercede old ones
 concurrency:

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -8,6 +8,8 @@ jobs:
   do_merge:
     name: try_merge_pr_${{ github.event.client_payload.pr_num }}
     runs-on: linux.20_04.4x
+    env:
+        GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -29,7 +31,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
-          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           FORCE: ${{ github.event.client_payload.force}}
           ON_GREEN: ${{ github.event.client_payload.on_green}}
           LAND_CHECKS: ${{ github.event.client_payload.land_checks }}
@@ -57,7 +58,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
-          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -ex
           python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "merge"

--- a/.github/workflows/trymerge.yml
+++ b/.github/workflows/trymerge.yml
@@ -58,7 +58,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
           GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_SENDER: ${{ github.event.sender.login }}
         run: |
           set -ex
           python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "merge"

--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   do_rebase:
     runs-on: ubuntu-20.04
+    env:
+        GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -30,7 +32,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
-          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BRANCH: ${{ github.event.client_payload.branch }}
         run: |
           set -ex
@@ -45,7 +46,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
-          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -ex
           python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "rebase"

--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -38,3 +38,13 @@ jobs:
           else
             python3 .github/scripts/tryrebase.py "${PR_NUM}"
           fi
+      - name: Comment on Canceled
+        if: ${{ cancelled() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
+          PR_NUM: ${{ github.event.client_payload.pr_num }}
+          GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_SENDER: ${{ github.event.sender.login }}
+        run: |
+          set -ex
+          python3 .github/scripts/trymerge.py "${PR_NUM}" "merge"

--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -15,6 +15,7 @@ jobs:
           architecture: x64
 
       - name: Checkout repo
+        id: checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -39,7 +40,8 @@ jobs:
             python3 .github/scripts/tryrebase.py "${PR_NUM}"
           fi
       - name: Comment on Canceled
-        if: ${{ cancelled() }}
+        if: ${{ cancelled() && steps.checkout.outcome == 'success' }}
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
@@ -47,4 +49,4 @@ jobs:
           GH_SENDER: ${{ github.event.sender.login }}
         run: |
           set -ex
-          python3 .github/scripts/trymerge.py "${PR_NUM}" "merge"
+          python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "rebase"

--- a/.github/workflows/tryrebase.yml
+++ b/.github/workflows/tryrebase.yml
@@ -46,7 +46,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGEBOT_TOKEN }}
           PR_NUM: ${{ github.event.client_payload.pr_num }}
           GH_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_SENDER: ${{ github.event.sender.login }}
         run: |
           set -ex
           python3 .github/scripts/comment_on_pr.py "${PR_NUM}" "rebase"


### PR DESCRIPTION
### Description
<!-- What did you change and why was it needed? -->
When someone cancels a PR merge, it's not apparent that it's canceled unless the user clicks into that job. In this PR, we add a message if the pr gets canceled. 

The only thing is the user will not receive  a comment if the PR is canceled immediately since posting the message requires that the checkout be finished.
### Issue
<!-- Link to Issue ticket or RFP -->
n/a

### Testing
<!-- How did you test your change? -->
Tested it on canary https://github.com/pytorch/pytorch-canary/pull/132