### PR TITLE
Add a workflow to cache third party dependencies on S3

### DIFF
--- a/.github/pytorch-cached-s3-dependencies.yml
+++ b/.github/pytorch-cached-s3-dependencies.yml
@@ -11,7 +11,7 @@ validation:
     - "miniconda/"
   ossci-linux:
     - "test/"
-    - "cuda/",
+    - "cuda/"
     - "cudnn/"
   ossci-macos:
     - "test/"

--- a/.github/pytorch-cached-s3-dependencies.yml
+++ b/.github/pytorch-cached-s3-dependencies.yml
@@ -1,0 +1,22 @@
+# A list of third-party dependencies cached on OSSCI S3.
+# All updates to this config will be automatically applied by "sync-s3-cache" workflow.
+# For more information and documentation, see:
+# https://github.com/pytorch/builder/main/thirdparty_deps/README.md
+# and https://github.com/pytorch/builder/pull/1096
+validation:
+  # Key: allowed S3 bucket name
+  # Value: list of allowed S3 key prefixes
+  ossci-windows:
+    - "test/"
+    - "miniconda/"
+  ossci-linux:
+    - "test/"
+    - "cuda/",
+    - "cudnn/"
+  ossci-macos:
+    - "test/"
+
+urls:
+  - bucket: ossci-windows
+    url: https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe
+    key: miniconda/Miniconda3-latest-Windows-x86_64.exe

--- a/.github/workflows/sync_s3_cache.yml
+++ b/.github/workflows/sync_s3_cache.yml
@@ -1,0 +1,31 @@
+# This workflow uploads third-party dependencies to OSSCI S3.
+# For more information and documentation, see:
+# * https://github.com/pytorch/builder/main/thirdparty_deps/README.md
+# * https://github.com/pytorch/builder/pull/1096
+# * .github/pytorch-cached-s3-dependencies.yml
+
+name: Update S3 dependencies on public OSSCI S3 buckets
+on:
+  schedule:
+    # Sync every hour
+    - cron: "0 * * * *"
+  # Have the ability to trigger this job manually using the API as well
+  workflow_dispatch:
+
+jobs:
+  sync-s3-cache:
+    runs-on: ubuntu-18.04
+    if: ${{ github.repository == 'pytorch/pytorch' }}
+    steps:
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+        with:
+          submodules: false
+          fetch-depth: 1
+      - name: Sync S3 file cache
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_UPDATE_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_UPDATE_SECRET_ACCESS_KEY }}
+        uses: docker://pytorch/sync_s3_thirdparty_deps
+        with:
+          args: ".github/pytorch-cached-s3-dependencies.yml"


### PR DESCRIPTION
For the context, see #75703, pytorch/builder#1096.

Note: depends on the docker image `pytorch/sync_s3_thirdparty_deps` from pytorch/builder#1096

Summary of additions:
* workflow config (based on pytorch/sync_s3_thirdparty_deps GH action)
* S3 mapping config (sync_s3_cache.yml)
