### PR TITLE
Setting memory size to metadata `sizes` when unpickling qtensor

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6332,7 +6332,7 @@
   device_check: NoCheck
   device_guard: False
   dispatch:
-    CPU, CUDA, Meta, MPS: set_
+    CPU, CUDA, Meta, MPS, QuantizedCPU: set_
   autogen: set.source_Storage, set.source_Storage_out
 
 - func: set_.source_Storage_storage_offset(Tensor(a!) self, Storage source, int storage_offset, int[] size, int[] stride=[]) -> Tensor(a!)

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -175,7 +175,11 @@ Tensor& set_storage_quantized_(
   auto* self_ = self.unsafeGetTensorImpl();
   self_->set_storage_keep_dtype(storage);
   self_->set_storage_offset(storage_offset);
-  self_->set_sizes_and_strides(sizes, strides);
+  if(strides.data() == nullptr){
+    self_->set_sizes_contiguous(sizes);
+  }else{
+    self_->set_sizes_and_strides(sizes, strides);
+  }
   return self;
 }
 

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -499,8 +499,7 @@ PickleOpCode Unpickler::readInstruction() {
 
       at::Tensor tensor;
       if (options.backend() == c10::Backend::QuantizedCPU) {
-        tensor = at::_empty_affine_quantized({}, options, 0, 0)
-                     .set_(storage, 0, {}, {});
+        tensor = at::_empty_affine_quantized({}, options, 0, 0).set_(storage);
       } else {
         tensor = at::empty({0}, options).set_(storage);
       }


### PR DESCRIPTION
### Description
When unpickling a `qtensor`, the metadata `size` is unpickled after unpickling `TensorStorage`.   Since `QuantizedCPU` backed has not  dispatching for schema `- func: set_.source_Storage(Tensor(a!) self, Storage source) -> Tensor(a!)` , using `at::_empty_affine_quantized({}, options, 0, 0).set_(storage, 0, {}, {})`  to initialize storage would result in meaningless `sizes` and `strides` metadata.  Specifically , both the `strides` and `sizes` is `[]` in `TensorStorage` of the unpicked qtensor.

Without proper `size` metadata, trying to copy this unpicked tensor to `non-cpu` backend would fail (line 508 in `unpickler.cpp`). This is because the `copy` would use `size` info to create memory on target device. Passing a `[]` is meaningless.

## Solution
Firstly, we my need enable `- func: set_.source_Storage(Tensor(a!) self, Storage source) -> Tensor(a!)` dispatching in `QuantizedCPU` backend, this `set_` would infer a `size` metadat according to the `nbytes` and `dtype().itemsize()`.

Secondly, in the `set_storage_quantized_`, we need to handle parameter `stride` has no elements. 

cc @EikanWang @jgong5 @wenzhe-nrv @sanchitintel