### PR TITLE
Rename PyFunctionPreHook to PyFunctionTensorPreHook

### DIFF
--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -78,7 +78,7 @@ PyObject* THPCppFunction_call(
 int THPCppFunction_traverse(PyObject* self, visitproc visit, void* arg) {
   auto& fn = *((THPCppFunction*)self)->cdata;
   for (const auto& hook : fn.pre_hooks()) {
-    if (auto pyhook = dynamic_cast<PyFunctionPreHook*>(hook.get())) {
+    if (auto pyhook = dynamic_cast<PyFunctionTensorPreHook*>(hook.get())) {
       Py_VISIT(pyhook->dict);
     }
   }
@@ -150,7 +150,7 @@ PyObject* THPCppFunction_register_hook_dict(PyObject* self, PyObject* _var) {
   }
   auto var = (THPVariable*)_var;
   auto& fn = *((THPCppFunction*)self)->cdata;
-  std::unique_ptr<FunctionPreHook> hook(new PyFunctionPreHook(
+  std::unique_ptr<FunctionPreHook> hook(new PyFunctionTensorPreHook(
       var->backward_hooks, THPVariable_Unpack(var).output_nr()));
   fn.add_pre_hook(std::move(hook));
   Py_RETURN_NONE;

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -213,7 +213,7 @@ static int THPFunction_traverse(THPFunction* self, visitproc visit, void* arg) {
   // that is stored in PyNode, since we don't really own that C++ object.
   if (auto cdata = self->cdata.lock()) {
     for (const auto& hook : cdata->pre_hooks()) {
-      if (auto pyhook = dynamic_cast<PyFunctionPreHook*>(hook.get())) {
+      if (auto pyhook = dynamic_cast<PyFunctionTensorPreHook*>(hook.get())) {
         Py_VISIT(pyhook->dict);
       }
     }
@@ -899,7 +899,7 @@ PyObject* THPFunction__register_hook_dict(PyObject* _self, PyObject* _var) {
   THPVariable* var = reinterpret_cast<THPVariable*>(_var);
   const auto& tensor = THPVariable_Unpack(var);
   std::unique_ptr<FunctionPreHook> hook(
-      new PyFunctionPreHook(var->backward_hooks, tensor.output_nr()));
+      new PyFunctionTensorPreHook(var->backward_hooks, tensor.output_nr()));
   auto self = (THPFunction*)_self;
   auto cdata = self->cdata.lock();
   TORCH_CHECK(

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -26,12 +26,12 @@ static void check_single_result(
 namespace torch {
 namespace autograd {
 
-PyFunctionPreHook::PyFunctionPreHook(PyObject* dict, int value_idx)
+PyFunctionTensorPreHook::PyFunctionTensorPreHook(PyObject* dict, int value_idx)
     : dict(dict), value_idx(value_idx) {
   Py_INCREF(dict);
 }
 
-PyFunctionPreHook::~PyFunctionPreHook() {
+PyFunctionTensorPreHook::~PyFunctionTensorPreHook() {
   // If python is already dead, leak the wrapped python objects
   if (Py_IsInitialized()) {
     pybind11::gil_scoped_acquire gil;
@@ -39,7 +39,7 @@ PyFunctionPreHook::~PyFunctionPreHook() {
   }
 }
 
-auto PyFunctionPreHook::operator()(const variable_list& values)
+auto PyFunctionTensorPreHook::operator()(const variable_list& values)
     -> variable_list {
   pybind11::gil_scoped_acquire gil;
 

--- a/torch/csrc/autograd/python_hook.h
+++ b/torch/csrc/autograd/python_hook.h
@@ -7,9 +7,9 @@
 namespace torch {
 namespace autograd {
 
-struct PyFunctionPreHook : public FunctionPreHook {
-  PyFunctionPreHook(PyObject* dict, int value_idx);
-  ~PyFunctionPreHook() override;
+struct PyFunctionTensorPreHook : public FunctionPreHook {
+  PyFunctionTensorPreHook(PyObject* dict, int value_idx);
+  ~PyFunctionTensorPreHook() override;
   variable_list operator()(const variable_list& values) override;
   PyObject* dict;
   int value_idx;

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -1198,7 +1198,7 @@ int THPVariable_set_backwards_hooks(
   torch::autograd::impl::clear_hooks(tensor);
   if (obj) {
     torch::autograd::impl::add_hook(
-        tensor, std::make_shared<PyFunctionPreHook>(obj, 0));
+        tensor, std::make_shared<PyFunctionTensorPreHook>(obj, 0));
   }
   return 0;
   END_HANDLE_TH_ERRORS_RET(-1)
@@ -2023,7 +2023,7 @@ static int THPVariable_subclass_traverse(
       }
 
       for (const auto& hook : torch::autograd::impl::hooks(tensor)) {
-        if (auto pyhook = dynamic_cast<PyFunctionPreHook*>(hook.get())) {
+        if (auto pyhook = dynamic_cast<PyFunctionTensorPreHook*>(hook.get())) {
           Py_VISIT(pyhook->dict);
         }
       }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #83331
* #83226
* __->__ #83225

Now that there will be two types of Python function prehooks, I prefer have the PyFunction hook taking all grad_outputs and returning all grad_inputs as the more "canonical" one