### PR TITLE
Fix building with Werror

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1407,9 +1407,12 @@ class DeviceCachingAllocator {
     BlockPool& pool = *p.pool;
 
     // because of std::unique_ptr, block cannot be trivially copied
-    Block key(0, 0, 0);
-    std::memcpy(&key, &p.search_key, sizeof(Block));
-    key.history.release();
+    Block key(
+        p.search_key.device,
+        p.search_key.stream,
+        p.search_key.size,
+        p.search_key.pool,
+        p.search_key.ptr);
     key.size = (key.size < CachingAllocatorConfig::max_split_size())
         ? CachingAllocatorConfig::max_split_size()
         : key.size;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83275

PR #82146 made `Block` non-copyable by adding a `unique_ptr` member,
and used this hacky work-around to copy it anyway. However, it
fails under -Werror with this message:
```
../c10/cuda/CUDACachingAllocator.cpp:1411:51: error: ‘void* memcpy(void*, const void*, size_t)’ writing to an object of type ‘struct c10::cuda::CUDACachingAllocator::{anonymous}::Block’ with no trivial copy-assignment [-Werror=class-memaccess]
 1411 |     std::memcpy(&key, &p.search_key, sizeof(Block));
 ```

Instead, this constructs a new `Block` with all the relevant
properties copied.