### PR TITLE
[dist.cp] Introduce LoadPlanner and SavePlanner extensibility API.

### DIFF
--- a/test/distributed/_shard/checkpoint/test_planner.py
+++ b/test/distributed/_shard/checkpoint/test_planner.py
@@ -28,7 +28,7 @@ from torch.distributed._shard.checkpoint.default_planner import (
     create_default_global_save_plan,
     create_default_local_save_plan,
     create_default_local_load_plan,
-    create_default_local_metadata
+    _create_default_local_metadata
 )
 
 if TEST_WITH_DEV_DBG_ASAN:
@@ -149,7 +149,7 @@ class TestSavePlan(TestCase):
                 }
 
         state_dict = create_state_dict(1)
-        metadata = create_default_local_metadata(state_dict)
+        metadata = _create_default_local_metadata(state_dict)
 
         load_plan = create_default_local_load_plan(state_dict, metadata)
         # This will create 3 entries
@@ -191,11 +191,11 @@ class TestSavePlan(TestCase):
 
         # Rank 1 has a 16 bytes shard from [16, 32[
         world8_state_dict = create_state_dict(rank=1, world_size=8)
-        world8_metadata = create_default_local_metadata(world8_state_dict)
+        world8_metadata = _create_default_local_metadata(world8_state_dict)
 
         # Rank 1 has a 32 bytes shard from [32, 64[
         world4_state_dict = create_state_dict(rank=1, world_size=4)
-        world4_metadata = create_default_local_metadata(world4_state_dict)
+        world4_metadata = _create_default_local_metadata(world4_state_dict)
 
         # First scenario, going from world=8 to world=4, need to load 2 shards
         # Each 4-world shard has 32 elements, so it needs to load 2 shards
@@ -240,7 +240,7 @@ class TestSavePlan(TestCase):
                 }
         # rank 1 has a 30 bytes shard from [30, 60[
         world4_state_dict = create_state_dict(rank=1, world_size=4)
-        world4_metadata = create_default_local_metadata(world4_state_dict)
+        world4_metadata = _create_default_local_metadata(world4_state_dict)
 
         # rank 1 has a 40 bytes shard from [40, 80[
         world3_state_dict = create_state_dict(rank=1, world_size=3)

