### PR TITLE
[NestedTensor]Remove tensor buffer replace with Storage type

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -121,8 +121,12 @@ NestedTensorImpl::NestedTensorImpl(
       offsets_(std::move(offsets)),
       opt_sizes_(construct_opt_sizes(nested_size_tensor_))
 {
-  auto buffer_size_vec{buffer.unsafeGetTensorImpl()->sizes().vec()};
-  TORCH_INTERNAL_ASSERT(buffer_size_vec.size() == 1, "The buffer used to construct the nested tensor did not have a size of 1.")
+  auto buffer_size_vec{buffer.unsafeGetTensorImpl()->sizes()};
+  TORCH_INTERNAL_ASSERT(
+      buffer_size_vec.size() == 1,
+      "NestedTensorImpl buffer is required to be 1 dimensional but got a buffer with ",
+      buffer.dim(),
+      " dimensions.");
   buffer_size_ = buffer_size_vec[0];
 
   TORCH_WARN_ONCE(

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -99,10 +99,7 @@ inline std::vector<int64_t> construct_offsets(const at::Tensor& sizes) {
 // correct Autograd key which is AutogradNestedTensor
 c10::DispatchKeySet generate_nested_key_set(at::Tensor buffer) {
   c10::DispatchKeySet key_set =
-      (c10::DispatchKeySet(DispatchKey::NestedTensor) |
-       c10::DispatchKeySet(
-           buffer.is_cuda() ? BackendComponent::CUDABit
-                            : BackendComponent::CPUBit));
+      c10::DispatchKeySet(DispatchKey::NestedTensor) | c10::DispatchKeySet{buffer.key_set().highestBackendKey()};
 
   // Add AutogradNestedTensor specific keys
   key_set = key_set | inplace_or_view_ks | autograd_nested;
@@ -113,21 +110,21 @@ NestedTensorImpl::NestedTensorImpl(
     at::Tensor buffer,
     at::Tensor nested_size_tensor,
     at::Tensor nested_stride_tensor,
-    const std::vector<int64_t>& offsets)
+    std::vector<int64_t> offsets)
     : TensorImpl(
+          Storage(buffer.storage()),
           generate_nested_key_set(buffer),
-          buffer.dtype(),
-          buffer.device()),
-      buffer_(std::move(buffer)),
+          buffer.dtype()),
+      buffer_size_(buffer.unsafeGetTensorImpl()->sizes().vec()),
       nested_size_tensor_(std::move(nested_size_tensor)),
       nested_stride_tensor_(std::move(nested_stride_tensor)),
-      offsets_(offsets),
+      offsets_(std::move(offsets)),
       opt_sizes_(construct_opt_sizes(nested_size_tensor_))
 {
   TORCH_WARN_ONCE(
       "The PyTorch API of nested tensors is in prototype stage and will change "
       "in the near future.");
-  TORCH_INTERNAL_ASSERT(buffer_.is_cuda() || buffer_.is_cpu(), "NestedTensorImpl buffer must be either CUDA or CPU but got ", buffer_);
+  TORCH_INTERNAL_ASSERT(buffer.is_cuda() || buffer.is_cpu(), "NestedTensorImpl buffer must be either CUDA or CPU but got ", buffer);
   TORCH_INTERNAL_ASSERT(nested_size_tensor_.is_contiguous());
   int64_t size_dim = nested_size_tensor_.dim();
   TORCH_INTERNAL_ASSERT(size_dim == 0 || size_dim == 2);

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -3,6 +3,7 @@
 #include <ATen/Tensor.h>
 #include <c10/core/MemoryFormat.h>
 #include <c10/core/TensorImpl.h>
+#include <c10/util/ArrayRef.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Metaprogramming.h>
 #include <c10/util/irange.h>
@@ -59,7 +60,7 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
         c10::DispatchKeySet{this->key_set_.highestBackendKey()};
     auto buffer_tensor_impl = c10::make_intrusive<TensorImpl>(
         Storage(storage_), buffer_key_set_, data_type_);
-    buffer_tensor_impl->set_sizes_contiguous(buffer_size_);
+    buffer_tensor_impl->set_sizes_contiguous(c10::makeArrayRef(buffer_size_));
     return Tensor(buffer_tensor_impl);
   }
 
@@ -89,9 +90,9 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   // to TensorImpl.
   void refresh_dim();
   // Store the size of the buffer for use in get_buffer().
-  // Get buffer constructs a flat, contiguous tensor from the NestedTensor
+  // get_buffer constructs a flat, contiguous tensor from the NestedTensor
   // storage
-  std::vector<long> buffer_size_;
+  std::vector<int64_t> buffer_size_;
   const at::Tensor nested_size_tensor_, nested_stride_tensor_;
   // The starting positions of the underlying tensors in contiguous buffer
   // i.e. the buffer memory offsets to get the underlying tensors

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -92,7 +92,7 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   // Store the size of the buffer for use in get_buffer().
   // get_buffer constructs a flat, contiguous tensor from the NestedTensor
   // storage
-  std::vector<int64_t> buffer_size_;
+  int64_t buffer_size_;
   const at::Tensor nested_size_tensor_, nested_stride_tensor_;
   // The starting positions of the underlying tensors in contiguous buffer
   // i.e. the buffer memory offsets to get the underlying tensors

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -15,7 +15,7 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
       at::Tensor buffer,
       at::Tensor nested_size_tensor,
       at::Tensor nested_stride_tensor,
-      const std::vector<int64_t>& offsets);
+      std::vector<int64_t> offsets);
   // assume contiguous, `nested_stride_tensor` and `offsets`
   // can be infered from `nested_size_tensor`
   explicit NestedTensorImpl(at::Tensor buffer, at::Tensor nested_size_tensor);
@@ -54,8 +54,13 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
     return *optional_size;
   }
 
