### PR TITLE
[functorch] delete old hack for namedtuples

### DIFF
--- a/functorch/test/test_ops.py
+++ b/functorch/test/test_ops.py
@@ -114,11 +114,6 @@ def normalize_op_input_output2(f, args, kwargs, output_process_fn_grad=None, req
         result = f(*_args, **kwargs)
         if output_process_fn_grad is not None:
             result = output_process_fn_grad(result)
-        if isinstance(result, tuple):
-            # TODO: Remove the following hack for namedtuples
-            result = tuple(result)
-            result = tuple(r for r in result if torch.is_floating_point(r))
-            assert len(result) > 0
         return result
     return wrapped, primals
 
@@ -141,11 +136,6 @@ def normalize_op_input_output3(f, args, kwargs, sample_args, output_process_fn_g
         result = f(*_args, **kwargs)
         if output_process_fn_grad is not None:
             result = output_process_fn_grad(result)
-        if isinstance(result, tuple):
-            # TODO: Remove the following hack for namedtuples
-            result = tuple(result)
-            result = tuple(r for r in result if torch.is_floating_point(r))
-            assert len(result) > 0
         return result
     return wrapped, primals
 
@@ -371,7 +361,6 @@ class TestOperators(TestCase):
              {torch.float32: tol(atol=4e-04, rtol=4e-04)}),
     ))
     def test_jvp(self, device, dtype, op):
-        # TODO: when we change supports_autograd to supports_backward_ad, also change in this file
         VJP_DECOMP = {
             'nn.functional.logsigmoid',
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #83073
* __->__ #83072
* #83017
* #83016
* #82972
* #83004
* #82903
* #82984

We had some hacks because pytree didn't support namedtuples. We've since
fixed those, so this PR removes them.

Also deletes an obsolete TODO about supports_autograd. It is still a
TODO, but it won't go unnoticed anymore because functorch is now in the
pytorch repo :).

Test Plan:
- tests