### PR TITLE
[Shape Fns] Fix handling of empty dim list in sum_mean_dim shape fn

### DIFF
--- a/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
+++ b/torch/csrc/jit/runtime/serialized_shape_function_registry.cpp
@@ -2121,25 +2121,35 @@ def transpose(self: List[int],
     dt: Any) -> List[int]:
   out = annotate(List[int], [])
   if torch.__is__(opt_dims, None):
-    dims = annotate(List[int], [])
+    _0, opt_dims0 = True, opt_dims
   else:
-    dims = unchecked_cast(List[int], opt_dims)
+    opt_dims1 = unchecked_cast(List[int], opt_dims)
+    _0, opt_dims0 = torch.eq(torch.len(opt_dims1), 0), opt_dims1
+  if _0:
+    _1 = torch.len(self)
+    dims0 = annotate(List[int], [])
+    for _2 in range(_1):
+      _3 = torch.append(dims0, _2)
+    dims = dims0
+  else:
+    opt_dims2 = unchecked_cast(List[int], opt_dims0)
+    dims = opt_dims2
   for idx in range(torch.len(self)):
     is_mean_dim = False
-    for _0 in range(torch.len(dims)):
-      reduce_dim = dims[_0]
-      _1 = torch.len(self)
-      if torch.le(_1, 0):
+    for _4 in range(torch.len(dims)):
+      reduce_dim = dims[_4]
+      _5 = torch.len(self)
+      if torch.le(_5, 0):
         dim_post_expr = 1
       else:
-        dim_post_expr = _1
+        dim_post_expr = _5
       min = torch.neg(dim_post_expr)
       max = torch.sub(dim_post_expr, 1)
       if torch.lt(reduce_dim, min):
-        _2 = True
+        _6 = True
       else:
-        _2 = torch.gt(reduce_dim, max)
-      if torch.__not__(_2):
+        _6 = torch.gt(reduce_dim, max)
+      if torch.__not__(_6):
         pass
       else:
         ops.prim.RaiseException("AssertionError: ")
@@ -2155,11 +2165,11 @@ def transpose(self: List[int],
       is_mean_dim = is_mean_dim0
     if is_mean_dim:
       if keep_dim:
-        _3 = torch.append(out, 1)
+        _7 = torch.append(out, 1)
       else:
         pass
     else:
-      _4 = torch.append(out, self[idx])
+      _8 = torch.append(out, self[idx])
   return out
 
 )=====")
@@ -2170,7 +2180,7 @@ def transpose(self: List[int],
   out = annotate(List[int], [])
   for idx in range(torch.len(self)):
     is_mean_dim = False
-    for _1 in range(1):
+    for _1 in range(torch.len(_0)):
       reduce_dim = _0[_1]
       _2 = torch.len(self)
       if torch.le(_2, 0):

--- a/torch/jit/_shape_functions.py
+++ b/torch/jit/_shape_functions.py
@@ -155,10 +155,11 @@ def view_one_unused(self: List[int], sizes: List[int], *, implicit: bool = False
 
 def sum_mean_dim(self: List[int], opt_dims: Optional[List[int]], keep_dim: bool, dt: Any):
     out: List[int] = []
-    if opt_dims is None:
-        dims: List[int] = []
+    if opt_dims is None or len(opt_dims) == 0:
+        dims: List[int] = list(range(len(self)))
     else:
         dims = opt_dims
+
     for idx in range(len(self)):
         is_mean_dim: bool = False
         for reduce_dim in dims:


### PR DESCRIPTION
The current implementation of the `sum_mean_dim` shape function
takes `dim=[]` and `dim=None` to mean "no reduction". However, in the
ops `torch.sum` and `torch.mean`, both `dim=[]` and `dim=None` are
equivalent to "reduce along all dimensions". This commit fixes the
handling of `dim` in the `sum_mean_dim` shape function.