### PR TITLE
optimization for zero_grad

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1947,7 +1947,7 @@ class Module:
                 "The parameters are copied (in a differentiable manner) from the original module. "
                 "This means they are not leaf nodes in autograd and so don't accumulate gradients. "
                 "If you need gradients in your forward method, consider using autograd.grad instead.")
-
+        tmp_group = []
         for p in self.parameters():
             if p.grad is not None:
                 if set_to_none:
@@ -1957,7 +1957,9 @@ class Module:
                         p.grad.detach_()
                     else:
                         p.grad.requires_grad_(False)
-                    p.grad.zero_()
+                    tmp_group.append(p)
+        if tmp_group:
+            torch._foreach_zero_(tmp_group)
 
     def share_memory(self: T) -> T:
         r"""See :meth:`torch.Tensor.share_memory_`"""

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1957,7 +1957,7 @@ class Module:
                         p.grad.detach_()
                     else:
                         p.grad.requires_grad_(False)
-                    tmp_group.append(p)
+                    tmp_group.append(p.grad)
         if tmp_group:
             torch._foreach_zero_(tmp_group)
 

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -261,7 +261,7 @@ class Optimizer(object):
                             else:
                                 p.grad.requires_grad_(False)
                             if (not foreach or p.grad.is_sparse):
-                                tmp_group.append(p)
+                                tmp_group.append(p.grad)
                             else:
                                 per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
                 if tmp_group:

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -250,6 +250,7 @@ class Optimizer(object):
             per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
         with torch.autograd.profiler.record_function(self._zero_grad_profile_name):
             for group in self.param_groups:
+                tmp_group = []
                 for p in group['params']:
                     if p.grad is not None:
                         if set_to_none:
@@ -260,9 +261,10 @@ class Optimizer(object):
                             else:
                                 p.grad.requires_grad_(False)
                             if (not foreach or p.grad.is_sparse):
-                                p.grad.zero_()
+                                tmp_group.append(p)
                             else:
                                 per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
+                torch._foreach_zero_(tmp_group)
             if foreach:
                 for _, per_dtype_grads in per_device_and_dtype_grads.items():
                     for grads in per_dtype_grads.values():

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -264,7 +264,8 @@ class Optimizer(object):
                                 tmp_group.append(p)
                             else:
                                 per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
-                torch._foreach_zero_(tmp_group)
+                if tmp_group:
+                    torch._foreach_zero_(tmp_group)
             if foreach:
                 for _, per_dtype_grads in per_device_and_dtype_grads.items():
                     for grads in per_dtype_grads.values():


### PR DESCRIPTION
### Description

The original `zero_grad` calls `grad.zero_()` for every eligible tensor. There will be a lot of tiny cuda kernels in this way. I add a temporary list to save all eligible tensors and call a `torch._foreach_zero_()` which will call a single kernel to process all tensors. Even the kernel is called at the end of the big loop, the optimization removes a lot of `aten::fill` and cuda kernel launch overhead, so the final speedup is still about 3X at function level. 



### Testing
There are 44 models involved in TorchBench and 9 models obtained over 1.02X speedup for training at model level on A100. The speedup is up to 1.04X for timm_efficientnet.

