### PR TITLE
fix a comment since the options in arg parser no longer require Declarations.yaml

### DIFF
--- a/tools/autograd/gen_autograd.py
+++ b/tools/autograd/gen_autograd.py
@@ -3,7 +3,6 @@ To run this file by hand from the root of the PyTorch
 repository, run:
 
 python -m tools.autograd.gen_autograd \
-       build/aten/src/ATen/Declarations.yaml \
        aten/src/ATen/native/native_functions.yaml \
        aten/src/ATen/native/tags.yaml \
        $OUTPUT_DIR \


### PR DESCRIPTION
fix a comment since the options in arg parser no longer require Declarations.yaml