### PR TITLE
Fix error_inputs for diag

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2503,8 +2503,11 @@ def error_inputs_ormqr(op_info, device, **kwargs):
 
 def error_inputs_diag(op_info, device, **kwargs):
     zero_d = torch.randn((), device=device)
-    yield ErrorInput(SampleInput(zero_d, args=(zero_d)), error_type=TypeError,
-                     error_regex="iteration over a 0-d tensor")
+    yield ErrorInput(SampleInput(zero_d, args=(0,)), error_type=RuntimeError,
+                     error_regex="matrix or a vector expected")
+    zero_d = torch.randn(1, 1, 1, device=device)
+    yield ErrorInput(SampleInput(zero_d, args=(0,)), error_type=RuntimeError,
+                     error_regex="matrix or a vector expected")
 
 def error_inputs_embedding(op_info, device, **kwargs):
     indices = torch.rand(2, 2, device=device).long()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #83004
* __->__ #82984

`args` must be a tuple. It was not a tuple, so the error that was being
checked was actually being raised in the testing suite and not in
torch.diag itself.

This PR changes the error input to check something more reasonable: that
the input must be a matrix or a vector.

Test Plan:
- run tests