### PR TITLE
[MPS] Allows scalar input with dim=0 specified

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -149,12 +149,13 @@ void reduction_out_mps
   auto input_t = (input_tensor.sizes().size() == 0) ? input_tensor.view({1}) : input_tensor;
 
   IntArrayRef input_shape = input_t.sizes();
+  int64_t input_dim = input_shape.size();
 
   if (opt_dim.has_value()) {
     IntArrayRef dim = opt_dim.value();
     for(int i = 0; i < dim.size(); i++) {
-      auto wrap_dim = maybe_wrap_dim(dim[i], input_shape.size());
-      TORCH_CHECK(wrap_dim < input_shape.size(),
+      auto wrap_dim = maybe_wrap_dim(dim[i], input_dim);
+      TORCH_CHECK(wrap_dim < input_dim || (wrap_dim == 0 && input_dim == 0),
       func_name+": reduction dim must be in the range of input shape")
     }
   }

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -155,8 +155,8 @@ void reduction_out_mps
     IntArrayRef dim = opt_dim.value();
     for(int i = 0; i < dim.size(); i++) {
       auto wrap_dim = maybe_wrap_dim(dim[i], input_dim);
-      TORCH_CHECK(wrap_dim < input_dim || (wrap_dim == 0 && input_dim == 0),
-      func_name+": reduction dim must be in the range of input shape")
+      TORCH_CHECK(wrap_dim == 0 || wrap_dim < input_dim,
+      func_name+": reduction dim must be in the range of input shape");
     }
   }
 

--- a/aten/src/ATen/native/mps/operations/ScatterGather.mm
+++ b/aten/src/ATen/native/mps/operations/ScatterGather.mm
@@ -33,7 +33,7 @@ TORCH_IMPL_FUNC(gather_out_mps)
   TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int, "index_select(): Expected dtype int32 or int64 for index");
   TORCH_CHECK(self.scalar_type() == output.scalar_type(),
               "gather(): self and output must have the same scalar type");
-  TORCH_CHECK(dim >= 0 && dim < self.dim(),
+  TORCH_CHECK(dim == 0 || dim < self.dim(),
               "gather(): Indexing dim ", dim, " is out of bounds of tensor");
 
 
@@ -170,7 +170,7 @@ void scatter_mps_general
   TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int, "index_select(): Expected dtype int32 or int64 for index");
   TORCH_CHECK(self.scalar_type() == output.scalar_type() && output.scalar_type() == src.scalar_type(),
               "scatter(): self, src and output must have the same scalar type");
-  TORCH_CHECK(dim >= 0 && dim < self.dim(),
+  TORCH_CHECK(dim == 0 || dim < self.dim(),
               "scatter(): Indexing dim ", dim, " is out of bounds of tensor");
 
 


### PR DESCRIPTION
### Description
Allows reduce ops, scatter, and gather to perform operations like the following:

```
x = torch.tensor(5.0)
out = x.sum(0)

x_mps = x.to("mps")
out = x_mps.sum(0)
```

### Issue
<!-- Link to Issue ticket or RFP -->

### Testing
<!-- How did you test your change? -->
