### PR TITLE
Skip TestNNAPI tests if QNNPACK is not supported

### DIFF
--- a/test/test_nnapi.py
+++ b/test/test_nnapi.py
@@ -4,10 +4,11 @@
 import os
 import ctypes
 import torch
+import unittest
 from typing import Tuple
 from torch.backends._nnapi.prepare import convert_model_to_nnapi
+from torch.testing._internal.common_quantized import supported_qengines
 from torch.testing._internal.common_utils import TestCase, run_tests
-
 
 def qpt(t, scale, zero_point, dtype=torch.quint8):
     t = torch.tensor(t)
@@ -20,6 +21,8 @@ def nhwc(t):
     return t
 
 
+@unittest.skipUnless('qnnpack' in supported_qengines,
+                     "This Pytorch Build has not been built with or does not support QNNPACK")
 class TestNNAPI(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
### Description
As the testcase unconditionally uses qnnpack skip the test if that isn't supported like other similar tests.

Fixes https://github.com/pytorch/pytorch/issues/82810

### Testing
Ran `test_nnapi.py` on PPC
