### PR TITLE
Properly compare floats in fully-connected-sparse-operator-tester

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-sparse-operator-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-sparse-operator-tester.h
@@ -577,7 +577,7 @@ class FullyConnectedSparseOperatorTester {
 
           for (size_t i = 0; i < batchSize(); i++) {
             for (size_t c = 0; c < outputChannels(); c++) {
-              ASSERT_EQ(
+              ASSERT_FLOAT_EQ(
                   output_dynamic[i * outputChannels() + c],
                   accumulators_float[i * outputChannels() + c])
                   << "at " << i << ", " << c


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/pull/82688

Example of current failure:

```
xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/test/fully-connected-sparse-operator-tester.h:582
Expected equality of these values:
  output_dynamic[i * outputChannels() + c]
    Which is: -3064.26
  accumulators_float[i * outputChannels() + c]
    Which is: -3064.26
at 0, 1: reference = -3064.2568359375, optimized = -3064.256591796875
```