### PR TITLE
Add mac-mps workflow

### DIFF
--- a/.github/workflows/mac-mps.yml
+++ b/.github/workflows/mac-mps.yml
@@ -1,0 +1,35 @@
+name: Mac MPS
+
+on:
+  push:
+    tags:
+      - ciflow/mps/*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  macos-12-py3-arm64-build:
+    name: macos-12-py3-arm64
+    uses: ./.github/workflows/_mac-build.yml
+    with:
+      sync-tag: macos-12-py3-arm64-build
+      build-environment: macos-12-py3-arm64
+      xcode-version: "13.3.1"
+      runner-type: macos-12-xl
+      build-generates-artifacts: true
+      # To match the one pre-installed in the m1 runners
+      python_version: 3.9.12
+    secrets:
+      MACOS_SCCACHE_S3_ACCESS_KEY_ID: ${{ secrets.MACOS_SCCACHE_S3_ACCESS_KEY_ID }}
+      MACOS_SCCACHE_S3_SECRET_ACCESS_KEY: ${{ secrets.MACOS_SCCACHE_S3_SECRET_ACCESS_KEY }}
+
+  macos-12-py3-arm64-mps-test:
+    name: macos-12-py3-arm64-mps
+    uses: ./.github/workflows/_mac-test-mps.yml
+    needs: macos-12-py3-arm64-build
+    with:
+      sync-tag: macos-12-py3-arm64-mps-test
+      build-environment: macos-12-py3-arm64

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -178,6 +178,7 @@ jobs:
     name: macos-12-py3-arm64
     uses: ./.github/workflows/_mac-build.yml
     with:
+      sync-tag: macos-12-py3-arm64-build
       build-environment: macos-12-py3-arm64
       xcode-version: "13.3.1"
       runner-type: macos-12-xl
@@ -193,6 +194,7 @@ jobs:
     uses: ./.github/workflows/_mac-test-mps.yml
     needs: macos-12-py3-arm64-build
     with:
+      sync-tag: macos-12-py3-arm64-mps-test
       build-environment: macos-12-py3-arm64
 
   macos-12-py3-arm64-test:


### PR DESCRIPTION
Which invokes only MPS tests if `ciflow/mps` tag is added
Use `sync-tag` to make jobs in those workflows dependent

Tested that it triggers the workflow if tag is added, see https://github.com/pytorch/pytorch/actions/runs/2843088226
