### PR TITLE
[FSDP] Prepare for non-recursive wrapping

### DIFF
--- a/test/distributed/fsdp/test_fsdp_comm.py
+++ b/test/distributed/fsdp/test_fsdp_comm.py
@@ -147,11 +147,6 @@ class TestCommunication(FSDPTest):
                 f"is_first_iter={is_first_iter} " \
                 f"is_last_iter_no_sync={is_last_iter_no_sync} " \
                 f"sharding_strategy={sharding_strategy}"
-        if is_first_iter and pass_type == PassType.FWD:
-            # With execution order validation, on the first iteration, we have
-            # an additional all-gather before every actual all-gather in the
-            # forward pass
-            num_all_gathers *= 2
         return num_all_gathers
 
     def _print_ref_num_all_gathers_in_pass(

--- a/test/distributed/fsdp/test_fsdp_exec_order.py
+++ b/test/distributed/fsdp/test_fsdp_exec_order.py
@@ -11,10 +11,10 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import ShardingStrategy
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTest
 from torch.testing._internal.common_utils import (
-    TEST_WITH_DEV_DBG_ASAN,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
 )
 
 if not dist.is_available():
@@ -36,6 +36,7 @@ class Model(torch.nn.Module):
     when flattened, which means that their corresponding all-gathers and
     reduce-scatters may be silently matched if we do not perform any checks.
     """
+
     def __init__(self) -> None:
         super().__init__()
         self.layer0 = torch.nn.Linear(5, 6)
@@ -54,8 +55,11 @@ class Model(torch.nn.Module):
         # `layer0` -> `layer1` (normal)
         # `layer0` -> `layer2` (alternate)
         z = self.relu(self.layer0(x))
-        z = self.relu(self.layer2(z)) if self.use_alt_path \
+        z = (
+            self.relu(self.layer2(z))
+            if self.use_alt_path
             else self.relu(self.layer1(z))
+        )
         return z
 
     def get_input(self, device: torch.device):
@@ -68,10 +72,12 @@ class Model(torch.nn.Module):
         loss.backward()
 
     def flip_path(self):
-        params_to_freeze = self.layer2.parameters() if self.use_alt_path \
-            else self.layer1.parameters()
-        params_to_unfreeze = self.layer1.parameters() if self.use_alt_path \
-            else self.layer2.parameters()
+        params_to_freeze = (
+            self.layer2.parameters() if self.use_alt_path else self.layer1.parameters()
+        )
+        params_to_unfreeze = (
+            self.layer1.parameters() if self.use_alt_path else self.layer2.parameters()
+        )
         for param in params_to_freeze:
             param.requires_grad = False
         for param in params_to_unfreeze:
@@ -103,6 +109,7 @@ class TestFSDPExecOrder(FSDPTest):
     ):
         """Tests that FSDP errors if the all-gather order differs across ranks
         in the first iteration."""
+        dist.set_debug_level(dist.DebugLevel.INFO)
         # Rank 0 runs the forward pass in one order and all other ranks run in
         # different order
         fsdp_model = Model.wrap(sharding_strategy, self.device)
@@ -127,6 +134,7 @@ class TestFSDPExecOrder(FSDPTest):
     ):
         """Tests that FSDP warns the user if the all-gather order changes after
         the first iteration."""
+        dist.set_debug_level(dist.DebugLevel.INFO)
         # On the first iteration, all ranks run the same order, and on the next
         # iteration, all but rank 0 run in a different order
         fsdp_model = Model.wrap(sharding_strategy, self.device)
@@ -136,12 +144,19 @@ class TestFSDPExecOrder(FSDPTest):
             loss = fsdp_model.module.get_loss(inp, output).to(self.device)
             fsdp_model.module.run_backward(loss)
         # Match the warning message with the following prefix
-        regex = "^(Forward order differs from that of the first iteration " \
-            f"on rank {self.rank} -- collectives are unchecked and may give " \
+        regex = (
+            "^(Forward order differs from that of the first iteration "
+            f"on rank {self.rank}. Collectives are unchecked and may give "
             "incorrect results or hang)"
-        context = self.assertWarnsRegex(
-            expected_warning=UserWarning, expected_regex=regex,
-        ) if self.rank != 0 else suppress()
+        )
+        context = (
+            self.assertWarnsRegex(
+                expected_warning=UserWarning,
+                expected_regex=regex,
+            )
+            if self.rank != 0
+            else suppress()
+        )
         if self.rank != 0:
             fsdp_model.flip_path()
         inp = fsdp_model.module.get_input(self.device)
@@ -162,6 +177,7 @@ class TestFSDPExecOrder(FSDPTest):
         [ShardingStrategy.FULL_SHARD, ShardingStrategy.SHARD_GRAD_OP],
     )
     def test_train_eval(self, sharding_strategy: ShardingStrategy):
+        dist.set_debug_level(dist.DebugLevel.INFO)
         fsdp_model = Model.wrap(sharding_strategy, self.device)
         NUM_ITERS = 3
         NUM_EPOCHS = 2
@@ -183,7 +199,9 @@ class TestFSDPExecOrder(FSDPTest):
         warning_prefix = "Forward order differs"
         for warning in w:
             if str(warning.message).startswith(warning_prefix):
-                raise AssertionError(f"Warning was incorrectly issued: {warning.message}")
+                raise AssertionError(
+                    f"Warning was incorrectly issued: {warning.message}"
+                )
         # If we still validate the forward execution order in eval mode, then
         # an `AssertionError` will be raised above for both sharding strategies
 

--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -170,7 +170,7 @@ class TestFSDPIgnoredModules(FSDPTest):
             expected_warning=UserWarning,
             expected_regex="Trying to ignore the top-level module passed into "
             "the FSDP constructor itself will result in all parameters being "
-            "ignored and is not supported",
+            "ignored",
         ):
             FSDP(model, ignored_modules=[model])
 

--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -148,7 +148,7 @@ class TestFSDPMisc(FSDPTest):
         )
         for fsdp_module in FSDP.fsdp_modules(fsdp_model):
             self.assertEqual(
-                fsdp_module.device_id,
+                fsdp_module.compute_device,
                 torch.device("cuda", torch.cuda.current_device()),
             )
 
@@ -236,7 +236,7 @@ class TestFSDPMisc(FSDPTest):
         )
         _check_device_matches(nested_wrapped_module, dev_id)
         # Check that passing in `torch.device("cuda")` for a GPU module warns
-        regex = "does not have explicit index"
+        regex = "does not have an explicit index"
         context = self.assertWarnsRegex(
             expected_warning=UserWarning, expected_regex=regex
         )
@@ -258,8 +258,8 @@ class TestFSDPMisc(FSDPTest):
         module that does not match the GPU device ID raises an error."""
         context = (
             self.assertRaisesRegex(
-                RuntimeError,
-                f"on rank {self.rank}.*cuda:0, but is on cuda:{self.rank}"
+                AssertionError,
+                f"cuda:{self.rank} vs cuda:0"
             ) if self.rank != 0 else suppress()
         )
         with context:

--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -175,9 +175,13 @@ class LinearMixedPrecision(nn.Module):
                 # local shard. This supports both FULL_SHARD and SHARD_GRAD_OP
                 # cases. In FULL_SHARD, we have the additional property that
                 # param._full_param_padded has not been freed.
+                param_is_sharded = (
+                    fsdp_module.sharding_strategy != ShardingStrategy.NO_SHARD
+                    and fsdp_module.world_size > 1
+                )
                 is_fsdp_unit_active = (
-                    param._is_sharded and
-                    (param.data.data_ptr() != param._local_shard.data_ptr())
+                    param_is_sharded
+                    and param.data.data_ptr() != param._local_shard.data_ptr()
                 )
                 if is_fsdp_unit_active:
                     num_active_fsdp += 1
@@ -190,7 +194,7 @@ class LinearMixedPrecision(nn.Module):
                         cls.assertEqual(0, param._mp_shard.storage().size())
                     else:
                         cls.assertFalse(hasattr(param, '_mp_shard'))
-                elif param._is_sharded:
+                elif param_is_sharded:
                     # This FSDP unit is not active as full param has been
                     # freed or not yet allocated. Ensure param points to full
                     # precision param.
@@ -342,15 +346,11 @@ class TestFSDPMixedPrecision(FSDPTest):
                         else:
                             self.assertEqual(buf.dtype, _BUFFER_ORIG_DTYPE)
                     # p._mp_shard should be freed.
-                    if model.params[0]._is_sharded:  # i.e. world_size > 1
-                        # TODO: free the mixed precision shard after forward
-                        # when world_size == 1 as well, currently when
-                        # world_size == 1 it is only freed after backward.
-                        if mp_config.param_dtype is not None:
-                            self._validate_mp_shard_freed(model)
-                        else:
-                            # We never should have allocated an _mp_shard.
-                            self._validate_no_mp_shard(model)
+                    if mp_config.param_dtype is not None:
+                        self._validate_mp_shard_freed(model)
+                    else:
+                        # We never should have allocated an _mp_shard.
+                        self._validate_no_mp_shard(model)
 
                     loss = act.sum()
                     loss = scaler.scale(loss)
@@ -614,7 +614,7 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
         )
         with self.assertWarnsRegex(
             expected_warning=UserWarning,
-            expected_regex="BatchNorm units will be wrapped as a separate"
+            expected_regex="batch norm submodules will be wrapped as separate"
         ):
             model = FSDP(
                 net,
@@ -627,8 +627,9 @@ class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
         # policy should not have wrapped any other submodules
         self.assertFalse(isinstance(model.fc1, FSDP))
         self.assertFalse(isinstance(model.fc2, FSDP))
-        self.assertEqual(None, bn.mixed_precision)
-        self.assertNotEqual(None, model.mixed_precision)
+        no_mixed_precision = MixedPrecision(None, None, None)
+        self.assertEqual(no_mixed_precision, bn.mixed_precision)
+        self.assertNotEqual(no_mixed_precision, model.mixed_precision)
 
         inp = torch.randn((1, 2), device='cuda')
         # Without FSDP BN mixed precision fix, this would result in

--- a/test/distributed/fsdp/test_fsdp_summon_full_params.py
+++ b/test/distributed/fsdp/test_fsdp_summon_full_params.py
@@ -85,7 +85,7 @@ class TestSummonFullParamsNoShard(FSDPTest):
     def test_summon_full_param_writeback(
         self, writeback, modify_outer, mixed_precision
     ):
-        mixed_precision = MixedPrecision() if mixed_precision else None
+        mixed_precision = MixedPrecision(torch.float16, None, None) if mixed_precision else None
         return _run_test_summon_full_param_writeback(
             self,
             writeback,
@@ -118,7 +118,7 @@ class TestSummonFullParams(FSDPTest):
     def test_summon_full_param_writeback(
         self, writeback, cpu_offload, mixed_precision, modify_outer
     ):
-        mixed_precision = MixedPrecision() if mixed_precision else None
+        mixed_precision = MixedPrecision(torch.float16, None, None) if mixed_precision else None
         return _run_test_summon_full_param_writeback(
             self,
             writeback,
@@ -130,7 +130,7 @@ class TestSummonFullParams(FSDPTest):
     @skip_if_lt_x_gpu(2)
     @parametrize("mixed_precision", [True, False])
     def test_summon_full_param_shard_value(self, mixed_precision):
-        mixed_precision = MixedPrecision() if mixed_precision else None
+        mixed_precision = MixedPrecision(torch.float16, None, None) if mixed_precision else None
         raw_model = nn.Linear(10, 11)
         raw_model_size = self.get_model_param_count(raw_model)
         expected_shard_size = self.get_expected_sharded_size(raw_model_size)
@@ -160,7 +160,7 @@ class TestSummonFullParams(FSDPTest):
     @parametrize("summon_outer", [True, False])
     @parametrize("mixed_precision", [True, False])
     def test_summon_full_param_recursive(self, recurse, summon_outer, mixed_precision):
-        mixed_precision = MixedPrecision() if mixed_precision else None
+        mixed_precision = MixedPrecision(torch.float16, None, None) if mixed_precision else None
         model = FSDP(
             nn.Sequential(
                 FSDP(nn.Linear(5, 5, bias=False), mixed_precision=mixed_precision),
@@ -234,7 +234,7 @@ class TestSummonFullParams(FSDPTest):
     @skip_if_lt_x_gpu(2)
     @parametrize("mixed_precision", [True, False])
     def test_summon_full_params_respects_reshard_after_forward(self, mixed_precision):
-        mixed_precision = MixedPrecision() if mixed_precision else None
+        mixed_precision = MixedPrecision(torch.float16, None, None) if mixed_precision else None
         model = FSDP(
             nn.Sequential(
                 FSDP(nn.Linear(5, 5, bias=False), mixed_precision=mixed_precision),
@@ -363,7 +363,7 @@ class TestSummonFullParams(FSDPTest):
     def test_reshard_outside_forward_backward_iteration(
         self, rank0_only, offload_to_cpu, mixed_precision
     ):
-        mixed_precision = MixedPrecision() if mixed_precision else None
+        mixed_precision = MixedPrecision(torch.float16, None, None) if mixed_precision else None
         model = FSDP(
             nn.Sequential(
                 FSDP(nn.Linear(5, 5, bias=False), mixed_precision=mixed_precision),
@@ -429,7 +429,7 @@ class TestSummonFullParams(FSDPTest):
     def test_params_are_unflattenned(self, rank0_only, offload_to_cpu, mixed_precision):
         layer_shape = (10, 12)
         model = nn.Linear(*layer_shape, bias=False).cuda(self.rank)
-        mixed_precision = MixedPrecision() if mixed_precision else None
+        mixed_precision = MixedPrecision(torch.float16, None, None) if mixed_precision else None
         fsdp_model = FSDP(deepcopy(model), mixed_precision=mixed_precision).cuda(
             self.rank
         )
@@ -478,7 +478,7 @@ class TestSummonFullParams(FSDPTest):
         offload_to_cpu: bool,
         mixed_precision: bool,
     ):
-        mixed_precision = MixedPrecision() if mixed_precision else None
+        mixed_precision = MixedPrecision(torch.float16, None, None) if mixed_precision else None
         model = NestedWrappedModule.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,

--- a/test/distributed/fsdp/test_wrap.py
+++ b/test/distributed/fsdp/test_wrap.py
@@ -235,7 +235,6 @@ class TestFSDPWrap(FSDPTest):
         [CUDAInitMode.CUDA_AFTER, CUDAInitMode.CUDA_BEFORE]
     )
     def test_main_wrap_api(self, cpu_offload, backward_prefetch, forward_prefetch, cuda_init_mode):
-
         if cuda_init_mode == CUDAInitMode.CUDA_AFTER and cpu_offload.offload_params:
             # they don't work together, expected
             return
@@ -298,14 +297,6 @@ class TestFSDPWrap(FSDPTest):
             loss = wrapped_model(inp).sum()
             loss.backward()
             optim.step()
-
-        # Since we ran with backward prefetch, verify backward prefetch related
-        # data.
-        for i, module in enumerate(modules_in_fsdp_graph_order):
-            self.assertEqual(i, module._my_fsdp_idx_in_graph)
-            self.assertTrue(
-                module._fsdp_graph_order == modules_in_fsdp_graph_order
-            )
 
 
 class TestAutoWrap(TestCase):

--- a/torch/distributed/fsdp/_utils.py
+++ b/torch/distributed/fsdp/_utils.py
@@ -1,11 +1,13 @@
+import traceback
 from collections import OrderedDict
 import dataclasses
 from typing import Any, Callable, Dict, List, Set, Tuple, Union
 
 import torch
 from torch.nn.modules.batchnorm import _BatchNorm
-from torch.nn.parallel.scatter_gather import _is_namedtuple  # type: ignore[attr-defined]
-
+from torch.nn.parallel.scatter_gather import (  # type: ignore[attr-defined]
+    _is_namedtuple,
+)
 from torch.nn.utils.rnn import PackedSequence
 
 """Useful functions to deal with tensor types with other python container types."""
@@ -78,3 +80,11 @@ def _apply_to_modules(
 
     f(root_module, "", *args, **kwargs)
     return return_fn(*args, **kwargs)
+
+def p_assert(cond: Any, s: Any) -> None:
+    """This is used as an alternate to ``assert`` when in the backward context
+    to print the error message ``s`` since otherwise, it is swallowed."""
+    if not cond:
+        print(s)
+        traceback.print_stack()
+        raise AssertionError

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -639,6 +639,9 @@ class FlatParamHandle:
         """
         if not self.needs_unshard():
             if self._uses_sharded_strategy:
+                # The handle may have been resharded without freeing the padded
+                # unsharded flattened parameter, in which case we need to
+                # switch to using the unsharded parameter
                 unsharded_flat_param = self._get_padded_unsharded_flat_param()
                 self._use_unsharded_flat_param(unsharded_flat_param)
             return

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -389,7 +389,7 @@ class FlatParamHandle:
         now, we decouple ``FlattenParamsWrapper` from a process group, but this
         makes the process-group-related attributes not necessarily defined.
         """
-        if not self._uses_sharded_strategy:
+        if not self.uses_sharded_strategy:
             return
         flat_param = self.flat_param
         self.process_group = process_group
@@ -597,7 +597,7 @@ class FlatParamHandle:
             communication and is what should be all-gathered. This means that
             it matches the dtype of the expected unsharded parameter.
         """
-        if self._uses_sharded_strategy and not self.needs_unshard():
+        if self.uses_sharded_strategy and not self.needs_unshard():
             # Do not prepare the sharded flattened parameter for an all-gather
             # if the handle does not need to be unsharded
             return
@@ -638,7 +638,7 @@ class FlatParamHandle:
         mixed precision, then the parameter is forced to full precision.
         """
         if not self.needs_unshard():
-            if self._uses_sharded_strategy:
+            if self.uses_sharded_strategy:
                 # The handle may have been resharded without freeing the padded
                 # unsharded flattened parameter, in which case we need to
                 # switch to using the unsharded parameter
@@ -650,7 +650,7 @@ class FlatParamHandle:
 
     def needs_unshard(self) -> bool:
         """Returns if the handle's flattened parameter needs to be unsharded."""
-        if not self._uses_sharded_strategy:
+        if not self.uses_sharded_strategy:
             return False
         unsharded_flat_param = self._get_padded_unsharded_flat_param()
         already_unsharded = (
@@ -739,7 +739,7 @@ class FlatParamHandle:
         shard if needed and preparing the gradient for the pre-backward if
         ``prepare_gradient`` and a gradient exists.
         """
-        if self._uses_param_mixed_precision and self._uses_sharded_strategy:
+        if self._uses_param_mixed_precision and self.uses_sharded_strategy:
             self._free_low_precision_sharded_param()
         if prepare_gradient:
             p_assert(
@@ -863,7 +863,7 @@ class FlatParamHandle:
         # we delay the free until the reshard.
         if (
             self._uses_param_mixed_precision
-            and not self._uses_sharded_strategy
+            and not self.uses_sharded_strategy
             and not self._force_full_precision  # did not use the low precision shard
         ):
             self._free_low_precision_sharded_param()
@@ -1010,7 +1010,7 @@ class FlatParamHandle:
     # CHECKS & INVARIANTS #
     #######################
     def _check_sharded_strategy(self):
-        p_assert(self._uses_sharded_strategy, "Expects sharded strategy")
+        p_assert(self.uses_sharded_strategy, "Expects sharded strategy")
 
     def _check_on_compute_device(self, tensor: Tensor):
         p_assert(
@@ -1050,7 +1050,7 @@ class FlatParamHandle:
     # PROPERTIES #
     ##############
     @property
-    def _uses_sharded_strategy(self) -> bool:
+    def uses_sharded_strategy(self) -> bool:
         return self._config.sharding_strategy != HandleShardingStrategy.NO_SHARD
 
     @property

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1,6 +1,9 @@
 import contextlib
+from dataclasses import dataclass
+from enum import auto, Enum
 from itertools import accumulate, chain
 from typing import (
+    cast,
     Dict,
     Generator,
     Iterator,
@@ -14,18 +17,25 @@ from typing import (
 )
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
+from ._utils import p_assert
+
 __all__ = [
-    "FlatParameter", "FlatParamHandle", "FlatParamShardMetadata",
-    "ParamInfo", "SharedParamInfo",
+    "FlatParameter",
+    "FlatParamHandle",
+    "FlatParamShardMetadata",
+    "ParamInfo",
+    "SharedParamInfo",
 ]
 
 
 class ParamInfo(NamedTuple):
     """Information for an original module parameter."""
+
     param_name: str  # unprefixed
     module: nn.Module
     module_name: str
@@ -40,6 +50,7 @@ class SharedParamInfo(NamedTuple):
     in the parameter walk. These are prefixed with "prim". The primary module
     and parameter do not have their own :class:`SharedParamInfo` instance.
     """
+
     param_name: str  # unprefixed
     module: nn.Module
     module_name: str
@@ -64,10 +75,38 @@ class FlatParamShardMetadata(NamedTuple):
             units of numels) giving this rank's part of each flattened
             original module parameter.
     """
+
     param_names: Tuple[str, ...]
     param_shapes: Tuple[torch.Size, ...]
     param_numels: Tuple[int, ...]
     param_offsets: Tuple[Tuple[int, int], ...]
+
+
+# TODO (awgu): Prefix these with "Handle" for now to avoid circular imports and
+# inadvertent misuses; coalesce with those in fully_sharded_data_parallel.py
+# later
+class HandleShardingStrategy(Enum):
+    FULL_SHARD = auto()
+    SHARD_GRAD_OPT = (
+        auto()
+    )  # TODO (awgu): will change to `SHARD_GRAD_OP` if I have to :/
+    NO_SHARD = auto()
+
+
+class HandleTrainingState(Enum):
+    IDLE = auto()
+    FORWARD = auto()
+    PRE_BACKWARD = auto()
+    POST_BACKWARD = auto()
+    SUMMON_FULL_PARAMS = auto()  # :(
+
+
+@dataclass
+class HandleConfig:
+    sharding_strategy: HandleShardingStrategy
+    offload_params: bool = False
+    param_dtype: Optional[torch.dtype] = None
+    reduce_dtype: Optional[torch.dtype] = None
 
 
 class FlatParameter(nn.Parameter):
@@ -93,7 +132,8 @@ class FlatParameter(nn.Parameter):
     Attributes:
         _is_sharded (bool): Whether the flattened parameter is *ever* sharded
             across ranks (not whether it is *currently* sharded).
-        _unsharded_size (torch.Size): Unsharded flattened parameter's size.
+        _unsharded_size (torch.Size): Unsharded flattened parameter's size
+            (without padding).
 
         _param_infos (Tuple[ParamInfo, ...]): Each parameter's parameter info
             entry; see :class:`ParamInfo`.
@@ -123,19 +163,30 @@ class FlatParameter(nn.Parameter):
         _shard_numel_padded (int): Numel padded for this rank's sharded
             flattened parameter.
 
-        _local_shard (Tensor): Sharded flattened parameter with padding.
+        _local_shard (Tensor): Sharded flattened parameter with padding if
+            using a sharded strategy. If using ``NO_SHARD``, then this is the
+            sharded flattened parameter, padded unsharded flattened parameter,
+            and unpadded unsharded flattened parameter, altogether.
         _full_param_padded (Tensor): Unsharded flattened parameter with
-            padding.
-        _shard_bwd_hook (Tuple[AccumulateGrad, RemovableHandle]): Flattened
-            parameter's :class:`AccumulateGrad` object and post-backward hook
-            handle.
-        _mp_shard (Tensor): Reduced-precision flattened parameter with padding.
+            padding. This is not defined for ``NO_SHARD``. When using mixed
+            precision for parameters, this has the low precision.
+        _full_prec_full_param_padded (Tensor): Full precision unsharded
+            flattened parameter with padding. This is used for unsharding
+            outside of computation when using mixed precision for parameters.
+            This is never defined for ``NO_SHARD``.
+        _post_backward_hook_state (Tuple[AccumulateGrad, RemovableHandle]):
+            Flattened parameter's :class:`AccumulateGrad` object and
+            post-backward hook handle.
+        _mp_shard (Tensor): Low precision flattened parameter with padding.
+            This is only defined when parameter mixed precision is enabled. For
+            ``NO_SHARD``, this is used for computation.
         _cpu_grad (Tensor): Sharded gradient with padding stored on CPU.
+            This is only defined when offloading parameters is enabled.
         _saved_grad_shard (Tensor): Sharded gradient with padding from previous
             iterations for gradient accumulation without :meth:`no_sync`.
     """
 
-    def init_metadata(
+    def _init_metadata(
         self,
         param_infos: List[ParamInfo],
         numels: List[int],
@@ -167,13 +218,13 @@ class FlatParameter(nn.Parameter):
         self._shapes = tuple(shapes)
         self._prefixed_param_names = tuple(prefixed_param_names)
         self._shared_param_infos = tuple(shared_param_infos)
-        self._is_sharded = False
         self._unsharded_size = self.size()
 
 
 class FlatParamHandle:
     """
-    This handle manages a flattened parameter (:class:`FlatParameter`).
+    This handle manages a flattened parameter (:class:`FlatParameter`). This
+    includes sharding and view management.
 
     Args:
         params (Sequence[nn.Parameter]): The parameters to use for the
@@ -182,20 +233,33 @@ class FlatParamHandle:
             all parameters in ``params``; for non-recursive wrapping, this must
             be the top-level module, while for recursive wrapping, this may not
             necessarily be the top-level module.
+        device (torch.device): The compute and communication device, which
+            should be a non-CPU device. We refer to it as the compute device.
+        config (HandleConfig): A config customizing the handle based on FSDP's
+            available features.
     """
+
+    ##################
+    # INITIALIZATION #
+    ##################
     def __init__(
         self,
         params: Sequence[nn.Parameter],
         module: nn.Module,
+        device: torch.device,
+        config: HandleConfig,
     ) -> None:
         super().__init__()
-        self._init_flat_param(module, params)
+        self.device = device
+        self._config = config
+        self._training_state = HandleTrainingState.IDLE
+        self._init_flat_param(params, module)
         self._unflatten(as_params=False)
 
     def _init_flat_param(
         self,
-        module: nn.Module,
         params: Sequence[Optional[nn.Parameter]],
+        module: nn.Module,
     ) -> None:
         """
         Initializes the flattened parameter ``self.flat_param`` by flattening
@@ -212,8 +276,9 @@ class FlatParamHandle:
         """
         params_set = set(params)
         params_set.discard(None)
-        assert len(params_set) > 0, \
-            "Cannot initialize a `FlatParameter` from an empty parameter list"
+        assert (
+            len(params_set) > 0
+        ), "Cannot initialize a `FlatParameter` from an empty parameter list"
         param_infos: List[ParamInfo] = []
         numels: List[int] = []
         shapes: List[torch.Size] = []
@@ -228,11 +293,19 @@ class FlatParamHandle:
                 if param not in params_set:
                     continue
                 if param in shared_param_memo:
-                    prim_module, prim_module_name, prim_param_name = shared_param_memo[param]
-                    shared_param_infos.append(SharedParamInfo(
-                        param_name, submodule, submodule_name, prim_param_name,
-                        prim_module, prim_module_name,
-                    ))
+                    prim_module, prim_module_name, prim_param_name = shared_param_memo[
+                        param
+                    ]
+                    shared_param_infos.append(
+                        SharedParamInfo(
+                            param_name,
+                            submodule,
+                            submodule_name,
+                            prim_param_name,
+                            prim_module,
+                            prim_module_name,
+                        )
+                    )
                 else:
                     if isinstance(param, FlatParameter):
                         raise ValueError("`FlatParameter` does not support nesting")
@@ -241,8 +314,15 @@ class FlatParamHandle:
                             "`FlatParameter` requires uniform dtype but got "
                             f"{dtype} and {param.dtype}"
                         )
-                    if requires_grad is not None and param.requires_grad != requires_grad:
-                        raise ValueError("`FlatParameter` requires uniform `requires_grad`")
+                    elif dtype is None and not param.is_floating_point():
+                        raise ValueError("Integer parameters are unsupported")
+                    if (
+                        requires_grad is not None
+                        and param.requires_grad != requires_grad
+                    ):
+                        raise ValueError(
+                            "`FlatParameter` requires uniform `requires_grad`"
+                        )
                     dtype = param.dtype
                     requires_grad = param.requires_grad
                     shared_param_memo[param] = (submodule, submodule_name, param_name)
@@ -250,13 +330,22 @@ class FlatParamHandle:
                     param_infos.append(ParamInfo(param_name, submodule, submodule_name))
                     numels.append(param.numel())
                     shapes.append(param.shape)
-                    prefixed_param_name = submodule_name + "." + param_name \
-                        if submodule_name else param_name
+                    prefixed_param_name = (
+                        submodule_name + "." + param_name
+                        if submodule_name
+                        else param_name
+                    )
                     prefixed_param_names.append(prefixed_param_name)
         assert requires_grad is not None
-        self.flat_param = FlatParamHandle.flatten_params(params_to_flatten, requires_grad)
-        self.flat_param.init_metadata(
-            param_infos, numels, shapes, prefixed_param_names, shared_param_infos,
+        self.flat_param = FlatParamHandle.flatten_params(
+            params_to_flatten, requires_grad
+        )
+        self.flat_param._init_metadata(
+            param_infos,
+            numels,
+            shapes,
+            prefixed_param_names,
+            shared_param_infos,
         )
 
     @staticmethod
@@ -271,88 +360,54 @@ class FlatParamHandle:
 
         We expose this factory method for checkpointing (e.g. sharded state
         dict). The flattened parameter's metadata should only be initialized
-        once (see :meth:`init_metadata`), but its tensor data may be reloaded.
+        once (see :meth:`_init_metadata`), but its tensor data may be reloaded.
         """
         with torch.no_grad():
             flat_params = [
-                p.detach().reshape(-1) if isinstance(p, nn.Parameter)
-                else p.reshape(-1) for p in params
+                p.detach().reshape(-1) if isinstance(p, nn.Parameter) else p.reshape(-1)
+                for p in params
             ]
             flat_param_data = torch.cat(flat_params, dim=0)
         flat_param = FlatParameter(flat_param_data, requires_grad=requires_grad)
         return flat_param
 
-    @staticmethod
-    def _get_unflat_views(
-        flat_param: FlatParameter,
-        tensor: Optional[torch.Tensor] = None,
-    ) -> Iterator[Tensor]:
+    ###################################
+    # SHARD INITIALIZATION & METADATA #
+    ###################################
+    @torch.no_grad()
+    def shard(self, process_group: dist.ProcessGroup):
         """
-        Returns unflattened ``Tensor`` views into ``tensor`` if it is not
-        ``None`` or ``flat_param`` otherwise, where the unflattening is based
-        on ``flat_param`` 's metadata.
+        Shards the handle's ``FlatParameter``. In terms of memory, this
+        allocates new memory for the sharded flattened parameter and frees the
+        unsharded flattened parameter's storage.
 
-        In other words, to get views into the unsharded flattened parameter,
-        pass ``tensor`` as ``None``, but to get views into tensor optimizer
-        state, pass ``tensor`` as the optimizer state tensor.
+        Postcondition: ``self.flat_param`` is the sharded flattened parameter.
+        ``process_group``, ``rank``, and ``world_size`` attributes are set.
+
+        TODO (awgu): Once we retire ``FlattenParamsWrapper``, we should pass
+        the process group directly to the ``FlatParamHandle`` constructor. For
+        now, we decouple ``FlattenParamsWrapper` from a process group, but this
+        makes the process-group-related attributes not necessarily defined.
         """
-        if tensor is None:
-            tensor = flat_param
-        assert tensor.numel() == flat_param._unsharded_size.numel(), \
-            f"Expects {flat_param._unsharded_size.numel()} numel but got " \
-            f"{tensor.numel()} numel"
-        views = (
-            subtensor.view(shape) for (subtensor, shape) in
-            zip(torch.split(tensor, flat_param._numels, dim=0), flat_param._shapes)  # type: ignore[arg-type]
+        if not self._uses_sharded_strategy:
+            return
+        flat_param = self.flat_param
+        self.process_group = process_group
+        self.rank = process_group.rank()
+        self.world_size = process_group.size()
+        assert (
+            flat_param.storage_offset() == 0
+        ), "The `FlatParameter` is not the sole occupant of its storage"
+        orig_storage = flat_param.storage()
+        local_shard, numel_padded = FlatParamHandle._get_shard(
+            flat_param, self.rank, self.world_size
         )
-        return views
+        flat_param.set_(local_shard)  # type: ignore[call-overload]
+        self._init_shard_metadata(local_shard.numel(), numel_padded, self.rank)
+        if orig_storage.size() > 0:
+            orig_storage.resize_(0)
 
-    def _unflatten(self, as_params: bool) -> None:
-        """
-        Unflattens the unsharded flattened parameter by setting the original
-        module parameter variables to be views into it.
-
-        Args:
-            as_params (bool): If ``True``, then registers the original
-                parameters as ``nn.Parameter`` s; if ``False``, then registers
-                the original parameters only as ``Tensor`` s. ``False`` should
-                be used during forward/backward computation and when hiding the
-                original parameters from :meth:`nn.Module.named_parameters`.
-        """
-        views = self._get_unflat_views(self.flat_param)
-        for view, (param_name, module, _) in zip(views, self.flat_param._param_infos):
-            if hasattr(module, param_name):
-                delattr(module, param_name)
-            if as_params:
-                module.register_parameter(param_name, nn.Parameter(view))
-            else:
-                setattr(module, param_name, view)
-        for (param_name, module, _, prim_param_name, prim_module, _) in self.flat_param._shared_param_infos:
-            if hasattr(module, param_name):
-                delattr(module, param_name)
-            assert hasattr(prim_module, prim_param_name)
-            param: Union[Tensor, nn.Parameter] = getattr(prim_module, prim_param_name)
-            if as_params:
-                assert isinstance(param, nn.Parameter)
-                module.register_parameter(param_name, param)
-            else:
-                setattr(module, param_name, param)
-
-    @contextlib.contextmanager
-    def unflatten_as_params(self) -> Generator:
-        """
-        Assumes the flattened parameter is unsharded. When in the context,
-        unflattens the original parameters as ``nn.Parameter`` views into the
-        flattened parameter, and after the context, restores the original
-        parameters as ``Tensor`` views into the flattened parameter.
-        """
-        self._unflatten(as_params=True)
-        try:
-            yield
-        finally:
-            self._unflatten(as_params=False)
-
-    def init_shard_metadata(
+    def _init_shard_metadata(
         self,
         sharded_flat_param_numel: int,
         numel_padded: int,
@@ -378,9 +433,10 @@ class FlatParamHandle:
             )
         start = sharded_flat_param_numel * rank
         end = sharded_flat_param_numel * (rank + 1) - 1  # inclusive
-        self.flat_param._shard_param_offsets, self.flat_param._shard_indices = (  # type: ignore[attr-defined]
-            self._get_shard_metadata(start, end)
-        )
+        (
+            self.flat_param._shard_param_offsets,  # type: ignore[attr-defined]
+            self.flat_param._shard_indices,  # type: ignore[attr-defined]
+        ) = self._get_shard_metadata(start, end)
         self.flat_param._shard_numel_padded = numel_padded  # type: ignore[attr-defined]
 
     def _get_shard_metadata(
@@ -421,16 +477,21 @@ class FlatParamHandle:
                 intra_param_start = start - param_start
             intra_param_end = min(param_end, end) - param_start
             shard_param_indices_range.append(i)
-            shard_param_offsets.append((intra_param_start, intra_param_end))  # both inclusive
+            shard_param_offsets.append(
+                (intra_param_start, intra_param_end)
+            )  # both inclusive
         if len(shard_param_indices_range) == 0:
             shard_param_indices = (0, 0)
             assert len(shard_param_offsets) == 0
         else:
             shard_param_indices = (
-                shard_param_indices_range[0], shard_param_indices_range[-1],
+                shard_param_indices_range[0],
+                shard_param_indices_range[-1],
             )
-            assert len(shard_param_offsets) == \
-                shard_param_indices[-1] - shard_param_indices[0] + 1
+            assert (
+                len(shard_param_offsets)
+                == shard_param_indices[-1] - shard_param_indices[0] + 1
+            )
         return tuple(shard_param_offsets), shard_param_indices
 
     @staticmethod
@@ -455,7 +516,9 @@ class FlatParamHandle:
         else:
             chunk = chunks[rank]
         numel_to_pad = chunks[0].numel() - chunk.numel()
-        assert numel_to_pad >= 0, "Chunk's size should be at most the first chunk's size"
+        assert (
+            numel_to_pad >= 0
+        ), "Chunk's size should be at most the first chunk's size"
         return chunk, numel_to_pad
 
     @staticmethod
@@ -471,7 +534,9 @@ class FlatParamHandle:
         This method allocates new memory (via :meth:`clone`) since the
         unsharded ``tensor`` may be deallocated after this method returns.
         """
-        chunk, numel_to_pad = FlatParamHandle._get_unpadded_shard(tensor, rank, world_size)
+        chunk, numel_to_pad = FlatParamHandle._get_unpadded_shard(
+            tensor, rank, world_size
+        )
         shard = chunk.clone()
         if numel_to_pad > 0:
             shard = F.pad(shard, [0, numel_to_pad])
@@ -485,8 +550,8 @@ class FlatParamHandle:
         shape is 1D.
         """
         assert len(tensor.shape) == 1, f"{tensor.shape}"
-        unpadded_sharded_tensor, numel_to_pad = (
-            FlatParamHandle._get_unpadded_shard(tensor, rank, world_size)
+        unpadded_sharded_tensor, numel_to_pad = FlatParamHandle._get_unpadded_shard(
+            tensor, rank, world_size
         )
         unpadded_sharded_size = unpadded_sharded_tensor.size()
         assert len(unpadded_sharded_size) == 1, f"{unpadded_sharded_size}"
@@ -506,19 +571,419 @@ class FlatParamHandle:
     ) -> FlatParamShardMetadata:
         """Returns shard-related metadata specific to this rank's shard of the
         flattened parameter."""
-        assert hasattr(self.flat_param, "_shard_indices") and \
-            hasattr(self.flat_param, "_shard_param_offsets"), \
-            "Shard metadata has not been initialized"
+        assert hasattr(self.flat_param, "_shard_indices") and hasattr(
+            self.flat_param, "_shard_param_offsets"
+        ), "Shard metadata has not been initialized"
         shard_param_start_index = self.flat_param._shard_indices[0]  # type: ignore[attr-defined]
         shard_param_end_index = self.flat_param._shard_indices[1]  # type: ignore[attr-defined]
-        sl = slice(shard_param_start_index, shard_param_end_index + 1) \
-            if shard_param_start_index <= shard_param_end_index else slice(0, 0)
+        sl = (
+            slice(shard_param_start_index, shard_param_end_index + 1)
+            if shard_param_start_index <= shard_param_end_index
+            else slice(0, 0)
+        )
         return FlatParamShardMetadata(
             self.flat_param._prefixed_param_names[sl],
             self.flat_param._shapes[sl],
             self.flat_param._numels[sl],
             self.flat_param._shard_param_offsets[:],  # type: ignore[attr-defined]
         )
+
+    ###################
+    # UNSHARD/RESHARD #
+    ###################
+    def pre_unshard(self):
+        """
+        Postcondition: ``self.flat_param`` 's data is on the device for
+            communication and is what should be all-gathered. This means that
+            it matches the dtype of the expected unsharded parameter.
+        """
+        if self._uses_sharded_strategy and not self.needs_unshard():
+            # Do not prepare the sharded flattened parameter for an all-gather
+            # if the handle does not need to be unsharded
+            return
+        if self._uses_param_mixed_precision and not self._force_full_precision:
+            self._use_low_precision_shard()
+        elif self._config.offload_params and self.flat_param.device != self.device:
+            # NOTE: This creates a new tensor distinct from any attributes.
+            self._flat_param_to(self.device, non_blocking=True)
+        self._check_on_compute_device(self.flat_param)
+
+    def _use_low_precision_shard(self):
+        """
+        Allocates the low precision shard directly on the compute device and
+        switches to using the low precision sharded flattened parameter.
+        """
+        self._check_low_precision_shard()
+        flat_param = self.flat_param
+        _alloc_storage(
+            flat_param._mp_shard, flat_param._local_shard.size()  # type: ignore[attr-defined]
+        )
+        # `copy_()` implicitly casts to the low precision
+        flat_param._mp_shard.copy_(  # type: ignore[attr-defined]
+            flat_param._local_shard.to(  # type: ignore[attr-defined]
+                self.device, non_blocking=True
+            )
+        )
+        # Invariant: `_mp_shard` is always on the compute device.
+        flat_param.data = flat_param._mp_shard  # type: ignore[attr-defined]
+
+    def unshard(self):
+        """
+        Runs the unshard logic. This includes all-gathering the flattened
+        parameter and switching to using the unsharded flattened parameter. If
+        the handle does not need unsharding, then this only switches to using
+        the unsharded flattened parameter. For ``NO_SHARD``, this is a no-op.
+
+        If FSDP is in :meth:`summon_full_params` and the handle uses parameter
+        mixed precision, then the parameter is forced to full precision.
+        """
+        if not self.needs_unshard():
+            if self._uses_sharded_strategy:
+                unsharded_flat_param = self._get_padded_unsharded_flat_param()
+                self._use_unsharded_flat_param(unsharded_flat_param)
+            return
+        unsharded_flat_param = self._alloc_padded_unsharded_flat_param()
+        self._all_gather_flat_param(unsharded_flat_param)
+
+    def needs_unshard(self) -> bool:
+        """Returns if the handle's flattened parameter needs to be unsharded."""
+        if not self._uses_sharded_strategy:
+            return False
+        unsharded_flat_param = self._get_padded_unsharded_flat_param()
+        already_unsharded = (
+            unsharded_flat_param.storage().size() == unsharded_flat_param.numel()
+        )
+        return not already_unsharded
+
+    def _alloc_padded_unsharded_flat_param(self):
+        """
+        Allocates the *padded* unsharded flattened parameter. The unpadded
+        unsharded flattened parameter is always a view into the padded one.
+        This padded parameter is saved to a different attribute on the
+        ``FlatParameter`` depending on if we force full precision.
+        """
+        self._check_sharded_strategy()
+        flat_param = self.flat_param
+        padded_unsharded_size = flat_param._full_param_padded.size()  # type: ignore[attr-defined]
+        unsharded_flat_param = self._get_padded_unsharded_flat_param()
+        self._check_storage_freed(unsharded_flat_param)
+        _alloc_storage(unsharded_flat_param, padded_unsharded_size)
+        return unsharded_flat_param
+
+    def _get_padded_unsharded_flat_param(self) -> torch.Tensor:
+        """
+        Returns a reference to the padded unsharded flattened parameter
+        depending on the calling context. This should only be called if using a
+        sharded strategy.
+        """
+        self._check_sharded_strategy()
+        flat_param = self.flat_param
+        if self._force_full_precision:
+            # When parameter mixed precision is enabled, we use a different
+            # tensor as the all-gather destination to preserve the invariant
+            # that  `_full_param_padded` is in the low precision
+            unsharded_flat_param = flat_param._full_prec_full_param_padded  # type: ignore[attr-defined]
+            p_assert(
+                unsharded_flat_param.dtype != self._config.param_dtype,
+                f"Expects full precision but got {self._config.param_dtype}",
+            )
+        else:
+            unsharded_flat_param = flat_param._full_param_padded  # type: ignore[attr-defined]
+        return unsharded_flat_param
+
+    def _all_gather_flat_param(
+        self,
+        padded_unsharded_flat_param: Tensor,
+    ) -> None:
+        """
+        All-gathers the handle's flattened parameter to the destination
+        ``padded_unsharded_flat_param``, and switches to using the all-gathered
+        tensor.
+        """
+        p_assert(
+            hasattr(self, "process_group") and hasattr(self, "world_size"),
+            "Expects a process group and world size to have been set via `shard()`",
+        )
+        sharded_flat_param = self.flat_param.data
+        expected_numel = sharded_flat_param.numel() * self.world_size
+        p_assert(
+            padded_unsharded_flat_param.numel() == expected_numel,
+            f"Expects {expected_numel} numel but got {padded_unsharded_flat_param.numel()}",
+        )
+        dist._all_gather_base(
+            padded_unsharded_flat_param,
+            sharded_flat_param,
+            self.process_group,
+        )
+        self._use_unsharded_flat_param(padded_unsharded_flat_param)
+
+    def _use_unsharded_flat_param(
+        self,
+        padded_unsharded_flat_param: torch.Tensor,
+    ) -> None:
+        """
+        Switches to using the *unpadded* unsharded flattened parameter, which
+        is a view into the *padded* unsharded flattened parameter.
+        """
+        unsharded_size = self.flat_param._unsharded_size
+        self.flat_param.data = padded_unsharded_flat_param[
+            : unsharded_size.numel()
+        ].view(unsharded_size)
+
+    def post_unshard(self, prepare_gradient: bool):
+        """
+        Runs the post-unshard logic. This includes freeing the low precision
+        shard if needed and preparing the gradient for the pre-backward if
+        ``prepare_gradient`` and a gradient exists.
+        """
+        if self._uses_param_mixed_precision and self._uses_sharded_strategy:
+            self._free_low_precision_sharded_param()
+        if prepare_gradient:
+            p_assert(
+                self._training_state
+                in (HandleTrainingState.PRE_BACKWARD, HandleTrainingState.IDLE),
+                "Expects to be in `PRE_BACKWARD` or `IDLE` (if prefetching)",
+            )
+            # Prepare for backward gradient computation by saving and clearing
+            # any existing sharded gradient in `.grad` to enable computing an
+            # unsharded gradient
+            flat_param = self.flat_param
+            if flat_param.grad is not None and (
+                flat_param.grad.size() != flat_param._unsharded_size
+                or flat_param.grad.device != flat_param.device  # grad on CPU
+            ):
+                self._check_on_compute_device(self.flat_param)
+                grad_offloaded = flat_param.grad.device != self.device
+                p_assert(
+                    not grad_offloaded or self._config.offload_params,
+                    f"Expects the sharded gradient to be on {self.device} "
+                    f"but got {flat_param.grad.device}",
+                )
+                prev_iter_synced_gradients = (
+                    flat_param.grad.size()
+                    == flat_param._local_shard.size()  # type: ignore[attr-defined]
+                )
+                if prev_iter_synced_gradients:
+                    # TODO (awgu): Gradient accumulation outside `no_sync()`
+                    # does not work with CPU offloading. The issue should be
+                    # that, in the post-backward hook, we cannot do an addition
+                    # between a CPU tensor (the existing sharded gradient) and
+                    # a GPU tensor (the new sharded gradient).
+                    if not grad_offloaded:
+                        flat_param._saved_grad_shard = flat_param.grad.data  # type: ignore[attr-defined]
+                else:
+                    padded_unsharded_size = flat_param._full_param_padded.size()  # type: ignore[attr-defined]
+                    p_assert(
+                        flat_param.grad.size() == padded_unsharded_size,
+                        "Expects `.grad` to be the unsharded gradient in "
+                        f"`no_sync()` with size {padded_unsharded_size} "
+                        f"but got size {flat_param.grad.size()}",
+                    )
+                flat_param.grad = None
+        self._check_on_compute_device(self.flat_param)
+
+    def _free_low_precision_sharded_param(self):
+        """Frees the low precision sharded flattened parameter."""
+        self._check_low_precision_shard()
+        _free_storage(self.flat_param._mp_shard)  # type: ignore[attr-defined]
+
+    @contextlib.contextmanager
+    def to_cpu(self):
+        """
+        Moves the unpadded unsharded flattened parameter to CPU while in the
+        context and moves it back to the previous device upon exit. For now,
+        this assumes the ``FlatParameter`` is the unpadded unsharded flattened
+        parameter since (1) there is no reason to include the padding in the
+        copy and (2) there is no use case for the sharded flattened parameter.
+
+        Precondition: ``self.flat_param`` 's data is the unpadded unsharded
+            flattened parameter on the compute device, and the handle uses a
+            sharded strategy.
+        Postcondition: Same as the precondition.
+        """
+        self._check_sharded_strategy()
+        p_assert(
+            self.flat_param.size() == self.flat_param._unsharded_size,
+            f"Expects size {self.flat_param._unsharded_size} but got {self.flat_param.size()}",
+        )
+        self._check_on_compute_device(self.flat_param)
+        # Check that the unpadded unsharded flattened parameter is a view into
+        # the padded unsharded flattened parameter as expected
+        # TODO (awgu): For correctness, this check is not strictly needed.
+        # However, the user should not be doing parameter swapping with
+        # `self.flat_param` either.
+        unpadded_storage_ptr = self.flat_param.storage().data_ptr()
+        padded_storage_ptr = (
+            self._get_padded_unsharded_flat_param().storage().data_ptr()
+        )
+        p_assert(
+            unpadded_storage_ptr == padded_storage_ptr,
+            "Expects the unpadded parameter to be a view into the padded parameter",
+        )
+        self._flat_param_to(torch.device("cpu"))
+        self._free_unsharded_flat_param()
+        try:
+            yield
+        finally:
+            p_assert(
+                self.flat_param.size() == self.flat_param._unsharded_size,
+                f"Expects size {self.flat_param._unsharded_size} but got {self.flat_param.size()}",
+            )
+            padded_unsharded_flat_param = self._alloc_padded_unsharded_flat_param()
+            # Copy from CPU to the compute device
+            padded_unsharded_flat_param[: self.flat_param.numel()].copy_(
+                self.flat_param
+            )
+            self._use_unsharded_flat_param(padded_unsharded_flat_param)
+
+    def reshard(self, free_unsharded_flat_param: bool):
+        """
+        Runs the reshard logic. This includes freeing the unsharded flattened
+        parameter if ``free_unsharded_flat_param`` and switching to using the
+        sharded flattened parameter.
+        """
+        if free_unsharded_flat_param:
+            self._free_unsharded_flat_param()
+        self._use_sharded_flat_param()
+
+    def post_reshard(self):
+        """
+        Runs the post-reshard logic. This includes freeing any memory that
+        can now be freed given that the ``FlatParameter`` points to the full
+        precision sharded flattened parameter.
+
+        Precondition: ``self.flat_param`` 's data points to the full precision
+            sharded flattened parameter.
+        """
+        # For `NO_SHARD`, `_mp_shard` is not freed in the post-unshard since
+        # it is also the low precision *unsharded* flattened parameter. Hence,
+        # we delay the free until the reshard.
+        if (
+            self._uses_param_mixed_precision
+            and not self._uses_sharded_strategy
+            and not self._force_full_precision  # did not use the low precision shard
+        ):
+            self._free_low_precision_sharded_param()
+
+    def _free_unsharded_flat_param(self):
+        """
+        Frees the padded unsharded flattened parameter. The tensor to free
+        depends on the calling context since the unshard may have forced full
+        precision, in which case a different tensor is used.
+        """
+        self._check_sharded_strategy()
+        unsharded_flat_param = self._get_padded_unsharded_flat_param()
+        self._check_storage_allocated(unsharded_flat_param)
+        self._check_on_compute_device(unsharded_flat_param)
+        # Do not free the memory until all ops in the current stream finish
+        unsharded_flat_param.record_stream(
+            cast(torch._C.Stream, torch.cuda.current_stream())
+        )
+        _free_storage(unsharded_flat_param)
+
+    def _use_sharded_flat_param(self) -> None:
+        """Switches to using the sharded flattened parameter."""
+        flat_param = self.flat_param
+        if self._config.offload_params:
+            device = flat_param._local_shard.device  # type: ignore[attr-defined]
+            p_assert(
+                device == torch.device("cpu"),
+                f"Expects the local shard to be on CPU but got {device}",
+            )
+        flat_param.data = flat_param._local_shard  # type: ignore[attr-defined]
+
+    #########
+    # VIEWS #
+    #########
+    @staticmethod
+    def _get_unflat_views(
+        flat_param: FlatParameter,
+        tensor: Optional[torch.Tensor] = None,
+    ) -> Iterator[Tensor]:
+        """
+        Returns unflattened ``Tensor`` views into ``tensor`` if it is not
+        ``None`` or ``flat_param`` otherwise, where the unflattening is based
+        on ``flat_param`` 's metadata.
+
+        In other words, to get views into the unsharded flattened parameter,
+        pass ``tensor`` as ``None``, but to get views into tensor optimizer
+        state, pass ``tensor`` as the optimizer state tensor.
+        """
+        if tensor is None:
+            tensor = flat_param
+        p_assert(
+            tensor.numel() == flat_param._unsharded_size.numel(),
+            f"Expects {flat_param._unsharded_size.numel()} numel but got "
+            f"{tensor.numel()} numel",
+        )
+        views = (
+            tensor.view(shape)
+            for (tensor, shape) in zip(
+                torch.split(tensor, flat_param._numels, dim=0), flat_param._shapes  # type: ignore[arg-type]
+            )
+        )
+        return views
+
+    def _unflatten(self, as_params: bool) -> None:
+        """
+        Unflattens the unsharded flattened parameter by setting the original
+        module parameter variables to be views into it.
+
+        Args:
+            as_params (bool): If ``True``, then registers the original
+                parameters as ``nn.Parameter`` s; if ``False``, then registers
+                the original parameters only as ``Tensor`` s. ``False`` should
+                be used during forward/backward computation and when hiding the
+                original parameters from :meth:`nn.Module.named_parameters`.
+        """
+        if self.flat_param.numel() != self.flat_param._unsharded_size.numel():
+            print(self)
+        views = self._get_unflat_views(self.flat_param)
+        for view, (param_name, module, _) in zip(views, self.flat_param._param_infos):
+            if hasattr(module, param_name):
+                delattr(module, param_name)
+            if as_params:
+                module.register_parameter(param_name, nn.Parameter(view))
+            else:
+                setattr(module, param_name, view)
+        for (
+            param_name,
+            module,
+            _,
+            prim_param_name,
+            prim_module,
+            _,
+        ) in self.flat_param._shared_param_infos:
+            if hasattr(module, param_name):
+                delattr(module, param_name)
+            assert hasattr(prim_module, prim_param_name)
+            param: Union[Tensor, nn.Parameter] = getattr(prim_module, prim_param_name)
+            if as_params:
+                assert isinstance(param, nn.Parameter)
+                module.register_parameter(param_name, param)
+            else:
+                setattr(module, param_name, param)
+
+    @contextlib.contextmanager
+    def unflatten_as_params(self) -> Generator:
+        """
+        Assumes the flattened parameter is unsharded. When in the context,
+        unflattens the original parameters as ``nn.Parameter`` views into the
+        flattened parameter, and after the context, restores the original
+        parameters as ``Tensor`` views into the flattened parameter.
+        """
+        self._unflatten(as_params=True)
+        try:
+            yield
+        finally:
+            self._unflatten(as_params=False)
+
+    ###########
+    # HELPERS #
+    ###########
+    def _flat_param_to(self, *args, **kwargs):
+        """Wraps an in-place call to ``.to()`` for ``self.flat_param``."""
+        self.flat_param.data = self.flat_param.to(*args, **kwargs)
 
     def _get_modules(self) -> Set[nn.Module]:
         """Returns a :class:`set` of the modules whose parameters are included
@@ -537,3 +1002,100 @@ class FlatParamHandle:
             self.flat_param._param_infos, shared_param_infos
         ):
             yield (param_name, module_name)
+
+    #######################
+    # CHECKS & INVARIANTS #
+    #######################
+    def _check_sharded_strategy(self):
+        p_assert(self._uses_sharded_strategy, "Expects sharded strategy")
+
+    def _check_on_compute_device(self, tensor: Tensor):
+        p_assert(
+            tensor.device == self.device,
+            f"Expects tensor to be on the compute device {self.device}",
+        )
+
+    @staticmethod
+    def _check_storage_freed(tensor: Tensor):
+        storage_size: int = tensor.storage().size()
+        p_assert(
+            storage_size == 0,
+            f"Expects storage to be freed but got storage with size {storage_size}",
+        )
+
+    @staticmethod
+    def _check_storage_allocated(tensor: Tensor):
+        storage_size: int = tensor.storage().size()
+        p_assert(storage_size > 0, "Expects storage to be allocated")
+
+    def _check_low_precision_shard(self):
+        p_assert(
+            self._uses_param_mixed_precision,
+            "Not using low precision for parameters",
+        )
+        p_assert(
+            getattr(self.flat_param, "_mp_shard", None) is not None,
+            "Expects `_mp_shard` to exist",
+        )
+        device = self.flat_param._mp_shard.device  # type: ignore[attr-defined]
+        p_assert(
+            device == self.device,
+            f"Expects the low precision shard to be on {self.device} but got {device}",
+        )
+
+    ##############
+    # PROPERTIES #
+    ##############
+    @property
+    def _uses_sharded_strategy(self) -> bool:
+        return self._config.sharding_strategy != HandleShardingStrategy.NO_SHARD
+
+    @property
+    def _uses_param_mixed_precision(self) -> bool:
+        return self._config.param_dtype is not None
+
+    @property
+    def _force_full_precision(self) -> bool:
+        return (
+            self._training_state == HandleTrainingState.SUMMON_FULL_PARAMS
+            and self._uses_param_mixed_precision
+        )
+
+
+@torch.no_grad()
+def _alloc_storage(tensor: torch.Tensor, size: torch.Size) -> bool:
+    """
+    Allocate storage for ``tensor`` with the given size.
+
+    Returns:
+        bool: ``True`` if this method allocated storage and ``False`` if the
+        storage was already allocated.
+    """
+    already_allocated = tensor.storage().size() == size.numel()
+    if not already_allocated:
+        tensor_storage_size = tensor.storage().size()
+        p_assert(
+            tensor_storage_size == 0,
+            f"Tensor storage should have been resized to be 0 but got {tensor_storage_size}",
+        )
+        tensor.storage().resize_(size.numel())
+    return not already_allocated
+
+
+@torch.no_grad()
+def _free_storage(tensor: torch.Tensor) -> bool:
+    """
+    Frees the underlying storage of ``tensor``.
+
+    Returns:
+        bool: ``True`` if the method freed the storage and ``False`` if the
+        storage was already freed.
+    """
+    already_freed = tensor.storage().size() == 0
+    if not already_freed:
+        p_assert(
+            tensor.storage_offset() == 0,
+            "Freeing a tensor's storage is unsafe when it is not the sole occupant",
+        )
+        tensor.storage().resize_(0)
+    return not already_freed

--- a/torch/distributed/fsdp/flatten_params_wrapper.py
+++ b/torch/distributed/fsdp/flatten_params_wrapper.py
@@ -9,10 +9,11 @@
 import contextlib
 from typing import Any, Dict, Generator, List
 
+import torch
 import torch.nn as nn
 from torch.distributed.utils import _replace_by_prefix
 
-from .flat_param import FlatParamHandle
+from .flat_param import FlatParamHandle, HandleConfig
 
 FLAT_PARAM = "flat_param"
 FPW_MODULE = "_fpw_module"
@@ -68,6 +69,10 @@ class FlattenParamsWrapper(nn.Module):
         module (nn.Module): Module to wrap.
         params (List[nn.Parameter]): Parameters in ``module`` 's subtree to
             flatten into a single flattened parameter.
+        device (torch.device): The compute and communication device for this
+            wrapper's handle.
+        config (HandleConfig): A config customizing this wrapper's handle based
+            on FSDP's available features.
 
     Attributes:
         flat_param (Optional[FlatParameter]): The flattened parameter.
@@ -81,6 +86,8 @@ class FlattenParamsWrapper(nn.Module):
         self,
         module: nn.Module,
         params: List[nn.Parameter],
+        device: torch.device,
+        config: HandleConfig,
     ) -> None:
         super().__init__()
         self._fpw_module = module
@@ -92,7 +99,7 @@ class FlattenParamsWrapper(nn.Module):
         self._register_load_state_dict_pre_hook(_pre_load_state_dict_hook)
         if len(params) == 0:
             return
-        self._flat_param_handle = FlatParamHandle(params, module)
+        self._flat_param_handle = FlatParamHandle(params, module, device, config)
         # Defining `self.flat_param` registers the `FlatParameter` and makes it
         # visible to `named_parameters()`
         self.flat_param = self._flat_param_handle.flat_param

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1443,7 +1443,7 @@ class FullyShardedDataParallel(nn.Module):
     def _unshard(
         self,
         handles: List[FlatParamHandle],
-        prepare_gradient: bool = False,
+        prepare_gradient: bool,
     ) -> None:
         """
         Unshards the handles in ``handles``. If ``prepare_gradient``, then
@@ -2702,7 +2702,7 @@ class FullyShardedDataParallel(nn.Module):
         handles_key = tuple(handles)
         params_prefetched = self._handles_prefetched.get(handles_key, False)
         if not params_prefetched:
-            self._unshard(handles)
+            self._unshard(handles, False)
         torch.cuda.current_stream().wait_stream(self._streams["all_gather"])
 
         # TODO (awgu): This is not necessarily the best place to reset the
@@ -2923,7 +2923,7 @@ class FullyShardedDataParallel(nn.Module):
             handle._training_state = HandleTrainingState.SUMMON_FULL_PARAMS
 
         free_unsharded_flat_params = [handle.needs_unshard() for handle in self._handles]
-        self._unshard(self._handles)
+        self._unshard(self._handles, False)
         torch.cuda.current_stream().wait_stream(self._streams["all_gather"])
 
         if rank0_only and self.rank != 0:

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -1575,33 +1575,21 @@ class FullyShardedDataParallel(nn.Module):
         Whether user explicitly enabled mixed precision for
         parameters or not.
         """
-        return (
-            # self.mixed_precision is not None
-            # and self.mixed_precision.param_dtype is not None
-            self.mixed_precision.param_dtype is not None
-        )
+        return self.mixed_precision.param_dtype is not None
 
     def _mixed_precision_enabled_for_buffers(self) -> bool:
         """
         Whether user explicitly enabled mixed precision for
         buffers or not.
         """
-        return (
-            # self.mixed_precision is not None
-            # and self.mixed_precision.buffer_dtype is not None
-            self.mixed_precision.buffer_dtype is not None
-        )
+        return self.mixed_precision.buffer_dtype is not None
 
     def _mixed_precision_enabled_for_reduce(self) -> bool:
         """
         Whether user explicitly enabled mixed precision for
         gradient reduction or not.
         """
-        return (
-            # self.mixed_precision is not None
-            # and self.mixed_precision.reduce_dtype is not None
-            self.mixed_precision.reduce_dtype is not None
-        )
+        return self.mixed_precision.reduce_dtype is not None
 
     def _low_precision_hook_enabled(self) -> bool:
         """


### PR DESCRIPTION
### Overview
This PR prepares PT-D FSDP for non-recursive wrapping.
- Immediate impact-wise, this prepares prefetching for non-recursive wrapping, which will provide additional QPS benefits; fixes a few bugs with `summon_full_params()`; and provides some solution for the high GPU reserved memory issue.
- Quality-wise, this simplifies the logic for unshard/reshard, FSDP initialization, and prefetching. This resulting modularization moves FSDP closer toward supporting a functional-like API.

See the below comments for how I would review the PR and the details of the changes.

