### PR TITLE
[Quant][fx] Remove WEIGHT_INDEX_DICT and BIAS_INDEX_DICT

### DIFF
--- a/torch/ao/quantization/backend_config/_common_operator_config_utils.py
+++ b/torch/ao/quantization/backend_config/_common_operator_config_utils.py
@@ -95,7 +95,8 @@ def _get_linear_configs(dtype_configs: List[DTypeConfig]) -> List[BackendPattern
     linear_configs.append(
         BackendPatternConfig(torch.nn.functional.linear)
             .set_observation_type(observation_type)  # noqa: E131
-            .set_dtype_configs(dtype_configs))
+            .set_dtype_configs(dtype_configs)
+            ._set_input_type_to_index({"weight": 1, "bias": 2}))
 
     # (2) Linear + relu
     # -------------------
@@ -197,7 +198,8 @@ def _get_conv_configs(dtype_configs):
         conv_configs.append(
             BackendPatternConfig(convs.func)
                 .set_observation_type(observation_type)  # noqa: E131
-                .set_dtype_configs(dtype_configs))
+                .set_dtype_configs(dtype_configs)
+                ._set_input_type_to_index({"weight": 1, "bias": 2}))
 
         # (2) Conv + relu
         # -----------------

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -155,7 +155,7 @@ def is_activation_post_process_node(node: Node, modules: Dict[str, torch.nn.Modu
         is_activation_post_process(modules[str(node.target)])
 
 def node_arg_is_weight(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
-    if isinstance(node, Node) and node.op == "call_function" and node.target in backend_config:
+    if isinstance(node, Node) and node.op == "call_function" and node.target in backend_config.configs:
         weight_index = backend_config.configs[node.target]._input_type_to_index.get("weight")
         if weight_index is not None and weight_index < len(node.args) and node.args[weight_index] is arg:
             return True
@@ -163,7 +163,7 @@ def node_arg_is_weight(node: Node, arg: Any, backend_config: BackendConfig) -> b
     return False
 
 def node_arg_is_bias(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
-    if isinstance(node, Node) and node.op == "call_function" and node.target in backend_config:
+    if isinstance(node, Node) and node.op == "call_function" and node.target in backend_config.configs:
         bias_index = backend_config.configs[node.target]._input_type_to_index.get("bias")
         if bias_index is not None and bias_index < len(node.args) and node.args[bias_index] is arg:
             return True

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -157,7 +157,7 @@ def is_activation_post_process_node(node: Node, modules: Dict[str, torch.nn.Modu
 
 
 def get_weight_and_bias_index_dicts(backend_config):
-    index_dicts = {
+    index_dicts: Dict[str, Dict[str, int]] = {
         "weight": {},
         "bias": {},
         "input": {}  # not used right now
@@ -211,7 +211,13 @@ def is_input_arg_dtype_supported_by_backend(
     is supported by the backend or not
     """
     if isinstance(arg, (list, tuple)):
-        return all(map(lambda a: is_input_arg_dtype_supported_by_backend(a, node, node_name_to_target_dtype, dtype_config, weight_index_dict, bias_index_dict), arg))
+        return all(map(lambda a: is_input_arg_dtype_supported_by_backend(a,
+                                                                         node,
+                                                                         node_name_to_target_dtype,
+                                                                         dtype_config,
+                                                                         weight_index_dict,
+                                                                         bias_index_dict),
+                       arg))
     if not isinstance(arg, Node):
         return True
     # TODO: support check for standalone module
@@ -585,7 +591,12 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
             qconfig.activation
 
         arg_as_output_target_dtype = get_arg_target_dtype_as_output(arg, modules, node_name_to_target_dtype)
-        arg_as_input_target_dtype = get_arg_target_dtype_as_input_to_node(arg, node, modules, node_name_to_target_dtype, weight_index_dict, bias_index_dict)
+        arg_as_input_target_dtype = get_arg_target_dtype_as_input_to_node(arg,
+                                                                          node,
+                                                                          modules,
+                                                                          node_name_to_target_dtype,
+                                                                          weight_index_dict,
+                                                                          bias_index_dict)
         arg_as_input_target_compute_dtype = \
             get_arg_target_compute_dtype_as_input_to_node(
                 arg, node, modules, node_name_to_target_dtype, weight_index_dict, bias_index_dict)

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -175,26 +175,26 @@ def get_weight_and_bias_index_dicts(backend_config: BackendConfig):
 
     return index_dicts['weight'], index_dicts['bias']
 
-def node_arg_is_weight(node: Node, arg: Any, weight_index_dict: Dict[str, int]) -> bool:
+def node_arg_is_weight(node: Node, arg: Any, weight_index_dict: Dict[str, List[int]]) -> bool:
     if isinstance(node, Node) and node.op == 'call_function' and \
             node.target in weight_index_dict:
         for i, node_arg in enumerate(node.args):
-            if (arg is node_arg and
-                i in weight_index_dict[node.target]):  # type: ignore[index]
+            if arg is node_arg and i in \
+                    weight_index_dict[node.target]:  # type: ignore[index]
                 return True
         for kwarg_name, kwarg_value in node.kwargs.items():
             if kwarg_name == 'weight' and arg is kwarg_value:
                 return True
     return False
 
-def node_arg_is_bias(node: Node, arg: Any, bias_index_dict: Dict[str, int]) -> bool:
+def node_arg_is_bias(node: Node, arg: Any, bias_index_dict: Dict[str, List[int]]) -> bool:
     if not isinstance(node, Node) or node.op != 'call_function' or \
        node.target not in bias_index_dict:
         return False
 
     for i, node_arg in enumerate(node.args):
-        if (arg is node_arg and
-            i in bias_index_dict[node.target]):  # type: ignore[index]
+        if arg is node_arg and i in \
+           bias_index_dict[node.target]:  # type: ignore[index]
             return True
 
     return node.kwargs.get('bias', None) is arg

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -91,8 +91,7 @@ from ..utils import (
 
 from ..backend_config.utils import (
     get_pattern_to_dtype_configs,
-    get_pattern_to_input_type_to_index,
-    get_module_to_qat_module,
+    p get_module_to_qat_module,
     get_fusion_pattern_to_root_node_getter,
 )
 from ..backend_config import (
@@ -155,16 +154,16 @@ def is_activation_post_process_node(node: Node, modules: Dict[str, torch.nn.Modu
     return isinstance(node, torch.fx.Node) and node.op == "call_module" and \
         is_activation_post_process(modules[str(node.target)])
 
-def node_arg_is_weight(node: Node, arg: Any, backend_config: Optional[BackendConfig]) -> bool:
-    if isinstance(node, Node) and node.op == 'call_function' or not backend_config:
+def node_arg_is_weight(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
+    if isinstance(node, Node) and node.op == 'call_function':
         weight_index = backend_config.configs[node.target]._input_type_to_index.get('weight')
         if weight_index and weight_index < len(node.args) and node.args[weight_index] is arg:
             return True
         return node.kwargs.get('weight') is arg
     return False
 
-def node_arg_is_bias(node: Node, arg: Any, backend_config: Optional[BackendConfig]) -> bool:
-    if isinstance(node, Node) and node.op == 'call_function' or not backend_config:
+def node_arg_is_bias(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
+    if isinstance(node, Node) and node.op == 'call_function':
         bias_index = backend_config.configs[node.target]._input_type_to_index.get('bias')
         if bias_index and bias_index < len(node.args) and node.args[bias_index] is arg:
             return True
@@ -237,7 +236,7 @@ def is_pattern_dtype_config_supported_by_backend(
     pattern: Optional[Pattern],
     matched_node_pattern: Optional[NodePattern],
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
-    backend_config: Optional[BackendConfig],
+    backend_config: BackendConfig,
 ) -> bool:
     """ Check is the dtype configuration of a pattern is supported by
     the backend or not
@@ -511,7 +510,7 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config: PrepareCustomConfig,
-    backend_config: Optional[BackendConfig],
+    backend_config: BackendConfig,
 ) -> Argument:
     """
     Given a `node` and an `arg`, inserts an input observer between
@@ -648,7 +647,7 @@ def maybe_insert_input_observers_for_node(
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config: PrepareCustomConfig,
-    backend_config: Optional[BackendConfig],
+    backend_config: BackendConfig,
 ) -> None:
     """
     If needed, inserts observers to the input args and kwargs of `node`.
@@ -1081,7 +1080,7 @@ def insert_observers_for_model(
     equalization_config_map: Dict[str, Any],
     input_quantized_idxs: List[int],
     output_quantized_idxs: List[int],
-    backend_config: Optional[BackendConfig],
+    backend_config: BackendConfig,
     observed_node_names: Set[str],
     is_qat: bool,
 ) -> Optional[Node]:
@@ -1370,7 +1369,7 @@ def run_prepare_fx_on_standalone_modules(
     modules: Dict[str, torch.nn.Module],
     matches: Any,
     prepare_custom_config: PrepareCustomConfig,
-    backend_config: Optional[BackendConfig],
+    backend_config: BackendConfig,
 ) -> None:
     """
     Runs prepare_fx on each standalone module. Note: this does

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -205,7 +205,7 @@ def is_input_arg_dtype_supported_by_backend(
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     dtype_config: DTypeConfig,
     weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int],
+    bias_index_dict: Dict[str, List[int]],
 ) -> bool:
     """ Check if the configured qconfig for the argument
     is supported by the backend or not

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -156,8 +156,8 @@ def is_activation_post_process_node(node: Node, modules: Dict[str, torch.nn.Modu
         is_activation_post_process(modules[str(node.target)])
 
 
-def get_weight_and_bias_index_dicts(backend_config):
-    index_dicts: Dict[str, Dict[str, int]] = {
+def get_weight_and_bias_index_dicts(backend_config: BackendConfig):
+    index_dicts: Dict[str, Dict[str, List[int]]] = {
         "weight": {},
         "bias": {},
         "input": {}  # not used right now

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -75,8 +75,6 @@ from .utils import (
     get_non_observable_arg_indexes_and_types,
     get_new_attr_name_with_prefix,
     NON_QUANTIZABLE_WEIGHT_OPS,
-    WEIGHT_INDEX_DICT,
-    BIAS_INDEX_DICT,
 )
 
 from torch.ao.quantization.quantize import (
@@ -157,26 +155,46 @@ def is_activation_post_process_node(node: Node, modules: Dict[str, torch.nn.Modu
     return isinstance(node, torch.fx.Node) and node.op == "call_module" and \
         is_activation_post_process(modules[str(node.target)])
 
-def node_arg_is_weight(node: Node, arg: Any) -> bool:
+
+def get_weight_and_bias_index_dicts(backend_config):
+    pattern_to_input_type_to_index = get_pattern_to_input_type_to_index(backend_config)
+    for pattern, input_type_to_index in pattern_to_input_type_to_index.items():
+        for input_type, index in input_type_to_index.items():
+            index_dicts = {
+                "weight": {},
+                "bias": {},
+                "input": {}  # not used right now
+            }
+            assert input_type in index_dicts.keys(), \
+                f"input type must be one of {index_dicts.keys()} but got: {input_type}"
+            index_dict = index_dicts[input_type]
+            if pattern in index_dict:  # type: ignore[operator]
+                index_dict[pattern].append(index)  # type: ignore[index]
+            else:
+                index_dict[pattern] = [index]  # type: ignore[index]
+
+    return index_dicts['weight'], index_dicts['bias']
+
+def node_arg_is_weight(node: Node, arg: Any, weight_index_dict: Dict[str, int]) -> bool:
     if isinstance(node, Node) and node.op == 'call_function' and \
-            node.target in WEIGHT_INDEX_DICT:
+            node.target in weight_index_dict:
         for i, node_arg in enumerate(node.args):
             if arg is node_arg and i in \
-                    WEIGHT_INDEX_DICT[node.target]:  # type: ignore[index]
+                    weight_index_dict[node.target]:  # type: ignore[index]
                 return True
         for kwarg_name, kwarg_value in node.kwargs.items():
             if kwarg_name == 'weight' and arg is kwarg_value:
                 return True
     return False
 
-def node_arg_is_bias(node: Node, arg: Any) -> bool:
+def node_arg_is_bias(node: Node, arg: Any, bias_index_dict: Dict[str, int]) -> bool:
     if not isinstance(node, Node) or node.op != 'call_function' or \
-       node.target not in BIAS_INDEX_DICT:
+       node.target not in bias_index_dict:
         return False
 
     for i, node_arg in enumerate(node.args):
         if arg is node_arg and i in \
-           BIAS_INDEX_DICT[node.target]:  # type: ignore[index]
+           bias_index_dict[node.target]:  # type: ignore[index]
             return True
 
     return node.kwargs.get('bias', None) is arg
@@ -186,17 +204,19 @@ def is_input_arg_dtype_supported_by_backend(
     node: Node,
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     dtype_config: DTypeConfig,
+    weight_index_dict: Dict[str, int],
+    bias_index_dict: Dict[str, int],
 ) -> bool:
     """ Check if the configured qconfig for the argument
     is supported by the backend or not
     """
     if isinstance(arg, (list, tuple)):
-        return all(map(lambda a: is_input_arg_dtype_supported_by_backend(a, node, node_name_to_target_dtype, dtype_config), arg))
+        return all(map(lambda a: is_input_arg_dtype_supported_by_backend(a, node, node_name_to_target_dtype, dtype_config, weight_index_dict, bias_index_dict), arg))
     if not isinstance(arg, Node):
         return True
     # TODO: support check for standalone module
-    is_weight = node_arg_is_weight(node, arg)
-    is_bias = node_arg_is_bias(node, arg)
+    is_weight = node_arg_is_weight(node, arg, weight_index_dict)
+    is_bias = node_arg_is_bias(node, arg, bias_index_dict)
     is_activation = not is_weight and not is_bias
     if is_activation:
         is_dynamic = dtype_config.is_dynamic
@@ -246,6 +266,8 @@ def is_pattern_dtype_config_supported_by_backend(
     matched_node_pattern: Optional[NodePattern],
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     backend_config: Optional[BackendConfig],
+    weight_index_dict: Dict[str, int],
+    bias_index_dict: Dict[str, int],
 ) -> bool:
     """ Check is the dtype configuration of a pattern is supported by
     the backend or not
@@ -267,11 +289,11 @@ def is_pattern_dtype_config_supported_by_backend(
         for arg in input_node.args:
             supported = supported and \
                 is_input_arg_dtype_supported_by_backend(
-                    arg, input_node, node_name_to_target_dtype, dtype_config)
+                    arg, input_node, node_name_to_target_dtype, dtype_config, weight_index_dict, bias_index_dict)
         for k, arg in input_node.kwargs.items():
             supported = supported and \
                 is_input_arg_dtype_supported_by_backend(
-                    arg, input_node, node_name_to_target_dtype, dtype_config)
+                    arg, input_node, node_name_to_target_dtype, dtype_config, weight_index_dict, bias_index_dict)
         # check if output dtype is supported
         supported = supported and is_output_dtype_supported_by_backend(
             output_node, node_name_to_target_dtype, dtype_config)
@@ -470,13 +492,15 @@ def get_arg_target_dtype_as_input_to_node(
     node: Node,
     modules: Dict[str, torch.nn.Module],
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
+    weight_index_dict: Dict[str, int],
+    bias_index_dict: Dict[str, int],
 ) -> Optional[Union[torch.dtype, type]]:
     """ Get the target argument dtype for the argument `arg`, as input
     to node `node`
     """
     assert isinstance(arg, Node)
-    is_weight = node_arg_is_weight(node, arg)
-    is_bias = node_arg_is_bias(node, arg)
+    is_weight = node_arg_is_weight(node, arg, weight_index_dict)
+    is_bias = node_arg_is_bias(node, arg, bias_index_dict)
     is_activation = not is_weight and not is_bias
     if is_activation:
         return node_name_to_target_dtype[node.name]["input_activation_dtype"]
@@ -493,13 +517,15 @@ def get_arg_target_compute_dtype_as_input_to_node(
     node: Node,
     modules: Dict[str, torch.nn.Module],
     node_name_to_target_dtype: Dict[str, Dict[str, Union[torch.dtype, type, None]]],
+    weight_index_dict: Dict[str, int],
+    bias_index_dict: Dict[str, int],
 ) -> Union[torch.dtype, type, None]:
     """ Get the target argument dtype for the argument `arg`, as input
     to node `node`
     """
     assert isinstance(arg, Node)
-    is_weight = node_arg_is_weight(node, arg)
-    is_bias = node_arg_is_bias(node, arg)
+    is_weight = node_arg_is_weight(node, arg, weight_index_dict)
+    is_bias = node_arg_is_bias(node, arg, bias_index_dict)
     is_activation = not is_weight and not is_bias
     if is_activation and \
        "input_activation_compute_dtype" in node_name_to_target_dtype[node.name]:
@@ -518,6 +544,8 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config: PrepareCustomConfig,
     backend_config: Optional[BackendConfig],
+    weight_index_dict: Dict[str, int],
+    bias_index_dict: Dict[str, int],
 ) -> Argument:
     """
     Given a `node` and an `arg`, inserts an input observer between
@@ -533,7 +561,9 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
                 graph, node_name_to_target_dtype,
                 qhandler,
                 prepare_custom_config,
-                backend_config)
+                backend_config,
+                weight_index_dict,
+                bias_index_dict)
             new_arg_to_return.append(new_inner_arg)
         return type(arg)(new_arg_to_return)
 
@@ -547,7 +577,7 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
     assert qconfig is not None
     if not is_standalone_module:
         # regular flow for most nodes, except standalone modules
-        is_weight = node_arg_is_weight(node, arg)
+        is_weight = node_arg_is_weight(node, arg, weight_index_dict)
 
         is_reuse_input_qconfig_ = is_reuse_input_qconfig(qconfig)
 
@@ -555,10 +585,10 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
             qconfig.activation
 
         arg_as_output_target_dtype = get_arg_target_dtype_as_output(arg, modules, node_name_to_target_dtype)
-        arg_as_input_target_dtype = get_arg_target_dtype_as_input_to_node(arg, node, modules, node_name_to_target_dtype)
+        arg_as_input_target_dtype = get_arg_target_dtype_as_input_to_node(arg, node, modules, node_name_to_target_dtype, weight_index_dict, bias_index_dict)
         arg_as_input_target_compute_dtype = \
             get_arg_target_compute_dtype_as_input_to_node(
-                arg, node, modules, node_name_to_target_dtype)
+                arg, node, modules, node_name_to_target_dtype, weight_index_dict, bias_index_dict)
         needs_obs = (
             # if the dtypes are different, we need an observer
             (arg_as_output_target_dtype != arg_as_input_target_dtype) and
@@ -651,6 +681,8 @@ def maybe_insert_input_observers_for_node(
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config: PrepareCustomConfig,
     backend_config: Optional[BackendConfig],
+    weight_index_dict: Dict[str, int],
+    bias_index_dict: Dict[str, int],
 ) -> None:
     """
     If needed, inserts observers to the input args and kwargs of `node`.
@@ -679,7 +711,9 @@ def maybe_insert_input_observers_for_node(
             node_name_to_target_dtype,
             qhandler,
             prepare_custom_config,
-            backend_config)
+            backend_config,
+            weight_index_dict,
+            bias_index_dict,)
         new_args.append(new_arg)
 
     new_kwargs = {}
@@ -689,7 +723,9 @@ def maybe_insert_input_observers_for_node(
             node_name_to_target_dtype,
             qhandler,
             prepare_custom_config,
-            backend_config)
+            backend_config,
+            weight_index_dict,
+            bias_index_dict,)
         new_kwargs[k] = new_kwarg
 
     # assign the new args and kwargs to the node, inplace
@@ -704,6 +740,8 @@ def maybe_insert_input_equalization_observers_for_node(
     graph: Graph,
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     is_branch: bool,
+    weight_index_dict: Dict[str, int],
+    bias_index_dict: Dict[str, int],
 ) -> None:
     """
     If `node` needs to be equalized, find the input/weight observers it needs in
@@ -722,11 +760,11 @@ def maybe_insert_input_equalization_observers_for_node(
 
     new_args = []
     for arg in node.args:
-        if not isinstance(arg, Node) or node_arg_is_bias(node, arg):
+        if not isinstance(arg, Node) or node_arg_is_bias(node, arg, bias_index_dict):
             new_args.append(arg)
             continue
 
-        is_weight = node_arg_is_weight(node, arg)
+        is_weight = node_arg_is_weight(node, arg, weight_index_dict)
 
         act_eq_process_ctr = equalization_qconfig.weight if is_weight else \
             equalization_qconfig.input_activation
@@ -1085,6 +1123,8 @@ def insert_observers_for_model(
     backend_config: Optional[BackendConfig],
     observed_node_names: Set[str],
     is_qat: bool,
+    weight_index_dict: Dict[str, int],
+    bias_index_dict: Dict[str, int],
 ) -> Optional[Node]:
     """
     Inserts observers, using the following high level algorithm:
@@ -1210,7 +1250,7 @@ def insert_observers_for_model(
             )
 
             is_supported_by_backend = is_pattern_dtype_config_supported_by_backend(
-                pattern, matched_node_pattern, node_name_to_target_dtype, backend_config)
+                pattern, matched_node_pattern, node_name_to_target_dtype, backend_config, weight_index_dict, bias_index_dict)
 
             if not skip_inserting_observers and is_supported_by_backend:
                 modules = dict(model.named_modules(remove_duplicate=False))
@@ -1256,12 +1296,14 @@ def insert_observers_for_model(
                             node_name_to_target_dtype,
                             qhandler,
                             prepare_custom_config,
-                            backend_config)
+                            backend_config,
+                            weight_index_dict,
+                            bias_index_dict)
 
                         # Insert equalization input observers if needed
                         maybe_insert_input_equalization_observers_for_node(
                             node, equalization_qconfig, model, modules, graph,
-                            node_name_to_target_dtype, is_quantized_branch)
+                            node_name_to_target_dtype, is_quantized_branch, weight_index_dict, bias_index_dict)
 
                     is_last_node_of_pattern = node is last_node
                     is_general_tensor_value_op = \
@@ -1503,30 +1545,14 @@ def prepare(
     #   ((<function relu at 0x7f766a7360d0>, <built-in function add>):
     #     <class 'torch.ao.quantization.fx.quantize.Add'>),
     # }
-    # TODO: rename to pattern_to_quantize_handler
-    patterns: Dict[Pattern, QuantizeHandler] = {}
+
+    pattern_to_quantize_handler: Dict[Pattern, QuantizeHandler] = {}
     if backend_config is None:
         backend_config = get_native_backend_config()
-    patterns = get_pattern_to_quantize_handlers(backend_config)
-    patterns = sorted_patterns_dict(patterns)
+    pattern_to_quantize_handler = get_pattern_to_quantize_handlers(backend_config)
+    pattern_to_quantize_handler = sorted_patterns_dict(pattern_to_quantize_handler)
 
-    # TODO: make WEIGHT_INDEX_DICT and BIAS_INDEX_DICT an argument to the functions that needs them
-    # TODO: refactor this part to return WEIGHT_INDEX_DICT and BIAS_INDEX_DICT
-    pattern_to_input_type_to_index = get_pattern_to_input_type_to_index(backend_config)
-    for pattern, input_type_to_index in pattern_to_input_type_to_index.items():
-        for input_type, index in input_type_to_index.items():
-            index_dicts = {
-                "weight": WEIGHT_INDEX_DICT,
-                "bias": BIAS_INDEX_DICT,
-                "input": {}  # not used right now
-            }
-            assert input_type in index_dicts.keys(), \
-                f"input type must be one of {index_dicts.keys()} but got: {input_type}"
-            index_dict = index_dicts[input_type]
-            if pattern in index_dict:  # type: ignore[operator]
-                index_dict[pattern].append(index)  # type: ignore[index]
-            else:
-                index_dict[pattern] = [index]  # type: ignore[index]
+    weight_index_dict, bias_index_dict = get_weight_and_bias_index_dicts(backend_config)
 
     root_node_getter_mapping = \
         get_fusion_pattern_to_root_node_getter(backend_config)
@@ -1563,7 +1589,7 @@ def prepare(
 
     custom_module_classes = get_custom_module_class_keys(prepare_custom_config.float_to_observed_mapping)
     matches_without_qconfig = find_matches(
-        model.graph, modules, patterns, root_node_getter_mapping,
+        model.graph, modules, pattern_to_quantize_handler, root_node_getter_mapping,
         standalone_module_names, standalone_module_classes, custom_module_classes)
 
     # map qconfig instances to matches
@@ -1591,7 +1617,9 @@ def prepare(
         output_quantized_idxs,
         backend_config,
         observed_node_names,
-        is_qat)
+        is_qat,
+        weight_index_dict,
+        bias_index_dict)
 
     save_state(model, qconfig_map, node_name_to_scope,
                prepare_custom_config, equalization_qconfig_map, qconfig_mapping, is_qat, observed_node_names)

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -211,13 +211,8 @@ def is_input_arg_dtype_supported_by_backend(
     is supported by the backend or not
     """
     if isinstance(arg, (list, tuple)):
-        return all(map(lambda a: is_input_arg_dtype_supported_by_backend(a,
-                                                                         node,
-                                                                         node_name_to_target_dtype,
-                                                                         dtype_config,
-                                                                         weight_index_dict,
-                                                                         bias_index_dict),
-                       arg))
+        return all(is_input_arg_dtype_supported_by_backend(a, node, node_name_to_target_dtype,
+                                                           dtype_config, weight_index_dict, bias_index_dict) for a in arg)
     if not isinstance(arg, Node):
         return True
     # TODO: support check for standalone module

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -268,7 +268,7 @@ def is_pattern_dtype_config_supported_by_backend(
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     backend_config: Optional[BackendConfig],
     weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int],
+    bias_index_dict: Dict[str, List[int]],
 ) -> bool:
     """ Check is the dtype configuration of a pattern is supported by
     the backend or not
@@ -494,7 +494,7 @@ def get_arg_target_dtype_as_input_to_node(
     modules: Dict[str, torch.nn.Module],
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int],
+    bias_index_dict: Dict[str, List[int]],
 ) -> Optional[Union[torch.dtype, type]]:
     """ Get the target argument dtype for the argument `arg`, as input
     to node `node`
@@ -519,7 +519,7 @@ def get_arg_target_compute_dtype_as_input_to_node(
     modules: Dict[str, torch.nn.Module],
     node_name_to_target_dtype: Dict[str, Dict[str, Union[torch.dtype, type, None]]],
     weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int],
+    bias_index_dict: Dict[str, List[int]],
 ) -> Union[torch.dtype, type, None]:
     """ Get the target argument dtype for the argument `arg`, as input
     to node `node`
@@ -546,7 +546,7 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
     prepare_custom_config: PrepareCustomConfig,
     backend_config: Optional[BackendConfig],
     weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int],
+    bias_index_dict: Dict[str, List[int]],
 ) -> Argument:
     """
     Given a `node` and an `arg`, inserts an input observer between
@@ -688,7 +688,7 @@ def maybe_insert_input_observers_for_node(
     prepare_custom_config: PrepareCustomConfig,
     backend_config: Optional[BackendConfig],
     weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int],
+    bias_index_dict: Dict[str, List[int]],
 ) -> None:
     """
     If needed, inserts observers to the input args and kwargs of `node`.
@@ -747,7 +747,7 @@ def maybe_insert_input_equalization_observers_for_node(
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     is_branch: bool,
     weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int],
+    bias_index_dict: Dict[str, List[int]],
 ) -> None:
     """
     If `node` needs to be equalized, find the input/weight observers it needs in
@@ -1130,7 +1130,7 @@ def insert_observers_for_model(
     observed_node_names: Set[str],
     is_qat: bool,
     weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int],
+    bias_index_dict: Dict[str, List[int]],
 ) -> Optional[Node]:
     """
     Inserts observers, using the following high level algorithm:

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -155,19 +155,19 @@ def is_activation_post_process_node(node: Node, modules: Dict[str, torch.nn.Modu
         is_activation_post_process(modules[str(node.target)])
 
 def node_arg_is_weight(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
-    if isinstance(node, Node) and node.op == 'call_function':
-        weight_index = backend_config.configs[node.target]._input_type_to_index.get('weight')
-        if weight_index and weight_index < len(node.args) and node.args[weight_index] is arg:
+    if isinstance(node, Node) and node.op == "call_function" and node.target in backend_config:
+        weight_index = backend_config.configs[node.target]._input_type_to_index.get("weight")
+        if weight_index is not None and weight_index < len(node.args) and node.args[weight_index] is arg:
             return True
-        return node.kwargs.get('weight') is arg
+        return node.kwargs.get("weight") is arg
     return False
 
 def node_arg_is_bias(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
-    if isinstance(node, Node) and node.op == 'call_function':
-        bias_index = backend_config.configs[node.target]._input_type_to_index.get('bias')
-        if bias_index and bias_index < len(node.args) and node.args[bias_index] is arg:
+    if isinstance(node, Node) and node.op == "call_function" and node.target in backend_config:
+        bias_index = backend_config.configs[node.target]._input_type_to_index.get("bias")
+        if bias_index is not None and bias_index < len(node.args) and node.args[bias_index] is arg:
             return True
-        return node.kwargs.get('bias') is arg
+        return node.kwargs.get("bias") is arg
     return False
 
 def is_input_arg_dtype_supported_by_backend(

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -91,7 +91,7 @@ from ..utils import (
 
 from ..backend_config.utils import (
     get_pattern_to_dtype_configs,
-    p get_module_to_qat_module,
+    get_module_to_qat_module,
     get_fusion_pattern_to_root_node_getter,
 )
 from ..backend_config import (

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -156,68 +156,38 @@ def is_activation_post_process_node(node: Node, modules: Dict[str, torch.nn.Modu
         is_activation_post_process(modules[str(node.target)])
 
 
-def _get_weight_and_bias_index_dicts(backend_config: BackendConfig):
-    index_dicts: Dict[str, Dict[str, List[int]]] = {
-        "weight": {},
-        "bias": {},
-        "input": {}  # not used right now
-    }
-    pattern_to_input_type_to_index = get_pattern_to_input_type_to_index(backend_config)
-    for pattern, input_type_to_index in pattern_to_input_type_to_index.items():
-        for input_type, index in input_type_to_index.items():
-            assert input_type in index_dicts.keys(), \
-                f"input type must be one of {index_dicts.keys()} but got: {input_type}"
-            index_dict = index_dicts[input_type]
-            if pattern in index_dict:  # type: ignore[operator]
-                index_dict[pattern].append(index)  # type: ignore[index]
-            else:
-                index_dict[pattern] = [index]  # type: ignore[index]
-
-    return index_dicts['weight'], index_dicts['bias']
-
-def node_arg_is_weight(node: Node, arg: Any, weight_index_dict: Dict[str, List[int]]) -> bool:
-    if isinstance(node, Node) and node.op == 'call_function' and \
-            node.target in weight_index_dict:
-        for i, node_arg in enumerate(node.args):
-            if arg is node_arg and i in \
-                    weight_index_dict[node.target]:  # type: ignore[index]
-                return True
-        for kwarg_name, kwarg_value in node.kwargs.items():
-            if kwarg_name == 'weight' and arg is kwarg_value:
-                return True
+def node_arg_is_weight(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
+    if isinstance(node, Node) and node.op == 'call_function':
+        weight_index = backend_config.configs[node.target]._input_type_to_index.get('weight')
+        return (weight_index and  weight_index < len(node.args) and node.args[weight_index] is arg) or node.kwargs.get('weight') is arg
     return False
 
-def node_arg_is_bias(node: Node, arg: Any, bias_index_dict: Dict[str, List[int]]) -> bool:
-    if not isinstance(node, Node) or node.op != 'call_function' or \
-       node.target not in bias_index_dict:
-        return False
 
-    for i, node_arg in enumerate(node.args):
-        if arg is node_arg and i in \
-           bias_index_dict[node.target]:  # type: ignore[index]
-            return True
+def node_arg_is_bias(node: Node, arg: Any, backend_config: BackendConfig) -> bool:
+    if isinstance(node, Node) and node.op == 'call_function':
+        bias_index = backend_config.configs[node.target]._input_type_to_index.get('bias')
+        return (bias_index and bias_index < len(node.args) and node.args[bias_index] is arg) or node.kwargs.get('bias') is arg
+    return False
 
-    return node.kwargs.get('bias', None) is arg
 
 def is_input_arg_dtype_supported_by_backend(
     arg: Argument,
     node: Node,
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     dtype_config: DTypeConfig,
-    weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int]],
+    backend_config: BackendConfig,
 ) -> bool:
     """ Check if the configured qconfig for the argument
     is supported by the backend or not
     """
     if isinstance(arg, (list, tuple)):
         return all(is_input_arg_dtype_supported_by_backend(a, node, node_name_to_target_dtype,
-                                                           dtype_config, weight_index_dict, bias_index_dict) for a in arg)
+                                                           dtype_config, backend_config) for a in arg)
     if not isinstance(arg, Node):
         return True
     # TODO: support check for standalone module
-    is_weight = node_arg_is_weight(node, arg, weight_index_dict)
-    is_bias = node_arg_is_bias(node, arg, bias_index_dict)
+    is_weight = node_arg_is_weight(node, arg, backend_config)
+    is_bias = node_arg_is_bias(node, arg, backend_config)
     is_activation = not is_weight and not is_bias
     if is_activation:
         is_dynamic = dtype_config.is_dynamic
@@ -237,6 +207,7 @@ def is_input_arg_dtype_supported_by_backend(
     else:  # bias
         bias_dtype = dtype_config.bias_dtype
         return bias_dtype is None or node_name_to_target_dtype[node.name]["bias_dtype"] == bias_dtype
+
 
 def is_output_dtype_supported_by_backend(
     node: Node,
@@ -267,8 +238,6 @@ def is_pattern_dtype_config_supported_by_backend(
     matched_node_pattern: Optional[NodePattern],
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     backend_config: Optional[BackendConfig],
-    weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int]],
 ) -> bool:
     """ Check is the dtype configuration of a pattern is supported by
     the backend or not
@@ -290,11 +259,11 @@ def is_pattern_dtype_config_supported_by_backend(
         for arg in input_node.args:
             supported = supported and \
                 is_input_arg_dtype_supported_by_backend(
-                    arg, input_node, node_name_to_target_dtype, dtype_config, weight_index_dict, bias_index_dict)
+                    arg, input_node, node_name_to_target_dtype, dtype_config, backend_config)
         for k, arg in input_node.kwargs.items():
             supported = supported and \
                 is_input_arg_dtype_supported_by_backend(
-                    arg, input_node, node_name_to_target_dtype, dtype_config, weight_index_dict, bias_index_dict)
+                    arg, input_node, node_name_to_target_dtype, dtype_config, backend_config)
         # check if output dtype is supported
         supported = supported and is_output_dtype_supported_by_backend(
             output_node, node_name_to_target_dtype, dtype_config)
@@ -493,15 +462,14 @@ def get_arg_target_dtype_as_input_to_node(
     node: Node,
     modules: Dict[str, torch.nn.Module],
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
-    weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int]],
+    backend_config: BackendConfig,
 ) -> Optional[Union[torch.dtype, type]]:
     """ Get the target argument dtype for the argument `arg`, as input
     to node `node`
     """
     assert isinstance(arg, Node)
-    is_weight = node_arg_is_weight(node, arg, weight_index_dict)
-    is_bias = node_arg_is_bias(node, arg, bias_index_dict)
+    is_weight = node_arg_is_weight(node, arg, backend_config)
+    is_bias = node_arg_is_bias(node, arg, backend_config)
     is_activation = not is_weight and not is_bias
     if is_activation:
         return node_name_to_target_dtype[node.name]["input_activation_dtype"]
@@ -518,15 +486,14 @@ def get_arg_target_compute_dtype_as_input_to_node(
     node: Node,
     modules: Dict[str, torch.nn.Module],
     node_name_to_target_dtype: Dict[str, Dict[str, Union[torch.dtype, type, None]]],
-    weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int]],
+    backend_config: BackendConfig,
 ) -> Union[torch.dtype, type, None]:
     """ Get the target argument dtype for the argument `arg`, as input
     to node `node`
     """
     assert isinstance(arg, Node)
-    is_weight = node_arg_is_weight(node, arg, weight_index_dict)
-    is_bias = node_arg_is_bias(node, arg, bias_index_dict)
+    is_weight = node_arg_is_weight(node, arg, backend_config)
+    is_bias = node_arg_is_bias(node, arg, backend_config)
     is_activation = not is_weight and not is_bias
     if is_activation and \
        "input_activation_compute_dtype" in node_name_to_target_dtype[node.name]:
@@ -545,8 +512,6 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config: PrepareCustomConfig,
     backend_config: Optional[BackendConfig],
-    weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int]],
 ) -> Argument:
     """
     Given a `node` and an `arg`, inserts an input observer between
@@ -562,9 +527,7 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
                 graph, node_name_to_target_dtype,
                 qhandler,
                 prepare_custom_config,
-                backend_config,
-                weight_index_dict,
-                bias_index_dict)
+                backend_config)
             new_arg_to_return.append(new_inner_arg)
         return type(arg)(new_arg_to_return)
 
@@ -578,7 +541,7 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
     assert qconfig is not None
     if not is_standalone_module:
         # regular flow for most nodes, except standalone modules
-        is_weight = node_arg_is_weight(node, arg, weight_index_dict)
+        is_weight = node_arg_is_weight(node, arg, backend_config)
 
         is_reuse_input_qconfig_ = is_reuse_input_qconfig(qconfig)
 
@@ -590,11 +553,10 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
                                                                           node,
                                                                           modules,
                                                                           node_name_to_target_dtype,
-                                                                          weight_index_dict,
-                                                                          bias_index_dict)
+                                                                          backend_config)
         arg_as_input_target_compute_dtype = \
             get_arg_target_compute_dtype_as_input_to_node(
-                arg, node, modules, node_name_to_target_dtype, weight_index_dict, bias_index_dict)
+                arg, node, modules, node_name_to_target_dtype, backend_config)
         needs_obs = (
             # if the dtypes are different, we need an observer
             (arg_as_output_target_dtype != arg_as_input_target_dtype) and
@@ -687,8 +649,6 @@ def maybe_insert_input_observers_for_node(
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config: PrepareCustomConfig,
     backend_config: Optional[BackendConfig],
-    weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int]],
 ) -> None:
     """
     If needed, inserts observers to the input args and kwargs of `node`.
@@ -717,9 +677,7 @@ def maybe_insert_input_observers_for_node(
             node_name_to_target_dtype,
             qhandler,
             prepare_custom_config,
-            backend_config,
-            weight_index_dict,
-            bias_index_dict,)
+            backend_config)
         new_args.append(new_arg)
 
     new_kwargs = {}
@@ -729,9 +687,7 @@ def maybe_insert_input_observers_for_node(
             node_name_to_target_dtype,
             qhandler,
             prepare_custom_config,
-            backend_config,
-            weight_index_dict,
-            bias_index_dict,)
+            backend_config)
         new_kwargs[k] = new_kwarg
 
     # assign the new args and kwargs to the node, inplace
