### PR TITLE
[functorch] fix unsqueeze_ batching rule

### DIFF
--- a/functorch/functorch/csrc/BatchedTensorImpl.h
+++ b/functorch/functorch/csrc/BatchedTensorImpl.h
@@ -81,6 +81,10 @@ struct BatchedTensorImpl : public c10::TensorImpl {
   void _unsafe_set_level(int64_t level) {
     level_ = level;
   }
+  void unsafe_set_bdim(int64_t bdim) {
+    // NB: you MUST call refreshTensorMetadata after doing this.
+    bdim_ = bdim;
+  }
  private:
   // see NOTE: [BatchedTensorImpl levels invariant]
   void checkInvariants() const;

--- a/functorch/functorch/csrc/LegacyBatchingRegistrations.cpp
+++ b/functorch/functorch/csrc/LegacyBatchingRegistrations.cpp
@@ -166,9 +166,13 @@ Tensor& unsqueeze__batching_rule(Tensor& self, int64_t dim) {
     return self.unsqueeze_(dim);
   }
   auto* batched = maybeGetBatchedImpl(self);
-  TORCH_CHECK(batched && batched->bdim() == 0);
   auto logical_dim = self.dim();
-  auto dim_physical = 1 + maybe_wrap_dim(dim, logical_dim + 1);
+  int64_t dim_physical = maybe_wrap_dim(dim, logical_dim + 1);
+  if (dim_physical >= batched->bdim()) {
+    dim_physical = 1 + dim_physical;
+  } else {
+    batched->unsafe_set_bdim(batched->bdim() + 1);
+  }
   batched->value().unsqueeze_(dim_physical);
 
   // Also need to change some metadata...

--- a/functorch/test/test_vmap.py
+++ b/functorch/test/test_vmap.py
@@ -3243,7 +3243,6 @@ class TestVmapOperatorsOpInfo(TestCase):
             'squeeze',
             't',
             'transpose',
-            'unsqueeze',
         )
         self.opinfo_vmap_test(device, dtype, op, check_has_batch_rule=False,
                               skip_inplace=inplace_failure_list)
@@ -3404,7 +3403,6 @@ class TestVmapOperatorsOpInfo(TestCase):
             'tril',
             'triu',
             'trunc',
-            'unsqueeze',
             'xlogy',
         )
         self.opinfo_vmap_test(device, dtype, op, check_has_batch_rule=True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #82905
* #82903
* __->__ #82899
* #82898
* #82897

The old batching rule assumed that the tensor's bdim was at dimension 0.
This is not always the case.

Test Plan:
- tests