### PR TITLE
[CI] Disable Libtorch Linux Bionic Cuda for Infra Flakiness

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -75,6 +75,7 @@ jobs:
   libtorch-linux-bionic-cuda11_6-py3_7-gcc7-build:
     name: libtorch-linux-bionic-cuda11.6-py3.7-gcc7
     uses: ./.github/workflows/_linux-build.yml
+    if: ${{ false }}
     with:
       build-environment: libtorch-linux-bionic-cuda11.6-py3.7-gcc7
       docker-image-name: pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7


### PR DESCRIPTION
TSIA. We're seeing some flakiness in this job. It's running out of memory after around 20 minutes randomly. 
![image](https://user-images.githubusercontent.com/34172846/182993841-04f422cd-e8eb-43a3-80fc-73e4865a8878.png)

I thought this was the offending PR https://github.com/pytorch/pytorch/pull/82393 but the revert didn't do anything. 

This could also be the PR but it looks like it passed the land checks https://github.com/pytorch/pytorch/pull/82177. 
```
2022-08-04T22:51:58.1442705Z Compiling  reduce_scatter.cu                   > /var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/reduce_scatter_sumpostdiv_f32.o
2022-08-04T22:51:58.3351114Z Compiling  reduce_scatter.cu                   > /var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/reduce_scatter_sumpostdiv_f64.o
2022-08-04T22:51:59.5663597Z Compiling  reduce_scatter.cu                   > /var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/reduce_scatter_sumpostdiv_bf16.o
2022-08-04T22:51:59.7195656Z Compiling  functions.cu                        > /var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/functions.o
2022-08-04T22:51:59.9692027Z Compiling  onerank_reduce.cu                   > /var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/onerank_reduce.o
2022-08-04T22:53:03.9194057Z virtual memory exhausted: Cannot allocate memory
2022-08-04T22:53:04.2315620Z Makefile:73: recipe for target '/var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/devlink.o' failed
2022-08-04T22:53:04.2316468Z make[5]: *** [/var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/devlink.o] Error 1
2022-08-04T22:53:04.2316953Z make[5]: Leaving directory '/var/lib/jenkins/workspace/third_party/nccl/nccl/src/collectives/device'
2022-08-04T22:53:04.2317474Z Makefile:51: recipe for target '/var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/colldevice.a' failed
2022-08-04T22:53:04.2317968Z make[4]: *** [/var/lib/jenkins/cpp-build/caffe2/build/nccl/obj/collectives/device/colldevice.a] Error 2
2022-08-04T22:53:04.2318372Z make[4]: Leaving directory '/var/lib/jenkins/workspace/third_party/nccl/nccl/src'
2022-08-04T22:53:04.2318686Z Makefile:25: recipe for target 'src.build' failed
2022-08-04T22:53:04.2318910Z make[3]: *** [src.build] Error 2
2022-08-04T22:53:04.2319231Z make[3]: Leaving directory '/var/lib/jenkins/workspace/third_party/nccl/nccl'
2022-08-04T22:53:04.2319713Z CMakeFiles/nccl_external.dir/build.make:85: recipe for target 'nccl_external-prefix/src/nccl_external-stamp/nccl_external-build' failed
2022-08-04T22:53:04.2320174Z make[2]: *** [nccl_external-prefix/src/nccl_external-stamp/nccl_external-build] Error 2
2022-08-04T22:53:04.2320549Z make[2]: Leaving directory '/var/lib/jenkins/cpp-build/caffe2/build'
2022-08-04T22:53:04.2320930Z CMakeFiles/Makefile2:2043: recipe for target 'CMakeFiles/nccl_external.dir/all' failed
2022-08-04T22:53:04.2321207Z make[1]: *** [CMakeFiles/nccl_external.dir/all] Error 2
2022-08-04T22:53:04.2321453Z make[1]: *** Waiting for unfinished jobs....
2022-08-04T22:53:20.2028858Z make[2]: Leaving directory '/var/lib/jenkins/cpp-build/caffe2/build'
```