@@ -746,8 +702,7 @@ def maybe_insert_input_equalization_observers_for_node(
     graph: Graph,
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     is_branch: bool,
-    weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int]],
+    backend_config: BackendConfig,
 ) -> None:
     """
     If `node` needs to be equalized, find the input/weight observers it needs in
@@ -766,11 +721,11 @@ def maybe_insert_input_equalization_observers_for_node(
 
     new_args = []
     for arg in node.args:
-        if not isinstance(arg, Node) or node_arg_is_bias(node, arg, bias_index_dict):
+        if not isinstance(arg, Node) or node_arg_is_bias(node, arg, backend_config):
             new_args.append(arg)
             continue
 
-        is_weight = node_arg_is_weight(node, arg, weight_index_dict)
+        is_weight = node_arg_is_weight(node, arg, backend_config)
 
         act_eq_process_ctr = equalization_qconfig.weight if is_weight else \
             equalization_qconfig.input_activation
@@ -1129,8 +1084,6 @@ def insert_observers_for_model(
     backend_config: Optional[BackendConfig],
     observed_node_names: Set[str],
     is_qat: bool,
-    weight_index_dict: Dict[str, List[int]],
-    bias_index_dict: Dict[str, List[int]],
 ) -> Optional[Node]:
     """
     Inserts observers, using the following high level algorithm:
