### PR TITLE
Nested tensor empty like

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -108,41 +108,60 @@ c10::DispatchKeySet generate_nested_key_set(at::Tensor buffer) {
 }
 
 NestedTensorImpl::NestedTensorImpl(
-    at::Tensor buffer,
+    int64_t buffer_size,
+    Storage storage,
+    c10::DispatchKeySet key_set,
+    const caffe2::TypeMeta data_type,
     at::Tensor nested_size_tensor,
     at::Tensor nested_stride_tensor,
     std::vector<int64_t> offsets)
-    : TensorImpl(
-          Storage(buffer.storage()),
-          generate_nested_key_set(buffer),
-          buffer.dtype()),
+    : TensorImpl(std::move(storage), key_set, data_type),
+      buffer_size_(buffer_size),
       nested_size_tensor_(std::move(nested_size_tensor)),
       nested_stride_tensor_(std::move(nested_stride_tensor)),
       offsets_(std::move(offsets)),
-      opt_sizes_(construct_opt_sizes(nested_size_tensor_))
-{
-  auto buffer_size_vec{buffer.unsafeGetTensorImpl()->sizes()};
-  TORCH_INTERNAL_ASSERT(
-      buffer_size_vec.size() == 1,
-      "NestedTensorImpl buffer is required to be 1 dimensional but got a buffer with ",
-      buffer.dim(),
-      " dimensions.");
-  buffer_size_ = buffer_size_vec[0];
-
+      opt_sizes_(construct_opt_sizes(nested_size_tensor_)) {
   TORCH_WARN_ONCE(
       "The PyTorch API of nested tensors is in prototype stage and will change "
       "in the near future.");
-  TORCH_INTERNAL_ASSERT(buffer.is_cuda() || buffer.is_cpu(), "NestedTensorImpl buffer must be either CUDA or CPU but got ", buffer.device());
   TORCH_INTERNAL_ASSERT(nested_size_tensor_.is_contiguous());
   int64_t size_dim = nested_size_tensor_.dim();
   TORCH_INTERNAL_ASSERT(size_dim == 0 || size_dim == 2);
   TORCH_INTERNAL_ASSERT(nested_stride_tensor_.is_contiguous());
   TORCH_INTERNAL_ASSERT(nested_stride_tensor_.dim() == size_dim);
-  TORCH_INTERNAL_ASSERT(nested_stride_tensor_.sizes() == nested_size_tensor_.sizes());
-  TORCH_INTERNAL_ASSERT((size_dim == 0 && (int64_t)offsets_.empty())
-      || (size_dim == 2 && nested_size_tensor_.size(0) == (int64_t)offsets_.size()));
+  TORCH_INTERNAL_ASSERT(
+      nested_stride_tensor_.sizes() == nested_size_tensor_.sizes());
+  TORCH_INTERNAL_ASSERT(
+      (size_dim == 0 && (int64_t)offsets_.empty()) ||
+      (size_dim == 2 &&
+       nested_size_tensor_.size(0) == (int64_t)offsets_.size()));
   refresh_dim();
   set_sizes_strides_policy(c10::TensorImpl::SizesStridesPolicy::CustomSizes);
+}
+
+NestedTensorImpl::NestedTensorImpl(
+    at::Tensor buffer,
+    at::Tensor nested_size_tensor,
+    at::Tensor nested_stride_tensor,
+    std::vector<int64_t> offsets)
+    : NestedTensorImpl(
+          buffer.sizes()[0],
+          buffer.storage(),
+          generate_nested_key_set(buffer),
+          buffer.dtype(),
+          nested_size_tensor,
+          nested_stride_tensor,
+          offsets) {
+
+  TORCH_INTERNAL_ASSERT(
+      buffer.dim() == 1,
+      "NestedTensorImpl buffer is required to be 1 dimensional but got a buffer with ",
+      buffer.dim(),
+      " dimensions.");
+  TORCH_INTERNAL_ASSERT(
+      buffer.is_cuda() || buffer.is_cpu(),
+      "NestedTensorImpl buffer must be either CUDA or CPU but got ",
+      buffer.device());
 }
 
 // assume contiguous, `nested_stride_tensor` and `offsets`
@@ -217,6 +236,53 @@ IntArrayRef NestedTensorImpl::strides_custom() const {
 
 const char* NestedTensorImpl::tensorimpl_type_name() const {
   return "NestedTensorImpl";
+}
+
+
+template <typename VariableVersion>
+c10::intrusive_ptr<TensorImpl> NestedTensorImpl::shallow_copy_and_detach_core(
+    VariableVersion&& version_counter,
+    bool allow_tensor_metadata_change) const {
+  if (key_set_.has(DispatchKey::Python) &&
+      !c10::impl::tls_is_dispatch_key_excluded(DispatchKey::Python)) {
+    auto r = pyobj_interpreter_.load(std::memory_order_acquire)->detach(this);
+    if (r) {
+      r->set_version_counter(std::forward<VariableVersion>(version_counter));
+      r->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
+      return r;
+    }
+    // otherwise just copy the TensorImpl and not the PyObject.  Since
+    // the interpreter is dead no one can call us out on it
+  }
+  auto impl = c10::make_intrusive<NestedTensorImpl>(
+      buffer_size_,
+      storage_,
+      key_set_,
+      data_type_,
+      nested_size_tensor_,
+      nested_stride_tensor_,
+      offsets_);
+
+      copy_tensor_metadata(
+          /*src_impl=*/this,
+          /*dest_impl=*/impl.get(),
+          /*version_counter=*/std::forward<VariableVersion>(version_counter),
+          /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
+  return impl;
+}
+
+c10::intrusive_ptr<TensorImpl> NestedTensorImpl::shallow_copy_and_detach(
+    const c10::VariableVersion& version_counter,
+    bool allow_tensor_metadata_change) const {
+  return shallow_copy_and_detach_core(
+      version_counter, allow_tensor_metadata_change);
+}
+
+c10::intrusive_ptr<TensorImpl> NestedTensorImpl::shallow_copy_and_detach(
+    c10::VariableVersion&& version_counter,
+    bool allow_tensor_metadata_change) const {
+  return shallow_copy_and_detach_core(
+      std::move(version_counter), allow_tensor_metadata_change);
 }
 
 } // namespace native

--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -124,6 +124,11 @@ NestedTensorImpl::NestedTensorImpl(
   TORCH_WARN_ONCE(
       "The PyTorch API of nested tensors is in prototype stage and will change "
       "in the near future.");
+  auto storage_device = storage_.device();
+  TORCH_INTERNAL_ASSERT(
+      storage_device.is_cpu() || storage_device.is_cuda(),
+      "NestedTensorImpl storage must be either CUDA or CPU but got ",
+      storage_device);
   TORCH_INTERNAL_ASSERT(nested_size_tensor_.is_contiguous());
   int64_t size_dim = nested_size_tensor_.dim();
   TORCH_INTERNAL_ASSERT(size_dim == 0 || size_dim == 2);
@@ -158,10 +163,6 @@ NestedTensorImpl::NestedTensorImpl(
       "NestedTensorImpl buffer is required to be 1 dimensional but got a buffer with ",
       buffer.dim(),
       " dimensions.");
-  TORCH_INTERNAL_ASSERT(
-      buffer.is_cuda() || buffer.is_cpu(),
-      "NestedTensorImpl buffer must be either CUDA or CPU but got ",
-      buffer.device());
 }
 
 // assume contiguous, `nested_stride_tensor` and `offsets`

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -43,6 +43,10 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
   const std::vector<int64_t>& get_offsets() const {
     return offsets_;
   }
+
+  int64_t get_buffer_size() const {
+    return buffer_size_;
+  }
   // Returns nullopt if the ith dimension is irregular. The ith dimension
   // of a NestedTensor is regular if the unbound tensors match in
   // size at the (i-1)th dimension.

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4548,9 +4548,6 @@
 # softmax allows positional dtype, unlike most operators, because kwonly is BC-breaking when loading jit models.
 - func: softmax.int(Tensor self, int dim, ScalarType? dtype=None) -> Tensor
   variants: function, method
-  dispatch:
-    CompositeImplicitAutograd: softmax
-    NestedTensorCPU, NestedTensorCUDA: softmax
 
 - func: softmax.int_out(Tensor self, int dim, ScalarType? dtype=None, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
@@ -4575,6 +4572,8 @@
 
 - func: _softmax_backward_data(Tensor grad_output, Tensor output, int dim, ScalarType input_dtype) -> Tensor
   structured_delegate: _softmax_backward_data.out
+  dispatch:
+    NestedTensorCPU, NestedTensorCUDA: nested_softmax_backward
 
 - func: _softmax_backward_data.out(Tensor grad_output, Tensor output, int dim, ScalarType input_dtype, *, Tensor(a!) grad_input) -> Tensor(a!)
   structured: True

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2108,7 +2108,8 @@
     QuantizedCPU, QuantizedCUDA: empty_like_quantized
     SparseCPU, SparseCUDA, SparseMeta: empty_like_sparse_coo
     SparseCsrCPU, SparseCsrCUDA: empty_like_sparse_csr
-    NestedTensorCPU, NestedTensorCUDA: empty_like_nested
+    NestedTensorCPU: empty_like_nested_cpu
+    NestedTensorCUDA: empty_like_nested_cuda
 
 - func: empty_strided(int[] size, int[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2108,6 +2108,7 @@
     QuantizedCPU, QuantizedCUDA: empty_like_quantized
     SparseCPU, SparseCUDA, SparseMeta: empty_like_sparse_coo
     SparseCsrCPU, SparseCsrCUDA: empty_like_sparse_csr
+    NestedTensorCPU, NestedTensorCUDA: empty_like_nested
 
 - func: empty_strided(int[] size, int[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   dispatch:

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -864,7 +864,13 @@ Tensor empty_like_nested(
       /*resizeable=*/true);
 
   auto tensor = detail::make_tensor_base<NestedTensorImpl>(
-      std::move(storage_impl), self.key_set(), options.dtype());
+      self_impl->get_buffer_size(),
+      std::move(storage_impl),
+      self.key_set(),
+      options.dtype(),
+      self_impl->get_nested_size_tensor().clone(),
+      self_impl->get_nested_stride_tensor().clone(),
+      self_impl->get_offsets());
   return tensor;
 }
 

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -730,7 +730,7 @@ Tensor softmax_nested(
   auto input_ptr = get_nested_tensor_impl(input);
   int64_t ntensors = input_ptr->size(0);
   if (ntensors == 0) {
-    return input;
+    return input.clone();
   }
   int64_t positive_dim = at::maybe_wrap_dim(dim, input_ptr->dim());
   TORCH_CHECK(
@@ -1097,7 +1097,7 @@ inline void NestedTensor_reshape_copy(
           buffer.as_strided(sizes[i], strides[i], offsets[i]).reshape(sizes_reshaped[i]));
     }
 }
-}
+} // namespace
 
 // Special rules for reshape(nested tensor):
 // 1. Only 1 regular dimension can be collapsed with

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -46,7 +46,8 @@ inline std::vector<IntArrayRef> NestedTensor_get_sizes(const NestedTensorImpl* s
     return sizes;
   }
   const int64_t* sizemat_ptr = sizemat.data_ptr<int64_t>();
-  for (int64_t i = 0; i < ntensors; i++) {
+
+  for(const auto i: c10::irange(ntensors)){
     sizes[i] = IntArrayRef(sizemat_ptr, sizemat_ptr + orig_dim);
     sizemat_ptr += orig_dim;
   }
@@ -72,7 +73,7 @@ inline std::vector<IntArrayRef> NestedTensor_get_strides(const NestedTensorImpl*
     return strides;
   }
   const int64_t* stridemat_ptr = stridemat.data_ptr<int64_t>();
-  for (int64_t i = 0; i < ntensors; i++) {
+  for(const auto i: c10::irange(ntensors)) {
     strides[i] = IntArrayRef(stridemat_ptr, stridemat_ptr + orig_dim);
     stridemat_ptr += orig_dim;
   }

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -93,6 +93,23 @@ TORCH_API Tensor NestedTensor_to_padded_tensor_generic(
     double padding,
     OptionalIntArrayRef output_size);
 
+TORCH_API TensorOptions verify_empty_parameters(
+    const at::Tensor& self,
+    c10::optional<ScalarType> dtype,
+    c10::optional<Layout> layout,
+    c10::optional<Device> device,
+    c10::optional<bool> pin_memory,
+    c10::optional<c10::MemoryFormat> optional_memory_format);
+
+TORCH_API at::Tensor empty_nested_generic(
+    int64_t buffer_size,
+    c10::Allocator* allocator,
+    TensorOptions options,
+    c10::DispatchKeySet key_set,
+    at::Tensor nested_size,
+    at::Tensor nested_stride,
+    std::vector<int64_t> offsets);
+
 namespace impl {
 
 template <typename T>

--- a/aten/src/ATen/native/nested/cuda/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/cuda/NestedTensorMath.cpp
@@ -1,0 +1,45 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <type_traits>
+
+#include <ATen/ATen.h>
+#include <ATen/NestedTensorImpl.h>
+
+#include <ATen/EmptyTensor.h>
+#include <ATen/native/nested/NestedTensorMath.h>
+#include <c10/core/Allocator.h>
+#include <c10/core/DeviceType.h>
+
+namespace at {
+namespace native {
+
+Tensor empty_like_nested_cuda(
+    const Tensor& self,
+    c10::optional<ScalarType> dtype,
+    c10::optional<Layout> layout,
+    c10::optional<Device> device,
+    c10::optional<bool> pin_memory,
+    c10::optional<c10::MemoryFormat> optional_memory_format) {
+  TORCH_CHECK(
+      device == self.device(),
+      "Currently nested tensors doesn't support creating an empty_like tensor on a different device.")
+  auto options = verify_empty_parameters(
+      self, dtype, layout, device, pin_memory, optional_memory_format);
+
+  auto* allocator = at::cuda::getCUDADeviceAllocator();
+  auto self_impl = get_nested_tensor_impl(self);
+  auto nested_size = self_impl->get_nested_size_tensor().clone();
+  auto nested_strides = self_impl->get_nested_stride_tensor().clone();
+  auto offsets = self_impl->get_offsets();
+
+  return empty_nested_generic(
+      self_impl->get_buffer_size(),
+      allocator,
+      options,
+      self.key_set(),
+      nested_size,
+      nested_strides,
+      offsets);
+}
+
+} // namespace native
+} // namespace at

--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -1425,6 +1425,7 @@ aten_cuda_cu_source_list = [
     "aten/src/ATen/native/cuda/TensorTopK.cpp",
     "aten/src/ATen/native/cuda/jit_utils.cpp",
     "aten/src/ATen/native/nested/cuda/NestedTensorTransformerFunctions.cpp",
+    "aten/src/ATen/native/nested/cuda/NestedTensorMath.cpp",
     "aten/src/ATen/native/sparse/cuda/SparseBlas.cpp",
     "aten/src/ATen/native/sparse/cuda/SparseBlasImpl.cpp",
     "aten/src/ATen/native/sparse/cuda/SparseBlasLegacy.cpp",

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -10,7 +10,7 @@ from torch.testing._internal.common_device_type import (
     skipMeta,
     onlyCPU
 )
-from torch.testing._internal.common_utils import TestCase, IS_FBCODE, run_tests, freeze_rng_state, parametrize
+from torch.testing._internal.common_utils import TestCase, IS_FBCODE, run_tests, freeze_rng_state, parametrize, gradcheck
 from torch import nested_tensor
 
 # Tests are ported from pytorch/nestedtensor.
@@ -274,7 +274,6 @@ class TestNestedTensor(TestCase):
         nt = torch.nested_tensor([])
         empty = nt.to_padded_tensor(4)
         self.assertEqual(empty, torch.tensor([]))
-
 class TestNestedTensorDeviceType(TestCase):
 
     # Helper function to generate a random nested tensor
@@ -482,6 +481,7 @@ class TestNestedTensorDeviceType(TestCase):
         self.assertEqual(nt.is_cuda, is_cuda)
 
     @dtypes(torch.float, torch.float16, torch.double)
+    @torch.inference_mode()
     def test_nested_tensor_indexing(self, device, dtype):
         # edge case: empty nested tensor
         nt0 = torch.nested_tensor([])
@@ -733,7 +733,6 @@ class TestNestedTensorDeviceType(TestCase):
 
     # cannot test torch.float16 because: RuntimeError: "softmax_kernel_impl" not implemented for 'Half'
     @dtypes(torch.float, torch.double)
-    @torch.inference_mode()
     def test_softmax(self, device, dtype):
         # normal nested tensor
         ntensors = 4
@@ -1278,7 +1277,7 @@ class TestNestedTensorAutograd(TestCase):
             nt = torch._nested_tensor_from_mask(inpt, mask)
             # This implicitly tests to_padded_tensor grads
             return nt.to_padded_tensor(0)
-        assert torch.autograd.gradcheck(grad_test_func, inputs=data)
+        assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
     def test_nested_tensor_from_padded(self):
         nested_size = torch.tensor([[1, 2], [2, 2]])
@@ -1292,7 +1291,7 @@ class TestNestedTensorAutograd(TestCase):
             return nt.to_padded_tensor(0)
 
         data = (padded_tensor, nested_size)
-        assert torch.autograd.gradcheck(grad_test_func, inputs=data)
+        assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
     def test_nested_tensor_from_padded_fused(self):
         nested_size = torch.tensor([[1, 8], [2, 8]])
@@ -1305,7 +1304,7 @@ class TestNestedTensorAutograd(TestCase):
             # This implicitly tests to_padded_tensor grads
             return nt.to_padded_tensor(0)
         data = (padded_tensor, nested_size)
-        assert torch.autograd.gradcheck(grad_test_func, inputs=data)
+        assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
     def test_nested_tensor_from_list(self):
 
@@ -1318,7 +1317,7 @@ class TestNestedTensorAutograd(TestCase):
             # This implictily tests to_padded_tensor grads
             return c.to_padded_tensor(0)
         data = (a, b, c)
-        assert torch.autograd.gradcheck(grad_test_func, inputs=data)
+        assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
     def test_size_dim(self):
         a = torch.nested_tensor([])
@@ -1467,11 +1466,26 @@ class TestNestedTensorAutograd(TestCase):
             d = torch.functional.F.linear(nt, weight, bias)
             return d.to_padded_tensor(0)
         data = (a, b, c, weight, bias)
-        assert torch.autograd.gradcheck(grad_test_func, inputs=data)
+        assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
         # Test linear with no bias added
         data = (a, b, c, weight)
-        assert torch.autograd.gradcheck(grad_test_func, inputs=data)
+        assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
+
+    def test_nested_tensor_softmax(self):
+        a = torch.randn(1, 2, requires_grad=True, dtype=torch.float64)
+        b = torch.randn(2, 2, requires_grad=True, dtype=torch.float64)
+        c = torch.randn(3, 2, requires_grad=True, dtype=torch.float64)
+
+        def grad_test_func(a, b, c, dim):
+            nt = torch.nested_tensor([a, b, c])
+            # This implicitly tests to_padded_tensor grads
+            d = torch.functional.F.softmax(nt, dim=dim)
+            return d.to_padded_tensor(0)
+
+        # softmax over last dim
+        data = (a, b, c, -1)
+        assert gradcheck(grad_test_func, inputs=data, check_batched_grad=False)
 
     def test_nested_tensor_linear_backward(self):
         a = torch.randn(1, 2, requires_grad=False)

--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -481,7 +481,6 @@ class TestNestedTensorDeviceType(TestCase):
         self.assertEqual(nt.is_cuda, is_cuda)
 
     @dtypes(torch.float, torch.float16, torch.double)
-    @torch.inference_mode()
     def test_nested_tensor_indexing(self, device, dtype):
         # edge case: empty nested tensor
         nt0 = torch.nested_tensor([])


### PR DESCRIPTION
## Summary
To better enable users to write triton kernels on nested nested tensors having empty_like support is helpful. This will be used to create a nested_tensor output buffer to write results of triton computation too. This function can be used for all shape preserving ops written on nested tensors using triton. 

### Current Issues
Currently there are no variable_factory functions that work on nested tensors. There are pseudo variable factories that created nested_tensors from existing "regular"tensors:
- from_padded()
- from_padded_and_mask()
- nested_tensor()

How this comes up in this PR is that in order to be able to create nested_tensor on different devices from the original nested_tensor we would ideal use a variable_factory like nested_empty() that can create this tensor on cpu, or cuda. The question that I am unsure of is what should the signature be of such a function. Only a tensor of nested_sizes and assume contiguous. nested_size and nested_strides and offsets. Having trouble figuring out how much guts to expose to python.

