### PR TITLE
[temp mitigation][ios] add timeout to Run Build Test step

### DIFF
--- a/.github/workflows/_ios-build-test.yml
+++ b/.github/workflows/_ios-build-test.yml
@@ -140,6 +140,7 @@ jobs:
           scripts/build_ios.sh
 
       - name: Run Build Test
+        timeout-minutes: 5
         run: |
           PROFILE=PyTorch_CI_2022
           # run the ruby build script


### PR DESCRIPTION
### Description
Mitigating https://github.com/pytorch/pytorch/issues/82890. We don't want a job to hog a runner for 4 hours if it should have failed 3 hours ago. This step normally takes less than 1 minute.