-  const at::Tensor& get_buffer() const {
-    return buffer_;
+  at::Tensor get_buffer() const {
+    auto buffer_key_set_ = c10::DispatchKeySet{c10::DispatchKey::Dense} |
+        c10::DispatchKeySet{this->key_set_.highestBackendKey()};
+    auto buffer_tensor_impl = c10::make_intrusive<TensorImpl>(
+        Storage(storage_), buffer_key_set_, data_type_);
+    buffer_tensor_impl->set_sizes_contiguous(buffer_size_);
+    return Tensor(buffer_tensor_impl);
   }
 
  protected:
@@ -83,8 +88,10 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   // Must be called after any changes to our dim() to sync the state
   // to TensorImpl.
   void refresh_dim();
-
-  at::Tensor buffer_;
+  // Store the size of the buffer for use in get_buffer().
+  // Get buffer constructs a flat, contiguous tensor from the NestedTensor
+  // storage
+  std::vector<long> buffer_size_;
   const at::Tensor nested_size_tensor_, nested_stride_tensor_;
   // The starting positions of the underlying tensors in contiguous buffer
   // i.e. the buffer memory offsets to get the underlying tensors

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -96,7 +96,7 @@ Tensor pad_tensor_to_shape(
 }
 } // namespace
 
-inline const at::Tensor& get_buffer(const at::Tensor& tensor) {
+inline at::Tensor get_buffer(const at::Tensor& tensor) {
   return get_nested_tensor_impl(tensor)->get_buffer();
 }
 
@@ -119,14 +119,15 @@ std::vector<at::Tensor> NestedTensor_unbind(
   std::vector<IntArrayRef> sizes = NestedTensor_get_sizes(self_ptr),
       strides = NestedTensor_get_strides(self_ptr);
   const std::vector<int64_t>& offsets = self_ptr->get_offsets();
-  for (int64_t i = 0; i < ntensors; i++) {
+  for (const int64_t i: c10::irange(ntensors)){
     result_tensors[i] = buffer.as_strided(sizes[i], strides[i], offsets[i]);
   }
   return result_tensors;
 }
 
 Tensor& NestedTensor_relu_(Tensor& self) {
-  at::relu_(const_cast<Tensor&>(get_nested_tensor_impl(self)->get_buffer()));
+  auto buffer = get_nested_tensor_impl(self) -> get_buffer();
+  at::relu_(buffer);
   return self;
 }
 
@@ -135,7 +136,8 @@ Tensor NestedTensor_relu(const Tensor& self) {
 }
 
 Tensor& NestedTensor_gelu_(Tensor& self, c10::string_view approximate) {
-  at::gelu_(const_cast<Tensor&>(get_nested_tensor_impl(self)->get_buffer()), approximate);
+  auto buffer = get_nested_tensor_impl(self) -> get_buffer();
+  at::gelu_(buffer,approximate);
   return self;
 }
 

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -122,7 +122,7 @@ std::vector<at::Tensor> NestedTensor_unbind(
 }
 
 Tensor& NestedTensor_relu_(Tensor& self) {
-  auto buffer = get_nested_tensor_impl(self) -> get_buffer();
+  auto buffer = get_nested_tensor_impl(self)->get_buffer();
   at::relu_(buffer);
   return self;
 }
@@ -132,8 +132,8 @@ Tensor NestedTensor_relu(const Tensor& self) {
 }
 
 Tensor& NestedTensor_gelu_(Tensor& self, c10::string_view approximate) {
-  auto buffer = get_nested_tensor_impl(self) -> get_buffer();
-  at::gelu_(buffer,approximate);
+  auto buffer = get_nested_tensor_impl(self)->get_buffer();
+  at::gelu_(buffer, approximate);
   return self;
 }
 

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -96,10 +96,6 @@ Tensor pad_tensor_to_shape(
 }
 } // namespace
 
-inline at::Tensor get_buffer(const at::Tensor& tensor) {
-  return get_nested_tensor_impl(tensor)->get_buffer();
-}
-
 std::vector<at::Tensor> NestedTensor_unbind(
     const at::Tensor& self,
     int64_t dim) {

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -28,6 +28,10 @@ inline at::Tensor wrap_buffer(
       std::move(nested_stride_tensor), offsets);
 }
 
+inline at::Tensor get_buffer(const at::Tensor& tensor) {
+  return get_nested_tensor_impl(tensor)->get_buffer();
+}
+
 // The sizes of the underlying tensors
 inline std::vector<IntArrayRef> NestedTensor_get_sizes(const NestedTensorImpl* self_ptr) {
   int64_t ntensors = self_ptr->size(0);

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -345,8 +345,7 @@ __host__ std::tuple<Tensor, Tensor, Tensor> transform_bias_rescale_qkv_cuda(
       accscalar_t,                                                      \
       assume_aligned>                                                   \
       <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(       \
-          nt_qkv->get_buffer()                                          \
-              .packed_accessor64<scalar_t, 1, RestrictPtrTraits>(),     \
+          qkv.packed_accessor64<scalar_t, 1, RestrictPtrTraits>(),     \
           qkv_bias.packed_accessor64<scalar_t, 1, RestrictPtrTraits>(), \
           offsets_ptr,                                                  \
           sizes_ptr,                                                    \
@@ -387,7 +386,7 @@ __host__ std::tuple<Tensor, Tensor, Tensor> transform_bias_rescale_qkv_cuda(
           const auto input_dim = sizes.sizes()[1];
           TORCH_INTERNAL_ASSERT_DEBUG_ONLY(input_dim == 1);
           if (aligned &&
-              ((reinterpret_cast<intptr_t>(nt_qkv->get_buffer().data_ptr()) %
+              ((reinterpret_cast<intptr_t>(qkv.data_ptr()) %
                 TRANSFORM_BIAS_RESCALE_VEC) == 0)) {
             CALL_ADD_PADDING_KERNEL(true);
           } else {

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -345,7 +345,8 @@ __host__ std::tuple<Tensor, Tensor, Tensor> transform_bias_rescale_qkv_cuda(
       accscalar_t,                                                      \
       assume_aligned>                                                   \
       <<<blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(       \
-          qkv.packed_accessor64<scalar_t, 1, RestrictPtrTraits>(),     \
+          nt_qkv_buffer                                          \
+              .packed_accessor64<scalar_t, 1, RestrictPtrTraits>(),     \
           qkv_bias.packed_accessor64<scalar_t, 1, RestrictPtrTraits>(), \
           offsets_ptr,                                                  \
           sizes_ptr,                                                    \
@@ -375,6 +376,7 @@ __host__ std::tuple<Tensor, Tensor, Tensor> transform_bias_rescale_qkv_cuda(
         }
         if (qkv.is_nested()) {
           auto* nt_qkv = get_nested_tensor_impl(qkv);
+          const at::Tensor& nt_qkv_buffer = nt_qkv->get_buffer();
           auto sizes = collapse_dims_1_and_2(nt_qkv->get_nested_size_tensor());
           auto offsets =
               NestedTensor_batch_offsets_from_size_tensor(sizes, sizes.numel());


### PR DESCRIPTION
### Description
In order to enable NestedTensor views NestedTensorImpl no longer stores its data in a at::Tensor buffer_ instead it conforms to the practice of most TensorImpls and uses a Storage class. This change will enable NestedTensor to use the view constructor defined on the base TensorImpl.

### Issue
#82671

### Testing 
The existing nested_tensor tests are utilized since this is core functionality and would break these tests if not successful.

### Performance
One change that has potentially large performance impact is that most nested_tensor kernels call `get_buffer` to get the buffer in Tensor form and perform ops on this buffer. Previously this was free since we stored the data as a Tensor but now each kernel must construct a Tensor from the storage. The most performance critical/heavy user of nested tensors is BetterTransformer. I would be curious to see if this change significantly impacts performance for this and other workloads.

