### PR TITLE
Add refs for real and imag to __all__

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1622,6 +1622,8 @@ class TestRefsOpsInfo(TestCase):
         '_refs.clone',  # test_meta.py: view size is not compatible with input tensor's size and stride
         '_refs.equal',  # 'bool' object has no attribute 'dtype'
         '_refs.conj',  # Calls _prims.conj
+        '_refs.real',
+        '_refs.imag',
     }
 
     @parametrize("op", ref_ops_names)

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -121,6 +121,7 @@ __all__ = [
     "hypot",
     "igamma",
     "igammac",
+    "imag",
     "isclose",
     "lcm",
     # 'ldexp',
@@ -139,6 +140,7 @@ __all__ = [
     "nextafter",
     # 'polar',  # abs, cos, sin
     "pow",
+    "real",
     "remainder",
     "rsub",
     # # special.xlog1py


### PR DESCRIPTION
`imag` and `real` were missing from the ref's `__all__` list.