### PR TITLE
Updated invalid type error message to explicitly say only float types…

### DIFF
--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -431,7 +431,7 @@ static bool PyTensorType_Check(PyObject* obj) {
 
 void py_set_default_tensor_type(PyObject* obj) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  TORCH_CHECK_TYPE(PyTensorType_Check(obj), "invalid type object");
+  TORCH_CHECK_TYPE(PyTensorType_Check(obj), "invalid type object: only floating-point types are supported as the default type");
   PyTensorType* type = (PyTensorType*)obj;
   if (type->is_cuda && !torch::utils::cuda_enabled()) {
     throw unavailable_type(*type);
@@ -440,7 +440,7 @@ void py_set_default_tensor_type(PyObject* obj) {
 }
 
 void py_set_default_dtype(PyObject* obj) {
-  TORCH_CHECK_TYPE(THPDtype_Check(obj), "invalid dtype object");
+  TORCH_CHECK_TYPE(THPDtype_Check(obj), "invalid dtype object: only floating-point types are supported as the default type");
   auto scalar_type = ((THPDtype*)obj)->scalar_type;
   set_default_tensor_type(/*backend=*/c10::nullopt, scalar_type);
 }

--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -431,7 +431,9 @@ static bool PyTensorType_Check(PyObject* obj) {
 
 void py_set_default_tensor_type(PyObject* obj) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  TORCH_CHECK_TYPE(PyTensorType_Check(obj), "invalid type object: only floating-point types are supported as the default type");
+  TORCH_CHECK_TYPE(
+      PyTensorType_Check(obj),
+      "invalid type object: only floating-point types are supported as the default type");
   PyTensorType* type = (PyTensorType*)obj;
   if (type->is_cuda && !torch::utils::cuda_enabled()) {
     throw unavailable_type(*type);
@@ -440,7 +442,9 @@ void py_set_default_tensor_type(PyObject* obj) {
 }
 
 void py_set_default_dtype(PyObject* obj) {
-  TORCH_CHECK_TYPE(THPDtype_Check(obj), "invalid dtype object: only floating-point types are supported as the default type");
+  TORCH_CHECK_TYPE(
+      THPDtype_Check(obj),
+      "invalid dtype object: only floating-point types are supported as the default type");
   auto scalar_type = ((THPDtype*)obj)->scalar_type;
   set_default_tensor_type(/*backend=*/c10::nullopt, scalar_type);
 }


### PR DESCRIPTION
… allowed

Fixes #82983

I added an error messages consistent with existing invalid type error messages (line 330 in torch/csrc/tensor/python_tensor.cpp).