@@ -1256,7 +1209,7 @@ def insert_observers_for_model(
             )
 
             is_supported_by_backend = is_pattern_dtype_config_supported_by_backend(
-                pattern, matched_node_pattern, node_name_to_target_dtype, backend_config, weight_index_dict, bias_index_dict)
+                pattern, matched_node_pattern, node_name_to_target_dtype, backend_config)
 
             if not skip_inserting_observers and is_supported_by_backend:
                 modules = dict(model.named_modules(remove_duplicate=False))
@@ -1302,14 +1255,12 @@ def insert_observers_for_model(
                             node_name_to_target_dtype,
                             qhandler,
                             prepare_custom_config,
-                            backend_config,
-                            weight_index_dict,
-                            bias_index_dict)
+                            backend_config)
 
                         # Insert equalization input observers if needed
                         maybe_insert_input_equalization_observers_for_node(
                             node, equalization_qconfig, model, modules, graph,
-                            node_name_to_target_dtype, is_quantized_branch, weight_index_dict, bias_index_dict)
+                            node_name_to_target_dtype, is_quantized_branch, backend_config)
 
                     is_last_node_of_pattern = node is last_node
                     is_general_tensor_value_op = \
@@ -1558,8 +1509,6 @@ def prepare(
     pattern_to_quantize_handler = get_pattern_to_quantize_handlers(backend_config)
     pattern_to_quantize_handler = sorted_patterns_dict(pattern_to_quantize_handler)
 
-    weight_index_dict, bias_index_dict = _get_weight_and_bias_index_dicts(backend_config)
-
     root_node_getter_mapping = \
         get_fusion_pattern_to_root_node_getter(backend_config)
 
@@ -1623,9 +1572,7 @@ def prepare(
         output_quantized_idxs,
         backend_config,
         observed_node_names,
-        is_qat,
-        weight_index_dict,
-        bias_index_dict)
+        is_qat)
 
     save_state(model, qconfig_map, node_name_to_scope,
                prepare_custom_config, equalization_qconfig_map, qconfig_mapping, is_qat, observed_node_names)

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -179,8 +179,8 @@ def node_arg_is_weight(node: Node, arg: Any, weight_index_dict: Dict[str, int]) 
     if isinstance(node, Node) and node.op == 'call_function' and \
             node.target in weight_index_dict:
         for i, node_arg in enumerate(node.args):
