### PR TITLE
[vulkan][fix] Fix unsafe direct array access

### DIFF
--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -181,6 +181,14 @@ class vTensor final {
   }
 
   /*
+   * Number of texels in the image texture.
+   */
+  inline VkDeviceSize numtexels() {
+    return view_->extents_.data[0u] * view_->extents_.data[1u] *
+        view_->extents_.data[2u];
+  }
+
+  /*
    * Number of "cells" in the image texture. 4 cells make up a texel.
    */
   inline VkDeviceSize numcells() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83432

This diff fixes an instance of unsafe array access of a sizes array.

Differential Revision: [D38710499](https://our.internmc.facebook.com/intern/diff/D38710499/)