### PR TITLE
embedded_interpreter_hip to enable torch::deploy on AMD

### DIFF
--- a/tools/target_definitions.bzl
+++ b/tools/target_definitions.bzl
@@ -448,6 +448,13 @@ def add_torch_libs():
         ],
     )
 
+    cpp_library(
+        name = "headers_for_torch_python_hip_deps",
+        exported_deps = [
+            ":_C_impl_hip",
+        ],
+    ) if is_amd_build() else None
+
     # This target compiles torch_python bindings, but skips the deps on actual
     # torch and python since those will be integrated specially in the wrapper for
     # libinterpreter.so used in torch::deploy
@@ -522,6 +529,28 @@ def add_torch_libs():
         build_script_dep = "//caffe2:fb_caffe2_hipify",
         output_gen_files = libtorch_python_hip_sources_hipified,
     )
+
+    cpp_library(
+        name = "torch_python_hip_without_torch",
+        srcs = [":fb_C_impl_hipify_gen={}".format(f) for f in (libtorch_python_hip_sources_hipified)] + libtorch_python_hip_sources + torch_cpp_srcs,
+        undefined_symbols = True,
+        preferred_linkage = "static",
+        exported_deps = [
+            ":headers_for_torch_python_hip_deps#headers",
+        ],
+        exported_external_deps = [
+            ("pybind11", None),
+            ("frozenpython", None, "python-headers"),
+        ],
+        compiler_flags = compiler_flags_cpu + [
+            "-DUSE_ROCM",
+            # some code in the Python bindings compiles differently
+            # when you are deploy
+            "-DUSE_DEPLOY",
+            "-Wno-error",
+        ],
+        compiler_specific_flags = common_flags["compiler_specific_flags"],
+    ) if is_amd_build() else None
 
     cpp_library(
         name = "_C_impl_hip",

--- a/torch/csrc/deploy/interpreter/defs.bzl
+++ b/torch/csrc/deploy/interpreter/defs.bzl
@@ -9,6 +9,7 @@ def embedded_interpreter(name, suffix, legacy = False, exported_deps = [], expor
     final_name = name
     is_all = suffix == "all"
     is_cuda = suffix == "cuda" or is_all
+    is_hip = suffix == "hip"
     platform_static_lib = []
     for platform in ["platform009", "platform010"]:
         name = platform + "_" + final_name
@@ -37,10 +38,13 @@ def embedded_interpreter(name, suffix, legacy = False, exported_deps = [], expor
                 ":builtin_registry_cuda",
                 "//caffe2:torch_python_cuda_without_torch",
                 "//deeplearning/trt/python:frozen_tensorrt",
-            ] if is_cuda else [
+            ] if is_cuda else ([
+                ":builtin_registry_hip",
+                "//caffe2:torch_python_hip_without_torch",
+            ] if is_hip else [
                 ":builtin_registry",
                 "//caffe2:torch_python_without_torch",
-            ]),
+            ])),
             external_deps =
                 [
                     # needed for interpreter.cpp itself, it uses pybind currently


### PR DESCRIPTION
Summary: Adding embedded_interpreter_hip and deps to enable torch::deploy on AMD.

Test Plan: Sandcastle

Reviewed By: zrphercule

Differential Revision: D38546701

