### PR TITLE
[vulkan] Add buffer to texture and texture to buffer copies

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -34,7 +34,7 @@ class CommandBuffer final {
     INVALID, // Used to indicate the command buffer is moved from
     NEW, // Set during constructor
     RECORDING, // Set during call to begin(), dispatch(), and
-               // copy_texture_to_texture()
+               // copy_*_to_*()
     PIPELINE_BOUND, // Set during call to  bind_pipeline()
     DESCRIPTORS_BOUND, // Set during call to bind_descriptors()
     BARRIERS_INSERTED, // Set during call to insert_barrier()
@@ -83,6 +83,20 @@ class CommandBuffer final {
 
   void copy_texture_to_texture(
       const api::VulkanImage&,
+      const api::VulkanImage&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&);
+
+  void copy_texture_to_buffer(
+      const api::VulkanImage&,
+      const api::VulkanBuffer&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&,
+      const api::utils::uvec3&);
+
+  void copy_buffer_to_texture(
+      const api::VulkanBuffer&,
       const api::VulkanImage&,
       const api::utils::uvec3&,
       const api::utils::uvec3&,

--- a/aten/src/ATen/native/vulkan/api/Resource.h
+++ b/aten/src/ATen/native/vulkan/api/Resource.h
@@ -3,6 +3,9 @@
 #ifdef USE_VULKAN_API
 
 #include <ATen/native/vulkan/api/Allocator.h>
+#include <ATen/native/vulkan/api/Utils.h>
+
+#include <c10/core/ScalarType.h>
 #include <c10/util/hash.h>
 
 #include <stack>
@@ -15,6 +18,8 @@ namespace api {
 typedef uint8_t MemoryAccessFlags;
 
 VkFormat vk_format(const caffe2::TypeMeta dtype);
+
+c10::ScalarType c10_scalartype(const VkFormat image_format);
 
 constexpr VmaAllocationCreateFlags DEFAULT_ALLOCATION_STRATEGY =
     VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT;
@@ -104,6 +109,10 @@ class VulkanBuffer final {
     return buffer_properties_.mem_range;
   }
 
+  inline VkDeviceSize mem_size() const {
+    return buffer_properties_.size;
+  }
+
   operator bool() const {
     return (allocation_ != VK_NULL_HANDLE);
   }
@@ -128,11 +137,16 @@ class MemoryMap final {
   VmaAllocator allocator_;
   VmaAllocation allocation_;
   void* data_;
+  VkDeviceSize data_len_;
 
  public:
   template <typename T>
   T* data() {
     return reinterpret_cast<T*>(data_);
+  }
+
+  inline size_t nbytes() {
+    return utils::safe_downcast<size_t>(data_len_);
   }
 
   void invalidate();
@@ -265,6 +279,10 @@ class VulkanImage final {
 
   inline VmaAllocation allocation() const {
     return allocation_;
+  }
+
+  inline VkFormat format() const {
+    return image_properties_.image_format;
   }
 
   inline VkExtent3D extents() const {

--- a/aten/src/ATen/native/vulkan/ops/Common.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Common.cpp
@@ -5,8 +5,7 @@ namespace native {
 namespace vulkan {
 namespace ops {
 
-uint32_t batch_size(const Tensor& tensor) {
-  const IntArrayRef sizes = tensor.sizes();
+uint32_t batch_size(const IntArrayRef sizes) {
   const uint32_t dims = sizes.size();
   if (dims < 4) {
     return 1;
@@ -14,8 +13,11 @@ uint32_t batch_size(const Tensor& tensor) {
   return sizes[dims - 4];
 }
 
-uint32_t channels_size(const Tensor& tensor) {
-  const IntArrayRef sizes = tensor.sizes();
+uint32_t batch_size(const Tensor& tensor) {
+  return batch_size(tensor.sizes());
+}
+
+uint32_t channels_size(const IntArrayRef sizes) {
   const uint32_t dims = sizes.size();
   if (dims < 3) {
     return 1;
@@ -23,8 +25,11 @@ uint32_t channels_size(const Tensor& tensor) {
   return sizes[dims - 3];
 }
 
-uint32_t height_size(const Tensor& tensor) {
-  const IntArrayRef sizes = tensor.sizes();
+uint32_t channels_size(const Tensor& tensor) {
+  return channels_size(tensor.sizes());
+}
+
+uint32_t height_size(const IntArrayRef sizes) {
   const uint32_t dims = sizes.size();
   if (dims < 2) {
     return 1;
@@ -32,13 +37,20 @@ uint32_t height_size(const Tensor& tensor) {
   return sizes[dims - 2];
 }
 
-uint32_t width_size(const Tensor& tensor) {
-  const IntArrayRef sizes = tensor.sizes();
+uint32_t height_size(const Tensor& tensor) {
+  return height_size(tensor.sizes());
+}
+
+uint32_t width_size(const IntArrayRef sizes) {
   const uint32_t dims = sizes.size();
   if (dims < 1) {
     return 1;
   }
   return sizes[dims - 1];
+}
+
+uint32_t width_size(const Tensor& tensor) {
+  return width_size(tensor.sizes());
 }
 
 api::utils::uvec3 adaptive_work_group_size(

--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -43,10 +43,17 @@ struct Layout final {
   };
 };
 
-uint32_t batch_size(const Tensor& tensor);
-uint32_t channels_size(const Tensor& tensor);
-uint32_t height_size(const Tensor& tensor);
-uint32_t width_size(const Tensor& tensor);
+uint32_t batch_size(const IntArrayRef);
+uint32_t batch_size(const Tensor&);
+
+uint32_t channels_size(const IntArrayRef);
+uint32_t channels_size(const Tensor&);
+
+uint32_t height_size(const IntArrayRef);
+uint32_t height_size(const Tensor&);
+
+uint32_t width_size(const IntArrayRef);
+uint32_t width_size(const Tensor&);
 
 api::utils::uvec3 adaptive_work_group_size(
     const api::utils::uvec3& global_work_group);

--- a/aten/src/ATen/native/vulkan/ops/Concat.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Concat.cpp
@@ -114,7 +114,7 @@ Tensor cat_feature_mult4ch(const TensorList tensors, vTensor& v_output) {
 
       api::PipelineBarrier pipeline_barrier{};
 
-      context->submit_texture_copy(
+      context->submit_copy<api::VulkanImage, api::VulkanImage>(
           // pipeline barrier
           pipeline_barrier,
           // images
@@ -152,7 +152,7 @@ Tensor cat_height(const TensorList tensors, vTensor& v_output) {
 
     api::PipelineBarrier pipeline_barrier{};
 
-    context->submit_texture_copy(
+    context->submit_copy<api::VulkanImage, api::VulkanImage>(
         // pipeline barrier
         pipeline_barrier,
         // images

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -83,7 +83,7 @@ vTensor pack_weights_dw(api::Context* const context, const Tensor& weight) {
       weight.options(),
   };
 
-  api::StagingBuffer staging(context, v_weight.buffer_bytes());
+  api::StorageBuffer staging(context, at::kFloat, v_weight.numcells());
   {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 
@@ -151,7 +151,7 @@ vTensor pack_weights_2d(
       weight.options(),
   };
 
-  api::StagingBuffer staging(context, v_weight.buffer_bytes());
+  api::StorageBuffer staging(context, at::kFloat, v_weight.numcells());
   {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 
@@ -239,7 +239,8 @@ vTensor pack_weights_dw_q(api::Context* const context, const Tensor& weight) {
       weight.q_scale(),
       weight.q_zero_point(),
   };
-  api::StagingBuffer staging(context, v_weight.buffer_bytes());
+
+  api::StorageBuffer staging(context, at::kFloat, v_weight.numcells());
   {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 
@@ -306,7 +307,7 @@ vTensor pack_weights_2d_q(api::Context* const context, const Tensor& weight) {
       weight.q_zero_point(),
   };
 
-  api::StagingBuffer staging(context, v_weight.buffer_bytes());
+  api::StorageBuffer staging(context, at::kFloat, v_weight.numcells());
   {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 
@@ -400,7 +401,7 @@ vTensor pack_biases_reg(
       weight.options(),
   };
 
-  api::StagingBuffer staging(context, v_bias.buffer_bytes());
+  api::StorageBuffer staging(context, at::kFloat, v_bias.numcells());
   {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 
@@ -451,7 +452,7 @@ vTensor pack_biases_q(const c10::optional<Tensor>& bias, const Tensor& weight) {
       weight.q_zero_point(),
   };
 
-  api::StagingBuffer staging(context, v_bias.buffer_bytes());
+  api::StorageBuffer staging(context, at::kFloat, v_bias.numcells());
   {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 

--- a/aten/src/ATen/native/vulkan/ops/Copy.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Copy.cpp
@@ -1,4 +1,4 @@
-#include <ATen/native/vulkan/ops/Common.h>
+#include <ATen/native/vulkan/ops/Copy.h>
 #include <ATen/native/vulkan/ops/Utils.h>
 
 namespace at {
@@ -6,12 +6,112 @@ namespace native {
 namespace vulkan {
 namespace ops {
 
-void copy_vulkan_to_vulkan(vTensor& src, vTensor& dst) {
+//
+// Utility functions for memcpy
+//
+
+void memcpy_to_mapping(const Tensor& src, api::MemoryMap& dst_mapping) {
+  if (src.dtype() == at::kFloat) {
+    memcpy_to_mapping_impl<float>(src, dst_mapping);
+  } else if (src.dtype() == at::kHalf) {
+    memcpy_to_mapping_impl<c10::Half>(src, dst_mapping);
+  } else if (src.dtype() == c10::kQUInt8) {
+    memcpy_to_mapping_impl<c10::quint8>(src, dst_mapping);
+  } else {
+    TORCH_CHECK(
+        false,
+        "Invalid Data Type: expected c10::QUint8, at::kHalf or at::Float but got ",
+        src.dtype());
+  }
+}
+
+void memcpy_from_mapping(api::MemoryMap& src_mapping, Tensor& dst) {
+  if (dst.dtype() == at::kFloat) {
+    memcpy_from_mapping_impl<float>(src_mapping, dst);
+  } else if (dst.dtype() == at::kHalf) {
+    memcpy_from_mapping_impl<c10::Half>(src_mapping, dst);
+  } else if (dst.dtype() == c10::kQUInt8) {
+    memcpy_from_mapping_impl<c10::quint8>(src_mapping, dst);
+  } else {
+    TORCH_CHECK(
+        false,
+        "Invalid Data Type: expected c10::QUint8, at::kHalf or Float but got ",
+        dst.dtype());
+  }
+}
+
+//
+// CPU <-> GPU copy implementations (these functions use Transfer commands)
+//
+
+void transfer_cpu_to_vulkan(const Tensor& src, vTensor& v_dst) {
+  api::Context* const context = api::context();
+
+  // Convert to dtype corresponding to the image format of the texture to
+  // ensure that byte alignment is consistent when copying. In some cases
+  // a 16 bit format will be used for at::kFloat.
+  Tensor src_nc4hw = utils::nchw_to_nc4hw(src).to(v_dst.texture_dtype());
+
+  api::StorageBuffer staging(context, v_dst.texture_dtype(), v_dst.numcells());
+  // Copy data into the staging buffer
+  {
+    api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
+    mapping.invalidate();
+
+    memcpy_to_mapping(src_nc4hw, mapping);
+  }
+
+  api::PipelineBarrier pipeline_barrier{};
+  utils::copy_buffer_to_vtensor(staging.buffer(), v_dst, pipeline_barrier);
+}
+
+void transfer_vulkan_to_cpu(vTensor& v_src, Tensor& dst) {
+  api::Context* const context = api::context();
+
+  // Temporary tensor to receive copied NC4HW data
+  at::Tensor dst_tmp = utils::create_staging_tensor(v_src);
+
+  api::StorageBuffer staging(context, v_src.texture_dtype(), v_src.numcells());
+
+  api::VulkanFence fence = context->fences().get_fence();
+
+  {
+    // Refer to comment in submit_compute_job. When syncing with the GPU, the
+    // context must not allow other threads to record dispatches into it between
+    // between calling vkQueueSubmit and flushing the context. Therefore,
+    // cmd_mutex_ must be manually managed by the calling thread.
+    std::unique_lock<std::mutex> context_lock(context->dispatch_lock());
+
+    api::PipelineBarrier pipeline_barrier{};
+    utils::copy_vtensor_to_buffer(
+        v_src, staging.buffer(), pipeline_barrier, fence.get_submit_handle());
+
+    fence.wait();
+
+    context->flush();
+    // cmd_mutex_ will be released when exiting this scope.
+  }
+
+  // Copy data from buffer back to CPU tensor.
+  {
+    api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::READ);
+    mapping.invalidate();
+
+    memcpy_from_mapping(mapping, dst_tmp);
+  }
+
+  context->fences().return_fence(fence);
+
+  dst =
+      utils::nc4hw_to_nchw(dst_tmp, v_src.sizes()).to(v_src.options().dtype());
+}
+
+void transfer_vulkan_to_vulkan(vTensor& src, vTensor& dst) {
   api::Context* const context = api::context();
 
   api::PipelineBarrier pipeline_barrier{};
 
-  context->submit_texture_copy(
+  context->submit_copy<api::VulkanImage, api::VulkanImage>(
       // pipeline barrier
       pipeline_barrier,
       // images
@@ -28,34 +128,42 @@ void copy_vulkan_to_vulkan(vTensor& src, vTensor& dst) {
       VK_NULL_HANDLE);
 }
 
-void copy_cpu_to_vulkan(const Tensor& src, vTensor& dst) {
+//
+// CPU <-> GPU copy implementations (these functions use compute shaders)
+//
+
+void pack_cpu_to_vulkan(const Tensor& src, vTensor& dst) {
   api::Context* const context = api::context();
 
-  api::StagingBuffer staging(context, dst.buffer_bytes());
+  // Note that the float data type has been enforced for the storage buffer
+  // below. The reason for this is that the nchw_to_image and image_to_nchw
+  // shaders which perform the transfer to/from an image texture expect a buffer
+  // of floats as input. GLSL/Vulkan does not natively support 16 bit arithmetic
+  // types, so for now storage buffers created for compute shaders must define
+  // floats as their base data type.
+  api::StorageBuffer staging(context, at::kFloat, dst.numcells());
   {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 
-    if (src.dtype() == c10::kQUInt8) {
-      c10::quint8* data_ptr = mapping.template data<c10::quint8>();
-      memcpy(
-          data_ptr,
-          src.contiguous().data_ptr<c10::quint8>(),
-          std::min(src.nbytes(), src.nbytes()));
+    // If the dtype() of src is at::kHalf, then first convert it to 32 bit
+    // float. This is required since the nchw_to_image shader uses a float
+    // buffer as input (note that at::kFloat is used to create the StorageBuffer
+    // above).
+    if (src.dtype() == at::kHalf) {
+      memcpy_to_mapping(src.to(at::kFloat), mapping);
     } else {
-      float* data_ptr = mapping.template data<float>();
-      memcpy(
-          data_ptr,
-          src.contiguous().data_ptr<float>(),
-          std::min(src.nbytes(), src.nbytes()));
+      memcpy_to_mapping(src, mapping);
     }
   }
   utils::pack_staging_to_vtensor(staging.buffer(), dst);
 }
 
-void copy_vulkan_to_cpu(vTensor& src, Tensor& dst) {
+void pack_vulkan_to_cpu(vTensor& src, Tensor& dst) {
   api::Context* const context = api::context();
 
-  api::StagingBuffer staging(context, src.buffer_bytes());
+  // Refer to the comment in pack_cpu_to_vulkan for why at::kFloat is specified
+  // for the storage buffer below.
+  api::StorageBuffer staging(context, at::kFloat, src.numcells());
 
   api::VulkanFence fence = context->fences().get_fence();
 
@@ -80,46 +188,41 @@ void copy_vulkan_to_cpu(vTensor& src, Tensor& dst) {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::READ);
     mapping.invalidate();
 
-    if (dst.is_quantized()) {
-      c10::quint8* data_ptr = mapping.template data<c10::quint8>();
-      memcpy(
-          dst.data_ptr<c10::quint8>(),
-          data_ptr,
-          std::min(src.nbytes(), dst.nbytes()));
+    // If the dtype() of dst is at::kHalf, then copy the data into a float
+    // version of it first, similar to pack_cpu_to_vulkan().
+    if (dst.dtype() == at::kHalf) {
+      Tensor dst_float = dst.to(at::kFloat);
+      memcpy_from_mapping(mapping, dst_float);
+      dst = dst_float.to(at::kHalf);
     } else {
-      float* data_ptr = mapping.template data<float>();
-      memcpy(
-          dst.data_ptr<float>(),
-          data_ptr,
-          std::min(src.nbytes(), dst.nbytes()));
+      memcpy_from_mapping(mapping, dst);
     }
   }
 
   context->fences().return_fence(fence);
 }
 
-Tensor& copy_(Tensor& self, const Tensor& src) {
+//
+// Copy op implementations
+//
+
+Tensor& copy_(Tensor& dst, const Tensor& src) {
   // Check that sizes are equal
   TORCH_CHECK(
-      self.sizes() == src.sizes(),
-      "Vulkan copy_: Tensor sizes are mismatched!");
+      dst.sizes() == src.sizes(), "Vulkan copy_: Tensor sizes are mismatched!");
 
   // X -> Vulkan
-  if (at::kVulkan == self.device().type()) {
-    vTensor& v_self = convert(self);
+  if (at::kVulkan == dst.device().type()) {
+    vTensor& v_self = convert(dst);
 
     // Vulkan -> Vulkan
     if (at::kVulkan == src.device().type()) {
       vTensor& v_src = convert(src);
-      copy_vulkan_to_vulkan(v_src, v_self);
+      transfer_vulkan_to_vulkan(v_src, v_self);
     }
     // CPU -> Vulkan
     else {
-      TORCH_CHECK(
-          src.dtype() == c10::kQUInt8 || src.dtype() == at::kFloat,
-          "Invalid Data Type: expected QUint8 or Float but got ",
-          src.dtype());
-      copy_cpu_to_vulkan(src, v_self);
+      pack_cpu_to_vulkan(src, v_self);
     }
   }
   // Vulkan -> X
@@ -127,12 +230,8 @@ Tensor& copy_(Tensor& self, const Tensor& src) {
     vTensor& v_src = convert(src);
 
     // Vulkan -> CPU
-    if (self.device().is_cpu()) {
-      TORCH_CHECK(
-          self.dtype() == c10::kQUInt8 || self.dtype() == at::kFloat,
-          "Invalid Data Type: expected QUint8 or Float but got ",
-          self.dtype());
-      copy_vulkan_to_cpu(v_src, self);
+    if (dst.device().is_cpu()) {
+      pack_vulkan_to_cpu(v_src, dst);
     } else {
       TORCH_CHECK(false, "Unsupported!");
     }
@@ -143,7 +242,7 @@ Tensor& copy_(Tensor& self, const Tensor& src) {
         "was expected to be Vulkan a tensor!  Incorrect dispatch?");
   }
 
-  return self;
+  return dst;
 }
 
 } // namespace ops

--- a/aten/src/ATen/native/vulkan/ops/Copy.h
+++ b/aten/src/ATen/native/vulkan/ops/Copy.h
@@ -9,7 +9,37 @@ namespace native {
 namespace vulkan {
 namespace ops {
 
-Tensor& copy_(Tensor& self, const Tensor& src);
+void transfer_cpu_to_vulkan(const Tensor&, vTensor&);
+
+void transfer_vulkan_to_cpu(vTensor&, Tensor&);
+
+Tensor& copy_(Tensor& dst, const Tensor& src);
+
+//
+// Utility functions for memcpy
+//
+
+template <typename T>
+void memcpy_to_mapping_impl(const Tensor& src, api::MemoryMap& dst_mapping) {
+  T* data_ptr = dst_mapping.template data<T>();
+  memcpy(
+      data_ptr,
+      src.contiguous().data_ptr<T>(),
+      std::min(src.nbytes(), dst_mapping.nbytes()));
+}
+
+template <typename T>
+void memcpy_from_mapping_impl(api::MemoryMap& src_mapping, Tensor& dst) {
+  T* data_ptr = src_mapping.template data<T>();
+  memcpy(
+      dst.data_ptr<T>(),
+      data_ptr,
+      std::min(src_mapping.nbytes(), dst.nbytes()));
+}
+
+void memcpy_to_mapping(const Tensor& src, api::MemoryMap& dst_mapping);
+
+void memcpy_from_mapping(api::MemoryMap& src_mapping, Tensor& dst);
 
 } // namespace ops
 } // namespace vulkan

--- a/aten/src/ATen/native/vulkan/ops/Mm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Mm.cpp
@@ -41,7 +41,7 @@ vTensor pack_weights(const Tensor& weight_arg) {
       weight.options(),
   };
 
-  api::StagingBuffer staging(context, v_weight.buffer_bytes());
+  api::StorageBuffer staging(context, at::kFloat, v_weight.numcells());
   {
     api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 
@@ -104,7 +104,7 @@ vTensor pack_biases(
         bias_arg->options(),
     };
 
-    api::StagingBuffer staging(context, v_bias.buffer_bytes());
+    api::StorageBuffer staging(context, at::kFloat, v_bias.numcells());
     {
       api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 
@@ -133,7 +133,7 @@ vTensor pack_biases(
         weight_arg.options(),
     };
 
-    api::StagingBuffer staging(context, v_bias.buffer_bytes());
+    api::StorageBuffer staging(context, at::kFloat, v_bias.numcells());
     {
       api::MemoryMap mapping(staging.buffer(), api::MemoryAccessType::WRITE);
 

--- a/aten/src/ATen/native/vulkan/ops/Shape.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Shape.cpp
@@ -22,7 +22,7 @@ Tensor view_internal(const Tensor& self_arg, const IntArrayRef shape) {
       self.options(),
   };
 
-  api::StagingBuffer buffer(context, v_self.buffer_bytes(), true);
+  api::StorageBuffer buffer(context, at::kFloat, v_self.numcells(), true);
 
   utils::pack_vtensor_to_staging(v_self, buffer.buffer());
 

--- a/aten/src/ATen/native/vulkan/ops/Slice.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Slice.cpp
@@ -95,7 +95,7 @@ Tensor slice_width(
 
     api::PipelineBarrier pipeline_barrier{};
 
-    context->submit_texture_copy(
+    context->submit_copy<api::VulkanImage, api::VulkanImage>(
         // pipeline barrier
         pipeline_barrier,
         // images
@@ -126,7 +126,7 @@ Tensor slice_width(
 
       api::PipelineBarrier pipeline_barrier{};
 
-      context->submit_texture_copy(
+      context->submit_copy<api::VulkanImage, api::VulkanImage>(
           // pipeline barrier
           pipeline_barrier,
           // images
@@ -171,7 +171,7 @@ Tensor slice_height(
 
     api::PipelineBarrier pipeline_barrier{};
 
-    context->submit_texture_copy(
+    context->submit_copy<api::VulkanImage, api::VulkanImage>(
         // pipeline barrier
         pipeline_barrier,
         // images
@@ -200,7 +200,7 @@ Tensor slice_height(
 
       api::PipelineBarrier pipeline_barrier{};
 
-      context->submit_texture_copy(
+      context->submit_copy<api::VulkanImage, api::VulkanImage>(
           // pipeline barrier
           pipeline_barrier,
           // images

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -80,6 +80,11 @@ class vTensorStorage final {
 
   // Validation
   void verify() const;
+
+ public:
+  inline VkFormat texture_format() {
+    return image_.format();
+  }
 };
 
 class vTensor final {
@@ -139,6 +144,13 @@ class vTensor final {
     return view_->extents_;
   }
 
+  /*
+   * Get a c10::ScalarType that corresponds to the image format of the texture
+   */
+  inline c10::ScalarType texture_dtype() const {
+    return api::c10_scalartype(view_->texture_format());
+  }
+
   inline const TensorOptions& options() const {
     return view_->options_;
   }
@@ -168,10 +180,20 @@ class vTensor final {
         c10::multiply_integers(sizes());
   }
 
-  inline VkDeviceSize buffer_bytes() {
-    return c10::elementSize(c10::typeMetaToScalarType(options().dtype())) *
-        view_->extents_.data[0u] * view_->extents_.data[1u] *
+  /*
+   * Number of "cells" in the image texture. 4 cells make up a texel.
+   */
+  inline VkDeviceSize numcells() {
+    return view_->extents_.data[0u] * view_->extents_.data[1u] *
         (4u * view_->extents_.data[2u]);
+  }
+
+  /*
+   * Number of bytes needed for a buffer to receive all data in the texture
+   */
+  inline VkDeviceSize buffer_bytes() {
+    return c10::elementSize(this->texture_dtype()) * view_->extents_.data[0u] *
+        view_->extents_.data[1u] * (4u * view_->extents_.data[2u]);
   }
 };
 

--- a/aten/src/ATen/native/vulkan/ops/Utils.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Utils.cpp
@@ -6,6 +6,156 @@ namespace vulkan {
 namespace ops {
 namespace utils {
 
+/*
+ * This function formats an input tensor in NCHW layout to NC4HW layout such
+ * that the buffer of the formatted tensor can be directly copied into a GPU
+ * texture. Conceptually, the formatting can be achieved via the following
+ * steps:
+ *
+ * 1. Given that the src tensor has size {N,C,H,W}
+ *
+ * 2. Combine the batch and channel dims by reshaping to {N*C, H, W}
+ *
+ * 3. Determine the amount of padding to add: determine how many channels to add
+ *    in order to align N*C to the next multiple of 4
+ *
+ * 4. Add padding to the tensor so that the batch-channel dimension is a
+ *    multiple of four; the shape of the tensor is now {NC_aligned, H, W}
+ *
+ * 5. Split the batch-channel dimension into groups of 4 by reshaping the tensor
+ *    to size {NC_aligned/4, 4, H, W}
+ *
+ * 6. The groups of 4 channels (dim 1) should be contiguous. Therefore, permute
+ *    the dims of the tensor in the order {0, 2, 3, 1}
+ *
+ * 7. Finally, return a contiguous version of the tensor. The final shape of the
+ *    tensor would be {NC_aligned/4, H, W, 4}
+ */
+Tensor nchw_to_nc4hw(const Tensor& src) {
+  uint32_t N = batch_size(src.sizes());
+  uint32_t C = channels_size(src.sizes());
+  uint32_t H = height_size(src.sizes());
+  uint32_t W = width_size(src.sizes());
+
+  uint32_t NC4 = api::utils::div_up(N * C, 4u);
+  uint32_t NC_aligned = api::utils::align_up(N * C, 4u);
+
+  // Add padding to the tensor so that the batch-channel dim is a multiple of 4
+  Tensor padding = at::zeros({NC_aligned - N * C, H, W}, src.options());
+  Tensor src_padded = at::cat({src.reshape({N * C, H, W}), padding});
+  // Reshape to group channels into groups of 4 and permute so that the groups
+  // are in the first dimension so that they are contiguous
+  Tensor src_NC4HW = src_padded.reshape({NC4, 4, H, W}).permute({0, 2, 3, 1});
+
+  // Return a contiguous version of the tensor
+  return src_NC4HW.contiguous();
+}
+
+/*
+ * Creates a staging tensor into which texture data, which will be in NC4HW
+ * format, can be copied directly. The shape of the staging tensor will be the
+ * same as the tensor produced by a call to format_src_tensor().
+ */
+Tensor create_staging_tensor(const vTensor& v_in) {
+  uint32_t N = batch_size(v_in.sizes());
+  uint32_t C = channels_size(v_in.sizes());
+  uint32_t H = height_size(v_in.sizes());
+  uint32_t W = width_size(v_in.sizes());
+
+  uint32_t NC4 = api::utils::div_up(N * C, 4u);
+
+  // Note that the dtype corresponding with the texture format of the vTensor is
+  // used instead of options().dtype(). This is to ensure the number of bytes in
+  // the staging tensor matches the number of bytes in the image texture. Refer
+  // to comments for api::vk_format()
+  return at::empty(
+      {NC4, H, W, 4}, at::device(at::kCPU).dtype(v_in.texture_dtype()));
+}
+
+/*
+ * After copying texture data, which will be in NC4HW format, to a staging
+ * tensor created in create_staging_tensor(), this function reformats the tensor
+ * to NCHW format. It essentially reverses the transformations made by
+ * format_src_tensor().
+ *
+ * Note that the sizes of the original tensor must be passed in to fully restore
+ * the properties of the original tensor.
+ */
+Tensor nc4hw_to_nchw(const Tensor& t_in, IntArrayRef sizes) {
+  uint32_t N = batch_size(sizes);
+  uint32_t C = channels_size(sizes);
+  uint32_t H = height_size(sizes);
+  uint32_t W = width_size(sizes);
+
+  uint32_t NC_aligned = api::utils::align_up(N * C, 4u);
+
+  // Undo the permute step and channel grouping step
+  Tensor t_in_padded = t_in.permute({0, 3, 1, 2}).reshape({NC_aligned, H, W});
+  // Remove the padding channels
+  Tensor t_in_shaved =
+      at::narrow(t_in_padded, /*dim=*/0, /*start*/ 0, /*end*/ N * C);
+
+  // Reshape to original sizing and dtype and return a contiguous Tensor
+  return t_in_shaved.reshape(sizes).contiguous();
+}
+
+void copy_buffer_to_vtensor(
+    api::VulkanBuffer& src_buffer,
+    vTensor& v_dst,
+    api::PipelineBarrier& pipeline_barrier) {
+  api::Context* const context = api::context();
+
+  TORCH_CHECK(
+      src_buffer.mem_size() == v_dst.buffer_bytes(),
+      "Vulkan copy_buffer_to_vtensor: source buffer and destination texture "
+      "do not have the same number of bytes");
+
+  context->submit_copy<api::VulkanBuffer, api::VulkanImage>(
+      // pipeline barrier
+      pipeline_barrier,
+      // resources
+      src_buffer,
+      v_dst.image(
+          pipeline_barrier,
+          api::PipelineStage::TRANSFER,
+          api::MemoryAccessType::WRITE),
+      // copy details
+      v_dst.extents(),
+      {0u, 0u, 0u},
+      {0u, 0u, 0u},
+      // fence handle
+      VK_NULL_HANDLE);
+}
+
+void copy_vtensor_to_buffer(
+    vTensor& v_src,
+    api::VulkanBuffer& dst_buffer,
+    api::PipelineBarrier& pipeline_barrier,
+    const VkFence fence_handle) {
+  api::Context* const context = api::context();
+
+  TORCH_CHECK(
+      v_src.buffer_bytes() == dst_buffer.mem_size(),
+      "Vulkan copy_vtensor_to_buffer: source texture and destination buffer "
+      "do not have the same number of bytes");
+
+  context->submit_copy<api::VulkanImage, api::VulkanBuffer>(
+      // pipeline barrier
+      pipeline_barrier,
+      // resources
+      v_src.image(
+          pipeline_barrier,
+          api::PipelineStage::TRANSFER,
+          api::MemoryAccessType::READ),
+      dst_buffer,
+      // copy details
+      v_src.extents(),
+      {0u, 0u, 0u},
+      {0u, 0u, 0u},
+      // fence handle
+      fence_handle);
+}
+
 void pack_buffer_to_vtensor(
     api::VulkanBuffer& buffer,
     vTensor& v_self,

--- a/aten/src/ATen/native/vulkan/ops/Utils.h
+++ b/aten/src/ATen/native/vulkan/ops/Utils.h
@@ -10,6 +10,23 @@ namespace vulkan {
 namespace ops {
 namespace utils {
 
+Tensor nchw_to_nc4hw(const Tensor&);
+
+Tensor create_staging_tensor(const vTensor&);
+
+Tensor nc4hw_to_nchw(const Tensor&, IntArrayRef);
+
+void copy_buffer_to_vtensor(
+    api::VulkanBuffer&,
+    vTensor&,
+    api::PipelineBarrier&);
+
+void copy_vtensor_to_buffer(
+    vTensor&,
+    api::VulkanBuffer&,
+    api::PipelineBarrier&,
+    const VkFence fence_handle = VK_NULL_HANDLE);
+
 inline int64_t normalize(const int64_t dimension, const int64_t n) {
   return (dimension % n + n) % n;
 }

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -4,6 +4,7 @@
 #include <ATen/ATen.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/native/vulkan/api/api.h>
+#include <ATen/native/vulkan/ops/Copy.h>
 #include <c10/util/irange.h>
 
 // TODO: These functions should move to a common place.
@@ -247,6 +248,31 @@ class VulkanAPITest : public ::testing::Test {
 #endif
   }
 };
+
+TEST_F(VulkanAPITest, copy_to_texture) {
+  at::Tensor test_tensors[] = {
+    // 4D
+    at::rand({7, 17, 134, 213}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+    // 3D
+    at::rand({67, 134, 213}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+    // 2D
+    at::rand({229, 213}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+    // 1D
+    at::rand({1902}, at::TensorOptions(at::kCPU).dtype(at::kFloat)),
+  };
+
+  for (auto in_cpu : test_tensors) {
+    at::Tensor in_vk_copied = in_cpu.vulkan();
+    at::Tensor out_copied = in_vk_copied.cpu();
+
+    const auto check_copy = almostEqual(out_copied, in_cpu);
+
+    if(!check_copy) {
+      std::cout << "Copy failed on size " << in_cpu.sizes()
+                << "with dtype" << in_cpu.dtype() << std::endl;
+    }
+  }
+}
 
 TEST_F(VulkanAPITest, adaptive_avg_pool2d) {
   c10::InferenceMode mode;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82799

This diff adds functions to transfer data to GPU textures not through the `nchw_to_image` and `image_to_nchw` shaders but with host side functions that convert CPU tensors between NCHW to NC4HW formats, allowing data to be copied directly into and out from image textures via `vkCmdCopy*` API calls. These functions can be used when loading tensors from memory when loading a model, as it has the following benefits:

1. No need to construct a compute pipeline to transfer data to/from the GPU. This saves time when loading Vulkan models/performing first inference.
2. `vkCmdCopy*` is faster than compute shaders. However, due to the need to rearrange data between NCHW and NC4HW formats, it is still faster to use compute shaders to transfer input and output tensors. However, for weight tensors that can be serialized directly in NC4HW format, it is more beneficial to copy data directly.
3. It is much clearer from the code how data is represented on the GPU



Note that this change necessitated changes to how the `StagingBuffer` class worked (now called `StorageBuffer`. This is because the data size and alignment of data copied to and from an image texture is dependent on the image format of the texture.

If an image texture is `VK_FORMAT_R16G16B16A16_SFLOAT` the buffer copied from the texture can be interpreted as a contiguous array of 16 bit values. If the image texture is `VK_FORMAT_R32G32B32A32_SFLOAT` then the data buffer is an array of 32 bit values. Previously, `StagingBuffer` was constructed under the assumption that an array of 32 bit floats would be used to receive the data from the texture. This causes isses when `USE_VULKAN_FP16_INFERENCE` is turned on, which forces the `VK_FORMAT_R16G16B16A16_SFLOAT` image format to be used. Therefore, the construction of `StorageBuffer` now requires a data type and number of elements to be specified in its constructor to ensure proper sizing of the data buffer.

Differential Revision: [D38264300](https://our.internmc.facebook.com/intern/diff/D38264300/)