### PR TITLE
[Shape Fns] Fix optional None for the actual shape functions

### DIFF
--- a/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
+++ b/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
@@ -2778,7 +2778,6 @@ const OperatorMap<std::pair<std::string, std::string>>& GetBoundedShapeMappings(
   return shape_mappings;
 }
 
-
 // clang-format on
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
+++ b/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
@@ -2120,10 +2120,10 @@ def transpose(self: List[int],
     keep_dim: bool,
     dt: Any) -> List[int]:
   out = annotate(List[int], [])
-  if opt_dims is None:
-    dims:List[int] = []
+  if torch.__is__(opt_dims, None):
+    dims = annotate(List[int], [])
   else:
-    dims = opt_dims
+    dims = unchecked_cast(List[int], opt_dims)
   for idx in range(torch.len(self)):
     is_mean_dim = False
     for _0 in range(torch.len(dims)):
@@ -2682,17 +2682,9 @@ def native_batch_norm(input: List[int],
   return out
 
 def nonzero_lower_bound(input: List[int]) -> List[int]:
-  if torch.ge(torch.len(input), 1):
-    pass
-  else:
-    ops.prim.RaiseException("AssertionError: ")
   return [0, torch.len(input)]
 
 def nonzero_upper_bound(input: List[int]) -> List[int]:
-  if torch.ge(torch.len(input), 1):
-    pass
-  else:
-    ops.prim.RaiseException("AssertionError: ")
   numel = 1
   for _0 in range(torch.len(input)):
     elem = input[_0]
@@ -2785,6 +2777,7 @@ const OperatorMap<std::pair<std::string, std::string>>& GetBoundedShapeMappings(
 
   return shape_mappings;
 }
+
 
 // clang-format on
 

--- a/torch/jit/_shape_functions.py
+++ b/torch/jit/_shape_functions.py
@@ -153,8 +153,12 @@ def view_one_unused(self: List[int], sizes: List[int], *, implicit: bool = False
     return view(self, sizes)
 
 
-def mean_dim(self: List[int], dims: List[int], keep_dim: bool, dt: Any):
+def sum_mean_dim(self: List[int], opt_dims: Optional[List[int]], keep_dim: bool, dt: Any):
     out: List[int] = []
+    if opt_dims is None:
+        dims: List[int] = []
+    else:
+        dims = opt_dims
     for idx in range(len(self)):
         is_mean_dim: bool = False
         for reduce_dim in dims:
@@ -168,7 +172,7 @@ def mean_dim(self: List[int], dims: List[int], keep_dim: bool, dt: Any):
     return out
 
 def max_dim(self: List[int], dim: int, keep_dim: bool):
-    out = mean_dim(self, [dim], keep_dim, None)
+    out = sum_mean_dim(self, [dim], keep_dim, None)
     return out, out
 
 # note: python already rounds down towards negative infinity on integer division, special arithmetic not needed
@@ -1003,8 +1007,8 @@ add_shape_compute_mapping("aten::permute(Tensor(a) self, int[] dims) -> Tensor(a
 add_shape_compute_mapping("aten::view(Tensor(a) self, int[] size) -> Tensor(a)", view)
 add_shape_compute_mapping("aten::expand_as(Tensor(a) self, Tensor other) -> Tensor(a)", expand)
 add_shape_compute_mapping("aten::expand(Tensor(a) self, int[] size, *, bool implicit=False) -> Tensor(a)", expand_one_unused)
-add_shape_compute_mapping("aten::mean.dim(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor", mean_dim)
-add_shape_compute_mapping("aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor", mean_dim)
+add_shape_compute_mapping("aten::mean.dim(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor", sum_mean_dim)
+add_shape_compute_mapping("aten::sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor", sum_mean_dim)
 add_shape_compute_mapping("aten::max.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)", max_dim)
 add_shape_compute_mapping("aten::mean(Tensor self, *, ScalarType? dtype=None) -> Tensor", zero_dim_tensor)
 add_shape_compute_mapping("aten::sum(Tensor self, *, ScalarType? dtype=None) -> Tensor", zero_dim_tensor)


### PR DESCRIPTION
I think the person who edited `mean.dim` edited the python and the associated Torchscript version manually in two different ways. This diff fixes that all up. It also fixes the inconsistencies in the `torch.nonzero` generated file

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #79571
* __->__ #83092
* #82850

