### PR TITLE
[PyTorch] Profiler execution graph record tensor device

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -318,6 +318,9 @@ class TestExecutionGraph(TestCase):
         assert fp.name == eg.get_output_file_path()
         nodes = self.get_execution_graph_root(fp.name)
         loop_count = 0
+        # Expected tensor object tuple size, in th form of:
+        # [tensor_id, storage_id, offset, numel, itemsize, device_str]
+        tensor_tuple_size = 6
         found_root_node = False
         for n in nodes:
             assert "name" in n
@@ -325,6 +328,9 @@ class TestExecutionGraph(TestCase):
                 found_root_node = True
             if n["name"].startswith("## LOOP "):
                 loop_count += 1
+            # Check if tensor tuple representation size is correct.
+            if n["name"] == "## TEST 2 ##":
+                assert len(n["inputs"][3][0]) == tensor_tuple_size
         assert found_root_node
         assert loop_count == expected_loop_events
 

--- a/torch/csrc/profiler/execution_graph_observer.cpp
+++ b/torch/csrc/profiler/execution_graph_observer.cpp
@@ -376,14 +376,23 @@ inline std::string convertIValue(
     size_t offset = 0;
     size_t numel = 0;
     size_t itemsize = 0;
+    std::string device_str = "";
     if (t->has_storage()) {
-      storage_id = getObjectID(ob, t->storage().data());
+      auto& t_storage = t->storage();
+      storage_id = getObjectID(ob, t_storage.data());
       offset = t->storage_offset();
       numel = t->numel();
       itemsize = t->itemsize();
+      device_str = t->device().str();
     }
-    return vectorToString(
-        std::vector<size_t>{tensor_id, storage_id, offset, numel, itemsize});
+    return fmt::format(
+        "[{},{},{},{},{},\"{}\"]",
+        tensor_id,
+        storage_id,
+        offset,
+        numel,
+        itemsize,
+        device_str);
   } else if (val.isTuple()) {
     std::vector<std::string> str_array;
     const auto& val_tuple = val.toTupleRef().elements();


### PR DESCRIPTION
Summary: During execution graph replay, we also want to know where the tensor is allocated to properly model the behavior. The device name is now captured inside the tensor tuple.

Test Plan:
buck build mode/dev-nosan caffe2/test:profiler --show-output
buck-out/gen/caffe2/test/profiler#binary.par test_profiler.TestExecutionGraph

Reviewed By: aaronenyeshi

Differential Revision: D38017717

