### PR TITLE
Set o_scale of u8 qsigmoid to valid integer range

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/sigmoid.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/sigmoid.c
@@ -69,7 +69,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_sigmoid_nc_q8(
 
   status = pytorch_qnnp_status_unsupported_parameter;
 
-  if (output_scale != 0x1.0p-8f) {
+  if (output_scale != 1.0 / 255.0) {
     pytorch_qnnp_log_error(
         "failed to create Sigmoid operator with %.7g output scale: only output scale of 1/256 is supported",
         output_scale);

--- a/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
@@ -106,7 +106,7 @@ Tensor sigmoid_quantized_cpu(const Tensor& qx) {
     // - For unsigned types output zero point is set to (qmax + qmin) / 2.0
     // See https://stackoverflow.com/a/34448562/3606192 for potential
     // optimizations
-    double output_scale = 0.00390625;  // 1.0 / 2^8
+    double output_scale = 0.00392157;  // 1.0 / (2^8 -1)
     int64_t output_zero_point = 0;
     // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
     if (SCALAR_TYPE == at::kQInt32) {

--- a/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qsigmoid.cpp
@@ -93,7 +93,7 @@ Tensor sigmoid_quantized_cpu(const Tensor& qx) {
 #ifdef USE_PYTORCH_QNNPACK
   if (at::globalContext().qEngine() == at::QEngine::QNNPACK &&
       qx.scalar_type() == kQUInt8) {
-    constexpr double output_scale = 1.0f / 256.0f;
+    constexpr double output_scale = 1.0f / 255.0f;
     constexpr int64_t output_zero_point = 0;
     return qnnpack_sigmoid(qx, output_scale, output_zero_point);
   }


### PR DESCRIPTION
### Description
For the output scale setting for u8 qtensor, we deem that `1/255` is more suitable.
Using `1/256` may resulting overflow, e.g. (value_f32=0.999, valut_uint8=255.744). Though using rounding can avoid overflow, from the view of methodology, `1/255` would ensure more accurate result. 