--- a/test/distributed/_shard/checkpoint/test_planner.py
+++ b/test/distributed/_shard/checkpoint/test_planner.py
@@ -1,0 +1,268 @@
+# Owner(s): ["oncall: distributed"]
+
+import sys
+
+import torch
+from torch.distributed._shard.checkpoint.planner import LoadItemType, WriteItemType
+
+from torch.distributed._shard.sharded_tensor import (
+    Shard,
+    ShardMetadata,
+    ShardedTensor,
+    ShardedTensorMetadata,
+)
+from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
+
+from torch.testing._internal.common_utils import (
+    TestCase,
+    TEST_WITH_DEV_DBG_ASAN,
+    run_tests,
+)
+from torch.distributed._shard.checkpoint.metadata import BytesStorageMetadata, MetadataIndex, TensorStorageMetadata
+from torch.testing._internal.distributed.distributed_utils import (
+    with_fake_comms,
+    with_dist
+)
+
+from torch.distributed._shard.checkpoint.default_planner import (
+    create_default_global_save_plan,
+    create_default_local_save_plan,
+    create_default_local_load_plan,
+    create_default_local_metadata
+)
+
+if TEST_WITH_DEV_DBG_ASAN:
+    print(
+        "Skip dev-asan as torch + multiprocessing spawn have known issues",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+def create_sharded_tensor(rank, world_size, shards_per_rank, shard_size=8):
+    shards_metadata = []
+    local_shards = []
+    for idx in range(0, world_size * shards_per_rank):
+        shard_rank = idx // shards_per_rank
+        shard_md = ShardMetadata(shard_offsets=[idx * shard_size], shard_sizes=[shard_size], placement=f"rank:{shard_rank}/cpu")
+        shards_metadata.append(shard_md)
+        if shard_rank == rank:
+            shard = Shard.from_tensor_and_offsets(
+                torch.rand(*shard_md.shard_sizes),
+                shard_offsets=shard_md.shard_offsets,
+                rank=rank
+            )
+            local_shards.append(shard)
+
+    sharded_tensor_md = ShardedTensorMetadata(
+        shards_metadata=shards_metadata,
+        size=torch.Size([shard_size * len(shards_metadata)]),
+        tensor_properties=TensorProperties.create_from_tensor(torch.zeros(1))
+    )
+
+    return ShardedTensor._init_from_local_shards_and_global_metadata(
+        local_shards=local_shards,
+        sharded_tensor_metadata=sharded_tensor_md
+    )
+
+
+class TestSavePlan(TestCase):
+    @with_fake_comms(rank=1, world_size=4)
+    def test_local_plan(self):
+        tensor = torch.rand(10)
+        val = [1, 2, 3]
+        st = create_sharded_tensor(rank=1, world_size=4, shards_per_rank=1)
+        state_dict = {
+            "tensor": tensor,
+            "value": val,
+            "st": st
+        }
+        plan = create_default_local_save_plan(state_dict, False)
+        self.assertEqual(1, len(plan.items))
+        wi = plan.items[0]
+        self.assertEqual(wi.index, MetadataIndex("st", [8]))
+        self.assertEqual(wi.type, WriteItemType.SHARD)
+        self.assertEqual(wi.tensor_data.size, st.size())
+        self.assertEqual(wi.tensor_data.properties, TensorProperties.create_from_tensor(torch.zeros(1)))
+        self.assertEqual(wi.tensor_data.chunk.offsets, torch.Size([8]))
+        self.assertEqual(wi.tensor_data.chunk.sizes, torch.Size([8]))
+
+        # Coordinator rank, should include replicated items as well
+        plan = create_default_local_save_plan(state_dict, True)
+        self.assertEqual(3, len(plan.items))
+
+        tensor_wi = next(wi for wi in plan.items if wi.type == WriteItemType.TENSOR)
+        self.assertEqual(tensor_wi.index, MetadataIndex("tensor", [0]))
+        self.assertEqual(tensor_wi.tensor_data.size, tensor.size())
+        self.assertEqual(tensor_wi.tensor_data.properties, TensorProperties.create_from_tensor(tensor))
+        self.assertEqual(tensor_wi.tensor_data.chunk.offsets, torch.Size([0]))
+        self.assertEqual(tensor_wi.tensor_data.chunk.sizes, torch.Size([10]))
+
+        bytes_wi = next(wi for wi in plan.items if wi.type == WriteItemType.BYTE_IO)
+        self.assertEqual(bytes_wi.index, MetadataIndex("value"))
+        self.assertIsNone(bytes_wi.tensor_data)
+
+    def test_global_plan(self):
+        def create_data(rank):
+            with with_dist(rank=rank, world_size=4):
+                tensor = torch.rand(10)
+                val = [1, 2, 3]
+                st = create_sharded_tensor(rank=rank, world_size=4, shards_per_rank=1)
+                state_dict = {
+                    "tensor": tensor,
+                    "value": val,
+                    "st": st
+                }
+                return create_default_local_save_plan(state_dict, rank == 0)
+
+        all_plans = [create_data(0), create_data(1), create_data(2), create_data(3)]
+        final_plans, metadata = create_default_global_save_plan(all_plans=all_plans)
+        # The default global plan updates all indexes to include hints
+        for new_plan, old_plan in zip(final_plans, all_plans):
+            for new_item, old_item in zip(new_plan.items, old_plan.items):
+                self.assertEqual(new_item.index, old_item.index)
+                self.assertEqual(new_item.type, old_item.type)
+                self.assertEqual(new_item.tensor_data, old_item.tensor_data)
+                self.assertIn(new_item.index.fqn, metadata.state_dict_metadata)
+
+                item_md = metadata.state_dict_metadata[new_item.index.fqn]
+                if new_item.type == WriteItemType.BYTE_IO:
+                    self.assertTrue(isinstance(item_md, BytesStorageMetadata))
+                else:
+                    self.assertTrue(isinstance(item_md, TensorStorageMetadata))
+                    self.assertEqual(item_md.size, old_item.tensor_data.size)
+                    self.assertEqual(item_md.properties, old_item.tensor_data.properties)
+
+                    self.assertIsNotNone(new_item.index.index)
+                    # Make sure the hint is correct
+                    self.assertEqual(item_md.chunks[new_item.index.index], old_item.tensor_data.chunk)
+
+    def test_local_load_plan(self):
+        def create_state_dict(rank):
+            with with_dist(rank=rank, world_size=4):
+                tensor = torch.rand(10)
+                val = [1, 2, 3]
+                st = create_sharded_tensor(rank=rank, world_size=4, shards_per_rank=1)
+                return {
+                    "tensor": tensor,
+                    "value": val,
+                    "st": st
+                }
+
+        state_dict = create_state_dict(1)
+        metadata = create_default_local_metadata(state_dict)
+
+        load_plan = create_default_local_load_plan(state_dict, metadata)
+        # This will create 3 entries
+        self.assertEqual(3, len(load_plan.items))
+        st_item = next(ri for ri in load_plan.items if ri.dest_index.fqn == "st")
+        tensor_item = next(ri for ri in load_plan.items if ri.dest_index.fqn == "tensor")
+        bytes_item = next(ri for ri in load_plan.items if ri.dest_index.fqn == "value")
+
+        self.assertEqual(st_item.type, LoadItemType.TENSOR)
+        # This is an exact copy
+        self.assertEqual(st_item.dest_index, MetadataIndex("st", [8]))
+        self.assertEqual(st_item.dest_offsets, torch.Size([0]))
+        self.assertEqual(st_item.storage_index, MetadataIndex("st", [8]))
+        self.assertEqual(st_item.storage_offsets, torch.Size([0]))
+        self.assertEqual(st_item.lengths, torch.Size([8]))
+
+        self.assertEqual(tensor_item.type, LoadItemType.TENSOR)
+        self.assertEqual(tensor_item.dest_index, MetadataIndex("tensor", [0]))
+        self.assertEqual(tensor_item.dest_offsets, torch.Size([0]))
+        self.assertEqual(tensor_item.storage_index, MetadataIndex("tensor", [0]))
+        self.assertEqual(tensor_item.storage_offsets, torch.Size([0]))
+        self.assertEqual(tensor_item.lengths, torch.Size([10]))
+
+        self.assertEqual(bytes_item.type, LoadItemType.BYTE_IO)
+        self.assertEqual(bytes_item.dest_index, MetadataIndex("value"))
+
+    def test_load_with_resharding(self):
+        def create_state_dict(rank, world_size):
+            with with_dist(rank=rank, world_size=world_size):
+                return {
+                    "st": create_sharded_tensor(
+                        rank=rank,
+                        world_size=world_size,
+                        shards_per_rank=1,
+                        shard_size=128 // world_size,
+                    )
+                }
+
+
+        # Rank 1 has a 16 bytes shard from [16, 32[
+        world8_state_dict = create_state_dict(rank=1, world_size=8)
+        world8_metadata = create_default_local_metadata(world8_state_dict)
+
+        # Rank 1 has a 32 bytes shard from [32, 64[
+        world4_state_dict = create_state_dict(rank=1, world_size=4)
+        world4_metadata = create_default_local_metadata(world4_state_dict)
+
+        # First scenario, going from world=8 to world=4, need to load 2 shards
+        # Each 4-world shard has 32 elements, so it needs to load 2 shards
+        load_plan = create_default_local_load_plan(world4_state_dict, world8_metadata)
+        self.assertEqual(2, len(load_plan.items))
+        low_ri = next(ri for ri in load_plan.items if ri.dest_offsets == torch.Size([0]))
+        high_ri = next(ri for ri in load_plan.items if ri.dest_offsets == torch.Size([16]))
+
+        self.assertEqual(low_ri.storage_index, MetadataIndex("st", [32]))
+        self.assertEqual(low_ri.storage_offsets, torch.Size([0]))
+        self.assertEqual(low_ri.dest_index, MetadataIndex("st", [32]))
+        self.assertEqual(low_ri.dest_offsets, torch.Size([0]))
+        self.assertEqual(low_ri.lengths, torch.Size([16]))
+
+        self.assertEqual(high_ri.storage_index, MetadataIndex("st", [48]))
+        self.assertEqual(high_ri.storage_offsets, torch.Size([0]))
+        self.assertEqual(high_ri.dest_index, MetadataIndex("st", [32]))
+        self.assertEqual(high_ri.dest_offsets, torch.Size([16]))
+        self.assertEqual(high_ri.lengths, torch.Size([16]))
+
+        # Second scenario, going from world=4 to world=8, need to load half of 1 shard
+        # rank1 on 8-world needs to load the upper half of the rank0 4-world shard
+        load_plan = create_default_local_load_plan(world8_state_dict, world4_metadata)
+        self.assertEqual(1, len(load_plan.items))
+        ri = load_plan.items[0]
+        self.assertEqual(ri.storage_index, MetadataIndex("st", [0]))
+        self.assertEqual(ri.storage_offsets, torch.Size([16]))
+        self.assertEqual(ri.dest_index, MetadataIndex("st", [16]))
+        self.assertEqual(ri.dest_offsets, torch.Size([0]))
+        self.assertEqual(ri.lengths, torch.Size([16]))
+
+    def test_load_with_world_size_diff_by_one(self):
+        def create_state_dict(rank, world_size):
+            with with_dist(rank=rank, world_size=world_size):
+                return {
+                    "st": create_sharded_tensor(
+                        rank=rank,
+                        world_size=world_size,
+                        shards_per_rank=1,
+                        shard_size=120 // world_size,
+                    )
+                }
+        # rank 1 has a 30 bytes shard from [30, 60[
+        world4_state_dict = create_state_dict(rank=1, world_size=4)
+        world4_metadata = create_default_local_metadata(world4_state_dict)
+
+        # rank 1 has a 40 bytes shard from [40, 80[
+        world3_state_dict = create_state_dict(rank=1, world_size=3)
+
+        load_plan = create_default_local_load_plan(world3_state_dict, world4_metadata)
+        self.assertEqual(2, len(load_plan.items))
+        # this is [30, 60] to load [40, 60]
+        low_ri = next(ri for ri in load_plan.items if ri.dest_offsets == torch.Size([0]))
+        # this is [60, 90] to load [60, 80]
+        high_ri = next(ri for ri in load_plan.items if ri.dest_offsets == torch.Size([20]))
+
+        self.assertEqual(low_ri.storage_index, MetadataIndex("st", [30]))
+        self.assertEqual(low_ri.storage_offsets, torch.Size([10]))
+        self.assertEqual(low_ri.dest_index, MetadataIndex("st", [40]))
+        self.assertEqual(low_ri.dest_offsets, torch.Size([0]))
+        self.assertEqual(low_ri.lengths, torch.Size([20]))
+
+        self.assertEqual(high_ri.storage_index, MetadataIndex("st", [60]))
+        self.assertEqual(high_ri.storage_offsets, torch.Size([0]))
+        self.assertEqual(high_ri.dest_index, MetadataIndex("st", [40]))
+        self.assertEqual(high_ri.dest_offsets, torch.Size([20]))
+        self.assertEqual(high_ri.lengths, torch.Size([20]))
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/_shard/checkpoint/test_utils.py
+++ b/test/distributed/_shard/checkpoint/test_utils.py
@@ -81,6 +81,8 @@ class TestMedatadaIndex(TestCase):
 
         a = find_state_dict_object(state_dict, MetadataIndex("a"))
         self.assertEqual(a, state_dict["a"])
+        a = find_state_dict_object(state_dict, MetadataIndex("a", [0]))
+        self.assertEqual(a, state_dict["a"])
         a = find_state_dict_object(state_dict, MetadataIndex("a", index=99))
         self.assertEqual(a, state_dict["a"])
 
@@ -91,8 +93,6 @@ class TestMedatadaIndex(TestCase):
 
         with self.assertRaisesRegex(ValueError, "FQN"):
             find_state_dict_object(state_dict, MetadataIndex("c"))
-        with self.assertRaisesRegex(ValueError, "ShardedTensor"):
-            find_state_dict_object(state_dict, MetadataIndex("a", [0]))
         with self.assertRaisesRegex(ValueError, "ShardedTensor"):
             find_state_dict_object(state_dict, MetadataIndex("b", [1]))
 

--- a/torch/distributed/_shard/checkpoint/__init__.py
+++ b/torch/distributed/_shard/checkpoint/__init__.py
@@ -13,3 +13,13 @@ from .state_dict_saver import save_state_dict
 from .storage import StorageReader, StorageWriter
 from .filesystem import FileSystemReader, FileSystemWriter
 from .api import CheckpointException
+
+
+from .planner import (
+    SavePlanner,
+    LoadPlanner,
+    SavePlan,
+    LoadPlan,
+    ReadItem,
+    WriteItem,
+)

--- a/torch/distributed/_shard/checkpoint/default_planner.py
+++ b/torch/distributed/_shard/checkpoint/default_planner.py
@@ -1,0 +1,352 @@
+import dataclasses
+import io
+from typing import List, Tuple, Dict, Any, Union, cast
+
+import torch
+
+from torch.distributed._shard._utils import narrow_tensor_by_index
+from torch.distributed._shard.metadata import ShardMetadata
+from torch.distributed._shard.sharded_tensor import ShardedTensor
+from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
+from torch.distributed._shard.sharded_tensor.shard import Shard
+
+from torch.distributed._shard.sharding_spec._internals import (
+    _check_shard_metadata_pair_overlap,
+)
+from .resharding import (
+    create_default_local_save_plan,
+    create_default_global_save_plan,
+    create_default_local_load_plan,
+    create_default_global_load_plan,
+)
+
+from .planner import (
+    LoadItemType,
+    SavePlanner,
+    LoadPlanner,
+    SavePlan,
+    LoadPlan,
+    ReadItem,
+    WriteItem,
+    WriteItemType,
+    TensorWriteData,
+)
+
+from .metadata import (
+    BytesStorageMetadata,
+    ChunkStorageMetadata,
+    TensorStorageMetadata,
+    MetadataIndex,
+    Metadata,
+    STATE_DICT_TYPE,
+    STORAGE_TYPES
+)
+
+from .resharding import (
+    _shards_get_overlap_region_wrt_saved_tensor
+)
+from .utils import (
+    find_state_dict_object
+)
+
+
+class DefaultSavePlanner(SavePlanner):
+    def init(self, state_dict: Dict[str, Any], is_coordinator: bool) -> None:
+        self.state_dict = state_dict
+        self.is_coordinator = is_coordinator
+
+    def create_local_plan(self) -> SavePlan:
+        self.plan = create_default_local_save_plan(self.state_dict, self.is_coordinator)
+        return self.plan
+
+    def create_global_plan(self, all_plans: List[SavePlan]) -> Tuple[List[SavePlan], Metadata]:
+        self.global_plan, self.metadata = create_default_global_save_plan(all_plans)
+        return self.global_plan, self.metadata
+
+    def finish_plan(self, new_plan: SavePlan) -> SavePlan:
+        self.plan = new_plan
+        return new_plan
+
+    def resolve_data(self, write_item: WriteItem) -> Union[torch.Tensor, io.BytesIO]:
+        object = self.lookup_object(write_item.index)
+        return self.transform_object(write_item, object)
+
+    def lookup_object(self, index: MetadataIndex) -> Any:
+        """
+        This is an extension from the planner interface to make it easy to extend the default planner
+        """
+        return find_state_dict_object(self.state_dict, index)
+
+    def transform_object(self, write_item: WriteItem, object: Any):
+        """
+        This is an extension from the planner interface to make it easy to extend the default planner
+        """
+        if write_item.type == WriteItemType.BYTE_IO:
+            bytes = io.BytesIO()
+            torch.save(object, bytes)
+            object = bytes
+        return object
+
+
+class DefaultLoadPlanner(LoadPlanner):
+    def init(self, state_dict: STATE_DICT_TYPE, metadata: Metadata, is_coordinator: bool) -> None:
+        self.state_dict = state_dict
+        self.metadata = metadata
+        self.is_coordinator = is_coordinator
+
+    def create_local_plan(self) -> LoadPlan:
+        return create_default_local_load_plan(self.state_dict, self.metadata)
+
+    def create_global_plan(self, global_plan: List[LoadPlan]) -> List[LoadPlan]:
+        return create_default_global_load_plan(global_plan)
+
+    def finish_plan(self, new_plan: LoadPlan) -> LoadPlan:
+        return new_plan
+
+    def load_bytes(self, read_item: ReadItem, value: io.BytesIO) -> None:
+        self.state_dict[read_item.dest_index.fqn] = torch.load(value)
+
+    def resolve_tensor(self, read_item: ReadItem):
+        tensor = self.lookup_tensor(read_item.dest_index)
+        return self.transform_tensor(read_item, tensor)
+
+    def commit_tensor(self, read_item: ReadItem, tensor: torch.Tensor) -> None:
+        pass
+
+    def lookup_tensor(self, index: MetadataIndex) -> torch.Tensor:
+        """
+        This is an extension from the planner interface to make it easy to extend the default planner
+        """
+        return find_state_dict_object(self.state_dict, index)
+
+    def transform_tensor(self, read_item: ReadItem, tensor: torch.Tensor):
+        """
+        This is an extension from the planner interface to make it easy to extend the default planner
+        """
+        return narrow_tensor_by_index(tensor, read_item.dest_offsets, read_item.lengths)
+
+
+def _create_shard_metadata(size: torch.Size) -> ShardMetadata:
+    return ShardMetadata(
+        shard_offsets=[0] * len(size),
+        shard_sizes=list(size),
+    )
+
+def _create_shard_from_tensor(tensor: torch.Tensor) -> Shard:
+    return Shard(
+        tensor=tensor,
+        metadata=_create_shard_metadata(tensor.size())
+    )
+
+def _chunk_for_sharmd(shard_md: ShardMetadata) -> ChunkStorageMetadata:
+    return ChunkStorageMetadata(
+        offsets=torch.Size(shard_md.shard_offsets),
+        sizes=torch.Size(shard_md.shard_sizes)
+    )
+
+def _sharded_tensor_metadata(sharded_tensor: ShardedTensor, shard_md: ShardMetadata) -> TensorWriteData:
+    return TensorWriteData(
+        chunk=_chunk_for_sharmd(shard_md),
+        properties=sharded_tensor.metadata().tensor_properties,
+        size=sharded_tensor.metadata().size,
+    )
+
+def _create_write_item_for_shard(fqn: str, sharded_tensor: ShardedTensor, shard_md: ShardMetadata) -> WriteItem:
+    offsets = torch.Size(shard_md.shard_offsets)
+    return WriteItem(
+        index=MetadataIndex(fqn, offsets),
+        type=WriteItemType.SHARD,
+        tensor_data=_sharded_tensor_metadata(sharded_tensor, shard_md),
+    )
+
+def _create_write_item_for_tensor(fqn: str, tensor: torch.Tensor) -> WriteItem:
+    offsets = torch.Size([0] * len(tensor.size()))
+    return WriteItem(
+        index=MetadataIndex(fqn, offsets),
+        type=WriteItemType.TENSOR,
+        tensor_data=TensorWriteData(
+            chunk=ChunkStorageMetadata(
+                offsets=offsets,
+                sizes=tensor.size()
+            ),
+            properties=TensorProperties.create_from_tensor(tensor),
+            size=tensor.size(),
+        )
+    )
+
+def _create_write_item_for_bytesio(fqn: str, bytes: Any):
+    return WriteItem(
+        index=MetadataIndex(fqn),
+        type=WriteItemType.BYTE_IO,
+    )
+
+def _create_read_item_for_byteio(dest_index, dest_offset, storage_index, storage_offset, length):
+    return ReadItem(
+        type=LoadItemType.BYTE_IO,
+        dest_index=dest_index,
+        dest_offsets=torch.Size((dest_offset,)),
+        storage_index=storage_index,
+        storage_offsets=torch.Size((storage_offset,)),
+        lengths=torch.Size((length,)),
+    )
+
+def _create_read_item_for_tensor(dest_index, dest_offsets, storage_index, storage_offsets, lengths):
+    return ReadItem(
+        type=LoadItemType.TENSOR,
+        dest_index=dest_index,
+        dest_offsets=torch.Size(dest_offsets),
+        storage_index=storage_index,
+        storage_offsets=torch.Size(storage_offsets),
+        lengths=torch.Size(lengths),
+    )
+
+def _create_sharded_read_items(
+    fqn: str,
+    checkpoint_md: TensorStorageMetadata,
+    local_shards: List[Shard],
+) -> List[ReadItem]:
+
+    read_items = []
+    # this is a naive quadratic algo that can be optimized later
+    for idx, shard in enumerate(local_shards):
+        for storage_idx, storage_md in enumerate(checkpoint_md.chunks):
+            shard_md_from_storage = ShardMetadata(
+                shard_sizes=list(storage_md.sizes),
+                shard_offsets=list(storage_md.offsets),
+            )
+
+            if not _check_shard_metadata_pair_overlap(
+                shard.metadata, shard_md_from_storage
+            ):
+                continue
+
+            storage_offsets = []
+            dest_offsets = []
+            lengths = []
+            for (
+                dim,
+                offset_for_saved_tensor,
+                offset_for_current_tensor,
+                length,
+            ) in _shards_get_overlap_region_wrt_saved_tensor(
+                saved_shard=shard_md_from_storage, current_shard=shard.metadata
+            ):
+                storage_offsets.append(offset_for_saved_tensor)
+                dest_offsets.append(offset_for_current_tensor)
+                lengths.append(length)
+
+            read_items.append(
+                _create_read_item_for_tensor(
+                    dest_index=MetadataIndex(fqn, shard.metadata.shard_offsets, idx),
+                    dest_offsets=dest_offsets,
+                    storage_index=MetadataIndex(fqn, storage_md.offsets, storage_idx),
+                    storage_offsets=storage_offsets,
+                    lengths=lengths,
+                )
+            )
+    return read_items
+
+def create_default_metadata_only_plan(state_dict: STATE_DICT_TYPE) -> SavePlan:
+    requests = []
+    for fqn, obj in state_dict.items():
+        if isinstance(obj, ShardedTensor):
+            for shard_md in obj.metadata().shards_metadata:
+                requests.append(_create_write_item_for_shard(fqn, obj, shard_md))
+        elif isinstance(obj, torch.Tensor):
+            requests.append(_create_write_item_for_tensor(fqn, obj))
+        else:
+            requests.append(_create_write_item_for_bytesio(fqn, obj))
+    return SavePlan(requests)
+
+def create_default_local_metadata(state_dict: STATE_DICT_TYPE) -> Metadata:
+    plan = create_default_metadata_only_plan(state_dict)
+    _, md = create_default_global_save_plan([plan])
+    return md
+
+def create_write_items(fqn: str, object: Any) -> List[WriteItem]:
+    if isinstance(object, ShardedTensor):
+        return [_create_write_item_for_shard(fqn, object, shard.metadata) for shard in object.local_shards()]
+    elif isinstance(object, torch.Tensor):
+        return [_create_write_item_for_tensor(fqn, object)]
+    else:
+        return [_create_write_item_for_bytesio(fqn, object)]
+
+def create_read_items(fqn: str, md: STORAGE_TYPES, obj: Any) -> List[ReadItem]:
+    if isinstance(md, BytesStorageMetadata):
+        return [_create_read_item_for_byteio(
+            dest_index=MetadataIndex(fqn),
+            dest_offset=0,
+            storage_index=MetadataIndex(fqn),
+            storage_offset=0,
+            length=0
+        )]
+    elif isinstance(obj, ShardedTensor):
+        local_shards = obj.local_shards()
+    elif isinstance(obj, torch.Tensor):
+        local_shards = [_create_shard_from_tensor(obj)]
+    else:
+        raise ValueError(
+            f"Invalid checkpoint metadata for {fqn}, " +
+            f"expected BytesStorageMetadata but found {type(md)}"
+        )
+
+    return _create_sharded_read_items(
+        fqn,
+        md,
+        local_shards)
+
+def create_default_local_load_plan(
+    state_dict: Dict[str, Any],
+    metadata: Metadata,
+) -> LoadPlan:
+    requests = []
+
+    """
+    Use the loaded metadata and the current state dict to map the saved tensors to current tensor
+    """
+    for fqn, obj in state_dict.items():
+        md = metadata.state_dict_metadata[fqn]
+        requests += create_read_items(fqn, md, obj)
+
+    return LoadPlan(requests)
+
+def create_default_global_load_plan(all_plans: List[LoadPlan]) -> List[LoadPlan]:
+    return all_plans
+
+def create_default_local_save_plan(state_dict: Dict[str, Any], is_coordinator: bool):
+    requests = []
+    for fqn, obj in state_dict.items():
+        if isinstance(obj, ShardedTensor) or is_coordinator:
+            requests += create_write_items(fqn, obj)
+    return SavePlan(requests)
+
+def create_default_global_save_plan(all_plans: List[SavePlan]) -> Tuple[List[SavePlan], Metadata]:
+    md: Dict[str, STORAGE_TYPES] = dict()
+    new_plans = []
+    for plan in all_plans:
+        new_items = []
+        for item in plan.items:
+            if not item.type == WriteItemType.SHARD:
+                assert item.index.fqn not in md
+
+            if item.type == WriteItemType.BYTE_IO:
+                md[item.index.fqn] = BytesStorageMetadata()
+                new_items.append(item)
+            else:
+                assert item.tensor_data is not None
+                tensor_md = cast(
+                    TensorStorageMetadata,
+                    md.setdefault(item.index.fqn, TensorStorageMetadata(
+                        properties=item.tensor_data.properties,
+                        size=item.tensor_data.size,
+                        chunks=[],
+                    ))
+                )
+                new_index = dataclasses.replace(item.index, index=len(tensor_md.chunks))
+                new_item = dataclasses.replace(item, index=new_index)
+                new_items.append(new_item)
+
+                assert item.tensor_data.chunk is not None, f"Cannot create MD for tensor without bounds. FQN: {item.index.fqn}"
+                tensor_md.chunks.append(item.tensor_data.chunk)
+        new_plans.append(dataclasses.replace(plan, items=new_items))
+    return (new_plans, Metadata(md))

--- a/torch/distributed/_shard/checkpoint/default_planner.py
+++ b/torch/distributed/_shard/checkpoint/default_planner.py
@@ -13,12 +13,6 @@ from torch.distributed._shard.sharded_tensor.shard import Shard
 from torch.distributed._shard.sharding_spec._internals import (
     _check_shard_metadata_pair_overlap,
 )
-from .resharding import (
-    create_default_local_save_plan,
-    create_default_global_save_plan,
-    create_default_local_load_plan,
-    create_default_global_load_plan,
-)
 
 from .planner import (
     LoadItemType,

--- a/torch/distributed/_shard/checkpoint/metadata.py
+++ b/torch/distributed/_shard/checkpoint/metadata.py
@@ -34,6 +34,7 @@ STATE_DICT_TYPE = Dict[str, Any]
 class Metadata:
     # Keys are the same from the `state_dict` used.
     state_dict_metadata: Dict[str, STORAGE_TYPES]
+    planner_data: Any = None
     storage_data: Any = None
 
 @dataclass

--- a/torch/distributed/_shard/checkpoint/planner.py
+++ b/torch/distributed/_shard/checkpoint/planner.py
@@ -1,0 +1,206 @@
+import abc
+from dataclasses import dataclass
+import io
+from typing import List, Tuple, Any, Union, Optional
+
+from enum import Enum, auto
+import torch
+
+from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
+
+from .metadata import (
+    ChunkStorageMetadata,
+    MetadataIndex,
+    Metadata,
+    STATE_DICT_TYPE
+)
+
+class WriteItemType(Enum):
+    TENSOR = auto()
+    SHARD = auto()
+    BYTE_IO = auto()
+
+class LoadItemType(Enum):
+    TENSOR = auto()
+    BYTE_IO = auto()
+
+@dataclass(frozen=True)
+class TensorWriteData:
+    chunk: ChunkStorageMetadata
+    properties: TensorProperties
+    size: torch.Size
+
+@dataclass(frozen=True)
+class WriteItem:
+    index: MetadataIndex
+    type: WriteItemType
+
+    # Value present if it's a tensor write
+    tensor_data: Optional[TensorWriteData] = None
+
+@dataclass(frozen=True)
+class ReadItem:
+    # Read Item
+    type: LoadItemType
+
+    # Index into the state_dict
+    dest_index: MetadataIndex
+    # Offsets into destination tensor
+    dest_offsets: torch.Size
+
+    # Index into the checkpoint
+    storage_index: MetadataIndex
+    # Offset into the checkpoint data
+    storage_offsets: torch.Size
+
+    # Size of the hypercube to copy
+    lengths: torch.Size
+
+@dataclass(frozen=True)
+class SavePlan:
+    items: List[WriteItem]
+    storage_data: Any = None
+    planner_data: Any = None
+
+@dataclass
+class LoadPlan:
+    items: List[ReadItem]
+    storage_data: Any = None
+    planner_data: Any = None
+
+class SavePlanner(abc.ABC):
+    """
+    Abstract class defining the protocol used by save_state_dict to plan the save process.
+    """
+
+    @abc.abstractmethod
+    def init(self, state_dict: STATE_DICT_TYPE, is_coordinator: bool) -> None:
+        """
+        Intialize this planner to save ``state_dict``.
+
+        This is called on all ranks.
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_local_plan(self) -> SavePlan:
+        """
+        Compute the save plan for the current rank.
+        This will be aggregated and passed to create_global_plan.
+        Planner specific data can be passed through SavePlan::planner_data.
+
+        This is called on all ranks.
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_global_plan(self, all_plans: List[SavePlan]) -> Tuple[List[SavePlan], Metadata]:
+        """
+        Compute the global checkpoint plan and return the local plan of each rank.
+
+        This is called on the coordinator rank only.
+        """
+        pass
+
+    @abc.abstractmethod
+    def finish_plan(self, new_plan: SavePlan) -> SavePlan:
+        """
+        Merge the plan created by `create_local_plan` and the result of `create_global_plan`.
+
+        This is called on all ranks.
+        """
+        pass
+
+    @abc.abstractmethod
+    def resolve_data(self, write_item: WriteItem) -> Union[torch.Tensor, io.BytesIO]:
+        """
+        Lookup the object associated with ``write_item``in `state_dict` and apply any
+        transformation (such as serialization) prior to the storage layer consuming it.
+
+        Called on each rank multiple times, at least once per WriteItem in the final SavePlan.
+
+        This method should be idepotent and thread-save. StorageWriter implementations
+        are free to call it as frequently as they need.
+
+        Any transformation that allocates memory should be lazily done when his method
+        is called in order to reduce peak memory required by checkpointing.
+
+        When returning tensors, they can be on any device or format, they can be views too.
+        It's the storage layer responsiblity to figure out how to save them.
+        """
+        pass
+
+class LoadPlanner:
+    """
+    Abstract class defining the protocol used by load_state_dict to plan the load process.
+
+    """
+    @abc.abstractmethod
+    def init(self, state_dict: STATE_DICT_TYPE, metadata: Metadata, is_coordinator: bool) -> None:
+        """
+        Initialize this instance to load data into ``state_dict``
+
+        . N.B. This is called on every rank.
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_local_plan(self) -> LoadPlan:
+        """
+        Create a LoadPlan based on state_dict and metadata provided by init.
+
+        . N.B. This is called on every rank.
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_global_plan(self, globla_plan: List[LoadPlan]) -> List[LoadPlan]:
+        """
+        Compute the global load plan and return plans for each rank.
+
+        . N.B. This is called on the coordinator rank only
+        """
+        pass
+
+    @abc.abstractmethod
+    def finish_plan(self, central_plan: LoadPlan) -> LoadPlan:
+        """
+        Accept the plan from coordinator and return final LoadPlan.
+        """
+        pass
+
+    @abc.abstractmethod
+    def load_bytes(self, read_item: ReadItem, value: io.BytesIO) -> None:
+        """
+        Load the item described by ``read_item``and ``value``.
+
+        This method is expected to modify in-place the underlying state_dict.
+
+        The contents of ``value`` are defined by the SavePlanner used to produce
+        the checkpoint being loaded.
+        """
+        pass
+
+    @abc.abstractmethod
+    def resolve_tensor(self, read_item: ReadItem) -> torch.Tensor:
+        """
+        Return the tensor described by ``read_item`` to be used by the StorageReader to load `read_item`.
+
+        The tensor should alias with one on the underlying state_dict as StorageReader will replace its contents.
+        If, for any reason, that's not possible, the planner can use the ``commit_tensor`` method to copy the data
+        back to the one in state_dict.
+        """
+        pass
+
+    @abc.abstractmethod
+    def commit_tensor(self, read_item: ReadItem, tensor: torch.Tensor) -> None:
+        """
+        This method is called once the StorageReader finished loading data into ``tensor``.
+
+        The provided tensor is the same one returned by the call to ``resolve_tensor``.
+        This method is only needed if this LoadPlanner needs to post process ``tensor`` prior to
+        copying it back to the one in the state_dict.
+
+        The contents of tensor will follow its device synchronization model.
+        """
+        pass

--- a/torch/distributed/_shard/checkpoint/planner_helpers.py
+++ b/torch/distributed/_shard/checkpoint/planner_helpers.py
@@ -1,0 +1,199 @@
+from typing import List, Dict, Any, cast
+
+import torch
+
+from torch.distributed._shard._utils import narrow_tensor_by_index
+from torch.distributed._shard.metadata import ShardMetadata
+from torch.distributed._shard.sharded_tensor import ShardedTensor
+from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
+from torch.distributed._shard.sharded_tensor.shard import Shard
+
+from torch.distributed._shard.sharding_spec._internals import (
+    _check_shard_metadata_pair_overlap,
+)
+
+from .planner import (
+    LoadItemType,
+    SavePlan,
+    ReadItem,
+    WriteItem,
+    WriteItemType,
+    TensorWriteData,
+)
+
+from .metadata import (
+    BytesStorageMetadata,
+    ChunkStorageMetadata,
+    TensorStorageMetadata,
+    MetadataIndex,
+    STATE_DICT_TYPE,
+    STORAGE_TYPES
+)
+
+from .resharding import (
+    _shards_get_overlap_region_wrt_saved_tensor
+)
+
+def _create_shard_metadata(size: torch.Size) -> ShardMetadata:
+    return ShardMetadata(
+        shard_offsets=[0] * len(size),
+        shard_sizes=list(size),
+    )
+
+def _create_shard_from_tensor(tensor: torch.Tensor) -> Shard:
+    return Shard(
+        tensor=tensor,
+        metadata=_create_shard_metadata(tensor.size())
+    )
+
+def _chunk_for_shard(shard_md: ShardMetadata) -> ChunkStorageMetadata:
+    return ChunkStorageMetadata(
+        offsets=torch.Size(shard_md.shard_offsets),
+        sizes=torch.Size(shard_md.shard_sizes)
+    )
+
+def _sharded_tensor_metadata(sharded_tensor: ShardedTensor, shard_md: ShardMetadata) -> TensorWriteData:
+    return TensorWriteData(
+        chunk=_chunk_for_shard(shard_md),
+        properties=sharded_tensor.metadata().tensor_properties,
+        size=sharded_tensor.metadata().size,
+    )
+
+def _create_write_item_for_shard(fqn: str, sharded_tensor: ShardedTensor, shard_md: ShardMetadata) -> WriteItem:
+    offsets = torch.Size(shard_md.shard_offsets)
+    return WriteItem(
+        index=MetadataIndex(fqn, offsets),
+        type=WriteItemType.SHARD,
+        tensor_data=_sharded_tensor_metadata(sharded_tensor, shard_md),
+    )
+
+def _create_write_item_for_tensor(fqn: str, tensor: torch.Tensor) -> WriteItem:
+    offsets = torch.Size([0] * len(tensor.size()))
+    return WriteItem(
+        index=MetadataIndex(fqn, offsets),
+        type=WriteItemType.TENSOR,
+        tensor_data=TensorWriteData(
+            chunk=ChunkStorageMetadata(
+                offsets=offsets,
+                sizes=tensor.size()
+            ),
+            properties=TensorProperties.create_from_tensor(tensor),
+            size=tensor.size(),
+        )
+    )
+
+def _create_write_item_for_bytesio(fqn: str, bytes: Any):
+    return WriteItem(
+        index=MetadataIndex(fqn),
+        type=WriteItemType.BYTE_IO,
+    )
+
+def _create_read_item_for_byteio(dest_index, dest_offset, storage_index, storage_offset, length):
+    return ReadItem(
+        type=LoadItemType.BYTE_IO,
+        dest_index=dest_index,
+        dest_offsets=torch.Size((dest_offset,)),
+        storage_index=storage_index,
+        storage_offsets=torch.Size((storage_offset,)),
+        lengths=torch.Size((length,)),
+    )
+
+def _create_read_item_for_tensor(dest_index, dest_offsets, storage_index, storage_offsets, lengths):
+    return ReadItem(
+        type=LoadItemType.TENSOR,
+        dest_index=dest_index,
+        dest_offsets=torch.Size(dest_offsets),
+        storage_index=storage_index,
+        storage_offsets=torch.Size(storage_offsets),
+        lengths=torch.Size(lengths),
+    )
+
+def _create_sharded_read_items(
+    fqn: str,
+    checkpoint_md: TensorStorageMetadata,
+    local_shards: List[Shard],
+) -> List[ReadItem]:
+
+    read_items = []
+    # this is a naive quadratic algo that can be optimized later
+    for idx, shard in enumerate(local_shards):
+        for storage_idx, storage_md in enumerate(checkpoint_md.chunks):
+            shard_md_from_storage = ShardMetadata(
+                shard_sizes=list(storage_md.sizes),
+                shard_offsets=list(storage_md.offsets),
+            )
+
+            if not _check_shard_metadata_pair_overlap(
+                shard.metadata, shard_md_from_storage
+            ):
+                continue
+
+            storage_offsets = []
+            dest_offsets = []
+            lengths = []
+            for (
+                dim,
+                offset_for_saved_tensor,
+                offset_for_current_tensor,
+                length,
+            ) in _shards_get_overlap_region_wrt_saved_tensor(
+                saved_shard=shard_md_from_storage, current_shard=shard.metadata
+            ):
+                storage_offsets.append(offset_for_saved_tensor)
+                dest_offsets.append(offset_for_current_tensor)
+                lengths.append(length)
+
+            read_items.append(
+                _create_read_item_for_tensor(
+                    dest_index=MetadataIndex(fqn, shard.metadata.shard_offsets, idx),
+                    dest_offsets=dest_offsets,
+                    storage_index=MetadataIndex(fqn, storage_md.offsets, storage_idx),
+                    storage_offsets=storage_offsets,
+                    lengths=lengths,
+                )
+            )
+    return read_items
+
+def _create_default_metadata_only_plan(state_dict: STATE_DICT_TYPE) -> SavePlan:
+    requests = []
+    for fqn, obj in state_dict.items():
+        if isinstance(obj, ShardedTensor):
+            for shard_md in obj.metadata().shards_metadata:
+                requests.append(_create_write_item_for_shard(fqn, obj, shard_md))
+        elif isinstance(obj, torch.Tensor):
+            requests.append(_create_write_item_for_tensor(fqn, obj))
+        else:
+            requests.append(_create_write_item_for_bytesio(fqn, obj))
+    return SavePlan(requests)
+
+def _create_write_items(fqn: str, object: Any) -> List[WriteItem]:
+    if isinstance(object, ShardedTensor):
+        return [_create_write_item_for_shard(fqn, object, shard.metadata) for shard in object.local_shards()]
+    elif isinstance(object, torch.Tensor):
+        return [_create_write_item_for_tensor(fqn, object)]
+    else:
+        return [_create_write_item_for_bytesio(fqn, object)]
+
+def _create_read_items(fqn: str, md: STORAGE_TYPES, obj: Any) -> List[ReadItem]:
+    if isinstance(md, BytesStorageMetadata):
+        return [_create_read_item_for_byteio(
+            dest_index=MetadataIndex(fqn),
+            dest_offset=0,
+            storage_index=MetadataIndex(fqn),
+            storage_offset=0,
+            length=0
+        )]
+    elif isinstance(obj, ShardedTensor):
+        local_shards = obj.local_shards()
+    elif isinstance(obj, torch.Tensor):
+        local_shards = [_create_shard_from_tensor(obj)]
+    else:
+        raise ValueError(
+            f"Invalid checkpoint metadata for {fqn}, " +
+            f"expected BytesStorageMetadata but found {type(md)}"
+        )
+
+    return _create_sharded_read_items(
+        fqn,
+        md,
+        local_shards)

--- a/torch/distributed/_shard/checkpoint/planner_helpers.py
+++ b/torch/distributed/_shard/checkpoint/planner_helpers.py
@@ -1,8 +1,7 @@
-from typing import List, Dict, Any, cast
+from typing import List, Any
 
 import torch
 
-from torch.distributed._shard._utils import narrow_tensor_by_index
 from torch.distributed._shard.metadata import ShardMetadata
 from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._shard.sharded_tensor.metadata import TensorProperties
@@ -196,4 +195,5 @@ def _create_read_items(fqn: str, md: STORAGE_TYPES, obj: Any) -> List[ReadItem]:
     return _create_sharded_read_items(
         fqn,
         md,
-        local_shards)
+        local_shards
+    )

--- a/torch/distributed/_shard/checkpoint/utils.py
+++ b/torch/distributed/_shard/checkpoint/utils.py
@@ -272,5 +272,8 @@ def find_state_dict_object(state_dict: STATE_DICT_TYPE, index: MetadataIndex) ->
     if isinstance(obj, ShardedTensor):
         return _find_shard(obj, index).tensor
     if index.offset is not None:
-        raise ValueError(f"FQN: '{index.fqn}' is not a ShardedTensor, can't find by offset")
+        # special case looking up a tensor by origin
+        if isinstance(obj, torch.Tensor) and index.offset == torch.Size([0] * len(obj.size())):
+            return obj
+        raise ValueError(f"FQN: '{index.fqn}' is not a ShardedTensor, can't find by offset: '{index.offset}'")
     return obj


### PR DESCRIPTION
The planners come with default implementations in default_planner.py.

The default planners expose their core functionality as separate functions
to make it easy for other checkpoint implementations to use this functionality.
