### PR TITLE
[ONNX] Use `errors.SymbolicValueError` for more context

### DIFF
--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -559,17 +559,21 @@ def _get_dim_for_cross(x: _C.Value, dim: Optional[int]):
     return dim
 
 
-def _unimplemented(op: str, msg: str):
+def _unimplemented(op: str, msg: str, value: Optional[_C.Value] = None) -> None:
     # For BC reasons, the behavior for Caffe2 does not raise exception for unimplemented operators
     if _C_onnx._CAFFE2_ATEN_FALLBACK:
-        warnings.warn(
-            "ONNX export failed on " + op + " because " + msg + " not supported"
-        )
+        warnings.warn(f"ONNX export failed on {op} because {msg} not supported")
     elif GLOBALS.operator_export_type == _C_onnx.OperatorExportTypes.ONNX:
-        _onnx_unsupported(f"{op}, {msg}")
+        _onnx_unsupported(f"{op}, {msg}", value)
 
 
-def _onnx_unsupported(op_name: str):
+def _onnx_unsupported(op_name: str, value: Optional[_C.Value] = None) -> None:
+    if isinstance(value, _C.Value):
+        raise errors.SymbolicValueError(
+            f"Unsupported: ONNX export of operator {op_name}. "
+            "Please feel free to request support or submit a pull request on PyTorch GitHub.",
+            value,
+        )
     raise RuntimeError(
         f"Unsupported: ONNX export of operator {op_name}. "
         "Please feel free to request support or submit a pull request on PyTorch GitHub."

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -5,7 +5,7 @@ import inspect
 import sys
 import typing
 import warnings
-from typing import Any, Callable, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Callable, List, NoReturn, Optional, Sequence, Set, Tuple, Union
 
 from typing_extensions import Literal
 
@@ -567,7 +567,7 @@ def _unimplemented(op: str, msg: str, value: Optional[_C.Value] = None) -> None:
         _onnx_unsupported(f"{op}, {msg}", value)
 
 
-def _onnx_unsupported(op_name: str, value: Optional[_C.Value] = None) -> None:
+def _onnx_unsupported(op_name: str, value: Optional[_C.Value] = None) -> NoReturn:
     message = (
         f"Unsupported: ONNX export of operator {op_name}. "
         f"Please feel free to request support or submit a pull request "
@@ -586,7 +586,7 @@ def _onnx_opset_unsupported(
     current_opset: int,
     supported_opset: int,
     value: Optional[_C.Value] = None,
-) -> None:
+) -> NoReturn:
     message = (
         f"Unsupported: ONNX export of {op_name} in opset {current_opset}. "
         f"Please try opset version {supported_opset}."
@@ -605,7 +605,7 @@ def _onnx_opset_unsupported_detailed(
     supported_opset: int,
     reason: str,
     value: Optional[_C.Value] = None,
-) -> None:
+) -> NoReturn:
     message = (
         f"Unsupported: ONNX export of {op_name} in "
         f"opset {current_opset}. {reason}. Please try opset version {supported_opset}."

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -233,7 +233,7 @@ def _interpolate(name, dim, interpolate_mode):
         symbolic_helper._interpolate_warning(interpolate_mode)
         align_corners = symbolic_helper._maybe_get_scalar(align_corners)
         if align_corners:
-            return symbolic_helper._unimplemented(name, "align_corners == True")
+            return symbolic_helper._unimplemented(name, "align_corners == True", input)
         if scales is None:
             scales = symbolic_helper._interpolate_size_to_scales(
                 g, input, output_size, dim

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -11,6 +11,7 @@ from torch import _C
 from torch.onnx import (  # noqa: F401
     _patch_torch,
     _type_utils,
+    errors,
     symbolic_helper,
     symbolic_opset9 as opset9,
 )
@@ -296,7 +297,7 @@ def slice(g, self, *args):
         start, end, step = args
         dim = 0
     else:
-        raise NotImplementedError("Unknown aten::slice signature")
+        raise errors.SymbolicValueError("Unknown aten::slice signature", self)
     is_start_none = start.node().kind() == "prim::Constant" and isinstance(
         start.type(), _C.NoneType
     )
@@ -447,11 +448,13 @@ def fake_quantize_per_tensor_affine(
             10,
             13,
             "Quantize range (0, 127) not supported, requires opset 13 Clip",
+            inputs,
         )
     if (quant_min, quant_max) not in [(0, 255), (-128, 127)]:
-        raise RuntimeError(
+        raise errors.SymbolicValueError(
             f"For (quant_min, quant_max), ONNX allows only (0, 255) and (-128, 127). "
-            f"Got ({quant_min}, {quant_max})"
+            f"Got ({quant_min}, {quant_max})",
+            inputs,
         )
     scale = symbolic_helper._maybe_get_scalar(scale)
     if scale is None:
@@ -460,6 +463,7 @@ def fake_quantize_per_tensor_affine(
             10,
             13,
             "Non-constant scale not supported",
+            inputs,
         )
     scale = scale.float().data  # Avoid exporter generating double type
     if quant_min == 0:

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -9,6 +9,7 @@ from torch import _C
 from torch._C import _onnx as _C_onnx
 from torch.onnx import (
     _type_utils,
+    errors,
     symbolic_helper,
     symbolic_opset10 as opset10,
     symbolic_opset9 as opset9,
@@ -212,8 +213,7 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
 
     if len(indices_list) > 1:
         for idx_ in range(len(indices_list)):
-            if indices_list[idx_].type().scalarType() == "Bool":  # type: ignore[attr-defined]
-                # TODO(justinchuby): Remove type ignore after #81112 is checked in.
+            if symbolic_helper._is_bool(indices_list[idx_]):
                 indices_list[idx_] = g.op("NonZero", indices_list[idx_])
         index = indices_list[0]
 
@@ -268,8 +268,7 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
         #   return (%33)
         index = indices_list[0]
         bool_inp = index
-        if bool_inp.type() is not None and bool_inp.type().scalarType() == "Bool":  # type: ignore[attr-defined]
-            # TODO(justinchuby): Remove type ignore after #81112 is checked in.
+        if symbolic_helper._is_bool(bool_inp):
             rank = symbolic_helper._get_tensor_rank(values)
             if rank is not None and rank == 0:
                 return opset9.masked_fill(g, self, bool_inp, values)
@@ -727,7 +726,7 @@ def pad(g, input, pad, mode, value):
     elif mode == "circular":
         return opset9._pad_circular(g, input, pad)
     else:
-        raise RuntimeError(f"Unrecognized padding mode {mode}")
+        raise errors.SymbolicValueError(f"Unrecognized padding mode {mode}", input)
 
 
 def linalg_det(g, self):
@@ -761,7 +760,7 @@ def arange(g, *args):
             "Constant",
             value_t=torch.tensor(1, dtype=type_.dtype()),
         )
-        arange_tensor = g.op("Range", start_default, end, delta_default)
+        return g.op("Range", start_default, end, delta_default)
     elif len(args) == 4 or len(args) == 7:
         if len(args) == 4:
             # aten::arange(Scalar start, Scalar end, Scalar step, Tensor out)
@@ -772,7 +771,7 @@ def arange(g, *args):
         _, end, start, step = symbolic_helper._arange_cast_helper(
             g, start=args[0], end=args[1], step=args[2], dtype=dtype
         )
-        arange_tensor = g.op("Range", start, end, step)
+        return g.op("Range", start, end, step)
     elif len(args) == 6:
         # aten::arange(Scalar start, Scalar end, ScalarType dtype, Layout, Device, bool pin_memory)
         dtype = _get_arange_dtype(args[2])
@@ -783,12 +782,9 @@ def arange(g, *args):
             "Constant",
             value_t=torch.tensor(1, dtype=type_.dtype()),
         )
-        arange_tensor = g.op("Range", start, end, delta_default)
+        return g.op("Range", start, end, delta_default)
     else:
-        raise NotImplementedError(
-            "Unknown aten::arange signature taking " + str(len(args)) + " arguments."
-        )
-    return arange_tensor
+        return symbolic_helper._unimplemented("aten::arange", f"with {len(args)} arguments")
 
 
 @symbolic_helper.parse_args("v", "i")
@@ -883,7 +879,7 @@ def index(g, self, index):
     if len(indices) == 1:
         index = indices[0]
         if not symbolic_helper._is_none(index) and (
-            index.type().scalarType() == "Bool" or index.type().scalarType() == "Byte"
+            symbolic_helper._is_bool(index) or index.type().scalarType() == "Byte"
         ):
             index = opset9.nonzero(g, index)
             return g.op("GatherND", self, index)
@@ -1254,9 +1250,10 @@ def embedding_renorm(g, weight, indices, max_norm, norm_type):
     elif norm_type == 2:
         norm_type = "ReduceL2"
     else:
-        raise RuntimeError(
+        raise errors.SymbolicValueError(
             f"Unsupported: ONNX export of embedding_renorm with norm: {norm_type}. "
-            "Only 1. and 2. are supported."
+            "Only 1. and 2. are supported.",
+            weight,
         )
     partial_weight_norm = g.op(norm_type, partial_weight, axes_i=[1], keepdims_i=1)
     # https://github.com/pytorch/pytorch/blob/0a07488ed2c47765e337e290bd138c0e6e459cbd/aten/src/ATen/native/Embedding.cpp#L177

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -784,7 +784,9 @@ def arange(g, *args):
         )
         return g.op("Range", start, end, delta_default)
     else:
-        return symbolic_helper._unimplemented("aten::arange", f"with {len(args)} arguments")
+        return symbolic_helper._unimplemented(
+            "aten::arange", f"with {len(args)} arguments"
+        )
 
 
 @symbolic_helper.parse_args("v", "i")

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -210,7 +210,8 @@ def binary_cross_entropy_with_logits(g, input, target, weight, pos_weight, reduc
         return g.op("ReduceSum", output, keepdims_i=0)
     else:
         return symbolic_helper._onnx_unsupported(
-            "binary_cross_entropy_with_logits with reduction other than none, mean, or sum"
+            "binary_cross_entropy_with_logits with reduction other than none, mean, or sum",
+            input,
         )
 
 

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -3,7 +3,13 @@ from typing import Optional, Tuple
 
 import torch
 from torch._C import _onnx as _C_onnx
-from torch.onnx import _type_utils, symbolic_helper, symbolic_opset9 as opset9, utils
+from torch.onnx import (
+    _type_utils,
+    errors,
+    symbolic_helper,
+    symbolic_opset9 as opset9,
+    utils,
+)
 
 
 # EDITING THIS FILE? READ THIS FIRST!
@@ -36,7 +42,7 @@ def _einsum_helper(g, equation, tensors):
     if not tensors:
         raise RuntimeError("Einsum inputs are empty.")
     # ONNX does not support bool for Einsum inputs.
-    if tensors[0].type().scalarType() == "Bool":
+    if symbolic_helper._is_bool(tensors[0]):
         tensors = [
             g.op("Cast", tensor, to_i=_C_onnx.TensorProtoDataType.INT64)
             for tensor in tensors
@@ -146,8 +152,10 @@ def cross_entropy_loss(
     reduction = reduction_vals[reduction]
 
     label_smoothing = symbolic_helper._maybe_get_const(label_smoothing, "f")
-    if label_smoothing > 0.0:
-        raise RuntimeError("Unsupported: ONNX does not support label_smoothing")
+    if label_smoothing is not None and label_smoothing > 0.0:
+        raise errors.SymbolicValueError(
+            "Unsupported: ONNX does not support label_smoothing", self
+        )
 
     # in onnx SoftmaxCrossEntropyLoss specification, ignore_index is optional without default value.
     # therefore we need to set ignore_index attribute even if it is not specified (e.g. ignore_index=-100).
@@ -326,14 +334,16 @@ def tensordot(g, input_a, input_b, dims_a, dims_b, out=None):
 
     dim_count_a = symbolic_helper._get_tensor_rank(input_a)
     if dim_count_a is None:
-        raise RuntimeError(
-            "Unsupported: ONNX export of tensordot for tensor(input_a) of unknown rank."
+        raise errors.SymbolicValueError(
+            "Unsupported: ONNX export of tensordot for tensor(input_a) of unknown rank.",
+            input_a,
         )
 
     dim_count_b = symbolic_helper._get_tensor_rank(input_b)
     if dim_count_b is None:
-        raise RuntimeError(
-            "Unsupported: ONNX export of tensordot for tensor(input_b) of unknown rank."
+        raise errors.SymbolicValueError(
+            "Unsupported: ONNX export of tensordot for tensor(input_b) of unknown rank.",
+            input_b,
         )
 
     dims_a = [

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -6,6 +6,7 @@ import torch
 import torch._C._onnx as _C_onnx
 from torch.onnx import (
     _type_utils,
+    errors,
     symbolic_helper,
     symbolic_opset11 as opset11,
     symbolic_opset9 as opset9,
@@ -91,7 +92,9 @@ def split(g, self, split_size_or_sizes, dim, _outputs=None):
         if _outputs is not None:
             size = split_size * _outputs
         else:
-            raise RuntimeError("Unknown dimension size not supported")
+            raise errors.SymbolicValueError(
+                "Unknown dimension size not supported", self
+            )
     splits = [split_size] * (size // split_size)
     leftover = size % split_size
     if leftover:
@@ -148,7 +151,9 @@ def tensor_split(g, self, indices_or_sections, dim, _outputs=None):
             if _outputs is not None:
                 size = split_size * _outputs
             else:
-                raise RuntimeError("Unknown dimension size not supported")
+                raise errors.SymbolicValueError(
+                    "Unknown dimension size not supported", self
+                )
 
         min_split_size = size // split_size
         num_splits_one_extra = size % split_size
@@ -270,7 +275,7 @@ def nonzero_numpy(g, input, _outputs=None):
 @symbolic_helper.parse_args("v", "v", "v", "i")
 def where(g, condition, self=None, other=None, _outputs=None):
     # Assumes that torch.where's first argument takes only Bool and Byte tensors.
-    if condition.type().scalarType() != "Bool":
+    if not symbolic_helper._is_bool(condition):
         condition = g.op("Cast", condition, to_i=_C_onnx.TensorProtoDataType.BOOL)
     if self is None:
         condition = opset9.nonzero(g, condition)
@@ -287,9 +292,10 @@ def fake_quantize_per_channel_affine(
     # NOTE: (0, 127) is allowed as special case. PyTorch restricts activations to be in the range (0, 127).
     #   https://github.com/pytorch/pytorch/blob/b34b192d6b97325c9f78e5995c48c8498ede34bd/torch/ao/quantization/observer.py#L1422
     if (quant_min, quant_max) not in [(0, 255), (-128, 127), (0, 127)]:
-        raise RuntimeError(
+        raise errors.SymbolicValueError(
             "For (quant_min, quant_max), ONNX allows only (0, 127), (0, 255) and (-128, 127). "
-            "Got ({}, {})".format(quant_min, quant_max)
+            f"Got ({quant_min}, {quant_max})",
+            inputs,
         )
     # ONNX defines zero_point to be int8 or uint8
     if quant_min == 0:
@@ -314,9 +320,10 @@ def fake_quantize_per_tensor_affine(
     # NOTE: (0, 127) is allowed as special case. PyTorch restricts activations to be in the range (0, 127).
     #   https://github.com/pytorch/pytorch/blob/b34b192d6b97325c9f78e5995c48c8498ede34bd/torch/ao/quantization/observer.py#L1422
     if (quant_min, quant_max) not in [(0, 255), (-128, 127), (0, 127)]:
-        raise RuntimeError(
+        raise errors.SymbolicValueError(
             "For (quant_min, quant_max), ONNX allows only (0, 127), (0, 255) and (-128, 127). "
-            "Got ({}, {})".format(quant_min, quant_max)
+            f"Got ({quant_min}, {quant_max})",
+            inputs,
         )
     if quant_min == 0:
         zero_point = g.op("Cast", zero_point, to_i=_C_onnx.TensorProtoDataType.UINT8)
@@ -428,16 +435,19 @@ def repeat_interleave(g, self, repeats, dim=None, output_size=None):
     repeats_sizes = symbolic_helper._get_tensor_sizes(repeats)
     input_sizes = symbolic_helper._get_tensor_sizes(input)
     if repeats_dim is None:
-        raise RuntimeError(
-            "Unsupported: ONNX export of repeat_interleave for unknown " "repeats rank."
+        raise errors.SymbolicValueError(
+            "Unsupported: ONNX export of repeat_interleave for unknown repeats rank.",
+            self,
         )
     if repeats_sizes is None:
-        raise RuntimeError(
-            "Unsupported: ONNX export of repeat_interleave for unknown " "repeats size."
+        raise errors.SymbolicValueError(
+            "Unsupported: ONNX export of repeat_interleave for unknown repeats size.",
+            self,
         )
     if input_sizes is None:
-        raise RuntimeError(
-            "Unsupported: ONNX export of repeat_interleave for unknown " "input size."
+        raise errors.SymbolicValueError(
+            "Unsupported: ONNX export of repeat_interleave for unknown input size.",
+            self,
         )
     # Handle cases where dim is negative
     if dim < 0:

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -361,7 +361,7 @@ def _reduce_with_dtype(onnx_op, name):
                     "Cast", self, to_i=_type_utils.JitScalarType(dtype).onnx_type()
                 )
             elif dtype.node().kind() != "prim::Constant":
-                return symbolic_helper._unimplemented(name, "dtype")
+                return symbolic_helper._unimplemented(name, "dtype", dtype)
             return symbolic(g, self)
 
         @symbolic_helper.parse_args("v", "v", "i", "none")
@@ -372,7 +372,7 @@ def _reduce_with_dtype(onnx_op, name):
                     "Cast", self, to_i=_type_utils.JitScalarType(dtype).onnx_type()
                 )
             elif dtype.node().kind() != "prim::Constant":
-                return symbolic_helper._unimplemented(name, "dtype")
+                return symbolic_helper._unimplemented(name, "dtype", dtype)
             return symbolic(g, self, dim, keepdim)
 
         return reduce_nodim, reduce_dim

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -71,6 +71,7 @@ def batch_norm(
             15,
             "All input tensors must have the same `dtype`."
             " Turn off Autocast or export using opset version 15.",
+            input,
         )
 
     symbolic_helper.check_training_mode(training, "batch_norm")

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -33,7 +33,8 @@ Updated operators:
 import warnings
 
 import torch
-from torch.onnx import _type_utils, symbolic_helper, symbolic_opset9 as opset9
+from torch.onnx import _type_utils, errors, symbolic_helper
+from torch.onnx import symbolic_opset9 as opset9
 
 block_listed_operators = [
     "nonzero",
@@ -67,7 +68,7 @@ def _interpolate(name, dim, interpolate_mode):
         symbolic_helper._interpolate_warning(interpolate_mode)
         align_corners = symbolic_helper._maybe_get_scalar(align_corners)
         if align_corners:
-            return symbolic_helper._unimplemented(name, "align_corners == True")
+            return symbolic_helper._unimplemented(name, "align_corners == True", input)
         output_size = symbolic_helper._maybe_get_const(output_size, "is")
         if symbolic_helper._is_value(output_size):
             return symbolic_helper._unimplemented(
@@ -200,7 +201,9 @@ def mm(g, self, other):
     # since beta = 0
     scalar_type = symbolic_helper._try_get_scalar_type(self, other)
     if scalar_type is None:
-        raise ValueError("mm can only operate on tensors with known types")
+        raise errors.SymbolicValueError(
+            "mm can only operate on tensors with known types", self
+        )
     zero_constant = g.op(
         "Constant",
         value_t=torch.tensor(

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -33,8 +33,7 @@ Updated operators:
 import warnings
 
 import torch
-from torch.onnx import _type_utils, errors, symbolic_helper
-from torch.onnx import symbolic_opset9 as opset9
+from torch.onnx import _type_utils, errors, symbolic_helper, symbolic_opset9 as opset9
 
 block_listed_operators = [
     "nonzero",

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -779,13 +779,12 @@ def _standard_gamma(g, self, generator):
     if symbolic_helper.is_caffe2_aten_fallback():
         if not symbolic_helper._is_none(generator):
             return symbolic_helper._unimplemented(
-                "_standard_gamma", "We are not able to export generator", self
+                "_standard_gamma", "not able to export generator", self
             )
         return g.at("_standard_gamma", self)
-    else:
-        return symbolic_helper._onnx_unsupported("_standard_gamma")
 
     return symbolic_helper._onnx_unsupported("_standard_gamma", self)
+
 
 def t(g, self):
     return g.op("Transpose", self, perm_i=(1, 0))
@@ -911,16 +910,15 @@ def transpose(g, self, dim0, dim1):
         axes = list(range(rank))
         axes[dim0], axes[dim1] = axes[dim1], axes[dim0]
         return g.op("Transpose", self, perm_i=axes)
-
-    # if we don't have dim information we cannot
-    # output a permute so use ATen instead
-    if symbolic_helper.is_caffe2_aten_fallback():
+    elif symbolic_helper.is_caffe2_aten_fallback():
+        # if we don't have dim information we cannot
+        # output a permute so use ATen instead
         return g.at("transpose", self, overload_name="int", dim0_i=dim0, dim1_i=dim1)
-
-    raise errors.SymbolicValueError(
-        "Unsupported: ONNX export of transpose for tensor of unknown rank.",
-        self,
-    )
+    else:
+        raise errors.SymbolicValueError(
+            "Unsupported: ONNX export of transpose for tensor of unknown rank.",
+            self,
+        )
 
 
 @symbolic_helper.parse_args("v", "is")


### PR DESCRIPTION
Replace runtime errors in torch.onnx with `errors.SymbolicValueError` for more context around jit values.

- Extend `_unimplemented`, `_onnx_unsupported`, `_onnx_opset_unsupported`, `_onnx_opset_unsupported_detailed` errors to include JIT value information
- Replace plain RuntimeError with `errors.SymbolicValueError`
- Clean up: Use `_is_bool` to replace string comparison on jit types
- Clean up: Remove the todo `Remove type ignore after #81112`

#77316