### PR TITLE
[LTC] Pass a BackendDevice parameter into GetIrValueForScalarFromCodegen

### DIFF
--- a/torch/csrc/lazy/core/lazy_graph_executor.cpp
+++ b/torch/csrc/lazy/core/lazy_graph_executor.cpp
@@ -530,13 +530,13 @@ Value LazyGraphExecutor::GetDeviceDataIrValue(
 }
 
 Value LazyGraphExecutor::GetIrValueForScalarFromCodegen(
-    const at::Scalar& value) {
+    const at::Scalar& value,
+    const BackendDevice& device) {
   if (IsSpecialScalar(value)) {
     return MakeScalar(value, value.type());
   }
-  auto cpu_device = getBackend()->GetBackendDevice(c10::Device(c10::kCPU, 0));
   BackendDataPtr data =
-      getBackend()->MakeComputationDataFromScalar(value, cpu_device);
+      getBackend()->MakeComputationDataFromScalar(value, device);
   data->SetInfo(
       std::make_shared<DeviceDataInfo>(/*tensor_id=*/-1, /*read_only=*/true));
   return MakeDeviceData(std::move(data));
@@ -549,8 +549,7 @@ Value LazyGraphExecutor::GetIrValueForScalar(
   if (IsSpecialScalar(value)) {
     return MakeScalar(value, type);
   }
-  return GetDeviceDataIrValue(
-      value, type, getBackend()->GetBackendDevice(c10::Device(c10::kCPU, 0)));
+  return GetDeviceDataIrValue(value, type, device);
 }
 
 Value LazyGraphExecutor::GetIrValueForScalar(

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -102,7 +102,9 @@ class TORCH_API LazyGraphExecutor {
   // use it in other cases where `GetIrValueForXXXScalar` is used, as well
   // In order to do that, we need to untangle the cases where we don't need
   // `expand` and where we don't expect a scalar tensor
-  Value GetIrValueForScalarFromCodegen(const at::Scalar& value);
+  Value GetIrValueForScalarFromCodegen(
+      const at::Scalar& value,
+      const BackendDevice& device);
   Value GetIrValueForExpandedScalar(
       const at::Scalar& value,
       const Shape& shape,

--- a/torchgen/dest/lazy_ir.py
+++ b/torchgen/dest/lazy_ir.py
@@ -393,13 +393,14 @@ class GenLazyNativeFuncDefinition:
                 if isinstance(arg.lazy_type, OptionalCType):
                     lazy_tensor_decls.append(
                         f"""auto node_{arg.name} = {arg.name} ?
-                c10::make_optional(torch::lazy::LazyGraphExecutor::Get()->GetIrValueForScalarFromCodegen(*{arg.name})):
+                c10::make_optional(torch::lazy::LazyGraphExecutor::Get()->
+                    GetIrValueForScalarFromCodegen(*{arg.name}, *common_device)):
                 c10::nullopt;"""
                     )
                 else:
                     lazy_tensor_decls.append(
-                        f"""auto node_{arg.name} =
-                torch::lazy::LazyGraphExecutor::Get()->GetIrValueForScalarFromCodegen({arg.name});"""
+                        f"""auto node_{arg.name} = torch::lazy::LazyGraphExecutor::Get()->
+                            GetIrValueForScalarFromCodegen({arg.name}, *common_device);"""
                     )
             elif arg.is_symint_or_list:
                 continue  # values are extracted in isValueType


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #82970

Summary: Currently GetIrValueForScalarFromCodegen uses CPU as the
default backend device for scalars, but we should make it a
backend-dependent decision.