### PR TITLE
Fix internal type conversions in floor_divide and trunc_divide

### DIFF
--- a/torch/_prims_common/__init__.py
+++ b/torch/_prims_common/__init__.py
@@ -747,6 +747,13 @@ def type_to_dtype(typ: type) -> torch.dtype:
     raise ValueError("Invalid type!")
 
 
+def get_dtype(x: Union[torch.Tensor, NumberType]):
+    if isinstance(x, torch.Tensor):
+        return x.dtype
+    else:
+        return type_to_dtype(type(x))
+
+
 _ordered_types = (bool, int, float, complex)
 
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1060,6 +1060,27 @@ def _floor_divide(
         else:
             b = prims.device_put(b, device=a.device)
 
+    dtype = a.dtype
+    if dtype.is_float_dtype(dtype):
+        return _floor_divide_float(a, b)
+    elif utils.is_integer_dtype(dtype):
+        return _floor_divide_integer(a, b)
+    else:
+        check(False, lambda: f"{dtype} not supported for floor_divide")
+
+
+def _floor_divide_integer(a: Tensor, b: Tensor) -> Tensor:
+    a, b = _maybe_broadcast(a, b)
+
+    if not a.dtype.is_signed:
+        return prims.div(a, b)
+
+    # Convert truncation to flooring:
+    offset = (torch.signbit(a) != torch.signbit(b)).logical_and(torch.fmod(a, b) != 0)
+    return (prims.div(a, b) - prims.convert_element_type(offset, a.dtype))
+
+
+def _floor_divide_float(a: Tensor, b: Tensor) -> Tensor:
     mod = fmod(a, b)
     div = true_divide(sub(a, mod), b)
 
@@ -1443,7 +1464,10 @@ true_divide = _make_elementwise_binary_reference(
 def _trunc_divide(
     a: Union[TensorLikeType, NumberType], b: Union[TensorLikeType, NumberType]
 ):
-    return trunc(true_divide(a, b))
+    if utils.is_integer_dtype(a.dtype):
+        return prims.div(a, b)
+
+    return trunc(prims.div(a, b))
 
 
 # TODO: add docstring

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -1060,8 +1060,9 @@ def _floor_divide(
         else:
             b = prims.device_put(b, device=a.device)
 
+    assert isinstance(a, Tensor) and isinstance(b, Tensor)
     dtype = a.dtype
-    if dtype.is_float_dtype(dtype):
+    if utils.is_float_dtype(dtype):
         return _floor_divide_float(a, b)
     elif utils.is_integer_dtype(dtype):
         return _floor_divide_integer(a, b)
@@ -1077,7 +1078,7 @@ def _floor_divide_integer(a: Tensor, b: Tensor) -> Tensor:
 
     # Convert truncation to flooring:
     offset = (torch.signbit(a) != torch.signbit(b)).logical_and(torch.fmod(a, b) != 0)
-    return (prims.div(a, b) - prims.convert_element_type(offset, a.dtype))
+    return prims.div(a, b) - prims.convert_element_type(offset, a.dtype)
 
 
 def _floor_divide_float(a: Tensor, b: Tensor) -> Tensor:
@@ -1464,7 +1465,8 @@ true_divide = _make_elementwise_binary_reference(
 def _trunc_divide(
     a: Union[TensorLikeType, NumberType], b: Union[TensorLikeType, NumberType]
 ):
-    if utils.is_integer_dtype(a.dtype):
+    dtype = utils.get_dtype(a)
+    if utils.is_integer_dtype(dtype):
         return prims.div(a, b)
 
     return trunc(prims.div(a, b))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83288

These refs used `true_divide` which promotes to floating point types
and the `_make_elementwise_binary_reference` wrapper converts back to
the original dtype at the end. This instead uses integer-specific
implemntations that match the existing ATen implementations.