### PR TITLE
[torchgen] Add logic in annotation parser to accept alias set

### DIFF
--- a/tools/test/test_codegen_model.py
+++ b/tools/test/test_codegen_model.py
@@ -194,6 +194,12 @@ class TestAnnotation(expecttest.TestCase):
         self.assertTrue(a.is_write)
         self.assertEqual(a.alias_set_after, ("a", "b"))
 
+    def test_before_and_after_alias_set_larger_than_1_raises_exception(self) -> None:
+        with self.assertRaisesRegex(
+                AssertionError, r"before alias set and after alias set cannot be larger than 1 at the same time"
+        ):
+            Annotation.parse("a|b -> c|d")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test/test_codegen_model.py
+++ b/tools/test/test_codegen_model.py
@@ -2,15 +2,21 @@
 
 import textwrap
 import unittest
+from typing import cast
 
 import expecttest
-import yaml
-from typing import cast
 
 import torchgen.dest as dest
 import torchgen.gen as gen
+import yaml
 from torchgen.gen import LineLoader, parse_native_yaml_struct
-from torchgen.model import CustomClassType, DispatchKey, NativeFunctionsGroup, Type, Annotation
+from torchgen.model import (
+    Annotation,
+    CustomClassType,
+    DispatchKey,
+    NativeFunctionsGroup,
+    Type,
+)
 
 
 class TestCodegenModel(expecttest.TestCase):
