### PR TITLE
Remove unnecessary copy constructor

### DIFF
--- a/c10/util/variant.h
+++ b/c10/util/variant.h
@@ -2253,7 +2253,6 @@ class impl : public copy_assignment<traits<Ts...>> {
 
  public:
   C10_MPARK_INHERITING_CTOR(impl, super)
-  impl& operator=(const impl& other) = default;
 
   template <std::size_t I, typename Arg>
   inline void assign(Arg&& arg) {


### PR DESCRIPTION
Re-land of https://github.com/pytorch/pytorch/pull/82626 which somehow broke deploy build
Fixes annoying warnings when building with clang:
```
../c10/util/variant.h:2256:9: warning: definition of implicit copy constructor for 'impl<c10::Scalar, c10::basic_string_view<char>>' is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
  impl& operator=(const impl& other) = default;
        ^
```

Preliminary step for switching MacOS builds to ones with `-Werror`