### PR TITLE
Turn off keychain timeout in CircleCI builds of ios/TestApp

### DIFF
--- a/ios/TestApp/fastlane/Fastfile
+++ b/ios/TestApp/fastlane/Fastfile
@@ -2,7 +2,7 @@ default_platform(:ios)
 
 platform :ios do
   before_all do
-    setup_circle_ci
+    setup_ci(provider: "circleci", timeout: 0)
   end
   lane :install_root_cert do
     import_certificate(


### PR DESCRIPTION
Fixes #82890

Default timeout is 1 hour, but our build sometimes exceeds this limit. Setting it to 0 turns the timeout off entirely. This is necessary because when our build exceeds the timeout codesign hangs indefinitely, ultimately causing the build to fail.