### PR TITLE
Enable xpu distributed data parallel (DDP) in a device-agnostic way

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -45,6 +45,7 @@ from torch.distributed.utils import (
 
 from torch.nn.parallel import DistributedDataParallel
 from torch.nn.parallel.distributed import _dump_DDP_relevant_env_vars
+from torch.nn.parallel._functions import _get_device_impl
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     TEST_SKIPS,
@@ -9313,6 +9314,16 @@ class DistributedTest:
                 start_powerSGD_iter=4,
             )
             self._test_hook_pickling(hook, powersgd_state)
+
+        @skip_if_no_gpu
+        def test_ddp_get_device_impl(self):
+            ddp_device_type, ddp_gpu = _get_device_impl()
+            if torch.cuda.is_available():
+                self.assertEqual(ddp_device_type, 'cuda')
+                self.assertEqual(ddp_gpu, torch.cuda)
+            elif hasattr(torch, "xpu") and torch.xpu.is_available():
+                self.assertEqual(ddp_device_type, 'xpu')
+                self.assertEqual(ddp_gpu, torch.xpu)
 
 
 instantiate_parametrized_tests(DistributedTest._DistTestBase)


### PR DESCRIPTION
* Support DDP both in xpu and cuda with minor code changes.
* Pytorch has supported xpu registration (_register_device_module (in torch/__init__.py), and we use _get_available_device_type (in torch/_utils.py) to get DDP device type.
* Use DDP device type to get the ddp_torch_module (torch.cuda or torch.xpu), replacing the hard code of xpu.
* Now we only support cuda-like devices, and not consider xla.

Co-authored-by: Zhu Hong <hong.zhu@intel.com>
Co-authored-by: Lu Chengjun <chengjun.lu@intel.com>

Fixes #ISSUE_NUMBER


cc @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @H-Huang @kwen2501 @awgu @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10