### PR TITLE
Always invoke decomps in fake tensors

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -192,6 +192,19 @@ class FakeTensorTest(TestCase):
             y1 = torch.randperm(5, device="cpu")
             prims.utils.compare_tensor_meta(y, y1)
 
+    def test_layernorm(self):
+        out = []
+        for ctx in (contextlib.nullcontext, FakeTensorMode):
+            with ctx():
+                a = torch.empty_strided([4, 576, 768], (442368, 1, 576))
+                b = [768]
+                c = torch.empty([768])
+                d = torch.empty([768])
+                e = .01
+                args = (a, b, c, d, e)
+                out.append(torch.ops.aten.native_layer_norm(*args))
+        for e1, e2 in zip(out[0], out[1]):
+            prims.utils.compare_tensor_meta(e1, e2, check_strides=True)
 
     @unittest.skipIf(not RUN_CUDA, "requires cuda")
     def test_cpu_fallback(self):

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -285,6 +285,19 @@ def run_and_return_new_tensor_of_input_device(fake_mode, func, args, kwargs):
     return FakeTensor(fake_mode, out, out_device)
 
 
+# TODO - use refs/decomps over math kernels more generally?
+@register_op_impl(aten.native_layer_norm.default)
+def layer_norm(fake_mode, func, *args, **kwargs):
+    _, new_kwargs = normalize_function(
+        func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
+    )
+    out_device = new_kwargs["input"].device
+    with in_kernel_invocation_manager(fake_mode):
+        out = torch._refs.native_layer_norm(*args, **kwargs)
+
+    return tuple([FakeTensor(fake_mode, out_meta, out_device) for out_meta in out])
+
+
 # Dont default to default device handling,
 # Since op can take in non-zero sized cpu
 # index tensors with cuda self
@@ -549,13 +562,6 @@ class FakeTensorMode(TorchDispatchMode):
                 return torch.device("meta")
             else:
                 return args[0].fake_device
-
-        # Use decompositions, and enable fake mode when running them
-        decomps = torch._decomp.get_decompositions([func])
-        if func in decomps:
-            with self.restore():
-                return decomps[func](*args, **kwargs)
-
         flat_arg_tensors = [
             i for i in tree_flatten((args, kwargs))[0] if isinstance(i, FakeTensor)
         ]
@@ -563,14 +569,19 @@ class FakeTensorMode(TorchDispatchMode):
         if has_symbolic_sizes:
             # TODO: Find better approach for this
             # Avoid circular import
+            from torch._decomp import decomposition_table
             from torch._meta_registrations import meta_table
 
             # TODO: hack, doesn't actually work.
             # see https://github.com/pytorch/pytorch/pull/81598#issuecomment-1192030435
-            with self.restore():
+            with enable_torch_dispatch_mode(
+                self
+            ), torch.overrides.enable_reentrant_dispatch():
                 if func in meta_table:
                     r = meta_table[func](*args, **kwargs)
                     return r
+                if func in decomposition_table:
+                    return decomposition_table[func](*args, **kwargs)
 
             with no_dispatch():
                 if symbolic_shapes.is_symbolic_op(func):
@@ -585,6 +596,7 @@ class FakeTensorMode(TorchDispatchMode):
         # and do device logic, we dont need do anything but run them
         # and ensure that Meta kernels are dispatched to (see)
         # Fake Tensor Dispatch Keys
+
         if "prims::" in func._schema.name and len(flat_arg_tensors) != 0:
             try:
                 torch._C._add_meta_to_tls_dispatch_include()

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -285,19 +285,6 @@ def run_and_return_new_tensor_of_input_device(fake_mode, func, args, kwargs):
     return FakeTensor(fake_mode, out, out_device)
 
 
-# TODO - use refs/decomps over math kernels more generally?
-@register_op_impl(aten.native_layer_norm.default)
-def layer_norm(fake_mode, func, *args, **kwargs):
-    _, new_kwargs = normalize_function(
-        func, args=args, kwargs=kwargs, normalize_to_only_use_kwargs=True
-    )
-    out_device = new_kwargs["input"].device
-    with in_kernel_invocation_manager(fake_mode):
-        out = torch._refs.native_layer_norm(*args, **kwargs)
-
-    return tuple([FakeTensor(fake_mode, out_meta, out_device) for out_meta in out])
-
-
 # Dont default to default device handling,
 # Since op can take in non-zero sized cpu
 # index tensors with cuda self


### PR DESCRIPTION
Use the prims layer_norm to workaround https://github.com/pytorch/pytorch/issues/83362.. Maybe we should be using the prims/decomps over math kernels?