### PR TITLE
[mergebot] Update merge bot messages to explain flags

### DIFF
--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1191,6 +1191,7 @@ def merge(pr_num: int, repo: GitRepo,
     initial_commit_sha = pr.last_commit()['oid']
     explainer = TryMergeExplainer(force, on_green, land_checks, pr.get_labels(), pr.pr_num, org, project)
     on_green, land_checks = explainer.get_flags()
+    land_check_commit = None
 
     check_for_sev(org, project, force)
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -907,11 +907,6 @@ class GitHubPR:
         repo._run_git('checkout', "-b", land_check_branch)
         repo._run_git('push', '-u', 'origin', land_check_branch, '--force')
         commit = repo.get_commit('HEAD').commit_hash
-        gh_post_pr_comment(self.org, self.project, self.pr_num,
-                           '@pytorchbot successfully started a merge and created land time checks.' +
-                           f' See merge status [here]({os.getenv("GH_RUN_URL")}) ' +
-                           f'and [land check]({BOT_COMMANDS_WIKI}) '
-                           f'progress [here](https://hud.pytorch.org/{self.org}/{self.project}/commit/{commit}).')
         return commit
 
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1195,15 +1195,15 @@ def merge(pr_num: int, repo: GitRepo,
     org, project = repo.gh_owner_and_name()
     pr = GitHubPR(org, project, pr_num)
     initial_commit_sha = pr.last_commit()['oid']
+    explainer = TryMergeExplainer(force, on_green, land_checks, pr, org, project)
+    on_green, land_checks = explainer.get_flags()
 
     check_for_sev(org, project, force)
 
     if land_checks:
         land_check_commit = pr.create_land_time_check_branch(repo, 'viable/strict', force=force, comment_id=comment_id)
 
-    explainer = TryMergeExplainer(force, on_green, land_checks, pr, org, project, land_check_commit)
-    on_green, land_checks = explainer.get_flags()
-    explainer.print_merge_message(dry_run)
+    explainer.print_merge_message(land_check_commit, dry_run)
 
     if force or can_skip_internal_checks(pr, comment_id):
         # do not wait for any pending signals if PR is closed as part of co-development process

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -6,15 +6,36 @@ import os
 import re
 import time
 import urllib.parse
-from datetime import datetime
 from dataclasses import dataclass
-from urllib.request import urlopen, Request
-from urllib.error import HTTPError
-from typing import Iterable, Pattern, cast, Any, Callable, Dict, List, Optional, Tuple, Union
-from gitutils import get_git_remote_name, get_git_repo_dir, patterns_to_regex, GitRepo
+from datetime import datetime
 from functools import lru_cache
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Pattern,
+    Tuple,
+    Union,
+    cast,
+)
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
 from warnings import warn
 
+from gitutils import (
+    GitRepo,
+    get_git_remote_name,
+    get_git_repo_dir,
+    patterns_to_regex,
+)
+from trymerge_explainer import (
+    TryMergeExplainer,
+    get_land_check_troubleshooting_message,
+    print_revert_message,
+)
 
 GH_PR_REVIEWS_FRAGMENT = """
 fragment PRReviews on PullRequestReviewConnection {
@@ -1174,15 +1195,21 @@ def merge(pr_num: int, repo: GitRepo,
     org, project = repo.gh_owner_and_name()
     pr = GitHubPR(org, project, pr_num)
     initial_commit_sha = pr.last_commit()['oid']
+
     check_for_sev(org, project, force)
+
+    if land_checks:
+        land_check_commit = pr.create_land_time_check_branch(repo, 'viable/strict', force=force, comment_id=comment_id)
+
+    explainer = TryMergeExplainer(force, on_green, land_checks, pr, org, project, land_check_commit)
+    on_green, land_checks = explainer.get_flags()
+    explainer.print_merge_message(dry_run)
+
     if force or can_skip_internal_checks(pr, comment_id):
         # do not wait for any pending signals if PR is closed as part of co-development process
         return pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)
     if (datetime.utcnow() - pr.last_pushed_at()).days > stale_pr_days:
         raise RuntimeError("This PR is too stale; the last push date was more than 3 days ago. Please rebase and try again.")
-
-    if land_checks:
-        land_check_commit = pr.create_land_time_check_branch(repo, 'viable/strict', force=force, comment_id=comment_id)
 
     start_time = time.time()
     last_exception = ''
@@ -1228,64 +1255,26 @@ def merge(pr_num: int, repo: GitRepo,
         gh_add_labels(org, project, pr_num, ["land-failed"])
     raise RuntimeError(msg)
 
-def get_msg_template(prefix, explaination):
-    return f"{prefix}. {explaination}"
-
-def get_flag_prefix(flag):
-    return f"The merge job was triggered with the {flag} flag."
-
-def get_flag_explaination_message(force, on_green, land_checks, has_trunk_label, has_ciflow_label):
-    if force:
-        return get_msg_template(get_flag_prefix("-f"),
-                                "This means your PR will be merged immediately, bypassing any checks")
-    elif on_green:
-        return get_msg_template(get_flag_prefix("-g"),
-                                "This means that your PR will be merged once all signals on your PR has passed.")
-    elif land_checks:
-        if has_trunk_label:
-            land_check_msg_suffix = f"have run since you have the {CIFLOW_TRUNK_LABEL}"
-        else:
-            land_check_msg_suffix = "and the land checks branch have run."
-        return get_msg_template(get_flag_prefix('-l'),
-                                "This means that your PR will be merged once all signals on your PR " +
-                                land_check_msg_suffix
-                                )
-    else:
-        if has_ciflow_label:
-            normal_msg_suffix = "Since your PR has a ciflow label, we will wait for all checks to be green on your PR."
-        else:
-            normal_msg_suffix = "Merge bot will wait for mandatory checks defined in the merge rules to be green before merging."
-        return get_msg_template("The merge job was triggered with no flags.", normal_msg_suffix)
-
-
 def main() -> None:
     args = parse_args()
     repo = GitRepo(get_git_repo_dir(), get_git_remote_name())
     org, project = repo.gh_owner_and_name()
     pr = GitHubPR(org, project, args.pr_num)
-    land_checks = args.land_checks and not has_label(pr.get_labels(), CIFLOW_TRUNK_LABEL)
-    on_green = args.on_green or has_label(pr.get_labels(), CIFLOW_LABEL)
 
     def handle_exception(e: Exception, msg: str = "Merge failed") -> None:
         msg += f" due to {e}"
         run_url = os.getenv("GH_RUN_URL")
         if run_url is not None:
             msg += f"\nRaised by {run_url}"
-        if land_checks:
-            msg += (" If you believe this is an error, you can use the old behavior with `@pytorchbot merge -g`" +
-                    ' (optionally with the "ciflow/trunk" to get land signals)' +
-                    ' or use `@pytorchbot merge -f "some reason here"`.' +
-                    f" For more information, see the [bot wiki]({BOT_COMMANDS_WIKI}).")
+        if args.land_checks:
+            msg += get_land_check_troubleshooting_message()
         gh_post_pr_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)
         import traceback
         traceback.print_exc()
-    if not land_checks:
-        msg = f"@pytorchbot successfully started a {'revert' if args.revert else 'merge'} job."
-        msg += f" Check the current status [here]({os.getenv('GH_RUN_URL')})."
-        gh_post_pr_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)
 
     if args.revert:
         try:
+            print_revert_message(org, project, args.pr_num, args.dry_run)
             try_revert(repo, pr, dry_run=args.dry_run, comment_id=args.comment_id, reason=args.reason)
         except Exception as e:
             handle_exception(e, f"Reverting PR {args.pr_num} failed")
@@ -1304,9 +1293,9 @@ def main() -> None:
               dry_run=args.dry_run,
               force=args.force,
               comment_id=args.comment_id,
-              on_green=on_green,
+              on_green=args.on_green,
               mandatory_only=args.on_mandatory,
-              land_checks=land_checks)
+              land_checks=args.land_checks)
     except Exception as e:
         handle_exception(e)
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -1236,7 +1236,7 @@ def merge(pr_num: int, repo: GitRepo,
             if (not mandatory_only and on_green) and len(pending) > 0:
                 raise MandatoryChecksMissingError(f"Still waiting for {len(pending)} additional jobs to finish, " +
                                                   f"first few of them are: {' ,'.join(x[0] for x in pending[:5])}")
-            if land_checks:
+            if land_checks and land_check_commit is not None:
                 validate_land_time_checks(org, project, land_check_commit)
 
             return pr.merge_into(repo, dry_run=dry_run, force=force, comment_id=comment_id)

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -9,7 +9,8 @@ CIFLOW_LABEL = re.compile(r"^ciflow/.+")
 CIFLOW_TRUNK_LABEL = re.compile(r"^ciflow/trunk")
 
 OFFICE_HOURS_LINK = "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours"
-CONTACT_US = f"If you have any questions or feedback, reach out to the [Pytorch DevX Team]({OFFICE_HOURS_LINK})!"
+CONTACT_US = f"Please reach out to the [PyTorch DevX Team]({OFFICE_HOURS_LINK}) with feedback or questions!"
+ALTERNATIVES = f"If this is not what you meant to do, try some of the other [flags]({BOT_COMMANDS_WIKI})."
 
 
 def has_label(labels: List[str], pattern: Pattern[str] = CIFLOW_LABEL) -> bool:
@@ -70,38 +71,29 @@ class TryMergeExplainer(object):
             return (
                 " and land check "
                 + f"progress [here](https://hud.pytorch.org/{self.org}/{self.project}/commit/{commit})."
-                + f"\n For other forms of merge, please refer to our [wiki]({BOT_COMMANDS_WIKI})."
             )
         else:
             return ""
 
     def _get_flag_explanation_message(self) -> str:
         if self.force:
-            return "This means your PR will be merged immediately, bypassing any CI signals."
+            return "This means your PR will be merged **immediately**, bypassing any CI checks (ETA: 1-5 minutes)."
         elif self.on_green:
-            return (
-                "This means that your PR will be merged once all signals have passed."
-            )
+            return "This means that your PR will be merged once all checks have passed (ETA: 0-4 Hours)."
         elif self.land_checks:
             if self.has_trunk_label:
-                land_check_msg_suffix = (
-                    "have run since you have added the ciflow/trunk label to your PR."
-                )
+                land_check_msg_suffix = "have passed since you have added the ciflow/trunk label to your PR (ETA 0-4 Hours)."
             else:
-                land_check_msg_suffix = "and the land checks have run (ETA 4 Hours)."
+                land_check_msg_suffix = "and the land checks have passed (ETA 4 Hours)."
             return (
                 "This means that your PR will be merged once all signals on your PR "
                 + land_check_msg_suffix
             )
-
         else:
-            if self.has_ciflow_label:
-                return "Since your PR has a ciflow label, we will wait for all checks to be green."
-            else:
-                return "This means only we will only wait for mandatory checks to be green."
+            return "This means that your PR will be merged once all checks have passed (ETA: 0-4 Hours)."
 
     def get_merge_message(self, commit: Optional[str] = None) -> str:
-        message_prefix = "@pytorchbot successfully started a merge job."
+        message_prefix = "@bot successfully started a merge job."
         progress_links = f"Check the current status [here]({os.getenv('GH_RUN_URL')}){self._get_land_check_progress(commit)}."
         flag_message = f"The merge job was triggered with{self._get_flag_msg()} flag."
         explanation_message = self._get_flag_explanation_message()
@@ -109,7 +101,8 @@ class TryMergeExplainer(object):
         msg = message_prefix + " "
         msg += progress_links + "\n"
         msg += flag_message + " "
-        msg += explanation_message + "\n"
+        msg += explanation_message + " "
+        msg += ALTERNATIVES + "\n"
         msg += CONTACT_US
         return msg
 
@@ -117,8 +110,9 @@ class TryMergeExplainer(object):
 def get_revert_message(org: str, project: str, pr_num: int) -> str:
     msg = (
         "@pytorchbot successfully started a revert job."
-        + f" Check the current status [here]({os.getenv('GH_RUN_URL')})\n"
+        + f" Check the current status [here]({os.getenv('GH_RUN_URL')})"
     )
+    msg += ALTERNATIVES + "\n"
     msg += CONTACT_US
     return msg
 
@@ -126,7 +120,7 @@ def get_revert_message(org: str, project: str, pr_num: int) -> str:
 def get_land_check_troubleshooting_message() -> str:
     return (
         " If you believe this is an error, you can use the old behavior with `@pytorchbot merge -g`"
-        + ' (optionally with the "ciflow/trunk" to get land signals)'
+        + ' (optionally with the "ciflow/trunk" to get land checks)'
         + ' or use `@pytorchbot merge -f "some reason here"`.'
         + f" For more information, see the [bot wiki]({BOT_COMMANDS_WIKI}). \n"
         + CONTACT_US

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -1,6 +1,5 @@
 import os
 import re
-from tkinter import OFF
 from typing import List, Pattern, Tuple, Optional
 
 
@@ -11,6 +10,7 @@ CIFLOW_TRUNK_LABEL = re.compile(r"^ciflow/trunk")
 
 OFFICE_HOURS_LINK = "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours"
 CONTACT_US = f"If you have any questions or feedback, reach out to the [Pytorch DevX Team]({OFFICE_HOURS_LINK})!"
+
 
 def has_label(labels: List[str], pattern: Pattern[str] = CIFLOW_LABEL) -> bool:
     return len(list(filter(pattern.match, labels))) > 0
@@ -84,7 +84,9 @@ class TryMergeExplainer(object):
             )
         elif self.land_checks:
             if self.has_trunk_label:
-                land_check_msg_suffix = f"have run since you have added the ciflow/trunk label to your PR."
+                land_check_msg_suffix = (
+                    "have run since you have added the ciflow/trunk label to your PR."
+                )
             else:
                 land_check_msg_suffix = "and the land checks have run (ETA 4 Hours)."
             return (
@@ -119,6 +121,7 @@ def get_revert_message(org: str, project: str, pr_num: int) -> str:
     )
     msg += CONTACT_US
     return msg
+
 
 def get_land_check_troubleshooting_message() -> str:
     return (

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -62,16 +62,17 @@ class TryMergeExplainer(object):
     def _get_land_check_progress(self, commit: Optional[str]) -> str:
         if commit is not None:
             return (
-                f" and [land check]({BOT_COMMANDS_WIKI}) "
-                + f"progress [here](https://hud.pytorch.org/{self.org}/{self.project}/commit/{commit})"
+                f" and land check "
+                + f"progress [here](https://hud.pytorch.org/{self.org}/{self.project}/commit/{commit})."
+                + f"\n For other forms of merge, please refer to our [wiki]({BOT_COMMANDS_WIKI})."
             )
         else:
             return ""
 
-    def _get_flag_explaination_message(self) -> str:
+    def _get_flag_explanation_message(self) -> str:
         if self.force:
             return (
-                "This means your PR will be merged immediately, bypassing any checks."
+                "This means your PR will be merged immediately, bypassing any CI signals."
             )
         elif self.on_green:
             return (
@@ -80,11 +81,11 @@ class TryMergeExplainer(object):
         elif self.land_checks:
             if self.has_trunk_label:
                 land_check_msg_suffix = (
-                    f"have run since you have the {CIFLOW_TRUNK_LABEL}."
+                    f"have run since you have added the {CIFLOW_TRUNK_LABEL} to your PR."
                 )
             else:
                 land_check_msg_suffix = (
-                    "and the land checks branch have run (ETA 4 Hours)."
+                    "and the land checks have run (ETA 4 Hours)."
                 )
             return (
                 "This means that your PR will be merged once all signals on your PR "
@@ -93,7 +94,7 @@ class TryMergeExplainer(object):
 
         else:
             if self.has_ciflow_label:
-                return "Since your PR has a ciflow label, we will wait for all checks to be."
+                return "Since your PR has a ciflow label, we will wait for all checks to be green."
             else:
                 return "This means only we will only wait for mandatory checks to be green."
 
@@ -101,7 +102,7 @@ class TryMergeExplainer(object):
         message_prefix = "@pytorchbot successfully started a merge job."
         progress_links = f"Check the current status [here]({os.getenv('GH_RUN_URL')}){self._get_land_check_progress(commit)}."
         flag_message = f"The merge job was triggered with{self._get_flag_msg()} flag."
-        explaination_message = self._get_flag_explaination_message()
+        explanation_message = self._get_flag_explaination_message()
 
         msg = message_prefix + " "
         msg += progress_links + "\n"

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -1,5 +1,6 @@
 import os
 import re
+from tkinter import OFF
 from typing import List, Pattern, Tuple, Optional
 
 
@@ -8,6 +9,8 @@ BOT_COMMANDS_WIKI = "https://github.com/pytorch/pytorch/wiki/Bot-commands"
 CIFLOW_LABEL = re.compile(r"^ciflow/.+")
 CIFLOW_TRUNK_LABEL = re.compile(r"^ciflow/trunk")
 
+OFFICE_HOURS_LINK = "https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours"
+CONTACT_US = f"If you have any questions or feedback, reach out to the [Pytorch DevX Team]({OFFICE_HOURS_LINK})!"
 
 def has_label(labels: List[str], pattern: Pattern[str] = CIFLOW_LABEL) -> bool:
     return len(list(filter(pattern.match, labels))) > 0
@@ -81,7 +84,7 @@ class TryMergeExplainer(object):
             )
         elif self.land_checks:
             if self.has_trunk_label:
-                land_check_msg_suffix = f"have run since you have added the {CIFLOW_TRUNK_LABEL} to your PR."
+                land_check_msg_suffix = f"have run since you have added the ciflow/trunk label to your PR."
             else:
                 land_check_msg_suffix = "and the land checks have run (ETA 4 Hours)."
             return (
@@ -104,15 +107,17 @@ class TryMergeExplainer(object):
         msg = message_prefix + " "
         msg += progress_links + "\n"
         msg += flag_message + " "
-        msg += explanation_message
+        msg += explanation_message + "\n"
+        msg += CONTACT_US
         return msg
 
 
 def get_revert_message(org: str, project: str, pr_num: int) -> str:
     msg = (
         "@pytorchbot successfully started a revert job."
-        + f"Check the current status [here]({os.getenv('GH_RUN_URL')})"
+        + f" Check the current status [here]({os.getenv('GH_RUN_URL')})\n"
     )
+    msg += CONTACT_US
     return msg
 
 def get_land_check_troubleshooting_message() -> str:
@@ -120,5 +125,6 @@ def get_land_check_troubleshooting_message() -> str:
         " If you believe this is an error, you can use the old behavior with `@pytorchbot merge -g`"
         + ' (optionally with the "ciflow/trunk" to get land signals)'
         + ' or use `@pytorchbot merge -f "some reason here"`.'
-        + f" For more information, see the [bot wiki]({BOT_COMMANDS_WIKI})."
+        + f" For more information, see the [bot wiki]({BOT_COMMANDS_WIKI}). \n"
+        + CONTACT_US
     )

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -1,0 +1,127 @@
+import os
+import re
+from typing import List, Pattern, Tuple
+
+from trymerge import BOT_COMMANDS_WIKI, GitHubPR, gh_post_pr_comment
+
+CIFLOW_LABEL = re.compile(r"^ciflow/.+")
+CIFLOW_TRUNK_LABEL = re.compile(r"^ciflow/trunk")
+
+
+def has_label(labels: List[str], pattern: Pattern[str] = CIFLOW_LABEL) -> bool:
+    return len(list(filter(pattern.match, labels))) > 0
+
+
+class TryMergeExplainer(object):
+    force: bool
+    on_green: bool
+    land_checks: bool
+    pr: GitHubPR
+    org: str
+    project: str
+    commit: str
+
+    has_trunk_label: bool
+    has_ciflow_label: bool
+
+    def __init__(
+        self,
+        force: bool,
+        on_green: bool,
+        land_checks: bool,
+        pr: GitHubPR,
+        org: str,
+        project: str,
+        commit: str,
+    ):
+        self.force = force
+        self.on_green = on_green
+        self.land_checks = land_checks
+        self.pr = pr
+        self.org = org
+        self.project = project
+        self.commit = commit
+
+    def get_flags(self) -> Tuple[bool, bool]:
+        self.has_trunk_label = has_label(self.pr.get_labels(), CIFLOW_TRUNK_LABEL)
+        self.has_ciflow_label = has_label(self.pr.get_labels(), CIFLOW_LABEL)
+        should_check_land_branch = self.land_checks and not self.has_trunk_label
+        should_check_green = self.on_green or self.has_ciflow_label
+
+        return (should_check_green, should_check_land_branch)
+
+    def _get_flag_msg(self) -> str:
+        if self.force:
+            return " the force (-f)"
+        elif self.on_green:
+            return " the green (-g)"
+        elif self.land_checks:
+            return " the land check (-l)"
+        else:
+            return "out a "
+
+    def _get_land_check_progress(self) -> str:
+        if self.commit != None:
+            return (
+                f" and [land check]({BOT_COMMANDS_WIKI}) "
+                + f"progress [here](https://hud.pytorch.org/{self.org}/{self.project}/commit/{self.commit})"
+            )
+        else:
+            return ""
+
+    def _get_flag_explaination_message(self) -> str:
+        if self.force:
+            return (
+                "This means your PR will be merged immediately, bypassing any checks."
+            )
+        elif self.on_green:
+            return "This means that your PR will be merged once all signals on your PR has passed."
+        elif self.land_checks:
+            if self.has_trunk_label:
+                land_check_msg_suffix = (
+                    f"have run since you have the {CIFLOW_TRUNK_LABEL}."
+                )
+            else:
+                land_check_msg_suffix = (
+                    "and the land checks branch have run (ETA 4 Hours)."
+                )
+            return (
+                "This means that your PR will be merged once all signals on your PR "
+                + land_check_msg_suffix
+            )
+
+        else:
+            if self.has_ciflow_label:
+                normal_msg_suffix = "Since your PR has a ciflow label, we will wait for all checks to be green on your PR."
+            else:
+                normal_msg_suffix = "Merge bot will wait for mandatory checks defined in the merge rules to be green before merging."
+            return "The merge job was triggered with no flags." + normal_msg_suffix
+
+    def print_merge_message(self, dry_run: bool) -> None:
+        message_prefix = f"@pytorchbot successfully started a merge job."
+        progress_links = f"Check the current status [here]({os.getenv('GH_RUN_URL')}){self._get_land_check_progress()}."
+        flag_message = f"The merge job was triggered with{self._get_flag_msg()} flag."
+        explaination_message = self._get_flag_explaination_message()
+
+        msg = message_prefix + " "
+        msg += progress_links + "\n"
+        msg += flag_message + " "
+        msg += explaination_message
+        gh_post_pr_comment(self.org, self.project, self.pr.pr_num, msg, dry_run)
+
+
+def print_revert_message(org: str, project: str, pr_num: int, dry_run: bool) -> None:
+    msg = (
+        "@pytorchbot successfully started a revert job."
+        + f"Check the current status [here]({os.getenv('GH_RUN_URL')})"
+    )
+    gh_post_pr_comment(org, project, pr_num, msg, dry_run)
+
+
+def get_land_check_troubleshooting_message() -> str:
+    return (
+        " If you believe this is an error, you can use the old behavior with `@pytorchbot merge -g`"
+        + ' (optionally with the "ciflow/trunk" to get land signals)'
+        + ' or use `@pytorchbot merge -f "some reason here"`.'
+        + f" For more information, see the [bot wiki]({BOT_COMMANDS_WIKI})."
+    )

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -78,7 +78,7 @@ class TryMergeExplainer(object):
         if commit is not None:
             return (
                 " and land check "
-                + f"progress [here](https://hud.pytorch.org/{self.org}/{self.project}/commit/{commit})."
+                + f"progress [here](https://hud.pytorch.org/{self.org}/{self.project}/commit/{commit})"
             )
         else:
             return ""

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -2,7 +2,6 @@ import os
 import re
 from typing import List, Pattern, Tuple, Optional
 
-from trymerge import GitHubPR, gh_post_pr_comment
 
 BOT_COMMANDS_WIKI = "https://github.com/pytorch/pytorch/wiki/Bot-commands"
 
@@ -18,7 +17,8 @@ class TryMergeExplainer(object):
     force: bool
     on_green: bool
     land_checks: bool
-    pr: GitHubPR
+    labels: List[str]
+    pr_num: int
     org: str
     project: str
 
@@ -30,20 +30,23 @@ class TryMergeExplainer(object):
         force: bool,
         on_green: bool,
         land_checks: bool,
-        pr: GitHubPR,
+        labels: List[str],
+        pr_num: int,
         org: str,
         project: str,
     ):
         self.force = force
         self.on_green = on_green
         self.land_checks = land_checks
-        self.pr = pr
+        self.labels = labels
+        self.pr_num = pr_num
         self.org = org
         self.project = project
+        self.get_flags()
 
     def get_flags(self) -> Tuple[bool, bool]:
-        self.has_trunk_label = has_label(self.pr.get_labels(), CIFLOW_TRUNK_LABEL)
-        self.has_ciflow_label = has_label(self.pr.get_labels(), CIFLOW_LABEL)
+        self.has_trunk_label = has_label(self.labels, CIFLOW_TRUNK_LABEL)
+        self.has_ciflow_label = has_label(self.labels, CIFLOW_LABEL)
         should_check_land_branch = self.land_checks and not self.has_trunk_label
         should_check_green = self.on_green or self.has_ciflow_label
 
@@ -62,7 +65,7 @@ class TryMergeExplainer(object):
     def _get_land_check_progress(self, commit: Optional[str]) -> str:
         if commit is not None:
             return (
-                f" and land check "
+                " and land check "
                 + f"progress [here](https://hud.pytorch.org/{self.org}/{self.project}/commit/{commit})."
                 + f"\n For other forms of merge, please refer to our [wiki]({BOT_COMMANDS_WIKI})."
             )
@@ -71,22 +74,16 @@ class TryMergeExplainer(object):
 
     def _get_flag_explanation_message(self) -> str:
         if self.force:
-            return (
-                "This means your PR will be merged immediately, bypassing any CI signals."
-            )
+            return "This means your PR will be merged immediately, bypassing any CI signals."
         elif self.on_green:
             return (
                 "This means that your PR will be merged once all signals have passed."
             )
         elif self.land_checks:
             if self.has_trunk_label:
-                land_check_msg_suffix = (
-                    f"have run since you have added the {CIFLOW_TRUNK_LABEL} to your PR."
-                )
+                land_check_msg_suffix = f"have run since you have added the {CIFLOW_TRUNK_LABEL} to your PR."
             else:
-                land_check_msg_suffix = (
-                    "and the land checks have run (ETA 4 Hours)."
-                )
+                land_check_msg_suffix = "and the land checks have run (ETA 4 Hours)."
             return (
                 "This means that your PR will be merged once all signals on your PR "
                 + land_check_msg_suffix
@@ -98,26 +95,25 @@ class TryMergeExplainer(object):
             else:
                 return "This means only we will only wait for mandatory checks to be green."
 
-    def print_merge_message(self, commit: Optional[str], dry_run: bool) -> None:
+    def get_merge_message(self, commit: Optional[str] = None) -> str:
         message_prefix = "@pytorchbot successfully started a merge job."
         progress_links = f"Check the current status [here]({os.getenv('GH_RUN_URL')}){self._get_land_check_progress(commit)}."
         flag_message = f"The merge job was triggered with{self._get_flag_msg()} flag."
-        explanation_message = self._get_flag_explaination_message()
+        explanation_message = self._get_flag_explanation_message()
 
         msg = message_prefix + " "
         msg += progress_links + "\n"
         msg += flag_message + " "
-        msg += explaination_message
-        gh_post_pr_comment(self.org, self.project, self.pr.pr_num, msg, dry_run)
+        msg += explanation_message
+        return msg
 
 
-def print_revert_message(org: str, project: str, pr_num: int, dry_run: bool) -> None:
+def get_revert_message(org: str, project: str, pr_num: int) -> str:
     msg = (
         "@pytorchbot successfully started a revert job."
         + f"Check the current status [here]({os.getenv('GH_RUN_URL')})"
     )
-    gh_post_pr_comment(org, project, pr_num, msg, dry_run)
-
+    return msg
 
 def get_land_check_troubleshooting_message() -> str:
     return (

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -2,7 +2,9 @@ import os
 import re
 from typing import List, Pattern, Tuple, Optional
 
-from trymerge import BOT_COMMANDS_WIKI, GitHubPR, gh_post_pr_comment
+from trymerge import GitHubPR, gh_post_pr_comment
+
+BOT_COMMANDS_WIKI = "https://github.com/pytorch/pytorch/wiki/Bot-commands"
 
 CIFLOW_LABEL = re.compile(r"^ciflow/.+")
 CIFLOW_TRUNK_LABEL = re.compile(r"^ciflow/trunk")
@@ -72,7 +74,9 @@ class TryMergeExplainer(object):
                 "This means your PR will be merged immediately, bypassing any checks."
             )
         elif self.on_green:
-            return "This means that your PR will be merged once all signals have passed."
+            return (
+                "This means that your PR will be merged once all signals have passed."
+            )
         elif self.land_checks:
             if self.has_trunk_label:
                 land_check_msg_suffix = (

--- a/.github/scripts/trymerge_explainer.py
+++ b/.github/scripts/trymerge_explainer.py
@@ -63,7 +63,7 @@ class TryMergeExplainer(object):
         elif self.land_checks:
             return " the land check (-l)"
         else:
-            return "out a "
+            return "out a"
 
     def _get_land_check_progress(self, commit: Optional[str]) -> str:
         if commit is not None:


### PR DESCRIPTION
## FORCE
@pytorchbot successfully started a merge job. Check the current status [here](None).
The merge job was triggered with the force (-f) flag. This means your change will be merged **immediately**, bypassing any CI checks (ETA: 1-5 minutes). If this is not the intended behavior, feel free to use some of the other merge options in the [wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands).
Please reach out to the [PyTorch DevX Team](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours) with feedback or questions!
## GREEN
@pytorchbot successfully started a merge job. Check the current status [here](None).
The merge job was triggered with the green (-g) flag. This means that your change will be merged once all checks on your PR have passed (ETA: 0-4 Hours). If this is not the intended behavior, feel free to use some of the other merge options in the [wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands).
Please reach out to the [PyTorch DevX Team](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours) with feedback or questions!
## LAND CHECKS
@pytorchbot successfully started a merge job. Check the current status [here](None).
The merge job was triggered with the land checks (-l) flag. If you did not specify this flag yourself,  you are likely enrolled in the [land checks rollout](https://github.com/pytorch/test-infra/blob/main/torchci/lib/bot/rolloutUtils.ts#L1-L34). This means that your change will be merged once all checks on your PR and the land checks have passed (**ETA 4 Hours**). If you need to coordinate lands between different changes and cannot risk a land race, please add the `ciflow/trunk` label to your PR and wait for signal to complete, and then land your changes in proper order. Having `trunk`, `pull`, and `Lint` pre-run on a PR will bypass land checks and the ETA should be immediate. If this is not the intended behavior, feel free to use some of the other merge options in the [wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands).
Please reach out to the [PyTorch DevX Team](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours) with feedback or questions!
## LAND CHECKS
@pytorchbot successfully started a merge job. Check the current status [here](None).
The merge job was triggered with the land checks (-l) flag. If you did not specify this flag yourself,  you are likely enrolled in the [land checks rollout](https://github.com/pytorch/test-infra/blob/main/torchci/lib/bot/rolloutUtils.ts#L1-L34). This means that your change will be merged once all checks on your PR have passed since you have added the `ciflow/trunk` label to your PR (ETA 0-4 Hours). If this is not the intended behavior, feel free to use some of the other merge options in the [wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands).
Please reach out to the [PyTorch DevX Team](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours) with feedback or questions!
## NORMAL
@pytorchbot successfully started a merge job. Check the current status [here](None).
The merge job was triggered without a flag. This means that your change will be merged once all checks on your PR have passed (ETA: 0-4 Hours). If this is not the intended behavior, feel free to use some of the other merge options in the [wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands).
Please reach out to the [PyTorch DevX Team](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours) with feedback or questions!
## Revert Message
@pytorchbot successfully started a revert job. Check the current status [here](None).
Please reach out to the [PyTorch DevX Team](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours) with feedback or questions!
## TROUBLESHOOTING 
 If you believe this is an error, you can use the old behavior with `@pytorchbot merge -g` (optionally with the `ciflow/trunk` to get land checks) or use `@pytorchbot merge -f "some reason here"`. For more information, see the [bot wiki](https://github.com/pytorch/pytorch/wiki/Bot-commands). 
Please reach out to the [PyTorch DevX Team](https://github.com/pytorch/pytorch/wiki/Dev-Infra-Office-Hours) with feedback or questions!