### PR TITLE
Add a line about module owners to labels mapping in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
+# For module labels => owners mapping, please see https://github.com/pytorch/pytorch/issues/24422.
 
 /torch/utils/cpp_extension.py @fmassa @soumith @ezyang
 


### PR DESCRIPTION
### Description
We have an issue that maps GitHub labels to owners and people who would like to subscribe to certain discussions. This change hopes to make this issue more discoverable.

### Issue
<!-- Link to Issue ticket or RFP -->

### Testing
<!-- How did you test your change? -->
Make sure the CODEOWNERS page is still ok
