### PR TITLE
Using a custom c10::SymtInt caster; missed a case in numel

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -2486,9 +2486,7 @@ c10::SymInt concrete_sym_numel_fn(
         "Cannot call numel on a tensor with symbolic shapes/strides");
     return self->sym_numel_default();
   }
-  return torch::is_symint_node(out)
-      ? out.cast<c10::SymIntNodeImpl*>()->toSymInt()
-      : c10::SymInt{py::cast<int64_t>(out)};
+  return py::cast<c10::SymInt>(out);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
The original custom caster PR was missing a use of `is_symint_node` which was introduced later in the `numel` PR.