### PR TITLE
Fix get_workflow_job_id to dynamically get the repo name

### DIFF
--- a/.github/scripts/get_workflow_job_id.py
+++ b/.github/scripts/get_workflow_job_id.py
@@ -31,7 +31,9 @@ parser.add_argument(
 args = parser.parse_args()
 
 
-PYTORCH_REPO = "https://api.github.com/repos/pytorch/pytorch"
+# From https://docs.github.com/en/actions/learn-github-actions/environment-variables
+PYTORCH_REPO = os.environ.get("GITHUB_REPOSITORY", "pytorch/pytorch")
+PYTORCH_GITHUB_API = f"https://api.github.com/repos/{PYTORCH_REPO}"
 GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
 REQUEST_HEADERS = {
     "Accept": "application/vnd.github.v3+json",
@@ -39,7 +41,7 @@ REQUEST_HEADERS = {
 }
 
 response = requests.get(
-    f"{PYTORCH_REPO}/actions/runs/{args.workflow_run_id}/jobs?per_page=100",
+    f"{PYTORCH_GITHUB_API}/actions/runs/{args.workflow_run_id}/jobs?per_page=100",
     headers=REQUEST_HEADERS,
 )
 


### PR DESCRIPTION
This helps testing on pytorch-canary, which has a different repo name. The different name fails the get_workflow_job_id step there because the canary PR refers to run ID and canary runner name, for example:

https://github.com/pytorch/pytorch-canary/runs/7735191886?check_suite_focus=true