### PR TITLE
properly raise an error in torch.ops.aten.foo.decompose when foo doesnt have a composite

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -74,7 +74,7 @@ class OpOverload:
         if torch._C._dispatch_has_kernel_for_dispatch_key(self.name, dk):
             return self._op_dk(dk, *args, **kwargs)
         else:
-            return NotImplemented
+            raise NotImplementedError
 
     @property
     def overloadpacket(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83190

