### PR TITLE
[ao] Changed ratio of channels needed for input-weight rec

### DIFF
--- a/torch/ao/quantization/fx/_model_report/detector.py
+++ b/torch/ao/quantization/fx/_model_report/detector.py
@@ -608,7 +608,7 @@ class InputWeightEqualizationDetector(DetectorBase):
     INPUT_STR = "input"
 
     # default for what ratio we recommend input weight
-    DEFAULT_RECOMMEND_INPUT_WEIGHT_CHANNEL_RATIO = 0.5
+    DEFAULT_RECOMMEND_INPUT_WEIGHT_CHANNEL_RATIO = 0.4
 
     def __init__(self, ratio_threshold: float, ch_axis: int = 1):
         # ensure passed in inputs are valid


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #82796
* __->__ #82795
* #82794

Summary: After working on a tutorial and spending more time
experimenting with the input-weight equalization recommendation feature,
I realized that having half as the number of channels to benefit from
input-weight was too high, and that it should be a bit more lenient.
Based on the example I played around with in an internal tutorial, I
found that somewhere in the 0.3 - 0.4 threshold made more sense. In the
future, more in-depth testing and experimenting with more models may
help further fine-tune this fraction of channels that would benefit.

Test Plan: python test/test_quantization.py TestFxDetectInputWeightEqualization

Reviewers:

Subscribers:

Tasks:

Tags: