### PR TITLE
Back out "Add an op_lowering_disallow_list in fx splitter base class. (#82288)"

### DIFF
--- a/torch/fx/passes/splitter_base.py
+++ b/torch/fx/passes/splitter_base.py
@@ -59,19 +59,11 @@ class _SplitterSettingBase:
             "we might not care about non-tensor data flow and we can set this option "
             "to true to disable the functionality that prevent non-tensor data flow.",
         )
-        parser.add_argument(
-            "--op_lowering_disallow_list",
-            default="",
-            type=str,
-            help="A comma separated string which represents a disallow_list of "
-            "operator names."
-        )
         args, unknown = parser.parse_known_args()
 
         self.min_acc_module_size: int = args.min_acc_module_size
         self.skip_fusion: bool = args.skip_fusion
         self.allow_non_tensor: bool = args.allow_non_tensor
-        self.op_lowering_disallow_list: List[str] = args.op_lowering_disallow_list.split(",")
 
 
 @compatibility(is_backward_compatible=False)


### PR DESCRIPTION
Summary:
Revert since this breaks BC test
More context:
failing test
https://www.internalfb.com/.../fblearner/details/361780349/
issue report thread
https://fb.workplace.com/groups/2211200152361974/permalink/2303690223112966/

Test Plan: All unit test

Differential Revision: D38399966

