### PR TITLE
[easy] Fix .sizes() call in saved_variable.cpp for nested tensor

### DIFF
--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -154,12 +154,19 @@ Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
         ? impl::version_counter(data_).current_version()
         : version_counter_.current_version();
 
+
+
     if (saved_version_ != current_version) {
       std::stringstream message;
       message
           << "one of the variables needed for gradient computation has been "
              "modified by an inplace operation: ["
-          << data_.toString() << " " << data_.sizes() << "]";
+          << data_.toString() << " ";
+       if (data_.is_nested()) {
+          message << data_._nested_tensor_size() << "]";
+       } else {
+          message << data_.sizes() << "]";
+       }
       if (grad_fn) {
         message << ", which is output " << output_nr_ << " of "
                 << grad_fn->name() << ",";

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -154,8 +154,6 @@ Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
         ? impl::version_counter(data_).current_version()
         : version_counter_.current_version();
 
-
-
     if (saved_version_ != current_version) {
       std::stringstream message;
       message

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -160,11 +160,11 @@ Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
           << "one of the variables needed for gradient computation has been "
              "modified by an inplace operation: ["
           << data_.toString() << " ";
-       if (data_.is_nested()) {
-          message << data_._nested_tensor_size() << "]";
-       } else {
-          message << data_.sizes() << "]";
-       }
+      if (data_.is_nested()) {
+        message << data_._nested_tensor_size() << "]";
+      } else {
+        message << data_.sizes() << "]";
+      }
       if (grad_fn) {
         message << ", which is output " << output_nr_ << " of "
                 << grad_fn->name() << ",";


### PR DESCRIPTION
Small fix so that TestMultipleDispatch in the above PR will throw the correct error when using an inplace operation on a saved nested input 
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #82625
* __->__ #83356

