### PR TITLE
Remove Deprecated Copy Constructor

### DIFF
--- a/c10/util/variant.h
+++ b/c10/util/variant.h
@@ -2253,7 +2253,6 @@ class impl : public copy_assignment<traits<Ts...>> {
 
  public:
   C10_MPARK_INHERITING_CTOR(impl, super)
-  impl& operator=(const impl& other) = default;
 
   template <std::size_t I, typename Arg>
   inline void assign(Arg&& arg) {


### PR DESCRIPTION
Summary: Fix the following compilation error https://www.internalfb.com/diffs/browse?start=0&phabricator_diff_id=379911240743608&selected_signal=c2xwOjE1NjA3NjQxMDc2MzQ0Nzk%3D&selected_signal_verification_phase=1&dst_version_fbid=746884619882827

Test Plan:
1. `maui install workvc`

2. `pull / linux-xenial-cuda11_3-py3_7-gcc7-deploy / build`
signal should pass

Differential Revision: D38433489

