### PR TITLE
Increase size limit on calling CublasLt in addmm by 32x

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -171,8 +171,8 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
          scalar_type == at::ScalarType::Half ||
          scalar_type == at::ScalarType::BFloat16) &&
         mat2_sizes[0] > 1 && mat2_sizes[1] > 1 &&
-        mat2_sizes[0] < 65535 && mat2_sizes[1] < 65535 &&
-        mat1_sizes[0] < 65535 && mat1_sizes[1] < 65535 &&
+        mat2_sizes[0] < 65535*32 && mat2_sizes[1] < 65535*32 &&
+        mat1_sizes[0] < 65535*32 && mat1_sizes[1] < 65535*32 &&
         // avoid leaing dim >> rows bugs
         ((mat1.strides()[0]==1 && mat1.strides()[1]==mat1_sizes[0]) || (mat1.strides()[1] == 1 && mat1.strides()[0] == mat1_sizes[1]) || (scalar_type != at::ScalarType::Half && scalar_type != at::ScalarType::BFloat16)) &&
         ((mat2.strides()[0]==1 && mat2.strides()[1]==mat2_sizes[0]) || (mat2.strides()[1] == 1 && mat2.strides()[0] == mat2_sizes[1]) || (scalar_type != at::ScalarType::Half && scalar_type != at::ScalarType::BFloat16));


### PR DESCRIPTION
Summary:
Increase the limit by 32 times to go to cublasLt fastpath for linear/addmm.

Why?
Discovered this when looking at linear performance for a linear with input/output  [512, 512] and an input of size [1024, 82, 512]. It was slow.

Did a sweep on inputs, and discovered there was a perf cliff between input sizes [799, 82, 512] and [800, 82, 512]. There is a check to call into CublasLt when input dim 1 is < 65535. So 799 * 82 = 65518 (fastpath), 800 * 82 = 65600 (slowpath).

With CublasLt we just get one nice sgemm. Without CublasLt, there is a copy then an sgemm, which can be almost 2x slower. This change roughly 1.6-1.9x the speed of linear/addmm. However, we only increased the limit. For matrices with even bigger sizes, it will go to the slow path again.

Test Plan: CI, manual testing with linear.

Differential Revision: D38478430

