### PR TITLE
move strip_overloads , add conj_physical

### DIFF
--- a/functorch/functorch/_src/aot_autograd.py
+++ b/functorch/functorch/_src/aot_autograd.py
@@ -135,6 +135,11 @@ def new_full(inp, size, value, dtype=None, layout=None, device=None, pin_memory=
     return torch.full(size, value, dtype=inp.dtype, device=inp.device)
 
 
+@register_decomposition(torch.ops.aten.zeros_like, aot_autograd_decompositions)
+def zeros_like(inp, dtype=None, layout=None, device=None, pin_memory=None):
+    return inp * 0
+
+
 graph_being_compiled: str = None
 nth_graph: int = 0
 model_name: str = "model"

--- a/functorch/functorch/_src/aot_autograd.py
+++ b/functorch/functorch/_src/aot_autograd.py
@@ -135,14 +135,6 @@ def new_full(inp, size, value, dtype=None, layout=None, device=None, pin_memory=
     return torch.full(size, value, dtype=inp.dtype, device=inp.device)
 
 
-# This is a hack to remove aten.zeros_like from the FX graph.
-# it cannot be fused by NVFuser, and it sometimes block fusible operators to
-# be fused. It is not entirely correct because float('nan') * 0 = nan instead of 0.
-@register_decomposition(torch.ops.aten.zeros_like, aot_autograd_decompositions)
-def zeros_like(inp, dtype=None, layout=None, device=None, pin_memory=None):
-    return inp * 0
-
-
 graph_being_compiled: str = None
 nth_graph: int = 0
 model_name: str = "model"

--- a/functorch/functorch/_src/aot_autograd.py
+++ b/functorch/functorch/_src/aot_autograd.py
@@ -135,6 +135,9 @@ def new_full(inp, size, value, dtype=None, layout=None, device=None, pin_memory=
     return torch.full(size, value, dtype=inp.dtype, device=inp.device)
 
 
+# This is a hack to remove aten.zeros_like from the FX graph.
+# it cannot be fused by NVFuser, and it sometimes block fusible operators to
+# be fused. It is not entirely correct because float('nan') * 0 = nan instead of 0.
 @register_decomposition(torch.ops.aten.zeros_like, aot_autograd_decompositions)
 def zeros_like(inp, dtype=None, layout=None, device=None, pin_memory=None):
     return inp * 0

--- a/functorch/functorch/_src/compilers.py
+++ b/functorch/functorch/_src/compilers.py
@@ -39,6 +39,9 @@ def ts_compile(fx_g: fx.GraphModule, _) -> Callable:
     Returns:
         Torch scripted model.
     """
+
+    strip_overloads(fx_g)
+
     for node in fx_g.graph.nodes:
         if (node.target == torch.ops.aten._to_copy and len(node.args) == 1
            and len(node.kwargs) == 1 and 'dtype' in node.kwargs):
@@ -52,7 +55,6 @@ def ts_compile(fx_g: fx.GraphModule, _) -> Callable:
             new_kwargs[k] = v
         node.kwargs = new_kwargs
 
-    strip_overloads(fx_g)
 
     fx_g.graph.lint()
 
@@ -270,6 +272,7 @@ default_decompositions = {
     aten.hardtanh,
     aten.hardswish,
     aten.hardsigmoid,
+    aten.conj_physical
 }
 
 default_decompositions = get_decompositions(default_decompositions)


### PR DESCRIPTION
Move strip_overloads to the beginning of ts_compile() so the ops are ready for other processing later in ts_compile().

Add conj_physical to default decomposition, this improved running time in GPT2.
