### PR TITLE
Remove unbalanced `pragma diagnostic pop`

### DIFF
--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -393,4 +393,3 @@ void cpu_serial_kernel_vec(TensorIteratorBase& iter, func_t&& op, vec_func_t&& v
 }
 
 }}}  // namespace at::native::<anonymous>
-

--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -394,6 +394,3 @@ void cpu_serial_kernel_vec(TensorIteratorBase& iter, func_t&& op, vec_func_t&& v
 
 }}}  // namespace at::native::<anonymous>
 
-#ifndef _MSC_VER
-#pragma GCC diagnostic pop
-#endif


### PR DESCRIPTION
Detected by internal CI, we should have it in OSS as well:
```
aten/src/ATen/native/cpu/Loops.h:398:24: error: pragma diagnostic pop could not pop, no matching push [-Werror,-Wunknown-pragmas]
#pragma GCC diagnostic pop
```
Regression introduced by https://github.com/pytorch/pytorch/pull/82883
