### PR TITLE
Added communication hook for sharded cases

### DIFF
--- a/test/distributed/fsdp/test_fsdp_comm_hooks.py
+++ b/test/distributed/fsdp/test_fsdp_comm_hooks.py
@@ -106,7 +106,7 @@ class DummyHook(object):
     def dummy_hook_for_sharded_fsdp(self, state: DummyState, grad: torch.Tensor, output: torch.Tensor):
         """
         This communication hook is for illustration and testing purposes only.
-        This communication hook is used during FSDF ``FULL_SHARD`` or ``SHARD_GRAD_OP`` training.
+        This communication hook is used during FSDP ``FULL_SHARD`` or ``SHARD_GRAD_OP`` training.
         It adds some noise to the provided ``grad`` parameter, uses
         ``reduce_scatter`` for gradient communication and stores a sharded gradient in ``output``.
         """
@@ -132,8 +132,8 @@ class TestCommunicationHooks(FSDPTest):
         """
         Tests FSDP's default communication hook's behavior and correctness.
         This test creates a simple linear net with weight shape  ``1 X N``,
-        where ``N`` - is the number of workers.
-        For sharded cases, ``N`` parameters are sharded across ``N`` workers. This test
+        where ``N`` is the number of workers.
+        For sharded cases, each worker gets 1 element of the weight parameter. This test
         checks that after backward, each worker has a proper value in its chunk of
         the gradient, or the whole gradient on every worker is equal to an expected value.
 
@@ -267,7 +267,7 @@ class TestCommunicationHooks(FSDPTest):
         loss = fsdp_model_with_hook(in_data).sum()
         # This Error is raised during backward pass and is checked with `p_assert`,
         # i.e. it prints error string but AssertionError raises nothing
-        with self.assertRaisesRegex(AssertionError, ''):
+        with self.assertRaises(AssertionError):
             loss.backward()
 
         for entry in FSDP.fsdp_modules(fsdp_model_with_hook):
@@ -275,7 +275,7 @@ class TestCommunicationHooks(FSDPTest):
             entry._communication_hook_state = None
         # Same as above
         loss = fsdp_model_with_hook(in_data).sum()
-        with self.assertRaisesRegex(AssertionError, ''):
+        with self.assertRaises(AssertionError):
             loss.backward()
 
 

--- a/torch/distributed/algorithms/_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/_comm_hooks/default_hooks.py
@@ -104,7 +104,7 @@ def reduce_scatter_hook(state: DefaultState, grad: torch.Tensor, output: torch.T
         state (DefaultState): State information, configures pre- and post-division factors
         grad (torch.Tensor): A full gradient for the local batch that needs to be
         communicated across ranks.
-        output (torch.Tensor): A single shard of the summed gradient.
+        output (torch.Tensor): Stores a single shard of the gradient after ``reduce_scatter``.
     """
     # Average grad by pre-division factor. Together pre- and post-division factors
     # lead to an overall averaging by world_size, required for consistency with PyTorch DDP.
@@ -135,8 +135,9 @@ def fp16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: tor
     This FSDP communication hook implements a simple gradient compression
     approach that casts ``grad`` to half-precision floating-point format (``torch.float16``).
     It also averages gradients by ``world_size`` in two steps: first it pre-divides gradients by a
-    ``state.predivide_factor``, and after an allreduce step gradients are averaged by a ``state.postdivide_factor``.
-    Onse post-division is done, compressed gradients are casted back to parameters' precision.
+    ``state.predivide_factor``, and after a communication step (``all_reduce`` or ``reduce_scatter``)
+    gradients are averaged by a ``state.postdivide_factor``.
+    Once post-division is done, compressed gradients are casted back to parameters' precision.
 
     Args:
         state (DefaultState): State information, configures pre- and post-division factors
@@ -151,8 +152,9 @@ def bf16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: tor
     This FSDP communication hook implements a simple gradient compression
     approach that casts ``grad`` to half-precision floating-point format (``torch.float16``).
     It also averages gradients by ``world_size`` in two steps: first it pre-divides gradients by a
-    ``state.predivide_factor``, and after an allreduce step gradients are averaged by a ``state.postdivide_factor``.
-    Onse post-division is done, compressed gradients are casted back to parameters' precision.
+    ``state.predivide_factor``, and afterafter a communication step (``all_reduce`` or ``reduce_scatter``)
+    gradients are averaged by a ``state.postdivide_factor``.
+    Once post-division is done, compressed gradients are casted back to parameters' precision.
 
     Args:
         state (DefaultState): State information, configures pre- and post-division factors

--- a/torch/distributed/algorithms/_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/_comm_hooks/default_hooks.py
@@ -67,7 +67,7 @@ class LowPrecisionState(DefaultState):
 def _decompress(state: LowPrecisionState, grad: torch.Tensor):
     """
     Casts gradients back to full parameter precision so that
-    further computation happens in full precision
+    further computation happens in full precision.
     """
     orig_grad_data = grad.data
     grad.data = grad.data.to(state.parameter_type)
@@ -80,7 +80,7 @@ def allreduce_hook(state: DefaultState, grad: torch.Tensor):
     and a necessary pre- and post-division of gradients.
 
     Args:
-        state (DefaultState): State information, configures pre- and post-division factors
+        state (DefaultState): State information, configures pre- and post-division factors.
         grad (torch.Tensor): A gradient for the local batch that needs to be communicated across ranks.
     """
     # Average grad by pre-division factor. Together pre- and post-division factors
@@ -99,7 +99,7 @@ def reduce_scatter_hook(state: DefaultState, grad: torch.Tensor, output: torch.T
     sharded FSDP strategies and a necessary pre- and post-division of gradients.
 
     Args:
-        state (DefaultState): State information, configures pre- and post-division factors
+        state (DefaultState): State information, configures pre- and post-division factors.
         grad (torch.Tensor): An unsharded gradient for the local batch that needs to be
         communicated across ranks.
         output (torch.Tensor): Stores a single shard of the gradient after ``reduce_scatter``.
@@ -129,12 +129,12 @@ def fp16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: tor
     This FSDP communication hook implements a simple gradient compression
     approach that casts ``grad`` to half-precision floating-point format (``torch.float16``).
     It also averages gradients by ``world_size`` in two steps: first it pre-divides gradients by a
-    ``self.gradient_predivide_factor``, and after a communication step (``all_reduce`` or ``reduce_scatter``)
+    ``state.gradient_predivide_factor``, and after a communication step (``all_reduce`` or ``reduce_scatter``)
     gradients are averaged by a ``state.gradient_postdivide_factor``.
     Once post-division is done, compressed gradients are casted back to parameters' precision.
 
     Args:
-        state (DefaultState): State information, configures pre- and post-division factors
+        state (LowPrecisionState): State information, configures pre- and post-division factors, parameters' precision.
         grad (torch.Tensor): A gradient for the local batch that needs to be communicated across ranks in a lower precision.
         output (torch.Tensor): Stores a single shard of the gradient after ``reduce_scatter``.
     """
@@ -146,12 +146,12 @@ def bf16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: tor
     This FSDP communication hook implements a simple gradient compression
     approach that casts ``grad`` to half-precision floating-point format (``torch.float16``).
     It also averages gradients by ``world_size`` in two steps: first it pre-divides gradients by a
-    ``self.gradient_predivide_factor``, and after a communication step (``all_reduce`` or ``reduce_scatter``)
+    ``state.gradient_predivide_factor``, and after a communication step (``all_reduce`` or ``reduce_scatter``)
     gradients are averaged by a ``state.gradient_postdivide_factor``.
     Once post-division is done, compressed gradients are casted back to parameters' precision.
 
     Args:
-        state (DefaultState): State information, configures pre- and post-division factors
+        state (LowPrecisionState): State information, configures pre- and post-division factors, parameters' precision.
         grad (torch.Tensor): A gradient for the local batch that needs to be communicated across ranks in a lower precision.
         output (torch.Tensor): Stores a single shard of the gradient after ``reduce_scatter``.
     """

--- a/torch/distributed/algorithms/_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/_comm_hooks/default_hooks.py
@@ -114,7 +114,7 @@ def reduce_scatter_hook(state: DefaultState, grad: torch.Tensor, output: torch.T
     if state.gradient_postdivide_factor > 1:
         output.div_(state.gradient_postdivide_factor)
 
-def _lower_precision_hook(prec: torch.dtype, state: LowPrecisionState, grad: torch.Tensor, output: torch.Tensor = None):
+def _low_precision_hook(prec: torch.dtype, state: LowPrecisionState, grad: torch.Tensor, output: torch.Tensor = None):
     grad.data = grad.data.to(prec)
     if output is not None:
         output.data = output.data.to(prec)
@@ -138,7 +138,7 @@ def fp16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: tor
         grad (torch.Tensor): A gradient for the local batch that needs to be communicated across ranks in a lower precision.
         output (torch.Tensor): Stores a single shard of the gradient after ``reduce_scatter``.
     """
-    fp16_hook = functools.partial(_lower_precision_hook, torch.float16)
+    fp16_hook = functools.partial(_low_precision_hook, torch.float16)
     return fp16_hook(state, grad, output)
 
 def bf16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: torch.Tensor = None):
@@ -155,5 +155,5 @@ def bf16_compress_hook(state: LowPrecisionState, grad: torch.Tensor, output: tor
         grad (torch.Tensor): A gradient for the local batch that needs to be communicated across ranks in a lower precision.
         output (torch.Tensor): Stores a single shard of the gradient after ``reduce_scatter``.
     """
-    bf16_hook = functools.partial(_lower_precision_hook, torch.bfloat16)
+    bf16_hook = functools.partial(_low_precision_hook, torch.bfloat16)
     return bf16_hook(state, grad, output)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/79114

An implementation of a FSDP communication hook interface for a sharded strategies:

- Added `reduce_scatter_hook` to default hooks. Note the difference of `reduce_scatter` from `all_reduce`, it requires 2 tensors:`input_gradient` and `output` variables and stores result in `output`, which is further used as a summed gradient shard.
- Adjusted FSDP logic to return `reduce_scatter_hook` as a default communication hook for sharded strategies, `DefaultState` is the same for sharded and non-sharded strategies.
- Adjusted low-precision hooks to work with both `all_reduce` and `reduce_scatter` depending on whether `output` tensor is provided or not.

Test plan:

Added all existing sharded strategies as an input parameters to existing tests.
For`test_default_communication_hook_behaviour` double checked how a linear layer is sharded across workers. This test creates a simple net ``1 X N``, where ``N`` - is the number of workers. For sharded cases, ``N`` parameters are sharded across ``N`` workers. This test checks that after backward, each worker has a proper value in it's chunk of the gradient, or the whole gradient on every worker is equal to an expected value.

Checked that low-precision tests work for sharded cases.