### PR TITLE
[ao] Fix punctuation issue with Dynamic Static Report

### DIFF
--- a/torch/ao/quantization/fx/_model_report/detector.py
+++ b/torch/ao/quantization/fx/_model_report/detector.py
@@ -497,7 +497,7 @@ class DynamicStaticDetector(DetectorBase):
             benefit_str = ""
 
             # strings for if dynamic quantized per tensor is needed
-            recommend_per_tensor = " We recommend to add a {} before this module if it is static."
+            recommend_per_tensor = ". We recommend to add a {} before this module if it is static."
             rec_lay_to_add = "dynamic quantize per tensor layer"
             dynamic_per_tensor_string = recommend_per_tensor.format(rec_lay_to_add)
             dynamic_per_tensor_reasoning_string = (


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #82796
* #82795
* __->__ #82794

Summary: This fixes a punctuation issue with the Dynamic Static Detector
that was missing a period when suggesting to use a dynamic quantize per
tensor layer.

Quick grammer fix and no other changes to code.

Test Plan: python test/test_quantization.py TestFxModelReportDetectDynamicStatic

Reviewers:

Subscribers:

Tasks:

Tags: