### PR TITLE
dump ios test simulator logs on a failure

### DIFF
--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -190,3 +190,9 @@ jobs:
           else
             bundle exec fastlane scan --only_testing TestAppTests/TestAppTests/testFullJIT
           fi
+      - name: Dump Simulator Tests On a Failure
+        if: |
+          failure() && inputs.ios-platform == 'SIMULATOR'
+        run: |
+          echo "Simulator Tests Logs:"
+          cat /Users/runner/Library/Logs/scan/*.log


### PR DESCRIPTION
### Description
This PR adds another step to `_ios-build-test.yml` to dump out the build and test logs to the mainline log in case of a failure.

### Issue
<!-- Link to Issue ticket or RFP -->

### Testing
<!-- How did you test your change? -->
