### PR TITLE
[dist.checkpoint] Add Planner APIs and optimized FileSystem writer

### DIFF
--- a/test/distributed/_shard/checkpoint/test_checkpoint.py
+++ b/test/distributed/_shard/checkpoint/test_checkpoint.py
@@ -111,6 +111,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
     def test_default_metadata(self) -> None:
+        device = f"cuda:{dist.get_rank()}"
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
@@ -121,7 +122,7 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
 
         state_dict = {
             'sharded': sharded_tensor.rand(spec, (10, 10, )),
-            'replicated': torch.rand(4, device="cpu"),
+            'replicated': torch.rand(4, device=device),
             'bytes': [1, 2, 3, 4],
         }
 

--- a/test/distributed/_shard/checkpoint/test_checkpoint.py
+++ b/test/distributed/_shard/checkpoint/test_checkpoint.py
@@ -1,8 +1,9 @@
 # Owner(s): ["oncall: distributed"]
 
-import random
 import sys
-from typing import Optional, List, Union, cast
+from typing import Optional, List, cast
+from torch.distributed._shard.checkpoint.storage import WriteResult
+
 from torch.distributed._shard.checkpoint import (
     StorageReader,
     StorageWriter,
@@ -16,26 +17,24 @@ import torch.distributed as dist
 import torch.nn
 import torch.futures
 from torch.futures import Future
-from torch.testing._internal.common_utils import TestCase
-
-from torch.distributed._shard.checkpoint.resharding import (
-    _prepare_sharded_tensor_write,
-    _create_storage_key
-)
 
 from torch.distributed._shard import sharded_tensor
 
-from torch.distributed._shard.checkpoint.state_dict_saver import (
-    _prepare,
+from torch.distributed._shard.checkpoint.resharding import (
+    create_default_local_metadata,
 )
 
 from torch.distributed._shard.checkpoint.metadata import (
+    BytesStorageMetadata,
     Metadata,
-    BytesReadRequest,
-    BytesWriteRequest,
-    MetadataIndex,
-    TensorReadRequest,
-    TensorWriteRequest,
+    TensorStorageMetadata,
+)
+
+from torch.distributed._shard.checkpoint.planner import (
+    SavePlan,
+    SavePlanner,
+    LoadPlan,
+    LoadPlanner,
 )
 
 from torch.distributed._shard.sharded_tensor import (
@@ -89,17 +88,6 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
     def world_size(self) -> int:
         return 2
 
-    def gen_metadata(self) -> Metadata:
-        module = TestModule()
-        # compute the default saved metadata (must pass include_non_replicated_tensors or we'll get incomplete MD)
-        metadata, _, _ = _prepare(module.state_dict(), True)
-
-        # _prepare only produc
-        metadata = [metadata]
-        dist.broadcast_object_list(metadata)
-
-        return metadata[0]
-
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
@@ -114,72 +102,46 @@ class TestDistributedCheckpointing(ShardedTensorTestBase):
         st = sharded_tensor.zeros(spec, 4, 4, dtype=torch.float64)
         mapping = dict()
 
-        (_, md, storage_md) = _prepare_sharded_tensor_write("fqn", st, "tensor", mapping)
+        md = create_default_local_metadata({"st": st})
 
-        self.assertEqual(1, len(storage_md))
-        self.assertEqual(1, len(mapping))
+        st_md = md.state_dict_metadata["st"]
+        self.assertEqual(1, len(st_md.chunks))
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(2)
     @requires_nccl()
-    def test_storage_key_mapping(self) -> None:
-        device = f"cuda:{dist.get_rank()}"
+    def test_default_metadata(self) -> None:
         spec = ChunkShardingSpec(
             dim=0,
             placements=[
-                "rank:0/cuda:0",
                 "rank:1/cuda:1",
+                "rank:0/cuda:0",
             ],
         )
 
         state_dict = {
             'sharded': sharded_tensor.rand(spec, (10, 10, )),
-            'replicated': torch.rand(4, device=device),
+            'replicated': torch.rand(4, device="cpu"),
             'bytes': [1, 2, 3, 4],
         }
 
-        metadata, bytes_reqs, tensor_reqs = _prepare(state_dict, write_replicated_data=self.rank == 0)
+        metadata = create_default_local_metadata(state_dict)
+        self.assertTrue('bytes' in metadata.state_dict_metadata)
+        self.assertIsInstance(metadata.state_dict_metadata['bytes'], BytesStorageMetadata)
 
-        if self.rank == 0:
-            self.assertEqual(1, len(bytes_reqs))
-            self.assertEqual(2, len(tensor_reqs))
+        self.assertTrue('replicated' in metadata.state_dict_metadata)
+        self.assertIsInstance(metadata.state_dict_metadata['replicated'], TensorStorageMetadata)
+        md = metadata.state_dict_metadata['replicated']
+        self.assertEqual(md.size, state_dict['replicated'].size())
+        self.assertEqual(md.properties.dtype, torch.float32)
+        self.assertEqual(1, len(md.chunks))
 
-            self.assertTrue('bytes' in metadata.state_dict_metadata)
-            self.assertTrue(MetadataIndex('bytes') in metadata.storage_data)
-
-            # tensor ordering is unspecified
-            if len(tensor_reqs[0].tensor.size()) == 1:
-                replicated = tensor_reqs[0]
-                shard = tensor_reqs[1]
-            else:
-                replicated = tensor_reqs[1]
-                shard = tensor_reqs[0]
-
-            self.assertTrue('replicated' in metadata.state_dict_metadata)
-            storage_key = MetadataIndex('replicated', torch.Size([0]))
-            self.assertTrue(storage_key in metadata.storage_data)
-            self.assertTrue(metadata.storage_data[storage_key], replicated.storage_key)
-        else:
-            self.assertEqual(0, len(bytes_reqs))
-            self.assertEqual(1, len(tensor_reqs))
-            shard = tensor_reqs[0]
-            local_shard = state_dict["sharded"].local_shards()[0]
-
-            self.assertTrue('sharded' in metadata.state_dict_metadata)
-            storage_key = MetadataIndex('sharded', torch.Size(local_shard.metadata.shard_offsets))
-            self.assertTrue(storage_key in metadata.storage_data)
-            self.assertTrue(metadata.storage_data[storage_key], shard.storage_key)
-
-
-class TestStorageKeys(TestCase):
-    def test_create_key_handles_collision(self):
-        keys = dict()
-        key0 = _create_storage_key(keys, "foo")
-        key1 = _create_storage_key(keys, "foo")
-        self.assertNotEqual(key0, key1)
-
-
-
+        self.assertTrue('sharded' in metadata.state_dict_metadata)
+        self.assertIsInstance(metadata.state_dict_metadata['sharded'], TensorStorageMetadata)
+        md = metadata.state_dict_metadata['sharded']
+        self.assertEqual(md.properties.dtype, torch.float32)
+        self.assertEqual(md.size, state_dict['sharded'].size())
+        self.assertEqual(2, len(md.chunks))
 
 class TestStorageBase:
     def __init__(
@@ -197,15 +159,14 @@ class TestStorageBase:
         if ranks is not None and self.rank in ranks:
             raise ValueError(f"rank fail {self.rank} for {name}")
 
-    def _fail_rank_async(self, name):
+    def _fail_rank_async(self, name, result=None):
         ranks = self._get_ranks(name)
         fut = Future()
         if ranks is not None and self.rank in ranks:
             fut.set_exception(ValueError(f"async rank fail {self.rank} for {name}"))
         else:
-            fut.set_result(None)
+            fut.set_result(result)
         return fut
-
 
 class FaultyStorageWriter(TestStorageBase, StorageWriter):
     def __init__(
@@ -214,22 +175,28 @@ class FaultyStorageWriter(TestStorageBase, StorageWriter):
     ):
         super(FaultyStorageWriter, self).__init__(fail_conf)
 
-    def prepare(self) -> None:
-        self._fail_rank("fail_prepare")
+    def init(self, is_coordinator: bool) -> None:
+        self._fail_rank("fail_init")
 
-    def write_bytes(self, requests: List[BytesWriteRequest]) -> Future[None]:
-        self._fail_rank("fail_write_bytes_on_ranks")
-        return self._fail_rank_async("fail_write_bytes_on_ranks_async")
+    def prepare_local_plan(self, plan: SavePlan) -> SavePlan:
+        self._fail_rank("fail_prepare_local_plan")
+        return plan
 
-    def write_tensors(self, requests: List[TensorWriteRequest]) -> Future[None]:
-        self._fail_rank("fail_write_tensors_on_ranks")
-        return self._fail_rank_async("fail_write_tensors_on_ranks_async")
+    def prepare_global_plan(self, plans: List[SavePlan]) -> List[SavePlan]:
+        self._fail_rank("fail_prepare_global_plan")
+        return plans
 
-    def finish(self, metadata: Metadata) -> None:
+    def write_data(
+        self,
+        plan: SavePlan,
+        planner: SavePlanner
+    ) -> Future[List[WriteResult]]:
+        self._fail_rank("fail_write_data")
+        return self._fail_rank_async("fail_write_data_async", [])
+
+    def finish(self, metadata: Metadata, results: List[List[WriteResult]]) -> None:
         self._fail_rank("fail_finish")
 
-    def prepare_storage(self, storage_writes: List[Union[TensorWriteRequest, BytesWriteRequest]]) -> None:
-        self._fail_rank("fail_prepare_storage")
 
 class FaultyStorageReader(TestStorageBase, StorageReader):
     def __init__(
@@ -240,22 +207,24 @@ class FaultyStorageReader(TestStorageBase, StorageReader):
         super(FaultyStorageReader, self).__init__(fail_conf)
         self.metadata = metadata
 
-    def read_bytes(self, requests: List[BytesReadRequest]) -> Future[None]:
-        self._fail_rank("fail_read_bytes")
-        bad_ranks = self._get_ranks("fail_deser_bytes")
-        for r in requests:
-            if bad_ranks is not None and self.rank in bad_ranks:
-                # this is not "guaranteed" to fail, but hard to beat
-                rand = random.Random(1237)
-                r.bytes.write(rand.randbytes(32))
-            else:
-                torch.save([1, 2, 3], r.bytes)
+    def init(self, metadata: Metadata, is_coordinator: bool) -> None:
+        self._fail_rank("fail_init")
 
-        return self._fail_rank_async("fail_read_bytes_async")
+    def prepare_local_plan(self, plan: LoadPlan) -> LoadPlan:
+        self._fail_rank("fail_prepare_local_plan")
+        return plan
 
-    def read_tensors(self, requests: List[TensorReadRequest]) -> Future[None]:
-        self._fail_rank("fail_read_tensors")
-        return self._fail_rank_async("fail_read_tensors_async")
+    def prepare_global_plan(self, plans: List[LoadPlan]) -> List[LoadPlan]:
+        self._fail_rank("fail_prepare_global_plan")
+        return plans
+
+    def read_data(
+        self,
+        plan: LoadPlan,
+        planner: LoadPlanner
+    ) -> Future[None]:
+        self._fail_rank("fail_read_data")
+        return self._fail_rank_async("fail_read_data_async")
 
     def read_metadata(self) -> Metadata:
         self._fail_rank("fail_read_metadata")
@@ -282,6 +251,18 @@ class TestDistributedFailure(ShardedTensorTestBase):
 
         save_state_dict(state_dict, FaultyStorageWriter({}))
 
+    @with_comms(init_rpc=False)
+    @skip_if_lt_x_gpu(2)
+    @requires_nccl()
+    def test_dummy_reader_works(self) -> None:
+        state_dict = {
+            'sharded': sharded_tensor.rand(self.get_spec(), 20, 20),
+            'replicated': torch.rand(10, 10),
+            'bytes': [1, 2, 3, 4]
+        }
+        metadata = create_default_local_metadata(state_dict)
+
+        load_state_dict(state_dict, FaultyStorageReader(metadata, {}))
 
     def _test_dist_failure(self, callback, kwargs):
         bad_ranks = list(kwargs.values())[0] if len(kwargs) > 0 else []
@@ -318,10 +299,9 @@ class TestDistributedFailure(ShardedTensorTestBase):
 
     def _test_load(self, state_dict, coordinator=0, **kwargs):
         no_dist = not dist.is_initialized()
-        write_replicated = dist.is_initialized() and dist.get_rank() == coordinator
 
         def _load():
-            metadata, _, _ = _prepare(state_dict, write_replicated)
+            metadata = create_default_local_metadata(state_dict)
             load_state_dict(
                 state_dict,
                 storage_reader=FaultyStorageReader(metadata, kwargs),
@@ -341,20 +321,16 @@ class TestDistributedFailure(ShardedTensorTestBase):
             'bytes': [1, 2, 3, 4]
         }
 
-        self._test_save(state_dict, fail_prepare=[0])
+        self._test_save(state_dict, fail_init=[0])
         self._test_save(state_dict, fail_finish=[0])
+        self._test_save(state_dict, fail_prepare_global_plan=[0])
 
-        self._test_save(state_dict, fail_prepare_storage=[0])
-        self._test_save(state_dict, fail_write_tensors_on_ranks=[1])
-        self._test_save(state_dict, fail_write_tensors_on_ranks_async=[2])
-        self._test_save(state_dict, fail_write_bytes_on_ranks=[3])
-        self._test_save(state_dict, fail_write_bytes_on_ranks_async=[1])
+        self._test_save(state_dict, fail_prepare_local_plan=[0])
+        self._test_save(state_dict, fail_write_data=[2])
+        self._test_save(state_dict, fail_write_data_async=[3])
 
-        self._test_save(state_dict, fail_write_tensors_on_ranks_async=[1, 3])
-
-        self._test_save(state_dict, coordinator=1, fail_prepare=[1])
+        self._test_save(state_dict, coordinator=1, fail_init=[1])
         self._test_save(state_dict, coordinator=1, fail_finish=[1])
-
 
     def test_save_error_handling_no_dist(self) -> None:
         state_dict = {
@@ -364,14 +340,13 @@ class TestDistributedFailure(ShardedTensorTestBase):
 
         self.assertFalse(dist.is_initialized())
 
-        self._test_save(state_dict, fail_prepare=[0])
+        self._test_save(state_dict, fail_init=[0])
         self._test_save(state_dict, fail_finish=[0])
+        self._test_save(state_dict, fail_prepare_global_plan=[0])
 
-        self._test_save(state_dict, fail_prepare_storage=[0])
-        self._test_save(state_dict, fail_write_tensors_on_ranks=[0])
-        self._test_save(state_dict, fail_write_tensors_on_ranks_async=[0])
-        self._test_save(state_dict, fail_write_bytes_on_ranks=[0])
-        self._test_save(state_dict, fail_write_bytes_on_ranks_async=[0])
+        self._test_save(state_dict, fail_prepare_local_plan=[0])
+        self._test_save(state_dict, fail_write_data=[0])
+        self._test_save(state_dict, fail_write_data_async=[0])
 
     @with_comms(init_rpc=False)
     @skip_if_lt_x_gpu(4)
@@ -384,17 +359,18 @@ class TestDistributedFailure(ShardedTensorTestBase):
         }
 
         self._test_load(state_dict)
+        self._test_load(state_dict, fail_init=[0])
+        self._test_load(state_dict, fail_prepare_global_plan=[0])
         self._test_load(state_dict, fail_read_metadata=[0])
-        self._test_load(state_dict, fail_read_bytes=[1])
-        self._test_load(state_dict, fail_read_bytes_async=[2])
-        self._test_load(state_dict, fail_read_tensors=[3])
-        self._test_load(state_dict, fail_read_tensors_async=[1])
-        # We don't want to depend on the actual exception raised by pickle
-        self._test_load(state_dict, fail_deser_bytes=[2], ignore_exception_type=True)
+        self._test_load(state_dict, fail_prepare_local_plan=[1])
+        self._test_load(state_dict, fail_read_data=[3])
+        self._test_load(state_dict, fail_read_data_async=[1])
 
+        self._test_load(state_dict, coordinator=3, fail_init=[0])
         self._test_load(state_dict, coordinator=1, fail_read_metadata=[3])
-        self._test_load(state_dict, coordinator=2, fail_read_bytes=[0])
-        self._test_load(state_dict, coordinator=3, fail_read_tensors_async=[2])
+        self._test_load(state_dict, coordinator=2, fail_read_data=[0])
+        self._test_load(state_dict, coordinator=3, fail_read_data_async=[2])
+        self._test_load(state_dict, coordinator=1, fail_prepare_global_plan=[1])
 
 
     def test_load_error_handling_no_dist(self) -> None:
@@ -403,11 +379,12 @@ class TestDistributedFailure(ShardedTensorTestBase):
             'bytes': [1, 2, 3, 4]
         }
         self._test_load(state_dict)
+        self._test_load(state_dict, fail_init=[0])
         self._test_load(state_dict, fail_read_metadata=[0])
-        self._test_load(state_dict, fail_read_bytes=[0])
-        self._test_load(state_dict, fail_read_bytes_async=[0])
-        self._test_load(state_dict, fail_read_tensors=[0])
-        self._test_load(state_dict, fail_read_tensors_async=[0])
-        self._test_load(state_dict, fail_deser_bytes=[0], ignore_exception_type=True)
+        self._test_load(state_dict, fail_prepare_local_plan=[0])
+        self._test_load(state_dict, fail_prepare_global_plan=[0])
+        self._test_load(state_dict, fail_read_data=[0])
+        self._test_load(state_dict, fail_read_data_async=[0])
+
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_shard/checkpoint/test_file_system_checkpoint.py
+++ b/test/distributed/_shard/checkpoint/test_file_system_checkpoint.py
@@ -1,6 +1,5 @@
 # Owner(s): ["oncall: distributed"]
 
-import sys
 import os
 import shutil
 import tempfile
@@ -106,6 +105,23 @@ class TestDistributedStateDictSaveLoad(TestCase):
             state_dict_to_save = MyTestModule().state_dict()
 
             fs_writer = FileSystemWriter(path=path)
+            save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer, no_dist=True)
+
+            state_dict_to_load_to = MyTestModule().state_dict()
+
+            with self.assertRaises(AssertionError):
+                assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
+
+            # Load from file without any resharding
+            fs_reader = FileSystemReader(path=path)
+            load_state_dict(state_dict=state_dict_to_load_to, storage_reader=fs_reader, no_dist=True)
+
+            assert_state_dict_equal(self, state_dict_to_load_to, state_dict_to_save)
+
+        with tempfile.TemporaryDirectory() as path:
+            state_dict_to_save = MyTestModule().state_dict()
+
+            fs_writer = FileSystemWriter(path=path, single_file_per_rank=True)
             save_state_dict(state_dict=state_dict_to_save, storage_writer=fs_writer, no_dist=True)
 
             state_dict_to_load_to = MyTestModule().state_dict()

--- a/test/distributed/_shard/checkpoint/test_planner.py
+++ b/test/distributed/_shard/checkpoint/test_planner.py
@@ -1,9 +1,10 @@
 # Owner(s): ["oncall: distributed"]
 
+from re import S
 import sys
 
 import torch
-from torch.distributed._shard.checkpoint.planner import WriteItemType
+from torch.distributed._shard.checkpoint.planner import LoadItemType, WriteItemType
 
 from torch.distributed._shard.sharded_tensor import (
     Shard,
@@ -18,7 +19,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
     run_tests,
 )
-from torch.distributed._shard.checkpoint.metadata import MetadataIndex
+from torch.distributed._shard.checkpoint.metadata import BytesStorageMetadata, MetadataIndex, TensorStorageMetadata
 from torch.testing._internal.distributed.distributed_utils import (
     with_fake_comms,
     with_dist
@@ -28,6 +29,7 @@ from torch.distributed._shard.checkpoint.resharding import (
     create_default_global_save_plan,
     create_default_local_save_plan,
     create_default_local_load_plan,
+    create_default_local_metadata
 )
 
 if TEST_WITH_DEV_DBG_ASAN:
@@ -37,12 +39,12 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
-def create_sharded_tensor(rank, world_size, shards_per_rank):
+def create_sharded_tensor(rank, world_size, shards_per_rank, shard_size=8):
     shards_metadata = []
     local_shards = []
     for idx in range(0, world_size * shards_per_rank):
         shard_rank = idx // shards_per_rank
-        shard_md = ShardMetadata(shard_offsets=[idx * 8], shard_sizes=[8], placement=f"rank:{shard_rank}/cpu")
+        shard_md = ShardMetadata(shard_offsets=[idx * shard_size], shard_sizes=[shard_size], placement=f"rank:{shard_rank}/cpu")
         shards_metadata.append(shard_md)
         if shard_rank == rank:
             shard = Shard.from_tensor_and_offsets(
@@ -54,7 +56,7 @@ def create_sharded_tensor(rank, world_size, shards_per_rank):
 
     sharded_tensor_md = ShardedTensorMetadata(
         shards_metadata=shards_metadata,
-        size=torch.Size([8 * len(shards_metadata)]),
+        size=torch.Size([shard_size * len(shards_metadata)]),
         tensor_properties=TensorProperties.create_from_tensor(torch.zeros(1))
     )
 
@@ -84,7 +86,6 @@ class TestSavePlan(TestCase):
         self.assertEqual(wi.tensor_data.properties, TensorProperties.create_from_tensor(torch.zeros(1)))
         self.assertEqual(wi.tensor_data.chunk.offsets, torch.Size([8]))
         self.assertEqual(wi.tensor_data.chunk.sizes, torch.Size([8]))
-        self.assertEqual(wi.tensor_data.chunk.size_in_bytes, -1)
 
         # Coordinator rank, should include replicated items as well
         plan = create_default_local_save_plan(state_dict, True)
@@ -96,7 +97,6 @@ class TestSavePlan(TestCase):
         self.assertEqual(tensor_wi.tensor_data.properties, TensorProperties.create_from_tensor(tensor))
         self.assertEqual(tensor_wi.tensor_data.chunk.offsets, torch.Size([0]))
         self.assertEqual(tensor_wi.tensor_data.chunk.sizes, torch.Size([10]))
-        self.assertEqual(tensor_wi.tensor_data.chunk.size_in_bytes, -1)
 
         bytes_wi = next(wi for wi in plan.items if wi.type == WriteItemType.BYTE_IO)
         self.assertEqual(bytes_wi.index, MetadataIndex("value"))
@@ -117,21 +117,153 @@ class TestSavePlan(TestCase):
 
         all_plans = [create_data(0), create_data(1), create_data(2), create_data(3)]
         final_plans, metadata = create_default_global_save_plan(all_plans=all_plans)
+        #the default global plan updates all indexes to include hints
+        for new_plan, old_plan in zip(final_plans, all_plans):
+            for new_item, old_item in zip(new_plan.items, old_plan.items):
+                self.assertEqual(new_item.index, old_item.index)
+                self.assertEqual(new_item.type, old_item.type)
+                self.assertEqual(new_item.tensor_data, old_item.tensor_data)
+                self.assertIn(new_item.index.fqn, metadata.state_dict_metadata)
+
+                item_md = metadata.state_dict_metadata[new_item.index.fqn]
+                if new_item.type == WriteItemType.BYTE_IO:
+                    self.assertTrue(isinstance(item_md, BytesStorageMetadata))
+                else:
+                    self.assertTrue(isinstance(item_md, TensorStorageMetadata))
+                    self.assertEqual(item_md.size, old_item.tensor_data.size)
+                    self.assertEqual(item_md.properties, old_item.tensor_data.properties)
+
+                    self.assertIsNotNone(new_item.index.index)
+                    #make sure the hint is correct
+                    self.assertEqual(item_md.chunks[new_item.index.index], old_item.tensor_data.chunk)
+
+    def test_local_load_plan(self):
+        def create_state_dict(rank):
+            with with_dist(rank=rank, world_size=4):
+                tensor = torch.rand(10)
+                val = [1, 2, 3]
+                st = create_sharded_tensor(rank=rank, world_size=4, shards_per_rank=1)
+                return {
+                    "tensor": tensor,
+                    "value": val,
+                    "st": st
+                }
+
+        state_dict = create_state_dict(1)
+        metadata = create_default_local_metadata(state_dict)
+
+        load_plan = create_default_local_load_plan(state_dict, metadata)
+        #This will create 3 entries
+        self.assertEqual(3, len(load_plan.items))
+        st_item = next(ri for ri in load_plan.items if ri.dest_index.fqn == "st")
+        tensor_item = next(ri for ri in load_plan.items if ri.dest_index.fqn == "tensor")
+        bytes_item = next(ri for ri in load_plan.items if ri.dest_index.fqn == "value")
+
+        self.assertEqual(st_item.type, LoadItemType.TENSOR)
+        # this is an exact copy 
+        self.assertEqual(st_item.dest_index, MetadataIndex("st", [8]))
+        self.assertEqual(st_item.dest_offsets, torch.Size([0]))
+        self.assertEqual(st_item.storage_index, MetadataIndex("st", [8]))
+        self.assertEqual(st_item.storage_offsets, torch.Size([0]))
+        self.assertEqual(st_item.lengths, torch.Size([8]))
+
+        self.assertEqual(tensor_item.type, LoadItemType.TENSOR)
+        self.assertEqual(tensor_item.dest_index, MetadataIndex("tensor", [0]))
+        self.assertEqual(tensor_item.dest_offsets, torch.Size([0]))
+        self.assertEqual(tensor_item.storage_index, MetadataIndex("tensor", [0]))
+        self.assertEqual(tensor_item.storage_offsets, torch.Size([0]))
+        self.assertEqual(tensor_item.lengths, torch.Size([10]))
+
+        self.assertEqual(bytes_item.type, LoadItemType.BYTE_IO)
+        self.assertEqual(bytes_item.dest_index, MetadataIndex("value"))
+
+    def test_load_with_resharding(self):
+        def create_state_dict(rank, world_size):
+            with with_dist(rank=rank, world_size=world_size):
+                return {
+                    "st": create_sharded_tensor(
+                        rank=rank,
+                        world_size=world_size,
+                        shards_per_rank=1,
+                        shard_size=128 // world_size,
+                    )
+                }
 
 
-"""
-I want tests for the following functionality:
+        # rank 1 has a 16 bytes shard from [16, 32[
+        world8_state_dict = create_state_dict(rank=1, world_size=8)
+        world8_metadata = create_default_local_metadata(world8_state_dict)
 
-create_default_global_save_plan
-create_default_local_save_plan
-create_default_local_load_plan
+        # rank 1 has a 32 bytes shard from [32, 64[
+        world4_state_dict = create_state_dict(rank=1, world_size=4)
+        world4_metadata = create_default_local_metadata(world4_state_dict)
 
-No need to test the default planners TBH.
+        #First scenario, going from world=8 to world=4, need to load 2 shards
+        # each 4-world shard has 32 elements, so it needs to load 2 shards
+        load_plan = create_default_local_load_plan(world4_state_dict, world8_metadata)
+        self.assertEqual(2, len(load_plan.items))
+        low_ri = next(ri for ri in load_plan.items if ri.dest_offsets == torch.Size([0]))
+        high_ri = next(ri for ri in load_plan.items if ri.dest_offsets == torch.Size([16]))
 
-The main complication I want in testing is resharding
-"""
+        self.assertEqual(low_ri.storage_index, MetadataIndex("st", [32]))
+        self.assertEqual(low_ri.storage_offsets, torch.Size([0]))
+        self.assertEqual(low_ri.dest_index, MetadataIndex("st", [32]))
+        self.assertEqual(low_ri.dest_offsets, torch.Size([0]))
+        self.assertEqual(low_ri.lengths, torch.Size([16]))
 
+        self.assertEqual(high_ri.storage_index, MetadataIndex("st", [48]))
+        self.assertEqual(high_ri.storage_offsets, torch.Size([0]))
+        self.assertEqual(high_ri.dest_index, MetadataIndex("st", [32]))
+        self.assertEqual(high_ri.dest_offsets, torch.Size([16]))
+        self.assertEqual(high_ri.lengths, torch.Size([16]))
 
+        # Second scenario, going from world=4 to world=8, need to load half of 1 shard
+        # rank1 on 8-world needs to load the upper half of the rank0 4-world shard
+        load_plan = create_default_local_load_plan(world8_state_dict, world4_metadata)
+        self.assertEqual(1, len(load_plan.items))
+        ri = load_plan.items[0]
+        self.assertEqual(ri.storage_index, MetadataIndex("st", [0]))
+        self.assertEqual(ri.storage_offsets, torch.Size([16]))
+        self.assertEqual(ri.dest_index, MetadataIndex("st", [16]))
+        self.assertEqual(ri.dest_offsets, torch.Size([0]))
+        self.assertEqual(ri.lengths, torch.Size([16]))
+
+    def test_load_with_world_size_diff_by_one(self):
+        def create_state_dict(rank, world_size):
+            with with_dist(rank=rank, world_size=world_size):
+                return {
+                    "st": create_sharded_tensor(
+                        rank=rank,
+                        world_size=world_size,
+                        shards_per_rank=1,
+                        shard_size=120 // world_size,
+                    )
+                }
+        # rank 1 has a 30 bytes shard from [30, 60[
+        world4_state_dict = create_state_dict(rank=1, world_size=4)
+        world4_metadata = create_default_local_metadata(world4_state_dict)
+
+        # rank 1 has a 40 bytes shard from [40, 80[
+        world3_state_dict = create_state_dict(rank=1, world_size=3)
+
+        load_plan = create_default_local_load_plan(world3_state_dict, world4_metadata)
+        self.assertEqual(2, len(load_plan.items))
+        # this is [30, 60] to load [40, 60] 
+        low_ri = next(ri for ri in load_plan.items if ri.dest_offsets == torch.Size([0]))
+        # this is [60, 90] to load [60, 80] 
+        high_ri = next(ri for ri in load_plan.items if ri.dest_offsets == torch.Size([20]))
+
+        self.assertEqual(low_ri.storage_index, MetadataIndex("st", [30]))
+        self.assertEqual(low_ri.storage_offsets, torch.Size([10]))
+        self.assertEqual(low_ri.dest_index, MetadataIndex("st", [40]))
+        self.assertEqual(low_ri.dest_offsets, torch.Size([0]))
+        self.assertEqual(low_ri.lengths, torch.Size([20]))
+
+        self.assertEqual(high_ri.storage_index, MetadataIndex("st", [60]))
+        self.assertEqual(high_ri.storage_offsets, torch.Size([0]))
+        self.assertEqual(high_ri.dest_index, MetadataIndex("st", [40]))
+        self.assertEqual(high_ri.dest_offsets, torch.Size([20]))
+        self.assertEqual(high_ri.lengths, torch.Size([20]))
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/_shard/checkpoint/test_planner.py
+++ b/test/distributed/_shard/checkpoint/test_planner.py
@@ -1,6 +1,5 @@
 # Owner(s): ["oncall: distributed"]
 
-from re import S
 import sys
 
 import torch
@@ -117,7 +116,7 @@ class TestSavePlan(TestCase):
 
         all_plans = [create_data(0), create_data(1), create_data(2), create_data(3)]
         final_plans, metadata = create_default_global_save_plan(all_plans=all_plans)
-        #the default global plan updates all indexes to include hints
+        # The default global plan updates all indexes to include hints
         for new_plan, old_plan in zip(final_plans, all_plans):
             for new_item, old_item in zip(new_plan.items, old_plan.items):
                 self.assertEqual(new_item.index, old_item.index)
@@ -134,7 +133,7 @@ class TestSavePlan(TestCase):
                     self.assertEqual(item_md.properties, old_item.tensor_data.properties)
 
                     self.assertIsNotNone(new_item.index.index)
-                    #make sure the hint is correct
+                    # Make sure the hint is correct
                     self.assertEqual(item_md.chunks[new_item.index.index], old_item.tensor_data.chunk)
 
     def test_local_load_plan(self):
@@ -153,14 +152,14 @@ class TestSavePlan(TestCase):
         metadata = create_default_local_metadata(state_dict)
 
         load_plan = create_default_local_load_plan(state_dict, metadata)
-        #This will create 3 entries
+        # This will create 3 entries
         self.assertEqual(3, len(load_plan.items))
         st_item = next(ri for ri in load_plan.items if ri.dest_index.fqn == "st")
         tensor_item = next(ri for ri in load_plan.items if ri.dest_index.fqn == "tensor")
         bytes_item = next(ri for ri in load_plan.items if ri.dest_index.fqn == "value")
 
         self.assertEqual(st_item.type, LoadItemType.TENSOR)
-        # this is an exact copy 
+        # This is an exact copy
         self.assertEqual(st_item.dest_index, MetadataIndex("st", [8]))
         self.assertEqual(st_item.dest_offsets, torch.Size([0]))
         self.assertEqual(st_item.storage_index, MetadataIndex("st", [8]))
@@ -190,16 +189,16 @@ class TestSavePlan(TestCase):
                 }
 
 
-        # rank 1 has a 16 bytes shard from [16, 32[
+        # Rank 1 has a 16 bytes shard from [16, 32[
         world8_state_dict = create_state_dict(rank=1, world_size=8)
         world8_metadata = create_default_local_metadata(world8_state_dict)
 
-        # rank 1 has a 32 bytes shard from [32, 64[
+        # Rank 1 has a 32 bytes shard from [32, 64[
         world4_state_dict = create_state_dict(rank=1, world_size=4)
         world4_metadata = create_default_local_metadata(world4_state_dict)
 
-        #First scenario, going from world=8 to world=4, need to load 2 shards
-        # each 4-world shard has 32 elements, so it needs to load 2 shards
+        # First scenario, going from world=8 to world=4, need to load 2 shards
+        # Each 4-world shard has 32 elements, so it needs to load 2 shards
         load_plan = create_default_local_load_plan(world4_state_dict, world8_metadata)
         self.assertEqual(2, len(load_plan.items))
         low_ri = next(ri for ri in load_plan.items if ri.dest_offsets == torch.Size([0]))
@@ -248,9 +247,9 @@ class TestSavePlan(TestCase):
 
         load_plan = create_default_local_load_plan(world3_state_dict, world4_metadata)
         self.assertEqual(2, len(load_plan.items))
-        # this is [30, 60] to load [40, 60] 
+        # this is [30, 60] to load [40, 60]
         low_ri = next(ri for ri in load_plan.items if ri.dest_offsets == torch.Size([0]))
-        # this is [60, 90] to load [60, 80] 
+        # this is [60, 90] to load [60, 80]
         high_ri = next(ri for ri in load_plan.items if ri.dest_offsets == torch.Size([20]))
 
         self.assertEqual(low_ri.storage_index, MetadataIndex("st", [30]))

--- a/test/distributed/_shard/checkpoint/test_planner.py
+++ b/test/distributed/_shard/checkpoint/test_planner.py
@@ -1,0 +1,137 @@
+# Owner(s): ["oncall: distributed"]
+
+import sys
+
+import torch
+from torch.distributed._shard.checkpoint.planner import WriteItemType
+
+from torch.distributed._shard.sharded_tensor import (
+    Shard,
+    ShardMetadata,
+    ShardedTensor,
+    ShardedTensorMetadata,
+)
+from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
+
+from torch.testing._internal.common_utils import (
+    TestCase,
+    TEST_WITH_DEV_DBG_ASAN,
+    run_tests,
+)
+from torch.distributed._shard.checkpoint.metadata import MetadataIndex
+from torch.testing._internal.distributed.distributed_utils import (
+    with_fake_comms,
+    with_dist
+)
+
+from torch.distributed._shard.checkpoint.resharding import (
+    create_default_global_save_plan,
+    create_default_local_save_plan,
+    create_default_local_load_plan,
+)
+
+if TEST_WITH_DEV_DBG_ASAN:
+    print(
+        "Skip dev-asan as torch + multiprocessing spawn have known issues",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+def create_sharded_tensor(rank, world_size, shards_per_rank):
+    shards_metadata = []
+    local_shards = []
+    for idx in range(0, world_size * shards_per_rank):
+        shard_rank = idx // shards_per_rank
+        shard_md = ShardMetadata(shard_offsets=[idx * 8], shard_sizes=[8], placement=f"rank:{shard_rank}/cpu")
+        shards_metadata.append(shard_md)
+        if shard_rank == rank:
+            shard = Shard.from_tensor_and_offsets(
+                torch.rand(*shard_md.shard_sizes),
+                shard_offsets=shard_md.shard_offsets,
+                rank=rank
+            )
+            local_shards.append(shard)
+
+    sharded_tensor_md = ShardedTensorMetadata(
+        shards_metadata=shards_metadata,
+        size=torch.Size([8 * len(shards_metadata)]),
+        tensor_properties=TensorProperties.create_from_tensor(torch.zeros(1))
+    )
+
+    return ShardedTensor._init_from_local_shards_and_global_metadata(
+        local_shards=local_shards,
+        sharded_tensor_metadata=sharded_tensor_md
+    )
+
+
+class TestSavePlan(TestCase):
+    @with_fake_comms(rank=1, world_size=4)
+    def test_local_plan(self):
+        tensor = torch.rand(10)
+        val = [1, 2, 3]
+        st = create_sharded_tensor(rank=1, world_size=4, shards_per_rank=1)
+        state_dict = {
+            "tensor": tensor,
+            "value": val,
+            "st": st
+        }
+        plan = create_default_local_save_plan(state_dict, False)
+        self.assertEqual(1, len(plan.items))
+        wi = plan.items[0]
+        self.assertEqual(wi.index, MetadataIndex("st", [8]))
+        self.assertEqual(wi.type, WriteItemType.SHARD)
+        self.assertEqual(wi.tensor_data.size, st.size())
+        self.assertEqual(wi.tensor_data.properties, TensorProperties.create_from_tensor(torch.zeros(1)))
+        self.assertEqual(wi.tensor_data.chunk.offsets, torch.Size([8]))
+        self.assertEqual(wi.tensor_data.chunk.sizes, torch.Size([8]))
+        self.assertEqual(wi.tensor_data.chunk.size_in_bytes, -1)
+
+        # Coordinator rank, should include replicated items as well
+        plan = create_default_local_save_plan(state_dict, True)
+        self.assertEqual(3, len(plan.items))
+
+        tensor_wi = next(wi for wi in plan.items if wi.type == WriteItemType.TENSOR)
+        self.assertEqual(tensor_wi.index, MetadataIndex("tensor", [0]))
+        self.assertEqual(tensor_wi.tensor_data.size, tensor.size())
+        self.assertEqual(tensor_wi.tensor_data.properties, TensorProperties.create_from_tensor(tensor))
+        self.assertEqual(tensor_wi.tensor_data.chunk.offsets, torch.Size([0]))
+        self.assertEqual(tensor_wi.tensor_data.chunk.sizes, torch.Size([10]))
+        self.assertEqual(tensor_wi.tensor_data.chunk.size_in_bytes, -1)
+
+        bytes_wi = next(wi for wi in plan.items if wi.type == WriteItemType.BYTE_IO)
+        self.assertEqual(bytes_wi.index, MetadataIndex("value"))
+        self.assertIsNone(bytes_wi.tensor_data)
+
+    def test_global_plan(self):
+        def create_data(rank):
+            with with_dist(rank=rank, world_size=4):
+                tensor = torch.rand(10)
+                val = [1, 2, 3]
+                st = create_sharded_tensor(rank=rank, world_size=4, shards_per_rank=1)
+                state_dict = {
+                    "tensor": tensor,
+                    "value": val,
+                    "st": st
+                }
+                return create_default_local_save_plan(state_dict, rank == 0)
+
+        all_plans = [create_data(0), create_data(1), create_data(2), create_data(3)]
+        final_plans, metadata = create_default_global_save_plan(all_plans=all_plans)
+
+
+"""
+I want tests for the following functionality:
+
+create_default_global_save_plan
+create_default_local_save_plan
+create_default_local_load_plan
+
+No need to test the default planners TBH.
+
+The main complication I want in testing is resharding
+"""
+
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/_shard/checkpoint/test_utils.py
+++ b/test/distributed/_shard/checkpoint/test_utils.py
@@ -81,6 +81,8 @@ class TestMedatadaIndex(TestCase):
 
         a = find_state_dict_object(state_dict, MetadataIndex("a"))
         self.assertEqual(a, state_dict["a"])
+        a = find_state_dict_object(state_dict, MetadataIndex("a", [0]))
+        self.assertEqual(a, state_dict["a"])
         a = find_state_dict_object(state_dict, MetadataIndex("a", index=99))
         self.assertEqual(a, state_dict["a"])
 
@@ -91,8 +93,6 @@ class TestMedatadaIndex(TestCase):
 
         with self.assertRaisesRegex(ValueError, "FQN"):
             find_state_dict_object(state_dict, MetadataIndex("c"))
-        with self.assertRaisesRegex(ValueError, "ShardedTensor"):
-            find_state_dict_object(state_dict, MetadataIndex("a", [0]))
         with self.assertRaisesRegex(ValueError, "ShardedTensor"):
             find_state_dict_object(state_dict, MetadataIndex("b", [1]))
 

--- a/torch/distributed/_shard/checkpoint/__init__.py
+++ b/torch/distributed/_shard/checkpoint/__init__.py
@@ -1,13 +1,15 @@
 from .metadata import (
-    BytesReadRequest,
-    BytesWriteRequest,
     TensorStorageMetadata,
     BytesStorageMetadata,
     ChunkStorageMetadata,
     Metadata,
-    TensorReadRequest,
-    TensorWriteRequest,
 )
+
+from .planner import (
+    SavePlanner,
+    LoadPlanner
+)
+
 from .state_dict_loader import load_state_dict
 from .state_dict_saver import save_state_dict
 from .storage import StorageReader, StorageWriter

--- a/torch/distributed/_shard/checkpoint/default_planner.py
+++ b/torch/distributed/_shard/checkpoint/default_planner.py
@@ -1,0 +1,109 @@
+import io
+from typing import List, Tuple, Dict, Any, Union
+
+import torch
+
+from torch.distributed._shard._utils import narrow_tensor_by_index
+
+from .resharding import (
+    create_default_local_save_plan,
+    create_default_global_save_plan,
+    create_default_local_load_plan,
+    create_default_global_load_plan,
+)
+
+from .planner import (
+    SavePlanner,
+    LoadPlanner,
+    SavePlan,
+    LoadPlan,
+    ReadItem,
+    WriteItem,
+    WriteItemType,
+)
+
+from .metadata import (
+    MetadataIndex,
+    Metadata,
+    STATE_DICT_TYPE
+)
+
+from .utils import (
+    find_state_dict_object
+)
+
+
+class DefaultSavePlanner(SavePlanner):
+    def init(self, state_dict: Dict[str, Any], is_coordinator: bool) -> None:
+        self.state_dict = state_dict
+        self.is_coordinator = is_coordinator
+
+    def create_local_plan(self) -> SavePlan:
+        self.plan = create_default_local_save_plan(self.state_dict, self.is_coordinator)
+        return self.plan
+
+    def create_global_plan(self, all_plans: List[SavePlan]) -> Tuple[List[SavePlan], Metadata]:
+        self.global_plan, self.metadata = create_default_global_save_plan(all_plans)
+        return self.global_plan, self.metadata
+
+    def finish_plan(self, new_plan: SavePlan) -> SavePlan:
+        self.plan = new_plan
+        return new_plan
+
+    def resolve_data(self, write_item: WriteItem) -> Union[torch.Tensor, io.BytesIO]:
+        object = self.lookup_object(write_item.index)
+        return self.transform_object(write_item, object)
+
+    def lookup_object(self, index: MetadataIndex) -> Any:
+        """
+        This is an extension from the planner interface to make it easy to extend the default planner
+        """
+        return find_state_dict_object(self.state_dict, index)
+
+    def transform_object(self, write_item: WriteItem, object: Any):
+        """
+        This is an extension from the planner interface to make it easy to extend the default planner
+        """
+        if write_item.type == WriteItemType.BYTE_IO:
+            bytes = io.BytesIO()
+            torch.save(object, bytes)
+            object = bytes
+        return object
+
+
+class DefaultLoadPlanner(LoadPlanner):
+    def init(self, state_dict: STATE_DICT_TYPE, metadata: Metadata, is_coordinator: bool) -> None:
+        self.state_dict = state_dict
+        self.metadata = metadata
+        self.is_coordinator = is_coordinator
+
+    def create_local_plan(self) -> LoadPlan:
+        return create_default_local_load_plan(self.state_dict, self.metadata)
+
+    def create_global_plan(self, global_plan: List[LoadPlan]) -> List[LoadPlan]:
+        return create_default_global_load_plan(global_plan)
+
+    def finish_plan(self, new_plan: LoadPlan) -> LoadPlan:
+        return new_plan
+
+    def load_bytes(self, read_item: ReadItem, value: io.BytesIO) -> None:
+        self.state_dict[read_item.dest_index.fqn] = torch.load(value)
+
+    def resolve_tensor(self, read_item: ReadItem):
+        tensor = self.lookup_tensor(read_item.dest_index)
+        return self.transform_tensor(read_item, tensor)
+
+    def commit_tensor(self, read_item: ReadItem, tensor: torch.Tensor) -> None:
+        pass
+
+    def lookup_tensor(self, index: MetadataIndex) -> torch.Tensor:
+        """
+        This is an extension from the planner interface to make it easy to extend the default planner
+        """
+        return find_state_dict_object(self.state_dict, index)
+
+    def transform_tensor(self, read_item: ReadItem, tensor: torch.Tensor):
+        """
+        This is an extension from the planner interface to make it easy to extend the default planner
+        """
+        return narrow_tensor_by_index(tensor, read_item.dest_offsets, read_item.lengths)

--- a/torch/distributed/_shard/checkpoint/filesystem.py
+++ b/torch/distributed/_shard/checkpoint/filesystem.py
@@ -1,7 +1,13 @@
+import abc
+import queue
+import threading
+import collections
+from dataclasses import dataclass
 import os
-import operator
+import dataclasses
+import io
 import pickle
-from typing import List, Optional, Union, cast
+from typing import List, Union, Dict, cast
 
 import torch
 from torch import Tensor
@@ -9,15 +15,248 @@ from torch.futures import Future
 from pathlib import Path
 
 from .metadata import (
-    BytesReadRequest,
-    BytesWriteRequest,
     Metadata,
-    TensorReadRequest,
-    TensorWriteRequest,
+    MetadataIndex,
 )
-from .storage import StorageReader, StorageWriter
+from .storage import (
+    StorageReader,
+    StorageWriter,
+    WriteResult,
+)
+
+from .planner import (
+    LoadItemType,
+    LoadPlanner,
+    LoadPlan,
+    SavePlan,
+    SavePlanner,
+    ReadItem,
+    WriteItem,
+    WriteItemType,
+)
+
 from torch.distributed._shard._utils import narrow_tensor_by_index
 
+
+@dataclass
+class _StorageInfo:
+    """
+    This is the per entry storage info
+    """
+    relative_path: str
+    offset: int
+    length: int
+
+@dataclass
+class _StoragePrefix:
+    prefix: str
+
+
+def result_from_write_item(item: WriteItem, size_in_bytes, storage_data) -> WriteResult:
+    return WriteResult(
+        index=item.index,
+        size_in_bytes=size_in_bytes,
+        storage_data=storage_data)
+
+def _tensor_size(tensor):
+    return tensor.numel() * tensor.element_size()
+
+
+class _TensorLoader(abc.ABC):
+    def add(self, size, obj):
+        pass
+
+    def start_loading(self):
+        pass
+
+    def values(self):
+        pass
+
+class _SerialCpuLoader(_TensorLoader):
+    def __init__(self, resolve_fun):
+        self.resolve_fun = resolve_fun
+        self.items = []
+
+    def add(self, size, obj):
+        self.items.append((size, obj))
+
+    def start_loading(self):
+        pass
+
+    def values(self):
+        for size, obj in self.items:
+            tensor = self.resolve_fun(obj).detach()
+            tensor = tensor.cpu()
+            if tensor.storage().size() != tensor.numel():
+                tensor = tensor.clone()
+            yield (tensor, obj,)
+
+class _OverlappingCpuLoader(_TensorLoader):
+    def __init__(self, resolve_fun, stream=None, inflight_threshhold=1_000_000):
+        self.resolve_fun = resolve_fun
+        self.items = []
+        self.inflight_threshhold = inflight_threshhold
+        self.in_flight_data = 0
+        self.current_items: collections.deque = collections.deque()
+        self.idx = 0
+        self.started = False
+        self.stream = stream or torch.cuda.current_stream()
+        if self.stream != torch.cuda.current_stream():
+            self.stream.wait_stream(torch.cuda.current_stream())
+
+    @property
+    def _done(self):
+        return self.idx >= len(self.items)
+
+    def _drain(self):
+        drained = []
+        if self.in_flight_data >= self.inflight_threshhold:
+            self.stream.synchronize()
+        while self.in_flight_data >= self.inflight_threshhold:
+            val = self.current_items.popleft()
+            self.in_flight_data -= val[0].numel() * val[0].element_size()
+            drained.append(val)
+        return drained
+
+    def _refill(self):
+        with torch.cuda.stream(self.stream):
+            while not self._done and self.in_flight_data < self.inflight_threshhold:
+                _, obj = self.items[self.idx]
+                self.idx += 1
+                tensor = self.resolve_fun(obj).detach()
+                if tensor.is_cuda:
+                    tensor = tensor.to(device="cpu", non_blocking=True)
+                elif tensor.device == torch.device("cpu"):
+                    if tensor.storage().size() != tensor.numel():
+                        # this forces the tensor to be both contiguous and with minimal storage
+                        tensor = tensor.clone()
+
+                self.current_items.append((tensor, obj,))
+                self.in_flight_data += tensor.numel() * tensor.element_size()
+
+    def _finish(self):
+        assert self._done
+        if len(self.current_items) > 0:
+            self.stream.synchronize()
+        return self.current_items
+
+    def add(self, size, obj):
+        if self.started:
+            raise RuntimeError("cannot add items after loading started")
+        self.items.append((size, obj))
+
+    def start_loading(self):
+        if self.started:
+            return
+        self.started = True
+        self.items.sort(key=lambda x: x[0])
+        self._refill()
+
+    def values(self):
+        self.start_loading()
+        while not self._done:
+            drained = self._drain()
+            self._refill()
+            for obj in drained:
+                yield obj
+
+        for val in self._finish():
+            yield val
+
+def _item_size(item: WriteItem) -> int:
+    assert item.tensor_data is not None
+    size = 1
+    # can't use math.prod as PT needs to support older python
+    for s in item.tensor_data.size:
+        size *= s
+
+    dtype = item.tensor_data.properties.dtype
+    return size * torch._utils._element_size(dtype)
+
+def _split_by_size_and_type(bins, items: List[WriteItem]):
+    bytes_w = [wi for wi in items if wi.type == WriteItemType.BYTE_IO]
+    tensor_w = [wi for wi in items if wi.type != WriteItemType.BYTE_IO]
+
+    buckets: List[List[WriteItem]] = [[] for _ in range(bins)]
+    bucket_sizes = [0 for _ in range(bins)]
+
+    tensor_w.sort(key=_item_size, reverse=True)
+
+    for i, wi in enumerate(bytes_w):
+        buckets[i % bins].append(wi)
+
+    for wi in tensor_w:
+        # TODO replace with headq
+        idx = min(enumerate(bucket_sizes), key=lambda x: x[1])[0]
+        buckets[idx].append(wi)
+        bucket_sizes[idx] += _item_size(wi)
+
+    return buckets
+
+def _write_item(stream, data, write_item, storage_key):
+    offset = stream.tell()
+
+    if write_item.type == WriteItemType.BYTE_IO:
+        assert isinstance(data, io.BytesIO)
+        stream.write(data.getbuffer())
+    else:
+        assert isinstance(data, torch.Tensor)
+        assert data.device == torch.device("cpu")
+        torch.save(data, stream)
+    length = stream.tell() - offset
+
+    return result_from_write_item(
+        write_item,
+        length,
+        _StorageInfo(storage_key, offset, length)
+    )
+
+# TODO the non queue params should go into a separate object to deal with growning number of args
+def _write_files_from_queue(
+    file_queue: queue.Queue,
+    result_queue: queue.Queue,
+    planner: SavePlanner,
+    inflight_threshhold: int,
+    use_fsync: bool,
+    is_main: bool,
+):
+    try:
+        while True:
+            file_name, write_items = file_queue.get_nowait()
+            loader: _TensorLoader
+
+            if torch.cuda.is_available() and inflight_threshhold > 0:
+                loader = _OverlappingCpuLoader(
+                    lambda x: planner.resolve_data(x),
+                    inflight_threshhold=inflight_threshhold,
+                )
+            else:
+                loader = _SerialCpuLoader(
+                    lambda x: planner.resolve_data(x),
+                )
+
+            tensor_w = [wi for wi in write_items if wi.type != WriteItemType.BYTE_IO]
+            for write_item in tensor_w:
+                loader.add(_item_size(write_item), write_item)
+            loader.start_loading()
+
+            bytes_w = [wi for wi in write_items if wi.type == WriteItemType.BYTE_IO]
+            write_results = []
+
+            with open(file_name, "wb") as stream:
+                for write_item in bytes_w:
+                    data = planner.resolve_data(write_item)
+                    write_results.append(_write_item(stream, data, write_item, file_name))
+
+                for tensor, write_item in loader.values():
+                    assert not tensor.is_cuda
+                    write_results.append(_write_item(stream, tensor, write_item, file_name))
+
+                if use_fsync:
+                    os.fsync(stream.fileno())
+            result_queue.put(write_results)
+    except queue.Empty:
+        pass
 
 class FileSystemWriter(StorageWriter):
     """
@@ -32,108 +271,179 @@ class FileSystemWriter(StorageWriter):
     a `.metadata` file with the serialized metadata.
 
     """
-    def __init__(self, path: Union[str, os.PathLike]) -> None:
+    def __init__(
+        self,
+        path: Union[str, os.PathLike],
+        single_file_per_rank: bool = False,
+        thread_count: int = 1,
+        sync_files: bool = True,
+        per_thread_copy_ahead: int = 10_000_000,
+    ) -> None:
         """
         Initialize the writer pointing to `path`
 
         Args:
             path: diretory where the checkpoint will be writen to.
+            single_file_per_rank: Produce one file per rank instead of one file per tensor/blob. Default to True.
+            thread_count: Number of concurrent threads to use to write. Default to 1.
+            sync_files: force files to be synced to permanent storage. Default to True.
+            per_thread_copy_ahead: Keeps at least this many bytes of copy ahead for CUDA tensors.
+                Set to zero to disable copy ahead. Default to 10M.
+
+        N. B. If sync_files is disabled, there's no guarantee that the checkpoint will be consistent in the case of a failure.
         """
         super().__init__()
         self.path = Path(path)
+        self.single_file_per_rank = single_file_per_rank
+        self.thread_count = thread_count
+        self.sync_files = sync_files
+        self.per_thread_copy_ahead = per_thread_copy_ahead
 
-    def write_bytes(self, requests: List[BytesWriteRequest]) -> Future[None]:
-        for req in requests:
-            with (self.path / req.storage_key).open("wb") as w:
-                w.write(req.bytes.getbuffer())
-                os.fsync(w.fileno())
+    def init(self, is_coordinator: bool) -> None:
+        pass
 
-        fut: Future[None] = Future()
-        fut.set_result(None)
-        return fut
+    def prepare_local_plan(self, plan: SavePlan) -> SavePlan:
+        # There's no storage input in the local plan
+        return plan
 
-    def write_tensors(self, requests: List[TensorWriteRequest]) -> Future[None]:
-        for req in requests:
-            # The following couple lines are simple implementation to get
-            # things going.
-            #
-            # At load time, to enable resharding, we use (sub)view of the tensor.
-            # Since the storage of the tensor might not be contiguous. we need to
-            # preserve the original view, to calculate the correct sub view at load.
-            #
-            # `torch.save` saves both the view and storage, it is a good option
-            # for unblocking. There are two drawbacks:
-            # 1. `torch.save` is pickle based, and pickle is not known for its
-            #   compatibility, we should consider replacing it with a more
-            #   stable option.
-            # 2. pickle is not streamable.
-            with (self.path / req.storage_key).open("wb") as w:
-                torch.save(req.tensor, w)
-                os.fsync(w.fileno())
-
-        fut: Future[None] = Future()
-        fut.set_result(None)
-        return fut
-
-    def prepare(self) -> None:
+    def prepare_global_plan(self, global_plan: List[SavePlan]) -> List[SavePlan]:
         self.path.mkdir(parents=True, exist_ok=True)
 
-    def finish(self, metadata: Metadata) -> None:
+        new_plans = [
+            dataclasses.replace(plan, storage_data=_StoragePrefix(f"__{i}_")) for i, plan in enumerate(global_plan)
+        ]
+        return new_plans
+
+    def write_data(
+        self,
+        plan: SavePlan,
+        planner: SavePlanner,
+    ) -> Future[List[WriteResult]]:
+        storage_plan: _StoragePrefix = plan.storage_data
+        file_count = 0
+
+        def gen_file():
+            nonlocal file_count
+            file_name = f"{storage_plan.prefix}{file_count}"
+            file_count += 1
+            return file_name
+
+        file_queue: queue.Queue = queue.Queue()
+        if self.single_file_per_rank:
+            for bucket in _split_by_size_and_type(self.thread_count, plan.items):
+                file_queue.put((self.path / gen_file(), bucket))
+        else:
+            for item in plan.items:
+                file_queue.put((self.path / gen_file(), [item]))
+
+        result_queue: queue.Queue = queue.Queue()
+
+        threads = []
+        for _ in range(1, self.thread_count):
+            t = threading.Thread(
+                target=_write_files_from_queue,
+                args=(file_queue, result_queue, planner, self.per_thread_copy_ahead, self.sync_files, False)
+            )
+            t.start()
+            threads.append(t)
+        _write_files_from_queue(
+            file_queue=file_queue,
+            result_queue=result_queue,
+            planner=planner,
+            inflight_threshhold=self.per_thread_copy_ahead,
+            use_fsync=self.sync_files,
+            is_main=True)
+
+        for t in threads:
+            t.join()
+
+        res = []
+        try:
+            while True:
+                res += result_queue.get_nowait()
+        except queue.Empty:
+            pass
+
+            fut: Future[List[WriteResult]] = Future()
+            fut.set_result(res)
+            return fut
+
+    def finish(self, metadata: Metadata, results: List[List[WriteResult]]) -> None:
+        storage_md = dict()
+        for wr_list in results:
+            storage_md.update({
+                wr.index: wr.storage_data for wr in wr_list
+            })
+        metadata.storage_data = storage_md
         with (self.path / ".metadata.tmp").open("wb") as metadata_file:
             pickle.dump(metadata, metadata_file)
             os.fsync(metadata_file.fileno())
 
         (self.path / ".metadata.tmp").rename(self.path / ".metadata")
 
+
+class SlicedBufferedReader(io.BufferedReader):
+    # TODO override read to handle (-1) correctly
+    def __init__(self, base_stream: io.RawIOBase, offset: int, len: int):
+        super().__init__(base_stream)
+        self.offset = offset
+        self.len = len
+        self.seek(0)
+
+    def seek(self, __offset: int, __whence: int = os.SEEK_SET) -> int:
+        if __whence == os.SEEK_SET:
+            __offset = self.offset + __offset
+        elif __whence == os.SEEK_END:
+            __whence = os.SEEK_SET
+            __offset = (self.offset + self.len) - __offset
+        return super().seek(__offset, __whence)
+
+    def tell(self) -> int:
+        return super().tell() - self.offset
+
 class FileSystemReader(StorageReader):
     def __init__(self, path: Union[str, os.PathLike]) -> None:
         super().__init__()
         self.path = Path(path)
+        self.storage_data: Dict[MetadataIndex, _StorageInfo] = dict()
 
-    def read_tensors(self, requests: List[TensorReadRequest]) -> Future[None]:
-        """
-        Very basic implementation that read from file system.
-        """
-        # Sort the the requests by storage key and try to reuse the loaded tensors
-        requests.sort(key=operator.attrgetter("storage_key"))
+    def _slice_file(self, file, sinfo: _StorageInfo):
+        return SlicedBufferedReader(
+            io.FileIO(file.fileno(), closefd=False),
+            sinfo.offset, sinfo.length
+        )
 
-        cached_storage_key = None
-        view_cached: Optional[Tensor] = None
+    def read_data(
+        self,
+        plan: LoadPlan,
+        planner: LoadPlanner
+    ) -> Future[None]:
+        # group requests by file
+        per_file: Dict[str, List[ReadItem]] = dict()
+        for read_item in plan.items:
+            item_md = self.storage_data[read_item.storage_index]
+            path = item_md.relative_path
+            per_file.setdefault(path, []).append(read_item)
 
-        for req in requests:
-            if cached_storage_key != req.storage_key or \
-                    (view_cached is not None and view_cached.device != req.tensor.device):
+        for relative_path, reqs in per_file.items():
+            with (self.path / relative_path).open("rb") as file:
+                # TODO sort by offset and cache the reading
+                for req in reqs:
+                    item_md = self.storage_data[req.storage_index]
+                    file_slice = self._slice_file(file, item_md)
+                    if req.type == LoadItemType.BYTE_IO:
+                        bytes = io.BytesIO(file_slice.read(item_md.length))
+                        bytes.seek(0)
+                        planner.load_bytes(req, bytes)
+                    else:
+                        tensor = cast(Tensor, torch.load(file_slice, map_location="cpu"))
+                        tensor = narrow_tensor_by_index(tensor, req.storage_offsets, req.lengths)
+                        target_tensor = planner.resolve_tensor(req).detach()
 
-                with (self.path / req.storage_key).open("rb") as storage:
-                    view_cached = cast(Tensor, torch.load(storage, map_location=req.tensor.device))
-                    cached_storage_key = req.storage_key
-
-            view_to_copy: Tensor = cast(Tensor, view_cached)
-            # FileSystemWrite writes the tensor as is during save.
-            # During load time, we will load the Tensor (with it orignal view)
-            # narrow it along all dimemsions, and copy_ it to the
-            # target tensor, which will be the same size.
-            view_to_copy = narrow_tensor_by_index(view_to_copy, req.offsets, req.lengths)
-
-            assert (
-                view_to_copy.size() == req.tensor.size()
-            ), f"The {req.storage_key} src/dst size does not match."
-
-
-            assert (
-                view_to_copy.device == req.tensor.device
-            ), f"cannot load across devices {view_to_copy.device} vs {req.tensor.device}"
-
-            req.tensor.copy_(view_to_copy)
-
-        fut: Future = Future()
-        fut.set_result(None)
-        return fut
-
-    def read_bytes(self, requests: List[BytesReadRequest]) -> Future[None]:
-        for req in requests:
-            with (self.path / req.storage_key).open("rb") as storage:
-                req.bytes.write(storage.read())
+                        assert (
+                            target_tensor.size() == tensor.size()
+                        ), f"req {req.storage_index} mismatch sizes {target_tensor.size()} vs {tensor.size()}"
+                        target_tensor.copy_(tensor)
 
         fut: Future = Future()
         fut.set_result(None)
@@ -142,4 +452,15 @@ class FileSystemReader(StorageReader):
     # Implementating the abstract function in StorageReader
     def read_metadata(self) -> Metadata:
         with (self.path / ".metadata").open("rb") as metadata_file:
-            return pickle.load(metadata_file)
+            md = pickle.load(metadata_file)
+            return md
+
+    def init(self, metadata: Metadata, is_coordinator: bool) -> None:
+        self.storage_data = metadata.storage_data
+        assert self.storage_data is not None
+
+    def prepare_local_plan(self, plan: LoadPlan) -> LoadPlan:
+        return plan
+
+    def prepare_global_plan(self, global_plan: List[LoadPlan]) -> List[LoadPlan]:
+        return global_plan

--- a/torch/distributed/_shard/checkpoint/metadata.py
+++ b/torch/distributed/_shard/checkpoint/metadata.py
@@ -1,12 +1,11 @@
-import io
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple, Union, Optional, Sequence, Any
+from typing import Dict, List, Union, Optional, Sequence, Any
+from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
 
 import torch
 from torch.distributed._shard.sharded_tensor import (
     ShardedTensor,
 )
-from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
 
 @dataclass
 class ChunkStorageMetadata:
@@ -35,34 +34,6 @@ class Metadata:
     # Keys are the same from the `state_dict` used.
     state_dict_metadata: Dict[str, STORAGE_TYPES]
     storage_data: Any = None
-
-@dataclass
-class BytesWriteRequest:
-    bytes: io.BytesIO
-    storage_key: str
-
-
-@dataclass
-class BytesReadRequest:
-    bytes: io.BytesIO
-    storage_key: str
-    fqn: str
-
-
-@dataclass
-class TensorWriteRequest:
-    tensor: torch.Tensor
-    storage_key: str
-
-
-@dataclass
-class TensorReadRequest:
-    tensor: torch.Tensor
-    storage_key: str
-    # offset and length w.r.t. to the storage identified by ``storage_key``
-    offsets: Tuple[int, ...]
-    lengths: Tuple[int, ...]
-
 
 @dataclass(frozen=True)
 class MetadataIndex:

--- a/torch/distributed/_shard/checkpoint/planner.py
+++ b/torch/distributed/_shard/checkpoint/planner.py
@@ -1,0 +1,206 @@
+import abc
+from dataclasses import dataclass
+import io
+from typing import List, Tuple, Any, Union, Optional
+
+from enum import Enum, auto
+import torch
+
+from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
+
+from .metadata import (
+    ChunkStorageMetadata,
+    MetadataIndex,
+    Metadata,
+    STATE_DICT_TYPE
+)
+
+class WriteItemType(Enum):
+    TENSOR = auto()
+    SHARD = auto()
+    BYTE_IO = auto()
+
+class LoadItemType(Enum):
+    TENSOR = auto()
+    BYTE_IO = auto()
+
+@dataclass(frozen=True)
+class TensorWriteData:
+    chunk: ChunkStorageMetadata
+    properties: TensorProperties
+    size: torch.Size
+
+@dataclass(frozen=True)
+class WriteItem:
+    index: MetadataIndex
+    type: WriteItemType
+
+    # Value present if it's a tensor write
+    tensor_data: Optional[TensorWriteData] = None
+
+@dataclass(frozen=True)
+class ReadItem:
+    # Read Item
+    type: LoadItemType
+
+    # Index into the state_dict
+    dest_index: MetadataIndex
+    # Offsets into destination tensor
+    dest_offsets: torch.Size
+
+    # Index into the checkpoint
+    storage_index: MetadataIndex
+    # Offset into the checkpoint data
+    storage_offsets: torch.Size
+
+    # Size of the hypercube to copy
+    lengths: torch.Size
+
+@dataclass(frozen=True)
+class SavePlan:
+    items: List[WriteItem]
+    storage_data: Any = None
+    planner_data: Any = None
+
+@dataclass
+class LoadPlan:
+    items: List[ReadItem]
+    storage_data: Any = None
+    planner_data: Any = None
+
+class SavePlanner(abc.ABC):
+    """
+    Abstract class defining the protocol used by save_state_dict to plan the save process.
+    """
+
+    @abc.abstractmethod
+    def init(self, state_dict: STATE_DICT_TYPE, is_coordinator: bool) -> None:
+        """
+        Intialize this planner to save ``state_dict``.
+
+        This is called on all ranks.
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_local_plan(self) -> SavePlan:
+        """
+        Compute the save plan for the current rank.
+        This will be aggregated and passed to create_global_plan.
+        Planner specific data can be passed through SavePlan::planner_data.
+
+        This is called on all ranks.
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_global_plan(self, all_plans: List[SavePlan]) -> Tuple[List[SavePlan], Metadata]:
+        """
+        Compute the global checkpoint plan and return the local plan of each rank.
+
+        This is called on the coordinator rank only.
+        """
+        pass
+
+    @abc.abstractmethod
+    def finish_plan(self, new_plan: SavePlan) -> SavePlan:
+        """
+        Merge the plan created by `create_local_plan` and the result of `create_global_plan`.
+
+        This is called on all ranks.
+        """
+        pass
+
+    @abc.abstractmethod
+    def resolve_data(self, write_item: WriteItem) -> Union[torch.Tensor, io.BytesIO]:
+        """
+        Lookup the object associated with ``write_item``in `state_dict` and apply any
+        transformation (such as serialization) prior to the storage layer consuming it.
+
+        Called on each rank multiple times, at least once per WriteItem in the final SavePlan.
+
+        This method should be idepotent and thread-save. StorageWriter implementations
+        are free to call it as frequently as they need.
+
+        Any transformation that allocates memory should be lazily done when his method
+        is called in order to reduce peak memory required by checkpointing.
+
+        When returning tensors, they can be on any device or format, they can be views too.
+        It's the storage layer responsiblity to figure out how to save them.
+        """
+        pass
+
+class LoadPlanner:
+    """
+    Abstract class defining the protocol used by load_state_dict to plan the load process.
+
+    """
+    @abc.abstractmethod
+    def init(self, state_dict: STATE_DICT_TYPE, metadata: Metadata, is_coordinator: bool) -> None:
+        """
+        Initialize this instance to load data into ``state_dict``
+
+        . N.B. This is called on every rank.
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_local_plan(self) -> LoadPlan:
+        """
+        Create a LoadPlan based on state_dict and metadata provided by init.
+
+        . N.B. This is called on every rank.
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_global_plan(self, globla_plan: List[LoadPlan]) -> List[LoadPlan]:
+        """
+        Compute the global load plan and return plans for each rank.
+
+        . N.B. This is called on the coordinator rank only
+        """
+        pass
+
+    @abc.abstractmethod
+    def finish_plan(self, central_plan: LoadPlan) -> LoadPlan:
+        """
+        Accept the plan from coordinator and return final LoadPlan.
+        """
+        pass
+
+    @abc.abstractmethod
+    def load_bytes(self, read_item: ReadItem, value: io.BytesIO) -> None:
+        """
+        Load the item described by ``read_item``and ``value``.
+
+        This method is expected to modify in-place the underlying state_dict.
+
+        The contents of ``value`` are defined by the SavePlanner used to produce
+        the checkpoint being loaded.
+        """
+        pass
+
+    @abc.abstractmethod
+    def resolve_tensor(self, read_item: ReadItem) -> torch.Tensor:
+        """
+        Return the tensor described by ``read_item`` to be used by the StorageReader to load `read_item`.
+
+        The tensor should alias with one on the underlying state_dict as StorageReader will replace its contents.
+        If, for any reason, that's not possible, the planner can use the ``commit_tensor`` method to copy the data
+        back to the one in state_dict.
+        """
+        pass
+
+    @abc.abstractmethod
+    def commit_tensor(self, read_item: ReadItem, tensor: torch.Tensor) -> None:
+        """
+        This method is called once the StorageReader finished loading data into ``tensor``.
+
+        The provided tensor is the same one returned by the call to ``resolve_tensor``.
+        This method is only needed if this LoadPlanner needs to post process ``tensor`` prior to
+        copying it back to the one in the state_dict.
+
+        The contents of tensor will follow its device synchronization model.
+        """
+        pass

--- a/torch/distributed/_shard/checkpoint/state_dict_loader.py
+++ b/torch/distributed/_shard/checkpoint/state_dict_loader.py
@@ -1,96 +1,22 @@
-import io
-from typing import Any, Dict, List, Tuple, Optional, cast
-from torch.distributed._shard.metadata import ShardMetadata
-from torch.distributed._shard.sharded_tensor.shard import Shard
+from typing import Any, Dict, Optional
 
-import torch
 import torch.distributed as dist
-from torch import Tensor
-from torch.distributed._shard.sharded_tensor import (
-    ShardedTensor,
-)
 
-from .metadata import (
-    BytesReadRequest,
-    BytesStorageMetadata,
-    TensorReadRequest,
-    TensorStorageMetadata,
-    Metadata,
-    MetadataIndex,
-)
-from .resharding import (
-    _prepare_generic_tensor_read,
-)
 from .storage import (
     StorageReader,
 )
+from .planner import LoadPlanner
+from .default_planner import DefaultLoadPlanner
 
 from .utils import _DistWrapper
-
-def _create_shard_metadata(size: torch.Size) -> ShardMetadata:
-    return ShardMetadata(
-        shard_offsets=[0] * len(size),
-        shard_sizes=list(size),
-    )
-
-def _create_shard_for(tensor: Tensor) -> Shard:
-    return Shard(
-        tensor=tensor,
-        metadata=_create_shard_metadata(tensor.size()),
-    )
-
-def _reshard_and_prepare_read_request(
-    state_dict: Dict[str, Any], metadata_from_storage: Metadata
-) -> Tuple[List[BytesReadRequest], List[TensorReadRequest]]:
-    """
-    Use the loaded metadata and the current state dict to map the saved tensors to current tensor
-    """
-    tensor_read_requests = []
-    bytes_read_requests = []
-    storage_md = cast(Dict[MetadataIndex, str], metadata_from_storage.storage_data)
-    for fqn, obj in state_dict.items():
-        md = metadata_from_storage.state_dict_metadata[fqn]
-        if isinstance(obj, ShardedTensor):
-            local_shards = obj.local_shards()
-        elif isinstance(obj, torch.Tensor):
-            local_shards = [_create_shard_for(obj)]
-        else:
-            if isinstance(md, BytesStorageMetadata):
-                bytes_io = io.BytesIO()
-                brr = BytesReadRequest(
-                    bytes=bytes_io,
-                    storage_key=storage_md[MetadataIndex(fqn)],
-                    fqn=fqn
-                )
-                bytes_read_requests.append(brr)
-            else:
-                raise ValueError(
-                    f"Invalid checkpoint metadata for {fqn}, " +
-                    f"expected BytesStorageMetadata but found {type(md)}"
-                )
-            continue
-
-        if isinstance(md, TensorStorageMetadata):
-            checkpoint_shards = md.chunks
-        else:
-            raise ValueError(
-                f"Invalid checkpoint metadata for {fqn}, " +
-                f"expected TensorStorageMetadata but found {type(md)}"
-            )
-
-        tensor_read_requests += _prepare_generic_tensor_read(fqn, checkpoint_shards, local_shards, storage_md)
-
-
-
-    return (bytes_read_requests, tensor_read_requests)
-
 
 def load_state_dict(
     state_dict: Dict[str, Any],
     storage_reader: StorageReader,
     process_group: Optional[dist.ProcessGroup] = None,
     coordinator_rank: int = 0,
-    no_dist: bool = False
+    no_dist: bool = False,
+    planner: LoadPlanner = None
 ) -> None:
     """
     Load a distributed state_dict in SPMD style.
@@ -149,25 +75,34 @@ def load_state_dict(
         has an individual GPU, via ``torch.cuda.set_device()``
     """
     distW = _DistWrapper(process_group, not no_dist, coordinator_rank)
+    if planner is None:
+        planner = DefaultLoadPlanner()
 
-    def load_model():
+
+    def local_step():
+        assert planner is not None
         metadata = storage_reader.read_metadata()
-        bytes_read_requests, tensor_read_requests = _reshard_and_prepare_read_request(
-            state_dict=state_dict, metadata_from_storage=metadata
-        )
-        bytes_futures = storage_reader.read_bytes(bytes_read_requests)
-        tensor_futures = storage_reader.read_tensors(tensor_read_requests)
+        planner.init(state_dict, metadata, distW.is_coordinator)
+        storage_reader.init(metadata, distW.is_coordinator)
 
-        bytes_futures.wait()
+        local_plan = planner.create_local_plan()
+        local_plan = storage_reader.prepare_local_plan(local_plan)
+        return local_plan
 
-        # Addtional steps are required to convert the bytes to its original type
-        # Note that this is NOT inplace,
-        # it creating a new object and replace what's in the state dict
-        for req in bytes_read_requests:
-            # Ensure the BytesIO is rewound
-            req.bytes.seek(0)
-            state_dict[req.fqn] = torch.load(req.bytes)
+    def global_step(all_local_plans):
+        assert planner is not None
+        all_local_plans = planner.create_global_plan(all_local_plans)
+        all_local_plans = storage_reader.prepare_global_plan(all_local_plans)
+        return all_local_plans
 
-        tensor_futures.wait()
+    central_plan = distW.reduce_scatter("plan", local_step, global_step)
 
-    distW.all_gather("checkpoint read", load_model)
+    def read_data():
+        assert planner is not None
+        final_local_plan = planner.finish_plan(central_plan)
+        all_reads = storage_reader.read_data(final_local_plan, planner)
+
+        all_reads.wait()
+        return None
+
+    _ = distW.all_gather("read", read_data)

--- a/torch/distributed/_shard/checkpoint/state_dict_saver.py
+++ b/torch/distributed/_shard/checkpoint/state_dict_saver.py
@@ -1,104 +1,28 @@
-import io
-from typing import Any, Dict, List, Tuple, Optional, Union
-
-
-import torch
+from typing import Optional
 import torch.distributed as dist
 
-from torch import Tensor
-from torch.distributed._shard.sharded_tensor import (
-    ShardedTensor,
-)
+from .planner import SavePlanner
+from .default_planner import DefaultSavePlanner
 
-from .metadata import (
-    Metadata,
-    BytesWriteRequest,
-    TensorWriteRequest,
-)
-from .resharding import (
-    _prepare_sharded_tensor_write,
-    _prepare_tensor_write,
-    _prepare_bytes_write
-)
 
 from .storage import (
     StorageWriter,
 )
 
+from .metadata import (
+    Metadata,
+    STATE_DICT_TYPE
+)
 from .utils import _DistWrapper
 
-
-# -------------- private functions --------------
-
-def _prepare(
-    state_dict: Dict[str, Any],
-    write_replicated_data: bool,
-) -> Tuple[Metadata, List[BytesWriteRequest], List[TensorWriteRequest]]:
-    """
-    Build the serialization plan for a given state_dict
-
-    Args:
-        state_dict: The instance to plan for.
-
-    Returns:
-        A tuple with the following values:
-
-        metadata: Metadata
-        The storage metadata describing Tensor and ShardedTensors
-        instances found in `state_dict`. See `Metadata` for the schema.
-
-        size_for_storage_keys: Dict[str, int]
-            Key is the storage key name, value is the associated size
-            It can used to pre allocate the storage for parallel and non sequential writes.
-
-        bytes_write_requests: List[BytesWriteRequest]
-            List of ByteIO write requests that should be performed by the writer.
-
-        tensor_write_requests: List[TensorWriteRequest]
-            List of Tensor write requests that should be performed by the writer.
-
-    """
-    metadata = Metadata(state_dict_metadata={})
-    tensor_write_requests: List[TensorWriteRequest] = []
-    bytes_write_requests: List[BytesWriteRequest] = []
-    storage_key_to_fqn: Dict[str, str] = dict()
-
-    storage_md = {}
-
-    for fqn, obj in state_dict.items():
-        if isinstance(obj, ShardedTensor):
-            st_write_reqs, st_md, storage_data = _prepare_sharded_tensor_write(fqn, obj, fqn, storage_key_to_fqn)
-            tensor_write_requests += st_write_reqs
-            metadata.state_dict_metadata[fqn] = st_md
-            storage_md.update(storage_data)
-        elif isinstance(obj, Tensor):
-            write_reqs, tensor_md, storage_data = _prepare_tensor_write(obj, fqn, storage_key_to_fqn)
-            if write_replicated_data:
-                tensor_write_requests += write_reqs
-            metadata.state_dict_metadata[fqn] = tensor_md
-            storage_md.update(storage_data)
-        else:
-            bytes_io = io.BytesIO()
-            # This produces incomplete MD for rank > 0 since we won't populate bytes_io.
-            # This is ok since only rank == 0 uses this data
-            if write_replicated_data:
-                torch.save(obj, bytes_io)
-            byte_write_reqs, bytes_md, storage_data = _prepare_bytes_write(bytes_io, fqn, storage_key_to_fqn)
-            if write_replicated_data:
-                bytes_write_requests += byte_write_reqs
-            metadata.state_dict_metadata[fqn] = bytes_md
-            storage_md.update(storage_data)
-
-    metadata.storage_data = storage_md
-    return (metadata, bytes_write_requests, tensor_write_requests)
-
 def save_state_dict(
-    state_dict: Dict[str, Any],
+    state_dict: STATE_DICT_TYPE,
     storage_writer: StorageWriter,
     process_group: Optional[dist.ProcessGroup] = None,
     coordinator_rank: int = 0,
-    no_dist: bool = False
-) -> None:
+    no_dist: bool = False,
+    planner: SavePlanner = None
+) -> Metadata:
     """
     Save a distributed model in SPMD style.
 
@@ -148,29 +72,41 @@ def save_state_dict(
         has an individual GPU, via ``torch.cuda.set_device()``
     """
     distW = _DistWrapper(process_group, not no_dist, coordinator_rank)
+    if planner is None:
+        planner = DefaultSavePlanner()
+    assert planner is not None
 
-    distW.broadcast("prepare", storage_writer.prepare)
-    metadata = None
+    global_metatadata = None
 
-    def write_step():
-        nonlocal metadata
-        (
-            metadata,
-            bytes_write_requests,
-            tensor_write_requests,
-        ) = _prepare(state_dict, distW.is_coordinator)
+    def local_step():
+        assert planner is not None
+        planner.init(state_dict, distW.is_coordinator)
+        storage_writer.init(distW.is_coordinator)
+        local_plan = planner.create_local_plan()
+        local_plan = storage_writer.prepare_local_plan(local_plan)
+        return local_plan
 
-        combined_writes: List[Union[TensorWriteRequest, BytesWriteRequest]] = []
-        combined_writes.extend(tensor_write_requests)
-        combined_writes.extend(bytes_write_requests)
+    def global_step(all_local_plans):
+        nonlocal global_metatadata
 
-        storage_writer.prepare_storage(combined_writes)
-        bytes_futures = storage_writer.write_bytes(bytes_write_requests)
-        tensor_futures = storage_writer.write_tensors(tensor_write_requests)
-        torch.futures.wait_all([bytes_futures, tensor_futures])
+        assert planner is not None
+        all_local_plans, global_metatadata = planner.create_global_plan(all_local_plans)
+        all_local_plans = storage_writer.prepare_global_plan(all_local_plans)
+        return all_local_plans
 
-    def finish_checkpoint(_):
-        assert metadata is not None
-        storage_writer.finish(metadata=metadata)
+    central_plan = distW.reduce_scatter("plan", local_step, global_step)
 
-    distW.all_reduce("checkpoitn write", write_step, finish_checkpoint)
+    def write_data():
+        assert planner is not None
+        final_local_plan = planner.finish_plan(central_plan)
+        all_writes = storage_writer.write_data(final_local_plan, planner)
+
+        all_writes.wait()
+        return all_writes.value()
+
+    def finish_checkpoint(all_results):
+        assert global_metatadata is not None
+        storage_writer.finish(metadata=global_metatadata, results=all_results)
+        return global_metatadata
+
+    return distW.all_reduce("write", write_data, finish_checkpoint)


### PR DESCRIPTION
Introduce SavePlanner and LoadPlanner classes and code to support the new extensible design.

This PR includes 3 optimizations to the file system writer:

- D2H copy overlap with IO
- multi-threaded save
- file per thread serialization (single file per rank if saving single threaded)

Will all this changes combined we are up to 30% faster than calling `torch.save` on each rank directly on a single host 8-GPU simulation of checkpointing a model with 40B fp32 params.