-            if arg is node_arg and i in \
-                    weight_index_dict[node.target]:  # type: ignore[index]
+            if (arg is node_arg and
+                i in weight_index_dict[node.target]):  # type: ignore[index]
                 return True
         for kwarg_name, kwarg_value in node.kwargs.items():
             if kwarg_name == 'weight' and arg is kwarg_value:
@@ -193,8 +193,8 @@ def node_arg_is_bias(node: Node, arg: Any, bias_index_dict: Dict[str, int]) -> b
         return False
 
     for i, node_arg in enumerate(node.args):
-        if arg is node_arg and i in \
-           bias_index_dict[node.target]:  # type: ignore[index]
+        if (arg is node_arg and
+            i in bias_index_dict[node.target]):  # type: ignore[index]
             return True
 
     return node.kwargs.get('bias', None) is arg

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -156,7 +156,7 @@ def is_activation_post_process_node(node: Node, modules: Dict[str, torch.nn.Modu
         is_activation_post_process(modules[str(node.target)])
 
 
-def get_weight_and_bias_index_dicts(backend_config: BackendConfig):
+def _get_weight_and_bias_index_dicts(backend_config: BackendConfig):
     index_dicts: Dict[str, Dict[str, List[int]]] = {
         "weight": {},
         "bias": {},
@@ -1558,7 +1558,7 @@ def prepare(
     pattern_to_quantize_handler = get_pattern_to_quantize_handlers(backend_config)
     pattern_to_quantize_handler = sorted_patterns_dict(pattern_to_quantize_handler)
 
-    weight_index_dict, bias_index_dict = get_weight_and_bias_index_dicts(backend_config)
+    weight_index_dict, bias_index_dict = _get_weight_and_bias_index_dicts(backend_config)
 
     root_node_getter_mapping = \
         get_fusion_pattern_to_root_node_getter(backend_config)

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -204,8 +204,8 @@ def is_input_arg_dtype_supported_by_backend(
     node: Node,
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     dtype_config: DTypeConfig,
-    weight_index_dict: Dict[str, int],
-    bias_index_dict: Dict[str, int],
+    weight_index_dict: Dict[str, List[int]],
+    bias_index_dict: Dict[str, List[int],
 ) -> bool:
     """ Check if the configured qconfig for the argument
     is supported by the backend or not
@@ -267,8 +267,8 @@ def is_pattern_dtype_config_supported_by_backend(
     matched_node_pattern: Optional[NodePattern],
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     backend_config: Optional[BackendConfig],
-    weight_index_dict: Dict[str, int],
-    bias_index_dict: Dict[str, int],
+    weight_index_dict: Dict[str, List[int]],
+    bias_index_dict: Dict[str, List[int],
 ) -> bool:
     """ Check is the dtype configuration of a pattern is supported by
     the backend or not
@@ -493,8 +493,8 @@ def get_arg_target_dtype_as_input_to_node(
     node: Node,
     modules: Dict[str, torch.nn.Module],
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
-    weight_index_dict: Dict[str, int],
-    bias_index_dict: Dict[str, int],
+    weight_index_dict: Dict[str, List[int]],
+    bias_index_dict: Dict[str, List[int],
 ) -> Optional[Union[torch.dtype, type]]:
     """ Get the target argument dtype for the argument `arg`, as input
     to node `node`
@@ -518,8 +518,8 @@ def get_arg_target_compute_dtype_as_input_to_node(
     node: Node,
     modules: Dict[str, torch.nn.Module],
     node_name_to_target_dtype: Dict[str, Dict[str, Union[torch.dtype, type, None]]],
-    weight_index_dict: Dict[str, int],
-    bias_index_dict: Dict[str, int],
+    weight_index_dict: Dict[str, List[int]],
+    bias_index_dict: Dict[str, List[int],
 ) -> Union[torch.dtype, type, None]:
     """ Get the target argument dtype for the argument `arg`, as input
     to node `node`
@@ -545,8 +545,8 @@ def maybe_insert_input_observer_for_arg_or_kwarg(
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config: PrepareCustomConfig,
     backend_config: Optional[BackendConfig],
-    weight_index_dict: Dict[str, int],
-    bias_index_dict: Dict[str, int],
+    weight_index_dict: Dict[str, List[int]],
+    bias_index_dict: Dict[str, List[int],
 ) -> Argument:
     """
     Given a `node` and an `arg`, inserts an input observer between
@@ -687,8 +687,8 @@ def maybe_insert_input_observers_for_node(
     qhandler: Optional[QuantizeHandler],
     prepare_custom_config: PrepareCustomConfig,
     backend_config: Optional[BackendConfig],
-    weight_index_dict: Dict[str, int],
-    bias_index_dict: Dict[str, int],
+    weight_index_dict: Dict[str, List[int]],
+    bias_index_dict: Dict[str, List[int],
 ) -> None:
     """
     If needed, inserts observers to the input args and kwargs of `node`.
@@ -746,8 +746,8 @@ def maybe_insert_input_equalization_observers_for_node(
     graph: Graph,
     node_name_to_target_dtype: Dict[str, Dict[str, Optional[Union[torch.dtype, type]]]],
     is_branch: bool,
-    weight_index_dict: Dict[str, int],
-    bias_index_dict: Dict[str, int],
+    weight_index_dict: Dict[str, List[int]],
+    bias_index_dict: Dict[str, List[int],
 ) -> None:
     """
     If `node` needs to be equalized, find the input/weight observers it needs in
@@ -1129,8 +1129,8 @@ def insert_observers_for_model(
     backend_config: Optional[BackendConfig],
     observed_node_names: Set[str],
     is_qat: bool,
-    weight_index_dict: Dict[str, int],
-    bias_index_dict: Dict[str, int],
+    weight_index_dict: Dict[str, List[int]],
+    bias_index_dict: Dict[str, List[int],
 ) -> Optional[Node]:
     """
     Inserts observers, using the following high level algorithm:

--- a/torch/ao/quantization/fx/prepare.py
+++ b/torch/ao/quantization/fx/prepare.py
@@ -157,14 +157,14 @@ def is_activation_post_process_node(node: Node, modules: Dict[str, torch.nn.Modu
 
 
 def get_weight_and_bias_index_dicts(backend_config):
+    index_dicts = {
+        "weight": {},
+        "bias": {},
+        "input": {}  # not used right now
+    }
     pattern_to_input_type_to_index = get_pattern_to_input_type_to_index(backend_config)
     for pattern, input_type_to_index in pattern_to_input_type_to_index.items():
         for input_type, index in input_type_to_index.items():
-            index_dicts = {
-                "weight": {},
-                "bias": {},
-                "input": {}  # not used right now
-            }
             assert input_type in index_dicts.keys(), \
                 f"input type must be one of {index_dicts.keys()} but got: {input_type}"
             index_dict = index_dicts[input_type]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83263

Summary:

This change adds in input_type_to_index mappings to the backend patterns for `nn.functional.linear`, `nn.functional.conv1d`, `nn.functional.conv1d`, and `nn.functional.conv3d`.

This let's us remove `WEIGHT_INDEX_DICT` and `BIAS_INDEX_DICT` from `prepare.py`. 
Instead we pass around `backend_config` and check wether an arg is weight/bias agains that config


Test Plan:
```
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps
```
Reviewers:
@andrewor14 

Subscribers:

Tasks:

Tags: quant, fx

Differential Revision: [D38705516](https://our.internmc.facebook.com/intern/diff/D38705516)