### PR TITLE
[ao] Fix per-channel histogram visualization in ModelReportVisualizer

### DIFF
--- a/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
+++ b/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
@@ -472,11 +472,12 @@ class ModelReportVisualizer:
 
         # offset should either be one of tensor or channel table or neither
         feature_column_offset = ModelReportVisualizer.NUM_NON_FEATURE_TENSOR_HEADERS
+        table = tensor_table
+
+        # if a per_channel plot, we have different offset and table
         if is_valid_per_channel_plot:
             feature_column_offset = ModelReportVisualizer.NUM_NON_FEATURE_CHANNEL_HEADERS
-
-        # keep track of per_channel or not
-        data_is_per_channel: bool = False
+            table = channel_table
 
         x_data: List = []
         y_data: List[List] = []
@@ -486,25 +487,26 @@ class ModelReportVisualizer:
             if is_valid_per_channel_plot:
                 # gather the x_data and multiple y_data
                 # calculate the number of channels
-                num_channels: int = max(row[self.CHANNEL_NUM_INDEX] for row in channel_table) + 1
+                num_channels: int = max(row[self.CHANNEL_NUM_INDEX] for row in table) + 1
                 for channel in range(num_channels):
                     y_data.append([])  # seperate data list per channel
 
-            for table_row_num, row in enumerate(tensor_table):
+            for table_row_num, row in enumerate(table):
                 # get x_value to append
                 x_val_to_append = table_row_num
-                current_channel: int = -1  # intially chose current channel
-                # if new module we are looking at, add it's index to x_data
-                if is_valid_per_channel_plot and row[self.CHANNEL_NUM_INDEX] == 0:
+                current_channel: int = -1  # set current channel to be used if per channel
+                if is_valid_per_channel_plot:
+                    current_channel = row[self.CHANNEL_NUM_INDEX]  # intially chose current channel
                     new_module_index: int = table_row_num // num_channels
                     x_val_to_append = new_module_index
-                    current_channel = row[self.CHANNEL_NUM_INDEX]
 
                 # the index of the feature will the 0 + num non feature columns
                 tensor_feature_index = feature_column_offset
                 row_value = row[tensor_feature_index]
                 if not type(row_value) == str:
-                    x_data.append(x_val_to_append)
+                    # only append if new index we are appending
+                    if len(x_data) == 0 or x_data[-1] != x_val_to_append:
+                        x_data.append(x_val_to_append)
                     # how we append y value depends on if per tensor or not
                     if is_valid_per_channel_plot:
                         y_data[current_channel].append(row_value)
@@ -518,7 +520,7 @@ class ModelReportVisualizer:
             raise ValueError(error_str)
 
         # return x, y values, and if data is per-channel
-        return (x_data, y_data, data_is_per_channel)
+        return (x_data, y_data, is_valid_per_channel_plot)
 
     def generate_plot_visualization(self, feature_filter: str, module_fqn_filter: str = ""):
         r"""
@@ -616,7 +618,6 @@ class ModelReportVisualizer:
 
         # for histogram, we just care about plotting the y data
         # plot based on whether data is per channel or not
-        fig = plt.figure()
         ax = plt.subplot()
         ax.set_xlabel(feature_filter)
         ax.set_ylabel("Frequency")
@@ -628,13 +629,13 @@ class ModelReportVisualizer:
             all_data = []
             for index, channel_info in enumerate(y_data):
                 all_data.extend(channel_info)
+
             val, bins, _ = plt.hist(
                 all_data,
                 bins=num_bins,
                 stacked=True,
                 rwidth=0.8,
             )
-            ax.legend(loc='upper right')
             plt.xticks(bins)
         else:
             val, bins, _ = plt.hist(

--- a/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
+++ b/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
@@ -482,23 +482,29 @@ class ModelReportVisualizer:
         x_data: List = []
         y_data: List[List] = []
         # the feature will either be a tensor feature or channel feature
-        if is_valid_per_tensor_plot or is_valid_per_channel_plot:
-            # extra setup for y_data if per channel
-            if is_valid_per_channel_plot:
-                # gather the x_data and multiple y_data
-                # calculate the number of channels
-                num_channels: int = max(row[self.CHANNEL_NUM_INDEX] for row in table) + 1
-                for channel in range(num_channels):
-                    y_data.append([])  # seperate data list per channel
+        if is_valid_per_tensor_plot:
+            for table_row_num, row in enumerate(table):
+                # get x_value to append
+                x_val_to_append = table_row_num
+                # the index of the feature will the 0 + num non feature columns
+                tensor_feature_index = feature_column_offset
+                row_value = row[tensor_feature_index]
+                if not type(row_value) == str:
+                    x_data.append(x_val_to_append)
+                    y_data.append(row_value)
+        elif is_valid_per_channel_plot:
+            # gather the x_data and multiple y_data
+            # calculate the number of channels
+            num_channels: int = max(row[self.CHANNEL_NUM_INDEX] for row in table) + 1
+            for channel in range(num_channels):
+                y_data.append([])  # seperate data list per channel
 
             for table_row_num, row in enumerate(table):
                 # get x_value to append
                 x_val_to_append = table_row_num
-                current_channel: int = -1  # set current channel to be used if per channel
-                if is_valid_per_channel_plot:
-                    current_channel = row[self.CHANNEL_NUM_INDEX]  # intially chose current channel
-                    new_module_index: int = table_row_num // num_channels
-                    x_val_to_append = new_module_index
+                current_channel = row[self.CHANNEL_NUM_INDEX]  # intially chose current channel
+                new_module_index: int = table_row_num // num_channels
+                x_val_to_append = new_module_index
 
                 # the index of the feature will the 0 + num non feature columns
                 tensor_feature_index = feature_column_offset
@@ -507,11 +513,9 @@ class ModelReportVisualizer:
                     # only append if new index we are appending
                     if len(x_data) == 0 or x_data[-1] != x_val_to_append:
                         x_data.append(x_val_to_append)
-                    # how we append y value depends on if per tensor or not
-                    if is_valid_per_channel_plot:
-                        y_data[current_channel].append(row_value)
-                    else:
-                        y_data.append(row_value)
+
+                    # append value for that channel
+                    y_data[current_channel].append(row_value)
         else:
             # more than one feature was chosen
             error_str = "Make sure to pick only a single feature with your filter to plot a graph."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #82918
* __->__ #82917

Summary: There was an issue with per-channel visualizations in the
ModelReportVisualizer that in specific scenarios in which there were
only per-channel features for a module, it would fail to specifically
get the channel by channel info.

After digging through the code, the core reason was a for loop that was
enumerating on the `tensor_table` (tensor level info) even in the
scenario in which we only had per-channel info.

This was fixed, and tested in a Bento to ensure expected functionality.

Test Plan: Tested visually

Reviewers:

Subscribers:

Tasks:

Tags: