### PR TITLE
Prevent ref cycle creation in inner hook

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 import textwrap
 import unittest
+from typing import List
 import torch
 import torch.nn as nn
 import torch.utils.data
@@ -361,6 +362,64 @@ class TestCheckpoint(TestCase):
         ):
             out = checkpoint(run_fn2, input_var, input_var2)
             out.sum().backward()
+
+    @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
+    def test_checkpointing_without_reentrant_early_free(self):
+        # I don't know how to check if the temporary saved variable buffer
+        # get de-allocated directly. So using cuda memory usage as a proxy
+
+        def _do_test(fn, should_free):
+            stats: List[int] = []
+
+            def track(x, idx):
+                # Track that at each step of the backward, some Tensor were
+                # de-allocated (which correspond to the checkpoint storage being
+                # emptied at each step)
+                def hook(_unused):
+                    self.assertEqual(len(stats), idx)
+                    torch.cuda.synchronize()
+                    stats.append(torch.cuda.memory_allocated())
+                    if idx > 0:
+                        if should_free:
+                            self.assertLess(stats[idx], stats[idx - 1])
+                        else:
+                            self.assertEqual(stats[idx], stats[idx - 1])
+
+                x.register_hook(hook)
+
+            def test_fn(x):
+                # The main property of this function is that it contains multiple
+                # operations that save gradients in a chain.
+                x = x ** 2
+                track(x, 2)
+                x = x ** 2
+                track(x, 1)
+                x = x ** 2
+                track(x, 0)
+                x = x ** 2
+                return x.sum()
+
+            fn(test_fn)
+
+            return stats
+
+        x = torch.zeros(10, device="cuda", requires_grad=True)
+        x.grad = torch.zeros_like(x)
+
+        # In a regular backward, buffers get eagerly freed
+        non_retain_stats = _do_test(lambda fn: fn(x).backward(), True)
+
+        # In a retain_grad backward, buffers get preserved
+        retain_stats = _do_test(lambda fn: fn(x).backward(retain_graph=True), False)
+
+        # In a regular backward with checkpoint, buffers get eagerly freed
+        checkpoint_non_retain_stats = _do_test(lambda fn: checkpoint(fn, x, use_reentrant=False).backward(), True)
+
+        # In a retain_grad backward with checkpoint, buffers get preserved
+        checkpoint_retain_stats = _do_test(lambda fn: checkpoint(fn, x, use_reentrant=False).backward(retain_graph=True), False)
+
+        self.assertEqual(non_retain_stats, checkpoint_non_retain_stats)
+        self.assertEqual(retain_stats, checkpoint_retain_stats)
 
 class TestDataLoaderUtils(TestCase):
     def setUp(self):

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -366,7 +366,7 @@ def _checkpoint_without_reentrant(function, preserve_rng_state=True, *args, **kw
 
             def inner_pack(inner):
                 nonlocal unpack_counter
-                storage[unpack_counter] = inner
+                storage[unpack_counter] = inner.detach()
                 unpack_counter += 1
                 return None
 

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1,7 +1,7 @@
 import torch
 import warnings
 import weakref
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Iterable, List, Tuple
 
 __all__ = [
     "checkpoint", "checkpoint_sequential", "CheckpointFunction",
@@ -322,7 +322,6 @@ def checkpoint_sequential(functions, segments, input, **kwargs):
                            preserve_rng_state=preserve)
     return run_function(end + 1, len(functions) - 1, functions)(input)
 
-tmp = []
 def _checkpoint_without_reentrant(function, preserve_rng_state=True, *args, **kwargs):
     """Checkpointining without re-entrant autograd
     Args:
@@ -360,7 +359,7 @@ def _checkpoint_without_reentrant(function, preserve_rng_state=True, *args, **kw
     # sure that this is the only object having an owning reference to ensure that
     # the Tensor stored in storage is deleted as soon as the corresponding SavedVariable
     # data is cleared.
-    storage: Dict[Holder, torch.Tensor] = weakref.WeakKeyDictionary()
+    storage: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
     weak_holder_list = []
 
     def pack(x):


### PR DESCRIPTION
Towards fixing https://github.com/pytorch/pytorch/issues/82482

This PR fixes two things:

## 1) memory leak
The .detach() call prevents a true memory leak in some cases where the user function is using multiple ops in a row that save their inputs. The following chain of objects keep each other alive
- the `storage` object
- a recomputed Tensor y
- y's grad_fn FooBackward (in c++)
- FooBackward's SavedVariables (in c++)
- SavedVariable Hook
- the `inner_pack` function
- captures `storage`

Since part of this cycle is in c++, the python gc is not able to break it.
Should THPCppFunction_traverse actually visit it's SavedVariables which in turn should visit their hooks? I think the answer is yes but I haven't dived into which python object is traversing what as if there is non-unique ownership of the c++ object, it makes the traversal a lot trickier. @ezyang do you think we should dive into this more?

In this case, this can be easily solved anyways by storing `y.detach()` in the `storage` object as we don't care about the temporary backward graph that gets created during the second forward call.

## 2) Lifetime of the recomputed buffers
The new storage system is now such that the lifetime of the recomputed buffer is directly linked to the SavedVariable c++ object. Meaning that this buffer will get deleted IIF the SavedVariable is cleared.
This means that we now get the exact same behavior as the version without the saved variable hook where Tensors are saved directly on the SavedVariable object.

This is great as this solves all the cases where the non-checkpoint version used to work but the checkpoint version does not (even double access or retain_graph=True).

The one drawback of this approach though is that the buffer do NOT get cleared when the user passes in `retain_graph=True`! The next backward won't even re-run the forward as it already has all the buffers available. Is this a problem that you think we would need to find a solution for @rohan-varma or it is niche enough that we don't care for now?