### PR TITLE
Refactor quant levels visualization

### DIFF
--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -141,8 +141,8 @@ class APoTObserver(ObserverBase):
             observer: APoTObserver to calculate qparams
             signed: bool to indicate if qparams should be signed/unsigned
     """
-    def quant_levels_visualization(self, observer: APoTObserver, signed=False):
-        alpha, gamma, quantization_levels, level_indices = observer.calculate_qparams(signed)
+    def quant_levels_visualization(self, signed=False):
+        alpha, gamma, quantization_levels, level_indices = self.calculate_qparams(signed)
 
         xs = [float(x) / 1000.0 for x in range(1000)]
         ys = [apot_to_float(float_to_apot(x, quantization_levels, level_indices, alpha),

--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -138,11 +138,12 @@ class APoTObserver(ObserverBase):
 
     r"""Displays visualization of APoT quantization levels
         Args:
-            alpha: alpha APoT qparam (Tensor)
-            quantization_levels: quantization levels APoT qparam (Tensor)
-            level_indices: level indices APoT qparam (Tensor)
+            observer: APoTObserver to calculate qparams
+            signed: bool to indicate if qparams should be signed/unsigned
     """
-    def quant_levels_visualization(self, alpha, quantization_levels, level_indices):
+    def quant_levels_visualization(self, observer: APoTObserver, signed=False):
+        alpha, gamma, quantization_levels, level_indices = observer.calculate_qparams(signed)
+
         xs = [float(x) / 1000.0 for x in range(1000)]
         ys = [apot_to_float(float_to_apot(x, quantization_levels, level_indices, alpha),
                             quantization_levels, level_indices).item() for x in xs]

--- a/torch/ao/quantization/experimental/observer.py
+++ b/torch/ao/quantization/experimental/observer.py
@@ -43,6 +43,7 @@ class APoTObserver(ObserverBase):
         min_val: optional arg that can override min_val internal attribute
         max_val: optional arg that can override max_val internal attribute
     Returns:
+        alpha: alpha quantization parameter, max of abs value of observed values
         gamma: gamma quantization parameter, defined to ensure that alpha is the maximum of the range
         quantization_levels: non-uniform quantization levels (fp representation)
         level_indices: int representation of quantization_levels indices
@@ -119,7 +120,9 @@ class APoTObserver(ObserverBase):
 
         return (alpha, gamma, quantization_levels, level_indices)
 
-    r"""Records the running minimum and maximum of ``x``."""
+    r"""Records the running minimum and maximum of ``x``.
+        Args:
+            x_orig: Tensor to be observed for min and max val"""
     def forward(self, x_orig):
         if x_orig.numel() == 0:
             return x_orig
@@ -133,10 +136,16 @@ class APoTObserver(ObserverBase):
         self.max_val = max_val
         return x_orig
 
-    def quant_levels_visualization(self, obs_result, filename):
+    r"""Displays visualization of APoT quantization levels
+        Args:
+            alpha: alpha APoT qparam (Tensor)
+            quantization_levels: quantization levels APoT qparam (Tensor)
+            level_indices: level indices APoT qparam (Tensor)
+    """
+    def quant_levels_visualization(self, alpha, quantization_levels, level_indices):
         xs = [float(x) / 1000.0 for x in range(1000)]
-        ys = [apot_to_float(float_to_apot(x, obs_result[1], obs_result[2]),
-                            obs_result[1], obs_result[2]).item() for x in xs]
+        ys = [apot_to_float(float_to_apot(x, quantization_levels, level_indices, alpha),
+                            quantization_levels, level_indices).item() for x in xs]
 
         f = plt.figure(figsize=(15, 10))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82790

### Summary
Refactors quantization levels visualization function to include alpha qparam in parameters of `float_to_apot` function call (due to `float_to_apot` function update). Also adds additional detail to the documentation for `quant_levels_visualization`.

### Test Plan
Print visualization by calling `quant_levels_visualization` function.