### PR TITLE
Temporarily disable test_fx for dynamo

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -178,6 +178,8 @@ test_dynamo_shard() {
     echo "NUM_TEST_SHARDS must be defined to run a Python test shard"
     exit 1
   fi
+  # Temporarily disable test_fx for dynamo pending the investigation on TTS
+  # regression in https://github.com/pytorch/torchdynamo/issues/784
   time python test/run_test.py \
     --exclude-jit-executor \
     --exclude-distributed-tests \
@@ -194,6 +196,7 @@ test_dynamo_shard() {
       test_profiler_tree \
       test_overrides \
       test_python_dispatch \
+      test_fx \
     --shard "$1" "$NUM_TEST_SHARDS" \
     --verbose
   assert_git_not_dirty


### PR DESCRIPTION
Pending the investigation from dynamo on TTS regression in https://github.com/pytorch/pytorch/issues/93620. More details can be found in the issue tracker.
