### PR TITLE
[docs] fix inconsistent default `rcond` value

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1040,7 +1040,7 @@ See also the `full description of these drivers`_
 when :attr:`driver` is one of (`'gelsy'`, `'gelsd'`, `'gelss'`).
 In this case, if :math:`\sigma_i` are the singular values of `A` in decreasing order,
 :math:`\sigma_i` will be rounded down to zero if :math:`\sigma_i \leq \text{rcond} \cdot \sigma_1`.
-If :attr:`rcond`\ `= None` (default), :attr:`rcond` is set to the machine precision of the dtype of :attr:`A`.
+If :attr:`rcond`\ `= None` (default), :attr:`rcond` is set to the machine precision of the dtype of :attr:`A` times `max(m, n)`.
 
 This function returns the solution to the problem and some extra information in a named tuple of
 four tensors `(solution, residuals, rank, singular_values)`. For inputs :attr:`A`, :attr:`B`


### PR DESCRIPTION
The default `rcond` value is described as "the machine precision of the dtype of :attr:`A`" in the text (line 1043) but "the machine precision of the dtype of :attr:`A` times `max(m, n)`" in the `Args` section (line 1079). The correct value, according to [this issue](https://github.com/pytorch/pytorch/issues/82868) is ":attr:`A` times `max(m, n)`", so I'm updating the description to match.

### Description
<!-- What did you change and why was it needed? -->

### Issue
https://github.com/pytorch/pytorch/issues/82868

### Testing
<!-- How did you test your change? -->
