### PR TITLE
[PyTorch] Allow const T& access to ListElementReference when possible

### DIFF
--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -69,11 +69,11 @@ struct ListElementConstReferenceTraits<c10::optional<std::string>> {
 template<class T, class Iterator>
 class ListElementReference final {
 public:
- operator std::conditional_t<
-     std::is_reference<typename c10::detail::
-                           ivalue_to_const_ref_overload_return<T>::type>::value,
-     const T&,
-     T>() const;
+  operator std::conditional_t<
+      std::is_reference<typename c10::detail::
+                            ivalue_to_const_ref_overload_return<T>::type>::value,
+      const T&,
+      T>() const;
 
   ListElementReference& operator=(T&& new_value) &&;
 

--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -69,7 +69,11 @@ struct ListElementConstReferenceTraits<c10::optional<std::string>> {
 template<class T, class Iterator>
 class ListElementReference final {
 public:
-  operator T() const;
+ operator std::conditional_t<
+     std::is_reference<typename c10::detail::
+                           ivalue_to_const_ref_overload_return<T>::type>::value,
+     const T&,
+     T>() const;
 
   ListElementReference& operator=(T&& new_value) &&;
 

--- a/aten/src/ATen/core/List_inl.h
+++ b/aten/src/ATen/core/List_inl.h
@@ -118,9 +118,13 @@ namespace detail {
 
 namespace impl {
 
-template<class T, class Iterator>
-ListElementReference<T, Iterator>::operator T() const {
-  return c10::detail::list_element_to<T>(*iterator_);
+template <class T, class Iterator>
+ListElementReference<T, Iterator>::operator std::conditional_t<
+    std::is_reference<typename c10::detail::ivalue_to_const_ref_overload_return<
+        T>::type>::value,
+    const T&,
+    T>() const {
+  return iterator_->template to<T>();
 }
 
 template<class T, class Iterator>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83177

`IValue` can provide const reference access to `Tensor`,
`std::string`, and `IValue`. Fixing this allows iterating over
`c10::List`s of these types without copies.

This was flagged on #67964 back in February; never found someone to
implement it so I just did it myself while going over my TODO list
after returning from vacation yesterday.

Note that we still need `ListElementReference::get()` because this
support does not work for `List<optional<Tensor>>`.

Differential Revision: [D38579022](https://our.internmc.facebook.com/intern/diff/D38579022/)