### PR TITLE
Fix buick-build-and-test

### DIFF
--- a/.github/workflows/_buck-build-test.yml
+++ b/.github/workflows/_buck-build-test.yml
@@ -51,7 +51,8 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           command: |
-            wget https://github.com/facebook/buck/releases/download/v2021.01.12.01/buck.2021.01.12.01_all.deb
+            sudo apt update -q
+            wget -q https://github.com/facebook/buck/releases/download/v2021.01.12.01/buck.2021.01.12.01_all.deb
             sudo apt install ./buck.2021.01.12.01_all.deb
 
       - name: Download third party libraries and generate wrappers


### PR DESCRIPTION
By updating apt-repo before trying to install buck package
Tested in https://github.com/malfet/deleteme/runs/7705552380?check_suite_focus=true
Fixes https://github.com/pytorch/pytorch/issues/82934
