### PR TITLE
Fix Tensor.__format__ for subclasses (#82764)

### DIFF
--- a/test/test_subclass.py
+++ b/test/test_subclass.py
@@ -24,6 +24,9 @@ from unittest import expectedFailure
 parametrize_tensor_cls = parametrize("tensor_cls", [
     subtest(tensor_cls, name=info.name) for tensor_cls, info in subclass_db.items()])
 
+# Simple class for testing __format__.
+class TensorSubclass(torch.Tensor):
+    pass
 
 class TestSubclass(TestCase):
     def _create_tensor(self, tensor_cls):
@@ -238,6 +241,14 @@ class TestSubclass(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, r"requires that detach\(\) returns an instance of the same type"):
             param = nn.Parameter(NonRewrappingTensor(torch.randn(3)))
+
+    def test_format(self):
+        # See that __format__ works for a scalar tensor.
+        x = torch.Tensor(torch.tensor(1.2345))
+        self.assertEqual(x.__format__(".4f"), '1.2345')
+        # And with a subclass.
+        y = TensorSubclass(torch.tensor(1.2345))
+        self.assertEqual(y.__format__(".4f"), '1.2345')
 
 instantiate_parametrized_tests(TestSubclass)
 

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -840,7 +840,7 @@ class Tensor(torch._C._TensorBase):
     def __format__(self, format_spec):
         if has_torch_function_unary(self):
             return handle_torch_function(Tensor.__format__, (self,), self, format_spec)
-        if self.dim() == 0 and not self.is_meta and type(self) is Tensor:
+        if self.dim() == 0 and not self.is_meta and issubclass(type(self), Tensor):
             return self.item().__format__(format_spec)
         return object.__format__(self, format_spec)
 


### PR DESCRIPTION
### Description
Adds support for subclasses in Tensor.__format__.

### Issue
#82764 

### Testing
Added unit test to test/test_subclass.py.
