### PR TITLE
[PGNCCL] Expose out-of-place _broadcast_oop to c10d

### DIFF
--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -172,6 +172,12 @@ class ProcessGroup:
         tensor: Tensor,
         root: int,
     ) -> Work: ...
+    def _broadcast_oop(
+        self,
+        output_tensor: Tensor,
+        input_tensor: Tensor,
+        opts=BroadcastOptions(),
+    ) -> Work: ...
     @overload
     def allreduce(
         self,

--- a/torch/csrc/distributed/c10d/Ops.hpp
+++ b/torch/csrc/distributed/c10d/Ops.hpp
@@ -16,6 +16,12 @@ TORCH_API c10::intrusive_ptr<ProcessGroup::Work> broadcast(
     at::TensorList tensors,
     const BroadcastOptions& opts = {});
 
+TORCH_API c10::intrusive_ptr<ProcessGroup::Work> _broadcast_oop(
+    const c10::intrusive_ptr<ProcessGroup> &process_group,
+    const std::vector<at::Tensor> &output_tensors,
+    const std::vector<at::Tensor> &input_tensors,
+    const BroadcastOptions &opts = {});
+
 TORCH_API c10::intrusive_ptr<ProcessGroup::Work> allreduce(
     const c10::intrusive_ptr<ProcessGroup>& process_group,
     at::TensorList tensors,

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -10,6 +10,8 @@ std::string opTypeToString(OpType opType) {
   switch (opType) {
     case OpType::BROADCAST:
       return "BROADCAST";
+    case OpType::_BROADCAST_OOP:
+      return "_BROADCAST_OOP";
     case OpType::ALLREDUCE:
       return "ALLREDUCE";
     case OpType::ALLREDUCE_COALESCED:

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -48,6 +48,7 @@ enum class OpType : std::uint8_t {
   RECVANYSOURCE = 14,
   BARRIER = 15,
   _REDUCE_SCATTER_BASE = 16,
+  _BROADCAST_OOP = 18,
   UNKNOWN = 100,
 };
 
@@ -223,6 +224,16 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
   // TODO: Find a way to force the above rule programmatically.
   virtual c10::intrusive_ptr<ProcessGroup::Work> broadcast(
       std::vector<at::Tensor>& /* tensors */,
+      const BroadcastOptions& /* opts */ = BroadcastOptions()) {
+    TORCH_CHECK(
+        false,
+        c10::str(
+            "ProcessGroup ", getBackendName(), "does not support broadcast"));
+  }
+
+  virtual c10::intrusive_ptr<ProcessGroup::Work> _broadcast_oop(
+      std::vector<at::Tensor>& /* outputTensors */,
+      std::vector<at::Tensor>& /* inputTensors */,
       const BroadcastOptions& /* opts */ = BroadcastOptions()) {
     TORCH_CHECK(
         false,

--- a/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp
@@ -284,6 +284,11 @@ class TORCH_API ProcessGroupNCCL : public ProcessGroup {
       std::vector<at::Tensor>& tensors,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
+  c10::intrusive_ptr<ProcessGroup::Work> _broadcast_oop(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const BroadcastOptions& opts = BroadcastOptions()) override;
+
   c10::intrusive_ptr<ProcessGroup::Work> allreduce(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1014,6 +1014,19 @@ Arguments:
               py::call_guard<py::gil_scoped_release>())
 
           .def(
+              "_broadcast_oop",
+              [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
+                 at::Tensor& y,
+                 at::Tensor& x,
+                 const ::c10d::BroadcastOptions& opts) {
+                return ::c10d::ops::_broadcast_oop(self, {y}, {x}, opts);
+              },
+              py::arg("output_tensor"),
+              py::arg("input_tensor"),
+              py::arg("root"),
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
               "allreduce",
               [](const c10::intrusive_ptr<::c10d::ProcessGroup>& self,
                  const std::vector<at::Tensor>& tensors,


### PR DESCRIPTION
Summary: This change exposes an out-of-place `_broadcast_oop` API from the ProcessGroupNCCL. It allows broadcasting an input tensor and placing the output in a separate output tensor.

Custom collectives may be implemented by coalescing broadcast operations. One such use-case is implementing a vector all_gather (`all_gather_v`) where unevenly sized inputs (uneven at dim-0) are gathered among participating ranks. Since all_gather provides an out-of-place API, an all_gather_v semantic implemented inside `dist.all_gather` also needs to support out-of-place, for which an out-of-place broadcast is required to be exposed.

Test Plan: Added `test_broadcast_oop_ops` in `caffe2/test/distributed/test_c10d_nccl.py` to test the newly exposed `_broadcast_oop` function in ProcessGroupNCCL.

Differential Revision: D37735263

