### PR TITLE
Change the input of `mvit_v2_s` on the FX test

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -4201,7 +4201,7 @@ class TestVisionTracing(JitTestCase):
     def generate_video_tests(cls):
         for k in torchvision_models.list_models(module=torchvision_models.video):
             test_name = 'test_torchvision_models_video_' + k
-            x = torch.rand(1, 3, 4, 112, 112) if k != 'mvit_v1_b' else torch.rand(1, 3, 16, 224, 224)
+            x = torch.rand(1, 3, 4, 112, 112) if k not in {'mvit_v1_b', 'mvit_v2_s'} else torch.rand(1, 3, 16, 224, 224)
             kwargs = dict(num_classes=50)
             model_test = cls.generate_test_fn(k, x, kwargs)
             setattr(cls, test_name, model_test)


### PR DESCRIPTION
Addresses some [breakages](https://github.com/pytorch/pytorch/runs/7782559841?check_suite_focus=true) from #82560

Context: The tests are breaking because a new architecture was added in TorchVision (see https://github.com/pytorch/vision/pull/6373) that requires a different input size. This PR addresses it by using the right size for the `mvit_v2_s` architecture.