### PR TITLE
Use fx.Interpreter for GraphModule.forward

### DIFF
--- a/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
@@ -41,7 +41,7 @@ torch.fx.interpreter.Interpreter.get_attr(self, target: 'Target', args: Tuple[to
 torch.fx.interpreter.Interpreter.map_nodes_to_values(self, args: torch.fx.node.Argument, n: torch.fx.node.Node) -> torch.fx.node.Argument
 torch.fx.interpreter.Interpreter.output(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any
 torch.fx.interpreter.Interpreter.placeholder(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any
-torch.fx.interpreter.Interpreter.run(self, *args, initial_env: Optional[Dict[torch.fx.node.Node, Any]] = None, enable_io_processing: bool = True) -> Any
+torch.fx.interpreter.Interpreter.run(self, *args, initial_env: Optional[Dict[torch.fx.node.Node, Any]] = None, enable_io_processing: bool = True, **kwargs) -> Any
 torch.fx.interpreter.Interpreter.run_node(self, n: torch.fx.node.Node) -> Any
 torch.fx.interpreter.Transformer.__init__(self, module)
 torch.fx.interpreter.Transformer.call_function(self, target: 'Target', args: Tuple[torch.fx.node.Argument, ...], kwargs: Dict[str, Any]) -> Any

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2616,13 +2616,11 @@ class TestFX(JitTestCase):
 
         traced.recompile()
 
-        with self.capture_stderr() as captured:
-            with self.assertRaises(TypeError):
-                traced(5)
+        with self.assertRaises(TypeError) as error:
+            traced(5)
 
-        self.assertRegex(captured[0],
-                         r"Call using an FX-traced Module, line .* of the "
-                         r"traced Module's generated forward function:")
+        self.assertEqual(repr(error.exception),
+                         "TypeError(\"dot(): argument 'tensor' (position 2) must be Tensor, not int\")")
 
     def test_custom_traceback_not_raised_when_exception_source_is_submodule(self):
         class M(torch.nn.Module):
@@ -3498,7 +3496,9 @@ def forward(self, args_list: List[torch.Tensor]){maybe_return_annotation}:
         graph.output(a)
         gm = torch.fx.GraphModule({}, graph)
         gm.recompile()
-        self.assertEqual(gm(2, 3), 6)
+        x = torch.tensor([2])
+        y = torch.tensor([3])
+        self.assertEqual(gm(x, y), 6)
         self.assertIn("a *= b", gm.code)
 
     def test_map_aggregate_doesnt_traverse_size(self):

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -630,6 +630,9 @@ class Tracer(TracerBase):
         old_is_fx_tracing_flag = _is_fx_tracing_flag
         _is_fx_tracing_flag = True
         try:
+            if isinstance(root, torch.fx.GraphModule):
+                self.root = root
+                return root.graph
             if isinstance(root, torch.nn.Module):
                 self.root = root
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -15,6 +15,7 @@ import traceback
 from pathlib import Path
 import os
 import warnings
+from contextlib import contextmanager
 
 # Normal exec loses the source code, however we can work with
 # the linecache module to recover it.
@@ -624,6 +625,15 @@ class {module_name}(torch.nn.Module):
             raise RuntimeError('Code has not been generated! Please report a bug to PyTorch')
         return self._code
 
+    @contextmanager
+    def _jit_script_mode(self):
+        saved_forward = self.forward
+        try:
+            self.forward = self.src_forward
+            yield
+        finally:
+            self.forward = saved_forward
+
     @compatibility(is_backward_compatible=True)
     def recompile(self) -> PythonCode:
         """
@@ -638,7 +648,14 @@ class {module_name}(torch.nn.Module):
         self._code = python_code.src
 
         cls = type(self)
-        cls.forward = _forward_from_src(self._code, python_code.globals)
+        cls.src_forward = _forward_from_src(self._code, python_code.globals)
+
+        self._interpreter = torch.fx.Interpreter(self)
+
+        def _forward_from_interpreter(cls, *args, **kwargs):
+            return self._interpreter.run(*args, **kwargs)
+
+        cls.forward = _forward_from_interpreter
 
         # Determine whether this class explicitly defines a __call__ implementation
         # to wrap. If it does, save it in order to have wrapped_call invoke it.
@@ -664,6 +681,7 @@ class {module_name}(torch.nn.Module):
         dict_without_graph = self.__dict__.copy()
         dict_without_graph['_graphmodule_cls_name'] = self.__class__.__name__
         del dict_without_graph['_graph']
+        del dict_without_graph['_interpreter']
 
         python_code = self.recompile()
         import_block = _format_import_block(python_code.globals, importer)
@@ -673,6 +691,7 @@ class {module_name}(torch.nn.Module):
         dict_without_graph = self.__dict__.copy()
         dict_without_graph['_graphmodule_cls_name'] = self.__class__.__name__
         del dict_without_graph['_graph']
+        del dict_without_graph['_interpreter']
 
         generated_module_name = f'fx-generated._{exporter.get_unique_id()}'
         python_code = self.recompile()
@@ -693,6 +712,7 @@ class {module_name}(torch.nn.Module):
         python_code = self.recompile()
         import_block = _format_import_block(python_code.globals, sys_importer)
         del dict_without_graph['_graph']
+        del dict_without_graph['_interpreter']
         return (reduce_graph_module, (dict_without_graph, import_block))
 
     # because __reduce__ is defined for serialization,
@@ -700,7 +720,11 @@ class {module_name}(torch.nn.Module):
     # and cause symbolic tracing to occur every time we try to copy the object
     def __deepcopy__(self, memo):
         fake_mod = torch.nn.Module()
-        fake_mod.__dict__ = copy.deepcopy(self.__dict__)
+
+        # self._interpreter references self
+        # skip deepcopying self._interpreter to avoid infinite recursive recursion
+        dict_without_interpreter = {k : v for k, v in self.__dict__.items() if k != '_interpreter'}
+        fake_mod.__dict__ = copy.deepcopy(dict_without_interpreter)
         return GraphModule(fake_mod, fake_mod.__dict__['_graph'])
 
     def __copy__(self):

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -4,7 +4,7 @@ import torch.overrides
 from torch.nn.modules.module import _addindent
 from torch.package import PackageImporter, PackageExporter
 import linecache
-from typing import Type, Dict, List, Any, Union, Optional, Set
+from typing import Type, Dict, List, Any, Union, Optional, Set, Callable
 from .graph import Graph, _PyTreeCodeGen, _is_from_torch, _custom_builtins, PythonCode
 from ._compatibility import compatibility
 from torch.package import Importer, sys_importer
@@ -625,14 +625,17 @@ class {module_name}(torch.nn.Module):
             raise RuntimeError('Code has not been generated! Please report a bug to PyTorch')
         return self._code
 
+    src_forward: Callable[..., Any]
+
     @contextmanager
     def _jit_script_mode(self):
-        saved_forward = self.forward
+        cls = type(self)
+        saved_forward = cls.forward
         try:
-            self.forward = self.src_forward
+            cls.forward = cls.src_forward
             yield
         finally:
-            self.forward = saved_forward
+            cls.forward = saved_forward
 
     @compatibility(is_backward_compatible=True)
     def recompile(self) -> PythonCode:

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -91,7 +91,7 @@ class Interpreter:
                 map_arg(node.kwargs, lambda n: register_last_uses(n, node))
 
     @compatibility(is_backward_compatible=True)
-    def run(self, *args, initial_env : Optional[Dict[Node, Any]] = None, enable_io_processing : bool = True,  **kwargs) -> Any:
+    def run(self, *args, initial_env : Optional[Dict[Node, Any]] = None, enable_io_processing : bool = True, **kwargs) -> Any:
         """
         Run `module` via interpretation and return the result.
 

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -91,7 +91,7 @@ class Interpreter:
                 map_arg(node.kwargs, lambda n: register_last_uses(n, node))
 
     @compatibility(is_backward_compatible=True)
-    def run(self, *args, initial_env : Optional[Dict[Node, Any]] = None, enable_io_processing : bool = True) -> Any:
+    def run(self, *args, initial_env : Optional[Dict[Node, Any]] = None, enable_io_processing : bool = True,  **kwargs) -> Any:
         """
         Run `module` via interpretation and return the result.
 
@@ -115,6 +115,7 @@ class Interpreter:
         if enable_io_processing:
             args = self.module.graph.process_inputs(*args)
         self.args_iter : Iterator[Any] = iter(args)
+        self.kwargs = kwargs
 
         for node in self.module.graph.nodes:
             if node in self.env:
@@ -173,7 +174,9 @@ class Interpreter:
             Any: The argument value that was retrieved.
         """
         assert isinstance(target, str)
-        if target.startswith('*'):
+        if target.startswith('**'):
+            return self.kwargs
+        elif target.startswith('*'):
             # For a starred parameter e.g. `*args`, retrieve all
             # remaining values from the args list.
             return list(self.args_iter)

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -15,7 +15,6 @@ import pickle
 import warnings
 from typing import Any, Dict, List, Set, Tuple, Union, Callable
 
-
 import torch
 import torch._jit_internal as _jit_internal
 from torch.utils import set_module
@@ -1281,6 +1280,12 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None,
                           "to enable Profile-Directed Typing in TorchScript. Refer to "
                           "https://github.com/Instagram/MonkeyType/blob/master/README.rst to install MonkeyType. ")
 
+    if isinstance(obj, torch.fx.GraphModule):  # type: ignore[attr-defined]
+        with obj._jit_script_mode():
+            obj = call_prepare_scriptable_func(obj)
+            return torch.jit._recursive.create_script_module(
+                obj, torch.jit._recursive.infer_methods_to_compile
+            )
     if isinstance(obj, torch.nn.Module):
         obj = call_prepare_scriptable_func(obj)
         return torch.jit._recursive.create_script_module(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82755

Currently, GraphModule.forward is running the python code generated  from the underlying Graph. 
All node-level contexts, including node.stack_trace, are lost during the conversion to python code. As a result, when running Tracer with GraphModule.forward, it couldn't recover the stack_trace in the original fx.Node. 

In this PR, GraphModule.forward is directly executing the underlying graph with a fx.Interpreter. 

Following are a few major problems exposed with this approach: 
- symbolic_trace(graph_module) now needs special handling. Previously, symbolic_trace will trace over the codegen python code. With the new implementation, symbolic_trace over a GraphModule will directly return the underlying Graph. 
- jit.trace(graph_module) now needs special handling. Previously, jit.trace will parse the codegened python code. In the new implementation, graph module will temporally swap to use the codegened forward so that jit.trace can still work. Once the tracing is done, it swap back to the interpreter-based forward. 
- Need additional handling on copy.__deepcopy__, pickle.dump()