### PR TITLE
[functorch] better error when vmap over no Tensor inputs

### DIFF
--- a/functorch/functorch/_src/vmap.py
+++ b/functorch/functorch/_src/vmap.py
@@ -43,6 +43,8 @@ def _validate_and_get_batch_size(
         flat_args: List) -> int:
     batch_sizes = [arg.size(in_dim) for in_dim, arg in zip(flat_in_dims, flat_args)
                    if in_dim is not None]
+    if len(batch_sizes) == 0:
+        raise ValueError('vmap: Expected at least one Tensor to vmap over')
     if batch_sizes and any(size != batch_sizes[0] for size in batch_sizes):
         raise ValueError(
             f'vmap: Expected all tensors to have the same size in the mapped '

--- a/functorch/test/test_vmap.py
+++ b/functorch/test/test_vmap.py
@@ -98,6 +98,13 @@ class TestVmapAPI(TestCase):
         with self.assertRaisesRegex(ValueError, expected_msg):
             vmap(bar)()
 
+    def test_func_with_no_tensors(self):
+        def foo(x):
+            return torch.randn(3)
+
+        with self.assertRaisesRegex(ValueError, 'at least one Tensor'):
+            vmap(foo, (None,))(1)
+
     def test_constant_function(self):
         output = vmap(lambda x: torch.tensor(3.14))(torch.ones(3))
         self.assertEqual(output, torch.tensor([3.14, 3.14, 3.14]))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #83017
* __->__ #83016
* #82972
* #83004
* #82903
* #82984

I thought we were testing this already, but I guess not.

Test Plan:
- new test