### PR TITLE
[Nested Tensor] Make offset copy and move assignment more explicit.

### DIFF
--- a/aten/src/ATen/NestedTensorImpl.cpp
+++ b/aten/src/ATen/NestedTensorImpl.cpp
@@ -131,7 +131,7 @@ NestedTensorImpl::NestedTensorImpl(
     const caffe2::TypeMeta data_type,
     at::Tensor nested_size_tensor,
     at::Tensor nested_stride_tensor,
-    std::vector<int64_t> offsets)
+    std::vector<int64_t>&& offsets)
     : TensorImpl(std::move(storage), key_set, data_type),
       nested_size_tensor_(std::move(nested_size_tensor)),
       nested_stride_tensor_(std::move(nested_stride_tensor)),
@@ -154,14 +154,14 @@ NestedTensorImpl::NestedTensorImpl(
     at::Tensor buffer,
     at::Tensor nested_size_tensor,
     at::Tensor nested_stride_tensor,
-    std::vector<int64_t> offsets)
+    std::vector<int64_t>&& offsets)
     : NestedTensorImpl(
           buffer.storage(),
           generate_nested_key_set(buffer),
           buffer.dtype(),
           nested_size_tensor,
           nested_stride_tensor,
-          offsets) {
+          std::move(offsets)) {
 
   TORCH_INTERNAL_ASSERT(
       buffer.dim() == 1,
@@ -286,7 +286,7 @@ c10::intrusive_ptr<TensorImpl> NestedTensorImpl::shallow_copy_and_detach_core(
       data_type_,
       nested_size_tensor_,
       nested_stride_tensor_,
-      offsets_);
+      std::vector<int64_t>(offsets_));
 
       copy_tensor_metadata(
           /*src_impl=*/this,

--- a/aten/src/ATen/NestedTensorImpl.h
+++ b/aten/src/ATen/NestedTensorImpl.h
@@ -20,13 +20,13 @@ struct TORCH_API NestedTensorImpl : public c10::TensorImpl {
       const caffe2::TypeMeta data_type,
       at::Tensor nested_size_tensor,
       at::Tensor nested_stride_tensor,
-      std::vector<int64_t> offsets);
+      std::vector<int64_t>&& offsets);
 
   explicit NestedTensorImpl(
       at::Tensor buffer,
       at::Tensor nested_size_tensor,
       at::Tensor nested_stride_tensor,
-      std::vector<int64_t> offsets);
+      std::vector<int64_t>&& offsets);
   // assume contiguous, `nested_stride_tensor` and `offsets`
   // can be infered from `nested_size_tensor`
   explicit NestedTensorImpl(at::Tensor buffer, at::Tensor nested_size_tensor);

--- a/aten/src/ATen/native/nested/NestedTensorMath.cpp
+++ b/aten/src/ATen/native/nested/NestedTensorMath.cpp
@@ -721,8 +721,8 @@ std::tuple<Tensor,Tensor> native_dropout_nested(const Tensor& input, double p, c
   }
   // regular tensor dropout reuses input size and stride
   // i.e. if input is not contiguous, then output is also discontiguous
-  Tensor output = wrap_buffer(output_buffer, sizemat.clone(), stridemat.clone(), offsets),
-      mask = wrap_buffer(mask_buffer, sizemat.clone(), stridemat.clone(), offsets);
+  Tensor output = wrap_buffer(output_buffer, sizemat.clone(), stridemat.clone(), std::vector<int64_t>(offsets)),
+      mask = wrap_buffer(mask_buffer, sizemat.clone(), stridemat.clone(), std::vector<int64_t>(offsets));
   return std::make_tuple(output, mask);
 }
 
@@ -1171,7 +1171,7 @@ Tensor _reshape_nested(const Tensor& self, IntArrayRef proposed_shape) {
   std::tie(reshape_as_view, sizemat_reshaped, stridemat_reshaped) = NestedTensor_reshape_size_stride(
       sizes, strides, proposed_shape, sizemat.options());
   if (reshape_as_view) {
-    return wrap_buffer(buffer, sizemat_reshaped, stridemat_reshaped, offsets);
+    return wrap_buffer(buffer, sizemat_reshaped, stridemat_reshaped, std::vector<int64_t>(offsets));
   }
   Tensor buffer_reshaped = buffer.new_empty(buffer.sizes());
   Tensor output = wrap_buffer(buffer_reshaped, sizemat_reshaped);

--- a/aten/src/ATen/native/nested/NestedTensorMath.h
+++ b/aten/src/ATen/native/nested/NestedTensorMath.h
@@ -24,11 +24,11 @@ inline at::Tensor wrap_buffer(at::Tensor buffer, at::Tensor nested_size_tensor) 
 
 inline at::Tensor wrap_buffer(
     at::Tensor buffer, at::Tensor nested_size_tensor,
-    at::Tensor nested_stride_tensor, const std::vector<int64_t>& offsets) {
+    at::Tensor nested_stride_tensor, std::vector<int64_t>&& offsets) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(buffer.is_contiguous(), "Given buffer must be contiguous.");
   return at::detail::make_tensor<NestedTensorImpl>(
       std::move(buffer), std::move(nested_size_tensor),
-      std::move(nested_stride_tensor), offsets);
+      std::move(nested_stride_tensor), std::move(offsets));
 }
 
 inline at::Tensor get_buffer(const at::Tensor& tensor) {


### PR DESCRIPTION
Currently the nested tensor construction for the offset_ parameter takes in references and in the chain of delegation uses value. This could lead to unnecessary copies.  Whenever a nested tensor impl is constructed it should take ownership of all its metadata. The only non-trivially copyable metadata associated with the class is `offsets_`. 

The goal of this PR is to make sure that consumers of nested_tensor_impl constructors ensure that they are passing offsets as a temporary - either buy explicitly copying a reference, or by constructing the offsets vector in the scope of construction.