### PR TITLE
Make test_jvpvjp_as_strided_scatter skipped due to flaky

### DIFF
--- a/functorch/test/test_ops.py
+++ b/functorch/test/test_ops.py
@@ -1088,7 +1088,7 @@ class TestOperators(TestCase):
         skip('linalg.householder_product', '', device_type='cuda'),  # flaky, I'm not sure why
         xfail('native_layer_norm', ''),
         xfail('sparse.sampled_addmm', ''),
-        xfail('as_strided_scatter', ''),
+        skip('as_strided_scatter', ''),  # seems flaky
         xfail('segment_reduce', 'offsets'),
         xfail('index_reduce', ''),
         xfail('segment_reduce', 'lengths'),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #83516

Signed-off-by: Edward Z. Yang <ezyang@fb.com>