### PR TITLE
[quant] Remove unneeded lines from APoT linear

### DIFF
--- a/torch/ao/quantization/experimental/linear.py
+++ b/torch/ao/quantization/experimental/linear.py
@@ -141,12 +141,6 @@ class LinearAPoT(WeightedQuantizedModule):
             for col in range(weight_cols):
                 decomposed_weight[row][col] = self.decompose_APoT(bin(self.weight_transposed[row][col]))
 
-        rows1 = self.weight_transposed.size(dim=0)
-        cols1 = self.weight_transposed.size(dim=1)
-
-        rows2 = activation.size(dim=0)
-        cols2 = activation.size(dim=1)
-
         result = self.matmul(decomposed_weight, activation).type(torch.FloatTensor)
 
         return result


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82909

### Summary
Remove unnecessary lines from APoT linear module

### Test Plan
Run unit tests with:` python /pytorch/test/quantization/core/experimental/test_linear.py`