### PR TITLE
[vulkan] Replace *_size() functions with get_dim<N>()

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Batchnorm.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Batchnorm.cpp
@@ -31,7 +31,7 @@ Tensor batch_norm(
       "running_var must be defined in evaluation mode.");
   TORCH_CHECK(input_arg.dim() == 4, "Vulkan batchnorm expects 4-dim input!");
   TORCH_CHECK(
-      channels_size(input_arg) % 4 == 0,
+      get_dim<Dim4D::Channel>(input_arg) % 4 == 0,
       "Vulkan batchnorm expects channel dim to be multiple of 4!");
 
   const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();

--- a/aten/src/ATen/native/vulkan/ops/Common.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Common.cpp
@@ -5,54 +5,6 @@ namespace native {
 namespace vulkan {
 namespace ops {
 
-uint32_t batch_size(const IntArrayRef sizes) {
-  const uint32_t dims = sizes.size();
-  if (dims < 4) {
-    return 1;
-  }
-  return sizes[dims - 4];
-}
-
-uint32_t batch_size(const Tensor& tensor) {
-  return batch_size(tensor.sizes());
-}
-
-uint32_t channels_size(const IntArrayRef sizes) {
-  const uint32_t dims = sizes.size();
-  if (dims < 3) {
-    return 1;
-  }
-  return sizes[dims - 3];
-}
-
-uint32_t channels_size(const Tensor& tensor) {
-  return channels_size(tensor.sizes());
-}
-
-uint32_t height_size(const IntArrayRef sizes) {
-  const uint32_t dims = sizes.size();
-  if (dims < 2) {
-    return 1;
-  }
-  return sizes[dims - 2];
-}
-
-uint32_t height_size(const Tensor& tensor) {
-  return height_size(tensor.sizes());
-}
-
-uint32_t width_size(const IntArrayRef sizes) {
-  const uint32_t dims = sizes.size();
-  if (dims < 1) {
-    return 1;
-  }
-  return sizes[dims - 1];
-}
-
-uint32_t width_size(const Tensor& tensor) {
-  return width_size(tensor.sizes());
-}
-
 api::utils::uvec3 adaptive_work_group_size(
     const api::utils::uvec3& global_work_group) {
   api::utils::uvec3 local_group_size = {4, 4, 4};

--- a/aten/src/ATen/native/vulkan/ops/Common.h
+++ b/aten/src/ATen/native/vulkan/ops/Common.h
@@ -43,17 +43,40 @@ struct Layout final {
   };
 };
 
-uint32_t batch_size(const IntArrayRef);
-uint32_t batch_size(const Tensor&);
+/*
+ * Maps a semantic dimension name to an integer that corresponds to its
+ * innermost ordering in a 4D tensor in NCHW format. Width is the innermost
+ * dimension, so it corresponds to 1, height is the next innermost, so it
+ * corresponds to 2, and so on.
+ */
+struct Dim4D {
+  static constexpr uint32_t Width = 1u;
+  static constexpr uint32_t Height = 2u;
+  static constexpr uint32_t Channel = 3u;
+  static constexpr uint32_t Batch = 4u;
+};
 
-uint32_t channels_size(const IntArrayRef);
-uint32_t channels_size(const Tensor&);
+/*
+ * The functions below safely return the size of the dimension at the N-th
+ * innermost index. If the dimensionality of the size array is not sufficient
+ * then 1 will be returned. The structs above are intended to be used with
+ * these functions.
+ */
+template <uint32_t N>
+uint32_t get_dim(const IntArrayRef sizes) {
+  const uint32_t dims = sizes.size();
+  return dims < N ? 1 : sizes[dims - N];
+}
 
-uint32_t height_size(const IntArrayRef);
-uint32_t height_size(const Tensor&);
+template <uint32_t N>
+uint32_t get_dim(const Tensor& t_in) {
+  return get_dim<N>(t_in.sizes());
+}
 
-uint32_t width_size(const IntArrayRef);
-uint32_t width_size(const Tensor&);
+template <uint32_t N>
+uint32_t get_dim(const vTensor& v_in) {
+  return get_dim<N>(v_in.sizes());
+}
 
 api::utils::uvec3 adaptive_work_group_size(
     const api::utils::uvec3& global_work_group);

--- a/aten/src/ATen/native/vulkan/ops/Glu.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Glu.cpp
@@ -16,7 +16,7 @@ Tensor glu(const at::Tensor& input_arg, const int64_t dim = -1) {
       "Vulkan glu only supports GLU for dim = 1, but got dim = ",
       dim);
   TORCH_CHECK(
-      channels_size(input_arg) % 2 == 0,
+      get_dim<Dim4D::Channel>(input_arg) % 2 == 0,
       "Vulkan glu expects channel dim to be multiple of 2!");
 
   const Tensor input = input_arg.is_vulkan() ? input_arg : input_arg.vulkan();

--- a/aten/src/ATen/native/vulkan/ops/Lerp.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Lerp.cpp
@@ -11,18 +11,18 @@ using namespace api::utils;
 
 void check_inputs_elementwise_op(const Tensor& input1, const Tensor& input2) {
   TORCH_CHECK(
-      channels_size(input1) == channels_size(input2),
+      get_dim<Dim4D::Channel>(input1) == get_dim<Dim4D::Channel>(input2),
       "Vulkan elementwise ops require channel dimension to be equal!");
-  if (batch_size(input1) != batch_size(input2)) {
+  if (get_dim<Dim4D::Batch>(input1) != get_dim<Dim4D::Batch>(input2)) {
     TORCH_CHECK(
-        channels_size(input1) % 4 == 0,
+        get_dim<Dim4D::Channel>(input1) % 4 == 0,
         "Vulkan elementwise ops require channel to be a multiple of 4 to broadcast along batch dimension!")
   }
 
-  const uint32_t input1_h = height_size(input1);
-  const uint32_t input1_w = width_size(input1);
-  const uint32_t input2_h = height_size(input2);
-  const uint32_t input2_w = width_size(input2);
+  const uint32_t input1_h = get_dim<Dim4D::Height>(input1);
+  const uint32_t input1_w = get_dim<Dim4D::Width>(input1);
+  const uint32_t input2_h = get_dim<Dim4D::Height>(input2);
+  const uint32_t input2_w = get_dim<Dim4D::Width>(input2);
 
   const std::string broadcast_error_msg =
       "Incompatible input dimensions for broadcasting for Vulkan elementwise op!";

--- a/aten/src/ATen/native/vulkan/ops/Utils.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Utils.cpp
@@ -32,10 +32,10 @@ namespace utils {
  *    tensor would be {NC_aligned/4, H, W, 4}
  */
 Tensor nchw_to_nc4hw(const Tensor& src) {
-  uint32_t N = batch_size(src.sizes());
-  uint32_t C = channels_size(src.sizes());
-  uint32_t H = height_size(src.sizes());
-  uint32_t W = width_size(src.sizes());
+  uint32_t N = get_dim<Dim4D::Batch>(src.sizes());
+  uint32_t C = get_dim<Dim4D::Channel>(src.sizes());
+  uint32_t H = get_dim<Dim4D::Height>(src.sizes());
+  uint32_t W = get_dim<Dim4D::Width>(src.sizes());
 
   uint32_t NC4 = api::utils::div_up(N * C, 4u);
   uint32_t NC_aligned = api::utils::align_up(N * C, 4u);
@@ -57,10 +57,10 @@ Tensor nchw_to_nc4hw(const Tensor& src) {
  * same as the tensor produced by a call to format_src_tensor().
  */
 Tensor create_staging_tensor(const vTensor& v_in) {
-  uint32_t N = batch_size(v_in.sizes());
-  uint32_t C = channels_size(v_in.sizes());
-  uint32_t H = height_size(v_in.sizes());
-  uint32_t W = width_size(v_in.sizes());
+  uint32_t N = get_dim<Dim4D::Batch>(v_in.sizes());
+  uint32_t C = get_dim<Dim4D::Channel>(v_in.sizes());
+  uint32_t H = get_dim<Dim4D::Height>(v_in.sizes());
+  uint32_t W = get_dim<Dim4D::Width>(v_in.sizes());
 
   uint32_t NC4 = api::utils::div_up(N * C, 4u);
 
@@ -82,10 +82,10 @@ Tensor create_staging_tensor(const vTensor& v_in) {
  * the properties of the original tensor.
  */
 Tensor nc4hw_to_nchw(const Tensor& t_in, IntArrayRef sizes) {
-  uint32_t N = batch_size(sizes);
-  uint32_t C = channels_size(sizes);
-  uint32_t H = height_size(sizes);
-  uint32_t W = width_size(sizes);
+  uint32_t N = get_dim<Dim4D::Batch>(sizes);
+  uint32_t C = get_dim<Dim4D::Channel>(sizes);
+  uint32_t H = get_dim<Dim4D::Height>(sizes);
+  uint32_t W = get_dim<Dim4D::Width>(sizes);
 
   uint32_t NC_aligned = api::utils::align_up(N * C, 4u);
 

--- a/aten/src/ATen/native/vulkan/ops/cumsum.cpp
+++ b/aten/src/ATen/native/vulkan/ops/cumsum.cpp
@@ -18,7 +18,8 @@ Tensor cumsum(
       input_arg.dim() <= 4, "Vulkan cumsum expects input dimension <= 4!");
 
   TORCH_CHECK(
-      batch_size(input_arg) == 1, "Vulkan cumsum expects batch size <= 1!");
+      get_dim<Dim4D::Batch>(input_arg) == 1,
+      "Vulkan cumsum expects batch size <= 1!");
 
   TORCH_CHECK(dim < 4, "Vulkan cumsum expects dim < 4!");
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83423

This diff replaces the `batch_size`, `channels_size`, etc. functions with a template function `get_dim<N>` to reduce duplicate code.

`batch_size()` has been replaced with `get_dim<Dim4D::Batch>` and so on.

Differential Revision: [D38706526](https://our.internmc.facebook.com/intern/diff/D38706526/)