### PR TITLE
[Quant] Make quantizable LSTM scriptable

### DIFF
--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -2826,8 +2826,7 @@ class TestQuantizedOps(TestCase):
                 jit_qmodule = torch.jit.trace(lstm_quantized, qx)
 
                 # Script
-                # TODO: Fix the scripting in the torch/nn/quantizable/modules/rnn.py
-                # jit_qmodule = torch.jit.script(lstm_quantized)
+                jit_qmodule = torch.jit.script(lstm_quantized)
 
     @override_qengines
     def test_custom_module_multi_head_attention(self):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -179,7 +179,7 @@ import itertools
 import operator
 import unittest
 import io
-from typing import Callable, Optional, List
+from typing import Callable, Optional, List, Tuple
 
 
 
@@ -4082,6 +4082,30 @@ class TestQuantizeFx(QuantizationTestCase):
         for n in m.graph.nodes:
             if n.target == "lstm":
                 self.assertEqual(type(n.args[1]), tuple)
+        m(example_inputs)
+
+    def test_lstm_scriptable(self):
+        """ Test that quantized LSTM is scriptable. """
+
+        class MyLSTM(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lstm = nn.LSTM(50, 50, 1)
+
+            def forward(self, inputs: torch.Tensor, hidden: Tuple[torch.Tensor, torch.Tensor]):
+                h = hidden[0]
+                c = hidden[1]
+                return self.lstm(inputs, (h, c))
+
+        m = MyLSTM().eval()
+        h0 = torch.randn(1, 3, 50)
+        c0 = torch.randn(1, 3, 50)
+        example_inputs = ((torch.randn(5, 3, 50), (h0, c0)),)
+        qconfig_mapping = QConfigMapping().set_object_type(nn.LSTM, default_dynamic_qconfig)
+        m = prepare_fx(m, qconfig_mapping, example_inputs=example_inputs)
+        m(*example_inputs[0])
+        m = convert_fx(m)
+        self.checkScriptable(m, example_inputs, check_save_load=True)
 
     def test_relu_lowering(self):
         class M(torch.nn.Module):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -179,7 +179,7 @@ import itertools
 import operator
 import unittest
 import io
-from typing import Callable, Optional, List, Tuple
+from typing import Callable, Optional, List
 
 
 
@@ -4082,7 +4082,6 @@ class TestQuantizeFx(QuantizationTestCase):
         for n in m.graph.nodes:
             if n.target == "lstm":
                 self.assertEqual(type(n.args[1]), tuple)
-        m(example_inputs)
 
     def test_relu_lowering(self):
         class M(torch.nn.Module):

--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -4084,29 +4084,6 @@ class TestQuantizeFx(QuantizationTestCase):
                 self.assertEqual(type(n.args[1]), tuple)
         m(example_inputs)
 
-    def test_lstm_scriptable(self):
-        """ Test that quantized LSTM is scriptable. """
-
-        class MyLSTM(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.lstm = nn.LSTM(50, 50, 1)
-
-            def forward(self, inputs: torch.Tensor, hidden: Tuple[torch.Tensor, torch.Tensor]):
-                h = hidden[0]
-                c = hidden[1]
-                return self.lstm(inputs, (h, c))
-
-        m = MyLSTM().eval()
-        h0 = torch.randn(1, 3, 50)
-        c0 = torch.randn(1, 3, 50)
-        example_inputs = ((torch.randn(5, 3, 50), (h0, c0)),)
-        qconfig_mapping = QConfigMapping().set_object_type(nn.LSTM, default_dynamic_qconfig)
-        m = prepare_fx(m, qconfig_mapping, example_inputs=example_inputs)
-        m(*example_inputs[0])
-        m = convert_fx(m)
-        self.checkScriptable(m, example_inputs, check_save_load=True)
-
     def test_relu_lowering(self):
         class M(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83304

Summary: Previously `torch.nn.quantizable.LSTM` was not scriptable
due to (1) the use of asterisk to unpack arguments, and (2) some
arguments being Optional, which was not understood by setitem.
This commit resolves both of these issues, enabling LSTM quantized
through custom modules to work with TorchScript.

Test Plan:
python test/test_quantization.py TestQuantizedOps.test_custom_module_lstm

Reviewers: jerryzh168, z-a-f

Subscribers: jerryzh168, z-a-f, supriyar

Tasks:
https://github.com/pytorch/pytorch/issues/83211
https://github.com/pytorch/pytorch/issues/75042