### PR TITLE
pytest - print message re skip info

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -734,6 +734,7 @@ def run_tests(argv=UNITTEST_ARGS):
                                     '--reruns=2', '-rfEX', f'--junit-xml-reruns={pytest_report_path}'])
             del os.environ["USING_PYTEST"]
             sanitize_pytest_xml(f'{pytest_report_path}')
+            print("Skip info is located in the xml test reports, please either go to s3 or the hud to download them")
             # exitcode of 5 means no tests were found, which happens since some test configs don't
             # run tests from certain files
             exit(0 if exit_code == 5 else exit_code)


### PR DESCRIPTION
### Description
Skip messages can't be found in the logs due to restrictions w/ running in parallel and they take up too much space/required a lot of scrolling if you wanted to look at failure info instead, so tell people that they can still be found in the xml files.

### Testing
Look at the logs to make sure it actually got printed