### PR TITLE
Make the derivative of masked_fill more efficient

### DIFF
--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1008,7 +1008,7 @@
 
 - name: masked_fill.Tensor(Tensor self, Tensor mask, Tensor value) -> Tensor
   self: grad.masked_fill(mask, 0)
-  value: at::where(mask, grad, 0).sum()
+  value: grad.masked_select(mask).sum()
   mask: non_differentiable
   result: self_t.masked_fill(mask, value_t)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1008,7 +1008,7 @@
 
 - name: masked_fill.Tensor(Tensor self, Tensor mask, Tensor value) -> Tensor
   self: grad.masked_fill(mask, 0)
-  value: grad.masked_select(mask).sum()
+  value: masked_fill_backward(grad, mask)
   mask: non_differentiable
   result: self_t.masked_fill(mask, value_t)
 

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -497,6 +497,13 @@ Tensor sgn_backward(const Tensor& x, const Tensor& gx, const Tensor& sgn) {
   }
 }
 
+Tensor masked_fill_backward(const Tensor& grad, const Tensor& mask) {
+  // masked_select does not work well with functorch, as its shape is data-dependent
+  return areAnyTensorSubclassLike({grad, mask}) ?
+          at::where(mask, grad, 0).sum() :
+          grad.masked_select(mask).sum();
+}
+
 Tensor mul_tensor_backward(Tensor grad, Tensor other, ScalarType self_st) {
   auto out = grad * other.conj();
   return handle_r_to_c(self_st, out);

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -498,10 +498,11 @@ Tensor sgn_backward(const Tensor& x, const Tensor& gx, const Tensor& sgn) {
 }
 
 Tensor masked_fill_backward(const Tensor& grad, const Tensor& mask) {
-  // masked_select does not work well with functorch, as its shape is data-dependent
-  return areAnyTensorSubclassLike({grad, mask}) ?
-          at::where(mask, grad, 0).sum() :
-          grad.masked_select(mask).sum();
+  // masked_select does not work well with functorch, as its shape is
+  // data-dependent
+  return areAnyTensorSubclassLike({grad, mask})
+      ? at::where(mask, grad, 0).sum()
+      : grad.masked_select(mask).sum();
 }
 
 Tensor mul_tensor_backward(Tensor grad, Tensor other, ScalarType self_st) {

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -307,6 +307,7 @@ at::Tensor evenly_distribute_backward(
     const at::Tensor& input,
     const at::Tensor& value);
 Tensor sgn_backward(const Tensor& x, const Tensor& gx, const Tensor& sgn);
+Tensor masked_fill_backward(const Tensor& grad, const Tensor& mask);
 at::Tensor var_backward(
     at::Tensor grad,
     const at::Tensor& self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83515

There's no need to add all the zeros if we extract all the non-zero
elements.