### PR TITLE
Be compatible with SYCL 2020 and SYCL1.2.1 for sycl.hpp

### DIFF
--- a/c10/util/Half-inl.h
+++ b/c10/util/Half-inl.h
@@ -12,8 +12,10 @@
 #include <hip/hip_fp16.h>
 #endif
 
-#ifdef SYCL_LANGUAGE_VERSION
-#include <CL/sycl.hpp>
+#if defined(SYCL_LANGUAGE_VERSION)
+#include <sycl/sycl.hpp> // for SYCL 2020
+#elif defined(CL_SYCL_LANGUAGE_VERSION)
+#include <CL/sycl.hpp> // for SYCL 1.2.1
 #endif
 
 C10_CLANG_DIAGNOSTIC_PUSH()

--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -45,8 +45,10 @@
 #include <hip/hip_fp16.h>
 #endif
 
-#ifdef SYCL_LANGUAGE_VERSION
-#include <CL/sycl.hpp>
+#if defined(SYCL_LANGUAGE_VERSION)
+#include <sycl/sycl.hpp> // for SYCL 2020
+#elif defined(CL_SYCL_LANGUAGE_VERSION)
+#include <CL/sycl.hpp> // for SYCL 1.2.1
 #endif
 
 // Standard check for compiling CUDA with clang


### PR DESCRIPTION
- In SYCL2020, SYCL provides one standard header file: <sycl/sycl.hpp>, which needs to be included in every translation unit that uses the SYCL programming API.

- For compatibility with SYCL 1.2.1, SYCL provides another standard header file: <CL/sycl.hpp>, which can be included in place of <sycl/sycl.hpp>.

- SYCL documents this change in [doc](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:headers-and-namespaces)(4.3).

- SYCL_LANGUAGE_VERSION substitutes an integer reflecting the version number and revision of the SYCL language being supported by the implementation in SYCL 2020. In SYCL1.2.1, the macro name is CL_SYCL_LANGUAGE_VERSION. So these two macros can be used to distinguish SYCL1.2.1 and SYCL2020.

- SYCL 2020 doc: https://registry.khronos.org/SYCL/specs/sycl-2020/pdf/sycl-2020.pdf
- SYCL 1.2.1 doc: https://registry.khronos.org/SYCL/specs/sycl-1.2.1.pdf