### PR TITLE
Update viable/strict only on pytorch repo

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   do_update_viablestrict:
     runs-on: ubuntu-20.04
+    if: ${{ github.repository == 'pytorch/pytorch' }}
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Because viable/strict is pretty much a protected branch in pytorch only. This floods the [canary repo](https://github.com/pytorch/pytorch-canary/actions) with failures about this workflow, and spam my inbox :)

@zengk95: Please take a look and let me know if you want to keep running `update-viablestrict` on canary, may be for testing?
