### PR TITLE
S3 third-party deps sync workflow: specify correct secrets

### DIFF
--- a/.github/workflows/sync_s3_cache.yml
+++ b/.github/workflows/sync_s3_cache.yml
@@ -24,8 +24,8 @@ jobs:
           fetch-depth: 1
       - name: Sync S3 file cache
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_UPDATE_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_UPDATE_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_S3_ACCESS_KEY }}
         uses: docker://pytorch/sync_s3_thirdparty_deps
         with:
           args: ".github/pytorch-cached-s3-dependencies.yml"


### PR DESCRIPTION
A followup for: #83306

#83306 used wrong S3 secrets: `AWS_S3_UPDATE_***`, that resulted a failure of the newly added job:
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/108101595/184759049-b4900753-5d29-4352-8704-ce56734be750.png">

The correct secrets to access OSSCI buckets have `AWS_OSSCI_S3_***` prefix.

This PR makes the workflow use the correct secrets.