### PR TITLE
[SSA] Clear Shape Cache on Load Error

### DIFF
--- a/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
+++ b/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
@@ -344,7 +344,7 @@ void loadModule(const CompilationUnit& module) {
 }
 
 void loadFunctions() {
-  try{
+  try {
     auto shape_compute_functions =
         GetSerializedShapeFunctions() + _xnnpack_shape_compute_functions;
 
@@ -359,8 +359,7 @@ void loadFunctions() {
     compilation_unit->define(
         c10::nullopt, shape_compute_functions, resolver, nullptr);
     loadModule(*compilation_unit);
-  }
-  catch (...){
+  } catch (...) {
     // Reset the cache and compilation unit so that we don't get weird errors
     // in later tests when one of the shape functions is invalid.
     compilation_unit = std::make_shared<CompilationUnit>();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #79571
* __->__ #82850

If we do not clear when loading shape cache items errors out, it instead produces unhelpful errors on retry.
Every single subsequent test errors out with `method 'unary' already defined`.

See this example error in PR #80860:

```
ERROR [0.000s]: test_zerodim_cpu (jit.test_device_analysis.TestDeviceAnalysis) [In device: (device(type='cpu'), device(type='cpu')), expected: cpu,
 mul
 shapes: ((1, 2, 2), (2, 2)),
 devices: (device(type='cpu'), device(type='cpu'))]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/test/jit/test_device_analysis.py", line 66, in assert_device_equal
    self.prop_device_on_graph(graph, in_devices, in_shapes)
  File "/var/lib/jenkins/workspace/test/jit/test_device_analysis.py", line 55, in prop_device_on_graph
    torch._C._jit_pass_propagate_shapes_on_graph(graph)
RuntimeError: expected eof but found ':' here:
aten::convolution : (Tensor, Tensor, Tensor?, int[], int[], int[], bool, int[], int) -> (Tensor)
                  ~ <--- HERE

======================================================================
ERROR [0.000s]: test_zerodim_cpu (jit.test_device_analysis.TestDeviceAnalysis) [In device: (device(type='cpu'), device(type='cpu')), expected: cpu,
 mul
 shapes: ((1, 2, 2), ()),
 devices: (device(type='cpu'), device(type='cpu'))]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/test/jit/test_device_analysis.py", line 66, in assert_device_equal
    self.prop_device_on_graph(graph, in_devices, in_shapes)
  File "/var/lib/jenkins/workspace/test/jit/test_device_analysis.py", line 55, in prop_device_on_graph
    torch._C._jit_pass_propagate_shapes_on_graph(graph)
RuntimeError: method 'unary' already defined.
```