@@ -154,38 +160,39 @@ cannot use CUDAFunctorOnSelf on non-binary function""",
 
 
 class TestAnnotation(expecttest.TestCase):
-
     def test_single_alias_no_write(self) -> None:
         a = Annotation.parse("a")
-        self.assertEqual(a.alias_set, tuple('a'))
+        self.assertEqual(a.alias_set, tuple("a"))
         self.assertFalse(a.is_write)
         self.assertEqual(a.alias_set_after, tuple())
 
     def test_single_alias_is_write(self) -> None:
         a = Annotation.parse("a!")
-        self.assertEqual(a.alias_set, tuple('a'))
+        self.assertEqual(a.alias_set, tuple("a"))
         self.assertTrue(a.is_write)
         self.assertEqual(a.alias_set_after, tuple())
 
     def test_single_alias_is_write_to_wildcard(self) -> None:
         a = Annotation.parse("a! -> *")
-        self.assertEqual(a.alias_set, tuple('a'))
+        self.assertEqual(a.alias_set, tuple("a"))
         self.assertTrue(a.is_write)
-        self.assertEqual(a.alias_set_after, tuple('*'))
+        self.assertEqual(a.alias_set_after, tuple("*"))
 
     def test_alias_set(self) -> None:
         a = Annotation.parse("a|b")
-        self.assertEqual(a.alias_set, ('a', 'b'))
+        self.assertEqual(a.alias_set, ("a", "b"))
 
     def test_alias_set_is_write_raises_exception(self) -> None:
-        with self.assertRaisesRegex(AssertionError, r"alias set larger than 1 is not mutable"):
+        with self.assertRaisesRegex(
+            AssertionError, r"alias set larger than 1 is not mutable"
+        ):
             Annotation.parse("a|b!")
 
     def test_single_alias_is_write_to_alias_set(self) -> None:
         a = Annotation.parse("a! -> a|b")
-        self.assertEqual(a.alias_set, tuple('a'))
+        self.assertEqual(a.alias_set, tuple("a"))
         self.assertTrue(a.is_write)
-        self.assertEqual(a.alias_set_after, ('a', 'b'))
+        self.assertEqual(a.alias_set_after, ("a", "b"))
 
 
 if __name__ == "__main__":

--- a/tools/test/test_codegen_model.py
+++ b/tools/test/test_codegen_model.py
@@ -196,7 +196,8 @@ class TestAnnotation(expecttest.TestCase):
 
     def test_before_and_after_alias_set_larger_than_1_raises_exception(self) -> None:
         with self.assertRaisesRegex(
-                AssertionError, r"before alias set and after alias set cannot be larger than 1 at the same time"
+            AssertionError,
+            r"before alias set and after alias set cannot be larger than 1 at the same time",
         ):
             Annotation.parse("a|b -> c|d")
 

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -901,7 +901,7 @@ class NativeFunction:
             "inplace_view" in self.tags and str(self.func.name) != "resize_"
         )
         is_wildcard_view = any(
-            inp.annotation is not None and '*' in inp.annotation.alias_set_after
+            inp.annotation is not None and "*" in inp.annotation.alias_set_after
             for inp in self.func.schema_order_arguments()
         )
         return is_non_mutating_view or is_inplace_view or is_wildcard_view
@@ -1581,6 +1581,7 @@ class Annotation:
 
     @staticmethod
     def parse(ann: str) -> "Annotation":
+        # TODO: implement a proper parser if this gets more ugly
         # Regex Explanation:
         # Example: "a! -> a|b"
         # Group #1: alias before optional '|', required. Matches the first
@@ -1597,13 +1598,13 @@ class Annotation:
         m = re.match(r"^([a-z])(\|[a-z])*(!?)( -> (\*|[a-z](\|[a-z])*))?$", ann)
 
         assert m is not None, f"unrecognized alias annotation {ann}"
-        before_alias = m.group(1) + (m.group(2) if m.group(2) else '')
-        alias_set = tuple(before_alias.split('|'))
+        before_alias = m.group(1) + (m.group(2) if m.group(2) else "")
+        alias_set = tuple(before_alias.split("|"))
         is_write = m.group(3) == "!"
-        assert not (is_write and len(alias_set) > 1), (
-            f"alias set larger than 1 is not mutable, got {ann} instead."
-        )
-        after_set = tuple(m.group(5).split('|')) if m.group(5) else tuple()
+        assert not (
+            is_write and len(alias_set) > 1
+        ), f"alias set larger than 1 is not mutable, got {ann} instead."
+        after_set = tuple(m.group(5).split("|")) if m.group(5) else tuple()
         r = Annotation(
             alias_set=alias_set, is_write=is_write, alias_set_after=after_set
         )

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -901,7 +901,7 @@ class NativeFunction:
             "inplace_view" in self.tags and str(self.func.name) != "resize_"
         )
         is_wildcard_view = any(
-            inp.annotation is not None and inp.annotation.alias_set_after != ""
+            inp.annotation is not None and '*' in inp.annotation.alias_set_after
             for inp in self.func.schema_order_arguments()
         )
         return is_non_mutating_view or is_inplace_view or is_wildcard_view
@@ -1577,26 +1577,33 @@ class Annotation:
     # we can conveniently assume it is canonically ordered
     alias_set: Tuple[str, ...]
     is_write: bool
-    alias_set_after: str
+    alias_set_after: Tuple[str, ...]
 
     @staticmethod
     def parse(ann: str) -> "Annotation":
-        # Only handling afterSet == Wildcard for now
-        becomes_wildcard_index = ann.find(" -> *")
-        if becomes_wildcard_index != -1:
-            after_set = "*"
-            # TODO: im not good enough with regexes to ignore -> *
-            m = re.match(
-                r"^([a-z])(!?)(!?)$",
-                ann[:becomes_wildcard_index]
-                + ann[becomes_wildcard_index + len(" -> *") :],
-            )
-        else:
-            after_set = ""
-            m = re.match(r"^([a-z])(!?)(!?)$", ann)
+        # Regex Explanation:
+        # Example: "a! -> a|b"
+        # Group #1: alias before optional '|', required. Matches the first
+        #   character 'a' in the example
+        # Group #2: optional alias set after optional '|', matches empty string
+        #   in the example
+        # Group #3: optional "is write" flag, matches '!' in the example.
+        # Group #4: optional section containing arrow, matches " -> a|b" in the
+        #   example.
+        # Group #5: optional alias after set, supports wildcard, matches "a|b"
+        #   in the example.
+        # Group #6: optional sub-section of alias after set, matches "|b" in the
+        #   example.
+        m = re.match(r"^([a-z])(\|[a-z])*(!?)( -> (\*|[a-z](\|[a-z])*))?$", ann)
+
         assert m is not None, f"unrecognized alias annotation {ann}"
-        alias_set = (m.group(1),)
-        is_write = m.group(2) == "!"
+        before_alias = m.group(1) + (m.group(2) if m.group(2) else '')
+        alias_set = tuple(before_alias.split('|'))
+        is_write = m.group(3) == "!"
+        assert not (is_write and len(alias_set) > 1), (
+            f"alias set larger than 1 is not mutable, got {ann} instead."
+        )
+        after_set = tuple(m.group(5).split('|')) if m.group(5) else tuple()
         r = Annotation(
             alias_set=alias_set, is_write=is_write, alias_set_after=after_set
         )
@@ -1605,10 +1612,12 @@ class Annotation:
 
     def __str__(self) -> str:
         alias_set = "|".join(self.alias_set)
-        if self.alias_set_after:
-            alias_set = f'{alias_set}{" -> "}{self.alias_set_after}'
-        is_write = "!" if self.is_write else ""
-        return f"{alias_set}{is_write}"
+        if self.is_write:
+            alias_set = f"{alias_set}!"
+        alias_set_after = "|".join(self.alias_set_after)
+        if alias_set_after:
+            alias_set = f'{alias_set}{" -> "}{alias_set_after}'
+        return alias_set
 
 
 # The base class for the type system.  This is also loosely modeled

--- a/torchgen/model.py
+++ b/torchgen/model.py
@@ -1605,6 +1605,9 @@ class Annotation:
             is_write and len(alias_set) > 1
         ), f"alias set larger than 1 is not mutable, got {ann} instead."
         after_set = tuple(m.group(5).split("|")) if m.group(5) else tuple()
+        assert not (
+            len(before_alias) > 1 and len(after_set) > 1
+        ), f"before alias set and after alias set cannot be larger than 1 at the same time, got {ann} instead."
         r = Annotation(
             alias_set=alias_set, is_write=is_write, alias_set_after=after_set
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83501

Extending the current regex in `model.py` to support annotation alias set. See issue #83214.

Ideally we should have a full fledged lexer similar to `schema_type_parser.cpp`, since regex can be more and more difficult to read if we add more support to it.

Adding this to unblock this issue for now.