### PR TITLE
Run Windows CUDA build only in trunk

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -237,15 +237,6 @@ jobs:
           { config: "functorch", shard: 1, num_shards: 1, runner: "windows.4xlarge" },
         ]}
 
-  win-vs2019-cuda11_6-py3-build:
-    if: github.event_name == 'pull_request'
-    name: win-vs2019-cuda11.6-py3
-    uses: ./.github/workflows/_win-build.yml
-    with:
-      build-environment: win-vs2019-cuda11.6-py3
-      cuda-version: "11.6"
-      sync-tag: win-cuda-build
-
   linux-xenial-cuda11_3-py3_7-gcc7-bazel-test:
     name: linux-xenial-cuda11.3-py3.7-gcc7-bazel-test
     uses: ./.github/workflows/_bazel-build-test.yml


### PR DESCRIPTION
Revisit the discussion in https://github.com/pytorch/pytorch/issues/76838 to move Windows CUDA build to trunk:
* Windows CUDA runner is expensive and in short supply
* Land validation is being rolled out, so we can reconsider the option to remove this from PR

(We can keep this PR around till land validation is fully available if need to)

