### PR TITLE
make sure arguments are tuples otherwise they won't be hashable

### DIFF
--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -2056,27 +2056,30 @@ class Arguments:
         if arguments.self_arg:
             arguments = dataclasses.replace(
                 arguments,
-                pre_self_positional=[
-                    x.symint_to_int() for x in arguments.pre_self_positional
-                ],
+                pre_self_positional=tuple(
+                    [x.symint_to_int() for x in arguments.pre_self_positional]
+                ),
             )
 
         if self.tensor_options:
             arguments = dataclasses.replace(
                 arguments,
-                post_tensor_options_kwarg_only=[
-                    x.symint_to_int() for x in arguments.post_tensor_options_kwarg_only
-                ],
+                post_tensor_options_kwarg_only=tuple(
+                    [
+                        x.symint_to_int()
+                        for x in arguments.post_tensor_options_kwarg_only
+                    ]
+                ),
             )
 
         arguments = dataclasses.replace(
             arguments,
-            post_self_positional=[
-                x.symint_to_int() for x in arguments.post_self_positional
-            ],
-            pre_tensor_options_kwarg_only=[
-                x.symint_to_int() for x in arguments.pre_tensor_options_kwarg_only
-            ],
+            post_self_positional=tuple(
+                [x.symint_to_int() for x in arguments.post_self_positional]
+            ),
+            pre_tensor_options_kwarg_only=tuple(
+                [x.symint_to_int() for x in arguments.pre_tensor_options_kwarg_only]
+            ),
         )
 
         return arguments

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -2057,7 +2057,7 @@ class Arguments:
             arguments = dataclasses.replace(
                 arguments,
                 pre_self_positional=tuple(
-                    [x.symint_to_int() for x in arguments.pre_self_positional]
+                    x.symint_to_int() for x in arguments.pre_self_positional
                 ),
             )
 
@@ -2065,20 +2065,17 @@ class Arguments:
             arguments = dataclasses.replace(
                 arguments,
                 post_tensor_options_kwarg_only=tuple(
-                    [
-                        x.symint_to_int()
-                        for x in arguments.post_tensor_options_kwarg_only
-                    ]
+                    x.symint_to_int() for x in arguments.post_tensor_options_kwarg_only
                 ),
             )
 
         arguments = dataclasses.replace(
             arguments,
             post_self_positional=tuple(
-                [x.symint_to_int() for x in arguments.post_self_positional]
+                x.symint_to_int() for x in arguments.post_self_positional
             ),
             pre_tensor_options_kwarg_only=tuple(
-                [x.symint_to_int() for x in arguments.pre_tensor_options_kwarg_only]
+                x.symint_to_int() for x in arguments.pre_tensor_options_kwarg_only
             ),
         )
 


### PR DESCRIPTION
make sure arguments are tuples otherwise they won't be hashable if used in autograd.py or any other places that uses dictionaries for that matter 