### PR TITLE
[caffe2] Make ListIterator compatible with libc++ 15

### DIFF
--- a/aten/src/ATen/core/List.h
+++ b/aten/src/ATen/core/List.h
@@ -106,9 +106,14 @@ private:
 
 // this wraps vector::iterator to make sure user code can't rely
 // on it being the type of the underlying vector.
-template<class T, class Iterator>
-class ListIterator final : public std::iterator<std::random_access_iterator_tag, T> {
-public:
+template <class T, class Iterator>
+class ListIterator final : public std::iterator<
+                               std::random_access_iterator_tag,
+                               T,
+                               std::ptrdiff_t,
+                               T*,
+                               ListElementReference<T, Iterator>> {
+ public:
   explicit ListIterator() = default;
   ~ListIterator() = default;
 


### PR DESCRIPTION
Summary:
We're working on upgrading our Android native code to build with libc++
15 (it currently uses libc++ 13). libc++ 15 diagnoses iterators whose
`iterator_traits<It>::reference` does not match the return type of `*it`:

```
third-party/llvm-project/15.x-android/llvm-project/libcxx/include/__algorithm/iterator_operations.h:84:5: error: static_assert failed due to requirement 'is_same<c10::impl::ListElementReference<at::Tensor, std::__wrap_iter<c10::IValue *>>, at::Tensor &>::value' "It looks like your iterator's `iterator_traits<It>::reference` does not match the return type of dereferencing the iterator, i.e., calling `*it`. This is undefined behavior according to [input.iterators] and can lead to dangling reference issues at runtime, so we are flagging this."
```

This was added by https://reviews.llvm.org/D130538, and there's some
discussion of the rationale there.

Set the `iterator_traits` for `ListIterator` appropriately to avoid this
error. I'm not sure if `iterator_traits<It>::pointer` should also be
updated to match.

Reviewed By: swolchok

Differential Revision: D38565649

