### PR TITLE
[torchgen] Give proper C++ function name to the scratch variant of an operator

### DIFF
--- a/torchgen/api/cpp.py
+++ b/torchgen/api/cpp.py
@@ -43,6 +43,7 @@ from torchgen.model import (
     SelfArgument,
     TensorOptionsArguments,
     Type,
+    SchemaKind,
 )
 from torchgen.utils import assert_never
 
@@ -68,7 +69,9 @@ def name(func: FunctionSchema, *, faithful_name_for_out_overloads: bool = False)
     name = str(func.name.name)
     if func.is_symint_fn():
         name += "_symint"
-    if func.is_out_fn():
+    if func.kind() == SchemaKind.scratch:
+        name += "_scratch"
+    elif func.is_out_fn():
         if faithful_name_for_out_overloads:
             name += "_outf"
         else:


### PR DESCRIPTION
Summary:
Scratch variant is recently introduced into the codegen system. One problem we are observing is that the C++ function name for scratch operator ends with `_out`, since the scratch variant we are adding includes `out` arguments. However this is causing issue at operator registration time since we have the same symbol for out variant and scratch variant. This PR fixes it by appending `_scratch` to the C++ function name.

Example:

{F758187835}

{F758187874}

Test Plan: CI and the operators can be registered correctly.

Differential Revision: D38397038

