### PR TITLE
Properly compare floats in gemm-block-sparse-microkernel-tester

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-block-sparse-microkernel-tester.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-block-sparse-microkernel-tester.h
@@ -475,7 +475,7 @@ class GemmBlockSparseMicrokernelTester {
 
       for (size_t mIndex = 0; mIndex < m(); mIndex++) {
         for (size_t nIndex = 0; nIndex < n(); nIndex++) {
-          ASSERT_EQ(
+          ASSERT_FLOAT_EQ(
               c[mIndex * cStride() + nIndex],
               acc[mIndex * n() + nIndex])
               << "at " << mIndex << ", " << nIndex


### PR DESCRIPTION
Similar to https://github.com/pytorch/pytorch/pull/82688

Example of current failure:

```
xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack/test/gemm-block-sparse-microkernel-tester.h:480
Expected equality of these values:
  c[mIndex * cStride() + nIndex]
    Which is: 34730.7
  acc[mIndex * n() + nIndex]
    Which is: 34730.7
at 7, 2: reference = 34730.65625, optimized = 34730.65234375, Mr x Nr = 8 x 4, M x N x K = 8 x 4 x 5
```