### PR TITLE
ci: Bump max_available for windows gpu to 100

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -65,5 +65,5 @@ runner_types:
   windows.8xlarge.nvidia.gpu:
     instance_type: p3.2xlarge
     os: windows
-    max_available: 50
+    max_available: 100
     disk_size: 256


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #83018

Noticed we were hitting our limit for windows GPU so this just raises
the limit to a more sane value

<img width="1321" alt="Screen Shot 2022-08-08 at 1 21 03 PM" src="https://user-images.githubusercontent.com/1700823/183507438-f62310dc-57b5-4d46-8362-379d50fd8453.png">

You can see the number of times we've hit this in the past ^

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>