### PR TITLE
Fix `torch.equal` on CPU

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1977,9 +1977,6 @@ bool cpu_equal(const Tensor& self, const Tensor& other) {
   at::NoNamesGuard guard;
   TORCH_CHECK(self.device() == other.device(), "Cannot compare two tensors on "
               "different devices. Got: ", self.device(), " and ", other.device());
-  TORCH_CHECK(self.dtype() == other.dtype(),
-              "Expected object of scalar type ", self.dtype(), " but got scalar type ",
-              other.dtype(), " for argument 'other'");
   if (!self.is_same_size(other)) {
     return false;
   }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6038,7 +6038,7 @@ class TestTorch(TestCase):
         # Different dtypes
         x = torch.tensor((1, 2, 3), dtype=torch.float)
         y = torch.tensor((1, 2, 3), dtype=torch.int)
-        z = torch.tensor((1, 1 ), dtype=torch.int)
+        z = torch.tensor((1, -1), dtype=torch.int)
         self.assertTrue(torch.equal(x, y))
         self.assertFalse(torch.equal(z, x))
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6035,6 +6035,13 @@ class TestTorch(TestCase):
         self.assertTrue(torch.equal(s1, s3))
         self.assertFalse(torch.equal(s1, s4))
 
+        # Different dtypes
+        x = torch.tensor((1, 2, 3), dtype=torch.float)
+        y = torch.tensor((1, 2, 3), dtype=torch.int)
+        z = torch.tensor((1, 1 ), dtype=torch.int)
+        self.assertTrue(torch.equal(x, y))
+        self.assertFalse(torch.equal(z, x))
+
     def test_element_size(self):
         byte = torch.ByteStorage().element_size()
         char = torch.CharStorage().element_size()


### PR DESCRIPTION
`torch.equal` should not raise an exception when comparing tensors of different types
I.e. `torch.equal(torch.tensor([1, 2]), torch.tensor([1, 2], dtype=torch.float)))` should return True rather than raise an exception.
Also, this makes it consistent with GPU behaviour

Fixes https://github.com/pytorch/pytorch/issues/83314

