### PR TITLE
[torchgen] Fix selective build error on custom namespace

### DIFF
--- a/torchgen/selective_build/selector.py
+++ b/torchgen/selective_build/selector.py
@@ -282,4 +282,4 @@ def combine_selective_builders(
 def op_name_from_native_function(f: NativeFunction) -> str:
     # This was originally read from the 'operator_name_with_overload' field in the
     # declaration dict, which was the part before the first '(' in 'schema_string'.
-    return f"aten::{f.func.name}"
+    return f"{f.namespace}::{f.func.name}"


### PR DESCRIPTION
Summary: Currently `SelectiveBuilder` is hardcoding namespace `aten` for operators. This is not working anymore since operators started to have custom namespaces. This fixes it.

Test Plan: Rely on newly added unit test

Differential Revision: D38565527

