### PR TITLE
remove unused/debug header

### DIFF
--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -222,7 +222,6 @@ static PyObject * THPVariable_dim(PyObject* self, PyObject* args)
 }
 
 // implemented on the python object to avoid dispatch overhead
-#include <iostream>
 static PyObject * THPVariable_numel(PyObject* self, PyObject* args)
 {
    HANDLE_TH_ERRORS


### PR DESCRIPTION
### Description
Missed one of the review comments in https://github.com/pytorch/pytorch/pull/82731 . Namely, to remove an unused `<iostream>` that was used for debugging

### Issue
<!-- Link to Issue ticket or RFP -->

### Testing
<!-- How did you test your change? -->
