### PR TITLE
[ao] Updated ModelReportVisualizer per-channel line plot

### DIFF
--- a/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
+++ b/torch/ao/quantization/fx/_model_report/model_report_visualizer.py
@@ -559,7 +559,6 @@ class ModelReportVisualizer:
         x_data, y_data, data_per_channel = self._get_plottable_data(feature_filter, module_fqn_filter)
 
         # plot based on whether data is per channel or not
-        fig = plt.figure()
         ax = plt.subplot()
         ax.set_ylabel(feature_filter)
         ax.set_title(feature_filter + " Plot")
@@ -568,10 +567,14 @@ class ModelReportVisualizer:
         if data_per_channel:
             ax.set_xlabel("First idx of module")
             # set the legend as well
-            # plot a seperate line for each channel
-            for index, channel_info in enumerate(y_data):
-                ax.plot(x_data, channel_info, label="Channel {}".format(index))
+            # plot a single line that is average of the channel values
+            num_modules = len(y_data[0])  # all y_data have same length, so get num modules
+            num_channels = len(y_data)  # we want num channels to be able to calculate average later
 
+            avg_vals = [sum(y_data[:][index]) / num_channels for index in range(num_modules)]
+
+            # plot the three things we measured
+            ax.plot(x_data, avg_vals, label="Average Value Across {} Channels".format(num_channels))
             ax.legend(loc='upper right')
         else:
             ax.set_xlabel("idx")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82918
* #82917

Summary: Before, the line plot for the ModelReportVisualizer used to
plot a different line for each channel. However, for models that have a
lot of channels, this can get really hard to read and parse and doesn't
provide much valuable information.

Now, we just have a single value per module that is the average of the
500 channels.

We also considered plotting 3 lines (a min line, a max line, and an
average line) but the issue was that large outliers could result in one
of the lines completely messing up the scale and the other two not being
visible. As a result, it made sense to do an average and let the user
use the report data to generate the other two if they wished to do so.

This was tested visually in a ipynb notebook

Test Plan: Tested visually in a ipynb notebook

Reviewers:

Subscribers:

Tasks:

Tags: