### PR TITLE
Reland "[functorch] add error inputs check to vmap test"

### DIFF
--- a/functorch/functorch/csrc/BatchRulesActivation.cpp
+++ b/functorch/functorch/csrc/BatchRulesActivation.cpp
@@ -58,6 +58,11 @@ std::tuple<Tensor,optional<int64_t>> prelu_batch_rule(
   const auto input_ = moveBatchDimToFront(input, input_bdim);
   auto weight_flatten = moveBatchDimToFront(weight, weight_bdim);
 
+  const auto weight_logical_dim = rankWithoutBatchDim(weight, weight_bdim);
+  TORCH_CHECK(weight_logical_dim == 0 || weight_logical_dim == 1,
+      "prelu: Expected `weight` to be a scalar or 1D tensor, but got ndim = ",
+      weight_logical_dim);
+
   if (weight_flatten.dim() > 1) {
     // for an input [N, C, ...]
     // weight can be a non-vector but the total number of elements must be the same as C


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #83178
* #83176
* #83119
* #83114
* #83077
* __->__ #83106
* #83105
* #83080

Reland of #83017. It was reverted because it was stacked on top of a
commit that failed trunk tests.

Test Plan:
- wait for tests