### PR TITLE
[vulkan] Pass correct output_padding_arg when creating conv2d contexts

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -1026,7 +1026,7 @@ c10::intrusive_ptr<Conv2dPackedContext> create_conv2d_context(
       dilation,
       /* transposed = */ false,
       /* quantized = */ false,
-      /* output_padding_arg = */ {},
+      /* output_padding_arg = */ {0},
       groups,
       output_min,
       output_max));
@@ -1402,7 +1402,7 @@ c10::intrusive_ptr<Conv2dOpContext> conv2d_clamp_prepack(
       std::move(padding),
       std::move(dilation),
       /* transposed = */ false,
-      /* output_padding = */ {},
+      /* output_padding = */ {0},
       groups,
       output_min,
       output_max));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82861

Passing `{}` as `output_padding` results in the following exception

```
c10::Error: expected output_padding to be a single integer value or a list of 2 values to match the convolution dimensions, but got output_padding=[]
```

when calling

```
const auto output_padding =
      expand_param_if_needed(output_padding_arg, "output_padding", 2);
```

in the constructor of `Conv2dPackedContext`. This can be fixed by passing `{0}` instead.

Differential Revision: [D38449709](https://our.internmc.facebook.com/intern/diff/D38449709/)