### PR TITLE
Fix FSDP device_id when CPU offloading

### DIFF
--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -9,7 +9,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.fsdp import FlatParameter
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.distributed.fsdp import ShardingStrategy
+from torch.distributed.fsdp import ShardingStrategy, CPUOffload
 from torch.distributed.fsdp.wrap import (
     always_wrap_policy,
     transformer_auto_wrap_policy,
@@ -117,6 +117,35 @@ class TestFSDPMisc(FSDPTest):
                 fsdp_module.device_id,
                 torch.device("cuda", torch.cuda.current_device()),
             )
+
+    @skip_if_lt_x_gpu(2)
+    def test_fsdp_device_id_cpu_offload(self):
+        """
+        Ensures that even if device_id is specified but we have
+        CPU offload, module is on CPU after init.
+        """
+        class MyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = nn.Linear(10, 10)
+                self.b = nn.Linear(10, 10)
+
+            def forward(self, x):
+                return self.b(self.a(x))
+
+        model = MyModel()
+
+        fsdp = FSDP(
+            model,
+            auto_wrap_policy=always_wrap_policy,
+            cpu_offload=CPUOffload(offload_params=True),
+            device_id=torch.cuda.current_device()
+        )
+
+        cpu_device = torch.device("cpu")
+        for fsdp_unit in FSDP.fsdp_modules(fsdp):
+            fsdp_param = next(fsdp_unit.parameters())
+            self.assertEqual(fsdp_param.device, cpu_device)
 
     @skip_if_lt_x_gpu(2)
     @parametrize("use_index", [True, False])

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -149,7 +149,7 @@ class TestFSDPMisc(FSDPTest):
             # any parameters.
             if len(fsdp_unit.params) > 0:
                 fsdp_param = fsdp_unit.params[0]
-            self.assertEqual(fsdp_param.device, cpu_device)
+                self.assertEqual(fsdp_param.device, cpu_device)
 
     @skip_if_lt_x_gpu(2)
     @parametrize("use_index", [True, False])

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -143,8 +143,12 @@ class TestFSDPMisc(FSDPTest):
         )
 
         cpu_device = torch.device("cpu")
+
         for fsdp_unit in FSDP.fsdp_modules(fsdp):
-            fsdp_param = next(fsdp_unit.parameters())
+            # This FSDP unit may not directly manage
+            # any parameters.
+            if len(fsdp_unit.params) > 0:
+                fsdp_param = fsdp_unit.params[0]
             self.assertEqual(fsdp_param.device, cpu_device)
 
     @skip_if_lt_x_gpu(2)

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1027,10 +1027,10 @@ class FullyShardedDataParallel(nn.Module):
 
     def _move_module_if_needed(self, module) -> None:
         """
-        Moves module appropriately depending on device_id and
-        whether module is on CPU. Returns a ``bool`` indicating
-        whether the module needs to be moved back to CPU before
-        returning to user.
+        Moves module if module is on CPU and device_id is specified.
+        If device_id is not specified and module is on CPU, we log a
+        warning to user mentioning to use ``device_id`` argument to speed
+        up initialization performance.
         """
         # Move module to device specified. Note that this is done prior to
         # setting compute_device to ensure that they align.
@@ -1051,7 +1051,11 @@ class FullyShardedDataParallel(nn.Module):
                 pass
 
             # For GPU modules, module device should match device_id.
-            if param is not None and param.device != self.device_id:
+            if (
+                param is not None
+                and not isinstance(param, FlatParameter)
+                and param.device != self.device_id
+            ):
                 raise RuntimeError(
                     f"Module on rank {self.rank} is given device_id argument "
                     f"{self.device_id}, but is on {param.device}. "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82892

See https://github.com/pytorch/pytorch/issues/82891 for full context. 

When we init FSDP with device_id + CPU offload, we could potentially hit a crash when an outer FSDP unit does not manage any params. What was happening is that it would end up getting a flat param of a child FSDP module, check the device of this, see it is CPU, and throw an error.

The fix is to avoid this check if we hit a flat param. Also fixes up the documentation of the function.