### PR TITLE
Add HIP libs into torch depoly init list & corresponding dependency for CURE benchmark running on AMD

### DIFF
--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -31,6 +31,7 @@ namespace deploy {
 
 const std::initializer_list<ExeSection> pythonInterpreterSection = {
     {".torch_deploy_payload.interpreter_all", true},
+    {".torch_deploy_payload.interpreter_hip", false},
     {".torch_deploy_payload.interpreter_cuda", false},
     {".torch_deploy_payload.interpreter_cpu", false},
 };
@@ -39,6 +40,9 @@ const std::initializer_list<InterpreterSymbol> kInterpreterSearchPath = {
     {"_binary_libtorch_deployinterpreter_all_so_start",
      "_binary_libtorch_deployinterpreter_all_so_end",
      true},
+    {"_binary_libtorch_deployinterpreter_hip_so_start",
+     "_binary_libtorch_deployinterpreter_hip_so_end",
+     false},
     {"_binary_libtorch_deployinterpreter_cuda_so_start",
      "_binary_libtorch_deployinterpreter_cuda_so_end",
      false},


### PR DESCRIPTION
Summary: This diff adds needed targets for CURE benchmark on AMD, and also add hip lib to torch deploy init list

Test Plan:
on AMD host fbcode/, With model generated by D38509136 model.pt.

cp model.pt /tmp/textray_v20220509.pt

buck build mode/{dev-nosan,amd-gpu} mode/lower-locally -c fbcode.enable_gpu_sections=true -c fbcode.rocm_arch=mi100 -c fbcode.platform=platform010 //accelerators/tools/benchmark:PyTorchPredictorInferenceBenchmark

buck-out/gen/accelerators/tools/benchmark/PyTorchPredictorInferenceBenchmark --replay_record_format recordio --replay_record_source /tmp/textray_20220509_prod.recordio --model_path /tmp/textray_v20220509.pt --batch_size=64 --batching_threads=1 --max_batch_wait_ms=500 --min_threads 5 --max_threads 5 --timeout_seconds 120 --check_allow_extra_field --diff_threshold 1e-3 --equal_threshold 1e-4 --thread_step 5 --use_cuda

Reviewed By: mikekgfb

Differential Revision: D38596119

